### PR TITLE
! Properly fix issues with HTML in forum title and maintenance mode title...

### DIFF
--- a/Sources/BoardIndex.php
+++ b/Sources/BoardIndex.php
@@ -121,7 +121,7 @@ function BoardIndex()
 		$context['membergroups'] = cache_quick_get('membergroup_list', 'Subs-Membergroups.php', 'cache_getMembergroupList', array());
 
 	// And back to normality.
-	$context['page_title'] = sprintf($txt['forum_index'], un_htmlspecialchars($context['forum_name']));
+	$context['page_title'] = sprintf($txt['forum_index'], $context['forum_name']);
 
 	// Mark read button
 	$context['mark_read_button'] = array(

--- a/Sources/Load.php
+++ b/Sources/Load.php
@@ -1756,7 +1756,7 @@ function loadTheme($id_theme = 0, $initialize = true)
 	$context['session_var'] = $_SESSION['session_var'];
 	$context['session_id'] = $_SESSION['session_value'];
 	$context['forum_name'] = $mbname;
-	$context['forum_name_html_safe'] = $context['forum_name'];
+	$context['forum_name_html_safe'] = $smcFunc['htmlspecialchars']($context['forum_name']);
 	$context['header_logo_url_html_safe'] = empty($settings['header_logo_url']) ? '' : $smcFunc['htmlspecialchars']($settings['header_logo_url']);
 	$context['current_action'] = isset($_REQUEST['action']) ? $smcFunc['htmlspecialchars']($_REQUEST['action']) : null;
 	$context['current_subaction'] = isset($_REQUEST['sa']) ? $_REQUEST['sa'] : null;

--- a/Sources/ManageServer.php
+++ b/Sources/ManageServer.php
@@ -983,10 +983,6 @@ function saveSettings(&$config_vars)
 	// All the checkboxes
 	$config_bools = array('db_persist', 'db_error_send', 'maintenance', 'image_proxy_enabled');
 
-	// No sneaky stuff...
-	$_POST['mbname'] = $smcFunc['htmlspecialchars']($_POST['mbname']);
-	$_POST['mtitle'] = $smcFunc['htmlspecialchars']($_POST['mtitle']);
-
 	// Now sort everything into a big array, and figure out arrays and etc.
 	$new_settings = array();
 	// Figure out which config vars we're saving here...

--- a/Sources/PersonalMessage.php
+++ b/Sources/PersonalMessage.php
@@ -1094,7 +1094,7 @@ function prepareMessageContext($type = 'subject', $reset = false)
 		$memberContext[$message['id_member_from']]['id'] = 0;
 
 		// Sometimes the forum sends messages itself (Warnings are an example) - in this case don't label it from a guest.
-		$memberContext[$message['id_member_from']]['group'] = $message['from_name'] == $context['forum_name'] ? '' : $txt['guest_title'];
+		$memberContext[$message['id_member_from']]['group'] = $message['from_name'] == $context['forum_name_html_safe'] ? '' : $txt['guest_title'];
 		$memberContext[$message['id_member_from']]['link'] = $message['from_name'];
 		$memberContext[$message['id_member_from']]['email'] = '';
 		$memberContext[$message['id_member_from']]['show_email'] = false;

--- a/Sources/Subs-Auth.php
+++ b/Sources/Subs-Auth.php
@@ -173,7 +173,7 @@ function KickGuest()
  */
 function InMaintenance()
 {
-	global $txt, $mtitle, $mmessage, $context;
+	global $txt, $mtitle, $mmessage, $context, $smcFunc;
 
 	loadLanguage('Login');
 	loadTemplate('Login');
@@ -184,7 +184,7 @@ function InMaintenance()
 
 	// Basic template stuff..
 	$context['sub_template'] = 'maintenance';
-	$context['title'] = &$mtitle;
+	$context['title'] = $smcFunc['htmlspecialchars']($mtitle);
 	$context['description'] = &$mmessage;
 	$context['page_title'] = $txt['maintain_mode'];
 }

--- a/Themes/default/Help.template.php
+++ b/Themes/default/Help.template.php
@@ -154,7 +154,7 @@ function template_manual()
 			</div>
 			<div id="help_container">
 				<div id="helpmain" class="windowbg2">
-					<p>', sprintf($txt['manual_welcome'], $context['forum_name']), '</p>
+					<p>', sprintf($txt['manual_welcome'], $context['forum_name_html_safe']), '</p>
 					<p>', $txt['manual_introduction'], '</p>
 					<ul>';
 
@@ -179,7 +179,7 @@ function template_terms()
 		echo '
 			<div class="cat_bar">
 				<h3 class="catbg">
-					', $txt['terms_and_rules'], ' - ', $context['forum_name'], '
+					', $txt['terms_and_rules'], ' - ', $context['forum_name_html_safe'], '
 				</h3>
 			</div>
 			<div class="roundframe">

--- a/Themes/default/index.template.php
+++ b/Themes/default/index.template.php
@@ -201,7 +201,7 @@ function template_body_above()
 	else
 		echo '
 			<ul class="floatleft welcome">
-				<li>', sprintf($txt[$context['can_register'] ? 'welcome_guest_register' : 'welcome_guest'], $txt['guest_title'], $context['forum_name'], $scripturl . '?action=login', 'return reqOverlayDiv(this.href, ' . JavaScriptEscape($txt['login']) . ');', $scripturl . '?action=signup'), '</li>
+				<li>', sprintf($txt[$context['can_register'] ? 'welcome_guest_register' : 'welcome_guest'], $txt['guest_title'], $context['forum_name_html_safe'], $scripturl . '?action=login', 'return reqOverlayDiv(this.href, ' . JavaScriptEscape($txt['login']) . ');', $scripturl . '?action=signup'), '</li>
 			</ul>';
 
 	if (!empty($context['languages']))
@@ -271,7 +271,7 @@ function template_body_above()
 	<div id="header">
 		<div class="frame">
 			<h1 class="forumtitle">
-				<a id="top" href="', $scripturl, '">', empty($context['header_logo_url_html_safe']) ? $context['forum_name'] : '<img src="' . $context['header_logo_url_html_safe'] . '" alt="' . $context['forum_name'] . '">', '</a>
+				<a id="top" href="', $scripturl, '">', empty($context['header_logo_url_html_safe']) ? $context['forum_name_html_safe'] : '<img src="' . $context['header_logo_url_html_safe'] . '" alt="' . $context['forum_name_html_safe'] . '">', '</a>
 			</h1>';
 
 	echo '

--- a/Themes/default/languages/Who.english.php
+++ b/Themes/default/languages/Who.english.php
@@ -116,7 +116,7 @@ $txt['whoallow_viewmembers'] = 'Viewing a list of members.';
 
 $txt['who_topic'] = 'Viewing the topic <a href="' . $scripturl . '?topic=%1$d.0">%2$s</a>.';
 $txt['who_board'] = 'Viewing the board <a href="' . $scripturl . '?board=%1$d.0">%2$s</a>.';
-$txt['who_index'] = 'Viewing the board index of <a href="' . $scripturl . '">' . $context['forum_name'] . '</a>.';
+$txt['who_index'] = 'Viewing the board index of <a href="' . $scripturl . '">' . $context['forum_name_html_safe'] . '</a>.';
 $txt['who_viewprofile'] = 'Viewing <a href="' . $scripturl . '?action=profile;u=%1$d">%2$s</a>\'s profile.';
 $txt['who_viewownprofile'] = 'Viewing <a href="' . $scripturl . '?action=profile;u=%1$d">their own profile</a>.';
 $txt['who_profile'] = 'Editing the profile of <a href="' . $scripturl . '?action=profile;u=%1$d">%2$s</a>.';


### PR DESCRIPTION
This will do the following:
1. Sanitize maintenance mode title only where it's used. Trying to sanitize it in the admin center will result in it being sanitized multiple times since SMF htmlspecialchars()'s things before displaying the values for editing.
2. Use $context['forum_name_html_safe'] in place of $context['forum_name'] in many places where we're using it in the template. $context['forum_name'] is used too many places to have it sanitized all the time, plus it would be sanitized multiple times whenever you go to edit server settings.

Signed-off-by: Michael Eshom oldiesmann@oldiesmann.us
