### PR TITLE
Hooks stuff

### DIFF
--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -4065,6 +4065,9 @@ function call_integration_hook($hook, $parameters = array())
 	if (empty($modSettings[$hook]))
 		return $results;
 
+	// Define some needed vars.
+	$function = false;
+
 	$functions = explode(',', $modSettings[$hook]);
 	// Loop through each function.
 	foreach ($functions as $function)
@@ -4075,7 +4078,7 @@ function call_integration_hook($hook, $parameters = array())
 		// Did we find a file to load?
 		if (strpos($function, '|') !== false)
 		{
-			list ($file, $func) = explode('|', $function);
+			list ($file, $function) = explode('|', $function);
 
 			// Match the wildcards to their regular vars.
 			if (empty($settings['theme_dir']))
@@ -4104,7 +4107,7 @@ function call_integration_hook($hook, $parameters = array())
 				}
 			}
 
-			$call = call_helper($func, true);
+			$call = call_helper($function, true);
 		}
 
 		// Figuring out what to do.
@@ -4116,11 +4119,6 @@ function call_integration_hook($hook, $parameters = array())
 			$results[$function] = call_user_func_array($call, $parameters);
 
 		// Whatever it was suppose to call, it failed :(
-		elseif (!empty($func) && !empty($absPath))
-		{
-			loadLanguage('Errors');
-			log_error(sprintf($txt['hook_fail_call_to'], $func, $absPath), 'general');
-		}
 		elseif (!empty($function) && !empty($absPath))
 		{
 			loadLanguage('Errors');

--- a/index.php
+++ b/index.php
@@ -241,7 +241,9 @@ function smf_main()
 		if (empty($board) && empty($topic))
 		{
 			$defaultActions = call_integration_hook('integrate_default_action');
-			foreach ($defaultActions as $defaultAction)
+
+			// Lets work with keys here.
+			foreach ($defaultActions as $defaultAction => $dummy)
 			{
 				$call = call_helper($defaultAction, true);
 

--- a/index.php
+++ b/index.php
@@ -373,18 +373,26 @@ function smf_main()
 			return 'WrapAction';
 		}
 
-		$fallbackActions = call_integration_hook('integrate_fallback_action');
-		foreach ($fallbackActions as $fallbackAction)
+		if (!empty($modSettings['integrate_fallback_action']))
 		{
+			$fallbackAction = explode(',', $modSettings['integrate_fallback_action']);
+
+			// Sorry, only one fallback action is needed.
+			$fallbackAction = $fallbackAction[0];
+
 			$call = call_helper($fallbackAction, true);
 
 			if (!empty($call))
 				return $call;
 		}
 
-		// Fall through to the board index then...
-		require_once($sourcedir . '/BoardIndex.php');
-		return 'BoardIndex';
+		// No fallback action huh? then go to our good old BoardIndex.
+		else
+		{
+			require_once($sourcedir . '/BoardIndex.php');
+
+			return 'BoardIndex';
+		}
 	}
 
 	// Otherwise, it was set - so let's go to that action.

--- a/index.php
+++ b/index.php
@@ -240,27 +240,37 @@ function smf_main()
 		// Action and board are both empty... BoardIndex! Unless someone else wants to do something different.
 		if (empty($board) && empty($topic))
 		{
-			$defaultActions = call_integration_hook('integrate_default_action');
+			$defaultAction = false;
 
-			// Lets work with keys here.
-			foreach ($defaultActions as $defaultAction => $dummy)
+			if (!empty($modSettings['integrate_default_action']))
 			{
+				$defaultAction = explode(',', $modSettings['integrate_default_action']);
+
+				// Sorry, only one default action is needed.
+				$defaultAction = $defaultAction[0];
+
 				$call = call_helper($defaultAction, true);
 
 				if (!empty($call))
 					return $call;
 			}
 
-			require_once($sourcedir . '/BoardIndex.php');
+			// No default action huh? then go to our good old BoardIndex.
+			else
+			{
+				require_once($sourcedir . '/BoardIndex.php');
 
-			return 'BoardIndex';
+				return 'BoardIndex';
+			}
 		}
+
 		// Topic is empty, and action is empty.... MessageIndex!
 		elseif (empty($topic))
 		{
 			require_once($sourcedir . '/MessageIndex.php');
 			return 'MessageIndex';
 		}
+
 		// Board is not empty... topic is not empty... action is empty.. Display!
 		else
 		{


### PR DESCRIPTION
While working on a small portal mod I realize the integrate_default_action hook could potentially end up calling multiple functions/method and will also end up calling BoardIndex, this is because call_integration_hook() will immediately call the function/method, then, if no returned value is given (which is the natural thing to assume), the code will proceed to call BoardIndex. If a return value is called smf_main() will call the function/method once again.

To avoid this we need to use $modSettings['integrate_default_action'] directly, this ensures that no multiple functions gets called as $call = call_helper($defaultAction, true); is not actually gonna execute the function/method, it will just format it and return a callable string that smf_main() will return.

It also makes sure that only one call from integrate_default_action gets called, in this case, the very first one who got registered since there is no priority system, this hook will only be used by portals so its really not a big deal.

Lastly, it removes the check to load a file from call_integration_hook() and makes it a separate function (load_file()), this way it can be used by call_helper() too
