### PR TITLE
Faster, more robust handling of BBCode parameters

### DIFF
--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -2049,9 +2049,7 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 				sort($given_params, SORT_STRING);
 				$given_param_string = implode(' ', $given_params);
 
-				$match_preg = '~^' . implode('', $preg) . '$~i';
-				
-				$match = preg_match($match_preg, $given_param_string, $matches) !== 0;
+				$match = preg_match('~^' . implode('', $preg) . '$~i', $given_param_string, $matches) !== 0;
 
 				// Didn't match our parameter list, try the next possible.
 				if (!$match)

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -2035,15 +2035,16 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 				}
 				
 				// Extract the parameters from the opening tag.
-				if ($possible['type'] != 'closed') {
+				if (isset($possible['type']) && $possible['type'] == 'closed') {
+					// Closed type BBCodes require a simpler approach. Side effect is that a closed type BBC can't accept a ] in its params. But SMF doesn't ship with any BBC that this would affect anyway.
+					$given_param_string = substr($message, $pos1 - 1, strpos($message, ']', $pos1) - $pos1 + 1);
+				else {
+				}	
 					// This regex works even if there are a bunch of ] characters in the params.
 					preg_match('~\[' . $possible['tag'] . '(.*)\](?' . '>.|(?R))*?\[/' . $possible['tag'] . '\]~i', substr($message, $pos), $matches);
 					$given_param_string = $matches[1];
 				}
-				else {
-					// Closed type BBCodes require another, simpler approach. Side effect is that a closed type BBC can't accept a ] in its params. But SMF doesn't ship with any BBC that this would affect anyway.
-					$given_param_string = substr($message, $pos1 - 1, strpos($message, ']', $pos1) - $pos1 + 1);
-				}	
+	
 
 				$given_params = preg_split('~\s(?=(' . implode('|', $splitters) . '))~i', $given_param_string);
 				sort($given_params, SORT_STRING);

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -897,59 +897,6 @@ function permute($array)
 	return $orders;
 }
 
- /**
- * Lexicographic permutation function.
- *
- * This is a special type of permutation which involves the order of the set. The next
- * lexicographic permutation of '32541' is '34125'. Numerically, it is simply the smallest
- * set larger than the current one.
- *
- * The benefit of this over a recursive solution is that the whole list does NOT need
- * to be held in memory. So it's actually possible to run 30! permutations without
- * causing a memory overflow.
- *
- * Source: O'Reilly PHP Cookbook
- *
- * @param mixed[] $p An array of permutations
- * @param int $size The size of our array
- *
- * @return mixed[] The next permutation of the passed array $p
- */
-function pc_next_permutation($p, $size)
-{
-	// Slide down the array looking for where we're smaller than the next guy
-	for ($i = $size - 1; isset($p[$i]) && $p[$i] >= $p[$i + 1]; --$i)
-	{
-	}
-
-	// If this doesn't occur, we've finished our permutations
-	// the array is reversed: (1, 2, 3, 4) => (4, 3, 2, 1)
-	if ($i === -1)
-	{
-		return false;
-	}
-
-	// Slide down the array looking for a bigger number than what we found before
-	for ($j = $size; $p[$j] <= $p[$i]; --$j)
-	{
-	}
-
-	// Swap them
-	$tmp = $p[$i];
-	$p[$i] = $p[$j];
-	$p[$j] = $tmp;
-
-	// Now reverse the elements in between by swapping the ends
-	for ($i, $j = $size; $i < $j; $i, --$j)
-	{
-		$tmp = $p[$i];
-		$p[$i] = $p[$j];
-		$p[$j] = $tmp;
-	}
-
-	return $p;
-}
-
 /**
  * Parse bulletin board code in a string, as well as smileys optionally.
  *
@@ -1696,6 +1643,10 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 
 		foreach ($codes as $code)
 		{
+			// Make it easier to process parameters later
+			if (!empty($code['parameters']))
+				ksort($code['parameters'], SORT_STRING);
+			
 			// If we are not doing every tag only do ones we are interested in.
 			if (empty($parse_tags) || in_array($code['tag'], $parse_tags))
 				$bbc_codes[substr($code['tag'], 0, 1)][] = $code;
@@ -2074,32 +2025,24 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 			// This is long, but it makes things much easier and cleaner.
 			if (!empty($possible['parameters']))
 			{
+				$given_param_string = substr($message, $pos1 - 1, strpos($message, ']', $pos1) - $pos1 + 1);
+				
 				// Build a regular expression for each parameter for the current tag.
+				// ... And also an array for use in another regular expression in a moment.
 				$preg = array();
-				foreach ($possible['parameters'] as $p => $info)
+				$splitters = array();
+				foreach ($possible['parameters'] as $p => $info) {
+					$splitters[] = $p . '=';
 					$preg[] = '(\s+' . $p . '=' . (empty($info['quoted']) ? '' : '&quot;') . (isset($info['match']) ? $info['match'] : '(.+?)') . (empty($info['quoted']) ? '' : '&quot;') . ')' . (empty($info['optional']) ? '' : '?');
-
-				// Okay, this may look ugly and it is, but it's not going to happen much and it is the best way of allowing any order of parameters but still parsing them right.
-				$param_size = count($preg) - 1;
-				$preg_keys = range(0, $param_size);
-				$message_stub = substr($message, $pos1 - 1);
-
-				// If sometthhing adds many parameters we can exceed max_execution time; let's prevent that.
-				// 5040 = 7, 40,320 = 8, (N!) etc
-				$max_iterations = 5040;
-
-				// Step, one by one, through all possible permutations of the parameters until we have a match.
-				do
-				{
-					$match_preg = '~^';
-					foreach ($preg_keys as $key)
-						$match_preg .= $preg[$key];
-					$match_preg .= '\]~i';
-
-					// Check if this combination of parameters matches the user input.
-					$match = preg_match($match_preg, $message_stub, $matches) !== 0;
 				}
-				while (!$match && --$max_iterations && ($preg_keys = pc_next_permutation($preg_keys, $param_size)));
+				
+				$given_params = preg_split('~\s(?=(' . implode('|', $splitters) . '))~i', $given_param_string);
+				sort($given_params, SORT_STRING);
+				$given_param_string = implode(' ', $given_params);
+
+				$match_preg = '~^' . implode('', $preg) . '$~i';
+				
+				$match = preg_match($match_preg, $given_param_string, $matches) !== 0;
 
 				// Didn't match our parameter list, try the next possible.
 				if (!$match)
@@ -2136,7 +2079,7 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 				if (isset($tag['content']))
 					$tag['content'] = strtr($tag['content'], $params);
 
-				$pos1 += strlen($matches[0]) - 1;
+				$pos1 += strlen($matches[0]);
 			}
 			else
 				$tag = $possible;

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -2025,8 +2025,6 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 			// This is long, but it makes things much easier and cleaner.
 			if (!empty($possible['parameters']))
 			{
-				$given_param_string = substr($message, $pos1 - 1, strpos($message, ']', $pos1) - $pos1 + 1);
-				
 				// Build a regular expression for each parameter for the current tag.
 				// ... And also an array for use in another regular expression in a moment.
 				$preg = array();
@@ -2036,6 +2034,17 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 					$preg[] = '(\s+' . $p . '=' . (empty($info['quoted']) ? '' : '&quot;') . (isset($info['match']) ? $info['match'] : '(.+?)') . (empty($info['quoted']) ? '' : '&quot;') . ')' . (empty($info['optional']) ? '' : '?');
 				}
 				
+				// Extract the parameters from the opening tag.
+				if ($possible['type'] != 'closed') {
+					// This regex works even if there are a bunch of ] characters in the params.
+					preg_match('~\[' . $possible['tag'] . '(.*)\](?' . '>.|(?R))*?\[/' . $possible['tag'] . '\]~i', substr($message, $pos), $matches);
+					$given_param_string = $matches[1];
+				}
+				else {
+					// Closed type BBCodes require another, simpler approach. Side effect is that a closed type BBC can't accept a ] in its params. But SMF doesn't ship with any BBC that this would affect anyway.
+					$given_param_string = substr($message, $pos1 - 1, strpos($message, ']', $pos1) - $pos1 + 1);
+				}	
+
 				$given_params = preg_split('~\s(?=(' . implode('|', $splitters) . '))~i', $given_param_string);
 				sort($given_params, SORT_STRING);
 				$given_param_string = implode(' ', $given_params);

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -2038,8 +2038,8 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 				if (isset($possible['type']) && $possible['type'] == 'closed') {
 					// Closed type BBCodes require a simpler approach. Side effect is that a closed type BBC can't accept a ] in its params. But SMF doesn't ship with any BBC that this would affect anyway.
 					$given_param_string = substr($message, $pos1 - 1, strpos($message, ']', $pos1) - $pos1 + 1);
+				}
 				else {
-				}	
 					// This regex works even if there are a bunch of ] characters in the params.
 					preg_match('~\[' . $possible['tag'] . '(.*)\](?' . '>.|(?R))*?\[/' . $possible['tag'] . '\]~i', substr($message, $pos), $matches);
 					$given_param_string = $matches[1];


### PR DESCRIPTION
- Fixes #3027 (alt parameter of img bbcode tag not always parsed properly)
- Fixes #2973 more effectively than #2975 by removing the need for permute() and pc_next_permutation()

The way this works is fairly straightforward. Instead of using permutations to figure out what arbitrary order a set of parameters happens to be in, we just sort them into a stable order and then work with that. As a result, we can avoid all the permutation stuff (and therefore the danger of factorially increasing computation times). Moreover, the parameters are **always** identified correctly no matter what order the user entered them in.

Gory details:
- Just as we are finishing building the array of BBCodes, ksort each BBCode's parameters sub-array (if present) in order to make sure they are arranged alphabetically by key name. Doing this job at this stage makes sure we only have to do it once.
- When it is time to parse the parameters the user entered, we do the following:
  1. Loop through the expected parameter values for this tag and build two arrays. One is the venerable regular expression we've long used to check for parameter conformance (step 4 below). The other is a list of keys (plus equals signs) that we'll use in step 3.
  2. Extract the string of parameters from the opening BBCode tag.
  3. Use preg_split to split the param string into an array of params. Then sort the array of params alphabetically and implode it back into a string.
  4. Use the regex we made in step 2 to see if the parameter string matches our expectations for this BBCode. Because both the expected params and the given params have been sorted alphabetically, we only need to check once: it either matches, or it doesn't.
  5. Assuming the regex matched, proceed to handle the matches the same way we always have.

I've tried pretty hard to find ways to break this, and it seem pretty solid. I've found one theoretical edge case where extracting parameters could get tripped up, but it does not and cannot arise for any of the BBCode that we actually ship with SMF. (See commit log for details.)

Given the importance of parse_bbc(), we don't want to commit any changes to it without careful testing. At the same time, this fixes two outstanding issues while removing all need to calculate n! permutations of a given set of parameters. So it'd be good if others could take a look at this and test it out.
