### PR TITLE
Update Subs-Graphics.php

### DIFF
--- a/Sources/Subs-Graphics.php
+++ b/Sources/Subs-Graphics.php
@@ -242,16 +242,10 @@ function checkImageContents($fileName, $extensiveCheck = false)
  */
 function checkGD()
 {
-	global $gd2;
-
-	// Ddetermine if GD2 is installed and store it in a global.
-	$gd2 = function_exists('imagecreatetruecolor');
-		
-	// Check to see if GD is installed.
-	if (function_exists('extension_loaded') && extension_loaded('gd'))
-		return true;
-
-	return false;
+    global $gd2;
+    // imagecreate is in both versions of GD, but imagecreatetruecolor only got added in GD2.
+    $gd2 = function_exists('imagecreatetruecolor');
+    return $gd2 || function_exists('imagecreate');
 }
 
 /**

--- a/Sources/Subs-Graphics.php
+++ b/Sources/Subs-Graphics.php
@@ -244,15 +244,13 @@ function checkGD()
 {
 	global $gd2;
 
-	// Check to see if GD is installed and what version.
-	if (function_exists('extension_loaded') && extension_loaded('gd')) {
-
-		// Also determine if GD2 is installed and store it in a global.
-		$gd2 = function_exists('imagecreatetruecolor');
+	// Ddetermine if GD2 is installed and store it in a global.
+	$gd2 = function_exists('imagecreatetruecolor');
 		
+	// Check to see if GD is installed.
+	if (function_exists('extension_loaded') && extension_loaded('gd'))
 		return true;
-	}
-	$gd2 = false;
+
 	return false;
 }
 

--- a/Sources/Subs-Graphics.php
+++ b/Sources/Subs-Graphics.php
@@ -245,7 +245,7 @@ function checkGD()
 	global $gd2;
 
 	// Check to see if GD is installed and what version.
-	if (function_exists(extension_loaded) && extension_loaded('gd')) {
+	if (function_exists('extension_loaded') && extension_loaded('gd')) {
 
 		// Also determine if GD2 is installed and store it in a global.
 		$gd2 = function_exists('imagecreatetruecolor');

--- a/Sources/Subs-Graphics.php
+++ b/Sources/Subs-Graphics.php
@@ -245,13 +245,15 @@ function checkGD()
 	global $gd2;
 
 	// Check to see if GD is installed and what version.
-	if (($extensionFunctions = get_extension_funcs('gd')) === false)
-		return false;
+	if (function_exists(extension_loaded) && extension_loaded('gd')) {
 
-	// Also determine if GD2 is installed and store it in a global.
-	$gd2 = in_array('imagecreatetruecolor', $extensionFunctions) && function_exists('imagecreatetruecolor');
-
-	return true;
+		// Also determine if GD2 is installed and store it in a global.
+		$gd2 = function_exists('imagecreatetruecolor');
+		
+		return true;
+	}
+	$gd2 = false;
+	return false;
 }
 
 /**


### PR DESCRIPTION
I did things differently because of this error:  PHP Fatal error:  Allowed memory size of 33554432 bytes exhausted (tried to allocate 36 bytes) in .../Sources/Subs-Graphics.php on line 300 using SMF 2.0.

Logic:
1.  This functions checks if GD is installed and adds a flag for GD2.  I wanted to get rid of the array created with get_extension_funcs so I replaced it with extension_loaded.  I did not look for a functions_exists GD function for this feature to avoid a fight. Besides extension_loaded seemed to be a good fit.  :0
2.  function_exists is all you need to check for GD2 (ref https://api.drupal.org/api/drupal/modules!system!image.gd.inc/function/image_gd_check_settings/7).  If you look it up you will find that their original code was a slightly improved version of this function.
