### PR TITLE
! This tinyint actually needs to be an int. Because this is a new-to-2.1...

### DIFF
--- a/other/install_2-1_mysql.sql
+++ b/other/install_2-1_mysql.sql
@@ -2108,7 +2108,7 @@ CREATE TABLE {$db_prefix}user_alerts (
   content_type varchar(255) NOT NULL default '',
   content_id int(10) unsigned NOT NULL default '0',
   content_action varchar(255) NOT NULL default '',
-  is_read tinyint(3) unsigned NOT NULL default '0',
+  is_read int(10) unsigned NOT NULL default '0',
   extra text NOT NULL,
   PRIMARY KEY (id_alert),
   KEY id_member (id_member),

--- a/other/install_2-1_postgresql.sql
+++ b/other/install_2-1_postgresql.sql
@@ -2657,7 +2657,7 @@ CREATE TABLE {$db_prefix}user_alerts (
   content_type varchar(255) NOT NULL default '',
   content_id int NOT NULL default '0',
   content_action varchar(255) NOT NULL default '',
-  is_read smallint NOT NULL default '0',
+  is_read int NOT NULL default '0',
   extra text NOT NULL,
   PRIMARY KEY (id_alert)
 );

--- a/other/install_2-1_sqlite.sql
+++ b/other/install_2-1_sqlite.sql
@@ -2265,7 +2265,7 @@ CREATE TABLE {$db_prefix}user_alerts (
   content_type varchar(255) NOT NULL default '',
   content_id int unsigned NOT NULL default '0',
   content_action varchar(255) NOT NULL default '',
-  is_read smallint unsigned NOT NULL default '0',
+  is_read int unsigned NOT NULL default '0',
   extra text NOT NULL,
   PRIMARY KEY (id_alert)
 );

--- a/other/install_2-1_sqlite3.sql
+++ b/other/install_2-1_sqlite3.sql
@@ -2266,7 +2266,7 @@ CREATE TABLE {$db_prefix}user_alerts (
   content_type varchar(255) NOT NULL default '',
   content_id int unsigned NOT NULL default '0',
   content_action varchar(255) NOT NULL default '',
-  is_read smallint unsigned NOT NULL default '0',
+  is_read int unsigned NOT NULL default '0',
   extra text NOT NULL,
   PRIMARY KEY (id_alert)
 );

--- a/other/upgrade_2-1_mysql.sql
+++ b/other/upgrade_2-1_mysql.sql
@@ -389,7 +389,7 @@ CREATE TABLE IF NOT EXISTS {$db_prefix}user_alerts (
   content_type varchar(255) NOT NULL default '',
   content_id int(10) unsigned NOT NULL default '0',
   content_action varchar(255) NOT NULL default '',
-  is_read tinyint(3) unsigned NOT NULL default '0',
+  is_read int(10) unsigned NOT NULL default '0',
   extra text NOT NULL,
   PRIMARY KEY (id_alert),
   KEY id_member (id_member),

--- a/other/upgrade_2-1_postgresql.sql
+++ b/other/upgrade_2-1_postgresql.sql
@@ -463,7 +463,7 @@ CREATE TABLE {$db_prefix}user_alerts (
   content_type varchar(255) NOT NULL default '',
   content_id int NOT NULL default '0',
   content_action varchar(255) NOT NULL default '',
-  is_read smallint NOT NULL default '0',
+  is_read int NOT NULL default '0',
   extra text NOT NULL,
   PRIMARY KEY (id_alert)
 );

--- a/other/upgrade_2-1_sqlite.sql
+++ b/other/upgrade_2-1_sqlite.sql
@@ -442,7 +442,7 @@ CREATE TABLE IF NOT EXISTS {$db_prefix}user_alerts (
   content_type varchar(255) NOT NULL default '',
   content_id int unsigned NOT NULL default '0',
   content_action varchar(255) NOT NULL default '',
-  is_read smallint unsigned NOT NULL default '0',
+  is_read int unsigned NOT NULL default '0',
   extra text NOT NULL,
   PRIMARY KEY (id_alert)
 );


### PR DESCRIPTION
... feature this should NOT be separately handled by the upgrader (i.e. the upgrader should NOT go out of its way to fix this). You may need to update your test installations by hand.

Signed-off-by: Peter Spicer sleeping@myperch.org
