### PR TITLE
! There really is no point having the cancel button on the Loading.... p...

### DIFF
--- a/Sources/Load.php
+++ b/Sources/Load.php
@@ -1816,7 +1816,6 @@ function loadTheme($id_theme = 0, $initialize = true)
 		'smf_session_var' => '"' . $context['session_var'] . '"',
 		'smf_member_id' => $context['user']['id'],
 		'ajax_notification_text' => JavaScriptEscape($txt['ajax_in_progress']),
-		'ajax_notification_cancel_text' => JavaScriptEscape($txt['modify_cancel']),
 		'help_popup_heading_text' => JavaScriptEscape($txt['help_popup']),
 	);
 

--- a/Themes/default/scripts/script.js
+++ b/Themes/default/scripts/script.js
@@ -972,22 +972,6 @@ function create_ajax_indicator_ele()
 	// Set the id so it'll load the style properly.
 	ajax_indicator_ele.id = 'ajax_in_progress';
 
-	// Add the image in and link to turn it off.
-	var cancel_link = document.createElement('a');
-	cancel_link.href = 'javascript:ajax_indicator(false)';
-	var cancel_img = document.createElement('img');
-	cancel_img.src = smf_images_url + '/icons/quick_remove.png';
-
-	if (typeof(ajax_notification_cancel_text) != 'undefined')
-	{
-		cancel_img.alt = ajax_notification_cancel_text;
-		cancel_img.title = ajax_notification_cancel_text;
-	}
-
-	// Add the cancel link and image to the indicator.
-	cancel_link.appendChild(cancel_img);
-	ajax_indicator_ele.appendChild(cancel_link);
-
 	// Set the text.  (Note:  You MUST append here and not overwrite.)
 	ajax_indicator_ele.innerHTML += ajax_notification_text;
 


### PR DESCRIPTION
...opup unless it cancels, and frankly, that seems like a massive waste of effort to do something that probably won't work right anyway (if it already failed for some reason, such that the popup didn't already go away, cancelling the XHR isn't actually likely to help). So just spirit it away instead, and nail Mantis 4962 at the same time.

Signed-off-by: Peter Spicer sleeping@myperch.org
