### PR TITLE
Tweak likes popup

### DIFF
--- a/Themes/default/css/index.css
+++ b/Themes/default/css/index.css
@@ -150,12 +150,13 @@ ul#likes li {
 }
 
 ul#likes span.avatar {
-	width: 45px;
-	height: 45px;
-	padding: 2px;
+	max-width: 100px;
+	max-height: 100px;
+	padding: 0 10px 0 0;
 }
 ul#likes span.avatar img {
-	max-height: 40px;
+	max-height: 90px;
+	max-width: 90px;
 }
 ul#likes li span.description {
 	font-style: italic;

--- a/Themes/default/scripts/topic.js
+++ b/Themes/default/scripts/topic.js
@@ -769,7 +769,7 @@ $(function() {
 		e.preventDefault();
 		var title = $(this).parent().text(),
 			url = $(this).attr('href') + ';js=1';
-		return reqOverlayDiv(url, title);
+		return reqOverlayDiv(url, title, 'post/thumbsup.png');
 	});
 
 	// Message likes.


### PR DESCRIPTION
Make the icon more relevant and prevent avatars from overlapping with text. Fixes #2947.
