### PR TITLE
Remove $modSettings['integrate_autotask_include'] 

### DIFF
--- a/Sources/ScheduledTasks.php
+++ b/Sources/ScheduledTasks.php
@@ -30,9 +30,6 @@ function AutoTask()
 	{
 		$task_string = '';
 
-		// Any external tasks?
-		$external_tasks = !empty($modSettings['integrate_autotask_include']) ? explode(',', $modSettings['integrate_autotask_include']) : array();
-
 		// Select the next task to do.
 		$request = $smcFunc['db_query']('', '
 			SELECT id_task, task, next_time, time_offset, time_regularity, time_unit, callable
@@ -84,16 +81,16 @@ function AutoTask()
 			$affected_rows = $smcFunc['db_affected_rows']();
 
 			// What kind of task are we handling?
-			if (!empty($external_tasks) && !empty($row['callable']) && in_array($row['callable'], $external_tasks))
+			if (!empty($row['callable']))
 				$task_string = $row['callable'];
-
-			// Using the task name huh?
-			elseif (!empty($external_tasks) && in_array($row['task'], $external_tasks))
-				$task_string = $row['task'];
 
 			// Default SMF task or old mods?
 			elseif (function_exists('scheduled_' . $row['task']))
 				$task_string = 'scheduled_' . $row['task'];
+
+			// One last resource, the task name.
+			else (!empty($row['task'])
+				$task_string = $row['task'];
 
 			// The function must exist or we are wasting our time, plus do some timestamp checking, and database check!
 			if (!empty($task_string) && (!isset($_GET['ts']) || $_GET['ts'] == $row['next_time']) && $affected_rows)


### PR DESCRIPTION
$modSettings['integrate_autotask_include']  was introduced as a way to allow adding functions to AutoTask() without having to edit the ScheduledTasks.php file, however, the new "callable" column makes $modSettings['integrate_autotask_include']  completely redundant.

With this you only have to include a string in the callable column, no need to validate it by adding it to $modSettings['integrate_autotask_include'] too.

Also, changed the priority of what is been called first:
- callable
- The normal scheduled_taskName
- The task name

Signed-off-by: Suki suki@missallsunday.com
