### PR TITLE
! Incorrect quotes in the code meant it wouldn't save properly, only in ...

### DIFF
--- a/Themes/default/ManageMembergroups.template.php
+++ b/Themes/default/ManageMembergroups.template.php
@@ -447,7 +447,7 @@ function template_add_edit_group_boards_list($collapse = true)
 			if (empty($modSettings['deny_boards_access']))
 				echo '
 										<li class="board" style="margin-', $context['right_to_left'] ? 'right' : 'left', ': ', $board['child_level'], 'em;">
-											<input type="checkbox" name="boardaccess[', $board['id'], ']" id="brd', $board['id'], '" value="\'allow\'"', $board['allow'] ? ' checked' : '', ' class="input_check"> <label for="brd', $board['id'], '">', $board['name'], '</label>
+											<input type="checkbox" name="boardaccess[', $board['id'], ']" id="brd', $board['id'], '" value="allow"', $board['allow'] ? ' checked' : '', ' class="input_check"> <label for="brd', $board['id'], '">', $board['name'], '</label>
 										</li>';
 			else
 				echo '


### PR DESCRIPTION
...no-deny and only for groups without manage boards permission, though only discovered after far too much investigation because all possible permutations had to be examined and retested rather than adequate information being given in the first place and irrelevant tangents involved in discussion. Fixes #1341

Signed-off-by: Peter Spicer sleeping@myperch.org
