### PR TITLE
! This should force all outgoing email (currently at least!) to have a M...

### DIFF
--- a/Sources/Groups.php
+++ b/Sources/Groups.php
@@ -604,7 +604,7 @@ function GroupRequests()
 
 						$emaildata = loadEmailTemplate('mc_group_approve', $replacements, $email['language']);
 
-						sendmail($email['email'], $emaildata['subject'], $emaildata['body'], null, null, false, 2);
+						sendmail($email['email'], $emaildata['subject'], $emaildata['body'], null, 'grpapp' . $email['rid'], false, 2);
 					}
 				}
 				// Otherwise, they are getting rejected (With or without a reason).
@@ -626,7 +626,7 @@ function GroupRequests()
 
 						$emaildata = loadEmailTemplate(empty($custom_reason) ? 'mc_group_reject' : 'mc_group_reject_reason', $replacements, $email['language']);
 
-						sendmail($email['email'], $emaildata['subject'], $emaildata['body'], null, null, false, 2);
+						sendmail($email['email'], $emaildata['subject'], $emaildata['body'], null, 'grprej' . $email['rid'], false, 2);
 					}
 				}
 			}

--- a/Sources/ManageMembers.php
+++ b/Sources/ManageMembers.php
@@ -1137,7 +1137,7 @@ function AdminApprove()
 				);
 
 				$emaildata = loadEmailTemplate('admin_approve_accept', $replacements, $member['language']);
-				sendmail($member['email'], $emaildata['subject'], $emaildata['body'], null, null, false, 0);
+				sendmail($member['email'], $emaildata['subject'], $emaildata['body'], null, 'accapp' . $member['id'], false, 0);
 			}
 		}
 	}
@@ -1177,7 +1177,7 @@ function AdminApprove()
 			);
 
 			$emaildata = loadEmailTemplate('admin_approve_activation', $replacements, $member['language']);
-			sendmail($member['email'], $emaildata['subject'], $emaildata['body'], null, null, false, 0);
+			sendmail($member['email'], $emaildata['subject'], $emaildata['body'], null, 'accact' . $member['id'], false, 0);
 		}
 	}
 	// Are we rejecting them?
@@ -1196,7 +1196,7 @@ function AdminApprove()
 				);
 
 				$emaildata = loadEmailTemplate('admin_approve_reject', $replacements, $member['language']);
-				sendmail($member['email'], $emaildata['subject'], $emaildata['body'], null, null, false, 1);
+				sendmail($member['email'], $emaildata['subject'], $emaildata['body'], null, 'accrej', false, 1);
 			}
 		}
 	}
@@ -1216,7 +1216,7 @@ function AdminApprove()
 				);
 
 				$emaildata = loadEmailTemplate('admin_approve_delete', $replacements, $member['language']);
-				sendmail($member['email'], $emaildata['subject'], $emaildata['body'], null, null, false, 1);
+				sendmail($member['email'], $emaildata['subject'], $emaildata['body'], null, 'accdel', false, 1);
 			}
 		}
 	}
@@ -1233,7 +1233,7 @@ function AdminApprove()
 			);
 
 			$emaildata = loadEmailTemplate('admin_approve_remind', $replacements, $member['language']);
-			sendmail($member['email'], $emaildata['subject'], $emaildata['body'], null, null, false, 1);
+			sendmail($member['email'], $emaildata['subject'], $emaildata['body'], null, 'accrem' . $member['id'], false, 1);
 		}
 	}
 

--- a/Sources/ManageNews.php
+++ b/Sources/ManageNews.php
@@ -898,7 +898,7 @@ function SendMailing($clean_only = false)
 			$email
 		);
 
-		sendmail($email, str_replace($from_member, $to_member, $_POST['subject']), str_replace($from_member, $to_member, $_POST['message']), null, null, !empty($_POST['send_html']), 5);
+		sendmail($email, str_replace($from_member, $to_member, $_POST['subject']), str_replace($from_member, $to_member, $_POST['message']), null, 'news', !empty($_POST['send_html']), 5);
 
 		// Done another...
 		$i++;
@@ -1005,7 +1005,7 @@ function SendMailing($clean_only = false)
 
 			// Send the actual email - or a PM!
 			if (!$context['send_pm'])
-				sendmail($row['email_address'], $subject, $message, null, null, !empty($_POST['send_html']), 5);
+				sendmail($row['email_address'], $subject, $message, null, 'news', !empty($_POST['send_html']), 5);
 			else
 				sendpm(array('to' => array($row['id_member']), 'bcc' => array()), $subject, $message);
 		}

--- a/Sources/Post.php
+++ b/Sources/Post.php
@@ -2289,7 +2289,7 @@ function AnnouncementSend()
 
 	// For each language send a different mail - low priority...
 	foreach ($announcements as $lang => $mail)
-		sendmail($mail['recipients'], $mail['subject'], $mail['body'], null, null, false, 5);
+		sendmail($mail['recipients'], $mail['subject'], $mail['body'], null, 'ann-' . $lang, false, 5);
 
 	$context['percentage_done'] = round(100 * $context['start'] / $modSettings['latestMember'], 1);
 
@@ -2437,7 +2437,7 @@ function notifyMembersBoard(&$topicData)
 			{
 				$emailtype .= $send_body ? '_body' : '';
 				$emaildata = loadEmailTemplate($emailtype, $replacements, $langloaded);
-				sendmail($rowmember['email_address'], $emaildata['subject'], $emaildata['body'], null, null, false, 3);
+				sendmail($rowmember['email_address'], $emaildata['subject'], $emaildata['body'], null, 'notbrd', false, 3);
 			}
 
 			$sentOnceAlready = 1;

--- a/Sources/Profile-Modify.php
+++ b/Sources/Profile-Modify.php
@@ -3424,7 +3424,7 @@ function profileSendActivation()
 
 	// Send off the email.
 	$emaildata = loadEmailTemplate('activate_reactivate', $replacements, empty($cur_profile['lngfile']) || empty($modSettings['userLanguage']) ? $language : $cur_profile['lngfile']);
-	sendmail($profile_vars['email_address'], $emaildata['subject'], $emaildata['body'], null, null, false, 0);
+	sendmail($profile_vars['email_address'], $emaildata['subject'], $emaildata['body'], null, 'reactivate', false, 0);
 
 	// Log the user out.
 	$smcFunc['db_query']('', '

--- a/Sources/Register.php
+++ b/Sources/Register.php
@@ -655,7 +655,7 @@ function Activate()
 
 		$emaildata = loadEmailTemplate('resend_activate_message', $replacements, empty($row['lngfile']) || empty($modSettings['userLanguage']) ? $language : $row['lngfile']);
 
-		sendmail($row['email_address'], $emaildata['subject'], $emaildata['body'], null, null, false, 0);
+		sendmail($row['email_address'], $emaildata['subject'], $emaildata['body'], null, 'resendact', false, 0);
 
 		$context['page_title'] = $txt['invalid_activation_resend'];
 

--- a/Sources/Reminder.php
+++ b/Sources/Reminder.php
@@ -144,7 +144,7 @@ function RemindPick()
 		$context['description'] = $txt['reminder_' . (!empty($row['openid_uri']) ? 'openid_' : '') . 'sent'];
 
 		// If they were using OpenID simply email them their OpenID identity.
-		sendmail($row['email_address'], $emaildata['subject'], $emaildata['body'], null, null, false, 1);
+		sendmail($row['email_address'], $emaildata['subject'], $emaildata['body'], null, 'reminder', false, 1);
 		if (empty($row['openid_uri']))
 			// Set the password in the database.
 			updateMemberData($row['id_member'], array('validation_code' => substr(md5($password), 0, 10)));

--- a/Sources/ScheduledTasks.php
+++ b/Sources/ScheduledTasks.php
@@ -348,7 +348,7 @@ function scheduled_approval_notification()
 		$emaildata = loadEmailTemplate('scheduled_approval', $replacements, $current_language);
 
 		// Send the actual email.
-		sendmail($member['email'], $emaildata['subject'], $emaildata['body'], null, null, false, 2);
+		sendmail($member['email'], $emaildata['subject'], $emaildata['body'], null, 'schedapp', false, 2);
 	}
 
 	// All went well!
@@ -769,7 +769,7 @@ function scheduled_daily_digest()
 		$email['body'] .= "\n\n" . $txt['regards_team'];
 
 		// Send it - low priority!
-		sendmail($email['email'], $email['subject'], $email['body'], null, null, false, 4);
+		sendmail($email['email'], $email['subject'], $email['body'], null, 'digest', false, 4);
 	}
 
 	// Clean up...
@@ -1375,7 +1375,7 @@ function scheduled_birthdayemails()
 
 			$emaildata = loadEmailTemplate('happy_birthday', $replacements, $lang, false);
 
-			sendmail($recp['email'], $emaildata['subject'], $emaildata['body'], null, null, false, 4);
+			sendmail($recp['email'], $emaildata['subject'], $emaildata['body'], null, 'birthday', false, 4);
 
 			// Try to stop a timeout, this would be bad...
 			@set_time_limit(300);
@@ -1646,7 +1646,7 @@ function scheduled_paid_subscriptions()
 		$emaildata = loadEmailTemplate('paid_subscription_reminder', $replacements, empty($row['lngfile']) || empty($modSettings['userLanguage']) ? $language : $row['lngfile']);
 
 		// Send the actual email.
-		sendmail($row['email_address'], $emaildata['subject'], $emaildata['body'], null, null, false, 2);
+		sendmail($row['email_address'], $emaildata['subject'], $emaildata['body'], null, 'paid_sub_remind', false, 2);
 	}
 	$smcFunc['db_free_result']($request);
 

--- a/Sources/SendTopic.php
+++ b/Sources/SendTopic.php
@@ -136,7 +136,7 @@ function SendTopic()
 
 	$emaildata = loadEmailTemplate($emailtemplate, $replacements);
 	// And off we go!
-	sendmail($_POST['r_email'], $emaildata['subject'], $emaildata['body'], $_POST['y_email']);
+	sendmail($_POST['r_email'], $emaildata['subject'], $emaildata['body'], $_POST['y_email'], 'sendtopic');
 
 	// Back to the topic!
 	redirectexit('topic=' . $topic . '.0;topicsent');
@@ -258,7 +258,7 @@ function CustomEmail()
 
 		// Get the template and get out!
 		$emaildata = loadEmailTemplate('send_email', $replacements);
-		sendmail($context['recipient']['email'], $emaildata['subject'], $emaildata['body'], $from_email, null, false, 1, null, true);
+		sendmail($context['recipient']['email'], $emaildata['subject'], $emaildata['body'], $from_email, 'custemail', false, 1, null, true);
 
 		// Now work out where to go!
 		if (isset($_REQUEST['uid']))

--- a/Sources/Subs-Admin.php
+++ b/Sources/Subs-Admin.php
@@ -506,7 +506,7 @@ function emailAdmins($template, $replacements = array(), $additional_recipients 
 		$emaildata = loadEmailTemplate($template, $replacements, empty($row['lngfile']) || empty($modSettings['userLanguage']) ? $language : $row['lngfile']);
 
 		// Then send the actual email.
-		sendmail($row['email_address'], $emaildata['subject'], $emaildata['body'], null, null, false, 1);
+		sendmail($row['email_address'], $emaildata['subject'], $emaildata['body'], null, $template, false, 1);
 
 		// Track who we emailed so we don't do it twice.
 		$emails_sent[] = $row['email_address'];
@@ -528,7 +528,7 @@ function emailAdmins($template, $replacements = array(), $additional_recipients 
 			$emaildata = loadEmailTemplate($template, $replacements, empty($recipient['lang']) || empty($modSettings['userLanguage']) ? $language : $recipient['lang']);
 
 			// Send off the email.
-			sendmail($recipient['email'], $emaildata['subject'], $emaildata['body'], null, null, false, 1);
+			sendmail($recipient['email'], $emaildata['subject'], $emaildata['body'], null, $template, false, 1);
 		}
 }
 

--- a/Sources/Subs-Auth.php
+++ b/Sources/Subs-Auth.php
@@ -587,7 +587,7 @@ function resetPassword($memID, $username = null)
 	$emaildata = loadEmailTemplate('change_password', $replacements, empty($lngfile) || empty($modSettings['userLanguage']) ? $language : $lngfile);
 
 	// Send them the email informing them of the change - then we're done!
-	sendmail($email, $emaildata['subject'], $emaildata['body'], null, null, false, 0);
+	sendmail($email, $emaildata['subject'], $emaildata['body'], null, 'chgpass' . $memID, false, 0);
 }
 
 /**

--- a/Sources/Subs-Db-mysql.php
+++ b/Sources/Subs-Db-mysql.php
@@ -555,7 +555,7 @@ function smf_db_error($db_string, $connection = null)
 					REPAIR TABLE $table", false, false);
 
 			// And send off an email!
-			sendmail($webmaster_email, $txt['database_error'], $txt['tried_to_repair']);
+			sendmail($webmaster_email, $txt['database_error'], $txt['tried_to_repair'], null, 'dberror');
 
 			$modSettings['cache_enable'] = $old_cache;
 

--- a/Sources/Subs-Db-mysqli.php
+++ b/Sources/Subs-Db-mysqli.php
@@ -605,7 +605,7 @@ function smf_db_error($db_string, $connection = null)
 					REPAIR TABLE $table", false, false);
 
 			// And send off an email!
-			sendmail($webmaster_email, $txt['database_error'], $txt['tried_to_repair']);
+			sendmail($webmaster_email, $txt['database_error'], $txt['tried_to_repair'], null, 'dberror');
 
 			$modSettings['cache_enable'] = $old_cache;
 

--- a/Sources/Subs-Members.php
+++ b/Sources/Subs-Members.php
@@ -786,7 +786,7 @@ function registerMember(&$regOptions, $return_errors = false)
 
 			$emaildata = loadEmailTemplate($email_message, $replacements);
 
-			sendmail($regOptions['email'], $emaildata['subject'], $emaildata['body'], null, null, false, 0);
+			sendmail($regOptions['email'], $emaildata['subject'], $emaildata['body'], null, $email_message . $memberID, false, 0);
 		}
 
 		// All admins are finished here.
@@ -806,7 +806,7 @@ function registerMember(&$regOptions, $return_errors = false)
 				'OPENID' => !empty($regOptions['openid']) ? $regOptions['openid'] : '',
 			);
 			$emaildata = loadEmailTemplate('register_' . ($regOptions['auth_method'] == 'openid' ? 'openid_' : '') . 'immediate', $replacements);
-			sendmail($regOptions['email'], $emaildata['subject'], $emaildata['body'], null, null, false, 0);
+			sendmail($regOptions['email'], $emaildata['subject'], $emaildata['body'], null, 'register', false, 0);
 		}
 
 		// Send admin their notification.
@@ -836,7 +836,7 @@ function registerMember(&$regOptions, $return_errors = false)
 
 		$emaildata = loadEmailTemplate('register_' . ($regOptions['auth_method'] == 'openid' ? 'openid_' : '') . ($regOptions['require'] == 'activation' ? 'activate' : 'coppa'), $replacements);
 
-		sendmail($regOptions['email'], $emaildata['subject'], $emaildata['body'], null, null, false, 0);
+		sendmail($regOptions['email'], $emaildata['subject'], $emaildata['body'], null, 'reg_' . $regOptions['require'] . $memberID, false, 0);
 	}
 	// Must be awaiting approval.
 	else
@@ -851,7 +851,7 @@ function registerMember(&$regOptions, $return_errors = false)
 
 		$emaildata = loadEmailTemplate('register_' . ($regOptions['auth_method'] == 'openid' ? 'openid_' : '') . 'pending', $replacements);
 
-		sendmail($regOptions['email'], $emaildata['subject'], $emaildata['body'], null, null, false, 0);
+		sendmail($regOptions['email'], $emaildata['subject'], $emaildata['body'], null, 'reg_pending', false, 0);
 
 		// Admin gets informed here...
 		adminNotify('approval', $memberID, $regOptions['username']);

--- a/Sources/tasks/GroupReq-Notify.php
+++ b/Sources/tasks/GroupReq-Notify.php
@@ -113,7 +113,7 @@ class GroupReq_Notify_Background extends SMF_BackgroundTask
 					);
 
 					$emaildata = loadEmailTemplate('request_membership', $replacements, empty($row['lngfile']) || empty($modSettings['userLanguage']) ? $language : $row['lngfile']);
-					sendmail($row['email_address'], $emaildata['subject'], $emaildata['body'], null, null, false, 2);
+					sendmail($row['email_address'], $emaildata['subject'], $emaildata['body'], null, 'groupreq' . $this->_details['id_group'], false, 2);
 				}
 			}
 		}

--- a/Sources/tasks/MsgReport-Notify.php
+++ b/Sources/tasks/MsgReport-Notify.php
@@ -171,7 +171,7 @@ class MsgReport_Notify_Background extends SMF_BackgroundTask
 
 				// And do the actual sending...
 				foreach ($recipients as $id_member => $email_address)
-					sendmail($email_address, $emaildata['subject'], $emaildata['body'], null, null, false, 2);
+					sendmail($email_address, $emaildata['subject'], $emaildata['body'], null, 'report' . $this->_details['report_id'], false, 2);
 			}
 		}
 

--- a/Sources/tasks/MsgReportReply-Notify.php
+++ b/Sources/tasks/MsgReportReply-Notify.php
@@ -201,7 +201,7 @@ class MsgReportReply_Notify_Background extends SMF_BackgroundTask
 
 				// And do the actual sending...
 				foreach ($recipients as $id_member => $email_address)
-					sendmail($email_address, $emaildata['subject'], $emaildata['body'], null, null, false, 3);
+					sendmail($email_address, $emaildata['subject'], $emaildata['body'], null, 'rptrpy' . $this->_details['comment_id'], false, 3);
 			}
 		}
 

--- a/Sources/tasks/Register-Notify.php
+++ b/Sources/tasks/Register-Notify.php
@@ -120,7 +120,7 @@ class Register_Notify_Background extends SMF_BackgroundTask
 
 				// And do the actual sending...
 				foreach ($recipients as $id_member => $email_address)
-					sendmail($email_address, $emaildata['subject'], $emaildata['body'], null, null, false, 0);
+					sendmail($email_address, $emaildata['subject'], $emaildata['body'], null, 'newmember' . $this->_details['new_member_id'], false, 0);
 			}
 		}
 


### PR DESCRIPTION
...essage-ID. Failure to supply a message id can cause emails to be dropped as spam. sendmail itself attempts to guarantee uniqueness with a hash of microtime, but wherever feasible I've also tried to make the id both meaningful and give it something that should uniquify it. Things like newsletters, though, can't really be uniquified at sending level, so we'll just use microtime to deal with that for us.

Signed-off-by: Peter Spicer sleeping@myperch.org
