### PR TITLE
Check the log(in|out) urls prior to using them

### DIFF
--- a/Sources/LogInOut.php
+++ b/Sources/LogInOut.php
@@ -115,6 +115,11 @@ function Login2()
 		// Some whitelisting for login_url...
 		if (empty($_SESSION['login_url']))
 			redirectexit();
+		elseif (!empty($_SESSION['login_url']) && (strpos('http://', $_SESSION['login_url']) === false && strpos('https://', $_SESSION['login_url']) === false))
+		{
+			unset ($_SESSION['login_url']);
+			redirectexit();
+		}
 		else
 		{
 			// Best not to clutter the session data too much...
@@ -602,11 +607,19 @@ function Logout($internal = false, $redirect = true)
 	// Empty the cookie! (set it in the past, and for id_member = 0)
 	setLoginCookie(-3600, 0);
 
+$redirect = true;
+$_SESSION['logout_url'] = 'ftp://localhost';
+
 	// Off to the merry board index we go!
 	if ($redirect)
 	{
 		if (empty($_SESSION['logout_url']))
 			redirectexit('', $context['server']['needs_login_fix']);
+		elseif (!empty($_SESSION['logout_url']) && (strpos('http://', $_SESSION['logout_url']) === false && strpos('https://', $_SESSION['logout_url']) === false))
+		{
+			unset ($_SESSION['logout_url']);
+			redirectexit();
+		}
 		else
 		{
 			$temp = $_SESSION['logout_url'];

--- a/Sources/LogInOut.php
+++ b/Sources/LogInOut.php
@@ -607,9 +607,6 @@ function Logout($internal = false, $redirect = true)
 	// Empty the cookie! (set it in the past, and for id_member = 0)
 	setLoginCookie(-3600, 0);
 
-$redirect = true;
-$_SESSION['logout_url'] = 'ftp://localhost';
-
 	// Off to the merry board index we go!
 	if ($redirect)
 	{


### PR DESCRIPTION
This validates these two urls before we use them.  Even though they should be safely setup by code, a simple check ensures we only use schemas we support (currently http and https).
