### PR TITLE
New package-info.xml commands for Release 2.1

### DIFF
--- a/Sources/Packages.php
+++ b/Sources/Packages.php
@@ -1002,10 +1002,8 @@ function PackageInstall()
 				// This is just here as reference for what is available.
 				global $txt, $boarddir, $sourcedir, $modSettings, $context, $settings, $forum_version, $smcFunc;
 
-				$context['new_inputs'] = array();
-				if (!empty($_POST['new_inputs']))
-					$context['new_inputs'] = $_POST['new_inputs'];	
-
+				$context['new_inputs'] = !empty($_POST['new_inputs']) ? $_POST['new_inputs'] : array();
+				
 				// Now include the file and be done with it ;).
 				if (file_exists($packagesdir . '/temp/' . $context['base_path'] . $action['filename']))
 					require($packagesdir . '/temp/' . $context['base_path'] . $action['filename']);

--- a/Sources/Packages.php
+++ b/Sources/Packages.php
@@ -1002,6 +1002,10 @@ function PackageInstall()
 				// This is just here as reference for what is available.
 				global $txt, $boarddir, $sourcedir, $modSettings, $context, $settings, $forum_version, $smcFunc;
 
+				$context['new_inputs'] = array();
+				if (!empty($_POST['new_inputs']))
+					$context['new_inputs'] = $_POST['new_inputs'];	
+
 				// Now include the file and be done with it ;).
 				if (file_exists($packagesdir . '/temp/' . $context['base_path'] . $action['filename']))
 					require($packagesdir . '/temp/' . $context['base_path'] . $action['filename']);

--- a/Sources/Subs-Package.php
+++ b/Sources/Subs-Package.php
@@ -1242,6 +1242,7 @@ if (in_array($actionType, array('readme', 'code', 'database', 'modification', 'r
                                                 continue 2;
                                             default:
                                                 $inputString .= $setCommand . '="'. $value .'" ';
+                                                continue 2;
                                         }
                                     }
                                 }

--- a/Sources/Subs-Package.php
+++ b/Sources/Subs-Package.php
@@ -1102,7 +1102,7 @@ function parsePackageInfo(&$packageXML, $testing_only = true, $method = 'install
 if (in_array($actionType, array('readme', 'code', 'database', 'modification', 'redirect', 'license', 'input')))	
 {
                     /* Add the input/textarea html tag where xml input was selected */
-                    if ($actionType == 'input')
+                    if ($actionType === 'input')
                     {
                         if (empty($action->array[0]["value"]) || !$action->array[0]["value"])
                             continue;
@@ -1161,12 +1161,12 @@ if (in_array($actionType, array('readme', 'code', 'database', 'modification', 'r
                             {
                                 foreach ($inputValues as $value)
                                 {
-                                    if (strpos('type="'.$input_type.'"',strtolower(trim($value))) !== false)
+                                    if (strpos('type="' . $input_type . '"',strtolower(trim($value))) !== false)
                                     {
                                         if ($input_type === 'textarea')
                                             $inputString = '';
                                         else
-                                            $inputString = '<input type="'.$input_type.'" ';
+                                            $inputString = '<input type="' . $input_type . '" ';
                                             
                                         $newType = $input_type;
                                     }
@@ -1201,7 +1201,7 @@ if (in_array($actionType, array('readme', 'code', 'database', 'modification', 'r
                                             $value = (int)$value;
                                         elseif ($command[1] === 'string' && $key !== 'text_before' && $key !== 'text_after' && $key !== 'value' && $key !== 'name' && $key !== 'class_before' && $key !== 'class_after' && $key !== 'class')
                                             $value = strtolower($value);
-                                        elseif ($command[1] == 'true')
+                                        elseif ($command[1] === 'true')
                                             $value = 'true';
                                         
                                         switch($key)
@@ -1216,7 +1216,7 @@ if (in_array($actionType, array('readme', 'code', 'database', 'modification', 'r
                                                 $newTextAfter = ' ' . $value;
                                                 continue 2;
                                             case 'name':
-                                                $inputString .= $setCommand . '="new_inputs['.$value.']" ';
+                                                $inputString .= $setCommand . '="new_inputs[' . $value . ']" ';
                                                 continue 2;
                                             case 'true':
                                                 $inputString .= $setCommand . ' ';
@@ -1237,13 +1237,13 @@ if (in_array($actionType, array('readme', 'code', 'database', 'modification', 'r
                                                 $class = 'class="' . $value . '" ';
                                                 continue 2;
                                             case 'value':
-                                                if ($newType == 'textarea')
+                                                if ($newType === 'textarea')
                                                 	$textArea = trim($value);
                                                 else
-                                                	$inputString .= $setCommand . '="'. $value .'" ';
+                                                	$inputString .= $setCommand . '="' . $value . '" ';
                                                 continue 2;
                                             default:
-                                                $inputString .= $setCommand . '="'. $value .'" ';
+                                                $inputString .= $setCommand . '="' . $value . '" ';
                                                 continue 2;
                                         }
                                     }
@@ -1268,20 +1268,20 @@ if (in_array($actionType, array('readme', 'code', 'database', 'modification', 'r
                             if ($newType === 'textarea')
                             {
                                 if ($styleBefore && $newTextBefore)
-                                    $newTextBefore = '<span ' . $classBefore . 'style ="'.$styleBefore.'">' . $newTextBefore . '</span>';
+                                    $newTextBefore = '<span ' . $classBefore . 'style ="' . $styleBefore . '">' . $newTextBefore . '</span>';
                                 
                                 if ($styleAfter && $newTextAfter)
-                                    $newTextAfter = '<span ' . $classAfter . 'style ="'.$styleAfter.'">' . $newTextAfter . '</span>';
+                                    $newTextAfter = '<span ' . $classAfter . 'style ="' . $styleAfter . '">' . $newTextAfter . '</span>';
                                     
                                 $context['new_package_inputs'][] = $newTextBefore . '<textarea ' . $class . $inputString . '>' . $textArea . '</textarea>' . $newTextAfter . $lineBreaks;
                             }
                             else
                             {
                                 if ($styleBefore && $newTextBefore)
-                                    $newTextBefore = '<span ' . $classBefore . 'style ="'.$styleBefore.'">' . $newTextBefore . '</span>';
+                                    $newTextBefore = '<span ' . $classBefore . 'style ="' . $styleBefore . '">' . $newTextBefore . '</span>';
                                 
                                 if ($styleAfter && $newTextAfter)
-                                    $newTextAfter = '<span ' . $classAfter . 'style ="'.$styleAfter.'">' . $newTextAfter . '</span>';
+                                    $newTextAfter = '<span ' . $classAfter . 'style ="' . $styleAfter . '">' . $newTextAfter . '</span>';
                                     
                                 $inputString .= ' ' . $class . '/>';
                                 $context['new_package_inputs'][] = $newTextBefore . $inputString . $newTextAfter . $lineBreaks;

--- a/Sources/Subs-Package.php
+++ b/Sources/Subs-Package.php
@@ -1239,6 +1239,7 @@ if (in_array($actionType, array('readme', 'code', 'database', 'modification', 'r
                                             case 'value':
                                                 if ($newType == 'textarea')
                                                     $textArea = trim($value);
+                                                $inputString .= $setCommand . '="'. $value .'" ';
                                                 continue 2;
                                             default:
                                                 $inputString .= $setCommand . '="'. $value .'" ';

--- a/Sources/Subs-Package.php
+++ b/Sources/Subs-Package.php
@@ -1238,8 +1238,9 @@ if (in_array($actionType, array('readme', 'code', 'database', 'modification', 'r
                                                 continue 2;
                                             case 'value':
                                                 if ($newType == 'textarea')
-                                                    $textArea = trim($value);
-                                                $inputString .= $setCommand . '="'. $value .'" ';
+                                                	$textArea = trim($value);
+                                                else
+                                                	$inputString .= $setCommand . '="'. $value .'" ';
                                                 continue 2;
                                             default:
                                                 $inputString .= $setCommand . '="'. $value .'" ';

--- a/Themes/default/Packages.template.php
+++ b/Themes/default/Packages.template.php
@@ -99,6 +99,23 @@ function template_view_package()
 				</h3>
 			</div>';
 
+	/* Are there any new custom inputs from the mod author? */	
+	if ((!empty($context['package_inputs'])) && is_array($context['package_inputs']))
+	{	
+		echo '
+			<div class="windowbg2">
+				<span class="topslice"><span></span></span>
+				<div class="content">';
+
+		foreach ($context['package_inputs'] as $new_input)
+			echo $new_input;
+
+		echo '
+				</div>
+				<span class="botslice"><span></span></span>
+			</div>';	
+	}
+
 	// Are there data changes to be removed?
 	if ($context['uninstalling'] && !empty($context['database_changes']))
 	{

--- a/Themes/default/Packages.template.php
+++ b/Themes/default/Packages.template.php
@@ -100,14 +100,14 @@ function template_view_package()
 			</div>';
 
 	/* Are there any new custom inputs from the mod author? */	
-	if ((!empty($context['package_inputs'])) && is_array($context['package_inputs']))
+	if ((!empty($context['new_package_inputs'])) && is_array($context['new_package_inputs']))
 	{	
 		echo '
 			<div class="windowbg2">
 				<span class="topslice"><span></span></span>
 				<div class="content">';
 
-		foreach ($context['package_inputs'] as $new_input)
+		foreach ($context['new_package_inputs'] as $new_input)
 			echo $new_input;
 
 		echo '

--- a/new_pkgs_commands-readme.txt
+++ b/new_pkgs_commands-readme.txt
@@ -1,0 +1,103 @@
+Changes:
+--------
+Adds ability to use input and/or textarea HTML5 commands for uninstall/install template
+
+
+Files affected:
+---------------
+/Sources/Packages.php
+/Sources/Subs-Package.php
+/Themes/default/Packages.template.php
+
+
+Syntax
+------
+
+Examples:
+---------
+<input>{type="checkbox"}{name="delete_tables"}{value="1"}{text_after="Remove all database tables related to this modification?"}{checked="false"}{break="2"}{style="position:relative;top:2px;"}</input>
+<input>{type="textarea"}{name="info"}{value="Comments"}{text_after="Enter your comments"}{style_after="position:relative;bottom:25px;color:blue;"}{style="color:red;"}{tabindex="5"}{rows="3"}{cols="50"}</input>
+
+
+Explanation:
+------------
+  The commands are filtered in Subs-Packages.php in an attempt to thwart errors from the package-info.xml file.
+Although it is up to the mod author to use the proper syntax, this was done to help ensure the xml code was entered correctly.
+Each command has to be separated by encased hard brackets and their values must be in quotations.
+Additional filtering can be added to thwart unnecessary white spaces in certain areas but as I said the mod author should use appropriate syntax.
+The command names and values are actual HTML5 syntax where some features were omitted as imo they do not apply for the packages template.
+Text can be displayed left and/or right of the input/textarea where each can have its own value & style/class elements.
+Style & class elements (css) can also be configured for the actual input/textarea.
+
+The form passes the user entered values via the $context['new_inputs'] array where the key values are the name values entered by the author.
+The $context['new_inputs'] array can be processed in any of their <code> files where they can manipulate the logic to do as they wish.
+
+Allowed input types:
+--------------------
+button, checkbox, color, date, datetime, datetime-local, email, hidden, image, month,
+number, password, radio, range, reset, search, submit, tel, text, textarea, time, url, week
+
+
+Allowed input/textarea attributes:
+---------------------------------
+alt           => for image                      (string)
+
+autocomplete  => for text, search, url, tel,    (string - on or off)
+                 password, datepickers, range,
+                 email, color
+
+autofocus     => for all types                  (true)
+
+break         => for all types                  (int - inserts additional line breaks after the input/textarea)
+
+checked       => for radio, checkbox            (true)
+
+class         => for all types                  (string - css class for input/textarea)
+
+class_before  => for all types                  (string - css class for text_before)
+
+class_after   => for all types                  (string - css class for text_after)
+
+cols          => for textarea                   (int)
+
+disable       => for all types                  (true)
+
+height        => for all types                  (int)
+
+maxlength     => for all types                  (int)
+
+name          => for all types                  (string)
+
+placeholder   => for text, search, url, tel,    (string)
+                 email, password, textarea
+
+readonly      => for all types                  (true)
+
+required      => for text, search, url, tel,    (true)
+                 email, password, date pickers,
+                 number, checkbox, radio,
+                 textarea
+
+rows          => for textarea                   (int)
+
+size          => for all types                  (int)
+
+src           => for image                      (int)
+
+style         => for all types                  (string - adds style attributes to input/textarea)
+
+tabindex      => for all types                  (int)
+
+text_before   => for all types                  (string - displays text prior to the input/textarea)
+
+text_after    => for all types                  (string - displays text after the input/textarea)
+
+style_after   => for all types                  (string - adds style attributes to text_after)
+
+style_before  => for all types                  (string - adds style attributes to text_before)
+
+value         => for all types                  (string - for textarea this will appear in the box)
+
+width         => for all types                  (int)
+
+wrap          => for textarea                   (string)


### PR DESCRIPTION
This is a proposal for adding the ability to use < input > tags in the package-info.xml file.
It gives mod authors the ability to use HTML5 input and textarea for installing or uninstalling their modifications where the data can be processed in files accessed via the < code > tags.

I authorize the use of this additional code for any releases of the SMF software package.

Signed,
Underdog @ webdevelop.comli.com  
Underdog-01 @ github.com        

Please feel free to email me or leave me a message on my forum with any questions or feedback.
Thank you.
