### PR TITLE
! A few fixes related to detailed version check of background task files

### DIFF
--- a/Sources/Subs-Admin.php
+++ b/Sources/Subs-Admin.php
@@ -252,6 +252,7 @@ function getFileVersions(&$versionOptions)
 		ksort($version_info['default_template_versions']);
 		ksort($version_info['template_versions']);
 		ksort($version_info['default_language_versions']);
+		ksort($version_info['tasks_versions']);
 
 		// For languages sort each language too.
 		foreach ($version_info['default_language_versions'] as $language => $dummy)

--- a/Themes/default/Admin.template.php
+++ b/Themes/default/Admin.template.php
@@ -508,10 +508,10 @@ function template_view_versions()
 											<a href="#" id="Tasks-link">', $txt['dvc_tasks'] ,'</a>
 										</td>
 										<td class="quarter_table">
-											<em id="yourTemplates">??</em>
+											<em id="yourTasks">??</em>
 										</td>
 										<td class="quarter_table">
-											<em id="currentTemplates">??</em>
+											<em id="currentTasks">??</em>
 										</td>
 									</tr>
 								</tbody>
@@ -527,10 +527,10 @@ function template_view_versions()
 											', $filename, '
 										</td>
 										<td class="quarter_table">
-											<em id="yourTemplates', $filename, '">', $version, '</em>
+											<em id="yourTasks', $filename, '">', $version, '</em>
 										</td>
 										<td class="quarter_table">
-											<em id="currentTemplates', $filename, '">??</em>
+											<em id="currentTasks', $filename, '">??</em>
 										</td>
 									</tr>';
 

--- a/Themes/default/scripts/admin.js
+++ b/Themes/default/scripts/admin.js
@@ -326,6 +326,11 @@ smf_ViewVersions.prototype.determineVersions = function ()
 	setInnerHTML(document.getElementById('currentLanguages'), oHighCurrent.Languages);
 	if (oLowVersion.Languages)
 		document.getElementById('yourLanguages').className = 'alert';
+
+	setInnerHTML(document.getElementById('yourTasks'), oLowVersion.Tasks ? oLowVersion.Tasks : oHighYour.Tasks);
+	setInnerHTML(document.getElementById('currentTasks'), oHighCurrent.Tasks);
+	if (oLowVersion.Tasks)
+		document.getElementById('yourTasks').className = 'alert';
 }
 
 function addNewWord()


### PR DESCRIPTION
This fixes three issues related to background task files in the detailed version list:
1. Filenames were not sorted (Subs-Admin.php)
2. Incorrect CSS ID in the template (Admin.template.php)
3. Missing JS to actually handle setting the "current" and overall versions

Partial fix for #2950.

Signed-off-by: Michael Eshom oldiesmann@oldiesmann.us
