### PR TITLE
Stats for likes

### DIFF
--- a/Sources/ManagePermissions.php
+++ b/Sources/ManagePermissions.php
@@ -1781,6 +1781,8 @@ function init_inline_permissions($permissions, $excluded_groups = array())
 				unset($context[$permission][$group]);
 		}
 	}
+
+	createToken('admin-mp');
 }
 
 /**

--- a/Sources/ManageSettings.php
+++ b/Sources/ManageSettings.php
@@ -132,7 +132,7 @@ function ModifyModSettings()
 }
 
 /**
- * Config array for chaning the basic forum settings
+ * Config array for changing the basic forum settings
  * Accessed  from ?action=admin;area=featuresettings;sa=basic;
  *
  * @param $return_config
@@ -348,7 +348,7 @@ function ModifyLayoutSettings($return_config = false)
 }
 
 /**
- * Config array for chanigng like settings
+ * Config array for changing like settings
  * Accessed  from ?action=admin;area=featuresettings;sa=likes;
  *
  * @param $return_config

--- a/Sources/Stats.php
+++ b/Sources/Stats.php
@@ -149,7 +149,7 @@ function DisplayStats()
 	);
 	$context['latest_member'] = &$context['common_stats']['latest_member'];
 
-	// Male vs. female ratio - let's calculate this only every four minutes.
+	// Let's calculate gender stats only every four minutes.
 	$disabled_fields = isset($modSettings['disabled_profile_fields']) ? explode(',', $modSettings['disabled_profile_fields']) : array();
 	if (!in_array('gender', $disabled_fields))
 	{

--- a/Sources/Stats.php
+++ b/Sources/Stats.php
@@ -567,29 +567,29 @@ function DisplayStats()
 		$context['stats_blocks']['liked_users'] = array();
 		$max_liked_users = 1;
 		$liked_users = $smcFunc['db_query']('', '
-			SELECT l.id_member, l.content_id, l.content_type, COUNT(mem.id_member) AS count, mem.id_member AS liked_user, mem.real_name, mem.posts
+			SELECT m.id_member AS liked_user, COUNT(l.content_id) AS count, mem.real_name
 			FROM {db_prefix}user_likes AS l
 				INNER JOIN {db_prefix}messages AS m ON (l.content_id = m.id_msg)
 				INNER JOIN {db_prefix}members AS mem ON (m.id_member = mem.id_member)
 			WHERE content_type = {literal:msg}
-				AND mem.posts > {int:no_posts}
-				AND mem.id_member > {int:no_posts}
-			GROUP BY mem.id_member
+				AND m.id_member > {int:zero}
+			GROUP BY m.id_member
 			ORDER BY count DESC
 			LIMIT 10',
 			array(
 				'no_posts' => 0,
+				'zero' => 0,
 			)
 		);
 
 		while ($row_liked_users = $smcFunc['db_fetch_assoc']($liked_users))
 		{
 			$context['stats_blocks']['liked_users'][] = array(
-				'name' => $row_liked_users['real_name'],
 				'id' => $row_liked_users['liked_user'],
 				'num' => $row_liked_users['count'],
 				'href' => $scripturl . '?action=profile;u=' . $row_liked_users['liked_user'],
-				'link' => '<a href="' . $scripturl . '?action=profile;u=' . $row_liked_users['liked_user'] . '">' . $row_liked_users['real_name'] . '</a>'
+				'name' => $row_liked_users['real_name'],
+				'link' => '<a href="' . $scripturl . '?action=profile;u=' . $row_liked_users['liked_user'] . '">' . $row_liked_users['real_name'] . '</a>',
 			);
 
 			if ($max_liked_users < $row_liked_users['count'])

--- a/Sources/Stats.php
+++ b/Sources/Stats.php
@@ -528,7 +528,7 @@ function DisplayStats()
 		$context['stats_blocks']['liked_messages'] = array();
 		$max_liked_message = 1;
 		$liked_messages = $smcFunc['db_query']('', '
-			SELECT m. id_msg, m.subject, m.likes, m.id_board, m.id_topic, t.approved
+			SELECT m.id_msg, m.subject, m.likes, m.id_board, m.id_topic, t.approved
 			FROM {db_prefix}messages as m
 				INNER JOIN {db_prefix}topics AS t ON (m.id_topic = t.id_topic)
 				INNER JOIN {db_prefix}boards AS b ON (b.id_board = t.id_board' . (!empty($modSettings['recycle_enable']) && $modSettings['recycle_board'] > 0 ? '
@@ -556,7 +556,7 @@ function DisplayStats()
 			);
 
 			if ($max_liked_message < $row_liked_message['likes'])
-				$max_liked_message= $row_liked_message['likes'];
+				$max_liked_message = $row_liked_message['likes'];
 		}
 		$smcFunc['db_free_result']($liked_messages);
 

--- a/Themes/default/Stats.template.php
+++ b/Themes/default/Stats.template.php
@@ -65,7 +65,7 @@ function template_main()
 	if (!empty($context['gender']))
 	{
 		echo '
-				<dt><b>', $txt['gender_stats'], ':</b></dt>
+				<dt>', $txt['gender_stats'], ':</dt>
 				<dd>';
 
 		foreach ($context['gender'] as $g => $n)

--- a/Themes/default/css/index.css
+++ b/Themes/default/css/index.css
@@ -2243,6 +2243,9 @@ dl {
 .stats_icon.starters, .stats_icon.people {
 	background-position: -80px -48px;
 }
+.stats_icon.liked_users, .stats_icon.liked_messages{
+	background: url(../images/generic_icons.png) no-repeat -64px 0;
+}
 dl.stats dt {
 	width: 50%;
 	float: left;

--- a/Themes/default/languages/Stats.english.php
+++ b/Themes/default/languages/Stats.english.php
@@ -23,6 +23,7 @@ $txt['top_starters'] = 'Top Topic Starters';
 $txt['top_time_online'] = 'Most Time Online';
 $txt['stats_more_detailed'] = 'more detailed &raquo;';
 $txt['top_liked_messages'] = 'Top liked messages';
+$txt['top_liked_users'] = 'Top liked users';
 
 $txt['average_members'] = 'Average registrations per day';
 $txt['average_posts'] = 'Average posts per day';

--- a/Themes/default/languages/Stats.english.php
+++ b/Themes/default/languages/Stats.english.php
@@ -22,6 +22,7 @@ $txt['smf_stats_14'] = 'Most Online';
 $txt['top_starters'] = 'Top Topic Starters';
 $txt['top_time_online'] = 'Most Time Online';
 $txt['stats_more_detailed'] = 'more detailed &raquo;';
+$txt['top_liked_messages'] = 'Top liked messages';
 
 $txt['average_members'] = 'Average registrations per day';
 $txt['average_posts'] = 'Average posts per day';


### PR DESCRIPTION
 Adds two more stats, top liked messages and top liked users, top liked users only takes into consideration liked messages (content_type == 'msg').

Might want to check the queries for getting the stats. Perhaps they could be improved.

I also encounter a token validation error while saving both mentions and likes settings, after some debugging it turns out the inline permissions were causing it, init_inline_permissions() needed to create the token that save_inline_permissions() validates, creating said token inside  init_inline_permissions() appers to fix the issue but more testing would be needed.
