### PR TITLE
Rename error_handler() to smf_error_handler

### DIFF
--- a/SSI.php
+++ b/SSI.php
@@ -2179,7 +2179,7 @@ function ssi_checkPassword($id = null, $password = null, $is_username = false)
  * @param string $output_method The output method. If 'echo', displays a table with links/info, otherwise returns an array with information about the attachments
  * @return void|array Displays a table of attachment info or returns an array containing info about the attachments, depending on output_method.
  */
-function ssi_recentAttachmenets($num_attachments = 10, $attachment_ext = array(), $output_method = 'echo')
+function ssi_recentAttachments($num_attachments = 10, $attachment_ext = array(), $output_method = 'echo')
 {
 	global $smcFunc, $modSettings, $scripturl, $txt, $settings;
 
@@ -2191,8 +2191,7 @@ function ssi_recentAttachmenets($num_attachments = 10, $attachment_ext = array()
 		return array();
 
 	// Is it an array?
-	if (!is_array($attachment_ext))
-		$attachment_ext = array($attachment_ext);
+	$attachment_ext = (array) $attachment_ext;
 
 	// Lets build the query.
 	$request = $smcFunc['db_query']('', '

--- a/Sources/Errors.php
+++ b/Sources/Errors.php
@@ -206,7 +206,7 @@ function fatal_lang_error($error, $log = 'general', $sprintf = array(), $status 
  * @param string $file The file where the error occurred
  * @param int $line The line where the error occurred
  */
-function error_handler($error_level, $error_string, $file, $line)
+function smf_error_handler($error_level, $error_string, $file, $line)
 {
 	global $settings, $modSettings, $db_show_debug;
 

--- a/Sources/Load.php
+++ b/Sources/Load.php
@@ -2254,7 +2254,7 @@ function loadSubTemplate($sub_template_name, $fatal = false)
 	if (allowedTo('admin_forum') && isset($_REQUEST['debug']) && !in_array($sub_template_name, array('init', 'main_below')) && ob_get_length() > 0 && !isset($_REQUEST['xml']))
 	{
 		echo '
-<div style="font-size: 8pt; border: 1px dashed red; background: orange; text-align: center; font-weight: bold;">---- ', $sub_template_name, ' ends ----</div>';
+<div class="warningbox">---- ', $sub_template_name, ' ends ----</div>';
 	}
 }
 

--- a/Sources/ManageBoards.php
+++ b/Sources/ManageBoards.php
@@ -223,6 +223,7 @@ function EditCategory()
 
 	loadTemplate('ManageBoards');
 	require_once($sourcedir . '/Subs-Boards.php');
+	require_once($sourcedir . '/Subs-Editor.php');
 	getBoardTree();
 
 	// id_cat must be a number.... if it exists.
@@ -259,8 +260,8 @@ function EditCategory()
 		$context['category'] = array(
 			'id' => $_REQUEST['cat'],
 			'name' => $cat_tree[$_REQUEST['cat']]['node']['name'],
-			'editable_name' => $smcFunc['htmlspecialchars']($cat_tree[$_REQUEST['cat']]['node']['name']),
-			'description' => $smcFunc['htmlspecialchars']($cat_tree[$_REQUEST['cat']]['node']['description']),
+			'editable_name' => html_to_bbc($cat_tree[$_REQUEST['cat']]['node']['name']),
+			'description' => html_to_bbc($cat_tree[$_REQUEST['cat']]['node']['description']),
 			'can_collapse' => !empty($cat_tree[$_REQUEST['cat']]['node']['can_collapse']),
 			'children' => array(),
 			'is_empty' => empty($cat_tree[$_REQUEST['cat']]['children'])
@@ -312,7 +313,7 @@ function EditCategory()
  */
 function EditCategory2()
 {
-	global $sourcedir;
+	global $sourcedir, $smcFunc, $context;
 
 	checkSession();
 	validateToken('admin-bc-' . $_REQUEST['cat']);
@@ -330,8 +331,8 @@ function EditCategory2()
 			$catOptions['move_after'] = (int) $_POST['cat_order'];
 
 		// Change "This & That" to "This &amp; That" but don't change "&cent" to "&amp;cent;"...
-		$catOptions['cat_name'] = preg_replace('~[&]([^;]{8}|[^;]{0,8}$)~', '&amp;$1', $_POST['cat_name']);
-		$catOptions['cat_desc'] = preg_replace('~[&]([^;]{8}|[^;]{0,8}$)~', '&amp;$1', $_POST['cat_desc']);
+		$catOptions['cat_name'] = parse_bbc($smcFunc['htmlspecialchars']($_POST['cat_name']), false, '', $context['description_allowed_tags']);
+		$catOptions['cat_desc'] = parse_bbc($smcFunc['htmlspecialchars']($_POST['cat_desc']), false, '', $context['description_allowed_tags']);
 
 		$catOptions['is_collapsible'] = isset($_POST['collapse']);
 
@@ -379,6 +380,7 @@ function EditBoard()
 
 	loadTemplate('ManageBoards');
 	require_once($sourcedir . '/Subs-Boards.php');
+	require_once($sourcedir . '/Subs-Editor.php');
 	getBoardTree();
 
 	// For editing the profile we'll need this.
@@ -433,8 +435,8 @@ function EditBoard()
 		// Just some easy shortcuts.
 		$curBoard = &$boards[$_REQUEST['boardid']];
 		$context['board'] = $boards[$_REQUEST['boardid']];
-		$context['board']['name'] = $smcFunc['htmlspecialchars'](strtr($context['board']['name'], array('&amp;' => '&')));
-		$context['board']['description'] = $smcFunc['htmlspecialchars']($context['board']['description']);
+		$context['board']['name'] = html_to_bbc($context['board']['name']);
+		$context['board']['description'] = html_to_bbc($context['board']['description']);
 		$context['board']['no_children'] = empty($boards[$_REQUEST['boardid']]['tree']['children']);
 		$context['board']['is_recycle'] = !empty($modSettings['recycle_enable']) && !empty($modSettings['recycle_board']) && $modSettings['recycle_board'] == $context['board']['id'];
 	}
@@ -673,9 +675,9 @@ function EditBoard2()
 		if (strlen(implode(',', $boardOptions['access_groups'])) > 255 || strlen(implode(',', $boardOptions['deny_groups'])) > 255)
 			fatal_lang_error('too_many_groups', false);
 
-		// Change '1 & 2' to '1 &amp; 2', but not '&amp;' to '&amp;amp;'...
-		$boardOptions['board_name'] = preg_replace('~[&]([^;]{8}|[^;]{0,8}$)~', '&amp;$1', $_POST['board_name']);
-		$boardOptions['board_description'] = preg_replace('~[&]([^;]{8}|[^;]{0,8}$)~', '&amp;$1', $_POST['desc']);
+		// Do not allow HTML tags. Parse the string.
+		$boardOptions['board_name'] = parse_bbc($smcFunc['htmlspecialchars']($_POST['board_name']), false, '', $context['description_allowed_tags']);
+		$boardOptions['board_description'] = parse_bbc($smcFunc['htmlspecialchars']($_POST['desc']), false, '', $context['description_allowed_tags']);
 
 		$boardOptions['moderator_string'] = $_POST['moderators'];
 

--- a/Sources/Subs-BoardIndex.php
+++ b/Sources/Subs-BoardIndex.php
@@ -99,7 +99,7 @@ function getBoardIndex($boardIndexOptions)
 				$categories[$row_board['id_cat']] = array(
 					'id' => $row_board['id_cat'],
 					'name' => $row_board['cat_name'],
-					'description' => parse_bbc($row_board['cat_desc'], false, '', $context['description_allowed_tags']),
+					'description' => $row_board['cat_desc'],
 					'is_collapsed' => isset($row_board['can_collapse']) && $row_board['can_collapse'] == 1 && !empty($options['collapse_category_' . $row_board['id_cat']]),
 					'can_collapse' => isset($row_board['can_collapse']) && $row_board['can_collapse'] == 1,
 					'href' => $scripturl . '#c' . $row_board['id_cat'],
@@ -134,7 +134,7 @@ function getBoardIndex($boardIndexOptions)
 					'new' => empty($row_board['is_read']),
 					'id' => $row_board['id_board'],
 					'name' => $row_board['board_name'],
-					'description' => parse_bbc($row_board['description'], false, '', $context['description_allowed_tags']),
+					'description' => $row_board['description'],
 					'moderators' => array(),
 					'moderator_groups' => array(),
 					'link_moderators' => array(),

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -3282,7 +3282,7 @@ function template_javascript($do_defered = false)
  */
 function template_css()
 {
-	global $context, $db_show_debug, $boardurl;
+	global $context, $db_show_debug, $boardurl, $settings;
 
 	// Use this hook to minify/optimize CSS files
 	call_integration_hook('integrate_pre_css_output');

--- a/Themes/default/ManageBoards.template.php
+++ b/Themes/default/ManageBoards.template.php
@@ -151,7 +151,7 @@ function template_modify_category()
 					</dd>
 					<dt>
 						<strong>', $txt['mboards_description'], '</strong><br>
-						<span class="smalltext">', $txt['mboards_cat_description_desc'], '</span>
+						<span class="smalltext">', str_replace('{allowed_tags}', implode(', ', $context['description_allowed_tags']), $txt['mboards_cat_description_desc']), '</span>
 					</dt>
 					<dd>
 						<textarea name="cat_desc" rows="3" cols="35" style="width: 99%;">', $context['category']['description'], '</textarea>
@@ -320,7 +320,7 @@ function template_modify_board()
 					</dd>
 					<dt>
 						<strong>', $txt['mboards_description'], ':</strong><br>
-						<span class="smalltext">', $txt['mboards_description_desc'], '</span>
+						<span class="smalltext">', str_replace('{allowed_tags}', implode(', ', $context['description_allowed_tags']), $txt['mboards_description_desc']), '</span>
 					</dt>
 					<dd>
 						<textarea name="desc" rows="3" cols="35" style="width:99%;">', $context['board']['description'], '</textarea>

--- a/Themes/default/Profile.template.php
+++ b/Themes/default/Profile.template.php
@@ -2852,8 +2852,8 @@ function template_profile_avatar_select()
 	{
 		echo '
 								<div id="avatar_upload">
-									<input type="file" size="44" name="attachment" id="avatar_upload_box" value="" onfocus="selectRadioByName(document.forms.creator.avatar_choice, \'upload\');" class="input_file" accept="image/gif, image/jpeg, image/jpg, image/png">', template_max_size('upload'), '
-									', (!empty($context['member']['avatar']['id_attach']) ? '<br><img src="' . $context['member']['avatar']['href'] . (strpos($context['member']['avatar']['href'], '?') === false ? '?' : '&amp;') . 'time=' . time() . '" alt=""><input type="hidden" name="id_attach" value="' . $context['member']['avatar']['id_attach'] . '">' : ''), '
+									<input type="file" size="44" name="attachment" id="avatar_upload_box" value="" onchange="readfromUpload(this)"  onfocus="selectRadioByName(document.forms.creator.avatar_choice, \'upload\');" class="input_file" accept="image/gif, image/jpeg, image/jpg, image/png">', template_max_size('upload'), '
+									', (!empty($context['member']['avatar']['id_attach']) ? '<br><img src="' . $context['member']['avatar']['href'] . (strpos($context['member']['avatar']['href'], '?') === false ? '?' : '&amp;') . 'time=' . time() . '" alt="" id="attached_image"><input type="hidden" name="id_attach" value="' . $context['member']['avatar']['id_attach'] . '">' : ''), '
 								</div>';
 	}
 

--- a/Themes/default/index.template.php
+++ b/Themes/default/index.template.php
@@ -581,7 +581,7 @@ function template_maint_warning_above()
 	<div class="errorbox" id="errors">
 		<dl>
 			<dt>
-				<strong id="error_serious">', $txt['forum_in_maintainence'], '</strong>
+				<strong id="error_serious">', $txt['forum_in_maintenance'], '</strong>
 			</dt>
 			<dd class="error" id="error_list">
 				', sprintf($txt['maintenance_page'], $scripturl . '?action=admin;area=serversettings;' . $context['session_var'] . '=' . $context['session_id']), '

--- a/Themes/default/languages/EmailTemplates.english.php
+++ b/Themes/default/languages/EmailTemplates.english.php
@@ -191,7 +191,7 @@ Should you have any problems with the activation, please visit {ACTIVATIONLINKWI
 {REGARDS}';
 
 $txt['admin_register_immediate_subject'] = 'Welcome to {FORUMNAME}';
-$txt['admin_register_immediate_body'] = 'Thank you for registering at {FORUMNAME}. Your username is {USERNAME} and your password is {PASSWORD}.
+$txt['admin_register_immediate_body'] = 'Thank you for registering at {FORUMNAME}. Your username is {USERNAME}, your password is {PASSWORD} and the forum url is: {SCRIPTURL}.
 
 {REGARDS}';
 

--- a/Themes/default/languages/ManageBoards.english.php
+++ b/Themes/default/languages/ManageBoards.english.php
@@ -46,8 +46,8 @@ $txt['mboards_delete_cancel'] = 'Cancel';
 
 $txt['mboards_category'] = 'Category';
 $txt['mboards_description'] = 'Description';
-$txt['mboards_description_desc'] = 'A short description of your board.';
-$txt['mboards_cat_description_desc'] = 'A short description of your category.';
+$txt['mboards_description_desc'] = 'A short description of your board. HTML is not allowed, you can use the following BBC tags: {allowed_tags}';
+$txt['mboards_cat_description_desc'] = 'A short description of your category. HTML is not allowed, you can use the following BBC tags: {allowed_tags}';
 $txt['mboards_groups'] = 'Allowed Groups';
 $txt['mboards_groups_desc'] = 'Groups allowed to access this board.<br><em>Note: if the member is in any group or post group checked, they will have access to this board.</em>';
 $txt['mboards_groups_regular_members'] = 'This group contains all members that have no primary group set.';

--- a/Themes/default/languages/index.english.php
+++ b/Themes/default/languages/index.english.php
@@ -338,7 +338,7 @@ $txt['days_word'] = 'days';
 $txt['search_for'] = 'Search for';
 $txt['search_match'] = 'Match';
 
-$txt['forum_in_maintainence'] = 'Your forum is in Maintenance Mode. Only administrators can currently log in.';
+$txt['forum_in_maintenance'] = 'Your forum is in Maintenance Mode. Only administrators can currently log in.';
 $txt['maintenance_page'] = 'You can turn off Maintenance Mode from the <a href="%1$s">Server Settings</a> area.';
 
 $txt['read_one_time'] = 'Read 1 time';

--- a/Themes/default/scripts/profile.js
+++ b/Themes/default/scripts/profile.js
@@ -239,3 +239,46 @@ function previewExternalAvatar(src)
 	}
 	document.getElementById("avatar").src = src;
 }
+
+function readfromUpload(input) {
+	if (input.files && input.files[0]) {
+		var reader = new FileReader();
+
+		reader.onload = function (e) {
+
+			// If there is an image already, hide it...
+			if ($('#attached_image').length){
+				$('#attached_image').remove();
+			}
+
+			if ($('#attached_image_new').length){
+				$('#attached_image_new').remove();
+			}
+
+			var tempImage = new Image();
+				tempImage.src = e.target.result;
+
+			var uploadedImage = $('<img />', {
+				id: 'attached_image_new',
+				src: e.target.result,
+				image: tempImage.width,
+				height: tempImage.height,
+			});
+
+			if (maxWidth != 0 && uploadedImage.width() > maxWidth)
+			{
+				uploadedImage.height(parseInt((maxWidth * uploadedImage.height()) / uploadedImage.width()) + "px");
+				uploadedImage.width(maxWidth + "px");
+			}
+			else if (maxHeight != 0 && uploadedImage.height() > maxHeight)
+			{
+				uploadedImage.width(parseInt((maxHeight * uploadedImage.width) / uploadedImage.height) + "px");
+				uploadedImage.height(maxHeight + "px");
+			}
+
+			uploadedImage.appendTo($('#avatar_upload'));
+		}
+
+		reader.readAsDataURL(input.files[0]);
+	}
+}

--- a/Themes/default/scripts/quotedText.js
+++ b/Themes/default/scripts/quotedText.js
@@ -28,7 +28,8 @@ function getSelectedText(divID)
 
 	var text = '',
 	selection,
-	found = 0;
+	found = 0,
+	container = document.createElement("div");
 
 	if (window.getSelection)
 	{
@@ -49,6 +50,8 @@ function getSelectedText(divID)
 			if (s !== null && e !== null)
 			{
 				found = 1;
+				container.appendChild(selection.getRangeAt(i).cloneContents());
+				text = container.innerHTML;
 				break;
 			}
 		}
@@ -81,14 +84,11 @@ function quotedTextClick(oOptions)
 				// Get the editor stuff.
 				var oEditor = $('#' + oEditorID).data('sceditor');
 
-				// Detect the mode.
-				if (oEditor.inSourceMode()){
-					oEditor.sourceEditorInsertText(text);
-				}
+				// Convert any HTML into BBC tags.
+				text = oEditor.toBBCode(text);
 
-				else{
-					oEditor.wysiwygEditorInsertHtml(oEditor.fromBBCode(text));
-				}
+				// Push the text to the editor.
+				oEditor.insert(text);
 
 				// Move the view to the quick reply box. If available.
 				if (typeof oJumpAnchor != 'undefined'){

--- a/Themes/default/scripts/quotedText.js
+++ b/Themes/default/scripts/quotedText.js
@@ -74,6 +74,9 @@ function quotedTextClick(oOptions)
 			beforeSend: function () {
 				ajax_indicator(true);
 			},
+			complete: function(jqXHR, textStatus){
+				ajax_indicator(false);
+			},
 			success: function (data, textStatus, xhr) {
 				// Search the xml data to get the quote tag.
 				text = $(data).find('quote').text();
@@ -97,11 +100,9 @@ function quotedTextClick(oOptions)
 					else
 						window.location.hash = '#' + oJumpAnchor;
 				}
-
-				ajax_indicator(false);
 			},
 			error: function (xhr, textStatus, errorThrown) {
-				ajax_indicator(false);
+				// @todo Show some error.
 			}
 		});
 }

--- a/Themes/default/scripts/quotedText.js
+++ b/Themes/default/scripts/quotedText.js
@@ -78,8 +78,17 @@ function quotedTextClick(oOptions)
 				// Insert the selected text between the quotes BBC tags.
 				text = text.match(/^\[quote(.*)]/ig) + oOptions.text + '[/quote]' + '\n\n';
 
-				// Add the whole text to the editor's instance.
-				$('#' + oEditorID).data('sceditor').sourceEditorInsertText(text);
+				// Get the editor stuff.
+				var oEditor = $('#' + oEditorID).data('sceditor');
+
+				// Detect the mode.
+				if (oEditor.inSourceMode()){
+					oEditor.sourceEditorInsertText(text);
+				}
+
+				else{
+					oEditor.wysiwygEditorInsertHtml(oEditor.fromBBCode(text));
+				}
 
 				// Move the view to the quick reply box. If available.
 				if (typeof oJumpAnchor != 'undefined'){

--- a/cron.php
+++ b/cron.php
@@ -87,7 +87,7 @@ loadDatabase();
 reloadSettings();
 
 // Just in case there's a problem...
-set_error_handler('error_handler_cron');
+set_error_handler('smf_error_handler_cron');
 $sc = '';
 $_SERVER['QUERY_STRING'] = '';
 $_SERVER['REQUEST_URL'] = FROM_CLI ? 'CLI cron.php' : $boardurl . '/cron.php';
@@ -242,7 +242,7 @@ function cleanRequest_cron()
  * @param int $line What line of the specified file the error occurred on
  * @return void
  */
-function error_handler_cron($error_level, $error_string, $file, $line)
+function smf_error_handler_cron($error_level, $error_string, $file, $line)
 {
 	global $modSettings;
 

--- a/index.php
+++ b/index.php
@@ -107,7 +107,7 @@ if (!empty($modSettings['enableCompressedOutput']) && !headers_sent())
 }
 
 // Register an error handler.
-set_error_handler('error_handler');
+set_error_handler('smf_error_handler');
 
 // Start the session. (assuming it hasn't already been.)
 loadSession();


### PR DESCRIPTION
Besides renaming the error handler function this PR also deals with removing HTML from category/board name and description.

Instead of parsing the string everytime, parsed it once before saving it to the DB.  use html_to_bbc() to retrieve back the original BBC tags, since the allowed tags are pretty basic, html_to_bbc() shouldn't have any issue converting them back.

Also deals with #3058 adding a way to preview uploaded avatars.

A bunch of other minor bugs fixed too.
