### PR TITLE
Update index.php

### DIFF
--- a/index.php
+++ b/index.php
@@ -25,7 +25,7 @@ $software_year = '2015';
 
 // Get everything started up...
 define('SMF', 1);
-if (function_exists('set_magic_quotes_runtime'))
+if (function_exists('set_magic_quotes_runtime') && strnatcmp(phpversion(),'5.3.0') < 0)
 	@set_magic_quotes_runtime(0);
 error_reporting(defined('E_STRICT') ? E_ALL | E_STRICT : E_ALL);
 $time_start = microtime();


### PR DESCRIPTION
- deprecated function throws an E_WARNING for PHP 5.3.0 and above
- either check version or get rid of it altogether

Signed-off-by: -Underdog- github.underdog@gmail.com
