### PR TITLE
reload settings table during mod installation

### DIFF
--- a/Sources/Packages.php
+++ b/Sources/Packages.php
@@ -1113,6 +1113,9 @@ function PackageInstall()
 		// Assuming we're not uninstalling, add the entry.
 		if (!$context['uninstalling'])
 		{
+			// Reload the settings table for mods that have altered them upon installation
+			reloadSettings();
+			
 			// Any db changes from older version?
 			if (!empty($old_db_changes))
 				$db_package_log = empty($db_package_log) ? $old_db_changes : array_merge($old_db_changes, $db_package_log);


### PR DESCRIPTION
- mods that alter the settings table during installation (ie. for adding hooks) need to have their possible values executed else errors may be logged during the process

ref.
https://github.com/SimpleMachines/SMF2.1/issues/2382

Signed-off-by: -Underdog- github.underdog@gmail.com
