### PR TITLE
Add compatibility with mods that uses the second argument in add_integration

### DIFF
--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -4075,11 +4075,11 @@ function call_integration_hook($hook, $parameters = array())
  *
  * @param string $hook The complete hook name.
  * @param string $function Function name, can be a call to a method via Class::method.
+ * @param bool $permanent = true if true, updates the value in settings table.
  * @param string $file Must include one of the following wildcards: $boarddir, $sourcedir, $themedir, example: $sourcedir/Test.php
  * @param bool $object Boolean Indicates if your class will be instantiated when its respective hook is called, your function must be a method.
- * @param bool $permanent = true if true, updates the value in settings table.
  */
-function add_integration_function($hook, $function, $file = '', $object = false, $permanent = true)
+function add_integration_function($hook, $function, $permanent = true, $file = '', $object = false)
 {
 	global $smcFunc, $modSettings;
 

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -4083,7 +4083,16 @@ function add_integration_function($hook, $function, $permanent = true, $file = '
 {
 	global $smcFunc, $modSettings;
 
-	$integration_call = (!empty($file) && is_string($file)) ? ($file . '|' . $function . ($object ? '#' : '')) : $function;
+	// Any objects?
+	if ($object)
+		$function = $function . '#';
+
+	// Any files  to load?
+	if (!empty($file) && is_string($file))
+		$function = $file . '|' . $function;
+
+	// Get the correct string.
+	$integration_call = $function;
 
 	// Is it going to be permanent?
 	if ($permanent)

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -4083,7 +4083,7 @@ function add_integration_function($hook, $function, $permanent = true, $file = '
 {
 	global $smcFunc, $modSettings;
 
-	$integration_call = (!empty($file) && $file !== true) ? ($file . '|' . $function . ($object ? '#' : '')) : $function;
+	$integration_call = (!empty($file) && is_string($file)) ? ($file . '|' . $function . ($object ? '#' : '')) : $function;
 
 	// Is it going to be permanent?
 	if ($permanent)


### PR DESCRIPTION
fixes #2382

And this is why I prefer this:

``` php
add_integration_function('integrate_menu_buttons', '$sourcedir/SomeFile.php|Class::method#');
```

over this:

``` php
add_integration_function('integrate_menu_buttons', 'Class::method', true, '$sourcedir/SomeFile.php', true);
```

Signed-off-by: Suki suki@missallsunday.com
