### PR TITLE
Use JSON encoding instead of serialize

### DIFF
--- a/Sources/Admin.php
+++ b/Sources/Admin.php
@@ -38,7 +38,7 @@ function AdminMain()
 	require_once($sourcedir . '/Subs-Menu.php');
 
 	// Some preferences.
-	$context['admin_preferences'] = !empty($options['admin_preferences']) ? unserialize($options['admin_preferences']) : array();
+	$context['admin_preferences'] = !empty($options['admin_preferences']) ? json_decode($options['admin_preferences']) : array();
 
 	/** @var array $admin_areas Defines the menu structure for the admin center. See {@link Subs-Menu.php Subs-Menu.php} for details! */
 	$admin_areas = array(

--- a/Sources/Admin.php
+++ b/Sources/Admin.php
@@ -38,7 +38,7 @@ function AdminMain()
 	require_once($sourcedir . '/Subs-Menu.php');
 
 	// Some preferences.
-	$context['admin_preferences'] = !empty($options['admin_preferences']) ? json_decode($options['admin_preferences']) : array();
+	$context['admin_preferences'] = !empty($options['admin_preferences']) ? json_decode($options['admin_preferences'], true) : array();
 
 	/** @var array $admin_areas Defines the menu structure for the admin center. See {@link Subs-Menu.php Subs-Menu.php} for details! */
 	$admin_areas = array(

--- a/Sources/Attachments.php
+++ b/Sources/Attachments.php
@@ -49,7 +49,7 @@ class Attachments
 		$this->_currentAttachmentUploadDir = !empty($modSettings['currentAttachmentUploadDir']) ? $modSettings['currentAttachmentUploadDir'] : '';
 
 		if (!is_array($modSettings['attachmentUploadDir']))
-			$this->_attachmentUploadDir = json_decode($modSettings['attachmentUploadDir']);
+			$this->_attachmentUploadDir = json_decode($modSettings['attachmentUploadDir'], true);
 
 		$this->_attchDir = $context['attach_dir'] = $this->_attachmentUploadDir[$modSettings['currentAttachmentUploadDir']];
 

--- a/Sources/Attachments.php
+++ b/Sources/Attachments.php
@@ -49,7 +49,7 @@ class Attachments
 		$this->_currentAttachmentUploadDir = !empty($modSettings['currentAttachmentUploadDir']) ? $modSettings['currentAttachmentUploadDir'] : '';
 
 		if (!is_array($modSettings['attachmentUploadDir']))
-			$this->_attachmentUploadDir = unserialize($modSettings['attachmentUploadDir']);
+			$this->_attachmentUploadDir = json_decode($modSettings['attachmentUploadDir']);
 
 		$this->_attchDir = $context['attach_dir'] = $this->_attachmentUploadDir[$modSettings['currentAttachmentUploadDir']];
 

--- a/Sources/Drafts.php
+++ b/Sources/Drafts.php
@@ -208,7 +208,7 @@ function SavePMDraft(&$post_errors, $recipientList)
 		$recipientList['bcc'] = isset($_POST['recipient_bcc']) ? explode(',', $_POST['recipient_bcc']) : array();
 	}
 	elseif (!empty($draft_info['to_list']) && empty($recipientList))
-		$recipientList = unserialize($draft_info['to_list']);
+		$recipientList = json_decode($draft_info['to_list']);
 
 	// prepare the data we got from the form
 	$reply_id = empty($_POST['replied_to']) ? 0 : (int) $_POST['replied_to'];
@@ -240,7 +240,7 @@ function SavePMDraft(&$post_errors, $recipientList)
 				'subject' => $draft['subject'],
 				'body' => $draft['body'],
 				'id_pm_draft' => $id_pm_draft,
-				'to_list' => serialize($recipientList),
+				'to_list' => json_encode($recipientList),
 			)
 		);
 
@@ -269,7 +269,7 @@ function SavePMDraft(&$post_errors, $recipientList)
 				$user_info['id'],
 				$draft['subject'],
 				$draft['body'],
-				serialize($recipientList),
+				json_encode($recipientList),
 			),
 			array(
 				'id_draft'
@@ -370,7 +370,7 @@ function ReadDraft($id_draft, $type = 0, $check = true, $load = false)
 			$_REQUEST['message'] = !empty($draft_info['body']) ? str_replace('<br>', "\n", un_htmlspecialchars(stripslashes($draft_info['body']))) : '';
 			$_REQUEST['replied_to'] = !empty($draft_info['id_reply']) ? $draft_info['id_reply'] : 0;
 			$context['id_pm_draft'] = !empty($draft_info['id_draft']) ? $draft_info['id_draft'] : 0;
-			$recipients = unserialize($draft_info['to_list']);
+			$recipients = json_decode($draft_info['to_list']);
 
 			// make sure we only have integers in this array
 			$recipients['to'] = array_map('intval', $recipients['to']);
@@ -779,7 +779,7 @@ function showPMDrafts($memID = -1)
 			'to' => array(),
 			'bcc' => array(),
 		);
-		$recipient_ids = (!empty($row['to_list'])) ? unserialize($row['to_list']) : array();
+		$recipient_ids = (!empty($row['to_list'])) ? json_decode($row['to_list']) : array();
 
 		// @todo ... this is a bit ugly since it runs an extra query for every message, do we want this?
 		// at least its only for draft PM's and only the user can see them ... so not heavily used .. still

--- a/Sources/Drafts.php
+++ b/Sources/Drafts.php
@@ -208,7 +208,7 @@ function SavePMDraft(&$post_errors, $recipientList)
 		$recipientList['bcc'] = isset($_POST['recipient_bcc']) ? explode(',', $_POST['recipient_bcc']) : array();
 	}
 	elseif (!empty($draft_info['to_list']) && empty($recipientList))
-		$recipientList = json_decode($draft_info['to_list']);
+		$recipientList = json_decode($draft_info['to_list'], true);
 
 	// prepare the data we got from the form
 	$reply_id = empty($_POST['replied_to']) ? 0 : (int) $_POST['replied_to'];
@@ -370,7 +370,7 @@ function ReadDraft($id_draft, $type = 0, $check = true, $load = false)
 			$_REQUEST['message'] = !empty($draft_info['body']) ? str_replace('<br>', "\n", un_htmlspecialchars(stripslashes($draft_info['body']))) : '';
 			$_REQUEST['replied_to'] = !empty($draft_info['id_reply']) ? $draft_info['id_reply'] : 0;
 			$context['id_pm_draft'] = !empty($draft_info['id_draft']) ? $draft_info['id_draft'] : 0;
-			$recipients = json_decode($draft_info['to_list']);
+			$recipients = json_decode($draft_info['to_list'], true);
 
 			// make sure we only have integers in this array
 			$recipients['to'] = array_map('intval', $recipients['to']);
@@ -779,7 +779,7 @@ function showPMDrafts($memID = -1)
 			'to' => array(),
 			'bcc' => array(),
 		);
-		$recipient_ids = (!empty($row['to_list'])) ? json_decode($row['to_list']) : array();
+		$recipient_ids = (!empty($row['to_list'])) ? json_decode($row['to_list'], true) : array();
 
 		// @todo ... this is a bit ugly since it runs an extra query for every message, do we want this?
 		// at least its only for draft PM's and only the user can see them ... so not heavily used .. still

--- a/Sources/Errors.php
+++ b/Sources/Errors.php
@@ -501,7 +501,7 @@ function log_error_online($error, $sprintf = array())
 	if ($smcFunc['db_num_rows']($request) != 0)
 	{
 		list ($url) = $smcFunc['db_fetch_row']($request);
-		$url = json_decode($url);
+		$url = json_decode($url, true);
 		$url['error'] = $error;
 
 		if (!empty($sprintf))

--- a/Sources/Errors.php
+++ b/Sources/Errors.php
@@ -501,7 +501,7 @@ function log_error_online($error, $sprintf = array())
 	if ($smcFunc['db_num_rows']($request) != 0)
 	{
 		list ($url) = $smcFunc['db_fetch_row']($request);
-		$url = unserialize($url);
+		$url = json_decode($url);
 		$url['error'] = $error;
 
 		if (!empty($sprintf))
@@ -512,7 +512,7 @@ function log_error_online($error, $sprintf = array())
 			SET url = {string:url}
 			WHERE session = {string:session}',
 			array(
-				'url' => serialize($url),
+				'url' => json_encode($url),
 				'session' => $session_id,
 			)
 		);

--- a/Sources/Groups.php
+++ b/Sources/Groups.php
@@ -524,7 +524,7 @@ function GroupRequests()
 			$smcFunc['db_free_result']($request);
 
 			// Add a background task to handle notifying people of this request
-			$data = serialize(array('member_id' => $user_info['id'], 'member_ip' => $user_info['ip'], 'request_list' => $request_list, 'status' => $_POST['req_action'], 'reason' => isset($_POST['groupreason']) ? $_POST['groupreason'] : '', 'time' => time()));
+			$data = json_encode(array('member_id' => $user_info['id'], 'member_ip' => $user_info['ip'], 'request_list' => $request_list, 'status' => $_POST['req_action'], 'reason' => isset($_POST['groupreason']) ? $_POST['groupreason'] : '', 'time' => time()));
 			$smcFunc['db_insert']('insert', '{db_prefix}background_tasks',
 				array('task_file' => 'string-255', 'task_class' => 'string-255', 'task_data' => 'string', 'claimed_time' => 'int'),
 				array('$sourcedir/tasks/GroupAct-Notify.php', 'GroupAct_Notify_Background', $data, 0), array()

--- a/Sources/Likes.php
+++ b/Sources/Likes.php
@@ -325,7 +325,7 @@ class Likes
 			$smcFunc['db_insert']('insert',
 				'{db_prefix}background_tasks',
 				array('task_file' => 'string', 'task_class' => 'string', 'task_data' => 'string', 'claimed_time' => 'int'),
-				array('$sourcedir/tasks/Likes-Notify.php', 'Likes_Notify_Background', serialize(array(
+				array('$sourcedir/tasks/Likes-Notify.php', 'Likes_Notify_Background', json_encode(array(
 					'content_id' => $content,
 					'content_type' => $type,
 					'sender_id' => $user['id'],

--- a/Sources/Load.php
+++ b/Sources/Load.php
@@ -375,13 +375,23 @@ function loadUserSettings()
 
 	if (empty($id_member) && isset($_COOKIE[$cookiename]))
 	{
-		list ($id_member, $password) = @unserialize($_COOKIE[$cookiename]);
+		$cookie_data = json_decode($_COOKIE[$cookiename], true);
+
+		if (is_null($cookie_data))
+			$cookie_data = @unserialize($_COOKIE[$cookiename]);
+
+		list ($id_member, $password) = $cookie_data;
 		$id_member = !empty($id_member) && strlen($password) > 0 ? (int) $id_member : 0;
 	}
 	elseif (empty($id_member) && isset($_SESSION['login_' . $cookiename]) && ($_SESSION['USER_AGENT'] == $_SERVER['HTTP_USER_AGENT'] || !empty($modSettings['disableCheckUA'])))
 	{
 		// @todo Perhaps we can do some more checking on this, such as on the first octet of the IP?
-		list ($id_member, $password, $login_span) = @unserialize($_SESSION['login_' . $cookiename]);
+		$cookie_data = json_decode($_SESSION['login_' . $cookiename]);
+
+		if (is_null($cookie_data))
+			$cookie_data = @unserialize($_SESSION['login_' . $cookiename]);
+
+		list ($id_member, $password, $login_span) = $cookie_data;
 		$id_member = !empty($id_member) && strlen($password) == 128 && $login_span > time() ? (int) $id_member : 0;
 	}
 
@@ -447,7 +457,12 @@ function loadUserSettings()
 			{
 				if (!empty($_COOKIE[$tfacookie]))
 				{
-					list ($tfamember, $tfasecret) = @unserialize($_COOKIE[$tfacookie]);
+					$tfa_data = json_decode($_COOKIE[$tfacookie]);
+
+					if (is_null($tfa_data))
+						$tfa_data = @unserialize($_COOKIE[$tfacookie]);
+
+					list ($tfamember, $tfasecret) = $tfa_data;
 
 					if ((int) $tfamember != $id_member)
 						$tfasecret = null;
@@ -599,7 +614,12 @@ function loadUserSettings()
 		// Expire the 2FA cookie
 		if (isset($_COOKIE[$cookiename . '_tfa']) && empty($context['tfa_member']))
 		{
-			list ($id, $user, $exp, $state, $preserve) = @unserialize($_COOKIE[$cookiename . '_tfa']);
+			$tfa_data = json_decode($_COOKIE[$cookiename . '_tfa'], true);
+
+			if (is_null($tfa_data))
+				$tfa_data = @unserialize($_COOKIE[$cookiename . '_tfa']);
+
+			list ($id, $user, $exp, $state, $preserve) = $tfa_data;
 
 			if (!$preserve || time() > $exp)
 			{

--- a/Sources/Load.php
+++ b/Sources/Load.php
@@ -255,7 +255,7 @@ function reloadSettings()
 	// Integration is cool.
 	if (defined('SMF_INTEGRATION_SETTINGS'))
 	{
-		$integration_settings = json_decode(SMF_INTEGRATION_SETTINGS);
+		$integration_settings = json_decode(SMF_INTEGRATION_SETTINGS, true);
 		foreach ($integration_settings as $hook => $function)
 			add_integration_function($hook, $function, '', false);
 	}
@@ -1469,7 +1469,7 @@ function loadMemberContext($user, $display_custom_fields = false)
 	{
 		$memberContext[$user]['custom_fields'] = array();
 		if (!isset($context['display_fields']))
-			$context['display_fields'] = json_decode($modSettings['displayFields']);
+			$context['display_fields'] = json_decode($modSettings['displayFields'], true);
 
 		foreach ($context['display_fields'] as $custom)
 		{
@@ -3256,7 +3256,7 @@ function cache_get_data($key, $ttl = 120)
 	if (function_exists('call_integration_hook') && isset($value))
 		call_integration_hook('cache_get_data', array(&$key, &$ttl, &$value));
 
-	return empty($value) ? null : @json_decode($value);
+	return empty($value) ? null : @json_decode($value, true);
 }
 
 /**

--- a/Sources/Load.php
+++ b/Sources/Load.php
@@ -247,7 +247,7 @@ function reloadSettings()
 	if (empty($modSettings['currentAttachmentUploadDir']))
 	{
 		updateSettings(array(
-			'attachmentUploadDir' => serialize(array(1 => $modSettings['attachmentUploadDir'])),
+			'attachmentUploadDir' => json_encode(array(1 => $modSettings['attachmentUploadDir'])),
 			'currentAttachmentUploadDir' => 1,
 		));
 	}
@@ -255,7 +255,7 @@ function reloadSettings()
 	// Integration is cool.
 	if (defined('SMF_INTEGRATION_SETTINGS'))
 	{
-		$integration_settings = unserialize(SMF_INTEGRATION_SETTINGS);
+		$integration_settings = json_decode(SMF_INTEGRATION_SETTINGS);
 		foreach ($integration_settings as $hook => $function)
 			add_integration_function($hook, $function, '', false);
 	}
@@ -1469,7 +1469,7 @@ function loadMemberContext($user, $display_custom_fields = false)
 	{
 		$memberContext[$user]['custom_fields'] = array();
 		if (!isset($context['display_fields']))
-			$context['display_fields'] = unserialize($modSettings['displayFields']);
+			$context['display_fields'] = json_decode($modSettings['displayFields']);
 
 		foreach ($context['display_fields'] as $custom)
 		{
@@ -3090,12 +3090,12 @@ function cache_put_data($key, $value, $ttl = 120)
 	$cache_count = isset($cache_count) ? $cache_count + 1 : 1;
 	if (isset($db_show_debug) && $db_show_debug === true)
 	{
-		$cache_hits[$cache_count] = array('k' => $key, 'd' => 'put', 's' => $value === null ? 0 : strlen(serialize($value)));
+		$cache_hits[$cache_count] = array('k' => $key, 'd' => 'put', 's' => $value === null ? 0 : strlen(json_encode($value)));
 		$st = microtime();
 	}
 
 	$key = md5($boardurl . filemtime($cachedir . '/' . 'index.php')) . '-SMF-' . strtr($key, ':/', '-_');
-	$value = $value === null ? null : serialize($value);
+	$value = $value === null ? null : json_encode($value);
 
 	switch ($cache_accelerator)
 	{
@@ -3256,7 +3256,7 @@ function cache_get_data($key, $ttl = 120)
 	if (function_exists('call_integration_hook') && isset($value))
 		call_integration_hook('cache_get_data', array(&$key, &$ttl, &$value));
 
-	return empty($value) ? null : @unserialize($value);
+	return empty($value) ? null : @json_decode($value);
 }
 
 /**

--- a/Sources/LogInOut.php
+++ b/Sources/LogInOut.php
@@ -98,9 +98,21 @@ function Login2()
 	if (isset($_GET['sa']) && $_GET['sa'] == 'salt' && !$user_info['is_guest'])
 	{
 		if (isset($_COOKIE[$cookiename]) && preg_match('~^a:[34]:\{i:0;i:\d{1,7};i:1;s:(0|128):"([a-fA-F0-9]{128})?";i:2;[id]:\d{1,14};(i:3;i:\d;)?\}$~', $_COOKIE[$cookiename]) === 1)
-			list (, , $timeout) = @unserialize($_COOKIE[$cookiename]);
+		{
+			list (, , $timeout) = json_decode($_COOKIE[$cookiename], true);
+
+			// That didn't work... Maybe it's using serialize?
+			if (is_null($timeout))
+				list (, , $timeout) = @unserialize($_COOKIE[$cookiename]);
+		}
 		elseif (isset($_SESSION['login_' . $cookiename]))
-			list (, , $timeout) = @unserialize($_SESSION['login_' . $cookiename]);
+		{
+			list (, , $timeout) = json_decode($_SESSION['login_' . $cookiename]);
+
+			// Try for old format
+			if (is_null($timeout))
+				list (, , $timeout) = @unserialize($_SESSION['login_' . $cookiename]);
+		}
 		else
 			trigger_error('Login2(): Cannot be logged in without a session or cookie', E_USER_ERROR);
 
@@ -110,7 +122,13 @@ function Login2()
 		// Preserve the 2FA cookie?
 		if (!empty($modSettings['tfa_mode']) && !empty($_COOKIE[$cookiename . '_tfa']))
 		{
-			list ($tfamember, $tfasecret, $exp, $state, $preserve) = @unserialize($_COOKIE[$cookiename . '_tfa']);
+			$tfadata = json_decode($_COOKIE[$cookiename . '_tfa'], true);
+
+			// If that didn't work, try unserialize instead...
+			if (is_null($tfadata))
+				$tfadata = @unserialize($_COOKIE[$cookiename . '_tfa']);
+
+			list ($tfamember, $tfasecret, $exp, $state, $preserve) = $tfadata;
 
 			// If we're preserving the cookie, reset it with updated salt
 			if ($preserve && time() < $exp)
@@ -667,7 +685,13 @@ function Logout($internal = false, $redirect = true)
 
 	if (!empty($modSettings['tfa_mode']) && !empty($user_info['id']) && !empty($_COOKIE[$cookiename . '_tfa']))
 	{
-		list ($tfamember, $tfasecret, $exp, $state, $preserve) = @unserialize($_COOKIE[$cookiename . '_tfa']);
+		$tfadata = json_decode($_COOKIE[$cookiename . '_tfa'], true);
+
+		// If that failed, try the old method
+		if (is_null($tfadata))
+			$tfadata = @unserialize($_COOKIE[$cookiename . '_tfa']);
+
+		list ($tfamember, $tfasecret, $exp, $state, $preserve) = $tfadata;
 
 		// If we're preserving the cookie, reset it with updated salt
 		if ($preserve && time() < $exp)

--- a/Sources/Logging.php
+++ b/Sources/Logging.php
@@ -59,7 +59,7 @@ function writeLog($force = false)
 			$context['session_var'] = $_SESSION['session_var'];
 
 		unset($serialized['sesc'], $serialized[$context['session_var']]);
-		$serialized = serialize($serialized);
+		$serialized = json_encode($serialized);
 	}
 	else
 		$serialized = '';
@@ -513,7 +513,7 @@ function logActions($logs)
 
 		$inserts[] = array(
 			time(), $log_types[$log['log_type']], $memID, $user_info['ip'], $log['action'],
-			$board_id, $topic_id, $msg_id, serialize($log['extra']),
+			$board_id, $topic_id, $msg_id, json_encode($log['extra']),
 		);
 	}
 

--- a/Sources/ManageAttachments.php
+++ b/Sources/ManageAttachments.php
@@ -92,7 +92,7 @@ function ManageAttachmentSettings($return_config = false)
 	require_once($sourcedir . '/Subs-Attachments.php');
 
 	// Get the current attachment directory.
-	$modSettings['attachmentUploadDir'] = json_decode($modSettings['attachmentUploadDir']);
+	$modSettings['attachmentUploadDir'] = json_decode($modSettings['attachmentUploadDir'], true);
 	$context['attachmentUploadDir'] = $modSettings['attachmentUploadDir'][$modSettings['currentAttachmentUploadDir']];
 
 	// First time here?
@@ -218,7 +218,7 @@ function ManageAttachmentSettings($return_config = false)
 			if (!empty($_POST['use_subdirectories_for_attachments']) && !empty($modSettings['attachment_basedirectories']))
 			{
 				if (!is_array($modSettings['attachment_basedirectories']))
-					$modSettings['attachment_basedirectories'] = json_decode($modSettings['attachment_basedirectories']);
+					$modSettings['attachment_basedirectories'] = json_decode($modSettings['attachment_basedirectories'], true);
 			}
 			else
 				$modSettings['attachment_basedirectories'] = array();
@@ -722,7 +722,7 @@ function MaintainFiles()
 	$context['sub_template'] = 'maintenance';
 
 	if (!empty($modSettings['currentAttachmentUploadDir']))
-		$attach_dirs = json_decode($modSettings['attachmentUploadDir']);
+		$attach_dirs = json_decode($modSettings['attachmentUploadDir'], true);
 	else
 		$attach_dirs = array($modSettings['attachmentUploadDir']);
 
@@ -795,7 +795,7 @@ function MaintainFiles()
 
 	$context['attach_multiple_dirs'] = count($attach_dirs) > 1 ? true : false;
 	$context['attach_dirs'] = $attach_dirs;
-	$context['base_dirs'] = !empty($modSettings['attachment_basedirectories']) ? json_decode($modSettings['attachment_basedirectories']) : array();
+	$context['base_dirs'] = !empty($modSettings['attachment_basedirectories']) ? json_decode($modSettings['attachment_basedirectories'], true) : array();
 	$context['checked'] = isset($_SESSION['checked']) ? $_SESSION['checked'] : true;
 	if (!empty($_SESSION['results']))
 	{
@@ -1345,7 +1345,7 @@ function RepairAttachments()
 						$attachment_name = $row['id_attach'] . '_' . $row['file_hash'] .'.dat';
 
 						if (!is_array($modSettings['attachmentUploadDir']))
-							$modSettings['attachmentUploadDir'] = json_decode($modSettings['attachmentUploadDir']);
+							$modSettings['attachmentUploadDir'] = json_decode($modSettings['attachmentUploadDir'], true);
 
 						// Loop through the other folders.
 						foreach ($modSettings['attachmentUploadDir'] as $id => $dir)
@@ -1590,7 +1590,7 @@ function RepairAttachments()
 	{
 		// Just use the current path for temp files.
 		if (!is_array($modSettings['attachmentUploadDir']))
-			$modSettings['attachmentUploadDir'] = json_decode($modSettings['attachmentUploadDir']);
+			$modSettings['attachmentUploadDir'] = json_decode($modSettings['attachmentUploadDir'], true);
 		$attach_dirs = $modSettings['attachmentUploadDir'];
 
 		$current_check = 0;
@@ -1910,11 +1910,11 @@ function ManageAttachmentPaths()
 
 	// Since this needs to be done eventually.
 	if (!is_array($modSettings['attachmentUploadDir']))
-		$modSettings['attachmentUploadDir'] = json_decode($modSettings['attachmentUploadDir']);
+		$modSettings['attachmentUploadDir'] = json_decode($modSettings['attachmentUploadDir'], true);
 	if (!isset($modSettings['attachment_basedirectories']))
 		$modSettings['attachment_basedirectories'] = array();
 	elseif (!is_array($modSettings['attachment_basedirectories']))
-		$modSettings['attachment_basedirectories'] = json_decode($modSettings['attachment_basedirectories']);
+		$modSettings['attachment_basedirectories'] = json_decode($modSettings['attachment_basedirectories'], true);
 
 	$errors = array();
 
@@ -1991,7 +1991,7 @@ function ManageAttachmentPaths()
 						'attachment_basedirectories' => json_encode($modSettings['attachment_basedirectories']),
 						'basedirectory_for_attachments' => $base,
 					));
-					$modSettings['attachment_basedirectories'] = json_decode($modSettings['attachment_basedirectories']);
+					$modSettings['attachment_basedirectories'] = json_decode($modSettings['attachment_basedirectories'], true);
 				}
 			}
 
@@ -2053,7 +2053,7 @@ function ManageAttachmentPaths()
 						{
 							unset($modSettings['attachment_basedirectories'][$id]);
 							updateSettings(array('attachment_basedirectories' => json_encode($modSettings['attachment_basedirectories'])));
-							$modSettings['attachment_basedirectories'] = json_decode($modSettings['attachment_basedirectories']);
+							$modSettings['attachment_basedirectories'] = json_decode($modSettings['attachment_basedirectories'], true);
 						}
 					}
 					else
@@ -2086,7 +2086,7 @@ function ManageAttachmentPaths()
 		if ($_POST['current_dir'] !=  $modSettings['currentAttachmentUploadDir']&& !empty($modSettings['last_attachments_directory']) && (isset($modSettings['last_attachments_directory'][$_POST['current_dir']]) || isset($modSettings['last_attachments_directory'][0])))
 		{
 			if (!is_array($modSettings['last_attachments_directory']))
-				$modSettings['last_attachments_directory'] = json_decode($modSettings['last_attachments_directory']);
+				$modSettings['last_attachments_directory'] = json_decode($modSettings['last_attachments_directory'], true);
 			$num = substr(strrchr($modSettings['attachmentUploadDir'][$_POST['current_dir']], '_'), 1);
 
 			if (is_numeric($num))
@@ -2611,9 +2611,9 @@ function TransferAttachments()
 
 	checkSession();
 
-	$modSettings['attachmentUploadDir'] = json_decode($modSettings['attachmentUploadDir']);
+	$modSettings['attachmentUploadDir'] = json_decode($modSettings['attachmentUploadDir'], true);
 	if (!empty($modSettings['attachment_basedirectories']))
-		$modSettings['attachment_basedirectories'] = json_decode($modSettings['attachment_basedirectories']);
+		$modSettings['attachment_basedirectories'] = json_decode($modSettings['attachment_basedirectories'], true);
 	else
 		$modSettings['basedirectory_for_attachments'] = array();
 

--- a/Sources/ManageAttachments.php
+++ b/Sources/ManageAttachments.php
@@ -92,7 +92,7 @@ function ManageAttachmentSettings($return_config = false)
 	require_once($sourcedir . '/Subs-Attachments.php');
 
 	// Get the current attachment directory.
-	$modSettings['attachmentUploadDir'] = unserialize($modSettings['attachmentUploadDir']);
+	$modSettings['attachmentUploadDir'] = json_decode($modSettings['attachmentUploadDir']);
 	$context['attachmentUploadDir'] = $modSettings['attachmentUploadDir'][$modSettings['currentAttachmentUploadDir']];
 
 	// First time here?
@@ -207,7 +207,7 @@ function ManageAttachmentSettings($return_config = false)
 				rename($modSettings['attachmentUploadDir'], $_POST['attachmentUploadDir']);
 
 			$modSettings['attachmentUploadDir'] = array(1 => $_POST['attachmentUploadDir']);
-			$_POST['attachmentUploadDir'] = serialize($modSettings['attachmentUploadDir']);
+			$_POST['attachmentUploadDir'] = json_encode($modSettings['attachmentUploadDir']);
 		}
 
 		if (!empty($_POST['use_subdirectories_for_attachments']))
@@ -218,7 +218,7 @@ function ManageAttachmentSettings($return_config = false)
 			if (!empty($_POST['use_subdirectories_for_attachments']) && !empty($modSettings['attachment_basedirectories']))
 			{
 				if (!is_array($modSettings['attachment_basedirectories']))
-					$modSettings['attachment_basedirectories'] = unserialize($modSettings['attachment_basedirectories']);
+					$modSettings['attachment_basedirectories'] = json_decode($modSettings['attachment_basedirectories']);
 			}
 			else
 				$modSettings['attachment_basedirectories'] = array();
@@ -237,12 +237,12 @@ function ManageAttachmentSettings($return_config = false)
 				{
 					$modSettings['attachment_basedirectories'][$modSettings['currentAttachmentUploadDir']] = $_POST['basedirectory_for_attachments'];
 					updateSettings(array(
-						'attachment_basedirectories' => serialize($modSettings['attachment_basedirectories']),
+						'attachment_basedirectories' => json_encode($modSettings['attachment_basedirectories']),
 						'currentAttachmentUploadDir' => $currentAttachmentUploadDir,
 					));
 
 					$_POST['use_subdirectories_for_attachments'] = 1;
-					$_POST['attachmentUploadDir'] = serialize($modSettings['attachmentUploadDir']);
+					$_POST['attachmentUploadDir'] = json_encode($modSettings['attachmentUploadDir']);
 
 				}
 			}
@@ -722,7 +722,7 @@ function MaintainFiles()
 	$context['sub_template'] = 'maintenance';
 
 	if (!empty($modSettings['currentAttachmentUploadDir']))
-		$attach_dirs = unserialize($modSettings['attachmentUploadDir']);
+		$attach_dirs = json_decode($modSettings['attachmentUploadDir']);
 	else
 		$attach_dirs = array($modSettings['attachmentUploadDir']);
 
@@ -795,7 +795,7 @@ function MaintainFiles()
 
 	$context['attach_multiple_dirs'] = count($attach_dirs) > 1 ? true : false;
 	$context['attach_dirs'] = $attach_dirs;
-	$context['base_dirs'] = !empty($modSettings['attachment_basedirectories']) ? unserialize($modSettings['attachment_basedirectories']) : array();
+	$context['base_dirs'] = !empty($modSettings['attachment_basedirectories']) ? json_decode($modSettings['attachment_basedirectories']) : array();
 	$context['checked'] = isset($_SESSION['checked']) ? $_SESSION['checked'] : true;
 	if (!empty($_SESSION['results']))
 	{
@@ -1345,7 +1345,7 @@ function RepairAttachments()
 						$attachment_name = $row['id_attach'] . '_' . $row['file_hash'] .'.dat';
 
 						if (!is_array($modSettings['attachmentUploadDir']))
-							$modSettings['attachmentUploadDir'] = unserialize($modSettings['attachmentUploadDir']);
+							$modSettings['attachmentUploadDir'] = json_decode($modSettings['attachmentUploadDir']);
 
 						// Loop through the other folders.
 						foreach ($modSettings['attachmentUploadDir'] as $id => $dir)
@@ -1590,7 +1590,7 @@ function RepairAttachments()
 	{
 		// Just use the current path for temp files.
 		if (!is_array($modSettings['attachmentUploadDir']))
-			$modSettings['attachmentUploadDir'] = unserialize($modSettings['attachmentUploadDir']);
+			$modSettings['attachmentUploadDir'] = json_decode($modSettings['attachmentUploadDir']);
 		$attach_dirs = $modSettings['attachmentUploadDir'];
 
 		$current_check = 0;
@@ -1910,11 +1910,11 @@ function ManageAttachmentPaths()
 
 	// Since this needs to be done eventually.
 	if (!is_array($modSettings['attachmentUploadDir']))
-		$modSettings['attachmentUploadDir'] = unserialize($modSettings['attachmentUploadDir']);
+		$modSettings['attachmentUploadDir'] = json_decode($modSettings['attachmentUploadDir']);
 	if (!isset($modSettings['attachment_basedirectories']))
 		$modSettings['attachment_basedirectories'] = array();
 	elseif (!is_array($modSettings['attachment_basedirectories']))
-		$modSettings['attachment_basedirectories'] = unserialize($modSettings['attachment_basedirectories']);
+		$modSettings['attachment_basedirectories'] = json_decode($modSettings['attachment_basedirectories']);
 
 	$errors = array();
 
@@ -1988,10 +1988,10 @@ function ManageAttachmentPaths()
 
 					$modSettings['attachment_basedirectories'][$id] = $path;
 					updateSettings(array(
-						'attachment_basedirectories' => serialize($modSettings['attachment_basedirectories']),
+						'attachment_basedirectories' => json_encode($modSettings['attachment_basedirectories']),
 						'basedirectory_for_attachments' => $base,
 					));
-					$modSettings['attachment_basedirectories'] = unserialize($modSettings['attachment_basedirectories']);
+					$modSettings['attachment_basedirectories'] = json_decode($modSettings['attachment_basedirectories']);
 				}
 			}
 
@@ -2052,8 +2052,8 @@ function ManageAttachmentPaths()
 						if (empty($error) && !empty($modSettings['attachment_basedirectories']))
 						{
 							unset($modSettings['attachment_basedirectories'][$id]);
-							updateSettings(array('attachment_basedirectories' => serialize($modSettings['attachment_basedirectories'])));
-							$modSettings['attachment_basedirectories'] = unserialize($modSettings['attachment_basedirectories']);
+							updateSettings(array('attachment_basedirectories' => json_encode($modSettings['attachment_basedirectories'])));
+							$modSettings['attachment_basedirectories'] = json_decode($modSettings['attachment_basedirectories']);
 						}
 					}
 					else
@@ -2086,7 +2086,7 @@ function ManageAttachmentPaths()
 		if ($_POST['current_dir'] !=  $modSettings['currentAttachmentUploadDir']&& !empty($modSettings['last_attachments_directory']) && (isset($modSettings['last_attachments_directory'][$_POST['current_dir']]) || isset($modSettings['last_attachments_directory'][0])))
 		{
 			if (!is_array($modSettings['last_attachments_directory']))
-				$modSettings['last_attachments_directory'] = unserialize($modSettings['last_attachments_directory']);
+				$modSettings['last_attachments_directory'] = json_decode($modSettings['last_attachments_directory']);
 			$num = substr(strrchr($modSettings['attachmentUploadDir'][$_POST['current_dir']], '_'), 1);
 
 			if (is_numeric($num))
@@ -2109,7 +2109,7 @@ function ManageAttachmentPaths()
 				$modSettings['basedirectory_for_attachments'] = !empty($modSettings['basedirectory_for_attachments']) ? $modSettings['basedirectory_for_attachments'] : '';
 				$modSettings['use_subdirectories_for_attachments'] = !empty($modSettings['use_subdirectories_for_attachments']) ? $modSettings['use_subdirectories_for_attachments'] : 0;
 				updateSettings(array(
-					'last_attachments_directory' => serialize($modSettings['last_attachments_directory']),
+					'last_attachments_directory' => json_encode($modSettings['last_attachments_directory']),
 					'basedirectory_for_attachments' => $bid == 0 ? $modSettings['basedirectory_for_attachments'] : $modSettings['attachment_basedirectories'][$bid],
 					'use_subdirectories_for_attachments' => $use_subdirectories_for_attachments,
 				));
@@ -2135,7 +2135,7 @@ function ManageAttachmentPaths()
 
 				$update = array(
 					'currentAttachmentUploadDir' => 1,
-					'attachmentUploadDir' => serialize(array(1 => $dir)),
+					'attachmentUploadDir' => json_encode(array(1 => $dir)),
 				);
 			}
 		}
@@ -2144,7 +2144,7 @@ function ManageAttachmentPaths()
 			// Save it to the database.
 			$update = array(
 				'currentAttachmentUploadDir' => $_POST['current_dir'],
-				'attachmentUploadDir' => serialize($new_dirs),
+				'attachmentUploadDir' => json_encode($new_dirs),
 			);
 		}
 
@@ -2185,8 +2185,8 @@ function ManageAttachmentPaths()
 						$modSettings['attachmentUploadDir'][$id] = $dir;
 						$modSettings['attachment_basedirectories'][$id] = $dir;
 						$update = (array(
-							'attachmentUploadDir' => serialize($modSettings['attachmentUploadDir']),
-							'attachment_basedirectories' => serialize($modSettings['attachment_basedirectories']),
+							'attachmentUploadDir' => json_encode($modSettings['attachmentUploadDir']),
+							'attachment_basedirectories' => json_encode($modSettings['attachment_basedirectories']),
 							'basedirectory_for_attachments' => $modSettings['attachmentUploadDir'][$_POST['current_base_dir']],
 						));
 					}
@@ -2202,7 +2202,7 @@ function ManageAttachmentPaths()
 
 					unset($modSettings['attachment_basedirectories'][$id]);
 					$update = (array(
-						'attachment_basedirectories' => serialize($modSettings['attachment_basedirectories']),
+						'attachment_basedirectories' => json_encode($modSettings['attachment_basedirectories']),
 						'basedirectory_for_attachments' => $modSettings['attachmentUploadDir'][$_POST['current_base_dir']],
 					));
 				}
@@ -2229,7 +2229,7 @@ function ManageAttachmentPaths()
 			ksort($modSettings['attachment_basedirectories']);
 
 			$update = (array(
-				'attachment_basedirectories' => serialize($modSettings['attachment_basedirectories']),
+				'attachment_basedirectories' => json_encode($modSettings['attachment_basedirectories']),
 				'basedirectory_for_attachments' => $_POST['new_base_dir'],
 				'currentAttachmentUploadDir' => $current_dir,
 			));
@@ -2611,9 +2611,9 @@ function TransferAttachments()
 
 	checkSession();
 
-	$modSettings['attachmentUploadDir'] = unserialize($modSettings['attachmentUploadDir']);
+	$modSettings['attachmentUploadDir'] = json_decode($modSettings['attachmentUploadDir']);
 	if (!empty($modSettings['attachment_basedirectories']))
-		$modSettings['attachment_basedirectories'] = unserialize($modSettings['attachment_basedirectories']);
+		$modSettings['attachment_basedirectories'] = json_decode($modSettings['attachment_basedirectories']);
 	else
 		$modSettings['basedirectory_for_attachments'] = array();
 

--- a/Sources/ManageMembers.php
+++ b/Sources/ManageMembers.php
@@ -269,7 +269,7 @@ function ViewMemberlist()
 
 		$search_params = array();
 		if ($context['sub_action'] == 'query' && !empty($_REQUEST['params']) && empty($_POST['types']))
-			$search_params = @json_decode(base64_decode($_REQUEST['params']));
+			$search_params = @json_decode(base64_decode($_REQUEST['params']), true);
 		elseif (!empty($_POST))
 		{
 			$search_params['types'] = $_POST['types'];

--- a/Sources/ManageMembers.php
+++ b/Sources/ManageMembers.php
@@ -269,7 +269,7 @@ function ViewMemberlist()
 
 		$search_params = array();
 		if ($context['sub_action'] == 'query' && !empty($_REQUEST['params']) && empty($_POST['types']))
-			$search_params = @unserialize(base64_decode($_REQUEST['params']));
+			$search_params = @json_decode(base64_decode($_REQUEST['params']));
 		elseif (!empty($_POST))
 		{
 			$search_params['types'] = $_POST['types'];
@@ -278,7 +278,7 @@ function ViewMemberlist()
 					$search_params[$param_name] = $_POST[$param_name];
 		}
 
-		$search_url_params = isset($search_params) ? base64_encode(serialize($search_params)) : null;
+		$search_url_params = isset($search_params) ? base64_encode(json_encode($search_params)) : null;
 
 		// @todo Validate a little more.
 

--- a/Sources/ManagePaid.php
+++ b/Sources/ManagePaid.php
@@ -564,7 +564,7 @@ function ModifySubscription()
 			if (empty($_POST['cost_day']) && empty($_POST['cost_week']) && empty($_POST['cost_month']) && empty($_POST['cost_year']))
 				fatal_lang_error('paid_all_freq_blank');
 		}
-		$cost = serialize($cost);
+		$cost = json_encode($cost);
 
 		// Having now validated everything that might throw an error, let's also now deal with the token.
 		validateToken('admin-pms');
@@ -698,7 +698,7 @@ function ModifySubscription()
 			$context['sub'] = array(
 				'name' => $row['name'],
 				'desc' => $row['description'],
-				'cost' => @unserialize($row['cost']),
+				'cost' => @json_decode($row['cost']),
 				'span' => array(
 					'value' => $span_value,
 					'unit' => $span_unit,
@@ -1271,14 +1271,14 @@ function ModifyUserSubscription()
 		$context['pending_payments'] = array();
 		if (!empty($row['pending_details']))
 		{
-			$pending_details = @unserialize($row['pending_details']);
+			$pending_details = @json_decode($row['pending_details']);
 			foreach ($pending_details as $id => $pending)
 			{
 				// Only this type need be displayed.
 				if ($pending[3] == 'payback')
 				{
 					// Work out what the options were.
-					$costs = @unserialize($context['current_subscription']['real_cost']);
+					$costs = @json_decode($context['current_subscription']['real_cost']);
 
 					if ($context['current_subscription']['real_length'] == 'F')
 					{
@@ -1312,7 +1312,7 @@ function ModifyUserSubscription()
 							addSubscription($context['current_subscription']['id'], $row['id_member'], $context['current_subscription']['real_length'] == 'F' ? strtoupper(substr($pending[2], 0, 1)) : 0);
 						unset($pending_details[$id]);
 
-						$new_details = serialize($pending_details);
+						$new_details = json_encode($pending_details);
 
 						// Update the entry.
 						$smcFunc['db_query']('', '
@@ -1840,7 +1840,7 @@ function loadSubscriptions()
 	while ($row = $smcFunc['db_fetch_assoc']($request))
 	{
 		// Pick a cost.
-		$costs = @unserialize($row['cost']);
+		$costs = @json_decode($row['cost']);
 
 		if ($row['length'] != 'F' && !empty($modSettings['paid_currency_symbol']) && !empty($costs['fixed']))
 			$cost = sprintf($modSettings['paid_currency_symbol'], $costs['fixed']);

--- a/Sources/ManagePaid.php
+++ b/Sources/ManagePaid.php
@@ -698,7 +698,7 @@ function ModifySubscription()
 			$context['sub'] = array(
 				'name' => $row['name'],
 				'desc' => $row['description'],
-				'cost' => @json_decode($row['cost']),
+				'cost' => @json_decode($row['cost'], true),
 				'span' => array(
 					'value' => $span_value,
 					'unit' => $span_unit,
@@ -1271,14 +1271,14 @@ function ModifyUserSubscription()
 		$context['pending_payments'] = array();
 		if (!empty($row['pending_details']))
 		{
-			$pending_details = @json_decode($row['pending_details']);
+			$pending_details = @json_decode($row['pending_details'], true);
 			foreach ($pending_details as $id => $pending)
 			{
 				// Only this type need be displayed.
 				if ($pending[3] == 'payback')
 				{
 					// Work out what the options were.
-					$costs = @json_decode($context['current_subscription']['real_cost']);
+					$costs = @json_decode($context['current_subscription']['real_cost'], true);
 
 					if ($context['current_subscription']['real_length'] == 'F')
 					{
@@ -1840,7 +1840,7 @@ function loadSubscriptions()
 	while ($row = $smcFunc['db_fetch_assoc']($request))
 	{
 		// Pick a cost.
-		$costs = @json_decode($row['cost']);
+		$costs = @json_decode($row['cost'], true);
 
 		if ($row['length'] != 'F' && !empty($modSettings['paid_currency_symbol']) && !empty($costs['fixed']))
 			$cost = sprintf($modSettings['paid_currency_symbol'], $costs['fixed']);

--- a/Sources/ManageSearch.php
+++ b/Sources/ManageSearch.php
@@ -485,7 +485,7 @@ function CreateMessageIndex()
 
 	if (isset($_REQUEST['resume']) && !empty($modSettings['search_custom_index_resume']))
 	{
-		$context['index_settings'] = json_decode($modSettings['search_custom_index_resume']);
+		$context['index_settings'] = json_decode($modSettings['search_custom_index_resume'], true);
 		$context['start'] = (int) $context['index_settings']['resume_at'];
 		unset($context['index_settings']['resume_at']);
 		$context['step'] = 1;

--- a/Sources/ManageSearch.php
+++ b/Sources/ManageSearch.php
@@ -485,7 +485,7 @@ function CreateMessageIndex()
 
 	if (isset($_REQUEST['resume']) && !empty($modSettings['search_custom_index_resume']))
 	{
-		$context['index_settings'] = unserialize($modSettings['search_custom_index_resume']);
+		$context['index_settings'] = json_decode($modSettings['search_custom_index_resume']);
 		$context['start'] = (int) $context['index_settings']['resume_at'];
 		unset($context['index_settings']['resume_at']);
 		$context['step'] = 1;
@@ -618,7 +618,7 @@ function CreateMessageIndex()
 					break;
 				}
 				else
-					updateSettings(array('search_custom_index_resume' => serialize(array_merge($context['index_settings'], array('resume_at' => $context['start'])))));
+					updateSettings(array('search_custom_index_resume' => json_encode(array_merge($context['index_settings'], array('resume_at' => $context['start'])))));
 			}
 
 			// Since there are still two steps to go, 80% is the maximum here.
@@ -683,7 +683,7 @@ function CreateMessageIndex()
 	{
 		$context['sub_template'] = 'create_index_done';
 
-		updateSettings(array('search_index' => 'custom', 'search_custom_index_config' => serialize($context['index_settings'])));
+		updateSettings(array('search_index' => 'custom', 'search_custom_index_config' => json_encode($context['index_settings'])));
 		$smcFunc['db_query']('', '
 			DELETE FROM {db_prefix}settings
 			WHERE variable = {string:search_custom_index_resume}',

--- a/Sources/ManageSearchEngines.php
+++ b/Sources/ManageSearchEngines.php
@@ -594,7 +594,7 @@ function logSpider()
 		{
 			$url = $_GET + array('USER_AGENT' => $_SERVER['HTTP_USER_AGENT']);
 			unset($url['sesc'], $url[$context['session_var']]);
-			$url = serialize($url);
+			$url = json_encode($url);
 		}
 		else
 			$url = '';
@@ -1109,7 +1109,7 @@ function recacheSpiderNames()
 		$spiders[$row['id_spider']] = $row['spider_name'];
 	$smcFunc['db_free_result']($request);
 
-	updateSettings(array('spider_name_cache' => serialize($spiders)));
+	updateSettings(array('spider_name_cache' => json_encode($spiders)));
 }
 
 ?>

--- a/Sources/ManageServer.php
+++ b/Sources/ManageServer.php
@@ -816,7 +816,7 @@ function prepareDBSettingContext(&$config_vars)
 						$value = 0;
 						break;
 					case 'select':
-						$value = !empty($config_var['multiple']) ? serialize(array()) : '';
+						$value = !empty($config_var['multiple']) ? json_encode(array()) : '';
 						break;
 					case 'boards':
 						$value = array();
@@ -865,7 +865,7 @@ function prepareDBSettingContext(&$config_vars)
 				if ($config_var[0] == 'select' && !empty($config_var['multiple']))
 				{
 					$context['config_vars'][$config_var[1]]['name'] .= '[]';
-					$context['config_vars'][$config_var[1]]['value'] = !empty($context['config_vars'][$config_var[1]]['value']) ? unserialize($context['config_vars'][$config_var[1]]['value']) : array();
+					$context['config_vars'][$config_var[1]]['value'] = !empty($context['config_vars'][$config_var[1]]['value']) ? json_decode($context['config_vars'][$config_var[1]]['value']) : array();
 				}
 
 				// If it's associative
@@ -1139,7 +1139,7 @@ function saveDBSettings(&$config_vars)
 				if (in_array($invar, array_keys($var[2])))
 					$options[] = $invar;
 
-			$setArray[$var[1]] = serialize($options);
+			$setArray[$var[1]] = json_encode($options);
 		}
 		// List of boards!
 		elseif ($var[0] == 'boards')

--- a/Sources/ManageServer.php
+++ b/Sources/ManageServer.php
@@ -865,7 +865,7 @@ function prepareDBSettingContext(&$config_vars)
 				if ($config_var[0] == 'select' && !empty($config_var['multiple']))
 				{
 					$context['config_vars'][$config_var[1]]['name'] .= '[]';
-					$context['config_vars'][$config_var[1]]['value'] = !empty($context['config_vars'][$config_var[1]]['value']) ? json_decode($context['config_vars'][$config_var[1]]['value']) : array();
+					$context['config_vars'][$config_var[1]]['value'] = !empty($context['config_vars'][$config_var[1]]['value']) ? json_decode($context['config_vars'][$config_var[1]]['value'], true) : array();
 				}
 
 				// If it's associative

--- a/Sources/ManageSettings.php
+++ b/Sources/ManageSettings.php
@@ -617,7 +617,7 @@ function ModifyAntispamSettings($return_config = false)
 		$context['question_answers'][$row['id_question']] = array(
 			'lngfile' => $lang,
 			'question' => $row['question'],
-			'answers' => json_decode($row['answers']),
+			'answers' => json_decode($row['answers'], true),
 		);
 		$context['qa_by_lang'][$lang][] = $row['id_question'];
 	}

--- a/Sources/ManageSettings.php
+++ b/Sources/ManageSettings.php
@@ -617,7 +617,7 @@ function ModifyAntispamSettings($return_config = false)
 		$context['question_answers'][$row['id_question']] = array(
 			'lngfile' => $lang,
 			'question' => $row['question'],
-			'answers' => unserialize($row['answers']),
+			'answers' => json_decode($row['answers']),
 		);
 		$context['qa_by_lang'][$lang][] = $row['id_question'];
 	}
@@ -732,7 +732,7 @@ function ModifyAntispamSettings($return_config = false)
 							$changes['delete'][] = $q_id;
 						continue;
 					}
-					$answers = serialize($answers);
+					$answers = json_encode($answers);
 
 					// At this point we know we have a question and some answers. What are we doing with it?
 					if (!isset($context['question_answers'][$q_id]))
@@ -2025,7 +2025,7 @@ function EditCustomProfiles()
 		}
 		$smcFunc['db_free_result']($request);
 
-		updateSettings(array('displayFields' => serialize($fields)));
+		updateSettings(array('displayFields' => json_encode($fields)));
 		$_SESSION['adm-save'] = true;
 		redirectexit('action=admin;area=featuresettings;sa=profile');
 	}

--- a/Sources/ManageSmileys.php
+++ b/Sources/ManageSmileys.php
@@ -1609,7 +1609,7 @@ function InstallSmileySet()
 		package_flush_cache();
 
 		// Credits tag?
-		$credits_tag = (empty($credits_tag)) ? '' : serialize($credits_tag);
+		$credits_tag = (empty($credits_tag)) ? '' : json_encode($credits_tag);
 		$smcFunc['db_insert']('',
 			'{db_prefix}log_packages',
 			array(

--- a/Sources/Memberlist.php
+++ b/Sources/Memberlist.php
@@ -177,7 +177,7 @@ function MLAll()
 	{
 		// Maybe there's something cached already.
 		if (!empty($modSettings['memberlist_cache']))
-			$memberlist_cache = @json_decode($modSettings['memberlist_cache']);
+			$memberlist_cache = @json_decode($modSettings['memberlist_cache'], true);
 
 		// The chunk size for the cached index.
 		$cache_step_size = 500;

--- a/Sources/Memberlist.php
+++ b/Sources/Memberlist.php
@@ -177,7 +177,7 @@ function MLAll()
 	{
 		// Maybe there's something cached already.
 		if (!empty($modSettings['memberlist_cache']))
-			$memberlist_cache = @unserialize($modSettings['memberlist_cache']);
+			$memberlist_cache = @json_decode($modSettings['memberlist_cache']);
 
 		// The chunk size for the cached index.
 		$cache_step_size = 500;
@@ -211,7 +211,7 @@ function MLAll()
 			$smcFunc['db_free_result']($request);
 
 			// Now we've got the cache...store it.
-			updateSettings(array('memberlist_cache' => serialize($memberlist_cache)));
+			updateSettings(array('memberlist_cache' => json_encode($memberlist_cache)));
 		}
 
 		$context['num_members'] = $memberlist_cache['num_members'];

--- a/Sources/ModerationCenter.php
+++ b/Sources/ModerationCenter.php
@@ -45,7 +45,7 @@ function ModerationMain($dont_call = false)
 	loadLanguage('ModerationCenter');
 	loadTemplate(false, 'admin');
 
-	$context['admin_preferences'] = !empty($options['admin_preferences']) ? json_decode($options['admin_preferences']) : array();
+	$context['admin_preferences'] = !empty($options['admin_preferences']) ? json_decode($options['admin_preferences'], true) : array();
 	$context['robot_no_index'] = true;
 
 	// This is the menu structure - refer to Subs-Menu.php for the details.
@@ -285,7 +285,7 @@ function ModerationHome()
 			$context['mod_blocks'][] = $block();
 	}
 
-	$context['admin_prefs'] = !empty($options['admin_preferences']) ? json_decode($options['admin_preferences']) : array();
+	$context['admin_prefs'] = !empty($options['admin_preferences']) ? json_decode($options['admin_preferences'], true) : array();
 }
 
 /**
@@ -1417,7 +1417,7 @@ function ViewWarningLog()
 	if (!empty($_REQUEST['params']) && empty($_REQUEST['is_search']))
 	{
 		$search_params = base64_decode(strtr($_REQUEST['params'], array(' ' => '+')));
-		$search_params = @json_decode($search_params);
+		$search_params = @json_decode($search_params, true);
 	}
 
 	// This array houses all the valid search types.

--- a/Sources/ModerationCenter.php
+++ b/Sources/ModerationCenter.php
@@ -45,7 +45,7 @@ function ModerationMain($dont_call = false)
 	loadLanguage('ModerationCenter');
 	loadTemplate(false, 'admin');
 
-	$context['admin_preferences'] = !empty($options['admin_preferences']) ? unserialize($options['admin_preferences']) : array();
+	$context['admin_preferences'] = !empty($options['admin_preferences']) ? json_decode($options['admin_preferences']) : array();
 	$context['robot_no_index'] = true;
 
 	// This is the menu structure - refer to Subs-Menu.php for the details.
@@ -285,7 +285,7 @@ function ModerationHome()
 			$context['mod_blocks'][] = $block();
 	}
 
-	$context['admin_prefs'] = !empty($options['admin_preferences']) ? unserialize($options['admin_preferences']) : array();
+	$context['admin_prefs'] = !empty($options['admin_preferences']) ? json_decode($options['admin_preferences']) : array();
 }
 
 /**
@@ -500,7 +500,7 @@ function ModBlockReportedPosts()
 	global $context, $user_info, $scripturl, $smcFunc;
 
 	// Got the info already?
-	$cachekey = md5(serialize($user_info['mod_cache']['bq']));
+	$cachekey = md5(json_encode($user_info['mod_cache']['bq']));
 	$context['reported_posts'] = array();
 	if ($user_info['mod_cache']['bq'] == '0=1')
 		return 'reported_posts_block';
@@ -614,7 +614,7 @@ function ModBlockReportedMembers()
 	global $context, $scripturl, $smcFunc;
 
 	// Got the info already?
-	$cachekey = md5(serialize((int) allowedTo('moderate_forum')));
+	$cachekey = md5(json_encode((int) allowedTo('moderate_forum')));
 	$context['reported_users'] = array();
 	if (!allowedTo('moderate_forum'))
 		return 'reported_users_block';
@@ -1417,7 +1417,7 @@ function ViewWarningLog()
 	if (!empty($_REQUEST['params']) && empty($_REQUEST['is_search']))
 	{
 		$search_params = base64_decode(strtr($_REQUEST['params'], array(' ' => '+')));
-		$search_params = @unserialize($search_params);
+		$search_params = @json_decode($search_params);
 	}
 
 	// This array houses all the valid search types.
@@ -1454,7 +1454,7 @@ function ViewWarningLog()
 	$context['url_start'] = '?action=moderate;area=warnings;sa=log;sort='.  $context['order'];
 
 	// Setup the search context.
-	$context['search_params'] = empty($search_params['string']) ? '' : base64_encode(serialize($search_params));
+	$context['search_params'] = empty($search_params['string']) ? '' : base64_encode(json_encode($search_params));
 	$context['search'] = array(
 		'string' => $search_params['string'],
 		'type' => $search_params['type'],

--- a/Sources/Modlog.php
+++ b/Sources/Modlog.php
@@ -103,7 +103,7 @@ function ViewModlog()
 	if (!empty($_REQUEST['params']) && empty($_REQUEST['is_search']))
 	{
 		$search_params = base64_decode(strtr($_REQUEST['params'], array(' ' => '+')));
-		$search_params = @json_decode($search_params);
+		$search_params = @json_decode($search_params, true);
 	}
 
 	// This array houses all the valid search types.
@@ -396,7 +396,7 @@ function list_getModLogEntries($start, $items_per_page, $sort, $query_string = '
 	$entries = array();
 	while ($row = $smcFunc['db_fetch_assoc']($result))
 	{
-		$row['extra'] = @json_decode($row['extra']);
+		$row['extra'] = @json_decode($row['extra'], true);
 
 		// Corrupt?
 		$row['extra'] = is_array($row['extra']) ? $row['extra'] : array();

--- a/Sources/Modlog.php
+++ b/Sources/Modlog.php
@@ -103,7 +103,7 @@ function ViewModlog()
 	if (!empty($_REQUEST['params']) && empty($_REQUEST['is_search']))
 	{
 		$search_params = base64_decode(strtr($_REQUEST['params'], array(' ' => '+')));
-		$search_params = @unserialize($search_params);
+		$search_params = @json_decode($search_params);
 	}
 
 	// This array houses all the valid search types.
@@ -131,7 +131,7 @@ function ViewModlog()
 	);
 
 	// Setup the search context.
-	$context['search_params'] = empty($search_params['string']) ? '' : base64_encode(serialize($search_params));
+	$context['search_params'] = empty($search_params['string']) ? '' : base64_encode(json_encode($search_params));
 	$context['search'] = array(
 		'string' => $search_params['string'],
 		'type' => $search_params['type'],
@@ -396,7 +396,7 @@ function list_getModLogEntries($start, $items_per_page, $sort, $query_string = '
 	$entries = array();
 	while ($row = $smcFunc['db_fetch_assoc']($result))
 	{
-		$row['extra'] = @unserialize($row['extra']);
+		$row['extra'] = @json_decode($row['extra']);
 
 		// Corrupt?
 		$row['extra'] = is_array($row['extra']) ? $row['extra'] : array();

--- a/Sources/News.php
+++ b/Sources/News.php
@@ -191,7 +191,7 @@ function ShowXmlFeed()
 	foreach (array('board', 'boards', 'c') as $var)
 		if (isset($_REQUEST[$var]))
 			$cachekey[] = $_REQUEST[$var];
-	$cachekey = md5(serialize($cachekey) . (!empty($query_this_board) ? $query_this_board : ''));
+	$cachekey = md5(json_encode($cachekey) . (!empty($query_this_board) ? $query_this_board : ''));
 	$cache_t = microtime();
 
 	// Get the associative array representing the xml.

--- a/Sources/Packages.php
+++ b/Sources/Packages.php
@@ -222,7 +222,7 @@ function PackageInstallTest()
 	{
 		$old_themes = explode(',', $row['themes_installed']);
 		$old_version = $row['version'];
-		$db_changes = empty($row['db_changes']) ? array() : unserialize($row['db_changes']);
+		$db_changes = empty($row['db_changes']) ? array() : json_decode($row['db_changes']);
 	}
 	$smcFunc['db_free_result']($request);
 
@@ -729,7 +729,7 @@ function PackageInstallTest()
 								'type' => $txt['package_delete'] . ' ' . ($action_data['type'] == 'require-dir' ? $txt['package_tree'] : $txt['package_file']),
 								'action' => strtr($real_path, array('\\' => '/', $boarddir => '.')),
 								'description' => '',
-								'value' => base64_encode(serialize(array('type' => $action_data['type'], 'orig' => $action_data['filename'], 'future' => $real_path, 'id' => $id))),
+								'value' => base64_encode(json_encode(array('type' => $action_data['type'], 'orig' => $action_data['filename'], 'future' => $real_path, 'id' => $id))),
 								'not_mod' => true,
 							);
 						else
@@ -737,7 +737,7 @@ function PackageInstallTest()
 								'type' => $txt['package_extract'] . ' ' . ($action_data['type'] == 'require-dir' ? $txt['package_tree'] : $txt['package_file']),
 								'action' => strtr($real_path, array('\\' => '/', $boarddir => '.')),
 								'description' => '',
-								'value' => base64_encode(serialize(array('type' => $action_data['type'], 'orig' => $action_data['destination'], 'future' => $real_path, 'id' => $id))),
+								'value' => base64_encode(json_encode(array('type' => $action_data['type'], 'orig' => $action_data['destination'], 'future' => $real_path, 'id' => $id))),
 								'not_mod' => true,
 							);
 					}
@@ -873,7 +873,7 @@ function PackageInstall()
 		{
 			if (empty($change))
 				continue;
-			$theme_data = unserialize(base64_decode($change));
+			$theme_data = json_decode(base64_decode($change));
 			if (empty($theme_data['type']))
 				continue;
 
@@ -921,7 +921,7 @@ function PackageInstall()
 	{
 		$old_themes = explode(',', $row['themes_installed']);
 		$old_version = $row['version'];
-		$db_changes = empty($row['db_changes']) ? array() : unserialize($row['db_changes']);
+		$db_changes = empty($row['db_changes']) ? array() : json_decode($row['db_changes']);
 	}
 	$smcFunc['db_free_result']($request);
 
@@ -1107,7 +1107,7 @@ function PackageInstall()
 			else
 			{
 				$is_upgrade = true;
-				$old_db_changes = empty($row['db_changes']) ? array() : unserialize($row['db_changes']);
+				$old_db_changes = empty($row['db_changes']) ? array() : json_decode($row['db_changes']);
 			}
 		}
 
@@ -1147,7 +1147,7 @@ function PackageInstall()
 					elseif (in_array($log[1], $tables))
 						unset($db_package_log[$k]);
 				}
-				$db_changes = serialize($db_package_log);
+				$db_changes = json_encode($db_package_log);
 			}
 			else
 				$db_changes = '';
@@ -1157,7 +1157,7 @@ function PackageInstall()
 			$themes_installed = implode(',', $themes_installed);
 
 			// What failed steps?
-			$failed_step_insert = serialize($failed_steps);
+			$failed_step_insert = json_encode($failed_steps);
 
 			// Un-sanitize things before we insert them...
 			$keys = array('filename', 'name', 'id', 'version');
@@ -1168,7 +1168,7 @@ function PackageInstall()
 			}
 
 			// Credits tag?
-			$credits_tag = (empty($credits_tag)) ? '' : serialize($credits_tag);
+			$credits_tag = (empty($credits_tag)) ? '' : json_encode($credits_tag);
 			$smcFunc['db_insert']('',
 				'{db_prefix}log_packages',
 				array(
@@ -2073,7 +2073,7 @@ function PackagePermissions()
 		unset($context['file_tree'][strtr($boarddir, array('\\' => '/'))]['contents']['attachments']);
 
 		if (!is_array($modSettings['attachmentUploadDir']))
-			$modSettings['attachmentUploadDir'] = unserialize($modSettings['attachmentUploadDir']);
+			$modSettings['attachmentUploadDir'] = json_decode($modSettings['attachmentUploadDir']);
 
 		// @todo Should we suggest non-current directories be read only?
 		foreach ($modSettings['attachmentUploadDir'] as $dir)
@@ -2176,7 +2176,7 @@ function PackagePermissions()
 	// Have we got a load of back-catalogue trees to expand from a submit etc?
 	if (!empty($_GET['back_look']))
 	{
-		$potententialTrees = unserialize(base64_decode($_GET['back_look']));
+		$potententialTrees = json_decode(base64_decode($_GET['back_look']));
 		foreach ($potententialTrees as $tree)
 			$context['look_for'][] = $tree;
 	}
@@ -2184,7 +2184,7 @@ function PackagePermissions()
 	if (!empty($_POST['back_look']))
 		$context['only_find'] = array_merge($context['only_find'], $_POST['back_look']);
 
-	$context['back_look_data'] = base64_encode(serialize(array_slice($context['look_for'], 0, 15)));
+	$context['back_look_data'] = base64_encode(json_encode(array_slice($context['look_for'], 0, 15)));
 
 	// Are we finding more files than first thought?
 	$context['file_offset'] = !empty($_REQUEST['fileoffset']) ? (int) $_REQUEST['fileoffset'] : 0;
@@ -2434,7 +2434,7 @@ function PackagePermissionsAction()
 
 		// Continuing?
 		if (isset($_POST['toProcess']))
-			$_POST['permStatus'] = unserialize(base64_decode($_POST['toProcess']));
+			$_POST['permStatus'] = json_decode(base64_decode($_POST['toProcess']));
 
 		if (isset($_POST['permStatus']))
 		{
@@ -2474,7 +2474,7 @@ function PackagePermissionsAction()
 
 			// Nothing to do?
 			if (empty($context['to_process']))
-				redirectexit('action=admin;area=packages;sa=perms' . (!empty($context['back_look_data']) ? ';back_look=' . base64_encode(serialize($context['back_look_data'])) : '') . ';' . $context['session_var'] . '=' . $context['session_id']);
+				redirectexit('action=admin;area=packages;sa=perms' . (!empty($context['back_look_data']) ? ';back_look=' . base64_encode(json_encode($context['back_look_data'])) : '') . ';' . $context['session_var'] . '=' . $context['session_id']);
 		}
 		// Should never get here,
 		else
@@ -2514,7 +2514,7 @@ function PackagePermissionsAction()
 		$context['predefined_type'] = isset($_POST['predefined']) ? $_POST['predefined'] : 'restricted';
 
 		$context['total_items'] = isset($_POST['totalItems']) ? (int) $_POST['totalItems'] : 0;
-		$context['directory_list'] = isset($_POST['dirList']) ? unserialize(base64_decode($_POST['dirList'])) : array();
+		$context['directory_list'] = isset($_POST['dirList']) ? json_decode(base64_decode($_POST['dirList'])) : array();
 
 		$context['file_offset'] = isset($_POST['fileOffset']) ? (int) $_POST['fileOffset'] : 0;
 
@@ -2589,7 +2589,7 @@ function PackagePermissionsAction()
 		elseif ($context['predefined_type'] == 'free')
 			$context['special_files'] = array();
 		else
-			$context['special_files'] = unserialize(base64_decode($_POST['specialFiles']));
+			$context['special_files'] = json_decode(base64_decode($_POST['specialFiles']));
 
 		// Now we definitely know where we are, we need to go through again doing the chmod!
 		foreach ($context['directory_list'] as $path => $dummy)
@@ -2640,7 +2640,7 @@ function PackagePermissionsAction()
 	}
 
 	// If we're here we are done!
-	redirectexit('action=admin;area=packages;sa=perms' . (!empty($context['back_look_data']) ? ';back_look=' . base64_encode(serialize($context['back_look_data'])) : '') . ';' . $context['session_var'] . '=' . $context['session_id']);
+	redirectexit('action=admin;area=packages;sa=perms' . (!empty($context['back_look_data']) ? ';back_look=' . base64_encode(json_encode($context['back_look_data'])) : '') . ';' . $context['session_var'] . '=' . $context['session_id']);
 }
 
 /**

--- a/Sources/Packages.php
+++ b/Sources/Packages.php
@@ -222,7 +222,7 @@ function PackageInstallTest()
 	{
 		$old_themes = explode(',', $row['themes_installed']);
 		$old_version = $row['version'];
-		$db_changes = empty($row['db_changes']) ? array() : json_decode($row['db_changes']);
+		$db_changes = empty($row['db_changes']) ? array() : json_decode($row['db_changes'], true);
 	}
 	$smcFunc['db_free_result']($request);
 
@@ -873,7 +873,7 @@ function PackageInstall()
 		{
 			if (empty($change))
 				continue;
-			$theme_data = json_decode(base64_decode($change));
+			$theme_data = json_decode(base64_decode($change), true);
 			if (empty($theme_data['type']))
 				continue;
 
@@ -921,7 +921,7 @@ function PackageInstall()
 	{
 		$old_themes = explode(',', $row['themes_installed']);
 		$old_version = $row['version'];
-		$db_changes = empty($row['db_changes']) ? array() : json_decode($row['db_changes']);
+		$db_changes = empty($row['db_changes']) ? array() : json_decode($row['db_changes'], true);
 	}
 	$smcFunc['db_free_result']($request);
 
@@ -1107,7 +1107,7 @@ function PackageInstall()
 			else
 			{
 				$is_upgrade = true;
-				$old_db_changes = empty($row['db_changes']) ? array() : json_decode($row['db_changes']);
+				$old_db_changes = empty($row['db_changes']) ? array() : json_decode($row['db_changes'], true);
 			}
 		}
 
@@ -1500,7 +1500,7 @@ function PackageBrowse()
 	$smcFunc['db_free_result']($get_versions);
 
 	// Decode the data.
-	$items = json_decode($data['data']);
+	$items = json_decode($data['data'], true);
 
 	$context['emulation_versions'] = preg_replace('~^SMF ~', '', $items);
 
@@ -2073,7 +2073,7 @@ function PackagePermissions()
 		unset($context['file_tree'][strtr($boarddir, array('\\' => '/'))]['contents']['attachments']);
 
 		if (!is_array($modSettings['attachmentUploadDir']))
-			$modSettings['attachmentUploadDir'] = json_decode($modSettings['attachmentUploadDir']);
+			$modSettings['attachmentUploadDir'] = json_decode($modSettings['attachmentUploadDir'], true);
 
 		// @todo Should we suggest non-current directories be read only?
 		foreach ($modSettings['attachmentUploadDir'] as $dir)
@@ -2176,7 +2176,7 @@ function PackagePermissions()
 	// Have we got a load of back-catalogue trees to expand from a submit etc?
 	if (!empty($_GET['back_look']))
 	{
-		$potententialTrees = json_decode(base64_decode($_GET['back_look']));
+		$potententialTrees = json_decode(base64_decode($_GET['back_look']), true);
 		foreach ($potententialTrees as $tree)
 			$context['look_for'][] = $tree;
 	}
@@ -2434,7 +2434,7 @@ function PackagePermissionsAction()
 
 		// Continuing?
 		if (isset($_POST['toProcess']))
-			$_POST['permStatus'] = json_decode(base64_decode($_POST['toProcess']));
+			$_POST['permStatus'] = json_decode(base64_decode($_POST['toProcess']), true);
 
 		if (isset($_POST['permStatus']))
 		{
@@ -2514,7 +2514,7 @@ function PackagePermissionsAction()
 		$context['predefined_type'] = isset($_POST['predefined']) ? $_POST['predefined'] : 'restricted';
 
 		$context['total_items'] = isset($_POST['totalItems']) ? (int) $_POST['totalItems'] : 0;
-		$context['directory_list'] = isset($_POST['dirList']) ? json_decode(base64_decode($_POST['dirList'])) : array();
+		$context['directory_list'] = isset($_POST['dirList']) ? json_decode(base64_decode($_POST['dirList']), true) : array();
 
 		$context['file_offset'] = isset($_POST['fileOffset']) ? (int) $_POST['fileOffset'] : 0;
 
@@ -2589,7 +2589,7 @@ function PackagePermissionsAction()
 		elseif ($context['predefined_type'] == 'free')
 			$context['special_files'] = array();
 		else
-			$context['special_files'] = json_decode(base64_decode($_POST['specialFiles']));
+			$context['special_files'] = json_decode(base64_decode($_POST['specialFiles']), true);
 
 		// Now we definitely know where we are, we need to go through again doing the chmod!
 		foreach ($context['directory_list'] as $path => $dummy)

--- a/Sources/PersonalMessage.php
+++ b/Sources/PersonalMessage.php
@@ -4085,8 +4085,8 @@ function LoadRules($reload = false)
 		$context['rules'][$row['id_rule']] = array(
 			'id' => $row['id_rule'],
 			'name' => $row['rule_name'],
-			'criteria' => json_decode($row['criteria']),
-			'actions' => json_decode($row['actions']),
+			'criteria' => json_decode($row['criteria'], true),
+			'actions' => json_decode($row['actions'], true),
 			'delete' => $row['delete_pm'],
 			'logic' => $row['is_or'] ? 'or' : 'and',
 		);

--- a/Sources/PersonalMessage.php
+++ b/Sources/PersonalMessage.php
@@ -3426,7 +3426,7 @@ function ManageLabels()
 						array(
 							'current_member' => $user_info['id'],
 							'id_rule' => $id,
-							'actions' => serialize($context['rules'][$id]['actions']),
+							'actions' => json_encode($context['rules'][$id]['actions']),
 						)
 					);
 					unset($rule_changes[$k]);
@@ -3869,8 +3869,8 @@ function ManageRules()
 			fatal_lang_error('pm_rule_no_criteria', false);
 
 		// What are we storing?
-		$criteria = serialize($criteria);
-		$actions = serialize($actions);
+		$criteria = json_encode($criteria);
+		$actions = json_encode($actions);
 
 		// Create the rule?
 		if (empty($context['rid']))
@@ -4085,8 +4085,8 @@ function LoadRules($reload = false)
 		$context['rules'][$row['id_rule']] = array(
 			'id' => $row['id_rule'],
 			'name' => $row['rule_name'],
-			'criteria' => unserialize($row['criteria']),
-			'actions' => unserialize($row['actions']),
+			'criteria' => json_decode($row['criteria']),
+			'actions' => json_decode($row['actions']),
 			'delete' => $row['delete_pm'],
 			'logic' => $row['is_or'] ? 'or' : 'and',
 		);

--- a/Sources/Profile-Actions.php
+++ b/Sources/Profile-Actions.php
@@ -734,7 +734,7 @@ function subscriptions($memID)
 	foreach ($context['subscriptions'] as $id => $sub)
 	{
 		// Work out the costs.
-		$costs = @unserialize($sub['real_cost']);
+		$costs = @json_decode($sub['real_cost']);
 
 		$cost_array = array();
 		if ($sub['real_length'] == 'F')
@@ -815,7 +815,7 @@ function subscriptions($memID)
 		if (isset($context['current'][$_GET['sub_id']]))
 		{
 			// What are the details like?
-			$current_pending = @unserialize($context['current'][$_GET['sub_id']]['pending_details']);
+			$current_pending = @json_decode($context['current'][$_GET['sub_id']]['pending_details']);
 			if (!empty($current_pending))
 			{
 				$current_pending = array_reverse($current_pending);
@@ -830,7 +830,7 @@ function subscriptions($memID)
 				}
 
 				// Save the details back.
-				$pending_details = serialize($current_pending);
+				$pending_details = json_encode($current_pending);
 
 				$smcFunc['db_query']('', '
 					UPDATE {db_prefix}log_subscribed
@@ -913,7 +913,7 @@ function subscriptions($memID)
 			// What are the details like?
 			$current_pending = array();
 			if ($context['current'][$context['sub']['id']]['pending_details'] != '')
-				$current_pending = @unserialize($context['current'][$context['sub']['id']]['pending_details']);
+				$current_pending = @json_decode($context['current'][$context['sub']['id']]['pending_details']);
 			// Don't get silly.
 			if (count($current_pending) > 9)
 				$current_pending = array();
@@ -926,7 +926,7 @@ function subscriptions($memID)
 			if (!in_array($new_data, $current_pending))
 			{
 				$current_pending[] = $new_data;
-				$pending_details = serialize($current_pending);
+				$pending_details = json_encode($current_pending);
 
 				$smcFunc['db_query']('', '
 					UPDATE {db_prefix}log_subscribed
@@ -946,7 +946,7 @@ function subscriptions($memID)
 		// Never had this before, lovely.
 		else
 		{
-			$pending_details = serialize(array($new_data));
+			$pending_details = json_encode(array($new_data));
 			$smcFunc['db_insert']('',
 				'{db_prefix}log_subscribed',
 				array(

--- a/Sources/Profile-Actions.php
+++ b/Sources/Profile-Actions.php
@@ -734,7 +734,7 @@ function subscriptions($memID)
 	foreach ($context['subscriptions'] as $id => $sub)
 	{
 		// Work out the costs.
-		$costs = @json_decode($sub['real_cost']);
+		$costs = @json_decode($sub['real_cost'], true);
 
 		$cost_array = array();
 		if ($sub['real_length'] == 'F')
@@ -815,7 +815,7 @@ function subscriptions($memID)
 		if (isset($context['current'][$_GET['sub_id']]))
 		{
 			// What are the details like?
-			$current_pending = @json_decode($context['current'][$_GET['sub_id']]['pending_details']);
+			$current_pending = @json_decode($context['current'][$_GET['sub_id']]['pending_details'], true);
 			if (!empty($current_pending))
 			{
 				$current_pending = array_reverse($current_pending);
@@ -913,7 +913,7 @@ function subscriptions($memID)
 			// What are the details like?
 			$current_pending = array();
 			if ($context['current'][$context['sub']['id']]['pending_details'] != '')
-				$current_pending = @json_decode($context['current'][$context['sub']['id']]['pending_details']);
+				$current_pending = @json_decode($context['current'][$context['sub']['id']]['pending_details'], true);
 			// Don't get silly.
 			if (count($current_pending) > 9)
 				$current_pending = array();

--- a/Sources/Profile-Modify.php
+++ b/Sources/Profile-Modify.php
@@ -3664,7 +3664,7 @@ function profileSendActivation()
 		)
 	);
 	$_SESSION['log_time'] = 0;
-	$_SESSION['login_' . $cookiename] = serialize(array(0, '', 0));
+	$_SESSION['login_' . $cookiename] = json_encode(array(0, '', 0));
 
 	if (isset($_COOKIE[$cookiename]))
 		$_COOKIE[$cookiename] = '';

--- a/Sources/Profile-Modify.php
+++ b/Sources/Profile-Modify.php
@@ -3939,7 +3939,7 @@ function groupMembership2($profile_vars, $post_errors, $memID)
 		);
 
 		// Set up some data for our background task...
-		$data = serialize(array('id_member' => $memID, 'member_name' => $user_info['name'], 'id_group' => $group_id, 'group_name' => $group_name, 'reason' => $_POST['reason'], 'time' => time()));
+		$data = json_encode(array('id_member' => $memID, 'member_name' => $user_info['name'], 'id_group' => $group_id, 'group_name' => $group_name, 'reason' => $_POST['reason'], 'time' => time()));
 
 		// Add a background task to handle notifying people of this request
 		$smcFunc['db_insert']('insert', '{db_prefix}background_tasks',

--- a/Sources/Profile-View.php
+++ b/Sources/Profile-View.php
@@ -238,7 +238,7 @@ function fetch_alerts($memID, $all = false, $counter = 0, $pagination = array())
 	{
 		$id_alert = array_shift($row);
 		$row['time'] = timeformat($row['alert_time']);
-		$row['extra'] = !empty($row['extra']) ? @unserialize($row['extra']) : array();
+		$row['extra'] = !empty($row['extra']) ? @json_decode($row['extra']) : array();
 		$alerts[$id_alert] = $row;
 
 		if (!empty($row['sender_id']))
@@ -2427,7 +2427,7 @@ function list_getProfileEdits($start, $items_per_page, $sort, $memID)
 	$members = array();
 	while ($row = $smcFunc['db_fetch_assoc']($request))
 	{
-		$extra = @unserialize($row['extra']);
+		$extra = @json_decode($row['extra']);
 		if (!empty($extra['applicator']))
 			$members[] = $extra['applicator'];
 

--- a/Sources/Profile-View.php
+++ b/Sources/Profile-View.php
@@ -238,7 +238,7 @@ function fetch_alerts($memID, $all = false, $counter = 0, $pagination = array())
 	{
 		$id_alert = array_shift($row);
 		$row['time'] = timeformat($row['alert_time']);
-		$row['extra'] = !empty($row['extra']) ? @json_decode($row['extra']) : array();
+		$row['extra'] = !empty($row['extra']) ? @json_decode($row['extra'], true) : array();
 		$alerts[$id_alert] = $row;
 
 		if (!empty($row['sender_id']))
@@ -2427,7 +2427,7 @@ function list_getProfileEdits($start, $items_per_page, $sort, $memID)
 	$members = array();
 	while ($row = $smcFunc['db_fetch_assoc']($request))
 	{
-		$extra = @json_decode($row['extra']);
+		$extra = @json_decode($row['extra'], true);
 		if (!empty($extra['applicator']))
 			$members[] = $extra['applicator'];
 

--- a/Sources/Recent.php
+++ b/Sources/Recent.php
@@ -272,7 +272,7 @@ function RecentPosts()
 	if ($context['is_redirect'])
 		$messages = 0;
 
-	$key = 'recent-' . $user_info['id'] . '-' . md5(serialize(array_diff_key($query_parameters, array('max_id_msg' => 0)))) . '-' . (int) $_REQUEST['start'];
+	$key = 'recent-' . $user_info['id'] . '-' . md5(json_encode(array_diff_key($query_parameters, array('max_id_msg' => 0)))) . '-' . (int) $_REQUEST['start'];
 	if (!$context['is_redirect'] && (empty($modSettings['cache_enable']) || ($messages = cache_get_data($key, 120)) == null))
 	{
 		$done = false;

--- a/Sources/RemoveTopic.php
+++ b/Sources/RemoveTopic.php
@@ -476,7 +476,7 @@ function removeTopics($topics, $decreasePostCount = true, $ignoreRecycling = fal
 	// Delete possible search index entries.
 	if (!empty($modSettings['search_custom_index_config']))
 	{
-		$customIndexSettings = unserialize($modSettings['search_custom_index_config']);
+		$customIndexSettings = json_decode($modSettings['search_custom_index_config']);
 
 		$words = array();
 		$messages = array();
@@ -959,7 +959,7 @@ function removeMessage($message, $decreasePostCount = true)
 
 		if (!empty($modSettings['search_custom_index_config']))
 		{
-			$customIndexSettings = unserialize($modSettings['search_custom_index_config']);
+			$customIndexSettings = json_decode($modSettings['search_custom_index_config']);
 			$words = text2words($row['body'], $customIndexSettings['bytes_per_word'], true);
 			if (!empty($words))
 				$smcFunc['db_query']('', '

--- a/Sources/RemoveTopic.php
+++ b/Sources/RemoveTopic.php
@@ -476,7 +476,7 @@ function removeTopics($topics, $decreasePostCount = true, $ignoreRecycling = fal
 	// Delete possible search index entries.
 	if (!empty($modSettings['search_custom_index_config']))
 	{
-		$customIndexSettings = json_decode($modSettings['search_custom_index_config']);
+		$customIndexSettings = json_decode($modSettings['search_custom_index_config'], true);
 
 		$words = array();
 		$messages = array();
@@ -959,7 +959,7 @@ function removeMessage($message, $decreasePostCount = true)
 
 		if (!empty($modSettings['search_custom_index_config']))
 		{
-			$customIndexSettings = json_decode($modSettings['search_custom_index_config']);
+			$customIndexSettings = json_decode($modSettings['search_custom_index_config'], true);
 			$words = text2words($row['body'], $customIndexSettings['bytes_per_word'], true);
 			if (!empty($words))
 				$smcFunc['db_query']('', '

--- a/Sources/ReportToMod.php
+++ b/Sources/ReportToMod.php
@@ -330,7 +330,7 @@ function reportPost($msg, $reason)
 		$smcFunc['db_insert']('insert',
 			'{db_prefix}background_tasks',
 			array('task_file' => 'string', 'task_class' => 'string', 'task_data' => 'string', 'claimed_time' => 'int'),
-			array('$sourcedir/tasks/MsgReport-Notify.php', 'MsgReport_Notify_Background', serialize(array(
+			array('$sourcedir/tasks/MsgReport-Notify.php', 'MsgReport_Notify_Background', json_encode(array(
 				'report_id' => $id_report,
 				'msg_id' => $_POST['msg'],
 				'topic_id' => $message['id_topic'],
@@ -452,7 +452,7 @@ function reportUser($id_member, $reason)
 		$smcFunc['db_insert']('insert',
 			'{db_prefix}background_tasks',
 			array('task_file' => 'string', 'task_class' => 'string', 'task_data' => 'string', 'claimed_time' => 'int'),
-			array('$sourcedir/tasks/MemberReport-Notify.php', 'MemberReport_Notify_Background', serialize(array(
+			array('$sourcedir/tasks/MemberReport-Notify.php', 'MemberReport_Notify_Background', json_encode(array(
 				'report_id' => $id_report,
 				'user_id' => $user['id_member'],
 				'user_name' => $user_name,

--- a/Sources/ScheduledTasks.php
+++ b/Sources/ScheduledTasks.php
@@ -1571,7 +1571,7 @@ function scheduled_paid_subscriptions()
 				'content_id' => $row['id_sublog'],
 				'content_action' => 'expiring',
 				'is_read' => 0,
-				'extra' => serialize(array(
+				'extra' => json_encode(array(
 					'subscription_name' => $row['name'],
 					'end_time' => strip_tags(timeformat($row['end_time'])),
 				)),
@@ -1617,7 +1617,7 @@ function scheduled_remove_temp_attachments()
 	if (!empty($modSettings['currentAttachmentUploadDir']))
 	{
 		if (!is_array($modSettings['attachmentUploadDir']))
-			$modSettings['attachmentUploadDir'] = unserialize($modSettings['attachmentUploadDir']);
+			$modSettings['attachmentUploadDir'] = json_decode($modSettings['attachmentUploadDir']);
 
 		// Just use the current path for temp files.
 		$attach_dirs = $modSettings['attachmentUploadDir'];

--- a/Sources/ScheduledTasks.php
+++ b/Sources/ScheduledTasks.php
@@ -1617,7 +1617,7 @@ function scheduled_remove_temp_attachments()
 	if (!empty($modSettings['currentAttachmentUploadDir']))
 	{
 		if (!is_array($modSettings['attachmentUploadDir']))
-			$modSettings['attachmentUploadDir'] = json_decode($modSettings['attachmentUploadDir']);
+			$modSettings['attachmentUploadDir'] = json_decode($modSettings['attachmentUploadDir'], true);
 
 		// Just use the current path for temp files.
 		$attach_dirs = $modSettings['attachmentUploadDir'];

--- a/Sources/SearchAPI-Custom.php
+++ b/Sources/SearchAPI-Custom.php
@@ -57,7 +57,7 @@ class custom_search extends search_api
 		if (empty($modSettings['search_custom_index_config']))
 			return;
 
-		$this->indexSettings = json_decode($modSettings['search_custom_index_config']);
+		$this->indexSettings = json_decode($modSettings['search_custom_index_config'], true);
 
 		$this->bannedWords = empty($modSettings['search_stopwords']) ? array() : explode(',', $modSettings['search_stopwords']);
 		$this->min_word_length = $this->indexSettings['bytes_per_word'];
@@ -233,7 +233,7 @@ class custom_search extends search_api
 	{
 		global $modSettings, $smcFunc;
 
-		$customIndexSettings = json_decode($modSettings['search_custom_index_config']);
+		$customIndexSettings = json_decode($modSettings['search_custom_index_config'], true);
 
 		$inserts = array();
 		foreach (text2words($msgOptions['body'], $customIndexSettings['bytes_per_word'], true) as $word)
@@ -257,7 +257,7 @@ class custom_search extends search_api
 
 		if (isset($msgOptions['body']))
 		{
-			$customIndexSettings = json_decode($modSettings['search_custom_index_config']);
+			$customIndexSettings = json_decode($modSettings['search_custom_index_config'], true);
 			$stopwords = empty($modSettings['search_stopwords']) ? array() : explode(',', $modSettings['search_stopwords']);
 			$old_body = isset($msgOptions['old_body']) ? $msgOptions['old_body'] : '';
 

--- a/Sources/SearchAPI-Custom.php
+++ b/Sources/SearchAPI-Custom.php
@@ -57,7 +57,7 @@ class custom_search extends search_api
 		if (empty($modSettings['search_custom_index_config']))
 			return;
 
-		$this->indexSettings = unserialize($modSettings['search_custom_index_config']);
+		$this->indexSettings = json_decode($modSettings['search_custom_index_config']);
 
 		$this->bannedWords = empty($modSettings['search_stopwords']) ? array() : explode(',', $modSettings['search_stopwords']);
 		$this->min_word_length = $this->indexSettings['bytes_per_word'];
@@ -233,7 +233,7 @@ class custom_search extends search_api
 	{
 		global $modSettings, $smcFunc;
 
-		$customIndexSettings = unserialize($modSettings['search_custom_index_config']);
+		$customIndexSettings = json_decode($modSettings['search_custom_index_config']);
 
 		$inserts = array();
 		foreach (text2words($msgOptions['body'], $customIndexSettings['bytes_per_word'], true) as $word)
@@ -257,7 +257,7 @@ class custom_search extends search_api
 
 		if (isset($msgOptions['body']))
 		{
-			$customIndexSettings = unserialize($modSettings['search_custom_index_config']);
+			$customIndexSettings = json_decode($modSettings['search_custom_index_config']);
 			$stopwords = empty($modSettings['search_stopwords']) ? array() : explode(',', $modSettings['search_stopwords']);
 			$old_body = isset($msgOptions['old_body']) ? $msgOptions['old_body'] : '';
 

--- a/Sources/Subs-Admin.php
+++ b/Sources/Subs-Admin.php
@@ -455,7 +455,7 @@ function updateAdminPreferences()
 		return false;
 
 	// This is what we'll be saving.
-	$options['admin_preferences'] = serialize($context['admin_preferences']);
+	$options['admin_preferences'] = json_encode($context['admin_preferences']);
 
 	// Just check we haven't ended up with something theme exclusive somehow.
 	$smcFunc['db_query']('', '

--- a/Sources/Subs-Attachments.php
+++ b/Sources/Subs-Attachments.php
@@ -56,7 +56,7 @@ function automanage_attachments_check_directory()
 	if (!empty($modSettings['attachment_basedirectories']) && !empty($modSettings['use_subdirectories_for_attachments']))
 	{
 			if (!is_array($modSettings['attachment_basedirectories']))
-				$modSettings['attachment_basedirectories'] = unserialize($modSettings['attachment_basedirectories']);
+				$modSettings['attachment_basedirectories'] = json_decode($modSettings['attachment_basedirectories']);
 			$base_dir = array_search($modSettings['basedirectory_for_attachments'], $modSettings['attachment_basedirectories']);
 	}
 	else
@@ -67,7 +67,7 @@ function automanage_attachments_check_directory()
 		if (!isset($modSettings['last_attachments_directory']))
 			$modSettings['last_attachments_directory'] = array();
 		if (!is_array($modSettings['last_attachments_directory']))
-			$modSettings['last_attachments_directory'] = unserialize($modSettings['last_attachments_directory']);
+			$modSettings['last_attachments_directory'] = json_decode($modSettings['last_attachments_directory']);
 		if (!isset($modSettings['last_attachments_directory'][$base_dir]))
 			$modSettings['last_attachments_directory'][$base_dir] = 0;
 	}
@@ -99,7 +99,7 @@ function automanage_attachments_check_directory()
 	}
 
 	if (!is_array($modSettings['attachmentUploadDir']))
-		$modSettings['attachmentUploadDir'] = unserialize($modSettings['attachmentUploadDir']);
+		$modSettings['attachmentUploadDir'] = json_decode($modSettings['attachmentUploadDir']);
 	if (!in_array($updir, $modSettings['attachmentUploadDir']) && !empty($updir))
 		$outputCreation = automanage_attachments_create_directory($updir);
 	elseif (in_array($updir, $modSettings['attachmentUploadDir']))
@@ -194,10 +194,10 @@ function automanage_attachments_create_directory($updir)
 		$modSettings['attachmentUploadDir'][$modSettings['currentAttachmentUploadDir']] = $updir;
 
 		updateSettings(array(
-			'attachmentUploadDir' => serialize($modSettings['attachmentUploadDir']),
+			'attachmentUploadDir' => json_encode($modSettings['attachmentUploadDir']),
 			'currentAttachmentUploadDir' => $modSettings['currentAttachmentUploadDir'],
 		), true);
-		$modSettings['attachmentUploadDir'] = unserialize($modSettings['attachmentUploadDir']);
+		$modSettings['attachmentUploadDir'] = json_decode($modSettings['attachmentUploadDir']);
 	}
 
 	$context['attach_dir'] = $modSettings['attachmentUploadDir'][$modSettings['currentAttachmentUploadDir']];
@@ -242,10 +242,10 @@ function automanage_attachments_by_space()
 	{
 		$modSettings['currentAttachmentUploadDir'] = array_search($updir, $modSettings['attachmentUploadDir']);
 		updateSettings(array(
-			'last_attachments_directory' => serialize($modSettings['last_attachments_directory']),
+			'last_attachments_directory' => json_encode($modSettings['last_attachments_directory']),
 			'currentAttachmentUploadDir' => $modSettings['currentAttachmentUploadDir'],
 		));
-		$modSettings['last_attachments_directory'] = unserialize($modSettings['last_attachments_directory']);
+		$modSettings['last_attachments_directory'] = json_decode($modSettings['last_attachments_directory']);
 
 		return true;
 	}
@@ -320,7 +320,7 @@ function processAttachments()
 		automanage_attachments_check_directory();
 
 	if (!is_array($modSettings['attachmentUploadDir']))
-		$modSettings['attachmentUploadDir'] = unserialize($modSettings['attachmentUploadDir']);
+		$modSettings['attachmentUploadDir'] = json_decode($modSettings['attachmentUploadDir']);
 
 	$context['attach_dir'] = $modSettings['attachmentUploadDir'][$modSettings['currentAttachmentUploadDir']];
 
@@ -1143,7 +1143,7 @@ function loadAttachmentContext($id_msg, $attachments)
 						if (!empty($modSettings['currentAttachmentUploadDir']))
 						{
 							if (!is_array($modSettings['attachmentUploadDir']))
-								$modSettings['attachmentUploadDir'] = @unserialize($modSettings['attachmentUploadDir']);
+								$modSettings['attachmentUploadDir'] = @json_decode($modSettings['attachmentUploadDir']);
 							$path = $modSettings['attachmentUploadDir'][$modSettings['currentAttachmentUploadDir']];
 							$id_folder_thumb = $modSettings['currentAttachmentUploadDir'];
 						}

--- a/Sources/Subs-Attachments.php
+++ b/Sources/Subs-Attachments.php
@@ -56,7 +56,7 @@ function automanage_attachments_check_directory()
 	if (!empty($modSettings['attachment_basedirectories']) && !empty($modSettings['use_subdirectories_for_attachments']))
 	{
 			if (!is_array($modSettings['attachment_basedirectories']))
-				$modSettings['attachment_basedirectories'] = json_decode($modSettings['attachment_basedirectories']);
+				$modSettings['attachment_basedirectories'] = json_decode($modSettings['attachment_basedirectories'], true);
 			$base_dir = array_search($modSettings['basedirectory_for_attachments'], $modSettings['attachment_basedirectories']);
 	}
 	else
@@ -67,7 +67,7 @@ function automanage_attachments_check_directory()
 		if (!isset($modSettings['last_attachments_directory']))
 			$modSettings['last_attachments_directory'] = array();
 		if (!is_array($modSettings['last_attachments_directory']))
-			$modSettings['last_attachments_directory'] = json_decode($modSettings['last_attachments_directory']);
+			$modSettings['last_attachments_directory'] = json_decode($modSettings['last_attachments_directory'], true);
 		if (!isset($modSettings['last_attachments_directory'][$base_dir]))
 			$modSettings['last_attachments_directory'][$base_dir] = 0;
 	}
@@ -99,7 +99,7 @@ function automanage_attachments_check_directory()
 	}
 
 	if (!is_array($modSettings['attachmentUploadDir']))
-		$modSettings['attachmentUploadDir'] = json_decode($modSettings['attachmentUploadDir']);
+		$modSettings['attachmentUploadDir'] = json_decode($modSettings['attachmentUploadDir'], true);
 	if (!in_array($updir, $modSettings['attachmentUploadDir']) && !empty($updir))
 		$outputCreation = automanage_attachments_create_directory($updir);
 	elseif (in_array($updir, $modSettings['attachmentUploadDir']))
@@ -197,7 +197,7 @@ function automanage_attachments_create_directory($updir)
 			'attachmentUploadDir' => json_encode($modSettings['attachmentUploadDir']),
 			'currentAttachmentUploadDir' => $modSettings['currentAttachmentUploadDir'],
 		), true);
-		$modSettings['attachmentUploadDir'] = json_decode($modSettings['attachmentUploadDir']);
+		$modSettings['attachmentUploadDir'] = json_decode($modSettings['attachmentUploadDir'], true);
 	}
 
 	$context['attach_dir'] = $modSettings['attachmentUploadDir'][$modSettings['currentAttachmentUploadDir']];
@@ -245,7 +245,7 @@ function automanage_attachments_by_space()
 			'last_attachments_directory' => json_encode($modSettings['last_attachments_directory']),
 			'currentAttachmentUploadDir' => $modSettings['currentAttachmentUploadDir'],
 		));
-		$modSettings['last_attachments_directory'] = json_decode($modSettings['last_attachments_directory']);
+		$modSettings['last_attachments_directory'] = json_decode($modSettings['last_attachments_directory'], true);
 
 		return true;
 	}
@@ -320,7 +320,7 @@ function processAttachments()
 		automanage_attachments_check_directory();
 
 	if (!is_array($modSettings['attachmentUploadDir']))
-		$modSettings['attachmentUploadDir'] = json_decode($modSettings['attachmentUploadDir']);
+		$modSettings['attachmentUploadDir'] = json_decode($modSettings['attachmentUploadDir'], true);
 
 	$context['attach_dir'] = $modSettings['attachmentUploadDir'][$modSettings['currentAttachmentUploadDir']];
 
@@ -1143,7 +1143,7 @@ function loadAttachmentContext($id_msg, $attachments)
 						if (!empty($modSettings['currentAttachmentUploadDir']))
 						{
 							if (!is_array($modSettings['attachmentUploadDir']))
-								$modSettings['attachmentUploadDir'] = @json_decode($modSettings['attachmentUploadDir']);
+								$modSettings['attachmentUploadDir'] = @json_decode($modSettings['attachmentUploadDir'], true);
 							$path = $modSettings['attachmentUploadDir'][$modSettings['currentAttachmentUploadDir']];
 							$id_folder_thumb = $modSettings['currentAttachmentUploadDir'];
 						}

--- a/Sources/Subs-Auth.php
+++ b/Sources/Subs-Auth.php
@@ -40,18 +40,22 @@ function setLoginCookie($cookie_length, $id, $password = '')
 	$cookie_state = (empty($modSettings['localCookies']) ? 0 : 1) | (empty($modSettings['globalCookies']) ? 0 : 2);
 	if (isset($_COOKIE[$cookiename]) && preg_match('~^a:[34]:\{i:0;i:\d{1,7};i:1;s:(0|128):"([a-fA-F0-9]{128})?";i:2;[id]:\d{1,14};(i:3;i:\d;)?\}$~', $_COOKIE[$cookiename]) === 1)
 	{
-		$array = @unserialize($_COOKIE[$cookiename]);
+		$array = json_decode($_COOKIE[$cookiename], true);
+
+		// Legacy format
+		if (is_null($array))
+			$array = @unserialize($_COOKIE[$cookiename]);
 
 		// Out with the old, in with the new!
 		if (isset($array[3]) && $array[3] != $cookie_state)
 		{
 			$cookie_url = url_parts($array[3] & 1 > 0, $array[3] & 2 > 0);
-			smf_setcookie($cookiename, serialize(array(0, '', 0)), time() - 3600, $cookie_url[1], $cookie_url[0]);
+			smf_setcookie($cookiename, json_encode(array(0, '', 0)), time() - 3600, $cookie_url[1], $cookie_url[0]);
 		}
 	}
 
 	// Get the data and path to set it on.
-	$data = serialize(empty($id) ? array(0, '', 0) : array($id, $password, time() + $cookie_length, $cookie_state));
+	$data = json_encode(empty($id) ? array(0, '', 0) : array($id, $password, time() + $cookie_length, $cookie_state));
 	$cookie_url = url_parts(!empty($modSettings['localCookies']), !empty($modSettings['globalCookies']));
 
 	// Set the cookie, $_COOKIE, and session variable.
@@ -126,7 +130,7 @@ function setTFACookie($cookie_length, $id, $secret, $preserve = false)
 		$cookie_length = 81600 * 30;
 
 	// Get the data and path to set it on.
-	$data = serialize(empty($id) ? array(0, '', 0, $cookie_state, false) : array($id, $secret, time() + $cookie_length, $cookie_state, $preserve));
+	$data = json_encode(empty($id) ? array(0, '', 0, $cookie_state, false) : array($id, $secret, time() + $cookie_length, $cookie_state, $preserve));
 	$cookie_url = url_parts(!empty($modSettings['localCookies']), !empty($modSettings['globalCookies']));
 
 	// Set the cookie, $_COOKIE, and session variable.

--- a/Sources/Subs-Calendar.php
+++ b/Sources/Subs-Calendar.php
@@ -855,7 +855,7 @@ function insertEvent(&$eventOptions)
 		$smcFunc['db_insert']('insert',
 			'{db_prefix}background_tasks',
 			array('task_file' => 'string', 'task_class' => 'string', 'task_data' => 'string', 'claimed_time' => 'int'),
-			array('$sourcedir/tasks/EventNew-Notify.php', 'EventNew_Notify_Background', serialize(array(
+			array('$sourcedir/tasks/EventNew-Notify.php', 'EventNew_Notify_Background', json_encode(array(
 				'event_title' => $eventOptions['title'],
 				'event_id' => $eventOptions['id'],
 				'sender_id' => $eventOptions['member'],

--- a/Sources/Subs-Editor.php
+++ b/Sources/Subs-Editor.php
@@ -2091,7 +2091,7 @@ function create_control_verification(&$verificationOptions, $do_test = false)
 				$id_question = $row['id_question'];
 				unset ($row['id_question']);
 				// Make them all lowercase. We can't directly use $smcFunc['strtolower'] with array_walk, so do it manually, eh?
-				$row['answers'] = unserialize($row['answers']);
+				$row['answers'] = json_decode($row['answers']);
 				foreach ($row['answers'] as $k => $v)
 					$row['answers'][$k] = $smcFunc['strtolower']($v);
 
@@ -2308,7 +2308,7 @@ function AutoSuggestHandler($checkRegistered = null)
 	loadTemplate('Xml');
 
 	// Any parameters?
-	$context['search_param'] = isset($_REQUEST['search_param']) ? unserialize(base64_decode($_REQUEST['search_param'])) : array();
+	$context['search_param'] = isset($_REQUEST['search_param']) ? json_decode(base64_decode($_REQUEST['search_param'])) : array();
 
 	if (isset($_REQUEST['suggest_type'], $_REQUEST['search']) && isset($searchTypes[$_REQUEST['suggest_type']]))
 	{

--- a/Sources/Subs-Editor.php
+++ b/Sources/Subs-Editor.php
@@ -2091,7 +2091,7 @@ function create_control_verification(&$verificationOptions, $do_test = false)
 				$id_question = $row['id_question'];
 				unset ($row['id_question']);
 				// Make them all lowercase. We can't directly use $smcFunc['strtolower'] with array_walk, so do it manually, eh?
-				$row['answers'] = json_decode($row['answers']);
+				$row['answers'] = json_decode($row['answers'], true);
 				foreach ($row['answers'] as $k => $v)
 					$row['answers'][$k] = $smcFunc['strtolower']($v);
 
@@ -2308,7 +2308,7 @@ function AutoSuggestHandler($checkRegistered = null)
 	loadTemplate('Xml');
 
 	// Any parameters?
-	$context['search_param'] = isset($_REQUEST['search_param']) ? json_decode(base64_decode($_REQUEST['search_param'])) : array();
+	$context['search_param'] = isset($_REQUEST['search_param']) ? json_decode(base64_decode($_REQUEST['search_param']), true) : array();
 
 	if (isset($_REQUEST['suggest_type'], $_REQUEST['search']) && isset($searchTypes[$_REQUEST['suggest_type']]))
 	{

--- a/Sources/Subs-Members.php
+++ b/Sources/Subs-Members.php
@@ -1268,7 +1268,7 @@ function BuddyListToggle()
 			$smcFunc['db_insert']('insert',
 				'{db_prefix}background_tasks',
 				array('task_file' => 'string', 'task_class' => 'string', 'task_data' => 'string', 'claimed_time' => 'int'),
-				array('$sourcedir/tasks/Buddy-Notify.php', 'Buddy_Notify_Background', serialize(array(
+				array('$sourcedir/tasks/Buddy-Notify.php', 'Buddy_Notify_Background', json_encode(array(
 					'receiver_id' => $userReceiver,
 					'id_member' => $user_info['id'],
 					'member_name' => $user_info['username'],

--- a/Sources/Subs-MembersOnline.php
+++ b/Sources/Subs-MembersOnline.php
@@ -68,7 +68,7 @@ function getMembersOnlineStats($membersOnlineOptions)
 	$spiders = array();
 	$spider_finds = array();
 	if (!empty($modSettings['show_spider_online']) && ($modSettings['show_spider_online'] < 3 || allowedTo('admin_forum')) && !empty($modSettings['spider_name_cache']))
-		$spiders = json_decode($modSettings['spider_name_cache']);
+		$spiders = json_decode($modSettings['spider_name_cache'], true);
 
 	// Load the users online right now.
 	$request = $smcFunc['db_query']('', '

--- a/Sources/Subs-MembersOnline.php
+++ b/Sources/Subs-MembersOnline.php
@@ -68,7 +68,7 @@ function getMembersOnlineStats($membersOnlineOptions)
 	$spiders = array();
 	$spider_finds = array();
 	if (!empty($modSettings['show_spider_online']) && ($modSettings['show_spider_online'] < 3 || allowedTo('admin_forum')) && !empty($modSettings['spider_name_cache']))
-		$spiders = unserialize($modSettings['spider_name_cache']);
+		$spiders = json_decode($modSettings['spider_name_cache']);
 
 	// Load the users online right now.
 	$request = $smcFunc['db_query']('', '

--- a/Sources/Subs-Post.php
+++ b/Sources/Subs-Post.php
@@ -884,7 +884,7 @@ function sendpm($recipients, $subject, $message, $store_outbox = false, $from = 
 	// Check whether we have to apply anything...
 	while ($row = $smcFunc['db_fetch_assoc']($request))
 	{
-		$criteria = unserialize($row['criteria']);
+		$criteria = json_decode($row['criteria']);
 		// Note we don't check the buddy status, cause deletion from buddy = madness!
 		$delete = false;
 		foreach ($criteria as $criterium)
@@ -1548,7 +1548,7 @@ function sendNotifications($topics, $type, $exclude = array(), $members_only = a
 		$row['body'] = trim(un_htmlspecialchars(strip_tags(strtr(parse_bbc($row['body'], false, $row['id_last_msg']), array('<br>' => "\n", '</div>' => "\n", '</li>' => "\n", '&#91;' => '[', '&#93;' => ']')))));
 
 		$task_rows[] = array(
-			'$sourcedir/tasks/CreatePost-Notify.php', 'CreatePost_Notify_Background', serialize(array(
+			'$sourcedir/tasks/CreatePost-Notify.php', 'CreatePost_Notify_Background', json_encode(array(
 				'msgOptions' => array(
 					'id' => $row['id_msg'],
 					'subject' => $row['subject'],
@@ -1877,7 +1877,7 @@ function createPost(&$msgOptions, &$topicOptions, &$posterOptions)
 			'{db_prefix}background_tasks',
 			array('task_file' => 'string', 'task_class' => 'string', 'task_data' => 'string', 'claimed_time' => 'int'),
 			array(
-				'$sourcedir/tasks/ApprovePost-Notify.php', 'ApprovePost_Notify_Background', serialize(array(
+				'$sourcedir/tasks/ApprovePost-Notify.php', 'ApprovePost_Notify_Background', json_encode(array(
 					'msgOptions' => $msgOptions,
 					'topicOptions' => $topicOptions,
 					'posterOptions' => $posterOptions,
@@ -1925,7 +1925,7 @@ function createPost(&$msgOptions, &$topicOptions, &$posterOptions)
 			'{db_prefix}background_tasks',
 			array('task_file' => 'string', 'task_class' => 'string', 'task_data' => 'string', 'claimed_time' => 'int'),
 			array(
-				'$sourcedir/tasks/ApproveReply-Notify.php', 'ApproveReply_Notify_Background', serialize(array(
+				'$sourcedir/tasks/ApproveReply-Notify.php', 'ApproveReply_Notify_Background', json_encode(array(
 					'msgOptions' => $msgOptions,
 					'topicOptions' => $topicOptions,
 					'posterOptions' => $posterOptions,
@@ -1968,7 +1968,7 @@ function createPost(&$msgOptions, &$topicOptions, &$posterOptions)
 		$smcFunc['db_insert']('',
 			'{db_prefix}background_tasks',
 			array('task_file' => 'string', 'task_class' => 'string', 'task_data' => 'string', 'claimed_time' => 'int'),
-			array('$sourcedir/tasks/CreatePost-Notify.php', 'CreatePost_Notify_Background', serialize(array(
+			array('$sourcedir/tasks/CreatePost-Notify.php', 'CreatePost_Notify_Background', json_encode(array(
 				'msgOptions' => $msgOptions,
 				'topicOptions' => $topicOptions,
 				'posterOptions' => $posterOptions,
@@ -2059,7 +2059,7 @@ function modifyPost(&$msgOptions, &$topicOptions, &$posterOptions)
 			$smcFunc['db_insert']('',
 				'{db_prefix}background_tasks',
 				array('task_file' => 'string', 'task_class' => 'string', 'task_data' => 'string', 'claimed_time' => 'int'),
-				array('$sourcedir/tasks/CreatePost-Notify.php', 'CreatePost_Notify_Background', serialize(array(
+				array('$sourcedir/tasks/CreatePost-Notify.php', 'CreatePost_Notify_Background', json_encode(array(
 					'msgOptions' => $msgOptions,
 					'topicOptions' => $topicOptions,
 					'posterOptions' => $posterOptions,
@@ -2359,7 +2359,7 @@ function approvePosts($msgs, $approve = true, $notify = true)
 		$task_rows = array();
 		foreach (array_merge($notification_topics, $notification_posts) as $topic)
 			$task_rows[] = array(
-				'$sourcedir/tasks/CreatePost-Notify.php', 'CreatePost_Notify_Background', serialize(array(
+				'$sourcedir/tasks/CreatePost-Notify.php', 'CreatePost_Notify_Background', json_encode(array(
 					'msgOptions' => array(
 						'id' => $topic['msg'],
 						'body' => $topic['body'],
@@ -2634,7 +2634,7 @@ function adminNotify($type, $memberID, $member_name = null)
 	$smcFunc['db_insert']('insert',
 		'{db_prefix}background_tasks',
 		array('task_file' => 'string', 'task_class' => 'string', 'task_data' => 'string', 'claimed_time' => 'int'),
-		array('$sourcedir/tasks/Register-Notify.php', 'Register_Notify_Background', serialize(array(
+		array('$sourcedir/tasks/Register-Notify.php', 'Register_Notify_Background', json_encode(array(
 			'new_member_id' => $memberID,
 			'new_member_name' => $member_name,
 			'notify_type' => $type,

--- a/Sources/Subs-Post.php
+++ b/Sources/Subs-Post.php
@@ -884,7 +884,7 @@ function sendpm($recipients, $subject, $message, $store_outbox = false, $from = 
 	// Check whether we have to apply anything...
 	while ($row = $smcFunc['db_fetch_assoc']($request))
 	{
-		$criteria = json_decode($row['criteria']);
+		$criteria = json_decode($row['criteria'], true);
 		// Note we don't check the buddy status, cause deletion from buddy = madness!
 		$delete = false;
 		foreach ($criteria as $criterium)

--- a/Sources/Subs-ReportedContent.php
+++ b/Sources/Subs-ReportedContent.php
@@ -619,7 +619,7 @@ function saveModComment($report_id, $data)
 		$smcFunc['db_insert']('insert',
 			'{db_prefix}background_tasks',
 			array('task_file' => 'string', 'task_class' => 'string', 'task_data' => 'string', 'claimed_time' => 'int'),
-			array('$sourcedir/tasks/' . $prefix . 'ReportReply-Notify.php', $prefix . 'ReportReply_Notify_Background', serialize($data), 0),
+			array('$sourcedir/tasks/' . $prefix . 'ReportReply-Notify.php', $prefix . 'ReportReply_Notify_Background', json_encode($data), 0),
 			array('id_task')
 		);
 }

--- a/Sources/Subs-Themes.php
+++ b/Sources/Subs-Themes.php
@@ -244,7 +244,7 @@ function get_theme_info($path)
 	}
 
 	if (!empty($theme_info_xml['extra']))
-		$xml_data += unserialize($theme_info_xml['extra']);
+		$xml_data += json_decode($theme_info_xml['extra']);
 
 	return $xml_data;
 }

--- a/Sources/Subs-Themes.php
+++ b/Sources/Subs-Themes.php
@@ -244,7 +244,7 @@ function get_theme_info($path)
 	}
 
 	if (!empty($theme_info_xml['extra']))
-		$xml_data += json_decode($theme_info_xml['extra']);
+		$xml_data += json_decode($theme_info_xml['extra'], true);
 
 	return $xml_data;
 }

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -1705,7 +1705,7 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 	if ($cache_id != '' && !empty($modSettings['cache_enable']) && (($modSettings['cache_enable'] >= 2 && isset($message[1000])) || isset($message[2400])) && empty($parse_tags))
 	{
 		// It's likely this will change if the message is modified.
-		$cache_key = 'parse:' . $cache_id . '-' . md5(md5($message) . '-' . $smileys . (empty($disabled) ? '' : implode(',', array_keys($disabled))) . serialize($context['browser']) . $txt['lang_locale'] . $user_info['time_offset'] . $user_info['time_format']);
+		$cache_key = 'parse:' . $cache_id . '-' . md5(md5($message) . '-' . $smileys . (empty($disabled) ? '' : implode(',', array_keys($disabled))) . json_encode($context['browser']) . $txt['lang_locale'] . $user_info['time_offset'] . $user_info['time_format']);
 
 		if (($temp = cache_get_data($cache_key, 240)) != null)
 			return $temp;
@@ -3141,7 +3141,7 @@ function template_header()
 			if (!empty($modSettings['currentAttachmentUploadDir']))
 			{
 				if (!is_array($modSettings['attachmentUploadDir']))
-					$modSettings['attachmentUploadDir'] = @unserialize($modSettings['attachmentUploadDir']);
+					$modSettings['attachmentUploadDir'] = @json_decode($modSettings['attachmentUploadDir']);
 				$path = $modSettings['attachmentUploadDir'][$modSettings['currentAttachmentUploadDir']];
 			}
 			else
@@ -3413,7 +3413,7 @@ function getAttachmentFilename($filename, $attachment_id, $dir = null, $new = fa
 	if (!empty($modSettings['currentAttachmentUploadDir']))
 	{
 		if (!is_array($modSettings['attachmentUploadDir']))
-			$modSettings['attachmentUploadDir'] = unserialize($modSettings['attachmentUploadDir']);
+			$modSettings['attachmentUploadDir'] = json_decode($modSettings['attachmentUploadDir']);
 		$path = $modSettings['attachmentUploadDir'][$dir];
 	}
 	else

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -3141,7 +3141,7 @@ function template_header()
 			if (!empty($modSettings['currentAttachmentUploadDir']))
 			{
 				if (!is_array($modSettings['attachmentUploadDir']))
-					$modSettings['attachmentUploadDir'] = @json_decode($modSettings['attachmentUploadDir']);
+					$modSettings['attachmentUploadDir'] = @json_decode($modSettings['attachmentUploadDir'], true);
 				$path = $modSettings['attachmentUploadDir'][$modSettings['currentAttachmentUploadDir']];
 			}
 			else
@@ -3413,7 +3413,7 @@ function getAttachmentFilename($filename, $attachment_id, $dir = null, $new = fa
 	if (!empty($modSettings['currentAttachmentUploadDir']))
 	{
 		if (!is_array($modSettings['attachmentUploadDir']))
-			$modSettings['attachmentUploadDir'] = json_decode($modSettings['attachmentUploadDir']);
+			$modSettings['attachmentUploadDir'] = json_decode($modSettings['attachmentUploadDir'], true);
 		$path = $modSettings['attachmentUploadDir'][$dir];
 	}
 	else

--- a/Sources/Themes.php
+++ b/Sources/Themes.php
@@ -1620,7 +1620,7 @@ function SetJavaScript()
 	// If this is the admin preferences the passed value will just be an element of it.
 	if ($_GET['var'] == 'admin_preferences')
 	{
-		$options['admin_preferences'] = !empty($options['admin_preferences']) ? json_decode($options['admin_preferences']) : array();
+		$options['admin_preferences'] = !empty($options['admin_preferences']) ? json_decode($options['admin_preferences'], true) : array();
 		// New thingy...
 		if (isset($_GET['admin_key']) && strlen($_GET['admin_key']) < 5)
 			$options['admin_preferences'][$_GET['admin_key']] = $_GET['val'];

--- a/Sources/Themes.php
+++ b/Sources/Themes.php
@@ -1620,13 +1620,13 @@ function SetJavaScript()
 	// If this is the admin preferences the passed value will just be an element of it.
 	if ($_GET['var'] == 'admin_preferences')
 	{
-		$options['admin_preferences'] = !empty($options['admin_preferences']) ? unserialize($options['admin_preferences']) : array();
+		$options['admin_preferences'] = !empty($options['admin_preferences']) ? json_decode($options['admin_preferences']) : array();
 		// New thingy...
 		if (isset($_GET['admin_key']) && strlen($_GET['admin_key']) < 5)
 			$options['admin_preferences'][$_GET['admin_key']] = $_GET['val'];
 
 		// Change the value to be something nice,
-		$_GET['val'] = serialize($options['admin_preferences']);
+		$_GET['val'] = json_encode($options['admin_preferences']);
 	}
 
 	// Update the option.

--- a/Sources/Who.php
+++ b/Sources/Who.php
@@ -155,7 +155,7 @@ function Who()
 	$url_data = array();
 	while ($row = $smcFunc['db_fetch_assoc']($request))
 	{
-		$actions = @json_decode($row['url']);
+		$actions = @json_decode($row['url'], true);
 		if ($actions === false)
 			continue;
 
@@ -195,7 +195,7 @@ function Who()
 	$spiderContext = array();
 	if (!empty($modSettings['show_spider_online']) && ($modSettings['show_spider_online'] == 2 || allowedTo('admin_forum')) && !empty($modSettings['spider_name_cache']))
 	{
-		foreach (json_decode($modSettings['spider_name_cache']) as $id => $name)
+		foreach (json_decode($modSettings['spider_name_cache'], true) as $id => $name)
 			$spiderContext[$id] = array(
 				'id' => 0,
 				'name' => $name,
@@ -306,7 +306,7 @@ function determineActions($urls, $preferred_prefix = false)
 	foreach ($url_list as $k => $url)
 	{
 		// Get the request parameters..
-		$actions = @json_decode($url[0]);
+		$actions = @json_decode($url[0], true);
 		if ($actions === false)
 			continue;
 
@@ -793,7 +793,7 @@ function Credits($in_admin = false)
 
 		while ($row = $smcFunc['db_fetch_assoc']($request))
 		{
-			$credit_info = json_decode($row['credits']);
+			$credit_info = json_decode($row['credits'], true);
 
 			$copyright = empty($credit_info['copyright']) ? '' : $txt['credits_copyright'] . ' &copy; ' . $smcFunc['htmlspecialchars']($credit_info['copyright']);
 			$license = empty($credit_info['license']) ? '' : $txt['credits_license'] . ': ' . (!empty($credit_info['licenseurl']) ? '<a href="'. $smcFunc['htmlspecialchars']($credit_info['licenseurl']) .'">'. $smcFunc['htmlspecialchars']($credit_info['license']) .'</a>' : $smcFunc['htmlspecialchars']($credit_info['license']));

--- a/Sources/Who.php
+++ b/Sources/Who.php
@@ -155,7 +155,7 @@ function Who()
 	$url_data = array();
 	while ($row = $smcFunc['db_fetch_assoc']($request))
 	{
-		$actions = @unserialize($row['url']);
+		$actions = @json_decode($row['url']);
 		if ($actions === false)
 			continue;
 
@@ -195,7 +195,7 @@ function Who()
 	$spiderContext = array();
 	if (!empty($modSettings['show_spider_online']) && ($modSettings['show_spider_online'] == 2 || allowedTo('admin_forum')) && !empty($modSettings['spider_name_cache']))
 	{
-		foreach (unserialize($modSettings['spider_name_cache']) as $id => $name)
+		foreach (json_decode($modSettings['spider_name_cache']) as $id => $name)
 			$spiderContext[$id] = array(
 				'id' => 0,
 				'name' => $name,
@@ -255,7 +255,7 @@ function Who()
  *    use whoallow_ACTION and add a list of possible permissions to the
  *    $allowedActions array, using ACTION as the key.
  *
- * @param mixed $urls  a single url (string) or an array of arrays, each inner array being (serialized request data, id_member)
+ * @param mixed $urls  a single url (string) or an array of arrays, each inner array being (JSON-encoded request data, id_member)
  * @param string $preferred_prefix = false
  * @return array, an array of descriptions if you passed an array, otherwise the string describing their current location.
  */
@@ -306,7 +306,7 @@ function determineActions($urls, $preferred_prefix = false)
 	foreach ($url_list as $k => $url)
 	{
 		// Get the request parameters..
-		$actions = @unserialize($url[0]);
+		$actions = @json_decode($url[0]);
 		if ($actions === false)
 			continue;
 
@@ -793,7 +793,7 @@ function Credits($in_admin = false)
 
 		while ($row = $smcFunc['db_fetch_assoc']($request))
 		{
-			$credit_info = unserialize($row['credits']);
+			$credit_info = json_decode($row['credits']);
 
 			$copyright = empty($credit_info['copyright']) ? '' : $txt['credits_copyright'] . ' &copy; ' . $smcFunc['htmlspecialchars']($credit_info['copyright']);
 			$license = empty($credit_info['license']) ? '' : $txt['credits_license'] . ': ' . (!empty($credit_info['licenseurl']) ? '<a href="'. $smcFunc['htmlspecialchars']($credit_info['licenseurl']) .'">'. $smcFunc['htmlspecialchars']($credit_info['license']) .'</a>' : $smcFunc['htmlspecialchars']($credit_info['license']));

--- a/Sources/tasks/ApprovePost-Notify.php
+++ b/Sources/tasks/ApprovePost-Notify.php
@@ -91,7 +91,7 @@ class ApprovePost_Notify_Background extends SMF_BackgroundTask
 					'content_id' => $topicOptions['id'],
 					'content_action' => $type,
 					'is_read' => 0,
-					'extra' => serialize(array(
+					'extra' => json_encode(array(
 						'topic' => $topicOptions['id'],
 						'board' => $topicOptions['board'],
 						'content_subject' => $msgOptions['subject'],

--- a/Sources/tasks/ApproveReply-Notify.php
+++ b/Sources/tasks/ApproveReply-Notify.php
@@ -84,7 +84,7 @@ class ApproveReply_Notify_Background extends SMF_BackgroundTask
 					'content_id' => $topicOptions['id'],
 					'content_action' => 'reply',
 					'is_read' => 0,
-					'extra' => serialize(array(
+					'extra' => json_encode(array(
 						'topic' => $topicOptions['id'],
 						'board' => $topicOptions['board'],
 						'content_subject' => $msgOptions['subject'],

--- a/Sources/tasks/Birthday-Notify.php
+++ b/Sources/tasks/Birthday-Notify.php
@@ -89,7 +89,7 @@ class Birthday_Notify_Background extends SMF_BackgroundTask
 							'content_id' => 0,
 							'content_action' => 'msg',
 							'is_read' => 0,
-							'extra' => serialize(array('happy_birthday' => $txt['happy_birthday_body'])),
+							'extra' => json_encode(array('happy_birthday' => $txt['happy_birthday_body'])),
 						);
 						updateMemberData($member_id, array('alerts' => '+'));
 					}

--- a/Sources/tasks/CreatePost-Notify.php
+++ b/Sources/tasks/CreatePost-Notify.php
@@ -173,7 +173,7 @@ class CreatePost_Notify_Background extends SMF_BackgroundTask
 					'content_id' => $topicOptions['id'],
 					'content_action' => $type,
 					'is_read' => 0,
-					'extra' => serialize(array(
+					'extra' => json_encode(array(
 						'topic' => $topicOptions['id'],
 						'board' => $topicOptions['board'],
 						'content_subject' => $msgOptions['subject'],
@@ -255,7 +255,7 @@ class CreatePost_Notify_Background extends SMF_BackgroundTask
 					'content_id' => $msgOptions['id'],
 					'content_action' => 'quote',
 					'is_read' => 0,
-					'extra' => serialize(array(
+					'extra' => json_encode(array(
 						'content_subject' => $msgOptions['subject'],
 						'content_link' => $scripturl . '?msg=' . $msgOptions['id'],
 					)),
@@ -367,7 +367,7 @@ class CreatePost_Notify_Background extends SMF_BackgroundTask
 					'content_id' => $msgOptions['id'],
 					'content_action' => 'mention',
 					'is_read' => 0,
-					'extra' => serialize(array(
+					'extra' => json_encode(array(
 						'content_subject' => $msgOptions['subject'],
 						'content_link' => $scripturl . '?msg=' . $msgOptions['id'],
 					)),

--- a/Sources/tasks/EventNew-Notify.php
+++ b/Sources/tasks/EventNew-Notify.php
@@ -80,7 +80,7 @@ class EventNew_Notify_Background extends SMF_BackgroundTask
 					'content_id' => $this->_details['event_id'],
 					'content_action' => empty($this->_details['sender_id']) ? 'new_guest' : 'new',
 					'is_read' => 0,
-					'extra' => serialize(array($this->_details['event_id'], $this->_details['event_title'])),
+					'extra' => json_encode(array($this->_details['event_id'], $this->_details['event_title'])),
 				);
 			}
 

--- a/Sources/tasks/GroupAct-Notify.php
+++ b/Sources/tasks/GroupAct-Notify.php
@@ -115,7 +115,7 @@ class GroupAct_Notify_Background extends SMF_BackgroundTask
 						'content_id' => 0,
 						'content_action' => $pref_name,
 						'is_read' => 0,
-						'extra' => serialize(array('group_name' => $user['group_name'], 'reason' => !empty($custom_reason) ? '<br><br>' . $custom_reason : '')),
+						'extra' => json_encode(array('group_name' => $user['group_name'], 'reason' => !empty($custom_reason) ? '<br><br>' . $custom_reason : '')),
 					);
 					updateMemberData($user['member_id'], array('alerts' => '+'));
 				}

--- a/Sources/tasks/GroupReq-Notify.php
+++ b/Sources/tasks/GroupReq-Notify.php
@@ -82,7 +82,7 @@ class GroupReq_Notify_Background extends SMF_BackgroundTask
 						'content_id' => 0,
 						'content_action' => 'group_request',
 						'is_read' => 0,
-						'extra' => serialize(array('group_name' => $this->_details['group_name'])),
+						'extra' => json_encode(array('group_name' => $this->_details['group_name'])),
 					);
 				}
 

--- a/Sources/tasks/MemberReport-Notify.php
+++ b/Sources/tasks/MemberReport-Notify.php
@@ -67,7 +67,7 @@ class MemberReport_Notify_Background extends SMF_BackgroundTask
 					'content_id' => $this->_details['user_id'],
 					'content_action' => 'report',
 					'is_read' => 0,
-					'extra' => serialize(
+					'extra' => json_encode(
 						array(
 							'report_link' => '?action=moderate;area=reportedmembers;report=' . $this->_details['report_id'], // We don't put $scripturl in these!
 							'user_name' => $this->_details['user_name'],

--- a/Sources/tasks/MemberReportReply-Notify.php
+++ b/Sources/tasks/MemberReportReply-Notify.php
@@ -94,7 +94,7 @@ class MemberReportReply_Notify_Background extends SMF_BackgroundTask
 					'content_id' => $this->_details['user_id'],
 					'content_action' => 'report_reply',
 					'is_read' => 0,
-					'extra' => serialize(
+					'extra' => json_encode(
 						array(
 							'report_link' => '?action=moderate;area=reportedmembers;sa=details;rid=' . $this->_details['report_id'], // We don't put $scripturl in these!
 							'user_name' => $this->_details['user_name'],

--- a/Sources/tasks/MsgReport-Notify.php
+++ b/Sources/tasks/MsgReport-Notify.php
@@ -102,7 +102,7 @@ class MsgReport_Notify_Background extends SMF_BackgroundTask
 					'content_id' => $this->_details['msg_id'],
 					'content_action' => 'report',
 					'is_read' => 0,
-					'extra' => serialize(
+					'extra' => json_encode(
 						array(
 							'report_link' => '?action=moderate;area=reportedposts;sa=details;rid=' . $this->_details['report_id'], // We don't put $scripturl in these!
 						)

--- a/Sources/tasks/MsgReportReply-Notify.php
+++ b/Sources/tasks/MsgReportReply-Notify.php
@@ -129,7 +129,7 @@ class MsgReportReply_Notify_Background extends SMF_BackgroundTask
 					'content_id' => $this->_details['msg_id'],
 					'content_action' => 'report_reply',
 					'is_read' => 0,
-					'extra' => serialize(
+					'extra' => json_encode(
 						array(
 							'report_link' => '?action=moderate;area=reportedposts;sa=details;rid=' . $this->_details['report_id'], // We don't put $scripturl in these!
 						)

--- a/Themes/default/Packages.template.php
+++ b/Themes/default/Packages.template.php
@@ -1779,14 +1779,14 @@ function template_action_permissions()
 		echo '
 				<input type="hidden" name="custom_value" value="', $context['custom_value'], '">
 				<input type="hidden" name="totalItems" value="', $context['total_items'], '">
-				<input type="hidden" name="toProcess" value="', base64_encode(serialize($context['to_process'])), '">';
+				<input type="hidden" name="toProcess" value="', base64_encode(json_encode($context['to_process'])), '">';
 	else
 		echo '
 				<input type="hidden" name="predefined" value="', $context['predefined_type'], '">
 				<input type="hidden" name="fileOffset" value="', $context['file_offset'], '">
 				<input type="hidden" name="totalItems" value="', $context['total_items'], '">
-				<input type="hidden" name="dirList" value="', base64_encode(serialize($context['directory_list'])), '">
-				<input type="hidden" name="specialFiles" value="', base64_encode(serialize($context['special_files'])), '">';
+				<input type="hidden" name="dirList" value="', base64_encode(json_encode($context['directory_list'])), '">
+				<input type="hidden" name="specialFiles" value="', base64_encode(json_encode($context['special_files'])), '">';
 
 	// Are we not using FTP for whatever reason.
 	if (!empty($context['skip_ftp']))

--- a/cron.php
+++ b/cron.php
@@ -202,7 +202,7 @@ function perform_task($task_details)
 	// All background tasks need to be classes.
 	elseif (class_exists($task_details['task_class']) && is_subclass_of($task_details['task_class'], 'SMF_BackgroundTask'))
 	{
-		$details = empty($task_details['task_data']) ? array() : unserialize($task_details['task_data']);
+		$details = empty($task_details['task_data']) ? array() : json_decode($task_details['task_data'], true);
 		$bgtask = new $task_details['task_class']($details);
 		return $bgtask->execute();
 	}

--- a/other/install_2-1_mysql.sql
+++ b/other/install_2-1_mysql.sql
@@ -2036,7 +2036,8 @@ VALUES ('smfVersion', '{$smf_version}'),
 	('loginHistoryDays', '30'),
 	('httponlyCookies', '1'),
 	('tfa_mode', '1'),
-	('allow_expire_redirect', '1');
+	('allow_expire_redirect', '1'),
+	('json_done', '1');
 
 # --------------------------------------------------------
 

--- a/other/install_2-1_postgresql.sql
+++ b/other/install_2-1_postgresql.sql
@@ -2614,6 +2614,7 @@ INSERT INTO {$db_prefix}settings (variable, value) VALUES ('loginHistoryDays', '
 INSERT INTO {$db_prefix}settings (variable, value) VALUES ('httponlyCookies', '1');
 INSERT INTO {$db_prefix}settings (variable, value) VALUES ('tfa_mode', '1');
 INSERT INTO {$db_prefix}settings (variable, value) VALUES ('allow_expire_redirect', '1');
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('json_done', '1');
 
 # --------------------------------------------------------
 #

--- a/other/upgrade.php
+++ b/other/upgrade.php
@@ -4066,7 +4066,7 @@ function convertUtf8()
 // Change serialized stuff to JSON...
 function serialize_to_json()
 {
-	global $command_line, $smcFunc, $modSettings;
+	global $command_line, $smcFunc, $modSettings, $sourcedir;
 
 	// This is set when we're done so we don't do it again
 	if (!empty($modSettings['json_done']))
@@ -4464,6 +4464,8 @@ function serialize_to_json()
 		}
 
 		// Last but not least, insert a dummy setting so we don't have to do this again in the future...
+		if (!function_exists('cache_put_data'))
+			require_once($sourcedir . '/Load.php');
 		updateSettings(array('json_done' => true));
 	}
 

--- a/other/upgrade.php
+++ b/other/upgrade.php
@@ -4180,7 +4180,7 @@ function serialize_to_json()
 			{
 				$row['failed_steps'] = json_encode(@unserialize($row['failed_steps']));
 				$row['db_changes'] = empty($row['db_changes']) ? '' : json_encode(@unserialize($row['db_changes']));
-				$row['credits'] = empty($row['credits']) ? '' : json_decode(@unserialize($row['credits']));
+				$row['credits'] = empty($row['credits']) ? '' : json_encode(@unserialize($row['credits']));
 
 				$smcFunc['db_query']('', '
 					UPDATE {db_prefix}log_packages

--- a/other/upgrade.php
+++ b/other/upgrade.php
@@ -4079,14 +4079,14 @@ function serialize_to_json()
 	// name => array('key', col1[,col2|true[,col3]])
 	// If 3rd item in array is true, it indicates that col1 could be empty...
 	$tables = array(
-		'background_tasks' => array('id_task', 'task_data', true),
+		'background_tasks' => array('id_task', 'task_data'),
 		'log_actions' => array('id_action', 'extra'),
 		'log_online' => array('session', 'url'),
 		'log_packages' => array('id_install', 'db_changes', 'failed_steps', 'credits'),
 		'log_spider_hits' => array('id_hit', 'url'),
 		'log_subscribed' => array('id_sublog', 'pending_details'),
 		'pm_rules' => array('id_rule', 'criteria', 'actions'),
-		'qanda' => array('id_question', 'answer'),
+		'qanda' => array('id_question', 'answers'),
 		'subscriptions' => array('id_subscribe', 'cost'),
 		'user_alerts' => array('id_alert', 'extra', true),
 		'user_drafts' => array('id_draft', 'to_list', true),
@@ -4157,7 +4157,7 @@ function serialize_to_json()
 				{
 					if (isset($modSettings[$var]))
 					{
-						$new_settings[$var] = json_encode(@unserialize($modSettings[$var]));
+						$new_settings[$var] = json_encode(unserialize($modSettings[$var]));
 					}
 				}
 
@@ -4187,7 +4187,7 @@ function serialize_to_json()
 
 					while ($row = $smcFunc['db_fetch_assoc']($query))
 					{
-						$row['admin_preferences'] = json_encode(@unserialize($row['admin_preferences']));
+						$row['admin_preferences'] = json_encode(unserialize($row['admin_preferences']));
 
 						// Even though we have all values from the table, UPDATE is still faster than REPLACE
 						$smcFunc['db_query']('', '
@@ -4219,7 +4219,7 @@ function serialize_to_json()
 				if (count($info) == 2 && $info[2] === true)
 				{
 					$col_select = $info[1];
-					$where = ' WHERE ' . $info[1] . ' != {string:empty}';
+					$where = ' WHERE ' . $info[1] . ' != {empty}';
 				}
 				else
 				{
@@ -4249,7 +4249,7 @@ function serialize_to_json()
 						{
 							if ($col !== true && $row[$col] != '')
 							{
-								$row[$col] = json_encode(@unserialize($row[$col]));
+								$row[$col] = json_encode(unserialize($row[$col]));
 
 								// Build our SET string and variables array
 								$update .= (empty($update) ? '' : ', ') . $col . ' = {string:' . $col . '}';
@@ -4261,12 +4261,14 @@ function serialize_to_json()
 
 						// In a few cases, we might have empty data, so don't try to update in those situations...
 						if (!empty($update))
+						{
 							$smcFunc['db_query']('', '
 								UPDATE {db_prefix}' . $table . '
 								SET ' . $update . '
 								WHERE ' . $key . ' = {' . ($key == 'session' ? 'string' : 'int') . ':' . $key . '}',
 								$vars
 							);
+						}
 					}
 
 					if ($is_debug || $command_line)

--- a/other/upgrade.php
+++ b/other/upgrade.php
@@ -4410,6 +4410,7 @@ function serialize_to_json()
 			'cal_today_holiday',
 			'displayFields',
 			'last_attachments_directory',
+			'memberlist_cache',
 			'search_index_custom_config',
 			'spider_name_cache'
 		);

--- a/other/upgrade.php
+++ b/other/upgrade.php
@@ -4059,6 +4059,413 @@ function convertUtf8()
 			echo "\nYour fulltext search index was dropped to facilitate the conversion. You will need to recreate it.";
 	}
 
+	return true;
+}
+
+// Change serialized stuff to JSON...
+function serialize_to_json()
+{
+	global $command_line, $smcFunc, $modSettings;
+
+	// This is set when we're done so we don't do it again
+	if (!empty($modSettings['json_done']))
+	{
+		echo 'JSON conversion already done. Skipping...';
+	}
+	else
+	{
+		// Try to buy some time here...
+		@set_time_limit(300);
+		if (function_exists('apache_reset_timeout'))
+			@apache_reset_timeout();
+
+		// First up, the background tasks...
+		$query = $smcFunc['db_query']('', '
+			SELECT id_task, task_data
+			FROM {db_prefix}background_tasks',
+			array()
+		);
+
+		if ($smcFunc['db_num_rows']($query) != 0)
+		{
+			echo 'Fixing background task data...';
+			while ($row = $smcFunc['db_fetch_assoc']($query))
+			{
+				$row['task_data'] = json_encode(@unserialize($row['task_data']));
+
+				$smcFunc['db_query']('', '
+					UPDATE {db_prefix}background_tasks
+					SET task_data = {string:task_data}
+					WHERE id_task = {int:id}',
+					array(
+						'task_data' => $row['task_data'],
+						'id' => $row['id_task']
+					)
+				);
+			}
+			echo " done.\n";
+			$smcFunc['db_free_result']($query);
+		}
+
+		// Next, the log_actions table
+		$query = $smcFunc['db_query']('', '
+			SELECT id_action, extra
+			FROM {db_prefix}log_actions
+			WHERE extra != {string:empty}',
+			array(
+				'empty' => ''
+			)
+		);
+
+		if ($smcFunc['db_num_rows']($query) != 0)
+		{
+			echo 'Fixing the \'extra\' column in the log_actions table...';
+			while ($row = $smcFunc['db_fetch_assoc']($query))
+			{
+				$row['extra'] = json_encode(@unserialize($row['extra']));
+				$smcFunc['db_query']('', '
+					UPDATE {db_prefix}log_actions
+					SET extra = {string:extra}
+					WHERE id_action = {int:id}',
+					array(
+						'extra' => $row['extra'],
+						'id' => $row['id_action']
+					)
+				);
+			}
+			echo " done.\n";
+			$smcFunc['db_free_result']($query);
+		}
+
+		// Now the log_online table...
+		$query = $smcFunc['db_query']('', '
+			SELECT session, url
+			FROM {db_prefix}log_online',
+			array()
+		);
+
+		if ($smcFunc['db_num_rows']($query) != 0)
+		{
+			echo 'Fixing the log_online table...';
+			while ($row = $smcFunc['db_fetch_assoc']($query))
+			{
+				$row['url'] = json_encode(@unserialize($row['url']));
+
+				$smcFunc['db_query']('', '
+					UPDATE {db_prefix}log_online
+					SET url = {string:url}
+					WHERE session = {string:session}',
+					array(
+						'url' => $row['url'],
+						'session' => $row['session']
+					)
+				);
+			}
+			echo " done.\n";
+			$smcFunc['db_free_result']($query);
+		}
+
+		// And the log_packages table...
+		$query = $smcFunc['db_query']('', '
+			SELECT id_install, failed_steps, db_changes, credits
+			FROM {db_prefix}log_packages',
+			array()
+		);
+
+		if ($smcFunc['db_num_rows']($query) != 0)
+		{
+			echo 'Fixing the log_packages table...';
+			while ($row = $smcFunc['db_fetch_assoc']($query))
+			{
+				$row['failed_steps'] = json_encode(@unserialize($row['failed_steps']));
+				$row['db_changes'] = empty($row['db_changes']) ? '' : json_encode(@unserialize($row['db_changes']));
+				$row['credits'] = empty($row['credits']) ? '' : json_decode(@unserialize($row['credits']));
+
+				$smcFunc['db_query']('', '
+					UPDATE {db_prefix}log_packages
+					SET failed_steps = {string:failed}, db_changes = {string:changes}, credits = {string:credits}
+					WHERE id_install = {int:id}',
+					array(
+						'failed' => $row['failed_steps'],
+						'changes' => $row['db_changes'],
+						'credits' => $row['credits'],
+						'id' => $row['id_install']
+					)
+				);
+			}
+			echo " done.\n";
+			$smcFunc['db_free_result']($query);
+		}
+
+		// Spider hits...
+		$query = $smcFunc['db_query']('', '
+			SELECT id_hit, url
+			FROM {db_prefix}log_spider_hits',
+			array()
+		);
+
+		if ($smcFunc['db_num_rows']($query) != 0)
+		{
+			echo 'Fixing the log_spider_hits table...';
+			while ($row = $smcFunc['db_fetch_assoc']($query))
+			{
+				$row['url'] = json_encode(@unserialize($row['url']));
+
+				$smcFunc['db_query']('', '
+					UPDATE {db_prefix}log_spider_hits
+					SET url = {string:url}
+					WHERE id_hit = {int:id}',
+					array(
+						'url' => $row['url'],
+						'id' => $row['id_hit']
+					)
+				);
+			}
+			echo " done.\n";
+			$smcFunc['db_free_result']($query);
+		}
+
+		// And the pm_rules table...
+		$query = $smcFunc['db_query']('', '
+			SELECT id_rules, criteria, actions
+			FROM {db_prefix}pm_rules',
+			array()
+		);
+
+		if ($smcFunc['db_num_rows']($query) != 0)
+		{
+			echo 'Fixing the pm_rules table...';
+			while ($row = $smcFunc['db_fetch_assoc']($query))
+			{
+				$row['criteria'] = json_encode(@unserialize($row['criteria']));
+				$row['actions'] = json_encode(@unserialize($row['actions']));
+
+				$smcFunc['db_query']('', '
+					UPDATE {db_prefix}pm_rules
+					SET criteria = {string:criteria}, actions = {string:actions}
+					WHERE id_rule = {int:id}',
+					array(
+						'criteria' => $row['criteria'],
+						'actions' => $row['actions'],
+						'id' => $row['id_rules']
+					)
+				);
+			}
+			echo " done.\n";
+			$smcFunc['db_free_result']($query);
+		}
+
+		// The qanda table...
+		$query = $smcFunc['db_query']('', '
+			SELECT id_question, answers
+			FROM {db_prefix}qanda',
+			array()
+		);
+
+		if ($smcFunc['db_num_rows'] != 0)
+		{
+			echo 'Fixing the qanda table...';
+			while($row = $smcFunc['db_fetch_assoc']($query))
+			{
+				$row['answers'] = json_encode(@unserialize($row['answers']));
+
+				$smcFunc['db_query']('', '
+					UPDATE {db_prefix}qanda
+					SET answers = {string:answers}
+					WHERE id_question = {int:id}',
+					array(
+						'answers' => $row['answers'],
+						'id' => $row['id']
+					)
+				);
+			}
+			echo " done.\n";
+			$smcFunc['db_free_result']($query);
+		}
+
+		// Paid subscription data
+		$query = $smcFunc['db_query']('', '
+			SELECT id_sublog, pending_details
+			FROM {db_prefix}log_subscribed',
+			array()
+		);
+
+		if ($smcFunc['db_num_rows']($query) != 0)
+		{
+			echo 'Fixing the log_subscribed table...';
+			while($row = $smcFunc['db_fetch_assoc']($query))
+			{
+				$row['pending_details'] = json_encode(@unserialize($row['pending_details']));
+
+				$smcFunc['db_query']('', '
+					UPDATE {db_prefix}log_subscribed
+					SET pending_details = {string:details}
+					WHERE id_sublog = {int:ind}',
+					array(
+						'details' => $row['pending_details'],
+						'id' => $row['id_sublog']
+					)
+				);
+			}
+			echo " done.\n";
+			$smcFunc['db_free_result']($query);
+		}
+
+		// More paid subs stuff
+		$query = $smcFunc['db_query']('', '
+			SELECT id_subscribe, cost
+			FROM {db_prefix}subscriptions',
+			array()
+		);
+
+		if ($smcFunc['db_num_rows']($query) != 0)
+		{
+			echo 'Fixing the subscriptions table...';
+			while($row = $smcFunc['db_fetch_assoc']($query))
+			{
+				$row['cost'] = json_encode($row['cost']);
+
+				$smcFunc['db_query']('', '
+					UPDATE {db_prefix}subscriptions
+					SET cost = {string:cost}
+					WHERE id-subscribe = {int:id}',
+					array(
+						'cost' => $row['cost'],
+						'id' => $row['id_subscribe']
+					)
+				);
+			}
+			echo " done.\n";
+			$smcFunc['db_free_result']($query);
+		}
+
+		// Alerts
+		$query = $smcFunc['db_query']('', '
+			SELECT id_alert, extra
+			FROM {db_prefix}user_alerts
+			WHERE extra != {string:empty}',
+				array(
+						'empty' => ''
+				)
+		);
+
+		if ($smcFunc['db_num_rows']($query) != 0)
+		{
+			echo 'Fixing the user_alerts table...';
+			while($row = $smcFunc['db_fetch_assoc']($query))
+			{
+				$row['extra'] = json_encode(@unserialize($row['extra']));
+
+				$smcFunc['db_query']('', '
+					UPDATE {db_prefix}user_alerts
+					SET extra = {string:extra}
+					WHERE id_alert = {int:id}',
+						array(
+								'extra' => $row['extra'],
+								'id' => $row['id_alert']
+						)
+				);
+			}
+			echo " done.\n";
+			$smcFunc['db_free_result']($query);
+		}
+
+		// Drafts
+		$query = $smcFunc['db_query']('', '
+			SELECT id_draft, to_list
+			FROM {db_prefix}user_drafts
+			WHERE to_list != {string:empty}',
+			array(
+				'empty' => ''
+			)
+		);
+
+		if ($smcFunc['db_num_rows']($query) != 0)
+		{
+			echo 'Fixing the user_drafts table...';
+			while($row = $smcFunc['db_fetch_assoc']($query))
+			{
+				$row['to_list'] = json_encode(@unserialize($row['to_list']));
+
+				$smcFunc['db_query']('', '
+					UPDATE {db_prefix}user_drafts
+					SET to_list = {string:to}
+					WHERE id_draft = {int:id}',
+					array(
+						'to' => $row['to_list'],
+						'id' => $row['id_draft']
+					)
+				);
+			}
+			echo " done.\n";
+			$smcFunc['db_free_result']($query);
+		}
+
+		// Now a few settings...
+		$serialized_settings = array(
+			'attachment_basedirectories',
+			'attachmentUploadDir',
+			'cal_today_birthday',
+			'cal_today_event',
+			'cal_today_holiday',
+			'displayFields',
+			'last_attachments_directory',
+			'search_index_custom_config',
+			'spider_name_cache'
+		);
+
+		// Loop through and fix these...
+		$new_settings = array();
+		echo 'Fixing the settings...';
+		foreach($serialized_settings as $var)
+		{
+			if (isset($modSettings[$var]))
+			{
+				$new_settings[$var] = json_encode(@unserialize($modSettings[$var]));
+			}
+		}
+
+		// Update everything at once
+		updateSettings($new_settings, true);
+		echo " done.\n";
+
+		// Last but not least, a few theme settings...
+		$query = $smcFunc['db_query']('', '
+			SELECT * FROM {db_prefix}themes
+			WHERE variable = {string:admin_prefs}',
+			array(
+				'admin_prefs' => 'admin_preferences'
+			)
+		);
+
+		if ($smcFunc['db_num_rows']($query) != 0)
+		{
+			echo 'Fixing admin preferences...';
+			while($row = $smcFunc['db_fetch_assoc']($query))
+			{
+				$row['admin_preferences'] = json_encode((@unserialize($row['admin_preferences'])));
+
+				// Even though we have all values from the table, UPDATE is still faster than REPLACE
+				$smcFunc['db_query']('', '
+					UPDATE {db_prefix}themes
+					SET value = {string:prefs}
+					WHERE id_theme = {int:theme}
+						AND id_member = {int:member}',
+					array(
+						'theme' => $row['id_theme'],
+						'member' => $row['id_member']
+					)
+				);
+			}
+			echo " done.\n";
+			$smcFunc['db_free_result']($query);
+		}
+
+		// Last but not least, insert a dummy setting so we don't have to do this again in the future...
+		updateSettings(array('json_done' => true));
+	}
+
+	// If we're running from command line, we're done here...
 	if ($command_line)
 	{
 		return DeleteUpgrade();

--- a/other/upgrade.php
+++ b/other/upgrade.php
@@ -4228,7 +4228,7 @@ function serialize_to_json()
 
 		// And the pm_rules table...
 		$query = $smcFunc['db_query']('', '
-			SELECT id_rules, criteria, actions
+			SELECT id_rule, criteria, actions
 			FROM {db_prefix}pm_rules',
 			array()
 		);
@@ -4248,7 +4248,7 @@ function serialize_to_json()
 					array(
 						'criteria' => $row['criteria'],
 						'actions' => $row['actions'],
-						'id' => $row['id_rules']
+						'id' => $row['id_rule']
 					)
 				);
 			}

--- a/other/upgrade.php
+++ b/other/upgrade.php
@@ -4428,6 +4428,8 @@ function serialize_to_json()
 		}
 
 		// Update everything at once
+		if (!function_exists('cache_put_data'))
+			require_once($sourcedir . '/Load.php');
 		updateSettings($new_settings, true);
 		echo " done.\n";
 
@@ -4462,10 +4464,7 @@ function serialize_to_json()
 			echo " done.\n";
 			$smcFunc['db_free_result']($query);
 		}
-
 		// Last but not least, insert a dummy setting so we don't have to do this again in the future...
-		if (!function_exists('cache_put_data'))
-			require_once($sourcedir . '/Load.php');
 		updateSettings(array('json_done' => true));
 	}
 

--- a/other/upgrade.php
+++ b/other/upgrade.php
@@ -4194,7 +4194,7 @@ function serialize_to_json()
 						if ($is_debug || $command_line)
 						{
 							if (!$temp)
-								echo "\n" . 'unserialize of admin_preferences for user ' . $row['id_member'] . ' failed. Skipping.'
+								echo "\n" . 'unserialize of admin_preferences for user ' . $row['id_member'] . ' failed. Skipping.';
 							else
 								echo "\n" . 'Fixing admin preferences...';
 						}

--- a/other/upgrade.php
+++ b/other/upgrade.php
@@ -64,9 +64,10 @@ $upcontext['steps'] = array(
 	2 => array(3, 'Backup', 'BackupDatabase', 10),
 	3 => array(4, 'Database Changes', 'DatabaseChanges', 50),
 	4 => array(5, 'Convert to UTF-8', 'ConvertUtf8', 20),
+	5 => array(6, 'Convert serialized strings to JSON', 'serialize_to_json', 10),
 	// This is removed as it doesn't really work right at the moment.
 	//4 => array(5, 'Cleanup Mods', 'CleanupMods', 10),
-	5 => array(6, 'Delete Upgrade.php', 'DeleteUpgrade', 1),
+	6 => array(7, 'Delete Upgrade.php', 'DeleteUpgrade', 1),
 );
 // Just to remember which one has files in it.
 $upcontext['database_step'] = 3;

--- a/other/upgrade.php
+++ b/other/upgrade.php
@@ -4190,7 +4190,7 @@ function serialize_to_json()
 
 							while($row = $smcFunc['db_fetch_assoc']($query))
 							{
-								$row['admin_preferences'] = json_encode((@unserialize($row['admin_preferences'])));
+								$row['admin_preferences'] = json_encode(@unserialize($row['admin_preferences']));
 
 								// Even though we have all values from the table, UPDATE is still faster than REPLACE
 								$smcFunc['db_query']('', '
@@ -4199,6 +4199,7 @@ function serialize_to_json()
 									WHERE id_theme = {int:theme}
 										AND id_member = {int:member}',
 									array(
+										'prefs' => $row['admin_preferences'],
 										'theme' => $row['id_theme'],
 										'member' => $row['id_member']
 									)

--- a/other/upgrade.php
+++ b/other/upgrade.php
@@ -4067,6 +4067,15 @@ function serialize_to_json()
 {
 	global $command_line, $smcFunc, $modSettings, $sourcedir, $upcontext, $support_js, $is_debug;
 
+	// First thing's first - did we already do this?
+	if (!empty($modSettings['json_done']))
+	{
+		if ($command_line)
+			return DeleteUpgrade();
+		else
+			return true;
+	}
+
 	// name => array('key', col1[,col2|true[,col3]])
 	// If 3rd item in array is true, it indicates that col1 could be empty...
 	$tables = array(
@@ -4160,7 +4169,8 @@ function serialize_to_json()
 							require_once($sourcedir . '/Load.php');
 						updateSettings($new_settings, true);
 
-						echo "\n done.";
+						if ($is_debug && $command_line)
+							echo "\n done.";
 					}
 					elseif ($table == 'themes')
 					{

--- a/subscriptions.php
+++ b/subscriptions.php
@@ -180,14 +180,14 @@ if ($gatewayClass->isRefund())
 // Otherwise is it what we want, a purchase?
 elseif ($gatewayClass->isPayment() || $gatewayClass->isSubscription())
 {
-	$cost = unserialize($subscription_info['cost']);
+	$cost = json_decode($subscription_info['cost'], true);
 	$total_cost = $gatewayClass->getCost();
 	$notify = false;
 
 	// For one off's we want to only capture them once!
 	if (!$gatewayClass->isSubscription())
 	{
-		$real_details = @unserialize($subscription_info['pending_details']);
+		$real_details = json_decode($subscription_info['pending_details'], true);
 		if (empty($real_details))
 			generateSubscriptionError(sprintf($txt['paid_count_not_find_outstanding_payment'], $member_id, $subscription_id));
 
@@ -201,7 +201,7 @@ elseif ($gatewayClass->isPayment() || $gatewayClass->isSubscription())
 			break;
 		}
 
-		$subscription_info['pending_details'] = empty($real_details) ? '' : serialize($real_details);
+		$subscription_info['pending_details'] = empty($real_details) ? '' : json_encode($real_details);
 
 		$smcFunc['db_query']('', '
 			UPDATE {db_prefix}log_subscribed


### PR DESCRIPTION
This replaces nearly every use of serialize() and unserialize() with json_encode() and json_decode() respectively. It also adds code for converting existing serialized data to JSON-encoded data during the upgrade, plus a setting to skip that once we've converted the data.

Note that this currently does not handle cookie data, but this can be added as well (we need to determine which format the cookie data is in then convert it if necessary).
