### PR TITLE
allow hooked BBcodes to use WYSIWYG/Source toggle

### DIFF
--- a/Sources/Subs-Editor.php
+++ b/Sources/Subs-Editor.php
@@ -1763,13 +1763,6 @@ function create_control_richedit($editorOptions)
 									return \'' . preg_replace(array('~\$1~', '~\$2~', '~\$3~'), array('\' + content + \'', '\' + attributes[0] + \'', '\' + attributes[1] + \''), '<div style="display:inline;" class="sceditor-ignore">' . $tag['html'] . '</div>') . '<span style="display: none;visibility: hidden;">' . str_replace((!empty($attrs[1]) ? $attrs[1] : ''), '\' + attributes[0] + \',\' + attributes[1] + \'', $tag['before']) . '\' + content + \'' . (isset($tag['after']) ? $tag['after'] . '</span>' : '</span>') . '\';
 								else
 									return \'' . preg_replace(array('~\$1~', '~\$2~'), array('\' + content + \'', '\' + attributes[0] + \''), '<div style="display:inline;" class="sceditor-ignore">' . $tag['html'] . '</div>') . '<span style="display: none;visibility: hidden;">' . str_replace((!empty($attrs[1]) ? $attrs[1] : ''), '\' + attributes[0] + \'', $tag['before']) . '\' + content + \'' . (isset($tag['after']) ? $tag['after'] . '</span>' : '</span>') . '\';
-						},
-						format: function($element, content) {
-							var element = $element[0];
-							if (element === "undefined")
-								return \'' . $tag['before'] . '\' + content + \'' . (isset($tag['after']) ? $tag['after'] : '') . '\';
-
-							return \'' . str_replace((!empty($attrs[1]) ? $attrs[1] : ''), '\' + elemement + \'', $tag['before']) . '\' + content + \'' . (isset($tag['after']) ? $tag['after'] : '') . '\';
 						}
 					}
 				);';

--- a/Sources/Subs-Editor.php
+++ b/Sources/Subs-Editor.php
@@ -1715,24 +1715,65 @@ function create_control_richedit($editorOptions)
 				if ((!empty($tag['code'])) && empty($context['disabled_tags'][$tag['code']]))
 				{
 					$tagsRow[] = $tag['code'];
+					$tag['allow_children'] = !empty($tag['allow_children']) && strpos($tag['allow_children'], 'null') === false ? array_map('trim', explode(',', $tag['allow_children'])) : array();
+
 					if (isset($tag['image']))
 						$bbcodes_styles .= '
 			.sceditor-button-' . $tag['code'] . ' div {
 				background: url(\'' . $settings['default_theme_url'] . '/images/bbc/' . $tag['image'] . '.png\');
 			}';
 					if (isset($tag['before']))
-					{
 						$context['bbcodes_handlers'] .= '
 				$.sceditor.command.set(
 					' . javaScriptEscape($tag['code']) . ', {
 					exec: function () {
-						this.wysiwygEditorInsertHtml(' . javaScriptEscape($tag['before']) . (isset($tag['after']) ? ', ' . javaScriptEscape($tag['after']) : '') . ');
+						this.wysiwygEditorInsertHtml(' . (!empty($tag['html']) ? javaScriptEscape($tag['html']) : javaScriptEscape($tag['before'] . (!empty($tag['after']) ? ', ' . $tag['after'] : ''))) . ');
 					},
 					txtExec: [' . javaScriptEscape($tag['before']) . (isset($tag['after']) ? ', ' . javaScriptEscape($tag['after']) : '') . '],
 					tooltip: ' . javaScriptEscape($tag['description']) . '
 				});';
-					}
 
+					if ((!empty($tag['html']) && !empty($tag['before'])))
+					{
+						preg_match('~=(.*?)]~', $tag['before'], $attrs);
+
+						$context['bbcodes_handlers'] .= '
+				$.sceditor.plugins.bbcode.bbcode.set(
+					' . javaScriptEscape($tag['code']) . ',
+					{
+						style: "' . $settings['default_theme_url'] . '/css/jquery.sceditor.default.css",
+						tags: {
+							"' . $tag['code'] . '": null
+						},
+						excludeClosing: ' . (!empty($tag['after']) ? 'false' : 'true') . ',
+						' . (!empty($tag['after']) && !empty($tag['allow_children']) ? 'allowedChildren: [' . javaScriptEscape(implode("', '", $tag['allow_children'])) . '],' : '') . '
+						skipLastLineBreak: true,
+						breakEnd: false,
+						quoteType: $.sceditor.BBCodeParser.QuoteType.auto,
+						isSelfClosing: ' . (!empty($tag['after']) ? 'false' : 'true') . ',
+						isInline: ' . (!empty($tag['block_lvl']) ? 'false' : 'true') . ',
+						html: 	function(token, attrs, content) {
+								if (typeof attrs.defaultattr === "undefined" || attrs.defaultattr.length === 0)
+									return \'' . preg_replace('~\$1~', '\' + content + \'', '<div style="display:inline;" class="sceditor-ignore">' . $tag['html'] . '</div>') . '<span style="display: none;visibility: hidden;">' . $tag['before'] . '\' + content + \'' . (isset($tag['after']) ? $tag['after'] . '</span>' : '</span>') . '\';
+
+								var attributes = attrs.defaultattr.split(",");
+								var checkSourceMode = true;
+
+								if (attributes.length === 2)
+									return \'' . preg_replace(array('~\$1~', '~\$2~', '~\$3~'), array('\' + content + \'', '\' + attributes[0] + \'', '\' + attributes[1] + \''), '<div style="display:inline;" class="sceditor-ignore">' . $tag['html'] . '</div>') . '<span style="display: none;visibility: hidden;">' . str_replace((!empty($attrs[1]) ? $attrs[1] : ''), '\' + attributes[0] + \',\' + attributes[1] + \'', $tag['before']) . '\' + content + \'' . (isset($tag['after']) ? $tag['after'] . '</span>' : '</span>') . '\';
+								else
+									return \'' . preg_replace(array('~\$1~', '~\$2~'), array('\' + content + \'', '\' + attributes[0] + \''), '<div style="display:inline;" class="sceditor-ignore">' . $tag['html'] . '</div>') . '<span style="display: none;visibility: hidden;">' . str_replace((!empty($attrs[1]) ? $attrs[1] : ''), '\' + attributes[0] + \'', $tag['before']) . '\' + content + \'' . (isset($tag['after']) ? $tag['after'] . '</span>' : '</span>') . '\';
+						},
+						format: function($element, content) {
+							var element = $element[0];
+							if (element === "undefined")
+								return \'' . $tag['before'] . '\' + content + \'' . (isset($tag['after']) ? $tag['after'] : '') . '\';
+
+							return \'' . str_replace((!empty($attrs[1]) ? $attrs[1] : ''), '\' + elemement + \'', $tag['before']) . '\' + content + \'' . (isset($tag['after']) ? $tag['after'] : '') . '\';
+						}
+					}
+				);';
+					}
 				}
 				else
 				{

--- a/Sources/Subs-Editor.php
+++ b/Sources/Subs-Editor.php
@@ -1754,14 +1754,14 @@ function create_control_richedit($editorOptions)
 						isInline: ' . (!empty($tag['block_lvl']) ? 'false' : 'true') . ',
 						html: 	function(token, attrs, content) {
 								if (typeof attrs.defaultattr === "undefined" || attrs.defaultattr.length === 0)
-									return \'' . preg_replace('~\$1~', '\' + content + \'', '<div style="display:inline;" class="sceditor-ignore">' . $tag['html'] . '</div>') . '<span style="display: none;visibility: hidden;">' . $tag['before'] . '\' + content + \'' . (isset($tag['after']) ? $tag['after'] . '</span>' : '</span>') . '\';
+									return \'' . preg_replace('~\$1~', '\' + content + \'', '<div class="sceditor-ignore">' . $tag['html'] . '</div>') . '<span class="editor">' . $tag['before'] . '\' + content + \'' . (isset($tag['after']) ? $tag['after'] . '</span>' : '</span>') . '\';
 
 								var attributes = attrs.defaultattr.split(",");
 
 								if (attributes.length === 2)
-									return \'' . preg_replace(array('~\$1~', '~\$2~', '~\$3~'), array('\' + content + \'', '\' + attributes[0] + \'', '\' + attributes[1] + \''), '<div style="display:inline;" class="sceditor-ignore">' . $tag['html'] . '</div>') . '<span style="display: none;visibility: hidden;">' . str_replace((!empty($attrs[1]) ? $attrs[1] : ''), '\' + attributes[0] + \',\' + attributes[1] + \'', $tag['before']) . '\' + content + \'' . (isset($tag['after']) ? $tag['after'] . '</span>' : '</span>') . '\';
+									return \'' . preg_replace(array('~\$1~', '~\$2~', '~\$3~'), array('\' + content + \'', '\' + attributes[0] + \'', '\' + attributes[1] + \''), '<div class="sceditor-ignore">' . $tag['html'] . '</div>') . '<span class="editor">' . str_replace((!empty($attrs[1]) ? $attrs[1] : ''), '\' + attributes[0] + \',\' + attributes[1] + \'', $tag['before']) . '\' + content + \'' . (isset($tag['after']) ? $tag['after'] . '</span>' : '</span>') . '\';
 								else
-									return \'' . preg_replace(array('~\$1~', '~\$2~'), array('\' + content + \'', '\' + attributes[0] + \''), '<div style="display:inline;" class="sceditor-ignore">' . $tag['html'] . '</div>') . '<span style="display: none;visibility: hidden;">' . str_replace((!empty($attrs[1]) ? $attrs[1] : ''), '\' + attributes[0] + \'', $tag['before']) . '\' + content + \'' . (isset($tag['after']) ? $tag['after'] . '</span>' : '</span>') . '\';
+									return \'' . preg_replace(array('~\$1~', '~\$2~'), array('\' + content + \'', '\' + attributes[0] + \''), '<div class="sceditor-ignore">' . $tag['html'] . '</div>') . '<span class="editor">' . str_replace((!empty($attrs[1]) ? $attrs[1] : ''), '\' + attributes[0] + \'', $tag['before']) . '\' + content + \'' . (isset($tag['after']) ? $tag['after'] . '</span>' : '</span>') . '\';
 						}
 					}
 				);';

--- a/Sources/Subs-Editor.php
+++ b/Sources/Subs-Editor.php
@@ -1733,10 +1733,9 @@ function create_control_richedit($editorOptions)
 					tooltip: ' . javaScriptEscape($tag['description']) . '
 				});';
 
-					if ((!empty($tag['html']) && !empty($tag['before'])))
+					if (!empty($tag['html']) && !empty($tag['before']))
 					{
 						preg_match('~=(.*?)]~', $tag['before'], $attrs);
-
 						$context['bbcodes_handlers'] .= '
 				$.sceditor.plugins.bbcode.bbcode.set(
 					' . javaScriptEscape($tag['code']) . ',
@@ -1757,7 +1756,6 @@ function create_control_richedit($editorOptions)
 									return \'' . preg_replace('~\$1~', '\' + content + \'', '<div style="display:inline;" class="sceditor-ignore">' . $tag['html'] . '</div>') . '<span style="display: none;visibility: hidden;">' . $tag['before'] . '\' + content + \'' . (isset($tag['after']) ? $tag['after'] . '</span>' : '</span>') . '\';
 
 								var attributes = attrs.defaultattr.split(",");
-								var checkSourceMode = true;
 
 								if (attributes.length === 2)
 									return \'' . preg_replace(array('~\$1~', '~\$2~', '~\$3~'), array('\' + content + \'', '\' + attributes[0] + \'', '\' + attributes[1] + \''), '<div style="display:inline;" class="sceditor-ignore">' . $tag['html'] . '</div>') . '<span style="display: none;visibility: hidden;">' . str_replace((!empty($attrs[1]) ? $attrs[1] : ''), '\' + attributes[0] + \',\' + attributes[1] + \'', $tag['before']) . '\' + content + \'' . (isset($tag['after']) ? $tag['after'] . '</span>' : '</span>') . '\';

--- a/Sources/Subs-Editor.php
+++ b/Sources/Subs-Editor.php
@@ -1748,6 +1748,7 @@ function create_control_richedit($editorOptions)
 						' . (!empty($tag['after']) && !empty($tag['allow_children']) ? 'allowedChildren: [' . javaScriptEscape(implode("', '", $tag['allow_children'])) . '],' : '') . '
 						skipLastLineBreak: true,
 						breakEnd: false,
+						allowsEmpty: true,
 						quoteType: $.sceditor.BBCodeParser.QuoteType.auto,
 						isSelfClosing: ' . (!empty($tag['after']) ? 'false' : 'true') . ',
 						isInline: ' . (!empty($tag['block_lvl']) ? 'false' : 'true') . ',

--- a/Sources/Subs-Editor.php
+++ b/Sources/Subs-Editor.php
@@ -1754,14 +1754,14 @@ function create_control_richedit($editorOptions)
 						isInline: ' . (!empty($tag['block_lvl']) ? 'false' : 'true') . ',
 						html: 	function(token, attrs, content) {
 								if (typeof attrs.defaultattr === "undefined" || attrs.defaultattr.length === 0)
-									return \'' . preg_replace('~\$1~', '\' + content + \'', '<div class="sceditor-ignore">' . $tag['html'] . '</div>') . '<span class="editor">' . $tag['before'] . '\' + content + \'' . (isset($tag['after']) ? $tag['after'] . '</span>' : '</span>') . '\';
+									return \'' . preg_replace('~\$1~', '\' + content + \'', '<div style="display:inline;" class="sceditor-ignore">' . $tag['html'] . '</div>') . '<span class="editor" style="display:none;">' . $tag['before'] . '\' + content + \'' . (isset($tag['after']) ? $tag['after'] . '</span>' : '</span>') . '\';
 
 								var attributes = attrs.defaultattr.split(",");
 
 								if (attributes.length === 2)
-									return \'' . preg_replace(array('~\$1~', '~\$2~', '~\$3~'), array('\' + content + \'', '\' + attributes[0] + \'', '\' + attributes[1] + \''), '<div class="sceditor-ignore">' . $tag['html'] . '</div>') . '<span class="editor">' . str_replace((!empty($attrs[1]) ? $attrs[1] : ''), '\' + attributes[0] + \',\' + attributes[1] + \'', $tag['before']) . '\' + content + \'' . (isset($tag['after']) ? $tag['after'] . '</span>' : '</span>') . '\';
+									return \'' . preg_replace(array('~\$1~', '~\$2~', '~\$3~'), array('\' + content + \'', '\' + attributes[0] + \'', '\' + attributes[1] + \''), '<div style="display:inline;" class="sceditor-ignore">' . $tag['html'] . '</div>') . '<span style="display:none;" class="editor">' . str_replace((!empty($attrs[1]) ? $attrs[1] : ''), '\' + attributes[0] + \',\' + attributes[1] + \'', $tag['before']) . '\' + content + \'' . (isset($tag['after']) ? $tag['after'] . '</span>' : '</span>') . '\';
 								else
-									return \'' . preg_replace(array('~\$1~', '~\$2~'), array('\' + content + \'', '\' + attributes[0] + \''), '<div class="sceditor-ignore">' . $tag['html'] . '</div>') . '<span class="editor">' . str_replace((!empty($attrs[1]) ? $attrs[1] : ''), '\' + attributes[0] + \'', $tag['before']) . '\' + content + \'' . (isset($tag['after']) ? $tag['after'] . '</span>' : '</span>') . '\';
+									return \'' . preg_replace(array('~\$1~', '~\$2~'), array('\' + content + \'', '\' + attributes[0] + \''), '<div style="display:inline;" class="sceditor-ignore">' . $tag['html'] . '</div>') . '<span style="display:none;" class="editor">' . str_replace((!empty($attrs[1]) ? $attrs[1] : ''), '\' + attributes[0] + \'', $tag['before']) . '\' + content + \'' . (isset($tag['after']) ? $tag['after'] . '</span>' : '</span>') . '\';
 						}
 					}
 				);';


### PR DESCRIPTION
Mod author paramters for the bbc array:
- includes backward compatibility for previous bbc array keys (code, description, before, after)
- mod authors must include code (<-name), description, before (and after if applicable) keys into bbc array
- if they want to use the WYSIWYG editor to toggle their BBCode
  they must include new keys of "html", "allowed_children" (<- defaults to null)
  and "block_lvl" (<- defaults to inline if 0 or not included in array)
- for the WYSIWYG editor to ignore toggling the BBC html,
  the "html" key should be empty or not included in the bbc array
- code works for all BBCode types
- the key of allowed_children defaults to null which allows all children unless otherwise specified within the array
  the # can be entered for this setting which will allow all text but will not execute a BBcode placed within. 
- other default BBC with the custom tag posted within will behave normally.
- setting for allowed_children examples:
  empty or null -> allow all children BBC's,
  "#" will treat other BBC's contained within as text,
  b, url, hr -> execute specific BBC HTML only (separated by commas)
- url's within custom bbc tags will not toggle to url, img, etc.
  unless those specific bbc tags are included ( :) <-- preferred behavior!!!)

---

Explanation of behavior:

I will suggest that some general information about the SCEditor is provided in the SMF wiki
  for mod authors regarding the use of the SCEditor within the SMF infrastructure.  
ie. for custom BBC mods they need to be informed that if they intend to enable WYSIWYG for their mod
  that it should be tested for conflicts with existing BBC's
else give their admin menu an option to enable/disable the feature with specific help text for that option.

This edit takes advantage of css styling elements and an existing sce css class
  to provide the desired effect within the html class function.
Meaning that the existing format class function for custom BBCodes added via the hook is ignored
  as it uses css style/class elements within the html class function for the desired effect.
  It behaves very similar to the existing behavior of the form/html class
  (as executed within ../jquery.sceditor.bbcode.js). 
The author has informed me via email that changes are pending regarding the above type of behavior
  or at least the ability to control it using the format class function (if I understood the response correctly).
This is because currently for SMF 2.1 the default behavior of the editor will change those to [img] and [url] BBC tags
  as it is hard coded into it via functions within jquery.sceditor.smf.js
  although this is not a desired effect for custom BBCodes.

---

Undesired effects of SCEditor within SMF 2.1 (this is default behavior without this edit):
- posting html within posts does not get converted to BBC renderring the usage of source/WYSIWYG toggling
  within the editor as only converting existing BBC to source and back again.
- meaning that people posting html into posts does not get converted to BBC (although smileys text still gets converted)
- disabled BBcodes are still controlled by the SCEditor which is incorrect behavior
  (needs $.sceditor.plugins.bbcode.bbcode.remove("[BBCODE]"); function added) 
- remove formatting option does not seem to function?

Notes:
$.sceditor.plugins.bbcode.bbcode.set(format: ...) (specifically the format class)
  has been removed due to incorrect IE behavior (the html class for this edit takes care of all display).
Adding before, after & html attributes to the BBC array for existing default SMF BBCodes
  will change their behavior (if desired) as they will use the conditions of the edit.

Signed-off-by: -Underdog- github.underdog@gmail.com
