### PR TITLE
Minimum PHP version is now 5.3.2...

### DIFF
--- a/other/install.php
+++ b/other/install.php
@@ -14,7 +14,7 @@
 $GLOBALS['current_smf_version'] = '2.1 Alpha 1';
 $GLOBALS['db_script_version'] = '2-1';
 
-$GLOBALS['required_php_version'] = '5.1.0';
+$GLOBALS['required_php_version'] = '5.3.2';
 
 // Don't have PHP support, do you?
 // ><html dir="ltr"><head><title>Error!</title></head><body>Sorry, this installer requires PHP!<div style="display: none;">

--- a/other/upgrade.php
+++ b/other/upgrade.php
@@ -15,7 +15,7 @@
 define('SMF_VERSION', '2.1 Alpha 1');
 define('SMF_LANG_VERSION', '2.1 Alpha 1');
 
-$GLOBALS['required_php_version'] = '5.1.0';
+$GLOBALS['required_php_version'] = '5.3.2';
 $GLOBALS['required_mysql_version'] = '4.0.18';
 
 $databases = array(


### PR DESCRIPTION
This is just the bare minimum at the moment - this doesn't take into account compatibility checks and such that may no longer be needed.

Signed-off-by: Michael Eshom oldiesmann@oldiesmann.us
