### PR TITLE
Moderation center

### DIFF
--- a/Sources/ModerationCenter.php
+++ b/Sources/ModerationCenter.php
@@ -224,11 +224,12 @@ function ModerationHome()
 	$context['page_title'] = $txt['moderation_center'];
 	$context['sub_template'] = 'moderation_center';
 
+	// Handle moderators notes.
+	ModBlockNotes();
+
 	// Load what blocks the user actually can see...
-	$valid_blocks = array(
-		'n' => 'LatestNews',
-		'p' => 'Notes',
-	);
+	$valid_blocks = array();
+
 	if ($context['can_moderate_groups'])
 		$valid_blocks['g'] = 'GroupRequests';
 	if ($context['can_moderate_boards'])
@@ -254,19 +255,6 @@ function ModerationHome()
 				$context['mod_blocks'][] = $block();
 		}
 	}
-}
-
-/**
- * Just prepares the time stuff for the simple machines latest news.
- */
-function ModBlockLatestNews()
-{
-	global $context, $user_info;
-
-	$context['time_format'] = urlencode($user_info['time_format']);
-
-	// Return the template to use.
-	return 'latest_news';
 }
 
 /**
@@ -320,7 +308,7 @@ function ModBlockNotes()
 	global $context, $smcFunc, $scripturl, $txt, $user_info;
 
 	// Are we saving a note?
-	if (isset($_POST['makenote']) && isset($_POST['new_note']))
+	if (isset($_GET['modnote']) && isset($_POST['makenote']) && isset($_POST['new_note']))
 	{
 		checkSession();
 

--- a/Sources/ModerationCenter.php
+++ b/Sources/ModerationCenter.php
@@ -415,7 +415,7 @@ function ModBlockNotes()
 		$context['notes'][] = array(
 			'author' => array(
 				'id' => $note['id_member'],
-				'link' => $note['id_member'] ? ('<a href="' . $scripturl . '?action=profile;u=' . $note['id_member'] . '" title="' . $txt['on'] . ' ' . strip_tags(timeformat($note['log_time'])) . '">' . $note['member_name'] . '</a>') : $note['member_name'],
+				'link' => $note['id_member'] ? ('<a href="' . $scripturl . '?action=profile;u=' . $note['id_member'] . '">' . $note['member_name'] . '</a>') : $note['member_name'],
 			),
 			'time' => timeformat($note['log_time']),
 			'text' => parse_bbc($note['body']),

--- a/Sources/ModerationCenter.php
+++ b/Sources/ModerationCenter.php
@@ -2066,10 +2066,8 @@ function ModerationSettings()
 	);
 
 	// What blocks can this user see?
-	$context['homepage_blocks'] = array(
-		'n' => $txt['mc_prefs_latest_news'],
-		'p' => $txt['mc_notes'],
-	);
+	$context['homepage_blocks'] = array();
+
 	if ($context['can_moderate_groups'])
 		$context['homepage_blocks']['g'] = $txt['mc_group_requests'];
 	if ($context['can_moderate_boards'])

--- a/Themes/default/ModerationCenter.template.php
+++ b/Themes/default/ModerationCenter.template.php
@@ -14,6 +14,9 @@ function template_moderation_center()
 {
 	global $settings, $options, $context, $txt, $scripturl;
 
+	// Show moderators notes.
+	template_notes();
+
 	// Show a welcome message to the user.
 	echo '
 	<div id="modcenter">';
@@ -146,39 +149,41 @@ function template_notes()
 	global $settings, $options, $context, $txt, $scripturl;
 
 	echo '
-		<form action="', $scripturl, '?action=moderate;area=index" method="post">
-			<div class="cat_bar">
-				<h3 class="catbg">', $txt['mc_notes'], '</h3>
-			</div>
-			<div class="windowbg">
-				<div class="content modbox">';
+		<div class="modnotes">
+			<form action="', $scripturl, '?action=moderate;area=index;modnote" method="post">
+				<div class="cat_bar">
+					<h3 class="catbg">', $txt['mc_notes'], '</h3>
+				</div>
+				<div class="windowbg">
+					<div class="content modbox">';
 
 		if (!empty($context['notes']))
 		{
 			echo '
-					<ul class="reset moderation_notes">';
+						<ul class="reset moderation_notes">';
 
 			// Cycle through the notes.
 			foreach ($context['notes'] as $note)
 				echo '
-						<li class="smalltext"><a href="', $note['delete_href'], '"><img src="', $settings['images_url'], '/pm_recipient_delete.png" alt="" /></a> <strong>', $note['author']['link'], ':</strong> ', $note['text'], '</li>';
+							<li class="smalltext"><a href="', $note['delete_href'], '"><img src="', $settings['images_url'], '/pm_recipient_delete.png" alt="" /></a> <strong>', $note['author']['link'], ':</strong> ', $note['text'], '</li>';
 
 			echo '
-					</ul>
-					<div class="pagesection notes">
-						<span class="smalltext">', $context['page_index'], '</span>
-					</div>';
+						</ul>
+						<div class="pagesection notes">
+							<span class="smalltext">', $context['page_index'], '</span>
+						</div>';
 		}
 
 		echo '
-					<div class="floatleft post_note">
+						<div class="floatleft post_note">
 						<input type="text" name="new_note" value="', $txt['mc_click_add_note'], '" style="width: 95%;" onclick="if (this.value == \'', $txt['mc_click_add_note'], '\') this.value = \'\';" class="input_text" />
+						</div>
+						<input type="submit" name="makenote" value="', $txt['mc_add_note'], '" class="button_submit" />
 					</div>
-					<input type="submit" name="makenote" value="', $txt['mc_add_note'], '" class="button_submit" />
 				</div>
-			</div>
-			<input type="hidden" name="', $context['session_var'], '" value="', $context['session_id'], '" />
-		</form>';
+				<input type="hidden" name="', $context['session_var'], '" value="', $context['session_id'], '" />
+			</form>
+		</div>';
 }
 
 function template_reported_posts()

--- a/Themes/default/ModerationCenter.template.php
+++ b/Themes/default/ModerationCenter.template.php
@@ -39,49 +39,6 @@ function template_moderation_center()
 	<br class="clear" />';
 }
 
-function template_latest_news()
-{
-	global $settings, $options, $context, $txt, $scripturl;
-
-	echo '
-		<div class="cat_bar">
-			<h3 class="catbg">
-				<a href="', $scripturl, '?action=helpadmin;help=live_news" onclick="return reqOverlayDiv(this.href);" class="help"><img src="', $settings['images_url'], '/helptopics_hd.png" alt="', $txt['help'], '" class="icon" /></a> ', $txt['mc_latest_news'], '
-			</h3>
-		</div>
-		<div class="windowbg">
-			<div class="content">
-				<div id="smfAnnouncements" class="smalltext">', $txt['mc_cannot_connect_sm'], '</div>
-			</div>
-		</div>';
-
-	// This requires a lot of javascript...
-	// @todo Put this in it's own file!!
-	echo '
-		<script type="text/javascript" src="', $scripturl, '?action=viewsmfile;filename=current-version.js"></script>
-		<script type="text/javascript" src="', $scripturl, '?action=viewsmfile;filename=latest-news.js"></script>
-		<script type="text/javascript"><!-- // --><![CDATA[
-			var oAdminIndex = new smf_AdminIndex({
-				sSelf: \'oAdminCenter\',
-
-				bLoadAnnouncements: true,
-				sAnnouncementTemplate: ', JavaScriptEscape('
-					<dl>
-						%content%
-					</dl>
-				'), ',
-				sAnnouncementMessageTemplate: ', JavaScriptEscape('
-					<dt><a href="%href%">%subject%</a> ' . $txt['on'] . ' %time%</dt>
-					<dd>
-						%message%
-					</dd>
-				'), ',
-				sAnnouncementContainerId: \'smfAnnouncements\'
-			});
-		// ]]></script>';
-
-}
-
 // Show all the group requests the user can see.
 function template_group_requests_block()
 {

--- a/Themes/default/ModerationCenter.template.php
+++ b/Themes/default/ModerationCenter.template.php
@@ -165,7 +165,7 @@ function template_notes()
 			// Cycle through the notes.
 			foreach ($context['notes'] as $note)
 				echo '
-							<li class="smalltext"><a href="', $note['delete_href'], '"><img src="', $settings['images_url'], '/pm_recipient_delete.png" alt="" /></a> <strong>', $note['author']['link'], ':</strong> ', $note['text'], '</li>';
+							<li class="smalltext"><a href="', $note['delete_href'], '"><img src="', $settings['images_url'], '/pm_recipient_delete.png" alt="" /></a>', $note['time'] ,' <strong>', $note['author']['link'], ':</strong> ', $note['text'], '</li>';
 
 			echo '
 						</ul>

--- a/Themes/default/languages/ModerationCenter.english.php
+++ b/Themes/default/languages/ModerationCenter.english.php
@@ -20,6 +20,7 @@ $txt['mc_scratch_board'] = 'Moderator Scratch Board';
 $txt['mc_latest_news'] = 'Simple Machines Latest News';
 $txt['mc_recent_reports'] = 'Recent Topic Reports';
 $txt['mc_warnings'] = 'Warnings';
+$txt['mc_notes'] = 'Moderator Notes';
 
 $txt['mc_cannot_connect_sm'] = 'You are unable to connect to simplemachines.org\'s latest news file.';
 
@@ -131,6 +132,7 @@ $txt['mc_settings'] = 'Change Settings';
 $txt['mc_prefs_title'] = 'Moderation Preferences';
 $txt['mc_prefs_desc'] = 'This section allows you to set some personal preferences for moderation related activities such as email notifications.';
 $txt['mc_prefs_homepage'] = 'Items to show on moderation homepage';
+$txt['mc_prefs_latest_news'] = 'SM News';
 $txt['mc_prefs_show_reports'] = 'Show open report count in forum header';
 $txt['mc_prefs_notify_report'] = 'Notify of topic reports';
 $txt['mc_prefs_notify_report_never'] = 'Never';

--- a/Themes/default/languages/ModerationCenter.english.php
+++ b/Themes/default/languages/ModerationCenter.english.php
@@ -20,7 +20,6 @@ $txt['mc_scratch_board'] = 'Moderator Scratch Board';
 $txt['mc_latest_news'] = 'Simple Machines Latest News';
 $txt['mc_recent_reports'] = 'Recent Topic Reports';
 $txt['mc_warnings'] = 'Warnings';
-$txt['mc_notes'] = 'Moderator Notes';
 
 $txt['mc_cannot_connect_sm'] = 'You are unable to connect to simplemachines.org\'s latest news file.';
 
@@ -132,7 +131,6 @@ $txt['mc_settings'] = 'Change Settings';
 $txt['mc_prefs_title'] = 'Moderation Preferences';
 $txt['mc_prefs_desc'] = 'This section allows you to set some personal preferences for moderation related activities such as email notifications.';
 $txt['mc_prefs_homepage'] = 'Items to show on moderation homepage';
-$txt['mc_prefs_latest_news'] = 'SM News';
 $txt['mc_prefs_show_reports'] = 'Show open report count in forum header';
 $txt['mc_prefs_notify_report'] = 'Notify of topic reports';
 $txt['mc_prefs_notify_report_never'] = 'Never';


### PR DESCRIPTION
Fixes #505 couldn't reproduce #635
- Puts the moderators notes outside the rest of blocks, uses all width available.
- Removes moderation settings for latest news and notes.
- Adds the time stamp to each note. Dunno whats the best place for it so I just put it at the beginning.

I know its a bit hackish, however, I wanted to avoid breaking as less things as possible.

Dunno if the latest news block will be used somewhere else, I just remove it.
