### PR TITLE
! [Upgrade] Closures caused syntax errors in upgrade.php for php < 5.3.8

### DIFF
--- a/other/upgrade.php
+++ b/other/upgrade.php
@@ -792,7 +792,7 @@ function redirectLocation($location, $addForm = true)
 // Load all essential data and connect to the DB as this is pre SSI.php
 function loadEssentialData()
 {
-	global $db_server, $db_user, $db_passwd, $db_name, $db_connection, $db_prefix, $db_character_set, $db_type;
+	global $txt, $db_server, $db_user, $db_passwd, $db_name, $db_connection, $db_prefix, $db_character_set, $db_type;
 	global $modSettings, $sourcedir, $smcFunc, $upcontext;
 
 	// Do the non-SSI stuff...
@@ -811,14 +811,14 @@ function loadEssentialData()
 	// We need this for authentication and some upgrade code
 	require_once($sourcedir . '/Subs-Auth.php');
 
-	$smcFunc['strtolower'] = $db_character_set != 'utf8'  ? 'strtolower' :
-		function($string) use ($sourcedir)
-		{
-			if (function_exists('mb_strtolower'))
-				return mb_strtolower($string, 'UTF-8');
-			require_once($sourcedir . '/Subs-Charset.php');
+	$smcFunc['strtolower'] = $db_character_set != 'utf8' && $txt['lang_character_set'] != 'UTF-8' ? 'strtolower' :
+		create_function('$string','
+            global $sourcedir;
+			if (function_exists(\'mb_strtolower\'))
+				return mb_strtolower($string, \'UTF-8\');
+			require_once($sourcedir . \'/Subs-Charset.php\');
 			return utf8_strtolower($string);
-		};
+		');
 
 	// Check we don't need some compatibility.
 	if (@version_compare(PHP_VERSION, '5.1', '<='))

--- a/other/upgrade.php
+++ b/other/upgrade.php
@@ -812,8 +812,8 @@ function loadEssentialData()
 	require_once($sourcedir . '/Subs-Auth.php');
 
 	$smcFunc['strtolower'] = $db_character_set != 'utf8' && $txt['lang_character_set'] != 'UTF-8' ? 'strtolower' :
-		create_function('$string','
-            global $sourcedir;
+		create_function('$string', '
+			global $sourcedir;
 			if (function_exists(\'mb_strtolower\'))
 				return mb_strtolower($string, \'UTF-8\');
 			require_once($sourcedir . \'/Subs-Charset.php\');


### PR DESCRIPTION
ref: #1798 

However, there is still an error: QueryString.php is loaded before the php version check is done, causing syntax error for php v 5.2.

Signed-off-by: Angelina Belle angelinabelle@hotmail.com
