### PR TITLE
Move "Please login or register" text down

### DIFF
--- a/Themes/default/css/index.css
+++ b/Themes/default/css/index.css
@@ -1491,6 +1491,7 @@ img#smflogo {
 .welcome
 {
 	padding-left: 10px;
+	padding-top: 5px;
 }
 /*
 /* The user info, news, etc.*/


### PR DESCRIPTION
When logged out, the text was too far to the top. This commit fixes that.

Signed-off-by: Yoshi2889 rick.2889@gmail.com
