### PR TITLE
! install.php php < 5.3 syntax errors

### DIFF
--- a/other/install.php
+++ b/other/install.php
@@ -1341,8 +1341,9 @@ function AdminAccount()
 
 	// We need this to properly hash the password for Admin
 	$smcFunc['strtolower'] = $db_character_set != 'utf8' && $txt['lang_character_set'] != 'UTF-8' ? 'strtolower' :
-		function($string) use ($sourcedir)
+		create_function($string)
 		{
+                        global $sourcedir;
 			if (function_exists('mb_strtolower'))
 				return mb_strtolower($string, 'UTF-8');
 			require_once($sourcedir . '/Subs-Charset.php');
@@ -1597,8 +1598,9 @@ function DeleteInstall()
 
 	// This function is needed to do the updateStats('subject') call.
 	$smcFunc['strtolower'] = $db_character_set != 'utf8' && $txt['lang_character_set'] != 'UTF-8' ? 'strtolower' :
-		function($string) use ($sourcedir)
+		create_function($string)
 		{
+                        global $sourcedir;
 			if (function_exists('mb_strtolower'))
 				return mb_strtolower($string, 'UTF-8');
 			require_once($sourcedir . '/Subs-Charset.php');

--- a/other/install.php
+++ b/other/install.php
@@ -1341,14 +1341,13 @@ function AdminAccount()
 
 	// We need this to properly hash the password for Admin
 	$smcFunc['strtolower'] = $db_character_set != 'utf8' && $txt['lang_character_set'] != 'UTF-8' ? 'strtolower' :
-		create_function($string)
-		{
+		create_function($string,'
                         global $sourcedir;
 			if (function_exists('mb_strtolower'))
 				return mb_strtolower($string, 'UTF-8');
 			require_once($sourcedir . '/Subs-Charset.php');
 			return utf8_strtolower($string);
-		};
+		');
 
 	if (!isset($_POST['username']))
 		$_POST['username'] = '';
@@ -1598,14 +1597,13 @@ function DeleteInstall()
 
 	// This function is needed to do the updateStats('subject') call.
 	$smcFunc['strtolower'] = $db_character_set != 'utf8' && $txt['lang_character_set'] != 'UTF-8' ? 'strtolower' :
-		create_function($string)
-		{
+		create_function($string,'
                         global $sourcedir;
 			if (function_exists('mb_strtolower'))
 				return mb_strtolower($string, 'UTF-8');
 			require_once($sourcedir . '/Subs-Charset.php');
 			return utf8_strtolower($string);
-		};
+		');
 
 	$request = $smcFunc['db_query']('', '
 		SELECT id_msg

--- a/other/install.php
+++ b/other/install.php
@@ -1343,9 +1343,9 @@ function AdminAccount()
 	$smcFunc['strtolower'] = $db_character_set != 'utf8' && $txt['lang_character_set'] != 'UTF-8' ? 'strtolower' :
 		create_function($string,'
                         global $sourcedir;
-			if (function_exists('mb_strtolower'))
-				return mb_strtolower($string, 'UTF-8');
-			require_once($sourcedir . '/Subs-Charset.php');
+			if (function_exists(\'mb_strtolower\'))
+				return mb_strtolower($string, \'UTF-8\');
+			require_once($sourcedir . \'/Subs-Charset.php\');
 			return utf8_strtolower($string);
 		');
 
@@ -1599,9 +1599,9 @@ function DeleteInstall()
 	$smcFunc['strtolower'] = $db_character_set != 'utf8' && $txt['lang_character_set'] != 'UTF-8' ? 'strtolower' :
 		create_function($string,'
                         global $sourcedir;
-			if (function_exists('mb_strtolower'))
-				return mb_strtolower($string, 'UTF-8');
-			require_once($sourcedir . '/Subs-Charset.php');
+			if (function_exists(\'mb_strtolower\'))
+				return mb_strtolower($string, \'UTF-8\');
+			require_once($sourcedir . \'/Subs-Charset.php\');
 			return utf8_strtolower($string);
 		');
 


### PR DESCRIPTION
Now, install.php will notify user that php version is too low.
Closures in install.php replaced with create_function.

Signed-off-by: Angelina Belle angelinabelle1@hotmail.com
