### PR TITLE
Fix Post reference warning in strict mode

### DIFF
--- a/Sources/Post.php
+++ b/Sources/Post.php
@@ -48,7 +48,9 @@ function Post($post_errors = array())
 
 	// Get notification preferences for later
 	require_once($sourcedir . '/Subs-Notify.php');
-	$context['notify_prefs'] = (array) array_pop(getNotifyPrefs($user_info['id']));
+	// use $temp to get around "Only variables should be passed by reference"
+	$temp = getNotifyPrefs($user_info['id']);
+	$context['notify_prefs'] = (array) array_pop($temp);
 	$context['auto_notify'] = !empty($context['notify_prefs']['msg_auto_notify']);
 
 	// You must be posting to *some* board.


### PR DESCRIPTION
In the strict mode of php a warning will be generate,
when you try post something: Notice: Only variables should be passed by reference in
G:\github\SMF2.1\Sources\Post.php on line 51

So I insert a variable to splitt this.
http://stackoverflow.com/questions/2354609/strict-standards-only-variables-should-be-passed-by-reference
