### PR TITLE
Prevent double sanitization of custom profile fields

### DIFF
--- a/Sources/Profile-Modify.php
+++ b/Sources/Profile-Modify.php
@@ -848,7 +848,7 @@ function saveProfileFields()
 		makeThemeChanges($context['id_member'], isset($_POST['id_theme']) ? (int) $_POST['id_theme'] : $old_profile['id_theme']);
 		if (!empty($_REQUEST['sa']))
 		{
-			$custom_fields_errors = makeCustomFieldChanges($context['id_member'], $_REQUEST['sa'], true, true);
+			$custom_fields_errors = makeCustomFieldChanges($context['id_member'], $_REQUEST['sa'], false, true);
 
 			if (!empty($custom_fields_errors))
 				$post_errors = array_merge($post_errors, $custom_fields_errors);


### PR DESCRIPTION
Profile() already recursively htmlspecialchars $_POST, don't let makeCustomFieldChanges() do that twice. Fixes #2575

Signed-off-by: Shitiz Garg mail@dragooon.net
