### PR TITLE
add "Drop table if exists" to smf_db_table_sql in pg

### DIFF
--- a/Sources/DbExtra-postgresql.php
+++ b/Sources/DbExtra-postgresql.php
@@ -235,6 +235,9 @@ function smf_db_table_sql($tableName)
 	// This will be needed...
 	$crlf = "\r\n";
 
+	// Drop it if it exists.
+	$schema_create = 'DROP TABLE IF EXISTS ' . $tableName . ';' . $crlf . $crlf;
+	
 	// Start the create table...
 	$schema_create = 'CREATE TABLE ' . $tableName . ' (' . $crlf;
 	$index_create = '';


### PR DESCRIPTION
In the mysql version of the function smf_db_table_sql came a drop before the create statement.

I added the same logic to the pg version of this function.
