### PR TITLE
Third level menus cannot have subsections

### DIFF
--- a/Themes/default/GenericMenu.template.php
+++ b/Themes/default/GenericMenu.template.php
@@ -167,7 +167,7 @@ function template_generic_menu_dropdown_above()
 					$url = isset($sub['url']) ? $sub['url'] : (isset($area['url']) ? $area['url'] : $menu_context['base_url'] . ';area=' . $i) . ';sa=' . $sa;
 
 					echo '
-							<li ', !empty($area['subsections']) ? ' class="subsections"' : '', '>
+							<li>
 								<a ', !empty($sub['selected']) ? 'class="chosen" ' : '', ' href="', $url, $menu_context['extra_parameters'], '">', $sub['label'], '</a>
 							</li>';
 				}

--- a/Themes/default/css/index.css
+++ b/Themes/default/css/index.css
@@ -1196,9 +1196,6 @@ img.sort {
 	content: "";
 	background: url(../images/admin/subsection.png) no-repeat;
 }
-.dropmenu li li.subsections li a:after, .adm_section .dropmenu li.subsections li a:after{
-	display: none;
-}
 /* Highlighting of current section */
 .dropmenu li li a.chosen {
 	font-weight: bold;


### PR DESCRIPTION
My new theme uses arrows on .subsections, and this fix prevents them from going on the third level menus, as that is the deepest level of nesting that SMF allows.
