### PR TITLE
Add SQLite3 support

### DIFF
--- a/Sources/DbExtra-sqlite3.php
+++ b/Sources/DbExtra-sqlite3.php
@@ -1,0 +1,369 @@
+<?php
+
+/**
+ * This file contains rarely used extended database functionality.
+ *
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines http://www.simplemachines.org
+ * @copyright 2013 Simple Machines and individual contributors
+ * @license http://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 2.1 Alpha 1
+ */
+
+if (!defined('SMF'))
+	die('No direct access...');
+
+/**
+ * Add the functions implemented in this file to the $smcFunc array.
+ */
+function db_extra_init()
+{
+	global $smcFunc;
+
+	if (!isset($smcFunc['db_backup_table']) || $smcFunc['db_backup_table'] != 'smf_db_backup_table')
+		$smcFunc += array(
+			'db_backup_table' => 'smf_db_backup_table',
+			'db_optimize_table' => 'smf_db_optimize_table',
+			'db_insert_sql' => 'smf_db_insert_sql',
+			'db_table_sql' => 'smf_db_table_sql',
+			'db_list_tables' => 'smf_db_list_tables',
+			'db_get_backup' => 'smf_db_get_backup',
+			'db_get_version' => 'smf_db_get_version',
+		);
+}
+
+/**
+ * Backup $table to $backup_table.
+ * @param string $table
+ * @param string $backup_table
+ * @return resource -the request handle to the table creation query
+ */
+function smf_db_backup_table($table, $backup_table)
+{
+	global $smcFunc, $db_prefix;
+
+	$table = str_replace('{db_prefix}', $db_prefix, $table);
+
+	$result = $smcFunc['db_query']('', '
+		SELECT sql
+		FROM sqlite_master
+		WHERE type = {string:txttable}
+			AND name = {string:table}',
+		array(
+			'table' => $table,
+			'txttable' => 'table'
+		)
+	);
+	list ($create) = $smcFunc['db_fetch_row']($result);
+	$smcFunc['db_free_result']($result);
+
+	$create = preg_split('/[\n\r]/', $create);
+	$auto_inc = '';
+
+	// Remove the first line and check to see if the second one contain useless info.
+	unset($create[0]);
+	if (trim($create[1]) == '(')
+		unset($create[1]);
+	if (trim($create[count($create)]) == ')')
+		unset($create[count($create)]);
+
+	foreach ($create as $k => $l)
+	{
+		// Get the name of the auto_increment column.
+		if (strpos($l, 'primary') || strpos($l, 'PRIMARY'))
+			$auto_inc = trim($l);
+
+		// Skip everything but keys...
+		if ((strpos($l, 'KEY') !== false && strpos($l, 'PRIMARY KEY') === false) || strpos($l, $table) !== false || strpos(trim($l), 'PRIMARY KEY') === 0)
+			unset($create[$k]);
+	}
+
+	if (!empty($create))
+		$create = '(
+			' . implode('
+			', $create) . ')';
+	else
+		$create = '';
+
+	// Is there an extra junk at the end?
+	if (substr($create, -2, 1) == ',')
+		$create = substr($create, 0, -2) . ')';
+	if (substr($create, -2) == '))')
+		$create = substr($create, 0, -1);
+
+	$smcFunc['db_query']('', '
+		DROP TABLE {raw:backup_table}',
+		array(
+			'backup_table' => $backup_table,
+			'db_error_skip' => true,
+		)
+	);
+
+	$request = $smcFunc['db_quote']('
+		CREATE TABLE {raw:backup_table} {raw:create}',
+		array(
+			'backup_table' => $backup_table,
+			'create' => $create,
+	));
+
+	$smcFunc['db_query']('', '
+		CREATE TABLE {raw:backup_table} {raw:create}',
+		array(
+			'backup_table' => $backup_table,
+			'create' => $create,
+	));
+
+	$request = $smcFunc['db_query']('', '
+		INSERT INTO {raw:backup_table}
+		SELECT *
+		FROM {raw:table}',
+		array(
+			'backup_table' => $backup_table,
+			'table' => $table,
+	));
+
+	return $request;
+}
+
+/**
+ * This function optimizes a table.
+ * @param string $table - the table to be optimized
+ * @return how much it was gained
+ */
+function smf_db_optimize_table($table)
+{
+	global $smcFunc, $db_prefix;
+
+	$table = str_replace('{db_prefix}', $db_prefix, $table);
+
+	$request = $smcFunc['db_query']('', '
+		VACUUM {raw:table}',
+		array(
+			'table' => $table,
+		)
+	);
+	if (!$request)
+		return -1;
+
+	$row = $smcFunc['db_fetch_assoc']($request);
+	$smcFunc['db_free_result']($request);
+
+	// The function returns nothing.
+	return 0;
+}
+
+/**
+ * This function lists all tables in the database.
+ * The listing could be filtered according to $filter.
+ *
+ * @param mixed $db string holding the table name, or false, default false
+ * @param mixed $filter string to filter by, or false, default false
+ * @return array an array of table names. (strings)
+ */
+function smf_db_list_tables($db = false, $filter = false)
+{
+	global $smcFunc;
+
+	$filter = $filter == false ? '' : ' AND name LIKE \'' . str_replace("\_", "_", $filter) . '\'';
+
+	$request = $smcFunc['db_query']('', '
+		SELECT name
+		FROM sqlite_master
+		WHERE type = {string:type}
+		{raw:filter}
+		ORDER BY name',
+		array(
+			'type' => 'table',
+			'filter' => $filter,
+		)
+	);
+	$tables = array();
+	while ($row = $smcFunc['db_fetch_row']($request))
+		$tables[] = $row[0];
+	$smcFunc['db_free_result']($request);
+
+	return $tables;
+}
+
+/**
+ * Gets all the necessary INSERTs for the table named table_name.
+ * It goes in 250 row segments.
+ *
+ * @param string $tableName - the table to create the inserts for.
+ * @param bool new_table
+ * @return string the query to insert the data back in, or an empty string if the table was empty.
+ */
+function smf_db_insert_sql($tableName, $new_table = false)
+{
+	global $smcFunc, $db_prefix;
+	static $start = 0, $num_rows, $fields, $limit;
+
+	if ($new_table)
+	{
+		$limit = strstr($tableName, 'log_') !== false ? 500 : 250;
+		$start = 0;
+	}
+
+	$data = '';
+	$tableName = str_replace('{db_prefix}', $db_prefix, $tableName);
+
+	// This will be handy...
+	$crlf = "\r\n";
+
+	$result = $smcFunc['db_query']('', '
+		SELECT *
+		FROM ' . $tableName . '
+		LIMIT ' . $start . ', ' . $limit,
+		array(
+			'security_override' => true,
+		)
+	);
+
+	// The number of rows, just for record keeping and breaking INSERTs up.
+	$num_rows = $smcFunc['db_num_rows']($result);
+
+	if ($num_rows == 0)
+		return '';
+
+	if ($new_table)
+	{
+		$fields = array_keys($smcFunc['db_fetch_assoc']($result));
+
+		// SQLite fetches an array so we need to filter out the numberic index for the columns.
+		foreach ($fields as $key => $name)
+			if (is_numeric($name))
+				unset($fields[$key]);
+
+		$smcFunc['db_data_seek']($result, 0);
+	}
+
+	// Start it off with the basic INSERT INTO.
+	$data = 'BEGIN TRANSACTION;' . $crlf;
+	$insert_msg = $crlf . 'INSERT INTO ' . $tableName . $crlf . "\t" . '(' . implode(', ', $fields) . ')' . $crlf . 'VALUES ' . $crlf . "\t";
+
+	// Loop through each row.
+	while ($row = $smcFunc['db_fetch_assoc']($result))
+	{
+		// Get the fields in this row...
+		$field_list = array();
+
+		foreach ($row as $key => $item)
+		{
+			// Try to figure out the type of each field. (NULL, number, or 'string'.)
+			if (!isset($item))
+				$field_list[] = 'NULL';
+			elseif (is_numeric($item) && (int) $item == $item)
+				$field_list[] = $item;
+			else
+				$field_list[] = '\'' . $smcFunc['db_escape_string']($item) . '\'';
+		}
+
+		// 'Insert' the data.
+		$data .= $insert_msg . '(' . implode(', ', $field_list) . ');' . $crlf;
+	}
+	$smcFunc['db_free_result']($result);
+
+	$data .= $crlf;
+
+	$start += $limit;
+
+	return $data;
+}
+
+/**
+ * Dumps the schema (CREATE) for a table.
+ * @todo why is this needed for?
+ * @param string $tableName - the table
+ * @return string - the CREATE statement as string
+ */
+function smf_db_table_sql($tableName)
+{
+	global $smcFunc, $db_prefix;
+
+	$tableName = str_replace('{db_prefix}', $db_prefix, $tableName);
+
+	// This will be needed...
+	$crlf = "\r\n";
+
+	// Start the create table...
+	$schema_create = '';
+	$index_create = '';
+
+	// Let's get the create statement directly from SQLite.
+	$result = $smcFunc['db_query']('', '
+		SELECT sql
+		FROM sqlite_master
+		WHERE type = {string:type}
+			AND name = {string:table_name}',
+		array(
+			'type' => 'table',
+			'table_name' => $tableName,
+		)
+	);
+	list ($schema_create) = $smcFunc['db_fetch_row']($result);
+	$smcFunc['db_free_result']($result);
+
+	// Now the indexes.
+	$result = $smcFunc['db_query']('', '
+		SELECT sql
+		FROM sqlite_master
+		WHERE type = {string:type}
+			AND tbl_name = {string:table_name}',
+		array(
+			'type' => 'index',
+			'table_name' => $tableName,
+		)
+	);
+	$indexes = array();
+	while ($row = $smcFunc['db_fetch_assoc']($result))
+		if (trim($row['sql']) != '')
+			$indexes[] = $row['sql'];
+	$smcFunc['db_free_result']($result);
+
+	$index_create .= implode(';' . $crlf, $indexes);
+	$schema_create = empty($indexes) ? rtrim($schema_create) : $schema_create . ';' . $crlf . $crlf;
+
+	return $schema_create . $index_create;
+}
+
+/**
+ *  Get the version number.
+ *  @return string - the version
+ */
+function smf_db_get_version()
+{
+	$version = SQLite3::version();
+	return $version['versionString'];
+}
+
+/**
+ * Simply return the database - and die!
+ * Used by DumpDatabase.php.
+ */
+function smf_db_get_backup()
+{
+	global $db_name;
+
+	$db_file = substr($db_name, -3) === '.db' ? $db_name : $db_name . '.db';
+
+	// Add more info if zipped...
+	$ext = '';
+	if (isset($_REQUEST['compress']) && function_exists('gzencode'))
+		$ext = '.gz';
+
+	// Do the remaining headers.
+	header('Content-Disposition: attachment; filename="' . $db_file . $ext . '"');
+	header('Cache-Control: private');
+	header('Connection: close');
+
+	// Literally dump the contents.  Try reading the file first.
+	if (@readfile($db_file) == null)
+		echo file_get_contents($db_file);
+
+	obExit(false);
+}
+
+?>

--- a/Sources/DbPackages-sqlite3.php
+++ b/Sources/DbPackages-sqlite3.php
@@ -1,0 +1,822 @@
+<?php
+
+/**
+ * This file contains database functionality specifically designed for packages (mods) to utilize.
+ *
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines http://www.simplemachines.org
+ * @copyright 2013 Simple Machines and individual contributors
+ * @license http://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 2.1 Alpha 1
+ */
+
+if (!defined('SMF'))
+	die('No direct access...');
+
+/**
+ * Add the file functions to the $smcFunc array.
+ */
+function db_packages_init()
+{
+	global $smcFunc, $reservedTables, $db_package_log, $db_prefix;
+
+	if (!isset($smcFunc['db_create_table']) || $smcFunc['db_create_table'] != 'smf_db_create_table')
+	{
+		$smcFunc += array(
+			'db_add_column' => 'smf_db_add_column',
+			'db_add_index' => 'smf_db_add_index',
+			'db_alter_table' => 'smf_db_alter_table',
+			'db_calculate_type' => 'smf_db_calculate_type',
+			'db_change_column' => 'smf_db_change_column',
+			'db_create_table' => 'smf_db_create_table',
+			'db_drop_table' => 'smf_db_drop_table',
+			'db_table_structure' => 'smf_db_table_structure',
+			'db_list_columns' => 'smf_db_list_columns',
+			'db_list_indexes' => 'smf_db_list_indexes',
+			'db_remove_column' => 'smf_db_remove_column',
+			'db_remove_index' => 'smf_db_remove_index',
+		);
+		$db_package_log = array();
+	}
+
+	// We setup an array of SMF tables we can't do auto-remove on - in case a mod writer cocks it up!
+	$reservedTables = array('admin_info_files', 'approval_queue', 'attachments', 'ban_groups', 'ban_items',
+		'board_permissions', 'boards', 'calendar', 'calendar_holidays', 'categories', 'collapsed_categories',
+		'custom_fields', 'group_moderators', 'log_actions', 'log_activity', 'log_banned', 'log_boards',
+		'log_digest', 'log_errors', 'log_floodcontrol', 'log_group_requests', 'log_karma', 'log_mark_read',
+		'log_notify', 'log_online', 'log_packages', 'log_polls', 'log_reported', 'log_reported_comments',
+		'log_scheduled_tasks', 'log_search_messages', 'log_search_results', 'log_search_subjects',
+		'log_search_topics', 'log_topics', 'mail_queue', 'membergroups', 'members', 'message_icons',
+		'messages', 'moderators', 'package_servers', 'permission_profiles', 'permissions', 'personal_messages',
+		'pm_recipients', 'poll_choices', 'polls', 'scheduled_tasks', 'sessions', 'settings', 'smileys',
+		'themes', 'topics');
+	foreach ($reservedTables as $k => $table_name)
+		$reservedTables[$k] = strtolower($db_prefix . $table_name);
+
+	// We in turn may need the extra stuff.
+	db_extend('extra');
+}
+
+/**
+ * This function can be used to create a table without worrying about schema
+ *  compatabilities across supported database systems.
+ *  - If the table exists will, by default, do nothing.
+ *  - Builds table with columns as passed to it - at least one column must be sent.
+ *  The columns array should have one sub-array for each column - these sub arrays contain:
+ *  	'name' = Column name
+ *  	'type' = Type of column - values from (smallint, mediumint, int, text, varchar, char, tinytext, mediumtext, largetext)
+ *  	'size' => Size of column (If applicable) - for example 255 for a large varchar, 10 for an int etc.
+ *  		If not set SMF will pick a size.
+ *  	- 'default' = Default value - do not set if no default required.
+ *  	- 'null' => Can it be null (true or false) - if not set default will be false.
+ *  	- 'auto' => Set to true to make it an auto incrementing column. Set to a numerical value to set from what
+ *  		 it should begin counting.
+ *  - Adds indexes as specified within indexes parameter. Each index should be a member of $indexes. Values are:
+ *  	- 'name' => Index name (If left empty SMF will generate).
+ *  	- 'type' => Type of index. Choose from 'primary', 'unique' or 'index'. If not set will default to 'index'.
+ *  	- 'columns' => Array containing columns that form part of key - in the order the index is to be created.
+ *  - parameters: (None yet)
+ *  - if_exists values:
+ *  	- 'ignore' will do nothing if the table exists. (And will return true)
+ *  	- 'overwrite' will drop any existing table of the same name.
+ *  	- 'error' will return false if the table already exists.
+ *
+ * @param string $table_name
+ * @param array $columns in the format specified.
+ * @param array $indexes default array(), in the format specified.
+ * @param array $parameters default array()
+ * @param string $if_exists default 'ignore'
+ * @param string $error default 'fatal'
+ */
+function smf_db_create_table($table_name, $columns, $indexes = array(), $parameters = array(), $if_exists = 'ignore', $error = 'fatal')
+{
+	global $reservedTables, $smcFunc, $db_package_log, $db_prefix;
+
+	// With or without the database name, the full name looks like this.
+	$real_prefix = preg_match('~^(`?)(.+?)\\1\\.(.*?)$~', $db_prefix, $match) === 1 ? $match[3] : $db_prefix;
+	$full_table_name = str_replace('{db_prefix}', $real_prefix, $table_name);
+	$table_name = str_replace('{db_prefix}', $db_prefix, $table_name);
+
+	// First - no way do we touch SMF tables.
+	// Commented out for now. We need to alter SMF tables in order to use this in the upgrade.
+/*
+	if (in_array(strtolower($table_name), $reservedTables))
+		return false;
+*/
+
+	// Log that we'll want to remove this on uninstall.
+	$db_package_log[] = array('remove_table', $table_name);
+
+	// Does this table exist or not?
+	$tables = $smcFunc['db_list_tables']();
+	if (in_array($full_table_name, $tables))
+	{
+		// This is a sad day... drop the table? If not, return false (error) by default.
+		if ($if_exists == 'overwrite')
+			$smcFunc['db_drop_table']($table_name);
+		else
+			return $if_exists == 'ignore';
+	}
+
+	// Righty - let's do the damn thing!
+	$table_query = 'CREATE TABLE ' . $table_name . "\n" . '(';
+	$done_primary = false;
+	foreach ($columns as $column)
+	{
+		// Auto increment is special
+		if (!empty($column['auto']))
+		{
+			$table_query .= "\n" . $column['name'] . ' integer PRIMARY KEY,';
+			$done_primary = true;
+			continue;
+		}
+		elseif (isset($column['default']) && $column['default'] !== null)
+			$default = 'default \'' . $smcFunc['db_escape_string']($column['default']) . '\'';
+		else
+			$default = '';
+
+		// Sort out the size... and stuff...
+		$column['size'] = isset($column['size']) && is_numeric($column['size']) ? $column['size'] : null;
+		list ($type, $size) = $smcFunc['db_calculate_type']($column['type'], $column['size']);
+		if ($size !== null)
+			$type = $type . '(' . $size . ')';
+
+		// Now just put it together!
+		$table_query .= "\n\t" . $column['name'] . ' ' . $type . ' ' . (!empty($column['null']) ? '' : 'NOT NULL') . ' ' . $default . ',';
+	}
+
+	// Loop through the indexes next...
+	$index_queries = array();
+	foreach ($indexes as $index)
+	{
+		$columns = implode(',', $index['columns']);
+
+		// Is it the primary?
+		if (isset($index['type']) && $index['type'] == 'primary')
+		{
+			// If we've done the primary via auto_inc, don't do it again!
+			if (!$done_primary)
+				$table_query .= "\n\t" . 'PRIMARY KEY (' . implode(',', $index['columns']) . '),';
+		}
+		else
+		{
+			if (empty($index['name']))
+				$index['name'] = implode('_', $index['columns']);
+			$index_queries[] = 'CREATE ' . (isset($index['type']) && $index['type'] == 'unique' ? 'UNIQUE' : '') . ' INDEX ' . $table_name . '_' . $index['name'] . ' ON ' . $table_name . ' (' . $columns . ')';
+		}
+	}
+
+	// No trailing commas!
+	if (substr($table_query, -1) == ',')
+		$table_query = substr($table_query, 0, -1);
+
+	$table_query .= ')';
+
+	if (empty($parameters['skip_transaction']))
+		$smcFunc['db_transaction']('begin');
+
+	// Do the table and indexes...
+	$smcFunc['db_query']('', $table_query,
+		array(
+			'security_override' => true,
+		)
+	);
+	foreach ($index_queries as $query)
+		$smcFunc['db_query']('', $query,
+		array(
+			'security_override' => true,
+		)
+	);
+
+	if (empty($parameters['skip_transaction']))
+		$smcFunc['db_transaction']('commit');
+}
+
+/**
+ * Drop a table.
+ *
+ * @param string $table_name
+ * @param array $parameters default array()
+ * @param bool $error
+ * @param string $error default 'fatal'
+ */
+function smf_db_drop_table($table_name, $parameters = array(), $error = 'fatal')
+{
+	global $reservedTables, $smcFunc, $db_prefix;
+
+	// Strip out the table name, we might not need it in some cases
+	$real_prefix = preg_match('~^(`?)(.+?)\\1\\.(.*?)$~', $db_prefix, $match) === 1 ? $match[3] : $db_prefix;
+	$full_table_name = str_replace('{db_prefix}', $real_prefix, $table_name);
+	$table_name = str_replace('{db_prefix}', $db_prefix, $table_name);
+
+	// God no - dropping one of these = bad.
+	if (in_array(strtolower($table_name), $reservedTables))
+		return false;
+
+	// Does it exist?
+	if (in_array($full_table_name, $smcFunc['db_list_tables']()))
+	{
+		$query = 'DROP TABLE ' . $table_name;
+		$smcFunc['db_query']('', $query,
+			array(
+				'security_override' => true,
+			)
+		);
+
+		return true;
+	}
+
+	// Otherwise do 'nout.
+	return false;
+}
+
+/**
+ * This function adds a column.
+ *
+ * @param string $table_name the name of the table
+ * @param array $column_info with column information
+ * @param array $parameters default array()
+ * @param string $if_exists default 'update'
+ * @param string $error default 'fatal'
+ */
+function smf_db_add_column($table_name, $column_info, $parameters = array(), $if_exists = 'update', $error = 'fatal')
+{
+	global $smcFunc, $db_package_log, $txt, $db_prefix;
+
+	$table_name = str_replace('{db_prefix}', $db_prefix, $table_name);
+
+	// Log that we will want to uninstall this!
+	$db_package_log[] = array('remove_column', $table_name, $column_info['name']);
+
+	// Does it exist - if so don't add it again!
+	$columns = $smcFunc['db_list_columns']($table_name, false);
+	foreach ($columns as $column)
+		if ($column == $column_info['name'])
+		{
+			// If we're going to overwrite then use change column.
+			if ($if_exists == 'update')
+				return $smcFunc['db_change_column']($table_name, $column_info['name'], $column_info);
+			else
+				return false;
+		}
+
+	// Alter the table to add the column.
+	if ($smcFunc['db_alter_table']($table_name, array('add' => array($column_info))) === false)
+		return false;
+
+	return true;
+}
+
+/**
+ * Removes a column.
+ *
+ * We can't reliably do this on SQLite - damn!
+ * @param string $table_name
+ * @param string $column_name
+ * @param array $parameters default array()
+ * @param string $error default 'fatal'
+ */
+function smf_db_remove_column($table_name, $column_name, $parameters = array(), $error = 'fatal')
+{
+	global $smcFunc, $db_prefix;
+
+	$table_name = str_replace('{db_prefix}', $db_prefix, $table_name);
+
+	if ($smcFunc['db_alter_table']($table_name, array('remove' => array(array('name' => $column_name)))))
+		return true;
+	else
+		return false;
+}
+
+/**
+ * Change a column.
+ *
+ * @param string $table_name
+ * @param $old_column
+ * @param $column_info
+ * @param array $parameters default array()
+ * @param string $error default 'fatal'
+ */
+function smf_db_change_column($table_name, $old_column, $column_info, $parameters = array(), $error = 'fatal')
+{
+	global $smcFunc, $db_prefix;
+
+	$table_name = str_replace('{db_prefix}', $db_prefix, $table_name);
+
+	if ($smcFunc['db_alter_table']($table_name, array('change' => array(array('name' => $old_column) + $column_info))))
+		return true;
+	else
+		return false;
+}
+
+/**
+ * Add an index.
+ *
+ * @param string $table_name
+ * @param array $index_info
+ * @param array $parameters default array()
+ * @param string $if_exists default 'update'
+ * @param string $error default 'fatal'
+ */
+function smf_db_add_index($table_name, $index_info, $parameters = array(), $if_exists = 'update', $error = 'fatal')
+{
+	global $smcFunc, $db_package_log, $db_prefix;
+
+	$table_name = str_replace('{db_prefix}', $db_prefix, $table_name);
+
+	// No columns = no index.
+	if (empty($index_info['columns']))
+		return false;
+	$columns = implode(',', $index_info['columns']);
+
+	// No name - make it up!
+	if (empty($index_info['name']))
+	{
+		// No need for primary.
+		if (isset($index_info['type']) && $index_info['type'] == 'primary')
+			$index_info['name'] = '';
+		else
+			$index_info['name'] = implode('_', $index_info['columns']);
+	}
+	else
+		$index_info['name'] = $index_info['name'];
+
+	// Log that we are going to want to remove this!
+	$db_package_log[] = array('remove_index', $table_name, $index_info['name']);
+
+	// Let's get all our indexes.
+	$indexes = $smcFunc['db_list_indexes']($table_name, true);
+	// Do we already have it?
+	foreach ($indexes as $index)
+	{
+		if ($index['name'] == $index_info['name'] || ($index['type'] == 'primary' && isset($index_info['type']) && $index_info['type'] == 'primary'))
+		{
+			// If we want to overwrite simply remove the current one then continue.
+			if ($if_exists != 'update' || $index['type'] == 'primary')
+				return false;
+			else
+				$smcFunc['db_remove_index']($table_name, $index_info['name']);
+		}
+	}
+
+	// If we're here we know we don't have the index - so just add it.
+	if (!empty($index_info['type']) && $index_info['type'] == 'primary')
+	{
+		// @todo Doesn't work with PRIMARY KEY yet.
+	}
+	else
+	{
+		$smcFunc['db_query']('', '
+			CREATE ' . (isset($index_info['type']) && $index_info['type'] == 'unique' ? 'UNIQUE' : '') . ' INDEX ' . $index_info['name'] . ' ON ' . $table_name . ' (' . $columns . ')',
+			array(
+				'security_override' => true,
+			)
+		);
+	}
+}
+
+/**
+ * Remove an index.
+ *
+ * @param string $table_name
+ * @param string $index_name
+ * @param array$parameters default array()
+ * @param string $error default 'fatal'
+ */
+function smf_db_remove_index($table_name, $index_name, $parameters = array(), $error = 'fatal')
+{
+	global $smcFunc, $db_prefix;
+
+	$table_name = str_replace('{db_prefix}', $db_prefix, $table_name);
+
+	// Better exist!
+	$indexes = $smcFunc['db_list_indexes']($table_name, true);
+
+	foreach ($indexes as $index)
+	{
+		// @todo Doesn't do primary key at the moment!
+		if ($index['type'] != 'primary' && $index['name'] == $index_name)
+		{
+			// Drop the bugger...
+			$smcFunc['db_query']('', '
+				DROP INDEX ' . $index_name,
+				array(
+					'security_override' => true,
+				)
+			);
+
+			return true;
+		}
+	}
+
+	// Not to be found ;(
+	return false;
+}
+
+/**
+ * Get the schema formatted name for a type.
+ *
+ * @param string $type_name
+ * @param $type_size
+ * @param $reverse
+ */
+function smf_db_calculate_type($type_name, $type_size = null, $reverse = false)
+{
+	// Let's be sure it's lowercase MySQL likes both, others no.
+	$type_name = strtolower($type_name);
+	// Generic => Specific.
+	if (!$reverse)
+	{
+		$types = array(
+			'mediumint' => 'int',
+			'tinyint' => 'smallint',
+			'mediumtext' => 'text',
+			'largetext' => 'text',
+		);
+	}
+	else
+	{
+		$types = array(
+			'integer' => 'int',
+		);
+	}
+
+	// Got it? Change it!
+	if (isset($types[$type_name]))
+	{
+		if ($type_name == 'tinytext')
+			$type_size = 255;
+		$type_name = $types[$type_name];
+	}
+	// Numbers don't have a size.
+	if (strpos($type_name, 'int') !== false)
+		$type_size = null;
+
+	return array($type_name, $type_size);
+}
+
+/**
+ * Get table structure.
+ *
+ * @param string $table_name
+ * @param array $parameters default array()
+ */
+function smf_db_table_structure($table_name, $parameters = array())
+{
+	global $smcFunc, $db_prefix;
+
+	$table_name = str_replace('{db_prefix}', $db_prefix, $table_name);
+
+	return array(
+		'name' => $table_name,
+		'columns' => $smcFunc['db_list_columns']($table_name, true),
+		'indexes' => $smcFunc['db_list_indexes']($table_name, true),
+	);
+}
+
+/**
+ * Return column information for a table.
+ * Harder than it should be, on sqlite!
+ *
+ * @param string $table_name
+ * @param bool $detail
+ * @param array $parameters default array()
+ * @return mixed
+ */
+function smf_db_list_columns($table_name, $detail = false, $parameters = array())
+{
+	global $smcFunc, $db_prefix;
+
+	$table_name = str_replace('{db_prefix}', $db_prefix, $table_name);
+
+	$result = $smcFunc['db_query']('', '
+		PRAGMA table_info(' . $table_name . ')',
+		array(
+			'security_override' => true,
+		)
+	);
+	$columns = array();
+
+	$primaries = array();
+	while ($row = $smcFunc['db_fetch_assoc']($result))
+	{
+		if (!$detail)
+		{
+			$columns[] = $row['name'];
+		}
+		else
+		{
+			// Auto increment is hard to tell really... if there's only one primary it probably is.
+			if ($row['pk'])
+				$primaries[] = $row['name'];
+
+			// Can we split out the size?
+			if (preg_match('~(.+?)\s*\((\d+)\)~i', $row['type'], $matches))
+			{
+				$type = $matches[1];
+				$size = $matches[2];
+			}
+			else
+			{
+				$type = $row['type'];
+				$size = null;
+			}
+
+			$columns[$row['name']] = array(
+				'name' => $row['name'],
+				'null' => $row['notnull'] ? false : true,
+				'default' => $row['dflt_value'],
+				'type' => $type,
+				'size' => $size,
+				'auto' => false,
+			);
+		}
+	}
+	$smcFunc['db_free_result']($result);
+
+	// Put in our guess at auto_inc.
+	if (count($primaries) == 1)
+		$columns[$primaries[0]]['auto'] = true;
+
+	return $columns;
+}
+
+/**
+ * Get index information.
+ *
+ * @param string $table_name
+ * @param bool $detail
+ * @param array $parameters
+ * @return mixed
+ */
+function smf_db_list_indexes($table_name, $detail = false, $parameters = array())
+{
+	global $smcFunc, $db_prefix;
+
+	$table_name = str_replace('{db_prefix}', $db_prefix, $table_name);
+
+	$result = $smcFunc['db_query']('', '
+		PRAGMA index_list(' . $table_name . ')',
+		array(
+			'security_override' => true,
+		)
+	);
+	$indexes = array();
+	while ($row = $smcFunc['db_fetch_assoc']($result))
+	{
+		if (!$detail)
+			$indexes[] = $row['name'];
+		else
+		{
+			$result2 = $smcFunc['db_query']('', '
+				PRAGMA index_info(' . $row['name'] . ')',
+				array(
+					'security_override' => true,
+				)
+			);
+			while ($row2 = $smcFunc['db_fetch_assoc']($result2))
+			{
+				// What is the type?
+				if ($row['unique'])
+					$type = 'unique';
+				else
+					$type = 'index';
+
+				// This is the first column we've seen?
+				if (empty($indexes[$row['name']]))
+				{
+					$indexes[$row['name']] = array(
+						'name' => $row['name'],
+						'type' => $type,
+						'columns' => array(),
+					);
+				}
+
+				// Add the column...
+				$indexes[$row['name']]['columns'][] = $row2['name'];
+			}
+			$smcFunc['db_free_result']($result2);
+		}
+	}
+	$smcFunc['db_free_result']($result);
+
+	return $indexes;
+}
+
+/**
+ * Alter table on SQLite.
+ *
+ * @param string $table_name
+ * @param array $columns
+ */
+function smf_db_alter_table($table_name, $columns)
+{
+	global $smcFunc, $db_prefix, $db_name, $boarddir;
+
+	$db_file = substr($db_name, -3) === '.db' ? $db_name : $db_name . '.db';
+
+	$table_name = str_replace('{db_prefix}', $db_prefix, $table_name);
+
+	// Let's get the current columns for the table.
+	$current_columns = $smcFunc['db_list_columns']($table_name, true);
+
+	// Let's get a list of columns for the temp table.
+	$temp_table_columns = array();
+
+	// Let's see if we have columns to remove or columns that are being added that already exist.
+	foreach ($current_columns as $key => $column)
+	{
+		$exists = false;
+		if (isset($columns['remove']))
+			foreach ($columns['remove'] as $drop)
+				if ($drop['name'] == $column['name'])
+				{
+					$exists = true;
+					break;
+				}
+
+		if (isset($columns['add']))
+			foreach ($columns['add'] as $key2 => $add)
+				if ($add['name'] == $column['name'])
+				{
+					unset($columns['add'][$key2]);
+					break;
+				}
+
+		// Doesn't exist then we 'remove'.
+		if (!$exists)
+			$temp_table_columns[] = $column['name'];
+	}
+
+	// If they are equal then that means that the column that we are adding exists or it doesn't exist and we are not looking to change any one of them.
+	if (count($temp_table_columns) == count($current_columns) && empty($columns['change']) && empty($columns['add']))
+		return true;
+
+	// Drop the temp table.
+	$smcFunc['db_query']('', '
+		DROP TABLE {raw:temp_table_name}',
+		array(
+			'temp_table_name' => $table_name . '_tmp',
+			'db_error_skip' => true,
+		)
+	);
+
+	// Let's make a backup of the current database.
+	// We only want the first backup of a table modification.  So if there is a backup file and older than an hour just delete and back up again
+	$db_backup_file = $boarddir . '/Packages/backups/backup_' . $table_name . '_' . basename($db_file) . md5($table_name . $db_file);
+	if (file_exists($db_backup_file) && time() - filemtime($db_backup_file) > 3600)
+	{
+		@unlink($db_backup_file);
+		@copy($db_file, $db_backup_file);
+	}
+	elseif (!file_exists($db_backup_file))
+		@copy($db_file, $db_backup_file);
+
+	// If we don't have temp tables then everything crapped out.  Just exit.
+	if (empty($temp_table_columns))
+		return false;
+
+	// Start
+	$smcFunc['db_transaction']('begin');
+
+	// Let's create the temporary table.
+	$createTempTable = $smcFunc['db_query']('', '
+		CREATE TEMPORARY TABLE {raw:temp_table_name}
+		(
+			{raw:columns}
+		);',
+		array(
+			'temp_table_name' => $table_name . '_tmp',
+			'columns' => implode(', ', $temp_table_columns),
+			'db_error_skip' => true,
+		)
+	) !== false;
+
+	if (!$createTempTable)
+		return false;
+
+	// Insert into temp table.
+	$smcFunc['db_query']('', '
+		INSERT INTO {raw:temp_table_name}
+			({raw:columns})
+		SELECT {raw:columns}
+		FROM {raw:table_name}',
+		array(
+			'table_name' => $table_name,
+			'columns' => implode(', ', $temp_table_columns),
+			'temp_table_name' => $table_name . '_tmp',
+		)
+	);
+
+	// Drop the current table.
+	$dropTable = $smcFunc['db_query']('', '
+		DROP TABLE {raw:table_name}',
+		array(
+			'table_name' => $table_name,
+			'db_error_skip' => true,
+		)
+	) !== false;
+
+	// If you can't drop the main table then there is no where to go from here. Just return.
+	if (!$dropTable)
+		return false;
+
+	// We need to keep track of the structure for the current columns and the new columns.
+	$new_columns = array();
+	$column_names = array();
+
+	// Let's get the ones that we already have first.
+	foreach ($current_columns as $name => $column)
+	{
+		if (in_array($name, $temp_table_columns))
+		{
+			$new_columns[$name] = array(
+				'name' => $name,
+				'type' => $column['type'],
+				'size' => isset($column['size']) ? (int) $column['size'] : null,
+				'null' => !empty($column['null']),
+				'auto' => isset($column['auto']) ? $column['auto'] : false,
+				'default' => isset($column['default']) ? $column['default'] : '',
+			);
+
+			// Lets keep track of the name for the column.
+			$column_names[$name] = $name;
+		}
+	}
+
+	// Now the new.
+	if (!empty($columns['add']))
+		foreach ($columns['add'] as $add)
+		{
+			$new_columns[$add['name']] = array(
+				'name' => $add['name'],
+				'type' => $add['type'],
+				'size' => isset($add['size']) ? (int) $add['size'] : null,
+				'null' => !empty($add['null']),
+				'auto' => isset($add['auto']) ? $add['auto'] : false,
+				'default' => isset($add['default']) ? $add['default'] : '',
+			);
+
+			// Let's keep track of the name for the column.
+			$column_names[$add['name']] = strstr('int', $add['type']) ? ' 0 AS ' . $add['name'] : ' {string:empty_string} AS ' . $add['name'];
+		}
+
+	// Now to change a column.  Not drop but change it.
+	if (isset($columns['change']))
+		foreach ($columns['change'] as $change)
+			if (isset($new_columns[$change['name']]))
+				$new_columns[$change['name']] = array(
+					'name' => $change['name'],
+					'type' => $change['type'],
+					'size' => isset($change['size']) ? (int) $change['size'] : null,
+					'null' => !empty($change['null']),
+					'auto' => isset($change['auto']) ? $change['auto'] : false,
+					'default' => isset($change['default']) ? $change['default'] : '',
+				);
+
+	// Now let's create the table.
+	$createTable = $smcFunc['db_create_table']($table_name, $new_columns, array(), array('skip_transaction' => true));
+
+	// Did it create correctly?
+	if ($createTable === false)
+		return false;
+
+	// Back to it's original table.
+	$insertData = $smcFunc['db_query']('', '
+		INSERT INTO {raw:table_name}
+			({raw:columns})
+		SELECT ' . implode(', ', $column_names) . '
+		FROM {raw:temp_table_name}',
+		array(
+			'table_name' => $table_name,
+			'columns' => implode(', ', array_keys($new_columns)),
+			'columns_select' => implode(', ', $column_names),
+			'temp_table_name' => $table_name . '_tmp',
+			'empty_string' => '',
+		)
+	);
+
+	// Did everything insert correctly?
+	if (!$insertData)
+		return false;
+
+	// Drop the temp table.
+	$smcFunc['db_query']('', '
+		DROP TABLE {raw:temp_table_name}',
+		array(
+			'temp_table_name' => $table_name . '_tmp',
+			'db_error_skip' => true,
+		)
+	);
+
+	// Commit or else there is no point in doing the previous steps.
+	$smcFunc['db_transaction']('commit');
+
+	// We got here so we're good.  The temp table should be deleted, if not it will be gone later on >:D.
+	return true;
+}
+
+?>

--- a/Sources/DbSearch-sqlite3.php
+++ b/Sources/DbSearch-sqlite3.php
@@ -1,0 +1,110 @@
+<?php
+
+/**
+ * This file contains database functions specific to search related activity.
+ *
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines http://www.simplemachines.org
+ * @copyright 2013 Simple Machines and individual contributors
+ * @license http://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 2.1 Alpha 1
+ */
+
+if (!defined('SMF'))
+	die('No direct access...');
+
+/**
+ *  Add the file functions to the $smcFunc array.
+ */
+function db_search_init()
+{
+	global $smcFunc;
+
+	if (!isset($smcFunc['db_search_query']) || $smcFunc['db_search_query'] != 'smf_db_search_query')
+		$smcFunc += array(
+			'db_search_query' => 'smf_db_search_query',
+			'db_search_support' => 'smf_db_search_support',
+			'db_create_word_search' => 'smf_db_create_word_search',
+			'db_support_ignore' => false,
+		);
+}
+
+/**
+ * This function will tell you whether this database type supports this search type.
+ *
+ * @param string $search_type
+ */
+function smf_db_search_support($search_type)
+{
+	$supported_types = array('custom');
+
+	return in_array($search_type, $supported_types);
+}
+
+/**
+ * Returns the correct query for this search type.
+ *
+ * @param string $identifier
+ * @param string $db_string
+ * @param array $db_values default array()
+ * @param resource $connection
+ */
+function smf_db_search_query($identifier, $db_string, $db_values = array(), $connection = null)
+{
+	global $smcFunc;
+
+	$replacements = array(
+		'create_tmp_log_search_topics' => array(
+			'~mediumint\(\d\)~i' => 'int',
+			'~TYPE=HEAP~i' => '',
+		),
+		'create_tmp_log_search_messages' => array(
+			'~mediumint\(\d\)~i' => 'int',
+			'~TYPE=HEAP~i' => '',
+		),
+	);
+
+	if (isset($replacements[$identifier]))
+		$db_string = preg_replace(array_keys($replacements[$identifier]), array_values($replacements[$identifier]), $db_string);
+	elseif (preg_match('~^\s*INSERT\sIGNORE~i', $db_string) != 0)
+	{
+		$db_string = preg_replace('~^\s*INSERT\sIGNORE~i', 'INSERT', $db_string);
+		// Don't error on multi-insert.
+		$db_values['db_error_skip'] = true;
+	}
+
+	$return = $smcFunc['db_query']('', $db_string,
+		$db_values, $connection
+	);
+
+	return $return;
+}
+
+/**
+ * Highly specific function, to create the custom word index table.
+ *
+ * @param $size
+ */
+function smf_db_create_word_search($size)
+{
+	global $smcFunc;
+
+	$size = 'int';
+
+	$smcFunc['db_query']('', '
+		CREATE TABLE {db_prefix}log_search_words (
+			id_word {raw:size} NOT NULL default {string:string_zero},
+			id_msg int(10) NOT NULL default {string:string_zero},
+			PRIMARY KEY (id_word, id_msg)
+		)',
+		array(
+			'size' => $size,
+			'string_zero' => '0',
+		)
+	);
+}
+
+?>

--- a/Sources/Subs-Db-sqlite3.php
+++ b/Sources/Subs-Db-sqlite3.php
@@ -1,0 +1,968 @@
+<?php
+
+/**
+ * This file has all the main functions in it that relate to the database.
+ *
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines http://www.simplemachines.org
+ * @copyright 2013 Simple Machines and individual contributors
+ * @license http://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 2.1 Alpha 1
+ */
+
+if (!defined('SMF'))
+	die('No direct access...');
+
+/**
+ *  Maps the implementations in this file (smf_db_function_name)
+ *  to the $smcFunc['db_function_name'] variable.
+ *
+ * @param string $db_server
+ * @param string $db_name
+ * @param string $db_user
+ * @param string $db_passwd
+ * @param string $db_prefix
+ * @param array $db_options
+ */
+function smf_db_initiate($db_server, $db_name, $db_user, $db_passwd, $db_prefix, $db_options = array())
+{
+	global $smcFunc, $mysql_set_mode, $db_in_transact, $sqlite_error;
+
+	// Map some database specific functions, only do this once.
+	// SQLite3 does not have any procedural functions, so we need to map them all...
+	if (!isset($smcFunc['db_fetch_assoc']) || $smcFunc['db_fetch_assoc'] != 'smf_db_fetch_array')
+		$smcFunc += array(
+			'db_query' => 'smf_db_query',
+			'db_quote' => 'smf_db_quote',
+			'db_fetch_assoc' => 'smf_db_fetch_array',
+			'db_fetch_row' => 'smf_db_fetch_row',
+			'db_free_result' => 'smf_db_free_result',
+			'db_insert' => 'smf_db_insert',
+			'db_insert_id' => 'smf_db_insert_id',
+			'db_num_rows' => 'smf_db_num_rows',
+			'db_data_seek' => 'smf_db_seek',
+			'db_num_fields' => 'smf_db_num_fields',
+			'db_escape_string' => 'smf_db_escape_string',
+			'db_unescape_string' => 'smf_db_unescape_string',
+			'db_server_info' => 'smf_db_libversion',
+			'db_affected_rows' => 'smf_db_affected_rows',
+			'db_transaction' => 'smf_db_transaction',
+			'db_error' => 'smf_db_last_error',
+			'db_select_db' => '',
+			'db_title' => 'SQLite3',
+			'db_sybase' => true,
+			'db_case_sensitive' => true,
+			'db_escape_wildcard_string' => 'smf_db_escape_wildcard_string',
+		);
+
+	if (substr($db_name, -3) != '.db')
+		$db_name .= '.db';
+
+	// SQLite3 doesn't support persistent connections...
+	$connection = new SQLite3($db_name);
+
+	// Something's wrong, show an error if its fatal (which we assume it is)
+	if (!$connection)
+	{
+		if (!empty($db_options['non_fatal']))
+			return null;
+		else
+			display_db_error();
+	}
+	$db_in_transact = false;
+
+	// This is frankly stupid - stop SQLite returning alias names!
+	@$connection->exec('PRAGMA short_column_names = 1');
+
+	// Make some user defined functions!
+	
+	$connection->createFunction('unix_timestamp', 'smf_udf_unix_timestamp', 0);
+	$connection->createFunction('inet_aton', 'smf_udf_inet_aton', 1);
+	$connection->createFunction('inet_ntoa', 'smf_udf_inet_ntoa', 1);
+	$connection->createFunction('find_in_set', 'smf_udf_find_in_set', 2);
+	$connection->createFunction('year', 'smf_udf_year', 1);
+	$connection->createFunction('month', 'smf_udf_month', 1);
+	$connection->createFunction('dayofmonth', 'smf_udf_dayofmonth', 1);
+	$connection->createFunction('concat', 'smf_udf_concat');
+	$connection->createFunction('locate', 'smf_udf_locate', 2);
+	$connection->createFunction('regexp', 'smf_udf_regexp', 2);
+
+	return $connection;
+}
+
+/**
+ * Extend the database functionality. It calls the respective file's init
+ * to add the implementations in that file to $smcFunc array.
+ *
+ * @param string $type indicated which additional file to load. ('extra', 'packages')
+ */
+function db_extend($type = 'extra')
+{
+	global $sourcedir, $db_type;
+
+	require_once($sourcedir . '/Db' . strtoupper($type[0]) . substr($type, 1) . '-' . $db_type . '.php');
+	$initFunc = 'db_' . $type . '_init';
+	$initFunc();
+}
+
+/**
+ * Verify that we have a valid connection
+ * 
+ * @param resource $connection
+ * Thanks to tinoet for this idea
+ */
+function smf_db_check_connection($connection)
+{
+	global $db_name;
+
+ 	if (!is_object($connection))
+ 	{
+ 		if (substr($db_name, -3) != '.db')
+ 			$db_name .= '.db';
+
+		$connection = new Sqlite3($connection);
+	}
+ 	
+	return $connection;
+}
+
+/**
+ * Fix db prefix if necessary.
+ * SQLite doesn't actually need this!
+ *
+ * @param type $db_prefix
+ * @param type $db_name
+ */
+function db_fix_prefix(&$db_prefix, $db_name)
+{
+	return false;
+}
+
+/**
+ * Callback for preg_replace_calback on the query.
+ * It allows to replace on the fly a few pre-defined strings, for
+ * convenience ('query_see_board', 'query_wanna_see_board'), with
+ * their current values from $user_info.
+ * In addition, it performs checks and sanitization on the values
+ * sent to the database.
+ *
+ * @param $matches
+ */
+function smf_db_replacement__callback($matches)
+{
+	global $db_callback, $user_info, $db_prefix;
+
+	list ($values, $connection) = $db_callback;
+
+	if ($matches[1] === 'db_prefix')
+		return $db_prefix;
+
+	if ($matches[1] === 'query_see_board')
+		return $user_info['query_see_board'];
+
+	if ($matches[1] === 'query_wanna_see_board')
+		return $user_info['query_wanna_see_board'];
+
+	if (!isset($matches[2]))
+		smf_db_error_backtrace('Invalid value inserted or no type specified.', '', E_USER_ERROR, __FILE__, __LINE__);
+
+	if (!isset($values[$matches[2]]))
+		smf_db_error_backtrace('The database value you\'re trying to insert does not exist: ' . htmlspecialchars($matches[2]), '', E_USER_ERROR, __FILE__, __LINE__);
+
+	$replacement = $values[$matches[2]];
+
+	switch ($matches[1])
+	{
+		case 'int':
+			if (!is_numeric($replacement) || (string) $replacement !== (string) (int) $replacement)
+				smf_db_error_backtrace('Wrong value type sent to the database. Integer expected. (' . $matches[2] . ')', '', E_USER_ERROR, __FILE__, __LINE__);
+			return (string) (int) $replacement;
+		break;
+
+		case 'string':
+		case 'text':
+			return sprintf('\'%1$s\'', SQLite3::escapeString($replacement));
+		break;
+
+		case 'array_int':
+			if (is_array($replacement))
+			{
+				if (empty($replacement))
+					smf_db_error_backtrace('Database error, given array of integer values is empty. (' . $matches[2] . ')', '', E_USER_ERROR, __FILE__, __LINE__);
+
+				foreach ($replacement as $key => $value)
+				{
+					if (!is_numeric($value) || (string) $value !== (string) (int) $value)
+						smf_db_error_backtrace('Wrong value type sent to the database. Array of integers expected. (' . $matches[2] . ')', '', E_USER_ERROR, __FILE__, __LINE__);
+
+					$replacement[$key] = (string) (int) $value;
+				}
+
+				return implode(', ', $replacement);
+			}
+			else
+				smf_db_error_backtrace('Wrong value type sent to the database. Array of integers expected. (' . $matches[2] . ')', '', E_USER_ERROR, __FILE__, __LINE__);
+
+		break;
+
+		case 'array_string':
+			if (is_array($replacement))
+			{
+				if (empty($replacement))
+					smf_db_error_backtrace('Database error, given array of string values is empty. (' . $matches[2] . ')', '', E_USER_ERROR, __FILE__, __LINE__);
+
+				foreach ($replacement as $key => $value)
+					$replacement[$key] = sprintf('\'%1$s\'', sqlite3::escape_string($value));
+
+				return implode(', ', $replacement);
+			}
+			else
+				smf_db_error_backtrace('Wrong value type sent to the database. Array of strings expected. (' . $matches[2] . ')', '', E_USER_ERROR, __FILE__, __LINE__);
+		break;
+
+		case 'date':
+			if (preg_match('~^(\d{4})-([0-1]?\d)-([0-3]?\d)$~', $replacement, $date_matches) === 1)
+				return sprintf('\'%04d-%02d-%02d\'', $date_matches[1], $date_matches[2], $date_matches[3]);
+			else
+				smf_db_error_backtrace('Wrong value type sent to the database. Date expected. (' . $matches[2] . ')', '', E_USER_ERROR, __FILE__, __LINE__);
+		break;
+
+		case 'float':
+			if (!is_numeric($replacement))
+				smf_db_error_backtrace('Wrong value type sent to the database. Floating point number expected. (' . $matches[2] . ')', '', E_USER_ERROR, __FILE__, __LINE__);
+			return (string) (float) $replacement;
+		break;
+
+		case 'identifier':
+			return '`' . strtr($replacement, array('`' => '', '.' => '')) . '`';
+		break;
+
+		case 'raw':
+			return $replacement;
+		break;
+
+		default:
+			smf_db_error_backtrace('Undefined type used in the database query. (' . $matches[1] . ':' . $matches[2] . ')', '', false, __FILE__, __LINE__);
+		break;
+	}
+}
+
+/**
+ * Just like the db_query, escape and quote a string,
+ * but not executing the query.
+ *
+ * @param string $db_string
+ * @param string $db_values
+ * @param resource $connection
+ */
+function smf_db_quote($db_string, $db_values, $connection = null)
+{
+	global $db_callback, $db_connection;
+
+	// Only bother if there's something to replace.
+	if (strpos($db_string, '{') !== false)
+	{
+		// This is needed by the callback function.
+		$db_callback = array($db_values, $connection === null ? $db_connection : $connection);
+
+		// Do the quoting and escaping
+		$db_string = preg_replace_callback('~{([a-z_]+)(?::([a-zA-Z0-9_-]+))?}~', 'smf_db_replacement__callback', $db_string);
+
+		// Clear this global variable.
+		$db_callback = array();
+	}
+
+	return $db_string;
+}
+
+/**
+ * 
+ * @param resource $handle
+ */
+function smf_db_fetch_array($handle)
+{
+	return $handle->fetchArray();
+}
+
+/**
+ * Do a query.  Takes care of errors too.
+ *
+ * @param string $identifier
+ * @param string $db_string
+ * @param string $db_values
+ * @param resource $connection
+ */
+function smf_db_query($identifier, $db_string, $db_values = array(), $connection = null)
+{
+	global $db_cache, $db_count, $db_connection, $db_show_debug, $time_start;
+	global $db_unbuffered, $db_callback, $modSettings;
+
+	// Decide which connection to use.
+	$connection = smf_db_check_connection($connection === null ? $db_connection : $connection);
+
+	// Special queries that need processing.
+	$replacements = array(
+		'birthday_array' => array(
+			'~DATE_FORMAT\(([^,]+),\s*([^\)]+)\s*\)~' => 'strftime($2, $1)'
+		),
+		'substring' => array(
+			'~SUBSTRING~' => 'SUBSTR',
+		),
+		'truncate_table' => array(
+			'~TRUNCATE~i' => 'DELETE FROM',
+		),
+		'user_activity_by_time' => array(
+			'~HOUR\(FROM_UNIXTIME\((poster_time\s+\+\s+\{int:.+\})\)\)~' => 'strftime(\'%H\', datetime($1, \'unixepoch\'))',
+		),
+		'unread_fetch_topic_count' => array(
+			'~\s*SELECT\sCOUNT\(DISTINCT\st\.id_topic\),\sMIN\(t\.id_last_msg\)(.+)$~is' => 'SELECT COUNT(id_topic), MIN(id_last_msg) FROM (SELECT DISTINCT t.id_topic, t.id_last_msg $1)',
+		),
+		'alter_table_boards' => array(
+			'~(.+)~' => '',
+		),
+		'get_random_number' => array(
+			'~RAND~' => 'RANDOM',
+		),
+		'set_character_set' => array(
+			'~(.+)~' => '',
+		),
+		'themes_count' => array(
+			'~\s*SELECT\sCOUNT\(DISTINCT\sid_member\)\sAS\svalue,\sid_theme.+FROM\s(.+themes)(.+)~is' => 'SELECT COUNT(id_member) AS value, id_theme FROM (SELECT DISTINCT id_member, id_theme, variable FROM $1) $2',
+		),
+		'attach_download_increase' => array(
+			'~LOW_PRIORITY~' => '',
+		),
+		'pm_conversation_list' => array(
+			'~ORDER BY id_pm~' => 'ORDER BY MAX(pm.id_pm)',
+		),
+		'boardindex_fetch_boards' => array(
+			'~(.)$~' => '$1 ORDER BY b.board_order',
+		),
+		'messageindex_fetch_boards' => array(
+			'~(.)$~' => '$1 ORDER BY b.board_order',
+		),
+		'order_by_board_order' => array(
+			'~(.)$~' => '$1 ORDER BY b.board_order',
+		),
+		'spider_check' => array(
+			'~(.)$~' => '$1 ORDER BY LENGTH(user_agent) DESC',
+		),
+	);
+
+	if (isset($replacements[$identifier]))
+		$db_string = preg_replace(array_keys($replacements[$identifier]), array_values($replacements[$identifier]), $db_string);
+
+	// SQLite doesn't support count(distinct).
+	$db_string = trim($db_string);
+	$db_string = preg_replace('~^\s*SELECT\s+?COUNT\(DISTINCT\s+?(.+?)\)(\s*AS\s*(.+?))*\s*(FROM.+)~is', 'SELECT COUNT(*) $2 FROM (SELECT DISTINCT $1 $4)', $db_string);
+
+	// Or RLIKE.
+	$db_string = preg_replace('~AND\s*(.+?)\s*RLIKE\s*(\{string:.+?\})~', 'AND REGEXP(\1, \2)', $db_string);
+
+	// INSTR?  No support for that buddy :(
+	if (preg_match('~INSTR\((.+?),\s(.+?)\)~', $db_string, $matches) === 1)
+	{
+		$db_string = preg_replace('~INSTR\((.+?),\s(.+?)\)~', '$1 LIKE $2', $db_string);
+		list(, $search) = explode(':', substr($matches[2], 1, -1));
+		$db_values[$search] = '%' . $db_values[$search] . '%';
+	}
+
+	// Lets remove ASC and DESC from GROUP BY clause.
+	if (preg_match('~GROUP BY .*? (?:ASC|DESC)~is', $db_string, $matches))
+	{
+		$replace = str_replace(array('ASC', 'DESC'), '', $matches[0]);
+		$db_string = str_replace($matches[0], $replace, $db_string);
+	}
+
+	// We need to replace the SUBSTRING in the sort identifier.
+	if ($identifier == 'substring_membergroups' && isset($db_values['sort']))
+		$db_values['sort'] = preg_replace('~SUBSTRING~', 'SUBSTR', $db_values['sort']);
+
+	// SQLite doesn't support TO_DAYS but has the julianday function which can be used in the same manner.  But make sure it is being used to calculate a span.
+	$db_string = preg_replace('~\(TO_DAYS\(([^)]+)\) - TO_DAYS\(([^)]+)\)\) AS span~', '(julianday($1) - julianday($2)) AS span', $db_string);
+
+	// One more query....
+	$db_count = !isset($db_count) ? 1 : $db_count + 1;
+
+	if (empty($modSettings['disableQueryCheck']) && strpos($db_string, '\'') !== false && empty($db_values['security_override']))
+		smf_db_error_backtrace('Hacking attempt...', 'Illegal character (\') used in query...', true, __FILE__, __LINE__);
+
+	if (empty($db_values['security_override']) && (!empty($db_values) || strpos($db_string, '{db_prefix}') !== false))
+	{
+		// Pass some values to the global space for use in the callback function.
+		$db_callback = array($db_values, $connection);
+
+		// Inject the values passed to this function.
+		$db_string = preg_replace_callback('~{([a-z_]+)(?::([a-zA-Z0-9_-]+))?}~', 'smf_db_replacement__callback', $db_string);
+
+		// This shouldn't be residing in global space any longer.
+		$db_callback = array();
+	}
+
+	// Debugging.
+	if (isset($db_show_debug) && $db_show_debug === true)
+	{
+		// Get the file and line number this function was called.
+		list ($file, $line) = smf_db_error_backtrace('', '', 'return', __FILE__, __LINE__);
+
+		// Initialize $db_cache if not already initialized.
+		if (!isset($db_cache))
+			$db_cache = array();
+
+		if (!empty($_SESSION['debug_redirect']))
+		{
+			$db_cache = array_merge($_SESSION['debug_redirect'], $db_cache);
+			$db_count = count($db_cache) + 1;
+			$_SESSION['debug_redirect'] = array();
+		}
+
+		$st = microtime();
+		// Don't overload it.
+		$db_cache[$db_count]['q'] = $db_count < 50 ? $db_string : '...';
+		$db_cache[$db_count]['f'] = $file;
+		$db_cache[$db_count]['l'] = $line;
+		$db_cache[$db_count]['s'] = array_sum(explode(' ', $st)) - array_sum(explode(' ', $time_start));
+	}
+
+	$ret = @$connection->query($db_string);
+	if ($ret === false && empty($db_values['db_error_skip']))
+	{
+		$err_msg = $ret->lastErrorMsg();
+		$ret = smf_db_error($db_string . '#!#' . $err_msg, $connection);
+	}
+
+	// Debugging.
+	if (isset($db_show_debug) && $db_show_debug === true)
+		$db_cache[$db_count]['t'] = array_sum(explode(' ', microtime())) - array_sum(explode(' ', $st));
+
+	return $ret;
+}
+
+/**
+ * affected_rows
+ *
+ * @param resource $connection
+ */
+function smf_db_affected_rows($connection = null)
+{
+	global $db_connection;
+	
+	$connection = smf_db_check_connection($connection == null ? $db_connection : $connection);
+
+	return $connection->changes();
+}
+
+/**
+ * insert_id
+ *
+ * @param string $table
+ * @param string $field = null
+ * @param resource $connection = null
+ */
+function smf_db_insert_id($table, $field = null, $connection = null)
+{
+	global $db_connection, $db_prefix;
+
+	$table = str_replace('{db_prefix}', $db_prefix, $table);
+	$connection = smf_db_check_connection($connection == null ? $db_connection : $connection);
+
+	// SQLite doesn't need the table or field information.
+	return $connection->lastInsertRowid();
+}
+
+/**
+ * Number of rows returned by a query.
+ * 
+ * @param resource $handle
+ */
+function smf_db_num_rows($handle)
+{
+	$num_rows = 0;
+	
+	// For some stupid reason, the sqlite3 extension doesn't have a numRows function
+	while ($handle->fetchArray())
+		$num_rows++;
+
+	return $num_rows;
+}
+
+/**
+ * Seek to a specific row in the result set
+ * 
+ * @param resource $handle
+ * @param int $row
+ */
+function smf_db_seek(&$handle, $row)
+{
+	if ($row === 0)
+	{
+		$handle->Reset();
+	}
+	else
+	{
+		$i = 0;
+		do
+		{
+			$handle->fetchArray();
+			$i++;
+		} while ($i < $row);
+	}
+	
+	return $handle;
+}
+
+/**
+ * 
+ * @param resource $handle
+ */
+function smf_db_num_fields($handle)
+{
+	return $handle->numColumns();
+}
+
+/**
+*
+* @param string $string
+*/
+function smf_db_escape_string($string)
+{
+	return SQLite3::escapeString();
+}
+
+/**
+ * Last error on SQLite
+ */
+function smf_db_last_error()
+{
+	global $db_connection, $sqlite_error;
+
+	$query_errno = $db_connection->lastErrorCode();
+	return $query_errno || empty($sqlite_error) ? $db_connection->lastErrorMsg() : $sqlite_error;
+}
+
+/**
+ * Do a transaction.
+ *
+ * @param string $type - the step to perform (i.e. 'begin', 'commit', 'rollback')
+ * @param resource $connection = null
+ */
+function smf_db_transaction($type = 'commit', $connection = null)
+{
+	global $db_connection, $db_in_transact;
+
+	// Decide which connection to use
+	$connection = smf_db_check_connection($connection === null ? $db_connection : $connection);
+
+	if ($type == 'begin')
+	{
+		$db_in_transact = true;
+		return @$connection->exec('BEGIN');
+	}
+	elseif ($type == 'rollback')
+	{
+		$db_in_transact = false;
+		return @$connection->exec('ROLLBACK');
+	}
+	elseif ($type == 'commit')
+	{
+		$db_in_transact = false;
+		return @$connection->exec('COMMIT');
+	}
+
+	return false;
+}
+
+/**
+ * Database error!
+ * Backtrace, log, try to fix.
+ *
+ * @param string $db_string
+ * @param resource $connection = null
+ */
+function smf_db_error($db_string, $connection = null)
+{
+	global $txt, $context, $sourcedir, $webmaster_email, $modSettings;
+	global $forum_version, $db_connection, $db_last_error, $db_persist;
+	global $db_server, $db_user, $db_passwd, $db_name, $db_show_debug, $ssi_db_user, $ssi_db_passwd;
+	global $smcFunc;
+
+	// We'll try recovering the file and line number the original db query was called from.
+	list ($file, $line) = smf_db_error_backtrace('', '', 'return', __FILE__, __LINE__);
+
+	// Decide which connection to use
+	$connection = smf_db_check_connection($connection === null ? $db_connection : $connection);
+
+	// This is the error message...
+	$query_errno = $connection->lastErrorCode();
+	$query_error = $connection->lastErrorMsg();
+
+	// Get the extra error message.
+	$errStart = strrpos($db_string, '#!#');
+	$query_error .= '<br />' . substr($db_string, $errStart + 3);
+	$db_string = substr($db_string, 0, $errStart);
+
+	// Log the error.
+	if (function_exists('log_error'))
+		log_error($txt['database_error'] . ': ' . $query_error . (!empty($modSettings['enableErrorQueryLogging']) ? "\n\n" .$db_string : ''), 'database', $file, $line);
+
+	// Sqlite optimizing - the actual error message isn't helpful or user friendly.
+	if (strpos($query_error, 'no_access') !== false || strpos($query_error, 'database schema has changed') !== false)
+	{
+		if (!empty($context) && !empty($txt) && !empty($txt['error_sqlite_optimizing']))
+			fatal_error($txt['error_sqlite_optimizing'], false);
+		else
+		{
+			// Don't cache this page!
+			header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+			header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+			header('Cache-Control: no-cache');
+
+			// Send the right error codes.
+			header('HTTP/1.1 503 Service Temporarily Unavailable');
+			header('Status: 503 Service Temporarily Unavailable');
+			header('Retry-After: 3600');
+
+			die('Sqlite is optimizing the database, the forum can not be accessed until it has finished.  Please try refreshing this page momentarily.');
+		}
+	}
+
+	// Nothing's defined yet... just die with it.
+	if (empty($context) || empty($txt))
+		die($query_error);
+
+	// Show an error message, if possible.
+	$context['error_title'] = $txt['database_error'];
+	if (allowedTo('admin_forum'))
+		$context['error_message'] = nl2br($query_error) . '<br />' . $txt['file'] . ': ' . $file . '<br />' . $txt['line'] . ': ' . $line;
+	else
+		$context['error_message'] = $txt['try_again'];
+
+	// A database error is often the sign of a database in need of updgrade.  Check forum versions, and if not identical suggest an upgrade... (not for Demo/CVS versions!)
+	if (allowedTo('admin_forum') && !empty($forum_version) && $forum_version != 'SMF ' . @$modSettings['smfVersion'] && strpos($forum_version, 'Demo') === false && strpos($forum_version, 'CVS') === false)
+		$context['error_message'] .= '<br /><br />' . sprintf($txt['database_error_versions'], $forum_version, $modSettings['smfVersion']);
+
+	if (allowedTo('admin_forum') && isset($db_show_debug) && $db_show_debug === true)
+	{
+		$context['error_message'] .= '<br /><br />' . nl2br($db_string);
+	}
+
+	// It's already been logged... don't log it again.
+	fatal_error($context['error_message'], false);
+}
+
+/**
+ * insert
+ *
+ * @param string $method, options 'replace', 'ignore', 'insert'
+ * @param $table
+ * @param $columns
+ * @param $data
+ * @param $keys
+ * @param bool $disable_trans = false
+ * @param resource $connection = null
+ */
+function smf_db_insert($method = 'replace', $table, $columns, $data, $keys, $disable_trans = false, $connection = null)
+{
+	global $db_in_transact, $db_connection, $smcFunc, $db_prefix;
+
+	$connection = $connection === null ? $db_connection : $connection;
+
+	if (empty($data))
+		return;
+
+	if (!is_array($data[array_rand($data)]))
+		$data = array($data);
+
+	// Replace the prefix holder with the actual prefix.
+	$table = str_replace('{db_prefix}', $db_prefix, $table);
+
+	$priv_trans = false;
+	if (count($data) > 1 && !$db_in_transact && !$disable_trans)
+	{
+		$smcFunc['db_transaction']('begin', $connection);
+		$priv_trans = true;
+	}
+
+	if (!empty($data))
+	{
+		// Create the mold for a single row insert.
+		$insertData = '(';
+		foreach ($columns as $columnName => $type)
+		{
+			// Are we restricting the length?
+			if (strpos($type, 'string-') !== false)
+				$insertData .= sprintf('SUBSTR({string:%1$s}, 1, ' . substr($type, 7) . '), ', $columnName);
+			else
+				$insertData .= sprintf('{%1$s:%2$s}, ', $type, $columnName);
+		}
+		$insertData = substr($insertData, 0, -2) . ')';
+
+		// Create an array consisting of only the columns.
+		$indexed_columns = array_keys($columns);
+
+		// Here's where the variables are injected to the query.
+		$insertRows = array();
+		foreach ($data as $dataRow)
+			$insertRows[] = smf_db_quote($insertData, array_combine($indexed_columns, $dataRow), $connection);
+
+		foreach ($insertRows as $entry)
+			// Do the insert.
+			$smcFunc['db_query']('',
+				(($method === 'replace') ? 'REPLACE' : (' INSERT' . ($method === 'ignore' ? ' OR IGNORE' : ''))) . ' INTO ' . $table . '(' . implode(', ', $indexed_columns) . ')
+				VALUES
+					' . $entry,
+				array(
+					'security_override' => true,
+					'db_error_skip' => $table === $db_prefix . 'log_errors',
+				),
+				$connection
+			);
+	}
+
+	if ($priv_trans)
+		$smcFunc['db_transaction']('commit', $connection);
+}
+
+/**
+ * free_result
+ *
+ * @param resource $handle = false
+ */
+function smf_db_free_result($handle = false)
+{
+	return $handle->finalize();
+}
+
+/**
+ * fetch_row
+ * Make sure we return no string indexes!
+ *
+ * @param $handle
+ */
+function smf_db_fetch_row($handle)
+{
+	return $handle->fetchArray(SQLITE3_NUM);
+}
+
+/**
+ * Unescape an escaped string!
+ *
+ * @param $string
+ */
+function smf_db_unescape_string($string)
+{
+	return strtr($string, array('\'\'' => '\''));
+}
+
+/**
+ * This function tries to work out additional error information from a back trace.
+ *
+ * @param $error_message
+ * @param $log_message
+ * @param $error_type
+ * @param $file
+ * @param $line
+ */
+function smf_db_error_backtrace($error_message, $log_message = '', $error_type = false, $file = null, $line = null)
+{
+	if (empty($log_message))
+		$log_message = $error_message;
+
+	foreach (debug_backtrace() as $step)
+	{
+		// Found it?
+		if (strpos($step['function'], 'query') === false && !in_array(substr($step['function'], 0, 7), array('smf_db_', 'preg_re', 'db_erro', 'call_us')) && strpos($step['function'], '__') !== 0)
+		{
+			$log_message .= '<br />Function: ' . $step['function'];
+			break;
+		}
+
+		if (isset($step['line']))
+		{
+			$file = $step['file'];
+			$line = $step['line'];
+		}
+	}
+
+	// A special case - we want the file and line numbers for debugging.
+	if ($error_type == 'return')
+		return array($file, $line);
+
+	// Is always a critical error.
+	if (function_exists('log_error'))
+		log_error($log_message, 'critical', $file, $line);
+
+	if (function_exists('fatal_error'))
+	{
+		fatal_error($error_message, $error_type);
+
+		// Cannot continue...
+		exit;
+	}
+	elseif ($error_type)
+		trigger_error($error_message . ($line !== null ? '<em>(' . basename($file) . '-' . $line . ')</em>' : ''), $error_type);
+	else
+		trigger_error($error_message . ($line !== null ? '<em>(' . basename($file) . '-' . $line . ')</em>' : ''));
+}
+
+/**
+ * Emulate UNIX_TIMESTAMP.
+ */
+function smf_udf_unix_timestamp()
+{
+	return strftime('%s', 'now');
+}
+
+/**
+ * Emulate INET_ATON.
+ *
+ * @param $ip
+ */
+function smf_udf_inet_aton($ip)
+{
+	$chunks = explode('.', $ip);
+	return @$chunks[0] * pow(256, 3) + @$chunks[1] * pow(256, 2) + @$chunks[2] * 256 + @$chunks[3];
+}
+
+/**
+ * Emulate INET_NTOA.
+ *
+ * @param $n
+ */
+function smf_udf_inet_ntoa($n)
+{
+	$t = array(0, 0, 0, 0);
+	$msk = 16777216.0;
+	$n += 0.0;
+		if ($n < 1)
+			return '0.0.0.0';
+
+	for ($i = 0; $i < 4; $i++)
+	{
+		$k = (int) ($n / $msk);
+		$n -= $msk * $k;
+		$t[$i] = $k;
+		$msk /= 256.0;
+	};
+
+	$a = join('.', $t);
+	return $a;
+}
+
+/**
+ * Emulate FIND_IN_SET.
+ *
+ * @param $find
+ * @param $groups
+ */
+function smf_udf_find_in_set($find, $groups)
+{
+	foreach (explode(',', $groups) as $key => $group)
+	{
+		if ($group == $find)
+			return $key + 1;
+	}
+
+	return 0;
+}
+
+/**
+ * Emulate YEAR.
+ *
+ * @param $date
+ */
+function smf_udf_year($date)
+{
+	return substr($date, 0, 4);
+}
+
+/**
+ * Emulate MONTH.
+ *
+ * @param $date
+ */
+function smf_udf_month($date)
+{
+	return substr($date, 5, 2);
+}
+
+/**
+ * Emulate DAYOFMONTH.
+ *
+ * @param $date
+ */
+function smf_udf_dayofmonth($date)
+{
+	return substr($date, 8, 2);
+}
+
+/**
+ * We need this since sqlite_libversion() doesn't take any parameters.
+ *
+ * @param $void
+ */
+function smf_db_libversion($void = null)
+{
+	$version = SQLite3::version();
+	return $version['versionString'];
+}
+
+/**
+ * This function uses variable argument lists so that it can handle more then two parameters.
+ * Emulates the CONCAT function.
+ */
+function smf_udf_concat()
+{
+	// Since we didn't specify any arguments we must get them from PHP.
+	$args = func_get_args();
+
+	// It really doesn't matter if there were 0 to 100 arguments, just slap them all together.
+	return implode('', $args);
+}
+
+/**
+ * We need to use PHP to locate the position in the string.
+ *
+ * @param string $find
+ * @param string $string
+ */
+function smf_udf_locate($find, $string)
+{
+	return strpos($string, $find);
+}
+
+/**
+ * This is used to replace RLIKE.
+ *
+ * @param string $exp
+ * @param string $search
+ */
+function smf_udf_regexp($exp, $search)
+{
+	if (preg_match($exp, $match))
+		return 1;
+	return 0;
+}
+
+/**
+ * Escape the LIKE wildcards so that they match the character and not the wildcard.
+ * The optional second parameter turns human readable wildcards into SQL wildcards.
+ */
+function smf_db_escape_wildcard_string($string, $translate_human_wildcards=false)
+{
+	$replacements = array(
+		'%' => '\%',
+		'\\' => '\\\\',
+	);
+
+	if ($translate_human_wildcards)
+		$replacements += array(
+			'*' => '%',
+		);
+
+	return strtr($string, $replacements);
+}
+?>

--- a/other/install.php
+++ b/other/install.php
@@ -129,7 +129,7 @@ $databases = array(
 			$value = preg_replace(\'~[^A-Za-z0-9_\$]~\', \'\', $value);
 
 			// Is it reserved?
-			if ($value == \'sqlite3_\')
+			if ($value == \'sqlite_\')
 				return $txt[\'error_db_prefix_reserved\'];
 
 			// Is the prefix numeric?

--- a/other/install.php
+++ b/other/install.php
@@ -113,6 +113,32 @@ $databases = array(
 			return true;
 		'),
 	),
+	'sqlite3' => array(
+		'name' => 'SQLite3',
+		'version' => '1',
+		'function_check' => 'SQLite3::version',
+		'version_check' => 'return 1;',
+		'supported' => is_callable(array('sqlite3', 'version')),
+		'always_has_db' => true,
+		'utf8_default' => true,
+		'utf8_required' => true,
+		'utf8_support' => false,
+		'validate_prefix' => create_function('&$value', '
+			global $incontext, $txt;
+
+			$value = preg_replace(\'~[^A-Za-z0-9_\$]~\', \'\', $value);
+
+			// Is it reserved?
+			if ($value == \'sqlite3_\')
+				return $txt[\'error_db_prefix_reserved\'];
+
+			// Is the prefix numeric?
+			if (preg_match(\'~^\d~\', $value))
+				return $txt[\'error_db_prefix_numeric\'];
+
+			return true;
+		'),
+	),
 );
 
 // Initialize everything and load the language files.
@@ -745,7 +771,7 @@ function DatabaseSettings()
 	if (isset($_POST['db_user']))
 	{
 		$incontext['db']['user'] = $_POST['db_user'];
-		$incontext['db']['name'] = $_POST['db_type'] == 'sqlite' && isset($_POST['db_filename']) ? $_POST['db_filename'] : $_POST['db_name'];
+		$incontext['db']['name'] = ($_POST['db_type'] == 'sqlite' || $_POST['db_type'] == 'sqlite3') && isset($_POST['db_filename']) ? $_POST['db_filename'] : $_POST['db_name'];
 		$incontext['db']['server'] = $_POST['db_server'];
 		$incontext['db']['prefix'] = $_POST['db_prefix'];
 	}
@@ -792,7 +818,7 @@ function DatabaseSettings()
 		// Take care of these variables...
 		$vars = array(
 			'db_type' => $db_type,
-			'db_name' => $_POST['db_type'] == 'sqlite' && isset($_POST['db_filename']) ? $_POST['db_filename'] : $_POST['db_name'],
+			'db_name' => ($_POST['db_type'] == 'sqlite' || $_POST['db_type'] == 'sqlite3') && isset($_POST['db_filename']) ? $_POST['db_filename'] : $_POST['db_name'],
 			'db_user' => $_POST['db_user'],
 			'db_passwd' => isset($_POST['db_passwd']) ? $_POST['db_passwd'] : '',
 			'db_server' => $_POST['db_server'],
@@ -935,7 +961,8 @@ function ForumSettings()
 	$incontext['detected_url'] = 'http' . (!empty($_SERVER['HTTPS']) && strtolower($_SERVER['HTTPS']) == 'on' ? 's' : '') . '://' . $host . substr($_SERVER['PHP_SELF'], 0, strrpos($_SERVER['PHP_SELF'], '/'));
 
 	// Check if the database sessions will even work.
-	$incontext['test_dbsession'] = ini_get('session.auto_start') != 1;
+	// DB-driven sessions are borked on SQLite3 for some reason
+	$incontext['test_dbsession'] = (ini_get('session.auto_start') != 1 && $db_type != 'sqlite3');
 	$incontext['utf8_default'] = $databases[$db_type]['utf8_default'];
 	$incontext['utf8_required'] = $databases[$db_type]['utf8_required'];
 
@@ -1248,7 +1275,7 @@ function DatabasePopulation()
 		$smcFunc['db_optimize_table']($table) != -1 or $db_messed = true;
 
 		// Optimizing one sqlite table, optimizes them all
-		if ($db_type == 'sqlite')
+		if ($db_type == 'sqlite' || $db_type == 'sqlite3')
 			break;
 
 		if (!empty($db_messed))
@@ -1303,7 +1330,7 @@ function AdminAccount()
 	$incontext['username'] = htmlspecialchars(stripslashes($_POST['username']));
 	$incontext['email'] = htmlspecialchars(stripslashes($_POST['email']));
 
-	$incontext['require_db_confirm'] = empty($db_type) || $db_type != 'sqlite';
+	$incontext['require_db_confirm'] = empty($db_type) || ($db_type != 'sqlite' && $db_type != 'sqlite3');
 
 	// Only allow skipping if we think they already have an account setup.
 	$request = $smcFunc['db_query']('', '
@@ -2406,7 +2433,7 @@ function template_database_settings()
 		{
 			// What state is it?';
 
-	if (!isset($incontext['supported_databases']['sqlite']))
+	if (!isset($incontext['supported_databases']['sqlite']) && !isset($incontext['supported_databases']['sqlite3']))
 		echo '
 			var showAll = true;';
 	elseif (count($incontext['supported_databases']) < 2)
@@ -2415,7 +2442,7 @@ function template_database_settings()
 	// If we have more than one DB including SQLite, what should we be doing?
 	else
 		echo '
-			var showAll = document.getElementById(\'db_type_input\').value == \'sqlite\' ? false : true;';
+			var showAll = (document.getElementById(\'db_type_input\').value == \'sqlite\' || document.getElementById(\'db_type_input\').value == \'sqlite3\') ? false : true;';
 
 	echo '
 			document.getElementById(\'db_passwd_contain\').style.display = showAll ? \'\' : \'none\';

--- a/other/install.php
+++ b/other/install.php
@@ -961,8 +961,7 @@ function ForumSettings()
 	$incontext['detected_url'] = 'http' . (!empty($_SERVER['HTTPS']) && strtolower($_SERVER['HTTPS']) == 'on' ? 's' : '') . '://' . $host . substr($_SERVER['PHP_SELF'], 0, strrpos($_SERVER['PHP_SELF'], '/'));
 
 	// Check if the database sessions will even work.
-	// DB-driven sessions are borked on SQLite3 for some reason
-	$incontext['test_dbsession'] = (ini_get('session.auto_start') != 1 && $db_type != 'sqlite3');
+	$incontext['test_dbsession'] = (ini_get('session.auto_start') != 1);
 	$incontext['utf8_default'] = $databases[$db_type]['utf8_default'];
 	$incontext['utf8_required'] = $databases[$db_type]['utf8_required'];
 

--- a/other/install_2-1_sqlite3.sql
+++ b/other/install_2-1_sqlite3.sql
@@ -1,0 +1,2254 @@
+#### ATTENTION: You do not need to run or use this file!  The install.php script does everything for you!
+#### Install script for SQLite3
+
+#
+# Table structure for table `admin_info_files`
+#
+
+CREATE TABLE {$db_prefix}admin_info_files (
+  id_file integer primary key,
+  filename varchar(255) NOT NULL,
+  path varchar(255) NOT NULL,
+  parameters varchar(255) NOT NULL,
+  data text NOT NULL,
+  filetype varchar(255) NOT NULL
+);
+
+#
+# Indexes for table `admin_info_files`
+#
+
+CREATE INDEX {$db_prefix}admin_info_files_filename ON {$db_prefix}admin_info_files (filename);
+
+#
+# Dumping data for table `admin_info_files`
+#
+
+BEGIN TRANSACTION;
+INSERT INTO {$db_prefix}admin_info_files (id_file, filename, path, parameters, data, filetype) VALUES (1, 'current-version.js', '/smf/', 'version=%3$s', '', 'text/javascript');
+INSERT INTO {$db_prefix}admin_info_files (id_file, filename, path, parameters, data, filetype) VALUES (2, 'detailed-version.js', '/smf/', 'language=%1$s&version=%3$s', '', 'text/javascript');
+INSERT INTO {$db_prefix}admin_info_files (id_file, filename, path, parameters, data, filetype) VALUES (3, 'latest-news.js', '/smf/', 'language=%1$s&format=%2$s', '', 'text/javascript');
+INSERT INTO {$db_prefix}admin_info_files (id_file, filename, path, parameters, data, filetype) VALUES (4, 'latest-packages.js', '/smf/', 'language=%1$s&version=%3$s', '', 'text/javascript');
+INSERT INTO {$db_prefix}admin_info_files (id_file, filename, path, parameters, data, filetype) VALUES (5, 'latest-smileys.js', '/smf/', 'language=%1$s&version=%3$s', '', 'text/javascript');
+INSERT INTO {$db_prefix}admin_info_files (id_file, filename, path, parameters, data, filetype) VALUES (6, 'latest-support.js', '/smf/', 'language=%1$s&version=%3$s', '', 'text/javascript');
+INSERT INTO {$db_prefix}admin_info_files (id_file, filename, path, parameters, data, filetype) VALUES (7, 'latest-themes.js', '/smf/', 'language=%1$s&version=%3$s', '', 'text/javascript');
+COMMIT;
+
+# --------------------------------------------------------
+
+#
+# Table structure for table `approval_queue`
+#
+
+CREATE TABLE {$db_prefix}approval_queue (
+  id_msg int NOT NULL default '0',
+  id_attach int NOT NULL default '0',
+  id_event smallint NOT NULL default '0'
+);
+
+#
+# Table structure for table `attachments`
+#
+
+CREATE TABLE {$db_prefix}attachments (
+  id_attach integer primary key,
+  id_thumb int NOT NULL default '0',
+  id_msg int NOT NULL default '0',
+  id_member int NOT NULL default '0',
+  id_folder smallint NOT NULL default '1',
+  attachment_type smallint NOT NULL default '0',
+  filename varchar(255) NOT NULL,
+  file_hash varchar(40) NOT NULL default '',
+  fileext varchar(8) NOT NULL default '',
+  size int NOT NULL default '0',
+  downloads int NOT NULL default '0',
+  width int NOT NULL default '0',
+  height int NOT NULL default '0',
+  mime_type varchar(20) NOT NULL default '',
+  approved smallint NOT NULL default '1'
+);
+
+#
+# Indexes for table `attachments`
+#
+
+CREATE UNIQUE INDEX {$db_prefix}attachments_id_member ON {$db_prefix}attachments (id_member, id_attach);
+CREATE INDEX {$db_prefix}attachments_id_msg ON {$db_prefix}attachments (id_msg);
+CREATE INDEX {$db_prefix}attachments_attachment_type ON {$db_prefix}attachments (attachment_type);
+
+#
+# Table structure for table `ban_groups`
+#
+
+CREATE TABLE {$db_prefix}ban_groups (
+  id_ban_group integer primary key,
+  name varchar(20) NOT NULL default '',
+  ban_time int NOT NULL default '0',
+  expire_time int,
+  cannot_access smallint NOT NULL default '0',
+  cannot_register smallint NOT NULL default '0',
+  cannot_post smallint NOT NULL default '0',
+  cannot_login smallint NOT NULL default '0',
+  reason varchar(255) NOT NULL,
+  notes text NOT NULL
+);
+
+#
+# Table structure for table `ban_items`
+#
+
+CREATE TABLE {$db_prefix}ban_items (
+  id_ban integer primary key,
+  id_ban_group smallint NOT NULL default '0',
+  ip_low1 smallint NOT NULL default '0',
+  ip_high1 smallint NOT NULL default '0',
+  ip_low2 smallint NOT NULL default '0',
+  ip_high2 smallint NOT NULL default '0',
+  ip_low3 smallint NOT NULL default '0',
+  ip_high3 smallint NOT NULL default '0',
+  ip_low4 smallint NOT NULL default '0',
+  ip_high4 smallint NOT NULL default '0',
+  ip_low5 smallint NOT NULL default '0',
+  ip_high5 smallint NOT NULL default '0',
+  ip_low6 smallint NOT NULL default '0',
+  ip_high6 smallint NOT NULL default '0',
+  ip_low7 smallint NOT NULL default '0',
+  ip_high7 smallint NOT NULL default '0',
+  ip_low8 smallint NOT NULL default '0',
+  ip_high8 smallint NOT NULL default '0',
+  hostname varchar(255) NOT NULL,
+  email_address varchar(255) NOT NULL,
+  id_member int NOT NULL default '0',
+  hits int NOT NULL default '0'
+);
+
+#
+# Indexes for table `ban_items`
+#
+
+CREATE INDEX {$db_prefix}ban_items_id_ban_group ON {$db_prefix}ban_items (id_ban_group);
+
+#
+# Table structure for table `board_permissions`
+#
+
+CREATE TABLE {$db_prefix}board_permissions (
+  id_group smallint NOT NULL default '0',
+  id_profile smallint NOT NULL default '0',
+  permission varchar(30) NOT NULL default '',
+  add_deny smallint NOT NULL default '1',
+  PRIMARY KEY (id_group, id_profile, permission)
+);
+
+#
+# Dumping data for table `board_permissions`
+#
+
+BEGIN TRANSACTION;
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (-1, 1, 'poll_view');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (0, 1, 'remove_own');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (0, 1, 'lock_own');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (0, 1, 'mark_any_notify');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (0, 1, 'mark_notify');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (0, 1, 'modify_own');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (0, 1, 'poll_add_own');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (0, 1, 'poll_edit_own');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (0, 1, 'poll_lock_own');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (0, 1, 'poll_post');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (0, 1, 'poll_view');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (0, 1, 'poll_vote');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (0, 1, 'post_attachment');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (0, 1, 'post_new');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (0, 1, 'post_draft');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (0, 1, 'post_autosave_draft');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (0, 1, 'post_reply_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (0, 1, 'post_reply_own');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (0, 1, 'post_unapproved_topics');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (0, 1, 'post_unapproved_replies_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (0, 1, 'post_unapproved_replies_own');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (0, 1, 'post_unapproved_attachments');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (0, 1, 'delete_own');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (0, 1, 'report_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (0, 1, 'send_topic');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (0, 1, 'view_attachments');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 1, 'moderate_board');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 1, 'post_new');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 1, 'post_draft');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 1, 'post_autosave_draft');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 1, 'post_reply_own');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 1, 'post_reply_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 1, 'post_unapproved_topics');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 1, 'post_unapproved_replies_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 1, 'post_unapproved_replies_own');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 1, 'post_unapproved_attachments');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 1, 'poll_post');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 1, 'poll_add_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 1, 'poll_remove_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 1, 'poll_view');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 1, 'poll_vote');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 1, 'poll_lock_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 1, 'poll_edit_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 1, 'report_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 1, 'lock_own');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 1, 'send_topic');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 1, 'mark_any_notify');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 1, 'mark_notify');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 1, 'delete_own');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 1, 'modify_own');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 1, 'make_sticky');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 1, 'lock_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 1, 'remove_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 1, 'move_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 1, 'merge_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 1, 'split_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 1, 'delete_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 1, 'modify_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 1, 'approve_posts');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 1, 'post_attachment');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 1, 'view_attachments');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 1, 'moderate_board');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 1, 'post_new');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 1, 'post_draft');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 1, 'post_autosave_draft');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 1, 'post_reply_own');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 1, 'post_reply_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 1, 'post_unapproved_topics');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 1, 'post_unapproved_replies_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 1, 'post_unapproved_replies_own');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 1, 'post_unapproved_attachments');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 1, 'poll_post');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 1, 'poll_add_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 1, 'poll_remove_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 1, 'poll_view');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 1, 'poll_vote');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 1, 'poll_lock_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 1, 'poll_edit_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 1, 'report_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 1, 'lock_own');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 1, 'send_topic');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 1, 'mark_any_notify');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 1, 'mark_notify');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 1, 'delete_own');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 1, 'modify_own');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 1, 'make_sticky');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 1, 'lock_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 1, 'remove_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 1, 'move_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 1, 'merge_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 1, 'split_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 1, 'delete_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 1, 'modify_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 1, 'approve_posts');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 1, 'post_attachment');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 1, 'view_attachments');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (-1, 2, 'poll_view');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (0, 2, 'remove_own');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (0, 2, 'lock_own');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (0, 2, 'mark_any_notify');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (0, 2, 'mark_notify');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (0, 2, 'modify_own');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (0, 2, 'poll_view');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (0, 2, 'poll_vote');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (0, 2, 'post_attachment');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (0, 2, 'post_new');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (0, 2, 'post_draft');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (0, 2, 'post_autosave_draft');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (0, 2, 'post_reply_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (0, 2, 'post_reply_own');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (0, 2, 'post_unapproved_topics');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (0, 2, 'post_unapproved_replies_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (0, 2, 'post_unapproved_replies_own');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (0, 2, 'post_unapproved_attachments');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (0, 2, 'delete_own');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (0, 2, 'report_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (0, 2, 'send_topic');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (0, 2, 'view_attachments');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 2, 'moderate_board');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 2, 'post_new');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 2, 'post_draft');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 2, 'post_autosave_draft');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 2, 'post_reply_own');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 2, 'post_reply_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 2, 'post_unapproved_topics');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 2, 'post_unapproved_replies_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 2, 'post_unapproved_replies_own');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 2, 'post_unapproved_attachments');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 2, 'poll_post');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 2, 'poll_add_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 2, 'poll_remove_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 2, 'poll_view');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 2, 'poll_vote');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 2, 'poll_lock_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 2, 'poll_edit_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 2, 'report_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 2, 'lock_own');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 2, 'send_topic');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 2, 'mark_any_notify');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 2, 'mark_notify');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 2, 'delete_own');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 2, 'modify_own');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 2, 'make_sticky');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 2, 'lock_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 2, 'remove_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 2, 'move_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 2, 'merge_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 2, 'split_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 2, 'delete_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 2, 'modify_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 2, 'approve_posts');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 2, 'post_attachment');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 2, 'view_attachments');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 2, 'moderate_board');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 2, 'post_new');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 2, 'post_draft');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 2, 'post_autosave_draft');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 2, 'post_reply_own');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 2, 'post_reply_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 2, 'post_unapproved_topics');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 2, 'post_unapproved_replies_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 2, 'post_unapproved_replies_own');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 2, 'post_unapproved_attachments');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 2, 'poll_post');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 2, 'poll_add_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 2, 'poll_remove_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 2, 'poll_view');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 2, 'poll_vote');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 2, 'poll_lock_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 2, 'poll_edit_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 2, 'report_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 2, 'lock_own');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 2, 'send_topic');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 2, 'mark_any_notify');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 2, 'mark_notify');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 2, 'delete_own');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 2, 'modify_own');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 2, 'make_sticky');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 2, 'lock_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 2, 'remove_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 2, 'move_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 2, 'merge_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 2, 'split_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 2, 'delete_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 2, 'modify_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 2, 'approve_posts');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 2, 'post_attachment');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 2, 'view_attachments');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (-1, 3, 'poll_view');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (0, 3, 'remove_own');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (0, 3, 'lock_own');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (0, 3, 'mark_any_notify');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (0, 3, 'mark_notify');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (0, 3, 'modify_own');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (0, 3, 'poll_view');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (0, 3, 'poll_vote');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (0, 3, 'post_attachment');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (0, 3, 'post_reply_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (0, 3, 'post_reply_own');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (0, 3, 'post_unapproved_replies_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (0, 3, 'post_unapproved_replies_own');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (0, 3, 'post_unapproved_attachments');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (0, 3, 'delete_own');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (0, 3, 'report_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (0, 3, 'send_topic');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (0, 3, 'view_attachments');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 3, 'moderate_board');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 3, 'post_new');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 3, 'post_draft');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 3, 'post_autosave_draft');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 3, 'post_reply_own');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 3, 'post_reply_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 3, 'post_unapproved_topics');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 3, 'post_unapproved_replies_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 3, 'post_unapproved_replies_own');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 3, 'post_unapproved_attachments');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 3, 'poll_post');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 3, 'poll_add_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 3, 'poll_remove_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 3, 'poll_view');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 3, 'poll_vote');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 3, 'poll_lock_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 3, 'poll_edit_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 3, 'report_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 3, 'lock_own');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 3, 'send_topic');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 3, 'mark_any_notify');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 3, 'mark_notify');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 3, 'delete_own');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 3, 'modify_own');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 3, 'make_sticky');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 3, 'lock_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 3, 'remove_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 3, 'move_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 3, 'merge_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 3, 'split_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 3, 'delete_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 3, 'modify_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 3, 'approve_posts');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 3, 'post_attachment');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 3, 'view_attachments');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 3, 'moderate_board');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 3, 'post_new');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 3, 'post_draft');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 3, 'post_autosave_draft');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 3, 'post_reply_own');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 3, 'post_reply_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 3, 'post_unapproved_topics');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 3, 'post_unapproved_replies_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 3, 'post_unapproved_replies_own');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 3, 'post_unapproved_attachments');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 3, 'poll_post');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 3, 'poll_add_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 3, 'poll_remove_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 3, 'poll_view');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 3, 'poll_vote');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 3, 'poll_lock_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 3, 'poll_edit_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 3, 'report_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 3, 'lock_own');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 3, 'send_topic');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 3, 'mark_any_notify');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 3, 'mark_notify');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 3, 'delete_own');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 3, 'modify_own');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 3, 'make_sticky');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 3, 'lock_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 3, 'remove_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 3, 'move_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 3, 'merge_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 3, 'split_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 3, 'delete_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 3, 'modify_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 3, 'approve_posts');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 3, 'post_attachment');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 3, 'view_attachments');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (-1, 4, 'poll_view');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (0, 4, 'mark_any_notify');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (0, 4, 'mark_notify');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (0, 4, 'poll_view');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (0, 4, 'poll_vote');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (0, 4, 'report_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (0, 4, 'send_topic');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (0, 4, 'view_attachments');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 4, 'moderate_board');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 4, 'post_new');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 4, 'post_draft');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 4, 'post_autosave_draft');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 4, 'post_reply_own');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 4, 'post_reply_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 4, 'post_unapproved_topics');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 4, 'post_unapproved_replies_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 4, 'post_unapproved_replies_own');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 4, 'post_unapproved_attachments');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 4, 'poll_post');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 4, 'poll_add_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 4, 'poll_remove_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 4, 'poll_view');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 4, 'poll_vote');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 4, 'poll_lock_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 4, 'poll_edit_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 4, 'report_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 4, 'lock_own');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 4, 'send_topic');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 4, 'mark_any_notify');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 4, 'mark_notify');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 4, 'delete_own');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 4, 'modify_own');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 4, 'make_sticky');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 4, 'lock_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 4, 'remove_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 4, 'move_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 4, 'merge_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 4, 'split_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 4, 'delete_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 4, 'modify_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 4, 'approve_posts');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 4, 'post_attachment');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (2, 4, 'view_attachments');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 4, 'moderate_board');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 4, 'post_new');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 4, 'post_draft');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 4, 'post_autosave_draft');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 4, 'post_reply_own');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 4, 'post_reply_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 4, 'post_unapproved_topics');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 4, 'post_unapproved_replies_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 4, 'post_unapproved_replies_own');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 4, 'post_unapproved_attachments');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 4, 'poll_post');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 4, 'poll_add_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 4, 'poll_remove_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 4, 'poll_view');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 4, 'poll_vote');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 4, 'poll_lock_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 4, 'poll_edit_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 4, 'report_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 4, 'lock_own');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 4, 'send_topic');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 4, 'mark_any_notify');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 4, 'mark_notify');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 4, 'delete_own');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 4, 'modify_own');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 4, 'make_sticky');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 4, 'lock_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 4, 'remove_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 4, 'move_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 4, 'merge_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 4, 'split_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 4, 'delete_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 4, 'modify_any');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 4, 'approve_posts');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 4, 'post_attachment');
+INSERT INTO {$db_prefix}board_permissions (id_group, id_profile, permission) VALUES (3, 4, 'view_attachments');
+COMMIT;
+
+# --------------------------------------------------------
+
+#
+# Table structure for table `boards`
+#
+
+CREATE TABLE {$db_prefix}boards (
+  id_board integer primary key,
+  id_cat smallint NOT NULL default '0',
+  child_level smallint NOT NULL default '0',
+  id_parent smallint NOT NULL default '0',
+  board_order smallint NOT NULL default '0',
+  id_last_msg int NOT NULL default '0',
+  id_msg_updated int NOT NULL default '0',
+  member_groups varchar(255) NOT NULL default '-1,0',
+  id_profile smallint NOT NULL default '1',
+  name varchar(255) NOT NULL,
+  description text NOT NULL,
+  num_topics int NOT NULL default '0',
+  num_posts int NOT NULL default '0',
+  count_posts smallint NOT NULL default '0',
+  id_theme smallint NOT NULL default '0',
+  override_theme smallint NOT NULL default '0',
+  unapproved_posts smallint NOT NULL default '0',
+  unapproved_topics smallint NOT NULL default '0',
+  redirect varchar(255) NOT NULL default '',
+  deny_member_groups varchar(255) NOT NULL default ''
+);
+
+#
+# Indexes for table `boards`
+#
+
+CREATE UNIQUE INDEX {$db_prefix}boards_categories ON {$db_prefix}boards (id_cat, id_board);
+CREATE INDEX {$db_prefix}boards_id_parent ON {$db_prefix}boards (id_parent);
+CREATE INDEX {$db_prefix}boards_id_msg_updated ON {$db_prefix}boards (id_msg_updated);
+CREATE INDEX {$db_prefix}boards_member_groups ON {$db_prefix}boards (member_groups);
+
+#
+# Dumping data for table `boards`
+#
+
+INSERT INTO {$db_prefix}boards
+	(id_board, id_cat, board_order, id_last_msg, id_msg_updated, name, description, num_topics, num_posts, member_groups)
+VALUES (1, 1, 1, 1, 1, '{$default_board_name}', '{$default_board_description}', 1, 1, '-1,0,2');
+# --------------------------------------------------------
+
+#
+# Table structure for table `calendar`
+#
+
+CREATE TABLE {$db_prefix}calendar (
+  id_event integer primary key,
+  start_date date NOT NULL default '0001-01-01',
+  end_date date NOT NULL default '0001-01-01',
+  id_board smallint NOT NULL default '0',
+  id_topic int NOT NULL default '0',
+  title varchar(255) NOT NULL default '',
+  id_member int NOT NULL default '0'
+);
+
+#
+# Indexes for table `calendar`
+#
+
+CREATE INDEX {$db_prefix}calendar_start_date ON {$db_prefix}calendar (start_date);
+CREATE INDEX {$db_prefix}calendar_end_date ON {$db_prefix}calendar (end_date);
+CREATE INDEX {$db_prefix}calendar_topic ON {$db_prefix}calendar (id_topic, id_member);
+
+#
+# Table structure for table `calendar_holidays`
+#
+
+CREATE TABLE {$db_prefix}calendar_holidays (
+  id_holiday integer primary key,
+  event_date date NOT NULL default '0001-01-01',
+  title varchar(255) NOT NULL default ''
+);
+
+#
+# Indexes for table `calendar_holidays`
+#
+
+CREATE INDEX {$db_prefix}calendar_holidays_event_date ON {$db_prefix}calendar_holidays (event_date);
+
+#
+# Dumping data for table `calendar_holidays`
+#
+
+BEGIN TRANSACTION;
+INSERT INTO {$db_prefix}calendar_holidays (title, event_date) VALUES ('New Year''s', '0004-01-01');
+INSERT INTO {$db_prefix}calendar_holidays (title, event_date) VALUES ('Christmas', '0004-12-25');
+INSERT INTO {$db_prefix}calendar_holidays (title, event_date) VALUES ('Valentine''s Day', '0004-02-14');
+INSERT INTO {$db_prefix}calendar_holidays (title, event_date) VALUES ('St. Patrick''s Day', '0004-03-17');
+INSERT INTO {$db_prefix}calendar_holidays (title, event_date) VALUES ('April Fools', '0004-04-01');
+INSERT INTO {$db_prefix}calendar_holidays (title, event_date) VALUES ('Earth Day', '0004-04-22');
+INSERT INTO {$db_prefix}calendar_holidays (title, event_date) VALUES ('United Nations Day', '0004-10-24');
+INSERT INTO {$db_prefix}calendar_holidays (title, event_date) VALUES ('Halloween', '0004-10-31');
+INSERT INTO {$db_prefix}calendar_holidays (title, event_date) VALUES ('Mother''s Day', '2010-05-09');
+INSERT INTO {$db_prefix}calendar_holidays (title, event_date) VALUES ('Mother''s Day', '2011-05-08');
+INSERT INTO {$db_prefix}calendar_holidays (title, event_date) VALUES ('Mother''s Day', '2012-05-13');
+INSERT INTO {$db_prefix}calendar_holidays (title, event_date) VALUES ('Mother''s Day', '2013-05-12');
+INSERT INTO {$db_prefix}calendar_holidays (title, event_date) VALUES ('Mother''s Day', '2014-05-11');
+INSERT INTO {$db_prefix}calendar_holidays (title, event_date) VALUES ('Mother''s Day', '2015-05-10');
+INSERT INTO {$db_prefix}calendar_holidays (title, event_date) VALUES ('Mother''s Day', '2016-05-08');
+INSERT INTO {$db_prefix}calendar_holidays (title, event_date) VALUES ('Mother''s Day', '2017-05-14');
+INSERT INTO {$db_prefix}calendar_holidays (title, event_date) VALUES ('Mother''s Day', '2018-05-13');
+INSERT INTO {$db_prefix}calendar_holidays (title, event_date) VALUES ('Mother''s Day', '2019-05-12');
+INSERT INTO {$db_prefix}calendar_holidays (title, event_date) VALUES ('Mother''s Day', '2020-05-10');
+INSERT INTO {$db_prefix}calendar_holidays (title, event_date) VALUES ('Father''s Day', '2010-06-20');
+INSERT INTO {$db_prefix}calendar_holidays (title, event_date) VALUES ('Father''s Day', '2011-06-19');
+INSERT INTO {$db_prefix}calendar_holidays (title, event_date) VALUES ('Father''s Day', '2012-06-17');
+INSERT INTO {$db_prefix}calendar_holidays (title, event_date) VALUES ('Father''s Day', '2013-06-16');
+INSERT INTO {$db_prefix}calendar_holidays (title, event_date) VALUES ('Father''s Day', '2014-06-15');
+INSERT INTO {$db_prefix}calendar_holidays (title, event_date) VALUES ('Father''s Day', '2015-06-21');
+INSERT INTO {$db_prefix}calendar_holidays (title, event_date) VALUES ('Father''s Day', '2016-06-19');
+INSERT INTO {$db_prefix}calendar_holidays (title, event_date) VALUES ('Father''s Day', '2017-06-18');
+INSERT INTO {$db_prefix}calendar_holidays (title, event_date) VALUES ('Father''s Day', '2018-06-17');
+INSERT INTO {$db_prefix}calendar_holidays (title, event_date) VALUES ('Father''s Day', '2019-06-16');
+INSERT INTO {$db_prefix}calendar_holidays (title, event_date) VALUES ('Father''s Day', '2020-06-21');
+INSERT INTO {$db_prefix}calendar_holidays (title, event_date) VALUES ('Summer Solstice', '2010-06-21');
+INSERT INTO {$db_prefix}calendar_holidays (title, event_date) VALUES ('Summer Solstice', '2011-06-21');
+INSERT INTO {$db_prefix}calendar_holidays (title, event_date) VALUES ('Summer Solstice', '2012-06-20');
+INSERT INTO {$db_prefix}calendar_holidays (title, event_date) VALUES ('Summer Solstice', '2013-06-21');
+INSERT INTO {$db_prefix}calendar_holidays (title, event_date) VALUES ('Summer Solstice', '2014-06-21');
+INSERT INTO {$db_prefix}calendar_holidays (title, event_date) VALUES ('Summer Solstice', '2015-06-21');
+INSERT INTO {$db_prefix}calendar_holidays (title, event_date) VALUES ('Summer Solstice', '2016-06-20');
+INSERT INTO {$db_prefix}calendar_holidays (title, event_date) VALUES ('Summer Solstice', '2017-06-20');
+INSERT INTO {$db_prefix}calendar_holidays (title, event_date) VALUES ('Summer Solstice', '2018-06-21');
+INSERT INTO {$db_prefix}calendar_holidays (title, event_date) VALUES ('Summer Solstice', '2019-06-21');
+INSERT INTO {$db_prefix}calendar_holidays (title, event_date) VALUES ('Summer Solstice', '2020-06-20');
+INSERT INTO {$db_prefix}calendar_holidays (title, event_date) VALUES ('Vernal Equinox', '2010-03-20');
+INSERT INTO {$db_prefix}calendar_holidays (title, event_date) VALUES ('Vernal Equinox', '2011-03-20');
+INSERT INTO {$db_prefix}calendar_holidays (title, event_date) VALUES ('Vernal Equinox', '2012-03-20');
+INSERT INTO {$db_prefix}calendar_holidays (title, event_date) VALUES ('Vernal Equinox', '2013-03-20');
+INSERT INTO {$db_prefix}calendar_holidays (title, event_date) VALUES ('Vernal Equinox', '2014-03-20');
+INSERT INTO {$db_prefix}calendar_holidays (title, event_date) VALUES ('Vernal Equinox', '2015-03-20');
+INSERT INTO {$db_prefix}calendar_holidays (title, event_date) VALUES ('Vernal Equinox', '2016-03-19');
+INSERT INTO {$db_prefix}calendar_holidays (title, event_date) VALUES ('Vernal Equinox', '2017-03-20');
+INSERT INTO {$db_prefix}calendar_holidays (title, event_date) VALUES ('Vernal Equinox', '2018-03-20');
+INSERT INTO {$db_prefix}calendar_holidays (title, event_date) VALUES ('Vernal Equinox', '2019-03-20');
+INSERT INTO {$db_prefix}calendar_holidays (title, event_date) VALUES ('Vernal Equinox', '2020-03-19');
+INSERT INTO {$db_prefix}calendar_holidays (title, event_date) VALUES ('Winter Solstice', '2010-12-21');
+INSERT INTO {$db_prefix}calendar_holidays (title, event_date) VALUES ('Winter Solstice', '2011-12-22');
+INSERT INTO {$db_prefix}calendar_holidays (title, event_date) VALUES ('Winter Solstice', '2012-12-21');
+INSERT INTO {$db_prefix}calendar_holidays (title, event_date) VALUES ('Winter Solstice', '2013-12-21');
+INSERT INTO {$db_prefix}calendar_holidays (title, event_date) VALUES ('Winter Solstice', '2014-12-21');
+INSERT INTO {$db_prefix}calendar_holidays (title, event_date) VALUES ('Winter Solstice', '2015-12-21');
+INSERT INTO {$db_prefix}calendar_holidays (title, event_date) VALUES ('Winter Solstice', '2016-12-21');
+INSERT INTO {$db_prefix}calendar_holidays (title, event_date) VALUES ('Winter Solstice', '2017-12-21');
+INSERT INTO {$db_prefix}calendar_holidays (title, event_date) VALUES ('Winter Solstice', '2018-12-21');
+INSERT INTO {$db_prefix}calendar_holidays (title, event_date) VALUES ('Winter Solstice', '2019-12-21');
+INSERT INTO {$db_prefix}calendar_holidays (title, event_date) VALUES ('Winter Solstice', '2020-12-21');
+INSERT INTO {$db_prefix}calendar_holidays (title, event_date) VALUES ('Autumnal Equinox', '2010-09-22');
+INSERT INTO {$db_prefix}calendar_holidays (title, event_date) VALUES ('Autumnal Equinox', '2011-09-23');
+INSERT INTO {$db_prefix}calendar_holidays (title, event_date) VALUES ('Autumnal Equinox', '2012-09-22');
+INSERT INTO {$db_prefix}calendar_holidays (title, event_date) VALUES ('Autumnal Equinox', '2013-09-22');
+INSERT INTO {$db_prefix}calendar_holidays (title, event_date) VALUES ('Autumnal Equinox', '2014-09-22');
+INSERT INTO {$db_prefix}calendar_holidays (title, event_date) VALUES ('Autumnal Equinox', '2015-09-23');
+INSERT INTO {$db_prefix}calendar_holidays (title, event_date) VALUES ('Autumnal Equinox', '2016-09-22');
+INSERT INTO {$db_prefix}calendar_holidays (title, event_date) VALUES ('Autumnal Equinox', '2017-09-22');
+INSERT INTO {$db_prefix}calendar_holidays (title, event_date) VALUES ('Autumnal Equinox', '2018-09-22');
+INSERT INTO {$db_prefix}calendar_holidays (title, event_date) VALUES ('Autumnal Equinox', '2019-09-23');
+INSERT INTO {$db_prefix}calendar_holidays (title, event_date) VALUES ('Autumnal Equinox', '2020-09-22');
+INSERT INTO {$db_prefix}calendar_holidays (title, event_date) VALUES ('Independence Day', '0004-07-04');
+INSERT INTO {$db_prefix}calendar_holidays (title, event_date) VALUES ('Cinco de Mayo', '0004-05-05');
+INSERT INTO {$db_prefix}calendar_holidays (title, event_date) VALUES ('Flag Day', '0004-06-14');
+INSERT INTO {$db_prefix}calendar_holidays (title, event_date) VALUES ('Veterans Day', '0004-11-11');
+INSERT INTO {$db_prefix}calendar_holidays (title, event_date) VALUES ('Groundhog Day', '0004-02-02');
+INSERT INTO {$db_prefix}calendar_holidays (title, event_date) VALUES ('Thanksgiving', '2010-11-25');
+INSERT INTO {$db_prefix}calendar_holidays (title, event_date) VALUES ('Thanksgiving', '2011-11-24');
+INSERT INTO {$db_prefix}calendar_holidays (title, event_date) VALUES ('Thanksgiving', '2012-11-22');
+INSERT INTO {$db_prefix}calendar_holidays (title, event_date) VALUES ('Thanksgiving', '2013-11-21');
+INSERT INTO {$db_prefix}calendar_holidays (title, event_date) VALUES ('Thanksgiving', '2014-11-20');
+INSERT INTO {$db_prefix}calendar_holidays (title, event_date) VALUES ('Thanksgiving', '2015-11-26');
+INSERT INTO {$db_prefix}calendar_holidays (title, event_date) VALUES ('Thanksgiving', '2016-11-24');
+INSERT INTO {$db_prefix}calendar_holidays (title, event_date) VALUES ('Thanksgiving', '2017-11-23');
+INSERT INTO {$db_prefix}calendar_holidays (title, event_date) VALUES ('Thanksgiving', '2018-11-22');
+INSERT INTO {$db_prefix}calendar_holidays (title, event_date) VALUES ('Thanksgiving', '2019-11-21');
+INSERT INTO {$db_prefix}calendar_holidays (title, event_date) VALUES ('Thanksgiving', '2020-11-26');
+INSERT INTO {$db_prefix}calendar_holidays (title, event_date) VALUES ('Memorial Day', '2010-05-31');
+INSERT INTO {$db_prefix}calendar_holidays (title, event_date) VALUES ('Memorial Day', '2011-05-30');
+INSERT INTO {$db_prefix}calendar_holidays (title, event_date) VALUES ('Memorial Day', '2012-05-28');
+INSERT INTO {$db_prefix}calendar_holidays (title, event_date) VALUES ('Memorial Day', '2013-05-27');
+INSERT INTO {$db_prefix}calendar_holidays (title, event_date) VALUES ('Memorial Day', '2014-05-26');
+INSERT INTO {$db_prefix}calendar_holidays (title, event_date) VALUES ('Memorial Day', '2015-05-25');
+INSERT INTO {$db_prefix}calendar_holidays (title, event_date) VALUES ('Memorial Day', '2016-05-30');
+INSERT INTO {$db_prefix}calendar_holidays (title, event_date) VALUES ('Memorial Day', '2017-05-29');
+INSERT INTO {$db_prefix}calendar_holidays (title, event_date) VALUES ('Memorial Day', '2018-05-28');
+INSERT INTO {$db_prefix}calendar_holidays (title, event_date) VALUES ('Memorial Day', '2019-05-27');
+INSERT INTO {$db_prefix}calendar_holidays (title, event_date) VALUES ('Memorial Day', '2020-05-25');
+INSERT INTO {$db_prefix}calendar_holidays (title, event_date) VALUES ('Labor Day', '2010-09-06');
+INSERT INTO {$db_prefix}calendar_holidays (title, event_date) VALUES ('Labor Day', '2011-09-05');
+INSERT INTO {$db_prefix}calendar_holidays (title, event_date) VALUES ('Labor Day', '2012-09-03');
+INSERT INTO {$db_prefix}calendar_holidays (title, event_date) VALUES ('Labor Day', '2013-09-09');
+INSERT INTO {$db_prefix}calendar_holidays (title, event_date) VALUES ('Labor Day', '2014-09-08');
+INSERT INTO {$db_prefix}calendar_holidays (title, event_date) VALUES ('Labor Day', '2015-09-07');
+INSERT INTO {$db_prefix}calendar_holidays (title, event_date) VALUES ('Labor Day', '2016-09-05');
+INSERT INTO {$db_prefix}calendar_holidays (title, event_date) VALUES ('Labor Day', '2017-09-04');
+INSERT INTO {$db_prefix}calendar_holidays (title, event_date) VALUES ('Labor Day', '2018-09-03');
+INSERT INTO {$db_prefix}calendar_holidays (title, event_date) VALUES ('Labor Day', '2019-09-09');
+INSERT INTO {$db_prefix}calendar_holidays (title, event_date) VALUES ('Labor Day', '2020-09-07');
+INSERT INTO {$db_prefix}calendar_holidays (title, event_date) VALUES ('D-Day', '0004-06-06');
+COMMIT;
+
+# --------------------------------------------------------
+
+#
+# Table structure for table `categories`
+#
+
+CREATE TABLE {$db_prefix}categories (
+  id_cat integer primary key,
+  cat_order smallint NOT NULL default '0',
+  name varchar(255) NOT NULL,
+  can_collapse smallint NOT NULL default '1'
+);
+
+#
+# Dumping data for table `categories`
+#
+
+INSERT INTO {$db_prefix}categories
+VALUES (1, 0, '{$default_category_name}', 1);
+# --------------------------------------------------------
+
+#
+# Table structure for table `collapsed_categories`
+#
+
+CREATE TABLE {$db_prefix}collapsed_categories (
+  id_cat smallint NOT NULL default '0',
+  id_member int NOT NULL default '0',
+  PRIMARY KEY (id_cat, id_member)
+);
+
+#
+# Table structure for table `custom_fields`
+#
+
+CREATE TABLE {$db_prefix}custom_fields (
+  id_field integer primary key,
+  col_name varchar(12) NOT NULL default '',
+  field_name varchar(40) NOT NULL default '',
+  field_desc varchar(255) NOT NULL,
+  field_type varchar(8) NOT NULL default 'text',
+  field_length smallint NOT NULL default '255',
+  field_options text NOT NULL,
+  mask varchar(255) NOT NULL,
+  show_reg smallint NOT NULL default '0',
+  show_display smallint NOT NULL default '0',
+  show_profile varchar(20) NOT NULL default 'forumprofile',
+  private smallint NOT NULL default '0',
+  active smallint NOT NULL default '1',
+  bbc smallint NOT NULL default '0',
+  can_search smallint NOT NULL default '0',
+  default_value varchar(255) NOT NULL,
+  enclose text NOT NULL,
+  placement smallint NOT NULL default '0'
+);
+
+#
+# Indexes for table `custom_fields`
+#
+
+CREATE UNIQUE INDEX {$db_prefix}custom_fields_col_name ON {$db_prefix}custom_fields (col_name);
+
+#
+# Table structure for table `group_moderators`
+#
+
+CREATE TABLE {$db_prefix}group_moderators (
+  id_group smallint NOT NULL default '0',
+  id_member int NOT NULL default '0',
+  PRIMARY KEY (id_group, id_member)
+);
+
+#
+# Table structure for table `log_actions`
+#
+
+CREATE TABLE {$db_prefix}log_actions (
+  id_action integer primary key,
+  id_log smallint NOT NULL default '1',
+  log_time int NOT NULL default '0',
+  id_member int NOT NULL default '0',
+  ip char(16) NOT NULL default '                ',
+  action varchar(30) NOT NULL default '',
+  id_board smallint NOT NULL default '0',
+  id_topic int NOT NULL default '0',
+  id_msg int NOT NULL default '0',
+  extra text NOT NULL
+);
+
+#
+# Indexes for table `log_actions`
+#
+
+CREATE INDEX {$db_prefix}log_actions_log_time ON {$db_prefix}log_actions (log_time);
+CREATE INDEX {$db_prefix}log_actions_id_member ON {$db_prefix}log_actions (id_member);
+CREATE INDEX {$db_prefix}log_actions_id_board ON {$db_prefix}log_actions (id_board);
+CREATE INDEX {$db_prefix}log_actions_id_msg ON {$db_prefix}log_actions (id_msg);
+CREATE INDEX {$db_prefix}log_actions_id_log ON {$db_prefix}log_actions (id_log);
+
+#
+# Table structure for table `log_activity`
+#
+
+CREATE TABLE {$db_prefix}log_activity (
+  date date NOT NULL default '0001-01-01',
+  hits int NOT NULL default '0',
+  topics smallint NOT NULL default '0',
+  posts smallint NOT NULL default '0',
+  registers smallint NOT NULL default '0',
+  most_on smallint NOT NULL default '0',
+  PRIMARY KEY (date)
+);
+
+#
+# Indexes for table `log_activity`
+#
+CREATE INDEX {$db_prefix}log_activity_most_on ON {$db_prefix}log_activity (most_on);
+
+#
+# Table structure for table `log_banned`
+#
+
+CREATE TABLE {$db_prefix}log_banned (
+  id_ban_log integer primary key,
+  id_member int NOT NULL default '0',
+  ip char(16) NOT NULL default '                ',
+  email varchar(255) NOT NULL,
+  log_time int NOT NULL default '0'
+);
+
+#
+# Indexes for table `log_banned`
+#
+
+CREATE INDEX {$db_prefix}log_banned_log_time ON {$db_prefix}log_banned (log_time);
+
+#
+# Table structure for table `log_boards`
+#
+
+CREATE TABLE {$db_prefix}log_boards (
+  id_member int NOT NULL default '0',
+  id_board smallint NOT NULL default '0',
+  id_msg int NOT NULL default '0',
+  PRIMARY KEY (id_member, id_board)
+);
+
+#
+# Table structure for table `log_comments`
+#
+
+CREATE TABLE {$db_prefix}log_comments (
+  id_comment integer primary key,
+  id_member int NOT NULL default '0',
+  member_name varchar(80) NOT NULL default '',
+  comment_type varchar(8) NOT NULL default 'warning',
+  id_recipient int NOT NULL default '0',
+  recipient_name varchar(255) NOT NULL,
+  log_time int NOT NULL default '0',
+  id_notice int NOT NULL default '0',
+  counter smallint NOT NULL default '0',
+  body text NOT NULL
+);
+
+#
+# Indexes for table `log_comments`
+#
+
+CREATE INDEX {$db_prefix}log_comments_id_recipient ON {$db_prefix}log_comments (id_recipient);
+CREATE INDEX {$db_prefix}log_comments_log_time ON {$db_prefix}log_comments (log_time);
+CREATE INDEX {$db_prefix}log_comments_comment_type ON {$db_prefix}log_comments (comment_type);
+
+#
+# Table structure for table `log_digest`
+#
+
+CREATE TABLE {$db_prefix}log_digest (
+  id_topic int NOT NULL,
+  id_msg int NOT NULL,
+  note_type varchar(10) NOT NULL default 'post',
+  daily smallint NOT NULL default '0',
+  exclude int NOT NULL default '0'
+);
+
+#
+# Table structure for table `log_errors`
+#
+
+CREATE TABLE {$db_prefix}log_errors (
+  id_error integer primary key,
+  log_time int NOT NULL default '0',
+  id_member int NOT NULL default '0',
+  ip char(16) NOT NULL default '                ',
+  url text NOT NULL,
+  message text NOT NULL,
+  session char(64) NOT NULL default '                                                                ',
+  error_type char(15) NOT NULL default 'general',
+  file varchar(255) NOT NULL,
+  line int NOT NULL default '0'
+);
+
+#
+# Indexes for table `log_errors`
+#
+
+CREATE INDEX {$db_prefix}log_errors_log_time ON {$db_prefix}log_errors (log_time);
+CREATE INDEX {$db_prefix}log_errors_id_member ON {$db_prefix}log_errors (id_member);
+CREATE INDEX {$db_prefix}log_errors_ip ON {$db_prefix}log_errors (ip);
+
+#
+# Table structure for table `log_floodcontrol`
+#
+
+CREATE TABLE {$db_prefix}log_floodcontrol (
+  ip char(16) NOT NULL default '                ',
+  log_time int NOT NULL default '0',
+  log_type varchar(8) NOT NULL default 'post',
+  PRIMARY KEY (ip, log_type)
+);
+
+#
+# Table structure for table `log_group_requests`
+#
+
+CREATE TABLE {$db_prefix}log_group_requests (
+  id_request integer primary key,
+  id_member int NOT NULL default '0',
+  id_group smallint NOT NULL default '0',
+  time_applied int NOT NULL default '0',
+  reason text NOT NULL
+);
+
+#
+# Indexes for table `log_group_requests`
+#
+
+CREATE UNIQUE INDEX {$db_prefix}log_group_requests_id_member ON {$db_prefix}log_group_requests (id_member, id_group);
+
+#
+# Table structure for table `log_karma`
+#
+
+CREATE TABLE {$db_prefix}log_karma (
+  id_target int NOT NULL default '0',
+  id_executor int NOT NULL default '0',
+  log_time int NOT NULL default '0',
+  action smallint NOT NULL default '0',
+  PRIMARY KEY (id_target, id_executor)
+);
+
+#
+# Indexes for table `log_karma`
+#
+
+CREATE INDEX {$db_prefix}log_karma_log_time ON {$db_prefix}log_karma (log_time);
+
+#
+# Table structure for table `log_mark_read`
+#
+
+CREATE TABLE {$db_prefix}log_mark_read (
+  id_member int NOT NULL default '0',
+  id_board smallint NOT NULL default '0',
+  id_msg int NOT NULL default '0',
+  PRIMARY KEY (id_member, id_board)
+);
+
+#
+# Table structure for table `log_member_notices`
+#
+
+CREATE TABLE {$db_prefix}log_member_notices (
+  id_notice integer primary key,
+  subject varchar(255) NOT NULL,
+  body text NOT NULL
+);
+
+#
+# Table structure for table `log_notify`
+#
+
+CREATE TABLE {$db_prefix}log_notify (
+  id_member int NOT NULL default '0',
+  id_topic int NOT NULL default '0',
+  id_board smallint NOT NULL default '0',
+  sent smallint NOT NULL default '0',
+  PRIMARY KEY (id_member, id_topic, id_board)
+);
+
+#
+# Indexes for table `log_notify`
+#
+
+CREATE INDEX {$db_prefix}log_notify_id_topic ON {$db_prefix}log_notify (id_topic, id_member);
+
+#
+# Table structure for table `log_online`
+#
+
+CREATE TABLE {$db_prefix}log_online (
+  session varchar(64) NOT NULL default '',
+  log_time int(10) NOT NULL default '0',
+  id_member int NOT NULL default '0',
+  id_spider smallint NOT NULL default '0',
+  ip int NOT NULL default '0',
+  url text NOT NULL,
+  PRIMARY KEY (session)
+);
+
+#
+# Indexes for table `log_online`
+#
+
+CREATE INDEX {$db_prefix}log_online_log_time ON {$db_prefix}log_online (log_time);
+CREATE INDEX {$db_prefix}log_online_id_member ON {$db_prefix}log_online (id_member);
+
+#
+# Table structure for table `log_packages`
+#
+
+CREATE TABLE {$db_prefix}log_packages (
+  id_install integer primary key,
+  filename varchar(255) NOT NULL,
+  package_id varchar(255) NOT NULL,
+  name varchar(255) NOT NULL,
+  version varchar(255) NOT NULL,
+  id_member_installed int NOT NULL default '0',
+  member_installed varchar(255) NOT NULL,
+  time_installed int NOT NULL default '0',
+  id_member_removed int NOT NULL default '0',
+  member_removed varchar(255) NOT NULL,
+  time_removed int NOT NULL default '0',
+  install_state smallint NOT NULL default '1',
+  failed_steps text NOT NULL,
+  db_changes text NOT NULL,
+  credits varchar(255) NOT NULL,
+  themes_installed varchar(255) NOT NULL
+);
+
+#
+# Indexes for table `log_packages`
+#
+
+CREATE INDEX {$db_prefix}log_packages_filename ON {$db_prefix}log_packages (filename);
+
+#
+# Table structure for table `log_polls`
+#
+
+CREATE TABLE {$db_prefix}log_polls (
+  id_poll int NOT NULL default '0',
+  id_member int NOT NULL default '0',
+  id_choice smallint NOT NULL default '0'
+);
+
+#
+# Indexes for table `log_polls`
+#
+
+CREATE INDEX {$db_prefix}log_polls_id_poll ON {$db_prefix}log_polls (id_poll, id_member, id_choice);
+
+#
+# Table structure for table `log_reported`
+#
+
+CREATE TABLE {$db_prefix}log_reported (
+  id_report integer primary key,
+  id_msg int NOT NULL default '0',
+  id_topic int NOT NULL default '0',
+  id_board smallint NOT NULL default '0',
+  id_member int NOT NULL default '0',
+  membername varchar(255) NOT NULL,
+  subject varchar(255) NOT NULL,
+  body text NOT NULL,
+  time_started int NOT NULL default '0',
+  time_updated int NOT NULL default '0',
+  num_reports int NOT NULL default '0',
+  closed smallint NOT NULL default '0',
+  ignore_all smallint NOT NULL default '0'
+);
+
+#
+# Indexes for table `log_reported`
+#
+
+CREATE INDEX {$db_prefix}log_reported_id_member ON {$db_prefix}log_reported (id_member);
+CREATE INDEX {$db_prefix}log_reported_id_topic ON {$db_prefix}log_reported (id_topic);
+CREATE INDEX {$db_prefix}log_reported_closed ON {$db_prefix}log_reported (closed);
+CREATE INDEX {$db_prefix}log_reported_time_started ON {$db_prefix}log_reported (time_started);
+CREATE INDEX {$db_prefix}log_reported_id_msg ON {$db_prefix}log_reported (id_msg);
+
+#
+# Table structure for table `log_reported_comments`
+#
+
+CREATE TABLE {$db_prefix}log_reported_comments (
+  id_comment integer primary key,
+  id_report int NOT NULL default '0',
+  id_member int NOT NULL,
+  membername varchar(255) NOT NULL,
+  email_address varchar(255) NOT NULL,
+  member_ip varchar(255) NOT NULL,
+  comment varchar(255) NOT NULL,
+  time_sent int NOT NULL
+);
+
+#
+# Indexes for table `log_reported_comments`
+#
+
+CREATE INDEX {$db_prefix}log_reported_comments_id_report ON {$db_prefix}log_reported_comments (id_report);
+CREATE INDEX {$db_prefix}log_reported_comments_id_member ON {$db_prefix}log_reported_comments (id_member);
+CREATE INDEX {$db_prefix}log_reported_comments_time_sent ON {$db_prefix}log_reported_comments (time_sent);
+
+#
+# Table structure for table `log_scheduled_tasks`
+#
+
+CREATE TABLE {$db_prefix}log_scheduled_tasks (
+  id_log integer primary key,
+  id_task smallint NOT NULL default '0',
+  time_run int NOT NULL default '0',
+  time_taken float NOT NULL default '0'
+);
+
+#
+# Table structure for table `log_search_messages`
+#
+
+CREATE TABLE {$db_prefix}log_search_messages (
+  id_search smallint NOT NULL default '0',
+  id_msg int NOT NULL default '0',
+  PRIMARY KEY (id_search, id_msg)
+);
+
+#
+# Table structure for table `log_search_results`
+#
+
+CREATE TABLE {$db_prefix}log_search_results (
+  id_search smallint NOT NULL default '0',
+  id_topic int NOT NULL default '0',
+  id_msg int NOT NULL default '0',
+  relevance smallint NOT NULL default '0',
+  num_matches smallint NOT NULL default '0',
+  PRIMARY KEY (id_search, id_topic)
+);
+
+#
+# Table structure for table `log_search_subjects`
+#
+
+CREATE TABLE {$db_prefix}log_search_subjects (
+  word varchar(20) NOT NULL default '',
+  id_topic int NOT NULL default '0',
+  PRIMARY KEY (word, id_topic)
+);
+
+#
+# Indexes for table `log_search_subjects`
+#
+
+CREATE INDEX {$db_prefix}log_search_subjects_id_topic ON {$db_prefix}log_search_subjects (id_topic);
+
+#
+# Table structure for table `log_search_topics`
+#
+
+CREATE TABLE {$db_prefix}log_search_topics (
+  id_search smallint NOT NULL default '0',
+  id_topic int NOT NULL default '0',
+  PRIMARY KEY (id_search, id_topic)
+);
+
+#
+# Table structure for table `log_spider_hits`
+#
+
+CREATE TABLE {$db_prefix}log_spider_hits (
+	id_hit integer primary key,
+  id_spider smallint NOT NULL default '0',
+  log_time int NOT NULL default '0',
+  url varchar(255) NOT NULL,
+  processed smallint NOT NULL default '0'
+);
+
+#
+# Indexes for table `log_spider_hits`
+#
+
+CREATE INDEX {$db_prefix}log_spider_hits_id_spider ON {$db_prefix}log_spider_hits (id_spider);
+CREATE INDEX {$db_prefix}log_spider_hits_log_time ON {$db_prefix}log_spider_hits (log_time);
+CREATE INDEX {$db_prefix}log_spider_hits_processed ON {$db_prefix}log_spider_hits (processed);
+
+#
+# Table structure for table `log_spider_stats`
+#
+
+CREATE TABLE {$db_prefix}log_spider_stats (
+  id_spider smallint NOT NULL default '0',
+  page_hits smallint NOT NULL default '0',
+  last_seen int NOT NULL default '0',
+  stat_date date NOT NULL default '0001-01-01',
+  PRIMARY KEY (stat_date, id_spider)
+);
+
+#
+# Table structure for table `log_subscribed`
+#
+
+CREATE TABLE {$db_prefix}log_subscribed (
+  id_sublog integer primary key,
+  id_subscribe smallint unsigned NOT NULL default '0',
+  id_member int NOT NULL default '0',
+  old_id_group int NOT NULL default '0',
+  start_time int NOT NULL default '0',
+  end_time int NOT NULL default '0',
+  status smallint NOT NULL default '0',
+  payments_pending smallint NOT NULL default '0',
+  pending_details text NOT NULL,
+  reminder_sent smallint NOT NULL default '0',
+  vendor_ref varchar(255) NOT NULL
+);
+
+#
+# Indexes for table `log_subscribed`
+#
+
+CREATE INDEX {$db_prefix}log_subscribed_id_subscribe ON {$db_prefix}log_subscribed (id_subscribe, id_member);
+CREATE INDEX {$db_prefix}log_subscribed_end_time ON {$db_prefix}log_subscribed (end_time);
+CREATE INDEX {$db_prefix}log_subscribed_reminder_sent ON {$db_prefix}log_subscribed (reminder_sent);
+CREATE INDEX {$db_prefix}log_subscribed_payments_pending ON {$db_prefix}log_subscribed (payments_pending);
+CREATE INDEX {$db_prefix}log_subscribed_status ON {$db_prefix}log_subscribed (status);
+CREATE INDEX {$db_prefix}log_subscribed_id_member ON {$db_prefix}log_subscribed (id_member);
+
+#
+# Table structure for table `log_topics`
+#
+
+CREATE TABLE {$db_prefix}log_topics (
+  id_member int NOT NULL default '0',
+  id_topic int NOT NULL default '0',
+  id_msg int NOT NULL default '0',
+  disregarded int NOT NULL default '0',
+  PRIMARY KEY (id_member, id_topic)
+);
+
+#
+# Indexes for table `log_topics`
+#
+
+CREATE INDEX {$db_prefix}log_topics_id_topic ON {$db_prefix}log_topics (id_topic);
+
+#
+# Table structure for table `mail_queue`
+#
+
+CREATE TABLE {$db_prefix}mail_queue (
+  id_mail integer primary key,
+  time_sent int NOT NULL default '0',
+  recipient varchar(255) NOT NULL,
+  body text NOT NULL,
+  subject varchar(255) NOT NULL,
+  headers text NOT NULL,
+  send_html smallint NOT NULL default '0',
+  priority smallint NOT NULL default '1',
+  private smallint NOT NULL default '0'
+);
+
+#
+# Indexes for table `mail_queue`
+#
+
+CREATE INDEX {$db_prefix}mail_queue_time_sent ON {$db_prefix}mail_queue (time_sent);
+CREATE INDEX {$db_prefix}mail_queue_mail_priority ON {$db_prefix}mail_queue (priority, id_mail);
+
+#
+# Table structure for table `membergroups`
+#
+
+CREATE TABLE {$db_prefix}membergroups (
+  id_group integer primary key,
+  group_name varchar(80) NOT NULL default '',
+  description text NOT NULL,
+  online_color varchar(20) NOT NULL default '',
+  min_posts int NOT NULL default '-1',
+  max_messages smallint NOT NULL default '0',
+  icons varchar(255) NOT NULL,
+  group_type smallint NOT NULL default '0',
+  hidden smallint NOT NULL default '0',
+  id_parent smallint NOT NULL default '-2'
+);
+
+#
+# Indexes for table `membergroups`
+#
+
+CREATE INDEX {$db_prefix}membergroups_min_posts ON {$db_prefix}membergroups (min_posts);
+
+#
+# Dumping data for table `membergroups`
+#
+
+BEGIN TRANSACTION;
+INSERT INTO {$db_prefix}membergroups (id_group, group_name, description, online_color, min_posts, icons, group_type) VALUES (1, '{$default_administrator_group}', '', '#FF0000', -1, '5#iconadmin.png', 1);
+INSERT INTO {$db_prefix}membergroups (id_group, group_name, description, online_color, min_posts, icons) VALUES (2, '{$default_global_moderator_group}', '', '#0000FF', -1, '5#icongmod.png');
+INSERT INTO {$db_prefix}membergroups (id_group, group_name, description, online_color, min_posts, icons) VALUES (3, '{$default_moderator_group}', '', '', -1, '5#iconmod.png');
+INSERT INTO {$db_prefix}membergroups (id_group, group_name, description, online_color, min_posts, icons) VALUES (4, '{$default_newbie_group}', '', '', 0, '1#icon.png');
+INSERT INTO {$db_prefix}membergroups (id_group, group_name, description, online_color, min_posts, icons) VALUES (5, '{$default_junior_group}', '', '', 50, '2#icon.png');
+INSERT INTO {$db_prefix}membergroups (id_group, group_name, description, online_color, min_posts, icons) VALUES (6, '{$default_full_group}', '', '', 100, '3#icon.png');
+INSERT INTO {$db_prefix}membergroups (id_group, group_name, description, online_color, min_posts, icons) VALUES (7, '{$default_senior_group}', '', '', 250, '4#icon.png');
+INSERT INTO {$db_prefix}membergroups (id_group, group_name, description, online_color, min_posts, icons) VALUES (8, '{$default_hero_group}', '', '', 500, '5#icon.png');
+COMMIT;
+
+# --------------------------------------------------------
+
+#
+# Table structure for table `members`
+#
+
+CREATE TABLE {$db_prefix}members (
+  id_member integer primary key,
+  member_name varchar(80) NOT NULL default '',
+  date_registered int NOT NULL default '0',
+  posts int NOT NULL default '0',
+  id_group smallint NOT NULL default '0',
+  lngfile varchar(255) NOT NULL,
+  last_login int NOT NULL default '0',
+  real_name varchar(255) NOT NULL,
+  instant_messages smallint NOT NULL default 0,
+  unread_messages smallint NOT NULL default 0,
+  new_pm smallint NOT NULL default '0',
+  buddy_list text NOT NULL,
+  pm_ignore_list varchar(255) NOT NULL,
+  pm_prefs int NOT NULL default '0',
+  mod_prefs varchar(20) NOT NULL default '',
+  message_labels text NOT NULL,
+  passwd varchar(64) NOT NULL default '',
+  openid_uri text NOT NULL,
+  email_address varchar(255) NOT NULL,
+  personal_text varchar(255) NOT NULL,
+  gender smallint NOT NULL default '0',
+  birthdate date NOT NULL default '0001-01-01',
+  website_title varchar(255) NOT NULL,
+  website_url varchar(255) NOT NULL,
+  location varchar(255) NOT NULL,
+  icq varchar(255) NOT NULL,
+  aim varchar(255) NOT NULL default '',
+  yim varchar(32) NOT NULL default '',
+  skype varchar(255) NOT NULL default '',
+  hide_email smallint NOT NULL default '0',
+  show_online smallint NOT NULL default '1',
+  time_format varchar(80) NOT NULL default '',
+  signature text NOT NULL,
+  time_offset float NOT NULL default '0',
+  avatar varchar(255) NOT NULL,
+  pm_email_notify smallint NOT NULL default '0',
+  karma_bad smallint NOT NULL default '0',
+  karma_good smallint NOT NULL default '0',
+  usertitle varchar(255) NOT NULL,
+  notify_announcements smallint NOT NULL default '1',
+  notify_regularity smallint NOT NULL default '1',
+  notify_send_body smallint NOT NULL default '0',
+  notify_types smallint NOT NULL default '2',
+  member_ip varchar(255) NOT NULL,
+  member_ip2 varchar(255) NOT NULL,
+  secret_question varchar(255) NOT NULL,
+  secret_answer varchar(64) NOT NULL default '',
+  id_theme smallint NOT NULL default '0',
+  is_activated smallint NOT NULL default '1',
+  validation_code varchar(10) NOT NULL default '',
+  id_msg_last_visit int NOT NULL default '0',
+  additional_groups varchar(255) NOT NULL,
+  smiley_set varchar(48) NOT NULL default '',
+  id_post_group smallint NOT NULL default '0',
+  total_time_logged_in int NOT NULL default '0',
+  password_salt varchar(255) NOT NULL default '',
+  ignore_boards text NOT NULL,
+  warning smallint NOT NULL default '0',
+  passwd_flood varchar(12) NOT NULL default '',
+  pm_receive_from smallint NOT NULL default '1'
+);
+
+#
+# Indexes for table `members`
+#
+
+CREATE INDEX {$db_prefix}members_member_name ON {$db_prefix}members (member_name);
+CREATE INDEX {$db_prefix}members_real_name ON {$db_prefix}members (real_name);
+CREATE INDEX {$db_prefix}members_date_registered ON {$db_prefix}members (date_registered);
+CREATE INDEX {$db_prefix}members_id_group ON {$db_prefix}members (id_group);
+CREATE INDEX {$db_prefix}members_birthdate ON {$db_prefix}members (birthdate);
+CREATE INDEX {$db_prefix}members_posts ON {$db_prefix}members (posts);
+CREATE INDEX {$db_prefix}members_last_login ON {$db_prefix}members (last_login);
+CREATE INDEX {$db_prefix}members_lngfile ON {$db_prefix}members (lngfile);
+CREATE INDEX {$db_prefix}members_id_post_group ON {$db_prefix}members (id_post_group);
+CREATE INDEX {$db_prefix}members_warning ON {$db_prefix}members (warning);
+CREATE INDEX {$db_prefix}members_total_time_logged_in ON {$db_prefix}members (total_time_logged_in);
+CREATE INDEX {$db_prefix}members_id_theme ON {$db_prefix}members (id_theme);
+
+
+#
+# Table structure for table `member_logins`
+#
+
+CREATE TABLE {$db_prefix}member_logins (
+  id_login integer primary key,
+  id_member int NOT NULL default '0',
+  time int(10) NOT NULL default '0',
+  ip varchar(255) NOT NULL default '0',
+  ip2 varchar(255) NOT NULL default '0'
+);
+
+#
+# Indexes for table `member_logins`
+#
+CREATE INDEX {$db_prefix}member_logins_id_member ON {$db_prefix}member_logins (id_member);
+CREATE INDEX {$db_prefix}member_logins_time ON {$db_prefix}member_logins (time);
+
+#
+# Table structure for table `message_icons`
+#
+
+CREATE TABLE {$db_prefix}message_icons (
+  id_icon integer primary key,
+  title varchar(80) NOT NULL default '',
+  filename varchar(80) NOT NULL default '',
+  id_board smallint NOT NULL default '0',
+  icon_order smallint NOT NULL default '0'
+);
+
+#
+# Indexes for table `message_icons`
+#
+
+CREATE INDEX {$db_prefix}message_icons_id_board ON {$db_prefix}message_icons (id_board);
+
+#
+# Dumping data for table `message_icons`
+#
+
+# // !!! i18n
+BEGIN TRANSACTION;
+INSERT INTO {$db_prefix}message_icons (filename, title, icon_order) VALUES ('xx', 'Standard', '0');
+INSERT INTO {$db_prefix}message_icons (filename, title, icon_order) VALUES ('thumbup', 'Thumb Up', '1');
+INSERT INTO {$db_prefix}message_icons (filename, title, icon_order) VALUES ('thumbdown', 'Thumb Down', '2');
+INSERT INTO {$db_prefix}message_icons (filename, title, icon_order) VALUES ('exclamation', 'Exclamation point', '3');
+INSERT INTO {$db_prefix}message_icons (filename, title, icon_order) VALUES ('question', 'Question mark', '4');
+INSERT INTO {$db_prefix}message_icons (filename, title, icon_order) VALUES ('lamp', 'Lamp', '5');
+INSERT INTO {$db_prefix}message_icons (filename, title, icon_order) VALUES ('smiley', 'Smiley', '6');
+INSERT INTO {$db_prefix}message_icons (filename, title, icon_order) VALUES ('angry', 'Angry', '7');
+INSERT INTO {$db_prefix}message_icons (filename, title, icon_order) VALUES ('cheesy', 'Cheesy', '8');
+INSERT INTO {$db_prefix}message_icons (filename, title, icon_order) VALUES ('grin', 'Grin', '9');
+INSERT INTO {$db_prefix}message_icons (filename, title, icon_order) VALUES ('sad', 'Sad', '10');
+INSERT INTO {$db_prefix}message_icons (filename, title, icon_order) VALUES ('wink', 'Wink', '11');
+INSERT INTO {$db_prefix}message_icons (filename, title, icon_order) VALUES ('poll', 'Poll', '12');
+COMMIT;
+
+# --------------------------------------------------------
+
+#
+# Table structure for table `messages`
+#
+
+CREATE TABLE {$db_prefix}messages (
+  id_msg integer primary key,
+  id_topic int NOT NULL default '0',
+  id_board smallint NOT NULL default '0',
+  poster_time int NOT NULL default '0',
+  id_member int NOT NULL default '0',
+  id_msg_modified int NOT NULL default '0',
+  subject varchar(255) NOT NULL,
+  poster_name varchar(255) NOT NULL,
+  poster_email varchar(255) NOT NULL,
+  poster_ip varchar(255) NOT NULL,
+  smileys_enabled smallint NOT NULL default '1',
+  modified_time int NOT NULL default '0',
+  modified_name varchar(255) NOT NULL,
+  body text NOT NULL,
+  icon varchar(16) NOT NULL default 'xx',
+  approved smallint NOT NULL default '1'
+);
+
+#
+# Indexes for table `messages`
+#
+
+CREATE UNIQUE INDEX {$db_prefix}messages_topic ON {$db_prefix}messages (id_topic, id_msg);
+CREATE UNIQUE INDEX {$db_prefix}messages_id_board ON {$db_prefix}messages (id_board, id_msg);
+CREATE UNIQUE INDEX {$db_prefix}messages_id_member ON {$db_prefix}messages (id_member, id_msg);
+CREATE INDEX {$db_prefix}messages_approved ON {$db_prefix}messages (approved);
+CREATE INDEX {$db_prefix}messages_ip_index ON {$db_prefix}messages (poster_ip, id_topic);
+CREATE INDEX {$db_prefix}messages_participation ON {$db_prefix}messages (id_member, id_topic);
+CREATE INDEX {$db_prefix}messages_show_posts ON {$db_prefix}messages (id_member, id_board);
+CREATE INDEX {$db_prefix}messages_id_topic ON {$db_prefix}messages (id_topic);
+CREATE INDEX {$db_prefix}messages_id_member_msg ON {$db_prefix}messages (id_member, approved, id_msg);
+CREATE INDEX {$db_prefix}messages_current_topic ON {$db_prefix}messages (id_topic, id_msg, id_member, approved);
+CREATE INDEX {$db_prefix}messages_related_ip ON {$db_prefix}messages (id_member, poster_ip, id_msg);
+#
+# Dumping data for table `messages`
+#
+
+INSERT INTO {$db_prefix}messages
+	(id_msg, id_msg_modified, id_topic, id_board, poster_time, subject, poster_name, poster_email, poster_ip, modified_name, body, icon)
+VALUES (1, 1, 1, 1, {$current_time}, '{$default_topic_subject}', 'Simple Machines', 'info@simplemachines.org', '127.0.0.1', '', '{$default_topic_message}', 'xx');
+# --------------------------------------------------------
+
+#
+# Table structure for table `moderators`
+#
+
+CREATE TABLE {$db_prefix}moderators (
+  id_board smallint NOT NULL default '0',
+  id_member int NOT NULL default '0',
+  PRIMARY KEY (id_board, id_member)
+);
+
+#
+# Table structure for table `moderator_groups`
+#
+
+CREATE TABLE {$db_prefix}moderator_groups (
+  id_board smallint NOT NULL default '0',
+  id_group smallint NOT NULL default '0',
+  PRIMARY KEY (id_board, id_group)
+);
+
+#
+# Table structure for table `openid_assoc`
+#
+
+CREATE TABLE {$db_prefix}openid_assoc (
+  server_url text NOT NULL,
+  handle varchar(255) NOT NULL,
+  secret text NOT NULL,
+  issued int NOT NULL default '0',
+  expires int NOT NULL default '0',
+  assoc_type varchar(64) NOT NULL,
+  PRIMARY KEY (server_url, handle)
+);
+
+#
+# Indexes for table `openid_assoc`
+#
+
+CREATE INDEX {$db_prefix}openid_assoc_expires ON {$db_prefix}openid_assoc (expires);
+
+#
+# Table structure for table `package_servers`
+#
+
+CREATE TABLE {$db_prefix}package_servers (
+  id_server integer primary key,
+  name varchar(255) NOT NULL,
+  url varchar(255) NOT NULL
+);
+
+#
+# Dumping data for table `package_servers`
+#
+
+INSERT INTO {$db_prefix}package_servers
+	(name, url)
+VALUES ('Simple Machines Third-party Mod Site', 'http://custom.simplemachines.org/packages/mods');
+# --------------------------------------------------------
+
+#
+# Table structure for table `permission_profiles`
+#
+
+CREATE TABLE {$db_prefix}permission_profiles (
+  id_profile integer primary key,
+  profile_name varchar(255) NOT NULL
+);
+
+#
+# Dumping data for table `permission_profiles`
+#
+
+BEGIN TRANSACTION;
+INSERT INTO {$db_prefix}permission_profiles (id_profile, profile_name) VALUES (1, 'default');
+INSERT INTO {$db_prefix}permission_profiles (id_profile, profile_name) VALUES (2, 'no_polls');
+INSERT INTO {$db_prefix}permission_profiles (id_profile, profile_name) VALUES (3, 'reply_only');
+INSERT INTO {$db_prefix}permission_profiles (id_profile, profile_name) VALUES (4, 'read_only');
+COMMIT;
+
+# --------------------------------------------------------
+
+#
+# Table structure for table `permissions`
+#
+
+CREATE TABLE {$db_prefix}permissions (
+  id_group smallint NOT NULL default '0',
+  permission varchar(30) NOT NULL default '',
+  add_deny smallint NOT NULL default '1',
+  PRIMARY KEY (id_group, permission)
+);
+
+#
+# Dumping data for table `permissions`
+#
+
+BEGIN TRANSACTION;
+INSERT INTO {$db_prefix}permissions (id_group, permission) VALUES (-1, 'search_posts');
+INSERT INTO {$db_prefix}permissions (id_group, permission) VALUES (-1, 'calendar_view');
+INSERT INTO {$db_prefix}permissions (id_group, permission) VALUES (-1, 'view_stats');
+INSERT INTO {$db_prefix}permissions (id_group, permission) VALUES (-1, 'profile_view_any');
+INSERT INTO {$db_prefix}permissions (id_group, permission) VALUES (0, 'view_mlist');
+INSERT INTO {$db_prefix}permissions (id_group, permission) VALUES (0, 'search_posts');
+INSERT INTO {$db_prefix}permissions (id_group, permission) VALUES (0, 'profile_view_own');
+INSERT INTO {$db_prefix}permissions (id_group, permission) VALUES (0, 'profile_view_any');
+INSERT INTO {$db_prefix}permissions (id_group, permission) VALUES (0, 'pm_read');
+INSERT INTO {$db_prefix}permissions (id_group, permission) VALUES (0, 'pm_send');
+INSERT INTO {$db_prefix}permissions (id_group, permission) VALUES (0, 'pm_draft');
+INSERT INTO {$db_prefix}permissions (id_group, permission) VALUES (0, 'pm_autosave_draft');
+INSERT INTO {$db_prefix}permissions (id_group, permission) VALUES (0, 'calendar_view');
+INSERT INTO {$db_prefix}permissions (id_group, permission) VALUES (0, 'view_stats');
+INSERT INTO {$db_prefix}permissions (id_group, permission) VALUES (0, 'who_view');
+INSERT INTO {$db_prefix}permissions (id_group, permission) VALUES (0, 'profile_identity_own');
+INSERT INTO {$db_prefix}permissions (id_group, permission) VALUES (0, 'profile_extra_own');
+INSERT INTO {$db_prefix}permissions (id_group, permission) VALUES (0, 'profile_remove_own');
+INSERT INTO {$db_prefix}permissions (id_group, permission) VALUES (0, 'profile_server_avatar');
+INSERT INTO {$db_prefix}permissions (id_group, permission) VALUES (0, 'profile_upload_avatar');
+INSERT INTO {$db_prefix}permissions (id_group, permission) VALUES (0, 'profile_remote_avatar');
+INSERT INTO {$db_prefix}permissions (id_group, permission) VALUES (0, 'send_email_to_members');
+INSERT INTO {$db_prefix}permissions (id_group, permission) VALUES (0, 'karma_edit');
+INSERT INTO {$db_prefix}permissions (id_group, permission) VALUES (2, 'view_mlist');
+INSERT INTO {$db_prefix}permissions (id_group, permission) VALUES (2, 'search_posts');
+INSERT INTO {$db_prefix}permissions (id_group, permission) VALUES (2, 'profile_view_own');
+INSERT INTO {$db_prefix}permissions (id_group, permission) VALUES (2, 'profile_view_any');
+INSERT INTO {$db_prefix}permissions (id_group, permission) VALUES (2, 'pm_read');
+INSERT INTO {$db_prefix}permissions (id_group, permission) VALUES (2, 'pm_send');
+INSERT INTO {$db_prefix}permissions (id_group, permission) VALUES (2, 'pm_draft');
+INSERT INTO {$db_prefix}permissions (id_group, permission) VALUES (2, 'pm_autosave_draft');
+INSERT INTO {$db_prefix}permissions (id_group, permission) VALUES (2, 'calendar_view');
+INSERT INTO {$db_prefix}permissions (id_group, permission) VALUES (2, 'view_stats');
+INSERT INTO {$db_prefix}permissions (id_group, permission) VALUES (2, 'who_view');
+INSERT INTO {$db_prefix}permissions (id_group, permission) VALUES (2, 'profile_identity_own');
+INSERT INTO {$db_prefix}permissions (id_group, permission) VALUES (2, 'profile_extra_own');
+INSERT INTO {$db_prefix}permissions (id_group, permission) VALUES (2, 'profile_remove_own');
+INSERT INTO {$db_prefix}permissions (id_group, permission) VALUES (2, 'profile_server_avatar');
+INSERT INTO {$db_prefix}permissions (id_group, permission) VALUES (2, 'profile_upload_avatar');
+INSERT INTO {$db_prefix}permissions (id_group, permission) VALUES (2, 'profile_remote_avatar');
+INSERT INTO {$db_prefix}permissions (id_group, permission) VALUES (2, 'send_email_to_members');
+INSERT INTO {$db_prefix}permissions (id_group, permission) VALUES (2, 'profile_title_own');
+INSERT INTO {$db_prefix}permissions (id_group, permission) VALUES (2, 'calendar_post');
+INSERT INTO {$db_prefix}permissions (id_group, permission) VALUES (2, 'calendar_edit_any');
+INSERT INTO {$db_prefix}permissions (id_group, permission) VALUES (2, 'karma_edit');
+INSERT INTO {$db_prefix}permissions (id_group, permission) VALUES (2, 'access_mod_center');
+COMMIT;
+
+# --------------------------------------------------------
+
+#
+# Table structure for table `personal_messages`
+#
+
+CREATE TABLE {$db_prefix}personal_messages (
+  id_pm integer primary key,
+  id_pm_head int NOT NULL default '0',
+  id_member_from int NOT NULL default '0',
+  deleted_by_sender smallint NOT NULL default '0',
+  from_name varchar(255) NOT NULL,
+  msgtime int NOT NULL default '0',
+  subject varchar(255) NOT NULL,
+  body text NOT NULL
+);
+
+#
+# Indexes for table `personal_messages`
+#
+
+CREATE INDEX {$db_prefix}personal_messages_id_member ON {$db_prefix}personal_messages (id_member_from, deleted_by_sender);
+CREATE INDEX {$db_prefix}personal_messages_msgtime ON {$db_prefix}personal_messages (msgtime);
+CREATE INDEX {$db_prefix}personal_messages_id_pm_head ON {$db_prefix}personal_messages (id_pm_head);
+
+#
+# Table structure for table `pm_recipients`
+#
+
+CREATE TABLE {$db_prefix}pm_recipients (
+  id_pm int NOT NULL default '0',
+  id_member int NOT NULL default '0',
+  labels varchar(60) NOT NULL default '-1',
+  bcc smallint NOT NULL default '0',
+  is_read smallint NOT NULL default '0',
+  is_new smallint NOT NULL default '0',
+  deleted smallint NOT NULL default '0',
+  PRIMARY KEY (id_pm, id_member)
+);
+
+#
+# Indexes for table `pm_recipients`
+#
+
+CREATE UNIQUE INDEX {$db_prefix}pm_recipients_id_member ON {$db_prefix}pm_recipients (id_member, deleted, id_pm);
+
+#
+# Table structure for table `pm_rules`
+#
+
+CREATE TABLE {$db_prefix}pm_rules (
+  id_rule integer primary key,
+  id_member integer NOT NULL default '0',
+  rule_name varchar(60) NOT NULL,
+  criteria text NOT NULL,
+  actions text NOT NULL,
+  delete_pm smallint NOT NULL default '0',
+  is_or smallint NOT NULL default '0'
+);
+
+#
+# Indexes for table `pm_rules`
+#
+
+CREATE INDEX {$db_prefix}pm_rules_id_member ON {$db_prefix}pm_rules (id_member);
+CREATE INDEX {$db_prefix}pm_rules_delete_pm ON {$db_prefix}pm_rules (delete_pm);
+
+#
+# Table structure for table `polls`
+#
+
+CREATE TABLE {$db_prefix}polls (
+  id_poll integer primary key,
+  question varchar(255) NOT NULL,
+  voting_locked smallint NOT NULL default '0',
+  max_votes smallint NOT NULL default '1',
+  expire_time int NOT NULL default '0',
+  hide_results smallint NOT NULL default '0',
+  change_vote smallint NOT NULL default '0',
+  guest_vote smallint NOT NULL default '0',
+  num_guest_voters int NOT NULL default '0',
+  reset_poll int NOT NULL default '0',
+  id_member int NOT NULL default '0',
+  poster_name varchar(255) NOT NULL
+);
+
+#
+# Table structure for table `poll_choices`
+#
+
+CREATE TABLE {$db_prefix}poll_choices (
+  id_poll int NOT NULL default '0',
+  id_choice smallint NOT NULL default '0',
+  label varchar(255) NOT NULL,
+  votes smallint NOT NULL default '0',
+  PRIMARY KEY (id_poll, id_choice)
+);
+
+#
+# Table structure for table `scheduled_tasks`
+#
+
+CREATE TABLE {$db_prefix}scheduled_tasks (
+  id_task integer primary key,
+  next_time int NOT NULL default '0',
+  time_offset int NOT NULL default '0',
+  time_regularity smallint NOT NULL default '0',
+  time_unit varchar(1) NOT NULL default 'h',
+  disabled smallint NOT NULL default '0',
+  task varchar(24) NOT NULL default ''
+);
+
+#
+# Indexes for table `scheduled_tasks`
+#
+
+CREATE INDEX {$db_prefix}scheduled_tasks_next_time ON {$db_prefix}scheduled_tasks (next_time);
+CREATE INDEX {$db_prefix}scheduled_tasks_disabled ON {$db_prefix}scheduled_tasks (disabled);
+CREATE UNIQUE INDEX {$db_prefix}scheduled_tasks_task ON {$db_prefix}scheduled_tasks (task);
+
+#
+# Dumping data for table `scheduled_tasks`
+#
+
+BEGIN TRANSACTION;
+INSERT INTO {$db_prefix}scheduled_tasks	(id_task, next_time, time_offset, time_regularity, time_unit, disabled, task) VALUES (1, 0, 0, 2, 'h', 0, 'approval_notification');
+INSERT INTO {$db_prefix}scheduled_tasks	(id_task, next_time, time_offset, time_regularity, time_unit, disabled, task) VALUES (2, 0, 0, 7, 'd', 0, 'auto_optimize');
+INSERT INTO {$db_prefix}scheduled_tasks	(id_task, next_time, time_offset, time_regularity, time_unit, disabled, task) VALUES (3, 0, 60, 1, 'd', 0, 'daily_maintenance');
+INSERT INTO {$db_prefix}scheduled_tasks	(id_task, next_time, time_offset, time_regularity, time_unit, disabled, task) VALUES (5, 0, 0, 1, 'd', 0, 'daily_digest');
+INSERT INTO {$db_prefix}scheduled_tasks	(id_task, next_time, time_offset, time_regularity, time_unit, disabled, task) VALUES (6, 0, 0, 1, 'w', 0, 'weekly_digest');
+INSERT INTO {$db_prefix}scheduled_tasks	(id_task, next_time, time_offset, time_regularity, time_unit, disabled, task) VALUES (7, 0, {$sched_task_offset}, 1, 'd', 0, 'fetchSMfiles');
+INSERT INTO {$db_prefix}scheduled_tasks	(id_task, next_time, time_offset, time_regularity, time_unit, disabled, task) VALUES (8, 0, 0, 1, 'd', 1, 'birthdayemails');
+INSERT INTO {$db_prefix}scheduled_tasks	(id_task, next_time, time_offset, time_regularity, time_unit, disabled, task) VALUES (9, 0, 0, 1, 'w', 0, 'weekly_maintenance');
+INSERT INTO {$db_prefix}scheduled_tasks	(id_task, next_time, time_offset, time_regularity, time_unit, disabled, task) VALUES (10, 0, 120, 1, 'd', 1, 'paid_subscriptions');
+INSERT INTO {$db_prefix}scheduled_tasks	(id_task, next_time, time_offset, time_regularity, time_unit, disabled, task) VALUES (11, 0, 120, 1, 'd', 0, 'remove_temp_attachments');
+INSERT INTO {$db_prefix}scheduled_tasks	(id_task, next_time, time_offset, time_regularity, time_unit, disabled, task) VALUES (12, 0, 180, 1, 'd', 0, 'remove_topic_redirect');
+INSERT INTO {$db_prefix}scheduled_tasks	(id_task, next_time, time_offset, time_regularity, time_unit, disabled, task) VALUES (13, 0, 240, 1, 'd', 0, 'remove_old_drafts');
+COMMIT;
+
+# --------------------------------------------------------
+
+#
+# Table structure for table `settings`
+#
+
+CREATE TABLE {$db_prefix}settings (
+  variable varchar(255) NOT NULL,
+  value text NOT NULL,
+  PRIMARY KEY (variable)
+);
+
+#
+# Dumping data for table `settings`
+#
+
+BEGIN TRANSACTION;
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('smfVersion', '{$smf_version}');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('news', '{$default_news}');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('compactTopicPagesContiguous', '5');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('compactTopicPagesEnable', '1');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('enableStickyTopics', '1');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('todayMod', '1');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('karmaMode', '0');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('karmaTimeRestrictAdmins', '1');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('enablePreviousNext', '1');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('pollMode', '1');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('enableVBStyleLogin', '1');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('enableCompressedOutput', '{$enableCompressedOutput}');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('karmaWaitTime', '1');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('karmaMinPosts', '0');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('karmaLabel', '{$default_karmaLabel}');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('karmaSmiteLabel', '{$default_karmaSmiteLabel}');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('karmaApplaudLabel', '{$default_karmaApplaudLabel}');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('attachmentSizeLimit', '128');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('attachmentPostLimit', '192');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('attachmentNumPerPostLimit', '4');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('attachmentDirSizeLimit', '10240');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('attachmentDirFileLimit', '1000');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('attachmentUploadDir', '{$boarddir}/attachments');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('attachmentExtensions', 'doc,gif,jpg,mpg,pdf,png,txt,zip');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('attachmentCheckExtensions', '0');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('attachmentShowImages', '1');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('attachmentEnable', '1');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('attachmentEncryptFilenames', '1');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('attachmentThumbnails', '1');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('attachmentThumbWidth', '150');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('attachmentThumbHeight', '150');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('use_subdirectories_for_attachments', '1');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('censorIgnoreCase', '1');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('mostOnline', '1');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('mostOnlineToday', '1');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('mostDate', {$current_time});
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('allow_disableAnnounce', '1');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('trackStats', '1');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('userLanguage', '1');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('titlesEnable', '1');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('topicSummaryPosts', '15');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('enableErrorLogging', '1');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('max_image_width', '0');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('max_image_height', '0');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('onlineEnable', '0');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('cal_enabled', '0');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('cal_maxyear', '2020');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('cal_minyear', '2008');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('cal_daysaslink', '0');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('cal_defaultboard', '');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('cal_showholidays', '1');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('cal_showbdays', '1');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('cal_showevents', '1');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('cal_maxspan', '7');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('cal_highlight_events', '3');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('cal_highlight_holidays', '3');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('cal_highlight_birthdays', '3');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('cal_disable_prev_next', '0');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('cal_display_type', '0');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('cal_week_links', '2');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('cal_prev_next_links', '1');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('cal_short_days', '0');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('cal_short_months', '0');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('cal_week_numbers', '0');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('smtp_host', '');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('smtp_port', '25');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('smtp_username', '');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('smtp_password', '');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('mail_type', '0');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('timeLoadPageEnable', '0');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('totalMembers', '0');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('totalTopics', '1');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('totalMessages', '1');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('simpleSearch', '0');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('censor_vulgar', '');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('censor_proper', '');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('enablePostHTML', '0');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('theme_allow', '1');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('theme_default', '1');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('theme_guests', '1');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('enableEmbeddedFlash', '0');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('xmlnews_enable', '1');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('xmlnews_maxlen', '255');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('hotTopicPosts', '15');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('hotTopicVeryPosts', '25');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('registration_method', '{$registration_method}');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('send_validation_onChange', '0');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('send_welcomeEmail', '1');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('allow_editDisplayName', '1');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('allow_hideOnline', '1');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('guest_hideContacts', '1');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('spamWaitTime', '5');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('pm_spam_settings', '10,5,20');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('reserveWord', '0');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('reserveCase', '1');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('reserveUser', '1');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('reserveName', '1');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('reserveNames', '{$default_reserved_names}');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('autoLinkUrls', '1');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('banLastUpdated', '0');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('smileys_dir', '{$boarddir}/Smileys');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('smileys_url', '{$boardurl}/Smileys');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('avatar_directory', '{$boarddir}/avatars');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('avatar_url', '{$boardurl}/avatars');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('avatar_max_height_external', '65');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('avatar_max_width_external', '65');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('avatar_action_too_large', 'option_html_resize');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('avatar_max_height_upload', '65');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('avatar_max_width_upload', '65');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('avatar_resize_upload', '1');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('avatar_download_png', '1');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('failed_login_threshold', '3');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('oldTopicDays', '120');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('edit_wait_time', '90');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('edit_disable_time', '0');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('autoFixDatabase', '1');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('allow_guestAccess', '1');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('time_format', '{$default_time_format}');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('number_format', '1234.00');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('enableBBC', '1');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('max_messageLength', '20000');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('signature_settings', '1,300,0,0,0,0,0,0:');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('autoOptMaxOnline', '0');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('defaultMaxMessages', '15');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('defaultMaxTopics', '20');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('defaultMaxMembers', '30');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('enableParticipation', '1');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('recycle_enable', '0');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('recycle_board', '0');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('maxMsgID', '1');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('enableAllMessages', '0');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('fixLongWords', '0');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('knownThemes', '1,2,3');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('who_enabled', '1');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('time_offset', '0');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('cookieTime', '60');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('lastActive', '15');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('smiley_sets_known', 'default,aaron,akyhne,fugue');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('smiley_sets_names', '{$default_smileyset_name}
+{$default_aaron_smileyset_name}
+{$default_akyhne_smileyset_name}
+{$default_fugue_smileyset_name}');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('smiley_sets_default', 'default');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('cal_days_for_index', '7');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('requireAgreement', '1');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('unapprovedMembers', '0');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('default_personal_text', '');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('package_make_backups', '1');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('databaseSession_enable', '{$databaseSession_enable}');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('databaseSession_loose', '1');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('databaseSession_lifetime', '2880');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('search_cache_size', '50');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('search_results_per_page', '30');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('search_weight_frequency', '30');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('search_weight_age', '25');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('search_weight_length', '20');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('search_weight_subject', '15');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('search_weight_first_message', '10');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('search_max_results', '1200');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('search_floodcontrol_time', '5');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('permission_enable_deny', '0');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('permission_enable_postgroups', '0');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('mail_next_send', '0');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('mail_recent', '0000000000|0');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('settings_updated', '0');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('next_task_time', '1');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('warning_settings', '1,20,0');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('warning_watch', '10');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('warning_moderate', '35');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('warning_mute', '60');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('admin_features', '');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('last_mod_report_action', '0');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('pruningOptions', '30,180,180,180,30,0');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('cache_enable', '1');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('reg_verification', '1');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('visual_verification_type', '3');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('enable_buddylist', '1');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('birthday_email', 'happy_birthday');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('dont_repeat_theme_core', '1');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('dont_repeat_smileys_20', '1');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('dont_repeat_buddylists', '1');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('attachment_image_reencode', '1');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('attachment_image_paranoid', '0');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('attachment_thumb_png', '1');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('avatar_reencode', '1');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('avatar_paranoid', '0');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('enable_disregard', '0');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('drafts_autosave_enabled', '1');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('drafts_show_saved_enabled', '1');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('drafts_keep_days', '7');
+COMMIT;
+
+# --------------------------------------------------------
+
+#
+# Table structure for table `sessions`
+#
+
+CREATE TABLE {$db_prefix}sessions (
+  session_id char(64) NOT NULL,
+  last_update int NOT NULL,
+  data text NOT NULL,
+  PRIMARY KEY (session_id)
+);
+
+#
+# Table structure for table `smileys`
+#
+
+CREATE TABLE {$db_prefix}smileys (
+  id_smiley integer primary key,
+  code varchar(30) NOT NULL default '',
+  filename varchar(48) NOT NULL default '',
+  description varchar(80) NOT NULL default '',
+  smiley_row smallint NOT NULL default '0',
+  smiley_order smallint NOT NULL default '0',
+  hidden smallint NOT NULL default '0'
+);
+
+#
+# Dumping data for table `smileys`
+#
+
+BEGIN TRANSACTION;
+INSERT INTO {$db_prefix}smileys	(code, filename, description, smiley_order, hidden) VALUES (':)', 'smiley.gif', '{$default_smiley_smiley}', 0, 0);
+INSERT INTO {$db_prefix}smileys	(code, filename, description, smiley_order, hidden) VALUES (';)', 'wink.gif', '{$default_wink_smiley}', 1, 0);
+INSERT INTO {$db_prefix}smileys	(code, filename, description, smiley_order, hidden) VALUES (':D', 'cheesy.gif', '{$default_cheesy_smiley}', 2, 0);
+INSERT INTO {$db_prefix}smileys	(code, filename, description, smiley_order, hidden) VALUES (';D', 'grin.gif', '{$default_grin_smiley}', 3, 0);
+INSERT INTO {$db_prefix}smileys	(code, filename, description, smiley_order, hidden) VALUES ('>:(', 'angry.gif', '{$default_angry_smiley}', 4, 0);
+INSERT INTO {$db_prefix}smileys	(code, filename, description, smiley_order, hidden) VALUES (':(', 'sad.gif', '{$default_sad_smiley}', 5, 0);
+INSERT INTO {$db_prefix}smileys	(code, filename, description, smiley_order, hidden) VALUES (':o', 'shocked.gif', '{$default_shocked_smiley}', 6, 0);
+INSERT INTO {$db_prefix}smileys	(code, filename, description, smiley_order, hidden) VALUES ('8)', 'cool.gif', '{$default_cool_smiley}', 7, 0);
+INSERT INTO {$db_prefix}smileys	(code, filename, description, smiley_order, hidden) VALUES ('???', 'huh.gif', '{$default_huh_smiley}', 8, 0);
+INSERT INTO {$db_prefix}smileys	(code, filename, description, smiley_order, hidden) VALUES ('::)', 'rolleyes.gif', '{$default_roll_eyes_smiley}', 9, 0);
+INSERT INTO {$db_prefix}smileys	(code, filename, description, smiley_order, hidden) VALUES (':P', 'tongue.gif', '{$default_tongue_smiley}', 10, 0);
+INSERT INTO {$db_prefix}smileys	(code, filename, description, smiley_order, hidden) VALUES (':-[', 'embarrassed.gif', '{$default_embarrassed_smiley}', 11, 0);
+INSERT INTO {$db_prefix}smileys	(code, filename, description, smiley_order, hidden) VALUES (':-X', 'lipsrsealed.gif', '{$default_lips_sealed_smiley}', 12, 0);
+INSERT INTO {$db_prefix}smileys	(code, filename, description, smiley_order, hidden) VALUES (':-\', 'undecided.gif', '{$default_undecided_smiley}', 13, 0);
+INSERT INTO {$db_prefix}smileys	(code, filename, description, smiley_order, hidden) VALUES (':-*', 'kiss.gif', '{$default_kiss_smiley}', 14, 0);
+INSERT INTO {$db_prefix}smileys	(code, filename, description, smiley_order, hidden) VALUES (':''(', 'cry.gif', '{$default_cry_smiley}', 15, 0);
+INSERT INTO {$db_prefix}smileys	(code, filename, description, smiley_order, hidden) VALUES ('>:D', 'evil.gif', '{$default_evil_smiley}', 16, 1);
+INSERT INTO {$db_prefix}smileys	(code, filename, description, smiley_order, hidden) VALUES ('^-^', 'azn.gif', '{$default_azn_smiley}', 17, 1);
+INSERT INTO {$db_prefix}smileys	(code, filename, description, smiley_order, hidden) VALUES ('O0', 'afro.gif', '{$default_afro_smiley}', 18, 1);
+INSERT INTO {$db_prefix}smileys	(code, filename, description, smiley_order, hidden) VALUES (':))', 'laugh.gif', '{$default_laugh_smiley}', 19, 1);
+INSERT INTO {$db_prefix}smileys	(code, filename, description, smiley_order, hidden) VALUES ('C:-)', 'police.gif', '{$default_police_smiley}', 20, 1);
+INSERT INTO {$db_prefix}smileys	(code, filename, description, smiley_order, hidden) VALUES ('O:-)', 'angel.gif', '{$default_angel_smiley}', 21, 1);
+COMMIT;
+
+# --------------------------------------------------------
+
+#
+# Table structure for table `spiders`
+#
+
+CREATE TABLE {$db_prefix}spiders (
+  id_spider integer primary key,
+  spider_name varchar(255) NOT NULL,
+  user_agent varchar(255) NOT NULL,
+  ip_info varchar(255) NOT NULL
+);
+
+#
+# Dumping data for table `spiders`
+#
+INSERT INTO {$db_prefix}spiders (id_spider, spider_name, user_agent, ip_info) VALUES (1, 'Google', 'googlebot', '');
+INSERT INTO {$db_prefix}spiders (id_spider, spider_name, user_agent, ip_info) VALUES (2, 'Yahoo!', 'slurp', '');
+INSERT INTO {$db_prefix}spiders (id_spider, spider_name, user_agent, ip_info) VALUES (3, 'MSN', 'msnbot', '');
+INSERT INTO {$db_prefix}spiders (id_spider, spider_name, user_agent, ip_info) VALUES (4, 'Google (Mobile)', 'Googlebot-Mobile', '');
+INSERT INTO {$db_prefix}spiders (id_spider, spider_name, user_agent, ip_info) VALUES (5, 'Google (Image)', 'Googlebot-Image', '');
+INSERT INTO {$db_prefix}spiders (id_spider, spider_name, user_agent, ip_info) VALUES (6, 'Google (AdSense)', 'Mediapartners-Google', '');
+INSERT INTO {$db_prefix}spiders (id_spider, spider_name, user_agent, ip_info) VALUES (7, 'Google (Adwords)', 'AdsBot-Google', '');
+INSERT INTO {$db_prefix}spiders (id_spider, spider_name, user_agent, ip_info) VALUES (8, 'Yahoo! (Mobile)', 'YahooSeeker/M1A1-R2D2', '');
+INSERT INTO {$db_prefix}spiders (id_spider, spider_name, user_agent, ip_info) VALUES (9, 'Yahoo! (Image)', 'Yahoo-MMCrawler', '');
+INSERT INTO {$db_prefix}spiders (id_spider, spider_name, user_agent, ip_info) VALUES (10, 'MSN (Mobile)', 'MSNBOT_Mobile', '');
+INSERT INTO {$db_prefix}spiders (id_spider, spider_name, user_agent, ip_info) VALUES (11, 'MSN (Media)', 'msnbot-media', '');
+INSERT INTO {$db_prefix}spiders (id_spider, spider_name, user_agent, ip_info) VALUES (12, 'Cuil', 'twiceler', '');
+INSERT INTO {$db_prefix}spiders (id_spider, spider_name, user_agent, ip_info) VALUES (13, 'Ask', 'Teoma', '');
+INSERT INTO {$db_prefix}spiders (id_spider, spider_name, user_agent, ip_info) VALUES (14, 'Baidu', 'Baiduspider', '');
+INSERT INTO {$db_prefix}spiders (id_spider, spider_name, user_agent, ip_info) VALUES (15, 'Gigablast', 'Gigabot', '');
+INSERT INTO {$db_prefix}spiders (id_spider, spider_name, user_agent, ip_info) VALUES (16, 'InternetArchive', 'ia_archiver-web.archive.org', '');
+INSERT INTO {$db_prefix}spiders (id_spider, spider_name, user_agent, ip_info) VALUES (17, 'Alexa', 'ia_archiver', '');
+INSERT INTO {$db_prefix}spiders (id_spider, spider_name, user_agent, ip_info) VALUES (18, 'Omgili', 'omgilibot', '');
+INSERT INTO {$db_prefix}spiders (id_spider, spider_name, user_agent, ip_info) VALUES (19, 'EntireWeb', 'Speedy Spider', '');
+
+#
+# Table structure for table `subscriptions`
+#
+
+CREATE TABLE {$db_prefix}subscriptions(
+  id_subscribe integer primary key,
+  name varchar(60) NOT NULL,
+  description varchar(255) NOT NULL,
+  cost text NOT NULL,
+  length varchar(6) NOT NULL,
+  id_group int NOT NULL default '0',
+  add_groups varchar(40) NOT NULL,
+  active smallint NOT NULL default '1',
+  repeatable smallint NOT NULL default '0',
+  allow_partial smallint NOT NULL default '0',
+  reminder smallint NOT NULL default '0',
+  email_complete text NOT NULL
+);
+
+#
+# Indexes for table `subscriptions`
+#
+
+CREATE INDEX {$db_prefix}subscriptions_active ON {$db_prefix}subscriptions (active);
+
+#
+# Table structure for table `themes`
+#
+
+CREATE TABLE {$db_prefix}themes (
+  id_member int NOT NULL default '0',
+  id_theme smallint NOT NULL default '1',
+  variable varchar(255) NOT NULL,
+  value text NOT NULL,
+  PRIMARY KEY (id_theme, id_member, variable)
+);
+
+#
+# Indexes for table `themes`
+#
+
+CREATE INDEX {$db_prefix}themes_id_member ON {$db_prefix}themes (id_member);
+
+#
+# Dumping data for table `themes`
+#
+
+BEGIN TRANSACTION;
+INSERT INTO {$db_prefix}themes (id_theme, variable, value) VALUES (1, 'name', '{$default_theme_name}');
+INSERT INTO {$db_prefix}themes (id_theme, variable, value) VALUES (1, 'theme_url', '{$boardurl}/Themes/default');
+INSERT INTO {$db_prefix}themes (id_theme, variable, value) VALUES (1, 'images_url', '{$boardurl}/Themes/default/images');
+INSERT INTO {$db_prefix}themes (id_theme, variable, value) VALUES (1, 'theme_dir', '{$boarddir}/Themes/default');
+INSERT INTO {$db_prefix}themes (id_theme, variable, value) VALUES (1, 'show_bbc', '1');
+INSERT INTO {$db_prefix}themes (id_theme, variable, value) VALUES (1, 'show_latest_member', '1');
+INSERT INTO {$db_prefix}themes (id_theme, variable, value) VALUES (1, 'show_modify', '1');
+INSERT INTO {$db_prefix}themes (id_theme, variable, value) VALUES (1, 'show_user_images', '1');
+INSERT INTO {$db_prefix}themes (id_theme, variable, value) VALUES (1, 'show_blurb', '1');
+INSERT INTO {$db_prefix}themes (id_theme, variable, value) VALUES (1, 'show_gender', '0');
+INSERT INTO {$db_prefix}themes (id_theme, variable, value) VALUES (1, 'show_newsfader', '0');
+INSERT INTO {$db_prefix}themes (id_theme, variable, value) VALUES (1, 'number_recent_posts', '0');
+INSERT INTO {$db_prefix}themes (id_theme, variable, value) VALUES (1, 'show_member_bar', '1');
+INSERT INTO {$db_prefix}themes (id_theme, variable, value) VALUES (1, 'linktree_link', '1');
+INSERT INTO {$db_prefix}themes (id_theme, variable, value) VALUES (1, 'show_profile_buttons', '1');
+INSERT INTO {$db_prefix}themes (id_theme, variable, value) VALUES (1, 'show_mark_read', '1');
+INSERT INTO {$db_prefix}themes (id_theme, variable, value) VALUES (1, 'show_stats_index', '1');
+INSERT INTO {$db_prefix}themes (id_theme, variable, value) VALUES (1, 'show_board_desc', '1');
+INSERT INTO {$db_prefix}themes (id_theme, variable, value) VALUES (1, 'newsfader_time', '5000');
+INSERT INTO {$db_prefix}themes (id_theme, variable, value) VALUES (1, 'allow_no_censored', '0');
+INSERT INTO {$db_prefix}themes (id_theme, variable, value) VALUES (1, 'additional_options_collapsable', '1');
+INSERT INTO {$db_prefix}themes (id_theme, variable, value) VALUES (1, 'use_image_buttons', '1');
+INSERT INTO {$db_prefix}themes (id_theme, variable, value) VALUES (1, 'enable_news', '1');
+INSERT INTO {$db_prefix}themes (id_theme, variable, value) VALUES (1, 'forum_width', '90%');
+INSERT INTO {$db_prefix}themes (id_theme, variable, value) VALUES (1, 'drafts_autosave_enabled', '1');
+INSERT INTO {$db_prefix}themes (id_theme, variable, value) VALUES (1, 'drafts_show_saved_enabled', '1');
+INSERT INTO {$db_prefix}themes (id_member, id_theme, variable, value) VALUES (-1, 1, 'display_quick_reply', '2');
+INSERT INTO {$db_prefix}themes (id_member, id_theme, variable, value) VALUES (-1, 1, 'posts_apply_ignore_list', '1');
+COMMIT;
+
+# --------------------------------------------------------
+
+#
+# Table structure for table `topics`
+#
+
+CREATE TABLE {$db_prefix}topics (
+  id_topic integer primary key,
+  is_sticky smallint NOT NULL default '0',
+  id_board smallint NOT NULL default '0',
+  id_first_msg int NOT NULL default '0',
+  id_last_msg int NOT NULL default '0',
+  id_member_started int NOT NULL default '0',
+  id_member_updated int NOT NULL default '0',
+  id_poll int NOT NULL default '0',
+  id_previous_board smallint NOT NULL default '0',
+  id_previous_topic int NOT NULL default '0',
+  num_replies int NOT NULL default '0',
+  num_views int NOT NULL default '0',
+  locked smallint NOT NULL default '0',
+  redirect_expires int NOT NULL default '0',
+  id_redirect_topic int NOT NULL default '0',
+  unapproved_posts smallint NOT NULL default '0',
+  approved smallint NOT NULL default '1'
+);
+
+#
+# Indexes for table `topics`
+#
+
+CREATE UNIQUE INDEX {$db_prefix}topics_last_message ON {$db_prefix}topics (id_last_msg, id_board);
+CREATE UNIQUE INDEX {$db_prefix}topics_first_message ON {$db_prefix}topics (id_first_msg, id_board);
+CREATE UNIQUE INDEX {$db_prefix}topics_poll ON {$db_prefix}topics (id_poll, id_topic);
+CREATE INDEX {$db_prefix}topics_is_sticky ON {$db_prefix}topics (is_sticky);
+CREATE INDEX {$db_prefix}topics_approved ON {$db_prefix}topics (approved);
+CREATE INDEX {$db_prefix}topics_id_board ON {$db_prefix}topics (id_board);
+CREATE INDEX {$db_prefix}topics_member_started ON {$db_prefix}topics (id_member_started, id_board);
+CREATE INDEX {$db_prefix}topics_last_message_sticky ON {$db_prefix}topics (id_board, is_sticky, id_last_msg);
+CREATE INDEX {$db_prefix}topics_board_news ON {$db_prefix}topics (id_board, id_first_msg);
+
+#
+# Dumping data for table `topics`
+#
+
+INSERT INTO {$db_prefix}topics
+	(id_topic, id_board, id_first_msg, id_last_msg, id_member_started, id_member_updated)
+VALUES (1, 1, 1, 1, 0, 0);
+# --------------------------------------------------------
+
+#
+# Table structure for table `user_drafts`
+#
+
+CREATE TABLE {$db_prefix}user_drafts (
+  id_draft int primary key,
+  id_topic int unsigned NOT NULL default '0',
+  id_board smallint unsigned NOT NULL default '0',
+  id_reply int unsigned NOT NULL default '0',
+  type smallint NOT NULL default '0',
+  poster_time int unsigned NOT NULL default '0',
+  id_member int unsigned NOT NULL default '0',
+  subject varchar(255) NOT NULL default '',
+  smileys_enabled smallint NOT NULL default '1',
+  body text NOT NULL,
+  icon varchar(16) NOT NULL default 'xx',
+  locked smallint NOT NULL default '0',
+  is_sticky smallint NOT NULL default '0',
+  to_list varchar(255) NOT NULL default '',
+  outbox smallint NOT NULL default '0'
+);
+
+#
+# Indexes for table `user_drafts`
+#
+
+CREATE UNIQUE INDEX {$db_prefix}id_member ON {$db_prefix}user_drafts (id_member, id_draft, type);


### PR DESCRIPTION
This commit adds support for installing/running SMF on an SQLite3 database. It currently does not support upgrading from 2.x to 3.x, but that functionality can be added later if needed.

Note that I haven't tested everything with this, but none of the actual SQL changed - just the PHP side of things. The basic functionality (installation, clicking around, posting, clearing the error log, etc.) works fine, so I don't expect anything else to break.
