### PR TITLE
Get rid of pregReplaceCurry and use closures instead

### DIFF
--- a/Sources/Modlog.php
+++ b/Sources/Modlog.php
@@ -606,7 +606,6 @@ function list_getModLogEntries($start, $items_per_page, $sort, $query_string = '
 	}
 
 	// Do some formatting of the action string.
-	$callback = pregReplaceCurry('list_getModLogEntriesCallback', 3);
 	foreach ($entries as $k => $entry)
 	{
 		// Make any message info links so its easier to go find that message.
@@ -629,29 +628,15 @@ function list_getModLogEntries($start, $items_per_page, $sort, $query_string = '
 
 		if (empty($entries[$k]['action_text']))
 			$entries[$k]['action_text'] = isset($txt['modlog_ac_' . $entry['action']]) ? $txt['modlog_ac_' . $entry['action']] : $entry['action'];
-		$entries[$k]['action_text'] = preg_replace_callback('~\{([A-Za-z\d_]+)\}~i', $callback($entries, $k), $entries[$k]['action_text']);
+		$entries[$k]['action_text'] = preg_replace_callback('~\{([A-Za-z\d_]+)\}~i',
+			function ($matches) use ($entries, $k)
+			{
+				return isset($entries[$k]['extra'][$matches[1]]) ? $entries[$k]['extra'][$matches[1]] : '';
+			}, $entries[$k]['action_text']);
 	}
 
 	// Back we go!
 	return $entries;
-}
-
-/**
- * Mog Log Replacment Callback.
- *
- * Our callback that does the actual replacments.
- *
- * Original code from: http://php.net/manual/en/function.preg-replace-callback.php#88013
- * This is needed until SMF only supports PHP 5.3+ and we change to "use"
- *
- * @param string $entries
- * @param string $key
- * @param string $matches
- * @return string the replaced results.
- */
-function list_getModLogEntriesCallback($entries, $key, $matches)
-{
-    return isset($entries[$key]['extra'][$matches[1]]) ? $entries[$key]['extra'][$matches[1]] : '';
 }
 
 ?>

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -2486,57 +2486,11 @@ function parsesmileys(&$message)
 	}
 
 	// Replace away!
-	/*
-	* TODO: When SMF supports only PHP 5.3+, we can change this to "uses" keyword and simpifly this.
-	*/
-	$callback = pregReplaceCurry('smielyPregReplaceCallback', 2);
-	$message = preg_replace_callback($smileyPregSearch, $callback($smileyPregReplacements), $message);
-}
-
-/**
- * Preg Replacment Curry.
- *
- * This allows use to do delayed argument binding and bring in
- * the replacement variables for some preg replacments.
- *
- * Original code from: http://php.net/manual/en/function.preg-replace-callback.php#88013
- * This is needed until SMF only supports PHP 5.3+ and we change to "use"
- *
- * @param string $func
- * @param string $arity
- * @return function a lambda function bound to $func.
- */
-function pregReplaceCurry($func, $arity)
-{
-	return create_function('', "
-		\$args = func_get_args();
-		if(count(\$args) >= $arity)
-			return call_user_func_array('$func', \$args);
-		\$args = var_export(\$args, 1);
-		return create_function('','
-			\$a = func_get_args();
-			\$z = ' . \$args . ';
-			\$a = array_merge(\$z,\$a);
-			return call_user_func_array(\'$func\', \$a);
-		');
-	");
-}
-
-/**
- * Smiely Replacment Callback.
- *
- * Our callback that does the actual smiley replacments.
- *
- * Original code from: http://php.net/manual/en/function.preg-replace-callback.php#88013
- * This is needed until SMF only supports PHP 5.3+ and we change to "use"
- *
- * @param string $replacements
- * @param string $matches
- * @return string the replaced results.
- */
-function smielyPregReplaceCallback($replacements, $matches)
-{
-    return $replacements[$matches[1]];
+	$message = preg_replace_callback($smileyPregSearch,
+		function ($matches) use ($smileyPregReplacements)
+		{
+			return $smileyPregReplacements[$matches[1]];
+		}, $message);
 }
 
 /**


### PR DESCRIPTION
Perks of PHP 5.3+, we can use closures instead of currying our way to pass scope into the callbacks, saves us from a lot of create_function hell

Signed-off-by: Shitiz Garg mail@dragooon.net
