### PR TITLE
! Remove 'recode line endings' UI item. It is a feature that some might ...

### DIFF
--- a/Sources/ManageAttachments.php
+++ b/Sources/ManageAttachments.php
@@ -136,9 +136,6 @@ function ManageAttachmentSettings($return_config = false)
 			// Are attachments enabled?
 			array('select', 'attachmentEnable', array($txt['attachmentEnable_deactivate'], $txt['attachmentEnable_enable_all'], $txt['attachmentEnable_disable_new'])),
 		'',
-			// Extension checks etc.
-			array('check', 'attachmentRecodeLineEndings'),
-		'',
 			// Directory and size limits.
 			array('select', 'automanage_attachments', array(0 => $txt['attachments_normal'], 1 => $txt['attachments_auto_space'], 2 => $txt['attachments_auto_years'], 3 => $txt['attachments_auto_months'], 4 => $txt['attachments_auto_16'])),
 			array('check', 'use_subdirectories_for_attachments', 'subtext' => $txt['use_subdirectories_for_attachments_note']),

--- a/Themes/default/languages/Admin.english.php
+++ b/Themes/default/languages/Admin.english.php
@@ -353,7 +353,6 @@ $txt['attachmentEnable_enable_all'] = 'Enable all attachments';
 $txt['attachmentEnable_disable_new'] = 'Disable new attachments';
 $txt['attachmentCheckExtensions'] = 'Check attachment\'s extension';
 $txt['attachmentExtensions'] = 'Allowed attachment extensions';
-$txt['attachmentRecodeLineEndings'] = 'Recode line endings in textual attachments';
 $txt['attachmentShowImages'] = 'Display image attachments as pictures under post';
 $txt['attachmentUploadDir'] = 'Attachments directory';
 $txt['attachmentUploadDir_multiple_configure'] = 'Manage attachment directories';


### PR DESCRIPTION
...depend on but that shouldn't have a UI item; a plugin can add it back if the option really is required but it can remain a hidden setting without any real trouble. This also fixes #600 - it's actually much better IMNSHO to pretend it doesn't exist for users than to confuse them with trying to explain it and if someone _does_ need it, we can direct them to turning it on again.

Signed-off-by: Peter Spicer sleeping@myperch.org
