### PR TITLE
Explicitely pass the array, don't abuse global scope

### DIFF
--- a/Sources/Load.php
+++ b/Sources/Load.php
@@ -1306,7 +1306,7 @@ function loadMemberContext($user, $display_custom_fields = false)
 		}
 	}
 
-	call_integration_hook('integrate_member_context', array(&$memberContext[$user], $display_custom_fields));
+	call_integration_hook('integrate_member_context', array(&$memberContext[$user], $user, $display_custom_fields));
 	return true;
 }
 

--- a/Sources/Load.php
+++ b/Sources/Load.php
@@ -1306,7 +1306,7 @@ function loadMemberContext($user, $display_custom_fields = false)
 		}
 	}
 
-	call_integration_hook('integrate_member_context', array(&$user, $display_custom_fields));
+	call_integration_hook('integrate_member_context', array(&$memberContext[$user], $display_custom_fields));
 	return true;
 }
 


### PR DESCRIPTION
We really shouldn't abuse the global scope, for things like $context its OK (and even at cases like that, I still argue we should pass the value) but for specific cases like this one, we really should pass the var.

Signed-off-by: Suki suki@missallsunday.com
