### PR TITLE
HTML5 tweaks/improvements. Closes #1408

### DIFF
--- a/Sources/ManageSettings.php
+++ b/Sources/ManageSettings.php
@@ -163,7 +163,7 @@ function ModifyBasicSettings($return_config = false)
 		'',
 			// Number formatting, timezones.
 			array('text', 'time_format'),
-			array('float', 'time_offset', 'subtext' => $txt['setting_time_offset_note'], 6, 'postinput' => $txt['hours']),
+			array('float', 'time_offset', 'subtext' => $txt['setting_time_offset_note'], 6, 'postinput' => $txt['hours'], 'step' => 0.25, 'min' => -23.5, 'max' => 23.5),
 			'default_timezone' => array('select', 'default_timezone', array()),
 		'',
 			// Who's online?

--- a/Sources/Profile-Modify.php
+++ b/Sources/Profile-Modify.php
@@ -152,7 +152,7 @@ function loadProfileFields($force_reload = false)
 			'),
 		),
 		'date_registered' => array(
-			'type' => 'text',
+			'type' => 'date',
 			'value' => empty($cur_profile['date_registered']) ? $txt['not_applicable'] : strftime('%Y-%m-%d', $cur_profile['date_registered'] + ($user_info['time_offset'] + $modSettings['time_offset']) * 3600),
 			'label' => $txt['date_registered'],
 			'log_change' => true,

--- a/Themes/default/Admin.template.php
+++ b/Themes/default/Admin.template.php
@@ -894,7 +894,13 @@ function template_show_settings()
 				{
 					// Figure out the exact type - use "number" for "float" and "int".
 					$type = in_array($config_var['type'], $text_types) ? $config_var['type'] : ($config_var['type'] == 'int' || $config_var['type'] == 'float' ? 'number' : 'text');
-					$step = $config_var['type'] == 'float' ? ' step="0.1"' : '';
+
+					// Extra options for float/int values - how much to decrease/increase by, the min value and the max value
+					// The step - only set if incrementing by something other than 1 for int or 0.1 for float
+					$step = isset($config_var['step']) ? ' step="' . $config_var['step'] . '"' : ($config_var['type'] == 'float') ? ' step="0.1"' : '';
+					// Minimum allowed value for this setting. Most settings are 0
+					$min = isset($config_var['min']) ? ' min="' . $config_var['min'] . '"' : ' min="0"';
+					$max = isset($config_var['max']) ? ' max="' . $config_var['max'] . '"' : '';
 
 					echo '
 											<input type="', $type ,'"', $javascript, $disabled, ' name="', $config_var['name'], '" id="', $config_var['name'], '" value="', $config_var['value'], '"', ($config_var['size'] ? ' size="' . $config_var['size'] . '"' : ''), ' class="input_text"', $step, '>';

--- a/Themes/default/Themes.template.php
+++ b/Themes/default/Themes.template.php
@@ -426,8 +426,25 @@ function template_set_options()
 							<br><span class="smalltext">', $setting['description'], '</span>';
 		echo '
 						</dt>
-						<dd ', $context['theme_options_reset'] ? 'style="width:40%"' : '', '>
-							<input type="text" name="', !empty($setting['default']) ? 'default_' : '', 'options[', $setting['id'], ']" id="options_', $setting['id'], '" value="', $setting['value'], '"', $setting['type'] == 'number' ? ' size="5"' : '', $context['theme_options_reset'] ? ' disabled' : '', ' class="input_text">';
+						<dd ', $context['theme_options_reset'] ? 'style="width:40%"' : '', '>';
+
+			if (isset($setting['type']) && $settings['type'] == 'number')
+			{
+				$min = isset($setting['min']) ? ' min="' . $setting['min'] . '"' : ' min="0"';
+				$max = isset($setting['max']) ? ' max="' . $setting['max'] . '"' : '';
+				$step = isset($setting['step']) ? ' step="' . $setting['step'] . '"' : '';
+
+				echo '
+							<input type="number"', $min . $max . $step;
+			}
+			else
+			{
+				echo '
+							<input type="text"';
+			}
+
+			
+			echo ' name="', !empty($setting['default']) ? 'default_' : '', 'options[', $setting['id'], ']" id="options_', $setting['id'], '" value="', $setting['value'], '"', $setting['type'] == 'number' ? ' size="5"' : '', $context['theme_options_reset'] ? ' disabled' : '', ' class="input_text">';
 		}
 
 		// end of this defintion


### PR DESCRIPTION
- Add support for min/max/step attributes for int and float settings in the admin center
- Add support for min/max/step attributes for "number" theme settings and use the "number" input type for these settings where appropriate
- Improve default time offset setting in the admin center - adds min and max values and changes the step to 0.25 to support the two weird timezones

Signed-off-by: Michael Eshom oldiesmann@oldiesmann.us
