### PR TITLE
Add some text to differentiate these 2 exact queries

### DIFF
--- a/Sources/Post.php
+++ b/Sources/Post.php
@@ -493,7 +493,7 @@ function Post($post_errors = array())
 		// Previewing an edit?
 		if (isset($_REQUEST['msg']) && !empty($topic))
 		{
-			// Get the existing message.
+			// Get the existing message. Previewing.
 			$request = $smcFunc['db_query']('', '
 				SELECT
 					m.id_member, m.modified_time, m.smileys_enabled, m.body,
@@ -607,7 +607,7 @@ function Post($post_errors = array())
 	{
 		$_REQUEST['msg'] = (int) $_REQUEST['msg'];
 
-		// Get the existing message.
+		// Get the existing message. Editing.
 		$request = $smcFunc['db_query']('', '
 			SELECT
 				m.id_member, m.modified_time, m.modified_name, m.smileys_enabled, m.body,


### PR DESCRIPTION
Frivolous PR, Post.php has the exact same query on 2 different places, this just adds some text to differentiate them. Quick and dirty fix...

Signed-off-by: Suki suki@missallsunday.com
