### PR TITLE
Improving how the ignore post toggles get created

### DIFF
--- a/Themes/default/Display.template.php
+++ b/Themes/default/Display.template.php
@@ -884,32 +884,7 @@ function template_main()
 	if (!empty($ignoredMsgs))
 	{
 		echo '
-					var aIgnoreToggles = new Array();';
-
-		foreach ($ignoredMsgs as $msgid)
-		{
-			echo '
-					aIgnoreToggles[', $msgid, '] = new smc_Toggle({
-						bToggleEnabled: true,
-						bCurrentlyCollapsed: true,
-						aSwappableContainers: [
-							\'msg_', $msgid, '_extra_info\',
-							\'msg_', $msgid, '\',
-							\'msg_', $msgid, '_footer\',
-							\'msg_', $msgid, '_quick_mod\',
-							\'modify_button_', $msgid, '\',
-							\'msg_', $msgid, '_signature\'
-
-						],
-						aSwapLinks: [
-							{
-								sId: \'msg_', $msgid, '_ignored_link\',
-								msgExpanded: \'\',
-								msgCollapsed: ', JavaScriptEscape($txt['show_ignore_user_post']), '
-							}
-						]
-					});';
-		}
+					ignore_toggles([', implode(', ', $ignoredMsgs), '], ', JavaScriptEscape($txt['show_ignore_user_post']), ');';
 	}
 
 	echo '

--- a/Themes/default/scripts/topic.js
+++ b/Themes/default/scripts/topic.js
@@ -612,3 +612,31 @@ function modify_topic_hide_edit(subject)
 	// Re-template the subject!
 	setInnerHTML(cur_subject_div, '<a href="' + smf_scripturl + '?topic=' + cur_topic_id + '.0">' + subject + '<' +'/a>');
 }
+
+function ignore_toggles(msgids, text)
+{
+	for (i = 0; i < msgids.length; i++)
+	{
+		var msgid = msgids[i];
+		new smc_Toggle({
+			bToggleEnabled: true,
+			bCurrentlyCollapsed: true,
+			aSwappableContainers: [
+				'msg_' + msgid + '_extra_info',
+				'msg_' + msgid,
+				'msg_' + msgid + '_footer',
+				'msg_' + msgid + '_quick_mod',
+				'modify_button_' + msgid,
+				'msg_' + msgid + '_signature'
+
+			],
+			aSwapLinks: [
+				{
+					sId: 'msg_' + msgid + '_ignored_link',
+					msgExpanded: '',
+					msgCollapsed: text
+				}
+			]
+		});
+	}
+}


### PR DESCRIPTION
There was no need to build out an array of them individually.  Reduces the amount of generated code.

Signed-off-by: Michael Miller mikemill@gmail.com
