### PR TITLE
! $context['from_ajax'] isn't always defined (fixes #1497)

### DIFF
--- a/Themes/default/Login.template.php
+++ b/Themes/default/Login.template.php
@@ -16,7 +16,7 @@ function template_login()
 	global $context, $settings, $scripturl, $modSettings, $txt;
 
 	// AJAX request?
-	if ($context['from_ajax'])
+	if (!empty($context['from_ajax']))
 		echo '
 		<script src="', $settings['default_theme_url'], '/scripts/sha1.js', $modSettings['browser_cache'] ,'"></script>';
 


### PR DESCRIPTION
Signed-off-by: Michael Eshom oldiesmann@oldiesmann.us
