### PR TITLE
Buddy alert

### DIFF
--- a/Sources/Profile-Modify.php
+++ b/Sources/Profile-Modify.php
@@ -1911,6 +1911,7 @@ function alert_configuration($memID)
 			'member_register' => array('alert' => 'yes', 'email' => 'yes', 'permission' => array('name' => 'moderate_forum', 'is_board' => false)),
 			'request_group' => array('alert' => 'yes', 'email' => 'yes'),
 			'warn_any' => array('alert' => 'yes', 'email' => 'yes', 'permission' => array('name' => 'issue_warning', 'is_board' => false)),
+			'buddy_request'  => array('alert' => 'yes', 'email' => 'never'),
 		),
 		'calendar' => array(
 			'event_new' => array('alert' => 'yes', 'email' => 'yes', 'help' => 'alert_event_new'),

--- a/Sources/Subs-Members.php
+++ b/Sources/Subs-Members.php
@@ -1271,8 +1271,8 @@ function BuddyListToggle()
 				array('task_file' => 'string', 'task_class' => 'string', 'task_data' => 'string', 'claimed_time' => 'int'),
 				array('$sourcedir/tasks/Buddy-Notify.php', 'Buddy_Notify_Background', serialize(array(
 					'receiver_id' => $userReceiver,
-					'sender_id' => $user_info['id'],
-					'sender_username' => $user_info['username'],
+					'id_member' => $user_info['id'],
+					'member_name' => $user_info['username'],
 					'time' => time(),
 				)), 0),
 				array('id_task')

--- a/Sources/Subs-Members.php
+++ b/Sources/Subs-Members.php
@@ -1242,29 +1242,52 @@ function reattributePosts($memID, $email = false, $membername = false, $post_cou
  */
 function BuddyListToggle()
 {
-	global $user_info;
+	global $user_info, $smcFunc;
 
 	checkSession('get');
 
 	isAllowedTo('profile_identity_own');
 	is_not_guest();
 
-	if (empty($_REQUEST['u']))
+	$userReceiver = (int) !empty($_REQUEST['u']) ? $_REQUEST['u'] : 0;
+
+	if (empty($userReceiver))
 		fatal_lang_error('no_access', false);
-	$_REQUEST['u'] = (int) $_REQUEST['u'];
 
 	// Remove if it's already there...
-	if (in_array($_REQUEST['u'], $user_info['buddies']))
-		$user_info['buddies'] = array_diff($user_info['buddies'], array($_REQUEST['u']));
+	if (in_array($userReceiver, $user_info['buddies']))
+		$user_info['buddies'] = array_diff($user_info['buddies'], array($userReceiver));
+
 	// ...or add if it's not and if it's not you.
-	elseif ($user_info['id'] != $_REQUEST['u'])
-		$user_info['buddies'][] = (int) $_REQUEST['u'];
+	elseif ($user_info['id'] != $userReceiver)
+	{
+		$user_info['buddies'][] = $userReceiver;
+
+		// And add a nice alert. Don't abuse though!
+		if ((cache_get_data('Buddy-sent-'. $user_info['id'] .'-'. $userReceiver, 86400)) == null)
+		{
+			$smcFunc['db_insert']('insert',
+				'{db_prefix}background_tasks',
+				array('task_file' => 'string', 'task_class' => 'string', 'task_data' => 'string', 'claimed_time' => 'int'),
+				array('$sourcedir/tasks/Buddy-Notify.php', 'Buddy_Notify_Background', serialize(array(
+					'receiver_id' => $userReceiver,
+					'sender_id' => $user_info['id'],
+					'sender_username' => $user_info['username'],
+					'time' => time(),
+				)), 0),
+				array('id_task')
+			);
+
+			// Store this in a cache entry to avoid creating multiple alerts. Give it a long life cycle.
+			cache_put_data('Buddy-sent-'. $user_info['id'] .'-'. $userReceiver, '1', 86400);
+		}
+	}
 
 	// Update the settings.
 	updateMemberData($user_info['id'], array('buddy_list' => implode(',', $user_info['buddies'])));
 
 	// Redirect back to the profile
-	redirectexit('action=profile;u=' . $_REQUEST['u']);
+	redirectexit('action=profile;u=' . $userReceiver);
 }
 
 /**

--- a/Sources/tasks/Buddy-Notify.php
+++ b/Sources/tasks/Buddy-Notify.php
@@ -21,9 +21,9 @@ class Buddy_Notify_Background extends SMF_BackgroundTask
 
 		// Figure out if the user wants to be notified.
 		require_once($sourcedir . '/Subs-Notify.php');
-		$prefs = getNotifyPrefs($this->_details['receiver_id'], 'request_buddy', true);
+		$prefs = getNotifyPrefs($this->_details['receiver_id'], 'buddy_request', true);
 
-		if ($prefs[$this->_details['receiver_id']]['request_buddy'])
+		if ($prefs[$this->_details['receiver_id']]['buddy_request'])
 		{
 			$alert_row = array(
 				'alert_time' => $this->_details['time'],

--- a/Sources/tasks/Buddy-Notify.php
+++ b/Sources/tasks/Buddy-Notify.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * This task handles notifying someone that an user has added him/her as his/her buddy.
+ *
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines http://www.simplemachines.org
+ * @copyright 2015 Simple Machines and individual contributors
+ * @license http://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 2.1 Beta 1
+ */
+
+class Buddy_Notify_Background extends SMF_BackgroundTask
+{
+	public function execute()
+ 	{
+ 		global $smcFunc, $sourcedir;
+
+		// Figure out if the user wants to be notified.
+		require_once($sourcedir . '/Subs-Notify.php');
+		$prefs = getNotifyPrefs($this->_details['receiver_id'], 'request_buddy', true);
+
+		if ($prefs[$this->_details['receiver_id']]['request_buddy'])
+		{
+			$alert_row = array(
+				'alert_time' => $this->_details['time'],
+				'id_member' => $this->_details['receiver_id'],
+				'id_member_started' => $this->_details['id_member'],
+				'member_name' => $this->_details['member_name'],
+				'content_type' => 'buddy',
+				'content_id' => 0,
+				'content_action' => 'buddy_request',
+				'is_read' => 0,
+				'extra' => '',
+			);
+
+			$smcFunc['db_insert']('insert', '{db_prefix}user_alerts',
+				array('alert_time' => 'int', 'id_member' => 'int', 'id_member_started' => 'int', 'member_name' => 'string',
+				'content_type' => 'string', 'content_id' => 'int', 'content_action' => 'string', 'is_read' => 'int', 'extra' => 'string'),
+				$alert_row, array()
+			);
+
+			updateMemberData($this->_details['receiver_id'], array('alerts' => '+'));
+		}
+
+		return true;
+	}
+}
+
+?>

--- a/Themes/default/languages/Alerts.english.php
+++ b/Themes/default/languages/Alerts.english.php
@@ -35,6 +35,7 @@ $txt['alert_event_new_guest'] = 'A new event, <a href="{scripturl}?action=calend
 $txt['alert_event_new'] = '{member_link} added a new event, <a href="{scripturl}?action=calendar;event={event_id}">{event_title}</a> to the calendar.';
 $txt['alert_event_new_topic'] = '{member_link} added a new event, {topic_msg}, to the calendar.';
 $txt['alert_paidsubs_expiring'] = 'Your subscription to <a href="{scripturl}?action=profile;area=subscriptions">{subscription_name}</a> is about to expire at {end_time}';
+$txt['alert_buddy_buddy_request'] = '{member_link} added you as his/her buddy';
 $txt['alerts_none'] = 'You have not any alerts yet.';
 
 ?>

--- a/Themes/default/languages/Profile.english.php
+++ b/Themes/default/languages/Profile.english.php
@@ -151,6 +151,7 @@ $txt['alert_msg_report_reply'] = 'When a post report I\'ve replied to gets repli
 $txt['alert_group_members'] = 'Members';
 $txt['alert_member_register'] = 'When a new person registers';
 $txt['alert_warn_any'] = 'When other members receive a warning';
+$txt['alert_buddy_request'] = 'When other members adds me as their buddy';
 $txt['alert_group_calendar'] = 'Calendar';
 $txt['alert_event_new'] = 'When a new event goes into the calendar';
 $txt['alert_request_group'] = 'When someone requests to join a group I moderate';


### PR DESCRIPTION
I was adding this to Breeze but it might as well be added it to core too. It adds a new alert when someone adds you as his/her buddy.

I solved the gender possessive stuff (to not show his/her and also be able to add custom ones) in Breeze by adding a couple of txt strings:

https://github.com/MissAllSunday/Breeze/blob/develop/Themes/default/languages/BreezeAlerts.english.php#L29

and taking advantage of the gender now been a custom profile field. This can be done here but requires some more work and I don't know if its worth doing it just for one single alert 
