### PR TITLE
Selected text to quote

### DIFF
--- a/Sources/Display.php
+++ b/Sources/Display.php
@@ -1276,6 +1276,9 @@ function Display()
 	// topic.js
 	loadJavascriptFile('topic.js', array('default_theme' => true, 'defer' => false), 'smf_topic');
 
+	// quotedText.js
+	loadJavascriptFile('quotedText.js', array('default_theme' => true, 'defer' => true), 'smf_quotedText');
+
 	// Mentions
 	if (!empty($modSettings['enable_mentions']) && allowedTo('mention'))
 	{

--- a/Sources/Display.php
+++ b/Sources/Display.php
@@ -961,7 +961,7 @@ function Display()
 	$context['topic_notification'] = !empty($user_info['id']) ? $topicinfo['notify_prefs'] : array();
 	// 0 => unwatched, 1 => normal, 2 => receive alerts, 3 => receive emails
 	$context['topic_notification_mode'] = !$user_info['is_guest'] ? ($context['topic_unwatched'] ? 0 : ($topicinfo['notify_prefs']['pref'] & 0x02 ? 3 : ($topicinfo['notify_prefs']['pref'] & 0x01 ? 2 : 1))) : 0;
-	
+
 	$attachments = array();
 
 	// If there _are_ messages here... (probably an error otherwise :!)

--- a/Sources/Post.php
+++ b/Sources/Post.php
@@ -1172,6 +1172,9 @@ function Post($post_errors = array())
 		loadJavascriptFile('mentions.js', array('default_theme' => true, 'defer' => true), 'smf_mention');
 	}
 
+	// quotedText.js
+	loadJavascriptFile('quotedText.js', array('default_theme' => true, 'defer' => true), 'smf_quotedText');
+
 	// Finally, load the template.
 	if (WIRELESS && WIRELESS_PROTOCOL != 'wap')
 		$context['sub_template'] = WIRELESS_PROTOCOL . '_post';

--- a/Themes/default/Display.template.php
+++ b/Themes/default/Display.template.php
@@ -568,7 +568,7 @@ function template_single_post($message)
 									', $txt['post_awaiting_approval'], '
 								</div>';
 	echo '
-								<div class="inner" id="msg_', $message['id'], '"', $ignoring ? ' style="display:none;"' : '', '>', $message['body'], '</div>
+								<div class="inner" data-msgid="', $post['id'], '" id="msg_', $message['id'], '"', $ignoring ? ' style="display:none;"' : '', '>', $message['body'], '</div>
 							</div>';
 
 	// Assuming there are attachments...
@@ -700,7 +700,7 @@ function template_single_post($message)
 		// Selected quote.
 		if ($context['can_quote'])
 			echo '
-									<li style="display:none;" id="quoteSelected_', $message['id'], '"><a href="javascript:void(0)" data-msg_id="', $message['id'], '" class="quote_selected_button">', $txt['quote_selected_action'] ,'</a></li>';
+									<li style="display:none;" id="quoteSelected_', $message['id'], '"><a href="javascript:void(0)" class="quote_selected_button">', $txt['quote_selected_action'] ,'</a></li>';
 
 		// Can they reply?
 		if ($context['can_quote'])

--- a/Themes/default/Display.template.php
+++ b/Themes/default/Display.template.php
@@ -568,7 +568,7 @@ function template_single_post($message)
 									', $txt['post_awaiting_approval'], '
 								</div>';
 	echo '
-								<div class="inner" data-msgid="', $post['id'], '" id="msg_', $message['id'], '"', $ignoring ? ' style="display:none;"' : '', '>', $message['body'], '</div>
+								<div class="inner" data-msgid="', $message['id'], '" id="msg_', $message['id'], '"', $ignoring ? ' style="display:none;"' : '', '>', $message['body'], '</div>
 							</div>';
 
 	// Assuming there are attachments...

--- a/Themes/default/Display.template.php
+++ b/Themes/default/Display.template.php
@@ -697,6 +697,11 @@ function template_single_post($message)
 		echo '
 								<ul class="quickbuttons">';
 
+		// Selected quote.
+		if ($context['can_quote'])
+			echo '
+									<li style="display:none;" id="quoteSelected_', $message['id'], '"><a href="javascript:void(0)" data-msg_id="', $message['id'], '" class="quote_selected_button">', $txt['quote_selected_action'] ,'</a></li>';
+
 		// Can they reply?
 		if ($context['can_quote'])
 			echo '
@@ -946,6 +951,9 @@ function template_quickreply()
 						sJumpAnchor: "quickreply",
 						bIsFull: true
 					});
+					var oEditorID = "', $context['post_box_name'] ,'";
+					var oEditorObject = oEditorHandle_', $context['post_box_name'], ';
+					var oJumpAnchor = "quickreply";
 				// ]]></script>';
 }
 ?>

--- a/Themes/default/Post.template.php
+++ b/Themes/default/Post.template.php
@@ -804,6 +804,8 @@ function template_main()
 			});';
 
 	echo '
+			var oEditorID = "', $context['post_box_name'] ,'";
+			var oEditorObject = oEditorHandle_', $context['post_box_name'], ';
 		// ]]></script>';
 
 	// If the user is replying to a topic show the previous posts.
@@ -834,6 +836,7 @@ function template_main()
 			{
 				echo '
 					<ul class="quickbuttons" id="msg_', $post['id'], '_quote">
+						<li style="display:none;" id="quoteSelected_', $post['id'], '"><a href="javascript:void(0)" data-msg_id="', $post['id'], '" class="quote_selected_button">', $txt['quote_selected_action'] ,'</a></li>
 						<li id="post_modify"><a href="#postmodify" onclick="return insertQuoteFast(', $post['id'], ');" class="quote_button">', $txt['quote'], '</a></li>
 					</ul>';
 			}

--- a/Themes/default/Post.template.php
+++ b/Themes/default/Post.template.php
@@ -836,7 +836,7 @@ function template_main()
 			{
 				echo '
 					<ul class="quickbuttons" id="msg_', $post['id'], '_quote">
-						<li style="display:none;" id="quoteSelected_', $post['id'], '"><a href="javascript:void(0)" data-msg_id="', $post['id'], '" class="quote_selected_button">', $txt['quote_selected_action'] ,'</a></li>
+						<li style="display:none;" id="quoteSelected_', $post['id'], '" data-msgid="', $post['id'], '"><a href="javascript:void(0)" class="quote_selected_button">', $txt['quote_selected_action'] ,'</a></li>
 						<li id="post_modify"><a href="#postmodify" onclick="return insertQuoteFast(', $post['id'], ');" class="quote_button">', $txt['quote'], '</a></li>
 					</ul>';
 			}
@@ -854,7 +854,7 @@ function template_main()
 			}
 
 			echo '
-					<div class="list_posts smalltext" id="msg_', $post['id'], '_body">', $post['message'], '</div>
+					<div class="list_posts smalltext" id="msg_', $post['id'], '_body" data-msgid="', $post['id'], '">', $post['message'], '</div>
 				</div>
 			</div>';
 		}

--- a/Themes/default/css/index.css
+++ b/Themes/default/css/index.css
@@ -1389,7 +1389,7 @@ ul li.greeting {
 .quickbuttons a:hover {
 	color: #a70;
 }
-.quickbuttons li a.quote_button {
+.quickbuttons li a.quote_button, .quickbuttons li a.quote_selected_button {
 	background-position: 0 -1px;
 	padding: 0 2px 0 20px;
 }

--- a/Themes/default/languages/index.english.php
+++ b/Themes/default/languages/index.english.php
@@ -419,6 +419,7 @@ $txt['code_select'] = '[Select]';
 $txt['quote_from'] = 'Quote from';
 $txt['quote'] = 'Quote';
 $txt['quote_action'] = 'Quote';
+$txt['quote_selected_action'] = 'Quote selected text';
 $txt['fulledit'] = 'Full&nbsp;edit';
 $txt['edit'] = 'Edit';
 $txt['quick_edit'] = 'Quick Edit';

--- a/Themes/default/scripts/quotedText.js
+++ b/Themes/default/scripts/quotedText.js
@@ -94,7 +94,7 @@ $(function() {
 		// Do we have some selected text?
 		if (typeof oSelected.text == 'undefined' || oSelected.text == false)
 			return false;
-console.log(oSelected);
+
 		// Show the "quote this" button.
 		$('#quoteSelected_' + oSelected.msgID).show();
 

--- a/Themes/default/scripts/quotedText.js
+++ b/Themes/default/scripts/quotedText.js
@@ -1,0 +1,107 @@
+function getSelectedText(divID)
+{
+	if (typeof divID == 'undefined' || divID == false)
+		return false;
+
+	var text = '',
+	selection,
+	found = 0;
+
+	if (window.getSelection)
+	{
+		selection = window.getSelection();
+		text = selection.toString();
+	}
+	else if (document.selection && document.selection.type != 'Control')
+	{
+		selection = document.selection.createRange();
+		text = selection.text;
+	}
+
+	// Need to be sure the selected text does belong to the right div.
+	for (var i = 0; i < selection.rangeCount; i++) {
+			s = selection.getRangeAt(i).startContainer.parentNode.id;
+			e = selection.getRangeAt(i).endContainer.parentNode.id;
+
+			if (s == divID || (s != divID && e == 'child'))
+			{
+				found = 1;
+				break;
+			}
+		}
+
+	return found === 1 ? text : false;
+}
+
+function quotedTextClick(oOptions)
+{
+		text = '';
+
+		// The process has been started, hide the button.
+		$('#quoteSelected_' + oOptions.msgID).hide();
+
+		// Do a call to make sure this is a valid message.
+		$.ajax({
+			url: smf_prepareScriptUrl(smf_scripturl) + 'action=quotefast;quote=' + oOptions.msgID + ';xml;pb='+ oEditorID + ';mode=' + (oEditorObject.bRichTextEnabled ? 1 : 0),
+			type: 'GET',
+			dataType: 'xml',
+			beforeSend: function () {
+				ajax_indicator(true);
+			},
+			success: function (data, textStatus, xhr) {
+				// Search the xml data to get the quote tag.
+				text = $(data).find('quote').text();
+
+				// Insert the selected text between the quotes BBC tags.
+				text = text.match(/^\[quote(.*)]/ig) + oOptions.text + '[/quote]' + '\n\n';
+
+				// Add the whole text to the editor's instance.
+				$('#' + oEditorID).data('sceditor').InsertText(text);
+
+				// Move the view to the quick reply box.
+				if (navigator.appName == 'Microsoft Internet Explorer')
+					window.location.hash = oJumpAnchor;
+				else
+					window.location.hash = '#' + oJumpAnchor;
+
+				ajax_indicator(false);
+			},
+			error: function (xhr, textStatus, errorThrown) {
+				ajax_indicator(false);
+			}
+		});
+}
+
+$(function() {
+
+	// Event for handling selected quotes.
+	$(document).on('mouseup', '.inner', function() {
+
+		// Get everything we need.
+		var oSelected = {
+			divID : $(this).attr('id'),
+			msgID : $(this).attr('id').replace('msg_',''),
+			reference : 'selectQuotedText' + $(this).attr('id')
+		};
+
+		// If the button is already visible, hide it!
+		$('#quoteSelected_' + oSelected.divID).hide();
+
+		// Get any selected text.
+		oSelected.text = getSelectedText(oSelected.divID);
+
+		// Do we have some selected text?
+		if (typeof oSelected.text == 'undefined' || oSelected.text == false)
+			return false;
+
+		// Show the "quote this" button.
+		$('#quoteSelected_' + oSelected.msgID).show();
+		
+			$(document).one('click', '#quoteSelected_' + oSelected.msgID + ' a', function(e){
+				e.preventDefault();
+				quotedTextClick(oSelected);
+			});
+
+		return false;
+	});
+});

--- a/Themes/default/scripts/quotedText.js
+++ b/Themes/default/scripts/quotedText.js
@@ -58,11 +58,13 @@ function quotedTextClick(oOptions)
 				// Add the whole text to the editor's instance.
 				$('#' + oEditorID).data('sceditor').InsertText(text);
 
-				// Move the view to the quick reply box.
-				if (navigator.appName == 'Microsoft Internet Explorer')
-					window.location.hash = oJumpAnchor;
-				else
-					window.location.hash = '#' + oJumpAnchor;
+				// Move the view to the quick reply box. If available.
+				if (typeof oJumpAnchor != 'undefined'){
+					if (navigator.appName == 'Microsoft Internet Explorer')
+						window.location.hash = oJumpAnchor;
+					else
+						window.location.hash = '#' + oJumpAnchor;
+				}
 
 				ajax_indicator(false);
 			},
@@ -75,7 +77,7 @@ function quotedTextClick(oOptions)
 $(function() {
 
 	// Event for handling selected quotes.
-	$(document).on('mouseup', '.inner', function() {
+	$(document).on('mouseup', '.inner, .list_posts', function() {
 
 		// Get everything we need.
 		var oSelected = {
@@ -96,7 +98,7 @@ $(function() {
 
 		// Show the "quote this" button.
 		$('#quoteSelected_' + oSelected.msgID).show();
-		
+
 			$(document).one('click', '#quoteSelected_' + oSelected.msgID + ' a', function(e){
 				e.preventDefault();
 				quotedTextClick(oSelected);

--- a/Themes/default/scripts/quotedText.js
+++ b/Themes/default/scripts/quotedText.js
@@ -82,8 +82,7 @@ $(function() {
 		// Get everything we need.
 		var oSelected = {
 			divID : $(this).attr('id'),
-			msgID : $(this).attr('id').replace('msg_',''),
-			reference : 'selectQuotedText' + $(this).attr('id')
+			msgID : $(this).data('msgid'),
 		};
 
 		// If the button is already visible, hide it!
@@ -95,7 +94,7 @@ $(function() {
 		// Do we have some selected text?
 		if (typeof oSelected.text == 'undefined' || oSelected.text == false)
 			return false;
-
+console.log(oSelected);
 		// Show the "quote this" button.
 		$('#quoteSelected_' + oSelected.msgID).show();
 

--- a/Themes/default/scripts/quotedText.js
+++ b/Themes/default/scripts/quotedText.js
@@ -86,7 +86,7 @@ $(function() {
 		};
 
 		// If the button is already visible, hide it!
-		$('#quoteSelected_' + oSelected.divID).hide();
+		$('#quoteSelected_' + oSelected.msgID).hide();
 
 		// Get any selected text.
 		oSelected.text = getSelectedText(oSelected.divID);

--- a/Themes/default/scripts/topic.js
+++ b/Themes/default/scripts/topic.js
@@ -257,6 +257,7 @@ QuickReply.prototype.quote = function (iMessageId, xDeprecated)
 			ajax_indicator(true);
 			if (this.bIsFull)
 				insertQuoteFast(iMessageId);
+
 			else
 				getXMLDocument(smf_prepareScriptUrl(this.opt.sScriptUrl) + 'action=quotefast;quote=' + iMessageId + ';xml', this.onQuoteReceived);
 		}
@@ -760,18 +761,91 @@ function ignore_toggles(msgids, text)
 	}
 }
 
-// Likes count for messages.
+function getSelectedText()
+{
+    var text = '';
+    if (window.getSelection)
+	{
+		text = window.getSelection().toString();
+	}
+	else if(document.getSelection){
+		return document.getSelection();
+	}
+	else if (document.selection && document.selection.type != 'Control')
+	{
+		text = document.selection.createRange().text;
+	}
+
+	return text;
+}
+
+// On document ready.
 $(function() {
+
+	// Event for handling selected quotes.
+	$(document).on('mouseup', '.inner', function() {
+
+		// Get any selected text.
+		var oSelectedText = getSelectedText();
+
+		// Get the message ID.
+		var oSelectedID = $(this).attr('id').replace('msg_','');
+
+		// If the button is already visible, hide it!
+		$('#quoteSelected_' + oSelectedID).hide();
+
+		// Do we have some selected text?
+		if (!oSelectedText)
+			return false;
+
+		// Show the "quote this" button.
+		$('#quoteSelected_' + oSelectedID).show();
+
+		// append an onclick event to this very own anchor tag.
+		$(document).one('click', '#quoteSelected_' + oSelectedID + ' a', function(e){
+			e.preventDefault();
+			var text = '';
+
+			$.ajax({
+				url: smf_prepareScriptUrl(smf_scripturl) + 'action=quotefast;quote=' + oSelectedID + ';xml;pb='+ oEditorID + ';mode=' + (oEditorObject.bRichTextEnabled ? 1 : 0),
+				type: 'GET',
+				dataType: 'xml',
+				beforeSend: function () {
+					ajax_indicator(true);
+				},
+				success: function (data, textStatus, xhr) {
+					text = $(data).find('quote').text();
+
+					text = text.match(/^\[quote(.*)]/ig) + oSelectedText + '[/quote]' + '\n\n';
+
+					$('#' + oEditorID).data('sceditor').InsertText(text);
+
+					// Move the view to the quick reply box.
+					if (navigator.appName == 'Microsoft Internet Explorer')
+						window.location.hash = oJumpAnchor;
+					else
+						window.location.hash = '#' + oJumpAnchor;
+
+					ajax_indicator(false);
+				},
+				error: function (xhr, textStatus, errorThrown) {
+					ajax_indicator(false);
+				}
+			});
+		});
+
+		return false;
+	});
+
+	// Likes count for messages.
 	$(document).on('click', '.like_count a', function(e){
 		e.preventDefault();
 		var title = $(this).parent().text(),
 			url = $(this).attr('href') + ';js=1';
 		return reqOverlayDiv(url, title);
 	});
-});
 
-// Message likes.
-$(function() {
+	// Message likes.
 	$(document).on('click', '.msg_like', function(event){
 		var obj = $(this);
 		event.preventDefault();

--- a/Themes/default/scripts/topic.js
+++ b/Themes/default/scripts/topic.js
@@ -836,6 +836,9 @@ $(function() {
 					ajax_indicator(false);
 				}
 			});
+
+			// The process has been done, hide the button.
+			$('#quoteSelected_' + oSelectedID).hide();
 		});
 
 		return false;

--- a/Themes/default/scripts/topic.js
+++ b/Themes/default/scripts/topic.js
@@ -806,6 +806,9 @@ $(function() {
 			e.preventDefault();
 			var text = '';
 
+			// The process has been started, hide the button.
+			$('#quoteSelected_' + oSelectedID).hide();
+
 			// Do a call to make sure this is a valid message.
 			$.ajax({
 				url: smf_prepareScriptUrl(smf_scripturl) + 'action=quotefast;quote=' + oSelectedID + ';xml;pb='+ oEditorID + ';mode=' + (oEditorObject.bRichTextEnabled ? 1 : 0),
@@ -836,9 +839,6 @@ $(function() {
 					ajax_indicator(false);
 				}
 			});
-
-			// The process has been done, hide the button.
-			$('#quoteSelected_' + oSelectedID).hide();
 		});
 
 		return false;

--- a/Themes/default/scripts/topic.js
+++ b/Themes/default/scripts/topic.js
@@ -801,11 +801,12 @@ $(function() {
 		// Show the "quote this" button.
 		$('#quoteSelected_' + oSelectedID).show();
 
-		// append an onclick event to this very own anchor tag.
+		// Append an on-click event to this very own anchor tag.
 		$(document).one('click', '#quoteSelected_' + oSelectedID + ' a', function(e){
 			e.preventDefault();
 			var text = '';
 
+			// Do a call to make sure this is a valid message.
 			$.ajax({
 				url: smf_prepareScriptUrl(smf_scripturl) + 'action=quotefast;quote=' + oSelectedID + ';xml;pb='+ oEditorID + ';mode=' + (oEditorObject.bRichTextEnabled ? 1 : 0),
 				type: 'GET',
@@ -814,10 +815,13 @@ $(function() {
 					ajax_indicator(true);
 				},
 				success: function (data, textStatus, xhr) {
+					// Search the xml data to get the quote tag.
 					text = $(data).find('quote').text();
 
+					// Insert the selected text between the quotes BBC tags.
 					text = text.match(/^\[quote(.*)]/ig) + oSelectedText + '[/quote]' + '\n\n';
 
+					// Add the whole text to the editor's instance.
 					$('#' + oEditorID).data('sceditor').InsertText(text);
 
 					// Move the view to the quick reply box.

--- a/Themes/default/scripts/topic.js
+++ b/Themes/default/scripts/topic.js
@@ -761,88 +761,8 @@ function ignore_toggles(msgids, text)
 	}
 }
 
-function getSelectedText()
-{
-    var text = '';
-    if (window.getSelection)
-	{
-		text = window.getSelection().toString();
-	}
-	else if(document.getSelection){
-		text = document.getSelection();
-	}
-	else if (document.selection && document.selection.type != 'Control')
-	{
-		text = document.selection.createRange().text;
-	}
-
-	return text;
-}
-
 // On document ready.
 $(function() {
-
-	// Event for handling selected quotes.
-	$(document).on('mouseup', '.inner', function() {
-
-		// Get any selected text.
-		var oSelectedText = getSelectedText();
-
-		// Get the message ID.
-		var oSelectedID = $(this).attr('id').replace('msg_','');
-
-		// If the button is already visible, hide it!
-		$('#quoteSelected_' + oSelectedID).hide();
-
-		// Do we have some selected text?
-		if (!oSelectedText)
-			return false;
-
-		// Show the "quote this" button.
-		$('#quoteSelected_' + oSelectedID).show();
-
-		// Append an on-click event to this very own anchor tag.
-		$(document).one('click', '#quoteSelected_' + oSelectedID + ' a', function(e){
-			e.preventDefault();
-			var text = '';
-
-			// The process has been started, hide the button.
-			$('#quoteSelected_' + oSelectedID).hide();
-
-			// Do a call to make sure this is a valid message.
-			$.ajax({
-				url: smf_prepareScriptUrl(smf_scripturl) + 'action=quotefast;quote=' + oSelectedID + ';xml;pb='+ oEditorID + ';mode=' + (oEditorObject.bRichTextEnabled ? 1 : 0),
-				type: 'GET',
-				dataType: 'xml',
-				beforeSend: function () {
-					ajax_indicator(true);
-				},
-				success: function (data, textStatus, xhr) {
-					// Search the xml data to get the quote tag.
-					text = $(data).find('quote').text();
-
-					// Insert the selected text between the quotes BBC tags.
-					text = text.match(/^\[quote(.*)]/ig) + oSelectedText + '[/quote]' + '\n\n';
-
-					// Add the whole text to the editor's instance.
-					$('#' + oEditorID).data('sceditor').InsertText(text);
-
-					// Move the view to the quick reply box.
-					if (navigator.appName == 'Microsoft Internet Explorer')
-						window.location.hash = oJumpAnchor;
-					else
-						window.location.hash = '#' + oJumpAnchor;
-
-					ajax_indicator(false);
-				},
-				error: function (xhr, textStatus, errorThrown) {
-					ajax_indicator(false);
-				}
-			});
-		});
-
-		return false;
-	});
 
 	// Likes count for messages.
 	$(document).on('click', '.like_count a', function(e){

--- a/Themes/default/scripts/topic.js
+++ b/Themes/default/scripts/topic.js
@@ -769,7 +769,7 @@ function getSelectedText()
 		text = window.getSelection().toString();
 	}
 	else if(document.getSelection){
-		return document.getSelection();
+		text = document.getSelection();
 	}
 	else if (document.selection && document.selection.type != 'Control')
 	{


### PR DESCRIPTION
As per this www.simplemachines.org/community/index.php?topic=533350.0

This PR offers pretty basic support for handling selected text to quote.

It uses a separate quote button, this button will appear on mouseup event if the user selected some text on that .inner div

It was build to be as unobtrusive as possible to not mess up with the existing quote system so everything is contained in a single mouseup event.

The quickbuttons sf-js-enabled sf-arrows li does not really like long text so the text I chose for this: "Quote selected text" looks weird.

I deliberately did not include the check on XMLHttpRequest

Needs tons of testing of course.
