### PR TITLE
! $context['smf_languages'] always has data even if it has no items (fix...

### DIFF
--- a/Themes/default/ManageLanguages.template.php
+++ b/Themes/default/ManageLanguages.template.php
@@ -459,7 +459,7 @@ function template_add_language()
 		';
 
 	// Had some results?
-	if (!empty($context['smf_languages']))
+	if (!empty($context['smf_languages']['rows']))
 	{
 		echo '
 			<div class="information">', $txt['add_language_smf_found'], '</div>';


### PR DESCRIPTION
...es #955)

Signed-off-by: Michael Eshom oldiesmann@oldiesmann.us
