### PR TITLE
.ignoreboards width fix

### DIFF
--- a/Themes/default/css/index.css
+++ b/Themes/default/css/index.css
@@ -3292,7 +3292,7 @@ img.centericon {
 .ignoreboards {
 	margin: 0 2%;
 	padding: 0;
-	width: 90%;
+	width: 45%;
 }
 .ignoreboards a {
 	font-weight: bold;


### PR DESCRIPTION
Boards on Ignore Boards Options page should be in 2 columns (.floatleft
and .floatright), but due to 90% width  that was not possible.

Signed-off-by: Hristo- Hristo-@users.noreply.github.com
