### PR TITLE
Bump minimum PHP version to 5.3.8

### DIFF
--- a/other/install.php
+++ b/other/install.php
@@ -14,7 +14,7 @@
 $GLOBALS['current_smf_version'] = '2.1 Alpha 1';
 $GLOBALS['db_script_version'] = '2-1';
 
-$GLOBALS['required_php_version'] = '5.3.7';
+$GLOBALS['required_php_version'] = '5.3.8';
 
 // Don't have PHP support, do you?
 // ><html dir="ltr"><head><title>Error!</title></head><body>Sorry, this installer requires PHP!<div style="display: none;">

--- a/other/upgrade.php
+++ b/other/upgrade.php
@@ -15,7 +15,7 @@
 define('SMF_VERSION', '2.1 Alpha 1');
 define('SMF_LANG_VERSION', '2.1 Alpha 1');
 
-$GLOBALS['required_php_version'] = '5.3.7';
+$GLOBALS['required_php_version'] = '5.3.8';
 $GLOBALS['required_mysql_version'] = '4.0.18';
 
 $databases = array(


### PR DESCRIPTION
crypt()'s md5 is broken in PHP 5.3.7 which would cause some problems, especially with legacy password compatibility. Thanks @Arantor

Signed-off-by: Shitiz Garg mail@dragooon.net
