### PR TITLE
Fixes for a handful of bugs in News.php's dumpTags()

### DIFF
--- a/Sources/News.php
+++ b/Sources/News.php
@@ -458,7 +458,7 @@ function dumpTags($data, $i, $tag = null, $xml_format = '')
 
 		// If it's empty/0/nothing simply output an empty tag.
 		if ($val == '')
-			echo '<', $key, '>';
+			echo '<', $key, ' />';
 		elseif ($xml_format == 'atom' && $key == 'category')
 			echo '<', $key, ' term="', $val, '" />';
 		else
@@ -475,18 +475,22 @@ function dumpTags($data, $i, $tag = null, $xml_format = '')
 			else
 				echo '<', $key, '>';
 
+			// The element's value.
 			if (is_array($val))
 			{
 				// An array.  Dump it, and then indent the tag.
 				dumpTags($val, $i + 1, null, $xml_format);
-				echo "\n", str_repeat("\t", $i), '</', $key, '>';
+				echo "\n", str_repeat("\t", $i);
 			}
 			// A string with returns in it.... show this as a multiline element.
-			elseif (strpos($val, "\n") !== false || strpos($val, '<br>') !== false)
-				echo "\n", fix_possible_url($val), "\n", str_repeat("\t", $i), '</', $key, '>';
+			elseif (strpos($val, "\n") !== false || !empty(preg_match('~<br ?/?' . '>~', $val)))
+				echo "\n", fix_possible_url($val), "\n", str_repeat("\t", $i);
 			// A simple string.
 			else
-				echo fix_possible_url($val), '</', $key, '>';
+				echo fix_possible_url($val);
+			
+			// Ending tag.
+			echo '</', $key, '>';
 		}
 	}
 }


### PR DESCRIPTION
- Generate empty element tags with a closing slash, as they should always have in XML.
- When checking for embedded line breaks, detect any of `<br>`, `<br/>`, and `<br />`
- Ensure that an element's closing tag is always generated. Previously that could potentially fail if for some reason something went wrong when handling the element's value. Plus, it's cleaner this way.

