### PR TITLE
! Fix syntax errors in Who.php

### DIFF
--- a/Sources/Who.php
+++ b/Sources/Who.php
@@ -612,7 +612,7 @@ function Credits($in_admin = false)
 						'Shadow82x',
 						'ѕησω',
 						'ChalkCat',
-						'Krash'
+						'Krash',
 						// Former Support Specialists
 						'CapadY',
 						'gbsothere',
@@ -631,10 +631,10 @@ function Credits($in_admin = false)
 						// Customizers
 						'Kays',
 						'Ricky.',
-						'Jack "akabugeyes" Thorsen'
+						'Jack "akabugeyes" Thorsen',
 						'Colin Schoen',
 						'SA™',
-						'Diego Andrés'
+						'Diego Andrés',
 						// Former Customizers
 						'Brannon &quot;B&quot; Hall',
 						'Joey &quot;Tyrsson&quot; Smith',


### PR DESCRIPTION
Any page that was loading up Sources\Who.php was generating a syntax error due to missing commas.
