### PR TITLE
Remove duplicate Mime-Version header from SMTP (Fixes #2883)

### DIFF
--- a/Sources/ScheduledTasks.php
+++ b/Sources/ScheduledTasks.php
@@ -944,7 +944,7 @@ function ReduceMailQueue($number = false, $override_limit = false, $force_send =
 				@apache_reset_timeout();
 		}
 		else
-			$result = smtp_mail(array($email['to']), $email['subject'], $email['body'], $email['send_html'] ? $email['headers'] : 'Mime-Version: 1.0' . "\r\n" . $email['headers']);
+			$result = smtp_mail(array($email['to']), $email['subject'], $email['body'], $email['headers']);
 
 		// Hopefully it sent?
 		if (!$result)


### PR DESCRIPTION
```
function ReduceMailQueue($number = false, $override_limit = false, $force_send = false)
```

Adds mine-version header if not html.

```
 $result = smtp_mail(array($email['to']), $email['subject'], $email['body'], $email['send_html'] ? $email['headers'] : 'Mime-Version: 1.0' . "\r\n" . $email['headers']);
```

ReduceMailQueue grabs mail from the database ->  mail_queue

Mail enters the mail_queue table only in: 

```
function AddMailQueue($flush = false, $to_array = array(), $subject = '', $message = '', $headers = '', $send_html = false, $priority = 3, $is_private = false)
```

This function only gets called with mail data from:

```
function sendmail($to, $subject, $message, $from = null, $message_id = null, $send_html = false, $priority = 3, $hotmail_fix = null, $is_private = false)
```

Which always adds an mime-version header

```
// Using mime, as it allows to send a plain unencoded alternative.
$headers .= 'Mime-Version: 1.0' . $line_break;
```
