### PR TITLE
Restoring Span For $button['title']

### DIFF
--- a/Themes/default/css/responsive.css
+++ b/Themes/default/css/responsive.css
@@ -40,7 +40,11 @@
 		margin: 0 0 0 -85px;
 	}
 	.dropmenu li {
-		width: 50%;
+		width: 10%;
+	}
+	.dropmenu li span.textmenu
+	{
+		display:none;
 	}
 	.dropmenu li a {
 		width: 65%;

--- a/Themes/default/css/responsive.css
+++ b/Themes/default/css/responsive.css
@@ -40,14 +40,20 @@
 		margin: 0 0 0 -85px;
 	}
 	.dropmenu li {
-		width: 10%;
+		width: auto;
 	}
-	.dropmenu li span.textmenu
-	{
-		display:none;
+	.dropmenu li > a {
+		width: 15px;
+		height: 24px;
+		overflow: hidden;
 	}
-	.dropmenu li a {
-		width: 65%;
+	ul#menu_nav > li {
+		width: auto;
+	}
+	ul#menu_nav > li > a {
+		width: 17px;
+		height: 20px;
+		overflow: hidden;
 	}
 	.dropmenu ul li a {
 		width: auto !important;

--- a/Themes/default/css/responsive.css
+++ b/Themes/default/css/responsive.css
@@ -40,12 +40,14 @@
 		margin: 0 0 0 -85px;
 	}
 	.dropmenu li {
-		width: auto;
+		width: 10%;
 	}
-	.dropmenu li > a {
-		width: 15px;
-		height: 24px;
-		overflow: hidden;
+	.dropmenu li span.textmenu
+	{
+		display:none;
+	}
+	.dropmenu li a {
+		width: 65%;
 	}
 	.dropmenu ul li a {
 		width: auto !important;

--- a/Themes/default/css/responsive.css
+++ b/Themes/default/css/responsive.css
@@ -40,14 +40,12 @@
 		margin: 0 0 0 -85px;
 	}
 	.dropmenu li {
-		width: 10%;
+		width: auto;
 	}
-	.dropmenu li span.textmenu
-	{
-		display:none;
-	}
-	.dropmenu li a {
-		width: 65%;
+	.dropmenu li > a {
+		width: 15px;
+		height: 24px;
+		overflow: hidden;
 	}
 	.dropmenu ul li a {
 		width: auto !important;

--- a/Themes/default/css/responsive.css
+++ b/Themes/default/css/responsive.css
@@ -40,20 +40,14 @@
 		margin: 0 0 0 -85px;
 	}
 	.dropmenu li {
-		width: auto;
+		width: 10%;
 	}
-	.dropmenu li > a {
-		width: 15px;
-		height: 24px;
-		overflow: hidden;
+	.dropmenu li span.textmenu
+	{
+		display:none;
 	}
-	ul#menu_nav > li {
-		width: auto;
-	}
-	ul#menu_nav > li > a {
-		width: 17px;
-		height: 20px;
-		overflow: hidden;
+	.dropmenu li a {
+		width: 65%;
 	}
 	.dropmenu ul li a {
 		width: auto !important;

--- a/Themes/default/index.template.php
+++ b/Themes/default/index.template.php
@@ -452,7 +452,7 @@ function template_menu()
 		echo '
 						<li id="button_', $act, '"', !empty($button['sub_buttons']) ? ' class="subsections"' :'', '>
 							<a', $button['active_button'] ? ' class="active"' : '', ' href="', $button['href'], '"', isset($button['target']) ? ' target="' . $button['target'] . '"' : '', '>
-								', $button['icon'], $button['title'], '
+								', $button['icon'],'<span class="textmenu">', $button['title'], '</span>
 							</a>';
 
 		if (!empty($button['sub_buttons']))

--- a/Themes/default/index.template.php
+++ b/Themes/default/index.template.php
@@ -452,7 +452,7 @@ function template_menu()
 		echo '
 						<li id="button_', $act, '"', !empty($button['sub_buttons']) ? ' class="subsections"' :'', '>
 							<a', $button['active_button'] ? ' class="active"' : '', ' href="', $button['href'], '"', isset($button['target']) ? ' target="' . $button['target'] . '"' : '', '>
-								', $button['icon'],'<span class="textmenu">', $button['title'], '</span>
+								', $button['icon'], $button['title'], '
 							</a>';
 
 		if (!empty($button['sub_buttons']))


### PR DESCRIPTION
This PR is only a suggestion for easy customization from this topic:
http://www.simplemachines.org/community/index.php?topic=536271.0. The
text menu can be easily removed by css display:none with the link and
icons left intact if the span is restored. There is no other easy way to
customize removing the text from menu so far without the span. While I
am pulling this request, I will leave this totally to the SMF Team
discretion to decide.

Signed-off-by: "ahrasis" Ahmad Rasyid Ismail ahrasis@gmail.com
