### PR TITLE
Connected board description to title bar on board index.

### DIFF
--- a/Themes/default/css/index.css
+++ b/Themes/default/css/index.css
@@ -3047,6 +3047,10 @@ span.postby {
 	margin-bottom: 0;
 	padding: 0;
 }
+#topic_header.title_bar {
+	margin: 0px;
+	border-radius: 0;
+}
 #messageindex .stats, #recent .stats {
 	text-align: center;
 }
@@ -3081,6 +3085,7 @@ span.postby {
 	padding: 8px 10px 8px 10px;
 	border-bottom-left-radius: 0;
 	border-bottom-right-radius: 0;
+	border-bottom: 0;
 }
 .lastpost span.last_post {
 	float: right;


### PR DESCRIPTION
On the topic listing for a board, the description bar was floating away from the title_bar style used for the "Subject / Started by" etc bar. Here's an example of it connected. Looks nicer I think.

Before:
![messageindex-spacing-before](https://cloud.githubusercontent.com/assets/8311876/4037771/e83f12b0-2ca8-11e4-8d08-0c8c90d2acc4.png)
After:
![messageindex-spacing-after](https://cloud.githubusercontent.com/assets/8311876/4037775/eb288f10-2ca8-11e4-9271-5b8f171906e1.png)
