### PR TITLE
! Preliminary support for notifying a user their options have been saved...

### DIFF
--- a/Sources/ManagePosts.php
+++ b/Sources/ManagePosts.php
@@ -242,7 +242,6 @@ function ModifyPostSettings($return_config = false)
 
 			if (isset($body_type) && ($_POST['max_messageLength'] > 65535 || $_POST['max_messageLength'] == 0) && $body_type == 'text')
 				fatal_lang_error('convert_to_mediumtext', false, array($scripturl . '?action=admin;area=maintain;sa=database'));
-
 		}
 
 		// If we're changing the post preview length let's check its valid
@@ -252,6 +251,7 @@ function ModifyPostSettings($return_config = false)
 		call_integration_hook('integrate_save_post_settings');
 
 		saveDBSettings($config_vars);
+		$_SESSION['adm-save'] = true;
 		redirectexit('action=admin;area=postsettings;sa=posts');
 	}
 
@@ -321,6 +321,7 @@ function ModifyBBCSettings($return_config = false)
 		call_integration_hook('integrate_save_bbc_settings', array($bbcTags));
 
 		saveDBSettings($config_vars);
+		$_SESSION['adm-save'] = true;
 		redirectexit('action=admin;area=postsettings;sa=bbc');
 	}
 
@@ -384,6 +385,7 @@ function ModifyTopicSettings($return_config = false)
 		call_integration_hook('integrate_save_topic_settings');
 
 		saveDBSettings($config_vars);
+		$_SESSION['adm-save'] = true;
 		redirectexit('action=admin;area=postsettings;sa=topics');
 	}
 
@@ -452,6 +454,7 @@ function ModifyDraftSettings($return_config = false)
 
 		// Save everything else and leave.
 		saveDBSettings($config_vars);
+		$_SESSION['adm-save'] = true;
 		redirectexit('action=admin;area=postsettings;sa=drafts');
 	}
 

--- a/Sources/ManageServer.php
+++ b/Sources/ManageServer.php
@@ -657,6 +657,16 @@ function prepareDBSettingContext(&$config_vars)
 
 	loadLanguage('Help');
 
+	if (isset($_SESSION['adm-save']))
+	{
+		if ($_SESSION['adm-save'] === true)
+			$context['saved_successful'] = true;
+		else
+			$context['saved_failed'] = $_SESSION['adm-save'];
+
+		unset($_SESSION['adm-save']);
+	}
+
 	$context['config_vars'] = array();
 	$inlinePermissions = array();
 	$bbcChoice = array();

--- a/Themes/default/Admin.template.php
+++ b/Themes/default/Admin.template.php
@@ -706,6 +706,13 @@ function template_show_settings()
 {
 	global $context, $txt, $settings, $scripturl;
 
+	if (!empty($context['saved_successful']))
+		echo '
+	<div class="infobox">', $txt['settings_saved'], '</div>';
+	elseif (!empty($context['saved_failed']))
+		echo '
+	<div class="errorbox">', sprintf($txt['settings_not_saved'], $context['saved_failed']), '</div>';
+
 	if (!empty($context['settings_pre_javascript']))
 		echo '
 	<script type="text/javascript"><!-- // --><![CDATA[', $context['settings_pre_javascript'], '// ]]></script>';

--- a/Themes/default/languages/Admin.english.php
+++ b/Themes/default/languages/Admin.english.php
@@ -6,6 +6,9 @@ global $settings, $scripturl;
 $txt['forum_in_maintainence'] = 'Your forum is in Maintenance Mode. Only administrators can currently log in.';
 $txt['maintenance_page'] = 'You can turn off Maintenance Mode from the <a href="%1$s">Server Settings</a> area.';
 
+$txt['settings_saved'] = 'The settings were successfully saved';
+$txt['settings_not_saved'] = 'Your changes were not saved because: %1$s';
+
 $txt['admin_boards'] = 'Boards and Categories';
 $txt['admin_users'] = 'Members';
 $txt['admin_newsletters'] = 'Newsletters';


### PR DESCRIPTION
... in the admin panel, per #802. This only covers 4 of the 5 in Forum > Posts and Topics but it's a start. Basically, set $_SESSION['adm-save'] to boolean true when settings were saved, or the error message if not.

Signed-off-by: Peter Spicer sleeping@myperch.org
