### PR TITLE
! Mod Center tweaks

### DIFF
--- a/Sources/ModerationCenter.php
+++ b/Sources/ModerationCenter.php
@@ -534,7 +534,6 @@ function ModBlockReportedPosts()
 				'link' => $row['id_author'] ? '<a href="' . $scripturl . '?action=profile;u=' . $row['id_author'] . '">' . $row['author_name'] . '</a>' : $row['author_name'],
 				'href' => $scripturl . '?action=profile;u=' . $row['id_author'],
 			),
-			'comments' => array(),
 			'subject' => $row['subject'],
 			'num_reports' => $row['num_reports'],
 		);
@@ -606,7 +605,7 @@ function ModBlockReportedMembers()
 	if (!allowedTo('moderate_forum'))
 		return 'reported_users_block';
 
-	if (($reported_posts = cache_get_data('reported_users_' . $cachekey, 90)) === null)
+	if (($reported_users = cache_get_data('reported_users_' . $cachekey, 90)) === null)
 	{
 		// By George, that means we in a position to get the reports, jolly good.
 		$request = $smcFunc['db_query']('', '
@@ -632,7 +631,7 @@ function ModBlockReportedMembers()
 		$smcFunc['db_free_result']($request);
 
 		// Cache it.
-		cache_put_data('reported_users_' . $cachekey, $reported_posts, 90);
+		cache_put_data('reported_users_' . $cachekey, $reported_users, 90);
 	}
 
 	$context['reported_users'] = array();
@@ -648,7 +647,6 @@ function ModBlockReportedMembers()
 				'link' => $row['id_user'] ? '<a href="' . $scripturl . '?action=profile;u=' . $row['id_user'] . '">' . $row['user_name'] . '</a>' : $row['user_name'],
 				'href' => $scripturl . '?action=profile;u=' . $row['id_user'],
 			),
-			'comments' => array(),
 			'num_reports' => $row['num_reports'],
 		);
 	}

--- a/Themes/default/ModerationCenter.template.php
+++ b/Themes/default/ModerationCenter.template.php
@@ -185,7 +185,7 @@ function template_reported_posts_block()
 		foreach ($context['reported_posts'] as $post)
 			echo '
 					<li>
-						<span class="smalltext">', sprintf($txt['mc_post_report'], $post['report_link'], $post['author']['link'], count($post['comments'])), '</span>
+						<span class="smalltext">', sprintf($txt['mc_post_report'], $post['report_link'], $post['author']['link']), '</span>
 					</li>';
 
 		// Don't have any watched users right now?
@@ -251,7 +251,7 @@ function template_reported_users_block()
 		foreach ($context['reported_users'] as $user)
 			echo '
 					<li>
-						<span class="smalltext">', sprintf($txt['mc_user_report'], $user['user']['link'], count($user['comments'])), '</span>
+						<span class="smalltext">', $user['user']['link'], '</span>
 					</li>';
 
 		// Don't have any watched users right now?

--- a/Themes/default/languages/ModerationCenter.english.php
+++ b/Themes/default/languages/ModerationCenter.english.php
@@ -32,8 +32,7 @@ $txt['mc_reported_users_none'] = 'There are no pending profile reports.';
 $txt['mc_seen'] = '%1$s last seen %2$s';
 $txt['mc_seen_never'] = '%1$s never seen';
 $txt['mc_groupr_by'] = 'by';
-$txt['mc_post_report'] = '%1$s by %2$s (%3$s comment(s))';
-$txt['mc_user_report'] = '%1$s (%2$s comment(s))';
+$txt['mc_post_report'] = '%1$s by %2$s';
 
 $txt['mc_reported_posts_desc'] = 'Here you can review all the post reports raised by members of the community.';
 $txt['mc_reportedp_active'] = 'Active Reports';


### PR DESCRIPTION
Fixes two issues:
1. Reported users block wasn't actually cached due to using the wrong variable name.
2. Don't show comment counts for reported users/posts (fixes #2333)

Signed-off-by: Michael Eshom oldiesmann@oldiesmann.us
