### PR TITLE
Limit max number of characters for password to 72

### DIFF
--- a/Sources/Subs-Password.php
+++ b/Sources/Subs-Password.php
@@ -16,7 +16,9 @@ namespace {
 
 		/**
 		 * Hash the password using the specified algorithm
-		 *
+		 * Limits the maximum length of password to 72, if a longer
+		 * string is supplied the first 72 characters are used
+		 * 
 		 * @param string $password The password to hash
 		 * @param int    $algo     The algorithm to use (Defined by PASSWORD_* constants)
 		 * @param array  $options  The options for the algorithm to use
@@ -35,6 +37,9 @@ namespace {
 			if (!is_int($algo)) {
 				trigger_error("password_hash() expects parameter 2 to be long, " . gettype($algo) . " given", E_USER_WARNING);
 				return null;
+			}
+			if (PasswordCompat\binary\_strlen($password) > 72) {
+				$password = PasswordCompat\binary\_substr($password, 0,72);
 			}
 			$resultLength = 0;
 			switch ($algo) {
@@ -220,6 +225,9 @@ namespace {
 			if (!function_exists('crypt')) {
 				trigger_error("Crypt must be loaded for password_verify to function", E_USER_WARNING);
 				return false;
+			}
+			if (PasswordCompat\binary\_strlen($password) > 72) {
+				$password = PasswordCompat\binary\_substr($password, 0,72);
 			}
 			$ret = crypt($password, $hash);
 			if (!is_string($ret) || PasswordCompat\binary\_strlen($ret) != PasswordCompat\binary\_strlen($hash) || PasswordCompat\binary\_strlen($ret) <= 13) {


### PR DESCRIPTION
Prevents DoS attack from large inputs, same behaviour as PHP 5.5's built-in password_hash
Signed-off-by: Shitiz Garg mail@dragooon.net
