### PR TITLE
Hooking goodies

### DIFF
--- a/Sources/Admin.php
+++ b/Sources/Admin.php
@@ -24,7 +24,8 @@ if (!defined('SMF'))
  */
 function AdminMain()
 {
-	global $txt, $context, $scripturl, $modSettings, $settings, $sourcedir, $options, $boarddir;
+	global $txt, $context, $scripturl, $modSettings, $settings;
+	global $sourcedir, $options, $boarddir, $db_show_debug;
 
 	// Load the language and templates....
 	loadLanguage('Admin');
@@ -489,7 +490,13 @@ function AdminMain()
 	{
 		// Is there an instance already? nope? then create it!
 		if (empty($context['instances'][$admin_include_data['class']]) || !($context['instances'][$admin_include_data['class']] instanceof $admin_include_data['class']))
+		{
 			$context['instances'][$admin_include_data['class']] = new $admin_include_data['class'];
+
+			// Add another one to the list.
+			if ($db_show_debug === true)
+				$context['debug']['instances'][$admin_include_data['class']] = $admin_include_data['class'];
+		}
 
 		$call = array($context['instances'][$admin_include_data['class']], $admin_include_data['function']);
 	}

--- a/Sources/Admin.php
+++ b/Sources/Admin.php
@@ -495,7 +495,12 @@ function AdminMain()
 
 			// Add another one to the list.
 			if ($db_show_debug === true)
+			{
+				if (!isset($context['debug']['instances']))
+					$context['debug']['instances'] = array();
+
 				$context['debug']['instances'][$admin_include_data['class']] = $admin_include_data['class'];
+			}
 		}
 
 		$call = array($context['instances'][$admin_include_data['class']], $admin_include_data['function']);

--- a/Sources/Profile.php
+++ b/Sources/Profile.php
@@ -27,6 +27,7 @@ function ModifyProfile($post_errors = array())
 {
 	global $txt, $scripturl, $user_info, $context, $sourcedir, $user_profile, $cur_profile;
 	global $modSettings, $memberContext, $profile_vars, $post_errors, $user_settings;
+	global $db_show_debug;
 
 	// Don't reload this as we may have processed error strings.
 	if (empty($post_errors))
@@ -728,7 +729,18 @@ function ModifyProfile($post_errors = array())
 	{
 		// Is there an instance already? nope? then create it!
 		if (empty($context['instances'][$profile_include_data['class']]) || !($context['instances'][$profile_include_data['class']] instanceof $profile_include_data['class']))
+		{
 			$context['instances'][$profile_include_data['class']] = new $profile_include_data['class'];
+
+			// Add another one to the list.
+			if ($db_show_debug === true)
+			{
+				if (!isset($context['debug']['instances']))
+					$context['debug']['instances'] = array();
+
+				$context['debug']['instances'][$profile_include_data['class']] = $profile_include_data['class'];
+			}
+		}
 
 		$call = array($context['instances'][$profile_include_data['class']], $profile_include_data['function']);
 	}

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -3992,7 +3992,7 @@ function setupMenuContext()
 	{
 		$context['menu_buttons']['moderate']['title'] .= ' <span class="amt">' . $total_mod_reports . '</span>';
 	}
-	
+
 }
 
 /**
@@ -4234,7 +4234,12 @@ function call_hook_helper($string)
 
 				// Add another one to the list.
 				if ($db_show_debug === true)
+				{
+					if (!isset($context['debug']['instances']))
+						$context['debug']['instances'] = array();
+
 					$context['debug']['instances'][$class] = $class;
+				}
 			}
 
 			return array($context['instances'][$class], $method);

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -4203,7 +4203,7 @@ function remove_integration_function($hook, $function, $file = '', $object = fal
 /**
  * Receives a string and tries to figure it out if its a method or a function.
  * If a method is found, it looks for a "#" which indicates SMF should create a new instance of the given class.
- * Prepare and returns callable depending on the type of method/function found.
+ * Prepare and returns a callable depending on the type of method/function found.
  *
  * @param string $string The string containing a function name
  * @return string|array Either a string or an array that contains a callable function name or an array with a class and method to call
@@ -4245,7 +4245,7 @@ function call_hook_helper($string)
 			return array($class, $method);
 	}
 
-	// Nope! just a plain regular function
+	// Nope! just a plain regular function.
 	else
 		return $string;
 }

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -4088,10 +4088,10 @@ function call_integration_hook($hook, $parameters = array())
 			$results[$function] = call_user_func_array($call, $parameters);
 
 		// Whatever it was suppose to call, it failed :(
-		elseif (!empty($func) && !empty($absPath))
+		elseif (!empty($function) && !empty($absPath))
 		{
 			loadLanguage('Errors');
-			log_error(sprintf($txt['hook_fail_call_to'], $func, $absPath), 'general');
+			log_error(sprintf($txt['hook_fail_call_to'], $function, $absPath), 'general');
 		}
 	}
 


### PR DESCRIPTION
- Re-writes call_integration_hook, there was some issues with using ":" as a wildcard for adding files so use the pipe | character instead.
- It is now possible to load a file and also create a new instance for a hook following this pattern:

'integrate_menu_buttons' => '$sourcedir/File.php|Class::method#',

The file needs to specify a directory wildcard, either $boarddir, $sourcedir or, if available, $themedir

If no dir wilcard was specified, SMF will attempt to try to load the file from $sourcedir
- Adds support for static and normal methods on Admin, Profile and the smf_main() function, uses the same procedure used in Subs::call_integration_hook()
