### PR TITLE
Trying to install a package with an empty directory caused a modifica…

### DIFF
--- a/Sources/Subs-Package.php
+++ b/Sources/Subs-Package.php
@@ -247,7 +247,7 @@ function read_zip_file($file, $destination, $single_file = false, $overwrite = f
 		$return = array();
 
 		$archive = new PharData($file, Phar::CURRENT_AS_FILEINFO, null, Phar::ZIP);
-		$iterator = new RecursiveIteratorIterator($archive);
+		$iterator = new RecursiveIteratorIterator($archive, RecursiveIteratorIterator::SELF_FIRST);
 
 		// go though each file in the archive
 		foreach ($iterator as $file_info)
@@ -1889,7 +1889,7 @@ function copytree($source, $destination)
 	if (!is_writable($destination))
 		mktree($destination, 0777);
 
-	$current_dir = opendir($source);
+	$current_dir = @opendir($source);
 	if ($current_dir == false)
 		return;
 


### PR DESCRIPTION
…tion parse error (fixes #2929)

Note: For some reason, empty directories get extracted into the Packages/temp folder as files rather than folders. Because of this, trying to copy the directory from temp to its destination causes an error ("Failed to open directory: not a directory"). However, since the destination folder is created prior to the attempt to copy the contents from the temporary location, this isn't an issue. I was unable to figure out why the folder was getting extracted as a file, so I just put an @ in front of the opendir call to suppress the error.

Signed-off-by: Michael Eshom oldiesmann@oldiesmann.us
