### PR TITLE
fix missing txt string $txt['board_moderator_groups']

### DIFF
--- a/Sources/Reports.php
+++ b/Sources/Reports.php
@@ -192,7 +192,7 @@ function BoardReport()
 		'override_theme' => $txt['board_override_theme'],
 		'profile' => $txt['board_profile'],
 		'moderators' => $txt['board_moderators'],
-		'moderator_groups' => $txt['board_moderator_groups'],
+		'moderator_groups' => $txt['board_moderator'],
 		'groups' => $txt['board_groups'],
 	);
 	if (!empty($modSettings['deny_boards_access']))


### PR DESCRIPTION
Signed-off-by: Illori illori@simplemachines.org
