### PR TITLE
Added MySQLi database abstraction layer

### DIFF
--- a/Sources/ManageMaintenance.php
+++ b/Sources/ManageMaintenance.php
@@ -131,10 +131,10 @@ function MaintainDatabase()
 	global $context, $db_type, $db_character_set, $modSettings, $smcFunc, $txt, $maintenance;
 
 	// Show some conversion options?
-	$context['convert_utf8'] = $db_type == 'mysql' && (!isset($db_character_set) || $db_character_set !== 'utf8' || empty($modSettings['global_character_set']) || $modSettings['global_character_set'] !== 'UTF-8') && version_compare('4.1.2', preg_replace('~\-.+?$~', '', $smcFunc['db_server_info']()), '<=');
-	$context['convert_entities'] = $db_type == 'mysql' && isset($db_character_set, $modSettings['global_character_set']) && $db_character_set === 'utf8' && $modSettings['global_character_set'] === 'UTF-8';
+	$context['convert_utf8'] = ($db_type == 'mysql' || $db_type == 'mysqli') && (!isset($db_character_set) || $db_character_set !== 'utf8' || empty($modSettings['global_character_set']) || $modSettings['global_character_set'] !== 'UTF-8') && version_compare('4.1.2', preg_replace('~\-.+?$~', '', $smcFunc['db_server_info']()), '<=');
+	$context['convert_entities'] = ($db_type == 'mysql' || $db_type == 'mysqli') && isset($db_character_set, $modSettings['global_character_set']) && $db_character_set === 'utf8' && $modSettings['global_character_set'] === 'UTF-8';
 
-	if ($db_type == 'mysql')
+	if ($db_type == 'mysql' || $db_type == 'mysqli')
 	{
 		db_extend('packages');
 
@@ -775,7 +775,7 @@ function ConvertMsgBody()
 	// Show me your badge!
 	isAllowedTo('admin_forum');
 
-	if ($db_type != 'mysql')
+	if ($db_type != 'mysql' && $db_type != 'mysqli')
 		return;
 
 	db_extend('packages');

--- a/Sources/ManagePosts.php
+++ b/Sources/ManagePosts.php
@@ -218,7 +218,7 @@ function ModifyPostSettings($return_config = false)
 		checkSession();
 
 		// If we're changing the message length (and we are using MySQL) let's check the column is big enough.
-		if (isset($_POST['max_messageLength']) && $_POST['max_messageLength'] != $modSettings['max_messageLength'] && $db_type == 'mysql')
+		if (isset($_POST['max_messageLength']) && $_POST['max_messageLength'] != $modSettings['max_messageLength'] && ($db_type == 'mysql' || $db_type == 'mysqli'))
 		{
 			db_extend('packages');
 

--- a/Sources/ManageSearch.php
+++ b/Sources/ManageSearch.php
@@ -308,7 +308,7 @@ function EditSearchMethod()
 	);
 
 	// Get some info about the messages table, to show its size and index size.
-	if ($db_type == 'mysql')
+	if ($db_type == 'mysql' || $db_type == 'mysqli')
 	{
 		if (preg_match('~^`(.+?)`\.(.+?)$~', $db_prefix, $match) !== 0)
 			$request = $smcFunc['db_query']('', '

--- a/Sources/ScheduledTasks.php
+++ b/Sources/ScheduledTasks.php
@@ -434,7 +434,7 @@ function scheduled_daily_maintenance()
 
 	// Check the database version - for some buggy MySQL version.
 	$server_version = $smcFunc['db_server_info']();
-	if ($db_type == 'mysql' && in_array(substr($server_version, 0, 6), array('5.0.50', '5.0.51')))
+	if (($db_type == 'mysql' || $db_type == 'mysqli') && in_array(substr($server_version, 0, 6), array('5.0.50', '5.0.51')))
 		updateSettings(array('db_mysql_group_by_fix' => '1'));
 	elseif (!empty($modSettings['db_mysql_group_by_fix']))
 		$smcFunc['db_query']('', '

--- a/Sources/SearchAPI-Custom.php
+++ b/Sources/SearchAPI-Custom.php
@@ -59,7 +59,7 @@ class custom_search
 	 * What databases support the custom index?
 	 * @var type
 	 */
-	protected $supported_databases = array('mysql', 'postgresql', 'sqlite');
+	protected $supported_databases = array('mysql', 'mysqli', 'postgresql', 'sqlite');
 
 	/**
 	 * constructor function

--- a/Sources/SearchAPI-Fulltext.php
+++ b/Sources/SearchAPI-Fulltext.php
@@ -54,7 +54,7 @@ class fulltext_search
 	 * What databases support the fulltext index?
 	 * @var type
 	 */
-	protected $supported_databases = array('mysql');
+	protected $supported_databases = array('mysql', 'mysqli');
 
 	/**
 	 * fulltext_search::__construct()

--- a/Sources/Subs-Db-mysqli.php
+++ b/Sources/Subs-Db-mysqli.php
@@ -1,0 +1,839 @@
+<?php
+
+/**
+ * This file has all the main functions in it that relate to the database.
+ *
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines http://www.simplemachines.org
+ * @copyright 2012 Simple Machines
+ * @license http://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 2.1 Alpha 1
+ */
+
+if (!defined('SMF'))
+	die('No direct access...');
+
+/**
+ *  Maps the implementations in this file (smf_db_function_name)
+ *  to the $smcFunc['db_function_name'] variable.
+ *
+ * @param string $db_server
+ * @param string $db_name
+ * @param string $db_user
+ * @param string $db_passwd
+ * @param string $db_prefix
+ * @param array $db_options
+ * @return null
+ */
+function smf_db_initiate($db_server, $db_name, $db_user, $db_passwd, $db_prefix, $db_options = array())
+{
+	global $smcFunc, $mysql_set_mode;
+
+	// Map some database specific functions, only do this once.
+	if (!isset($smcFunc['db_fetch_assoc']) || $smcFunc['db_fetch_assoc'] != 'mysqli_fetch_assoc')
+		$smcFunc += array(
+			'db_query'                  => 'smf_db_query',
+			'db_quote'                  => 'smf_db_quote',
+			'db_fetch_assoc'            => 'mysqli_fetch_assoc',
+			'db_fetch_row'              => 'mysqli_fetch_row',
+			'db_free_result'            => 'mysqli_free_result',
+			'db_insert'                 => 'smf_db_insert',
+			'db_insert_id'              => 'smf_db_insert_id',
+			'db_num_rows'               => 'mysqli_num_rows',
+			'db_data_seek'              => 'mysqli_data_seek',
+			'db_num_fields'             => 'mysqli_num_fields',
+			'db_escape_string'          => 'addslashes',
+			'db_unescape_string'        => 'stripslashes',
+			'db_server_info'            => 'smf_db_get_server_info',
+			'db_affected_rows'          => 'smf_db_affected_rows',
+			'db_transaction'            => 'smf_db_transaction',
+			'db_error'                  => 'mysqli_error',
+			'db_select_db'              => 'smf_db_select',
+			'db_title'                  => 'MySQLi',
+			'db_sybase'                 => false,
+			'db_case_sensitive'         => false,
+			'db_escape_wildcard_string' => 'smf_db_escape_wildcard_string',
+		);
+
+	if (!empty($db_options['persist']))
+		$connection = @mysqli_connect('p:' . $db_server, $db_user, $db_passwd);
+	else
+		$connection = @mysqli_connect($db_server, $db_user, $db_passwd);
+
+	// Something's wrong, show an error if its fatal (which we assume it is)
+	if (!$connection)
+	{
+		if (!empty($db_options['non_fatal']))
+			return null;
+		else
+			display_db_error();
+	}
+
+	// Select the database, unless told not to
+	if (empty($db_options['dont_select_db']) && !@mysqli_select_db($connection, $db_name) && empty($db_options['non_fatal']))
+		display_db_error();
+
+	// This makes it possible to have SMF automatically change the sql_mode and autocommit if needed.
+	if (isset($mysql_set_mode) && $mysql_set_mode === true)
+		$smcFunc['db_query']('', 'SET sql_mode = \'\', AUTOCOMMIT = 1',
+		array(),
+		false
+	);
+
+	return $connection;
+}
+
+/**
+ * Extend the database functionality. It calls the respective file's init
+ * to add the implementations in that file to $smcFunc array.
+ *
+ * @param string $type indicated which additional file to load. ('extra', 'packages')
+ */
+function db_extend($type = 'extra')
+{
+	global $sourcedir;
+
+	// we force the MySQL files as nothing syntactically changes with MySQLi
+	require_once($sourcedir . '/Db' . strtoupper($type[0]) . substr($type, 1) . '-mysql.php');
+	$initFunc = 'db_' . $type . '_init';
+	$initFunc();
+}
+
+/**
+ * Fix up the prefix so it doesn't require the database to be selected.
+ *
+ * @param string &db_prefix
+ * @param string $db_name
+ */
+function db_fix_prefix(&$db_prefix, $db_name)
+{
+	$db_prefix = is_numeric(substr($db_prefix, 0, 1)) ? $db_name . '.' . $db_prefix : '`' . $db_name . '`.' . $db_prefix;
+}
+
+/**
+ * Wrap mysqli_select_db so the connection does not need to be specified
+ *
+ * @param string &database
+ * @param object $connection
+ */
+function smf_db_select($database, $connection = null)
+{
+	global $db_connection;
+	return mysqli_select_db($connection === null ? $db_connection : $connection, $database);
+}
+
+/**
+ * Wrap mysqli_get_server_info so the connection does not need to be specified
+ *
+ * @param object $connection
+ */
+function smf_db_get_server_info($connection = null)
+{
+	global $db_connection;
+	return mysqli_get_server_info($connection === null ? $db_connection : $connection);
+}
+
+/**
+ * Callback for preg_replace_callback on the query.
+ * It allows to replace on the fly a few pre-defined strings, for convenience ('query_see_board', 'query_wanna_see_board'), with
+ * their current values from $user_info.
+ * In addition, it performs checks and sanitization on the values sent to the database.
+ *
+ * @param $matches
+ */
+function smf_db_replacement__callback($matches)
+{
+	global $db_callback, $user_info, $db_prefix;
+
+	list ($values, $connection) = $db_callback;
+	if (!is_object($connection))
+		display_db_error();
+
+	if ($matches[1] === 'db_prefix')
+		return $db_prefix;
+
+	if ($matches[1] === 'query_see_board')
+		return $user_info['query_see_board'];
+
+	if ($matches[1] === 'query_wanna_see_board')
+		return $user_info['query_wanna_see_board'];
+
+	if (!isset($matches[2]))
+		smf_db_error_backtrace('Invalid value inserted or no type specified.', '', E_USER_ERROR, __FILE__, __LINE__);
+
+	if (!isset($values[$matches[2]]))
+		smf_db_error_backtrace('The database value you\'re trying to insert does not exist: ' . htmlspecialchars($matches[2]), '', E_USER_ERROR, __FILE__, __LINE__);
+
+	$replacement = $values[$matches[2]];
+
+	switch ($matches[1])
+	{
+		case 'int':
+			if (!is_numeric($replacement) || (string) $replacement !== (string) (int) $replacement)
+				smf_db_error_backtrace('Wrong value type sent to the database. Integer expected. (' . $matches[2] . ')', '', E_USER_ERROR, __FILE__, __LINE__);
+			return (string) (int) $replacement;
+		break;
+
+		case 'string':
+		case 'text':
+			return sprintf('\'%1$s\'', mysqli_real_escape_string($connection, $replacement));
+		break;
+
+		case 'array_int':
+			if (is_array($replacement))
+			{
+				if (empty($replacement))
+					smf_db_error_backtrace('Database error, given array of integer values is empty. (' . $matches[2] . ')', '', E_USER_ERROR, __FILE__, __LINE__);
+
+				foreach ($replacement as $key => $value)
+				{
+					if (!is_numeric($value) || (string) $value !== (string) (int) $value)
+						smf_db_error_backtrace('Wrong value type sent to the database. Array of integers expected. (' . $matches[2] . ')', '', E_USER_ERROR, __FILE__, __LINE__);
+
+					$replacement[$key] = (string) (int) $value;
+				}
+
+				return implode(', ', $replacement);
+			}
+			else
+				smf_db_error_backtrace('Wrong value type sent to the database. Array of integers expected. (' . $matches[2] . ')', '', E_USER_ERROR, __FILE__, __LINE__);
+
+		break;
+
+		case 'array_string':
+			if (is_array($replacement))
+			{
+				if (empty($replacement))
+					smf_db_error_backtrace('Database error, given array of string values is empty. (' . $matches[2] . ')', '', E_USER_ERROR, __FILE__, __LINE__);
+
+				foreach ($replacement as $key => $value)
+					$replacement[$key] = sprintf('\'%1$s\'', mysqli_real_escape_string($connection, $value));
+
+				return implode(', ', $replacement);
+			}
+			else
+				smf_db_error_backtrace('Wrong value type sent to the database. Array of strings expected. (' . $matches[2] . ')', '', E_USER_ERROR, __FILE__, __LINE__);
+		break;
+
+		case 'date':
+			if (preg_match('~^(\d{4})-([0-1]?\d)-([0-3]?\d)$~', $replacement, $date_matches) === 1)
+				return sprintf('\'%04d-%02d-%02d\'', $date_matches[1], $date_matches[2], $date_matches[3]);
+			else
+				smf_db_error_backtrace('Wrong value type sent to the database. Date expected. (' . $matches[2] . ')', '', E_USER_ERROR, __FILE__, __LINE__);
+		break;
+
+		case 'float':
+			if (!is_numeric($replacement))
+				smf_db_error_backtrace('Wrong value type sent to the database. Floating point number expected. (' . $matches[2] . ')', '', E_USER_ERROR, __FILE__, __LINE__);
+			return (string) (float) $replacement;
+		break;
+
+		case 'identifier':
+			// Backticks inside identifiers are supported as of MySQL 4.1. We don't need them for SMF.
+			return '`' . strtr($replacement, array('`' => '', '.' => '')) . '`';
+		break;
+
+		case 'raw':
+			return $replacement;
+		break;
+
+		default:
+			smf_db_error_backtrace('Undefined type used in the database query. (' . $matches[1] . ':' . $matches[2] . ')', '', false, __FILE__, __LINE__);
+		break;
+	}
+}
+
+/**
+ * Just like the db_query, escape and quote a string, but not executing the query.
+ *
+ * @param string $db_string
+ * @param array $db_values
+ * @param object $connection = null
+ */
+function smf_db_quote($db_string, $db_values, $connection = null)
+{
+	global $db_callback, $db_connection;
+
+	// Only bother if there's something to replace.
+	if (strpos($db_string, '{') !== false)
+	{
+		// This is needed by the callback function.
+		$db_callback = array($db_values, $connection === null ? $db_connection : $connection);
+
+		// Do the quoting and escaping
+		$db_string = preg_replace_callback('~{([a-z_]+)(?::([a-zA-Z0-9_-]+))?}~', 'smf_db_replacement__callback', $db_string);
+
+		// Clear this global variable.
+		$db_callback = array();
+	}
+
+	return $db_string;
+}
+
+/**
+ * Do a query.  Takes care of errors too.
+ *
+ * @param string $identifier
+ * @param string $db_string
+ * @param array $db_values = array()
+ * @param object $connection = null
+ */
+function smf_db_query($identifier, $db_string, $db_values = array(), $connection = null)
+{
+	global $db_cache, $db_count, $db_connection, $db_show_debug, $time_start;
+	global $db_unbuffered, $db_callback, $modSettings;
+
+	// Comments that are allowed in a query are preg_removed.
+	static $allowed_comments_from = array(
+		'~\s+~s',
+		'~/\*!40001 SQL_NO_CACHE \*/~',
+		'~/\*!40000 USE INDEX \([A-Za-z\_]+?\) \*/~',
+		'~/\*!40100 ON DUPLICATE KEY UPDATE id_msg = \d+ \*/~',
+	);
+	static $allowed_comments_to = array(
+		' ',
+		'',
+		'',
+		'',
+	);
+
+	// Decide which connection to use.
+	$connection = $connection === null ? $db_connection : $connection;
+
+	// Get a connection if we are shutting down, sometimes the link is closed before sessions are written
+        if (!is_object($connection))
+	{
+		global $db_server, $db_user, $db_passwd, $db_name, $db_show_debug, $ssi_db_user, $ssi_db_passwd;
+
+		// Are we in SSI mode?  If so try that username and password first
+		if (SMF == 'SSI' && !empty($ssi_db_user) && !empty($ssi_db_passwd))
+		{
+			if (empty($db_persist))
+				$db_connection = @mysqli_connect($db_server, $ssi_db_user, $ssi_db_passwd);
+			else
+				$db_connection = @mysqli_connect('p:' . $db_server, $ssi_db_user, $ssi_db_passwd);
+		}
+		// Fall back to the regular username and password if need be
+		if (!$db_connection)
+		{
+			if (empty($db_persist))
+				$db_connection = @mysqli_connect($db_server, $db_user, $db_passwd);
+			else
+				$db_connection = @mysqli_connect('p:' . $db_server, $db_user, $db_passwd);
+		}
+
+		if (!$db_connection || !@mysqli_select_db($db_connection, $db_name))
+			$db_connection = false;
+
+		$connection = $db_connection;
+	}
+
+	// One more query....
+	$db_count = !isset($db_count) ? 1 : $db_count + 1;
+
+	if (empty($modSettings['disableQueryCheck']) && strpos($db_string, '\'') !== false && empty($db_values['security_override']))
+		smf_db_error_backtrace('Hacking attempt...', 'Illegal character (\') used in query...', true, __FILE__, __LINE__);
+
+	// Use "ORDER BY null" to prevent Mysql doing filesorts for Group By clauses without an Order By
+	if (strpos($db_string, 'GROUP BY') !== false && strpos($db_string, 'ORDER BY') === false && strpos($db_string, 'INSERT INTO') === false)
+	{
+		// Add before LIMIT
+		if ($pos = strpos($db_string, 'LIMIT '))
+			$db_string = substr($db_string, 0, $pos) . "\t\t\tORDER BY null\n" . substr($db_string, $pos, strlen($db_string));
+		else
+			// Append it.
+			$db_string .= "\n\t\t\tORDER BY null";
+	}
+
+	if (empty($db_values['security_override']) && (!empty($db_values) || strpos($db_string, '{db_prefix}') !== false))
+	{
+		// Pass some values to the global space for use in the callback function.
+		$db_callback = array($db_values, $connection);
+
+		// Inject the values passed to this function.
+		$db_string = preg_replace_callback('~{([a-z_]+)(?::([a-zA-Z0-9_-]+))?}~', 'smf_db_replacement__callback', $db_string);
+
+		// This shouldn't be residing in global space any longer.
+		$db_callback = array();
+	}
+
+	// Debugging.
+	if (isset($db_show_debug) && $db_show_debug === true)
+	{
+		// Get the file and line number this function was called.
+		list ($file, $line) = smf_db_error_backtrace('', '', 'return', __FILE__, __LINE__);
+
+		// Initialize $db_cache if not already initialized.
+		if (!isset($db_cache))
+			$db_cache = array();
+
+		if (!empty($_SESSION['debug_redirect']))
+		{
+			$db_cache = array_merge($_SESSION['debug_redirect'], $db_cache);
+			$db_count = count($db_cache) + 1;
+			$_SESSION['debug_redirect'] = array();
+		}
+
+		// Don't overload it.
+		$st = microtime();
+		$db_cache[$db_count]['q'] = $db_count < 50 ? $db_string : '...';
+		$db_cache[$db_count]['f'] = $file;
+		$db_cache[$db_count]['l'] = $line;
+		$db_cache[$db_count]['s'] = array_sum(explode(' ', $st)) - array_sum(explode(' ', $time_start));
+	}
+
+	// First, we clean strings out of the query, reduce whitespace, lowercase, and trim - so we can check it over.
+	if (empty($modSettings['disableQueryCheck']))
+	{
+		$clean = '';
+		$old_pos = 0;
+		$pos = -1;
+		while (true)
+		{
+			$pos = strpos($db_string, '\'', $pos + 1);
+			if ($pos === false)
+				break;
+			$clean .= substr($db_string, $old_pos, $pos - $old_pos);
+
+			while (true)
+			{
+				$pos1 = strpos($db_string, '\'', $pos + 1);
+				$pos2 = strpos($db_string, '\\', $pos + 1);
+				if ($pos1 === false)
+					break;
+				elseif ($pos2 == false || $pos2 > $pos1)
+				{
+					$pos = $pos1;
+					break;
+				}
+
+				$pos = $pos2 + 1;
+			}
+			$clean .= ' %s ';
+
+			$old_pos = $pos + 1;
+		}
+		$clean .= substr($db_string, $old_pos);
+		$clean = trim(strtolower(preg_replace($allowed_comments_from, $allowed_comments_to, $clean)));
+
+		// We don't use UNION in SMF, at least so far.  But it's useful for injections.
+		if (strpos($clean, 'union') !== false && preg_match('~(^|[^a-z])union($|[^[a-z])~s', $clean) != 0)
+			$fail = true;
+		// Comments?  We don't use comments in our queries, we leave 'em outside!
+		elseif (strpos($clean, '/*') > 2 || strpos($clean, '--') !== false || strpos($clean, ';') !== false)
+			$fail = true;
+		// Trying to change passwords, slow us down, or something?
+		elseif (strpos($clean, 'sleep') !== false && preg_match('~(^|[^a-z])sleep($|[^[_a-z])~s', $clean) != 0)
+			$fail = true;
+		elseif (strpos($clean, 'benchmark') !== false && preg_match('~(^|[^a-z])benchmark($|[^[a-z])~s', $clean) != 0)
+			$fail = true;
+		// Sub selects?  We don't use those either.
+		elseif (preg_match('~\([^)]*?select~s', $clean) != 0)
+			$fail = true;
+
+		if (!empty($fail) && function_exists('log_error'))
+			smf_db_error_backtrace('Hacking attempt...', 'Hacking attempt...' . "\n" . $db_string, E_USER_ERROR, __FILE__, __LINE__);
+	}
+
+	if (empty($db_unbuffered))
+		$ret = @mysqli_query($connection, $db_string);
+	else
+		$ret = @mysqli_query($connection, $db_string, MYSQLI_USE_RESULT);
+
+	if ($ret === false && empty($db_values['db_error_skip']))
+		$ret = smf_db_error($db_string, $connection);
+
+	// Debugging.
+	if (isset($db_show_debug) && $db_show_debug === true)
+		$db_cache[$db_count]['t'] = array_sum(explode(' ', microtime())) - array_sum(explode(' ', $st));
+
+	return $ret;
+}
+
+/**
+ * affected_rows
+ * @param object $connection
+ */
+function smf_db_affected_rows($connection = null)
+{
+	global $db_connection;
+
+	return mysqli_affected_rows($connection === null ? $db_connection : $connection);
+}
+
+/**
+ * insert_id
+ *
+ * @param string $table
+ * @param string $field = null
+ * @param object $connection = null
+ */
+function smf_db_insert_id($table, $field = null, $connection = null)
+{
+	global $db_connection, $db_prefix;
+
+	$table = str_replace('{db_prefix}', $db_prefix, $table);
+
+	// MySQL doesn't need the table or field information.
+	return mysqli_insert_id($connection === null ? $db_connection : $connection);
+}
+
+/**
+ * Do a transaction.
+ *
+ * @param string $type - the step to perform (i.e. 'begin', 'commit', 'rollback')
+ * @param object $connection = null
+ */
+function smf_db_transaction($type = 'commit', $connection = null)
+{
+	global $db_connection;
+
+	// Decide which connection to use
+	$connection = $connection === null ? $db_connection : $connection;
+
+	if ($type == 'begin')
+		return @mysqli_query($connection, 'BEGIN');
+	elseif ($type == 'rollback')
+		return @mysqli_query($connection, 'ROLLBACK');
+	elseif ($type == 'commit')
+		return @mysqli_query($connection, 'COMMIT');
+
+	return false;
+}
+
+/**
+ * Database error!
+ * Backtrace, log, try to fix.
+ *
+ * @param string $db_string
+ * @param object $connection = null
+ */
+function smf_db_error($db_string, $connection = null)
+{
+	global $txt, $context, $sourcedir, $webmaster_email, $modSettings;
+	global $forum_version, $db_connection, $db_last_error, $db_persist;
+	global $db_server, $db_user, $db_passwd, $db_name, $db_show_debug, $ssi_db_user, $ssi_db_passwd;
+	global $smcFunc;
+
+	// Get the file and line numbers.
+	list ($file, $line) = smf_db_error_backtrace('', '', 'return', __FILE__, __LINE__);
+
+	// Decide which connection to use
+	$connection = $connection === null ? $db_connection : $connection;
+
+	// This is the error message...
+	$query_error = mysqli_error($connection);
+	$query_errno = mysqli_errno($connection);
+
+	// Error numbers:
+	//    1016: Can't open file '....MYI'
+	//    1030: Got error ??? from table handler.
+	//    1034: Incorrect key file for table.
+	//    1035: Old key file for table.
+	//    1205: Lock wait timeout exceeded.
+	//    1213: Deadlock found.
+	//    2006: Server has gone away.
+	//    2013: Lost connection to server during query.
+
+	// Log the error.
+	if ($query_errno != 1213 && $query_errno != 1205 && function_exists('log_error'))
+		log_error($txt['database_error'] . ': ' . $query_error . (!empty($modSettings['enableErrorQueryLogging']) ? "\n\n$db_string" : ''), 'database', $file, $line);
+
+	// Database error auto fixing ;).
+	if (function_exists('cache_get_data') && (!isset($modSettings['autoFixDatabase']) || $modSettings['autoFixDatabase'] == '1'))
+	{
+		// Force caching on, just for the error checking.
+		$old_cache = @$modSettings['cache_enable'];
+		$modSettings['cache_enable'] = '1';
+
+		if (($temp = cache_get_data('db_last_error', 600)) !== null)
+			$db_last_error = max(@$db_last_error, $temp);
+
+		if (@$db_last_error < time() - 3600 * 24 * 3)
+		{
+			// We know there's a problem... but what?  Try to auto detect.
+			if ($query_errno == 1030 && strpos($query_error, ' 127 ') !== false)
+			{
+				preg_match_all('~(?:[\n\r]|^)[^\']+?(?:FROM|JOIN|UPDATE|TABLE) ((?:[^\n\r(]+?(?:, )?)*)~s', $db_string, $matches);
+
+				$fix_tables = array();
+				foreach ($matches[1] as $tables)
+				{
+					$tables = array_unique(explode(',', $tables));
+					foreach ($tables as $table)
+					{
+						// Now, it's still theoretically possible this could be an injection.  So backtick it!
+						if (trim($table) != '')
+							$fix_tables[] = '`' . strtr(trim($table), array('`' => '')) . '`';
+					}
+				}
+
+				$fix_tables = array_unique($fix_tables);
+			}
+			// Table crashed.  Let's try to fix it.
+			elseif ($query_errno == 1016)
+			{
+				if (preg_match('~\'([^\.\']+)~', $query_error, $match) != 0)
+					$fix_tables = array('`' . $match[1] . '`');
+			}
+			// Indexes crashed.  Should be easy to fix!
+			elseif ($query_errno == 1034 || $query_errno == 1035)
+			{
+				preg_match('~\'([^\']+?)\'~', $query_error, $match);
+				$fix_tables = array('`' . $match[1] . '`');
+			}
+		}
+
+		// Check for errors like 145... only fix it once every three days, and send an email. (can't use empty because it might not be set yet...)
+		if (!empty($fix_tables))
+		{
+			// Subs-Admin.php for updateSettingsFile(), Subs-Post.php for sendmail().
+			require_once($sourcedir . '/Subs-Admin.php');
+			require_once($sourcedir . '/Subs-Post.php');
+
+			// Make a note of the REPAIR...
+			cache_put_data('db_last_error', time(), 600);
+			if (($temp = cache_get_data('db_last_error', 600)) === null)
+				updateSettingsFile(array('db_last_error' => time()));
+
+			// Attempt to find and repair the broken table.
+			foreach ($fix_tables as $table)
+				$smcFunc['db_query']('', "
+					REPAIR TABLE $table", false, false);
+
+			// And send off an email!
+			sendmail($webmaster_email, $txt['database_error'], $txt['tried_to_repair']);
+
+			$modSettings['cache_enable'] = $old_cache;
+
+			// Try the query again...?
+			$ret = $smcFunc['db_query']('', $db_string, false, false);
+			if ($ret !== false)
+				return $ret;
+		}
+		else
+			$modSettings['cache_enable'] = $old_cache;
+
+		// Check for the "lost connection" or "deadlock found" errors - and try it just one more time.
+		if (in_array($query_errno, array(1205, 1213, 2006, 2013)))
+		{
+			if (in_array($query_errno, array(2006, 2013)) && $db_connection == $connection)
+			{
+				// Are we in SSI mode?  If so try that username and password first
+				if (SMF == 'SSI' && !empty($ssi_db_user) && !empty($ssi_db_passwd))
+				{
+					if (empty($db_persist))
+						$db_connection = @mysqli_connect($db_server, $ssi_db_user, $ssi_db_passwd);
+					else
+						$db_connection = @mysqli_connect('p:' . $db_server, $ssi_db_user, $ssi_db_passwd);
+				}
+				// Fall back to the regular username and password if need be
+				if (!$db_connection)
+				{
+					if (empty($db_persist))
+						$db_connection = @mysqli_connect($db_server, $db_user, $db_passwd);
+					else
+						$db_connection = @mysqli_connect('p:' . $db_server, $db_user, $db_passwd);
+				}
+
+				if (!$db_connection || !@mysqli_select_db($db_connection, $db_name))
+					$db_connection = false;
+			}
+
+			if ($db_connection)
+			{
+				// Try a deadlock more than once more.
+				for ($n = 0; $n < 4; $n++)
+				{
+					$ret = $smcFunc['db_query']('', $db_string, false, false);
+
+					$new_errno = mysqli_errno($db_connection);
+					if ($ret !== false || in_array($new_errno, array(1205, 1213)))
+						break;
+				}
+
+				// If it failed again, shucks to be you... we're not trying it over and over.
+				if ($ret !== false)
+					return $ret;
+			}
+		}
+		// Are they out of space, perhaps?
+		elseif ($query_errno == 1030 && (strpos($query_error, ' -1 ') !== false || strpos($query_error, ' 28 ') !== false || strpos($query_error, ' 12 ') !== false))
+		{
+			if (!isset($txt))
+				$query_error .= ' - check database storage space.';
+			else
+			{
+				if (!isset($txt['mysql_error_space']))
+					loadLanguage('Errors');
+
+				$query_error .= !isset($txt['mysql_error_space']) ? ' - check database storage space.' : $txt['mysql_error_space'];
+			}
+		}
+	}
+
+	// Nothing's defined yet... just die with it.
+	if (empty($context) || empty($txt))
+		die($query_error);
+
+	// Show an error message, if possible.
+	$context['error_title'] = $txt['database_error'];
+	if (allowedTo('admin_forum'))
+		$context['error_message'] = nl2br($query_error) . '<br />' . $txt['file'] . ': ' . $file . '<br />' . $txt['line'] . ': ' . $line;
+	else
+		$context['error_message'] = $txt['try_again'];
+
+	// A database error is often the sign of a database in need of upgrade.  Check forum versions, and if not identical suggest an upgrade... (not for Demo/CVS versions!)
+	if (allowedTo('admin_forum') && !empty($forum_version) && $forum_version != 'SMF ' . @$modSettings['smfVersion'] && strpos($forum_version, 'Demo') === false && strpos($forum_version, 'CVS') === false)
+		$context['error_message'] .= '<br /><br />' . sprintf($txt['database_error_versions'], $forum_version, $modSettings['smfVersion']);
+
+	if (allowedTo('admin_forum') && isset($db_show_debug) && $db_show_debug === true)
+	{
+		$context['error_message'] .= '<br /><br />' . nl2br($db_string);
+	}
+
+	// It's already been logged... don't log it again.
+	fatal_error($context['error_message'], false);
+}
+
+/**
+ * insert
+ *
+ * @param string $method - options 'replace', 'ignore', 'insert'
+ * @param $table
+ * @param $columns
+ * @param $data
+ * @param $keys
+ * @param bool $disable_trans = false
+ * @param object $connection = null
+ */
+function smf_db_insert($method = 'replace', $table, $columns, $data, $keys, $disable_trans = false, $connection = null)
+{
+	global $smcFunc, $db_connection, $db_prefix;
+
+	$connection = $connection === null ? $db_connection : $connection;
+
+	// With nothing to insert, simply return.
+	if (empty($data))
+		return;
+
+	// Replace the prefix holder with the actual prefix.
+	$table = str_replace('{db_prefix}', $db_prefix, $table);
+
+	// Inserting data as a single row can be done as a single array.
+	if (!is_array($data[array_rand($data)]))
+		$data = array($data);
+
+	// Create the mold for a single row insert.
+	$insertData = '(';
+	foreach ($columns as $columnName => $type)
+	{
+		// Are we restricting the length?
+		if (strpos($type, 'string-') !== false)
+			$insertData .= sprintf('SUBSTRING({string:%1$s}, 1, ' . substr($type, 7) . '), ', $columnName);
+		else
+			$insertData .= sprintf('{%1$s:%2$s}, ', $type, $columnName);
+	}
+	$insertData = substr($insertData, 0, -2) . ')';
+
+	// Create an array consisting of only the columns.
+	$indexed_columns = array_keys($columns);
+
+	// Here's where the variables are injected to the query.
+	$insertRows = array();
+	foreach ($data as $dataRow)
+		$insertRows[] = smf_db_quote($insertData, array_combine($indexed_columns, $dataRow), $connection);
+
+	// Determine the method of insertion.
+	$queryTitle = $method == 'replace' ? 'REPLACE' : ($method == 'ignore' ? 'INSERT IGNORE' : 'INSERT');
+
+	// Do the insert.
+	$smcFunc['db_query']('', '
+		' . $queryTitle . ' INTO ' . $table . '(`' . implode('`, `', $indexed_columns) . '`)
+		VALUES
+			' . implode(',
+			', $insertRows),
+		array(
+			'security_override' => true,
+			'db_error_skip' => $table === $db_prefix . 'log_errors',
+		),
+		$connection
+	);
+}
+
+/**
+ * This function tries to work out additional error information from a back trace.
+ *
+ * @param $error_message
+ * @param $log_message
+ * @param $error_type
+ * @param $file
+ * @param $line
+ */
+function smf_db_error_backtrace($error_message, $log_message = '', $error_type = false, $file = null, $line = null)
+{
+	if (empty($log_message))
+		$log_message = $error_message;
+
+	foreach (debug_backtrace() as $step)
+	{
+		// Found it?
+		if (strpos($step['function'], 'query') === false && !in_array(substr($step['function'], 0, 7), array('smf_db_', 'preg_re', 'db_erro', 'call_us')) && strpos($step['function'], '__') !== 0)
+		{
+			$log_message .= '<br />Function: ' . $step['function'];
+			break;
+		}
+
+		if (isset($step['line']))
+		{
+			$file = $step['file'];
+			$line = $step['line'];
+		}
+	}
+
+	// A special case - we want the file and line numbers for debugging.
+	if ($error_type == 'return')
+		return array($file, $line);
+
+	// Is always a critical error.
+	if (function_exists('log_error'))
+		log_error($log_message, 'critical', $file, $line);
+
+	if (function_exists('fatal_error'))
+	{
+		fatal_error($error_message, false);
+
+		// Cannot continue...
+		exit;
+	}
+	elseif ($error_type)
+		trigger_error($error_message . ($line !== null ? '<em>(' . basename($file) . '-' . $line . ')</em>' : ''), $error_type);
+	else
+		trigger_error($error_message . ($line !== null ? '<em>(' . basename($file) . '-' . $line . ')</em>' : ''));
+}
+
+/**
+ * Escape the LIKE wildcards so that they match the character and not the wildcard.
+ *
+ * @param $string
+ * @param bool $translate_human_wildcards = false, if true, turns human readable wildcards into SQL wildcards.
+ */
+function smf_db_escape_wildcard_string($string, $translate_human_wildcards=false)
+{
+	$replacements = array(
+		'%' => '\%',
+		'_' => '\_',
+		'\\' => '\\\\',
+	);
+
+	if ($translate_human_wildcards)
+		$replacements += array(
+			'*' => '%',
+		);
+
+	return strtr($string, $replacements);
+}
+?>

--- a/other/upgrade.php
+++ b/other/upgrade.php
@@ -19,6 +19,15 @@ $GLOBALS['required_php_version'] = '5.1.0';
 $GLOBALS['required_mysql_version'] = '4.0.18';
 
 $databases = array(
+	'mysqli' => array(
+		'name' => 'MySQLi',
+		'version' => '4.0.18',
+		'version_check' => 'return min(mysqli_get_server_info($db_connection), mysqli_get_client_info());',
+		'utf8_support' => true,
+		'utf8_version' => '4.1.0',
+		'utf8_version_check' => 'return mysqli_get_server_info($db_connection);',
+		'alter_support' => true,
+	),
 	'mysql' => array(
 		'name' => 'MySQL',
 		'version' => '4.0.18',
@@ -822,7 +831,7 @@ function loadEssentialData()
 		if ($db_connection === null)
 			die('Unable to connect to database - please check username and password are correct in Settings.php');
 
-		if ($db_type == 'mysql' && isset($db_character_set) && preg_match('~^\w+$~', $db_character_set) === 1)
+		if (($db_type == 'mysql' || $db_type == 'mysqli') && isset($db_character_set) && preg_match('~^\w+$~', $db_character_set) === 1)
 			$smcFunc['db_query']('', '
 			SET NAMES ' . $db_character_set,
 			array(
@@ -884,11 +893,13 @@ function initialize_inputs()
 	{
 		@unlink(__FILE__);
 
+		$type = ($db_type == 'mysqli') ? 'mysql' : $db_type;
+
 		// And the extra little files ;).
 		@unlink(dirname(__FILE__) . '/upgrade_1-0.sql');
 		@unlink(dirname(__FILE__) . '/upgrade_1-1.sql');
-		@unlink(dirname(__FILE__) . '/upgrade_2-0_' . $db_type . '.sql');
-		@unlink(dirname(__FILE__) . '/upgrade_2-1_' . $db_type . '.sql');
+		@unlink(dirname(__FILE__) . '/upgrade_2-0_' . $type . '.sql');
+		@unlink(dirname(__FILE__) . '/upgrade_2-1_' . $type . '.sql');
 		@unlink(dirname(__FILE__) . '/webinstall.php');
 
 		$dh = opendir(dirname(__FILE__));
@@ -943,15 +954,17 @@ function WelcomeLogin()
 
 	$upcontext['sub_template'] = 'welcome_message';
 
+	$type = ($db_type == 'mysqli') ? 'mysql' : $db_type;
+
 	// Check for some key files - one template, one language, and a new and an old source file.
 	$check = @file_exists($modSettings['theme_dir'] . '/index.template.php')
 		&& @file_exists($sourcedir . '/QueryString.php')
 		&& @file_exists($sourcedir . '/Subs-Db-' . $db_type . '.php')
-		&& @file_exists(dirname(__FILE__) . '/upgrade_2-1_' . $db_type . '.sql');
+		&& @file_exists(dirname(__FILE__) . '/upgrade_2-1_' . $type . '.sql');
 
 	// Need legacy scripts?
 	if (!isset($modSettings['smfVersion']) || $modSettings['smfVersion'] < 2.1)
-		$check &= @file_exists(dirname(__FILE__) . '/upgrade_2-0_' . $db_type . '.sql');
+		$check &= @file_exists(dirname(__FILE__) . '/upgrade_2-0_' . $type . '.sql');
 	if (!isset($modSettings['smfVersion']) || $modSettings['smfVersion'] < 2.0)
 		$check &= @file_exists(dirname(__FILE__) . '/upgrade_1-1.sql');
 	if (!isset($modSettings['smfVersion']) || $modSettings['smfVersion'] < 1.1)
@@ -1059,7 +1072,7 @@ function checkLogin()
 
 		// Before 2.0 these column names were different!
 		$oldDB = false;
-		if (empty($db_type) || $db_type == 'mysql')
+		if (empty($db_type) || $db_type == 'mysql' || $db_type == 'mysqli')
 		{
 			$request = $smcFunc['db_query']('', '
 				SHOW COLUMNS
@@ -1459,13 +1472,15 @@ function DatabaseChanges()
 	$upcontext['sub_template'] = isset($_GET['xml']) ? 'database_xml' : 'database_changes';
 	$upcontext['page_title'] = 'Database Changes';
 
+	$type = ($db_type == 'mysqli') ? 'mysql' : $db_type;
+
 	// All possible files.
 	// Name, <version, insert_on_complete
 	$files = array(
 		array('upgrade_1-0.sql', '1.1', '1.1 RC0'),
 		array('upgrade_1-1.sql', '2.0', '2.0 a'),
-		array('upgrade_2-0_' . $db_type . '.sql', '2.1', '2.1 dev0'),
-		array('upgrade_2-1_' . $db_type . '.sql', '3.0', SMF_VERSION),
+		array('upgrade_2-0_' . $type . '.sql', '2.1', '2.1 dev0'),
+		array('upgrade_2-1_' . $type . '.sql', '3.0', SMF_VERSION),
 	);
 
 	// How many files are there in total?
@@ -1941,7 +1956,7 @@ function DeleteUpgrade()
 
 	// Save the current database version.
 	$server_version = $smcFunc['db_server_info']();
-	if ($db_type == 'mysql' && in_array(substr($server_version, 0, 6), array('5.0.50', '5.0.51')))
+	if (($db_type == 'mysql' || $db_type == 'mysqli') && in_array(substr($server_version, 0, 6), array('5.0.50', '5.0.51')))
 		updateSettings(array('db_mysql_group_by_fix' => '1'));
 
 	if ($command_line)
@@ -2544,9 +2559,9 @@ function upgrade_query($string, $unbuffered = false)
 
 	$db_error_message = $smcFunc['db_error']($db_connection);
 	// If MySQL we do something more clever.
-	if ($db_type == 'mysql')
+	if ($db_type == 'mysql' || $db_type == 'mysqli')
 	{
-		$mysql_errno = mysql_errno($db_connection);
+		$mysql_errno = ($db_type == 'mysqli') ? mysqli_errno($db_connection) : mysql_errno($db_connection);
 		$error_query = in_array(substr(trim($string), 0, 11), array('INSERT INTO', 'UPDATE IGNO', 'ALTER TABLE', 'DROP TABLE ', 'ALTER IGNOR'));
 
 		// Error numbers:
@@ -2565,24 +2580,43 @@ function upgrade_query($string, $unbuffered = false)
 		if ($mysql_errno == 1016)
 		{
 			if (preg_match('~\'([^\.\']+)~', $db_error_message, $match) != 0 && !empty($match[1]))
-				mysql_query( '
-					REPAIR TABLE `' . $match[1] . '`');
-
-			$result = mysql_query($string);
-			if ($result !== false)
-				return $result;
+			{
+				if ($db_type == 'mysql')
+				{
+					mysql_query('REPAIR TABLE `' . $match[1] . '`');
+					$result = mysql_query($string);
+				}
+				else
+				{
+					mysqli_query($db_connection, 'REPAIR TABLE `' . $match[1] . '`');
+					$result = mysqli_query($db_connection, $string);
+				}
+				if ($result !== false)
+					return $result;
+			}
 		}
 		elseif ($mysql_errno == 2013)
 		{
 			$db_connection = mysql_connect($db_server, $db_user, $db_passwd);
-			mysql_select_db($db_name, $db_connection);
-
-			if ($db_connection)
+			if ($db_type == 'mysql')
 			{
-				$result = mysql_query($string);
-
-				if ($result !== false)
-					return $result;
+				mysql_select_db($db_name, $db_connection);
+				if ($db_connection)
+				{
+					$result = mysql_query($string);
+					if ($result !== false)
+						return $result;
+				}
+			}
+			else
+			{
+				mysqli_select_db($db_connection, $db_name);
+				if ($db_connection)
+				{
+					$result = mysqli_query($db_connection, $string);
+					if ($result !== false)
+						return $result;
+				}
 			}
 		}
 		// Duplicate column name... should be okay ;).
@@ -2653,6 +2687,42 @@ function upgrade_query($string, $unbuffered = false)
 		</div>';
 
 	upgradeExit();
+}
+
+function smf_mysql_fetch_assoc($rs)
+{
+	global $db_type;
+	return ($db_type == 'mysql') ? mysql_fetch_assoc($rs) : mysqli_fetch_assoc($rs);
+}
+
+function smf_mysql_fetch_row($rs)
+{
+	global $db_type;
+	return ($db_type == 'mysql') ? mysql_fetch_row($rs) : mysqli_fetch_row($rs);
+}
+
+function smf_mysql_free_result($rs)
+{
+	global $db_type;
+	return ($db_type == 'mysql') ? mysql_free_result($rs) : mysqli_free_result($rs);
+}
+
+function smf_mysql_insert_id($rs)
+{
+	global $db_type;
+	return ($db_type == 'mysql') ? mysql_insert_id($rs) : mysqli_insert_id($rs);
+}
+
+function smf_mysql_num_rows($rs)
+{
+	global $db_type;
+	return ($db_type == 'mysql') ? mysql_num_rows($rs) : mysqli_num_rows($rs);
+}
+
+function smf_mysql_real_escape_string($string)
+{
+	global $db_type, $db_connection;
+	return ($db_type == 'mysql') ? mysql_real_escape_string($string, $db_connection) : mysqli_real_escape_string($db_connection, $string);
 }
 
 // This performs a table alter, but does it unbuffered so the script can time out professionally.
@@ -2849,7 +2919,7 @@ function checkChange(&$change)
 	if (empty($database_version))
 	{
 		$database_version = $databases[$db_type]['version_check'];
-		$where_field_support = $db_type == 'mysql' && version_compare('5.0', $database_version, '<=');
+		$where_field_support = ($db_type == 'mysql' || $db_type == 'mysqli') && version_compare('5.0', $database_version, '<=');
 	}
 
 	// Not a column we need to check on?
@@ -3838,7 +3908,7 @@ function template_upgrade_options()
 				<table cellpadding="1" cellspacing="0">
 					<tr valign="top">
 						<td width="2%">
-							<input type="checkbox" name="backup" id="backup" value="1"', $db_type != 'mysql' && $db_type != 'postgresql' ? ' disabled="disabled"' : '', ' class="input_check" />
+							<input type="checkbox" name="backup" id="backup" value="1"', $db_type != 'mysql' && $db_type != 'mysqli' && $db_type != 'postgresql' ? ' disabled="disabled"' : '', ' class="input_check" />
 						</td>
 						<td width="100%">
 							<label for="backup">Backup tables in your database with the prefix &quot;backup_' . $db_prefix . '&quot;.</label>', isset($modSettings['smfVersion']) ? '' : ' (recommended!)', '

--- a/other/upgrade_1-0.sql
+++ b/other/upgrade_1-0.sql
@@ -301,9 +301,9 @@ $request = upgrade_query("
 		LEFT JOIN {$db_prefix}log_boards AS lb ON (lb.ID_BOARD = lmr.ID_BOARD AND lb.ID_MEMBER = lmr.ID_MEMBER)
 	WHERE lb.logTime < lmr.logTime");
 $replaceRows = '';
-while ($row = mysql_fetch_assoc($request))
+while ($row = smf_mysql_fetch_assoc($request))
 	$replaceRows .= "($row[ID_BOARD], $row[ID_MEMBER], $row[logTime]),";
-mysql_free_result($request);
+smf_mysql_free_result($request);
 if (!empty($replaceRows))
 {
 	$replaceRows = substr($replaceRows, 0, -1);
@@ -408,7 +408,7 @@ if ($result !== false)
 	$result = upgrade_query("
 		SELECT TRIM(memberGroups) AS memberGroups, ID_CAT
 		FROM {$db_prefix}categories");
-	while ($row = mysql_fetch_assoc($result))
+	while ($row = smf_mysql_fetch_assoc($result))
 	{
 		if (trim($row['memberGroups']) == '')
 			$groups = '-1,0,2';
@@ -456,7 +456,7 @@ $request = upgrade_query("
 	SHOW COLUMNS
 	FROM {$db_prefix}boards
 	LIKE 'notifyAnnouncements'");
-if (mysql_num_rows($request) > 0)
+if (smf_mysql_num_rows($request) > 0)
 {
 	$conversions = array(
 		'moderate_forum' => array('manage_membergroups', 'manage_bans'),
@@ -470,11 +470,11 @@ if (mysql_num_rows($request) > 0)
 			SELECT ID_GROUP, addDeny
 			FROM {$db_prefix}permissions
 			WHERE permission = '$original_permission'");
-		while ($row = mysql_fetch_assoc($result))
+		while ($row = smf_mysql_fetch_assoc($result))
 			$setString .= "
 				('" . implode("', $row[ID_GROUP], $row[addDeny]),
 				('", $new_permissions) . "', $row[ID_GROUP], $row[addDeny]),";
-		mysql_free_result($result);
+		smf_mysql_free_result($result);
 
 		if ($setString != '')
 			upgrade_query("
@@ -483,7 +483,7 @@ if (mysql_num_rows($request) > 0)
 				VALUES" . substr($setString, 0, -1));
 	}
 }
-mysql_free_result($request);
+smf_mysql_free_result($request);
 ---}
 
 DELETE FROM {$db_prefix}permissions
@@ -501,9 +501,9 @@ $result = upgrade_query("
 	WHERE m.ID_MSG = t.ID_LAST_MSG
 	GROUP BY t.ID_BOARD");
 $last_msgs = array();
-while ($row = mysql_fetch_assoc($result))
+while ($row = smf_mysql_fetch_assoc($result))
 	$last_msgs[] = $row['ID_LAST_MSG'];
-mysql_free_result($result);
+smf_mysql_free_result($result);
 
 if (!empty($last_msgs))
 {
@@ -513,7 +513,7 @@ if (!empty($last_msgs))
 		WHERE t.ID_TOPIC = m.ID_TOPIC
 			AND m.ID_MSG IN (" . implode(',', $last_msgs) . ")
 		LIMIT " . count($last_msgs));
-	while ($row = mysql_fetch_assoc($result))
+	while ($row = smf_mysql_fetch_assoc($result))
 	{
 		upgrade_query("
 			UPDATE {$db_prefix}boards
@@ -521,7 +521,7 @@ if (!empty($last_msgs))
 			WHERE ID_BOARD = $row[ID_BOARD]
 			LIMIT 1");
 	}
-	mysql_free_result($result);
+	smf_mysql_free_result($result);
 }
 ---}
 ---#
@@ -532,8 +532,8 @@ $request = upgrade_query("
 	SHOW COLUMNS
 	FROM {$db_prefix}boards
 	LIKE 'moderators'");
-$do_moderators = mysql_num_rows($request) > 0;
-mysql_free_result($request);
+$do_moderators = smf_mysql_num_rows($request) > 0;
+smf_mysql_free_result($request);
 
 if ($do_moderators)
 {
@@ -541,7 +541,7 @@ if ($do_moderators)
 		SELECT TRIM(moderators) AS moderators, ID_BOARD
 		FROM {$db_prefix}boards
 		WHERE TRIM(moderators) != ''");
-	while ($row = mysql_fetch_assoc($result))
+	while ($row = smf_mysql_fetch_assoc($result))
 	{
 		$moderators = array_unique(explode(',', $row['moderators']));
 		foreach ($moderators as $k => $dummy)
@@ -579,7 +579,7 @@ $request = upgrade_query("
 $catOrder = -1;
 $boardOrder = -1;
 $curCat = -1;
-while ($row = mysql_fetch_assoc($request))
+while ($row = smf_mysql_fetch_assoc($request))
 {
 	if ($curCat != $row['ID_CAT'])
 	{
@@ -598,7 +598,7 @@ while ($row = mysql_fetch_assoc($request))
 			WHERE ID_BOARD = $row[ID_BOARD]
 			LIMIT 1");
 }
-mysql_free_result($request);
+smf_mysql_free_result($request);
 ---}
 ---#
 
@@ -610,15 +610,15 @@ if (empty($modSettings['smfVersion']) || (substr($modSettings['smfVersion'], 0, 
 	$result = upgrade_query("
 		SELECT ID_GROUP
 		FROM {$db_prefix}membergroups");
-	while ($row = mysql_fetch_assoc($result))
+	while ($row = smf_mysql_fetch_assoc($result))
 		$all_groups[] = $row['ID_GROUP'];
-	mysql_free_result($result);
+	smf_mysql_free_result($result);
 
 	$result = upgrade_query("
 		SELECT ID_BOARD, memberGroups
 		FROM {$db_prefix}boards
 		WHERE FIND_IN_SET(0, memberGroups)");
-	while ($row = mysql_fetch_assoc($result))
+	while ($row = smf_mysql_fetch_assoc($result))
 	{
 		upgrade_query("
 			UPDATE {$db_prefix}boards
@@ -626,7 +626,7 @@ if (empty($modSettings['smfVersion']) || (substr($modSettings['smfVersion'], 0, 
 			WHERE ID_BOARD = $row[ID_BOARD]
 			LIMIT 1");
 	}
-	mysql_free_result($result);
+	smf_mysql_free_result($result);
 }
 ---}
 ---#
@@ -724,7 +724,7 @@ while (true)
 			AND m.ID_BOARD = 0
 		LIMIT 1400");
 	$boards = array();
-	while ($row = mysql_fetch_assoc($request))
+	while ($row = smf_mysql_fetch_assoc($request))
 		$boards[$row['ID_BOARD']][] = $row['ID_TOPIC'];
 
 	foreach ($boards as $board => $topics)
@@ -733,10 +733,10 @@ while (true)
 			SET ID_BOARD = $board
 			WHERE ID_TOPIC IN (" . implode(', ', $topics) . ')');
 
-	if (mysql_num_rows($request) < 1400)
+	if (smf_mysql_num_rows($request) < 1400)
 		break;
 
-	mysql_free_result($request);
+	smf_mysql_free_result($request);
 }
 ---}
 ---#
@@ -814,8 +814,8 @@ $request = upgrade_query("
 	SHOW COLUMNS
 	FROM {$db_prefix}members
 	LIKE 'im_ignore_list'");
-$do_it = mysql_num_rows($request) != 0;
-mysql_free_result($request);
+$do_it = smf_mysql_num_rows($request) != 0;
+smf_mysql_free_result($request);
 
 while ($do_it)
 {
@@ -826,16 +826,16 @@ while ($do_it)
 		FROM {$db_prefix}members
 		WHERE im_ignore_list RLIKE '[a-z]'
 		LIMIT 512");
-	while ($row = mysql_fetch_assoc($request))
+	while ($row = smf_mysql_fetch_assoc($request))
 	{
 		$request2 = upgrade_query("
 			SELECT ID_MEMBER
 			FROM {$db_prefix}members
 			WHERE FIND_IN_SET(memberName, '" . addslashes($row['im_ignore_list']) . "')");
 		$im_ignore_list = '';
-		while ($row2 = mysql_fetch_assoc($request2))
+		while ($row2 = smf_mysql_fetch_assoc($request2))
 			$im_ignore_list .= ',' . $row2['ID_MEMBER'];
-		mysql_free_result($request2);
+		smf_mysql_free_result($request2);
 
 		upgrade_query("
 			UPDATE {$db_prefix}members
@@ -843,9 +843,9 @@ while ($do_it)
 			WHERE ID_MEMBER = $row[ID_MEMBER]
 			LIMIT 1");
 	}
-	if (mysql_num_rows($request) < 512)
+	if (smf_mysql_num_rows($request) < 512)
 		break;
-	mysql_free_result($request);
+	smf_mysql_free_result($request);
 }
 ---}
 ---#
@@ -1076,7 +1076,7 @@ ADD PRIMARY KEY (ID_PM, ID_MEMBER);
 
 ---# Updating data in "instant_messages" (part 1)...
 ---{
-$request = mysql_query("
+$request = upgrade_query("
 	SHOW COLUMNS
 	FROM {$db_prefix}instant_messages
 	LIKE 'readBy'");
@@ -1084,10 +1084,10 @@ $do_it = $request !== false;
 
 if ($do_it)
 {
-	$adv_im = mysql_num_rows($request) == 0;
-	mysql_free_result($request);
+	$adv_im = smf_mysql_num_rows($request) == 0;
+	smf_mysql_free_result($request);
 
-	mysql_query("
+	upgrade_query("
 		INSERT IGNORE INTO {$db_prefix}im_recipients
 			(ID_PM, ID_MEMBER, bcc, is_read, deleted)
 		SELECT ID_PM, ID_MEMBER_TO, 0, IF(" . (!$adv_im ? 'readBy' : 'alerted') . " != 0, 1, 0), IF(deletedBy = '1', 1, 0)
@@ -1120,16 +1120,16 @@ ADD INDEX ID_MEMBER (ID_MEMBER_FROM, deletedBySender);
 
 ---# Recounting personal message totals...
 ---{
-$request = mysql_query("
+$request = upgrade_query("
 	SHOW CREATE TABLE {$db_prefix}instant_messages");
 $do_it = $request !== false;
-@mysql_free_result($request);
+@smf_mysql_free_result($request);
 
 $request = upgrade_query("
 	SELECT COUNT(*)
 	FROM {$db_prefix}members");
-list ($totalMembers) = mysql_fetch_row($request);
-mysql_free_result($request);
+list ($totalMembers) = smf_mysql_fetch_row($request);
+smf_mysql_free_result($request);
 
 $_GET['m'] = (int) @$_GET['m'];
 
@@ -1146,7 +1146,7 @@ while ($_GET['m'] < $totalMembers && $do_it)
 		GROUP BY mem.ID_MEMBER
 		HAVING instantMessages_real != instantMessages
 		LIMIT 512");
-	while ($row = mysql_fetch_assoc($mrequest))
+	while ($row = smf_mysql_fetch_assoc($mrequest))
 	{
 		upgrade_query("
 			UPDATE {$db_prefix}members
@@ -1160,16 +1160,16 @@ while ($_GET['m'] < $totalMembers && $do_it)
 unset($_GET['m']);
 ---}
 ---{
-$request = mysql_query("
+$request = upgrade_query("
 	SHOW CREATE TABLE {$db_prefix}instant_messages");
 $do_it = $request !== false;
-@mysql_free_result($request);
+@smf_mysql_free_result($request);
 
 $request = upgrade_query("
 	SELECT COUNT(*)
 	FROM {$db_prefix}members");
-list ($totalMembers) = mysql_fetch_row($request);
-mysql_free_result($request);
+list ($totalMembers) = smf_mysql_fetch_row($request);
+smf_mysql_free_result($request);
 
 $_GET['m'] = (int) @$_GET['m'];
 
@@ -1186,7 +1186,7 @@ while ($_GET['m'] < $totalMembers && $do_it)
 		GROUP BY mem.ID_MEMBER
 		HAVING unreadMessages_real != unreadMessages
 		LIMIT 512");
-	while ($row = mysql_fetch_assoc($mrequest))
+	while ($row = smf_mysql_fetch_assoc($mrequest))
 	{
 		upgrade_query("
 			UPDATE {$db_prefix}members
@@ -1205,7 +1205,7 @@ unset($_GET['m']);
 ---{
 global $JrPostNum, $FullPostNum, $SrPostNum, $GodPostNum;
 
-$result = mysql_query("
+$result = upgrade_query("
 	SELECT minPosts
 	FROM {$db_prefix}membergroups
 	LIMIT 1");
@@ -1331,21 +1331,21 @@ if ($result === false)
 
 ---# Converting "reserved_names"...
 ---{
-$request = mysql_query("
+$request = upgrade_query("
 	SELECT setting, value
 	FROM {$db_prefix}reserved_names");
 if ($request !== false)
 {
 	$words = array();
 	$match_settings = array();
-	while ($row = mysql_fetch_assoc($request))
+	while ($row = smf_mysql_fetch_assoc($request))
 	{
 		if (substr($row['setting'], 0, 5) == 'match')
 			$match_settings[$row['setting']] = $row['value'];
 		else
 			$words[] = $row['value'];
 	}
-	mysql_free_result($request);
+	smf_mysql_free_result($request);
 
 	upgrade_query("
 		INSERT IGNORE INTO {$db_prefix}settings
@@ -1373,15 +1373,15 @@ $request = upgrade_query("
 	WHERE minPosts != -1
 	ORDER BY minPosts DESC");
 $post_groups = array();
-while ($row = mysql_fetch_assoc($request))
+while ($row = smf_mysql_fetch_assoc($request))
 	$post_groups[$row['minPosts']] = $row['ID_GROUP'];
-mysql_free_result($request);
+smf_mysql_free_result($request);
 
 $request = upgrade_query("
 	SELECT ID_MEMBER, posts
 	FROM {$db_prefix}members");
 $mg_updates = array();
-while ($row = mysql_fetch_assoc($request))
+while ($row = smf_mysql_fetch_assoc($request))
 {
 	$group = 4;
 	foreach ($post_groups as $min_posts => $group_id)
@@ -1393,7 +1393,7 @@ while ($row = mysql_fetch_assoc($request))
 
 	$mg_updates[$group][] = $row['ID_MEMBER'];
 }
-mysql_free_result($request);
+smf_mysql_free_result($request);
 
 foreach ($mg_updates as $group_to => $update_members)
 	upgrade_query("
@@ -1417,12 +1417,12 @@ if (!isset($modSettings['censor_vulgar']) || !isset($modSettings['censor_proper'
 		FROM {$db_prefix}censor");
 	$censor_vulgar = array();
 	$censor_proper = array();
-	while ($row = mysql_fetch_row($request))
+	while ($row = smf_mysql_fetch_row($request))
 	{
 		$censor_vulgar[] = trim($row[0]);
 		$censor_proper[] = trim($row[1]);
 	}
-	mysql_free_result($request);
+	smf_mysql_free_result($request);
 
 	$modSettings['censor_vulgar'] = addslashes(implode("\n", $censor_vulgar));
 	$modSettings['censor_proper'] = addslashes(implode("\n", $censor_proper));
@@ -1442,14 +1442,14 @@ if (!isset($modSettings['censor_vulgar']) || !isset($modSettings['censor_proper'
 
 ---# Converting topic notifications...
 ---{
-$result = mysql_query("
+$result = upgrade_query("
 	SELECT COUNT(*)
 	FROM {$db_prefix}topics
 	WHERE notifies != ''");
 if ($result !== false)
 {
-	list ($numNotifies) = mysql_fetch_row($result);
-	mysql_free_result($result);
+	list ($numNotifies) = smf_mysql_fetch_row($result);
+	smf_mysql_free_result($result);
 
 	$_GET['t'] = (int) @$_GET['t'];
 
@@ -1478,14 +1478,14 @@ DROP notifies;
 
 ---# Converting "banned"...
 ---{
-$request = mysql_query("
+$request = upgrade_query("
 	SELECT type, value
 	FROM {$db_prefix}banned
 	WHERE type = 'ip'");
 if ($request !== false)
 {
 	$insertEntries = array();
-	while ($row = mysql_fetch_assoc($request))
+	while ($row = smf_mysql_fetch_assoc($request))
 	{
 		if (preg_match('~^\d{1,3}\.(\d{1,3}|\*)\.(\d{1,3}|\*)\.(\d{1,3}|\*)$~', $row['value']) == 0)
 			continue;
@@ -1493,7 +1493,7 @@ if ($request !== false)
 		$ip_parts = ip2range($row['value']);
 		$insertEntries[] = "('ip_ban', {$ip_parts[0]['low']}, {$ip_parts[0]['high']}, {$ip_parts[1]['low']}, {$ip_parts[1]['high']}, {$ip_parts[2]['low']}, {$ip_parts[2]['high']}, {$ip_parts[3]['low']}, {$ip_parts[3]['high']}, '', '', 0, " . time() . ", NULL, 'full_ban', '', 'Imported from YaBB SE')";
 	}
-	mysql_free_result($request);
+	smf_mysql_free_result($request);
 
 	upgrade_query("
 		CREATE TABLE IF NOT EXISTS {$db_prefix}banned2 (
@@ -1605,8 +1605,8 @@ CREATE TABLE IF NOT EXISTS {$db_prefix}calendar_holidays (
 $result = upgrade_query("
 	SELECT COUNT(*)
 	FROM {$db_prefix}calendar_holidays");
-list ($size) = mysql_fetch_row($result);
-mysql_free_result($result);
+list ($size) = smf_mysql_fetch_row($result);
+smf_mysql_free_result($result);
 
 if (empty($size))
 {
@@ -1676,13 +1676,13 @@ FROM {$db_prefix}polls;
 
 ---# Converting data to "log_polls"...
 ---{
-$query = mysql_query("
+$query = upgrade_query("
 	SELECT ID_POLL, votedMemberIDs
 	FROM {$db_prefix}polls");
 if ($query !== false)
 {
 	$setStringLog = '';
-	while ($row = mysql_fetch_assoc($query))
+	while ($row = smf_mysql_fetch_assoc($query))
 	{
 		$members = explode(',', $row['votedMemberIDs']);
 		foreach ($members as $member)
@@ -1731,7 +1731,7 @@ $result = upgrade_query("
 		AND p.ID_POLL = t.ID_POLL
 		AND p.ID_MEMBER = 0
 		AND t.ID_MEMBER_STARTED != 0");
-while ($row = mysql_fetch_assoc($result))
+while ($row = smf_mysql_fetch_assoc($result))
 {
 	upgrade_query("
 		UPDATE {$db_prefix}polls
@@ -1739,7 +1739,7 @@ while ($row = mysql_fetch_assoc($result))
 		WHERE ID_POLL = $row[ID_POLL]
 		LIMIT 1");
 }
-mysql_free_result($result);
+smf_mysql_free_result($result);
 ---}
 ---#
 
@@ -1769,9 +1769,9 @@ $request = upgrade_query("
 	SELECT ID_THEME, IF(value = '2', 5, value) AS value
 	FROM {$db_prefix}themes
 	WHERE variable = 'display_recent_bar'");
-while ($row = mysql_fetch_assoc($request))
+while ($row = smf_mysql_fetch_assoc($request))
 	$insertRows .= "($row[ID_THEME], 'number_recent_posts', '$row[value]'),";
-mysql_free_result($request);
+smf_mysql_free_result($request);
 if (!empty($insertRows))
 {
 	$insertRows = substr($insertRows, 0, -1);

--- a/other/upgrade_1-1.sql
+++ b/other/upgrade_1-1.sql
@@ -10,9 +10,9 @@ $request = upgrade_query("
 	SHOW KEYS
 	FROM {$db_prefix}messages");
 $found = false;
-while ($row = mysql_fetch_assoc($request))
+while ($row = smf_mysql_fetch_assoc($request))
 	$found |= $row['Key_name'] == 'ID_BOARD' && $row['Column_name'] == 'ID_MSG';
-mysql_free_result($request);
+smf_mysql_free_result($request);
 
 if (!$found)
 	upgrade_query("
@@ -386,7 +386,7 @@ if ((!isset($modSettings['smfVersion']) || $modSettings['smfVersion'] <= '1.1 RC
 		WHERE variable = 'theme_dir'
 			AND value LIKE '%babylon'");
 	// Only do the upgrade if it doesn't find the theme already.
-	if (mysql_num_rows($theme_request) == 0)
+	if (smf_mysql_num_rows($theme_request) == 0)
 	{
 		// Try to get some settings from the current default theme.
 		$request = upgrade_query("
@@ -402,9 +402,9 @@ if ((!isset($modSettings['smfVersion']) || $modSettings['smfVersion'] <= '1.1 RC
 				AND t3.ID_MEMBER = 0
 				AND t3.variable = 'images_url'
 			LIMIT 1");
-		if (mysql_num_rows($request) != 0)
+		if (smf_mysql_num_rows($request) != 0)
 		{
-			$core = mysql_fetch_assoc($request);
+			$core = smf_mysql_fetch_assoc($request);
 
 			if (substr_count($core['theme_dir'], 'default') === 1)
 				$babylon['theme_dir'] = strtr($core['theme_dir'], array('default' => 'babylon'));
@@ -413,7 +413,7 @@ if ((!isset($modSettings['smfVersion']) || $modSettings['smfVersion'] <= '1.1 RC
 			if (substr_count($core['images_url'], 'default') === 1)
 				$babylon['images_url'] = strtr($core['images_url'], array('default' => 'babylon'));
 		}
-		mysql_free_result($request);
+		smf_mysql_free_result($request);
 
 		if (!isset($babylon['theme_dir']))
 			$babylon['theme_dir'] = addslashes($GLOBALS['boarddir']) . '/Themes/babylon';
@@ -426,8 +426,8 @@ if ((!isset($modSettings['smfVersion']) || $modSettings['smfVersion'] <= '1.1 RC
 		$request = upgrade_query("
 			SELECT MAX(ID_THEME) + 1
 			FROM {$db_prefix}themes");
-		list ($ID_OLD_THEME) = mysql_fetch_row($request);
-		mysql_free_result($request);
+		list ($ID_OLD_THEME) = smf_mysql_fetch_row($request);
+		smf_mysql_free_result($request);
 
 		// Insert the babylon theme into the tables.
 		upgrade_query("
@@ -454,7 +454,7 @@ if ((!isset($modSettings['smfVersion']) || $modSettings['smfVersion'] <= '1.1 RC
 				SELECT DISTINCT ID_THEME
 				FROM {$db_prefix}themes");
 			$themes = array();
-			while ($row = mysql_fetch_assoc($request))
+			while ($row = smf_mysql_fetch_assoc($request))
 				$themes[] = $row['ID_THEME'];
 			$modSettings['knownThemes'] = implode(',', $themes);
 			upgrade_query("
@@ -496,9 +496,9 @@ if ((!isset($modSettings['smfVersion']) || $modSettings['smfVersion'] <= '1.1 RC
 				SELECT DISTINCT ID_THEME
 				FROM {$db_prefix}themes
 				WHERE variable = 'base_theme_dir'");
-			while ($row = mysql_fetch_assoc($request))
+			while ($row = smf_mysql_fetch_assoc($request))
 				$babylonBasedThemes = array_diff($babylonBasedThemes, array($row['ID_THEME']));
-			mysql_free_result($request);
+			smf_mysql_free_result($request);
 
 			// Only base themes if there are templates that need a fall-back.
 			$insertRows = array();
@@ -508,7 +508,7 @@ if ((!isset($modSettings['smfVersion']) || $modSettings['smfVersion'] <= '1.1 RC
 				WHERE ID_THEME IN (" . implode(', ', $babylonBasedThemes) . ")
 					AND ID_MEMBER = 0
 					AND variable = 'theme_dir'");
-			while ($row = mysql_fetch_assoc($request))
+			while ($row = smf_mysql_fetch_assoc($request))
 			{
 				if (!file_exists($row['theme_dir'] . '/BoardIndex.template.php') || !file_exists($row['theme_dir'] . '/Display.template.php') || !file_exists($row['theme_dir'] . '/index.template.php') || !file_exists($row['theme_dir'] . '/MessageIndex.template.php') || !file_exists($row['theme_dir'] . '/Settings.template.php'))
 				{
@@ -516,7 +516,7 @@ if ((!isset($modSettings['smfVersion']) || $modSettings['smfVersion'] <= '1.1 RC
 					$insertRows[] = "(0, $row[ID_THEME], 'base_theme_url', '" . addslashes($babylon['theme_url']) . "')";
 				}
 			}
-			mysql_free_result($request);
+			smf_mysql_free_result($request);
 
 			if (!empty($insertRows))
 				upgrade_query("
@@ -527,7 +527,7 @@ if ((!isset($modSettings['smfVersion']) || $modSettings['smfVersion'] <= '1.1 RC
 						', $insertRows));
 		}
 	}
-	mysql_free_result($theme_request);
+	smf_mysql_free_result($theme_request);
 
 	// This ain't running twice either - not with the risk of log_tables timing us all out!
 	upgrade_query("
@@ -613,8 +613,8 @@ $result = upgrade_query("
 	FROM {$db_prefix}calendar_holidays
 	WHERE YEAR(eventDate) > 2010
 	LIMIT 1");
-$do_it = mysql_num_rows($result) == 0;
-mysql_free_result($result);
+$do_it = smf_mysql_num_rows($result) == 0;
+smf_mysql_free_result($result);
 
 if ($do_it)
 {
@@ -792,14 +792,14 @@ WHERE YEAR(birthdate) = 0;
 
 ---# Checking for an old table...
 ---{
-$request = mysql_query("
+$request = upgrade_query("
 	SHOW COLUMNS
 	FROM {$db_prefix}message_icons");
 $test = false;
-while ($request && $row = mysql_fetch_row($request))
+while ($request && $row = smf_mysql_fetch_row($request))
 	$test |= $row[0] == 'Name';
 if ($request)
-	mysql_free_result($request);
+	smf_mysql_free_result($request);
 
 if ($test)
 {
@@ -949,8 +949,8 @@ CHANGE COLUMN lastLogin lastLogin int(10) unsigned NOT NULL default 0;
 $request = upgrade_query("
 	SELECT COUNT(*)
 	FROM {$db_prefix}members");
-list ($totalMembers) = mysql_fetch_row($request);
-mysql_free_result($request);
+list ($totalMembers) = smf_mysql_fetch_row($request);
+smf_mysql_free_result($request);
 
 $_GET['m'] = isset($_GET['m']) ? (int) $_GET['m'] : 0;
 
@@ -967,7 +967,7 @@ while ($_GET['m'] < $totalMembers)
 		GROUP BY mem.ID_MEMBER
 		HAVING instantMessages_real != instantMessages
 		LIMIT 256");
-	while ($row = mysql_fetch_assoc($mrequest))
+	while ($row = smf_mysql_fetch_assoc($mrequest))
 	{
 		upgrade_query("
 			UPDATE {$db_prefix}members
@@ -987,8 +987,8 @@ unset($_GET['m']);
 $request = upgrade_query("
 	SELECT COUNT(*)
 	FROM {$db_prefix}members");
-list ($totalMembers) = mysql_fetch_row($request);
-mysql_free_result($request);
+list ($totalMembers) = smf_mysql_fetch_row($request);
+smf_mysql_free_result($request);
 
 $_GET['m'] = isset($_GET['m']) ? (int) $_GET['m'] : 0;
 
@@ -1005,7 +1005,7 @@ while ($_GET['m'] < $totalMembers)
 		GROUP BY mem.ID_MEMBER
 		HAVING unreadMessages_real != unreadMessages
 		LIMIT 256");
-	while ($row = mysql_fetch_assoc($mrequest))
+	while ($row = smf_mysql_fetch_assoc($mrequest))
 	{
 		upgrade_query("
 			UPDATE {$db_prefix}members
@@ -1078,17 +1078,17 @@ WHERE variable IN ('avatar_allow_external_url', 'avatar_check_size', 'avatar_all
 ---# Registering thumbs...
 ---{
 // Checkout the current structure of the attachment table.
-$request = mysql_query("
+$request = upgrade_query("
 	SHOW COLUMNS
 	FROM {$db_prefix}attachments");
 $has_customAvatarDir_column = false;
 $has_attachmentType_column = false;
-while ($row = mysql_fetch_assoc($request))
+while ($row = smf_mysql_fetch_assoc($request))
 {
 	$has_customAvatarDir_column |= $row['Field'] == 'customAvatarDir';
 	$has_attachmentType_column |= $row['Field'] == 'attachmentType';
 }
-mysql_free_result($request);
+smf_mysql_free_result($request);
 
 // Post SMF 1.1 Beta 1.
 if ($has_customAvatarDir_column)
@@ -1116,7 +1116,7 @@ if (!$has_attachmentType_column)
 	$filenames = array();
 	$encrypted_filenames = array();
 	$ID_MSG = array();
-	while ($row = mysql_fetch_assoc($request))
+	while ($row = smf_mysql_fetch_assoc($request))
 	{
 		$clean_name = strtr($row['filename'], 'ŠŽšžŸÀÁÂÃÄÅÇÈÉÊËÌÍÎÏÑÒÓÔÕÖØÙÚÛÜÝàáâãäåçèéêëìíîïñòóôõöøùúûüýÿ', 'SZszYAAAAAACEEEEIIIINOOOOOOUUUUYaaaaaaceeeeiiiinoooooouuuuyy');
 		$clean_name = strtr($clean_name, array('Þ' => 'TH', 'þ' => 'th', 'Ð' => 'DH', 'ð' => 'dh', 'ß' => 'ss', 'Œ' => 'OE', 'œ' => 'oe', 'Æ' => 'AE', 'æ' => 'ae', 'µ' => 'u'));
@@ -1135,7 +1135,7 @@ if (!$has_attachmentType_column)
 		$encrypted_filenames[$row['ID_ATTACH']] = $filename;
 		$ID_MSG[$row['ID_ATTACH']] = $row['ID_MSG'];
 	}
-	mysql_free_result($request);
+	smf_mysql_free_result($request);
 
 	// Let's loop through the attachments
 	if (is_dir($modSettings['attachmentUploadDir']) && $dir = @opendir($modSettings['attachmentUploadDir']))
@@ -1173,7 +1173,7 @@ if (!$has_attachmentType_column)
 					INSERT INTO {$db_prefix}attachments
 						(ID_MSG, attachmentType, filename, size, width, height)
 					VALUES (" . $ID_MSG[$attach_id] . ", 3, '$thumb_filename', " . (int) $thumb_size . ', ' . (int) $thumb_width . ', ' . (int) $thumb_height . ')');
-				$thumb_attach_id = mysql_insert_id();
+				$thumb_attach_id = smf_mysql_insert_id();
 
 				// Determine the dimensions of the original attachment.
 				$attach_width = $attach_height = 0;
@@ -1210,7 +1210,7 @@ $request = upgrade_query("
 		AND (RIGHT(filename, 4) IN ('.gif', '.jpg', '.png', '.bmp') OR RIGHT(filename, 5) = '.jpeg')
 		AND width = 0
 		AND height = 0");
-while ($row = mysql_fetch_assoc($request))
+while ($row = smf_mysql_fetch_assoc($request))
 {
 	if ($row['attachmentType'] == 1)
 		$filename = $modSettings['custom_avatar_dir'] . '/' . $row['filename'];
@@ -1242,7 +1242,7 @@ while ($row = mysql_fetch_assoc($request))
 			WHERE ID_ATTACH = $row[ID_ATTACH]
 			LIMIT 1");
 }
-mysql_free_result($request);
+smf_mysql_free_result($request);
 ---}
 ---#
 
@@ -1253,11 +1253,11 @@ mysql_free_result($request);
 ---# Splitting ban table...
 ---{
 // Checkout the current structure of the attachment table.
-$request = mysql_query("
+$request = upgrade_query("
 	SHOW TABLES
 	LIKE '{$db_prefix}banned'");
-$upgradeBanTable = mysql_num_rows($request) == 1;
-mysql_free_result($request);
+$upgradeBanTable = smf_mysql_num_rows($request) == 1;
+smf_mysql_free_result($request);
 
 if ($upgradeBanTable)
 {
@@ -1318,7 +1318,7 @@ if ($upgradeBanTable)
 		ALTER TABLE {$db_prefix}ban_groups
 		ADD COLUMN name varchar(20) NOT NULL default '' AFTER id_ban_group");
 
-	$request = mysql_query("
+	$request = upgrade_query("
 		SELECT id_ban_group, restriction_type
 		FROM {$db_prefix}ban_groups
 		ORDER BY ban_time ASC");
@@ -1329,16 +1329,16 @@ if ($upgradeBanTable)
 	);
 	if ($request != false)
 	{
-		while ($row = mysql_fetch_assoc($request))
+		while ($row = smf_mysql_fetch_assoc($request))
 			upgrade_query("
 				UPDATE {$db_prefix}ban_groups
 				SET name = '" . $row['restriction_type'] . '_' . str_pad($ban_names[$row['restriction_type']]++, 3, '0', STR_PAD_LEFT) . "'
 				WHERE id_ban_group = $row[id_ban_group]");
-		mysql_free_result($request);
+		smf_mysql_free_result($request);
 	}
 
 	// Move each restriction type to its own column.
-	mysql_query("
+	upgrade_query("
 		UPDATE {$db_prefix}ban_groups
 		SET
 			cannot_access = IF(restriction_type = 'full_ban', 1, 0),
@@ -1368,9 +1368,9 @@ if ($upgradeBanTable)
 			AND (mem.ID_MEMBER = bi.ID_MEMBER OR mem.emailAddress LIKE bi.email_address)
 			AND mem.is_activated < 10");
 	$updates = array();
-	while ($row = mysql_fetch_assoc($request))
+	while ($row = smf_mysql_fetch_assoc($request))
 		$updates[$row['new_value']][] = $row['ID_MEMBER'];
-	mysql_free_result($request);
+	smf_mysql_free_result($request);
 
 	// Find members that are wrongfully marked as banned.
 	$request = upgrade_query("
@@ -1380,9 +1380,9 @@ if ($upgradeBanTable)
 			LEFT JOIN {$db_prefix}ban_groups AS bg ON (bg.id_ban_group = bi.id_ban_group AND bg.cannot_access = 1 AND (bg.expire_time IS NULL OR bg.expire_time > " . time() . "))
 		WHERE (bi.id_ban IS NULL OR bg.id_ban_group IS NULL)
 			AND mem.is_activated >= 10");
-	while ($row = mysql_fetch_assoc($request))
+	while ($row = smf_mysql_fetch_assoc($request))
 		$updates[$row['new_value']][] = $row['ID_MEMBER'];
-	mysql_free_result($request);
+	smf_mysql_free_result($request);
 
 	if (!empty($updates))
 		foreach ($updates as $newStatus => $members)
@@ -1438,8 +1438,8 @@ if (!isset($modSettings['permission_enable_deny']))
 		FROM {$db_prefix}permissions
 		WHERE addDeny = 0
 		LIMIT 1");
-	$disable_deny_permissions = mysql_num_rows($request) == 0;
-	mysql_free_result($request);
+	$disable_deny_permissions = smf_mysql_num_rows($request) == 0;
+	smf_mysql_free_result($request);
 
 	// Still wanna disable deny permissions? Check board permissions.
 	if ($disable_deny_permissions)
@@ -1449,8 +1449,8 @@ if (!isset($modSettings['permission_enable_deny']))
 			FROM {$db_prefix}board_permissions
 			WHERE addDeny = 0
 			LIMIT 1");
-		$disable_deny_permissions &= mysql_num_rows($request) == 0;
-		mysql_free_result($request);
+		$disable_deny_permissions &= smf_mysql_num_rows($request) == 0;
+		smf_mysql_free_result($request);
 	}
 
 	$request = upgrade_query("
@@ -1473,8 +1473,8 @@ if (!isset($modSettings['permission_enable_postgroups']))
 		WHERE mg.ID_GROUP = p.ID_GROUP
 			AND mg.minPosts != -1
 		LIMIT 1");
-	$disable_postgroup_permissions &= mysql_num_rows($request) == 0;
-	mysql_free_result($request);
+	$disable_postgroup_permissions &= smf_mysql_num_rows($request) == 0;
+	smf_mysql_free_result($request);
 
 	// Still wanna disable postgroup permissions? Check board permissions.
 	if ($disable_postgroup_permissions)
@@ -1485,8 +1485,8 @@ if (!isset($modSettings['permission_enable_postgroups']))
 			WHERE mg.ID_GROUP = bp.ID_GROUP
 				AND mg.minPosts != -1
 			LIMIT 1");
-		$disable_postgroup_permissions &= mysql_num_rows($request) == 0;
-		mysql_free_result($request);
+		$disable_postgroup_permissions &= smf_mysql_num_rows($request) == 0;
+		smf_mysql_free_result($request);
 	}
 
 	$request = upgrade_query("
@@ -1510,8 +1510,8 @@ if (!isset($modSettings['permission_enable_by_board']))
 		FROM {$db_prefix}boards
 		WHERE permission_mode = 1
 		LIMIT 1");
-	$enable_by_board = mysql_num_rows($request) == 1 ? '1' : '0';
-	mysql_free_result($request);
+	$enable_by_board = smf_mysql_num_rows($request) == 1 ? '1' : '0';
+	smf_mysql_free_result($request);
 
 	$request = upgrade_query("
 		INSERT INTO {$db_prefix}settings
@@ -1587,9 +1587,9 @@ $request = upgrade_query("
 	SHOW KEYS
 	FROM {$db_prefix}messages");
 $found = false;
-while ($row = mysql_fetch_assoc($request))
+while ($row = smf_mysql_fetch_assoc($request))
 	$found |= $row['Key_name'] == 'subject' && $row['Column_name'] == 'subject';
-mysql_free_result($request);
+smf_mysql_free_result($request);
 if ($found)
 {
 	$request = upgrade_query("
@@ -1606,15 +1606,15 @@ if ($found)
 $request = upgrade_query("
 	SELECT COUNT(*)
 	FROM {$db_prefix}log_search_subjects");
-list ($numIndexedWords) = mysql_fetch_row($request);
-mysql_free_result($request);
+list ($numIndexedWords) = smf_mysql_fetch_row($request);
+smf_mysql_free_result($request);
 if ($numIndexedWords == 0 || isset($_GET['lt']))
 {
 	$request = upgrade_query("
 		SELECT COUNT(*)
 		FROM {$db_prefix}topics");
-	list ($maxTopics) = mysql_fetch_row($request);
-	mysql_free_result($request);
+	list ($maxTopics) = smf_mysql_fetch_row($request);
+	smf_mysql_free_result($request);
 
 	$_GET['lt'] = isset($_GET['lt']) ? (int) $_GET['lt'] : 0;
 	$step_progress['name'] = 'Indexing Topic Subjects';
@@ -1629,12 +1629,12 @@ if ($numIndexedWords == 0 || isset($_GET['lt']))
 			WHERE m.ID_MSG = t.ID_FIRST_MSG
 			LIMIT $_GET[lt], 250");
 		$inserts = array();
-		while ($row = mysql_fetch_assoc($request))
+		while ($row = smf_mysql_fetch_assoc($request))
 		{
 			foreach (text2words($row['subject']) as $word)
-				$inserts[] = "'" . mysql_real_escape_string($word) . "', $row[ID_TOPIC]";
+				$inserts[] = "'" . smf_mysql_real_escape_string($word) . "', $row[ID_TOPIC]";
 		}
-		mysql_free_result($request);
+		smf_mysql_free_result($request);
 
 		if (!empty($inserts))
 			upgrade_query("
@@ -1694,10 +1694,10 @@ $request = upgrade_query("
 	SHOW COLUMNS
 	FROM {$db_prefix}log_topics");
 $upgradeLogTable = false;
-while ($request && $row = mysql_fetch_row($request))
+while ($request && $row = smf_mysql_fetch_row($request))
 	$upgradeLogTable |= $row[0] == 'logTime';
 if ($request !== false)
-	mysql_free_result($request);
+	smf_mysql_free_result($request);
 
 if ($upgradeLogTable)
 {
@@ -1762,10 +1762,10 @@ $request = upgrade_query("
 	SHOW COLUMNS
 	FROM {$db_prefix}log_topics");
 $upgradeLogTable = false;
-while ($request && $row = mysql_fetch_row($request))
+while ($request && $row = smf_mysql_fetch_row($request))
 	$upgradeLogTable |= $row[0] == 'logTime';
 if ($request !== false)
-	mysql_free_result($request);
+	smf_mysql_free_result($request);
 
 if ($upgradeLogTable)
 {
@@ -1876,18 +1876,18 @@ $request = upgrade_query("
 	SHOW COLUMNS
 	FROM {$db_prefix}log_topics");
 $upgradeLogTable = false;
-while ($request && $row = mysql_fetch_row($request))
+while ($request && $row = smf_mysql_fetch_row($request))
 	$upgradeLogTable |= $row[0] == 'logTime';
 if ($request !== false)
-	mysql_free_result($request);
+	smf_mysql_free_result($request);
 
 if ($upgradeLogTable)
 {
 	$request = upgrade_query("
 		SELECT MAX(ID_MSG)
 		FROM {$db_prefix}messages");
-	list($maxMsg) = mysql_fetch_row($request);
-	mysql_free_result($request);
+	list($maxMsg) = smf_mysql_fetch_row($request);
+	smf_mysql_free_result($request);
 
 	if (empty($maxMsg))
 		$maxMsg = 0;
@@ -1910,8 +1910,8 @@ if ($upgradeLogTable)
 			SELECT posterTime
 			FROM {$db_prefix}messages
 			WHERE ID_MSG = $maxMsg");
-		list($maxPosterTime) = mysql_fetch_row($request);
-		mysql_free_result($request);
+		list($maxPosterTime) = smf_mysql_fetch_row($request);
+		smf_mysql_free_result($request);
 
 		if (empty($maxPosterTime))
 			$maxPosterTime = 0;
@@ -1943,8 +1943,8 @@ if ($upgradeLogTable)
 			SELECT MAX(posterTime) + 1
 			FROM {$db_prefix}messages
 			WHERE ID_MSG < $_GET[m]");
-		list($lower_limit) = mysql_fetch_row($request);
-		mysql_free_result($request);
+		list($lower_limit) = smf_mysql_fetch_row($request);
+		smf_mysql_free_result($request);
 
 		if (empty($lower_limit))
 			$lower_limit = 1;
@@ -1964,7 +1964,7 @@ if ($upgradeLogTable)
 			GROUP BY posterTime
 			ORDER BY posterTime
 			LIMIT 300");
-		while ($row = mysql_fetch_assoc($request))
+		while ($row = smf_mysql_fetch_assoc($request))
 		{
 			if ($condition === '')
 				$condition = "IF(logTime BETWEEN $lower_limit AND $row[posterTime], $row[ID_MSG], %else%)";
@@ -1973,7 +1973,7 @@ if ($upgradeLogTable)
 
 			$lower_limit = $row['posterTime'] + 1;
 		}
-		mysql_free_result($request);
+		smf_mysql_free_result($request);
 
 		if ($condition !== '')
 		{
@@ -2017,18 +2017,18 @@ $request = upgrade_query("
 	SHOW COLUMNS
 	FROM {$db_prefix}boards");
 $upgradeBoardsTable = false;
-while ($request && $row = mysql_fetch_row($request))
+while ($request && $row = smf_mysql_fetch_row($request))
 	$upgradeBoardsTable |= $row[0] == 'lastUpdated';
 if ($request !== false)
-	mysql_free_result($request);
+	smf_mysql_free_result($request);
 
 if ($upgradeBoardsTable)
 {
 	$request = upgrade_query("
 		SELECT MAX(ID_BOARD)
 		FROM {$db_prefix}boards");
-	list ($maxBoard) = mysql_fetch_row($request);
-	mysql_free_result($request);
+	list ($maxBoard) = smf_mysql_fetch_row($request);
+	smf_mysql_free_result($request);
 
 	$_GET['bdi'] = isset($_GET['bdi']) ? (int) $_GET['bdi'] : 0;
 	$step_progress['name'] = 'Updating Last Board ID';
@@ -2039,7 +2039,7 @@ if ($upgradeBoardsTable)
 	$request = upgrade_query("
 		SELECT ID_BOARD, lastUpdated
 		FROM {$db_prefix}boards");
-	while ($row = mysql_fetch_assoc($request))
+	while ($row = smf_mysql_fetch_assoc($request))
 	{
 		// Done this?
 		if ($row['ID_BOARD'] < $_GET['bdi'])
@@ -2055,7 +2055,7 @@ if ($upgradeBoardsTable)
 				SELECT MIN(ID_MSG)
 				FROM {$db_prefix}messages
 				WHERE posterTime >= $row[lastUpdated]");
-			list ($ID_MSG) = mysql_fetch_row($request2);
+			list ($ID_MSG) = smf_mysql_fetch_row($request2);
 
 			if (empty($ID_MSG))
 				$ID_MSG = 0;
@@ -2081,10 +2081,10 @@ $request = upgrade_query("
 	SHOW COLUMNS
 	FROM {$db_prefix}log_topics");
 $upgradeLogTable = false;
-while ($request && $row = mysql_fetch_row($request))
+while ($request && $row = smf_mysql_fetch_row($request))
 	$upgradeLogTable |= $row[0] == 'logTime';
 if ($request !== false)
-	mysql_free_result($request);
+	smf_mysql_free_result($request);
 
 if ($upgradeLogTable)
 {
@@ -2195,8 +2195,8 @@ $request = upgrade_query("
 	SHOW COLUMNS
 	FROM {$db_prefix}messages
 	LIKE 'body'");
-$body_row = mysql_fetch_assoc($request);
-mysql_free_result($request);
+$body_row = smf_mysql_fetch_assoc($request);
+smf_mysql_free_result($request);
 
 $body_type = $body_row['Type'];
 

--- a/other/upgrade_2-0_mysql.sql
+++ b/other/upgrade_2-0_mysql.sql
@@ -368,12 +368,12 @@ foreach ($nameChanges as $table_name => $table)
 	$request = upgrade_query("
 		SHOW TABLES
 		LIKE '{$db_prefix}$table_name'");
-	if (mysql_num_rows($request) == 0)
+	if (smf_mysql_num_rows($request) == 0)
 	{
-		mysql_free_result($request);
+		smf_mysql_free_result($request);
 		continue;
 	}
-	mysql_free_result($request);
+	smf_mysql_free_result($request);
 
 	// Check each column!
 	$actualChanges = array();
@@ -539,7 +539,7 @@ $request = upgrade_query("
 	SELECT value
 	FROM {$db_prefix}themes
 	WHERE variable = 'show_sp1_info'");
-if (mysql_num_rows($request) != 0)
+if (smf_mysql_num_rows($request) != 0)
 {
 	upgrade_query("
 		DELETE FROM {$db_prefix}themes
@@ -587,9 +587,9 @@ $request = upgrade_query("
 	SELECT value
 	FROM {$db_prefix}settings
 	WHERE variable = 'disable_visual_verification'");
-if (mysql_num_rows($request) != 0)
+if (smf_mysql_num_rows($request) != 0)
 {
-	list ($oldValue) = mysql_fetch_row($request);
+	list ($oldValue) = smf_mysql_fetch_row($request);
 	if ($oldValue != 0)
 	{
 		// We have changed the medium setting from SMF 1.1.2.
@@ -614,7 +614,7 @@ $request = upgrade_query("
 	SELECT value
 	FROM {$db_prefix}settings
 	WHERE variable = 'reg_verification'");
-if (mysql_num_rows($request) == 0)
+if (smf_mysql_num_rows($request) == 0)
 {
 	// Upgrade visual verification again!
 	if (!empty($modSettings['visual_verification_type']))
@@ -797,11 +797,11 @@ $request = upgrade_query("
 	WHERE variable = 'theme_layers'
 		OR variable = 'theme_dir'");
 $themeLayerChanges = array();
-while ($row = mysql_fetch_assoc($request))
+while ($row = smf_mysql_fetch_assoc($request))
 {
 	$themeLayerChanges[$row['id_theme']][$row['variable']] = $row['value'];
 }
-mysql_free_result($request);
+smf_mysql_free_result($request);
 
 foreach ($themeLayerChanges as $id_theme => $data)
 {
@@ -896,7 +896,7 @@ $request = upgrade_query("
 		AND active = 1
 		AND private != 2");
 $fields = array();
-while ($row = mysql_fetch_assoc($request))
+while ($row = smf_mysql_fetch_assoc($request))
 {
 	$fields[] = array(
 		'c' => strtr($row['col_name'], array('|' => '', ';' => '')),
@@ -904,11 +904,11 @@ while ($row = mysql_fetch_assoc($request))
 		'b' => ($row['bbc'] ? '1' : '0')
 	);
 }
-mysql_free_result($request);
+smf_mysql_free_result($request);
 
 upgrade_query("
 	UPDATE {$db_prefix}settings
-	SET value = '" . mysql_real_escape_string(serialize($fields)) . "'
+	SET value = '" . smf_mysql_real_escape_string(serialize($fields)) . "'
 	WHERE variable = 'displayFields'");
 }
 ---}
@@ -1079,11 +1079,11 @@ if (@$modSettings['smfVersion'] < '2.0')
 		FROM {$db_prefix}permissions
 		WHERE permission = 'calendar_edit_any'");
 	$inserts = array();
-	while ($row = mysql_fetch_assoc($request))
+	while ($row = smf_mysql_fetch_assoc($request))
 	{
 		$inserts[] = "($row[id_group], 'access_mod_center', $row[add_deny])";
 	}
-	mysql_free_result($request);
+	smf_mysql_free_result($request);
 
 	if (!empty($inserts))
 		upgrade_query("
@@ -1407,11 +1407,11 @@ if (@$modSettings['smfVersion'] < '2.0')
 		FROM {$db_prefix}board_permissions
 		WHERE permission = 'modify_any'");
 	$inserts = array();
-	while ($row = mysql_fetch_assoc($request))
+	while ($row = smf_mysql_fetch_assoc($request))
 	{
 		$inserts[] = "($row[id_group], $row[id_board], 'approve_posts', $row[add_deny])";
 	}
-	mysql_free_result($request);
+	smf_mysql_free_result($request);
 
 	if (!empty($inserts))
 		upgrade_query("
@@ -1440,8 +1440,8 @@ ADD line mediumint(8) unsigned NOT NULL default '0';
 $request = upgrade_query("
 	SELECT COUNT(*)
 	FROM {$db_prefix}log_errors");
-list($totalActions) = mysql_fetch_row($request);
-mysql_free_result($request);
+list($totalActions) = smf_mysql_fetch_row($request);
+smf_mysql_free_result($request);
 
 $_GET['m'] = !empty($_GET['m']) ? (int) $_GET['m'] : '0';
 $step_progress['total'] = $totalActions;
@@ -1455,7 +1455,7 @@ while ($_GET['m'] < $totalActions)
 		SELECT id_error, message, file, line
 		FROM {$db_prefix}log_errors
 		LIMIT $_GET[m], 500");
-	while($row = mysql_fetch_assoc($request))
+	while($row = smf_mysql_fetch_assoc($request))
 	{
 		preg_match('~<br />(%1\$s: )?([\w\. \\\\/\-_:]+)<br />(%2\$s: )?([\d]+)~', $row['message'], $matches);
 		if (!empty($matches[2]) && !empty($matches[4]) && empty($row['file']) && empty($row['line']))
@@ -1630,9 +1630,9 @@ $request = upgrade_query("
 	FROM {$db_prefix}permission_profiles
 	WHERE profile_name = ''");
 $profiles = array();
-while ($row = mysql_fetch_assoc($request))
+while ($row = smf_mysql_fetch_assoc($request))
 	$profiles[] = $row['id_profile'];
-mysql_free_result($request);
+smf_mysql_free_result($request);
 
 if (!empty($profiles))
 {
@@ -1641,20 +1641,20 @@ if (!empty($profiles))
 		FROM {$db_prefix}boards
 		WHERE id_profile IN (" . implode(',', $profiles) . ")");
 	$done_ids = array();
-	while ($row = mysql_fetch_assoc($request))
+	while ($row = smf_mysql_fetch_assoc($request))
 	{
 		if (isset($done_ids[$row['id_profile']]))
 			continue;
 		$done_ids[$row['id_profile']] = true;
 
-		$row['name'] = mysql_real_escape_string($row['name']);
+		$row['name'] = smf_mysql_real_escape_string($row['name']);
 
 		upgrade_query("
 			UPDATE {$db_prefix}permission_profiles
 			SET profile_name = '$row[name]'
 			WHERE id_profile = $row[id_profile]");
 	}
-	mysql_free_result($request);
+	smf_mysql_free_result($request);
 }
 ---}
 ---#
@@ -1666,8 +1666,8 @@ if (!empty($profiles))
 $request = upgrade_query("
 	SELECT COUNT(*)
 	FROM {$db_prefix}permission_profiles");
-list ($profileCount) = mysql_fetch_row($request);
-mysql_free_result($request);
+list ($profileCount) = smf_mysql_fetch_row($request);
+smf_mysql_free_result($request);
 
 if ($profileCount == 0)
 {
@@ -1698,16 +1698,16 @@ if ($profileCount == 0)
 		FROM {$db_prefix}board_permissions
 		WHERE id_profile = 0");
 	$all_perms = array();
-	while ($row = mysql_fetch_assoc($request))
+	while ($row = smf_mysql_fetch_assoc($request))
 		$all_perms[$row['id_board']][$row['id_group']][$row['permission']] = $row['add_deny'];
-	mysql_free_result($request);
+	smf_mysql_free_result($request);
 
 	// Now we have the profile profiles for this installation. We now need to go through each board and work out what the permission profile should be!
 	$request = upgrade_query("
 		SELECT id_board, name, permission_mode
 		FROM {$db_prefix}boards");
 	$board_updates = array();
-	while ($row = mysql_fetch_assoc($request))
+	while ($row = smf_mysql_fetch_assoc($request))
 	{
 		$row['name'] = addslashes($row['name']);
 
@@ -1720,7 +1720,7 @@ if ($profileCount == 0)
 					(profile_name)
 				VALUES
 					('$row[name]')");
-			$board_updates[mysql_insert_id()][] = $row['id_board'];
+			$board_updates[smf_mysql_insert_id()][] = $row['id_board'];
 		}
 		// Otherwise, dear god, this is an old school "simple" permission...
 		elseif ($row['permission_mode'] > 1 && $row['permission_mode'] < 5)
@@ -1731,7 +1731,7 @@ if ($profileCount == 0)
 		else
 			$board_updates[1][] = $row['id_board'];
 	}
-	mysql_free_result($request);
+	smf_mysql_free_result($request);
 
 	// Update the board tables.
 	foreach ($board_updates as $profile => $boards)
@@ -1810,7 +1810,7 @@ $request = upgrade_query("
 	WHERE id_group != 0
 		AND min_posts = -1");
 $inserts = array();
-while ($row = mysql_fetch_assoc($request))
+while ($row = smf_mysql_fetch_assoc($request))
 {
 	if ($row['id_group'] == 2 || $row['id_group'] == 3)
 	{
@@ -1831,7 +1831,7 @@ while ($row = mysql_fetch_assoc($request))
 			$inserts[] = "($row[id_group], 4, '$permission')";
 	}
 }
-mysql_free_result($request);
+smf_mysql_free_result($request);
 
 upgrade_query("
 	INSERT INTO {$db_prefix}board_permissions
@@ -1958,8 +1958,8 @@ ADD KEY id_log (id_log);
 $request = upgrade_query("
 	SELECT COUNT(*)
 	FROM {$db_prefix}log_actions");
-list($totalActions) = mysql_fetch_row($request);
-mysql_free_result($request);
+list($totalActions) = smf_mysql_fetch_row($request);
+smf_mysql_free_result($request);
 
 $_GET['m'] = !empty($_GET['m']) ? (int) $_GET['m'] : '0';
 $step_progress['total'] = $totalActions;
@@ -1974,7 +1974,7 @@ while ($_GET['m'] < $totalActions)
 		FROM {$db_prefix}log_actions
 		LIMIT $_GET[m], 500");
 
-	while ($row = mysql_fetch_assoc($mrequest))
+	while ($row = smf_mysql_fetch_assoc($mrequest))
 	{
 		if (!empty($row['id_board']) || !empty($row['id_topic']) || !empty($row['id_msg']))
 			continue;
@@ -2005,9 +2005,9 @@ while ($_GET['m'] < $totalActions)
 					FROM {$db_prefix}topics
 					WHERE id_topic=$topic_id
 					LIMIT 1");
-				if (mysql_num_rows($trequest))
-					list($board_id) = mysql_fetch_row($trequest);
-				mysql_free_result($trequest);
+				if (smf_mysql_num_rows($trequest))
+					list($board_id) = smf_mysql_fetch_row($trequest);
+				smf_mysql_free_result($trequest);
 			}
 		}
 		else
@@ -2024,9 +2024,9 @@ while ($_GET['m'] < $totalActions)
 					FROM {$db_prefix}messages
 					WHERE id_msg=$msg_id
 					LIMIT 1");
-				if (mysql_num_rows($trequest))
-					list($board_id, $topic_id) = mysql_fetch_row($trequest);
-				mysql_free_result($trequest);
+				if (smf_mysql_num_rows($trequest))
+					list($board_id, $topic_id) = smf_mysql_fetch_row($trequest);
+				smf_mysql_free_result($trequest);
 			}
 		}
 		else
@@ -2239,14 +2239,14 @@ $request = upgrade_query("
 	FROM {$db_prefix}subscriptions");
 $new_cols = array('repeatable', 'reminder', 'email_complete', 'allow_partial');
 $new_cols = array_flip($new_cols);
-while ($request && $row = mysql_fetch_row($request))
+while ($request && $row = smf_mysql_fetch_row($request))
 {
 	$row[0] = strtolower($row[0]);
 	if (isset($new_cols[$row[0]]))
 		unset($new_cols[$row[0]]);
 }
 if ($request)
-	mysql_free_result($request);
+	smf_mysql_free_result($request);
 
 if (isset($new_cols['repeatable']))
 	upgrade_query("
@@ -2270,13 +2270,13 @@ $request = upgrade_query("
 	FROM {$db_prefix}log_subscribed");
 $new_cols = array('reminder_sent', 'vendor_ref', 'payments_pending', 'pending_details');
 $new_cols = array_flip($new_cols);
-while ($request && $row = mysql_fetch_row($request))
+while ($request && $row = smf_mysql_fetch_row($request))
 {
 	if (isset($new_cols[$row[0]]))
 		unset($new_cols[$row[0]]);
 }
 if ($request)
-	mysql_free_result($request);
+	smf_mysql_free_result($request);
 
 if (isset($new_cols['reminder_sent']))
 	upgrade_query("
@@ -2561,25 +2561,25 @@ foreach ($nameChanges as $table_name => $table)
 	$request = upgrade_query("
 		SHOW TABLES
 		LIKE '{$db_prefix}$table_name'");
-	if (mysql_num_rows($request) == 0)
+	if (smf_mysql_num_rows($request) == 0)
 	{
-		mysql_free_result($request);
+		smf_mysql_free_result($request);
 		continue;
 	}
-	mysql_free_result($request);
+	smf_mysql_free_result($request);
 
 	// Converting is intensive, so make damn sure that we need to do it.
 	$request = upgrade_query("
 		SHOW FIELDS
 		FROM `{$db_prefix}$table_name`");
 	$tinytextColumns = array();
-	while($row = mysql_fetch_assoc($request))
+	while($row = smf_mysql_fetch_assoc($request))
 	{
 		// Tinytext detected so store column name.
 		if ($row['Type'] == 'tinytext')
 			$tinytextColumns[$row['Field']] = $row['Field'];
 	}
-	mysql_free_result($request);
+	smf_mysql_free_result($request);
 
 	// Check each column!
 	$actualChanges = array();
@@ -2774,7 +2774,7 @@ if ((!isset($modSettings['smfVersion']) || $modSettings['smfVersion'] <= '2.0 RC
 		WHERE variable = 'theme_dir'
 			AND value LIKE '%core'");
 	// Only do the upgrade if it doesn't find the theme already.
-	if (mysql_num_rows($theme_request) == 0)
+	if (smf_mysql_num_rows($theme_request) == 0)
 	{
 		// Try to get some settings from the current default theme.
 		$request = upgrade_query("
@@ -2790,9 +2790,9 @@ if ((!isset($modSettings['smfVersion']) || $modSettings['smfVersion'] <= '2.0 RC
 				AND t3.id_member = 0
 				AND t3.variable = 'images_url'
 			LIMIT 1");
-		if (mysql_num_rows($request) != 0)
+		if (smf_mysql_num_rows($request) != 0)
 		{
-			$curve = mysql_fetch_assoc($request);
+			$curve = smf_mysql_fetch_assoc($request);
 
 			if (substr_count($curve['theme_dir'], 'default') === 1)
 				$core['theme_dir'] = strtr($curve['theme_dir'], array('default' => 'core'));
@@ -2801,7 +2801,7 @@ if ((!isset($modSettings['smfVersion']) || $modSettings['smfVersion'] <= '2.0 RC
 			if (substr_count($curve['images_url'], 'default') === 1)
 				$core['images_url'] = strtr($curve['images_url'], array('default' => 'core'));
 		}
-		mysql_free_result($request);
+		smf_mysql_free_result($request);
 
 		if (!isset($core['theme_dir']))
 			$core['theme_dir'] = addslashes($GLOBALS['boarddir']) . '/Themes/core';
@@ -2814,8 +2814,8 @@ if ((!isset($modSettings['smfVersion']) || $modSettings['smfVersion'] <= '2.0 RC
 		$request = upgrade_query("
 			SELECT MAX(id_theme) + 1
 			FROM {$db_prefix}themes");
-		list ($id_core_theme) = mysql_fetch_row($request);
-		mysql_free_result($request);
+		list ($id_core_theme) = smf_mysql_fetch_row($request);
+		smf_mysql_free_result($request);
 
 		// Insert the core theme into the tables.
 		upgrade_query("
@@ -2841,7 +2841,7 @@ if ((!isset($modSettings['smfVersion']) || $modSettings['smfVersion'] <= '2.0 RC
 				SELECT DISTINCT id_theme
 				FROM {$db_prefix}themes");
 			$themes = array();
-			while ($row = mysql_fetch_assoc($request))
+			while ($row = smf_mysql_fetch_assoc($request))
 				$themes[] = $row['id_theme'];
 			$modSettings['knownThemes'] = implode(',', $themes);
 			upgrade_query("
@@ -2872,9 +2872,9 @@ if ((!isset($modSettings['smfVersion']) || $modSettings['smfVersion'] <= '2.0 RC
 				SELECT DISTINCT id_theme
 				FROM {$db_prefix}themes
 				WHERE variable = 'base_theme_dir'");
-			while ($row = mysql_fetch_assoc($request))
+			while ($row = smf_mysql_fetch_assoc($request))
 				$coreBasedThemes = array_diff($coreBasedThemes, array($row['id_theme']));
-			mysql_free_result($request);
+			smf_mysql_free_result($request);
 
 			// Only base themes if there are templates that need a fall-back.
 			$insertRows = array();
@@ -2884,7 +2884,7 @@ if ((!isset($modSettings['smfVersion']) || $modSettings['smfVersion'] <= '2.0 RC
 				WHERE id_theme IN (" . implode(', ', $coreBasedThemes) . ")
 					AND id_member = 0
 					AND variable = 'theme_dir'");
-			while ($row = mysql_fetch_assoc($request))
+			while ($row = smf_mysql_fetch_assoc($request))
 			{
 				if (!file_exists($row['theme_dir'] . '/BoardIndex.template.php') || !file_exists($row['theme_dir'] . '/Display.template.php') || !file_exists($row['theme_dir'] . '/index.template.php') || !file_exists($row['theme_dir'] . '/MessageIndex.template.php') || !file_exists($row['theme_dir'] . '/Settings.template.php'))
 				{
@@ -2892,7 +2892,7 @@ if ((!isset($modSettings['smfVersion']) || $modSettings['smfVersion'] <= '2.0 RC
 					$insertRows[] = "(0, $row[id_theme], 'base_theme_url', '" . addslashes($core['theme_url']) . "')";
 				}
 			}
-			mysql_free_result($request);
+			smf_mysql_free_result($request);
 
 			if (!empty($insertRows))
 				upgrade_query("
@@ -2903,7 +2903,7 @@ if ((!isset($modSettings['smfVersion']) || $modSettings['smfVersion'] <= '2.0 RC
 						', $insertRows));
 		}
 	}
-	mysql_free_result($theme_request);
+	smf_mysql_free_result($theme_request);
 
 	// This ain't running twice either.
 	upgrade_query("
@@ -2989,7 +2989,7 @@ $request = upgrade_query("
 );
 
 // Drop the existing index before we recreate it.
-while ($row = mysql_fetch_assoc($request))
+while ($row = smf_mysql_fetch_assoc($request))
 {
 	if ($row['Key_name'] === 'real_name' && $row['Sub_part'] == 30)
 	{
@@ -3001,7 +3001,7 @@ while ($row = mysql_fetch_assoc($request))
 	}
 }
 
-mysql_free_result($request);
+smf_mysql_free_result($request);
 ---}
 ---#
 
@@ -3019,7 +3019,7 @@ $request = upgrade_query("
 );
 
 // Drop the existing index before we recreate it.
-while ($row = mysql_fetch_assoc($request))
+while ($row = smf_mysql_fetch_assoc($request))
 {
 	if ($row['Key_name'] === 'member_name' && $row['Sub_part'] == 30)
 	{
@@ -3031,7 +3031,7 @@ while ($row = mysql_fetch_assoc($request))
 	}
 }
 
-mysql_free_result($request);
+smf_mysql_free_result($request);
 
 ---}
 ---#
@@ -3100,8 +3100,8 @@ $request = upgrade_query("
 	FROM {$db_prefix}membergroups
 	WHERE id_group = 1
 	LIMIT 1");
-list ($admin_group_type) = mysql_fetch_row($request);
-mysql_free_result($request);
+list ($admin_group_type) = smf_mysql_fetch_row($request);
+smf_mysql_free_result($request);
 
 // Not protected means we haven't updated yet!
 if ($admin_group_type != 1)

--- a/other/upgrade_2-1_mysql.sql
+++ b/other/upgrade_2-1_mysql.sql
@@ -252,12 +252,12 @@ if (@$modSettings['smfVersion'] < '2.1')
 		FROM {$db_prefix}board_permissions
 		WHERE permission = 'post_unapproved_topics'");
 	$inserts = array();
-	while ($row = mysql_fetch_assoc($request))
+	while ($row = smf_mysql_fetch_assoc($request))
 	{
 		$inserts[] = "($row[id_group], $row[id_board], 'post_draft', $row[add_deny])";
 		$inserts[] = "($row[id_group], $row[id_board], 'post_autosave_draft', $row[add_deny])";
 	}
-	mysql_free_result($request);
+	smf_mysql_free_result($request);
 
 	if (!empty($inserts))
 		upgrade_query("
@@ -272,12 +272,12 @@ if (@$modSettings['smfVersion'] < '2.1')
 		FROM {$db_prefix}permissions
 		WHERE permission = 'pm_send'");
 	$inserts = array();
-	while ($row = mysql_fetch_assoc($request))
+	while ($row = smf_mysql_fetch_assoc($request))
 	{
 		$inserts[] = "($row[id_group], 'pm_draft', $row[add_deny])";
 		$inserts[] = "($row[id_group], 'pm_autosave_draft', $row[add_deny])";
 	}
-	mysql_free_result($request);
+	smf_mysql_free_result($request);
 
 	if (!empty($inserts))
 		upgrade_query("


### PR DESCRIPTION
This commit adds a MySQLi abstraction layer wihout duplication all the code in DbExtra-mysql.php etc. This should be used as the default as the mysql_\* API is being deprecated as well as has problems with persistant connections on versions of PHP later then 4.0.

See: http://php.net/manual/en/mysqli.persistconns.php

> The problem with persistent connections is that they can be left in unpredictable states by clients. For example, a table lock might be activated before a client terminates unexpectedly. A new client process reusing this persistent connection will get the connection "as is". Any cleanup would need to be done by the new client process before it could make good use of the persistent connection, increasing the burden on the programmer.
> 
> The persistent connection of the mysqli extension however provides built-in cleanup handling code.
