### PR TITLE
Pg fulltext search 2

### DIFF
--- a/Sources/DbSearch-postgresql.php
+++ b/Sources/DbSearch-postgresql.php
@@ -40,7 +40,7 @@ function db_search_init()
  */
 function smf_db_search_support($search_type)
 {
-	$supported_types = array('custom');
+	$supported_types = array('custom','fulltext');
 
 	return in_array($search_type, $supported_types);
 }

--- a/Sources/ManageSearch.php
+++ b/Sources/ManageSearch.php
@@ -223,6 +223,22 @@ function EditSearchMethod()
 		checkSession('get');
 		validateToken('admin-msm', 'get');
 
+	    if ($db_type == 'postgresql') {
+		$smcFunc['db_query']('', '
+			DROP INDEX IF EXISTS {db_prefix}messages_ftx',
+			array(
+			    'db_error_skip' => true,
+			)
+		);
+		$smcFunc['db_query']('', '
+			CREATE INDEX smf_messages_ftx ON smf_messages 
+			USING gin(to_tsvector({string:language},body))',
+			array(
+			    'language' => 'simple'
+			)
+		);
+	    } else {
+
 		// Make sure it's gone before creating it.
 		$smcFunc['db_query']('', '
 			ALTER TABLE {db_prefix}messages
@@ -238,6 +254,7 @@ function EditSearchMethod()
 			array(
 			)
 		);
+	    }
 
 		$context['fulltext_index'] = 'body';
 	}
@@ -379,12 +396,25 @@ function EditSearchMethod()
 
 		// PostGreSql has some hidden sizes.
 		$request = $smcFunc['db_query']('', '
-			SELECT relname, relpages * 8 *1024 AS "KB" FROM pg_class
-			WHERE relname = {string:messages} OR relname = {string:log_search_words}
-			ORDER BY relpages DESC',
+			SELECT
+				indexname,
+				pg_relation_size(quote_ident(t.tablename)::text) AS table_size,
+				pg_relation_size(quote_ident(indexrelname)::text) AS index_size
+			FROM pg_tables t
+			LEFT OUTER JOIN pg_class c ON t.tablename=c.relname
+			LEFT OUTER JOIN
+				( SELECT c.relname AS ctablename, ipg.relname AS indexname,   indexrelname FROM pg_index x
+					   JOIN pg_class c ON c.oid = x.indrelid
+					   JOIN pg_class ipg ON ipg.oid = x.indexrelid
+					   JOIN pg_stat_all_indexes psai ON x.indexrelid = psai.indexrelid )
+				AS foo
+				ON t.tablename = foo.ctablename
+			WHERE t.schemaname= {string:schema} and ( 
+				indexname = {string:messages_ftx} OR indexname = {string:log_search_words} )',
 			array(
-				'messages' => $db_prefix. 'messages',
+				'messages_ftx' => $db_prefix. 'messages_ftx',
 				'log_search_words' => $db_prefix. 'log_search_words',
+				'schema' => 'public',
 			)
 		);
 
@@ -392,17 +422,16 @@ function EditSearchMethod()
 		{
 			while ($row = $smcFunc['db_fetch_assoc']($request))
 			{
-				if ($row['relname'] == $db_prefix . 'messages')
+				if ($row['indexname'] == $db_prefix . 'messages_ftx')
 				{
-					$context['table_info']['data_length'] = (int) $row['KB'];
-					$context['table_info']['index_length'] = (int) $row['KB'];
-					// Doesn't support fulltext
-					$context['table_info']['fulltext_length'] = $txt['not_applicable'];
+					$context['table_info']['data_length'] = (int) $row['table_size'];
+					$context['table_info']['index_length'] = (int) $row['index_size'];
+					$context['table_info']['fulltext_length'] = (int) $row['index_size'];
 				}
-				elseif ($row['relname'] == $db_prefix. 'log_search_words')
+				elseif ($row['indexname'] == $db_prefix. 'log_search_words')
 				{
-					$context['table_info']['index_length'] = (int) $row['KB'];
-					$context['table_info']['custom_index_length'] = (int) $row['KB'];
+					$context['table_info']['index_length'] = (int) $row['index_size'];
+					$context['table_info']['custom_index_length'] = (int) $row['index_size'];
 				}
 			}
 			$smcFunc['db_free_result']($request);
@@ -756,49 +785,71 @@ function detectFulltextIndex()
 	// We need this for db_get_version
 	db_extend();
 
-	$request = $smcFunc['db_query']('', '
-		SHOW INDEX
-		FROM {db_prefix}messages',
-		array(
-		)
-	);
-	$context['fulltext_index'] = '';
-	if ($request !== false || $smcFunc['db_num_rows']($request) != 0)
-	{
-		while ($row = $smcFunc['db_fetch_assoc']($request))
-			if ($row['Column_name'] == 'body' && (isset($row['Index_type']) && $row['Index_type'] == 'FULLTEXT' || isset($row['Comment']) && $row['Comment'] == 'FULLTEXT'))
-				$context['fulltext_index'][] = $row['Key_name'];
-		$smcFunc['db_free_result']($request);
-
-		if (is_array($context['fulltext_index']))
-			$context['fulltext_index'] = array_unique($context['fulltext_index']);
-	}
-
-	if (preg_match('~^`(.+?)`\.(.+?)$~', $db_prefix, $match) !== 0)
+	if ($smcFunc['db_title'] == 'PostgreSQL'){
 		$request = $smcFunc['db_query']('', '
+		    SELECT
+			    indexname
+		    FROM pg_tables t
+		    LEFT OUTER JOIN
+			    ( SELECT c.relname AS ctablename, ipg.relname AS indexname,   indexrelname FROM pg_index x
+				       JOIN pg_class c ON c.oid = x.indrelid
+				       JOIN pg_class ipg ON ipg.oid = x.indexrelid
+				       JOIN pg_stat_all_indexes psai ON x.indexrelid = psai.indexrelid )
+			    AS foo
+			    ON t.tablename = foo.ctablename
+		    WHERE t.schemaname= {string:schema} and indexname = {string:messages_ftx}',
+		    array(
+			    'schema' => 'public',
+			    'messages_ftx' => $db_prefix.'messages_ftx',
+		    )
+		);
+		while ($row = $smcFunc['db_fetch_assoc']($request))
+		    $context['fulltext_index'][] = $row['indexname'];
+	} else {
+		$request = $smcFunc['db_query']('', '
+		    SHOW INDEX
+		    FROM {db_prefix}messages',
+		    array(
+		    )
+		);
+		$context['fulltext_index'] = '';
+		if ($request !== false || $smcFunc['db_num_rows']($request) != 0)
+		{
+		    while ($row = $smcFunc['db_fetch_assoc']($request))
+			if ($row['Column_name'] == 'body' && (isset($row['Index_type']) && $row['Index_type'] == 'FULLTEXT' || isset($row['Comment']) && $row['Comment'] == 'FULLTEXT'))
+			    $context['fulltext_index'][] = $row['Key_name'];
+		    $smcFunc['db_free_result']($request);
+
+		    if (is_array($context['fulltext_index']))
+			$context['fulltext_index'] = array_unique($context['fulltext_index']);
+		}
+
+		if (preg_match('~^`(.+?)`\.(.+?)$~', $db_prefix, $match) !== 0)
+		    $request = $smcFunc['db_query']('', '
 			SHOW TABLE STATUS
 			FROM {string:database_name}
 			LIKE {string:table_name}',
 			array(
-				'database_name' => '`' . strtr($match[1], array('`' => '')) . '`',
-				'table_name' => str_replace('_', '\_', $match[2]) . 'messages',
+			    'database_name' => '`' . strtr($match[1], array('`' => '')) . '`',
+			    'table_name' => str_replace('_', '\_', $match[2]) . 'messages',
 			)
-		);
-	else
-		$request = $smcFunc['db_query']('', '
+		    );
+		else
+		    $request = $smcFunc['db_query']('', '
 			SHOW TABLE STATUS
 			LIKE {string:table_name}',
 			array(
-				'table_name' => str_replace('_', '\_', $db_prefix) . 'messages',
+			    'table_name' => str_replace('_', '\_', $db_prefix) . 'messages',
 			)
-		);
+		    );
 
-	if ($request !== false)
-	{
-		while ($row = $smcFunc['db_fetch_assoc']($request))
+		if ($request !== false)
+		{
+		    while ($row = $smcFunc['db_fetch_assoc']($request))
 			if (isset($row['Engine']) && strtolower($row['Engine']) != 'myisam' && !(strtolower($row['Engine']) == 'innodb' && version_compare($smcFunc['db_get_version'], '5.6.4', '>=')))
-				$context['cannot_create_fulltext'] = true;
-		$smcFunc['db_free_result']($request);
+			    $context['cannot_create_fulltext'] = true;
+		    $smcFunc['db_free_result']($request);
+		}
 	}
 }
 

--- a/Sources/ManageSearch.php
+++ b/Sources/ManageSearch.php
@@ -230,11 +230,26 @@ function EditSearchMethod()
 			    'db_error_skip' => true,
 			)
 		);
+		
+		$request = $smcFunc['db_query']('','
+			SHOW default_text_search_config',
+			array(
+			    
+			)
+		);
+		
+		if ($request !== false && $smcFunc['db_num_rows']($request) == 1)
+		{
+		    $row = $smcFunc['db_fetch_assoc']($request);
+		    $language_ftx = $row['default_text_search_config'];
+		}
+		
+		
 		$smcFunc['db_query']('', '
 			CREATE INDEX smf_messages_ftx ON smf_messages 
 			USING gin(to_tsvector({string:language},body))',
 			array(
-			    'language' => 'simple'
+			    'language' => $language_ftx
 			)
 		);
 	    } else {

--- a/Sources/SearchAPI-Fulltext.php
+++ b/Sources/SearchAPI-Fulltext.php
@@ -206,7 +206,10 @@ class fulltext_search extends search_api
 
 		if (!empty($modSettings['search_simple_fulltext']))
 		{
-			$query_where[] = 'MATCH (body) AGAINST ({string:body_match})';
+			if($smcFunc['db_title'] == "PostgreSQL") 
+				$query_where[] = 'to_tsvector(\'simple\',body) @@ to_tsquery(\'simple\',{string:body_match})';
+			else
+				$query_where[] = 'MATCH (body) AGAINST ({string:body_match})';
 			$query_params['body_match'] = implode(' ', array_diff($words['indexed_words'], $query_params['excluded_index_words']));
 		}
 		else
@@ -216,13 +219,28 @@ class fulltext_search extends search_api
 			// remove any indexed words that are used in the complex body search terms
 			$words['indexed_words'] = array_diff($words['indexed_words'], $words['complex_words']);
 
-			foreach ($words['indexed_words'] as $fulltextWord)
-				$query_params['boolean_match'] .= (in_array($fulltextWord, $query_params['excluded_index_words']) ? '-' : '+') . $fulltextWord . ' ';
+			if($smcFunc['db_title'] == "PostgreSQL"){
+				$row = 0;
+				foreach ($words['indexed_words'] as $fulltextWord) {
+					$query_params['boolean_match'] .= ($row <> 0 ? '&' : '');
+					$query_params['boolean_match'] .= (in_array($fulltextWord, $query_params['excluded_index_words']) ? '!' : '') . $fulltextWord . ' ';
+					$row++;
+				} 
+			}
+			else
+				foreach ($words['indexed_words'] as $fulltextWord)
+					$query_params['boolean_match'] .= (in_array($fulltextWord, $query_params['excluded_index_words']) ? '-' : '+') . $fulltextWord . ' ';
+					
 			$query_params['boolean_match'] = substr($query_params['boolean_match'], 0, -1);
 
 			// if we have bool terms to search, add them in
-			if ($query_params['boolean_match'])
-				$query_where[] = 'MATCH (body) AGAINST ({string:boolean_match} IN BOOLEAN MODE)';
+			if ($query_params['boolean_match']) {
+				if($smcFunc['db_title'] == "PostgreSQL") 
+					$query_where[] = 'to_tsvector(\'simple\',body) @@ to_tsquery(\'simple\',{string:boolean_match})';
+				else
+					$query_where[] = 'MATCH (body) AGAINST ({string:boolean_match} IN BOOLEAN MODE)';
+			}
+				
 		}
 
 		$ignoreRequest = $smcFunc['db_search_query']('insert_into_log_messages_fulltext', ($smcFunc['db_support_ignore'] ? ( '

--- a/Sources/SearchAPI-Fulltext.php
+++ b/Sources/SearchAPI-Fulltext.php
@@ -206,8 +206,10 @@ class fulltext_search extends search_api
 
 		if (!empty($modSettings['search_simple_fulltext']))
 		{
-			if($smcFunc['db_title'] == "PostgreSQL") 
-				$query_where[] = 'to_tsvector(\'simple\',body) @@ to_tsquery(\'simple\',{string:body_match})';
+			if($smcFunc['db_title'] == "PostgreSQL")
+				//we use the default language "default_text_search_config", otherwise we had to assgine the language here
+				//to_tsvector(body) -> to_tsvector($language,body) to_tsquery(...) -> to_tsquery($language,...)
+				$query_where[] = 'to_tsvector(body) @@ to_tsquery({string:body_match})';
 			else
 				$query_where[] = 'MATCH (body) AGAINST ({string:body_match})';
 			$query_params['body_match'] = implode(' ', array_diff($words['indexed_words'], $query_params['excluded_index_words']));
@@ -235,8 +237,10 @@ class fulltext_search extends search_api
 
 			// if we have bool terms to search, add them in
 			if ($query_params['boolean_match']) {
-				if($smcFunc['db_title'] == "PostgreSQL") 
-					$query_where[] = 'to_tsvector(\'simple\',body) @@ to_tsquery(\'simple\',{string:boolean_match})';
+				if($smcFunc['db_title'] == "PostgreSQL")
+					//we use the default language "default_text_search_config", otherwise we had to assgine the language here
+					//to_tsvector(body) -> to_tsvector($language,body) to_tsquery(...) -> to_tsquery($language,...)
+					$query_where[] = 'to_tsvector(body) @@ to_tsquery({string:boolean_match})';
 				else
 					$query_where[] = 'MATCH (body) AGAINST ({string:boolean_match} IN BOOLEAN MODE)';
 			}


### PR DESCRIPTION
A Clean version of https://github.com/SimpleMachines/SMF2.1/pull/3209
with the custom support and "else" in a own line.

Missing is the use of default language(default_text_search_config) of the db user.
More complicate solution would be to give the admin the choice,
based on the table pg_ts_config

related issue: https://github.com/SimpleMachines/SMF2.1/issues/273
