### PR TITLE
Partial fix for #3026

### DIFF
--- a/Sources/Display.php
+++ b/Sources/Display.php
@@ -1283,6 +1283,7 @@ function Display()
 	if (!empty($modSettings['enable_mentions']) && allowedTo('mention'))
 	{
 		loadJavascriptFile('jquery.atwho.min.js', array('default_theme' => true, 'defer' => true), 'smf_atwho');
+		loadJavascriptFile('jquery.caret.min.js', array('default_theme' => true, 'defer' => true), 'smf_caret');
 		loadJavascriptFile('mentions.js', array('default_theme' => true, 'defer' => true), 'smf_mention');
 	}
 }


### PR DESCRIPTION
This fixes the issue with mentions not working in non-WYSIWYG mode in the quick reply box. However, something is causing Firefox to complain about "not well-formed" JS somewhere along the lines with this fix. Everything still works though.
