### PR TITLE
Membergroup icons/stars/images

### DIFF
--- a/other/upgrade_2-1_mysql.sql
+++ b/other/upgrade_2-1_mysql.sql
@@ -606,6 +606,59 @@ SET id_theme = 0;
 ---#
 
 /******************************************************************************/
+--- Membergroup icons changes
+/******************************************************************************/
+$request = $smcFunc['db_query']('', '
+	SELECT icons
+	FROM {db_prefix}membergroups',
+	array()
+);
+$toMove = array();
+$toChange = array();
+while ($row = $smcFunc['db_fetch_assoc']($request))
+{
+	if (strpos($row['icons'], 'star.gif') !== false)
+		$toChange[] = array(
+			'old' => $row['icons'],
+			'new' => str_replace('star.gif', 'icon.png', $row['icons']),
+		);
+
+	elseif (strpos($row['icons'], 'starmod.gif') !== false)
+		$toChange[] = array(
+			'old' => $row['icons'],
+			'new' => str_replace('starmod.gif', 'iconmod.png', $row['icons']),
+		);
+
+	elseif (strpos($row['icons'], 'staradmin.gif') !== false)
+		$toChange[] = array(
+			'old' => $row['icons'],
+			'new' => str_replace('staradmin.gif', 'iconadmin.png', $row['icons']),
+		);
+
+	else
+		$toMove[] = $row['icons'];
+}
+$smcFunc['db_free_result']($request);
+
+foreach ($toChange as $change)
+	$smcFunc['db_query']('', '
+		UPDATE {db_prefix}membergroups
+		SET icons = {string:new}
+		WHERE icons = {string:old}',
+		array(
+			'new' => $change['new'],
+			'old' => $change['old'],
+		)
+	);
+
+	$request = $smcFunc['db_query']('', '
+	SELECT icons
+	FROM {db_prefix}membergroups',
+	array()
+);
+
+
+/******************************************************************************/
 --- Cleaning up after old themes...
 /******************************************************************************/
 ---# Checking for "core" and removing it if necessary...

--- a/other/upgrade_2-1_mysql.sql
+++ b/other/upgrade_2-1_mysql.sql
@@ -608,7 +608,7 @@ SET id_theme = 0;
 /******************************************************************************/
 --- Membergroup icons changes
 /******************************************************************************/
----# Checking for "core" and removing it if necessary...
+---# Check the current saved names for icons and change them to the new name.
 ---{
 $request = $smcFunc['db_query']('', '
 	SELECT icons
@@ -658,6 +658,7 @@ foreach ($toChange as $change)
 	FROM {db_prefix}membergroups',
 	array()
 );
+---}
 ---#
 
 /******************************************************************************/

--- a/other/upgrade_2-1_mysql.sql
+++ b/other/upgrade_2-1_mysql.sql
@@ -653,14 +653,16 @@ foreach ($toChange as $change)
 		)
 	);
 
-	$request = $smcFunc['db_query']('', '
-	SELECT icons
-	FROM {db_prefix}membergroups',
-	array()
-);
+// Attempt to move any custom uploaded icons.
+foreach ($toMove as $move)
+{
+	// Get the actual image.
+	$image = explode('#', $move);
+	$image = $image[1];
+	@rename($modSettings['theme_dir'] . '/images/'. $image, $modSettings['theme_dir'] . '/images/membericons/'. $image);
+}
 ---}
 ---#
-
 /******************************************************************************/
 --- Cleaning up after old themes...
 /******************************************************************************/

--- a/other/upgrade_2-1_mysql.sql
+++ b/other/upgrade_2-1_mysql.sql
@@ -608,6 +608,8 @@ SET id_theme = 0;
 /******************************************************************************/
 --- Membergroup icons changes
 /******************************************************************************/
+---# Checking for "core" and removing it if necessary...
+---{
 $request = $smcFunc['db_query']('', '
 	SELECT icons
 	FROM {db_prefix}membergroups',
@@ -656,7 +658,7 @@ foreach ($toChange as $change)
 	FROM {db_prefix}membergroups',
 	array()
 );
-
+---#
 
 /******************************************************************************/
 --- Cleaning up after old themes...

--- a/other/upgrade_2-1_postgresql.sql
+++ b/other/upgrade_2-1_postgresql.sql
@@ -669,7 +669,7 @@ SET id_theme = 0;
 /******************************************************************************/
 --- Membergroup icons changes
 /******************************************************************************/
----# Checking for "core" and removing it if necessary...
+---# Check the current saved names for icons and change them to the new name.
 ---{
 $request = $smcFunc['db_query']('', '
 	SELECT icons
@@ -719,6 +719,7 @@ foreach ($toChange as $change)
 	FROM {db_prefix}membergroups',
 	array()
 );
+---}
 ---#
 
 /******************************************************************************/

--- a/other/upgrade_2-1_postgresql.sql
+++ b/other/upgrade_2-1_postgresql.sql
@@ -714,11 +714,14 @@ foreach ($toChange as $change)
 		)
 	);
 
-	$request = $smcFunc['db_query']('', '
-	SELECT icons
-	FROM {db_prefix}membergroups',
-	array()
-);
+// Attempt to move any custom uploaded icons.
+foreach ($toMove as $move)
+{
+	// Get the actual image.
+	$image = explode('#', $move);
+	$image = $image[1];
+	@rename($modSettings['theme_dir'] . '/images/'. $image, $modSettings['theme_dir'] . '/images/membericons/'. $image);
+}
 ---}
 ---#
 

--- a/other/upgrade_2-1_postgresql.sql
+++ b/other/upgrade_2-1_postgresql.sql
@@ -667,6 +667,61 @@ SET id_theme = 0;
 ---#
 
 /******************************************************************************/
+--- Membergroup icons changes
+/******************************************************************************/
+---# Checking for "core" and removing it if necessary...
+---{
+$request = $smcFunc['db_query']('', '
+	SELECT icons
+	FROM {db_prefix}membergroups',
+	array()
+);
+$toMove = array();
+$toChange = array();
+while ($row = $smcFunc['db_fetch_assoc']($request))
+{
+	if (strpos($row['icons'], 'star.gif') !== false)
+		$toChange[] = array(
+			'old' => $row['icons'],
+			'new' => str_replace('star.gif', 'icon.png', $row['icons']),
+		);
+
+	elseif (strpos($row['icons'], 'starmod.gif') !== false)
+		$toChange[] = array(
+			'old' => $row['icons'],
+			'new' => str_replace('starmod.gif', 'iconmod.png', $row['icons']),
+		);
+
+	elseif (strpos($row['icons'], 'staradmin.gif') !== false)
+		$toChange[] = array(
+			'old' => $row['icons'],
+			'new' => str_replace('staradmin.gif', 'iconadmin.png', $row['icons']),
+		);
+
+	else
+		$toMove[] = $row['icons'];
+}
+$smcFunc['db_free_result']($request);
+
+foreach ($toChange as $change)
+	$smcFunc['db_query']('', '
+		UPDATE {db_prefix}membergroups
+		SET icons = {string:new}
+		WHERE icons = {string:old}',
+		array(
+			'new' => $change['new'],
+			'old' => $change['old'],
+		)
+	);
+
+	$request = $smcFunc['db_query']('', '
+	SELECT icons
+	FROM {db_prefix}membergroups',
+	array()
+);
+---#
+
+/******************************************************************************/
 --- Cleaning up after old themes...
 /******************************************************************************/
 ---# Checking for "core" and removing it if necessary...

--- a/other/upgrade_2-1_sqlite.sql
+++ b/other/upgrade_2-1_sqlite.sql
@@ -712,11 +712,14 @@ foreach ($toChange as $change)
 		)
 	);
 
-	$request = $smcFunc['db_query']('', '
-	SELECT icons
-	FROM {db_prefix}membergroups',
-	array()
-);
+// Attempt to move any custom uploaded icons.
+foreach ($toMove as $move)
+{
+	// Get the actual image.
+	$image = explode('#', $move);
+	$image = $image[1];
+	@rename($modSettings['theme_dir'] . '/images/'. $image, $modSettings['theme_dir'] . '/images/membericons/'. $image);
+}
 ---}
 ---#
 

--- a/other/upgrade_2-1_sqlite.sql
+++ b/other/upgrade_2-1_sqlite.sql
@@ -665,6 +665,61 @@ SET id_theme = 0;
 ---#
 
 /******************************************************************************/
+--- Membergroup icons changes
+/******************************************************************************/
+---# Checking for "core" and removing it if necessary...
+---{
+$request = $smcFunc['db_query']('', '
+	SELECT icons
+	FROM {db_prefix}membergroups',
+	array()
+);
+$toMove = array();
+$toChange = array();
+while ($row = $smcFunc['db_fetch_assoc']($request))
+{
+	if (strpos($row['icons'], 'star.gif') !== false)
+		$toChange[] = array(
+			'old' => $row['icons'],
+			'new' => str_replace('star.gif', 'icon.png', $row['icons']),
+		);
+
+	elseif (strpos($row['icons'], 'starmod.gif') !== false)
+		$toChange[] = array(
+			'old' => $row['icons'],
+			'new' => str_replace('starmod.gif', 'iconmod.png', $row['icons']),
+		);
+
+	elseif (strpos($row['icons'], 'staradmin.gif') !== false)
+		$toChange[] = array(
+			'old' => $row['icons'],
+			'new' => str_replace('staradmin.gif', 'iconadmin.png', $row['icons']),
+		);
+
+	else
+		$toMove[] = $row['icons'];
+}
+$smcFunc['db_free_result']($request);
+
+foreach ($toChange as $change)
+	$smcFunc['db_query']('', '
+		UPDATE {db_prefix}membergroups
+		SET icons = {string:new}
+		WHERE icons = {string:old}',
+		array(
+			'new' => $change['new'],
+			'old' => $change['old'],
+		)
+	);
+
+	$request = $smcFunc['db_query']('', '
+	SELECT icons
+	FROM {db_prefix}membergroups',
+	array()
+);
+---#
+
+/******************************************************************************/
 --- Cleaning up after old themes...
 /******************************************************************************/
 ---# Checking for "core" and removing it if necessary...

--- a/other/upgrade_2-1_sqlite.sql
+++ b/other/upgrade_2-1_sqlite.sql
@@ -667,7 +667,7 @@ SET id_theme = 0;
 /******************************************************************************/
 --- Membergroup icons changes
 /******************************************************************************/
----# Checking for "core" and removing it if necessary...
+---# Check the current saved names for icons and change them to the new name.
 ---{
 $request = $smcFunc['db_query']('', '
 	SELECT icons
@@ -717,6 +717,7 @@ foreach ($toChange as $change)
 	FROM {db_prefix}membergroups',
 	array()
 );
+---}
 ---#
 
 /******************************************************************************/


### PR DESCRIPTION
Membergroup images were changed from stars to icons  but the actual records on the DB needs to address this change too.
- Changes the old name and extension.
- Attempts to move any custom uploaded image to the new directory /membericons
