### PR TITLE
Use version_compare on php_version_check()

### DIFF
--- a/other/upgrade.php
+++ b/other/upgrade.php
@@ -2306,10 +2306,7 @@ function updateLastError()
 
 function php_version_check()
 {
-	$minver = explode('.', $GLOBALS['required_php_version']);
-	$curver = explode('.', PHP_VERSION);
-
-	return !(($curver[0] <= $minver[0]) && ($curver[1] <= $minver[1]) && ($curver[1] <= $minver[1]) && ($curver[2] < $minver[2]));
+	return version_compare(PHP_VERSION, $GLOBALS['required_php_version'], '>=');
 }
 
 function db_version_check()


### PR DESCRIPTION
fixes #2423

There are a few redundant checks for PHP 4 and of course Subs-Compat.php I guess its just safer to leave that as it is. 

Signed-off-by: Suki suki@missallsunday.com
