### PR TITLE
Declare language attribute on html element

### DIFF
--- a/Themes/default/index.template.php
+++ b/Themes/default/index.template.php
@@ -85,7 +85,7 @@ function template_html_above()
 
 	// Show right to left and the character set for ease of translating.
 	echo '<!DOCTYPE html>
-<html', $context['right_to_left'] ? ' dir="rtl"' : '', '>
+	<html', $context['right_to_left'] ? ' dir="rtl"' : '', !empty($txt['lang_locale']) ? ' lang="' . substr($txt['lang_locale'], 0, 2) . '"' : '' , '>
 <head>
 	<meta charset="', $context['character_set'], '">';
 


### PR DESCRIPTION
This is good for accessibility and styling features, among other reasons. See https://www.w3.org/International/questions/qa-lang-why.en

