### PR TITLE
jQuery's computed height iisn't consistent across browsers, so use the r...

### DIFF
--- a/Themes/default/scripts/jquery.custom-scrollbar.js
+++ b/Themes/default/scripts/jquery.custom-scrollbar.js
@@ -643,7 +643,7 @@
 				if (arg)
 					return $el.height(arg);
 				else
-					return $el.height();
+					return parseInt($el.css("height")) || 0;
 			},
 
 			minSize: function ($el) {


### PR DESCRIPTION
...aw CSS instead (ref #1990)

Signed-off-by: John Rayes live627@gmail.com
