### PR TITLE
Theme fixes

### DIFF
--- a/Sources/Subs-Package.php
+++ b/Sources/Subs-Package.php
@@ -243,7 +243,13 @@ function read_zip_file($file, $destination, $single_file = false, $overwrite = f
 {
 	try
 	{
-		$archive = new PharData($file, Phar::CURRENT_AS_FILEINFO);
+		// This may not always be defined...
+		$return = array();
+
+		// PharData requires a valid file extension, so give it one...
+		@rename($file, $file . '.zip');
+
+		$archive = new PharData($file . '.zip', Phar::CURRENT_AS_FILEINFO);
 		$iterator = new RecursiveIteratorIterator($archive);
 
 		// go though each file in the archive

--- a/Sources/Themes.php
+++ b/Sources/Themes.php
@@ -1290,6 +1290,10 @@ function InstallFile()
 	// Set a temp dir for dumping all required files on it.
 	$dirtemp = $themedir .'/temp';
 
+	// Make sure the temp dir doesn't already exist
+	if (file_exists($dirtemp))
+		remove_dir($dirtemp);
+
 	// Create the temp dir.
 	mkdir($dirtemp, 0777);
 


### PR DESCRIPTION
Fixes a few issues with installing themes:
- Make sure the temp dir doesn't exist before trying to create it
- Extracting zip archives failed because PharData didn't like the lack of a valid file extension
- $return wasn't always defined in read_zip_file()
