### PR TITLE
Unlogged table in pg

### DIFF
--- a/other/install.php
+++ b/other/install.php
@@ -1083,6 +1083,25 @@ function DatabasePopulation()
 		}
 	}
 
+	// PostgreSQL-specific stuff - unlogged table
+	if ($db_type == 'postgresql')
+	{
+		$result = $smcFunc['db_query']('', '
+			SHOW server_version_num'
+		);
+		if ($result !== false)
+		{
+			while ($row = $smcFunc['db_fetch_assoc']($result))
+				$pg_version = $row['server_version_num'];
+			$smcFunc['db_free_result']($result);
+		}
+		
+		if(isset($pg_version) && $pg_version >= 90100)
+			$replaces['{$unlogged}'] = 'UNLOGGED';
+		else
+			$replaces['{$unlogged}'] = '';
+	}
+
 	// Read in the SQL.  Turn this on and that off... internationalize... etc.
 	$type = ($db_type == 'mysqli' ? 'mysql' : $db_type);
 	$sql_lines = explode("\n", strtr(implode(' ', file(dirname(__FILE__) . '/install_' . $GLOBALS['db_script_version'] . '_' . $type . '.sql')), $replaces));

--- a/other/install_2-1_postgresql.sql
+++ b/other/install_2-1_postgresql.sql
@@ -725,7 +725,7 @@ CREATE INDEX {$db_prefix}log_notify_id_topic ON {$db_prefix}log_notify (id_topic
 # Table structure for table `log_online`
 #
 
-CREATE TABLE {$db_prefix}log_online (
+CREATE {$unlogged} TABLE {$db_prefix}log_online (
   session varchar(64) NOT NULL default '',
   log_time int NOT NULL default '0',
   id_member int NOT NULL default '0',
@@ -1539,7 +1539,7 @@ CREATE TABLE {$db_prefix}settings (
 # Table structure for table `sessions`
 #
 
-CREATE TABLE {$db_prefix}sessions (
+CREATE {$unlogged} TABLE {$db_prefix}sessions (
   session_id char(64) NOT NULL,
   last_update int NOT NULL,
   data text NOT NULL,

--- a/other/install_2-1_postgresql.sql
+++ b/other/install_2-1_postgresql.sql
@@ -638,7 +638,7 @@ CREATE INDEX {$db_prefix}log_errors_ip ON {$db_prefix}log_errors (ip);
 # Table structure for table `log_floodcontrol`
 #
 
-CREATE TABLE {$db_prefix}log_floodcontrol (
+CREATE {$unlogged} TABLE {$db_prefix}log_floodcontrol (
   ip char(16) NOT NULL default '                ',
   log_time int NOT NULL default '0',
   log_type varchar(8) NOT NULL default 'post',

--- a/other/upgrade_2-1_postgresql.sql
+++ b/other/upgrade_2-1_postgresql.sql
@@ -1996,3 +1996,50 @@ UPDATE {$db_prefix}personal_messages SET body = REPLACE(REPLACE(body, '[green]',
 UPDATE {$db_prefix}messages SET body = REPLACE(REPLACE(body, '[blue]', '[color=blue]'), '[/blue]', '[/color]') WHERE body LIKE '%[blue]%';
 UPDATE {$db_prefix}personal_messages SET body = REPLACE(REPLACE(body, '[blue]', '[color=blue]'), '[/blue]', '[/color]') WHERE body LIKE '%[blue]%';
 ---#
+
+/******************************************************************************/
+---UNLOGGED Table PG 9.1+
+/******************************************************************************/
+$result = $smcFunc['db_query']('', '
+	SHOW server_version_num'
+);
+if ($result !== false)
+{
+	while ($row = $smcFunc['db_fetch_assoc']($result))
+		$pg_version = $row['server_version_num'];
+	$smcFunc['db_free_result']($result);
+}
+		
+if(isset($pg_version) && $pg_version >= 90100)
+{
+	$tables = array('log_online','log_floodcontrol','sessions');
+	foreach($tables as $tab)
+	{
+		if($pg_version >= 90500)
+			upgrade_query("ALTER TABLE {$db_prefix}".$tab." SET UNLOGGED;");
+		ELSE
+			upgrade_query("
+			alter table {$db_prefix}".$tab." rename to old_{$db_prefix}".$tab.";
+
+			do 
+			$$ 
+			declare r record; 
+			begin 
+				for r in select * from pg_constraint where conrelid='old_{$db_prefix}".$tab."'::regclass loop 
+					execute format('alter table old_{$db_prefix}".$tab." rename constraint %I to %I', r.conname, 'old_' || r.conname); 
+				end loop; 
+				for r in select * from pg_indexes where tablename='old_{$db_prefix}".$tab."' and indexname !~ '^old_' loop
+					execute format('alter index %I rename to %I', r.indexname, 'old_' || r.indexname); 
+				end loop; 
+			end; 
+			$$;
+
+			create unlogged table {$db_prefix}".$tab." (like old_{$db_prefix}".$tab." including all);
+
+			insert into {$db_prefix}".$tab." select * from old_{$db_prefix}".$tab.";
+
+			drop table old_{$db_prefix}".$tab.";"
+			);
+	}
+
+}


### PR DESCRIPTION
I noticed some table which are from type like caching,
exp. session or log_online table

These are brilliant for unlogged table type,
This kind is faster to fill,
but they lost there complete data when the pg-server get crashed.
more information: http://michael.otacoo.com/postgresql-2/unlogged-table-performance-in-postgresql-9-1/

This feature works only with pg 9.1+, but I placed a version check so this will
no harm the min pg requirement.

Give me feedback if you want go this way.
When yes than i will implement a upgrade script and
give me a hint which table could be unlogged too.
