### PR TITLE
! Don't disable the WYSIWYG editor in IE11

### DIFF
--- a/Themes/default/GenericControls.template.php
+++ b/Themes/default/GenericControls.template.php
@@ -111,7 +111,7 @@ function template_control_richedit($editor_id, $smileyContainer = null, $bbcCont
 				$(".sceditor-container").width("100%").height("100%");',
 				$editor_context['rich_active'] ? '' : '
 				$("#' . $editor_id . '").data("sceditor").setTextMode();', '
-				if (!(is_ie || is_ff || is_opera || is_safari || is_chrome))
+				if (!(is_ie || is_ie11 || is_ff || is_opera || is_safari || is_chrome))
 				{
 					$("#' . $editor_id . '").data("sceditor").setTextMode();
 					$(".sceditor-button-source").hide();

--- a/Themes/default/scripts/script.js
+++ b/Themes/default/scripts/script.js
@@ -14,6 +14,8 @@ var is_safari = ua.indexOf('applewebkit') != -1 && !is_chrome;
 var is_webkit = ua.indexOf('applewebkit') != -1;
 
 var is_ie = ua.indexOf('msie') != -1 && !is_opera;
+// Stupid Microsoft...
+var is_ie11 = ua.indexOf('trident') != -1 && ua.indexOf('gecko') != -1;
 var is_iphone = ua.indexOf('iphone') != -1 || ua.indexOf('ipod') != -1;
 var is_android = ua.indexOf('android') != -1;
 


### PR DESCRIPTION
This is the only obvious place where explicit IE11 detection is needed, at least for now. Note that this change also doesn't stop IE from being identified as Gecko because that doesn't seem to break anything. Detection for IE11 will be added to the browser detection class in the near future.

Signed-off-by: Michael Eshom oldiesmann@oldiesmann.us
