### PR TITLE
Fixes 580 pr

### DIFF
--- a/other/upgrade_2-1_mysql.sql
+++ b/other/upgrade_2-1_mysql.sql
@@ -203,6 +203,11 @@ VALUES
 	('enable_unwatch', 0);
 ---#
 
+---# Fixing column name change...
+ALTER TABLE {$db_prefix}log_topics
+CHANGE COLUMN disregarded unwatched tinyint(3) NOT NULL DEFAULT '0';
+---#
+
 /******************************************************************************/
 --- Fixing mail queue for long messages
 /******************************************************************************/

--- a/other/upgrade_2-1_postgresql.sql
+++ b/other/upgrade_2-1_postgresql.sql
@@ -263,6 +263,14 @@ VALUES
 ---}
 ---#
 
+---# Fixing column name change...
+---{
+upgrade_query("
+	ALTER TABLE {$db_prefix}log_topics
+	CHANGE COLUMN disregarded unwatched tinyint(3) NOT NULL DEFAULT '0';");
+---}
+---#
+
 /******************************************************************************/
 --- Name changes
 /******************************************************************************/

--- a/other/upgrade_2-1_sqlite.sql
+++ b/other/upgrade_2-1_sqlite.sql
@@ -247,6 +247,22 @@ VALUES
 ---}
 ---#
 
+---# Fixing column name change...
+---{
+$smcFunc['db_alter_table']('{db_prefix}log_topics', array(
+	'change' => array(
+		'disregarded' => array(
+			'name' => 'unwatched',
+			'null' => false,
+			'default' => 0,
+			'type' => 'int',
+			'auto' => false,
+		),
+	)
+));
+---}
+---#
+
 /******************************************************************************/
 --- Name changes
 /******************************************************************************/


### PR DESCRIPTION
Submitting this as a simple fix to the pull request 580 which changed disregarded to unwatched.  SMF's upgrade script gracefully handles database errors.

I don't have the capacity to test the PostgreSQL or sqlite changes, but the code is based on other similar parts of our upgrade scripts and thus should work.  Please let me know if they need adjusted though.
