### PR TITLE
Logging.php FixEmptyJson

### DIFF
--- a/Sources/Logging.php
+++ b/Sources/Logging.php
@@ -62,7 +62,7 @@ function writeLog($force = false)
 		$serialized = json_encode($serialized);
 	}
 	else
-		$serialized = '';
+		$serialized = '{}';
 
 	// Guests use 0, members use their session ID.
 	$session_id = $user_info['is_guest'] ? 'ip' . $user_info['ip'] : session_id();


### PR DESCRIPTION
I notice that the url field in log_online is a json field and
a valid form for empty is {}.

But this solution is not best(but the easiest) solution from my point of view.
The best solution would be to change the database field nullable and write null into this field.

When wanted I can build the other solution too.
