### PR TITLE
Search API cleanup

### DIFF
--- a/Sources/Class-SearchAPI.php
+++ b/Sources/Class-SearchAPI.php
@@ -23,7 +23,7 @@ interface search_api_interface
 	 * @param array $query_params
 	 * @return boolean
 	 */
-	public function supportsMethod($methodName, $query_params);
+	public function supportsMethod($methodName, $query_params = array());
 
 	/**
 	 * Whether this method is valid for implementation or not
@@ -89,6 +89,34 @@ interface search_api_interface
 	 * @return void
 	 */
 	public function postModified(array &$msgOptions, array &$topicOptions, array &$posterOptions);
+
+	/**
+	 * Callback when a post is removed
+	 *
+	 * @access public
+	 * @param int $id_msg
+	 * @return void
+	 */
+	public function postRemoved($id_msg);
+
+	/**
+	 * Callback when a topic is removed
+	 *
+	 * @access public
+	 * @param array $topics
+	 * @return void
+	 */
+	public function topicsRemoved(array $topics);
+
+	/**
+	 * Callback when a topic is moved
+	 *
+	 * @access public
+	 * @param array $topics
+	 * @param int $board_to
+	 * @return void
+	 */
+	public function topicsMoved(array $topics, $board_to);
 
 	/**
 	 * Callback for actually performing the search query
@@ -163,6 +191,27 @@ abstract class search_api implements search_api_interface
 	 * {@inheritDoc}
 	 */
 	public function postModified(array &$msgOptions, array &$topicOptions, array &$posterOptions)
+	{
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function postRemoved($id_msg)
+	{
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function topicsRemoved(array $topics)
+	{
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function topicsMoved(array $topics, $board_to)
 	{
 	}
 

--- a/Sources/Class-SearchAPI.php
+++ b/Sources/Class-SearchAPI.php
@@ -1,0 +1,175 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines http://www.simplemachines.org
+ * @copyright 2014 Simple Machines and individual contributors
+ * @license http://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 2.1 Alpha 1
+ */
+
+interface search_api_interface
+{
+	/**
+	 * Check whether the specific search operation can be performed by this API.
+	 * The operations are the functions listed in the interface, if not supported
+	 * they need not be declared
+	 *
+	 * @access public
+	 * @param string $methodName
+	 * @param array $query_params
+	 * @return boolean
+	 */
+	public function supportsMethod($methodName, $query_params);
+
+	/**
+	 * Whether this method is valid for implementation or not
+	 *
+	 * @access public
+	 * @return bool
+	 */
+	public function isValid();
+
+	/**
+	 * Callback function for usort used to sort the fulltext results.
+	 * the order of sorting is: large words, small words, large words that
+	 * are excluded from the search, small words that are excluded.
+	 *
+	 * @access public
+	 * @param string $a Word A
+	 * @param string $b Word B
+	 * @return int
+	 */
+	public function searchSort($a, $b);
+
+	/**
+	 * Callback while preparing indexes for searching
+	 *
+	 * @access public
+	 * @param string $word
+	 * @param array $wordsSearch
+	 * @param array $wordsExclude
+	 * @param bool $isExcluded
+	 */
+	public function prepareIndexes($word, array &$wordsSearch, array &$wordsExclude, $isExcluded);
+
+	/**
+	 * Search for indexed words.
+	 *
+	 * @access public
+	 * @param array $words
+	 * @param array $search_data
+	 * @return mixed
+	 */
+	public function indexedWordQuery(array $words, array $search_data);
+
+	/**
+	 * Callback when a post is created
+	 * {@see createPost()}
+	 *
+	 * @access public
+	 * @param array $msgOptions
+	 * @param array $topicOptions
+	 * @param array $posterOptions
+	 * @return void
+	 */
+	public function postCreated(array &$msgOptions, array &$topicOptions, array &$posterOptions);
+
+	/**
+	 * Callback when a post is modified
+	 * {@see modifyPost()}
+	 *
+	 * @access public
+	 * @param array $msgOptions
+	 * @param array $topicOptions
+	 * @param array $posterOptions
+	 * @return void
+	 */
+	public function postModified(array &$msgOptions, array &$topicOptions, array &$posterOptions);
+
+	/**
+	 * Callback for actually performing the search query
+	 *
+	 * @access public
+	 * @param array $query_params
+	 * @param array $searchWords
+	 * @param array $excludedIndexWords
+	 * @param array $participants
+	 * @param array $searchArray
+	 * @return mixed
+	 */
+	public function searchQuery(array $query_params, array $searchWords, array $excludedIndexWords, array $participants, array $searchArray);
+}
+
+abstract class search_api implements search_api_interface
+{
+	/**
+	 * This is the last version of SMF that this was tested on, to protect against API changes.
+	 * @var type
+	 */
+	public $version_compatible = 'SMF 2.1 Alpha 1';
+
+	/**
+	 * This won't work with versions of SMF less than this.
+	 * @var type
+	 */
+	public $min_smf_version = 'SMF 2.1 Alpha 1';
+
+	/**
+	 * Is it supported?
+	 * @var type
+	 */
+	public $is_supported = true;
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function isValid()
+	{
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function searchSort($a, $b)
+	{
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function prepareIndexes($word, array &$wordsSearch, array &$wordsExclude, $isExcluded)
+	{
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function indexedWordQuery(array $words, array $search_data)
+	{
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function postCreated(array &$msgOptions, array &$topicOptions, array &$posterOptions)
+	{
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function postModified(array &$msgOptions, array &$topicOptions, array &$posterOptions)
+	{
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function searchQuery(array $query_params, array $searchWords, array $excludedIndexWords, array $participants, array $searchArray)
+	{
+	}
+}

--- a/Sources/MoveTopic.php
+++ b/Sources/MoveTopic.php
@@ -379,9 +379,9 @@ function MoveTopic2()
  * Handles the moving of mark_read data
  * Updates the posts count of the affected boards
  *
- * @param type $topics
- * @param type $toBoard
- * @return type
+ * @param array $topics
+ * @param int $toBoard
+ * @return void
  */
 function moveTopics($topics, $toBoard)
 {

--- a/Sources/MoveTopic.php
+++ b/Sources/MoveTopic.php
@@ -385,7 +385,7 @@ function MoveTopic2()
  */
 function moveTopics($topics, $toBoard)
 {
-	global $sourcedir, $user_info, $modSettings, $smcFunc;
+	global $sourcedir, $user_info, $modSettings, $smcFunc, $sourcedir;
 
 	// Empty array?
 	if (empty($topics))
@@ -403,6 +403,12 @@ function moveTopics($topics, $toBoard)
 
 	// Are we moving to the recycle board?
 	$isRecycleDest = !empty($modSettings['recycle_enable']) && $modSettings['recycle_board'] == $toBoard;
+
+	// Callback for search APIs to do their thing
+	require_once($sourcedir . '/Search.php');
+	$searchAPI = findSearchAPI();
+	if ($searchAPI->supportsMethod('topicsMoved'))
+		$searchAPI->topicsMoved($topics, $toBoard);
 
 	// Determine the source boards...
 	$request = $smcFunc['db_query']('', '

--- a/Sources/RemoveTopic.php
+++ b/Sources/RemoveTopic.php
@@ -345,6 +345,12 @@ function removeTopics($topics, $decreasePostCount = true, $ignoreRecycling = fal
 	if (empty($topics))
 		return;
 
+	// Callback for search APIs to do their thing
+	require_once($sourcedir . '/Search.php');
+	$searchAPI = findSearchAPI();
+	if ($searchAPI->supportsMethod('topicsRemoved'))
+		$searchAPI->topicsRemoved($topics);
+
 	$adjustBoards = array();
 
 	// Find out how many posts we are deleting.
@@ -925,6 +931,12 @@ function removeMessage($message, $decreasePostCount = true)
 	// Only remove posts if they're not recycled.
 	if (!$recycle)
 	{
+		// Callback for search APIs to do their thing
+		require_once($sourcedir . '/Search.php');
+		$searchAPI = findSearchAPI();
+		if ($searchAPI->supportsMethod('postRemoved'))
+			$searchAPI->postRemoved($message);
+
 		// Remove the message!
 		$smcFunc['db_query']('', '
 			DELETE FROM {db_prefix}messages

--- a/Sources/Search.php
+++ b/Sources/Search.php
@@ -2126,6 +2126,7 @@ function findSearchAPI()
 	global $sourcedir, $modSettings, $search_versions, $searchAPI, $txt;
 
 	require_once($sourcedir . '/Subs-Package.php');
+	require_once($sourcedir . '/Class-SearchAPI.php');
 
 	// Search has a special database set.
 	db_extend('search');

--- a/Sources/Search.php
+++ b/Sources/Search.php
@@ -2142,7 +2142,7 @@ function findSearchAPI()
 	$searchAPI = new $search_class_name();
 
 	// An invalid Search API.
-	if (!$searchAPI || ($searchAPI->supportsMethod('isValid') && !$searchAPI->isValid()) || !matchPackageVersion($search_versions['forum_version'], $searchAPI->min_smf_version . '-' . $searchAPI->version_compatible))
+	if (!$searchAPI || !($searchAPI instanceof search_api_interface) || ($searchAPI->supportsMethod('isValid') && !$searchAPI->isValid()) || !matchPackageVersion($search_versions['forum_version'], $searchAPI->min_smf_version . '-' . $searchAPI->version_compatible))
 	{
 		// Log the error.
 		loadLanguage('Errors');

--- a/Sources/Search.php
+++ b/Sources/Search.php
@@ -2120,6 +2120,7 @@ function prepareSearchContext($reset = false)
 /**
  * Creates a search API and returns the object.
  *
+ * @return search_api_interface
  */
 function findSearchAPI()
 {

--- a/Sources/SearchAPI-Custom.php
+++ b/Sources/SearchAPI-Custom.php
@@ -17,26 +17,8 @@ if (!defined('SMF'))
 /**
  * Custom Search API class .. used when custom SMF index is used
  */
-class custom_search
+class custom_search extends search_api
 {
-	/**
-	 *This is the last version of SMF that this was tested on, to protect against API changes.
-	 * @var type
-	 */
-	public $version_compatible = 'SMF 2.1 Alpha 1';
-
-	/**
-	 *This won't work with versions of SMF less than this.
-	 * @var type
-	 */
-	public $min_smf_version = 'SMF 2.1 Alpha 1';
-
-	/**
-	 * Is it supported?
-	 * @var type
-	 */
-	public $is_supported = true;
-
 	/**
 	 * Index Settings
 	 * @var type
@@ -63,8 +45,6 @@ class custom_search
 
 	/**
 	 * constructor function
-	 *
-	 * @return type
 	 */
 	public function __construct()
 	{
@@ -87,11 +67,7 @@ class custom_search
 	}
 
 	/**
-	 * Check whether the search can be performed by this API.
-	 *
-	 * @param type $methodName
-	 * @param type $query_params
-	 * @return boolean
+	 * {@inheritDoc}
 	 */
 	public function supportsMethod($methodName, $query_params = null)
 	{
@@ -114,9 +90,7 @@ class custom_search
 	}
 
 	/**
-	 * If the settings don't exist we can't continue.
-	 *
-	 * @return type
+	 * {@inheritDoc}
 	 */
 	public function isValid()
 	{
@@ -126,12 +100,7 @@ class custom_search
 	}
 
 	/**
-	 * callback function for usort used to sort the fulltext results.
-	 * the order of sorting is: large words, small words, large words that
-	 * are excluded from the search, small words that are excluded.
-	 * @param string $a Word A
-	 * @param string $b Word B
-	 * @return int
+	 * {@inheritDoc}
 	 */
 	public function searchSort($a, $b)
 	{
@@ -144,14 +113,9 @@ class custom_search
 	}
 
 	/**
-	 * Do we have to do some work with the words we are searching for to prepare them?
-	 *
-	 * @param type $word
-	 * @param type $wordsSearch
-	 * @param type $wordsExclude
-	 * @param type $isExcluded
+	 * {@inheritDoc}
 	 */
-	public function prepareIndexes($word, &$wordsSearch, &$wordsExclude, $isExcluded)
+	public function prepareIndexes($word, array &$wordsSearch, array &$wordsExclude, $isExcluded)
 	{
 		global $modSettings, $smcFunc;
 
@@ -162,7 +126,7 @@ class custom_search
 
 		// Excluded phrases don't benefit from being split into subwords.
 		if (count($subwords) > 1 && $isExcluded)
-			continue;
+			return;
 		else
 		{
 			foreach ($subwords as $subword)
@@ -178,13 +142,9 @@ class custom_search
 	}
 
 	/**
-	 * Search for indexed words.
-	 *
-	 * @param type $words
-	 * @param type $search_data
-	 * @return type
+	 * {@inheritDoc}
 	 */
-	public function indexedWordQuery($words, $search_data)
+	public function indexedWordQuery(array $words, array $search_data)
 	{
 		global $modSettings, $smcFunc;
 
@@ -270,13 +230,9 @@ class custom_search
 	}
 
 	/**
-	 *  After a post is made, we update the search index database
-	 *
-	 * @param type $msgOptions
-	 * @param type $topicOptions
-	 * @param type $posterOptions
+	 * {@inheritDoc}
 	 */
-	public function postCreated($msgOptions, $topicOptions, $posterOptions)
+	public function postCreated(array &$msgOptions, array &$topicOptions, array &$posterOptions)
 	{
 		global $modSettings, $smcFunc;
 
@@ -296,13 +252,9 @@ class custom_search
 	}
 
 	/**
-	 * After a post is modified, we update the search index database.
-	 *
-	 * @param type $msgOptions
-	 * @param type $topicOptions
-	 * @param type $posterOptions
+	 * {@inheritDoc}
 	 */
-	public function postModified($msgOptions, $topicOptions, $posterOptions)
+	public function postModified(array &$msgOptions, array &$topicOptions, array &$posterOptions)
 	{
 		global $modSettings, $smcFunc;
 

--- a/Sources/SearchAPI-Fulltext.php
+++ b/Sources/SearchAPI-Fulltext.php
@@ -17,27 +17,8 @@ if (!defined('SMF'))
 /**
  * Fulltext API, used when an SQL fulltext index is used
  */
-class fulltext_search
+class fulltext_search extends search_api
 {
-	/**
-	 * This is the last version of SMF that this was tested on, to protect against API changes.
-	 * @var type
-	 */
-	public $version_compatible = 'SMF 2.1 Alpha 1';
-
-	/**
-	 * This won't work with versions of SMF less than this.
-	 * @var type
-	 */
-	public $min_smf_version = 'SMF 2.1 Alpha 1';
-
-	/**
-	 * Is it supported?
-	 *
-	 * @var type
-	 */
-	public $is_supported = true;
-
 	/**
 	 * What words are banned?
 	 * @var type
@@ -58,7 +39,6 @@ class fulltext_search
 
 	/**
 	 * fulltext_search::__construct()
-	 *
 	 */
 	public function __construct()
 	{
@@ -76,13 +56,7 @@ class fulltext_search
 	}
 
 	/**
-	 * fulltext_search::supportsMethod()
-	 *
-	 * Check whether the method can be performed by this API.
-	 *
-	 * @param mixed $methodName
-	 * @param mixed $query_params
-	 * @return
+	 * {@inheritDoc}
 	 */
 	public function supportsMethod($methodName, $query_params = null)
 	{
@@ -106,7 +80,7 @@ class fulltext_search
 	 *
 	 * What is the minimum word length full text supports?
 	 *
-	 * @return
+	 * @return int
 	 */
 	protected function _getMinWordLength()
 	{
@@ -133,13 +107,7 @@ class fulltext_search
 	}
 
 	/**
-	 * callback function for usort used to sort the fulltext results.
-	 * the order of sorting is: large words, small words, large words that
-	 * are excluded from the search, small words that are excluded.
-	 *
-	 * @param string $a Word A
-	 * @param string $b Word B
-	 * @return int
+	 * {@inheritDoc}
 	 */
 	public function searchSort($a, $b)
 	{
@@ -152,17 +120,9 @@ class fulltext_search
 	}
 
 	/**
-	 * fulltext_search::prepareIndexes()
-	 *
-	 * Do we have to do some work with the words we are searching for to prepare them?
-	 *
-	 * @param mixed $word
-	 * @param mixed $wordsSearch
-	 * @param mixed $wordsExclude
-	 * @param mixed $isExcluded
-	 * @return
+	 * {@inheritDoc}
 	 */
-	public function prepareIndexes($word, &$wordsSearch, &$wordsExclude, $isExcluded)
+	public function prepareIndexes($word, array &$wordsSearch, array &$wordsExclude, $isExcluded)
 	{
 		global $modSettings, $smcFunc;
 
@@ -196,15 +156,9 @@ class fulltext_search
 	}
 
 	/**
-	 * fulltext_search::indexedWordQuery()
-	 *
-	 * Search for indexed words.
-	 *
-	 * @param mixed $words
-	 * @param mixed $search_data
-	 * @return
+	 * {@inheritDoc}
 	 */
-	public function indexedWordQuery($words, $search_data)
+	public function indexedWordQuery(array $words, array $search_data)
 	{
 		global $modSettings, $smcFunc;
 

--- a/Sources/SearchAPI-Standard.php
+++ b/Sources/SearchAPI-Standard.php
@@ -17,34 +17,10 @@ if (!defined('SMF'))
 /**
  * Standard non full index, non custom index search
  */
-class standard_search
+class standard_search extends search_api
 {
 	/**
-	 * This is the last version of SMF that this was tested on, to protect against API changes.
-	 *
-	 * @var type
-	 */
-	public $version_compatible = 'SMF 2.1 ALpha';
-
-	/**
-	 * This won't work with versions of SMF less than this.
-	 *
-	 * @var type
-	 */
-	public $min_smf_version = 'SMF 2.1 Alpha 1';
-
-	/**
-	 * Standard search is supported by default.
-	 * @var type
-	 */
-	public $is_supported = true;
-
-	/**
-	 * Method to check whether the method can be performed by the API.
-	 *
-	 * @param type $methodName
-	 * @param type $query_params
-	 * @return boolean
+	 * {@inheritDoc}
 	 */
 	public function supportsMethod($methodName, $query_params = null)
 	{


### PR DESCRIPTION
Introduce search_api_interface and search_api in order define the full functionality and capabilities of a Search API.  Simplify the extending classes in order to improve the code reusability and readability.

Don't merge yet, I'd like to address SimpleMachines#1563 first.
