### PR TITLE
Fix an undefined variable error on Subs-Auth.php

### DIFF
--- a/Sources/Subs-Auth.php
+++ b/Sources/Subs-Auth.php
@@ -199,7 +199,7 @@ function InMaintenance()
  */
 function adminLogin($type = 'admin')
 {
-	global $context, $txt, $user_settings;
+	global $context, $txt, $user_settings, $user_info;
 
 	loadLanguage('Admin');
 	loadTemplate('Login');


### PR DESCRIPTION
If you failed a login attempt, SMF tries to log to the error log describing the failure. This error caused SMF to not log the IP associated to said user and PHP to throw an undefined variable error. This commit fixes both.

Signed-off-by: Yoshi2889 rick.2889@gmail.com
