### PR TITLE
Interfaces

### DIFF
--- a/Sources/tasks/CreatePost-Notify.php
+++ b/Sources/tasks/CreatePost-Notify.php
@@ -14,6 +14,11 @@
 
 class CreatePost_Notify_Background implements SMF_BackgroundTask
 {
+	public function __construct($details)
+	{
+		$this->_details = $details;
+	}
+
 	public function execute()
 	{
 		global $smcFunc, $sourcedir, $scripturl, $language, $modSettings, $language;

--- a/Sources/tasks/CreatePost-Notify.php
+++ b/Sources/tasks/CreatePost-Notify.php
@@ -12,7 +12,7 @@
  * @version 2.1 Beta 1
  */
 
-class CreatePost_Notify_Background extends SMF_BackgroundTask
+class CreatePost_Notify_Background implements SMF_BackgroundTask
 {
 	public function execute()
 	{

--- a/Sources/tasks/CreatePost-Notify.php
+++ b/Sources/tasks/CreatePost-Notify.php
@@ -14,6 +14,8 @@
 
 class CreatePost_Notify_Background implements SMF_BackgroundTask
 {
+	protected $_details = array();
+
 	public function __construct($details)
 	{
 		$this->_details = $details;

--- a/Sources/tasks/EventNew-Notify.php
+++ b/Sources/tasks/EventNew-Notify.php
@@ -16,6 +16,11 @@
 
 class EventNew_Notify_Background implements SMF_BackgroundTask
 {
+	public function __construct($details)
+	{
+		$this->_details = $details;
+	}
+
 	public function execute()
  	{
  		global $sourcedir, $smcFunc, $user_profile;

--- a/Sources/tasks/EventNew-Notify.php
+++ b/Sources/tasks/EventNew-Notify.php
@@ -16,6 +16,8 @@
 
 class EventNew_Notify_Background implements SMF_BackgroundTask
 {
+	protected $_details = array();
+
 	public function __construct($details)
 	{
 		$this->_details = $details;

--- a/Sources/tasks/EventNew-Notify.php
+++ b/Sources/tasks/EventNew-Notify.php
@@ -14,7 +14,7 @@
  * @version SMF 2.1 Beta 1
  */
 
-class EventNew_Notify_Background extends SMF_BackgroundTask
+class EventNew_Notify_Background implements SMF_BackgroundTask
 {
 	public function execute()
  	{

--- a/Sources/tasks/GroupReq-Notify.php
+++ b/Sources/tasks/GroupReq-Notify.php
@@ -16,6 +16,8 @@
 
 class GroupReq_Notify_Background implements SMF_BackgroundTask
 {
+	protected $_details = array();
+
 	public function __construct($details)
 	{
 		$this->_details = $details;

--- a/Sources/tasks/GroupReq-Notify.php
+++ b/Sources/tasks/GroupReq-Notify.php
@@ -14,7 +14,7 @@
  * @version SMF 2.1 Beta 1
  */
 
-class GroupReq_Notify_Background extends SMF_BackgroundTask
+class GroupReq_Notify_Background implements SMF_BackgroundTask
 {
 	public function execute()
  	{

--- a/Sources/tasks/GroupReq-Notify.php
+++ b/Sources/tasks/GroupReq-Notify.php
@@ -16,6 +16,11 @@
 
 class GroupReq_Notify_Background implements SMF_BackgroundTask
 {
+	public function __construct($details)
+	{
+		$this->_details = $details;
+	}
+
 	public function execute()
  	{
  		global $sourcedir, $smcFunc, $language, $modSettings, $scripturl;

--- a/Sources/tasks/Likes-Notify.php
+++ b/Sources/tasks/Likes-Notify.php
@@ -13,7 +13,7 @@
  * @version 2.1 Beta 1
  */
 
-class Likes_Notify_Background extends SMF_BackgroundTask
+class Likes_Notify_Background implements SMF_BackgroundTask
 {
 	public function execute()
 	{

--- a/Sources/tasks/Likes-Notify.php
+++ b/Sources/tasks/Likes-Notify.php
@@ -15,6 +15,11 @@
 
 class Likes_Notify_Background implements SMF_BackgroundTask
 {
+	public function __construct($details)
+	{
+		$this->_details = $details;
+	}
+
 	public function execute()
 	{
 		global $smcFunc, $sourcedir;

--- a/Sources/tasks/Likes-Notify.php
+++ b/Sources/tasks/Likes-Notify.php
@@ -15,6 +15,8 @@
 
 class Likes_Notify_Background implements SMF_BackgroundTask
 {
+	protected $_details = array();
+
 	public function __construct($details)
 	{
 		$this->_details = $details;

--- a/Sources/tasks/MemberReport-Notify.php
+++ b/Sources/tasks/MemberReport-Notify.php
@@ -15,6 +15,11 @@
 
 class MemberReport_Notify_Background implements SMF_BackgroundTask
 {
+	public function __construct($details)
+	{
+		$this->_details = $details;
+	}
+
 	public function execute()
 	{
 		global $smcFunc, $sourcedir, $modSettings, $language, $scripturl;

--- a/Sources/tasks/MemberReport-Notify.php
+++ b/Sources/tasks/MemberReport-Notify.php
@@ -13,7 +13,7 @@
  * @version 2.1 Beta 1
  */
 
-class MemberReport_Notify_Background extends SMF_BackgroundTask
+class MemberReport_Notify_Background implements SMF_BackgroundTask
 {
 	public function execute()
 	{

--- a/Sources/tasks/MemberReport-Notify.php
+++ b/Sources/tasks/MemberReport-Notify.php
@@ -15,6 +15,8 @@
 
 class MemberReport_Notify_Background implements SMF_BackgroundTask
 {
+	protected $_details = array();
+
 	public function __construct($details)
 	{
 		$this->_details = $details;

--- a/Sources/tasks/MemberReportReply-Notify.php
+++ b/Sources/tasks/MemberReportReply-Notify.php
@@ -16,6 +16,11 @@
 
 class MemberReportReply_Notify_Background implements SMF_BackgroundTask
 {
+	public function __construct($details)
+	{
+		$this->_details = $details;
+	}
+
 	public function execute()
 	{
 		global $smcFunc, $sourcedir, $modSettings, $language, $scripturl;

--- a/Sources/tasks/MemberReportReply-Notify.php
+++ b/Sources/tasks/MemberReportReply-Notify.php
@@ -14,7 +14,7 @@
  * @version 2.1 Beta 1
  */
 
-class MemberReportReply_Notify_Background extends SMF_BackgroundTask
+class MemberReportReply_Notify_Background implements SMF_BackgroundTask
 {
 	public function execute()
 	{

--- a/Sources/tasks/MemberReportReply-Notify.php
+++ b/Sources/tasks/MemberReportReply-Notify.php
@@ -16,6 +16,8 @@
 
 class MemberReportReply_Notify_Background implements SMF_BackgroundTask
 {
+	protected $_details = array();
+
 	public function __construct($details)
 	{
 		$this->_details = $details;

--- a/Sources/tasks/MsgReport-Notify.php
+++ b/Sources/tasks/MsgReport-Notify.php
@@ -15,6 +15,11 @@
 
 class MsgReport_Notify_Background implements SMF_BackgroundTask
 {
+	public function __construct($details)
+	{
+		$this->_details = $details;
+	}
+
 	public function execute()
 	{
 		global $smcFunc, $sourcedir, $modSettings, $language, $scripturl;

--- a/Sources/tasks/MsgReport-Notify.php
+++ b/Sources/tasks/MsgReport-Notify.php
@@ -13,7 +13,7 @@
  * @version 2.1 Beta 1
  */
 
-class MsgReport_Notify_Background extends SMF_BackgroundTask
+class MsgReport_Notify_Background implements SMF_BackgroundTask
 {
 	public function execute()
 	{

--- a/Sources/tasks/MsgReport-Notify.php
+++ b/Sources/tasks/MsgReport-Notify.php
@@ -15,6 +15,8 @@
 
 class MsgReport_Notify_Background implements SMF_BackgroundTask
 {
+	protected $_details = array();
+
 	public function __construct($details)
 	{
 		$this->_details = $details;

--- a/Sources/tasks/MsgReportReply-Notify.php
+++ b/Sources/tasks/MsgReportReply-Notify.php
@@ -16,6 +16,11 @@
 
 class MsgReportReply_Notify_Background implements SMF_BackgroundTask
 {
+	public function __construct($details)
+	{
+		$this->_details = $details;
+	}
+
 	public function execute()
 	{
 		global $smcFunc, $sourcedir, $modSettings, $language, $scripturl;

--- a/Sources/tasks/MsgReportReply-Notify.php
+++ b/Sources/tasks/MsgReportReply-Notify.php
@@ -14,7 +14,7 @@
  * @version 2.1 Beta 1
  */
 
-class MsgReportReply_Notify_Background extends SMF_BackgroundTask
+class MsgReportReply_Notify_Background implements SMF_BackgroundTask
 {
 	public function execute()
 	{

--- a/Sources/tasks/MsgReportReply-Notify.php
+++ b/Sources/tasks/MsgReportReply-Notify.php
@@ -16,6 +16,8 @@
 
 class MsgReportReply_Notify_Background implements SMF_BackgroundTask
 {
+	protected $_details = array();
+
 	public function __construct($details)
 	{
 		$this->_details = $details;

--- a/Sources/tasks/Register-Notify.php
+++ b/Sources/tasks/Register-Notify.php
@@ -13,7 +13,7 @@
  * @version 2.1 Beta 1
  */
 
-class Register_Notify_Background extends SMF_BackgroundTask
+class Register_Notify_Background implements SMF_BackgroundTask
 {
 	public function execute()
 	{

--- a/Sources/tasks/Register-Notify.php
+++ b/Sources/tasks/Register-Notify.php
@@ -15,6 +15,11 @@
 
 class Register_Notify_Background implements SMF_BackgroundTask
 {
+	public function __construct($details)
+	{
+		$this->_details = $details;
+	}
+
 	public function execute()
 	{
 		global $smcFunc, $sourcedir, $modSettings, $language, $scripturl;

--- a/Sources/tasks/Register-Notify.php
+++ b/Sources/tasks/Register-Notify.php
@@ -15,6 +15,9 @@
 
 class Register_Notify_Background implements SMF_BackgroundTask
 {
+
+	protected $_details = array();
+
 	public function __construct($details)
 	{
 		$this->_details = $details;

--- a/cron.php
+++ b/cron.php
@@ -194,11 +194,16 @@ function perform_task($task_details)
 	}
 
 	// All background tasks need to be classes.
-	elseif (class_exists($task_details['task_class']) && is_subclass_of($task_details['task_class'], 'SMF_BackgroundTask'))
+	elseif (class_exists($task_details['task_class']))
 	{
 		$details = empty($task_details['task_data']) ? array() : unserialize($task_details['task_data']);
 		$bgtask = new $task_details['task_class']($details);
-		return $bgtask->execute();
+
+		if (in_array('SMF_BackgroundTask', class_implements($bgtask)))
+			return $bgtask->execute();
+
+		else
+			return true; // So we clear it from the queue.
 	}
 	else
 	{

--- a/cron.php
+++ b/cron.php
@@ -254,15 +254,8 @@ function obExit_cron()
 
 // We would like this to be defined, but we don't want to have to load more stuff than necessary.
 // Thus we declare it here, and any legitimate background task must implement this.
-abstract class SMF_BackgroundTask
+interface SMF_BackgroundTask
 {
-	protected $_details;
-
-	public function __construct($details)
-	{
-		$this->_details = $details;
-	}
-
-	abstract public function execute();
+	public function execute();
 }
 ?>


### PR DESCRIPTION
Usage of SMF_BackgroundTask as an interface.

Since we're on 5.3 why not use a proper interface, this allows custom notification classes to implement the interface while still be able to extend a third party class or even implement another third party interface, it also gives back full control of the __constructor magic method back to each notification class.

Meh... TBH this is just a selfish thing, I'm pretty sure I'm gonna be the only one implementing while also extending a third party class. Then again, most of the stuff I've been adding will not be fully used by mod authors anyway :cry: 
