### PR TITLE
Properly create quotes on sceditor

### DIFF
--- a/Themes/default/scripts/jquery.sceditor.smf.js
+++ b/Themes/default/scripts/jquery.sceditor.smf.js
@@ -468,12 +468,12 @@ $.sceditor.plugins.bbcode.bbcode.set(
 
 			if (element.attr('author'))
 				author = ' author=' + element.attr('author').php_unhtmlspecialchars();
-			if (element.attr('date'))
-				date = ' date=' + element.attr('date');
 			if (element.attr('link'))
 				link = ' link=' + element.attr('link');
+			if (element.attr('date'))
+				date = ' date=' + element.attr('date');
 
-			return '[quote' + author + date + link + ']' + content + '[/quote]';
+			return '[quote' + author + link + date + ']' + content + '[/quote]';
 		},
 		html: function (element, attrs, content) {
 			var attr_author = '', author = '';


### PR DESCRIPTION
Signed-off-by: Marcos Del Sol Vives socram8888@gmail.com

Apparently if date is before msg=link quote parsing does not work properly:
![Imgur](http://i.imgur.com/Ng5V418.png)

Maybe improving parsing of those parameters could be a good thing to do in the future, but meanwhile this is clean and does the job.
