### PR TITLE
PG 9.5 replace

### DIFF
--- a/Sources/Subs-Db-postgresql.php
+++ b/Sources/Subs-Db-postgresql.php
@@ -699,7 +699,7 @@ function smf_db_insert($method = 'replace', $table, $columns, $data, $keys, $dis
 		
 		$count = 0;
 		$where = '';
-		$count_pk =  0;
+		$count_pk = 0;
 		
 		If($replace_support)
 		{
@@ -721,7 +721,8 @@ function smf_db_insert($method = 'replace', $table, $columns, $data, $keys, $dis
 			}
 			$replace = ' ON CONFLICT ('.$key_str.') DO UPDATE SET '.$col_str;
 		} 
-		else {
+		else
+		{
 			foreach ($columns as $columnName => $type)
 			{
 				// Are we restricting the length?


### PR DESCRIPTION
An implementation of replace function of pg 9.5 with version compare.
replace format is
Insert into <table_name>(id,id2,col) values(1,1,2),(1,3,1) ON CONFLICT (id,id2) DO UPDATE SET col = EXCLUDED.col
