### PR TITLE
Fix moderation alerts being sent for boards

### DIFF
--- a/Sources/tasks/CreatePost-Notify.php
+++ b/Sources/tasks/CreatePost-Notify.php
@@ -116,7 +116,8 @@ class CreatePost_Notify_Background extends SMF_BackgroundTask
 
 				$content_type = 'topic';
 			}
-			else
+			// A new topic in a watched board then?
+			elseif ($type == 'topic')
 			{
 				$pref = !empty($prefs[$member]['board_notify_' . $topicOptions['board']]) ? $prefs[$member]['board_notify_' . $topicOptions['board']] : $prefs[$member]['board_notify'];
 
@@ -124,7 +125,10 @@ class CreatePost_Notify_Background extends SMF_BackgroundTask
 
 				$message_type = !empty($frequency) ? 'notify_boards_once' : 'notify_boards';
 			}
-
+			// If neither of the above, this might be a redundent row due to the OR clause in our SQL query, skip
+			else
+				continue;
+			
 			if (!empty($prefs[$member]['msg_receive_body']) && in_array($type, array('topic', 'reply')))
 				$message_type .= '_body';
 


### PR DESCRIPTION
When a user is subscribed to both, a topic and the board the topic belongs to and the topic has a moderation action then it would also issue a duplicate (but empty) alert for the board as well

Signed-off-by: Shitiz Garg mail@dragooon.net
