### PR TITLE
! Improve handling of login history (fixes #2290)

### DIFF
--- a/Sources/ManageServer.php
+++ b/Sources/ManageServer.php
@@ -358,7 +358,7 @@ function ModifyGeneralSecuritySettings($return_config = false)
 
 	$config_vars = array(
 			array('int', 'failed_login_threshold'),
-			array('int', 'loginHistoryDays'),
+			array('int', 'loginHistoryDays', 'subtext' => $txt['zero_to_disable']),
 		'',
 			array('check', 'securityDisable'),
 			array('check', 'securityDisable_moderate'),

--- a/Sources/Profile.php
+++ b/Sources/Profile.php
@@ -208,7 +208,7 @@ function ModifyProfile($post_errors = array())
 						'ip' => array($txt['trackIP'], 'moderate_forum'),
 						'edits' => array($txt['trackEdits'], 'moderate_forum', 'enabled' => !empty($modSettings['userlog_enabled'])),
 						'groupreq' => array($txt['trackGroupRequests'], 'approve_group_requests', 'enabled' => !empty($modSettings['show_group_membership'])),
-						'logins' => array($txt['trackLogins'], 'moderate_forum'),
+						'logins' => array($txt['trackLogins'], 'moderate_forum', 'enabled' => !empty($modSettings['loginHistoryDays'])),
 					),
 					'permission' => array(
 						'own' => array('moderate_forum', 'approve_group_requests'),

--- a/other/install_2-1_mysql.sql
+++ b/other/install_2-1_mysql.sql
@@ -1842,7 +1842,8 @@ VALUES ('smfVersion', '{$smf_version}'),
 	('gravatarOverride', '0'),
 	('gravatarAllowExtraEmail', '1'),
 	('gravatarMaxRating', 'PG'),
-	('defaultMaxListItems', '15');
+	('defaultMaxListItems', '15'),
+	('loginHistoryDays', '30');
 
 # --------------------------------------------------------
 

--- a/other/install_2-1_postgresql.sql
+++ b/other/install_2-1_postgresql.sql
@@ -2349,6 +2349,7 @@ INSERT INTO {$db_prefix}settings (variable, value) VALUES ('gravatarOverride', '
 INSERT INTO {$db_prefix}settings (variable, value) VALUES ('gravatarAllowExtraEmail', '1');
 INSERT INTO {$db_prefix}settings (variable, value) VALUES ('gravatarMaxRating', 'PG');
 INSERT INTO {$db_prefix}settings (variable, value) VALUES ('defaultMaxListItems', '15');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('loginHistoryDays', '30');
 
 # --------------------------------------------------------
 

--- a/other/upgrade_2-1_mysql.sql
+++ b/other/upgrade_2-1_mysql.sql
@@ -106,6 +106,18 @@ INSERT INTO {$db_prefix}settings (variable, value) VALUES ('additional_options_c
 INSERT INTO {$db_prefix}settings (variable, value) VALUES ('defaultMaxListItems', '15');
 ---#
 
+---# Adding new "loginHistoryDays" setting
+---{
+	if (!isset($modSettings['loginHistoryDays']))
+		$smcFunc['db_insert']('insert', 
+			'{db_prefix}settings', 
+			array('variable' => 'string', 'value' => 'string'), 
+			array('loginHistoryDays', '30'), 
+			array()
+		);
+---}
+---#
+
 ---# Enable some settings we ripped from Theme settings
 ---{
 	$ripped_settings = array('show_modify', 'show_user_images', 'show_blurb', 'show_profile_buttons', 'subject_toggle', 'hide_post_group');

--- a/other/upgrade_2-1_postgresql.sql
+++ b/other/upgrade_2-1_postgresql.sql
@@ -108,6 +108,18 @@ INSERT INTO {$db_prefix}settings (variable, value) VALUES ('additional_options_c
 INSERT INTO {$db_prefix}settings (variable, value) VALUES ('defaultMaxListItems', '15');
 ---#
 
+---# Adding new "loginHistoryDays" setting
+---{
+	if (!isset($modSettings['loginHistoryDays']))
+		$smcFunc['db_insert']('insert', 
+			'{db_prefix}settings', 
+			array('variable' => 'string', 'value' => 'string'), 
+			array('loginHistoryDays', '30'), 
+			array()
+		);
+---}
+---#
+
 ---# Enable some settings we ripped from Theme settings
 ---{
 	$ripped_settings = array('show_modify', 'show_user_images', 'show_blurb', 'show_profile_buttons', 'subject_toggle', 'hide_post_group');


### PR DESCRIPTION
This does three things:
1. Hides the option to view login history in the profile if the setting is disabled.
2. Sets it to a default of 30 days to be consistent with the help text
3. Adds the standard "(0 to disable)" help subtext for the setting in the admin center (should be obvious, but can't hurt either way)

Signed-off-by: Michael Eshom oldiesmann@oldiesmann.us
