### PR TITLE
Fix If statement check in Subscriptions-PayPal.php as reported in #2795

### DIFF
--- a/Sources/Subscriptions-PayPal.php
+++ b/Sources/Subscriptions-PayPal.php
@@ -153,7 +153,7 @@ class paypal_payment
 		global $modSettings;
 
 		// Has the user set up an email address?
-		if ((empty($modSettings['paidsubs_test']) && empty($modSettings['paypal_email'])) || empty($modSettings['paypal_sandbox_email']))
+		if ((empty($modSettings['paidsubs_test']) && empty($modSettings['paypal_email'])) || (!empty($modSettings['paidsubs_test']) && empty($modSettings['paypal_sandbox_email'])))
 			return false;
 		// Check the correct transaction types are even here.
 		if ((!isset($_POST['txn_type']) && !isset($_POST['payment_status'])) || (!isset($_POST['business']) && !isset($_POST['receiver_email'])))


### PR DESCRIPTION
This IF statement denied payments if the following condition was met: there is no sandbox email set.
This is obviously wrong, as it should only deny this when we are in testing mode.

(Manually tested the if-statement fix as I do not have paid subscriptions, it is also based on the following [forum post](http://www.simplemachines.org/community/index.php?topic=535039.msg3801971#msg3801971), however completely disabling it seemed like a bad idea).

After making the commit I also found out the code I commited is almost the same as in this [forum post](http://www.simplemachines.org/community/index.php?topic=535070.msg3802091#msg3802091) 
