### PR TITLE
Undefined: current_pm

### DIFF
--- a/Sources/PersonalMessage.php
+++ b/Sources/PersonalMessage.php
@@ -837,6 +837,18 @@ function MessageFolder()
 				'id_member' => $context['folder'] == 'sent' ? 'pmr.id_member' : 'pm.id_member_from',
 			)
 		);
+
+		// Build the conversation button array.
+		if ($context['display_mode'] == 2)
+		{
+			$context['conversation_buttons'] = array(
+				'reply' => array('text' => 'reply_to_all', 'image' => 'reply.png', 'lang' => true, 'url' => $scripturl . '?action=pm;sa=send;f=' . $context['folder'] . ($context['current_label_id'] != -1 ? ';l=' . $context['current_label_id'] : '') . ';pmsg=' . $context['current_pm'] . ';u=all', 'active' => true),
+				'delete' => array('text' => 'delete_conversation', 'image' => 'delete.png', 'lang' => true, 'url' => $scripturl . '?action=pm;sa=pmactions;pm_actions[' . $context['current_pm'] . ']=delete;conversation;f=' . $context['folder'] . ';start=' . $context['start'] . ($context['current_label_id'] != -1 ? ';l=' . $context['current_label_id'] : '') . ';' . $context['session_var'] . '=' . $context['session_id'], 'custom' => 'onclick="return confirm(\'' . addslashes($txt['remove_message']) . '?\');"'),
+			);
+	
+			// Allow mods to add additional buttons here
+			call_integration_hook('integrate_conversation_buttons');
+		}
 	}
 	else
 		$messages_request = false;
@@ -856,18 +868,6 @@ function MessageFolder()
 		// Otherwise do just the current one!
 		elseif (!empty($context['current_pm']))
 			markMessages($display_pms, $context['current_label_id']);
-	}
-
-	// Build the conversation button array.
-	if ($context['display_mode'] == 2)
-	{
-		$context['conversation_buttons'] = array(
-			'reply' => array('text' => 'reply_to_all', 'image' => 'reply.png', 'lang' => true, 'url' => $scripturl . '?action=pm;sa=send;f=' . $context['folder'] . ($context['current_label_id'] != -1 ? ';l=' . $context['current_label_id'] : '') . ';pmsg=' . $context['current_pm'] . ';u=all', 'active' => true),
-			'delete' => array('text' => 'delete_conversation', 'image' => 'delete.png', 'lang' => true, 'url' => $scripturl . '?action=pm;sa=pmactions;pm_actions[' . $context['current_pm'] . ']=delete;conversation;f=' . $context['folder'] . ';start=' . $context['start'] . ($context['current_label_id'] != -1 ? ';l=' . $context['current_label_id'] : '') . ';' . $context['session_var'] . '=' . $context['session_id'], 'custom' => 'onclick="return confirm(\'' . addslashes($txt['remove_message']) . '?\');"'),
-		);
-
-		// Allow mods to add additional buttons here
-		call_integration_hook('integrate_conversation_buttons');
 	}
 }
 


### PR DESCRIPTION
Prior to the commit, the conversation mode buttons were being
constructed even if there were no message (reply | delete). Simply
moving this condition block into the above block if (!empty($pms)) is
the most efficient fix.

Huge thanks to @Akyhne for pointing this issue out (#236), and to
@The-Craw for beginning to work on resolving it.

Signed-Off: Matthew Kerle creativewebdsign@gmail.com
