### PR TITLE
Notify integrated systems of username changes

### DIFF
--- a/Sources/Profile-Modify.php
+++ b/Sources/Profile-Modify.php
@@ -292,6 +292,9 @@ function loadProfileFields($force_reload = false)
 					{
 						validateUsername($context['id_member'], trim(preg_replace('~[\t\n\r \x0B\0' . ($context['utf8'] ? '\x{A0}\x{AD}\x{2000}-\x{200F}\x{201F}\x{202F}\x{3000}\x{FEFF}' : '\x00-\x08\x0B\x0C\x0E-\x19\xA0') . ']+~' . ($context['utf8'] ? 'u' : ''), ' ', $value)));
 						updateMemberData($context['id_member'], array('member_name' => $value));
+
+						// Call this here so any integrated systems will know about the name change (resetPassword() takes care of this if we're letting SMF generate the password)
+						call_integration_hook('integrate_reset_pass', array($cur_profile['member_name'], $value, $_POST['passwrd1']));
 					}
 				}
 				return false;


### PR DESCRIPTION
Per http://www.simplemachines.org/community/index.php?topic=539958.0, if an admin changed a user's password when changing their username (instead of having SMF generate a temporary password for the user), information about the username change was never sent via integration hooks.
