### PR TITLE
$func and $file were inverted

### DIFF
--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -4061,7 +4061,7 @@ function call_integration_hook($hook, $parameters = array())
 		// Did we find a file to load?
 		if (strpos($function, '|') !== false)
 		{
-			list($func, $file) = explode('|', $function);
+			list($file, $func) = explode('|', $function);
 
 			// Match the wildcards to their regular vars.
 			if (empty($settings['theme_dir']))


### PR DESCRIPTION
the correct way for adding a hook is:  file|class::method#

Signed-off-by: Suki suki@missallsunday.com
