### PR TITLE
Missing global caused $boardurl to not be updated globally

### DIFF
--- a/other/install.php
+++ b/other/install.php
@@ -938,7 +938,7 @@ function DatabaseSettings()
 // Let's start with basic forum type settings.
 function ForumSettings()
 {
-	global $txt, $incontext, $databases, $smcFunc, $db_connection, $db_type;
+	global $txt, $incontext, $databases, $smcFunc, $db_connection, $db_type, $boardurl;
 
 	$incontext['sub_template'] = 'forum_settings';
 	$incontext['page_title'] = $txt['install_settings'];


### PR DESCRIPTION
! Missing global caused $boardurl to not be updated globally after updating it in Settings.php

This fixes bug #868
