### PR TITLE
+ Added db_is_resource to validate a database result is a valid

### DIFF
--- a/Sources/Display.php
+++ b/Sources/Display.php
@@ -1486,7 +1486,7 @@ function Download()
 	// Do we have a hook wanting to use our attachment system? We use $attachRequest to prevent accidental usage of $request.
 	$attachRequest = null;
 	call_integration_hook('integrate_download_request', array(&$attachRequest));
-	if (!is_null($attachRequest) && is_resource($attachRequest))
+	if (!is_null($attachRequest) && $smcFunc['db_is_resource']($attachRequest))
 		$request = $attachRequest;
 	else
 	{

--- a/Sources/Subs-Db-mysql.php
+++ b/Sources/Subs-Db-mysql.php
@@ -56,6 +56,7 @@ function smf_db_initiate($db_server, $db_name, $db_user, $db_passwd, $db_prefix,
 			'db_sybase' => false,
 			'db_case_sensitive' => false,
 			'db_escape_wildcard_string' => 'smf_db_escape_wildcard_string',
+			'db_is_resource' => 'is_resource',
 		);
 
 	if (!empty($db_options['port']))

--- a/Sources/Subs-Db-mysqli.php
+++ b/Sources/Subs-Db-mysqli.php
@@ -56,6 +56,7 @@ function smf_db_initiate($db_server, $db_name, $db_user, $db_passwd, $db_prefix,
 			'db_sybase'                 => false,
 			'db_case_sensitive'         => false,
 			'db_escape_wildcard_string' => 'smf_db_escape_wildcard_string',
+			'db_is_resource'            => 'smf_is_resource',
 		);
 
 	if (!empty($db_options['persist']))
@@ -844,6 +845,21 @@ function smf_db_escape_wildcard_string($string, $translate_human_wildcards=false
 		);
 
 	return strtr($string, $replacements);
+}
+
+/**
+ * Validates whether the resource is a valid mysqli instance.
+ * Mysqli uses objects rather than resource. https://bugs.php.net/bug.php?id=42797
+ *
+ * @param mixed $result The string to test
+ * @return bool True if it is, false otherwise
+ */
+function smf_is_resource($result)
+{
+	if ($result instanceof mysqli_result)
+		return true;
+
+	return false;
 }
 
 ?>

--- a/Sources/Subs-Db-postgresql.php
+++ b/Sources/Subs-Db-postgresql.php
@@ -57,6 +57,7 @@ function smf_db_initiate($db_server, $db_name, $db_user, $db_passwd, &$db_prefix
 			'db_sybase' => true,
 			'db_case_sensitive' => true,
 			'db_escape_wildcard_string' => 'smf_db_escape_wildcard_string',
+			'db_is_resource' => 'is_resource',
 		);
 
 	if (!empty($db_options['persist']))


### PR DESCRIPTION
As explained in the notes for mysqli, it appears that is_resource checks fail for mysqli as they are objects.  This simply creates a way for us to validate database results are valid.

Signed-off-by: jdarwood007 <unmonitored+github@sleepycode.com>
