### PR TITLE
! $context['ban'] isn't always defined (Fixes #2100)

### DIFF
--- a/Sources/ManageBans.php
+++ b/Sources/ManageBans.php
@@ -427,7 +427,7 @@ function BanEdit()
 						'data' => array(
 							'function' => function ($ban_item) use ($txt, $context, $scripturl)
 							{
-								return '<a href="' . $scripturl . '?action=admin;area=ban;sa=edittrigger;bg=' . $context['ban']['id'] . ';bi=' . $ban_item['id'] . '">' . $txt['ban_edit_trigger'] . '</a>';
+								return '<a href="' . $scripturl . '?action=admin;area=ban;sa=edittrigger;bg=' . $context['ban_group_id'] . ';bi=' . $ban_item['id'] . '">' . $txt['ban_edit_trigger'] . '</a>';
 							},
 							'style' => 'text-align: center;',
 						),


### PR DESCRIPTION
Signed-off-by: Michael Eshom oldiesmann@oldiesmann.us
