### PR TITLE
! Assorted merge-related fixes

### DIFF
--- a/Sources/SplitTopics.php
+++ b/Sources/SplitTopics.php
@@ -957,7 +957,7 @@ function MergeIndex()
 	}
 	$smcFunc['db_free_result']($request);
 
-	if (empty($context['topics']) && count($context['boards']) <= 1)
+	if (empty($context['topics']) && count($merge_boards) <= 1 && !in_array(0, $merge_boards))
 		fatal_lang_error('merge_need_more_topics');
 
 	$context['sub_template'] = 'merge';

--- a/Themes/default/SplitTopics.template.php
+++ b/Themes/default/SplitTopics.template.php
@@ -269,39 +269,47 @@ function template_merge()
 			<div class="cat_bar">
 				<h3 class="catbg">', $txt['target_topic'], '</h3>
 			</div>
-			<form action="', $scripturl , '?action=mergetopics;sa=options" method="post" accept-charset="', $context['character_set'], '">
-				<div class="title_bar">
-					<h4 class="titlebg">', $txt['target_below'];
+			<div class="title_bar">
+				<h4 class="titlebg">';
 
-		if (isset($context['merge_categories']))
+	if (isset($context['merge_categories']))
+	{
+		echo '
+					<form action="' . $scripturl . '?action=mergetopics;from=' . $context['origin_topic'] . ';targetboard=' . $context['target_board'] . ';board=' . $context['current_board'] . '.0" method="post" accept-charset="', $context['character_set'], '" id="mergeSelectBoard">
+						', $txt['target_below'], ' (', $txt['board'], ':&nbsp;
+						<select name="targetboard" onchange="this.form.submit();">';
+		foreach ($context['merge_categories'] as $cat)
 		{
-			echo ' (', $txt['board'], ':&nbsp;
-						<form action="' . $scripturl . '?action=mergetopics;from=' . $context['origin_topic'] . ';targetboard=' . $context['target_board'] . ';board=' . $context['current_board'] . '.0" method="post" accept-charset="', $context['character_set'], '">
-							<input type="hidden" name="from" value="' . $context['origin_topic'] . '">
-							<select name="targetboard" onchange="this.form.submit();">';
-			foreach ($context['merge_categories'] as $cat)
+			echo '
+							<optgroup label="', $cat['name'], '">';
+
+			foreach ($cat['boards'] as $board)
 			{
 				echo '
-								<optgroup label="', $cat['name'], '">';
-
-				foreach ($cat['boards'] as $board)
-				{
-					echo '
-									<option value="', $board['id'], '"', $board['selected'] ? ' selected' : '', '>', $board['child_level'] > 0 ? str_repeat('==', $board['child_level'] - 1) . '=&gt;' : '', ' ', $board['name'], '&nbsp;</option>';
-				}
-
-				echo '
-								</optgroup>';
+								<option value="', $board['id'], '"', $board['selected'] ? ' selected' : '', '>', $board['child_level'] > 0 ? str_repeat('==', $board['child_level'] - 1) . '=&gt;' : '', ' ', $board['name'], '&nbsp;</option>';
 			}
+
 			echo '
-							</select>
-							<input type="submit" value="', $txt['go'], '" class="">
-						</form>)';
-
+							</optgroup>';
 		}
+		echo '
+						</select>)
+						<input type="hidden" name="from" value="' . $context['origin_topic'] . '">
+						<input type="submit" value="', $txt['go'], '" class="button_submit">
+					</form>';
 
-		echo '</h4>
-				</div>
+	}
+	else
+		echo $txt['target_below'];
+
+	echo '				</h4>
+			</div>';
+
+	// Don't show this if there aren't any topics...
+	if (!empty($context['topics']))
+	{
+		echo '
+			<form action="', $scripturl, '?action=mergetopics;sa=options" method="post" accept-charset="', $context['character_set'], '">
 				<div class="pagesection">
 					', $context['page_index'], '
 				</div>
@@ -323,8 +331,17 @@ function template_merge()
 				</div>
 				<div class="pagesection">
 					', $context['page_index'], '
-				</div><br>
+				</div>';
+	}
+	else
+	{
+		// Just a nice "There aren't any topics" message
+		echo '
+				<div class="windowbg2">', $txt['topic_alert_none'], '</div>';
+	}
 
+	echo '
+				<br>
 				<div class="title_bar">
 					<h4 class="titlebg">', $txt['target_id'], '</h4>
 				</div>

--- a/Themes/default/css/index.css
+++ b/Themes/default/css/index.css
@@ -167,7 +167,7 @@ ul.reset, ul.reset li {
 }
 
 /* Buttons should be styled a bit differently, in order to make them look more button'ish. */
-#frmLogin input.button_submit, #guest_form input.button_submit, #calendar_navigation input.button_submit {
+#frmLogin input.button_submit, #guest_form input.button_submit, #calendar_navigation input.button_submit, #mergeBoardSelect input.button_submit {
 	float: none;
 	margin-left: inherit;
 }


### PR DESCRIPTION
This fixes #1792 and adds some minor UI tweaks as well.

Fixes:
1. Clicking "Merge Topics" from within a topic resulted in an error if it was the only topic in that board but you could still select other boards.
2. The board selection form caused a session error when selecting a different board due to nested HTML forms (wrong form was being submitted).

UI tweaks:
- Show a friendly message instead of a page index and empty box with "Merge Topics" button when there aren't any topics in the selected board
- Minor tweaks to the board selection form to account for it looking differently when not nested inside a nested form
- Add standard "button_submit" class to board selection form button
- Add ID to form and tweak index.css to prevent previously-mentioned button from being floated to the right

Signed-off-by: Michael Eshom oldiesmann@oldiesmann.us
