### PR TITLE
! Dropping support for eAccelerator and Turck MMcache, as these are not ...

### DIFF
--- a/Sources/Admin.php
+++ b/Sources/Admin.php
@@ -526,8 +526,6 @@ function AdminHome()
 		'gd',
 		'imagemagick',
 		'db_server',
-		'mmcache',
-		'eaccelerator',
 		'phpa',
 		'apc',
 		'memcache',

--- a/Sources/Load.php
+++ b/Sources/Load.php
@@ -2744,11 +2744,9 @@ function cache_quick_get($key, $file, $function, $params, $level = 1)
  * - It may "miss" so shouldn't be depended on
  * - Uses the cache engine chosen in the ACP and saved in settings.php
  * - It supports:
- *     Turck MMCache: http://turck-mmcache.sourceforge.net/index_old.html#api
  *     Xcache: http://xcache.lighttpd.net/wiki/XcacheApi
  *     memcache: http://www.php.net/memcache
  *     APC: http://www.php.net/apc
- *     eAccelerator: http://bart.eaccelerator.net/doc/phpdoc/
  *     Zend: http://files.zend.com/help/Zend-Platform/output_cache_functions.htm
  *     Zend: http://files.zend.com/help/Zend-Platform/zend_cache_functions.htm
  *
@@ -2788,36 +2786,6 @@ function cache_put_data($key, $value, $ttl = 120)
 					return;
 
 				memcache_set($memcached, $key, $value, 0, $ttl);
-			}
-			break;
-		case 'eaccelerator':
-			// eAccelerator...
-			if (function_exists('eaccelerator_put'))
-			{
-				if (mt_rand(0, 10) == 1)
-					eaccelerator_gc();
-
-				if ($value === null)
-					@eaccelerator_rm($key);
-				else
-					eaccelerator_put($key, $value, $ttl);
-			}
-			break;
-		case 'mmcache':
-			// Turck MMCache?
-			if (function_exists('mmcache_put'))
-			{
-				if (mt_rand(0, 10) == 1)
-					mmcache_gc();
-
-				if ($value === null)
-					@mmcache_rm($key);
-				else
-				{
-					mmcache_lock($key);
-					mmcache_put($key, $value, $ttl);
-					mmcache_unlock($key);
-				}
 			}
 			break;
 		case 'apc':
@@ -2911,16 +2879,6 @@ function cache_get_data($key, $ttl = 120)
 
 				$value = (function_exists('memcache_get')) ? memcache_get($cache['connection'], $key) : memcached_get($cache['connection'], $key);
 			}
-			break;
-		case 'eaccelerator':
-			// Again, eAccelerator.
-			if (function_exists('eaccelerator_get'))
-				$value = eaccelerator_get($key);
-			break;
-		case 'mmcache':
-			// The older, but ever-stable, Turck MMCache...
-			if (function_exists('mmcache_get'))
-				$value = mmcache_get($key);
 			break;
 		case 'apc':
 			// This is the free APC from PECL.

--- a/Sources/ManageServer.php
+++ b/Sources/ManageServer.php
@@ -396,10 +396,6 @@ function ModifyCacheSettings($return_config = false)
 
 	// Detect all available optimizers
 	$detected = array();
-	if (function_exists('eaccelerator_put'))
-		$detected['eaccelerator'] = $txt['eAccelerator_cache'];
-	if (function_exists('mmcache_put'))
-		$detected['mmcache'] = $txt['mmcache_cache'];
 	if (function_exists('apc_store'))
 		$detected['apc'] = $txt['apc_cache'];
 	if (function_exists('output_cache_put') || function_exists('zend_shm_cache_store'))

--- a/Sources/Session.php
+++ b/Sources/Session.php
@@ -71,14 +71,7 @@ function loadSession()
 
 		// Use cache setting sessions?
 		if (empty($modSettings['databaseSession_enable']) && !empty($modSettings['cache_enable']) && php_sapi_name() != 'cli')
-		{
 			call_integration_hook('integrate_session_handlers');
-			// @todo move these to a plugin.
-			if (function_exists('mmcache_set_session_handlers'))
-				mmcache_set_session_handlers();
-			elseif (function_exists('eaccelerator_set_session_handlers'))
-				eaccelerator_set_session_handlers();
-		}
 
 		session_start();
 

--- a/Sources/Subs-Admin.php
+++ b/Sources/Subs-Admin.php
@@ -74,10 +74,6 @@ function getServerVersions($checkFor)
 		get_memcached_server();
 
 	// Check to see if we have any accelerators installed...
-	if (in_array('mmcache', $checkFor) && defined('MMCACHE_VERSION'))
-		$versions['mmcache'] = array('title' => 'Turck MMCache', 'version' => MMCACHE_VERSION);
-	if (in_array('eaccelerator', $checkFor) && defined('EACCELERATOR_VERSION'))
-		$versions['eaccelerator'] = array('title' => 'eAccelerator', 'version' => EACCELERATOR_VERSION);
 	if (in_array('phpa', $checkFor) && isset($_PHPA))
 		$versions['phpa'] = array('title' => 'ionCube PHP-Accelerator', 'version' => $_PHPA['VERSION']);
 	if (in_array('apc', $checkFor) && extension_loaded('apc'))

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -3686,24 +3686,6 @@ function clean_cache($type = '')
 					memcached_flush($memcached);
 			}
 			break;
-		case 'eaccelerator':
-			if (function_exists('eaccelerator_clear') && function_exists('eaccelerator_clean') )
-			{
-				// Clean out the already expired items
-				@eaccelerator_clean();
-
-				// Remove all unused scripts and data from shared memory and disk cache,
-				// e.g. all data that isn't used in the current requests.
-				@eaccelerator_clear();
-			}
-		case 'mmcache':
-			if (function_exists('mmcache_gc'))
-			{
-				// removes all expired keys from shared memory, this is not a complete cache flush :(
-				// @todo there is no clear function, should we try to find all of the keys and delete those? with mmcache_rm
-				mmcache_gc();
-			}
-			break;
 		case 'apc':
 			if (function_exists('apc_clear_cache'))
 			{

--- a/Themes/default/languages/ManageSettings.english.php
+++ b/Themes/default/languages/ManageSettings.english.php
@@ -105,8 +105,6 @@ $txt['karmaSmiteLabel'] = 'Karma smite label';
 $txt['caching_information'] = 'SMF supports caching through the use of accelerators. The currently supported accelerators include:
 <ul class="normallist">
 	<li>APC</li>
-	<li>eAccelerator</li>
-	<li>Turck MMCache</li>
 	<li>Memcached</li>
 	<li>Zend Platform/Performance Suite (Not Zend Optimizer)</li>
 	<li>XCache</li>
@@ -125,8 +123,6 @@ $txt['cache_memcached'] = 'Memcache settings';
 $txt['cache_accelerator'] = 'Caching Accelerator';
 $txt['default_cache'] = 'SMF file based caching';
 $txt['apc_cache'] = 'APC';
-$txt['eAccelerator_cache'] = 'eAccelerator';
-$txt['mmcache_cache'] = 'Turck MMCache';
 $txt['memcached_cache'] = 'Memcached';
 $txt['zend_cache'] = 'Zend Platform/Performance Suite';
 $txt['xcache_cache'] = 'XCache';

--- a/other/Settings.php
+++ b/other/Settings.php
@@ -119,7 +119,7 @@ $db_error_send = 0;
 ########## Cache Info ##########
 /**
  * Select a cache system. You want to leave this up to the cache area of the admin panel for
- * proper detection of apc, eaccelerator, memcache, mmcache, output_cache, smf, or xcache
+ * proper detection of apc, memcache, output_cache, smf, or xcache
  * (you can add more with a mod).
  * @var string
  */


### PR DESCRIPTION
...supported on current PHP releases for key/value pairs like we use.

Signed-off-by: Peter Spicer sleeping@myperch.org
