### PR TITLE
Improve handling of files when installing languages

### DIFF
--- a/Sources/ManageLanguages.php
+++ b/Sources/ManageLanguages.php
@@ -358,16 +358,15 @@ function DownloadLanguage()
 			// Add the context data to the main set.
 			$context['files']['lang'][] = $context_data;
 		}
+		elseif ($extension == '.txt' && stripos($filename, 'agreement') !== false)
+		{
+			// Registration agreement is a primary file
+			$context['files']['lang'][] = $context_data;
+		}
 		else
 		{
-			// If we think it's a theme thing, work out what the theme is.
-			if (strpos($dirname, 'Themes') === 0 && preg_match('~Themes[\\/]([^\\/]+)[\\/]~', $dirname, $match))
-				$theme_name = $match[1];
-			else
-				$theme_name = 'misc';
-
-			// Assume it's an image, could be an acceptance note etc but rare.
-			$context['files']['images'][$theme_name][] = $context_data;
+			// There shouldn't be anything else, but load this into "other" in case we decide to handle it in the future
+			$context['files']['other'][] = $context_data;
 		}
 
 		// Collect together all non-writable areas.

--- a/Themes/default/ManageLanguages.template.php
+++ b/Themes/default/ManageLanguages.template.php
@@ -63,68 +63,6 @@ function template_download_language()
 	// Show the main files.
 	template_show_list('lang_main_files_list');
 
-	// Now, all the images and the likes, hidden via javascript 'cause there are so fecking many.
-	echo '
-			<br>
-			<div class="cat_bar">
-				<h3 class="catbg">
-					', $txt['languages_download_theme_files'], '
-				</h3>
-			</div>
-			<table class="table_grid">
-				<thead>
-					<tr class="title_bar">
-						<th scope="col">
-							', $txt['languages_download_filename'], '
-						</th>
-						<th scope="col" style="width: 100px">
-							', $txt['languages_download_writable'], '
-						</th>
-						<th scope="col" style="width: 100px">
-							', $txt['languages_download_exists'], '
-						</th>
-						<th class="centercol" scope="col" style="width: 4%">
-							', $txt['languages_download_copy'], '
-						</th>
-					</tr>
-				</thead>
-				<tbody>';
-
-	foreach ($context['files']['images'] as $theme => $group)
-	{
-		$count = 0;
-		echo '
-				<tr class="titlebg">
-					<td colspan="4">
-						<img class="sort" src="', $settings['images_url'], '/selected_open.png" id="toggle_image_', $theme, '" alt="*">&nbsp;', isset($context['theme_names'][$theme]) ? $context['theme_names'][$theme] : $theme, '
-					</td>
-				</tr>';
-
-		foreach ($group as $file)
-		{
-			echo '
-				<tr class="windowbg" id="', $theme, '-', $count++, '">
-					<td>
-						<strong>', $file['name'], '</strong><br>
-						<span class="smalltext">', $txt['languages_download_dest'], ': ', $file['destination'], '</span>
-					</td>
-					<td>
-						<span style="color: ', ($file['writable'] ? 'green' : 'red'), ';">', ($file['writable'] ? $txt['yes'] : $txt['no']), '</span>
-					</td>
-					<td>
-						', $file['exists'] ? ($file['exists'] == 'same' ? $txt['languages_download_exists_same'] : $txt['languages_download_exists_different']) : $txt['no'], '
-					</td>
-					<td class="centercol">
-						<input type="checkbox" name="copy_file[]" value="', $file['generaldest'], '"', ($file['default_copy'] ? ' checked' : ''), ' class="input_check">
-					</td>
-				</tr>';
-		}
-	}
-
-	echo '
-			</tbody>
-			</table>';
-
 	// Do we want some FTP baby?
 	// If the files are not writable, we might!
 	if (!empty($context['still_not_writable']))
@@ -185,40 +123,6 @@ function template_download_language()
 			</div>
 		</form>
 	</div>';
-
-	// The javascript for expand and collapse of sections.
-	echo '
-	<script>';
-
-	// Each theme gets its own handler.
-	foreach ($context['files']['images'] as $theme => $group)
-	{
-		$count = 0;
-		echo '
-			var oTogglePanel_', $theme, ' = new smc_Toggle({
-				bToggleEnabled: true,
-				bCurrentlyCollapsed: true,
-				aSwappableContainers: [';
-		foreach ($group as $file)
-			echo '
-					', JavaScriptEscape($theme . '-' . $count++), ',';
-		echo '
-					null
-				],
-				aSwapImages: [
-					{
-						sId: \'toggle_image_', $theme, '\',
-						srcExpanded: smf_images_url + \'/selected_open.png\',
-						altExpanded: \'*\',
-						srcCollapsed: smf_images_url + \'/selected.png\',
-						altCollapsed: \'*\'
-					}
-				]
-			});';
-	}
-
-	echo '
-	</script>';
 }
 
 /**

--- a/Themes/default/languages/ManageSettings.english.php
+++ b/Themes/default/languages/ManageSettings.english.php
@@ -338,8 +338,7 @@ $txt['languages_download_info'] = '<strong>Note:</strong>
 		<li>Where a file already exists on your forum the &quot;Already Exists&quot; column will have one of two values. &quot;Identical&quot; indicates that the file already exists in an identical form and need not be overwritten. &quot;Different&quot; means that the contents vary in some way and overwriting is probably the optimum solution.</li>
 	</ul>';
 
-$txt['languages_download_main_files'] = 'Primary Files';
-$txt['languages_download_theme_files'] = 'Theme-related Files';
+$txt['languages_download_main_files'] = 'Primary Files';+
 $txt['languages_download_filename'] = 'File Name';
 $txt['languages_download_dest'] = 'Destination';
 $txt['languages_download_writable'] = 'Writable';


### PR DESCRIPTION
This changes the install language inteface to remove handling of "Theme-related" files. At this point it was only treating the registration agreement and Themes/default/languages/index.php as theme-related files and generated errors if neither file existed in the package. Since we don't need to overwrite index.php and the agreement isn't a theme file, that code really isn't needed anymore.
