### PR TITLE
Propage call hook helper()

### DIFF
--- a/Sources/Admin.php
+++ b/Sources/Admin.php
@@ -509,7 +509,7 @@ function AdminMain()
 
 	// A static one or more likely, a plain good old function.
 	else
-		$call = $admin_include_data['function'];
+		$call = call_helper($admin_include_data['function'], true);
 
 	// Is it valid?
 	if (is_callable($call))

--- a/Sources/Calendar.php
+++ b/Sources/Calendar.php
@@ -47,7 +47,7 @@ function CalendarMain()
 	);
 
 	if (isset($_GET['sa']) && isset($subActions[$_GET['sa']]) && !WIRELESS)
-		return $subActions[$_GET['sa']]();
+		return call_helper($subActions[$_GET['sa']]);
 
 	// You can't do anything if the calendar is off.
 	if (empty($modSettings['cal_enabled']))

--- a/Sources/Class-BrowserDetect.php
+++ b/Sources/Class-BrowserDetect.php
@@ -72,7 +72,7 @@ class browser_detector
 		// Just a few mobile checks
 		$this->isOperaMini();
 		$this->isOperaMobi();
-		
+
 		// IE11 seems to be fine by itself without being lumped into the "is_ie" category
 		$this->isIe11();
 
@@ -121,7 +121,7 @@ class browser_detector
 			$this->_browsers['is_ie'] = !$this->isOpera() && !$this->isGecko() && !$this->isWebTv() && preg_match('~MSIE \d+~', $_SERVER['HTTP_USER_AGENT']) === 1;
 		return $this->_browsers['is_ie'];
 	}
-	
+
 	/**
 	* Determine if the browser is IE11 or not
 	* @return boolean true if the browser is IE11 otherwise false

--- a/Sources/Groups.php
+++ b/Sources/Groups.php
@@ -58,6 +58,9 @@ function Groups()
 		);
 	}
 
+	// CRUD $subActions as needed.
+	call_integration_hook('integrate_Groups_subActions', array(&$subActions));
+
 	// Call the actual function.
 	$subActions[$_REQUEST['sa']][0]();
 }

--- a/Sources/Groups.php
+++ b/Sources/Groups.php
@@ -62,7 +62,7 @@ function Groups()
 	call_integration_hook('integrate_Groups_subActions', array(&$subActions));
 
 	// Call the actual function.
-	$subActions[$_REQUEST['sa']][0]();
+	call_helper($subActions[$_REQUEST['sa']][0]);
 }
 
 /**

--- a/Sources/Groups.php
+++ b/Sources/Groups.php
@@ -59,7 +59,7 @@ function Groups()
 	}
 
 	// CRUD $subActions as needed.
-	call_integration_hook('integrate_Groups_subActions', array(&$subActions));
+	call_integration_hook('integrate_manage_groups', array(&$subActions));
 
 	// Call the actual function.
 	call_helper($subActions[$_REQUEST['sa']][0]);

--- a/Sources/Help.php
+++ b/Sources/Help.php
@@ -36,7 +36,7 @@ function ShowHelp()
 	call_integration_hook('integrate_ShowHelp_subActions', array(&$subActions));
 
 	$sa = isset($_GET['sa'], $subActions[$_GET['sa']]) ? $_GET['sa'] : 'index';
-	$subActions[$sa]();
+	call_helper($subActions[$sa]);
 }
 
 function HelpIndex()

--- a/Sources/Help.php
+++ b/Sources/Help.php
@@ -33,7 +33,7 @@ function ShowHelp()
 	);
 
 	// CRUD $subActions as needed.
-	call_integration_hook('integrate_ShowHelp_subActions', array(&$subActions));
+	call_integration_hook('integrate_manage_help', array(&$subActions));
 
 	$sa = isset($_GET['sa'], $subActions[$_GET['sa']]) ? $_GET['sa'] : 'index';
 	call_helper($subActions[$sa]);

--- a/Sources/Help.php
+++ b/Sources/Help.php
@@ -32,6 +32,9 @@ function ShowHelp()
 		'rules' => 'HelpRules',
 	);
 
+	// CRUD $subActions as needed.
+	call_integration_hook('integrate_ShowHelp_subActions', array(&$subActions));
+
 	$sa = isset($_GET['sa'], $subActions[$_GET['sa']]) ? $_GET['sa'] : 'index';
 	$subActions[$sa]();
 }

--- a/Sources/Likes.php
+++ b/Sources/Likes.php
@@ -388,7 +388,7 @@ class Likes
 		// Any callbacks?
 		elseif (!empty($this->_validLikes['callback']))
 		{
-			$call = call_helper($this->_validLikes['callback']);
+			$call = call_helper($this->_validLikes['callback'], true);
 			call_user_func_array($call, array($this->_type, $this->_content, $this->_numLikes, empty($this->_alreadyLiked)));
 		}
 

--- a/Sources/Likes.php
+++ b/Sources/Likes.php
@@ -61,7 +61,7 @@ class Likes
 	 * => 'redirect' string To add support for non JS users, It is highly encouraged to set a valid URL to redirect the user to, if you don't provide any, the code will redirect the user to the main page. The code only performs a light check to see if the redirect is valid so be extra careful while building it.
 	 * => 'type' string 6 letters or numbers. The unique identifier for your content, the code doesn't check for duplicate entries, if there are 2 or more exact hook calls, the code will take the first registered one so make sure you provide a unique identifier. Must match with what you sent in $_GET['ltype'].
 	 * => 'flush_cache' boolean this is optional, it tells the code to reset your like content's cache entry after a new entry has been inserted.
-	 * => 'callback' callable optional, useful if you don't want to issue a separate hook for updating your data, it is called immediately after the data was inserted or deleted and before the actual hook. Uses call_hook_helper(); so the same format for your function/method can be applied here.
+	 * => 'callback' callable optional, useful if you don't want to issue a separate hook for updating your data, it is called immediately after the data was inserted or deleted and before the actual hook. Uses call_helper(); so the same format for your function/method can be applied here.
 	 * => 'json' boolean optional defaults to false, if true the Like class will return a json object as response instead of HTML.
 	 */
 	protected $_validLikes = array(
@@ -388,7 +388,7 @@ class Likes
 		// Any callbacks?
 		elseif (!empty($this->_validLikes['callback']))
 		{
-			$call = call_hook_helper($this->_validLikes['callback']);
+			$call = call_helper($this->_validLikes['callback']);
 			call_user_func_array($call, array($this->_type, $this->_content, $this->_numLikes, empty($this->_alreadyLiked)));
 		}
 

--- a/Sources/ManageAttachments.php
+++ b/Sources/ManageAttachments.php
@@ -72,7 +72,7 @@ function ManageAttachments()
 	);
 
 	// Finally fall through to what we are doing.
-	$subActions[$context['sub_action']]();
+	call_helper($subActions[$context['sub_action']]);
 }
 
 /**

--- a/Sources/ManageBans.php
+++ b/Sources/ManageBans.php
@@ -44,8 +44,6 @@ function Ban()
 		'log' => 'BanLog',
 	);
 
-	call_integration_hook('integrate_manage_bans', array(&$subActions));
-
 	// Default the sub-action to 'view ban list'.
 	$_REQUEST['sa'] = isset($_REQUEST['sa']) && isset($subActions[$_REQUEST['sa']]) ? $_REQUEST['sa'] : 'list';
 
@@ -82,8 +80,10 @@ function Ban()
 		),
 	);
 
+	call_integration_hook('integrate_manage_bans', array(&$subActions));
+
 	// Call the right function for this sub-action.
-	$subActions[$_REQUEST['sa']]();
+	call_helper($subActions[$_REQUEST['sa']]);
 }
 
 /**

--- a/Sources/ManageBoards.php
+++ b/Sources/ManageBoards.php
@@ -44,8 +44,6 @@ function ManageBoards()
 		'settings' => array('EditBoardSettings', 'admin_forum'),
 	);
 
-	call_integration_hook('integrate_manage_boards', array(&$subActions));
-
 	// Default to sub action 'main' or 'settings' depending on permissions.
 	$_REQUEST['sa'] = isset($_REQUEST['sa']) && isset($subActions[$_REQUEST['sa']]) ? $_REQUEST['sa'] : (allowedTo('manage_boards') ? 'main' : 'settings');
 
@@ -68,7 +66,9 @@ function ManageBoards()
 		),
 	);
 
-	$subActions[$_REQUEST['sa']][0]();
+	call_integration_hook('integrate_manage_boards', array(&$subActions));
+
+	call_helper($subActions[$_REQUEST['sa']][0]);
 }
 
 /**

--- a/Sources/ManageCalendar.php
+++ b/Sources/ManageCalendar.php
@@ -52,8 +52,6 @@ function ManageCalendar()
 		$default = 'settings';
 	}
 
-	call_integration_hook('integrate_manage_calendar', array(&$subActions));
-
 	$_REQUEST['sa'] = isset($_REQUEST['sa']) && isset($subActions[$_REQUEST['sa']]) ? $_REQUEST['sa'] : $default;
 
 	// Set up the two tabs here...
@@ -72,7 +70,9 @@ function ManageCalendar()
 			),
 		);
 
-	$subActions[$_REQUEST['sa']]();
+	call_integration_hook('integrate_manage_calendar', array(&$subActions));
+
+	call_helper($subActions[$_REQUEST['sa']]);
 }
 
 /**

--- a/Sources/ManageLanguages.php
+++ b/Sources/ManageLanguages.php
@@ -42,8 +42,6 @@ function ManageLanguages()
 		'editlang' => 'ModifyLanguage',
 	);
 
-	call_integration_hook('integrate_manage_languages', array(&$subActions));
-
 	// By default we're managing languages.
 	$_REQUEST['sa'] = isset($_REQUEST['sa']) && isset($subActions[$_REQUEST['sa']]) ? $_REQUEST['sa'] : 'edit';
 	$context['sub_action'] = $_REQUEST['sa'];
@@ -54,8 +52,10 @@ function ManageLanguages()
 		'description' => $txt['language_description'],
 	);
 
+	call_integration_hook('integrate_manage_languages', array(&$subActions));
+
 	// Call the right function for this sub-action.
-	$subActions[$_REQUEST['sa']]();
+	call_helper($subActions[$_REQUEST['sa']]);
 }
 
 /**

--- a/Sources/ManageMail.php
+++ b/Sources/ManageMail.php
@@ -43,8 +43,6 @@ function ManageMail()
 		'settings' => 'ModifyMailSettings',
 	);
 
-	call_integration_hook('integrate_manage_mail', array(&$subActions));
-
 	// By default we want to browse
 	$_REQUEST['sa'] = isset($_REQUEST['sa']) && isset($subActions[$_REQUEST['sa']]) ? $_REQUEST['sa'] : 'browse';
 	$context['sub_action'] = $_REQUEST['sa'];
@@ -56,8 +54,10 @@ function ManageMail()
 		'description' => $txt['mailqueue_desc'],
 	);
 
+	call_integration_hook('integrate_manage_mail', array(&$subActions));
+
 	// Call the right function for this sub-action.
-	$subActions[$_REQUEST['sa']]();
+	call_helper($subActions[$_REQUEST['sa']]);
 }
 
 /**

--- a/Sources/ManageMaintenance.php
+++ b/Sources/ManageMaintenance.php
@@ -111,11 +111,11 @@ function ManageMaintenance()
 	$context['sub_template'] = !empty($subActions[$subAction]['template']) ? $subActions[$subAction]['template'] : '';
 
 	// Finally fall through to what we are doing.
-	$subActions[$subAction]['function']();
+	call_helper($subActions[$subAction]['function']);
 
 	// Any special activity?
 	if (isset($activity))
-		$subActions[$subAction]['activities'][$activity]();
+		call_helper($subActions[$subAction]['activities'][$activity]);
 
 	//converted to UTF-8? show a small maintenance info
 	if (isset($_GET['done']) && $_GET['done'] == 'convertutf8')

--- a/Sources/ManageMembergroups.php
+++ b/Sources/ManageMembergroups.php
@@ -40,8 +40,6 @@ function ModifyMembergroups()
 		'settings' => array('ModifyMembergroupsettings', 'admin_forum'),
 	);
 
-	call_integration_hook('integrate_manage_membergroups', array(&$subActions));
-
 	// Default to sub action 'index' or 'settings' depending on permissions.
 	$_REQUEST['sa'] = isset($_REQUEST['sa']) && isset($subActions[$_REQUEST['sa']]) ? $_REQUEST['sa'] : (allowedTo('manage_membergroups') ? 'index' : 'settings');
 
@@ -63,8 +61,10 @@ function ModifyMembergroups()
 		'description' => $txt['membergroups_description'],
 	);
 
+	call_integration_hook('integrate_manage_membergroups', array(&$subActions));
+
 	// Call the right function.
-	$subActions[$_REQUEST['sa']][0]();
+	call_helper($subActions[$_REQUEST['sa']][0]);
 }
 
 /**

--- a/Sources/ManageMembers.php
+++ b/Sources/ManageMembers.php
@@ -129,7 +129,7 @@ function ViewMembers()
 		unset($context['tabs']['approve']);
 	}
 
-	$subActions[$_REQUEST['sa']][0]();
+	call_helper($subActions[$_REQUEST['sa']][0]);
 }
 
 /**

--- a/Sources/ManageNews.php
+++ b/Sources/ManageNews.php
@@ -70,7 +70,7 @@ function ManageNews()
 	if (substr($_REQUEST['sa'], 0, 7) == 'mailing')
 		$context[$context['admin_menu_name']]['current_subsection'] = 'mailingmembers';
 
-	$subActions[$_REQUEST['sa']][0]();
+	call_helper($subActions[$_REQUEST['sa']][0]);
 }
 
 /**

--- a/Sources/ManagePaid.php
+++ b/Sources/ManagePaid.php
@@ -45,8 +45,6 @@ function ManagePaidSubscriptions()
 			'settings' => array('ModifySubscriptionSettings', 'admin_forum'),
 		);
 
-	call_integration_hook('integrate_manage_subscriptions', array(&$subActions));
-
 	// Default the sub-action to 'view subscriptions', but only if they have already set things up..
 	$_REQUEST['sa'] = isset($_REQUEST['sa']) && isset($subActions[$_REQUEST['sa']]) ? $_REQUEST['sa'] : (!empty($modSettings['paid_currency_symbol']) && !empty($modSettings['paid_enabled']) ? 'view' : 'settings');
 
@@ -71,8 +69,10 @@ function ManagePaidSubscriptions()
 			),
 		);
 
+	call_integration_hook('integrate_manage_subscriptions', array(&$subActions));
+
 	// Call the right function for this sub-action.
-	$subActions[$_REQUEST['sa']][0]();
+	call_helper($subActions[$_REQUEST['sa']][0]);
 }
 
 /**

--- a/Sources/ManagePermissions.php
+++ b/Sources/ManagePermissions.php
@@ -44,8 +44,6 @@ function ModifyPermissions()
 		'settings' => array('GeneralPermissionSettings', 'admin_forum'),
 	);
 
-	call_integration_hook('integrate_manage_permissions', array(&$subActions));
-
 	$_REQUEST['sa'] = isset($_REQUEST['sa']) && isset($subActions[$_REQUEST['sa']]) && empty($subActions[$_REQUEST['sa']]['disabled']) ? $_REQUEST['sa'] : (allowedTo('manage_permissions') ? 'index' : 'settings');
 	isAllowedTo($subActions[$_REQUEST['sa']][1]);
 
@@ -73,7 +71,9 @@ function ModifyPermissions()
 		),
 	);
 
-	$subActions[$_REQUEST['sa']][0]();
+	call_integration_hook('integrate_manage_permissions', array(&$subActions));
+
+	call_helper($subActions[$_REQUEST['sa']][0]);
 }
 
 /**

--- a/Sources/ManagePosts.php
+++ b/Sources/ManagePosts.php
@@ -39,8 +39,6 @@ function ManagePostSettings()
 		'drafts' => 'ModifyDraftSettings',
 	);
 
-	call_integration_hook('integrate_manage_posts', array(&$subActions));
-
 	// Default the sub-action to 'posts'.
 	$_REQUEST['sa'] = isset($_REQUEST['sa']) && isset($subActions[$_REQUEST['sa']]) ? $_REQUEST['sa'] : 'posts';
 
@@ -67,8 +65,10 @@ function ManagePostSettings()
 		),
 	);
 
+	call_integration_hook('integrate_manage_posts', array(&$subActions));
+
 	// Call the right function for this sub-action.
-	$subActions[$_REQUEST['sa']]();
+	call_helper($subActions[$_REQUEST['sa']]);
 }
 
 /**
@@ -189,14 +189,14 @@ function ModifyPostSettings($return_config = false)
 	if (function_exists('pspell_new'))
 		$can_spell_check = true;
 	elseif (function_exists('enchant_broker_init') && ($txt['lang_charset'] == 'UTF-8' || function_exists('iconv')))
-		$can_spell_check = true;			
+		$can_spell_check = true;
 
 	// All the settings...
 	$config_vars = array(
 			// Simple post options...
 			array('check', 'removeNestedQuotes'),
 			array('check', 'enableEmbeddedFlash', 'subtext' => $txt['enableEmbeddedFlash_warning']),
-			// Note show the warning as red if: pspell not installed and (enchant not installed or not using UTF-8 and iconv not installed) 
+			// Note show the warning as red if: pspell not installed and (enchant not installed or not using UTF-8 and iconv not installed)
 			array('check', 'enableSpellChecking', 'subtext' => ($can_spell_check ? $txt['enableSpellChecking_warning'] : ('<span class="alert">' . $txt['enableSpellChecking_warning'] . '</span>'))),
 			array('check', 'disable_wysiwyg'),
 		'',

--- a/Sources/ManageRegistration.php
+++ b/Sources/ManageRegistration.php
@@ -41,8 +41,6 @@ function RegCenter()
 		'settings' => array('ModifyRegistrationSettings', 'admin_forum'),
 	);
 
-	call_integration_hook('integrate_manage_registrations', array(&$subActions));
-
 	// Work out which to call...
 	$context['sub_action'] = isset($_REQUEST['sa']) && isset($subActions[$_REQUEST['sa']]) ? $_REQUEST['sa'] : (allowedTo('moderate_forum') ? 'register' : 'settings');
 
@@ -74,8 +72,10 @@ function RegCenter()
 		)
 	);
 
+	call_integration_hook('integrate_manage_registrations', array(&$subActions));
+
 	// Finally, get around to calling the function...
-	$subActions[$context['sub_action']][0]();
+	call_helper($subActions[$context['sub_action']][0]);
 }
 
 /**

--- a/Sources/ManageScheduledTasks.php
+++ b/Sources/ManageScheduledTasks.php
@@ -39,8 +39,6 @@ function ManageScheduledTasks()
 		'tasks' => 'ScheduledTasks',
 	);
 
-	call_integration_hook('integrate_manage_scheduled_tasks', array(&$subActions));
-
 	// We need to find what's the action.
 	if (isset($_REQUEST['sa']) && isset($subActions[$_REQUEST['sa']]))
 		$context['sub_action'] = $_REQUEST['sa'];
@@ -62,8 +60,10 @@ function ManageScheduledTasks()
 		),
 	);
 
+	call_integration_hook('integrate_manage_scheduled_tasks', array(&$subActions));
+
 	// Call it.
-	$subActions[$context['sub_action']]();
+	call_helper($subActions[$context['sub_action']]);
 }
 
 /**

--- a/Sources/ManageSearch.php
+++ b/Sources/ManageSearch.php
@@ -48,8 +48,6 @@ function ManageSearch()
 		'createmsgindex' => 'CreateMessageIndex',
 	);
 
-	call_integration_hook('integrate_manage_search', array(&$subActions));
-
 	// Default the sub-action to 'edit search settings'.
 	$_REQUEST['sa'] = isset($_REQUEST['sa']) && isset($subActions[$_REQUEST['sa']]) ? $_REQUEST['sa'] : 'weights';
 
@@ -73,8 +71,10 @@ function ManageSearch()
 		),
 	);
 
+	call_integration_hook('integrate_manage_search', array(&$subActions));
+
 	// Call the right function for this sub-action.
-	$subActions[$_REQUEST['sa']]();
+	call_helper($subActions[$_REQUEST['sa']]);
 }
 
 /**

--- a/Sources/ManageSearchEngines.php
+++ b/Sources/ManageSearchEngines.php
@@ -47,8 +47,6 @@ function SearchEngines()
 		$default = 'settings';
 	}
 
-	call_integration_hook('integrate_manage_search_engines', array(&$subActions));
-
 	// Ensure we have a valid subaction.
 	$context['sub_action'] = isset($_REQUEST['sa']) && isset($subActions[$_REQUEST['sa']]) ? $_REQUEST['sa'] : $default;
 
@@ -60,8 +58,10 @@ function SearchEngines()
 		'description' => $txt['search_engines_description'],
 	);
 
+	call_integration_hook('integrate_manage_search_engines', array(&$subActions));
+
 	// Call the function!
-	$subActions[$context['sub_action']]();
+	call_helper($subActions[$context['sub_action']]);
 }
 
 /**

--- a/Sources/ManageServer.php
+++ b/Sources/ManageServer.php
@@ -103,8 +103,6 @@ function ModifySettings()
 		'phpinfo' => 'ShowPHPinfoSettings',
 	);
 
-	call_integration_hook('integrate_server_settings', array(&$subActions));
-
 	// By default we're editing the core settings
 	$_REQUEST['sa'] = isset($_REQUEST['sa']) && isset($subActions[$_REQUEST['sa']]) ? $_REQUEST['sa'] : 'general';
 	$context['sub_action'] = $_REQUEST['sa'];
@@ -124,8 +122,10 @@ function ModifySettings()
 		$context['settings_not_writable'] = $settings_not_writable;
 	}
 
+	call_integration_hook('integrate_server_settings', array(&$subActions));
+
 	// Call the right function for this sub-action.
-	$subActions[$_REQUEST['sa']]();
+	call_helper($subActions[$_REQUEST['sa']]);
 }
 
 /**

--- a/Sources/ManageSettings.php
+++ b/Sources/ManageSettings.php
@@ -63,8 +63,6 @@ function ModifyFeatureSettings()
 		'mentions' => 'ModifyMentionsSettings',
 	);
 
-	call_integration_hook('integrate_modify_features', array(&$subActions));
-
 	loadGeneralSettingParameters($subActions, 'basic');
 
 	// Load up all the tabs...
@@ -93,8 +91,10 @@ function ModifyFeatureSettings()
 		),
 	);
 
+	call_integration_hook('integrate_modify_features', array(&$subActions));
+
 	// Call the right function for this sub-action.
-	$subActions[$_REQUEST['sa']]();
+	call_helper($subActions[$_REQUEST['sa']]);
 }
 
 /**

--- a/Sources/ManageSmileys.php
+++ b/Sources/ManageSmileys.php
@@ -42,8 +42,6 @@ function ManageSmileys()
 		'install' => 'InstallSmileySet'
 	);
 
-	call_integration_hook('integrate_manage_smileys', array(&$subActions));
-
 	// If customized smileys is disabled don't show the setting page
 	if (empty($modSettings['smiley_enable']))
 	{
@@ -102,8 +100,10 @@ function ManageSmileys()
 		$context[$context['admin_menu_name']]['tab_data']['tabs']['setorder']['disabled'] = true;
 	}
 
+	call_integration_hook('integrate_manage_smileys', array(&$subActions));
+
 	// Call the right function for this sub-action.
-	$subActions[$_REQUEST['sa']]();
+	call_helper($subActions[$_REQUEST['sa']]);
 }
 
 /**

--- a/Sources/Memberlist.php
+++ b/Sources/Memberlist.php
@@ -149,9 +149,10 @@ function Memberlist()
 
 	// Jump to the sub action.
 	if (isset($subActions[$context['listing_by']]))
-		$subActions[$context['listing_by']][1]();
+		call_helper($subActions[$context['listing_by']][1]);
+
 	else
-		$subActions['all'][1]();
+		call_helper($subActions['all'][1]);
 }
 
 /**

--- a/Sources/ModerationCenter.php
+++ b/Sources/ModerationCenter.php
@@ -236,7 +236,7 @@ function ModerationMain($dont_call = false)
 		if (isset($mod_include_data['file']))
 			require_once($sourcedir . '/' . $mod_include_data['file']);
 
-		$mod_include_data['function']();
+		call_helper($mod_include_data['function']);
 	}
 }
 

--- a/Sources/MoveTopic.php
+++ b/Sources/MoveTopic.php
@@ -63,10 +63,10 @@ function MoveTopic()
 		else
 			isAllowedTo('move_any');
 	}
-	
+
 	$context['move_any'] = $user_info['is_admin'] || $modSettings['topic_move_any'];
 	$boards = array();
-	
+
 	if (!$context['move_any'])
 	{
 		$boards = array_diff(boardsAllowedTo('post_new'), array($board));

--- a/Sources/PackageGet.php
+++ b/Sources/PackageGet.php
@@ -77,7 +77,9 @@ function PackageGet()
 		),
 	);
 
-	$subActions[$context['sub_action']]();
+	call_integration_hook('integrate_package_get', array(&$subActions));
+
+	call_helper($subActions[$context['sub_action']]);
 }
 
 /**

--- a/Sources/Packages.php
+++ b/Sources/Packages.php
@@ -89,8 +89,10 @@ function Packages()
 	if ($context['sub_action'] == 'browse')
 		loadJavascriptFile('suggest.js', array('default_theme' => true, 'defer' => false), 'smf_suggest');
 
+	call_integration_hook('integrate_manage_packages', array(&$subActions));
+
 	// Call the function we're handing control to.
-	$subActions[$context['sub_action']]();
+	call_helper($subActions[$context['sub_action']]);
 }
 
 /**

--- a/Sources/PostModeration.php
+++ b/Sources/PostModeration.php
@@ -42,7 +42,9 @@ function PostModerationMain()
 	if (!isset($_REQUEST['sa']) || !isset($subactions[$_REQUEST['sa']]))
 		$_REQUEST['sa'] = 'replies';
 
-	$subactions[$_REQUEST['sa']]();
+	call_integration_hook('integrate_post_moderation', array(&$subActions));
+
+	call_helper($subactions[$_REQUEST['sa']]);
 }
 
 /**

--- a/Sources/Profile.php
+++ b/Sources/Profile.php
@@ -757,7 +757,7 @@ function ModifyProfile($post_errors = array())
 
 	// A static one or more likely, a plain good old function.
 	else
-		$call = $profile_include_data['function'];
+		$call = call_helper($profile_include_data['function'], true);
 
 	// Is it valid?
 	if (is_callable($call))

--- a/Sources/Reminder.php
+++ b/Sources/Reminder.php
@@ -39,7 +39,8 @@ function RemindMe()
 
 	// Any subaction?  If none, fall through to the main template, which will ask for one.
 	if (isset($_REQUEST['sa']) && isset($subActions[$_REQUEST['sa']]))
-		$subActions[$_REQUEST['sa']]();
+		call_helper($subActions[$_REQUEST['sa']]);
+
 	// Creating a one time token.
 	else
 		createToken('remind');

--- a/Sources/ReportedContent.php
+++ b/Sources/ReportedContent.php
@@ -57,7 +57,7 @@ function ReportedContent()
 	if ($context['report_type'] == 'members' || $user_info['mod_cache']['bq'] == '0=1')
 		isAllowedTo('moderate_forum');
 
-	$sub_actions = array(
+	$subActions = array(
 		'show' => 'ShowReports',
 		'closed' => 'ShowClosedReports',
 		'handle' => 'HandleReport', // Deals with closing/opening reports.
@@ -67,17 +67,17 @@ function ReportedContent()
 	);
 
 	// Go ahead and add your own sub-actions.
-	call_integration_hook('integrate_reported_' . $context['report_type'], array(&$sub_actions));
+	call_integration_hook('integrate_reported_' . $context['report_type'], array(&$subActions));
 
 	// By default we call the open sub-action.
-	if (isset($_REQUEST['sa']) && isset($sub_actions[$_REQUEST['sa']]))
+	if (isset($_REQUEST['sa']) && isset($subActions[$_REQUEST['sa']]))
 		$context['sub_action'] = $smcFunc['htmltrim']($smcFunc['htmlspecialchars']($_REQUEST['sa']), ENT_QUOTES);
 
 	else
 		$context['sub_action'] = 'show';
 
 	// Hi Ho Silver Away!
-	$sub_actions[$context['sub_action']]();
+	call_helper($subActions[$context['sub_action']]);
 }
 
 /**

--- a/Sources/SplitTopics.php
+++ b/Sources/SplitTopics.php
@@ -52,8 +52,9 @@ function SplitTopics()
 	// ?action=splittopics;sa=LETSBREAKIT won't work, sorry.
 	if (empty($_REQUEST['sa']) || !isset($subActions[$_REQUEST['sa']]))
 		SplitIndex();
+
 	else
-		$subActions[$_REQUEST['sa']]();
+		call_helper($subActions[$_REQUEST['sa']]);
 }
 
 /**
@@ -908,7 +909,7 @@ function MergeIndex()
 			'not_redirection' => true,
 			'selected_board' => $context['target_board'],
 		);
-	
+
 		// Only include these boards in the list (0 means you're an admin')
 		if (!in_array(0, $merge_boards))
 			$options['included_boards'] = $merge_boards;

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -2722,7 +2722,7 @@ function obExit($header = null, $do_footer = null, $from_index = false, $from_fa
 			foreach ($buffers as $function)
 			{
 				$function = trim($function);
-				$call = call_hook_helper($function);
+				$call = call_helper($function);
 
 				// Is it valid?
 				if (is_callable($call))
@@ -4099,12 +4099,12 @@ function call_integration_hook($hook, $parameters = array())
 				}
 			}
 
-			$call = call_hook_helper($func);
+			$call = call_helper($func);
 		}
 
 		// Figuring out what to do.
 		else
-			$call = call_hook_helper($function);
+			$call = call_helper($function);
 
 		// Is it valid?
 		if (!empty($call) && is_callable($call))
@@ -4236,7 +4236,7 @@ function remove_integration_function($hook, $function, $file = '', $object = fal
  * @param boolean $return If true, the function will not call the function/method but instead will return the formated string.
  * @return string|array Either a string or an array that contains a callable function name or an array with a class and method to call
  */
-function call_hook_helper($string, $return = false)
+function call_helper($string, $return = false)
 {
 	global $context, $db_show_debug;
 

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -2722,7 +2722,7 @@ function obExit($header = null, $do_footer = null, $from_index = false, $from_fa
 			foreach ($buffers as $function)
 			{
 				$function = trim($function);
-				$call = call_helper($function);
+				$call = call_helper($function, true);
 
 				// Is it valid?
 				if (is_callable($call))
@@ -4099,12 +4099,12 @@ function call_integration_hook($hook, $parameters = array())
 				}
 			}
 
-			$call = call_helper($func);
+			$call = call_helper($func, true);
 		}
 
 		// Figuring out what to do.
 		else
-			$call = call_helper($function);
+			$call = call_helper($function, true);
 
 		// Is it valid?
 		if (!empty($call) && is_callable($call))
@@ -4232,8 +4232,8 @@ function remove_integration_function($hook, $function, $file = '', $object = fal
  * If a method is found, it looks for a "#" which indicates SMF should create a new instance of the given class.
  * Prepare and returns a callable depending on the type of method/function found.
  *
- * @param string $string The string containing a function name
- * @param boolean $return If true, the function will not call the function/method but instead will return the formated string.
+ * @param string $string The string containing a function name or a static call.
+ * @param boolean $return If true, the function will not call the function/method but instead will return the formatted string.
  * @return string|array Either a string or an array that contains a callable function name or an array with a class and method to call
  */
 function call_helper($string, $return = false)

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -4233,15 +4233,19 @@ function remove_integration_function($hook, $function, $file = '', $object = fal
  * Prepare and returns a callable depending on the type of method/function found.
  *
  * @param string $string The string containing a function name
+ * @param boolean $return If true, the function will not call the function/method but instead will return the formated string.
  * @return string|array Either a string or an array that contains a callable function name or an array with a class and method to call
  */
-function call_hook_helper($string)
+function call_hook_helper($string, $return = false)
 {
 	global $context, $db_show_debug;
 
 	// Really?
 	if (empty($string))
 		return false;
+
+	// The soon to be populated var.
+	$func = false;
 
 	// Found a method.
 	if (strpos($string, '::') !== false)
@@ -4269,17 +4273,31 @@ function call_hook_helper($string)
 				}
 			}
 
-			return array($context['instances'][$class], $method);
+			$func = array($context['instances'][$class], $method);
 		}
 
 		// Right then. This is a call to a static method.
 		else
-			return array($class, $method);
+			$func = array($class, $method);
 	}
 
 	// Nope! just a plain regular function.
 	else
-		return $string;
+		$func = $string;
+
+	// What are we gonna do about it?
+	if ($return)
+		return $func;
+
+	// If this is a plain function, avoid the heat of calling call_user_func().
+	else
+	{
+		if (is_array($func))
+			call_user_func($func);
+
+		else
+			$func();
+	}
 }
 
 /**

--- a/Sources/Themes.php
+++ b/Sources/Themes.php
@@ -97,7 +97,7 @@ function ThemesMain()
 	}
 
 	// CRUD $subActions as needed.
-	call_integration_hook('integrate_ThemesMain_subActions', array(&$subActions));
+	call_integration_hook('integrate_manage_themes', array(&$subActions));
 
 	// Follow the sa or just go to administration.
 	if (isset($_GET['sa']) && !empty($subActions[$_GET['sa']]))

--- a/Sources/Themes.php
+++ b/Sources/Themes.php
@@ -72,9 +72,6 @@ function ThemesMain()
 		'copy' => 'CopyTemplate',
 	);
 
-	// CRUD $subActions as needed.
-	call_integration_hook('integrate_ThemesMain_subActions', array(&$subActions));
-
 	// @todo Layout Settings?  huh?
 	if (!empty($context['admin_menu_name']))
 	{
@@ -99,11 +96,15 @@ function ThemesMain()
 		);
 	}
 
+	// CRUD $subActions as needed.
+	call_integration_hook('integrate_ThemesMain_subActions', array(&$subActions));
+
 	// Follow the sa or just go to administration.
 	if (isset($_GET['sa']) && !empty($subActions[$_GET['sa']]))
-		$subActions[$_GET['sa']]();
+		call_helper($subActions[$_GET['sa']]);
+
 	else
-		$subActions['admin']();
+		call_helper($subActions['admin']);
 }
 
 /**

--- a/Sources/Themes.php
+++ b/Sources/Themes.php
@@ -72,7 +72,10 @@ function ThemesMain()
 		'copy' => 'CopyTemplate',
 	);
 
-	// @todo Layout Settings?
+	// CRUD $subActions as needed.
+	call_integration_hook('integrate_ThemesMain_subActions', array(&$subActions));
+
+	// @todo Layout Settings?  huh?
 	if (!empty($context['admin_menu_name']))
 	{
 		$context[$context['admin_menu_name']]['tab_data'] = array(

--- a/Sources/Xml.php
+++ b/Sources/Xml.php
@@ -21,25 +21,19 @@ function XMLhttpMain()
 {
 	loadTemplate('Xml');
 
-	$sub_actions = array(
-		'jumpto' => array(
-			'function' => 'GetJumpTo',
-		),
-		'messageicons' => array(
-			'function' => 'ListMessageIcons',
-		),
-		'previews' => array(
-			'function' => 'RetrievePreview',
-		),
+	$subActions = array(
+		'jumpto' =>  'GetJumpTo',
+		'messageicons' => 'ListMessageIcons',
+		'previews' => 'RetrievePreview',
 	);
 
-	// Easy adding of sub actions
- 	call_integration_hook('integrate_xmlhttp', array(&$sub_actions));
+	// Easy adding of sub actions.
+	call_integration_hook('integrate_XMLhttpMain_subActions', array(&$subActions));
 
-	if (!isset($_REQUEST['sa'], $sub_actions[$_REQUEST['sa']]))
+	if (!isset($_REQUEST['sa'], $subActions[$_REQUEST['sa']]))
 		fatal_lang_error('no_access', false);
 
-	$sub_actions[$_REQUEST['sa']]['function']();
+	call_helper($subActions[$_REQUEST['sa']]);
 }
 
 /**

--- a/index.php
+++ b/index.php
@@ -243,7 +243,7 @@ function smf_main()
 			$defaultActions = call_integration_hook('integrate_default_action');
 			foreach ($defaultActions as $defaultAction)
 			{
-				$call = call_hook_helper($defaultAction);
+				$call = call_helper($defaultAction);
 				if (!empty($call) && is_callable($call))
 					return $call;
 			}
@@ -363,7 +363,7 @@ function smf_main()
 		$fallbackActions = call_integration_hook('integrate_fallback_action');
 		foreach ($fallbackActions as $fallbackAction)
 		{
-			$call = call_hook_helper($fallbackAction);
+			$call = call_helper($fallbackAction);
 			if (!empty($call) && is_callable($call))
 				return $call;
 		}
@@ -377,7 +377,7 @@ function smf_main()
 	require_once($sourcedir . '/' . $actionArray[$_REQUEST['action']][0]);
 
 	// Do the right thing.
-	return call_hook_helper($actionArray[$_REQUEST['action']][1]);
+	return call_helper($actionArray[$_REQUEST['action']][1]);
 }
 
 ?>

--- a/index.php
+++ b/index.php
@@ -243,7 +243,7 @@ function smf_main()
 			$defaultActions = call_integration_hook('integrate_default_action');
 			foreach ($defaultActions as $defaultAction)
 			{
-				$call = call_helper($defaultAction);
+				$call = call_helper($defaultAction, true);
 				if (!empty($call) && is_callable($call))
 					return $call;
 			}
@@ -363,7 +363,7 @@ function smf_main()
 		$fallbackActions = call_integration_hook('integrate_fallback_action');
 		foreach ($fallbackActions as $fallbackAction)
 		{
-			$call = call_helper($fallbackAction);
+			$call = call_helper($fallbackAction, true);
 			if (!empty($call) && is_callable($call))
 				return $call;
 		}
@@ -377,7 +377,7 @@ function smf_main()
 	require_once($sourcedir . '/' . $actionArray[$_REQUEST['action']][0]);
 
 	// Do the right thing.
-	return call_helper($actionArray[$_REQUEST['action']][1]);
+	return call_helper($actionArray[$_REQUEST['action']][1], true);
 }
 
 ?>


### PR DESCRIPTION
- Modifies call_hook_helper() to allow executing the given string or return the formated string.
- Uses call_helper() on every subAction call.
- Normalizes $sub_actions and other variations to camelCase $subActions

oh and fixes #1895 
