### PR TITLE
! [Installer] Closures caused syntax errors in install.php for php < 5.3.8

### DIFF
--- a/other/install.php
+++ b/other/install.php
@@ -1341,13 +1341,13 @@ function AdminAccount()
 
 	// We need this to properly hash the password for Admin
 	$smcFunc['strtolower'] = $db_character_set != 'utf8' && $txt['lang_character_set'] != 'UTF-8' ? 'strtolower' :
-		function($string) use ($sourcedir)
-		{
-			if (function_exists('mb_strtolower'))
-				return mb_strtolower($string, 'UTF-8');
-			require_once($sourcedir . '/Subs-Charset.php');
+		create_function($string,'
+                        global $sourcedir;
+			if (function_exists(\'mb_strtolower\'))
+				return mb_strtolower($string, \'UTF-8\');
+			require_once($sourcedir . \'/Subs-Charset.php\');
 			return utf8_strtolower($string);
-		};
+		');
 
 	if (!isset($_POST['username']))
 		$_POST['username'] = '';
@@ -1597,13 +1597,13 @@ function DeleteInstall()
 
 	// This function is needed to do the updateStats('subject') call.
 	$smcFunc['strtolower'] = $db_character_set != 'utf8' && $txt['lang_character_set'] != 'UTF-8' ? 'strtolower' :
-		function($string) use ($sourcedir)
-		{
-			if (function_exists('mb_strtolower'))
-				return mb_strtolower($string, 'UTF-8');
-			require_once($sourcedir . '/Subs-Charset.php');
+		create_function($string,'
+                        global $sourcedir;
+			if (function_exists(\'mb_strtolower\'))
+				return mb_strtolower($string, \'UTF-8\');
+			require_once($sourcedir . \'/Subs-Charset.php\');
 			return utf8_strtolower($string);
-		};
+		');
 
 	$request = $smcFunc['db_query']('', '
 		SELECT id_msg

--- a/other/install.php
+++ b/other/install.php
@@ -1341,8 +1341,8 @@ function AdminAccount()
 
 	// We need this to properly hash the password for Admin
 	$smcFunc['strtolower'] = $db_character_set != 'utf8' && $txt['lang_character_set'] != 'UTF-8' ? 'strtolower' :
-		create_function('$string','
-            global $sourcedir;
+		create_function('$string', '
+			global $sourcedir;
 			if (function_exists(\'mb_strtolower\'))
 				return mb_strtolower($string, \'UTF-8\');
 			require_once($sourcedir . \'/Subs-Charset.php\');
@@ -1597,8 +1597,8 @@ function DeleteInstall()
 
 	// This function is needed to do the updateStats('subject') call.
 	$smcFunc['strtolower'] = $db_character_set != 'utf8' && $txt['lang_character_set'] != 'UTF-8' ? 'strtolower' :
-		create_function('$string','
-            global $sourcedir;
+		create_function('$string', '
+			global $sourcedir;
 			if (function_exists(\'mb_strtolower\'))
 				return mb_strtolower($string, \'UTF-8\');
 			require_once($sourcedir . \'/Subs-Charset.php\');

--- a/other/install.php
+++ b/other/install.php
@@ -1341,8 +1341,8 @@ function AdminAccount()
 
 	// We need this to properly hash the password for Admin
 	$smcFunc['strtolower'] = $db_character_set != 'utf8' && $txt['lang_character_set'] != 'UTF-8' ? 'strtolower' :
-		create_function($string,'
-                        global $sourcedir;
+		create_function('$string','
+            global $sourcedir;
 			if (function_exists(\'mb_strtolower\'))
 				return mb_strtolower($string, \'UTF-8\');
 			require_once($sourcedir . \'/Subs-Charset.php\');
@@ -1597,8 +1597,8 @@ function DeleteInstall()
 
 	// This function is needed to do the updateStats('subject') call.
 	$smcFunc['strtolower'] = $db_character_set != 'utf8' && $txt['lang_character_set'] != 'UTF-8' ? 'strtolower' :
-		create_function($string,'
-                        global $sourcedir;
+		create_function('$string','
+            global $sourcedir;
 			if (function_exists(\'mb_strtolower\'))
 				return mb_strtolower($string, \'UTF-8\');
 			require_once($sourcedir . \'/Subs-Charset.php\');


### PR DESCRIPTION
Use create_function instead, so installer can let user know that php version is too low.

ref: #1798 
ref: #1810 (improperly signed off)

Signed-off-by: Angelina Belle angelinabelle1@hotmail.com
