### PR TITLE
Floating cat_bar's should get rounded corners.

### DIFF
--- a/Themes/default/css/index.css
+++ b/Themes/default/css/index.css
@@ -3247,6 +3247,7 @@ div#pollmoderation {
 }
 #forumposts .cat_bar {
 	margin: 0 0 -4px 0;
+	border-radius: 6px;
 }
 /* Topic information */
 #forumposts .catbg img {
@@ -3400,6 +3401,9 @@ img.smiley {
 /* Styles for the quick reply area. */
 #quickreplybox {
 	clear: both;
+}
+#quickreplybox .cat_bar {
+	border-radius: 6px;
 }
 #quickReplyOptions .roundframe {
 	margin: 8px 0 0 0;


### PR DESCRIPTION
If a cat_bar is visually floating and not attached to any container, like the category headers on the index page, then they should have rounded corners all around. This one I'm just tossing up as an idea, if you guys don't like it, feel free to reject.

Before:
![post-rounded-corners-before](https://cloud.githubusercontent.com/assets/8311876/4037606/54908a6e-2ca6-11e4-9f65-a1bf11a0728c.png)
After:
![post-rounded-corners-after](https://cloud.githubusercontent.com/assets/8311876/4037608/579d232a-2ca6-11e4-9668-7bad345fffea.png)

If you guys like this one, and _before_ you merge in the pull request, let me know and I'll make the changes to all cat_bar's that aren't visually attached to a container.
