### PR TITLE
SQL Query not needed for guests since they can not be a group moderator

### DIFF
--- a/Sources/Subs-Auth.php
+++ b/Sources/Subs-Auth.php
@@ -695,7 +695,7 @@ function rebuildModCache()
 	// What groups can they moderate?
 	$group_query = allowedTo('manage_membergroups') ? '1=1' : '0=1';
 
-	if ($group_query == '0=1')
+	if ($group_query == '0=1' && !$user_info['is_guest'])
 	{
 		$request = $smcFunc['db_query']('', '
 			SELECT id_group


### PR DESCRIPTION
SQL Query not needed for guests since they can not be a group moderator
Signed-off-by: vbgamer45 vbgamer45@gmail.com
