### PR TITLE
! For attachment limits below 1MB, use KB like we always used to, for at...

### DIFF
--- a/Sources/Post.php
+++ b/Sources/Post.php
@@ -1125,12 +1125,12 @@ function Post($post_errors = array())
 		foreach ($attachmentRestrictionTypes as $type)
 			if (!empty($modSettings[$type]))
 			{
-				$context['attachment_restrictions'][] = sprintf($txt['attach_restrict_' . $type], comma_format($modSettings[$type], 0));
+				$context['attachment_restrictions'][] = sprintf($txt['attach_restrict_' . $type . ($modSettings[$type] >= 1024 ? '_MB' : '')], comma_format($modSettings[$type], 0));
 				// Show some numbers. If they exist.
 				if ($type == 'attachmentNumPerPostLimit' && $context['attachments']['quantity'] > 0)
 					$context['attachment_restrictions'][] = sprintf($txt['attach_remaining'], $modSettings['attachmentNumPerPostLimit'] - $context['attachments']['quantity']);
 				elseif ($type == 'attachmentPostLimit' && $context['attachments']['total_size'] > 0)
-					$context['attachment_restrictions'][] = sprintf($txt['attach_available'], comma_format(round(max($modSettings['attachmentPostLimit'] - ($context['attachments']['total_size'] / 1028), 0)), 0));
+					$context['attachment_restrictions'][] = sprintf($txt['attach_available'], comma_format(round(max($modSettings['attachmentPostLimit'] - ($context['attachments']['total_size'] / 1024), 0)), 0));
 			}
 	}
 

--- a/Themes/default/languages/Post.english.php
+++ b/Themes/default/languages/Post.english.php
@@ -66,7 +66,9 @@ $txt['board_moderate'] = 'on a board you moderate';
 $txt['report_comment'] = 'The reporter has made the following comment';
 
 $txt['attach_restrict_attachmentPostLimit'] = 'maximum total size %1$d KB';
+$txt['attach_restrict_attachmentPostLimit_MB'] = 'maximum total size %1$d MB';
 $txt['attach_restrict_attachmentSizeLimit'] = 'maximum individual size %1$d KB';
+$txt['attach_restrict_attachmentSizeLimit_MB'] = 'maximum individual size %1$d MB';
 $txt['attach_restrict_attachmentNumPerPostLimit'] = '%1$d per post';
 $txt['attach_restrictions'] = 'Restrictions:';
 


### PR DESCRIPTION
...tachment limits above 1MB, round to MB like we were doing but with a proper language string for it this time.

Signed-off-by: Peter Spicer sleeping@myperch.org
