### PR TITLE
Makes SCEditor more responsive to on-the-fly changes in display size

### DIFF
--- a/Themes/default/css/jquery.sceditor.css
+++ b/Themes/default/css/jquery.sceditor.css
@@ -146,6 +146,8 @@ div.sceditor-grip {
 	font-weight: 700;
 	border-radius: 4px;
 	background-clip: padding-box;
+	min-width: 100%;
+	max-width: 100%;
 }
 .sceditor-container {
 	font-weight: normal;
@@ -163,10 +165,12 @@ div.sceditor-grip {
 	font-size: 13px;
 	color: #111;
 	padding: 0;
-	margin: 5px;
+	margin: 0;
 	resize: none;
 	background: #fff;
 	display: block;
+	min-width: 100%;
+	max-width: 100%;
 }
 div.sceditor-resize-cover {
 	position: absolute;

--- a/Themes/default/css/jquery.sceditor.css
+++ b/Themes/default/css/jquery.sceditor.css
@@ -164,7 +164,7 @@ div.sceditor-grip {
 	font-family: Verdana, Arial, Helvetica, sans-serif;
 	font-size: 13px;
 	color: #111;
-	padding: 0;
+	padding: 5px 0;
 	margin: 0;
 	resize: none;
 	background: #fff;

--- a/Themes/default/css/jquery.sceditor.css
+++ b/Themes/default/css/jquery.sceditor.css
@@ -172,6 +172,9 @@ div.sceditor-grip {
 	min-width: 100%;
 	max-width: 100%;
 }
+.sceditor-container textarea {
+	padding: 5px;
+}
 div.sceditor-resize-cover {
 	position: absolute;
 	top: 0;

--- a/Themes/default/css/jquery.sceditor.default.css
+++ b/Themes/default/css/jquery.sceditor.default.css
@@ -1,5 +1,5 @@
 /*! SCEditor | (C) 2011-2013, Sam Clarke | sceditor.com/license */
-html, body, p, code:before, table {
+html, p, code:before, table {
 	margin: 0;
 	padding: 0;
 }
@@ -14,6 +14,8 @@ body {
 	min-height: 100%;
 	word-wrap: break-word;
 	overflow: auto;
+	margin: 5px;
+	padding: 0;
 }
 ol, ul {
 	margin-top: 0;

--- a/Themes/default/css/jquery.sceditor.default.css
+++ b/Themes/default/css/jquery.sceditor.default.css
@@ -14,7 +14,7 @@ body {
 	min-height: 100%;
 	word-wrap: break-word;
 	overflow: auto;
-	margin: 5px;
+	margin: 0 5px;
 	padding: 0;
 }
 ol, ul {


### PR DESCRIPTION
SCEditor uses JavaScript to calculate the dimensions of the iframe and textarea on page load. But this doesn't work when the display size changes after page load, e.g. if a mobile user rotates their device. This can be fixed by setting the min-width and max-width values in a few key places. Technically, this makes SCEditor's calculations pointless, since they are overridden by the CSS anyway, but that doesn't hurt anything.

