### PR TITLE
Return always array on loadMemberData

### DIFF
--- a/Sources/Display.php
+++ b/Sources/Display.php
@@ -1015,8 +1015,7 @@ function Display()
 		call_integration_hook('integrate_query_message', array(&$msg_selects, &$msg_tables, &$msg_parameters));
 
 		// What?  It's not like it *couldn't* be only guests in this topic...
-		if (!empty($posters))
-			loadMemberData($posters);
+		loadMemberData($posters);
 		$messages_request = $smcFunc['db_query']('', '
 			SELECT
 				id_msg, icon, subject, poster_time, poster_ip, id_member, modified_time, modified_name, modified_reason, body,

--- a/Sources/Load.php
+++ b/Sources/Load.php
@@ -1127,7 +1127,7 @@ function loadPermissions()
  * @param array|string $users An array of users by id or name or a single username/id
  * @param bool $is_name Whether $users contains names
  * @param string $set What kind of data to load (normal, profile, minimal)
- * @return array|bool The ids of the members loaded or false if no data was loaded
+ * @return array The ids of the members loaded
  */
 function loadMemberData($users, $is_name = false, $set = 'normal')
 {
@@ -1136,7 +1136,7 @@ function loadMemberData($users, $is_name = false, $set = 'normal')
 
 	// Can't just look for no users :P.
 	if (empty($users))
-		return false;
+		return array();
 
 	// Pass the set value
 	$context['loadMemberContext_set'] = $set;
@@ -1303,7 +1303,7 @@ function loadMemberData($users, $is_name = false, $set = 'normal')
 		}
 	}
 
-	return empty($loaded_ids) ? false : $loaded_ids;
+	return $loaded_ids;
 }
 
 /**

--- a/Sources/News.php
+++ b/Sources/News.php
@@ -860,7 +860,7 @@ function getXmlProfile($xml_format)
 	global $scripturl, $memberContext, $user_profile, $user_info;
 
 	// You must input a valid user....
-	if (empty($_GET['u']) || loadMemberData((int) $_GET['u']) === false)
+	if (empty($_GET['u']) || !loadMemberData((int) $_GET['u']))
 		return array();
 
 	// Make sure the id is a number and not "I like trying to hack the database".

--- a/Sources/PersonalMessage.php
+++ b/Sources/PersonalMessage.php
@@ -441,12 +441,9 @@ function MessagePopup()
 		}
 		$smcFunc['db_free_result']($request);
 
-		if (!empty($senders))
-		{
-			$senders = loadMemberData($senders);
-			foreach ($senders as $member)
-				loadMemberContext($member);
-		}
+		$senders = loadMemberData($senders);
+		foreach ($senders as $member)
+			loadMemberContext($member);
 
 		// Having loaded everyone, attach them to the PMs.
 		foreach ($context['unread_pms'] as $id_pm => $details)
@@ -929,9 +926,7 @@ function MessageFolder()
 		}
 
 		// Load any users....
-		$posters = array_unique($posters);
-		if (!empty($posters))
-			loadMemberData($posters);
+		loadMemberData($posters);
 
 		// If we're on grouped/restricted view get a restricted list of messages.
 		if ($context['display_mode'] != 0)
@@ -1629,9 +1624,7 @@ function MessageSearch2()
 	}
 
 	// Load the users...
-	$posters = array_unique($posters);
-	if (!empty($posters))
-		loadMemberData($posters);
+	loadMemberData($posters);
 
 	// Sort out the page index.
 	$context['page_index'] = constructPageIndex($scripturl . '?action=pm;sa=search2;params=' . $context['params'], $_GET['start'], $numResults, $modSettings['search_results_per_page'], false);
@@ -2059,7 +2052,7 @@ function MessageDrafts()
 
 	// validate with loadMemberData()
 	$memberResult = loadMemberData($user_info['id'], false);
-	if (!is_array($memberResult))
+	if (!$memberResult)
 		fatal_lang_error('not_a_user', false);
 	list ($memID) = $memberResult;
 

--- a/Sources/Profile-View.php
+++ b/Sources/Profile-View.php
@@ -246,12 +246,9 @@ function fetch_alerts($memID, $all = false, $counter = 0, $pagination = array())
 	}
 	$smcFunc['db_free_result']($request);
 
-	if (!empty($senders))
-	{
-		$senders = loadMemberData($senders);
-		foreach ($senders as $member)
-			loadMemberContext($member);
-	}
+	$senders = loadMemberData($senders);
+	foreach ($senders as $member)
+		loadMemberContext($member);
 
 	// Now go through and actually make with the text.
 	loadLanguage('Alerts');

--- a/Sources/Profile.php
+++ b/Sources/Profile.php
@@ -51,7 +51,7 @@ function ModifyProfile($post_errors = array())
 	}
 
 	// Check if loadMemberData() has returned a valid result.
-	if (!is_array($memberResult))
+	if (!$memberResult)
 		fatal_lang_error('not_a_user', false, 404);
 
 	// If all went well, we have a valid member ID!


### PR DESCRIPTION
Signed-off-by: Marcos Del Sol Vives socram8888@gmail.com

This little modification reduces boilerplate as you may see on diff: no need to previously check for empty variables, call `array_unique` (`loadMemberData` already does it) or special-case return values, as `foreach` on empty arrays just won't run any iterations instead of yelling "not an array" as it does with `false`s.

As side effect, this also fixes a bug where attempting to see like count on a post with no likes (for instance if it had a like but was disliked after the user loaded a page) threw an error on SMF log error:

```
2: array_diff(): Argument #2 is not an array
File: /var/www/src/smf-2.1-github/Sources/Likes.php
Line: 502
```

```
2: Invalid argument supplied for foreach()
File: /var/www/src/smf-2.1-github/Sources/Likes.php
Line: 503
```

(Note whoever programmed this expected loadMemberData to return an array always, which is IMHO, a better behaviour, hence this PR).
