### PR TITLE
Spellcheck

### DIFF
--- a/Sources/Subs-Editor.php
+++ b/Sources/Subs-Editor.php
@@ -1487,17 +1487,18 @@ function create_control_richedit($editorOptions)
 			loadJavascriptFile($scripturl . '?action=loadeditorlocale', array(), 'sceditor_language');
 
 		$context['shortcuts_text'] = $txt['shortcuts' . (!empty($context['drafts_save']) ? '_drafts' : '') . (isBrowser('is_firefox') ? '_firefox' : '')];
+		
 		$context['show_spellchecking'] = !empty($modSettings['enableSpellChecking']) && function_exists('pspell_new');
 		if ($context['show_spellchecking'])
 		{
-			loadJavascriptFile('spellcheck.js', array('default_theme' => true));
-
-			// Some hidden information is needed in order to make the spell checking work.
+			// Some hidden information is needed in order to make spell check work.
 			if (!isset($_REQUEST['xml']))
 				$context['insert_after_template'] .= '
 		<form name="spell_form" id="spell_form" method="post" accept-charset="' . $context['character_set'] . '" target="spellWindow" action="' . $scripturl . '?action=spellcheck">
 			<input type="hidden" name="spellstring" value="" />
-		</form>';
+			<input type="hidden" name="fulleditor" value="" />
+		</form>
+		<script type="text/javascript" src="' . $settings['default_theme_url'] . '/scripts/spellcheck.js"></script>';
 		}
 	}
 

--- a/Sources/Subs-Post.php
+++ b/Sources/Subs-Post.php
@@ -1480,7 +1480,7 @@ function SpellCheck()
 	// Construct a bit of Javascript code.
 	$context['spell_js'] = '
 		var txt = {"done": "' . $txt['spellcheck_done'] . '"};
-		var mispstr = window.opener.spellCheckGetText(spell_fieldname);
+		var mispstr = ' . ($_POST['fulleditor'] === 'true' ? 'window.opener.spellCheckGetText(spell_fieldname)' : 'window.opener.document.forms[spell_formname][spell_fieldname].value') . ';
 		var misps = Array(';
 
 	// Get all the words (Javascript already separated them).

--- a/Themes/default/Display.template.php
+++ b/Themes/default/Display.template.php
@@ -734,8 +734,9 @@ function template_main()
 		if ($context['require_verification'])
 			echo '
 							<strong>', $txt['verification'], ':</strong>', template_control_verification($context['visual_verification_id'], 'quick_reply'), '<br />';
-
-		if ($options['display_quick_reply'] < 3)
+		
+		// Not using the full editor?
+		if (empty($options['use_editor_quick_reply']))
 		{
 			echo '
 							<div class="quickReplyContent">
@@ -786,7 +787,7 @@ function template_main()
 
 		if ($context['show_spellchecking'])
 			echo '
-								<input type="button" value="', $txt['spell_check'], '" onclick="spellCheck(\'postmodify\', \'message\');" tabindex="', $context['tabindex']++, '" class="button_submit" />';
+								<input type="button" value="', $txt['spell_check'], '" onclick="spellCheck(\'postmodify\', \'message\', ', (empty($options['use_editor_quick_reply']) ? 'false' : 'true'), ')" tabindex="', $context['tabindex']++, '" class="button_submit" />';
 
 		if ($context['drafts_save'] && !empty($options['drafts_show_saved_enabled']))
 			echo '
@@ -822,11 +823,15 @@ function template_main()
 					iFreq: ', (empty($modSettings['masterAutoSaveDraftsDelay']) ? 60000 : $modSettings['masterAutoSaveDraftsDelay'] * 1000), '
 				});
 			// ]]></script>';
-
-	if ($context['show_spellchecking'])
+			
+	// Spell check for quick modify and quick reply (w/o the editor)
+	if ($context['show_spellchecking'] && (empty($options['use_editor_quick_reply']) || empty($options['display_quick_reply'])))
 		echo '
-			<form action="', $scripturl, '?action=spellcheck" method="post" accept-charset="', $context['character_set'], '" name="spell_form" id="spell_form" target="spellWindow"><input type="hidden" name="spellstring" value="" /></form>
-				<script type="text/javascript" src="', $settings['default_theme_url'], '/scripts/spellcheck.js"></script>';
+				<form name="spell_form" id="spell_form" method="post" accept-charset="', $context['character_set'], '" target="spellWindow" action="', $scripturl, '?action=spellcheck">
+					<input type="hidden" name="spellstring" value="" />
+					<input type="hidden" name="fulleditor" value="" />
+				</form>
+				<script type="text/javascript" src="' . $settings['default_theme_url'] . '/scripts/spellcheck.js"></script>';
 
 	echo '
 				<script type="text/javascript" src="', $settings['default_theme_url'], '/scripts/topic.js"></script>
@@ -890,7 +895,7 @@ function template_main()
 									<input type="hidden" name="topic" value="' . $context['current_topic'] . '" />
 									<input type="hidden" name="msg" value="%msg_id%" />
 									<div class="righttext">
-										<input type="submit" name="post" value="' . $txt['save'] . '" tabindex="' . $context['tabindex']++ . '" onclick="return oQuickModify.modifySave(\'' . $context['session_id'] . '\', \'' . $context['session_var'] . '\');" accesskey="s" class="button_submit" />&nbsp;&nbsp;' . ($context['show_spellchecking'] ? '<input type="button" value="' . $txt['spell_check'] . '" tabindex="' . $context['tabindex']++ . '" onclick="spellCheck(\'quickModForm\', \'message\');" class="button_submit" />&nbsp;&nbsp;' : '') . '<input type="submit" name="cancel" value="' . $txt['modify_cancel'] . '" tabindex="' . $context['tabindex']++ . '" onclick="return oQuickModify.modifyCancel();" class="button_submit" />
+										<input type="submit" name="post" value="' . $txt['save'] . '" tabindex="' . $context['tabindex']++ . '" onclick="return oQuickModify.modifySave(\'' . $context['session_id'] . '\', \'' . $context['session_var'] . '\');" accesskey="s" class="button_submit" />&nbsp;&nbsp;' . ($context['show_spellchecking'] ? '<input type="button" value="' . $txt['spell_check'] . '" tabindex="' . $context['tabindex']++ . '" onclick="spellCheck(\'quickModForm\', \'message\', false);" class="button_submit" />&nbsp;&nbsp;' : '') . '<input type="submit" name="cancel" value="' . $txt['modify_cancel'] . '" tabindex="' . $context['tabindex']++ . '" onclick="return oQuickModify.modifyCancel();" class="button_submit" />
 									</div>
 								</div>'), ',
 							sTemplateSubjectEdit: ', JavaScriptEscape('<input type="text" style="width: 90%;" name="subject" value="%subject%" size="80" maxlength="80" tabindex="' . $context['tabindex']++ . '" class="input_text" />'), ',

--- a/Themes/default/GenericControls.template.php
+++ b/Themes/default/GenericControls.template.php
@@ -148,7 +148,8 @@ function template_control_richedit_buttons($editor_id)
 
 	if ($context['show_spellchecking'])
 		echo '
-		<input type="button" value="', $txt['spell_check'], '" tabindex="', $context['tabindex']++, '" onclick="oEditorHandle_', $editor_id, '.spellCheckStart();" class="button_submit" />';
+		<input type="button" value="', $txt['spell_check'], '" tabindex="', $context['tabindex']++, '" onclick="oEditorHandle_', $editor_id, '.spellCheckStart();" class="button_submit" />
+		<script type="text/javascript" src="', $settings['default_theme_url'], '/scripts/spellcheck.js"></script>';
 
 	if (!empty($context['drafts_save']))
 	{

--- a/Themes/default/Post.template.php
+++ b/Themes/default/Post.template.php
@@ -939,20 +939,21 @@ function template_spellcheck()
 				height: 314px;
 				overflow: auto;
 				background: #ffffff;
-			}';
+			}
+		</style>';
 
-	// As you may expect - we need a lot of javascript for this... load it form the separate files.
+	// As you may expect - we need a lot of javascript for this... load it from the separate files.
 	echo '
-		</style>
 		<script type="text/javascript"><!-- // --><![CDATA[
 			var spell_formname = window.opener.spell_formname;
 			var spell_fieldname = window.opener.spell_fieldname;
-		// ]]></script>
+			var spell_full = window.opener.spell_full;
+		// ]]></script>	
 		<script type="text/javascript" src="', $settings['default_theme_url'], '/scripts/spellcheck.js"></script>
 		<script type="text/javascript" src="', $settings['default_theme_url'], '/scripts/script.js"></script>
 		<script type="text/javascript"><!-- // --><![CDATA[
 			', $context['spell_js'], '
-		// ]]></script>
+		// ]]></script>	
 	</head>
 	<body onload="nextWord(false);">
 		<form action="#" method="post" accept-charset="', $context['character_set'], '" name="spellingForm" id="spellingForm" onsubmit="return false;" style="margin: 0;">

--- a/Themes/default/Profile.template.php
+++ b/Themes/default/Profile.template.php
@@ -1433,7 +1433,11 @@ function template_edit_options()
 	// Any final spellchecking stuff?
 	if (!empty($context['show_spellchecking']))
 		echo '
-		<form name="spell_form" id="spell_form" method="post" accept-charset="', $context['character_set'], '" target="spellWindow" action="', $scripturl, '?action=spellcheck"><input type="hidden" name="spellstring" value="" /></form>';
+		<form name="spell_form" id="spell_form" method="post" accept-charset="', $context['character_set'], '" target="spellWindow" action="', $scripturl, '?action=spellcheck">
+			<input type="hidden" name="spellstring" value="" />
+			<input type="hidden" name="fulleditor" value="" />
+		</form>
+		<script type="text/javascript" src="' . $settings['default_theme_url'] . '/scripts/spellcheck.js"></script>';
 }
 
 // Personal Message settings.
@@ -2681,14 +2685,9 @@ function template_profile_signature_modify()
 	echo '
 							<dt>
 								<strong>', $txt['signature'], ':</strong><br />
-								<span class="smalltext">', $txt['sig_info'], '</span><br />
-								<br />';
-
-	if ($context['show_spellchecking'])
-		echo '
-								<input type="button" value="', $txt['spell_check'], '" onclick="spellCheck(\'creator\', \'signature\');" class="button_submit" />';
-
-		echo '
+								<span class="smalltext">', $txt['sig_info'], '</span>
+								<br />
+								<br />
 							</dt>
 							<dd>
 								<textarea class="editor" onkeyup="calcCharLeft();" id="signature" name="signature" rows="5" cols="50" style="min-width: 50%; max-width: 99%;">', $context['member']['signature'], '</textarea><br />';
@@ -2698,18 +2697,17 @@ function template_profile_signature_modify()
 		echo '
 								<span class="smalltext">', sprintf($txt['max_sig_characters'], $context['signature_limits']['max_length']), ' <span id="signatureLeft">', $context['signature_limits']['max_length'], '</span></span><br />';
 
+	if ($context['show_spellchecking'])
+		echo '
+						<input type="button" value="', $txt['spell_check'], '" onclick="spellCheck(\'creator\', \'signature\', false);"  tabindex="', $context['tabindex']++, '" class="button_submit" />';
 	if (!empty($context['show_preview_button']))
 		echo '
-						<input type="submit" name="preview_signature" id="preview_button" value="', $txt['preview_signature'], '" class="button_submit" />';
+						<input type="submit" name="preview_signature" id="preview_button" value="', $txt['preview_signature'], '"  tabindex="', $context['tabindex']++, '" class="button_submit" />';
 
 	if ($context['signature_warning'])
 		echo '
 								<span class="smalltext">', $context['signature_warning'], '</span>';
 
-	// Load the spell checker?
-	if ($context['show_spellchecking'])
-		echo '
-								<script type="text/javascript" src="', $settings['default_theme_url'], '/scripts/spellcheck.js"></script>';
 
 	// Some javascript used to count how many characters have been used so far in the signature.
 	echo '


### PR DESCRIPTION
Yeah I know, but it still had to be fixed.  The spell check did not work with regular text areas used in quick mod, quick reply (with full editor off) or signature .... now it does.  Also had a habit of swap in/out of wysiwyg or not picking up the text correctly, I think thats fixed now as well.
