### PR TITLE
Magic quotes doesn't exist in PHP7

### DIFF
--- a/other/upgrade.php
+++ b/other/upgrade.php
@@ -790,7 +790,9 @@ function loadEssentialData()
 	global $modSettings, $sourcedir, $smcFunc;
 
 	// Do the non-SSI stuff...
-	@set_magic_quotes_runtime(0);
+	if (function_exists('set_magic_quotes_runtime'))
+		@set_magic_quotes_runtime(0);
+
 	error_reporting(E_ALL);
 	define('SMF', 1);
 


### PR DESCRIPTION
The set_magic_quotes_runtime function will cause a fatal error in php 7

Signed-off-by: Michael Eshom oldiesmann@oldiesmann.us
