### PR TITLE
Issue: #338 - $user_info['id'] === $int;

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,4 +46,4 @@ Thumbs.db
 /nbproject/private/
 /nbproject/
 .directory
-
+.idea/

--- a/Sources/Load.php
+++ b/Sources/Load.php
@@ -298,7 +298,7 @@ function loadUserSettings()
 				$check = false;
 
 			// Wrong password or not activated - either way, you're going nowhere.
-			$id_member = $check && ($user_settings['is_activated'] == 1 || $user_settings['is_activated'] == 11) ? $user_settings['id_member'] : 0;
+			$id_member = $check && ($user_settings['is_activated'] == 1 || $user_settings['is_activated'] == 11) ? (int) $user_settings['id_member'] : 0;
 		}
 		else
 			$id_member = 0;


### PR DESCRIPTION
- $user_info['id'] and $context['user']['id'] are now cast to integers.

Thanks to @The-Craw for pointing this out.

Signed-Off: Matthew "Labradoodle-360" Kerle |
lab360@simplemachines.org
