### PR TITLE
! Default who's online to members instead of 'everyone'. Of course the o...

### DIFF
--- a/Sources/Who.php
+++ b/Sources/Who.php
@@ -116,7 +116,7 @@ function Who()
 		$conditions[] = $show_methods[$_SESSION['who_online_filter']];
 	}
 	else
-		$context['show_by'] = $_SESSION['who_online_filter'] = 'all';
+		$context['show_by'] = $_SESSION['who_online_filter'] = 'members';
 
 	// Get the total amount of members online.
 	$request = $smcFunc['db_query']('', '


### PR DESCRIPTION
...ther options haven't gone away, but the new default is marginally more sane.

Signed-off-by: Peter Spicer sleeping@myperch.org
