### PR TITLE
! Fix #660: Paid subscription can fail using custom currency code

### DIFF
--- a/Sources/Subscriptions-PayPal.php
+++ b/Sources/Subscriptions-PayPal.php
@@ -261,7 +261,7 @@ class paypal_payment
 			$this->_findSubscription();
 
 		// Verify the currency!
-		if (strtolower($_POST['mc_currency']) !== $modSettings['paid_currency_code'])
+		if (strtolower($_POST['mc_currency']) !== strtolower($modSettings['paid_currency_code']))
 			exit;
 
 		// Can't exist if it doesn't contain anything.


### PR DESCRIPTION
Signed-off-by: John Rayes live627@gmail.com
