### PR TITLE
// If they are for sure registered, let other people to know about it

### DIFF
--- a/Sources/Subs-Members.php
+++ b/Sources/Subs-Members.php
@@ -845,6 +845,9 @@ function registerMember(&$regOptions, $return_errors = false)
 	// Okay, they're for sure registered... make sure the session is aware of this for security. (Just married :P!)
 	$_SESSION['just_registered'] = 1;
 
+	// If they are for sure registered, let other people to know about it
+	call_integration_hook('integrate_register_after', array($regOptions, $memberID));
+
 	return $memberID;
 }
 

--- a/Sources/Subs-Post.php
+++ b/Sources/Subs-Post.php
@@ -1868,6 +1868,9 @@ function createPost(&$msgOptions, &$topicOptions, &$posterOptions)
 			)
 		);
 
+	// What if we want to export new posts out to a CMS?
+	call_integration_hook('integrate_after_create_post', array($msgOptions, $topicOptions, $posterOptions, $message_columns, $message_parameters));
+
 	// Insert a new topic (if the topicID was left empty.)
 	if ($new_topic)
 	{


### PR DESCRIPTION
This is just to pass the newly created user ID for others to use.

 I needed a way to set up a notification when an user was registered and integrate_register for obvious reasons doesn't provide the user ID. 

There's no pass by reference since at this point there's nothing you can do, this is just for reference only.

Signed-off-by: Suki suki@missallsunday.com
