### PR TITLE
For static and normal methods is_callable will return false

### DIFF
--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -4115,7 +4115,7 @@ function call_integration_hook($hook, $parameters = array())
 			$call = call_helper($function, true);
 
 		// Is it valid?
-		if (!empty($call) && is_callable($call))
+		if (!empty($call))
 			$results[$function] = call_user_func_array($call, $parameters);
 
 		// Whatever it was suppose to call, it failed :(


### PR DESCRIPTION
the check is redundant anyway.

Signed-off-by: Suki suki@missallsunday.com
