### PR TITLE
fix add spider -> doublicate key constraint

### DIFF
--- a/other/install_2-1_mysql.sql
+++ b/other/install_2-1_mysql.sql
@@ -2061,27 +2061,27 @@ VALUES (':)', 'smiley.gif', '{$default_smiley_smiley}', 0, 0),
 #
 
 INSERT INTO {$db_prefix}spiders
-	(id_spider, spider_name, user_agent, ip_info)
-VALUES (1, 'Google', 'googlebot', ''),
-	(2, 'Yahoo!', 'slurp', ''),
-	(3, 'MSN', 'msnbot', ''),
-	(4, 'Google (Mobile)', 'Googlebot-Mobile', ''),
-	(5, 'Google (Image)', 'Googlebot-Image', ''),
-	(6, 'Google (AdSense)', 'Mediapartners-Google', ''),
-	(7, 'Google (Adwords)', 'AdsBot-Google', ''),
-	(8, 'Yahoo! (Mobile)', 'YahooSeeker/M1A1-R2D2', ''),
-	(9, 'Yahoo! (Image)', 'Yahoo-MMCrawler', ''),
-	(10, 'MSN (Mobile)', 'MSNBOT_Mobile', ''),
-	(11, 'MSN (Media)', 'msnbot-media', ''),
-	(12, 'Cuil', 'twiceler', ''),
-	(13, 'Ask', 'Teoma', ''),
-	(14, 'Baidu', 'Baiduspider', ''),
-	(15, 'Gigablast', 'Gigabot', ''),
-	(16, 'InternetArchive', 'ia_archiver-web.archive.org', ''),
-	(17, 'Alexa', 'ia_archiver', ''),
-	(18, 'Omgili', 'omgilibot', ''),
-	(19, 'EntireWeb', 'Speedy Spider', ''),
-	(20, 'Yandex', 'yandex', '');
+	(spider_name, user_agent, ip_info)
+VALUES ('Google', 'googlebot', ''),
+	('Yahoo!', 'slurp', ''),
+	('MSN', 'msnbot', ''),
+	('Google (Mobile)', 'Googlebot-Mobile', ''),
+	('Google (Image)', 'Googlebot-Image', ''),
+	('Google (AdSense)', 'Mediapartners-Google', ''),
+	('Google (Adwords)', 'AdsBot-Google', ''),
+	('Yahoo! (Mobile)', 'YahooSeeker/M1A1-R2D2', ''),
+	('Yahoo! (Image)', 'Yahoo-MMCrawler', ''),
+	('MSN (Mobile)', 'MSNBOT_Mobile', ''),
+	('MSN (Media)', 'msnbot-media', ''),
+	('Cuil', 'twiceler', ''),
+	('Ask', 'Teoma', ''),
+	('Baidu', 'Baiduspider', ''),
+	('Gigablast', 'Gigabot', ''),
+	('InternetArchive', 'ia_archiver-web.archive.org', ''),
+	('Alexa', 'ia_archiver', ''),
+	('Omgili', 'omgilibot', ''),
+	('EntireWeb', 'Speedy Spider', ''),
+	('Yandex', 'yandex', '');
 #---------------------------------------------------------
 
 #

--- a/other/install_2-1_postgresql.sql
+++ b/other/install_2-1_postgresql.sql
@@ -2610,26 +2610,26 @@ INSERT INTO {$db_prefix}smileys	(code, filename, description, smiley_order, hidd
 # Dumping data for table `spiders`
 #
 
-INSERT INTO {$db_prefix}spiders (id_spider, spider_name, user_agent, ip_info) VALUES (1, 'Google', 'googlebot', '');
-INSERT INTO {$db_prefix}spiders (id_spider, spider_name, user_agent, ip_info) VALUES (2, 'Yahoo!', 'slurp', '');
-INSERT INTO {$db_prefix}spiders (id_spider, spider_name, user_agent, ip_info) VALUES (3, 'MSN', 'msnbot', '');
-INSERT INTO {$db_prefix}spiders (id_spider, spider_name, user_agent, ip_info) VALUES (4, 'Google (Mobile)', 'Googlebot-Mobile', '');
-INSERT INTO {$db_prefix}spiders (id_spider, spider_name, user_agent, ip_info) VALUES (5, 'Google (Image)', 'Googlebot-Image', '');
-INSERT INTO {$db_prefix}spiders (id_spider, spider_name, user_agent, ip_info) VALUES (6, 'Google (AdSense)', 'Mediapartners-Google', '');
-INSERT INTO {$db_prefix}spiders (id_spider, spider_name, user_agent, ip_info) VALUES (7, 'Google (Adwords)', 'AdsBot-Google', '');
-INSERT INTO {$db_prefix}spiders (id_spider, spider_name, user_agent, ip_info) VALUES (8, 'Yahoo! (Mobile)', 'YahooSeeker/M1A1-R2D2', '');
-INSERT INTO {$db_prefix}spiders (id_spider, spider_name, user_agent, ip_info) VALUES (9, 'Yahoo! (Image)', 'Yahoo-MMCrawler', '');
-INSERT INTO {$db_prefix}spiders (id_spider, spider_name, user_agent, ip_info) VALUES (10, 'MSN (Mobile)', 'MSNBOT_Mobile', '');
-INSERT INTO {$db_prefix}spiders (id_spider, spider_name, user_agent, ip_info) VALUES (11, 'MSN (Media)', 'msnbot-media', '');
-INSERT INTO {$db_prefix}spiders (id_spider, spider_name, user_agent, ip_info) VALUES (12, 'Cuil', 'twiceler', '');
-INSERT INTO {$db_prefix}spiders (id_spider, spider_name, user_agent, ip_info) VALUES (13, 'Ask', 'Teoma', '');
-INSERT INTO {$db_prefix}spiders (id_spider, spider_name, user_agent, ip_info) VALUES (14, 'Baidu', 'Baiduspider', '');
-INSERT INTO {$db_prefix}spiders (id_spider, spider_name, user_agent, ip_info) VALUES (15, 'Gigablast', 'Gigabot', '');
-INSERT INTO {$db_prefix}spiders (id_spider, spider_name, user_agent, ip_info) VALUES (16, 'InternetArchive', 'ia_archiver-web.archive.org', '');
-INSERT INTO {$db_prefix}spiders (id_spider, spider_name, user_agent, ip_info) VALUES (17, 'Alexa', 'ia_archiver', '');
-INSERT INTO {$db_prefix}spiders (id_spider, spider_name, user_agent, ip_info) VALUES (18, 'Omgili', 'omgilibot', '');
-INSERT INTO {$db_prefix}spiders (id_spider, spider_name, user_agent, ip_info) VALUES (19, 'EntireWeb', 'Speedy Spider', '');
-INSERT INTO {$db_prefix}spiders (id_spider, spider_name, user_agent, ip_info) VALUES (20, 'Yandex', 'yandex', '');
+INSERT INTO {$db_prefix}spiders (spider_name, user_agent, ip_info) VALUES ('Google', 'googlebot', '');
+INSERT INTO {$db_prefix}spiders (spider_name, user_agent, ip_info) VALUES ('Yahoo!', 'slurp', '');
+INSERT INTO {$db_prefix}spiders (spider_name, user_agent, ip_info) VALUES ('MSN', 'msnbot', '');
+INSERT INTO {$db_prefix}spiders (spider_name, user_agent, ip_info) VALUES ('Google (Mobile)', 'Googlebot-Mobile', '');
+INSERT INTO {$db_prefix}spiders (spider_name, user_agent, ip_info) VALUES ('Google (Image)', 'Googlebot-Image', '');
+INSERT INTO {$db_prefix}spiders (spider_name, user_agent, ip_info) VALUES ('Google (AdSense)', 'Mediapartners-Google', '');
+INSERT INTO {$db_prefix}spiders (spider_name, user_agent, ip_info) VALUES ('Google (Adwords)', 'AdsBot-Google', '');
+INSERT INTO {$db_prefix}spiders (spider_name, user_agent, ip_info) VALUES ('Yahoo! (Mobile)', 'YahooSeeker/M1A1-R2D2', '');
+INSERT INTO {$db_prefix}spiders (spider_name, user_agent, ip_info) VALUES ('Yahoo! (Image)', 'Yahoo-MMCrawler', '');
+INSERT INTO {$db_prefix}spiders (spider_name, user_agent, ip_info) VALUES ('MSN (Mobile)', 'MSNBOT_Mobile', '');
+INSERT INTO {$db_prefix}spiders (spider_name, user_agent, ip_info) VALUES ('MSN (Media)', 'msnbot-media', '');
+INSERT INTO {$db_prefix}spiders (spider_name, user_agent, ip_info) VALUES ('Cuil', 'twiceler', '');
+INSERT INTO {$db_prefix}spiders (spider_name, user_agent, ip_info) VALUES ('Ask', 'Teoma', '');
+INSERT INTO {$db_prefix}spiders (spider_name, user_agent, ip_info) VALUES ('Baidu', 'Baiduspider', '');
+INSERT INTO {$db_prefix}spiders (spider_name, user_agent, ip_info) VALUES ('Gigablast', 'Gigabot', '');
+INSERT INTO {$db_prefix}spiders (spider_name, user_agent, ip_info) VALUES ('InternetArchive', 'ia_archiver-web.archive.org', '');
+INSERT INTO {$db_prefix}spiders (spider_name, user_agent, ip_info) VALUES ('Alexa', 'ia_archiver', '');
+INSERT INTO {$db_prefix}spiders (spider_name, user_agent, ip_info) VALUES ('Omgili', 'omgilibot', '');
+INSERT INTO {$db_prefix}spiders (spider_name, user_agent, ip_info) VALUES ('EntireWeb', 'Speedy Spider', '');
+INSERT INTO {$db_prefix}spiders (spider_name, user_agent, ip_info) VALUES ('Yandex', 'yandex', '');
 
 #
 # Dumping data for table `themes`

--- a/other/upgrade_2-1_postgresql.sql
+++ b/other/upgrade_2-1_postgresql.sql
@@ -2028,3 +2028,10 @@ WHERE ip_low1 > 0;
 ---# index
 CREATE INDEX {$db_prefix}ban_items_id_ban_ip ON {$db_prefix}ban_items (ip_low,ip_high);
 ---#
+
+/******************************************************************************/
+--- update sequence from spider table
+/******************************************************************************/
+---# update sequence
+SELECT setval('{$db_prefix}spiders_seq',(SELECT GREATEST(MAX(id_spider)+1,nextval('{$db_prefix}spiders_seq'))-1 FROM {$db_prefix}spiders));
+---#


### PR DESCRIPTION
when the id is direct given the sequence will not updated,
get douplicate key conflict on the first insert without hard id

by adding a new spider
in managedsearchengine line 417 try to insert a new row without id -> error
reason is that the sequence stand on 1.

btw this problem exists since 2.0.x
