### PR TITLE
Groups without "online list color" also show in board index's group key

### DIFF
--- a/Sources/Subs-Membergroups.php
+++ b/Sources/Subs-Membergroups.php
@@ -667,7 +667,6 @@ function cache_getMembergroupList()
 			'min_posts' => -1,
 			'not_hidden' => 0,
 			'mod_group' => 3,
-			'blank_string' => '',
 		)
 	);
 	$groupCache = array();

--- a/Sources/Subs-Membergroups.php
+++ b/Sources/Subs-Membergroups.php
@@ -662,7 +662,6 @@ function cache_getMembergroupList()
 		WHERE min_posts = {int:min_posts}
 			AND hidden = {int:not_hidden}
 			AND id_group != {int:mod_group}
-			AND online_color != {string:blank_string}
 		ORDER BY group_name',
 		array(
 			'min_posts' => -1,


### PR DESCRIPTION
Fixes #2801

Signed-off-by: Bruno Alves bruno.m.alves@gmail.com
