### PR TITLE
Remove board's names from link tree which cannot be seen by the member

### DIFF
--- a/Themes/default/languages/index.english.php
+++ b/Themes/default/languages/index.english.php
@@ -525,6 +525,7 @@ $txt['theme_template_error'] = 'Unable to load the \'%1$s\' template.';
 $txt['theme_language_error'] = 'Unable to load the \'%1$s\' language file.';
 
 $txt['sub_boards'] = 'Sub-Boards';
+$txt['restricted_board'] = 'Restricted Board';
 
 $txt['smtp_no_connect'] = 'Could not connect to SMTP host';
 $txt['smtp_port_ssl'] = 'SMTP port setting incorrect; it should be 465 for SSL servers.';


### PR DESCRIPTION
The members which cannot see the boards in linktree will instead see "Restricted Board" in italic instead, the idea being to respect board privacy and not give out names which aren't supposed to be. I'm still adding "Restricted Board" in order to avoid possible confusion about the board's visibility on BoardIndex and it's child depth

Fixes SImpleMachines#1629
