### PR TITLE
Fix default category having "1" as description on fresh SQLite3 install

### DIFF
--- a/other/install_2-1_sqlite3.sql
+++ b/other/install_2-1_sqlite3.sql
@@ -699,7 +699,7 @@ CREATE TABLE {$db_prefix}categories (
 #
 
 INSERT INTO {$db_prefix}categories
-VALUES (1, 0, '{$default_category_name}', 1, 1);
+VALUES (1, 0, '{$default_category_name}', '', 1);
 # --------------------------------------------------------
 
 #


### PR DESCRIPTION
Signed-off-by: Shitiz Garg mail@dragooon.net
