### PR TITLE
Pass the entire likes object

### DIFF
--- a/Sources/Likes.php
+++ b/Sources/Likes.php
@@ -397,11 +397,11 @@ class Likes
 			$call = call_helper($this->_validLikes['callback'], true);
 
 			if (!empty($call))
-				call_user_func_array($call, array($this->_type, $this->_content, $this->_numLikes, empty($this->_alreadyLiked)));
+				call_user_func_array($call, array($this));
 		}
 
 		// Sometimes there might be other things that need updating after we do this like.
-		call_integration_hook('integrate_issue_like', array($this->_type, $this->_content, $this->_numLikes, empty($this->_alreadyLiked)));
+		call_integration_hook('integrate_issue_like', array($this));
 
 		// Now some clean up. This is provided here for any like handlers that want to do any cache flushing.
 		// This way a like handler doesn't need to explicitly declare anything in integrate_issue_like, but do so


### PR DESCRIPTION
While I was working on using the alerts system for my mod, I realize that both the callback and the integrate_issue_like hook doesn't really passes all the info a mod can use.

For example, I'm implementing the likes system for Breeze and I also want to integrate an alert for that, the current hook passes the following info:

$this->_type, $this->_content, $this->_numLikes, empty($this->_alreadyLiked

Which is not enough info to create an alert, a mod will def gonna need the ID of the user who liked the content as well as the  "can_like" and "can_see" info since it will be futile to tell an user that somebody else liked something that the user cannot see.

Yes, I know passing an object is somehow "tabu"... still, its either this or passing a huge amount of arguments.

Signed-off-by: Suki suki@missallsunday.com
