### PR TITLE
IFNULL no longer needed

### DIFF
--- a/other/install_2-1_postgresql.sql
+++ b/other/install_2-1_postgresql.sql
@@ -10,30 +10,6 @@ CREATE OR REPLACE FUNCTION FROM_UNIXTIME(integer) RETURNS timestamp AS
   'SELECT timestamp ''epoch'' + $1 * interval ''1 second'' AS result'
 LANGUAGE 'sql';
 
-CREATE OR REPLACE FUNCTION IFNULL (text, text) RETURNS text AS
-  'SELECT COALESCE($1, $2) AS result'
-LANGUAGE 'sql';
-
-CREATE OR REPLACE FUNCTION IFNULL (int4, int4) RETURNS int4 AS
-  'SELECT COALESCE($1, $2) AS result'
-LANGUAGE 'sql';
-
-CREATE OR REPLACE FUNCTION IFNULL (int8, int8) RETURNS int8 AS
-  'SELECT COALESCE($1, $2) AS result'
-LANGUAGE 'sql';
-
-CREATE OR REPLACE FUNCTION IFNULL (character varying, character varying) RETURNS character varying AS
-  'SELECT COALESCE($1, $2) AS result'
-LANGUAGE 'sql';
-
-CREATE OR REPLACE FUNCTION IFNULL (character varying, boolean) RETURNS character varying AS
-  'SELECT COALESCE($1, CAST(CAST($2 AS int) AS varchar)) AS result'
-LANGUAGE 'sql';
-
-CREATE OR REPLACE FUNCTION IFNULL (int, boolean) RETURNS int AS
-  'SELECT COALESCE($1, CAST($2 AS int)) AS result'
-LANGUAGE 'sql';
-
 CREATE OR REPLACE FUNCTION INET_ATON(text) RETURNS bigint AS '
 	SELECT
 	CASE WHEN


### PR DESCRIPTION
Since we use coalesce() all the time now we don't need these IFNULL functions in PostgreSQL

Signed-off-by: Michael Eshom oldiesmann@oldiesmann.us
