### PR TITLE
! A couple more changes for IE11

### DIFF
--- a/Sources/Class-BrowserDetect.php
+++ b/Sources/Class-BrowserDetect.php
@@ -72,6 +72,9 @@ class browser_detector
 		// Just a few mobile checks
 		$this->isOperaMini();
 		$this->isOperaMobi();
+		
+		// IE11 seems to be fine by itself without being lumped into the "is_ie" category
+		$this->isIe11();
 
 		// Be you robot or human?
 		if ($user_info['possibly_robot'])
@@ -118,6 +121,19 @@ class browser_detector
 			$this->_browsers['is_ie'] = !$this->isOpera() && !$this->isGecko() && !$this->isWebTv() && preg_match('~MSIE \d+~', $_SERVER['HTTP_USER_AGENT']) === 1;
 		return $this->_browsers['is_ie'];
 	}
+	
+	/**
+	* Determine if the browser is IE11 or not
+	* @return boolean true if the browser is IE11 otherwise false
+	*/
+	function isIe11()
+	{
+		// IE11 is a bit different than earlier versions
+		// The isGecko() part is to ensure we get this right...
+		if (!isset($this->_browsers['is_ie11']))
+			$this->_browsers['is_ie11'] = strpos($_SERVER['HTTP_USER_AGENT'], 'Trident') !== false && $this->isGecko();
+		return $this->_browsers['is_ie11'];
+ 	}
 
 	/**
 	* Determine if the browser is a Webkit based one or not
@@ -257,7 +273,7 @@ class browser_detector
 			$this->_browsers['is_ie' . $msie_match[1]] = true;
 		}
 
-		// "modern" ie uses trident 4=ie8, 5=ie9, 6=ie10, even in compatability view
+		// "modern" ie uses trident 4=ie8, 5=ie9, 6=ie10, 7=ie11 even in compatability view
 		if (preg_match('~Trident/([0-9.])~i', $_SERVER['HTTP_USER_AGENT'], $trident_match) === 1)
 		{
 			$this->_browsers['is_ie' . ((int) $trident_match[1] + 4)] = true;
@@ -341,6 +357,7 @@ class browser_detector
 				'is_ie8' => 'ie8',
 				'is_ie9' => 'ie9',
 				'is_ie10' => 'ie10',
+				'is_ie11' => 'ie11',
 				'is_ie' => 'ie',
 				'is_firefox' => 'firefox',
 				'is_chrome' => 'chrome',

--- a/Themes/default/Register.template.php
+++ b/Themes/default/Register.template.php
@@ -479,7 +479,7 @@ function template_verification_sound()
 	</head>
 	<body style="margin: 1ex;">
 		<div class="windowbg description" style="text-align: center;">';
-	if (isBrowser('is_ie'))
+	if (isBrowser('is_ie') || isBrowser('is_ie11'))
 		echo '
 			<object classid="clsid:22D6F312-B0F6-11D0-94AB-0080C74C7E95" type="audio/x-wav">
 				<param name="AutoStart" value="1" />
@@ -490,6 +490,7 @@ function template_verification_sound()
 			<object type="audio/x-wav" data="', $context['verification_sound_href'], '">
 				<a href="', $context['verification_sound_href'], '" rel="nofollow">', $context['verification_sound_href'], '</a>
 			</object>';
+
 	echo '
 		<br />
 		<a href="', $context['verification_sound_href'], ';sound" rel="nofollow">', $txt['visual_verification_sound_again'], '</a><br />


### PR DESCRIPTION
This adds support for detecting IE11 (based on both Gecko and Trident being in the user agent, which seems to be the best method for now) and also fixes the "listen to the letters" feature in IE11.

Note that IE11 is currently singled out - isBrowser('is_ie') will return false for IE11. SMF uses isBrowser('is_ie') in three spots, and only one of those situations applies to IE11 as well (at least from what I can tell). Easier to modify one line of code for IE11 support than to modify two lines of code to exclude IE11 :wink:

Signed-off-by: Michael Eshom oldiesmann@oldiesmann.us
