### PR TITLE
Convert recent table styling to div styling

### DIFF
--- a/Themes/default/MessageIndex.template.php
+++ b/Themes/default/MessageIndex.template.php
@@ -135,7 +135,7 @@ function template_main()
 	<form action="', $scripturl, '?action=quickmod;board=', $context['current_board'], '.', $context['start'], '" method="post" accept-charset="', $context['character_set'], '" class="clear" name="quickModForm" id="quickModForm">';
 
 		echo '
-		<div class="tborder topic_table" id="messageindex">';
+		<div id="messageindex">';
 		if (!empty($settings['display_who_viewing']))
 		{
 		echo '

--- a/Themes/default/Recent.template.php
+++ b/Themes/default/Recent.template.php
@@ -107,38 +107,34 @@ function template_unread()
 				', !empty($context['recent_buttons']) ? template_button_strip($context['recent_buttons'], 'right') : '', '
 			</div>';
 
-		// [WIP] There is trial code here to hide the topic icon column. Colspan can be cleaned up later.
 		echo '
-			<div class="tborder topic_table" id="unread">
-				<table class="table_grid" cellspacing="0">
-					<thead>
-						<tr class="title_bar">
-							<th scope="col" class="first_th" width="8%" colspan="1">&nbsp;</th>
-							<th scope="col">
-								<a href="', $scripturl, '?action=unread', $context['showing_all_topics'] ? ';all' : '', $context['querystring_board_limits'], ';sort=subject', $context['sort_by'] == 'subject' && $context['sort_direction'] == 'up' ? ';desc' : '', '">', $txt['subject'], $context['sort_by'] == 'subject' ? ' <span class="sort sort_' . $context['sort_direction'] . '"></span>' : '', '</a>
-							</th>
-							<th scope="col" width="14%" align="center">
-								<a href="', $scripturl, '?action=unread', $context['showing_all_topics'] ? ';all' : '', $context['querystring_board_limits'], ';sort=replies', $context['sort_by'] == 'replies' && $context['sort_direction'] == 'up' ? ';desc' : '', '">', $txt['replies'], $context['sort_by'] == 'replies' ? ' <span class="sort sort_' . $context['sort_direction'] . '"></span>' : '', '</a>
-							</th>';
+			<div id="unread">
+				<div id="topic_header" class="title_bar">
+					<div class="icon"></div>
+					<div class="info">
+						<a href="', $scripturl, '?action=unread', $context['showing_all_topics'] ? ';all' : '', $context['querystring_board_limits'], ';sort=subject', $context['sort_by'] == 'subject' && $context['sort_direction'] == 'up' ? ';desc' : '', '">', $txt['subject'], $context['sort_by'] == 'subject' ? ' <span class="sort sort_' . $context['sort_direction'] . '"></span>' : '', '</a>
+					</div>
+					<div class="stats">
+						<a href="', $scripturl, '?action=unread', $context['showing_all_topics'] ? ';all' : '', $context['querystring_board_limits'], ';sort=replies', $context['sort_by'] == 'replies' && $context['sort_direction'] == 'up' ? ';desc' : '', '">', $txt['replies'], $context['sort_by'] == 'replies' ? ' <span class="sort sort_' . $context['sort_direction'] . '"></span>' : '', '</a>
+					</div>';
 
 		// Show a "select all" box for quick moderation?
 		if ($context['showCheckboxes'])
 			echo '
-							<th scope="col" width="22%">
-								<a href="', $scripturl, '?action=unread', $context['showing_all_topics'] ? ';all' : '', $context['querystring_board_limits'], ';sort=last_post', $context['sort_by'] == 'last_post' && $context['sort_direction'] == 'up' ? ';desc' : '', '">', $txt['last_post'], $context['sort_by'] == 'last_post' ? ' <span class="sort sort_' . $context['sort_direction'] . '"></span>' : '', '</a>
-							</th>
-							<th class="last_th">
-								<input type="checkbox" onclick="invertAll(this, this.form, \'topics[]\');" class="input_check">
-							</th>';
+					<div class="lastpost">
+						<a href="', $scripturl, '?action=unread', $context['showing_all_topics'] ? ';all' : '', $context['querystring_board_limits'], ';sort=last_post', $context['sort_by'] == 'last_post' && $context['sort_direction'] == 'up' ? ';desc' : '', '">', $txt['last_post'], $context['sort_by'] == 'last_post' ? ' <span class="sort sort_' . $context['sort_direction'] . '"></span>' : '', '</a>
+					</div>
+					<div class="moderation">
+						<input type="checkbox" onclick="invertAll(this, this.form, \'topics[]\');" class="input_check">
+					</div>';
 		else
 			echo '
-							<th scope="col" class="smalltext last_th" width="22%">
-								<a href="', $scripturl, '?action=unread', $context['showing_all_topics'] ? ';all' : '', $context['querystring_board_limits'], ';sort=last_post', $context['sort_by'] == 'last_post' && $context['sort_direction'] == 'up' ? ';desc' : '', '">', $txt['last_post'], $context['sort_by'] == 'last_post' ? ' <span class="sort sort_' . $context['sort_direction'] . '"></span>' : '', '</a>
-							</th>';
+					<div class="lastpost">
+						<a href="', $scripturl, '?action=unread', $context['showing_all_topics'] ? ';all' : '', $context['querystring_board_limits'], ';sort=last_post', $context['sort_by'] == 'last_post' && $context['sort_direction'] == 'up' ? ';desc' : '', '">', $txt['last_post'], $context['sort_by'] == 'last_post' ? ' <span class="sort sort_' . $context['sort_direction'] . '"></span>' : '', '</a>
+					</div>';
 		echo '
-						</tr>
-					</thead>
-					<tbody>';
+				</div>
+				<div id="topic_container">';
 
 		foreach ($context['topics'] as $topic)
 		{
@@ -153,72 +149,69 @@ function template_unread()
 
 			$color_class2 = $color_class . '2';
 
-			// [WIP] There is trial code here to hide the topic icon column. Hardly anyone will miss it.
-			// [WIP] Markup can be cleaned up later. CSS can go in the CSS files later.
 			echo '
-						<tr>
-							<td class="', $color_class, ' icon2">
-								<div style="position: relative; width: 40px; margin: auto;">
-									<img src="', $topic['first_post']['icon_url'], '" alt="">
-									', $topic['is_posted_in'] ? '<img src="'. $settings['images_url']. '/icons/profile_sm.png" alt="" style="position: absolute; z-index: 5; right: 4px; bottom: -3px;">' : '','
-								</div>
-							</td>
-							<td class="subject ', $color_class2, '">
-								<div>';
+					<div class="', $color_class, '">
+						<div class="icon">
+							<img src="', $topic['first_post']['icon_url'], '" alt="">
+								', $topic['is_posted_in'] ? '<img src="'. $settings['images_url']. '/icons/profile_sm.png" alt="" style="position: absolute; z-index: 5; right: 4px; bottom: -3px;">' : '','
+						</div>
+						<div class="info">';
 
 			// Now we handle the icons
 			echo '
-									<div class="icons">';
+							<div class="icons">';
 			if ($topic['is_locked'])
 				echo '
-										<span class="generic_icons lock floatright"></span>';
+								<span class="generic_icons lock floatright"></span>';
 			if ($topic['is_sticky'])
 				echo '
-										<span class="generic_icons sticky floatright"></span>';
+								<span class="generic_icons sticky floatright"></span>';
 			if ($topic['is_poll'])
 				echo '
-										<span class="generic_icons poll floatright"></span>';
+								<span class="generic_icons poll floatright"></span>';
 			echo '
-									</div>';
+							</div>';
 
-			// [WIP] MEthinks the orange icons look better if they aren't all over the page.
 			echo '
-									<div class="recent_title">
-										<a href="', $topic['new_href'], '" id="newicon', $topic['first_post']['id'], '"><span class="new_posts">' . $txt['new'] . '</span></a>
-										', $topic['is_sticky'] ? '<strong>' : '', '<span class="preview" title="', $topic[(empty($modSettings['message_index_preview_first']) ? 'last_post' : 'first_post')]['preview'], '"><span id="msg_' . $topic['first_post']['id'] . '">', $topic['first_post']['link'], '</span></span>', $topic['is_sticky'] ? '</strong>' : '', '
-									</div>
-									<p class="floatleft">
-										', $topic['first_post']['started_by'], '
-									</p>
-									<small id="pages', $topic['first_post']['id'], '">&nbsp;', $topic['pages'], '</small>
-								</div>
-							</td>
-							<td class="', $color_class, ' stats">
+							<div class="recent_title">
+								<a href="', $topic['new_href'], '" id="newicon', $topic['first_post']['id'], '"><span class="new_posts">' . $txt['new'] . '</span></a>
+								', $topic['is_sticky'] ? '<strong>' : '', '<span class="preview" title="', $topic[(empty($modSettings['message_index_preview_first']) ? 'last_post' : 'first_post')]['preview'], '"><span id="msg_' . $topic['first_post']['id'] . '">', $topic['first_post']['link'], '</span></span>', $topic['is_sticky'] ? '</strong>' : '', '
+							</div>
+							<p class="floatleft">
+								', $topic['first_post']['started_by'], '
+							</p>
+							<small id="pages', $topic['first_post']['id'], '">&nbsp;', $topic['pages'], '</small>
+						</div>
+						<div class="stats">
+							<p>
 								', $topic['replies'], ' ', $txt['replies'], '
 								<br>
 								', $topic['views'], ' ', $txt['views'], '
-							</td>
-							<td class="', $color_class2, ' lastpost">
-								', sprintf($txt['last_post_topic'], '<a href="' . $topic['last_post']['href'] . '">' . $topic['last_post']['time'] . '</a>', $topic['last_post']['member']['link']), '
-							</td>';
+							</p>
+						</div>
+						<div class="lastpost">
+							', sprintf($txt['last_post_topic'], '<a href="' . $topic['last_post']['href'] . '">' . $topic['last_post']['time'] . '</a>', $topic['last_post']['member']['link']), '
+						</div>';
 
 			if ($context['showCheckboxes'])
 				echo '
-							<td class="', $color_class2, ' moderation" valign="middle" align="center">
-								<input type="checkbox" name="topics[]" value="', $topic['id'], '" class="input_check">
-							</td>';
-			echo '
-						</tr>';
+						<div class="moderation" valign="middle" align="center">
+							<input type="checkbox" name="topics[]" value="', $topic['id'], '" class="input_check">
+						</div>';
+
+				echo '
+					</div>';
 		}
 
 		if (empty($context['topics']))
 			echo '
-					<tr style="display: none;"><td></td></tr>';
+						<div style="display: none;"></div>';
 
 		echo '
-					</tbody>
-				</table>
-			</div>
+				</div>
+			</div>';
+
+		echo '
 			<div class="pagesection">
 				', !empty($context['recent_buttons']) ? template_button_strip($context['recent_buttons'], 'right') : '', '
 				', $context['menu_separator'], '<a href="#recent" class="topbottom floatleft">', $txt['go_up'], '</a>
@@ -267,38 +260,34 @@ function template_replies()
 				', !empty($context['recent_buttons']) ? template_button_strip($context['recent_buttons'], 'right') : '', '
 			</div>';
 
-		// [WIP] There is trial code here to hide the topic icon column. Colspan can be cleaned up later.
 		echo '
-			<div class="tborder topic_table" id="unreadreplies">
-				<table class="table_grid" cellspacing="0">
-					<thead>
-						<tr class="title_bar">
-							<th scope="col" class="first_th" width="8%" colspan="1">&nbsp;</th>
-							<th scope="col">
-								<a href="', $scripturl, '?action=unreadreplies', $context['querystring_board_limits'], ';sort=subject', $context['sort_by'] === 'subject' && $context['sort_direction'] === 'up' ? ';desc' : '', '">', $txt['subject'], $context['sort_by'] === 'subject' ? ' <span class="sort sort_' . $context['sort_direction'] . '"></span>' : '', '</a>
-							</th>
-							<th scope="col" width="14%" align="center">
-								<a href="', $scripturl, '?action=unreadreplies', $context['querystring_board_limits'], ';sort=replies', $context['sort_by'] === 'replies' && $context['sort_direction'] === 'up' ? ';desc' : '', '">', $txt['replies'], $context['sort_by'] === 'replies' ? ' <span class="sort sort_' . $context['sort_direction'] . '"></span>' : '', '</a>
-							</th>';
+			<div id="unreadreplies">
+				<div id="topic_header" class="title_bar">
+					<div class="icon"></div>
+					<div class="info">
+						<a href="', $scripturl, '?action=unreadreplies', $context['querystring_board_limits'], ';sort=subject', $context['sort_by'] === 'subject' && $context['sort_direction'] === 'up' ? ';desc' : '', '">', $txt['subject'], $context['sort_by'] === 'subject' ? ' <span class="sort sort_' . $context['sort_direction'] . '"></span>' : '', '</a>
+					</div>
+					<div class="stats">
+						<a href="', $scripturl, '?action=unreadreplies', $context['querystring_board_limits'], ';sort=replies', $context['sort_by'] === 'replies' && $context['sort_direction'] === 'up' ? ';desc' : '', '">', $txt['replies'], $context['sort_by'] === 'replies' ? ' <span class="sort sort_' . $context['sort_direction'] . '"></span>' : '', '</a>
+					</div>';
 
 		// Show a "select all" box for quick moderation?
 		if ($context['showCheckboxes'])
 				echo '
-							<th scope="col" width="22%">
-								<a href="', $scripturl, '?action=unreadreplies', $context['querystring_board_limits'], ';sort=last_post', $context['sort_by'] === 'last_post' && $context['sort_direction'] === 'up' ? ';desc' : '', '">', $txt['last_post'], $context['sort_by'] === 'last_post' ? ' <span class="sort sort_' . $context['sort_direction'] . '"></span>' : '', '</a>
-							</th>
-							<th class="last_th">
-								<input type="checkbox" onclick="invertAll(this, this.form, \'topics[]\');" class="input_check">
-							</th>';
+					<div class="lastpost">
+						<a href="', $scripturl, '?action=unreadreplies', $context['querystring_board_limits'], ';sort=last_post', $context['sort_by'] === 'last_post' && $context['sort_direction'] === 'up' ? ';desc' : '', '">', $txt['last_post'], $context['sort_by'] === 'last_post' ? ' <span class="sort sort_' . $context['sort_direction'] . '"></span>' : '', '</a>
+					</div>
+					<div class="moderation">
+						<input type="checkbox" onclick="invertAll(this, this.form, \'topics[]\');" class="input_check">
+					</div>';
 		else
 			echo '
-							<th scope="col" class="last_th" width="22%">
-								<a href="', $scripturl, '?action=unreadreplies', $context['querystring_board_limits'], ';sort=last_post', $context['sort_by'] === 'last_post' && $context['sort_direction'] === 'up' ? ';desc' : '', '">', $txt['last_post'], $context['sort_by'] === 'last_post' ? ' <span class="sort sort_' . $context['sort_direction'] . '"></span>' : '', '</a>
-							</th>';
+					<div class="lastpost">
+						<a href="', $scripturl, '?action=unreadreplies', $context['querystring_board_limits'], ';sort=last_post', $context['sort_by'] === 'last_post' && $context['sort_direction'] === 'up' ? ';desc' : '', '">', $txt['last_post'], $context['sort_by'] === 'last_post' ? ' <span class="sort sort_' . $context['sort_direction'] . '"></span>' : '', '</a>
+					</div>';
 		echo '
-						</tr>
-					</thead>
-					<tbody>';
+				</div>
+				<div id="topic_container">';
 
 		foreach ($context['topics'] as $topic)
 		{
@@ -313,67 +302,61 @@ function template_replies()
 
 			$color_class2 = $color_class . '2';
 
-			// [WIP] There is trial code here to hide the topic icon column. Hardly anyone will miss it.
-			// [WIP] Markup can be cleaned up later. CSS can go in the CSS files later.
 			echo '
-						<tr>
-							<td class="', $color_class, ' icon2">
-								<div style="position: relative; width: 40px; margin: auto;">
-									<img src="', $topic['first_post']['icon_url'], '" alt="">
-									', $topic['is_posted_in'] ? '<img class="posted" src="' . $settings['images_url'] . '/icons/profile_sm.png" alt="">' : '','
-								</div>
-							</td>
-							<td class="subject ', $color_class2, '">
-								<div>';
+						<div class="', $color_class, '">
+							<div class="icon">
+								<img src="', $topic['first_post']['icon_url'], '" alt="">
+								', $topic['is_posted_in'] ? '<img class="posted" src="' . $settings['images_url'] . '/icons/profile_sm.png" alt="">' : '','
+							</div>
+							<div class="info">';
 
 			// Now we handle the icons
 			echo '
-									<div class="icons">';
+								<div class="icons">';
 			if ($topic['is_locked'])
 				echo '
-										<span class="generic_icons lock floatright"></span>';
+									<span class="generic_icons lock floatright"></span>';
 			if ($topic['is_sticky'])
 				echo '
-										<span class="generic_icons sticky floatright"></span>';
+									<span class="generic_icons sticky floatright"></span>';
 			if ($topic['is_poll'])
 				echo '
-										<span class="generic_icons poll floatright"></span>';
+									<span class="generic_icons poll floatright"></span>';
 			echo '
-									</div>';
+								</div>';
 
-			// [WIP] MEthinks the orange icons look better if they aren't all over the page.
 			echo '
-									<div class="recent_title">
-										<a href="', $topic['new_href'], '" id="newicon', $topic['first_post']['id'], '"><span class="new_posts">' . $txt['new'] . '</span></a>
-										', $topic['is_sticky'] ? '<strong>' : '', '<span title="', $topic[(empty($modSettings['message_index_preview_first']) ? 'last_post' : 'first_post')]['preview'], '"><span id="msg_' . $topic['first_post']['id'] . '">', $topic['first_post']['link'], '</span>', $topic['is_sticky'] ? '</strong>' : '', '
-									</div>
-									<p class="floatleft">
-										', $topic['first_post']['started_by'], '
-									</p>
-									<small id="pages', $topic['first_post']['id'], '">&nbsp;', $topic['pages'], '</small>
+								<div class="recent_title">
+									<a href="', $topic['new_href'], '" id="newicon', $topic['first_post']['id'], '"><span class="new_posts">' . $txt['new'] . '</span></a>
+									', $topic['is_sticky'] ? '<strong>' : '', '<span title="', $topic[(empty($modSettings['message_index_preview_first']) ? 'last_post' : 'first_post')]['preview'], '"><span id="msg_' . $topic['first_post']['id'] . '">', $topic['first_post']['link'], '</span>', $topic['is_sticky'] ? '</strong>' : '', '
 								</div>
-							</td>
-							<td class="', $color_class, ' stats">
-								', $topic['replies'], ' ', $txt['replies'], '
-								<br>
-								', $topic['views'], ' ', $txt['views'], '
-							</td>
-							<td class="', $color_class2, ' lastpost">
+								<p class="floatleft">
+									', $topic['first_post']['started_by'], '
+								</p>
+								<small id="pages', $topic['first_post']['id'], '">&nbsp;', $topic['pages'], '</small>	
+							</div>
+							<div class="stats">
+								<p>
+									', $topic['replies'], ' ', $txt['replies'], '
+									<br>
+									', $topic['views'], ' ', $txt['views'], '
+								</p>
+							</div>
+							<div class="lastpost">
 								', sprintf($txt['last_post_topic'], '<a href="' . $topic['last_post']['href'] . '">' . $topic['last_post']['time'] . '</a>', $topic['last_post']['member']['link']), '
-							</td>';
+							</div>';
 
 			if ($context['showCheckboxes'])
 				echo '
-							<td class="', $color_class2, ' moderation" valign="middle" align="center">
+							<div class="moderation">
 								<input type="checkbox" name="topics[]" value="', $topic['id'], '" class="input_check">
-							</td>';
+							</div>';
 			echo '
-						</tr>';
+						</div>';
 		}
 
 		echo '
-					</tbody>
-				</table>
+					</div>
 			</div>
 			<div class="pagesection">
 				', !empty($context['recent_buttons']) ? template_button_strip($context['recent_buttons'], 'right') : '', '

--- a/Themes/default/Who.template.php
+++ b/Themes/default/Who.template.php
@@ -22,7 +22,7 @@ function template_main()
 			<div class="cat_bar">
 				<h4 class="catbg">', $txt['who_title'], '</h4>
 			</div>
-			<div class="topic_table" id="mlist">
+			<div id="mlist">
 				<div class="pagesection">
 					<div class="pagelinks floatleft">', $context['page_index'], '</div>';
 	echo '

--- a/Themes/default/css/index.css
+++ b/Themes/default/css/index.css
@@ -1832,7 +1832,7 @@ ul#smfFadeScroller li {
 }
 p.whoisviewing {
 	font-size: 0.9em;
-	padding: 0 2px;
+	padding: 2px 0 2px 5px;
 }
 .lastpost span.last_post {
 	float: right;
@@ -2825,59 +2825,6 @@ tr.windowbg td, tr.windowbg2 td, tr.highlight2 td, .table_grid tr td {
 	padding: 0;
 }
 
-/* Styles for generic tables.
-------------------------------------------------------- */
-.topic_table table {
-	width: 100%;
-}
-.topic_table .icon2 {
-	text-align: center;
-}
-.topic_table .icon2 div {
-	position: relative;
-	width: 40px;
-	margin: auto;
-}
-.topic_table .icon2 img.posted {
-	position: absolute;
-	z-index: 5;
-	right: 4px;
-	bottom: -3px;
-}
-.topic_table .stats {
-	text-align: center;
-	line-height: 1.5em;
-}
-.topic_table table thead {
-	border-bottom: 1px solid #fff;
-}
-/* the subject column */
-.topic_table td {
-	font-size: 1em;
-}
-.topic_table td.subject p, .topic_table td.stats {
-	font-size: 0.9em;
-	padding: 0;
-	margin: 0;
-}
-.topic_table td.lastpost {
-	font-size: 0.9em;
-	line-height: 1.5em;
-	padding: 4px;
-}
-
-/* Space those icons out a bit */
-.topic_table .icons span {
-	margin: 2px 0 0 5px;
-}
-/* Nobody wants them to stand out much. */
-.topic_table td.lockedbg {
-	background: #e7eaef no-repeat 98% 4px;
-}
-.topic_table td.lockedbg2 {
-	background: #e7eaef no-repeat 98% 4px;
-}
-
 .errorfile_table {
 	background: #f0f4f7;
 	border-spacing: 3px;
@@ -3523,9 +3470,6 @@ dl.addrules dt.floatleft {
 
 /* Styles for the search results page.
 ------------------------------------------------- */
-.topic_table td blockquote, .topic_table td .quoteheader {
-	margin: 6px;
-}
 .search_results_posts {
 	overflow: hidden;
 }
@@ -3726,7 +3670,7 @@ dl.addrules dt.floatleft {
 }
 
 .generic_list_wrapper, .action_profile  #permissions,
-#profileview, #messageindex, #recent .core_posts, #recent .topic_table,
+#profileview, #recent .core_posts,
 .windowbg, .windowbg2, #forumposts .approvebg, #forumposts .approvebg2 {
 	background: #f0f4f7;
 	margin: 12px 0 0 0;
@@ -4035,6 +3979,9 @@ div.lastpost p {
 	margin-top: 3px;
 	padding: 0;
 }
+#messageindex .stats, #recent .stats {
+	text-align: center;
+}
 #topic_header input {
 	margin-top: 5px !important;
 }
@@ -4051,10 +3998,13 @@ div.lastpost p {
 	overflow: hidden;
 	height: 3.5em;
 }
+#topic_container .icons span {
+	margin: 2px 0 0 5px;
+}
 .icon img, .moderation input {
 	margin-top: 15px;
 }
-.info .icons, #messageindex .stats p, .lastpost p {
+.info .icons, #messageindex .stats p, .lastpost p, #unread .stats p, #unreadreplies .stats p {
 	margin-top: 5px;
 	border: none;
 }
@@ -4146,4 +4096,7 @@ p.information  img {
 #messageindex .information, #topic_container .info {
 	border-radius: 0;
 	margin: 0;
+}
+#topic_icons .information {
+	border-top: 1px solid #ddd;
 }

--- a/Themes/default/css/rtl.css
+++ b/Themes/default/css/rtl.css
@@ -583,9 +583,6 @@ div#admin_menu {
 }
 /* Styles for generic tables.
 ------------------------------------------------------- */
-.topic_table td.lastpost {
-	background: none;
-}
 #info_center .cat_bar, .table_grid tr.catbg th {
 	text-align: right;
 }


### PR DESCRIPTION
with using same elements from our #messageindex
- removed topic_table from CSS its no longer in SMF
- some very small css changes/improvements

Signed-off-by: Antes antes@simplemachines.org
