### PR TITLE
BBCode is a master setting.

### DIFF
--- a/Sources/Admin.php
+++ b/Sources/Admin.php
@@ -107,6 +107,7 @@ function AdminMain()
 					'icon' => 'features.png',
 					'subsections' => array(
 						'basic' => array($txt['mods_cat_features']),
+						'bbc' => array($txt['manageposts_bbc_settings']),
 						'layout' => array($txt['mods_cat_layout']),
 						'karma' => array($txt['karma']),
 						'sig' => array($txt['signature_settings_short']),
@@ -188,7 +189,6 @@ function AdminMain()
 					'icon' => 'posts.png',
 					'subsections' => array(
 						'posts' => array($txt['manageposts_settings']),
-						'bbc' => array($txt['manageposts_bbc_settings']),
 						'censor' => array($txt['admin_censored_words']),
 						'topics' => array($txt['manageposts_topic_settings']),
 						'drafts' => array($txt['manage_drafts']),
@@ -708,6 +708,7 @@ function AdminSearchInternal()
 	// This is a special array of functions that contain setting data - we query all these to simply pull all setting bits!
 	$settings_search = array(
 		array('ModifyBasicSettings', 'area=featuresettings;sa=basic'),
+		array('ModifyBBCSettings', 'area=featuresettings;sa=bbc'),
 		array('ModifyLayoutSettings', 'area=featuresettings;sa=layout'),
 		array('ModifyKarmaSettings', 'area=featuresettings;sa=karma'),
 		array('ModifySignatureSettings', 'area=featuresettings;sa=sig'),
@@ -723,7 +724,6 @@ function AdminSearchInternal()
 		array('ModifyNewsSettings', 'area=news;sa=settings'),
 		array('GeneralPermissionSettings', 'area=permissions;sa=settings'),
 		array('ModifyPostSettings', 'area=postsettings;sa=posts'),
-		array('ModifyBBCSettings', 'area=postsettings;sa=bbc'),
 		array('ModifyTopicSettings', 'area=postsettings;sa=topics'),
 		array('ModifyDraftSettings', 'area=postsettings;sa=drafts'),
 		array('EditSearchSettings', 'area=managesearch;sa=settings'),

--- a/Sources/ManagePosts.php
+++ b/Sources/ManagePosts.php
@@ -34,7 +34,6 @@ function ManagePostSettings()
 
 	$subActions = array(
 		'posts' => 'ModifyPostSettings',
-		'bbc' => 'ModifyBBCSettings',
 		'censor' => 'SetCensor',
 		'topics' => 'ModifyTopicSettings',
 		'drafts' => 'ModifyDraftSettings',
@@ -55,9 +54,6 @@ function ManagePostSettings()
 		'tabs' => array(
 			'posts' => array(
 				'description' => $txt['manageposts_settings_description'],
-			),
-			'bbc' => array(
-				'description' => $txt['manageposts_bbc_settings_description'],
 			),
 			'censor' => array(
 				'description' => $txt['admin_censored_desc'],
@@ -268,74 +264,6 @@ function ModifyPostSettings($return_config = false)
 	$context['settings_title'] = $txt['manageposts_settings'];
 
 	// Prepare the settings...
-	prepareDBSettingContext($config_vars);
-}
-
-/**
- * Set a few Bulletin Board Code settings. It loads a list of Bulletin Board Code tags to allow disabling tags.
- * Requires the admin_forum permission.
- * Accessed from ?action=admin;area=postsettings;sa=bbc.
- *
- * @param bool $return_config = false
- * @uses Admin template, edit_bbc_settings sub-template.
- */
-function ModifyBBCSettings($return_config = false)
-{
-	global $context, $txt, $modSettings, $helptxt, $scripturl, $sourcedir;
-
-	$config_vars = array(
-			// Main tweaks
-			array('check', 'enableBBC'),
-			array('check', 'enableBBC', 0, 'onchange' => 'toggleBBCDisabled(\'disabledBBC\', !this.checked);'),
-			array('check', 'enablePostHTML'),
-			array('check', 'autoLinkUrls'),
-		'',
-			array('bbc', 'disabledBBC'),
-	);
-
-	$context['settings_post_javascript'] = '
-		toggleBBCDisabled(\'disabledBBC\', ' . (empty($modSettings['enableBBC']) ? 'true' : 'false') . ');';
-
-	call_integration_hook('integrate_modify_bbc_settings', array(&$config_vars));
-
-	if ($return_config)
-		return $config_vars;
-
-	// Setup the template.
-	require_once($sourcedir . '/ManageServer.php');
-	$context['sub_template'] = 'show_settings';
-	$context['page_title'] = $txt['manageposts_bbc_settings_title'];
-
-	// Make sure we check the right tags!
-	$modSettings['bbc_disabled_disabledBBC'] = empty($modSettings['disabledBBC']) ? array() : explode(',', $modSettings['disabledBBC']);
-
-	// Saving?
-	if (isset($_GET['save']))
-	{
-		checkSession();
-
-		// Clean up the tags.
-		$bbcTags = array();
-		foreach (parse_bbc(false) as $tag)
-			$bbcTags[] = $tag['tag'];
-
-		if (!isset($_POST['disabledBBC_enabledTags']))
-			$_POST['disabledBBC_enabledTags'] = array();
-		elseif (!is_array($_POST['disabledBBC_enabledTags']))
-			$_POST['disabledBBC_enabledTags'] = array($_POST['disabledBBC_enabledTags']);
-		// Work out what is actually disabled!
-		$_POST['disabledBBC'] = implode(',', array_diff($bbcTags, $_POST['disabledBBC_enabledTags']));
-
-		call_integration_hook('integrate_save_bbc_settings', array($bbcTags));
-
-		saveDBSettings($config_vars);
-		$_SESSION['adm-save'] = true;
-		redirectexit('action=admin;area=postsettings;sa=bbc');
-	}
-
-	$context['post_url'] = $scripturl . '?action=admin;area=postsettings;save;sa=bbc';
-	$context['settings_title'] = $txt['manageposts_bbc_settings_title'];
-
 	prepareDBSettingContext($config_vars);
 }
 


### PR DESCRIPTION
Currently BBCode controls looks like controlling only Topics & Posts but not, BBCode settings under Posts & Topics is a master setting and something changed there effecting whole site, due that its better to be placed under more upper place.

Alternative fix; doing some additions to current system to respect sub-settings (Not sure maybe rewrite of HTML parsing & parse_bbc function).

fixes #1541
Signed-off-by: Antes antes@simplemachines.org
