### PR TITLE
Addresses issue in #3066

### DIFF
--- a/Sources/Stats.php
+++ b/Sources/Stats.php
@@ -60,6 +60,12 @@ function DisplayStats()
 			obExit(false);
 
 		$context['sub_template'] = 'stats';
+		
+		if (!isset($month, $year))
+		{
+		    return;
+		}
+		
 		getDailyStats('YEAR(date) = {int:year} AND MONTH(date) = {int:month}', array('year' => $year, 'month' => $month));
 		$context['yearly'][$year]['months'][$month]['date'] = array(
 			'month' => sprintf('%02d', $month),


### PR DESCRIPTION
Prevent undefined variable errors and xml issues when `$month` and `$year`
cannot be set.

Signed-off-by: Georald Camposano georaldc@gmail.com
