### PR TITLE
integrate_register_check

### DIFF
--- a/Sources/Subs-Members.php
+++ b/Sources/Subs-Members.php
@@ -541,6 +541,9 @@ function registerMember(&$regOptions, $return_errors = false)
 		$reg_errors[] = array('lang', 'email_in_use', false, array(htmlspecialchars($regOptions['email'])));
 	$smcFunc['db_free_result']($request);
 
+	// Perhaps someone else wants to check this user
+	call_integration_hook('integrate_register_check', array($$regOptions, &$reg_errors));
+
 	// If we found any errors we need to do something about it right away!
 	foreach ($reg_errors as $key => $error)
 	{

--- a/Sources/Subs-Members.php
+++ b/Sources/Subs-Members.php
@@ -542,7 +542,7 @@ function registerMember(&$regOptions, $return_errors = false)
 	$smcFunc['db_free_result']($request);
 
 	// Perhaps someone else wants to check this user
-	call_integration_hook('integrate_register_check', array($$regOptions, &$reg_errors));
+	call_integration_hook('integrate_register_check', array(&$regOptions, &$reg_errors));
 
 	// If we found any errors we need to do something about it right away!
 	foreach ($reg_errors as $key => $error)


### PR DESCRIPTION
Another hook.

Make it easier to any anti-spam mods to check the user, add their own reg_error entries and/or end the execution before the user gets added to the DB.

Signed-off-by: Suki suki@missallsunday.com
