### PR TITLE
Calendar - Min/Max Year Fix (#1249)

### DIFF
--- a/Sources/Calendar.php
+++ b/Sources/Calendar.php
@@ -150,9 +150,11 @@ function CalendarMain()
 
 	// Load up the previous and next months.
 	$context['calendar_grid_current'] = getCalendarGrid($curPage['month'], $curPage['year'], $calendarOptions);
+
 	// Only show previous month if it isn't pre-January of the min-year
 	if ($context['calendar_grid_current']['previous_calendar']['year'] > $modSettings['cal_minyear'] || $curPage['month'] != 1)
 		$context['calendar_grid_prev'] = getCalendarGrid($context['calendar_grid_current']['previous_calendar']['month'], $context['calendar_grid_current']['previous_calendar']['year'], $calendarOptions, true);
+
 	// Only show next month if it isn't post-December of the max-year
 	if ($context['calendar_grid_current']['next_calendar']['year'] < $modSettings['cal_maxyear'] || $curPage['month'] != 12)
 		$context['calendar_grid_next'] = getCalendarGrid($context['calendar_grid_current']['next_calendar']['month'], $context['calendar_grid_current']['next_calendar']['year'], $calendarOptions);

--- a/Themes/default/Calendar.template.php
+++ b/Themes/default/Calendar.template.php
@@ -282,9 +282,9 @@ function template_show_month_grid($grid_name, $is_mini = false)
 			// Otherwise, assuming it's not a mini-calendar, we can show previous / next month days!
 			elseif ($is_mini === false)
 			{
-				if ($current_month_started === false && !empty($context['calendar_grid_prev']))
+				if (empty($current_month_started) && !empty($context['calendar_grid_prev']))
 					echo '<a href="', $scripturl, '?action=calendar;year=', $context['calendar_grid_prev']['current_year'], ';month=', $context['calendar_grid_prev']['current_month'], '">', $context['calendar_grid_prev']['last_of_month'] - $calendar_data['shift']-- + 1, '</a>';
-				elseif (!empty($context['calendar_grid_next']))
+				elseif (!empty($current_month_started) && !empty($context['calendar_grid_next']))
 					echo '<a href="', $scripturl, '?action=calendar;year=', $context['calendar_grid_next']['current_year'], ';month=', $context['calendar_grid_next']['current_month'], '">', $current_month_started + 1 == $count ? (!empty($calendar_data['short_month_titles']) ? $txt['months_short'][$context['calendar_grid_next']['current_month']] . ' ' : $txt['months_titles'][$context['calendar_grid_next']['current_month']] . ' ') : '', $final_count++, '</a>';
 			}
 


### PR DESCRIPTION
- $current_month_started now is conditioned with empty() rather than
  === since it's only a bool if not set; otherwise it's set to $count, so
  an integer. (Maybe this should be a bool then realistically?)
- Added proper condition to elseif statement.

When the code was originally written, line 287 used to be an else, not
an elseif. If the current month hadn't started, it was still the
previous month in that week. Otherwise, if the current month HAD
started and the loop had finished the days, but there were slots left
in the grid, it would feed the next few days from the NEXT month.

When the condition was updated to fix the undefined errors that I so
foolishly overlooked, the condition was not fully understood. It was
changed to: "IF the current month isn't started and there's a previous
grid THEN show the previous days OR if there is a next month grid THEN
show it.

The gap in this logic is that if there is a next grid, it should only
be shown AFTER the main grid loop is completed - which is where NOW the
additional condition comes in and is much necessary
(!empty($current_month_started)).

Which is why for instance if you were on January 2008 (default minimum)
it would show "February 1, 2" ahead of January, because "February 1, 2"
are the first elements of calendar_grid_next.

This fixes #1249.

Signed-Off: Matthew P. Kerle / Labradoodle-360
(creativewebdsign@gmail.com)
