### PR TITLE
Prevent username shadowing due to case-sensitive name checks in PostgreSQL

### DIFF
--- a/Sources/Subs-Db-postgresql.php
+++ b/Sources/Subs-Db-postgresql.php
@@ -323,6 +323,9 @@ function smf_db_query($identifier, $db_string, $db_values = array(), $connection
 		'profile_board_stats' => array(
 			'~COUNT\(\*\) \/ MAX\(b.num_posts\)~' => 'CAST(COUNT(*) AS DECIMAL) / CAST(b.num_posts AS DECIMAL)',
 		),
+		'case_insensitive' => array(
+			'~LIKE~' => 'ILIKE',
+		),
 	);
 
 	if (isset($replacements[$identifier]))

--- a/Sources/Subs-Members.php
+++ b/Sources/Subs-Members.php
@@ -920,7 +920,7 @@ function isReservedName($name, $current_ID_MEMBER = 0, $is_name = true, $fatal =
 	$checkName = strtr($name, array('_' => '\\_', '%' => '\\%'));
 
 	// Make sure they don't want someone else's name.
-	$request = $smcFunc['db_query']('', '
+	$request = $smcFunc['db_query']('case_insensitive', '
 		SELECT id_member
 		FROM {db_prefix}members
 		WHERE ' . (empty($current_ID_MEMBER) ? '' : 'id_member != {int:current_member}


### PR DESCRIPTION
Signed-off-by: Milosz Gaczkowski milosz@omgomg.eu

Currently, PostgreSQL will allow case-insensitive logins but case-sensitive registrations. A critical consequence of that is that a newly-registered _UsErNaMe_ may easily shadow _username_, rendering one of them unable to log in. Particularly problematic if all of the forum's admins are targetted.

Overall, it's worth keeping in mind that PostgreSQL's LIKE is case-sensitive, unlike MySQL's LIKE. Since we claim to support PostgreSQL, we should be conscious of this and ensure that the case-insensitive ILIKE is used appropriately. This issue likely affects more than just registrations, but this commit at least deals with the giant security hole.
