### PR TITLE
BBC integration hook/autolinks

### DIFF
--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -1566,8 +1566,16 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 			),
 		);
 
+		// Inside these tags autolink is not recommendable.
+		$no_autolink_tags = array(
+			'url',
+			'iurl',
+			'ftp',
+			'email',
+		);
+		
 		// Let mods add new BBC without hassle.
-		call_integration_hook('integrate_bbc_codes', array(&$codes));
+		call_integration_hook('integrate_bbc_codes', array(&$codes, &$no_autolink_tags));
 
 		// This is mainly for the bbc manager, so it's easy to add tags above.  Custom BBC should be added above this line.
 		if ($message === false)
@@ -1593,14 +1601,6 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 			foreach ($itemcodes as $c => $dummy)
 				$bbc_codes[$c] = array();
 		}
-
-		// Inside these tags autolink is not recommendable.
-		$no_autolink_tags = array(
-			'url',
-			'iurl',
-			'ftp',
-			'email',
-		);
 
 		// Shhhh!
 		if (!isset($disabled['color']))


### PR DESCRIPTION
BBC integration hook should allow adding to the no autolink array.
Parsed BBC's added via the hook may use url's whereas being automatically changed to hyperlinks can cause an issue.  
Signed-off-by: -Underdog- github.underdog@gmail.com
