### PR TITLE
! Upgrade fixes

### DIFF
--- a/other/upgrade_2-1_mysql.sql
+++ b/other/upgrade_2-1_mysql.sql
@@ -156,7 +156,19 @@ $custom_av_dir = !empty($modSettings['custom_avatar_dir']) ? $modSettings['custo
 
 // This little fellow has to cooperate...
 if (!is_writable($custom_av_dir))
-	@chmod($custom_av_dir, 0777);
+{
+	// Try 755 and 775 first since 777 doesn't always work and could be a risk...
+	$chmod_values = array(0755, 0775, 0777);
+
+	foreach($chmod_values as $val)
+	{
+		// If it's writable, break out of the loop
+		if (is_writable($custom_av_dir))
+			break;
+		else
+			@chmod($custom_av_dir, $val);
+	}
+}
 
 // If we already are using a custom dir, delete the predefined one.
 if ($custom_av_dir != $GLOBALS['boarddir'] .'/custom_avatar')

--- a/other/upgrade_2-1_mysql.sql
+++ b/other/upgrade_2-1_mysql.sql
@@ -174,7 +174,16 @@ if (!is_writable($custom_av_dir))
 if ($custom_av_dir != $GLOBALS['boarddir'] .'/custom_avatar')
 {
 	// Borrow custom_avatars index.php file.
-	@rename($GLOBALS['boarddir'] .'/custom_avatar/index.php', $custom_av_dir .'/index.php');
+	if (!file_exists($custom_av_dir . '/index.php'))
+		@rename($GLOBALS['boarddir'] .'/custom_avatar/index.php', $custom_av_dir .'/index.php');
+	else
+		@unlink($GLOBALS['boarddir'] . '/custom_avatar/index.php');
+
+	// Borrow blank.png as well
+	if (!file_exists($custom_av_dir . '/blank.png'))
+		@rename($GLOBALS['boarddir'] . '/custom_avatar/blank.png', $custom_av_dir . '/blank.png');
+	else
+		@unlink($GLOBALS['boarddir'] . '/custom_avatar/blank.png')
 
 	// Attempt to delete the directory.
 	@rmdir($GLOBALS['boarddir'] .'/custom_avatar');

--- a/other/upgrade_2-1_mysql.sql
+++ b/other/upgrade_2-1_mysql.sql
@@ -647,8 +647,11 @@ SET id_theme = 0;
 ---{
 $request = $smcFunc['db_query']('', '
 	SELECT icons
-	FROM {db_prefix}membergroups',
-	array()
+	FROM {db_prefix}membergroups
+	WHERE icons != {string:blank}',
+	array(
+		'blank' => '',
+	)
 );
 $toMove = array();
 $toChange = array();
@@ -664,6 +667,12 @@ while ($row = $smcFunc['db_fetch_assoc']($request))
 		$toChange[] = array(
 			'old' => $row['icons'],
 			'new' => str_replace('starmod.gif', 'iconmod.png', $row['icons']),
+		);
+
+	elseif (strpos($row['icons'], 'stargmod.gif') !== false)
+		$toChange[] = array(
+			'old' => $row['icons'],
+			'new' => str_replace('stargmod.gif', 'icongmod.png', $row['icons']),
 		);
 
 	elseif (strpos($row['icons'], 'staradmin.gif') !== false)

--- a/other/upgrade_2-1_mysql.sql
+++ b/other/upgrade_2-1_mysql.sql
@@ -241,6 +241,10 @@ while (!$is_done)
 		{
 			$oldFile = $currentFolder . '/' . $row['id_attach'] . '_' . $row['file_hash'];
 			$newFile = $currentFolder . '/' . $row['id_attach'] . '_' . $row['file_hash'] .'.dat';
+
+			// Make sure it exists...
+			if (!file_exists($oldFile))
+				$oldFile = false;
 		}
 
 		if (!$oldFile)
@@ -678,7 +682,10 @@ foreach ($toMove as $move)
 	// Get the actual image.
 	$image = explode('#', $move);
 	$image = $image[1];
-	@rename($modSettings['theme_dir'] . '/images/'. $image, $modSettings['theme_dir'] . '/images/membericons/'. $image);
+	
+	// PHP won't suppress errors when running things from shell, so make sure it exists first...
+	if (file_exists($modSettings['theme_dir'] . '/images/' . $image))  
+		@rename($modSettings['theme_dir'] . '/images/' . $image, $modSettings['theme_dir'] . '/images/membericons/'. $image);
 }
 ---}
 ---#
@@ -1597,7 +1604,7 @@ DROP openid_uri;
 ---#
 
 ---# Dropping the openid_assoc table
-DROP TABLE {$db_prefix}openid_assoc;
+DROP TABLE IF EXISTS {$db_prefix}openid_assoc;
 ---#
 
 ---# Removing related settings

--- a/other/upgrade_2-1_postgresql.sql
+++ b/other/upgrade_2-1_postgresql.sql
@@ -166,7 +166,16 @@ if (!is_writable($custom_av_dir))
 if ($custom_av_dir != $GLOBALS['boarddir'] .'/custom_avatar')
 {
 	// Borrow custom_avatars index.php file.
-	@rename($GLOBALS['boarddir'] .'/custom_avatar/index.php', $custom_av_dir .'/index.php');
+	if (!file_exists($custom_av_dir . '/index.php'))
+		@rename($GLOBALS['boarddir'] .'/custom_avatar/index.php', $custom_av_dir .'/index.php');
+	else
+		@unlink($GLOBALS['boarddir'] . '/custom_avatar/index.php');
+
+	// Borrow blank.png as well
+	if (!file_exists($custom_av_dir . '/blank.png'))
+		@rename($GLOBALS['boarddir'] . '/custom_avatar/blank.png', $custom_av_dir . '/blank.png');
+	else
+		@unlink($GLOBALS['boarddir'] . '/custom_avatar/blank.png')
 
 	// Attempt to delete the directory.
 	@rmdir($GLOBALS['boarddir'] .'/custom_avatar');

--- a/other/upgrade_2-1_postgresql.sql
+++ b/other/upgrade_2-1_postgresql.sql
@@ -233,6 +233,10 @@ while (!$is_done)
 		{
 			$oldFile = $currentFolder . '/' . $row['id_attach'] . '_' . $row['file_hash'];
 			$newFile = $currentFolder . '/' . $row['id_attach'] . '_' . $row['file_hash'] .'.dat';
+
+			// Make sure it exists...
+			if (!file_exists($oldFile))
+				$oldFile = false;
 		}
 
 		if (!$oldFile)
@@ -742,7 +746,10 @@ foreach ($toMove as $move)
 	// Get the actual image.
 	$image = explode('#', $move);
 	$image = $image[1];
-	@rename($modSettings['theme_dir'] . '/images/'. $image, $modSettings['theme_dir'] . '/images/membericons/'. $image);
+
+	// PHP won't suppress errors when running things from shell, so make sure it exists first...
+	if (file_exists($modSettings['theme_dir'] . '/images/' . $image))  
+		@rename($modSettings['theme_dir'] . '/images/' . $image, $modSettings['theme_dir'] . '/images/membericons/'. $image);
 }
 ---}
 ---#
@@ -1702,7 +1709,7 @@ DROP openid_uri;
 ---#
 
 ---# Dropping the openid_assoc table
-DROP TABLE {$db_prefix}openid_assoc;
+DROP TABLE IF EXISTS {$db_prefix}openid_assoc;
 ---#
 
 ---# Removing related settings

--- a/other/upgrade_2-1_postgresql.sql
+++ b/other/upgrade_2-1_postgresql.sql
@@ -148,7 +148,19 @@ $custom_av_dir = !empty($modSettings['custom_avatar_dir']) ? $modSettings['custo
 
 // This little fellow has to cooperate...
 if (!is_writable($custom_av_dir))
-	@chmod($custom_av_dir, 0777);
+{
+	// Try 755 and 775 first since 777 doesn't always work and could be a risk...
+	$chmod_values = array(0755, 0775, 0777);
+
+	foreach($chmod_values as $val)
+	{
+		// If it's writable, break out of the loop
+		if (is_writable($custom_av_dir))
+			break;
+		else
+			@chmod($custom_av_dir, $val);
+	}
+}
 
 // If we already are using a custom dir, delete the predefined one.
 if ($custom_av_dir != $GLOBALS['boarddir'] .'/custom_avatar')

--- a/other/upgrade_2-1_postgresql.sql
+++ b/other/upgrade_2-1_postgresql.sql
@@ -711,8 +711,11 @@ SET id_theme = 0;
 ---{
 $request = $smcFunc['db_query']('', '
 	SELECT icons
-	FROM {db_prefix}membergroups',
-	array()
+	FROM {db_prefix}membergroups
+	WHERE icons != {string:blank}',
+	array(
+		'blank' => '',
+	)
 );
 $toMove = array();
 $toChange = array();
@@ -728,6 +731,12 @@ while ($row = $smcFunc['db_fetch_assoc']($request))
 		$toChange[] = array(
 			'old' => $row['icons'],
 			'new' => str_replace('starmod.gif', 'iconmod.png', $row['icons']),
+		);
+
+	elseif (strpos($row['icons'], 'stargmod.gif') !== false)
+		$toChange[] = array(
+			'old' => $row['icons'],
+			'new' => str_replace('stargmod.gif', 'icongmod.png', $row['icons']),
 		);
 
 	elseif (strpos($row['icons'], 'staradmin.gif') !== false)


### PR DESCRIPTION
This fixes the following issues:
1. The upgrade script only tries CHMOD 777 if the custom av. directory isn't writable; should try 755 and 775 first since 777 isn't necessary in many cases.
2. The @ operator doesn't suppress errors when running the script via shell/command line, so don't try to rename/move files unless they exist.
3. The code to move/rename old group icons wasn't handling stargmod.gif or situations where the group had no icons.
4. Database error caused by attempting to drop a non-existent table.

Signed-off-by: Michael Eshom oldiesmann@oldiesmann.us
