### PR TITLE
Guest vote fix

### DIFF
--- a/Sources/Poll.php
+++ b/Sources/Poll.php
@@ -197,7 +197,7 @@ function Vote()
 		// Time is stored in case the poll is reset later, plus what they voted for.
 		$_COOKIE['guest_poll_vote'] = empty($_COOKIE['guest_poll_vote']) ? '' : $_COOKIE['guest_poll_vote'];
 		// ;id,timestamp,[vote,vote...]; etc
-		$_COOKIE['guest_poll_vote'] .= ';' . $row['id_poll'] . ',' . time() . ',' . (count($pollOptions) > 1 ? explode(',' . $pollOptions) : $pollOptions[0]);
+		$_COOKIE['guest_poll_vote'] .= ';' . $row['id_poll'] . ',' . time() . ',' . implode(',', $pollOptions);
 
 		// Increase num guest voters count by 1
 		$smcFunc['db_query']('', '


### PR DESCRIPTION
! Guests could not submit multiple votes to a poll without errors. Funnily enough, it did not adversely affect workflow.
