### PR TITLE
Do not use DEFAULT on TEXT/BLOB

### DIFF
--- a/other/upgrade.php
+++ b/other/upgrade.php
@@ -996,7 +996,7 @@ function WelcomeLogin()
 	$create = $smcFunc['db_create_table']('{db_prefix}priv_check', array(array('name' => 'id_test', 'type' => 'int', 'size' => 10, 'unsigned' => true, 'auto' => true)), array(array('columns' => array('id_test'), 'type' => 'primary')), array(), 'overwrite');
 
 	// ALTER
-	$alter = $smcFunc['db_add_column']('{db_prefix}priv_check', array('name' => 'txt', 'type' => 'tinytext', 'null' => false, 'default' => ''));
+	$alter = $smcFunc['db_add_column']('{db_prefix}priv_check', array('name' => 'txt', 'type' => 'varchar', 'size' => 4, 'null' => false, 'default' => ''));
 
 	// DROP
 	$drop = $smcFunc['db_drop_table']('{db_prefix}priv_check');


### PR DESCRIPTION
`upgrade.php` was failing to check permissions, as my version of MySQL apparently won't allow `DEFAULT`s on `TEXT`/`BLOB` colums (see https://stackoverflow.com/questions/3466872/why-cant-a-text-column-have-a-default-value-in-mysql)
