### PR TITLE
Make call_helper to also support closures

### DIFF
--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -4205,6 +4205,10 @@ function call_helper($string, $return = false)
 	if (empty($string))
 		return false;
 
+	// Is this a closure?
+	if (is_object($string) && ($string instanceof Closure))
+		return $string;
+
 	// Stay vitaminized my friends...
 	$string = $smcFunc['htmlspecialchars']($smcFunc['htmltrim']($string));
 

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -4206,7 +4206,7 @@ function call_helper($string, $return = false)
 		return false;
 
 	// Is this a closure?
-	if (is_object($string) && ($string instanceof Closure))
+	if ($string instanceof Closure)
 		return $string;
 
 	// Stay vitaminized my friends...


### PR DESCRIPTION
This is a tricky one, haven't realize that you could also pass a closure to call_helper but its more common that I imagined, usage of createList() heavily relies on closures.

In theory this should sufice to detect any closure and just return the object, downside of this is the case when create_function() is used but since we're now on 5.3, modders shouldn't really use that anyway.

I'm tempted to change the && for a || just in case someone passes an already instantiated method as a var:

$var = $this->foo();

call_helper($var);

Signed-off-by: Suki suki@missallsunday.com
