### PR TITLE
fixed smiley search in admin panel

### DIFF
--- a/Sources/ManageSmileys.php
+++ b/Sources/ManageSmileys.php
@@ -122,7 +122,7 @@ function EditSmileySettings($return_config = false)
 
 	// Get the names of the smiley sets.
 	$smiley_sets = explode(',', $modSettings['smiley_sets_known']);
-	$set_names = explode("\n", $modSettings['smiley_sets_names']);
+	$set_names = explode('\n', $modSettings['smiley_sets_names']);
 
 	$smiley_context = array();
 	foreach ($smiley_sets as $i => $set)


### PR DESCRIPTION
When i was in the admin panel and used the search function
by quick search as input "asd" category "task/settings"
then i got errors like:

 0e7b0e7d6d3ea23830a821df567d9a6f
Type of error: Undefined
8: Undefined offset: 1
http://localhost/SMF2.1/index.php?action=admin;area=search
File: G:/github/SMF2.1/Sources/ManageSmileys.php
Line: 129

After the change of the explode it's works,
but i'm not sure why it's before.
