### PR TITLE
Fixing incorrect test, $_COOKIE[session_name()] will be different tha...

### DIFF
--- a/Sources/Subs-Auth.php
+++ b/Sources/Subs-Auth.php
@@ -101,13 +101,6 @@ function setLoginCookie($cookie_length, $id, $password = '')
 		session_regenerate_id();
 		$_SESSION = $oldSessionData;
 
-		// Make sure to store the cookie of the new session.
-		if (!isset($_COOKIE[session_name()]) || $_COOKIE[session_name()] != session_id())
-		{
-			$sessionCookieLifetime = ini_get('session.cookie_lifetime');
-			smf_setcookie(session_name(), session_id(), time() + (empty($sessionCookieLifetime) ? $cookie_length : $sessionCookieLifetime), $cookie_url[1], $cookie_url[0], !empty($modSettings['secureCookies']));
-		}
-
 		$_SESSION['login_' . $cookiename] = $data;
 	}
 }


### PR DESCRIPTION
...n session_id since session_id was just regenerated. $_COOKIE array will be only filled again by PHP at the next page load, not at this point of execution in the script. So testing here if it's filled "correctly" for the _new_ id is not meaningful.

In addition, this re-set of the cookie has been the cause of a security weakness pre-SMF 2.0: losing session data (the rest of session variables) for the new session. If you really want this in, it needs tested for login spamming: incrementing $_SESSION variables such as failed_login must work as expected (i.e. prevent further login attempts after the maximum number of attempts is reached).

Signed-off-by: Norv norv@simplemachines.org
