### PR TITLE
add param permanent to remove_integration function

### DIFF
--- a/Sources/Load.php
+++ b/Sources/Load.php
@@ -19,8 +19,6 @@ if (!defined('SMF'))
 /**
  * Load the $modSettings array.
  *
- * @todo okay question of the day: why a function for loading settings is called reloadSettings()
- *
  */
 function reloadSettings()
 {

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -4138,15 +4138,28 @@ function add_integration_function($hook, $function, $permanent = true, $file = '
  * Removes the given function from the given hook.
  * Does nothing if the function is not available.
  *
- * @param string $hook
- * @param string $function
- * @param string $file
+ * @param string $hook The complete hook name.
+ * @param string $function Function name, can be a call to a method via Class::method.
+ * @params boolean $permanent Irrelevant for the function itself but need to declare it to match 
+ * @param string $file Must include one of the following wildcards: $boarddir, $sourcedir, $themedir, example: $sourcedir/Test.php
+add_integration_function
+ * @param boolean $object
+ * @see add_integration_function
  */
-function remove_integration_function($hook, $function, $file = '', $object = false)
+function remove_integration_function($hook, $function, $permanent = true, $file = '', $object = false)
 {
 	global $smcFunc, $modSettings;
 
-	$integration_call = (!empty($file)) ? $file . '|' . $function .($object ? '#' : '') : $function;
+	// Any objects?
+	if ($object)
+		$function = $function . '#';
+
+	// Any files  to load?
+	if (!empty($file) && is_string($file))
+		$function = $file . '|' . $function;
+
+	// Get the correct string.
+	$integration_call = $function;
 
 	// Get the permanent functions.
 	$request = $smcFunc['db_query']('', '


### PR DESCRIPTION
Since some mod authors uses the same vars for installing/uninstalling a hook, remove_integration_function needs to have the same params an the same order add_integration_function does. Otherwise the hook will not be uninstalled.
