### PR TITLE
Mod center improvements

### DIFF
--- a/Sources/ModerationCenter.php
+++ b/Sources/ModerationCenter.php
@@ -548,6 +548,9 @@ function ReportedPosts()
 
 	loadTemplate('ModerationCenter');
 
+	// Set an empty var for the server response.
+	$context['report_post_action'] = '';
+
 	// Put the open and closed options into tabs, because we can...
 	$context[$context['moderation_menu_name']]['tab_data'] = array(
 		'title' => $txt['mc_reported_posts'],
@@ -589,6 +592,9 @@ function ReportedPosts()
 			)
 		);
 
+		// Tell the user about it.
+		$context['report_post_action'] = isset($_GET['ignore']) ? 'ignore' : (isset($_GET['close']) ? 'close' : 'open');
+
 		// Time to update.
 		updateSettings(array('last_mod_report_action' => time()));
 		recountOpenReports();
@@ -619,6 +625,9 @@ function ReportedPosts()
 			updateSettings(array('last_mod_report_action' => time()));
 			recountOpenReports();
 		}
+
+		// Go on and tell the result.
+		$context['report_post_action'] = 'close_all';
 	}
 
 	// How many entries are we viewing?
@@ -721,6 +730,10 @@ function ReportedPosts()
 	// Get the boards where the current user can remove any message.
 	$context['report_remove_any_boards'] = $user_info['is_admin'] ? $report_boards_ids : array_intersect($report_boards_ids, boardsAllowedTo('remove_any'));
 	$context['report_manage_bans'] = allowedTo('manage_bans');
+
+	// Do we deleted a message?
+	if (isset($_REQUEST['done']))
+		$context['report_post_action'] = 'message_deleted';
 }
 
 /**

--- a/Sources/ModerationCenter.php
+++ b/Sources/ModerationCenter.php
@@ -655,9 +655,11 @@ function ReportedPosts()
 	);
 	$context['reports'] = array();
 	$report_ids = array();
+	$report_boards_ids = array();
 	for ($i = 0; $row = $smcFunc['db_fetch_assoc']($request); $i++)
 	{
 		$report_ids[] = $row['id_report'];
+		$report_boards_ids[] = $row['id_board'];
 		$context['reports'][$row['id_report']] = array(
 			'id' => $row['id_report'],
 			'alternate' => $i % 2,
@@ -715,6 +717,10 @@ function ReportedPosts()
 		}
 		$smcFunc['db_free_result']($request);
 	}
+
+	// Get the boards where the current user can remove any message.
+	$context['report_remove_any_boards'] = $user_info['is_admin'] ? $report_boards_ids : array_intersect($report_boards_ids, boardsAllowedTo('remove_any'));
+	$context['report_manage_bans'] = allowedTo('manage_bans');
 }
 
 /**

--- a/Sources/ModerationCenter.php
+++ b/Sources/ModerationCenter.php
@@ -664,7 +664,7 @@ function ReportedPosts()
 			'topic' => array(
 				'id' => $row['id_topic'],
 				'id_msg' => $row['id_msg'],
-				'id_board' => $row['if_board'],
+				'id_board' => $row['id_board'],
 				'href' => $scripturl . '?topic=' . $row['id_topic'] . '.msg' . $row['id_msg'] . '#msg' . $row['id_msg'],
 			),
 			'report_href' => $scripturl . '?action=moderate;area=reports;report=' . $row['id_report'],

--- a/Sources/ModerationCenter.php
+++ b/Sources/ModerationCenter.php
@@ -661,7 +661,12 @@ function ReportedPosts()
 		$context['reports'][$row['id_report']] = array(
 			'id' => $row['id_report'],
 			'alternate' => $i % 2,
-			'topic_href' => $scripturl . '?topic=' . $row['id_topic'] . '.msg' . $row['id_msg'] . '#msg' . $row['id_msg'],
+			'topic' => array(
+				'id' => $row['id_topic'],
+				'id_msg' => $row['id_msg'],
+				'id_board' => $row['if_board'],
+				'href' => $scripturl . '?topic=' . $row['id_topic'] . '.msg' . $row['id_msg'] . '#msg' . $row['id_msg'],
+			),
 			'report_href' => $scripturl . '?action=moderate;area=reports;report=' . $row['id_report'],
 			'author' => array(
 				'id' => $row['id_author'],

--- a/Sources/ModerationCenter.php
+++ b/Sources/ModerationCenter.php
@@ -593,7 +593,7 @@ function ReportedPosts()
 		);
 
 		// Tell the user about it.
-		$context['report_post_action'] = isset($_GET['ignore']) ? 'ignore' : (isset($_GET['close']) ? 'close' : 'open');
+		$context['report_post_action'] = isset($_GET['ignore']) ? (!empty($_GET['ignore']) ? 'ignore' : 'unignore') : (!empty($_GET['close']) ? 'close' : 'open');
 
 		// Time to update.
 		updateSettings(array('last_mod_report_action' => time()));

--- a/Sources/RemoveTopic.php
+++ b/Sources/RemoveTopic.php
@@ -136,7 +136,9 @@ function DeleteMessage()
 		logAction('delete', array('topic' => $topic, 'subject' => $subject, 'member' => $poster, 'board' => $board));
 
 	// We want to redirect back to recent action.
-	if (isset($_REQUEST['recent']))
+	if (isset($_REQUEST['modcenter']))
+		redirectexit('action=moderate;area=reports;done');
+	elseif (isset($_REQUEST['recent']))
 		redirectexit('action=recent');
 	elseif (isset($_REQUEST['profile'], $_REQUEST['start'], $_REQUEST['u']))
 		redirectexit('action=profile;u=' . $_REQUEST['u'] . ';area=showposts;start=' . $_REQUEST['start']);

--- a/Themes/default/ModerationCenter.template.php
+++ b/Themes/default/ModerationCenter.template.php
@@ -237,12 +237,12 @@ function template_reported_posts()
 					<li><a href="', $scripturl, '?action=moderate;area=reports', $context['view_closed'] ? ';sa=closed' : '', ';close=', (int) !$report['closed'], ';rid=', $report['id'], ';start=', $context['start'], ';', $context['session_var'], '=', $context['session_id'], '">', $close_button, '</a></li>';
 
 		// Delete message button.
-		if (allowedTo('remove_any', $report['topic']['id_board']))
+		if (!$report['closed'] && allowedTo('remove_any', $report['topic']['id_board']))
 			echo '
 					<li><a href="', $scripturl, '?action=deletemsg;topic=', $report['topic']['id'] ,'.0;msg=', $report['topic']['id_msg'] ,';', $context['session_var'], '=', $context['session_id'], '" onclick="return confirm(\'' , $txt['mc_reportedp_delete_confirm'] , '\');">', $delete_button, '</a></li>';
 
 		// Ban this user button.
-		if (allowedTo('manage_bans', $report['topic']['id_board']))
+		if (!$report['closed'] && allowedTo('manage_bans', $report['topic']['id_board']))
 			echo '
 					<li><a href="', $scripturl, '?action=admin;area=ban;sa=add;u=', $report['author']['id'] ,';', $context['session_var'], '=', $context['session_id'], '">', $ban_button, '</a></li>';
 

--- a/Themes/default/ModerationCenter.template.php
+++ b/Themes/default/ModerationCenter.template.php
@@ -239,12 +239,12 @@ function template_reported_posts()
 		// Delete message button.
 		if (allowedTo('remove_any', $report['topic']['id_board']))
 			echo '
-					<li><a href="', $scripturl, '?action=deletemsg;topic=', $report['topic']['id'] ,'.0;msg=', $report['topic']['id_msg'] ,'" onclick="return confirm(\'' , $txt['mc_reportedp_delete_confirm'] , '\');>', $delete_button, '</a></li>';
+					<li><a href="', $scripturl, '?action=deletemsg;topic=', $report['topic']['id'] ,'.0;msg=', $report['topic']['id_msg'] ,';', $context['session_var'], '=', $context['session_id'], '" onclick="return confirm(\'' , $txt['mc_reportedp_delete_confirm'] , '\');">', $delete_button, '</a></li>';
 
 		// Ban this user button.
 		if (allowedTo('manage_bans', $report['topic']['id_board']))
 			echo '
-					<li><a href="', $scripturl, '?action=admin;area=ban;sa=add;u=', $report['author']['id'] ,'">', $ban_button, '</a></li>';
+					<li><a href="', $scripturl, '?action=admin;area=ban;sa=add;u=', $report['author']['id'] ,';', $context['session_var'], '=', $context['session_id'], '">', $ban_button, '</a></li>';
 
 		echo '
 					<li>', !$context['view_closed'] ? '<input type="checkbox" name="close[]" value="' . $report['id'] . '" class="input_check" />' : '', '</li>

--- a/Themes/default/ModerationCenter.template.php
+++ b/Themes/default/ModerationCenter.template.php
@@ -237,12 +237,12 @@ function template_reported_posts()
 					<li><a href="', $scripturl, '?action=moderate;area=reports', $context['view_closed'] ? ';sa=closed' : '', ';close=', (int) !$report['closed'], ';rid=', $report['id'], ';start=', $context['start'], ';', $context['session_var'], '=', $context['session_id'], '">', $close_button, '</a></li>';
 
 		// Delete message button.
-		if (!$report['closed'] && allowedTo('remove_any', $report['topic']['id_board']))
+		if (!$report['closed'] && (is_array($context['report_remove_any_boards']) && in_array($report['topic']['id_board'], $context['report_remove_any_boards'])))
 			echo '
 					<li><a href="', $scripturl, '?action=deletemsg;topic=', $report['topic']['id'] ,'.0;msg=', $report['topic']['id_msg'] ,';', $context['session_var'], '=', $context['session_id'], '" onclick="return confirm(\'' , $txt['mc_reportedp_delete_confirm'] , '\');">', $delete_button, '</a></li>';
 
 		// Ban this user button.
-		if (!$report['closed'] && allowedTo('manage_bans', $report['topic']['id_board']))
+		if (!$report['closed'] && !empty($context['report_manage_bans']))
 			echo '
 					<li><a href="', $scripturl, '?action=admin;area=ban;sa=add;u=', $report['author']['id'] ,';', $context['session_var'], '=', $context['session_id'], '">', $ban_button, '</a></li>';
 

--- a/Themes/default/ModerationCenter.template.php
+++ b/Themes/default/ModerationCenter.template.php
@@ -206,7 +206,7 @@ function template_reported_posts()
 	$details_button = create_button('details.png', 'mc_reportedp_details', 'mc_reportedp_details', 'class="centericon"');
 	$ignore_button = create_button('ignore.png', 'mc_reportedp_ignore', 'mc_reportedp_ignore', 'class="centericon"');
 	$unignore_button = create_button('ignore.png', 'mc_reportedp_unignore', 'mc_reportedp_unignore', 'class="centericon"');
-	$ban_button = create_button('delete.png', 'mc_reportedp_ban', 'mc_reportedp_ban', 'class="centericon"');
+	$ban_button = create_button('close.png', 'mc_reportedp_ban', 'mc_reportedp_ban', 'class="centericon"');
 	$delete_button = create_button('delete.png', 'mc_reportedp_delete', 'mc_reportedp_delete', 'class="centericon"');
 
 	foreach ($context['reports'] as $report)
@@ -234,7 +234,14 @@ function template_reported_posts()
 				<ul class="quickbuttons">
 					<li><a href="', $report['report_href'], '">', $details_button, '</a></li>
 					<li><a href="', $scripturl, '?action=moderate;area=reports', $context['view_closed'] ? ';sa=closed' : '', ';ignore=', (int) !$report['ignore'], ';rid=', $report['id'], ';start=', $context['start'], ';', $context['session_var'], '=', $context['session_id'], '" ', !$report['ignore'] ? 'onclick="return confirm(\'' . $txt['mc_reportedp_ignore_confirm'] . '\');"' : '', '>', $report['ignore'] ? $unignore_button : $ignore_button, '</a></li>
-					<li><a href="', $scripturl, '?action=moderate;area=reports', $context['view_closed'] ? ';sa=closed' : '', ';close=', (int) !$report['closed'], ';rid=', $report['id'], ';start=', $context['start'], ';', $context['session_var'], '=', $context['session_id'], '">', $close_button, '</a></li>
+					<li><a href="', $scripturl, '?action=moderate;area=reports', $context['view_closed'] ? ';sa=closed' : '', ';close=', (int) !$report['closed'], ';rid=', $report['id'], ';start=', $context['start'], ';', $context['session_var'], '=', $context['session_id'], '">', $close_button, '</a></li>';
+
+		// Ban this user button.
+		if (allowedTo('manage_bans', $report['topic']['id_board']))
+			echo '
+					<li><a href="', $scripturl, '?action=admin;area=ban;sa=add;u=', $report['author']['id'] ,'">', $ban_button, '</a></li>';
+
+		echo '
 					<li>', !$context['view_closed'] ? '<input type="checkbox" name="close[]" value="' . $report['id'] . '" class="input_check" />' : '', '</li>
 				</ul>
 			</div>

--- a/Themes/default/ModerationCenter.template.php
+++ b/Themes/default/ModerationCenter.template.php
@@ -253,7 +253,7 @@ function template_reported_posts()
 		// Ban this user button.
 		if (!$report['closed'] && !empty($context['report_manage_bans']))
 			echo '
-					<li><a href="', $scripturl, '?action=admin;area=ban;sa=add;u=', $report['author']['id'] ,';', $context['session_var'], '=', $context['session_id'], '">', $ban_button, '</a></li>';
+					<li><a href="', $scripturl, '?action=admin;area=ban;sa=add', (!empty($report['author']['id']) ? ';u='. $report['author']['id'] : ';msg='. $report['topic']['id_msg']) ,';', $context['session_var'], '=', $context['session_id'], '">', $ban_button, '</a></li>';
 
 		echo '
 					<li>', !$context['view_closed'] ? '<input type="checkbox" name="close[]" value="' . $report['id'] . '" class="input_check" />' : '', '</li>

--- a/Themes/default/ModerationCenter.template.php
+++ b/Themes/default/ModerationCenter.template.php
@@ -206,6 +206,8 @@ function template_reported_posts()
 	$details_button = create_button('details.png', 'mc_reportedp_details', 'mc_reportedp_details', 'class="centericon"');
 	$ignore_button = create_button('ignore.png', 'mc_reportedp_ignore', 'mc_reportedp_ignore', 'class="centericon"');
 	$unignore_button = create_button('ignore.png', 'mc_reportedp_unignore', 'mc_reportedp_unignore', 'class="centericon"');
+	$ban_button = create_button('delete.png', 'mc_reportedp_ban', 'mc_reportedp_ban', 'class="centericon"');
+	$delete_button = create_button('delete.png', 'mc_reportedp_delete', 'mc_reportedp_delete', 'class="centericon"');
 
 	foreach ($context['reports'] as $report)
 	{
@@ -213,7 +215,7 @@ function template_reported_posts()
 		<div class="generic_list_wrapper ', $report['alternate'] ? 'windowbg' : 'windowbg2', '">
 			<div class="content">
 				<h5>
-					<strong><a href="', $report['topic_href'], '">', $report['subject'], '</a></strong> ', $txt['mc_reportedp_by'], ' <strong>', $report['author']['link'], '</strong>
+					<strong><a href="', $report['topic']['href'], '">', $report['subject'], '</a></strong> ', $txt['mc_reportedp_by'], ' <strong>', $report['author']['link'], '</strong>
 				</h5>
 				<div class="smalltext">
 					', $txt['mc_reportedp_last_reported'], ': ', $report['last_updated'], '&nbsp;-&nbsp;';

--- a/Themes/default/ModerationCenter.template.php
+++ b/Themes/default/ModerationCenter.template.php
@@ -190,6 +190,15 @@ function template_reported_posts()
 {
 	global $settings, $options, $context, $txt, $scripturl;
 
+	// Let them know the action was a success.
+	if (!empty($context['report_post_action']) && !empty($txt['report_action_'. $context['report_post_action']]))
+	{
+		echo '
+			<div class="infobox">
+				', $txt['report_action_'. $context['report_post_action']], '
+			</div>';
+	}
+
 	echo '
 	<form id="reported_posts" action="', $scripturl, '?action=moderate;area=reports', $context['view_closed'] ? ';sa=closed' : '', ';start=', $context['start'], '" method="post" accept-charset="', $context['character_set'], '">
 		<div class="cat_bar">
@@ -239,7 +248,7 @@ function template_reported_posts()
 		// Delete message button.
 		if (!$report['closed'] && (is_array($context['report_remove_any_boards']) && in_array($report['topic']['id_board'], $context['report_remove_any_boards'])))
 			echo '
-					<li><a href="', $scripturl, '?action=deletemsg;topic=', $report['topic']['id'] ,'.0;msg=', $report['topic']['id_msg'] ,';', $context['session_var'], '=', $context['session_id'], '" onclick="return confirm(\'' , $txt['mc_reportedp_delete_confirm'] , '\');">', $delete_button, '</a></li>';
+					<li><a href="', $scripturl, '?action=deletemsg;topic=', $report['topic']['id'] ,'.0;msg=', $report['topic']['id_msg'] ,';modcenter;', $context['session_var'], '=', $context['session_id'], '" onclick="return confirm(\'' , $txt['mc_reportedp_delete_confirm'] , '\');">', $delete_button, '</a></li>';
 
 		// Ban this user button.
 		if (!$report['closed'] && !empty($context['report_manage_bans']))

--- a/Themes/default/ModerationCenter.template.php
+++ b/Themes/default/ModerationCenter.template.php
@@ -236,6 +236,11 @@ function template_reported_posts()
 					<li><a href="', $scripturl, '?action=moderate;area=reports', $context['view_closed'] ? ';sa=closed' : '', ';ignore=', (int) !$report['ignore'], ';rid=', $report['id'], ';start=', $context['start'], ';', $context['session_var'], '=', $context['session_id'], '" ', !$report['ignore'] ? 'onclick="return confirm(\'' . $txt['mc_reportedp_ignore_confirm'] . '\');"' : '', '>', $report['ignore'] ? $unignore_button : $ignore_button, '</a></li>
 					<li><a href="', $scripturl, '?action=moderate;area=reports', $context['view_closed'] ? ';sa=closed' : '', ';close=', (int) !$report['closed'], ';rid=', $report['id'], ';start=', $context['start'], ';', $context['session_var'], '=', $context['session_id'], '">', $close_button, '</a></li>';
 
+		// Delete message button.
+		if (allowedTo('remove_any', $report['topic']['id_board']))
+			echo '
+					<li><a href="', $scripturl, '?action=deletemsg;topic=', $report['topic']['id'] ,'.0;msg=', $report['topic']['id_msg'] ,'" onclick="return confirm(\'' , $txt['mc_reportedp_delete_confirm'] , '\');>', $delete_button, '</a></li>';
+
 		// Ban this user button.
 		if (allowedTo('manage_bans', $report['topic']['id_board']))
 			echo '

--- a/Themes/default/languages/ModerationCenter.english.php
+++ b/Themes/default/languages/ModerationCenter.english.php
@@ -45,6 +45,8 @@ $txt['mc_reportedp_close'] = 'Close';
 $txt['mc_reportedp_open'] = 'Open';
 $txt['mc_reportedp_ignore'] = 'Ignore';
 $txt['mc_reportedp_unignore'] = 'Un-Ignore';
+$txt['mc_reportedp_delete'] = 'Delete';
+$txt['mc_reportedp_ban'] = 'Ban this user';
 // Do not use numeric entries in the below string.
 $txt['mc_reportedp_ignore_confirm'] = 'Are you sure you wish to ignore further reports about this message?\\n\\nThis will turn off further reports for all moderators of the forum.';
 $txt['mc_reportedp_close_selected'] = 'Close Selected';

--- a/Themes/default/languages/ModerationCenter.english.php
+++ b/Themes/default/languages/ModerationCenter.english.php
@@ -123,6 +123,7 @@ $txt['mc_warning_template_delete'] = 'Delete Selected';
 $txt['mc_warning_template_delete_confirm'] = 'Are you sure you want to delete the selected templates?';
 $txt['report_action_message_deleted'] = 'The message was successfully deleted.';
 $txt['report_action_ignore'] = 'The report was successfully ignored.';
+$txt['report_action_unignore'] = 'The report was successfully un-ignored.';
 $txt['report_action_close'] = 'The report was successfully closed.';
 $txt['report_action_open'] = 'The report was successfully open.';
 $txt['report_action_close_all'] = 'You successfully closed all selected reports.';

--- a/Themes/default/languages/ModerationCenter.english.php
+++ b/Themes/default/languages/ModerationCenter.english.php
@@ -45,7 +45,8 @@ $txt['mc_reportedp_close'] = 'Close';
 $txt['mc_reportedp_open'] = 'Open';
 $txt['mc_reportedp_ignore'] = 'Ignore';
 $txt['mc_reportedp_unignore'] = 'Un-Ignore';
-$txt['mc_reportedp_delete'] = 'Delete';
+$txt['mc_reportedp_delete'] = 'Delete message';
+$txt['mc_reportedp_delete_confirm'] = 'Are you sure you wish to delete this message?';
 $txt['mc_reportedp_ban'] = 'Ban this user';
 // Do not use numeric entries in the below string.
 $txt['mc_reportedp_ignore_confirm'] = 'Are you sure you wish to ignore further reports about this message?\\n\\nThis will turn off further reports for all moderators of the forum.';

--- a/Themes/default/languages/ModerationCenter.english.php
+++ b/Themes/default/languages/ModerationCenter.english.php
@@ -121,6 +121,11 @@ $txt['mc_warning_template_add'] = 'Add Template';
 $txt['mc_warning_template_modify'] = 'Edit Template';
 $txt['mc_warning_template_delete'] = 'Delete Selected';
 $txt['mc_warning_template_delete_confirm'] = 'Are you sure you want to delete the selected templates?';
+$txt['report_action_message_deleted'] = 'The message was successfully deleted.';
+$txt['report_action_ignore'] = 'The report was successfully ignored.';
+$txt['report_action_close'] = 'The report was successfully closed.';
+$txt['report_action_open'] = 'The report was successfully open.';
+$txt['report_action_close_all'] = 'You successfully closed all selected reports.';
 
 $txt['mc_warning_template_desc'] = 'Use this page to fill in the details of the template. Note that the subject for the email is not part of the template. Note that as the notification is sent by PM you can use BBC within the template. Note if you use the {MESSAGE} variable then this template will not be available when issuing a generic warning (i.e. A warning not linked to a post).';
 $txt['mc_warning_template_title'] = 'Template Title';


### PR DESCRIPTION
As per Mantis 4416 bug report.

This PR adds some functionality to the mod center
- Adds a delete message.button
- Adds a ban this user button, handles guest posting too.
- Adds a confirmation message when doing an action (ignore, close, delete, open) to an report.

There are some things that do bother me, 
- Theres a nasty inline-double ternary to find out which action the user is doing.
- I added some new text strings so the usual check must be done, it feels weird typing "un-ignore" or "un-ignored".
- Dunno if a mod_log should be set when deleting a message.
- Is it worth to also apply this changes to the report details page?
