### PR TITLE
PharData does not actually need .zip

### DIFF
--- a/Sources/Subs-Package.php
+++ b/Sources/Subs-Package.php
@@ -246,10 +246,7 @@ function read_zip_file($file, $destination, $single_file = false, $overwrite = f
 		// This may not always be defined...
 		$return = array();
 
-		// PharData requires a valid file extension, so give it one...
-		@rename($file, $file . '.zip');
-
-		$archive = new PharData($file . '.zip', Phar::CURRENT_AS_FILEINFO);
+		$archive = new PharData($file, Phar::CURRENT_AS_FILEINFO, null, Phar::ZIP);
 		$iterator = new RecursiveIteratorIterator($archive);
 
 		// go though each file in the archive


### PR DESCRIPTION
Signed-off-by: Marcos Del Sol Vives socram8888@gmail.com
This prevents packages from being renamed, which may fail if:
- `Packages` folder isn't writable
- Package name contains another dot. Somehow PharData was detecting "MyMod-2.0.zip" extension as ".0.zip", which was causing an "unknown format" exception.
