### PR TITLE
Pruning options

### DIFF
--- a/Sources/ManageSettings.php
+++ b/Sources/ManageSettings.php
@@ -492,7 +492,7 @@ function ModifyBasicSettings($return_config = false)
 		'',
 			// Option-ish things... miscellaneous sorta.
 			array('check', 'allow_disableAnnounce'),
-			array('check', 'disallow_sendBody'),	
+			array('check', 'disallow_sendBody'),
 	);
 
 	// Get all the time zones.
@@ -1737,7 +1737,7 @@ function EditCustomProfiles()
 		// Regex you say?  Do a very basic test to see if the pattern is valid
 		if (!empty($_POST['regex']) && @preg_match($_POST['regex'], 'dummy') === false)
 			redirectexit($scripturl . '?action=admin;area=featuresettings;sa=profileedit;fid=' . $_GET['fid'] . ';msg=regex_error');
-			
+
 		$_POST['field_name'] = $smcFunc['htmlspecialchars']($_POST['field_name']);
 		$_POST['field_desc'] = $smcFunc['htmlspecialchars']($_POST['field_desc']);
 
@@ -2104,10 +2104,15 @@ function ModifyPruningSettings($return_config = false)
 	$context['sub_template'] = 'show_settings';
 
 	// Get the actual values
-	if (!empty($modSettings['pruningOptions']))
-		@list ($modSettings['pruneErrorLog'], $modSettings['pruneModLog'], $modSettings['pruneBanLog'], $modSettings['pruneReportLog'], $modSettings['pruneScheduledTaskLog'], $modSettings['pruneSpiderHitLog']) = explode(',', $modSettings['pruningOptions']);
-	else
-		$modSettings['pruneErrorLog'] = $modSettings['pruneModLog'] = $modSettings['pruneBanLog'] = $modSettings['pruneReportLog'] = $modSettings['pruneScheduledTaskLog'] = $modSettings['pruneSpiderHitLog'] = 0;
+	$pruningOptions = @unserialize($modSettings['pruningOptions']);
+	$vals = array();
+	foreach ($config_vars as $index => $dummy)
+	{
+		if (!is_array($dummy) || $index == 'pruningOptions')
+			continue;
+
+		$modSettings[$dummy[1]] = empty($pruningOptions[$dummy[1]]) ? 0 : (int) $pruningOptions[$dummy[1]];
+	}
 
 	prepareDBSettingContext($config_vars);
 }

--- a/Sources/ManageSettings.php
+++ b/Sources/ManageSettings.php
@@ -478,7 +478,7 @@ function ModifyBasicSettings($return_config = false)
 		'',
 			// Number formatting, timezones.
 			array('text', 'time_format'),
-			array('select', 'number_format', array(array('', '','Custom'), '1234.00' => '1234.00', '1,234.00' => '1,234.00', '1.234,00' => '1.234,00', '1 234,00' => '1 234,00', '1234,00' => '1234,00')),
+			array('select', 'number_format', array('1234.00' => '1234.00', '1,234.00' => '1,234.00', '1.234,00' => '1.234,00', '1 234,00' => '1 234,00', '1234,00' => '1234,00')),
 			array('float', 'time_offset', 'subtext' => $txt['setting_time_offset_note'], 6, 'postinput' => $txt['hours']),
 			'default_timezone' => array('select', 'default_timezone', array()),
 		'',
@@ -1737,7 +1737,7 @@ function EditCustomProfiles()
 		// Regex you say?  Do a very basic test to see if the pattern is valid
 		if (!empty($_POST['regex']) && @preg_match($_POST['regex'], 'dummy') === false)
 			redirectexit($scripturl . '?action=admin;area=featuresettings;sa=profileedit;fid=' . $_GET['fid'] . ';msg=regex_error');
-
+			
 		$_POST['field_name'] = $smcFunc['htmlspecialchars']($_POST['field_name']);
 		$_POST['field_desc'] = $smcFunc['htmlspecialchars']($_POST['field_desc']);
 
@@ -2088,9 +2088,9 @@ function ModifyPruningSettings($return_config = false)
 				if (!is_array($dummy) || $index == 'pruningOptions')
 					continue;
 
-				$vals += array($dummy[1] => empty($_POST[$dummy[1]]) || $_POST[$dummy[1]] < 0 ? 0 : (int) $_POST[$dummy[1]]);
+				$vals[] = empty($_POST[$dummy[1]]) || $_POST[$dummy[1]] < 0 ? 0 : (int) $_POST[$dummy[1]];
 			}
-			$_POST['pruningOptions'] = serialize($vals);
+			$_POST['pruningOptions'] = implode(',', $vals);
 		}
 		else
 			$_POST['pruningOptions'] = '';
@@ -2104,15 +2104,10 @@ function ModifyPruningSettings($return_config = false)
 	$context['sub_template'] = 'show_settings';
 
 	// Get the actual values
-	$pruningOptions = @unserialize($modSettings['pruningOptions']);
-	$vals = array();
-	foreach ($config_vars as $index => $dummy)
-	{
-		if (!is_array($dummy) || $index == 'pruningOptions')
-			continue;
-
-		$modSettings[$dummy[1]] = empty($pruningOptions[$dummy[1]]) ? 0 : (int) $pruningOptions[$dummy[1]];
-	}
+	if (!empty($modSettings['pruningOptions']))
+		@list ($modSettings['pruneErrorLog'], $modSettings['pruneModLog'], $modSettings['pruneBanLog'], $modSettings['pruneReportLog'], $modSettings['pruneScheduledTaskLog'], $modSettings['pruneSpiderHitLog']) = explode(',', $modSettings['pruningOptions']);
+	else
+		$modSettings['pruneErrorLog'] = $modSettings['pruneModLog'] = $modSettings['pruneBanLog'] = $modSettings['pruneReportLog'] = $modSettings['pruneScheduledTaskLog'] = $modSettings['pruneSpiderHitLog'] = 0;
 
 	prepareDBSettingContext($config_vars);
 }

--- a/Sources/ManageSettings.php
+++ b/Sources/ManageSettings.php
@@ -478,7 +478,7 @@ function ModifyBasicSettings($return_config = false)
 		'',
 			// Number formatting, timezones.
 			array('text', 'time_format'),
-			array('select', 'number_format', array('1234.00' => '1234.00', '1,234.00' => '1,234.00', '1.234,00' => '1.234,00', '1 234,00' => '1 234,00', '1234,00' => '1234,00')),
+			array('select', 'number_format', array(array('', '','Custom'), '1234.00' => '1234.00', '1,234.00' => '1,234.00', '1.234,00' => '1.234,00', '1 234,00' => '1 234,00', '1234,00' => '1234,00')),
 			array('float', 'time_offset', 'subtext' => $txt['setting_time_offset_note'], 6, 'postinput' => $txt['hours']),
 			'default_timezone' => array('select', 'default_timezone', array()),
 		'',
@@ -1737,7 +1737,7 @@ function EditCustomProfiles()
 		// Regex you say?  Do a very basic test to see if the pattern is valid
 		if (!empty($_POST['regex']) && @preg_match($_POST['regex'], 'dummy') === false)
 			redirectexit($scripturl . '?action=admin;area=featuresettings;sa=profileedit;fid=' . $_GET['fid'] . ';msg=regex_error');
-			
+
 		$_POST['field_name'] = $smcFunc['htmlspecialchars']($_POST['field_name']);
 		$_POST['field_desc'] = $smcFunc['htmlspecialchars']($_POST['field_desc']);
 
@@ -2088,9 +2088,9 @@ function ModifyPruningSettings($return_config = false)
 				if (!is_array($dummy) || $index == 'pruningOptions')
 					continue;
 
-				$vals[] = empty($_POST[$dummy[1]]) || $_POST[$dummy[1]] < 0 ? 0 : (int) $_POST[$dummy[1]];
+				$vals += array($dummy[1] => empty($_POST[$dummy[1]]) || $_POST[$dummy[1]] < 0 ? 0 : (int) $_POST[$dummy[1]]);
 			}
-			$_POST['pruningOptions'] = implode(',', $vals);
+			$_POST['pruningOptions'] = serialize($vals);
 		}
 		else
 			$_POST['pruningOptions'] = '';
@@ -2104,10 +2104,15 @@ function ModifyPruningSettings($return_config = false)
 	$context['sub_template'] = 'show_settings';
 
 	// Get the actual values
-	if (!empty($modSettings['pruningOptions']))
-		@list ($modSettings['pruneErrorLog'], $modSettings['pruneModLog'], $modSettings['pruneBanLog'], $modSettings['pruneReportLog'], $modSettings['pruneScheduledTaskLog'], $modSettings['pruneSpiderHitLog']) = explode(',', $modSettings['pruningOptions']);
-	else
-		$modSettings['pruneErrorLog'] = $modSettings['pruneModLog'] = $modSettings['pruneBanLog'] = $modSettings['pruneReportLog'] = $modSettings['pruneScheduledTaskLog'] = $modSettings['pruneSpiderHitLog'] = 0;
+	$pruningOptions = @unserialize($modSettings['pruningOptions']);
+	$vals = array();
+	foreach ($config_vars as $index => $dummy)
+	{
+		if (!is_array($dummy) || $index == 'pruningOptions')
+			continue;
+
+		$modSettings[$dummy[1]] = empty($pruningOptions[$dummy[1]]) ? 0 : (int) $pruningOptions[$dummy[1]];
+	}
 
 	prepareDBSettingContext($config_vars);
 }

--- a/Sources/ScheduledTasks.php
+++ b/Sources/ScheduledTasks.php
@@ -2,7 +2,7 @@
 
 /**
  * This file is automatically called and handles all manner of scheduled things.
- * 
+ *
  * Simple Machines Forum (SMF)
  *
  * @package SMF
@@ -1412,13 +1412,12 @@ function scheduled_weekly_maintenance()
 	// Ok should we prune the logs?
 	if (!empty($modSettings['pruningOptions']))
 	{
-		if (!empty($modSettings['pruningOptions']) && strpos($modSettings['pruningOptions'], ',') !== false)
-			list ($modSettings['pruneErrorLog'], $modSettings['pruneModLog'], $modSettings['pruneBanLog'], $modSettings['pruneReportLog'], $modSettings['pruneScheduledTaskLog'], $modSettings['pruneSpiderHitLog']) = explode(',', $modSettings['pruningOptions']);
+		$pruningOptions = @unserialize($modSettings['pruningOptions']);
 
-		if (!empty($modSettings['pruneErrorLog']))
+		if (!empty($pruningOptions['pruneErrorLog']))
 		{
 			// Figure out when our cutoff time is.  1 day = 86400 seconds.
-			$t = time() - $modSettings['pruneErrorLog'] * 86400;
+			$t = time() - $pruningOptions['pruneErrorLog'] * 86400;
 
 			$smcFunc['db_query']('', '
 				DELETE FROM {db_prefix}log_errors
@@ -1429,10 +1428,10 @@ function scheduled_weekly_maintenance()
 			);
 		}
 
-		if (!empty($modSettings['pruneModLog']))
+		if (!empty($pruningOptions['pruneModLog']))
 		{
 			// Figure out when our cutoff time is.  1 day = 86400 seconds.
-			$t = time() - $modSettings['pruneModLog'] * 86400;
+			$t = time() - $pruningOptions['pruneModLog'] * 86400;
 
 			$smcFunc['db_query']('', '
 				DELETE FROM {db_prefix}log_actions
@@ -1445,10 +1444,10 @@ function scheduled_weekly_maintenance()
 			);
 		}
 
-		if (!empty($modSettings['pruneBanLog']))
+		if (!empty($pruningOptions['pruneBanLog']))
 		{
 			// Figure out when our cutoff time is.  1 day = 86400 seconds.
-			$t = time() - $modSettings['pruneBanLog'] * 86400;
+			$t = time() - $pruningOptions['pruneBanLog'] * 86400;
 
 			$smcFunc['db_query']('', '
 				DELETE FROM {db_prefix}log_banned
@@ -1459,10 +1458,10 @@ function scheduled_weekly_maintenance()
 			);
 		}
 
-		if (!empty($modSettings['pruneReportLog']))
+		if (!empty($pruningOptions['pruneReportLog']))
 		{
 			// Figure out when our cutoff time is.  1 day = 86400 seconds.
-			$t = time() - $modSettings['pruneReportLog'] * 86400;
+			$t = time() - $pruningOptions['pruneReportLog'] * 86400;
 
 			// This one is more complex then the other logs.  First we need to figure out which reports are too old.
 			$reports = array();
@@ -1501,10 +1500,10 @@ function scheduled_weekly_maintenance()
 			}
 		}
 
-		if (!empty($modSettings['pruneScheduledTaskLog']))
+		if (!empty($pruningOptions['pruneScheduledTaskLog']))
 		{
 			// Figure out when our cutoff time is.  1 day = 86400 seconds.
-			$t = time() - $modSettings['pruneScheduledTaskLog'] * 86400;
+			$t = time() - $pruningOptions['pruneScheduledTaskLog'] * 86400;
 
 			$smcFunc['db_query']('', '
 				DELETE FROM {db_prefix}log_scheduled_tasks
@@ -1515,10 +1514,10 @@ function scheduled_weekly_maintenance()
 			);
 		}
 
-		if (!empty($modSettings['pruneSpiderHitLog']))
+		if (!empty($pruningOptions['pruneSpiderHitLog']))
 		{
 			// Figure out when our cutoff time is.  1 day = 86400 seconds.
-			$t = time() - $modSettings['pruneSpiderHitLog'] * 86400;
+			$t = time() - $pruningOptions['pruneSpiderHitLog'] * 86400;
 
 			$smcFunc['db_query']('', '
 				DELETE FROM {db_prefix}log_spider_hits
@@ -1530,7 +1529,7 @@ function scheduled_weekly_maintenance()
 		}
 	}
 
-	// Get rid of any paid subscriptions that were never actioned.
+	// Get rid of any paid subscriptions that were never activated.
 	$smcFunc['db_query']('', '
 		DELETE FROM {db_prefix}log_subscribed
 		WHERE end_time = {int:no_end_time}
@@ -1685,16 +1684,16 @@ function scheduled_remove_temp_attachments()
 /**
  * Check for move topic notices that have past their best by date
  */
-function scheduled_remove_topic_redirect() 
+function scheduled_remove_topic_redirect()
 {
 	global $smcFunc, $sourcedir;
-	
+
 	// init
 	$topics = array();
-	
+
 	// We will need this for lanaguage files
 	loadEssentialThemeData();
-	
+
 	// Find all of the old MOVE topic notices that were set to expire
 	$request = $smcFunc['db_query']('', '
 		SELECT id_topic
@@ -1705,12 +1704,12 @@ function scheduled_remove_topic_redirect()
 			'redirect_expires' => time(),
 		)
 	);
-	
+
 	while ($row = $smcFunc['db_fetch_row']($request))
 		$topics[] = $row[0];
 	$smcFunc['db_free_result']($request);
-	
-	// Zap, your gone
+
+	// Zap, you're gone
 	if (count($topics) > 0)
 	{
 		require_once($sourcedir . '/RemoveTopic.php');

--- a/other/install.php
+++ b/other/install.php
@@ -1023,6 +1023,14 @@ function DatabasePopulation()
 		'{$smf_version}' => $GLOBALS['current_smf_version'],
 		'{$current_time}' => time(),
 		'{$sched_task_offset}' => 82800 + mt_rand(0, 86399),
+		'{$pruning_options}' => serialize(array(
+			'pruneErrorLog' => 30,
+			'pruneModLog' => 180,
+			'pruneBanLog' => 180,
+			'pruneReportLog' => 180,
+			'pruneScheduledTaskLog' => 30,
+			'pruneSpiderHitLog' => 0,
+		)),
 	);
 
 	foreach ($txt as $key => $value)
@@ -1962,11 +1970,11 @@ function updateSettingsFile($vars)
 	return true;
 }
 
-function updateDbLastError() 
+function updateDbLastError()
 {
-	// Write out the db_last_error file with the error timestamp 
+	// Write out the db_last_error file with the error timestamp
 	file_put_contents(dirname(__FILE__) . '/db_last_error.php', '<' . '?' . "php\n" . '$db_last_error = 0;' . "\n" . '?' . '>');
-	
+
 	return true;
 }
 

--- a/other/install_2-1_mysql.sql
+++ b/other/install_2-1_mysql.sql
@@ -1617,7 +1617,7 @@ VALUES
 	(10, 0, 120, 1, 'd', 1, 'paid_subscriptions'),
 	(11, 0, 120, 1, 'd', 1, 'remove_temp_attachments'),
 	(12, 0, 180, 1, 'd', 1, 'remove_topic_redirect');
-	
+
 # --------------------------------------------------------
 
 #
@@ -1794,7 +1794,7 @@ VALUES ('smfVersion', '{$smf_version}'),
 	('warning_mute', '60'),
 	('admin_features', ''),
 	('last_mod_report_action', '0'),
-	('pruningOptions', '30,180,180,180,30,0'),
+	('pruningOptions', '{$pruning_options}'),
 	('cache_enable', '1'),
 	('reg_verification', '1'),
 	('visual_verification_type', '3'),

--- a/other/install_2-1_postgresql.sql
+++ b/other/install_2-1_postgresql.sql
@@ -2283,7 +2283,7 @@ INSERT INTO {$db_prefix}settings (variable, value) VALUES ('warning_moderate', '
 INSERT INTO {$db_prefix}settings (variable, value) VALUES ('warning_mute', '60');
 INSERT INTO {$db_prefix}settings (variable, value) VALUES ('admin_features', '');
 INSERT INTO {$db_prefix}settings (variable, value) VALUES ('last_mod_report_action', '0');
-INSERT INTO {$db_prefix}settings (variable, value) VALUES ('pruningOptions', '30,180,180,180,30,0');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('pruningOptions', '{$pruning_options}');
 INSERT INTO {$db_prefix}settings (variable, value) VALUES ('cache_enable', '1');
 INSERT INTO {$db_prefix}settings (variable, value) VALUES ('reg_verification', '1');
 INSERT INTO {$db_prefix}settings (variable, value) VALUES ('visual_verification_type', '3');

--- a/other/install_2-1_sqlite.sql
+++ b/other/install_2-1_sqlite.sql
@@ -1939,7 +1939,7 @@ INSERT INTO {$db_prefix}settings (variable, value) VALUES ('warning_moderate', '
 INSERT INTO {$db_prefix}settings (variable, value) VALUES ('warning_mute', '60');
 INSERT INTO {$db_prefix}settings (variable, value) VALUES ('admin_features', '');
 INSERT INTO {$db_prefix}settings (variable, value) VALUES ('last_mod_report_action', '0');
-INSERT INTO {$db_prefix}settings (variable, value) VALUES ('pruningOptions', '30,180,180,180,30,0');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('pruningOptions', '{$pruning_options}');
 INSERT INTO {$db_prefix}settings (variable, value) VALUES ('cache_enable', '1');
 INSERT INTO {$db_prefix}settings (variable, value) VALUES ('reg_verification', '1');
 INSERT INTO {$db_prefix}settings (variable, value) VALUES ('visual_verification_type', '3');

--- a/other/upgrade_2-1_mysql.sql
+++ b/other/upgrade_2-1_mysql.sql
@@ -222,5 +222,6 @@ if (mysql_num_rows($request) != 0)
 			WHERE variable = 'pruningOptions'");
 	}
 }
+mysql_free_result($request);
 ---}
 ---#

--- a/other/upgrade_2-1_mysql.sql
+++ b/other/upgrade_2-1_mysql.sql
@@ -190,3 +190,37 @@ CHANGE body body mediumtext NOT NULL;
 ALTER TABLE {$db_prefix}membergroups
 CHANGE `stars` `icons` varchar(255) NOT NULL DEFAULT '';
 ---#
+
+/******************************************************************************/
+--- Updating settings
+/******************************************************************************/
+---# Pruning options to use our new formmat
+---{
+$request = upgrade_query("
+	SELECT value
+	FROM {$db_prefix}settings
+	WHERE variable = 'pruningOptions'");
+if (mysql_num_rows($request) != 0)
+{
+	list ($oldValue) = mysql_fetch_row($request);
+	if (!empty($oldValue) && strpos($oldValue, ',') !== false)
+	{
+		list ($pruneErrorLog, $pruneModLog, $pruneBanLog, $pruneReportLog, $pruneScheduledTaskLog, $pruneSpiderHitLog) = explode(',', $oldValue);
+
+		$pruning_options => serialize(array(
+			'pruneErrorLog' => $pruneErrorLog,
+			'pruneModLog' => $pruneModLog,
+			'pruneBanLog' => $pruneBanLog,
+			'pruneReportLog' => $pruneReportLog,
+			'pruneScheduledTaskLog' => $pruneScheduledTaskLog,
+			'pruneSpiderHitLog' => $pruneSpiderHitLog,
+		));
+
+		upgrade_query("
+			UPDATE {$db_prefix}settings
+			SET value = '$pruning_options'
+			WHERE variable = 'pruningOptions'");
+	}
+}
+---}
+---#

--- a/other/upgrade_2-1_postgresql.sql
+++ b/other/upgrade_2-1_postgresql.sql
@@ -174,7 +174,7 @@ upgrade_query("
 
 	ALTER TABLE {$db_prefix}sessions
 	ALTER COLUMN session_id type char(64);");
-	
+
 upgrade_query("
 	ALTER TABLE {$db_prefix}log_online
 	ALTER COLUMN session SET DEFAULT '';
@@ -240,5 +240,39 @@ upgrade_query("
 upgrade_query("
 	ALTER TABLE {$db_prefix}membergroups
 	CHANGE `stars` `icons` varchar(255) NOT NULL DEFAULT ''");
+---}
+---#
+
+/******************************************************************************/
+--- Updating settings
+/******************************************************************************/
+---# Pruning options to use our new formmat
+---{
+$request = upgrade_query("
+	SELECT value
+	FROM {$db_prefix}settings
+	WHERE variable = 'pruningOptions'");
+if (mysql_num_rows($request) != 0)
+{
+	list ($oldValue) = mysql_fetch_row($request);
+	if (!empty($oldValue) && strpos($oldValue, ',') !== false)
+	{
+		list ($pruneErrorLog, $pruneModLog, $pruneBanLog, $pruneReportLog, $pruneScheduledTaskLog, $pruneSpiderHitLog) = explode(',', $oldValue);
+
+		$pruning_options => serialize(array(
+			'pruneErrorLog' => $pruneErrorLog,
+			'pruneModLog' => $pruneModLog,
+			'pruneBanLog' => $pruneBanLog,
+			'pruneReportLog' => $pruneReportLog,
+			'pruneScheduledTaskLog' => $pruneScheduledTaskLog,
+			'pruneSpiderHitLog' => $pruneSpiderHitLog,
+		));
+
+		upgrade_query("
+			UPDATE {$db_prefix}settings
+			SET value = '$pruning_options'
+			WHERE variable = 'pruningOptions'");
+	}
+}
 ---}
 ---#

--- a/other/upgrade_2-1_postgresql.sql
+++ b/other/upgrade_2-1_postgresql.sql
@@ -252,7 +252,7 @@ $request = upgrade_query("
 	SELECT value
 	FROM {$db_prefix}settings
 	WHERE variable = 'pruningOptions'");
-if (mysql_num_rows($request) != 0)
+if (pg_num_rows($request) != 0)
 {
 	list ($oldValue) = mysql_fetch_row($request);
 	if (!empty($oldValue) && strpos($oldValue, ',') !== false)
@@ -274,5 +274,6 @@ if (mysql_num_rows($request) != 0)
 			WHERE variable = 'pruningOptions'");
 	}
 }
+pg_free_result($request);
 ---}
 ---#

--- a/other/upgrade_2-1_sqlite.sql
+++ b/other/upgrade_2-1_sqlite.sql
@@ -218,3 +218,37 @@ upgrade_query("
 	CHANGE `stars` `icons` varchar(255) NOT NULL DEFAULT ''");
 ---}
 ---#
+
+/******************************************************************************/
+--- Updating settings
+/******************************************************************************/
+---# Pruning options to use our new formmat
+---{
+$request = upgrade_query("
+	SELECT value
+	FROM {$db_prefix}settings
+	WHERE variable = 'pruningOptions'");
+if (mysql_num_rows($request) != 0)
+{
+	list ($oldValue) = mysql_fetch_row($request);
+	if (!empty($oldValue) && strpos($oldValue, ',') !== false)
+	{
+		list ($pruneErrorLog, $pruneModLog, $pruneBanLog, $pruneReportLog, $pruneScheduledTaskLog, $pruneSpiderHitLog) = explode(',', $oldValue);
+
+		$pruning_options => serialize(array(
+			'pruneErrorLog' => $pruneErrorLog,
+			'pruneModLog' => $pruneModLog,
+			'pruneBanLog' => $pruneBanLog,
+			'pruneReportLog' => $pruneReportLog,
+			'pruneScheduledTaskLog' => $pruneScheduledTaskLog,
+			'pruneSpiderHitLog' => $pruneSpiderHitLog,
+		));
+
+		upgrade_query("
+			UPDATE {$db_prefix}settings
+			SET value = '$pruning_options'
+			WHERE variable = 'pruningOptions'");
+	}
+}
+---}
+---#

--- a/other/upgrade_2-1_sqlite.sql
+++ b/other/upgrade_2-1_sqlite.sql
@@ -250,5 +250,6 @@ if (mysql_num_rows($request) != 0)
 			WHERE variable = 'pruningOptions'");
 	}
 }
+mysql_free_result($request);
 ---}
 ---#


### PR DESCRIPTION
This set of commits tries to make it easier for mods to add their own pruning options. The most reliable way I could think of was to amalgamate them into a serialised array. I've added to the installer and upgrader to reflect this.

Currently, in the weekly scheduled task, there's no way to add a  pruning parameter without editing the file. I was thinking of splitting each pruning task into different methods, probably protected. What is the lowest PHP supported? 5.1.x?
