### PR TITLE
! Add Personal Text to the list of standard profile fields, incidentally...

### DIFF
--- a/Sources/ManageSettings.php
+++ b/Sources/ManageSettings.php
@@ -496,6 +496,12 @@ function ModifyBasicSettings($return_config = false)
 {
 	global $txt, $scripturl, $context, $settings, $sc, $modSettings;
 
+	// We need to know if personal text is enabled, and if it's in the registration fields option.
+	// If admins have set it up as an on-registration thing, they can't set a default value (because it'll never be used)
+	$disabled_fields = isset($modSettings['disabled_profile_fields']) ? explode(',', $modSettings['disabled_profile_fields']) : array();
+	$reg_fields = isset($modSettings['registration_fields']) ? explode(',', $modSettings['registration_fields']) : array();
+	$can_personal_text = !in_array('personal_text', $disabled_fields) && !in_array('personal_text', $reg_fields);
+
 	$config_vars = array(
 			// Big Options... polls, sticky, bbc....
 			array('select', 'pollMode', array($txt['disable_polls'], $txt['enable_polls'], $txt['polls_as_topics'])),
@@ -507,7 +513,7 @@ function ModifyBasicSettings($return_config = false)
 			array('check', 'allow_editDisplayName'),
 			array('check', 'allow_hideOnline'),
 			array('check', 'titlesEnable'),
-			array('text', 'default_personal_text', 'subtext' => $txt['default_personal_text_note']),
+			array('text', 'default_personal_text', 'subtext' => $txt['default_personal_text_note'], 'disabled' => !$can_personal_text),
 		'',
 			// Jquery source
 			array('select', 'jquery_source', array('auto' => $txt['jquery_auto'], 'local' => $txt['jquery_local'], 'cdn' => $txt['jquery_cdn'], 'custom' => $txt['jquery_custom']), 'onchange' => 'if (this.value == \'custom\'){document.getElementById(\'jquery_custom\').disabled = false; } else {document.getElementById(\'jquery_custom\').disabled = true;}'),
@@ -1385,7 +1391,7 @@ function ShowCustomProfiles()
 	$context['sub_template'] = 'show_custom_profile';
 
 	// What about standard fields they can tweak?
-	$standard_fields = array('icq', 'aim', 'yim', 'skype', 'location', 'gender', 'website', 'posts', 'warning_status');
+	$standard_fields = array('icq', 'aim', 'yim', 'skype', 'location', 'gender', 'website', 'personal_text', 'posts', 'warning_status');
 	// What fields can't you put on the registration page?
 	$context['fields_no_registration'] = array('posts', 'warning_status');
 
@@ -1618,7 +1624,7 @@ function list_getProfileFields($start, $items_per_page, $sort, $standardFields)
 
 	if ($standardFields)
 	{
-		$standard_fields = array('icq', 'aim', 'yim', 'skype', 'location', 'gender', 'website', 'posts', 'warning_status');
+		$standard_fields = array('icq', 'aim', 'yim', 'skype', 'location', 'gender', 'website', 'personal_text', 'posts', 'warning_status');
 		$fields_no_registration = array('posts', 'warning_status');
 		$disabled_fields = isset($modSettings['disabled_profile_fields']) ? explode(',', $modSettings['disabled_profile_fields']) : array();
 		$registration_fields = isset($modSettings['registration_fields']) ? explode(',', $modSettings['registration_fields']) : array();

--- a/Themes/default/languages/Help.english.php
+++ b/Themes/default/languages/Help.english.php
@@ -432,7 +432,7 @@ $helptxt['max_pm_recipients'] = 'This option allows you to set the maximum amoun
 $helptxt['pm_posts_verification'] = 'This setting will force users to enter a code shown on a verification image each time they are sending a personal message. Only users with a post count below the number set will need to enter the code - this should help combat automated spamming scripts.';
 $helptxt['pm_posts_per_hour'] = 'This will limit the number of personal messages which may be sent by a user in a one hour period. This does not affect admins or moderators.';
 
-$helptxt['default_personal_text'] = 'Sets the default text a new user will have as their &quot;personal text.&quot;';
+$helptxt['default_personal_text'] = 'Sets the default text a new user will have as their &quot;personal text.&quot; This option is not available when personal text is disabled, or when users can set personal text on registration for themselves.';
 
 $helptxt['modlog_enabled'] = 'Logs all moderation actions.';
 

--- a/Themes/default/languages/Profile.english.php
+++ b/Themes/default/languages/Profile.english.php
@@ -14,7 +14,6 @@ $txt['current_signature'] = 'Current signature';
 $txt['signature_preview'] = 'Signature preview';
 $txt['delete_user'] = 'Delete user';
 $txt['current_status'] = 'Current Status:';
-$txt['personal_text'] = 'Personal Text';
 $txt['personal_picture'] = 'Personalized Picture';
 $txt['no_avatar'] = 'No avatar';
 $txt['choose_avatar_gallery'] = 'Choose avatar from gallery';

--- a/Themes/default/languages/index.english.php
+++ b/Themes/default/languages/index.english.php
@@ -201,6 +201,7 @@ $txt['recent_posts'] = 'Recent Posts';
 
 $txt['location'] = 'Location';
 $txt['gender'] = 'Gender';
+$txt['personal_text'] = 'Personal Text';
 $txt['date_registered'] = 'Date Registered';
 
 $txt['recent_view'] = 'View the most recent posts on the forum.';


### PR DESCRIPTION
... this makes the field available on registration, as an option. Because of conflicts with the ability to set default text, setting default text is only available when the field is enabled and not shown at registration (the default). We _could_ amend birthday to be disabled but we probably shouldn't, we can revisit that in future, which means this should resolve #301.

Signed-off-by: Peter Spicer sleeping@myperch.org
