### PR TITLE
- zend_shm_cache_fetch doesn't need a TTL parameter. (Load.php)

### DIFF
--- a/Sources/Load.php
+++ b/Sources/Load.php
@@ -2924,7 +2924,7 @@ function cache_get_data($key, $ttl = 120)
 		case 'zend':
 			// Zend's pricey stuff.
 			if (function_exists('zend_shm_cache_fetch'))
-				$value = zend_shm_cache_fetch('SMF::' . $key, $ttl);
+				$value = zend_shm_cache_fetch('SMF::' . $key);
 			elseif (function_exists('output_cache_get'))
 				$value = output_cache_get($key, $ttl);
 			break;


### PR DESCRIPTION
Signed-off-by: Nao nao@wedge
