### PR TITLE
HTML5 Goodies

### DIFF
--- a/Sources/ManageNews.php
+++ b/Sources/ManageNews.php
@@ -1050,7 +1050,7 @@ function ModifyNewsSettings($return_config = false)
 		'',
 			// Just the remaining settings.
 			array('check', 'xmlnews_enable', 'onclick' => 'document.getElementById(\'xmlnews_maxlen\').disabled = !this.checked;'),
-			array('text', 'xmlnews_maxlen', 'subtext' => $txt['xmlnews_maxlen_note'], 10),
+			array('number', 'xmlnews_maxlen', 'subtext' => $txt['xmlnews_maxlen_note'], 10),
 	);
 
 	call_integration_hook('integrate_modify_news_settings', array(&$config_vars));

--- a/Sources/ManagePaid.php
+++ b/Sources/ManagePaid.php
@@ -99,7 +99,7 @@ function ModifySubscriptionSettings($return_config = false)
 				array('check', 'paid_enabled'),
 			'',
 				array('select', 'paid_email', array(0 => $txt['paid_email_no'], 1 => $txt['paid_email_error'], 2 => $txt['paid_email_all']), 'subtext' => $txt['paid_email_desc']),
-				array('text', 'paid_email_to', 'subtext' => $txt['paid_email_to_desc'], 'size' => 60),
+				array('email', 'paid_email_to', 'subtext' => $txt['paid_email_to_desc'], 'size' => 60),
 			'',
 				'dummy_currency' => array('select', 'paid_currency', array('usd' => $txt['usd'], 'eur' => $txt['eur'], 'gbp' => $txt['gbp'], 'cad' => $txt['cad'], 'aud' => $txt['aud'], 'other' => $txt['other']), 'javascript' => 'onchange="toggleOther();"'),
 				array('text', 'paid_currency_code', 'subtext' => $txt['paid_currency_code_desc'], 'size' => 5, 'force_div_id' => 'custom_currency_code_div'),

--- a/Sources/ManageServer.php
+++ b/Sources/ManageServer.php
@@ -1048,7 +1048,7 @@ function saveDBSettings(&$config_vars)
 		elseif ($var[0] == 'float')
 			$setArray[$var[1]] = (float) $_POST[$var[1]];
 		// Text!
-		elseif ($var[0] == 'text' || $var[0] == 'large_text')
+		elseif ($var[0] == 'text' || in_array($var[0], array('color', 'date', 'datetime', 'datetime-local', 'email', 'month', 'number', 'time')))
 			$setArray[$var[1]] = $_POST[$var[1]];
 		// Passwords!
 		elseif ($var[0] == 'password')

--- a/Sources/Profile-Modify.php
+++ b/Sources/Profile-Modify.php
@@ -176,7 +176,7 @@ function loadProfileFields($force_reload = false)
 			'),
 		),
 		'email_address' => array(
-			'type' => 'text',
+			'type' => 'email',
 			'label' => $txt['user_email_address'],
 			'subtext' => $txt['valid_email'],
 			'log_change' => true,
@@ -654,7 +654,7 @@ function loadProfileFields($force_reload = false)
 			'link_with' => 'website',
 		),
 		'website_url' => array(
-			'type' => 'text',
+			'type' => 'url',
 			'label' => $txt['website_url'],
 			'subtext' => $txt['complete_url'],
 			'size' => 50,

--- a/Themes/default/Admin.template.php
+++ b/Themes/default/Admin.template.php
@@ -792,6 +792,9 @@ function template_show_settings()
 				$javascript = $config_var['javascript'];
 				$disabled = !empty($config_var['disabled']) ? ' disabled' : '';
 				$subtext = !empty($config_var['subtext']) ? '<br><span class="smalltext"> ' . $config_var['subtext'] . '</span>' : '';
+				
+				// Various HTML5 input types that are basically enhanced textboxes
+				$text_types = array('color', 'date', 'datetime', 'datetime-local', 'email', 'month', 'number', 'time');
 
 				// Show the [?] button.
 				if ($config_var['help'])
@@ -886,10 +889,15 @@ function template_show_settings()
 				elseif ($config_var['type'] == 'var_message')
 					echo '
 											<div', !empty($config_var['name']) ? ' id="' . $config_var['name'] . '"' : '', '>', $config_var['var_message'], '</div>';
-				// Assume it must be a text box.
+				// Assume it must be a text box
 				else
+				{
+					// Figure out the exact type - use "number" for "float" and "int".
+					$type = in_array($config_var['type'], $txt_types) ? $config_var['type'] : ($config_var['type'] == 'int' || $config_var['type'] == 'float' ? 'number' : 'text');
+
 					echo '
-											<input type="text"', $javascript, $disabled, ' name="', $config_var['name'], '" id="', $config_var['name'], '" value="', $config_var['value'], '"', ($config_var['size'] ? ' size="' . $config_var['size'] . '"' : ''), ' class="input_text">';
+											<input type="', $type ,'"', $javascript, $disabled, ' name="', $config_var['name'], '" id="', $config_var['name'], '" value="', $config_var['value'], '"', ($config_var['size'] ? ' size="' . $config_var['size'] . '"' : ''), ' class="input_text">';
+				}
 
 				echo isset($config_var['postinput']) ? '
 											' . $config_var['postinput'] : '',
@@ -1229,7 +1237,7 @@ function template_admin_search_results()
 							<h3 class="catbg">
 								<object id="quick_search">
 									<form action="', $scripturl, '?action=admin;area=search" method="post" accept-charset="', $context['character_set'], '" class="floatright">
-										<input type="text" name="search_term" value="', $context['search_term'], '" class="input_text">
+										<input type="search" name="search_term" value="', $context['search_term'], '" class="input_text">
 										<input type="hidden" name="search_type" value="', $context['search_type'], '">
 										<input type="submit" name="search_go" value="', $txt['admin_search_results_again'], '" class="button_submit">
 									</form>

--- a/Themes/default/Login.template.php
+++ b/Themes/default/Login.template.php
@@ -57,7 +57,7 @@ function template_login()
 	echo '
 				<dl>
 					<dt>', $txt['mins_logged_in'], ':</dt>
-					<dd><input type="text" name="cookielength" size="4" maxlength="4" value="', $modSettings['cookieTime'], '"', $context['never_expire'] ? ' disabled' : '', ' class="input_text"></dd>
+					<dd><input type="number" name="cookielength" size="4" maxlength="4" value="', $modSettings['cookieTime'], '"', $context['never_expire'] ? ' disabled' : '', ' class="input_text"></dd>
 					<dt>', $txt['always_logged_in'], ':</dt>
 					<dd><input type="checkbox" name="cookieneverexp"', $context['never_expire'] ? ' checked' : '', ' class="input_check" onclick="this.form.cookielength.disabled = this.checked;"></dd>';
 	// If they have deleted their account, give them a chance to change their mind.

--- a/Themes/default/ManageAttachments.template.php
+++ b/Themes/default/ManageAttachments.template.php
@@ -74,7 +74,7 @@ function template_maintenance()
 		<div class="windowbg">
 			<div class="content">
 				<form action="', $scripturl, '?action=admin;area=manageattachments" method="post" accept-charset="', $context['character_set'], '" onsubmit="return confirm(\'', $txt['attachment_pruning_warning'], '\');" style="margin: 0 0 2ex 0;">
-					', $txt['attachment_remove_old'], ' <input type="text" name="age" value="25" size="4" class="input_text"> ', $txt['days_word'], '<br>
+					', $txt['attachment_remove_old'], ' <input type="number" name="age" value="25" size="4" class="input_text"> ', $txt['days_word'], '<br>
 					', $txt['attachment_pruning_message'], ': <input type="text" name="notice" value="', $txt['attachment_delete_admin'], '" size="40" class="input_text"><br>
 					<input type="submit" name="remove" value="', $txt['remove'], '" class="button_submit">
 					<input type="hidden" name="type" value="attachments">
@@ -84,7 +84,7 @@ function template_maintenance()
 				</form>
 				<hr>
 				<form action="', $scripturl, '?action=admin;area=manageattachments" method="post" accept-charset="', $context['character_set'], '" onsubmit="return confirm(\'', $txt['attachment_pruning_warning'], '\');" style="margin: 0 0 2ex 0;">
-					', $txt['attachment_remove_size'], ' <input type="text" name="size" id="size" value="100" size="4" class="input_text"> ', $txt['kilobyte'], '<br>
+					', $txt['attachment_remove_size'], ' <input type="number" name="size" id="size" value="100" size="4" class="input_text"> ', $txt['kilobyte'], '<br>
 					', $txt['attachment_pruning_message'], ': <input type="text" name="notice" value="', $txt['attachment_delete_admin'], '" size="40" class="input_text"><br>
 					<input type="submit" name="remove" value="', $txt['remove'], '" class="button_submit">
 					<input type="hidden" name="type" value="attachments">
@@ -94,7 +94,7 @@ function template_maintenance()
 				</form>
 				<hr>
 				<form action="', $scripturl, '?action=admin;area=manageattachments" method="post" accept-charset="', $context['character_set'], '" onsubmit="return confirm(\'', $txt['attachment_pruning_warning'], '\');" style="margin: 0 0 2ex 0;">
-					', $txt['attachment_manager_avatars_older'], ' <input type="text" name="age" value="45" size="4" class="input_text"> ', $txt['days_word'], '<br>
+					', $txt['attachment_manager_avatars_older'], ' <input type="number" name="age" value="45" size="4" class="input_text"> ', $txt['days_word'], '<br>
 					<input type="submit" name="remove" value="', $txt['remove'], '" class="button_submit">
 					<input type="hidden" name="type" value="avatars">
 					<input type="hidden" name="', $context['session_var'], '" value="', $context['session_id'], '">

--- a/Themes/default/ManageBans.template.php
+++ b/Themes/default/ManageBans.template.php
@@ -81,7 +81,7 @@ function template_ban_edit()
 						', $txt['ban_expiration'], '
 					</legend>
 					<input type="radio" name="expiration" value="never" id="never_expires" onclick="fUpdateStatus();"', $context['ban']['expiration']['status'] == 'never' ? ' checked' : '', ' class="input_radio"> <label for="never_expires">', $txt['never'], '</label><br>
-					<input type="radio" name="expiration" value="one_day" id="expires_one_day" onclick="fUpdateStatus();"', $context['ban']['expiration']['status'] == 'one_day' ? ' checked' : '', ' class="input_radio"> <label for="expires_one_day">', $txt['ban_will_expire_within'], '</label>: <input type="text" name="expire_date" id="expire_date" size="3" value="', $context['ban']['expiration']['days'], '" class="input_text"> ', $txt['ban_days'], '<br>
+					<input type="radio" name="expiration" value="one_day" id="expires_one_day" onclick="fUpdateStatus();"', $context['ban']['expiration']['status'] == 'one_day' ? ' checked' : '', ' class="input_radio"> <label for="expires_one_day">', $txt['ban_will_expire_within'], '</label>: <input type="number" name="expire_date" id="expire_date" size="3" value="', $context['ban']['expiration']['days'], '" class="input_text"> ', $txt['ban_days'], '<br>
 					<input type="radio" name="expiration" value="expired" id="already_expired" onclick="fUpdateStatus();"', $context['ban']['expiration']['status'] == 'expired' ? ' checked' : '', ' class="input_radio"> <label for="already_expired">', $txt['ban_expired'], '</label>
 				</fieldset>
 				<fieldset class="ban_settings floatright">

--- a/Themes/default/ManageMaintenance.template.php
+++ b/Themes/default/ManageMaintenance.template.php
@@ -309,7 +309,7 @@ function template_maintain_members()
 					<select name="del_type">
 						<option value="activated" selected>', $txt['maintain_members_activated'], '</option>
 						<option value="logged">', $txt['maintain_members_logged_in'], '</option>
-					</select> ', $txt['maintain_members_since2'], ' <input type="text" name="maxdays" value="30" size="3" class="input_text">', $txt['maintain_members_since3'], '</p>';
+					</select> ', $txt['maintain_members_since2'], ' <input type="number" name="maxdays" value="30" size="3" class="input_text">', $txt['maintain_members_since3'], '</p>';
 
 	echo '
 					<p><a href="#membersLink" onclick="swapMembers();"><img src="', $settings['images_url'], '/selected.png" alt="+" id="membersIcon"></a> <a href="#membersLink" onclick="swapMembers();" id="membersText" style="font-weight: bold;">', $txt['maintain_members_all'], '</a></p>
@@ -407,7 +407,7 @@ function template_maintain_topics()
 	// The otherwise hidden "choose which boards to prune".
 	echo '
 					<p>
-						<a id="rotLink"></a>', $txt['maintain_old_since_days1'], '<input type="text" name="maxdays" value="30" size="3">', $txt['maintain_old_since_days2'], '
+						<a id="rotLink"></a>', $txt['maintain_old_since_days1'], '<input type="number" name="maxdays" value="30" size="3">', $txt['maintain_old_since_days2'], '
 					</p>
 					<p>
 						<label for="delete_type_nothing"><input type="radio" name="delete_type" id="delete_type_nothing" value="nothing" class="input_radio"> ', $txt['maintain_old_nothing_else'], '</label><br>
@@ -466,7 +466,7 @@ function template_maintain_topics()
 		<div class="windowbg">
 			<div class="content">
 				<form action="', $scripturl, '?action=admin;area=maintain;sa=topics;activity=olddrafts" method="post" accept-charset="', $context['character_set'], '">
-					<p>', $txt['maintain_old_drafts_days'], '&nbsp;<input type="text" name="draftdays" value="', (!empty($modSettings['drafts_keep_days']) ? $modSettings['drafts_keep_days'] : 30), '" size="3">&nbsp;', $txt['days_word'], '</p>
+					<p>', $txt['maintain_old_drafts_days'], '&nbsp;<input type="number" name="draftdays" value="', (!empty($modSettings['drafts_keep_days']) ? $modSettings['drafts_keep_days'] : 30), '" size="3">&nbsp;', $txt['days_word'], '</p>
 					<input type="submit" value="', $txt['maintain_old_remove'], '" onclick="return confirm(\'', $txt['maintain_old_drafts_confirm'], '\');" class="button_submit">
 					<input type="hidden" name="', $context['session_var'], '" value="', $context['session_id'], '">
 					<input type="hidden" name="', $context['admin-maint_token_var'], '" value="', $context['admin-maint_token'], '">
@@ -519,7 +519,7 @@ function template_maintain_topics()
 	echo '
 					</select></p>
 					<p>
-						', $txt['move_topics_older_than'], '<input type="text" name="maxdays" value="30" size="3">', $txt['manageposts_days'], '&nbsp;(', $txt['move_zero_all'], ')
+						', $txt['move_topics_older_than'], '<input type="number" name="maxdays" value="30" size="3">', $txt['manageposts_days'], '&nbsp;(', $txt['move_zero_all'], ')
 					</p>
 					<p>
 						<label for="move_type_locked"><input type="checkbox" name="move_type_locked" id="move_type_locked" class="input_check" checked> ', $txt['move_type_locked'], '</label><br>

--- a/Themes/default/ManageMembergroups.template.php
+++ b/Themes/default/ManageMembergroups.template.php
@@ -65,7 +65,7 @@ function template_new_group()
 							<strong>', $txt['membergroups_min_posts'], ':</strong>
 						</dt>
 						<dd>
-							<input type="text" name="min_posts" id="min_posts_input" size="5" class="input_text">
+							<input type="number" name="min_posts" id="min_posts_input" size="5" class="input_text">
 						</dd>';
 	if (!$context['post_group'] || !empty($modSettings['permission_enable_postgroups']))
 	{
@@ -253,7 +253,7 @@ function template_edit_group()
 							<label for="min_posts_input"><strong>', $txt['membergroups_min_posts'], ':</strong></label>
 						</dt>
 						<dd>
-							<input type="text" name="min_posts" id="min_posts_input"', $context['group']['is_post_group'] ? ' value="' . $context['group']['min_posts'] . '"' : '', ' size="6" class="input_text">
+							<input type="number" name="min_posts" id="min_posts_input"', $context['group']['is_post_group'] ? ' value="' . $context['group']['min_posts'] . '"' : '', ' size="6" class="input_text">
 						</dd>';
 	echo '
 						<dt>
@@ -266,7 +266,7 @@ function template_edit_group()
 							<label for="icon_count_input"><strong>', $txt['membergroups_icon_count'], ':</strong></label>
 						</dt>
 						<dd>
-							<input type="text" name="icon_count" id="icon_count_input" value="', $context['group']['icon_count'], '" size="4" class="input_text">
+							<input type="number" name="icon_count" id="icon_count_input" value="', $context['group']['icon_count'], '" size="4" class="input_text">
 						</dd>';
 
 	// Do we have any possible icons to select from?

--- a/Themes/default/ManageMembers.template.php
+++ b/Themes/default/ManageMembers.template.php
@@ -40,7 +40,7 @@ function template_search_members()
 									</select>
 								</dt>
 								<dd>
-									<input type="text" name="mem_id" id="mem_id" value="" size="6" class="input_text">
+									<input type="number" name="mem_id" id="mem_id" value="" size="6" class="input_text">
 								</dd>
 								<dt class="righttext">
 									<strong><label for="age">', $txt['age'], ':</label></strong>
@@ -53,7 +53,7 @@ function template_search_members()
 									</select>
 								</dt>
 								<dd>
-									<input type="text" name="age" id="age" value="" size="6" class="input_text">
+									<input type="number" name="age" id="age" value="" size="6" class="input_text">
 								</dd>
 								<dt class="righttext">
 									<strong><label for="posts">', $txt['member_postcount'], ':</label></strong>
@@ -66,7 +66,7 @@ function template_search_members()
 									</select>
 								</dt>
 								<dd>
-									<input type="text" name="posts" id="posts" value="" size="6" class="input_text">
+									<input type="number" name="posts" id="posts" value="" size="6" class="input_text">
 								</dd>
 								<dt class="righttext">
 									<strong><label for="reg_date">', $txt['date_registered'], ':</label></strong>
@@ -79,7 +79,7 @@ function template_search_members()
 									</select>
 								</dt>
 								<dd>
-									<input type="text" name="reg_date" id="reg_date" value="" size="10" class="input_text"><span class="smalltext">', $txt['date_format'], '</span>
+									<input type="date" name="reg_date" id="reg_date" value="" size="10" class="input_text"><span class="smalltext">', $txt['date_format'], '</span>
 								</dd>
 								<dt class="righttext">
 									<strong><label for="last_online">', $txt['viewmembers_online'], ':</label></strong>
@@ -132,7 +132,7 @@ function template_search_members()
 									<strong><label for="messenger">', $txt['messenger_address'], ':</label></strong>
 								</dt>
 								<dd>
-									<input type="text" name="messenger" id="messenger" value="" class="input_text">
+									<input type="number" name="messenger" id="messenger" value="" class="input_text">
 								</dd>
 							</dl>
 						</div>

--- a/Themes/default/ManagePaid.template.php
+++ b/Themes/default/ManagePaid.template.php
@@ -90,7 +90,7 @@ function template_modify_subscription()
 							', $txt['paid_mod_reminder'], ':<br><span class="smalltext">', $txt['paid_mod_reminder_desc'], '</span>
 						</dt>
 						<dd>
-							<input type="text" name="reminder" value="', $context['sub']['reminder'], '" size="6" class="input_text">
+							<input type="number" name="reminder" value="', $context['sub']['reminder'], '" size="6" class="input_text">
 						</dd>
 						<dt>
 							', $txt['paid_mod_email'], ':<br><span class="smalltext">', $txt['paid_mod_email_desc'], '</span>
@@ -110,13 +110,13 @@ function template_modify_subscription()
 									', $txt['paid_cost'], ' (', str_replace('%1.2f', '', $modSettings['paid_currency_symbol']), '):
 								</dt>
 								<dd>
-									<input type="text" name="cost" value="', empty($context['sub']['cost']['fixed']) ? '0' : $context['sub']['cost']['fixed'], '" size="4" class="input_text">
+									<input type="number" name="cost" value="', empty($context['sub']['cost']['fixed']) ? '0' : $context['sub']['cost']['fixed'], '" size="4" class="input_text">
 								</dd>
 								<dt>
 									', $txt['paid_mod_span'], ':
 								</dt>
 								<dd>
-									<input type="text" name="span_value" value="', $context['sub']['span']['value'], '" size="4" class="input_text">
+									<input type="number" name="span_value" value="', $context['sub']['span']['value'], '" size="4" class="input_text">
 									<select name="span_unit">
 										<option value="D"', $context['sub']['span']['unit'] == 'D' ? ' selected' : '', '>', $txt['paid_mod_span_days'], '</option>
 										<option value="W"', $context['sub']['span']['unit'] == 'W' ? ' selected' : '', '>', $txt['paid_mod_span_weeks'], '</option>
@@ -161,25 +161,25 @@ function template_modify_subscription()
 									', $txt['paid_per_day'], ':
 								</dt>
 								<dd>
-									<input type="text" name="cost_day" value="', empty($context['sub']['cost']['day']) ? '0' : $context['sub']['cost']['day'], '" size="5" class="input_text">
+									<input type="number" name="cost_day" value="', empty($context['sub']['cost']['day']) ? '0' : $context['sub']['cost']['day'], '" size="5" class="input_text">
 								</dd>
 								<dt>
 									', $txt['paid_per_week'], ':
 								</dt>
 								<dd>
-									<input type="text" name="cost_week" value="', empty($context['sub']['cost']['week']) ? '0' : $context['sub']['cost']['week'], '" size="5" class="input_text">
+									<input type="number" name="cost_week" value="', empty($context['sub']['cost']['week']) ? '0' : $context['sub']['cost']['week'], '" size="5" class="input_text">
 								</dd>
 								<dt>
 									', $txt['paid_per_month'], ':
 								</dt>
 								<dd>
-									<input type="text" name="cost_month" value="', empty($context['sub']['cost']['month']) ? '0' : $context['sub']['cost']['month'], '" size="5" class="input_text">
+									<input type="number" name="cost_month" value="', empty($context['sub']['cost']['month']) ? '0' : $context['sub']['cost']['month'], '" size="5" class="input_text">
 								</dd>
 								<dt>
 									', $txt['paid_per_year'], ':
 								</dt>
 								<dd>
-									<input type="text" name="cost_year" value="', empty($context['sub']['cost']['year']) ? '0' : $context['sub']['cost']['year'], '" size="5" class="input_text">
+									<input type="number" name="cost_year" value="', empty($context['sub']['cost']['year']) ? '0' : $context['sub']['cost']['year'], '" size="5" class="input_text">
 								</dd>
 							</dl>
 						</fieldset>
@@ -331,8 +331,8 @@ function template_modify_user_subscription()
 
 	echo '
 						</select>
-						', $txt['hour'], ': <input type="text" name="hourend" value="', $context['sub']['end']['hour'], '" size="2" class="input_text">
-						', $txt['minute'], ': <input type="text" name="minuteend" value="', $context['sub']['end']['min'], '" size="2" class="input_text">
+						', $txt['hour'], ': <input type="number" name="hourend" value="', $context['sub']['end']['hour'], '" size="2" class="input_text">
+						', $txt['minute'], ': <input type="number" name="minuteend" value="', $context['sub']['end']['min'], '" size="2" class="input_text">
 					</fieldset>
 					<input type="submit" name="save_sub" value="', $txt['paid_settings_save'], '" class="button_submit">
 				</div>

--- a/Themes/default/PersonalMessage.template.php
+++ b/Themes/default/PersonalMessage.template.php
@@ -725,7 +725,7 @@ function template_search()
 			<div class="roundframe">
 				<div id="search_term_input">
 					<strong>', $txt['pm_search_text'], ':</strong>
-					<input type="text" name="search"', !empty($context['search_params']['search']) ? ' value="' . $context['search_params']['search'] . '"' : '', ' size="40" class="input_text">
+					<input type="search" name="search"', !empty($context['search_params']['search']) ? ' value="' . $context['search_params']['search'] . '"' : '', ' size="40" class="input_text">
 					<input type="submit" name="pm_search" value="', $txt['pm_search_go'], '" class="button_submit">
 				</div>
 				<a href="', $scripturl, '?action=pm;sa=search;advanced" onclick="this.href += \';search=\' + escape(document.forms.searchform.search.value);">', $txt['pm_search_advanced'], '</a>
@@ -770,7 +770,7 @@ function template_search()
 						<label for="subject_only"><input type="checkbox" name="subject_only" id="subject_only" value="1"', !empty($context['search_params']['subject_only']) ? ' checked' : '', ' class="input_check"> ', $txt['pm_search_subject_only'], '</label>
 					</dd>
 					<dt class="between">', $txt['pm_search_post_age'], ':</dt>
-					<dd>', $txt['pm_search_between'], ' <input type="text" name="minage" value="', empty($context['search_params']['minage']) ? '0' : $context['search_params']['minage'], '" size="5" maxlength="5" class="input_text">&nbsp;', $txt['pm_search_between_and'], '&nbsp;<input type="text" name="maxage" value="', empty($context['search_params']['maxage']) ? '9999' : $context['search_params']['maxage'], '" size="5" maxlength="5" class="input_text"> ', $txt['pm_search_between_days'], '</dd>
+					<dd>', $txt['pm_search_between'], ' <input type="number" name="minage" value="', empty($context['search_params']['minage']) ? '0' : $context['search_params']['minage'], '" size="5" maxlength="5" class="input_text">&nbsp;', $txt['pm_search_between_and'], '&nbsp;<input type="number" name="maxage" value="', empty($context['search_params']['maxage']) ? '9999' : $context['search_params']['maxage'], '" size="5" maxlength="5" class="input_text"> ', $txt['pm_search_between_days'], '</dd>
 				</dl>';
 		if (!$context['currently_using_labels'])
 			echo '

--- a/Themes/default/Profile.template.php
+++ b/Themes/default/Profile.template.php
@@ -1386,10 +1386,16 @@ function template_edit_options()
 							', $field['value'];
 
 			// Maybe it's a text box - very likely!
-			elseif (in_array($field['type'], array('int', 'float', 'text', 'password')))
-				echo '
-							<input type="', $field['type'] == 'password' ? 'password' : 'text', '" name="', $key, '" id="', $key, '" size="', empty($field['size']) ? 30 : $field['size'], '" value="', $field['value'], '" ', $field['input_attr'], ' class="input_', $field['type'] == 'password' ? 'password' : 'text', '">';
+			elseif (in_array($field['type'], array('int', 'float', 'text', 'password', 'color', 'date', 'datetime', 'datetime-local', 'email', 'month', 'number', 'time', 'url')))
+			{
+				if ($field['type'] == 'int' || $field['type'] == 'float')
+					$type = 'number';
+				else
+					$type = $field['type'];
 
+				echo '
+							<input type="', $type, '" name="', $key, '" id="', $key, '" size="', empty($field['size']) ? 30 : $field['size'], '" value="', $field['value'], '" ', $field['input_attr'], ' class="input_', $field['type'] == 'password' ? 'password' : 'text', '">';
+			}
 			// You "checking" me out? ;)
 			elseif ($field['type'] == 'check')
 				echo '
@@ -2989,7 +2995,7 @@ function template_profile_avatar_select()
 	{
 		echo '
 								<div id="avatar_upload">
-									<input type="file" size="44" name="attachment" id="avatar_upload_box" value="" onfocus="selectRadioByName(document.forms.creator.avatar_choice, \'upload\');" class="input_file">', template_max_size('upload'), '
+									<input type="file" size="44" name="attachment" id="avatar_upload_box" value="" onfocus="selectRadioByName(document.forms.creator.avatar_choice, \'upload\');" class="input_file" accept="image/gif, image/jpeg, image/jpg, image/png">', template_max_size('upload'), '
 									', ($context['member']['avatar']['id_attach'] > 0 ? '<br><img src="' . $context['member']['avatar']['href'] . (strpos($context['member']['avatar']['href'], '?') === false ? '?' : '&amp;') . 'time=' . time() . '" alt=""><input type="hidden" name="id_attach" value="' . $context['member']['avatar']['id_attach'] . '">' : ''), '
 								</div>';
 	}
@@ -3096,7 +3102,7 @@ function template_profile_timeoffset_modify()
 								<span class="smalltext">', $txt['personal_time_offset'], '</span>
 							</dt>
 							<dd>
-								<input type="text" name="time_offset" id="time_offset" size="5" maxlength="5" value="', $context['member']['time_offset'], '" class="input_text"> ', $txt['hours'], ' [<a href="javascript:void(0);" onclick="currentDate = new Date(', $context['current_forum_time_js'], '); document.getElementById(\'time_offset\').value = autoDetectTimeOffset(currentDate); return false;">', $txt['timeoffset_autodetect'], '</a>]<br>', $txt['current_time'], ': <em>', $context['current_forum_time'], '</em>
+								<input type="number" name="time_offset" id="time_offset" size="5" maxlength="5" value="', $context['member']['time_offset'], '" class="input_text"> ', $txt['hours'], ' [<a href="javascript:void(0);" onclick="currentDate = new Date(', $context['current_forum_time_js'], '); document.getElementById(\'time_offset\').value = autoDetectTimeOffset(currentDate); return false;">', $txt['timeoffset_autodetect'], '</a>]<br>', $txt['current_time'], ': <em>', $context['current_forum_time'], '</em>
 							</dd>';
 }
 

--- a/Themes/default/Search.template.php
+++ b/Themes/default/Search.template.php
@@ -72,7 +72,7 @@ function template_main()
 						<strong><label for="searchfor">', $txt['search_for'], ':</label></strong>
 					</dt>
 					<dd>
-						<input type="text" name="search" id="searchfor" ', !empty($context['search_params']['search']) ? ' value="' . $context['search_params']['search'] . '"' : '', ' maxlength="', $context['search_string_limit'], '" size="40" class="input_text">';
+						<input type="search" name="search" id="searchfor" ', !empty($context['search_params']['search']) ? ' value="' . $context['search_params']['search'] . '"' : '', ' maxlength="', $context['search_string_limit'], '" size="40" class="input_text">';
 
 		if (empty($modSettings['search_simple_fulltext']))
 			echo '

--- a/Themes/default/Search.template.php
+++ b/Themes/default/Search.template.php
@@ -123,7 +123,7 @@ function template_main()
 						$txt['search_post_age'], ':
 					</dt>
 					<dd><label for="minage">',
-						$txt['search_between'], '</label><input type="text" name="minage" id="minage" value="', empty($context['search_params']['minage']) ? '0' : $context['search_params']['minage'], '" size="5" maxlength="4" class="input_text">&nbsp;<label for="maxage">', $txt['search_and'], '&nbsp;</label><input type="text" name="maxage" id="maxage" value="', empty($context['search_params']['maxage']) ? '9999' : $context['search_params']['maxage'], '" size="5" maxlength="4" class="input_text"> ', $txt['days_word'], '
+						$txt['search_between'], '</label><input type="number" name="minage" id="minage" value="', empty($context['search_params']['minage']) ? '0' : $context['search_params']['minage'], '" size="5" maxlength="4" class="input_text">&nbsp;<label for="maxage">', $txt['search_and'], '&nbsp;</label><input type="number" name="maxage" id="maxage" value="', empty($context['search_params']['maxage']) ? '9999' : $context['search_params']['maxage'], '" size="5" maxlength="4" class="input_text"> ', $txt['days_word'], '
 					</dd>
 				</dl>
 				<script><!-- // --><![CDATA[

--- a/Themes/default/index.template.php
+++ b/Themes/default/index.template.php
@@ -202,7 +202,7 @@ function template_body_above()
 	{
 		echo '
 			<form id="search_form" class="floatright" action="', $scripturl, '?action=search2" method="post" accept-charset="', $context['character_set'], '">
-				<input type="text" name="search" value="" class="input_text">&nbsp;';
+				<input type="search" name="search" value="" class="input_text">&nbsp;';
 
 		// Using the quick search dropdown?
 		if (!empty($modSettings['search_dropdown']))


### PR DESCRIPTION
This adds support in various spots for some of the new HTML5 input types.

Added support for new settings types based on HTML5 input types in the profile and admin center
Most (if not all) numeric fields should now be using the "number" type (including "float" and "int" settings)
E-mail field in the profile uses the "email" type
Website URL field in the profile uses the "url" type
Registration date field in the profile and admin member search uses the "date" type
Search boxes (index.template.php, search page and PM search) use the "search" type

More will likely come later.
