### PR TITLE
MySQL fixes

### DIFF
--- a/Sources/DbPackages-mysql.php
+++ b/Sources/DbPackages-mysql.php
@@ -155,7 +155,7 @@ function smf_db_create_table($table_name, $columns, $indexes = array(), $paramet
 
 		while ($row = $smcFunc['db_fetch_assoc']($get_engines))
 		{
-			if ($row['Support'] == 'YES')
+			if ($row['Support'] == 'YES' || $row['Support'] == 'DEFAULT')
 				$engines[] = $row['Engine'];
 		}
 

--- a/other/install.php
+++ b/other/install.php
@@ -1050,7 +1050,7 @@ function DatabasePopulation()
 
 		while ($row = $smcFunc['db_fetch_assoc']($get_engines))
 		{
-			if ($row['Support'] == 'YES')
+			if ($row['Support'] == 'YES' || $row['Support'] == 'DEFAULT')
 				$engines[] = $row['Engine'];
 		}
 
@@ -1064,7 +1064,7 @@ function DatabasePopulation()
 		if (!empty($databases[$db_type]['utf8_support']) && (!empty($databases[$db_type]['utf8_required']) || isset($_POST['utf8'])))
 		{
 			$replaces['{$engine}'] .= ' DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci';
-			$replaces['{$memory}'] .= ' DEFAULT CHARSET=utf8 COLLAGE=utf8_general_ci';
+			$replaces['{$memory}'] .= ' DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci';
 		}
 	}
 


### PR DESCRIPTION
1. Storage engine replacement info in the installer was getting defined after other replacements had been done, preventing tables from getting created
2. Minor code improvements
3. Code didn't properly handle all possible values for "Support" from MySQL's SHOW ENGINES list
