### PR TITLE
Update loadMemberCustomFields()

### DIFF
--- a/Sources/Load.php
+++ b/Sources/Load.php
@@ -1323,7 +1323,12 @@ function loadMemberCustomFields($users, $params)
 
 		// More than 1? knock yourself out...
 		else
-			$return[$row['id_member']][$row['id_field']] = $row;
+		{
+			if (!isset($return[$row['id_member']]))
+				$return[$row['id_member']] = array();
+
+			$return[$row['id_member']][$row['variable']] = $row;
+		}
 	}
 
 	$smcFunc['db_free_result']($request);


### PR DESCRIPTION
- Fix undefined index error  from PHP/5.3.x
- We don't expect random numbers spewed out; return same parameters we gave it

Signed-off-by: John Rayes live627@gmail.com
