### PR TITLE
improvment of exist real/membername check

### DIFF
--- a/Sources/Subs-Db-postgresql.php
+++ b/Sources/Subs-Db-postgresql.php
@@ -321,9 +321,6 @@ function smf_db_query($identifier, $db_string, $db_values = array(), $connection
 		'profile_board_stats' => array(
 			'~COUNT\(\*\) \/ MAX\(b.num_posts\)~' => 'CAST(COUNT(*) AS DECIMAL) / CAST(b.num_posts AS DECIMAL)',
 		),
-		'case_insensitive' => array(
-			'~LIKE~' => 'ILIKE',
-		),
 	);
 
 	if (isset($replacements[$identifier]))

--- a/Sources/Subs-Members.php
+++ b/Sources/Subs-Members.php
@@ -905,13 +905,14 @@ function isReservedName($name, $current_ID_MEMBER = 0, $is_name = true, $fatal =
 		SELECT id_member
 		FROM {db_prefix}members
 		WHERE ' . (empty($current_ID_MEMBER) ? '' : 'id_member != {int:current_member}
-			AND ') . '({raw:real_name} '.$operator.' LOWER({string:check_name}) OR {raw:member_name} '.$operator.' LOWER({string:check_name}))
+			AND ') . '({raw:real_name} {raw:operator} LOWER({string:check_name}) OR {raw:member_name} {raw:operator} LOWER({string:check_name}))
 		LIMIT 1',
 		array(
 			'real_name' => $smcFunc['db_case_sensitive'] ? 'LOWER(real_name)' : 'real_name',
 			'member_name' => $smcFunc['db_case_sensitive'] ? 'LOWER(member_name)' : 'member_name',
 			'current_member' => $current_ID_MEMBER,
 			'check_name' => $checkName,
+			'operator' => $operator,
 		)
 	);
 	if ($smcFunc['db_num_rows']($request) > 0)

--- a/Sources/Subs-Members.php
+++ b/Sources/Subs-Members.php
@@ -898,11 +898,11 @@ function isReservedName($name, $current_ID_MEMBER = 0, $is_name = true, $fatal =
 	$checkName = strtr($name, array('_' => '\\_', '%' => '\\%'));
 
 	// Make sure they don't want someone else's name.
-	$request = $smcFunc['db_query']('case_insensitive', '
+	$request = $smcFunc['db_query']('', '
 		SELECT id_member
 		FROM {db_prefix}members
 		WHERE ' . (empty($current_ID_MEMBER) ? '' : 'id_member != {int:current_member}
-			AND ') . '({raw:real_name} LIKE {string:check_name} OR {raw:member_name} LIKE {string:check_name})
+			AND ') . '({raw:real_name} LIKE LOWER({string:check_name}) OR {raw:member_name} LIKE LOWER({string:check_name}))
 		LIMIT 1',
 		array(
 			'real_name' => $smcFunc['db_case_sensitive'] ? 'LOWER(real_name)' : 'real_name',

--- a/Sources/Subs-Members.php
+++ b/Sources/Subs-Members.php
@@ -896,13 +896,16 @@ function isReservedName($name, $current_ID_MEMBER = 0, $is_name = true, $fatal =
 
 	// Get rid of any SQL parts of the reserved name...
 	$checkName = strtr($name, array('_' => '\\_', '%' => '\\%'));
+	
+	//when we got no wildcard we can use equal -> fast
+	$operator = (strpos($checkName, '%') || strpos($checkName, '_') ? 'LIKE' : '=' );
 
 	// Make sure they don't want someone else's name.
 	$request = $smcFunc['db_query']('', '
 		SELECT id_member
 		FROM {db_prefix}members
 		WHERE ' . (empty($current_ID_MEMBER) ? '' : 'id_member != {int:current_member}
-			AND ') . '({raw:real_name} LIKE LOWER({string:check_name}) OR {raw:member_name} LIKE LOWER({string:check_name}))
+			AND ') . '({raw:real_name} '.$operator.' LOWER({string:check_name}) OR {raw:member_name} '.$operator.' LOWER({string:check_name}))
 		LIMIT 1',
 		array(
 			'real_name' => $smcFunc['db_case_sensitive'] ? 'LOWER(real_name)' : 'real_name',


### PR DESCRIPTION
Some improvments around realname and membername check.

This query got already a lower(col) for db who are cs,
so it's exists no reason to use ilike.

Under some special circumstance we can now use the index from: https://github.com/SimpleMachines/SMF2.1/pull/3215

And when no wildcard is used, we can use = instead of LIKE
