### PR TITLE
Likes perm

### DIFF
--- a/other/upgrade.php
+++ b/other/upgrade.php
@@ -1322,17 +1322,16 @@ function UpgradeOptions()
 
 		// Cleaning up old karma member settings.
 		$smcFunc['db_query']('', '
-			DELETE FROM {db_prefix}members
-			WHERE variable IN ({array_string:karma_vars})',
-			array(
-				'karma_vars' => array('karma_bad', 'karma_good'),
-			)
+			ALTER TABLE {db_prefix}members
+			DROP karma_bad,
+			DROP karma_good',
+			array()
 		);
 
 		// Cleaning up old karma permissions.
 		$smcFunc['db_query']('', '
-			DELETE FROM {db_prefix}members
-			WHERE variable = {string:karma_vars}',
+			DELETE FROM {db_prefix}permissions
+			WHERE permission = {string:karma_vars}',
 			array(
 				'karma_vars' => 'karma_edit',
 			)

--- a/other/upgrade.php
+++ b/other/upgrade.php
@@ -2284,7 +2284,7 @@ function php_version_check()
 	$minver = explode('.', $GLOBALS['required_php_version']);
 	$curver = explode('.', PHP_VERSION);
 
-	return !(($curver[0] <= $minver[0]) && ($curver[1] <= $minver[1]) && ($curver[1] <= $minver[1]) && ($curver[2][0] < $minver[2][0]));
+	return !(($curver[0] <= $minver[0]) && ($curver[1] <= $minver[1]) && ($curver[1] <= $minver[1]) && ($curver[2] < $minver[2]));
 }
 
 function db_version_check()


### PR DESCRIPTION
Fix some silly mistakes I made.

Change $curver[2][0] to $curver[2]

$curver[2][0] will tell PHP to only accept the first value on the string so if you have for example php version 5.3.13 the check will only take the 1 instead of taking the whole 13  so when doing a check against our current min version:  5.3.7  the check will fail because 1 < 7
