### PR TITLE
Stable icons

### DIFF
--- a/SSI.php
+++ b/SSI.php
@@ -450,9 +450,8 @@ function ssi_recentTopics($num_recent = 8, $exclude_boards = null, $include_boar
 		$include_boards = array();
 	}
 
-	$stable_icons = array('xx', 'thumbup', 'thumbdown', 'exclamation', 'question', 'lamp', 'smiley', 'angry', 'cheesy', 'grin', 'sad', 'wink', 'poll', 'moved', 'recycled', 'wireless', 'clip');
 	$icon_sources = array();
-	foreach ($stable_icons as $icon)
+	foreach ($context['stable_icons'] as $icon)
 		$icon_sources[$icon] = 'images_url';
 
 	// Find all the posts in distinct topics.  Newer ones will have higher IDs.
@@ -1696,10 +1695,8 @@ function ssi_boardNews($board = null, $limit = null, $start = null, $length = nu
 	list ($board) = $smcFunc['db_fetch_row']($request);
 	$smcFunc['db_free_result']($request);
 
-	// Load the message icons - the usual suspects.
-	$stable_icons = array('xx', 'thumbup', 'thumbdown', 'exclamation', 'question', 'lamp', 'smiley', 'angry', 'cheesy', 'grin', 'sad', 'wink', 'poll', 'moved', 'recycled', 'wireless', 'clip');
 	$icon_sources = array();
-	foreach ($stable_icons as $icon)
+	foreach ($context['stable_icons'] as $icon)
 		$icon_sources[$icon] = 'images_url';
 
 	if (!empty($modSettings['enable_likes']))

--- a/SSI.php
+++ b/SSI.php
@@ -432,7 +432,7 @@ function ssi_queryPosts($query_where = '', $query_where_params = array(), $query
 function ssi_recentTopics($num_recent = 8, $exclude_boards = null, $include_boards = null, $output_method = 'echo')
 {
 	global $settings, $scripturl, $txt, $user_info;
-	global $modSettings, $smcFunc;
+	global $modSettings, $smcFunc, $context;
 
 	if ($exclude_boards === null && !empty($modSettings['recycle_enable']) && $modSettings['recycle_board'] > 0)
 		$exclude_boards = array($modSettings['recycle_board']);

--- a/Sources/Display.php
+++ b/Sources/Display.php
@@ -1274,9 +1274,8 @@ function prepareDisplayContext($reset = false)
 	// $context['icon_sources'] says where each icon should come from - here we set up the ones which will always exist!
 	if (empty($context['icon_sources']))
 	{
-		$stable_icons = array('xx', 'thumbup', 'thumbdown', 'exclamation', 'question', 'lamp', 'smiley', 'angry', 'cheesy', 'grin', 'sad', 'wink', 'poll', 'moved', 'recycled', 'wireless', 'clip');
 		$context['icon_sources'] = array();
-		foreach ($stable_icons as $icon)
+		foreach ($context['stable_icons'] as $icon)
 			$context['icon_sources'][$icon] = 'images_url';
 	}
 

--- a/Sources/Load.php
+++ b/Sources/Load.php
@@ -81,7 +81,7 @@ function reloadSettings()
 	// Preg_replace space characters depend on the character set in use
 	$space_chars = $utf8 ? '\x{A0}\x{AD}\x{2000}-\x{200F}\x{201F}\x{202F}\x{3000}\x{FEFF}' : '\x00-\x08\x0B\x0C\x0E-\x19\xA0';
 
-	// global array of anonymous helper functions, used mosly to properly handle multi byte strings
+	// global array of anonymous helper functions, used mostly to properly handle multi byte strings
 	$smcFunc += array(
 		'entity_fix' => function ($string)
 		{
@@ -252,6 +252,12 @@ function reloadSettings()
 	);
 	// A bug in some versions of IIS under CGI (older ones) makes cookie setting not work with Location: headers.
 	$context['server']['needs_login_fix'] = $context['server']['is_cgi'] && $context['server']['is_iis'];
+
+	// Define a list of icons used across multiple places.
+	$context['stable_icons'] = array('xx', 'thumbup', 'thumbdown', 'exclamation', 'question', 'lamp', 'smiley', 'angry', 'cheesy', 'grin', 'sad', 'wink', 'poll', 'moved', 'recycled', 'wireless', 'clip');
+
+	// Add your own icons.
+	call_integration_hook('integrate_stable_icons');
 }
 
 /**

--- a/Sources/MessageIndex.php
+++ b/Sources/MessageIndex.php
@@ -276,9 +276,8 @@ function MessageIndex()
 		$fake_ascending = false;
 
 	// Setup the default topic icons...
-	$stable_icons = array('xx', 'thumbup', 'thumbdown', 'exclamation', 'question', 'lamp', 'smiley', 'angry', 'cheesy', 'grin', 'sad', 'wink', 'poll', 'moved', 'recycled', 'wireless', 'clip');
 	$context['icon_sources'] = array();
-	foreach ($stable_icons as $icon)
+	foreach ($context['stable_icons'] as $icon)
 		$context['icon_sources'][$icon] = 'images_url';
 
 	$topic_ids = array();

--- a/Sources/Recent.php
+++ b/Sources/Recent.php
@@ -694,9 +694,8 @@ function UnreadTopics()
 	}
 
 	// Setup the default topic icons... for checking they exist and the like ;)
-	$stable_icons = array('xx', 'thumbup', 'thumbdown', 'exclamation', 'question', 'lamp', 'smiley', 'angry', 'cheesy', 'grin', 'sad', 'wink', 'poll', 'moved', 'recycled', 'wireless', 'clip');
 	$context['icon_sources'] = array();
-	foreach ($stable_icons as $icon)
+	foreach ($context['stable_icons'] as $icon)
 		$context['icon_sources'][$icon] = 'images_url';
 
 	$is_topics = $_REQUEST['action'] == 'unread';

--- a/Sources/Search.php
+++ b/Sources/Search.php
@@ -1826,9 +1826,8 @@ function PlushSearch2()
 	$context['key_words'] = &$searchArray;
 
 	// Setup the default topic icons... for checking they exist and the like!
-	$stable_icons = array('xx', 'thumbup', 'thumbdown', 'exclamation', 'question', 'lamp', 'smiley', 'angry', 'cheesy', 'grin', 'sad', 'wink', 'poll', 'moved', 'recycled', 'wireless', 'clip');
 	$context['icon_sources'] = array();
-	foreach ($stable_icons as $icon)
+	foreach ($context['stable_icons'] as $icon)
 		$context['icon_sources'][$icon] = 'images_url';
 
 	$context['sub_template'] = 'results';


### PR DESCRIPTION
There are a few places where $stable_icons is defined, this PR removes all those places and instead creates an always avaliable $context var. Useful for keeping everything under control.

The var was created as earlier as possible to help mods or integrations to be able to use this new var. It also adds a new hook to CRUD the icons, despite my dislike for abusing global scope, it should follow the same pattern as the rest of the hooks.
