### PR TITLE
Saner, faster, wiser CDATA wrapping in XML feeds

### DIFF
--- a/Sources/News.php
+++ b/Sources/News.php
@@ -361,11 +361,7 @@ function fix_possible_url($val)
  */
 function cdata_parse($data, $ns = '')
 {
-	global $smcFunc, $cdata_override;
-
-	// Are we not doing it?
-	if (!empty($cdata_override))
-		return $data;
+	global $smcFunc;
 	
 	// Do we even need to do this?
 	if (empty(strpbrk($data, '<>&')))


### PR DESCRIPTION
- Instead of preemptively running data through cdata_parse() as we gather it, wait until we are building the XML and then deal with the bits we need to. This separates the acquisition and formatting stages cleanly, and makes life much easier for anyone using the 'integrate_xml_data' hook.
- When we do run data through cdata_parse(), only do anything if the data actually needs it. Cleaner feeds and faster execution - what's not to love?
