### PR TITLE
Don't require a RTL version of a theme variant

### DIFF
--- a/Themes/default/index.template.php
+++ b/Themes/default/index.template.php
@@ -114,7 +114,7 @@ function template_html_above()
 		echo '
 		<link rel="stylesheet" type="text/css" href="', $settings['theme_url'], '/css/rtl.css?alp21" />';
 
-	if (!empty($context['theme_variant']))
+	if (!empty($context['theme_variant']) && file_exists($settings['theme_url'], '/css/rtl', $context['theme_variant'], '.css'))
 		echo '
 		<link rel="stylesheet" type="text/css" href="', $settings['theme_url'], '/css/rtl', $context['theme_variant'], '.css?alp21" />';
 	}


### PR DESCRIPTION
Most theme variants might not supply their own RTL layouts, so let''s load it only if present.
