### PR TITLE
Fix missing boards on Topic Maintenance

### DIFF
--- a/Sources/ManageMaintenance.php
+++ b/Sources/ManageMaintenance.php
@@ -228,7 +228,7 @@ function MaintainTopics()
 				'boards' => array()
 			);
 
-		$context['categories'][$row['id_cat']]['boards'][] = array(
+		$context['categories'][$row['id_cat']]['boards'][$row['id_board']] = array(
 			'id' => $row['id_board'],
 			'name' => $row['name'],
 			'child_level' => $row['child_level']


### PR DESCRIPTION
Category's board array needs to be indexed by board ID to be able to be properly sorted
