### PR TITLE
Set httponly to be true for cookies

### DIFF
--- a/Sources/Subs-Auth.php
+++ b/Sources/Subs-Auth.php
@@ -787,9 +787,9 @@ function rebuildModCache()
  * @param string $path = ''
  * @param string $domain = ''
  * @param bool $secure = false
- * @param bool $httponly = null
+ * @param bool $httponly = true
  */
-function smf_setcookie($name, $value = '', $expire = 0, $path = '', $domain = '', $secure = null, $httponly = null)
+function smf_setcookie($name, $value = '', $expire = 0, $path = '', $domain = '', $secure = null, $httponly = true)
 {
 	global $modSettings;
 

--- a/other/install_2-1_mysql.sql
+++ b/other/install_2-1_mysql.sql
@@ -1842,7 +1842,8 @@ VALUES ('smfVersion', '{$smf_version}'),
 	('gravatarAllowExtraEmail', '1'),
 	('gravatarMaxRating', 'PG'),
 	('defaultMaxListItems', '15'),
-	('loginHistoryDays', '30');
+	('loginHistoryDays', '30'),
+	('httponlyCookies', '1');
 
 # --------------------------------------------------------
 

--- a/other/install_2-1_postgresql.sql
+++ b/other/install_2-1_postgresql.sql
@@ -2349,6 +2349,7 @@ INSERT INTO {$db_prefix}settings (variable, value) VALUES ('gravatarAllowExtraEm
 INSERT INTO {$db_prefix}settings (variable, value) VALUES ('gravatarMaxRating', 'PG');
 INSERT INTO {$db_prefix}settings (variable, value) VALUES ('defaultMaxListItems', '15');
 INSERT INTO {$db_prefix}settings (variable, value) VALUES ('loginHistoryDays', '30');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('httponlyCookies', '1');
 
 # --------------------------------------------------------
 

--- a/other/upgrade_2-1_mysql.sql
+++ b/other/upgrade_2-1_mysql.sql
@@ -146,6 +146,18 @@ INSERT INTO {$db_prefix}settings (variable, value) VALUES ('defaultMaxListItems'
 ---}
 ---#
 
+---# Adding new "httponlyCookies" setting
+---{
+	if (!isset($modSettings['httponlyCookies']))
+		$smcFunc['db_insert']('insert',
+			'{db_prefix}settings',
+			array('variable' => 'string', 'value' => 'string'),
+			array('httponlyCookies', '1'),
+			array()
+		);
+---}
+---#
+
 ---# Calculate appropriate hash cost
 ---{
   $smcFunc['db_insert']('replace',

--- a/other/upgrade_2-1_postgresql.sql
+++ b/other/upgrade_2-1_postgresql.sql
@@ -1223,6 +1223,18 @@ DELETE FROM {$db_prefix}themes
 WHERE variable IN ('show_board_desc', 'no_new_reply_warning', 'display_quick_reply', 'show_mark_read', 'show_member_bar', 'linktree_link', 'show_bbc', 'additional_options_collapsable', 'subject_toggle', 'show_modify', 'show_profile_buttons', 'show_user_images', 'show_blurb', 'show_gender', 'hide_post_group', 'drafts_autosave_enabled');
 ---#
 
+---# Adding new "httponlyCookies" setting
+---{
+	if (!isset($modSettings['httponlyCookies']))
+		$smcFunc['db_insert']('insert',
+			'{db_prefix}settings',
+			array('variable' => 'string', 'value' => 'string'),
+			array('httponlyCookies', '1'),
+			array()
+		);
+---}
+---#
+
 ---# Calculate appropriate hash cost
 ---{
   $smcFunc['db_insert']('replace',


### PR DESCRIPTION
There's no reason to avoid this, http cookies allows protection against XSS attacks by not exposing them to JS and similar scripting languages. Since we don't manipulate cookies on a JS level it shouldn't affect us.

Set it to true by default, if an admin really wants he/she can disable it via ACP

Signed-off-by: Shitiz Garg mail@dragooon.net
