### PR TITLE
Easy toggle

### DIFF
--- a/Sources/Load.php
+++ b/Sources/Load.php
@@ -1813,6 +1813,9 @@ function loadTheme($id_theme = 0, $initialize = true)
 		'ajax_notification_text' => JavaScriptEscape($txt['ajax_in_progress']),
 		'ajax_notification_cancel_text' => JavaScriptEscape($txt['modify_cancel']),
 		'help_popup_heading_text' => JavaScriptEscape($txt['help_popup']),
+		'header_is_collapsed' => JavaScriptEscape(!empty($options['collapse_header'])),
+		'show_txt' => JavaScriptEscape($txt['show']),
+		'hide_txt' => JavaScriptEscape($txt['hide']),
 	);
 
 	// Add the JQuery library to the list of files to load.

--- a/Themes/default/BoardIndex.template.php
+++ b/Themes/default/BoardIndex.template.php
@@ -36,7 +36,7 @@ function template_newsfader()
 			<div id="newsfader">
 				<div class="cat_bar">
 					<h3 class="catbg">
-						<img id="newsupshrink" src="', $settings['images_url'], '/collapse.png" alt="*" title="', $txt['hide'], '" align="bottom" style="display: none;" />
+						<img id="newsupshrink" src="', $settings['images_url'], '/collapse.png" alt="*" title="', $txt['hide'], '" align="bottom" />
 						', $txt['news'], '
 					</h3>
 				</div>
@@ -59,32 +59,7 @@ function template_newsfader()
 				});
 		
 				// Create the news fader toggle.
-				var smfNewsFadeToggle = new smc_Toggle({
-					bToggleEnabled: true,
-					bCurrentlyCollapsed: ', empty($options['collapse_news_fader']) ? 'false' : 'true', ',
-					aSwappableContainers: [
-						\'smfFadeScrollerCont\'
-					],
-					aSwapImages: [
-						{
-							sId: \'newsupshrink\',
-							srcExpanded: smf_images_url + \'/collapse.png\',
-							altExpanded: ', JavaScriptEscape($txt['hide']), ',
-							srcCollapsed: smf_images_url + \'/expand.png\',
-							altCollapsed: ', JavaScriptEscape($txt['show']), '
-						}
-					],
-					oThemeOptions: {
-						bUseThemeSettings: ', $context['user']['is_guest'] ? 'false' : 'true', ',
-						sOptionName: \'collapse_news_fader\',
-						sSessionVar: smf_session_var,
-						sSessionId: smf_session_id
-					},
-					oCookieOptions: {
-						bUseCookie: ', $context['user']['is_guest'] ? 'true' : 'false', ',
-						sCookieName: \'newsupshrink\'
-					}
-				});
+				toggleElementEvent("#smfFadeScrollerCont", "#newsupshrink", null, ', (!empty($options['collapse_news_fader']) ? 'true' : 'false'), ');
 			// ]]></script>
 		';
 	}

--- a/Themes/default/Search.template.php
+++ b/Themes/default/Search.template.php
@@ -159,16 +159,16 @@ function template_main()
 		<fieldset class="flow_hidden">
 			<div class="roundframe">
 				<div class="title_bar">
-					<h4 class="titlebg">
+					<h4 class="titlebg pointer" id="expandBoards">
 						<span class="floatright">
-							<a href="javascript:void(0);" onclick="expandCollapseBoards(); return false;"><img src="', $settings['images_url'], '/expand.png" id="expandBoardsIcon" alt=""  class="icon"/></a>
+							<img src="', $settings['images_url'], '/expand.png" id="expandBoardsIcon" alt=""  class="icon"/>
 						</span>
 						<span>
-							<a href="javascript:void(0);" onclick="expandCollapseBoards(); return false;"><strong>', $txt['choose_board'], '</strong></a>
+							<strong>', $txt['choose_board'], '</strong>
 						</span>
 					</h4>
 				</div>
-				<div class="flow_auto" id="searchBoardsExpand"', $context['boards_check_all'] ? ' style="display: none;"' : '', '>
+				<div class="flow_auto" id="searchBoardsExpand">
 					<ul class="ignoreboards floatleft">';
 
 	$i = 0;
@@ -218,7 +218,14 @@ function template_main()
 					<input type="submit" name="b_search" value="', $txt['search'], '" class="button_submit" />
 				</div>
 			</div>
-		</fieldset>';
+		</fieldset>
+		<script type="text/javascript">
+			//<![CDATA[
+			
+			toggleElementEvent("#searchBoardsExpand", "#expandBoards", {isimage: false, eimage: "#expandBoardsIcon"}, ', ($context['boards_check_all'] ? 'true' : 'false'), ');
+			
+			//]]>
+		</script>';
 		}
 	echo '
 		<script type="text/javascript" src="', $settings['default_theme_url'], '/scripts/suggest.js?alp21"></script>

--- a/Themes/default/css/index.css
+++ b/Themes/default/css/index.css
@@ -75,6 +75,12 @@ ul.reset, ul.reset li {
 	list-style: none;
 }
 
+/* Class for pointers */
+.pointer
+{
+	cursor: pointer;
+}
+
 /* We can style the different types of input buttons to be uniform throughout different browsers and their color themes.
 	.button_submit - covers input[type=submit], input[type=button], button[type=submit] and button[type=button] in all browsers
 	.button_link   - covers links to make them look like a submit button

--- a/Themes/default/index.template.php
+++ b/Themes/default/index.template.php
@@ -515,45 +515,12 @@ function template_menu()
 	// If anyone is terrified of losing 40px out of the menu bar, set your theme to 92% instead of 90%. :P
 	echo '
 				<li id="collapse_button">
-					<img id="upshrink" src="', $settings['images_url'], '/upshrink.png" alt="*" title="', $txt['upshrink_description'], '" style="padding: 4px 9px 3px 9px; display: none;" />
+					<img id="upshrink" src="', $settings['images_url'], '/upshrink.png" alt="*" title="', $txt['upshrink_description'], '" style="padding: 4px 9px 3px 9px" />
 				</li>';
 
 	echo '
 			</ul>
 		</div>';
-
-	// Define the upper_section toggle in JavaScript.
-	// Note that this definition had to be shifted for the js to work with the new markup.
-	echo '
-		<script type="text/javascript"><!-- // --><![CDATA[
-			var oMainHeaderToggle = new smc_Toggle({
-				bToggleEnabled: true,
-				bCurrentlyCollapsed: ', empty($options['collapse_header']) ? 'false' : 'true', ',
-				aSwappableContainers: [
-					\'inner_wrap\'
-				],
-				aSwapImages: [
-					{
-						sId: \'upshrink\',
-						srcExpanded: smf_images_url + \'/upshrink.png\',
-						altExpanded: ', JavaScriptEscape($txt['upshrink_description']), ',
-						srcCollapsed: smf_images_url + \'/upshrink2.png\',
-						altCollapsed: ', JavaScriptEscape($txt['upshrink_description']), '
-					}
-				],
-				oThemeOptions: {
-					bUseThemeSettings: smf_member_id == 0 ? false : true,
-					sOptionName: \'collapse_header\',
-					sSessionVar: smf_session_var,
-					sSessionId: smf_session_id
-				},
-				oCookieOptions: {
-					bUseCookie: smf_member_id == 0 ? true : false,
-					sCookieName: \'upshrink\'
-				}
-			});
-		// ]]></script>';
-
 }
 
 /**

--- a/Themes/default/scripts/theme.js
+++ b/Themes/default/scripts/theme.js
@@ -7,7 +7,73 @@ $(document).ready(function() {
 
 	// find all nested linked images and turn off the border
 	$('a.bbc_link img.bbc_img').parent().css('border', '0');
+	
+	// Allow us to click that lil button to collapse and expand stuff.
+	toggleElementEvent("#inner_wrap", "#upshrink", null, header_is_collapsed);
 });
+
+// Toggle an element.
+function toggleElement(element, image, imageoptions, duration)
+{
+	if ($(element).length == 0 || $(image).length == 0)
+		return;
+	
+	imageoptions = {
+		visibleimage: imageoptions && imageoptions.visibleimage || smf_images_url + "/upshrink.png",
+		hideimage: imageoptions && imageoptions.hideimage || smf_images_url + "/upshrink2.png",
+		visibletxt: imageoptions && imageoptions.visibletxt || hide_txt,
+		hidetxt: imageoptions && imageoptions.hidetxt || show_txt,
+		isimage: imageoptions && !imageoptions.isimage ? false : true,
+		eimage: imageoptions && imageoptions.eimage || null
+	};
+	
+	$(element).slideToggle(duration || "fast", "linear", function()
+	{
+		if (imageoptions.isimage || (!imageoptions.isimage && imageoptions.eimage))
+		{
+			mimage = (imageoptions.isimage === true ? image : imageoptions.eimage);
+			if ($(element).is(":visible"))
+			{
+				$(mimage).attr("src", imageoptions.visibleimage);
+				$(mimage).attr("title", imageoptions.visibletxt);
+			}
+			else
+			{
+				$(mimage).attr("src", imageoptions.hideimage);	
+				$(mimage).attr("title", imageoptions.hidetxt);
+			}
+		}
+	});
+}
+
+// Add the event for toggleElement.
+function toggleElementEvent(element, image, imageoptions, iscollapsed)
+{
+	if ($(element).length == 0 || $(image).length == 0)
+		return;
+		
+	imageoptions = {
+		visibleimage: imageoptions && imageoptions.visibleimage || smf_images_url + "/upshrink.png",
+		hideimage: imageoptions && imageoptions.hideimage || smf_images_url + "/upshrink2.png",
+		visibletxt: imageoptions && imageoptions.visibletxt || hide_txt,
+		hidetxt: imageoptions && imageoptions.hidetxt || show_txt,
+		isimage: imageoptions && !imageoptions.isimage ? false : true,
+		eimage: imageoptions && imageoptions.eimage || null
+	};
+		
+	$(image).click(function ()
+	{
+		toggleElement(element, image, imageoptions);
+	});
+	
+	// Add a nice pointer to this image if we got one.
+	if (imageoptions.isimage)
+		$(image).addClass("pointer");
+	
+	// If it is collapsed, toggle it now.
+	if (iscollapsed)
+		toggleElement(element, image, imageoptions, 0.1);
+}
 
 // The purpose of this code is to fix the height of overflow: auto blocks, because some browsers can't figure it out for themselves.
 function smf_codeBoxFix()


### PR DESCRIPTION
Signed-off-by: Rick Kerkhof rick.2889@gmail.com (my commit is signed)

Prefered method of creating toggles is toggleElementEvent(), because it creates the event and assigns the correct class to the image (if any).

Syntax (toggleElement):
toggleElement(element to toggle (jQuery selector), the item that toggles it (jQuery selector), any image options (see below), the duration of the animation (string or int))

toggleElementEvent is nearly identical, with exception of the last parameter:
toggleElementEvent(element to toggle (jQuery selector), the item that toggles it (jQuery selector), any image options (see below), is collapsed? (bool))

imageoptions consists of:
visibleimage: The image that is shown when the toggled element is visible. (default: upshrink.png, URL to image path)
hideimage: The image that is shown when the toggled element is hidden. (default: upshrink2.png, URL to image path)

visibletxt: The hover text that is shown when the toggled element is visible (default: hide_txt, or "Hide", string)
hidetxt: The hover text that is shown when the toggled element is hidden (default: show_txt or "Show", string)
Both visibletxt and hidetxt are disregarded when the toggle "button" is NOT an image.

isimage: If the toggle "button" is an image. (bool)
eimage: An external image, if wanted. (jQuery selector)

This function aims to replace smc_Toggle.
