### PR TITLE
PHP 5.5 Compatibility

### DIFF
--- a/Sources/Admin.php
+++ b/Sources/Admin.php
@@ -127,7 +127,7 @@ function AdminMain()
 					'subsections' => array(
 						'general' => array($txt['mods_cat_security_general']),
 						'spam' => array($txt['antispam_title']),
-						'moderation' => array($txt['moderation_settings_short'], 'enabled' => in_array('w', $context['admin_features'])),
+						'moderation' => array($txt['moderation_settings_short'], 'enabled' => substr($modSettings['warning_settings'], 0, 1) == 1),
 					),
 				),
 				'languages' => array(

--- a/Sources/Admin.php
+++ b/Sources/Admin.php
@@ -127,7 +127,7 @@ function AdminMain()
 					'subsections' => array(
 						'general' => array($txt['mods_cat_security_general']),
 						'spam' => array($txt['antispam_title']),
-						'moderation' => array($txt['moderation_settings_short'], 'enabled' => substr($modSettings['warning_settings'], 0, 1) == 1),
+						'moderation' => array($txt['moderation_settings_short'], 'enabled' => in_array('w', $context['admin_features'])),
 					),
 				),
 				'languages' => array(

--- a/Sources/Class-Package.php
+++ b/Sources/Class-Package.php
@@ -612,7 +612,7 @@ class xmlArray
 		$trans_tbl = array_flip(get_html_translation_table(HTML_ENTITIES, ENT_QUOTES));
 
 		// Translate all the entities out.
-		$data = strtr(preg_replace('~&#(\d{1,4});~e', "chr('\$1')", $data), $trans_tbl);
+		$data = strtr(preg_replace_callback('~&#(\d{1,4});~e', create_function('$m', 'return chr("\$m[1]");'), $data), $trans_tbl);
 
 		return $this->trim ? trim($data) : $data;
 	}

--- a/Sources/Modlog.php
+++ b/Sources/Modlog.php
@@ -630,14 +630,15 @@ function list_getModLogEntries($start, $items_per_page, $sort, $query_string = '
 }
 
 /**
- * Smiely Replacment Callback.
+ * Mog Log Replacment Callback.
  *
- * Our callback that does the actual smiley replacments.
+ * Our callback that does the actual replacments.
  *
  * Original code from: http://php.net/manual/en/function.preg-replace-callback.php#88013
  * This is needed until SMF only supports PHP 5.3+ and we change to "use"
  *
- * @param string $replacements
+ * @param string $entries
+ * @param string $key
  * @param string $matches
  * @return string the replaced results.
  */

--- a/Sources/Modlog.php
+++ b/Sources/Modlog.php
@@ -607,6 +607,7 @@ function list_getModLogEntries($start, $items_per_page, $sort, $query_string = '
 	}
 
 	// Do some formatting of the action string.
+	$callback = pregReplaceCurry('list_getModLogEntriesCallback', 3);
 	foreach ($entries as $k => $entry)
 	{
 		// Make any message info links so its easier to go find that message.
@@ -620,11 +621,29 @@ function list_getModLogEntries($start, $items_per_page, $sort, $query_string = '
 
 		if (empty($entries[$k]['action_text']))
 			$entries[$k]['action_text'] = isset($txt['modlog_ac_' . $entry['action']]) ? $txt['modlog_ac_' . $entry['action']] : $entry['action'];
-		$entries[$k]['action_text'] = preg_replace('~\{([A-Za-z\d_]+)\}~ie', 'isset($entries[$k][\'extra\'][\'$1\']) ? $entries[$k][\'extra\'][\'$1\'] : \'\'', $entries[$k]['action_text']);
+		$entries[$k]['action_text'] = preg_replace_callback('~\{([A-Za-z\d_]+)\}~i', $callback($entries, $k), $entries[$k]['action_text']);
+
 	}
 
 	// Back we go!
 	return $entries;
+}
+
+/**
+ * Smiely Replacment Callback.
+ *
+ * Our callback that does the actual smiley replacments.
+ *
+ * Original code from: http://php.net/manual/en/function.preg-replace-callback.php#88013
+ * This is needed until SMF only supports PHP 5.3+ and we change to "use"
+ *
+ * @param string $replacements
+ * @param string $matches
+ * @return string the replaced results.
+ */
+function list_getModLogEntriesCallback($entries, $key, $matches)
+{
+    return isset($entries[$key]['extra'][$matches[1]]) ? $entries[$key]['extra'][$matches[1]] : '';
 }
 
 ?>

--- a/Sources/Search.php
+++ b/Sources/Search.php
@@ -1934,7 +1934,6 @@ function prepareSearchContext($reset = false)
 				foreach ($context['key_words'] as $keyword)
 				{
 					$keyword = un_htmlspecialchars($keyword);
-//					$keyword = preg_replace('~(&amp;#(\d{1,7}|x[0-9a-fA-F]{1,6});)~e', 'entity_fix__callback', strtr($keyword, array('\\\'' => '\'', '&' => '&amp;')));
 					$keyword = preg_replace_callback('~(&amp;#(\d{1,7}|x[0-9a-fA-F]{1,6});)~', 'entity_fix__callback', strtr($keyword, array('\\\'' => '\'', '&' => '&amp;')));
 
 					if (preg_match('~[\'\.,/@%&;:(){}\[\]_\-+\\\\]$~', $keyword) != 0 || preg_match('~^[\'\.,/@%&;:(){}\[\]_\-+\\\\]~', $keyword) != 0)

--- a/Sources/Search.php
+++ b/Sources/Search.php
@@ -1934,7 +1934,8 @@ function prepareSearchContext($reset = false)
 				foreach ($context['key_words'] as $keyword)
 				{
 					$keyword = un_htmlspecialchars($keyword);
-					$keyword = preg_replace('~(&amp;#(\d{1,7}|x[0-9a-fA-F]{1,6});)~e', 'entity_fix__callback', strtr($keyword, array('\\\'' => '\'', '&' => '&amp;')));
+//					$keyword = preg_replace('~(&amp;#(\d{1,7}|x[0-9a-fA-F]{1,6});)~e', 'entity_fix__callback', strtr($keyword, array('\\\'' => '\'', '&' => '&amp;')));
+					$keyword = preg_replace_callback('~(&amp;#(\d{1,7}|x[0-9a-fA-F]{1,6});)~', 'entity_fix__callback', strtr($keyword, array('\\\'' => '\'', '&' => '&amp;')));
 
 					if (preg_match('~[\'\.,/@%&;:(){}\[\]_\-+\\\\]$~', $keyword) != 0 || preg_match('~^[\'\.,/@%&;:(){}\[\]_\-+\\\\]~', $keyword) != 0)
 						$force_partial_word = true;
@@ -1958,7 +1959,7 @@ function prepareSearchContext($reset = false)
 			}
 
 			// Re-fix the international characters.
-			$message['body'] = preg_replace('~(&amp;#(\d{1,7}|x[0-9a-fA-F]{1,6});)~e', 'entity_fix__callback', $message['body']);
+			$message['body'] = preg_replace_callback('~(&amp;#(\d{1,7}|x[0-9a-fA-F]{1,6});)~', 'entity_fix__callback', $message['body']);
 		}
 	}
 	else
@@ -2088,7 +2089,7 @@ function prepareSearchContext($reset = false)
 		$query = trim($query, "\*+");
 		$query = strtr($smcFunc['htmlspecialchars']($query), array('\\\'' => '\''));
 
-		$body_highlighted = preg_replace('/((<[^>]*)|' . preg_quote(strtr($query, array('\'' => '&#039;')), '/') . ')/ie' . ($context['utf8'] ? 'u' : ''), "'\$2' == '\$1' ? stripslashes('\$1') : '<strong class=\"highlight\">\$1</strong>'", $body_highlighted);
+		$body_highlighted = preg_replace_callback('/((<[^>]*)|' . preg_quote(strtr($query, array('\'' => '&#039;')), '/') . ')/i' . ($context['utf8'] ? 'u' : ''), create_function('$m', 'return isset($m[2]) && "$m[2]" == "$m[1]" ? stripslashes("$m[1]") : "<strong class=\"highlight\">$m[1]</strong>";'), $body_highlighted);
 		$subject_highlighted = preg_replace('/(' . preg_quote($query, '/') . ')/i' . ($context['utf8'] ? 'u' : ''), '<strong class="highlight">$1</strong>', $subject_highlighted);
 	}
 

--- a/Sources/Subs-Editor.php
+++ b/Sources/Subs-Editor.php
@@ -76,7 +76,7 @@ function bbc_to_html($text, $compat_mode = false)
 
 	// Parse unique ID's and disable javascript into the smileys - using the double space.
 	$i = 1;
-	$text = preg_replace('~(?:\s|&nbsp;)?<(img\ssrc="' . preg_quote($modSettings['smileys_url'], '~') . '/[^<>]+?/([^<>]+?)"\s*)[^<>]*?class="smiley" />~e', '\'<\' . ' . 'stripslashes(\'$1\') . \'alt="" title="" onresizestart="return false;" id="smiley_\' . ' . "\$" . 'i++ . \'_$2" style="padding: 0 3px 0 3px;" />\'', $text);
+	$text = preg_replace_callback('~(?:\s|&nbsp;)?<(img\ssrc="' . preg_quote($modSettings['smileys_url'], '~') . '/[^<>]+?/([^<>]+?)"\s*)[^<>]*?class="smiley" />~', create_function('$m', 'return \'<\' . ' . 'stripslashes(\'$1\') . \'alt="" title="" onresizestart="return false;" id="smiley_\' . ' . "\$" . 'i++ . \'_$2" style="padding: 0 3px 0 3px;" />\';'), $text);
 
 	return $text;
 }

--- a/Sources/Subs-Post.php
+++ b/Sources/Subs-Post.php
@@ -267,16 +267,31 @@ function un_preparsecode($message)
 		// If $i is a multiple of four (0, 4, 8, ...) then it's not a code section...
 		if ($i % 4 == 0)
 		{
-			$parts[$i] = preg_replace('~\[html\](.+?)\[/html\]~ie', '\'[html]\' . strtr(htmlspecialchars(\'$1\', ENT_QUOTES), array(\'\\&quot;\' => \'&quot;\', \'&amp;#13;\' => \'<br />\', \'&amp;#32;\' => \' \', \'&amp;#91;\' => \'[\', \'&amp;#93;\' => \']\')) . \'[/html]\'', $parts[$i]);
-			// $parts[$i] = preg_replace('~\[html\](.+?)\[/html\]~ie', '\'[html]\' . strtr(htmlspecialchars(\'$1\', ENT_QUOTES), array(\'\\&quot;\' => \'&quot;\', \'&amp;#13;\' => \'<br />\', \'&amp;#32;\' => \' \', \'&amp;#38;\' => \'&#38;\', \'&amp;#91;\' => \'[\', \'&amp;#93;\' => \']\')) . \'[/html]\'', $parts[$i]);
+			$parts[$i] = preg_replace_callback('~\[html\](.+?)\[/html\]~i', create_function('$m', 'return \'[html]\' . strtr(htmlspecialchars(\'$m[1]\', ENT_QUOTES), array(\'\\&quot;\' => \'&quot;\', \'&amp;#13;\' => \'<br />\', \'&amp;#32;\' => \' \', \'&amp;#91;\' => \'[\', \'&amp;#93;\' => \']\')) . \'[/html]\';
+'), $parts[$i]);
 
 			// Attempt to un-parse the time to something less awful.
-			$parts[$i] = preg_replace('~\[time\](\d{0,10})\[/time\]~ie', '\'[time]\' . timeformat(\'$1\', false) . \'[/time]\'', $parts[$i]);
+			$parts[$i] = preg_replace('~\[time\](\d{0,10})\[/time\]~i', create_function('$m', ' return \'[time]\' . timeformat(\'$m[1]\', false) . \'[/time]\';'), $parts[$i]);
 		}
 	}
 
 	// Change breaks back to \n's and &nsbp; back to spaces.
 	return preg_replace('~<br( /)?' . '>~', "\n", str_replace('&nbsp;', ' ', implode('', $parts)));
+}
+
+function un_preparsecodeCallback($matches)
+{
+			return '[html]' .
+				strtr(
+					htmlspecialchars('$matches[1]', ENT_QUOTES),
+					array(
+						'\\&quot;' => '&quot;',
+						'&amp;#13;' => '<br />',
+						'&amp;#32;' => ' ',
+						'&amp;#91;' => '[',
+						'&amp;#93;' => ']'
+					)
+				) . '[/html]';
 }
 
 /**

--- a/Sources/Subs-Post.php
+++ b/Sources/Subs-Post.php
@@ -278,21 +278,6 @@ function un_preparsecode($message)
 	return preg_replace('~<br( /)?' . '>~', "\n", str_replace('&nbsp;', ' ', implode('', $parts)));
 }
 
-function un_preparsecodeCallback($matches)
-{
-			return '[html]' .
-				strtr(
-					htmlspecialchars('$matches[1]', ENT_QUOTES),
-					array(
-						'\\&quot;' => '&quot;',
-						'&amp;#13;' => '<br />',
-						'&amp;#32;' => ' ',
-						'&amp;#91;' => '[',
-						'&amp;#93;' => ']'
-					)
-				) . '[/html]';
-}
-
 /**
  * Fix any URLs posted - ie. remove 'javascript:'.
  * Used by preparsecode, fixes links in message and returns nothing.

--- a/Sources/Subs-Post.php
+++ b/Sources/Subs-Post.php
@@ -1221,7 +1221,7 @@ function mimespecialchars($string, $with_charset = true, $hotmail_fix = false, $
 		unset($matches);
 
 		if ($simple)
-			$string = preg_replace('~&#(\d{3,8});~e', 'chr(\'$1\')', $string);
+			$string = preg_replace_callback('~&#(\d{3,8});~', create_function('$m', ' return chr("$m[1]");'), $string);
 		else
 		{
 			// Try to convert the string to UTF-8.
@@ -1249,7 +1249,8 @@ function mimespecialchars($string, $with_charset = true, $hotmail_fix = false, $
 				$string = $newstring;
 		}
 
-		$entityConvert = create_function('$c', '
+		$entityConvert = create_function('$m', '
+			$c = $m[1];
 			if (strlen($c) === 1 && ord($c[0]) <= 0x7F)
 				return $c;
 			elseif (strlen($c) === 2 && ord($c[0]) >= 0xC0 && ord($c[0]) <= 0xDF)
@@ -1262,7 +1263,7 @@ function mimespecialchars($string, $with_charset = true, $hotmail_fix = false, $
 				return "";');
 
 		// Convert all 'special' characters to HTML entities.
-		return array($charset, preg_replace('~([\x80-\x{10FFFF}])~eu', '$entityConvert(\'\1\')', $string), '7bit');
+		return array($charset, preg_replace_callback('~([\x80-\x{10FFFF}])~u', $entityConvert, $string), '7bit');
 	}
 
 	// We don't need to mess with the subject line if no special characters were in it..

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -2470,15 +2470,15 @@ function parsesmileys(&$message)
 	/*
 	* TODO: When SMF supports only PHP 5.3+, we can change this to "uses" keyword and simpifly this.
 	*/
-	$callback = smielyPregReplaceCurry('smielyPregReplaceCallback', 2);
+	$callback = pregReplaceCurry('smielyPregReplaceCallback', 2);
 	$message = preg_replace_callback($smileyPregSearch, $callback($smileyPregReplacements), $message);
 }
 
 /**
- * Smiely Replacment Curry.
+ * Preg Replacment Curry.
  *
  * This allows use to do delayed argument binding and bring in
- * the replacement variables for smiley replacments.
+ * the replacement variables for some preg replacments.
  *
  * Original code from: http://php.net/manual/en/function.preg-replace-callback.php#88013
  * This is needed until SMF only supports PHP 5.3+ and we change to "use"
@@ -2487,7 +2487,7 @@ function parsesmileys(&$message)
  * @param string $arity
  * @return function a lambda function bound to $func.
  */
-function smielyPregReplaceCurry($func, $arity)
+function pregReplaceCurry($func, $arity)
 {
 	return create_function('', "
 		\$args = func_get_args();

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -2393,9 +2393,7 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 function parsesmileys(&$message)
 {
 	global $modSettings, $txt, $user_info, $context, $smcFunc;
-//	static $smileyPregSearch = null, $smileyPregReplacements = array();
-	static $smileyPregSearch = null;
-	global $smileyPregReplacements;
+	static $smileyPregSearch = null, $smileyPregReplacements = array();
 
 	// No smiley set at all?!
 	if ($user_info['smiley_set'] == 'none' || trim($message) == '')
@@ -2462,7 +2460,6 @@ function parsesmileys(&$message)
 			}
 		}
 
-//		$smileyPregSearch = '~(?<=[>:\?\.\s' . $non_breaking_space . '[\]()*\\\;]|^)(' . implode('|', $searchParts) . ')(?=[^[:alpha:]0-9]|$)~e' . ($context['utf8'] ? 'u' : '');
 		$smileyPregSearch = '~(?<=[>:\?\.\s' . $non_breaking_space . '[\]()*\\\;]|^)(' . implode('|', $searchParts) . ')(?=[^[:alpha:]0-9]|$)~' . ($context['utf8'] ? 'u' : '');
 	}
 


### PR DESCRIPTION
These are changes that are needed to support PHP 5.5.  So far this appears to be /e preg_replace fixes.  This has required changing over to callbacks and some curry functions.  Everything changed will need testing.  I've done testing to ensure things still appear to work, but am not sure if I missed something in testing.  I am also not sure if I missed any or any other 5.5 replacements are needed.
