### PR TITLE
Call helper

### DIFF
--- a/Sources/Admin.php
+++ b/Sources/Admin.php
@@ -512,7 +512,7 @@ function AdminMain()
 		$call = call_helper($admin_include_data['function'], true);
 
 	// Is it valid?
-	if (is_callable($call))
+	if (!empty($call))
 		call_user_func($call);
 }
 

--- a/Sources/Admin.php
+++ b/Sources/Admin.php
@@ -959,7 +959,7 @@ function AdminLogs()
 	);
 
 	require_once($sourcedir . '/' . $log_functions[$subActions][0]);
-	$log_functions[$subActions][1]);
+	call_helper($log_functions[$subActions][1]);
 }
 
 /**

--- a/Sources/Admin.php
+++ b/Sources/Admin.php
@@ -681,7 +681,7 @@ function AdminSearch()
 	if (trim($context['search_term']) == '')
 		$context['search_results'] = array();
 	else
-		$subactions[$context['search_type']]();
+		call_helper($subactions[$context['search_type']]);
 }
 
 /**

--- a/Sources/Admin.php
+++ b/Sources/Admin.php
@@ -922,7 +922,7 @@ function AdminLogs()
 
 	call_integration_hook('integrate_manage_logs', array(&$log_functions));
 
-	$sub_action = isset($_REQUEST['sa']) && isset($log_functions[$_REQUEST['sa']]) && empty($log_functions[$_REQUEST['sa']]['disabled']) ? $_REQUEST['sa'] : 'errorlog';
+	$subActions = isset($_REQUEST['sa']) && isset($log_functions[$_REQUEST['sa']]) && empty($log_functions[$_REQUEST['sa']]['disabled']) ? $_REQUEST['sa'] : 'errorlog';
 	// If it's not got a sa set it must have come here for first time, pretend error log should be reversed.
 	if (!isset($_REQUEST['sa']))
 		$_REQUEST['desc'] = true;
@@ -958,8 +958,8 @@ function AdminLogs()
 		),
 	);
 
-	require_once($sourcedir . '/' . $log_functions[$sub_action][0]);
-	$log_functions[$sub_action][1]();
+	require_once($sourcedir . '/' . $log_functions[$subActions][0]);
+	$log_functions[$subActions][1]);
 }
 
 /**

--- a/Sources/Admin.php
+++ b/Sources/Admin.php
@@ -656,13 +656,13 @@ function AdminSearch()
 	isAllowedTo('admin_forum');
 
 	// What can we search for?
-	$subactions = array(
+	$subActions = array(
 		'internal' => 'AdminSearchInternal',
 		'online' => 'AdminSearchOM',
 		'member' => 'AdminSearchMember',
 	);
 
-	$context['search_type'] = !isset($_REQUEST['search_type']) || !isset($subactions[$_REQUEST['search_type']]) ? 'internal' : $_REQUEST['search_type'];
+	$context['search_type'] = !isset($_REQUEST['search_type']) || !isset($subActions[$_REQUEST['search_type']]) ? 'internal' : $_REQUEST['search_type'];
 	$context['search_term'] = isset($_REQUEST['search_term']) ? $smcFunc['htmlspecialchars']($_REQUEST['search_term'], ENT_QUOTES) : '';
 
 	$context['sub_template'] = 'admin_search_results';
@@ -681,7 +681,7 @@ function AdminSearch()
 	if (trim($context['search_term']) == '')
 		$context['search_results'] = array();
 	else
-		call_helper($subactions[$context['search_type']]);
+		call_helper($subActions[$context['search_type']]);
 }
 
 /**

--- a/Sources/Admin.php
+++ b/Sources/Admin.php
@@ -922,7 +922,7 @@ function AdminLogs()
 
 	call_integration_hook('integrate_manage_logs', array(&$log_functions));
 
-	$subActions = isset($_REQUEST['sa']) && isset($log_functions[$_REQUEST['sa']]) && empty($log_functions[$_REQUEST['sa']]['disabled']) ? $_REQUEST['sa'] : 'errorlog';
+	$subAction = isset($_REQUEST['sa']) && isset($log_functions[$_REQUEST['sa']]) && empty($log_functions[$_REQUEST['sa']]['disabled']) ? $_REQUEST['sa'] : 'errorlog';
 	// If it's not got a sa set it must have come here for first time, pretend error log should be reversed.
 	if (!isset($_REQUEST['sa']))
 		$_REQUEST['desc'] = true;
@@ -958,8 +958,8 @@ function AdminLogs()
 		),
 	);
 
-	require_once($sourcedir . '/' . $log_functions[$subActions][0]);
-	call_helper($log_functions[$subActions][1]);
+	require_once($sourcedir . '/' . $log_functions[$subAction][0]);
+	call_helper($log_functions[$subAction][1]);
 }
 
 /**

--- a/Sources/Admin.php
+++ b/Sources/Admin.php
@@ -920,8 +920,6 @@ function AdminLogs()
 		'settings' => array('ManageSettings.php', 'ModifyLogSettings'),
 	);
 
-	call_integration_hook('integrate_manage_logs', array(&$log_functions));
-
 	$subAction = isset($_REQUEST['sa']) && isset($log_functions[$_REQUEST['sa']]) && empty($log_functions[$_REQUEST['sa']]['disabled']) ? $_REQUEST['sa'] : 'errorlog';
 	// If it's not got a sa set it must have come here for first time, pretend error log should be reversed.
 	if (!isset($_REQUEST['sa']))
@@ -957,6 +955,8 @@ function AdminLogs()
 			),
 		),
 	);
+
+	call_integration_hook('integrate_manage_logs', array(&$log_functions));
 
 	require_once($sourcedir . '/' . $log_functions[$subAction][0]);
 	call_helper($log_functions[$subAction][1]);

--- a/Sources/Likes.php
+++ b/Sources/Likes.php
@@ -389,7 +389,9 @@ class Likes
 		elseif (!empty($this->_validLikes['callback']))
 		{
 			$call = call_helper($this->_validLikes['callback'], true);
-			call_user_func_array($call, array($this->_type, $this->_content, $this->_numLikes, empty($this->_alreadyLiked)));
+
+			if (!empty($call))
+				call_user_func_array($call, array($this->_type, $this->_content, $this->_numLikes, empty($this->_alreadyLiked)));
 		}
 
 		// Sometimes there might be other things that need updating after we do this like.

--- a/Sources/ManageSettings.php
+++ b/Sources/ManageSettings.php
@@ -128,7 +128,7 @@ function ModifyModSettings()
 	);
 
 	// Call the right function for this sub-action.
-	$subActions[$_REQUEST['sa']]();
+	call_helper($subActions[$_REQUEST['sa']]);
 }
 
 /**

--- a/Sources/ModerationCenter.php
+++ b/Sources/ModerationCenter.php
@@ -910,7 +910,7 @@ function ModerateGroups()
 	$context['sub_action'] = $_GET['sa'];
 
 	// Call the relevant function.
-	$subActions[$context['sub_action']]();
+	call_helper($subActions[$context['sub_action']]);
 }
 
 /**

--- a/Sources/ModerationCenter.php
+++ b/Sources/ModerationCenter.php
@@ -1385,7 +1385,7 @@ function ViewWarnings()
 	);
 
 	// Call the right function.
-	$subActions[$_REQUEST['sa']][0]();
+	call_helper($subActions[$_REQUEST['sa']][0]);
 }
 
 /**

--- a/Sources/ModerationCenter.php
+++ b/Sources/ModerationCenter.php
@@ -900,17 +900,17 @@ function ModerateGroups()
 	loadTemplate('ModerationCenter');
 
 	// Setup the subactions...
-	$subactions = array(
+	$subActions = array(
 		'requests' => 'GroupRequests',
 		'view' => 'ViewGroups',
 	);
 
-	if (!isset($_GET['sa']) || !isset($subactions[$_GET['sa']]))
+	if (!isset($_GET['sa']) || !isset($subActions[$_GET['sa']]))
 		$_GET['sa'] = 'view';
 	$context['sub_action'] = $_GET['sa'];
 
 	// Call the relevant function.
-	$subactions[$context['sub_action']]();
+	$subActions[$context['sub_action']]();
 }
 
 /**

--- a/Sources/News.php
+++ b/Sources/News.php
@@ -199,7 +199,8 @@ function ShowXmlFeed()
 		$xml = cache_get_data('xmlfeed-' . $xml_format . ':' . ($user_info['is_guest'] ? '' : $user_info['id'] . '-') . $cachekey, 240);
 	if (empty($xml))
 	{
-		$xml = $subActions[$_GET['sa']][0]($xml_format);
+		$call = call_helper($subActions[$_GET['sa']][0], true);
+		$xml = call_user_func($call, $xml_format);
 
 		if (!empty($modSettings['cache_enable']) && (($user_info['is_guest'] && $modSettings['cache_enable'] >= 3)
 		|| (!$user_info['is_guest'] && (array_sum(explode(' ', microtime())) - array_sum(explode(' ', $cache_t)) > 0.2))))

--- a/Sources/News.php
+++ b/Sources/News.php
@@ -200,7 +200,9 @@ function ShowXmlFeed()
 	if (empty($xml))
 	{
 		$call = call_helper($subActions[$_GET['sa']][0], true);
-		$xml = call_user_func($call, $xml_format);
+
+		if (!empty($call))
+			$xml = call_user_func($call, $xml_format);
 
 		if (!empty($modSettings['cache_enable']) && (($user_info['is_guest'] && $modSettings['cache_enable'] >= 3)
 		|| (!$user_info['is_guest'] && (array_sum(explode(' ', microtime())) - array_sum(explode(' ', $cache_t)) > 0.2))))

--- a/Sources/PersonalMessage.php
+++ b/Sources/PersonalMessage.php
@@ -220,7 +220,7 @@ function MessageMain()
 	{
 		if (!isset($_REQUEST['xml']) && $_REQUEST['sa'] != 'popup')
 			messageIndexBar($_REQUEST['sa']);
-		$subActions[$_REQUEST['sa']]();
+		call_helper($subActions[$_REQUEST['sa']]);
 	}
 }
 

--- a/Sources/Post.php
+++ b/Sources/Post.php
@@ -2071,7 +2071,8 @@ function AnnounceTopic()
 	$context['page_title'] = $txt['announce_topic'];
 
 	// Call the function based on the sub-action.
-	$subActions[isset($_REQUEST['sa']) && isset($subActions[$_REQUEST['sa']]) ? $_REQUEST['sa'] : 'selectgroup']();
+	$call = isset($_REQUEST['sa']) && isset($subActions[$_REQUEST['sa']]) ? $_REQUEST['sa'] : 'selectgroup';
+	call_helper($subActions[$call]);
 }
 
 /**

--- a/Sources/PostModeration.php
+++ b/Sources/PostModeration.php
@@ -31,7 +31,7 @@ function PostModerationMain()
 	require_once($sourcedir . '/ModerationCenter.php');
 
 	// Allowed sub-actions, you know the drill by now!
-	$subactions = array(
+	$subActions = array(
 		'approve' => 'ApproveMessage',
 		'attachments' => 'UnapprovedAttachments',
 		'replies' => 'UnapprovedPosts',
@@ -39,12 +39,12 @@ function PostModerationMain()
 	);
 
 	// Pick something valid...
-	if (!isset($_REQUEST['sa']) || !isset($subactions[$_REQUEST['sa']]))
+	if (!isset($_REQUEST['sa']) || !isset($subActions[$_REQUEST['sa']]))
 		$_REQUEST['sa'] = 'replies';
 
 	call_integration_hook('integrate_post_moderation', array(&$subActions));
 
-	call_helper($subactions[$_REQUEST['sa']]);
+	call_helper($subActions[$_REQUEST['sa']]);
 }
 
 /**

--- a/Sources/Profile-Modify.php
+++ b/Sources/Profile-Modify.php
@@ -1281,7 +1281,8 @@ function editBuddyIgnoreLists($memID)
 
 	// Pass on to the actual function.
 	$context['sub_template'] = $subActions[$context['list_area']][0];
-	$subActions[$context['list_area']][0]($memID);
+	$call = call_helper($subActions[$context['list_area']][0], true);
+	call_user_func($call, $memID);
 }
 
 /**

--- a/Sources/Profile-Modify.php
+++ b/Sources/Profile-Modify.php
@@ -1282,7 +1282,9 @@ function editBuddyIgnoreLists($memID)
 	// Pass on to the actual function.
 	$context['sub_template'] = $subActions[$context['list_area']][0];
 	$call = call_helper($subActions[$context['list_area']][0], true);
-	call_user_func($call, $memID);
+
+	if (!empty($call))
+		call_user_func($call, $memID);
 }
 
 /**

--- a/Sources/Profile-View.php
+++ b/Sources/Profile-View.php
@@ -1384,7 +1384,8 @@ function tracking($memID)
 
 	// Pass on to the actual function.
 	$context['sub_template'] = $subActions[$context['tracking_area']][0];
-	$subActions[$context['tracking_area']][0]($memID);
+	$call = call_helper($subActions[$context['tracking_area']][0], true);
+	call_user_func($call, $memID);
 }
 
 /**

--- a/Sources/Profile-View.php
+++ b/Sources/Profile-View.php
@@ -1385,7 +1385,9 @@ function tracking($memID)
 	// Pass on to the actual function.
 	$context['sub_template'] = $subActions[$context['tracking_area']][0];
 	$call = call_helper($subActions[$context['tracking_area']][0], true);
-	call_user_func($call, $memID);
+
+	if (!empty($call))
+		call_user_func($call, $memID);
 }
 
 /**

--- a/Sources/Profile.php
+++ b/Sources/Profile.php
@@ -760,7 +760,7 @@ function ModifyProfile($post_errors = array())
 		$call = call_helper($profile_include_data['function'], true);
 
 	// Is it valid?
-	if (is_callable($call))
+	if (!empty($call))
 		call_user_func($call, $memID);
 
 	// Set the page title if it's not already set...

--- a/Sources/SplitTopics.php
+++ b/Sources/SplitTopics.php
@@ -818,8 +818,9 @@ function MergeTopics()
 	// ?action=mergetopics;sa=LETSBREAKIT won't work, sorry.
 	if (empty($_REQUEST['sa']) || !isset($subActions[$_REQUEST['sa']]))
 		MergeIndex();
+
 	else
-		$subActions[$_REQUEST['sa']]();
+		call_helper($subActions[$_REQUEST['sa']]);
 }
 
 /**

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -2721,11 +2721,10 @@ function obExit($header = null, $do_footer = null, $from_index = false, $from_fa
 		if (!empty($buffers))
 			foreach ($buffers as $function)
 			{
-				$function = trim($function);
 				$call = call_helper($function, true);
 
 				// Is it valid?
-				if (is_callable($call))
+				if (!empty($call))
 					ob_start($call);
 			}
 

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -4253,7 +4253,7 @@ function call_helper($string, $return = false)
 		return false;
 
 	// Stay vitaminized my friends...
-	$string = $smcFunc['htmlspecialchars']($smcFunc['htmltrim']($string)):
+	$string = $smcFunc['htmlspecialchars']($smcFunc['htmltrim']($string));
 
 	// The soon to be populated var.
 	$func = false;

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -4238,19 +4238,23 @@ function remove_integration_function($hook, $function, $file = '', $object = fal
 /**
  * Receives a string and tries to figure it out if its a method or a function.
  * If a method is found, it looks for a "#" which indicates SMF should create a new instance of the given class.
+ * Checks the string/array for is_callable() and return false/fatal_lang_error is the given value results in a non callable string/array.
  * Prepare and returns a callable depending on the type of method/function found.
  *
  * @param string $string The string containing a function name or a static call.
  * @param boolean $return If true, the function will not call the function/method but instead will return the formatted string.
- * @return string|array Either a string or an array that contains a callable function name or an array with a class and method to call
+ * @return string|array|boolean Either a string or an array that contains a callable function name or an array with a class and method to call. Boolean false if the given string cannot produce a callable var.
  */
 function call_helper($string, $return = false)
 {
-	global $context, $db_show_debug;
+	global $context, $smcFunc, $txt, $db_show_debug;
 
 	// Really?
 	if (empty($string))
 		return false;
+
+	// Stay vitaminized my friends...
+	$string = $smcFunc['htmlspecialchars']($smcFunc['htmltrim']($string)):
 
 	// The soon to be populated var.
 	$func = false;
@@ -4293,18 +4297,32 @@ function call_helper($string, $return = false)
 	else
 		$func = $string;
 
-	// What are we gonna do about it?
-	if ($return)
-		return $func;
+	// Right, we got what we need, time to do some checks.
+	if (!is_callable($func, false, $callable_name))
+	{
+		loadLanguage('Errors');
+		log_error(sprintf($txt['subAction_fail'], $callable_name), 'general');
 
-	// If this is a plain function, avoid the heat of calling call_user_func().
+		// Gotta tell everybody.
+		return false;
+	}
+
+	// Everything went better than expected.
 	else
 	{
-		if (is_array($func))
-			call_user_func($func);
+		// What are we gonna do about it?
+		if ($return)
+			return $func;
 
+		// If this is a plain function, avoid the heat of calling call_user_func().
 		else
-			$func();
+		{
+			if (is_array($func))
+				call_user_func($func);
+
+			else
+				$func();
+		}
 	}
 }
 

--- a/Themes/default/languages/Errors.english.php
+++ b/Themes/default/languages/Errors.english.php
@@ -428,6 +428,9 @@ $txt['search_api_not_compatible'] = 'The selected search API the forum is using 
 $txt['hook_fail_loading_file'] = 'Hook call: The file at path: %s could not be loaded.';
 $txt['hook_fail_call_to'] = 'Hook call: function "%1$s" in file %2$s could not be called.';
 
+// SubActions failed attempt.
+$txt['subAction_fail'] = 'The callable %s could not be called.';
+
 // Restore topic/posts
 $txt['cannot_restore_first_post'] = 'You cannot restore the first post in a topic.';
 $txt['parent_topic_missing'] = 'The parent topic of the post you are trying to restore has been deleted.';

--- a/index.php
+++ b/index.php
@@ -244,7 +244,8 @@ function smf_main()
 			foreach ($defaultActions as $defaultAction)
 			{
 				$call = call_helper($defaultAction, true);
-				if (!empty($call) && is_callable($call))
+
+				if (!empty($call))
 					return $call;
 			}
 
@@ -364,7 +365,8 @@ function smf_main()
 		foreach ($fallbackActions as $fallbackAction)
 		{
 			$call = call_helper($fallbackAction, true);
-			if (!empty($call) && is_callable($call))
+
+			if (!empty($call))
 				return $call;
 		}
 


### PR DESCRIPTION
Another round for finding calls to sub-actions.
- My other search missed some variants like $sub_action and $subaction thus a few other places were still using the string directly fixes #1895  /me hopes...
- call_helper() will now return a boolean false/log an error if the given string cannot produce a callable var.
- Removes some is_callable() checks and instead it places an !empty()
