### PR TITLE
Optimise and improve board queries and sorting

### DIFF
--- a/Sources/ManageBoards.php
+++ b/Sources/ManageBoards.php
@@ -826,7 +826,6 @@ function EditBoardSettings($return_config = false)
 	global $context, $txt, $sourcedir, $scripturl, $smcFunc;
 
 	// Load the boards list - for the recycle bin!
-	$recycle_boards = array('');
 	$request = $smcFunc['db_query']('order_by_board_order', '
 		SELECT b.id_board, b.name AS board_name, c.name AS cat_name
 		FROM {db_prefix}boards AS b
@@ -839,6 +838,11 @@ function EditBoardSettings($return_config = false)
 	while ($row = $smcFunc['db_fetch_assoc']($request))
 		$recycle_boards[$row['id_board']] = $row['cat_name'] . ' - ' . $row['board_name'];
 	$smcFunc['db_free_result']($request);
+
+	require_once($sourcedir . '/Subs-Boards.php');
+	sortBoards($recycle_boards);
+
+	array_unshift($recycle_boards, '');
 
 	// Here and the board settings...
 	$config_vars = array(

--- a/Sources/ManageCalendar.php
+++ b/Sources/ManageCalendar.php
@@ -317,6 +317,9 @@ function ModifyCalendarSettings($return_config = false)
 		$boards[$row['id_board']] = $row['cat_name'] . ' - ' . $row['board_name'];
 	$smcFunc['db_free_result']($request);
 
+	require_once($sourcedir . '/Subs-Boards.php');
+	sortBoards($boards);
+
 	// Look, all the calendar settings - of which there are many!
 	if (!empty($modSettings['cal_enabled']))
 		$config_vars = array(

--- a/Sources/ManageMaintenance.php
+++ b/Sources/ManageMaintenance.php
@@ -206,7 +206,7 @@ function MaintainMembers()
  */
 function MaintainTopics()
 {
-	global $context, $smcFunc, $txt;
+	global $context, $smcFunc, $txt, $sourcedir;
 
 	// Let's load up the boards in case they are useful.
 	$result = $smcFunc['db_query']('order_by_board_order', '
@@ -235,6 +235,9 @@ function MaintainTopics()
 		);
 	}
 	$smcFunc['db_free_result']($result);
+
+	require_once($sourcedir . '/Subs-Boards.php');
+	sortCategories($context['categories']);
 
 	if (isset($_GET['done']) && $_GET['done'] == 'purgeold')
 		$context['maintenance_finished'] = $txt['maintain_old'];

--- a/Sources/Profile-Modify.php
+++ b/Sources/Profile-Modify.php
@@ -2600,7 +2600,7 @@ function loadThemeOptions($memID)
  */
 function ignoreboards($memID)
 {
-	global $txt, $context, $modSettings, $smcFunc, $cur_profile;
+	global $txt, $context, $modSettings, $smcFunc, $cur_profile, $sourcedir;
 
 	// Have the admins enabled this option?
 	if (empty($modSettings['allow_ignore_boards']))
@@ -2640,6 +2640,9 @@ function ignoreboards($memID)
 		);
 	}
 	$smcFunc['db_free_result']($request);
+
+	require_once($sourcedir . '/Subs-Boards.php');
+	sortCategories($context['categories']);
 
 	// Now, let's sort the list of categories into the boards for templates that like that.
 	$temp_boards = array();

--- a/Sources/Profile-View.php
+++ b/Sources/Profile-View.php
@@ -2602,6 +2602,9 @@ function showPermissions($memID)
 	}
 	$smcFunc['db_free_result']($request);
 
+	require_once($sourcedir . '/Subs-Boards.php');
+	sortBoards($context['boards']);
+
 	if (!empty($context['no_access_boards']))
 		$context['no_access_boards'][count($context['no_access_boards']) - 1]['is_last'] = true;
 

--- a/Sources/Reports.php
+++ b/Sources/Reports.php
@@ -208,7 +208,8 @@ function BoardReport()
 		FROM {db_prefix}boards AS b
 			LEFT JOIN {db_prefix}categories AS c ON (c.id_cat = b.id_cat)
 			LEFT JOIN {db_prefix}boards AS par ON (par.id_board = b.id_parent)
-			LEFT JOIN {db_prefix}themes AS th ON (th.id_theme = b.id_theme AND th.variable = {string:name})',
+			LEFT JOIN {db_prefix}themes AS th ON (th.id_theme = b.id_theme AND th.variable = {string:name})
+		ORDER BY b.board_order',
 		array(
 			'name' => 'name',
 			'text_none' => $txt['none'],

--- a/Sources/Search.php
+++ b/Sources/Search.php
@@ -164,6 +164,9 @@ function PlushSearch1()
 	}
 	$smcFunc['db_free_result']($request);
 
+	require_once($sourcedir . '/Subs-Boards.php');
+	sortCategories($context['categories']);
+
 	// Now, let's sort the list of categories into the boards for templates that like that.
 	$temp_boards = array();
 	foreach ($context['categories'] as $category)

--- a/Sources/Subs-BoardIndex.php
+++ b/Sources/Subs-BoardIndex.php
@@ -323,6 +323,7 @@ function getBoardIndex($boardIndexOptions)
 	if ($boardIndexOptions['include_categories'])
 	{
 		foreach ($categories as $k => $category)
+		{
 			foreach ($category['boards'] as $j => $board)
 			{
 				if (!empty($moderators[$board['id']]))
@@ -341,6 +342,7 @@ function getBoardIndex($boardIndexOptions)
 					}
 				}
 			}
+		}
 	}
 	else
 	{

--- a/Sources/Subs-BoardIndex.php
+++ b/Sources/Subs-BoardIndex.php
@@ -361,6 +361,11 @@ function getBoardIndex($boardIndexOptions)
 		}
 	}
 
+	if ($boardIndexOptions['include_categories'])
+		sortCategories($categories);
+	else
+		sortBoards($this_category);
+
 	// By now we should know the most recent post...if we wanna know it that is.
 	if (!empty($boardIndexOptions['set_latest_post']) && !empty($latest_post['ref']))
 		$context['latest_post'] = $latest_post['ref'];

--- a/Sources/Subs-BoardIndex.php
+++ b/Sources/Subs-BoardIndex.php
@@ -32,7 +32,9 @@ if (!defined('SMF'))
 function getBoardIndex($boardIndexOptions)
 {
 	global $smcFunc, $scripturl, $user_info, $modSettings, $txt;
-	global $settings, $options, $context;
+	global $settings, $options, $context, $sourcedir;
+
+	require_once($sourcedir . '/Subs-Boards.php');
 
 	// For performance, track the latest post while going through the boards.
 	if (!empty($boardIndexOptions['set_latest_post']))
@@ -53,19 +55,13 @@ function getBoardIndex($boardIndexOptions)
 			' . ($user_info['is_guest'] ? ' 1 AS is_read, 0 AS new_from,' : '
 			(IFNULL(lb.id_msg, 0) >= b.id_msg_updated) AS is_read, IFNULL(lb.id_msg, -1) + 1 AS new_from,' . ($boardIndexOptions['include_categories'] ? '
 			c.can_collapse,' : '')) . '
-			IFNULL(mem.id_member, 0) AS id_member, mem.avatar, m.id_msg,
-			IFNULL(mods_grp.id_group, 0) AS id_moderator_group, mods_grp.group_name AS mod_group_name,
-			IFNULL(mods_mem.id_member, 0) AS id_moderator, mods_mem.real_name AS mod_real_name' . (!empty($settings['avatars_on_indexes']) ? ',
+			IFNULL(mem.id_member, 0) AS id_member, mem.avatar, m.id_msg' . (!empty($settings['avatars_on_indexes']) ? ',
 			IFNULL(a.id_attach, 0) AS id_attach, a.filename, a.attachment_type' : '') . '
 		FROM {db_prefix}boards AS b' . ($boardIndexOptions['include_categories'] ? '
 			LEFT JOIN {db_prefix}categories AS c ON (c.id_cat = b.id_cat)' : '') . '
 			LEFT JOIN {db_prefix}messages AS m ON (m.id_msg = b.id_last_msg)
 			LEFT JOIN {db_prefix}members AS mem ON (mem.id_member = m.id_member)' . ($user_info['is_guest'] ? '' : '
-			LEFT JOIN {db_prefix}log_boards AS lb ON (lb.id_board = b.id_board AND lb.id_member = {int:current_member})') . '
-			LEFT JOIN {db_prefix}moderators AS mods ON (mods.id_board = b.id_board)
-			LEFT JOIN {db_prefix}moderator_groups AS mods_g ON (mods_g.id_board = b.id_board)
-			LEFT JOIN {db_prefix}membergroups AS mods_grp ON (mods_grp.id_group = mods_g.id_group)
-			LEFT JOIN {db_prefix}members AS mods_mem ON (mods_mem.id_member = mods.id_member)' . (!empty($settings['avatars_on_indexes']) ? '
+			LEFT JOIN {db_prefix}log_boards AS lb ON (lb.id_board = b.id_board AND lb.id_member = {int:current_member})') . (!empty($settings['avatars_on_indexes']) ? '
 			LEFT JOIN {db_prefix}attachments AS a ON (a.id_member = m.id_member)' : '') . '
 		WHERE {query_see_board}' . (empty($boardIndexOptions['countChildPosts']) ? (empty($boardIndexOptions['base_level']) ? '' : '
 			AND b.child_level >= {int:child_level}') : '
@@ -82,6 +78,7 @@ function getBoardIndex($boardIndexOptions)
 		$categories = array();
 	else
 		$this_category = array();
+	$boards = array();
 
 	// Run through the categories and boards (or only boards)....
 	while ($row_board = $smcFunc['db_fetch_assoc']($result_boards))
@@ -89,6 +86,7 @@ function getBoardIndex($boardIndexOptions)
 		// Perhaps we are ignoring this board?
 		$ignoreThisBoard = in_array($row_board['id_board'], $user_info['ignoreboards']);
 		$row_board['is_read'] = !empty($row_board['is_read']) || $ignoreThisBoard ? '1' : '0';
+		$boards[] = $row_board['id_board'];
 
 		if ($boardIndexOptions['include_categories'])
 		{
@@ -168,32 +166,6 @@ function getBoardIndex($boardIndexOptions)
 				{
 					$this_category[$row_board['id_board']]['board_tooltip'] = $txt['old_posts'];
 				}
-			}
-			if (!empty($row_board['id_moderator']))
-			{
-				$this_category[$row_board['id_board']]['moderators'][$row_board['id_moderator']] = array(
-					'id' => $row_board['id_moderator'],
-					'name' => $row_board['mod_real_name'],
-					'href' => $scripturl . '?action=profile;u=' . $row_board['id_moderator'],
-					'link' => '<a href="' . $scripturl . '?action=profile;u=' . $row_board['id_moderator'] . '" title="' . $txt['board_moderator'] . '">' . $row_board['mod_real_name'] . '</a>'
-				);
-				$this_category[$row_board['id_board']]['link_moderators'][] = '<a href="' . $scripturl . '?action=profile;u=' . $row_board['id_moderator'] . '" title="' . $txt['board_moderator'] . '">' . $row_board['mod_real_name'] . '</a>';
-			}
-			if (!empty($row_board['id_moderator_group']))
-			{
-				$this_category[$row_board['id_board']]['moderator_groups'][$row_board['id_moderator_group']] = array(
-					'id' => $row_board['id_moderator_group'],
-					'name' => $row_board['mod_group_name'],
-					'href' => $scripturl . '?action=groups;sa=members;group=' . $row_board['id_moderator_group'],
-					'link' => '<a href="' . $scripturl . '?action=groups;sa=members;group=' . $row_board['id_moderator_group'] . '" title="' . $txt['board_moderator'] . '">' . $row_board['mod_group_name'] . '</a>'
-				);
-				$this_category[$row_board['id_board']]['link_moderator_groups'][] = '<a href="' . $scripturl . '?action=groups;sa=members;group=' . $row_board['id_moderator_group'] . '" title="' . $txt['board_moderator'] . '">' . $row_board['mod_group_name'] . '</a>';
-			}
-
-			// Merge the two lists of moderators
-			if (!empty($this_category[$row_board['id_board']]['link_moderator_groups']))
-			{
-				$this_category[$row_board['id_board']]['link_moderators'] = array_merge($this_category[$row_board['id_board']]['link_moderators'], $this_category[$row_board['id_board']]['link_moderator_groups']);
 			}
 		}
 		// Found a child board.... make sure we've found its parent and the child hasn't been set already.
@@ -340,6 +312,54 @@ function getBoardIndex($boardIndexOptions)
 			);
 	}
 	$smcFunc['db_free_result']($result_boards);
+
+	// Fetch the board's moderators and moderator groups
+	$boards = array_unique($boards);
+	$moderators = getBoardModerators($boards);
+	$groups = getBoardModeratorGroups($boards);
+	if ($boardIndexOptions['include_categories'])
+	{
+		foreach ($categories as $k => $category)
+			foreach ($category['boards'] as $j => $board)
+			{
+				if (!empty($moderators[$board['id']]))
+				{
+					$categories[$k]['boards'][$j]['moderators'] = $moderators[$board['id']];
+					foreach ($moderators[$board['id']] as $moderator)
+						$categories[$k]['boards'][$j]['link_moderators'][] = $moderator['link'];
+				}
+				if (!empty($groups[$board['id']]))
+				{
+					$categories[$k]['boards'][$j]['moderator_groups'] = $groups[$board['id']];
+					foreach ($groups[$board['id']] as $group)
+					{
+						$categories[$k]['boards'][$j]['link_moderators'][] = $group['link'];
+						$categories[$k]['boards'][$j]['link_moderator_groups'][] = $group['link'];
+					}
+				}
+			}
+	}
+	else
+	{
+		foreach ($this_category as $k => $board)
+		{
+			if (!empty($moderators[$board['id']]))
+			{
+				$this_category[$k]['moderators'] = $moderators[$board['id']];
+				foreach ($moderators[$board['id']] as $moderator)
+					$this_category[$k]['link_moderators'][] = $moderator['link'];
+			}
+			if (!empty($groups[$board['id']]))
+			{
+				$this_category[$k]['moderator_groups'] = $groups[$board['id']];
+				foreach ($groups[$board['id']] as $group)
+				{
+					$this_category[$k]['link_moderators'][] = $group['link'];
+					$this_category[$k]['link_moderator_groups'][] = $group['link'];
+				}
+			}
+		}
+	}
 
 	// By now we should know the most recent post...if we wanna know it that is.
 	if (!empty($boardIndexOptions['set_latest_post']) && !empty($latest_post['ref']))

--- a/Sources/Subs-BoardIndex.php
+++ b/Sources/Subs-BoardIndex.php
@@ -86,7 +86,10 @@ function getBoardIndex($boardIndexOptions)
 		// Perhaps we are ignoring this board?
 		$ignoreThisBoard = in_array($row_board['id_board'], $user_info['ignoreboards']);
 		$row_board['is_read'] = !empty($row_board['is_read']) || $ignoreThisBoard ? '1' : '0';
-		$boards[] = $row_board['id_board'];
+
+		// Add parent boards to the $boards list later used to fetch moderators
+		if ($row_board['id_parent'] == $boardIndexOptions['parent_id'])
+			$boards[] = $row_board['id_board'];
 
 		if ($boardIndexOptions['include_categories'])
 		{

--- a/Sources/Subs-Boards.php
+++ b/Sources/Subs-Boards.php
@@ -1128,7 +1128,8 @@ function fixChildren($parent, $newLevel, $newParent)
 
 /**
  * Tries to load up the entire board order and category very very quickly
- * Returns an array with two elements, cat and board
+ * Returns an array with two elements, cats and boards
+ * 
  * @return array
  */
 function getTreeOrder()
@@ -1149,7 +1150,6 @@ function getTreeOrder()
 		return $cached;
 	}
 
-	// Using a single query will cause us to revert back to
 	$request = $smcFunc['db_query']('', '
 		SELECT b.id_board, b.id_cat
 		FROM {db_prefix}boards AS b

--- a/Sources/Subs-Boards.php
+++ b/Sources/Subs-Boards.php
@@ -1133,6 +1133,85 @@ function fixChildren($parent, $newLevel, $newParent)
 }
 
 /**
+ * Returns the given board's moderators, with their names and link
+ *
+ * @param array $boards
+ * @return array
+ */
+function getBoardModerators(array $boards)
+{
+	global $smcFunc, $scripturl, $txt;
+
+	if (empty($boards))
+		return array();
+
+	$request = $smcFunc['db_query']('', '
+		SELECT mem.id_member, mem.real_name, mo.id_board
+		FROM {db_prefix}moderators AS mo
+		  INNER JOIN {db_prefix}members AS mem ON (mem.id_member = mo.id_member)
+		WHERE mo.id_board IN ({array_int:boards})',
+		array(
+			'boards' => $boards,
+		)
+	);
+	$moderators = array();
+	while ($row = $smcFunc['db_fetch_assoc']($request))
+	{
+		if (empty($moderators[$row['id_board']]))
+			$moderators[$row['id_board']] = array();
+
+		$moderators[$row['id_board']][] = array(
+			'id' => $row['id_member'],
+			'name' => $row['real_name'],
+			'href' => $scripturl . '?action=profile;u=' . $row['id_member'],
+			'link' => '<a href="' . $scripturl . '?action=profile;u=' . $row['id_member'] . '" title="' . $txt['board_moderator'] . '">' . $row['real_name'] . '</a>',
+		);
+	}
+	$smcFunc['db_free_result']($request);
+
+	return $moderators;
+}
+
+/**
+ * Returns board's moderator groups with their names and link
+ *
+ * @param array $boards
+ * @return array
+ */
+function getBoardModeratorGroups(array $boards)
+{
+	global $smcFunc, $scripturl, $txt;
+
+	if (empty($boards))
+		return array();
+
+	$request = $smcFunc['db_query']('', '
+		SELECT mg.id_group, mg.group_name, bg.id_board
+		FROM {db_prefix}moderator_groups AS bg
+		  INNER JOIN {db_prefix}membergroups AS mg ON (mg.id_group = bg.id_group)
+		WHERE bg.id_board IN ({array_int:boards})',
+		array(
+			'boards' => $boards,
+		)
+	);
+	$groups = array();
+	while ($row = $smcFunc['db_fetch_assoc']($request))
+	{
+		if (empty($groups[$row['id_board']]))
+			$groups[$row['id_board']] = array();
+
+		$groups[$row['id_board']][] = array(
+			'id' => $row['id_group'],
+			'name' => $row['group_name'],
+			'href' => $scripturl . '?action=groups;sa=members;group=' . $row['id_group'],
+			'link' => '<a href="' . $scripturl . '?action=groups;sa=members;group=' . $row['id_group'] . '" title="' . $txt['board_moderator'] . '">' . $row['group_name'] . '</a>',
+		);
+	}
+
+	return $groups;
+}
+
+/**
  * Load a lot of useful information regarding the boards and categories.
  * The information retrieved is stored in globals:
  *  $boards		properties of each board.

--- a/Sources/Subs-Boards.php
+++ b/Sources/Subs-Boards.php
@@ -1189,7 +1189,7 @@ function sortBoards(array &$boards)
 				sortBoards($ordered[$board]['boards']);
 
 			if (is_array($ordered[$board]) && !empty($ordered[$board]['children']))
-				sortboards($ordered[$board]['children']);
+				sortBoards($ordered[$board]['children']);
 		}
 
 	$boards = $ordered;

--- a/Sources/Subs-Db-postgresql.php
+++ b/Sources/Subs-Db-postgresql.php
@@ -273,9 +273,6 @@ function smf_db_query($identifier, $db_string, $db_values = array(), $connection
 
 	// Special queries that need processing.
 	$replacements = array(
-		'alter_table_boards' => array(
-			'~(.+)~' => '',
-		),
 		'ban_suggest_error_ips' => array(
 			'~RLIKE~' => '~',
 			'~\\.~' => '\.',

--- a/Sources/Subs-Db-postgresql.php
+++ b/Sources/Subs-Db-postgresql.php
@@ -301,7 +301,6 @@ function smf_db_query($identifier, $db_string, $db_values = array(), $connection
 		),
 		'boardindex_fetch_boards' => array(
 			'~IFNULL\(lb.id_msg, 0\) >= b.id_msg_updated~' => 'CASE WHEN IFNULL(lb.id_msg, 0) >= b.id_msg_updated THEN 1 ELSE 0 END',
-			'~(.)$~' => '$1 ORDER BY b.board_order',
 		),
 		'get_random_number' => array(
 			'~RAND~' => 'RANDOM',
@@ -323,9 +322,6 @@ function smf_db_query($identifier, $db_string, $db_values = array(), $connection
 		),
 		'top_topic_starters' => array(
 			'~ORDER BY FIND_IN_SET\(id_member,(.+?)\)~' => 'ORDER BY STRPOS(\',\' || $1 || \',\', \',\' || id_member|| \',\')',
-		),
-		'order_by_board_order' => array(
-			'~(.)$~' => '$1 ORDER BY b.board_order',
 		),
 		'unread_replies' => array(
 			'~SELECT\\s+DISTINCT\\s+t.id_topic~' => 'SELECT t.id_topic, {raw:sort}',

--- a/Sources/Subs-Db-sqlite.php
+++ b/Sources/Subs-Db-sqlite.php
@@ -296,9 +296,6 @@ function smf_db_query($identifier, $db_string, $db_values = array(), $connection
 		'unread_fetch_topic_count' => array(
 			'~\s*SELECT\sCOUNT\(DISTINCT\st\.id_topic\),\sMIN\(t\.id_last_msg\)(.+)$~is' => 'SELECT COUNT(id_topic), MIN(id_last_msg) FROM (SELECT DISTINCT t.id_topic, t.id_last_msg $1)',
 		),
-		'alter_table_boards' => array(
-			'~(.+)~' => '',
-		),
 		'get_random_number' => array(
 			'~RAND~' => 'RANDOM',
 		),

--- a/Sources/Subs-Db-sqlite.php
+++ b/Sources/Subs-Db-sqlite.php
@@ -314,12 +314,6 @@ function smf_db_query($identifier, $db_string, $db_values = array(), $connection
 		'pm_conversation_list' => array(
 			'~ORDER BY id_pm~' => 'ORDER BY MAX(pm.id_pm)',
 		),
-		'boardindex_fetch_boards' => array(
-			'~(.)$~' => '$1 ORDER BY b.board_order',
-		),
-		'order_by_board_order' => array(
-			'~(.)$~' => '$1 ORDER BY b.board_order',
-		),
 	);
 
 	if (isset($replacements[$identifier]))

--- a/Sources/Subs-Db-sqlite3.php
+++ b/Sources/Subs-Db-sqlite3.php
@@ -354,12 +354,6 @@ function smf_db_query($identifier, $db_string, $db_values = array(), $connection
 		'pm_conversation_list' => array(
 			'~ORDER BY id_pm~' => 'ORDER BY MAX(pm.id_pm)',
 		),
-		'boardindex_fetch_boards' => array(
-			'~(.)$~' => '$1 ORDER BY b.board_order',
-		),
-		'order_by_board_order' => array(
-			'~(.)$~' => '$1 ORDER BY b.board_order',
-		),
 	);
 
 	if (isset($replacements[$identifier]))

--- a/Sources/Subs-Db-sqlite3.php
+++ b/Sources/Subs-Db-sqlite3.php
@@ -336,9 +336,6 @@ function smf_db_query($identifier, $db_string, $db_values = array(), $connection
 		'unread_fetch_topic_count' => array(
 			'~\s*SELECT\sCOUNT\(DISTINCT\st\.id_topic\),\sMIN\(t\.id_last_msg\)(.+)$~is' => 'SELECT COUNT(id_topic), MIN(id_last_msg) FROM (SELECT DISTINCT t.id_topic, t.id_last_msg $1)',
 		),
-		'alter_table_boards' => array(
-			'~(.+)~' => '',
-		),
 		'get_random_number' => array(
 			'~RAND~' => 'RANDOM',
 		),

--- a/Sources/Subs-MessageIndex.php
+++ b/Sources/Subs-MessageIndex.php
@@ -23,7 +23,7 @@ if (!defined('SMF'))
  */
 function getBoardList($boardListOptions = array())
 {
-	global $smcFunc;
+	global $smcFunc, $sourcedir;
 
 	if (isset($boardListOptions['excluded_boards']) && isset($boardListOptions['included_boards']))
 		trigger_error('getBoardList(): Setting both excluded_boards and included_boards is not allowed.', E_USER_ERROR);
@@ -75,7 +75,7 @@ function getBoardList($boardListOptions = array())
 					'boards' => array(),
 				);
 
-			$return_value[$row['id_cat']]['boards'][] = array(
+			$return_value[$row['id_cat']]['boards'][$row['id_board']] = array(
 				'id' => $row['id_board'],
 				'name' => $row['board_name'],
 				'child_level' => $row['child_level'],
@@ -84,6 +84,9 @@ function getBoardList($boardListOptions = array())
 		}
 	}
 	$smcFunc['db_free_result']($request);
+
+	require_once($sourcedir . '/Subs-Boards.php');
+	sortCategories($return_value);
 
 	return $return_value;
 }


### PR DESCRIPTION
Does two things:

1) Breaks down BoardIndex query into three smaller queries, the sum of which is slightly faster than the single query. It breaks the moderator and moderator_group fetching code into separate queries

2) Explicitly sort boards everywhere, instead of relying on database table's sorted structure

Fixes SimpleMachines#858 and SimpleMachines#887 and maybe even SimpleMachines#1366
