### PR TITLE
Fix for the "New" icon on the message index

### DIFF
--- a/Themes/default/Display.template.php
+++ b/Themes/default/Display.template.php
@@ -701,7 +701,7 @@ function template_main()
 	echo '
 			<div class="pagesection">
 				', template_button_strip($context['normal_buttons'], 'right'), '
-				', !empty($modSettings['topbottomEnable']) ? $context['menu_separator'] . '<a href="#top" class="topbottom floatleft">' . $txt['go_up'] . '</a>' : '', '
+				', !empty($modSettings['topbottomEnable']) ? $context['menu_separator'] . '<a href="#main_content_section" class="topbottom floatleft">' . $txt['go_up'] . '</a>' : '', '
 				<div class="pagelinks floatleft">
 					', $context['page_index'], '
 				</div>

--- a/Themes/default/MessageIndex.template.php
+++ b/Themes/default/MessageIndex.template.php
@@ -254,9 +254,8 @@ function template_main()
 								<span class="preview', $topic['is_sticky'] ? ' bold_text' : '', '" title="', $topic[(empty($settings['message_index_preview_first']) ? 'last_post' : 'first_post')]['preview'], '">
 									<span id="msg_', $topic['first_post']['id'], '">', $topic['first_post']['link'], ($context['can_approve_posts'] && !$topic['approved'] ? '&nbsp;<em>(' . $txt['awaiting_approval'] . ')</em>' : ''), '</span>
 								</span>
-								<br class="clear" />
+							', $topic['new'] && $context['user']['is_logged'] ? '<a href="' . $topic['new_href'] . '" id="newicon' . $topic['first_post']['id'] . '" style="display: inline-block; margin: 7px 0 5px 3px;"><span class="new_posts">' . $txt['new'] . '</span></a>' : '', '
 							</div>
-							', $topic['new'] && $context['user']['is_logged'] ? '<a href="' . $topic['new_href'] . '" class="floatleft" id="newicon' . $topic['first_post']['id'] . '" style="display: block; margin: 9px 0 0 3px;"><span class="new_posts">' . $txt['new'] . '</span></a>' : '', '
 							<br class="clear" />
 							<p class="floatleft">', $txt['started_by'], ' ', $topic['first_post']['member']['link'], '
 								<small id="pages', $topic['first_post']['id'], '">', $topic['pages'], '</small>

--- a/Themes/default/MessageIndex.template.php
+++ b/Themes/default/MessageIndex.template.php
@@ -347,7 +347,7 @@ function template_main()
 		echo '
 	<div class="pagesection">
 		', template_button_strip($context['normal_buttons'], 'right'), '
-		', !empty($modSettings['topbottomEnable']) ? $context['menu_separator'] . '<a href="#top" class="topbottom floatleft">' . $txt['go_up'] . '</a>' : '', '
+		', !empty($modSettings['topbottomEnable']) ? $context['menu_separator'] . '<a href="#main_content_section" class="topbottom floatleft">' . $txt['go_up'] . '</a>' : '', '
 		<div class="pagelinks">', $context['page_index'], '</div>
 	</div>';
 	}

--- a/Themes/default/Recent.template.php
+++ b/Themes/default/Recent.template.php
@@ -213,7 +213,7 @@ function template_unread()
 			template_button_strip($context['recent_buttons'], 'right');
 
 		echo '
-				<div class="pagelinks floatleft">', $context['page_index'], !empty($modSettings['topbottomEnable']) ? $context['menu_separator'] . ' &nbsp;&nbsp;<a href="#top"><strong>' . $txt['go_up'] . '</strong></a>' : '', '</div>
+				<div class="pagelinks floatleft">', $context['page_index'], !empty($modSettings['topbottomEnable']) ? $context['menu_separator'] . ' &nbsp;&nbsp;<a href="#main_content_section"><strong>' . $txt['go_up'] . '</strong></a>' : '', '</div>
 			</div>';
 	}
 	else
@@ -377,7 +377,7 @@ function template_replies()
 			template_button_strip($context['recent_buttons'], 'right');
 
 		echo '
-				<div class="pagelinks floatleft">', $context['page_index'], !empty($modSettings['topbottomEnable']) ? $context['menu_separator'] . ' &nbsp;&nbsp;<a href="#top"><strong>' . $txt['go_up'] . '</strong></a>' : '', '</div>
+				<div class="pagelinks floatleft">', $context['page_index'], !empty($modSettings['topbottomEnable']) ? $context['menu_separator'] . ' &nbsp;&nbsp;<a href="#main_content_section"><strong>' . $txt['go_up'] . '</strong></a>' : '', '</div>
  			</div>';
 	}
 	else

--- a/Themes/default/css/index.css
+++ b/Themes/default/css/index.css
@@ -2002,10 +2002,6 @@ td#quick_actions {
 	padding: 4px 6px 2px 6px;
 }
 
-.message_index_title {
-	margin-bottom: -3px;
-}
-
 /* Styles for the display template (topic view).
 ---------------------------------------------------- */
 /* Events */

--- a/Themes/default/index.template.php
+++ b/Themes/default/index.template.php
@@ -369,7 +369,7 @@ function template_body_below()
 
 	// There is now a global "Go to top" link at the right.
 		echo '
-			<a href="#top" id="bot" class="go_up">', $txt['go_up'], '</a>
+			<a href="#top_section" id="bot" class="go_up">', $txt['go_up'], '</a>
 			<ul class="reset">
 				<li class="copyright">', theme_copyright(), '</li>
 			</ul>';


### PR DESCRIPTION
I already hate Git and GitHub! Will try again.

After I made all the changes noticed the section is under todo - [WIP], but well here it is:

![ff25before](https://f.cloud.github.com/assets/6107569/1711300/183f2638-614a-11e3-8157-bbee104ba08f.png)
![ff25after](https://f.cloud.github.com/assets/6107569/1711302/2270d1c4-614a-11e3-9d79-877e7084683c.png)
![chrome31before](https://f.cloud.github.com/assets/6107569/1711303/268f8a48-614a-11e3-93c0-bc12ff26f202.png)
![chrome31after](https://f.cloud.github.com/assets/6107569/1711304/2a746746-614a-11e3-9ee8-60fee20575a0.png)
![opera12 15before](https://f.cloud.github.com/assets/6107569/1711380/db489db0-614c-11e3-8039-39ee38fb3126.png)
![opera12 15after](https://f.cloud.github.com/assets/6107569/1711381/de0cbf2c-614c-11e3-9ad9-4aa6935ba8c2.png)
![opera18before](https://f.cloud.github.com/assets/6107569/1711309/464cdf3e-614a-11e3-9f8b-5d81ed93bb66.png)
![opera18after](https://f.cloud.github.com/assets/6107569/1711310/48a697c0-614a-11e3-907c-e27fc2401c1a.png)
![ie8before](https://f.cloud.github.com/assets/6107569/1711313/4e8d537c-614a-11e3-9c10-f82b4785e0d5.png)
![ie8after](https://f.cloud.github.com/assets/6107569/1711314/5093fcf2-614a-11e3-90b0-b33dd7b806e5.png)

Signed-off-by: Hristo- Hristo-@users.noreply.github.com
