### PR TITLE
Unneeded code

### DIFF
--- a/Sources/Admin.php
+++ b/Sources/Admin.php
@@ -485,30 +485,8 @@ function AdminMain()
 	if (isset($admin_include_data['file']))
 		require_once($sourcedir . '/' . $admin_include_data['file']);
 
-	// Do we defined a class for this function?
-	if (isset($admin_include_data['class']) && !empty($admin_include_data['class']) && is_string($admin_include_data['class']))
-	{
-		// Is there an instance already? nope? then create it!
-		if (empty($context['instances'][$admin_include_data['class']]) || !($context['instances'][$admin_include_data['class']] instanceof $admin_include_data['class']))
-		{
-			$context['instances'][$admin_include_data['class']] = new $admin_include_data['class'];
-
-			// Add another one to the list.
-			if ($db_show_debug === true)
-			{
-				if (!isset($context['debug']['instances']))
-					$context['debug']['instances'] = array();
-
-				$context['debug']['instances'][$admin_include_data['class']] = $admin_include_data['class'];
-			}
-		}
-
-		$call = array($context['instances'][$admin_include_data['class']], $admin_include_data['function']);
-	}
-
-	// A static one or more likely, a plain good old function.
-	else
-		$call = call_helper($admin_include_data['function'], true);
+	// Get the right callable.
+	$call = call_helper($admin_include_data['function'], true);
 
 	// Is it valid?
 	if (!empty($call))

--- a/Sources/Profile.php
+++ b/Sources/Profile.php
@@ -734,30 +734,9 @@ function ModifyProfile($post_errors = array())
 	elseif (!empty($force_redirect))
 		redirectexit('action=profile' . ($context['user']['is_owner'] ? '' : ';u=' . $memID) . ';area=' . $current_area);
 
-	// Is this a "real" method?
-	if (isset($profile_include_data['class']) && !empty($profile_include_data['class']) && is_string($profile_include_data['class']))
-	{
-		// Is there an instance already? nope? then create it!
-		if (empty($context['instances'][$profile_include_data['class']]) || !($context['instances'][$profile_include_data['class']] instanceof $profile_include_data['class']))
-		{
-			$context['instances'][$profile_include_data['class']] = new $profile_include_data['class'];
 
-			// Add another one to the list.
-			if ($db_show_debug === true)
-			{
-				if (!isset($context['debug']['instances']))
-					$context['debug']['instances'] = array();
-
-				$context['debug']['instances'][$profile_include_data['class']] = $profile_include_data['class'];
-			}
-		}
-
-		$call = array($context['instances'][$profile_include_data['class']], $profile_include_data['function']);
-	}
-
-	// A static one or more likely, a plain good old function.
-	else
-		$call = call_helper($profile_include_data['function'], true);
+	// Get the right callable.
+	$call = call_helper($profile_include_data['function'], true);
 
 	// Is it valid?
 	if (!empty($call))

--- a/Sources/Subs-Editor.php
+++ b/Sources/Subs-Editor.php
@@ -1661,7 +1661,7 @@ function create_control_richedit($editorOptions)
 			'sub' => 'subscript',
 			'hr' => 'horizontalrule',
 		);
-		
+
 		// Allow mods to modify BBC buttons.
 		// Note: pass the array here is not necessary and is deprecated, but it is ketp for backward compatibility with 2.0
 		call_integration_hook('integrate_bbc_buttons', array(&$context['bbc_tags']));
@@ -1694,7 +1694,7 @@ function create_control_richedit($editorOptions)
 				$context['disabled_tags']['bulletlist'] = true;
 				$context['disabled_tags']['orderedlist'] = true;
 			}
-			
+
 			foreach ($disabled_editor_tags as $thisTag => $tagNameBBC)
 				if ($tag === $thisTag)
 					$context['disabled_tags'][$tagNameBBC] = true;
@@ -2013,7 +2013,6 @@ function create_control_verification(&$verificationOptions, $do_test = false)
 		$force_refresh = true;
 
 	$verification_errors = array();
-
 	// Start with any testing.
 	if ($do_test)
 	{
@@ -2357,7 +2356,6 @@ function AutoSuggest_Search_SMFVersions()
 	// Just in case we don't have ANYthing.
 	if (empty($versions))
 		$versions = array('SMF 2.0');
-	
 
 	foreach ($versions as $id => $version)
 		if (strpos($version, strtoupper($_REQUEST['search'])) !== false)


### PR DESCRIPTION
This was code I introduced for handling methods before call_helper(), now call_helper() can handle calls to instantiated methods so this is redundant, it wasn't used by anyone but me so its safe to remove it.
