### PR TITLE
Issue: #326 - Immediate Registration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,4 +46,4 @@ Thumbs.db
 /nbproject/private/
 /nbproject/
 .directory
-
+.idea/

--- a/Themes/default/languages/Install.english.php
+++ b/Themes/default/languages/Install.english.php
@@ -94,6 +94,13 @@ $txt['install_settings_name_info'] = 'This is the name of your forum, ie. &quot;
 $txt['install_settings_name_default'] = 'My Community';
 $txt['install_settings_url'] = 'Forum URL';
 $txt['install_settings_url_info'] = 'This is the URL to your forum <strong>without the trailing \'/\'!</strong>.<br />In most cases, you can leave the default value in this box alone - it is usually right.';
+$txt['install_settings_reg_mode'] = 'Registration Mode';
+$txt['install_settings_reg_modes'] = 'Registration Modes';
+$txt['install_settings_reg_immediate'] = 'Immediate Registration';
+$txt['install_settings_reg_email'] = 'Email Activation';
+$txt['install_settings_reg_admin'] = 'Admin Approval';
+$txt['install_settings_reg_disabled'] = 'Registration Disabled';
+$txt['install_settings_reg_mode_info'] = 'This field allows you to change the mode of registration on installation to prevent unwanted registrations.';
 $txt['install_settings_compress'] = 'Gzip Output';
 $txt['install_settings_compress_title'] = 'Compress output to save bandwidth.';
 // In this string, you can translate the word "PASS" to change what it says when the test passes.

--- a/other/install.php
+++ b/other/install.php
@@ -957,6 +957,17 @@ function ForumSettings()
 				updateSettingsFile(array('db_character_set' => 'utf8'));
 		}
 
+		//-- Set the registration mode...
+		$smcFunc['db_query']('', '
+			UPDATE {db_prefix}settings
+			SET value = {int:reg_mode}
+			WHERE variable = {string:this_variable}',
+			array(
+				'reg_mode' => isset($_POST['reg_mode']) ? $_POST['reg_mode'] : 0,
+				'this_variable' => 'registration_method',
+			)
+		);
+
 		// Good, skip on.
 		return true;
 	}
@@ -2411,47 +2422,81 @@ function template_forum_settings()
 	template_warning_divs();
 
 	echo '
-		<table width="100%" cellpadding="0" cellspacing="0" border="0" style="margin: 1em 0;">
+		<table style="width: 100%; margin: 1em 0;">
 			<tr>
-				<td width="20%" valign="top" class="textbox"><label for="mbname_input">', $txt['install_settings_name'], ':</label></td>
+				<td class="textbox" style="width: 20%; vertical-align: top;">
+					<label for="mbname_input">', $txt['install_settings_name'], ':</label>
+				</td>
 				<td>
 					<input type="text" name="mbname" id="mbname_input" value="', $txt['install_settings_name_default'], '" size="65" class="input_text" />
 					<div style="font-size: smaller; margin-bottom: 2ex;">', $txt['install_settings_name_info'], '</div>
 				</td>
-			</tr><tr>
-				<td valign="top" class="textbox"><label for="boardurl_input">', $txt['install_settings_url'], ':</label></td>
+			</tr>
+			<tr>
+				<td class="textbox" style="vertical-align: top;">
+					<label for="boardurl_input">', $txt['install_settings_url'], ':</label>
+				</td>
 				<td>
-					<input type="text" name="boardurl" id="boardurl_input" value="', $incontext['detected_url'], '" size="65" class="input_text" /><br />
+					<input type="text" name="boardurl" id="boardurl_input" value="', $incontext['detected_url'], '" size="65" class="input_text" />
+					<br />
 					<div style="font-size: smaller; margin-bottom: 2ex;">', $txt['install_settings_url_info'], '</div>
 				</td>
-			</tr><tr>
-				<td valign="top" class="textbox">', $txt['install_settings_compress'], ':</td>
+			</tr>
+			<tr>
+				<td class="textbox" style="vertical-align: top;">
+					<label for="reg_mode">', $txt['install_settings_reg_mode'], ':</label>
+				</td>
 				<td>
-					<input type="checkbox" name="compress" id="compress_check" checked="checked" class="input_check" /> <label for="compress_check">', $txt['install_settings_compress_title'], '</label><br />
+					<select name="reg_mode" id="reg_mode">
+						<optgroup label="', $txt['install_settings_reg_modes'], ':">
+							<option value="0" selected="selected">', $txt['install_settings_reg_immediate'], '</option>
+							<option value="1">', $txt['install_settings_reg_email'], '</option>
+							<option value="2">', $txt['install_settings_reg_admin'], '</option>
+							<option value="3">', $txt['install_settings_reg_disabled'], '</option>
+						</optgroup>
+					</select>
+					<br />
+					<div style="font-size: smaller; margin-bottom: 2ex;">', $txt['install_settings_reg_mode_info'], '</div>
+				</td>
+			</tr>
+			<tr>
+				<td class="textbox" style="vertical-align: top;">', $txt['install_settings_compress'], ':</td>
+				<td>
+					<input type="checkbox" name="compress" id="compress_check" checked="checked" class="input_check" />&nbsp;
+					<label for="compress_check">', $txt['install_settings_compress_title'], '</label>
+					<br />
 					<div style="font-size: smaller; margin-bottom: 2ex;">', $txt['install_settings_compress_info'], '</div>
 				</td>
-			</tr><tr>
-				<td valign="top" class="textbox">', $txt['install_settings_dbsession'], ':</td>
+			</tr>
+			<tr>
+				<td class="textbox" style="vertical-align: top;">', $txt['install_settings_dbsession'], ':</td>
 				<td>
-					<input type="checkbox" name="dbsession" id="dbsession_check" checked="checked" class="input_check" /> <label for="dbsession_check">', $txt['install_settings_dbsession_title'], '</label><br />
+					<input type="checkbox" name="dbsession" id="dbsession_check" checked="checked" class="input_check" />&nbsp;
+					<label for="dbsession_check">', $txt['install_settings_dbsession_title'], '</label>
+					<br />
 					<div style="font-size: smaller; margin-bottom: 2ex;">', $incontext['test_dbsession'] ? $txt['install_settings_dbsession_info1'] : $txt['install_settings_dbsession_info2'], '</div>
 				</td>
 			</tr>
 			<tr>
-				<td valign="top" class="textbox">', $txt['install_settings_utf8'], ':</td>
+				<td class="textbox" style="vertical-align: top;">', $txt['install_settings_utf8'], ':</td>
 				<td>
-					<input type="checkbox" name="utf8" id="utf8_check"', $incontext['utf8_default'] ? ' checked="checked"' : '', ' class="input_check"', $incontext['utf8_required'] ? ' disabled="disabled"' : '', ' /> <label for="utf8_check">', $txt['install_settings_utf8_title'], '</label><br />
+					<input type="checkbox" name="utf8" id="utf8_check"', $incontext['utf8_default'] ? ' checked="checked"' : '', ' class="input_check"', $incontext['utf8_required'] ? ' disabled="disabled"' : '', ' />&nbsp;
+					<label for="utf8_check">', $txt['install_settings_utf8_title'], '</label>
+					<br />
 					<div style="font-size: smaller; margin-bottom: 2ex;">', $txt['install_settings_utf8_info'], '</div>
 				</td>
 			</tr>
 			<tr>
-				<td valign="top" class="textbox">', $txt['install_settings_stats'], ':</td>
+				<td class="textbox" style="vertical-align: top;">', $txt['install_settings_stats'], ':</td>
 				<td>
-					<input type="checkbox" name="stats" id="stats_check" class="input_check" /> <label for="stats_check">', $txt['install_settings_stats_title'], '</label><br />
+					<input type="checkbox" name="stats" id="stats_check" class="input_check" />&nbsp;
+					<label for="stats_check">', $txt['install_settings_stats_title'], '</label>
+					<br />
 					<div style="font-size: smaller; margin-bottom: 2ex;">', $txt['install_settings_stats_info'], '</div>
 				</td>
 			</tr>
-		</table>';
+		</table>
+	';
 }
 
 // Show results of the database population.


### PR DESCRIPTION
- Registration Mode: Added the ability to select the registration mode
  upon installing SMF to provide further control from unwanted
  registrations before the setting can be changed from the admin panel or
  for people who are unaware it exists. The setting defaults to Immediate
  Registration (registration_mode = 0).
- Cleaned up the syntax of the forum_settings template, removed invalid
  HTML5.

Reference: Issue - #326 by @redonesmf

Signed-Off: Matthew "Labradoodle-360" Kerle |
lab360@simplemachines.org
