### PR TITLE
Image proxy security improvements

### DIFF
--- a/other/install.php
+++ b/other/install.php
@@ -937,7 +937,7 @@ function ForumSettings()
 			'cachedir' => addslashes(dirname(__FILE__)) . '/cache',
 			'mbname' => strtr($_POST['mbname'], array('\"' => '"')),
 			'language' => substr($_SESSION['installer_temp_lang'], 8, -4),
-			'image_proxy_secret' => substr(sha1(mt_rand()), 0, 8),
+			'image_proxy_secret' => substr(sha1(mt_rand()), 0, 20),
 			'image_proxy_enabled' => !empty($_POST['force_ssl']),
 		);
 

--- a/other/upgrade.php
+++ b/other/upgrade.php
@@ -2077,7 +2077,7 @@ function DeleteUpgrade()
 	}
 
 	require_once($sourcedir . '/Subs-Admin.php');
-	updateSettingsFile(array('image_proxy_secret' => '\'' . substr(sha1(mt_rand()), 0, 8) . '\''));
+	updateSettingsFile(array('image_proxy_secret' => '\'' . substr(sha1(mt_rand()), 0, 20) . '\''));
 
 	// Make sure it says we're done.
 	$upcontext['overall_percent'] = 100;

--- a/proxy.php
+++ b/proxy.php
@@ -93,6 +93,11 @@ class ProxyServer
 			exit;
 		}
 
+		// Make sure we're serving an image
+		$contentParts = explode('/', !empty($cached['content-type']) ? $cached['content-type'] : '');
+		if ($contentParts[0] != 'image')
+			exit;
+
 		header('Content-type: ' . $cached['content_type']);
 		header('Content-length: ' . $cached['size']);
 		echo base64_decode($cached['body']);


### PR DESCRIPTION
Increase default hash length and ensure we're serving an image, fixes #2507 
