### PR TITLE
This makes no sense.  Why return something that is saved in $context and...

### DIFF
--- a/Sources/Security.php
+++ b/Sources/Security.php
@@ -751,7 +751,8 @@ function createToken($action, $type = 'post')
 	$context[$action . '_token'] = $token;
 	$context[$action . '_token_var'] = $token_var;
 
-	return array($token_var, $token);
+	unset($token, $token_var);
+	return;
 }
 
 /**


### PR DESCRIPTION
... not used.

Looking deeper into the code I do not see a comparison of the $_session token vs the $context values created here.  I only see $context used to hide something in a form.  Then $context is not unset?  Maybe I missed something.  Please explain?
-s
