### PR TITLE
Avoid 'Go Up' and 'Upshrink' confusion.

### DIFF
--- a/Themes/default/css/index.css
+++ b/Themes/default/css/index.css
@@ -1300,20 +1300,6 @@ ul li.greeting {
 	display: block;
 }
 
-/* Globally accessible "go up" link. */
-#bot {
-	display: block;
-	margin: 0;
-	width: 25px;
-	float: right;
-}
-span.go_up {
-	background: url(../images/toggle.png) no-repeat;
-	height: 17px;
-	width: 17px;
-	display: inline-block
-}
-
 /* the posting icons */
 #postbuttons_upper ul li a span {
 	line-height: 19px;

--- a/Themes/default/index.template.php
+++ b/Themes/default/index.template.php
@@ -328,9 +328,8 @@ function template_body_below()
 
 	// There is now a global "Go to top" link at the right.
 		echo '
-			<a href="#top_section" id="bot" title="', $txt['go_up'], '"><span class="go_up"></span></a>
 			<ul class="floatright">
-				<li><a href="', $scripturl, '?action=help">', $txt['help'], '</a> ', (!empty($modSettings['requireAgreement'])) ? '| <a href="'. $scripturl. '?action=help;sa=rules">'. $txt['terms_and_rules']. '</a></li>' : '</li>', '
+				<li><a href="', $scripturl, '?action=help">', $txt['help'], '</a> ', (!empty($modSettings['requireAgreement'])) ? '| <a href="'. $scripturl. '?action=help;sa=rules">'. $txt['terms_and_rules']. '</a>' : '', ' | <a href="#top_section" title="', $txt['go_up'], '">', $txt['go_up'], ' &#9650;</a></li>
 			</ul>
 			<ul class="reset">
 				<li class="copyright">', theme_copyright(), '</li>


### PR DESCRIPTION
Because the up arrow graphic is used for collapsing various items like 'Info Center' it's confusing to include it in the footer as the top link that sends the user to the top of the page. Using a text version of the arrow, like the down arrow for the user menu drop-down in the top-bar, eases this confusion.
