### PR TITLE
! Cast the user id to an int when we first get it set up because that's ...

### DIFF
--- a/Sources/Drafts.php
+++ b/Sources/Drafts.php
@@ -654,7 +654,8 @@ function showProfileDrafts($memID, $draft_type = 0)
 
 	// Menu tab
 	$context[$context['profile_menu_name']]['tab_data'] = array(
-		'title' => $txt['drafts_show'] . ' - ' . $context['member']['name'],
+		'title' => $txt['drafts_show'],
+		'description' => $txt['drafts_show_desc'],
 		'icon' => 'message_sm.png'
 	);
 	$context['sub_template'] = 'showDrafts';

--- a/Sources/Load.php
+++ b/Sources/Load.php
@@ -298,7 +298,7 @@ function loadUserSettings()
 				$check = false;
 
 			// Wrong password or not activated - either way, you're going nowhere.
-			$id_member = $check && ($user_settings['is_activated'] == 1 || $user_settings['is_activated'] == 11) ? $user_settings['id_member'] : 0;
+			$id_member = $check && ($user_settings['is_activated'] == 1 || $user_settings['is_activated'] == 11) ? (int) $user_settings['id_member'] : 0;
 		}
 		else
 			$id_member = 0;

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -3744,6 +3744,7 @@ function clean_cache($type = '')
 	// Invalidate cache, to be sure!
 	// ... as long as Load.php can be modified, anyway.
 	@touch($sourcedir . '/' . 'Load.php');
+	call_integration_hook('integrate_clean_cache');
 	clearstatcache();
 }
 

--- a/Themes/default/Profile.template.php
+++ b/Themes/default/Profile.template.php
@@ -437,9 +437,14 @@ function template_showDrafts()
 	global $context, $settings, $options, $scripturl, $modSettings, $txt;
 
 	echo '
-		<div class="pagesection" style="margin-bottom: 0;">
-			<div class="pagelinks">', $context['page_index'], '</div>
-		</div>';
+		<div class="cat_bar">
+			<h3 class="catbg">
+				', $txt['drafts'], ' - ', $context['member']['name'], '
+			</h3>
+		</div>', !empty($context['page_index']) ? '
+		<div class="pagesection">
+			<div class="pagelinks">' . $context['page_index'] . '</div>
+		</div>' : '';
 
 	// Button shortcuts
 	$edit_button = create_button('modify_inline.png', 'draft_edit', 'draft_edit', 'class="centericon"');

--- a/Themes/default/languages/Drafts.english.php
+++ b/Themes/default/languages/Drafts.english.php
@@ -5,6 +5,7 @@ global $scripturl, $context;
 
 // profile
 $txt['drafts_show'] = 'Show Drafts';
+$txt['drafts_show_desc'] = 'This area shows you all the drafts you currently have saved. From here you can edit them before posting, or you can remove them';
 $txt['drafts_autosave_enabled'] = 'Enable the automatic saving of drafts.';
 $txt['drafts_show_saved_enabled'] = 'Enable selection of drafts from posting screens.';
 


### PR DESCRIPTION
...the right thing to do. Essentially as per #338 and #355 but without any edit conflicts.

! Add a new hook for cache cleaning as per #381.
! Brought the profile/show drafts to look the same as show posts, in terms of providing a description and the extra header for sidebar mode.

Signed-off-by: Peter Spicer sleeping@myperch.org
