### PR TITLE
removed hook call

### DIFF
--- a/Sources/Admin.php
+++ b/Sources/Admin.php
@@ -448,9 +448,6 @@ function AdminMain()
 		}
 	}
 
-	// Let them modify admin areas easily.
-	call_integration_hook('integrate_admin_areas', array(&$admin_areas));
-
 	// Make sure the administrator has a valid session...
 	validateSession();
 


### PR DESCRIPTION
This causes a php error when it turns existing string to an array.
It seems the hooks to the admin section are already added prior to this hook call.
Perhaps there is some editing in place that is half finished?

Either way.. install a mod that uses hooks and test it out for yourself.
Removing the hook resolves the issue and the mod is still added prior to it.
Even if another method is going to be implemented using this hook call, it needs to be fixed so it works.

Signed-off-by: -Underdog- github.underdog@gmail.com
