### PR TITLE
adjust bitmask & get_html_translation_table output

### DIFF
--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -793,7 +793,7 @@ function un_htmlspecialchars($string)
 	static $translation = array();
 
 	if (empty($translation))
-		$translation = array_flip(get_html_translation_table(HTML_SPECIALCHARS, ENT_QUOTES)) + array('&#039;' => '\'', '&nbsp;' => ' ');
+		$translation = array_flip(get_html_translation_table(HTML_SPECIALCHARS, ENT_QUOTES | ENT_HTML5)) + array('&#039;' => '\'', '&#39;' => '\'', '&nbsp;' => ' ');
 
 	return strtr($string, $translation);
 }

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -790,10 +790,11 @@ function timeformat($log_time, $show_today = true, $offset_type = false)
  */
 function un_htmlspecialchars($string)
 {
+	global $context;
 	static $translation = array();
 
 	if (empty($translation))
-		$translation = array_flip(get_html_translation_table(HTML_SPECIALCHARS, ENT_QUOTES)) + array('&#039;' => '\'', '&#39;' => '\'', '&nbsp;' => ' ');
+		$translation = array_flip(get_html_translation_table(HTML_SPECIALCHARS, ENT_QUOTES, $context['character_set'])) + array('&#039;' => '\'', '&#39;' => '\'', '&nbsp;' => ' ');
 
 	return strtr($string, $translation);
 }

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -793,7 +793,7 @@ function un_htmlspecialchars($string)
 	static $translation = array();
 
 	if (empty($translation))
-		$translation = array_flip(get_html_translation_table(HTML_SPECIALCHARS, ENT_QUOTES | ENT_HTML5)) + array('&#039;' => '\'', '&#39;' => '\'', '&nbsp;' => ' ');
+		$translation = array_flip(get_html_translation_table(HTML_SPECIALCHARS, ENT_QUOTES)) + array('&#039;' => '\'', '&#39;' => '\'', '&nbsp;' => ' ');
 
 	return strtr($string, $translation);
 }


### PR DESCRIPTION
- the function of get_html_translation_table actually filters spaces to the entity of & # 39; (without the 0) so this has to be added to the replacement array
- the default document charset encoding varies dependant on PHP version and should be specified 

Signed-off-by: -Underdog- github.underdog@gmail.com
