### PR TITLE
PHP 7 Session Handling

### DIFF
--- a/Sources/Session.php
+++ b/Sources/Session.php
@@ -177,7 +177,7 @@ function sessionWrite($session_id, $data)
 			array('session_id')
 		);
 
-	return $result;
+	return ($smcFunc['db_affected_rows']() == 0 ? false : true);
 }
 
 /**
@@ -194,13 +194,15 @@ function sessionDestroy($session_id)
 		return false;
 
 	// Just delete the row...
-	return $smcFunc['db_query']('', '
+	$smcFunc['db_query']('', '
 		DELETE FROM {db_prefix}sessions
 		WHERE session_id = {string:session_id}',
 		array(
 			'session_id' => $session_id,
 		)
 	);
+	
+	return ($smcFunc['db_affected_rows']() == 0 ? false : true);
 }
 
 /**
@@ -219,13 +221,15 @@ function sessionGC($max_lifetime)
 		$max_lifetime = max($modSettings['databaseSession_lifetime'], 60);
 
 	// Clean up after yerself ;).
-	return $smcFunc['db_query']('', '
+	$smcFunc['db_query']('', '
 		DELETE FROM {db_prefix}sessions
 		WHERE last_update < {int:last_update}',
 		array(
 			'last_update' => time() - $max_lifetime,
 		)
 	);
+	
+	return ($smcFunc['db_affected_rows']() == 0 ? false : true);
 }
 
 ?>

--- a/Sources/Session.php
+++ b/Sources/Session.php
@@ -202,7 +202,7 @@ function sessionDestroy($session_id)
 		)
 	);
 	
-	return ($smcFunc['db_affected_rows']() == 0 ? false : true);
+	return true;
 }
 
 /**


### PR DESCRIPTION
I played today with php 7 and noticed that php 7 got a stricter version of customer session handling,
see: http://stackoverflow.com/questions/34117651/php7-symfony-2-8-failed-to-write-session-data

So I modified some session function that they return true or false.
Based on the information if the db action was successful or not.

The intial error was: http://snag.gy/hDZPk.jpg

Error-msg in log:
2: Unknown: Session callback expects true/false return value

2: Unknown: Failed to write session data (user). Please verify that the current setting of session.save_path is correct (D:\Programme\xampp\tmp)
