### PR TITLE
Fix missing jQuery file; add mentions for all sc-editors on enabled p…

### DIFF
--- a/Sources/Display.php
+++ b/Sources/Display.php
@@ -1293,7 +1293,7 @@ function Display()
 	// Mentions
 	if (!empty($modSettings['enable_mentions']) && allowedTo('mention'))
 	{
-		loadJavascriptFile('jquery.atwho.js', array('default_theme' => true, 'defer' => true), 'smf_atwho');
+		loadJavascriptFile('jquery.atwho.min.js', array('default_theme' => true, 'defer' => true), 'smf_atwho');
 		loadJavascriptFile('mentions.js', array('default_theme' => true, 'defer' => true), 'smf_mention');
 	}
 }

--- a/Sources/PersonalMessage.php
+++ b/Sources/PersonalMessage.php
@@ -1784,6 +1784,13 @@ function MessagePost()
 		loadTemplate('PersonalMessage');
 		loadJavascriptFile('PersonalMessage.js', array('default_theme' => true, 'defer' => false), 'smf_pms');
 		loadJavascriptFile('suggest.js', array('default_theme' => true, 'defer' => false), 'smf_suggest');
+		// Mentions
+		if (!empty($modSettings['enable_mentions']) && allowedTo('mention'))
+		{
+			loadJavascriptFile('jquery.atwho.min.js', array('default_theme' => true, 'defer' => true), 'smf_atwho');
+			loadJavascriptFile('mentions.js', array('default_theme' => true, 'defer' => true), 'smf_mention');
+		}
+
 		$context['sub_template'] = 'send';
 	}
 
@@ -2096,6 +2103,12 @@ function messagePostError($error_types, $named_recipients, $recipient_ids = arra
 		$context['sub_template'] = 'send';
 		loadJavascriptFile('PersonalMessage.js', array('default_theme' => true, 'defer' => false), 'smf_pms');
 		loadJavascriptFile('suggest.js', array('default_theme' => true, 'defer' => false), 'smf_suggest');
+		// Mentions
+		if (!empty($modSettings['enable_mentions']) && allowedTo('mention'))
+		{
+			loadJavascriptFile('jquery.atwho.min.js', array('default_theme' => true, 'defer' => true), 'smf_atwho');
+			loadJavascriptFile('mentions.js', array('default_theme' => true, 'defer' => true), 'smf_mention');
+		}
 	}
 	elseif (isset($_REQUEST['xml']))
 		$context['sub_template'] = 'pm';

--- a/Themes/default/scripts/mentions.js
+++ b/Themes/default/scripts/mentions.js
@@ -61,9 +61,8 @@ var config = {
 $(function()
 {
 	$('textarea[name=message]').atwho(config);
-
-	$('#message').parent().find('textarea').atwho(config);
-	var iframe = $('#message').parent().find('iframe')[0];
+	$('.sceditor-container').find('textarea').atwho(config);
+	var iframe = $('.sceditor-container').find('iframe')[0];
 	if (typeof iframe != 'undefined')
 		$(iframe.contentDocument.body).atwho(config);
 });


### PR DESCRIPTION
…ages. Signed-off-by: Anthony Calandra anthony@anthony-calandra.com

This commit fixes an error being thrown in the topic display where the browser can't find `jquery.atwho.js` since it doesn't exist. Also, adjusted the jQuery selectors that attach the `atwho` plugin to all sc-editors when loaded on the page; this includes adding support for quick reply and creating PMs.
