### PR TITLE
Release 2.1

### DIFF
--- a/Sources/Packages.php
+++ b/Sources/Packages.php
@@ -1001,7 +1001,13 @@ function PackageInstall()
 			{
 				// This is just here as reference for what is available.
 				global $txt, $boarddir, $sourcedir, $modSettings, $context, $settings, $forum_version, $smcFunc;
-
+				
+				$context['new_inputs'] = array();
+				if (!empty($_POST['new_inputs']))
+				{					
+					$context['new_inputs'] = $_POST['new_inputs'];				
+				}
+				
 				// Now include the file and be done with it ;).
 				if (file_exists($boarddir . '/Packages/temp/' . $context['base_path'] . $action['filename']))
 					require($boarddir . '/Packages/temp/' . $context['base_path'] . $action['filename']);

--- a/Sources/Subs-Package.php
+++ b/Sources/Subs-Package.php
@@ -1107,8 +1107,8 @@ function parsePackageInfo(&$packageXML, $testing_only = true, $method = 'install
                             continue;
                             
                         /* These looped values must first be null */
-                        $null_values = array(array(), false, false, false, false, false, false, false, 0, 0);
-                        list ($inputValues, $newType, $newTextAfter, $newTextBefore, $lineBreaks, $styleBefore, $styleAfter, $textArea, $breakCount, $newBreak) = $null_values;
+                        $null_values = array(array(), false, false, false, false, false, false, false, false, false, false, 0, 0);
+                        list ($inputValues, $newType, $newTextAfter, $newTextBefore, $lineBreaks, $styleBefore, $styleAfter, $textArea, $class, $classBefore, $classAfter, $breakCount, $newBreak) = $null_values;
                                                         
                         /* Now extract all new values into an array from the xml input tag */
                         $input_structures = explode('}{', $action->array[0]["value"]);
@@ -1130,6 +1130,9 @@ function parsePackageInfo(&$packageXML, $testing_only = true, $method = 'install
                                                 'autofocus' => array('all', 'true'),
                                                 'break' => array('all', 'int'),
                                                 'checked' => array('radio, checkbox', 'true'),
+                                                'class' => array('all', 'string'),
+                                                'class_before' => array('all', 'string'),
+                                                'class_after' => array('all', 'string'),  
                                                 'cols' => array('textarea', 'int'),
                                                 'disable' => array('all', 'true'),
                                                 'height' => array('all', 'int'),
@@ -1197,7 +1200,7 @@ function parsePackageInfo(&$packageXML, $testing_only = true, $method = 'install
                                         
                                         if ($command[1] == 'int')
                                             $value = (int)$value;
-                                        elseif ($command[1] == 'string' && $key != 'text_before' && $key != 'text_after' && $key != 'value' && $key != 'name')
+                                        elseif ($command[1] == 'string' && $key != 'text_before' && $key != 'text_after' && $key != 'value' && $key != 'name' && $key !='class_before' && $key != 'class_after' && $key != 'class')
                                             $value = strtolower($value);
                                         elseif ($command[1] == 'true')
                                             $value = 'true';                                        
@@ -1218,7 +1221,13 @@ function parsePackageInfo(&$packageXML, $testing_only = true, $method = 'install
                                         elseif ($key == 'style_before')
                                             $styleBefore = $value;
                                         elseif ($key == 'style_after')
-                                            $styleAfter = $value;    
+                                            $styleAfter = $value; 
+                                        elseif ($key == 'class_before')
+                                            $classBefore = 'class="' . $value . '" ';
+                                        elseif ($key == 'class_after')
+                                            $classAfter = 'class="' . $value . '" ';
+                                        elseif ($key == 'class')
+                                            $class = 'class="' . $value . '" ';    
                                         elseif ($newType == 'textarea' && $key == 'value')
                                             $textArea = trim($value);
                                         else
@@ -1242,26 +1251,26 @@ function parsePackageInfo(&$packageXML, $testing_only = true, $method = 'install
                                 }
                             }                  
                                                         
-                            /* Close the input/textarea and add it to the appropriate $context array */
+                             /* Close the input/textarea and add it to the appropriate $context array */
                             if ($newType == 'textarea')
-                            {
+                            {                         
                                 if ($styleBefore && $newTextBefore)
-                                    $newTextBefore = '<span style ="'.$styleBefore.'">' . $newTextBefore . '</span>';
+                                    $newTextBefore = '<span ' . $classBefore . 'style ="'.$styleBefore.'">' . $newTextBefore . '</span>';
                                 
                                 if ($styleAfter && $newTextAfter)
-                                    $newTextAfter = '<span style ="'.$styleAfter.'">' . $newTextAfter . '</span>';
+                                    $newTextAfter = '<span ' . $classAfter . 'style ="'.$styleAfter.'">' . $newTextAfter . '</span>';
                                     
-                                $context['new_package_inputs'][] = $newTextBefore . '<textarea ' . $inputString . '>' . $textArea . '</textarea>' . $newTextAfter . $lineBreaks;                                
+                                $context['new_package_inputs'][] = $newTextBefore . '<textarea ' . $class . $inputString . '>' . $textArea . '</textarea>' . $newTextAfter . $lineBreaks;                                
                             }                            
                             else
                             {
                                 if ($styleBefore && $newTextBefore)
-                                    $newTextBefore = '<span style ="'.$styleBefore.'">' . $newTextBefore . '</span>';
+                                    $newTextBefore = '<span ' . $classBefore . 'style ="'.$styleBefore.'">' . $newTextBefore . '</span>';
                                 
                                 if ($styleAfter && $newTextAfter)
-                                    $newTextAfter = '<span style ="'.$styleAfter.'">' . $newTextAfter . '</span>';
+                                    $newTextAfter = '<span ' . $classAfter . 'style ="'.$styleAfter.'">' . $newTextAfter . '</span>';
                                     
-                                $inputString .= '/>';                            
+                                $inputString .= ' ' . $class . '/>';                            
                                 $context['new_package_inputs'][] = $newTextBefore . $inputString . $newTextAfter . $lineBreaks;
                             }
                             

--- a/Sources/Subs-Package.php
+++ b/Sources/Subs-Package.php
@@ -1098,8 +1098,176 @@ function parsePackageInfo(&$packageXML, $testing_only = true, $method = 'install
 	{
 		$actionType = $action->name();
 
-		if (in_array($actionType, array('readme', 'code', 'database', 'modification', 'redirect', 'license')))
-		{
+		if (in_array($actionType, array('readme', 'code', 'database', 'modification', 'redirect', 'license', 'input')))
+		{		
+                    /* Add the input/textarea html tag where xml input was selected */
+                    if ($actionType == 'input')
+                    {
+                        if (empty($action->array[0]["value"]) || !$action->array[0]["value"])
+                            continue;
+                            
+                        /* These looped values must first be null */
+                        $null_values = array(array(), false, false, false, false, false, false, false, 0, 0);
+                        list ($inputValues, $newType, $newTextAfter, $newTextBefore, $lineBreaks, $styleBefore, $styleAfter, $textArea, $breakCount, $newBreak) = $null_values;
+                                                        
+                        /* Now extract all new values into an array from the xml input tag */
+                        $input_structures = explode('}{', $action->array[0]["value"]);
+                        foreach ($input_structures as $input_structure)
+                        {
+                            $input_structure = trim($input_structure, '{');
+                            $input_structure = trim($input_structure, '}');
+                            if (strpos($input_structure, 'text=') !== true)
+                                $input_structure = trim($input_structure);
+                                
+                            $inputValues[] = $input_structure;    
+                        }    
+                            
+                        /* Set up the necessary arrays to filter the input */                         
+                        $input_types = array('button', 'checkbox', 'color', 'date', 'datetime', 'datetime-local', 'email', 'hidden', 'image', 'month', 'number', 'password', 'radio', 'range', 'reset', 'search', 'submit', 'tel', 'text', 'textarea', 'time', 'url', 'week');
+                        $input_commands = array(
+                                                'alt' => array('image', 'string'),
+                                                'autocomplete' => array('text, search, url, tel, email, password, datepickers, range, color', 'string'),
+                                                'autofocus' => array('all', 'true'),
+                                                'break' => array('all', 'int'),
+                                                'checked' => array('radio, checkbox', 'true'),
+                                                'cols' => array('textarea', 'int'),
+                                                'disable' => array('all', 'true'),
+                                                'height' => array('all', 'int'),
+                                                'maxlength' => array('all', 'int'),
+                                                'name' => array('all', 'string'),
+                                                'placeholder' => array('text, search, url, tel, email, password, textarea', 'string'),
+                                                'readonly' => array('all', 'true'),
+                                                'required' => array('text, search, url, tel, email, password, date pickers, number, checkbox, radio, textarea', 'true'),
+                                                'rows' => array('textarea', 'int'),
+                                                'size' => array('all', 'int'),
+                                                'src' => array('image', 'int'),
+                                                'style' => array('all', 'string'),
+                                                'tabindex' => array('all', 'int'), 
+                                                'text_before' => array('all', 'string'),
+                                                'text_after' => array('all', 'string'),
+                                                'style_after' => array('all', 'string'),
+                                                'style_before' => array('all', 'string'),
+                                                'value' => array('all', 'string'),
+                                                'width' => array('all', 'int'),
+                                                'wrap' => array('textarea', 'string')
+                                            );
+                            
+                            /* If the type is valid set it as such else skip the process */
+                            foreach ($input_types as $input_type)
+                            {
+                                foreach ($inputValues as $value)
+                                {                                        
+                                    if (strpos('type="'.$input_type.'"',strtolower(trim($value))) !== false)
+                                    {
+                                        if ($input_type == 'textarea')
+                                            $inputString = '';
+                                        else    
+                                            $inputString = '<input type="'.$input_type.'" ';
+                                            
+                                        $newType = $input_type;                                        
+                                    }
+                                }    
+                            }
+                            
+                            if (!$newType)                           
+                                continue;
+                            
+                            /* Loop through the commands and set it if we find a match */
+                            foreach ($input_commands as $key => $command)
+                            {
+                                $check = explode(',', $command[0]);
+                                
+                                foreach ($inputValues as $value)
+                                {
+                                    
+                                    if (strpos(strtolower($value), 'type=') !== false)
+                                        continue;
+                                    
+                                    if (strpos(strtolower($value), $key.'=') !== false)
+                                    {
+                                        $setCommand = $key;                                        
+                                                                                
+                                        if (!in_array($newType, $check) && $check[0] != 'all')
+                                            continue;
+                                        
+                                        $value = str_replace($key.'=', '', $value);
+                                        $value = substr($value, 1, (strlen($value)-2));
+                                        $value = trim($value);                                        
+                                        
+                                        
+                                        if ($command[1] == 'int')
+                                            $value = (int)$value;
+                                        elseif ($command[1] == 'string' && $key != 'text_before' && $key != 'text_after' && $key != 'value' && $key != 'name')
+                                            $value = strtolower($value);
+                                        elseif ($command[1] == 'true')
+                                            $value = 'true';                                        
+                                        
+                                        if ($key == 'break')
+                                            $newBreak = (int)$value;
+                                        elseif ($key == 'text_before')
+                                            $newTextBefore = $value . ' ';
+                                        elseif ($key == 'text_after')
+                                            $newTextAfter = ' ' . $value;
+                                        elseif ($key == 'name')
+                                        {
+                                            
+                                            $inputString .= $setCommand . '="new_inputs['.$value.']" ';                                        
+                                        }
+                                        elseif ($value == 'true')
+                                            $inputString .= $setCommand . ' ';
+                                        elseif ($key == 'style_before')
+                                            $styleBefore = $value;
+                                        elseif ($key == 'style_after')
+                                            $styleAfter = $value;    
+                                        elseif ($newType == 'textarea' && $key == 'value')
+                                            $textArea = trim($value);
+                                        else
+                                            $inputString .= $setCommand . '="'. $value .'" ';
+                                        
+                                    }    
+                                }         
+                            }
+                            
+                            /* Figure out how many line breaks were opted */
+                            if ((int)$newBreak > 0)
+                            {
+                                while ((int)$breakCount < (int)$newBreak)
+                                {
+                                    /* Stop the loop just in case... 10 line breaks is too many anyhow! */
+                                    if ((int)$breakCount > 9)
+                                        break;
+                                    
+                                    $lineBreaks .= '<br />';
+                                    $breakCount++;                                    
+                                }
+                            }                  
+                                                        
+                            /* Close the input/textarea and add it to the appropriate $context array */
+                            if ($newType == 'textarea')
+                            {
+                                if ($styleBefore && $newTextBefore)
+                                    $newTextBefore = '<span style ="'.$styleBefore.'">' . $newTextBefore . '</span>';
+                                
+                                if ($styleAfter && $newTextAfter)
+                                    $newTextAfter = '<span style ="'.$styleAfter.'">' . $newTextAfter . '</span>';
+                                    
+                                $context['new_package_inputs'][] = $newTextBefore . '<textarea ' . $inputString . '>' . $textArea . '</textarea>' . $newTextAfter . $lineBreaks;                                
+                            }                            
+                            else
+                            {
+                                if ($styleBefore && $newTextBefore)
+                                    $newTextBefore = '<span style ="'.$styleBefore.'">' . $newTextBefore . '</span>';
+                                
+                                if ($styleAfter && $newTextAfter)
+                                    $newTextAfter = '<span style ="'.$styleAfter.'">' . $newTextAfter . '</span>';
+                                    
+                                $inputString .= '/>';                            
+                                $context['new_package_inputs'][] = $newTextBefore . $inputString . $newTextAfter . $lineBreaks;
+                            }
+                            
+                          continue;                            
+                        }
+                        
 			// Allow for translated readme and license files.
 			if ($actionType == 'readme' || $actionType == 'license')
 			{

--- a/Sources/Subs-Package.php
+++ b/Sources/Subs-Package.php
@@ -1211,12 +1211,9 @@ function parsePackageInfo(&$packageXML, $testing_only = true, $method = 'install
                                             $newTextBefore = $value . ' ';
                                         elseif ($key == 'text_after')
                                             $newTextAfter = ' ' . $value;
-                                        elseif ($key == 'name')
-                                        {
-                                            
-                                            $inputString .= $setCommand . '="new_inputs['.$value.']" ';                                        
-                                        }
-                                        elseif ($value == 'true')
+                                        elseif ($key == 'name')                                                    
+                                            $inputString .= $setCommand . '="new_inputs['.$value.']" ';             
+					elseif ($value == 'true')
                                             $inputString .= $setCommand . ' ';
                                         elseif ($key == 'style_before')
                                             $styleBefore = $value;

--- a/Themes/default/Packages.template.php
+++ b/Themes/default/Packages.template.php
@@ -98,7 +98,24 @@ function template_view_package()
 					', $context['uninstalling'] ? $txt['package_uninstall_actions'] : $txt['package_install_actions'], ' &quot;', $context['package_name'], '&quot;
 				</h3>
 			</div>';
-
+			
+	/* Are there any new custom inputs from the mod author? */		
+	if (isset($context['new_package_inputs']))
+	{		
+		echo '
+			<div class="windowbg2">
+				<span class="topslice"><span></span></span>
+				<div class="content">';
+				
+			foreach ($context['new_package_inputs'] as $new_input)
+				echo $new_input;
+			
+			echo '	
+		        	</div>
+				<span class="botslice"><span></span></span>
+			</div>';			
+	}
+	
 	// Are there data changes to be removed?
 	if ($context['uninstalling'] && !empty($context['database_changes']))
 	{

--- a/Underdog-Additions-README..txt
+++ b/Underdog-Additions-README..txt
@@ -81,7 +81,7 @@ size          => for all types                      (int)
 
 src           => for image                          (int)
 
-style         => for all types                      (string - addes style attributes to value (internal) of textarea)
+style         => for all types                      (string - style attributes for input/textarea)
 
 tabindex      => for all types                      (int)
 
@@ -93,7 +93,7 @@ style_after   => for all types                      (string - adds style attribu
 
 style_before  => for all types                      (string - adds style attributes to text_before)
 
-value         => for all types                      (string - for textarea thsi will appear in the box)
+value         => for all types                      (string - for textarea this will appear in the box)
 
 width         => for all types                      (int)
 

--- a/Underdog-Additions-README..txt
+++ b/Underdog-Additions-README..txt
@@ -1,4 +1,3 @@
-
 Changes:
 
 - added ability to use input and/or textarea HTML5 commands for uninstall/install template
@@ -22,7 +21,7 @@ Examples:
 Explanation:
 
   The commands are filtered in Subs-Packages.php in an attempt to thwart errors from the package-info.xml file. 
-Although it is up to the mod author to use the proper syntax, this was done to help ensure the xml code was entered correct;y/
+Although it is up to the mod author to use the proper syntax, this was done to help ensure the xml code was entered correctly.
 Each command has to be separated by encased hard brackets and their values must be in quotations. 
 Additional filtering can be added to thwart unnecessary white spaces in certain areas but as I said the mod author should use appropriate syntax.
 The command names and values are actual HTML5 syntax where some features were omitted as imo they do not apply for the packages template.
@@ -38,7 +37,7 @@ button, checkbox, color, date, datetime, datetime-local, email, hidden, image, m
 number, password, radio, range, reset, search, submit, tel, text, textarea, time, url, week 
 
 
-Allowed input/textare attributes:
+Allowed input/textarea attributes:
 alt           => for image                          (string)
 
 autocomplete  => for text, search, url, tel,        (string - on or off)

--- a/Underdog-Additions-README..txt
+++ b/Underdog-Additions-README..txt
@@ -1,0 +1,104 @@
+
+Changes:
+
+- added ability to use input and/or textarea HTML5 commands for uninstall/install template
+
+
+Files affected:
+
+/Sources/Packages.php
+/Sources/Subs-Package.php
+/Themes/default/Packages.template.php
+
+
+Syntax
+------
+
+Examples:
+<input>{type="checkbox"}{name="delete_tables"}{value="1"}{text_after="Remove all database tables related to this modification?"}{checked="false"}{break="2"}{style="position:relative;top:2px;"}</input>
+<input>{type="textarea"}{name="info"}{value="Comments"}{text_after="Enter your comments"}{style_after="position:relative;bottom:25px;color:blue;"}{style="color:red;"}{tabindex="5"}{rows="3"}{cols="50"}</input>
+
+
+Explanation:
+
+  The commands are filtered in Subs-Packages.php in an attempt to thwart errors from the package-info.xml file. 
+Although it is up to the mod author to use the proper syntax, this was done to help ensure the xml code was entered correct;y/
+Each command has to be separated by encased hard brackets and their values must be in quotations. 
+Additional filtering can be added to thwart unnecessary white spaces in certain areas but as I said the mod author should use appropriate syntax.
+The command names and values are actual HTML5 syntax where some features were omitted as imo they do not apply for the packages template.
+Text can be displayed left and/or right of the input/textarea where each can have its own value & style/class elements.
+Style & class elements (css) can also be configured for the actual input/textarea. 
+
+The form passes the user entered values via the $context['new_inputs'] array where the key values are the name values entered by the author.
+The $context['new_inputs'] array can be processed in any of their <code> files where they can manipulate the logic to do as they wish.
+
+Allowed input types:
+
+button, checkbox, color, date, datetime, datetime-local, email, hidden, image, month, 
+number, password, radio, range, reset, search, submit, tel, text, textarea, time, url, week 
+
+
+Allowed input/textare attributes:
+alt           => for image                          (string)
+
+autocomplete  => for text, search, url, tel,        (string - on or off)
+                 password, datepickers, range,
+                 email, color
+
+autofocus     => for all types                      (true)
+
+break         => for all types                      (integer - inserts additional line breaks after the input/textarea)
+
+checked       => for radio, checkbox                (true)
+
+class         => for all types                      (string - css class for input/textarea)
+
+class_before  => for all types                      (string - css class for text_before)
+
+class_after   => for all types                      (string - css class for text_after)
+
+cols          => for textarea                       (integer)
+
+disable       => for all types                      (true)
+
+height        => for all types                      (integer)
+
+maxlength     => for all types                      (integer)
+
+name          => for all types                      (string)
+
+placeholder   => for text, search, url, tel,        (string)
+                 email, password, textarea 
+
+readonly      => for all types                      (true)
+
+required      => for text, search, url, tel,        (true)
+                 email, password, date pickers,
+                 number, checkbox, radio, textarea
+
+rows          => for textarea                       (integer)
+
+size          => for all types                      (int)
+
+src           => for image                          (int)
+
+style         => for all types                      (string - addes style attributes to value (internal) of textarea)
+
+tabindex      => for all types                      (int)
+
+text_before   => for all types                      (string - displays text prior to the input/textarea)
+
+text_after    => for all types                      (string - displays text after the input/textarea)
+
+style_after   => for all types                      (string - adds style attributes to text_after)
+
+style_before  => for all types                      (string - adds style attributes to text_before)
+
+value         => for all types                      (string - for textarea thsi will appear in the box)
+
+width         => for all types                      (int)
+
+wrap          => for textarea                       (string)
+
+
+

--- a/Underdog-Additions-README..txt
+++ b/Underdog-Additions-README..txt
@@ -93,7 +93,7 @@ style_after   => for all types                      (string - adds style attribu
 
 style_before  => for all types                      (string - adds style attributes to text_before)
 
-value         => for all types                      (string - for textarea this will appear in the box)
+value         => for all types                      (string - for textarea it will appear in the box, else input value)
 
 width         => for all types                      (int)
 

--- a/Underdog-Additions-README..txt
+++ b/Underdog-Additions-README..txt
@@ -14,8 +14,8 @@ Syntax
 ------
 
 Examples:
-<input>{type="checkbox"}{name="delete_tables"}{value="1"}{text_after="Remove all database tables related to this modification?"}{checked="false"}{break="2"}{style="position:relative;top:2px;"}</input>
-<input>{type="textarea"}{name="info"}{value="Comments"}{text_after="Enter your comments"}{style_after="position:relative;bottom:25px;color:blue;"}{style="color:red;"}{tabindex="5"}{rows="3"}{cols="50"}</input>
+<input>{type="checkbox"}{name="delete_tables"}{value="1"}{text_after="Remove all database tables related to this modification?"}{checked="false"}{break="2"}</input>
+<input>{type="textarea"}{name="info"}{value="Comments"}{text_after="Enter your comments"}{style_after="color:blue;"}{style="color:red;"}{tabindex="5"}{rows="3"}{cols="50"}</input>
 
 
 Explanation:


### PR DESCRIPTION
Additional commands for package-info.xml (installing/uninstalling mods)

Added additional commands for installing/uninstalling modifications for SMF.
The edits give mod authors the ability to add various input types (including textarea) to the install/uninstall packages template. These inputs can be processed in any of their installation files used from xml code tags.

Pending: < script > (Javascript) xml tags to execute javascript code for the packages template and also javascript input/textarea attributes to be added to this current addition (which can possibly use the added javascript as functions).

Syntax and examples are located in the additional text README file in my SMF 2.1 repository.
