### PR TITLE
Viewquery with EXPLAIN ANALYZE

### DIFF
--- a/Sources/ViewQuery.php
+++ b/Sources/ViewQuery.php
@@ -139,7 +139,7 @@ function ViewQuery()
 		if ($query_id == $q && $is_select_query)
 		{
 			$result = $smcFunc['db_query']('', '
-				EXPLAIN ' . $select,
+				EXPLAIN '.($smcFunc['db_title'] == 'PostgreSQL' ? 'ANALYZE ':'') . $select,
 				array(
 				)
 			);


### PR DESCRIPTION
PostgreSQL two stages of explain,
1. is the explain
Shows data from the planer
2. explain analyze
Shows data from the planer + real data
like execution time from the whole query and parts (joins etc.)
show the amount of space is needed for sort
is the sort done in memory or on disk.
 When you got a sort on disk it's likely to increas the work_mem.

Exp.
with
Limit (cost=1.19..1.20 rows=7 width=10) (actual time=0.047..0.048 rows=7 loops=1)
-> Sort (cost=1.19..1.20 rows=7 width=10) (actual time=0.047..0.047 rows=7 loops=1)
Sort Key: id_msg
Sort Method: quicksort Memory: 25kB
-> Seq Scan on smf_messages (cost=0.00..1.09 rows=7 width=10) (actual time=0.003..0.005 rows=7 loops=1)
Filter: (id_topic = 1)
Planning time: 0.691 ms
Execution time: 0.063 ms

without
Limit (cost=1.19..1.20 rows=7 width=10)
-> Sort (cost=1.19..1.20 rows=7 width=10)
Sort Key: id_msg
-> Seq Scan on smf_messages (cost=0.00..1.09 rows=7 width=10)
Filter: (id_topic = 1)

based on query:
   SELECT id_msg, id_member, approved
   FROM smf_messages
   WHERE id_topic = 1
   ORDER BY id_msg
LIMIT 15 OFFSET 0 
