### PR TITLE
CSS/JS loading functions in the source

### DIFF
--- a/Sources/Admin.php
+++ b/Sources/Admin.php
@@ -30,7 +30,7 @@ function AdminMain()
 	// Load the language and templates....
 	loadLanguage('Admin');
 	loadTemplate('Admin', 'admin');
-	loadJavascriptFile('scripts/admin.js?alp21', array('default_theme' => true));
+	loadJavascriptFile('admin.js?alp21', array('default_theme' => true));
 
 	// No indexing evil stuff.
 	$context['robot_no_index'] = true;

--- a/Sources/ModerationCenter.php
+++ b/Sources/ModerationCenter.php
@@ -225,7 +225,7 @@ function ModerationHome()
 	global $txt, $context, $scripturl, $modSettings, $user_info, $user_settings;
 
 	loadTemplate('ModerationCenter');
-	loadJavascriptFile('scripts/admin.js?alp21', array('default_theme' => true));
+	loadJavascriptFile('admin.js?alp21', array('default_theme' => true));
 
 	$context['page_title'] = $txt['moderation_center'];
 	$context['sub_template'] = 'moderation_center';

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -3243,7 +3243,22 @@ function template_javascript($do_defered = false)
 
 	// Use this hook to minify/optimize Javascript files and vars
 	call_integration_hook('pre_javascript_output');
+	
+	// Javascript variables.
+	if (!empty($context['javascript_vars']) && !$do_defered)
+	{
+		echo '
+	<script type="text/javascript"><!-- // --><![CDATA[';
 
+		foreach ($context['javascript_vars'] as $key => $value)
+			echo '
+		var ', $key, ' = ', $value, ';';
+
+		echo '
+	// ]]></script>';
+	}
+
+	// Javascript files
 	foreach ($context['javascript_files'] as $id => $file)
 	{
 		if ((!$do_defered && empty($file['options']['defer'])) || ($do_defered && !empty($file['options']['defer'])))
@@ -3257,20 +3272,6 @@ function template_javascript($do_defered = false)
 		window.jQuery || document.write(\'<script src="' . $settings['default_theme_url'] . '/scripts/jquery-1.7.1.min.js"><\/script>\');
 	// ]]></script>';
 
-	}
-
-	// Javascript variables.
-	if (!empty($context['javascript_vars']) && !$do_defered)
-	{
-		echo '
-	<script type="text/javascript"><!-- // --><![CDATA[';
-
-		foreach ($context['javascript_vars'] as $key => $value)
-			echo '
-		var ', $key, ' = ', $value, ';';
-
-		echo '
-	// ]]></script>';
 	}
 	
 	// Inline JavaScript - Actually useful some times!

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -2934,6 +2934,17 @@ function setupThemeContext($forceload = false)
 	// This is done to allow theme authors to customize it as they want.
 	$context['show_pm_popup'] = $context['user']['popup_messages'] && !empty($options['popup_messages']) && (!isset($_REQUEST['action']) || $_REQUEST['action'] != 'pm');
 
+	// 2.1+: Add the PM popup here instead. Theme authors can still override it simply by editing/removing the 'fPmPopup' in the array.
+	if($context['show_pm_popup'])
+		addInlineJavascript('
+		$(document).ready(function(){
+			new smc_Popup({
+				heading: ' . JavaScriptEscape($txt['show_personal_messages_heading']) . ',
+				content: ' . JavaScriptEscape(sprintf($txt['show_personal_messages'], $context['user']['unread_messages'], $scripturl . '?action=pm')) . ',
+				icon: smf_images_url + \'/im_sm_newmsg.png\'
+			});
+		});');
+
 	// Resize avatars the fancy, but non-GD requiring way.
 	if ($modSettings['avatar_action_too_large'] == 'option_js_resize' && (!empty($modSettings['avatar_max_width_external']) || !empty($modSettings['avatar_max_height_external'])))
 	{
@@ -3224,32 +3235,72 @@ function template_footer()
 }
 
 /**
- * Output the Javascript files
+ * Output the Javascript files (messed up tabbing in this function is to make the HTML source look good)
  */
 function template_javascript($do_defered = false)
 {
-	global $context;
+	global $context, $modSettings, $settings;
 
-	// Use this hook to minify/optimize Javascript files
+	// Use this hook to minify/optimize Javascript files and vars
 	call_integration_hook('pre_javascript_output');
 
-	foreach ($context['javascript_files'] as $filename => $options)
-		if ((!$do_defered && empty($options['defer'])) || ($do_defered && !empty($options['defer'])))
+	foreach ($context['javascript_files'] as $id => $file)
+	{
+		if ((!$do_defered && empty($file['options']['defer'])) || ($do_defered && !empty($file['options']['defer'])))
 			echo '
-		<script type="text/javascript" src="', $filename, '"></script>';
+	<script type="text/javascript" src="', $file['filename'], '" id="', $id,'"' , !empty($file['options']['async']) ? ' async="async"' : '' ,'></script>';
+	
+		// If this was JQuery being loaded and we are set to 'auto' load it, add the inline JS stuff here
+		if($id == 'jquery' && (!isset($modSettings['jquery_source']) || !in_array($modSettings['jquery_source'],array('local', 'cdn'))))
+		echo '
+	<script type="text/javascript"><!-- // --><![CDATA[
+		window.jQuery || document.write(\'<script src="' . $settings['default_theme_url'] . '/scripts/jquery-1.7.1.min.js"><\/script>\');
+	// ]]></script>';
 
-	if (!empty($context['javascript_vars']))
+	}
+
+	// Javascript variables.
+	if (!empty($context['javascript_vars']) && !$do_defered)
 	{
 		echo '
-		<script type="text/javascript"><!-- // --><![CDATA[';
+	<script type="text/javascript"><!-- // --><![CDATA[';
 
 		foreach ($context['javascript_vars'] as $key => $value)
 			echo '
-			var ', $key, ' = ', $value;
+		var ', $key, ' = ', $value, ';';
 
 		echo '
-		// ]]></script>';
+	// ]]></script>';
+	}
+	
+	// Inline JavaScript - Actually useful some times!
+	if (!empty($context['javascript_inline']))
+	{
+		if(!empty($context['javascript_inline']['defer']) && $do_defered)
+		{
+			echo '
+<script type="text/javascript"><!-- // --><![CDATA[
+	';
 
+			foreach ($context['javascript_inline']['defer'] as $code)
+				echo $code;
+					
+			echo'
+// ]]></script>';
+		}
+
+		if(!empty($context['javascript_inline']['standard']) && !$do_defered)
+		{
+			echo '
+	<script type="text/javascript"><!-- // --><![CDATA[
+		';
+
+			foreach ($context['javascript_inline']['standard'] as $code)
+				echo $code;
+					
+			echo'
+	// ]]></script>';
+		}
 	}
 }
 
@@ -3263,9 +3314,9 @@ function template_css()
 	// Use this hook to minify/optimize CSS files
 	call_integration_hook('pre_css_output');
 
-	foreach ($context['css_files'] as $filename => $options)
+	foreach ($context['css_files'] as $id => $file)
 		echo '
-	<link rel="stylesheet" type="text/css" href="', $filename, '" />';
+	<link rel="stylesheet" type="text/css" href="', $file['filename'], '" id="', $id,'" />';
 }
 
 /**

--- a/Themes/default/index.template.php
+++ b/Themes/default/index.template.php
@@ -99,71 +99,10 @@ function template_html_above()
 		echo '
 	<link rel="stylesheet" type="text/css" href="', $settings['theme_url'], '/css/rtl.css" />';
 
-	// load in any css from mods or themes so they can overwrite if wanted
+	// Load in any css from mods
 	template_css();
-
-	// Jquery Librarys
-	if (isset($modSettings['jquery_source']) && $modSettings['jquery_source'] == 'cdn')
-		echo '
-	<script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js"></script>';
-	elseif (isset($modSettings['jquery_source']) && $modSettings['jquery_source'] == 'local')
-		echo '
-	<script type="text/javascript" src="', $settings['theme_url'], '/scripts/jquery-1.7.1.min.js"></script>';
-	else
-		echo '
-	<script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js"></script>
-	<script type="text/javascript"><!-- // --><![CDATA[
-		window.jQuery || document.write(\'<script src="', $settings['theme_url'], '/scripts/jquery-1.7.1.min.js"><\/script>\');
-	// ]]></script>';
-
-	// Note that the Superfish function seems to like being called by the full syntax.
-	// It doesn't appear to like being called by short syntax. Please test if contemplating changes.
-	echo '
-	<script type="text/javascript" src="', $settings['theme_url'], '/scripts/smf_jquery_plugins.js"></script>';
 	
-	// Here comes the JavaScript bits!
-	echo '
-	<script type="text/javascript" src="', $settings['default_theme_url'], '/scripts/script.js?alp21"></script>
-	<script type="text/javascript" src="', $settings['theme_url'], '/scripts/theme.js?alp21"></script>
-	<script type="text/javascript"><!-- // --><![CDATA[
-		var smf_theme_url = "', $settings['theme_url'], '";
-		var smf_default_theme_url = "', $settings['default_theme_url'], '";
-		var smf_images_url = "', $settings['images_url'], '";
-		var smf_scripturl = "', $scripturl, '";
-		var smf_iso_case_folding = ', $context['server']['iso_case_folding'] ? 'true' : 'false', ';
-		var smf_charset = "', $context['character_set'], '";
-		var smf_session_id = "', $context['session_id'], '";
-		var smf_session_var = "', $context['session_var'], '";
-		var smf_member_id = "', $context['user']['id'], '";', $context['show_pm_popup'] ? '
-		var fPmPopup = function ()
-		{
-			new smc_Popup({
-				heading: ' . JavaScriptEscape($txt['show_personal_messages_heading']) . ',
-				content: ' . JavaScriptEscape(sprintf($txt['show_personal_messages'], $context['user']['unread_messages'], $scripturl . '?action=pm')) . ',
-				icon: smf_images_url + \'/im_sm_newmsg.png\'
-			});
-		}
-		addLoadEvent(fPmPopup);' : '', '
-		var ajax_notification_text = "', $txt['ajax_in_progress'], '";
-		var ajax_notification_cancel_text = "', $txt['modify_cancel'], '";
-		var help_popup_heading_text = "', $txt['help_popup'], '";
-	// ]]></script>';
-
-	echo '
-	<script type="text/javascript"><!-- // --><![CDATA[
-		$(document).ready(function() {
-			// menu drop downs
-			$("ul.dropmenu").superfish();
-			
-			// tooltips
-			$(".preview").SMFtooltip();
-
-			// find all nested linked images and turn off the border
-			$("a.bbc_link img.bbc_img").parent().css("border", "0");
-		});
-	// ]]></script>';
-
-	// load in any javascript files from mods and themes
+	// Load in default Javascript variables as well as stuff added by mods (new in 2.1, so themers won't have to bother with it)
 	template_javascript();
 		
 	echo '

--- a/Themes/default/scripts/theme.js
+++ b/Themes/default/scripts/theme.js
@@ -1,3 +1,14 @@
+$(document).ready(function() {
+	// menu drop downs
+	$('ul.dropmenu').superfish();
+	
+	// tooltips
+	$('.preview').SMFtooltip();
+
+	// find all nested linked images and turn off the border
+	$('a.bbc_link img.bbc_img').parent().css('border', '0');
+});
+
 // The purpose of this code is to fix the height of overflow: auto blocks, because some browsers can't figure it out for themselves.
 function smf_codeBoxFix()
 {


### PR DESCRIPTION
Spent some time updating loadCSSFile() and loadJavascriptFile() to make them more useful. Added a couple of more functions to handle JS, and moved some common stuff out of index.template.php and into the sources since they're not really per-theme (JQuery and script.js, for example).

addInlineJavascript() and addJavascriptVar() are essentially just updating their respective entry in $context, so they're very small and really just wrappers, but it makes it a little cleaner and saves a few seconds for modders.

I didn't go as far as to moving the standard CSS files out of index.template.php even though that could be done since they're essentially the same in all themes, and if a theme should want to use style.css or whatever instead of index.css, they could just edit $context['css_files'] in template_init(). That's up for discussion!

Something we may also want to consider is moving ALL the default JS files to the bottom of the HTML ($options['defer'] = true in loadJavascriptFile()) as well as maybe adding the HTML5 async attribute to external scripts for browsers that support it ($options['async'] = true in loadJavascriptFile()). This would be for the sake of page loading times.
