### PR TITLE
Adds a hook to modify XML feeds before output

### DIFF
--- a/Sources/News.php
+++ b/Sources/News.php
@@ -210,6 +210,10 @@ function ShowXmlFeed()
 	}
 
 	$feed_title = $smcFunc['htmlspecialchars'](strip_tags($context['forum_name'])) . (isset($feed_title) ? $feed_title : '');
+	
+	// If mods want to do somthing with this feed, let them do that now.
+	// Provide the feed's data, title, format, and content type.
+	call_integration_hook('integrate_xml_data', array(&$xml, &$feed_title, $xml_format, $_GET['sa']));
 
 	// This is an xml file....
 	ob_end_clean();


### PR DESCRIPTION
This adds an integration hook to News.php to allow mods access to the content of XML feeds (RSS, Atom, etc.) just before output.