### PR TITLE
Added bottom margin to #topic_header columns

### DIFF
--- a/Themes/default/css/index.css
+++ b/Themes/default/css/index.css
@@ -3970,6 +3970,7 @@ div.lastpost p {
 	font-weight: bold;
 	font-size: 1em;
 	margin-top: 3px;
+	margin-bottom: 0;
 	padding: 0;
 }
 #messageindex .stats, #recent .stats {


### PR DESCRIPTION
When box-sizing is changed to border-box globally for all elements the
info column header becomes higher than the rest. This pushes the subject
div in the first row to the right. This is no error at all. It's only
for upward compatibility when using SMF curved theme in context with
other software that uses a different box model.

Signed-off-by: Michael 'Tekkla' Zorn tekkla@tekkla.de
