### PR TITLE
! The menu code didn't handle invalid "current_area" values properly, wh...

### DIFF
--- a/Sources/Subs-Menu.php
+++ b/Sources/Subs-Menu.php
@@ -200,27 +200,27 @@ function createMenu($menuData, $menuOptions = array())
 							}
 						}
 					}
-				}
 
-				// Is this the current section?
-				if ($menu_context['current_area'] == $area_id && empty($found_section))
-				{
-					// Only do this once?
-					$found_section = true;
+					// Is this the current section?
+					if ($menu_context['current_area'] == $area_id && empty($found_section))
+					{
+						// Only do this once?
+						$found_section = true;
 
-					// Update the context if required - as we can have areas pretending to be others. ;)
-					$menu_context['current_section'] = $section_id;
-					$menu_context['current_area'] = isset($area['select']) ? $area['select'] : $area_id;
+						// Update the context if required - as we can have areas pretending to be others. ;)
+						$menu_context['current_section'] = $section_id;
+						$menu_context['current_area'] = isset($area['select']) ? $area['select'] : $area_id;
 
-					// This will be the data we return.
-					$include_data = $area;
-				}
-				// Make sure we have something in case it's an invalid area.
-				elseif (empty($found_section) && empty($include_data))
-				{
-					$menu_context['current_section'] = $section_id;
-					$backup_area = isset($area['select']) ? $area['select'] : $area_id;
-					$include_data = $area;
+						// This will be the data we return.
+						$include_data = $area;
+					}
+					// Make sure we have something in case it's an invalid area.
+					elseif (empty($found_section) && empty($include_data))
+					{
+						$menu_context['current_section'] = $section_id;
+						$backup_area = isset($area['select']) ? $area['select'] : $area_id;
+						$include_data = $area;
+					}
 				}
 			}
 		}
@@ -228,6 +228,10 @@ function createMenu($menuData, $menuOptions = array())
 
 	// Should we use a custom base url, or use the default?
 	$menu_context['base_url'] = isset($menuOptions['base_url']) ? $menuOptions['base_url'] : $scripturl . '?action=' . $menu_context['current_action'];
+
+	// If we didn't find the area we were looking for go to a default one.
+	if (isset($backup_area) && empty($found_section))
+		$menu_context['current_area'] = $backup_area;
 
 	// If there are sections quickly goes through all the sections to check if the base menu has an url
 	if (!empty($menu_context['current_section']))
@@ -247,10 +251,6 @@ function createMenu($menuData, $menuOptions = array())
 				}
 			}
 	}
-
-	// If we didn't find the area we were looking for go to a default one.
-	if (isset($backup_area) && empty($found_section))
-		$menu_context['current_area'] = $backup_area;
 
 	// If still no data then return - nothing to show!
 	if (empty($menu_context['sections']))


### PR DESCRIPTION
...ich could cause errors (fixes #2414)

This just moves two sections of code to fix a couple of issues:
1. The $backup_area, which is used as the current area if we didn't find a section for the original "current area", was being set outside the loop that goes through each area, which would result in it being set to the _last_ area of a section, rather than the first.
2. The current area was not validated and set to $backup_area until after we already specified that its menu item should be selected. This caused the invalid area to be added to the current section's areas, which in turn caused the errors since no menu data was defined for that area.

Signed-off-by: Michael Eshom oldiesmann@oldiesmann.us
