### PR TITLE
Fix scope issues in DeleteInstall

### DIFF
--- a/other/install.php
+++ b/other/install.php
@@ -1445,7 +1445,7 @@ function AdminAccount()
 function DeleteInstall()
 {
 	global $txt, $incontext;
-	global $smcFunc, $db_character_set, $context;
+	global $smcFunc, $db_character_set, $context, $cookiename;
 	global $current_smf_version, $databases, $sourcedir, $forum_version, $modSettings, $user_info, $db_type, $boardurl;
 
 	$incontext['page_title'] = $txt['congratulations'];


### PR DESCRIPTION
$cookiename would not get globalised since DeleteInstall was including Settings.php by itself, causing Admin to not get logged in and/or some undefined indexes.

Signed-off-by: Shitiz Garg mail@dragooon.net
