### PR TITLE
! Remove useless function param

### DIFF
--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -416,9 +416,8 @@ function updateMemberData($members, $data)
  *
  * @param array $changeArray
  * @param bool $update = false
- * @param bool $debug = false
  */
-function updateSettings($changeArray, $update = false, $debug = false)
+function updateSettings($changeArray, $update = false)
 {
 	global $modSettings, $smcFunc;
 


### PR DESCRIPTION
Not sure why it's there, but might as well remove the "ghost".
