### PR TITLE
Add missing default entries to user_alerts_prefs

### DIFF
--- a/other/install_2-1_mysql.sql
+++ b/other/install_2-1_mysql.sql
@@ -2090,7 +2090,19 @@ VALUES (0, 'member_group_request', 1),
 	(0, 'msg_like', 1),
 	(0, 'msg_report', 1),
 	(0, 'msg_report_reply', 1),
-	(0, 'unapproved_reply', 3);
+	(0, 'unapproved_reply', 3),
+	(0, 'topic_notify', 1),
+	(0, 'board_notify', 1),
+	(0, 'msg_mention', 1),
+	(0, 'msg_quote', 1),
+	(0, 'pm_new', 1),
+	(0, 'pm_reply', 1),
+	(0, 'member_report_reply', 3),
+	(0, 'member_report', 3),
+	(0, 'unapproved_post', 1),
+	(0, 'buddy_request', 1),
+	(0, 'warn_any', 1),
+	(0, 'request_group', 1);
 # --------------------------------------------------------
 
 #

--- a/other/install_2-1_postgresql.sql
+++ b/other/install_2-1_postgresql.sql
@@ -2638,6 +2638,18 @@ INSERT INTO {$db_prefix}user_alerts_prefs (id_member, alert_pref, alert_value) V
 INSERT INTO {$db_prefix}user_alerts_prefs (id_member, alert_pref, alert_value) VALUES (0, 'msg_report', 1);
 INSERT INTO {$db_prefix}user_alerts_prefs (id_member, alert_pref, alert_value) VALUES (0, 'msg_report_reply', 1);
 INSERT INTO {$db_prefix}user_alerts_prefs (id_member, alert_pref, alert_value) VALUES (0, 'unapproved_reply', 3);
+INSERT INTO {$db_prefix}user_alerts_prefs (id_member, alert_pref, alert_value) VALUES (0, 'topic_notify', 1);
+INSERT INTO {$db_prefix}user_alerts_prefs (id_member, alert_pref, alert_value) VALUES (0, 'board_notify', 1);
+INSERT INTO {$db_prefix}user_alerts_prefs (id_member, alert_pref, alert_value) VALUES (0, 'msg_mention', 1);
+INSERT INTO {$db_prefix}user_alerts_prefs (id_member, alert_pref, alert_value) VALUES (0, 'msg_quote', 1);
+INSERT INTO {$db_prefix}user_alerts_prefs (id_member, alert_pref, alert_value) VALUES (0, 'pm_new', 1);
+INSERT INTO {$db_prefix}user_alerts_prefs (id_member, alert_pref, alert_value) VALUES (0, 'pm_reply', 1);
+INSERT INTO {$db_prefix}user_alerts_prefs (id_member, alert_pref, alert_value) VALUES (0, 'member_report_reply', 3);
+INSERT INTO {$db_prefix}user_alerts_prefs (id_member, alert_pref, alert_value) VALUES (0, 'member_report', 3);
+INSERT INTO {$db_prefix}user_alerts_prefs (id_member, alert_pref, alert_value) VALUES (0, 'unapproved_post', 1);
+INSERT INTO {$db_prefix}user_alerts_prefs (id_member, alert_pref, alert_value) VALUES (0, 'buddy_request', 1);
+INSERT INTO {$db_prefix}user_alerts_prefs (id_member, alert_pref, alert_value) VALUES (0, 'warn_any', 1);
+INSERT INTO {$db_prefix}user_alerts_prefs (id_member, alert_pref, alert_value) VALUES (0, 'request_group', 1);
 # --------------------------------------------------------
 
 #

--- a/other/upgrade_2-1_mysql.sql
+++ b/other/upgrade_2-1_mysql.sql
@@ -642,7 +642,19 @@ VALUES (0, 'member_group_request', 1),
 	(0, 'msg_like', 1),
 	(0, 'msg_report', 1),
 	(0, 'msg_report_reply', 1),
-	(0, 'unapproved_reply', 3);
+	(0, 'unapproved_reply', 3),
+	(0, 'topic_notify', 1),
+	(0, 'board_notify', 1),
+	(0, 'msg_mention', 1),
+	(0, 'msg_quote', 1),
+	(0, 'pm_new', 1),
+	(0, 'pm_reply', 1),
+	(0, 'member_report_reply', 3),
+	(0, 'member_report', 3),
+	(0, 'unapproved_post', 1),
+	(0, 'buddy_request', 1),
+	(0, 'warn_any', 1),
+	(0, 'request_group', 1);
 ---#
 
 /******************************************************************************/

--- a/other/upgrade_2-1_postgresql.sql
+++ b/other/upgrade_2-1_postgresql.sql
@@ -697,6 +697,18 @@ INSERT INTO {$db_prefix}user_alerts_prefs (id_member, alert_pref, alert_value) V
 INSERT INTO {$db_prefix}user_alerts_prefs (id_member, alert_pref, alert_value) VALUES (0, 'msg_report', 1);
 INSERT INTO {$db_prefix}user_alerts_prefs (id_member, alert_pref, alert_value) VALUES (0, 'msg_report_reply', 1);
 INSERT INTO {$db_prefix}user_alerts_prefs (id_member, alert_pref, alert_value) VALUES (0, 'unapproved_reply', 3);
+INSERT INTO {$db_prefix}user_alerts_prefs (id_member, alert_pref, alert_value) VALUES (0, 'topic_notify', 1);
+INSERT INTO {$db_prefix}user_alerts_prefs (id_member, alert_pref, alert_value) VALUES (0, 'board_notify', 1);
+INSERT INTO {$db_prefix}user_alerts_prefs (id_member, alert_pref, alert_value) VALUES (0, 'msg_mention', 1);
+INSERT INTO {$db_prefix}user_alerts_prefs (id_member, alert_pref, alert_value) VALUES (0, 'msg_quote', 1);
+INSERT INTO {$db_prefix}user_alerts_prefs (id_member, alert_pref, alert_value) VALUES (0, 'pm_new', 1);
+INSERT INTO {$db_prefix}user_alerts_prefs (id_member, alert_pref, alert_value) VALUES (0, 'pm_reply', 1);
+INSERT INTO {$db_prefix}user_alerts_prefs (id_member, alert_pref, alert_value) VALUES (0, 'member_report_reply', 3);
+INSERT INTO {$db_prefix}user_alerts_prefs (id_member, alert_pref, alert_value) VALUES (0, 'member_report', 3);
+INSERT INTO {$db_prefix}user_alerts_prefs (id_member, alert_pref, alert_value) VALUES (0, 'unapproved_post', 1);
+INSERT INTO {$db_prefix}user_alerts_prefs (id_member, alert_pref, alert_value) VALUES (0, 'buddy_request', 1);
+INSERT INTO {$db_prefix}user_alerts_prefs (id_member, alert_pref, alert_value) VALUES (0, 'warn_any', 1);
+INSERT INTO {$db_prefix}user_alerts_prefs (id_member, alert_pref, alert_value) VALUES (0, 'request_group', 1);
 ---#
 
 /******************************************************************************/


### PR DESCRIPTION
based on the Notifications Settings page.

This should fix some issues (Like there being no index of a member when someone is added as an buddy).
The following preferences were not on that page, and are not included (As they do not seem to use the default value of user '0' anyway.):
msg_auto_notify, alert_timeout, msg_notify_pref, msg_notify_type, msg_receive_body, pm_notify

Signed-off-by: Stefan git@fearthe1337.com
