### PR TITLE
Fix for upgrade errors when there is a permission problem

### DIFF
--- a/other/upgrade.php
+++ b/other/upgrade.php
@@ -3502,7 +3502,7 @@ function quickFileWritable($file)
 // This is what is displayed if there's any chmod to be done. If not it returns nothing...
 function template_chmod()
 {
-	global $upcontext, $settings;
+	global $upcontext, $txt, $settings;
 
 	// Don't call me twice!
 	if (!empty($upcontext['chmod_called']))


### PR DESCRIPTION
When upgrading a forum that lacks necessary write permissions, the `template_chmod` function requires the $txt global. Without this fix, the `template_chmod` function generates many error messages. I don't use ftp, but this fix does make the error situation much more readable.

This code apparently was originally added by Spuds, who did a similar fix to Elkarte earlier this year: elkarte/Elkarte@e1d0997aab4549679ea7b5394baff0b1a9aa9e91

Signed-off-by: Noteworthy Software, Inc online@noteworthysoftware.com
