### PR TITLE
! Fix assorted Recent Posts bugs

### DIFF
--- a/Themes/default/Recent.template.php
+++ b/Themes/default/Recent.template.php
@@ -25,6 +25,12 @@ function template_recent()
 			<span>', $context['page_index'], '</span>
 		</div>';
 
+	if (empty($context['posts']))
+	{
+		echo '
+			<div class="windowbg">', $txt['no_messages'], '</div>';
+	}
+
 	foreach ($context['posts'] as $post)
 	{
 		echo '


### PR DESCRIPTION
This fixes #1378 and one other issue.

Specifics:
- Pagination was incorrect in many situations
- No message was shown when there weren't any posts to display
- Posts from ignored boards and the recycling bin (if you could view it) were being included when viewing recent posts in a specific category or categories

Signed-off-by: Michael Eshom oldiesmann@oldiesmann.us
