### PR TITLE
SCE set.command deprecated for SCE v1.4

### DIFF
--- a/Sources/Subs-Editor.php
+++ b/Sources/Subs-Editor.php
@@ -1727,15 +1727,14 @@ function create_control_richedit($editorOptions)
 						if (isset($tag['before']))
 						{
 							$context['bbcodes_handlers'] = '
-				$.sceditor.setCommand(
-					' . javaScriptEscape($tag['code']) . ',
-					function () {
+				$.sceditor.command.set(
+					' . javaScriptEscape($tag['code']) . ', {
+					exec: function () {
 						this.wysiwygEditorInsertHtml(' . javaScriptEscape($tag['before']) . (isset($tag['after']) ? ', ' . javaScriptEscape($tag['after']) : '') . ');
 					},
-					' . javaScriptEscape($tag['description']) . ',
-					null,
-					[' . javaScriptEscape($tag['before']) . (isset($tag['after']) ? ', ' . javaScriptEscape($tag['after']) : '') . ']
-				);';
+					txtExec: [' . javaScriptEscape($tag['before']) . (isset($tag['after']) ? ', ' . javaScriptEscape($tag['after']) : '') . '],
+					tooltip: ' . javaScriptEscape($tag['description']) . '
+				});';
 						}
 					}
 				}


### PR DESCRIPTION
The set.command function is deprecated as of SCE v1.4 and has been removed from the SCE library of functions. 
Since this function no longer exists in the SCE infrastructure the javascript for adding to the BBC toolbar completely crashes when the code attempts to use set.command to add the "before" key from the array. This caused backward compatibility with mods that add BBC's via hooks to fail (not to mention the entire toolbar went null).

The newer SCE function that takes its place is named command.set which has a different syntax.
The edit shown here replaces the deprecated function with the new one and its proper syntax.

The report was filed here: https://github.com/SimpleMachines/SMF2.1/issues/1845

Signed-off-by: -Underdog- github.underdog@gmail.com
