### PR TITLE
Fix bugs with spider log

### DIFF
--- a/Sources/ManageSearchEngines.php
+++ b/Sources/ManageSearchEngines.php
@@ -778,14 +778,15 @@ function SpiderLogs()
 	if (!empty($context['spider_logs']['rows']))
 	{
 		$urls = array();
+
 		// Grab the current /url.
 		foreach ($context['spider_logs']['rows'] as $k => $row)
 		{
 			// Feature disabled?
-			if (empty($row['viewing']['value']) && isset($modSettings['spider_mode']) && $modSettings['spider_mode'] < 3)
+			if (empty($row['data']['viewing']['value']) && isset($modSettings['spider_mode']) && $modSettings['spider_mode'] < 3)
 				$context['spider_logs']['rows'][$k]['viewing']['value'] = '<em>' . $txt['spider_disabled'] . '</em>';
 			else
-				$urls[$k] = array($row['viewing']['value'], -1);
+				$urls[$k] = array($row['data']['viewing']['value'], -1);
 		}
 
 		// Now stick in the new URLs.
@@ -793,7 +794,7 @@ function SpiderLogs()
 		$urls = determineActions($urls, 'whospider_');
 		foreach ($urls as $k => $new_url)
 		{
-			$context['spider_logs']['rows'][$k]['viewing']['value'] = $new_url;
+			$context['spider_logs']['rows'][$k]['data']['viewing']['value'] = $new_url;
 		}
 	}
 

--- a/other/install_2-1_mysql.sql
+++ b/other/install_2-1_mysql.sql
@@ -1068,7 +1068,7 @@ CREATE TABLE {$db_prefix}log_spider_hits (
 	id_hit int(10) unsigned NOT NULL auto_increment,
   id_spider smallint(5) unsigned NOT NULL default '0',
   log_time int(10) unsigned NOT NULL default '0',
-  url varchar(255) NOT NULL default '',
+  url varchar(1024) NOT NULL default '',
   processed tinyint(3) NOT NULL default '0',
   PRIMARY KEY (id_hit),
   KEY id_spider(id_spider),

--- a/other/install_2-1_postgresql.sql
+++ b/other/install_2-1_postgresql.sql
@@ -1420,7 +1420,7 @@ CREATE TABLE {$db_prefix}log_spider_hits (
   id_hit int default nextval('{$db_prefix}log_spider_hits_seq'),
   id_spider smallint NOT NULL default '0',
   log_time int NOT NULL default '0',
-  url varchar(255) NOT NULL,
+  url varchar(1024) NOT NULL,
   processed smallint NOT NULL default '0',
   PRIMARY KEY (id_hit)
 );

--- a/other/upgrade_2-1_mysql.sql
+++ b/other/upgrade_2-1_mysql.sql
@@ -1684,3 +1684,11 @@ WHERE variable='enableOpenID' OR variable='dh_keys';
   }
   $smcFunc['db_free_result']($existing_notify);
 ---}
+
+/******************************************************************************/
+--- Fixing the url column in the log_spider_hits table
+/******************************************************************************/
+---#
+ALTER TABLE {$db_prefix}log_spider_hits
+CHANGE `url` `url` varchar(1024) NOT NULL DEFAULT '';
+---#

--- a/other/upgrade_2-1_postgresql.sql
+++ b/other/upgrade_2-1_postgresql.sql
@@ -1789,3 +1789,11 @@ WHERE variable='enableOpenID' OR variable='dh_keys';
   }
   $smcFunc['db_free_result']($existing_notify);
 ---}
+
+/******************************************************************************/
+--- Fixing the url column in the log_spider_hits table
+/******************************************************************************/
+---#
+ALTER TABLE {$db_prefix}log_spider_hits
+ALTER url TYPE varchar(255)
+---#

--- a/other/upgrade_2-1_postgresql.sql
+++ b/other/upgrade_2-1_postgresql.sql
@@ -1795,5 +1795,5 @@ WHERE variable='enableOpenID' OR variable='dh_keys';
 /******************************************************************************/
 ---#
 ALTER TABLE {$db_prefix}log_spider_hits
-ALTER url TYPE varchar(255)
+ALTER url TYPE varchar(255);
 ---#


### PR DESCRIPTION
1. Increase size of "url" column in log_spider_hits to prevent data from getting cut off
2. Change $row['viewing']['value'] to $row['data']['viewing']['value'] to fix issues outlined in #2106.

Fixes #2106 and closes #2108.
