### PR TITLE
BBC font tag

### DIFF
--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -1239,7 +1239,7 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 			array(
 				'tag' => 'font',
 				'type' => 'unparsed_equals',
-				'test' => '(([A-Za-z0-9_\-]+|&#39;.*&#39;),\s*)+([A-Za-z0-9_\-]+|&#39;.*&#39;)\]',
+				'test' => '[A-Za-z0-9_,\-\s]+?\]',
 				'before' => '<span style="font-family: $1;" class="bbc_font">',
 				'after' => '</span>',
 			),

--- a/Themes/default/scripts/jquery.sceditor.smf.js
+++ b/Themes/default/scripts/jquery.sceditor.smf.js
@@ -717,3 +717,19 @@ $.sceditor.plugins.bbcode.bbcode.set(
 		}
 	}
 );
+
+$.sceditor.plugins.bbcode.bbcode.set('font', {
+	format: function ($element, content) {
+		var font;
+
+		// Get the raw font value from the DOM
+		if (!$element.is('font') || !(font = $element.attr('face'))) {
+			font = $element.css('font-family');
+		}
+
+		// Strip all quotes
+		font = font.replace(/['"]/g, '');
+
+		return '[font=' + font + ']' + content + '[/font]';
+	}
+});


### PR DESCRIPTION
Uses Sam Clark's approach and removes all apostrophes form the tag so parse_bbc can handle it.

fixes #1768

Signed-off-by: Suki suki@missallsunday.com
