### PR TITLE
Update GenericMenu.template.php

### DIFF
--- a/Themes/default/GenericMenu.template.php
+++ b/Themes/default/GenericMenu.template.php
@@ -120,8 +120,9 @@ function template_generic_menu_tabs(&$menu_context)
 	if (!empty($tab_context['title']))
 	{
 		echo '
-					<div class="cat_bar">
-						<h3 class="catbg">';
+					<div class="cat_bar">', (function_exists('template_admin_quick_search') ? '
+						<form action="' . $scripturl . '?action=admin;area=search" method="post" accept-charset="' . $context['character_set'] . '">' : ''), '
+							<h3 class="catbg">';
 
 		// The function is in Admin.template.php, but since this template is used elsewhere too better check if the function is available
 		if (function_exists('template_admin_quick_search'))
@@ -197,7 +198,8 @@ function template_generic_menu_tabs(&$menu_context)
 		}
 
 		echo '
-						</h3>
+							</h3>', (function_exists('template_admin_quick_search') ? '
+						</form>' : ''), '
 					</div>';
 	}
 


### PR DESCRIPTION
Part 2 of 3 Pull Requests (please see other relevant PL's within this timeframe)
- form tag not allowed within h3 tag
- applies specifically to template_admin_quick_search() from Admin.template.php

Signed-off-by: -Underdog- github.underdog@gmail.com
