### PR TITLE
! The "db_alter_table" function only exists for SQLite/SQLite3 (fixes #1533)...

### DIFF
--- a/other/upgrade_2-1_mysql.sql
+++ b/other/upgrade_2-1_mysql.sql
@@ -1331,6 +1331,10 @@ ADD COLUMN modified_reason varchar(255) NOT NULL default '';
 
 ---# Dropping the "hide_email" column from the members table
 ---{
-	$smcFunc['db_alter_table']('{db_prefix}members', array('remove' => array('hide_email')));
+	$smcFunc['db_query']('', '
+		ALTER TABLE {db_prefix}members
+		DROP hide_email',
+		array()
+	);
 ---}
 ---#

--- a/other/upgrade_2-1_postgresql.sql
+++ b/other/upgrade_2-1_postgresql.sql
@@ -1425,6 +1425,10 @@ ADD COLUMN modified_reason varchar(255) NOT NULL default '';
 
 ---# Dropping the "hide_email" column from the members table
 ---{
-	$smcFunc['db_alter_table']('{db_prefix}members', array('remove' => array('hide_email')));
+	$smcFunc['db_query']('', '
+		ALTER TABLE {db_prefix}members
+		DROP hide_email',
+		array()
+	);
 ---}
 ---#


### PR DESCRIPTION
Signed-off-by: Michael Eshom oldiesmann@oldiesmann.us
