### PR TITLE
Profile.template.php - show posts/topics/attachements.

### DIFF
--- a/Themes/default/Profile.template.php
+++ b/Themes/default/Profile.template.php
@@ -416,9 +416,10 @@ function template_showPosts()
 	// No posts? Just end with a informative message.
 	if ((isset($context['attachments']) && empty($context['attachments'])) || (!isset($context['attachments']) && empty($context['posts'])))
 		echo '
-			<div class="', $post['alternate'] == 0 ? 'windowbg2' : 'windowbg', ' core_posts">
-				<div class="content">
-					', isset($context['attachments']) ? $txt['show_attachments_none'] : ($context['is_topics'] ? $txt['show_topics_none'] : $txt['show_posts_none']), '
+				<div class="windowbg2 core_posts">
+					<div class="content">
+						', isset($context['attachments']) ? $txt['show_attachments_none'] : ($context['is_topics'] ? $txt['show_topics_none'] : $txt['show_posts_none']), '
+					</div>
 				</div>
 			</div>';
 

--- a/Themes/default/Profile.template.php
+++ b/Themes/default/Profile.template.php
@@ -416,12 +416,12 @@ function template_showPosts()
 	// No posts? Just end with a informative message.
 	if ((isset($context['attachments']) && empty($context['attachments'])) || (!isset($context['attachments']) && empty($context['posts'])))
 		echo '
-				<div class="windowbg2 core_posts">
-					<div class="content">
-						', isset($context['attachments']) ? $txt['show_attachments_none'] : ($context['is_topics'] ? $txt['show_topics_none'] : $txt['show_posts_none']), '
-					</div>
+			<div class="windowbg2 core_posts">
+				<div class="content">
+					', isset($context['attachments']) ? $txt['show_attachments_none'] : ($context['is_topics'] ? $txt['show_topics_none'] : $txt['show_posts_none']), '
 				</div>
-			</div>';
+			</div>
+		</div>';
 
 	// Show more page numbers.
 	if (!empty($context['page_index']))

--- a/Themes/default/Profile.template.php
+++ b/Themes/default/Profile.template.php
@@ -413,18 +413,14 @@ function template_showPosts()
 	else
 		template_show_list('attachments');
 
-	// No posts? Just end the table with a informative message.
+	// No posts? Just end with a informative message.
 	if ((isset($context['attachments']) && empty($context['attachments'])) || (!isset($context['attachments']) && empty($context['posts'])))
 		echo '
-				<tr>
-					<td class="tborder windowbg2 padding centertext" colspan="4">
-						', isset($context['attachments']) ? $txt['show_attachments_none'] : ($context['is_topics'] ? $txt['show_topics_none'] : $txt['show_posts_none']), '
-					</td>
-				</tr>';
-
-		echo '
-			</tbody>
-		</table>';
+			<div class="', $post['alternate'] == 0 ? 'windowbg2' : 'windowbg', ' core_posts">
+				<div class="content">
+					', isset($context['attachments']) ? $txt['show_attachments_none'] : ($context['is_topics'] ? $txt['show_topics_none'] : $txt['show_posts_none']), '
+				</div>
+			</div>';
 
 	// Show more page numbers.
 	if (!empty($context['page_index']))


### PR DESCRIPTION
A closed table tag they never open (old code?) what give a validate errors if you have no topics or messages. I have removed that and replace with a correct code.

Signed-off-by: PortaMx (Feline) support@portamx.com
