### PR TITLE
Add a db engine to our support information

### DIFF
--- a/Sources/DbExtra-mysql.php
+++ b/Sources/DbExtra-mysql.php
@@ -469,6 +469,7 @@ function smf_db_get_engine()
 
 	$request = $smcFunc['db_query']('', 'SELECT @@version_comment');
 	list ($comment) = $smcFunc['db_fetch_row']($request);
+	$smcFunc['db_free_result']($request);
 
 	// Skip these if we don't have a comment.
 	if (!empty($comment))

--- a/Sources/DbExtra-mysql.php
+++ b/Sources/DbExtra-mysql.php
@@ -31,6 +31,7 @@ function db_extra_init()
 			'db_table_sql' => 'smf_db_table_sql',
 			'db_list_tables' => 'smf_db_list_tables',
 			'db_get_version' => 'smf_db_get_version',
+			'db_get_engine' => 'smf_db_get_engine',
 		);
 }
 
@@ -451,6 +452,36 @@ function smf_db_get_version()
 	$smcFunc['db_free_result']($request);
 
 	return $ver;
+}
+
+/**
+ * Figures out if we are using MySQL, Percona or MariaDB
+ *
+ * @return string The database engine we are using
+*/
+function smf_db_get_engine()
+{
+	global $smcFunc;
+	static $db_type;
+
+	if (!empty($db_type))
+		return $db_type;
+
+	$request = $smcFunc['db_query']('', 'SELECT @@version_comment');
+	list ($comment) = $smcFunc['db_fetch_row']($request);
+
+	// Skip these if we don't have a comment.
+	if (!empty($comment))
+	{
+		if (stripos($comment, 'percona') !== false)
+			return 'Percona';
+		if (stripos($comment, 'mariadb') !== false)
+			return 'MariaDB';
+	}
+	else
+		return 'fail';
+	
+	return 'MySQLi';
 }
 
 ?>

--- a/Sources/DbExtra-postgresql.php
+++ b/Sources/DbExtra-postgresql.php
@@ -31,6 +31,7 @@ function db_extra_init()
 			'db_table_sql' => 'smf_db_table_sql',
 			'db_list_tables' => 'smf_db_list_tables',
 			'db_get_version' => 'smf_db_get_version',
+			'db_get_engine' => create_function('', 'return \'PostgreSQL\';'),
 		);
 }
 

--- a/Sources/Subs-Admin.php
+++ b/Sources/Subs-Admin.php
@@ -65,6 +65,9 @@ function getServerVersions($checkFor)
 			trigger_error('getServerVersions(): you need to be connected to the database in order to get its server version', E_USER_NOTICE);
 		else
 		{
+			$versions['db_engine'] = array('title' => sprintf($txt['support_versions_db_engine'], $smcFunc['db_title']), 'version' => '');
+			$versions['db_engine']['version'] = $smcFunc['db_get_engine']();
+
 			$versions['db_server'] = array('title' => sprintf($txt['support_versions_db'], $smcFunc['db_title']), 'version' => '');
 			$versions['db_server']['version'] = $smcFunc['db_get_version']();
 		}

--- a/Themes/default/languages/Admin.english.php
+++ b/Themes/default/languages/Admin.english.php
@@ -299,6 +299,7 @@ $txt['support_versions_current'] = 'Current SMF version';
 $txt['support_versions_forum'] = 'Forum version';
 $txt['support_versions_php'] = 'PHP version';
 $txt['support_versions_db'] = '%1$s version';
+$txt['support_versions_db_engine'] = '%1$s engine';
 $txt['support_versions_server'] = 'Server version';
 $txt['support_versions_gd'] = 'GD version';
 $txt['support_versions_imagemagick'] = 'ImageMagick version';


### PR DESCRIPTION
Signed-off-by: jdarwood007 <unmonitored+github@sleepycode.com>

This is so we can see things like Percona and MariaDB in the support information.  At this point the purpose of this is only for support usage incase ever in the future we have Percona, MariaDB or MySQL based issues.
