### PR TITLE
Static get db version

### DIFF
--- a/Sources/DbExtra-mysql.php
+++ b/Sources/DbExtra-mysql.php
@@ -440,6 +440,10 @@ function smf_db_table_sql($tableName)
  */
 function smf_db_get_version()
 {
+	static $ver;
+
+	if(!empty($ver)) return $ver;
+
 	global $smcFunc;
 
 	$request = $smcFunc['db_query']('', '

--- a/Sources/DbExtra-postgresql.php
+++ b/Sources/DbExtra-postgresql.php
@@ -333,6 +333,10 @@ function smf_db_table_sql($tableName)
  */
 function smf_db_get_version()
 {
+	static $ver;
+
+	if(!empty($ver)) return $ver;
+
 	global $smcFunc;
 
 	$request = $smcFunc['db_query']('', '


### PR DESCRIPTION
I think it's not needed to call everytime the query behind the db get version.

So this is a offer to prohibit this behavior.
