### PR TITLE
PostgreSQL fixes

### DIFF
--- a/other/install_2-1_postgresql.sql
+++ b/other/install_2-1_postgresql.sql
@@ -1243,7 +1243,7 @@ CREATE TABLE {$db_prefix}log_online (
   log_time int NOT NULL default '0',
   id_member int NOT NULL default '0',
   id_spider smallint NOT NULL default '0',
-  ip int NOT NULL default '0',
+  ip bigint NOT NULL default '0',
   url text NOT NULL,
   PRIMARY KEY (session)
 );

--- a/other/install_2-1_postgresql.sql
+++ b/other/install_2-1_postgresql.sql
@@ -1962,8 +1962,8 @@ INSERT INTO {$db_prefix}permissions (id_group, permission) VALUES (2, 'profile_v
 INSERT INTO {$db_prefix}permissions (id_group, permission) VALUES (2, 'profile_view_any');
 INSERT INTO {$db_prefix}permissions (id_group, permission) VALUES (2, 'pm_read');
 INSERT INTO {$db_prefix}permissions (id_group, permission) VALUES (2, 'pm_send');
-INSERT INTO {$db_prefix}permissions (id_group, permission) VALUES (0, 'pm_draft');
-INSERT INTO {$db_prefix}permissions (id_group, permission) VALUES (0, 'pm_autosave_draft');
+INSERT INTO {$db_prefix}permissions (id_group, permission) VALUES (2, 'pm_draft');
+INSERT INTO {$db_prefix}permissions (id_group, permission) VALUES (2, 'pm_autosave_draft');
 INSERT INTO {$db_prefix}permissions (id_group, permission) VALUES (2, 'calendar_view');
 INSERT INTO {$db_prefix}permissions (id_group, permission) VALUES (2, 'view_stats');
 INSERT INTO {$db_prefix}permissions (id_group, permission) VALUES (2, 'who_view');
@@ -2114,7 +2114,7 @@ CREATE TABLE {$db_prefix}qanda (
   question varchar(255) NOT NULL default '',
   answers text NOT NULL,
   PRIMARY KEY (id_question)
-) ENGINE=MyISAM;
+);
 
 #
 # Indexes for table `qanda`

--- a/other/install_2-1_postgresql.sql
+++ b/other/install_2-1_postgresql.sql
@@ -2631,12 +2631,12 @@ CREATE SEQUENCE {$db_prefix}user_drafts_seq;
 
 CREATE TABLE {$db_prefix}user_drafts (
   id_draft int default nextval('{$db_prefix}user_drafts_seq'),
-  id_topic int unsigned NOT NULL default '0',
-  id_board smallint unsigned NOT NULL default '0',
-  id_reply int unsigned NOT NULL default '0',
+  id_topic int NOT NULL default '0',
+  id_board smallint NOT NULL default '0',
+  id_reply int NOT NULL default '0',
   type smallint NOT NULL default '0',
-  poster_time int unsigned NOT NULL default '0',
-  id_member int unsigned NOT NULL default '0',
+  poster_time int NOT NULL default '0',
+  id_member int NOT NULL default '0',
   subject varchar(255) NOT NULL default '',
   smileys_enabled smallint NOT NULL default '1',
   body text NOT NULL,

--- a/other/upgrade_2-0_postgresql.sql
+++ b/other/upgrade_2-0_postgresql.sql
@@ -253,7 +253,7 @@ CREATE TABLE {$db_prefix}log_online (
   log_time int NOT NULL default '0',
   id_member int NOT NULL default '0',
   id_spider smallint NOT NULL default '0',
-  ip int NOT NULL default '0',
+  ip bigint NOT NULL default '0',
   url text NOT NULL,
   PRIMARY KEY (session)
 );

--- a/other/upgrade_2-1_postgresql.sql
+++ b/other/upgrade_2-1_postgresql.sql
@@ -385,15 +385,15 @@ if (file_exists($GLOBALS['boarddir'] . '/Themes/core'))
 /******************************************************************************/
 ---# Creating drafts table.
 CREATE TABLE {$db_prefix}user_drafts (
-	id_draft int unsigned NOT NULL auto_increment,
-	id_topic int unsigned NOT NULL default '0',
-	id_board smallint unsigned NOT NULL default '0',
-	id_reply int unsigned NOT NULL default '0',
+	id_draft int NOT NULL auto_increment,
+	id_topic int NOT NULL default '0',
+	id_board smallint NOT NULL default '0',
+	id_reply int NOT NULL default '0',
 	type smallint NOT NULL default '0',
-	poster_time int unsigned NOT NULL default '0',
-	id_member int unsigned NOT NULL default '0',
+	poster_time int NOT NULL default '0',
+	id_member int NOT NULL default '0',
 	subject varchar(255) NOT NULL default '',
-	smileys_enabled smallint NOT NULL default '1',
+	smileys_enabled NOT NULL default '1',
 	body text NOT NULL,
 	icon varchar(16) NOT NULL default 'xx',
 	locked smallint NOT NULL default '0',

--- a/other/upgrade_2-1_postgresql.sql
+++ b/other/upgrade_2-1_postgresql.sql
@@ -534,3 +534,10 @@ CREATE TABLE {$db_prefix}qanda (
 	}
 ---}
 ---#
+
+/******************************************************************************/
+--- Fixing log_online table
+/******************************************************************************/
+---# Changing ip to bigint
+ALTER TABLE {$db_prefix}log_online ALTER ip TYPE bigint;
+---#


### PR DESCRIPTION
Fix instances of "unsigned" being used in CREATE TABLE queries
Change "ip" column in log_online to bigint due to Postgres not supporting unsigned ints
Remove "ENGINE=MyISAM" from a CREATE TABLE query
