### PR TITLE
Enhancements to Groups-as-moderators

### DIFF
--- a/Sources/ManageMembergroups.php
+++ b/Sources/ManageMembergroups.php
@@ -828,6 +828,15 @@ function EditMembergroup()
 
 			foreach ($updates as $additional_groups => $memberArray)
 				updateMemberData($memberArray, array('additional_groups' => implode(',', array_diff(explode(',', $additional_groups), array((int) $_REQUEST['group'])))));
+			
+			// Sorry, but post groups can't moderate boards
+			$request = $smcFunc['db_query']('', '
+				DELETE FROM {db_prefix}moderator_groups
+				WHERE id_group = {int:current_group}',
+				array(
+					'current_group' => (int) $_REQUEST['group'],
+				)
+			);
 		}
 		elseif ($_REQUEST['group'] != 3)
 		{
@@ -857,6 +866,15 @@ function EditMembergroup()
 					WHERE id_group = {int:current_group}',
 					array(
 						'regular_member' => 0,
+						'current_group' => $_REQUEST['group'],
+					)
+				);
+				
+				// Hidden groups can't moderate boards
+				$smcFunc['db_query']('', '
+					DELETE FROM {db_prefix}moderator_groups
+					WHERE id_group = {int:current_group}',
+					array(
 						'current_group' => $_REQUEST['group'],
 					)
 				);

--- a/Sources/Subs-Membergroups.php
+++ b/Sources/Subs-Membergroups.php
@@ -112,6 +112,13 @@ function deleteMembergroups($groups)
 			'group_list' => $groups,
 		)
 	);
+	$smcFunc['db_query']('', '
+		DELETE FROM {db_prefix}moderator_groups
+		WHERE id_group IN ({array_int:group_list})',
+		array(
+			'group_list' => $groups,
+		)
+	);
 
 	// Delete any outstanding requests.
 	$smcFunc['db_query']('', '

--- a/Themes/default/ManageMembergroups.template.php
+++ b/Themes/default/ManageMembergroups.template.php
@@ -365,10 +365,38 @@ function template_edit_group()
 		<script type="text/javascript"><!-- // --><![CDATA[
 			function swapPostGroup(isChecked)
 			{
+				var is_moderator_group = ', $context['is_moderator_group'], ';
+				var group_type = ', $context['group']['type'], ';
 				var min_posts_text = document.getElementById(\'min_posts_text\');
 				var group_desc_text = document.getElementById(\'group_desc_text\');
 				var group_hidden_text = document.getElementById(\'group_hidden_text\');
 				var group_moderators_text = document.getElementById(\'group_moderators_text\');
+				
+				// If it\'s a moderator group, warn of possible problems... and remember the group type
+				if (isChecked && is_moderator_group && !confirm(\'', $txt['membergroups_swap_mod'], '\'))
+				{
+					isChecked = false;
+
+					switch(group_type)
+					{
+						case 0:
+							document.getElementById(\'group_type_private\').checked = true;
+							break;
+						case 1:
+							document.getElementById(\'group_type_protected\').checked = true;
+							break;
+						case 2:
+							document.getElementById(\'group_type_request\').checked = true;
+							break;
+						case 3:
+							document.getElementById(\'group_type_free\').checked = true;
+							break;
+						default:
+							document.getElementById(\'group_type_private\').checked = true;
+							break;
+					}
+				}
+				
 				document.forms.groupForm.min_posts.disabled = !isChecked;
 				min_posts_text.style.color = isChecked ? "" : "#888888";
 				document.forms.groupForm.group_desc_input.disabled = isChecked;
@@ -377,7 +405,9 @@ function template_edit_group()
 				group_hidden_text.style.color = !isChecked ? "" : "#888888";
 				document.forms.groupForm.group_moderators.disabled = isChecked;
 				group_moderators_text.style.color = !isChecked ? "" : "#888888";
-			}
+			}';
+			
+			echo '				
 			swapPostGroup(', $context['group']['is_post_group'] ? 'true' : 'false', ');
 		// ]]></script>';
 }

--- a/Themes/default/ManageMembergroups.template.php
+++ b/Themes/default/ManageMembergroups.template.php
@@ -405,9 +405,8 @@ function template_edit_group()
 				group_hidden_text.style.color = !isChecked ? "" : "#888888";
 				document.forms.groupForm.group_moderators.disabled = isChecked;
 				group_moderators_text.style.color = !isChecked ? "" : "#888888";
-			}';
-			
-			echo '				
+			}
+				
 			swapPostGroup(', $context['group']['is_post_group'] ? 'true' : 'false', ');
 		// ]]></script>';
 }

--- a/Themes/default/languages/ManageMembers.english.php
+++ b/Themes/default/languages/ManageMembers.english.php
@@ -36,7 +36,7 @@ $txt['membergroups_edit_hidden_no'] = 'Visible';
 $txt['membergroups_edit_hidden_boardindex'] = 'Visible - Apart from in group key';
 $txt['membergroups_edit_hidden_all'] = 'Invisible';
 // Do not use numeric entities in the below string.
-$txt['membergroups_edit_hidden_warning'] = 'Are you sure you want to disallow assignment of this group as a users primary group?\\n\\nDoing so will restrict assignment to additional groups only, and will update all current &quot;primary&quot; members to have it as an additional group only.';
+$txt['membergroups_edit_hidden_warning'] = 'Are you sure you want to disallow assignment of this group as a users primary group?\\n\\nDoing so will restrict assignment to additional groups only, and will update all current &quot;primary&quot; members to have it as an additional group only.\\n\\nIt will also remove the group as moderator from any boards it is currently assigned to moderate.';
 $txt['membergroups_edit_desc'] = 'Group description';
 $txt['membergroups_edit_group_type'] = 'Group type';
 $txt['membergroups_edit_select_group_type'] = 'Select Group type';
@@ -56,6 +56,7 @@ $txt['membergroups_edit_save'] = 'Save';
 $txt['membergroups_delete'] = 'Delete';
 $txt['membergroups_confirm_delete'] = 'Are you sure you want to delete this group?';
 $txt['membergroups_confirm_delete_mod'] = 'This group is assigned to moderate one or more boards. Are you sure you want to delete it?';
+$txt['membergroups_swap_mod'] = 'This group is assigned to moderate one or more boards. Changing it to a post group will result in that group being dropped as moderator of those boards.';
 
 $txt['membergroups_members_title'] = 'Viewing Group';
 $txt['membergroups_members_group_members'] = 'Group Members';


### PR DESCRIPTION
This puts the "finishing touches" on groups-as-moderators feature:
- Warns users when changing a group's visibility to hidden
- Warns users when changing a group's type to "post based"
- Removes moderator groups from boards when the visibility is changed to hidden
- Removes moderator groups from boards when the type is set to "post based"
- Removes moderator groups from boards when the group itself is deleted (somehow I forgot that...)
