### PR TITLE
! New hook for post-registration notifications (once we have the user's ...

### DIFF
--- a/Sources/Subs-Members.php
+++ b/Sources/Subs-Members.php
@@ -729,6 +729,9 @@ function registerMember(&$regOptions, $return_errors = false)
 	);
 	$memberID = $smcFunc['db_insert_id']('{db_prefix}members', 'id_member');
 
+	// Call an optional function as notification of registration.
+	call_integration_hook('integrate_post_register', array(&$regOptions, &$theme_vars, &$memberID));
+
 	// Update the number of members and latest member's info - and pass the name, but remove the 's.
 	if ($regOptions['register_vars']['is_activated'] == 1)
 		updateStats('member', $memberID, $regOptions['register_vars']['real_name']);


### PR DESCRIPTION
...new id), fixes #242 (there's already a hook for the register_validate part called register_check, this adds the other hook as suggested)

Signed-off-by: Peter Spicer sleeping@myperch.org
