### PR TITLE
! Redo move topic stuff per comments on #921

### DIFF
--- a/Sources/Display.php
+++ b/Sources/Display.php
@@ -1089,23 +1089,14 @@ function Display()
 	foreach ($anyown_permissions as $contextual => $perm)
 		$context[$contextual] = allowedTo($perm . '_any') || ($context['user']['started'] && allowedTo($perm . '_own'));
 
-	if (!$user_info['is_admin'])
+	if (!$user_info['is_admin'] && !$modSettings['topic_move_any'])
 	{
 		// We'll use this in a minute
-		$boards_allowed = boardsAllowedTo(array('move_any', 'move_own'));
+		$boards_allowed = array_diff(boardsAllowedTo('post_new'), array($board));
 
-		// Boards other than this one where you can move_any or move_own 
-		$other_boards_move_any = array_diff($boards_allowed['move_any'], array($board));
-		$other_boards_move_own = array_diff($boards_allowed['move_own'], array($board));
-
-		// How many boards can you do this on besides this one?
-		$context['can_move_any'] = !empty($other_boards_move_any);
-		$context['can_move_own'] = !empty($other_boards_move_own);
-
-		/* You can't move this unless:
-			You have move_any on at least one other board OR
-			You started the topic and have move_own on at least one other board*/
-		$context['move'] &= $context['can_move_any'] || ($context['topic_starter_id'] == $user_info['id'] && $context['can_move_own']);
+		/* You can't move this unless you have permission
+			to start new topics on at least one other board */
+		$context['move'] &= count($boards_allowed) > 1;
 	}
 
 	// Cleanup all the permissions with extra stuff...

--- a/Sources/ManageSettings.php
+++ b/Sources/ManageSettings.php
@@ -151,6 +151,7 @@ function ModifyBasicSettings($return_config = false)
 			array('check', 'allow_hideOnline'),
 			array('check', 'titlesEnable'),
 			array('text', 'default_personal_text', 'subtext' => $txt['default_personal_text_note'], 'disabled' => !$can_personal_text),
+			array('check', 'topic_move_any'),
 		'',
 			// Jquery source
 			array('select', 'jquery_source', array('auto' => $txt['jquery_auto'], 'local' => $txt['jquery_local'], 'cdn' => $txt['jquery_cdn'], 'custom' => $txt['jquery_custom']), 'onchange' => 'if (this.value == \'custom\'){document.getElementById(\'jquery_custom\').disabled = false; } else {document.getElementById(\'jquery_custom\').disabled = true;}'),

--- a/Sources/MessageIndex.php
+++ b/Sources/MessageIndex.php
@@ -730,7 +730,6 @@ function QuickModeration()
 		);
 
 		$redirect_url = 'board=' . $board . '.' . $_REQUEST['start'];
-		
 	}
 	else
 	{
@@ -755,7 +754,7 @@ function QuickModeration()
 		{
 			$boards_can['post_new'] = boardsAllowedTo('post_new');
 		}
-		
+
 		if (empty($boards_can['post_new']))
 		{
 			$boards_can['move_any'] = $boards_can['move_own'] = array();

--- a/Themes/default/languages/Help.english.php
+++ b/Themes/default/languages/Help.english.php
@@ -638,4 +638,5 @@ $helptxt['custom_mask'] = 'The input mask is important for your forum\'s securit
 	</div><br /><br />
 	More information and advanced techniques may be found on the internet.';
 
+$helptxt['topic_move_any'] = 'If checked, users will be allowed to move topics to any board they can see. Otherwise, they will only be able to move them to boards where they can post new topics.';
 ?>

--- a/Themes/default/languages/ManageSettings.english.php
+++ b/Themes/default/languages/ManageSettings.english.php
@@ -356,4 +356,6 @@ $txt['setting_frame_security_DISABLE'] = 'Disabled';
 
 $txt['select_boards_from_list'] = 'Select boards which apply';
 
+$txt['topic_move_any'] = 'Allow moving of topics to read-only boards';
+
 ?>

--- a/other/install_2-1_mysql.sql
+++ b/other/install_2-1_mysql.sql
@@ -1900,7 +1900,8 @@ VALUES ('smfVersion', '{$smf_version}'),
 	('drafts_pm_enabled', '1'),
 	('drafts_autosave_enabled', '1'),
 	('drafts_show_saved_enabled', '1'),
-	('drafts_keep_days', '7');
+	('drafts_keep_days', '7'),
+	('topic_move_any', '0');
 # --------------------------------------------------------
 
 #

--- a/other/install_2-1_postgresql.sql
+++ b/other/install_2-1_postgresql.sql
@@ -2410,6 +2410,7 @@ INSERT INTO {$db_prefix}settings (variable, value) VALUES ('drafts_pm_enabled', 
 INSERT INTO {$db_prefix}settings (variable, value) VALUES ('drafts_autosave_enabled', '1');
 INSERT INTO {$db_prefix}settings (variable, value) VALUES ('drafts_show_saved_enabled', '1');
 INSERT INTO {$db_prefix}settings (variable, value) VALUES ('drafts_keep_days', '7');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('topic_move_any', '0');
 # --------------------------------------------------------
 
 #

--- a/other/install_2-1_sqlite.sql
+++ b/other/install_2-1_sqlite.sql
@@ -2051,6 +2051,7 @@ INSERT INTO {$db_prefix}settings (variable, value) VALUES ('drafts_pm_enabled', 
 INSERT INTO {$db_prefix}settings (variable, value) VALUES ('drafts_autosave_enabled', '1');
 INSERT INTO {$db_prefix}settings (variable, value) VALUES ('drafts_show_saved_enabled', '1');
 INSERT INTO {$db_prefix}settings (variable, value) VALUES ('drafts_keep_days', '7');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('topic_move_any', '0');
 COMMIT;
 
 # --------------------------------------------------------

--- a/other/install_2-1_sqlite3.sql
+++ b/other/install_2-1_sqlite3.sql
@@ -2051,6 +2051,7 @@ INSERT INTO {$db_prefix}settings (variable, value) VALUES ('drafts_pm_enabled', 
 INSERT INTO {$db_prefix}settings (variable, value) VALUES ('drafts_autosave_enabled', '1');
 INSERT INTO {$db_prefix}settings (variable, value) VALUES ('drafts_show_saved_enabled', '1');
 INSERT INTO {$db_prefix}settings (variable, value) VALUES ('drafts_keep_days', '7');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('topic_move_any', '0');
 COMMIT;
 
 # --------------------------------------------------------

--- a/other/upgrade_2-1_mysql.sql
+++ b/other/upgrade_2-1_mysql.sql
@@ -57,6 +57,10 @@ if (!isset($modSettings['allow_no_censored']))
 ---}
 ---#
 
+---# Adding new "topic_move_any" setting
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('topic_move_any', '1');
+---#
+
 /******************************************************************************/
 --- Updating legacy attachments...
 /******************************************************************************/

--- a/other/upgrade_2-1_postgresql.sql
+++ b/other/upgrade_2-1_postgresql.sql
@@ -59,6 +59,10 @@ if (!isset($modSettings['allow_no_censored']))
 ---}
 ---#
 
+---# Adding new "topic_move_any" setting
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('topic_move_any', '1');
+---#
+
 /******************************************************************************/
 --- Updating legacy attachments...
 /******************************************************************************/

--- a/other/upgrade_2-1_sqlite.sql
+++ b/other/upgrade_2-1_sqlite.sql
@@ -57,6 +57,10 @@ if (!isset($modSettings['allow_no_censored']))
 ---}
 ---#
 
+---# Adding new "topic_move_any" setting
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('topic_move_any', '1');
+---#
+
 /******************************************************************************/
 --- Updating legacy attachments...
 /******************************************************************************/


### PR DESCRIPTION
This changes move topic functionality per comments on #921:
1. New setting added to allow existing functionality (enabled by default on upgrades, but not on new installs).
2. Code changes to not allow moving to boards where you don't have post_new if the new setting is enabled.
