### PR TITLE
remove redundant index

### DIFF
--- a/other/install_2-1_mysql.sql
+++ b/other/install_2-1_mysql.sql
@@ -802,14 +802,12 @@ CREATE TABLE {$db_prefix}messages (
   approved TINYINT(3) NOT NULL DEFAULT '1',
   likes SMALLINT(5) UNSIGNED NOT NULL DEFAULT '0',
   PRIMARY KEY (id_msg),
-  UNIQUE idx_topic (id_topic, id_msg),
   UNIQUE idx_id_board (id_board, id_msg),
   UNIQUE idx_id_member (id_member, id_msg),
   INDEX idx_approved (approved),
   INDEX idx_ip_index (poster_ip(15), id_topic),
   INDEX idx_participation (id_member, id_topic),
   INDEX idx_show_posts (id_member, id_board),
-  INDEX idx_id_topic (id_topic),
   INDEX idx_id_member_msg (id_member, approved, id_msg),
   INDEX idx_current_topic (id_topic, id_msg, id_member, approved),
   INDEX idx_related_ip (id_member, poster_ip, id_msg)
@@ -1112,7 +1110,6 @@ CREATE TABLE {$db_prefix}topics (
   UNIQUE idx_poll (id_poll, id_topic),
   INDEX idx_is_sticky (is_sticky),
   INDEX idx_approved (approved),
-  INDEX idx_id_board (id_board),
   INDEX idx_member_started (id_member_started, id_board),
   INDEX idx_last_message_sticky (id_board, is_sticky, id_last_msg),
   INDEX idx_board_news (id_board, id_first_msg)

--- a/other/install_2-1_postgresql.sql
+++ b/other/install_2-1_postgresql.sql
@@ -1287,14 +1287,12 @@ CREATE TABLE {$db_prefix}messages (
 # Indexes for table `messages`
 #
 
-CREATE UNIQUE INDEX {$db_prefix}messages_topic ON {$db_prefix}messages (id_topic, id_msg);
 CREATE UNIQUE INDEX {$db_prefix}messages_id_board ON {$db_prefix}messages (id_board, id_msg);
 CREATE UNIQUE INDEX {$db_prefix}messages_id_member ON {$db_prefix}messages (id_member, id_msg);
 CREATE INDEX {$db_prefix}messages_approved ON {$db_prefix}messages (approved);
 CREATE INDEX {$db_prefix}messages_ip_index ON {$db_prefix}messages (poster_ip, id_topic);
 CREATE INDEX {$db_prefix}messages_participation ON {$db_prefix}messages (id_member, id_topic);
 CREATE INDEX {$db_prefix}messages_show_posts ON {$db_prefix}messages (id_member, id_board);
-CREATE INDEX {$db_prefix}messages_id_topic ON {$db_prefix}messages (id_topic);
 CREATE INDEX {$db_prefix}messages_id_member_msg ON {$db_prefix}messages (id_member, approved, id_msg);
 CREATE INDEX {$db_prefix}messages_current_topic ON {$db_prefix}messages (id_topic, id_msg, id_member, approved);
 CREATE INDEX {$db_prefix}messages_related_ip ON {$db_prefix}messages (id_member, poster_ip, id_msg);
@@ -1675,7 +1673,6 @@ CREATE UNIQUE INDEX {$db_prefix}topics_first_message ON {$db_prefix}topics (id_f
 CREATE UNIQUE INDEX {$db_prefix}topics_poll ON {$db_prefix}topics (id_poll, id_topic);
 CREATE INDEX {$db_prefix}topics_is_sticky ON {$db_prefix}topics (is_sticky);
 CREATE INDEX {$db_prefix}topics_approved ON {$db_prefix}topics (approved);
-CREATE INDEX {$db_prefix}topics_id_board ON {$db_prefix}topics (id_board);
 CREATE INDEX {$db_prefix}topics_member_started ON {$db_prefix}topics (id_member_started, id_board);
 CREATE INDEX {$db_prefix}topics_last_message_sticky ON {$db_prefix}topics (id_board, is_sticky, id_last_msg);
 CREATE INDEX {$db_prefix}topics_board_news ON {$db_prefix}topics (id_board, id_first_msg);

--- a/other/upgrade_2-1_mysql.sql
+++ b/other/upgrade_2-1_mysql.sql
@@ -1891,3 +1891,16 @@ UPDATE {$db_prefix}personal_messages SET body = REPLACE(REPLACE(body, '[green]',
 UPDATE {$db_prefix}messages SET body = REPLACE(REPLACE(body, '[blue]', '[color=blue]'), '[/blue]', '[/color]') WHERE body LIKE '%[blue]%';
 UPDATE {$db_prefix}personal_messages SET body = REPLACE(REPLACE(body, '[blue]', '[color=blue]'), '[/blue]', '[/color]') WHERE body LIKE '%[blue]%';
 ---#
+
+/******************************************************************************/
+--- remove redundant index
+/******************************************************************************/
+
+---# duplicate to messages_current_topic
+DROP INDEX idx_id_topic on {$db_prefix}messages;
+DROP INDEX idx_topic on {$db_prefix}messages;
+---#
+ 
+---# duplicate to topics_last_message_sticky and topics_board_news
+DROP INDEX idx_id_board on {$db_prefix}topics;
+---#

--- a/other/upgrade_2-1_postgresql.sql
+++ b/other/upgrade_2-1_postgresql.sql
@@ -1996,3 +1996,16 @@ UPDATE {$db_prefix}personal_messages SET body = REPLACE(REPLACE(body, '[green]',
 UPDATE {$db_prefix}messages SET body = REPLACE(REPLACE(body, '[blue]', '[color=blue]'), '[/blue]', '[/color]') WHERE body LIKE '%[blue]%';
 UPDATE {$db_prefix}personal_messages SET body = REPLACE(REPLACE(body, '[blue]', '[color=blue]'), '[/blue]', '[/color]') WHERE body LIKE '%[blue]%';
 ---#
+
+/******************************************************************************/
+--- remove redundant index
+/******************************************************************************/
+
+---# duplicate to messages_current_topic
+DROP INDEX IF EXISTS {$db_prefix}messages_id_topic;
+DROP INDEX IF EXISTS {$db_prefix}messages_topic;
+---#
+ 
+---# duplicate to topics_last_message_sticky and topics_board_news
+DROP INDEX IF EXISTS {$db_prefix}topics_id_board;
+---#


### PR DESCRIPTION
Hello,

I notice three index, they index columns which already present in other index.

From the point of performance(insert and update opteration) and less space using it's a good idea to get ride of this index.

So the messages_id_topic, index the col id_topic on the table messages,
but the index messages_current_topic(id_topic, id_msg, id_member, approved) do already the same.
And the topics_id_board index the col id_board on the table topics and
the replace are topics_board_news(id_board, id_first_msg) and topics_last_message_sticky(id_board, is_sticky, id_last_msg).

The unique messages_topic(id_topic, id_msg) make no sense from constraint point of view,
because of the pk constraint of id_msg and
the index in this order of col already exist in messages_current_topic.

The other unique index in messages table make no sense, too.
But this is not the target of this pull request.

For more technical information please hav a look http://dev.mysql.com/doc/refman/5.7/en/mysql-indexes.html "If the table has a multiple-column index, any leftmost prefix of the index can be used by the optimizer to look up rows. For example, if you have a three-column index on (col1, col2, col3), you have indexed search capabilities on (col1), (col1, col2), and (col1, col2, col3). For more information, see Section 8.3.5, “Multiple-Column Indexes”. "

I should notice that IF EXISTS for table and index exists with the pg 8.2 and higher,
this project got current as requirement pg 8.0 and higher.

Signed-off-by: albertlast
