### PR TITLE
JS error if an available update is marked critical (fixes #619)

### DIFF
--- a/Themes/default/scripts/admin.js
+++ b/Themes/default/scripts/admin.js
@@ -98,7 +98,6 @@ smf_AdminIndex.prototype.checkUpdateAvailable = function ()
 	// If we decide to override life into "red" mode, do it.
 	if ('smfUpdateCritical' in window)
 	{
-		document.getElementById('update_table').style.backgroundColor = '#aa2222';
 		document.getElementById('update_title').style.backgroundColor = '#dd2222';
 		document.getElementById('update_title').style.color = 'white';
 		document.getElementById('update_message').style.backgroundColor = '#eebbbb';


### PR DESCRIPTION
There is no longer an "update_table" element in the admin template. (Note that the multiple commits are due to me putting the wrong issue # in there first and accidentally amending the commit to fix it twice).
