### PR TITLE
Implements responsive design for the calendar

### DIFF
--- a/Themes/default/Calendar.template.php
+++ b/Themes/default/Calendar.template.php
@@ -51,7 +51,7 @@ function template_main()
 	}
 
 	// Close our wrapper.
-	echo '<br class="clear">
+	echo '
 	</div>';
 }
 
@@ -90,24 +90,24 @@ function template_show_month_grid($grid_name, $is_mini = false)
 				if (empty($calendar_data['previous_calendar']['disabled']) && $calendar_data['show_next_prev'] && $is_mini === false)
 				{
 					echo '
-						<span class="floatleft xlarge_text">
+						<span class="floatleft">
 							<a href="', $calendar_data['previous_calendar']['href'], '">&#171;</a>
+						</span>
+					';
+				}
+
+				// Next Link: if we're showing prev / next and it's not a mini-calendar.
+				if (empty($calendar_data['next_calendar']['disabled']) && $calendar_data['show_next_prev'] && $is_mini === false)
+				{
+					echo '
+						<span class="floatright">
+							<a href="', $calendar_data['next_calendar']['href'], '">&#187;</a>
 						</span>
 					';
 				}
 
 				// Arguably the most exciting part, the title!
 				echo '<a href="', $scripturl, '?action=calendar;year=', $calendar_data['current_year'], ';month=', $calendar_data['current_month'], '">', $txt['months_titles'][$calendar_data['current_month']], ' ', $calendar_data['current_year'], '</a>';
-
-				// Next Link: if we're showing prev / next and it's not a mini-calendar.
-				if (empty($calendar_data['next_calendar']['disabled']) && $calendar_data['show_next_prev'] && $is_mini === false)
-				{
-					echo '
-						<span class="floatright xlarge_text">
-							<a href="', $calendar_data['next_calendar']['href'], '">&#187;</a>
-						</span>
-					';
-				}
 
 				echo '
 				</h3>
@@ -193,6 +193,8 @@ function template_show_month_grid($grid_name, $is_mini = false)
 				}
 			}
 			else
+				// Default Classes (either compact or comfortable and disabled).
+				$classes[] = !empty($calendar_data['size']) && $calendar_data['size'] == 'small' ? 'compact' : 'comfortable';
 				$classes[] = 'disabled';
 
 			// Now, implode the classes for each day.
@@ -338,24 +340,24 @@ function template_show_week_grid($grid_name)
 					if (empty($calendar_data['previous_calendar']['disabled']) && !empty($calendar_data['show_next_prev']))
 					{
 						echo '
-							<span class="floatleft xlarge_text">
+							<span class="floatleft">
 								<a href="', $calendar_data['previous_week']['href'], '">&#171;</a>
 							</span>
 						';
 					}
 
-					// The Month Title + Week Number...
-					if (!empty($calendar_data['week_title']))
-							echo $calendar_data['week_title'];
-
 					// Next Week Link...
 					if (empty($calendar_data['next_calendar']['disabled']) && !empty($calendar_data['show_next_prev']))
 					{
 						echo '
-							<span class="floatright xlarge_text">
+							<span class="floatright">
 								<a href="', $calendar_data['next_week']['href'], '">&#187;</a>
 							</span>';
 					}
+
+					// The Month Title + Week Number...
+					if (!empty($calendar_data['week_title']))
+							echo $calendar_data['week_title'];
 
 					echo '
 					</h3>
@@ -397,7 +399,7 @@ function template_show_week_grid($grid_name)
 								echo $txt['days'][$day['day_of_week']], ' - ', $day['day'];
 
 							echo '</td>
-							<td class="', implode(' ', $classes), '', empty($day['events']) ? (' disabled' . ($context['can_post'] ? ' week_post' : '')) : ' events', '">';
+							<td class="', implode(' ', $classes), '', empty($day['events']) ? (' disabled' . ($context['can_post'] ? ' week_post' : '')) : ' events', ' event_col">';
 							// Show any events...
 							if (!empty($day['events']))
 							{
@@ -442,13 +444,13 @@ function template_show_week_grid($grid_name)
 								}
 							}
 							echo '</td>
-							<td class="', implode(' ', $classes), !empty($day['holidays']) ? ' holidays' : ' disabled', '">';
+							<td class="', implode(' ', $classes), !empty($day['holidays']) ? ' holidays' : ' disabled', ' holiday_col">';
 							// Show any holidays!
 							if (!empty($day['holidays']))
 								echo implode('<br>', $day['holidays']);
 
 							echo '</td>
-							<td class="', implode(' ', $classes), '', !empty($day['birthdays']) ? ' birthdays' : ' disabled', '">';
+							<td class="', implode(' ', $classes), '', !empty($day['birthdays']) ? ' birthdays' : ' disabled', ' birthday_col">';
 							// Show any birthdays...
 							if (!empty($day['birthdays']))
 							{
@@ -508,7 +510,6 @@ function template_calendar_base($col_span = 1)
 					echo '</select>
 					<input type="submit" class="button_submit" id="view_button" value="', $txt['view'], '">
 				</form>
-				<br class="clear">
 			</td>
 		</tr>';
 }

--- a/Themes/default/css/calendar.css
+++ b/Themes/default/css/calendar.css
@@ -3,23 +3,28 @@
 #calendar {
 	overflow: hidden;
 }
-#calendar .windowbg, #calendar .windowbg2 {
+#calendar .windowbg,
+#calendar .windowbg2 {
 	box-shadow: none;
 	border-radius: 0;
+	box-sizing: content-box;
 }
 /* Used to indicate the current day in the grid. */
-#main_grid .calendar_today span.day_text, #month_grid .calendar_today, .calendar_week tr.days_wrapper td.calendar_today:first-child {
+#main_grid .calendar_today span.day_text,
+#month_grid .calendar_today,
+.calendar_week tr.days_wrapper td.calendar_today:first-child {
 	font-weight: bold;
 }
-.calendar_today, td.days:hover {
+.calendar_today,
+td.days:hover {
 	background: #fff;
 }
 #month_grid {
-	width: 284px;
+	width: 214px;
 	float: left;
 	text-align: center;
 	overflow: hidden;
-	margin-right: 1%;
+	margin-right: 10px;
 }
 #month_grid h3 a {
 	padding: 0 6px 0 6px;
@@ -41,7 +46,9 @@
 	margin: 1px 0 0 0;
 	border: 1px solid #ddd;
 	overflow: auto;
-	-moz-box-sizing: border-box; box-sizing: border-box; -webkit-box-sizing: border-box;
+	-moz-box-sizing: border-box;
+	box-sizing: border-box;
+	-webkit-box-sizing: border-box;
 	margin-left: 1px;
 }
 #main_grid .cat_bar {
@@ -53,19 +60,23 @@
 }
 #month_grid table th.days {
 	background: #e7eaef;
+	font-size: smaller;
 }
-#month_grid table th.days, #month_grid table td.weeks {
-	padding: 5px;
+#month_grid table th.days,
+#month_grid table td.weeks {
+	padding: 2px;
 	text-align: center;
 }
 #month_grid table td.weeks {
 	font-size: large;
 	background: #e7eaef;
+	width: 5%;
 }
 #month_grid td.weeks a:hover {
 	text-decoration: underline;
 }
-#month_grid h3.catbg, #main_grid h3.catbg {
+#month_grid h3.catbg,
+#main_grid h3.catbg {
 	padding: 8px 6px 4px 6px;
 }
 #main_grid h3.catbg span {
@@ -78,7 +89,7 @@
 }
 #main_grid table th.days {
 	width: 14%;
-	padding: 10px;
+	padding: 0 10px;
 	text-align: left;
 	background: #e7eaef;
 }
@@ -87,51 +98,66 @@
 	font-weight: bold;
 	font-size: 1.8em;
 	background: #e7eaef;
+	padding: 5px;
 }
 #main_grid table td.weeks a:hover {
 	text-decoration: none;
 }
 /* Main Highlighting */
-#main_grid table td.disabled, #month_grid table td.disabled {
+#main_grid table td.disabled,
+#month_grid table td.disabled {
 	background: rgba(238, 238, 238, 1.0);
+	border: 1px solid #ddd;
 }
-#main_grid table td.events, #month_grid table td.events {
+#main_grid table td.events,
+#month_grid table td.events {
 	background: rgba(30, 245, 20, 0.1);
 }
-#main_grid table td.holidays, #month_grid table td.holidays {
+#main_grid table td.holidays,
+#month_grid table td.holidays {
 	background: rgba(23, 110, 245, 0.1);
 }
-#main_grid table td.birthdays, #month_grid table td.birthdays {
+#main_grid table td.birthdays,
+#month_grid table td.birthdays {
 	background: rgba(102, 0, 255, 0.1);
 }
 /* Special Case Highlighting */
-#main_grid table td.events:hover, #month_grid table td.events:hover, #month_grid table td.calendar_today.events {
+#main_grid table td.events:hover,
+#month_grid table td.events:hover,
+#month_grid table td.calendar_today.events {
 	background: rgba(30, 245, 20, 0.2);
 }
-#main_grid table td.holidays:hover, #month_grid table td.holidays:hover, #month_grid table td.calendar_today.holidays {
+#main_grid table td.holidays:hover,
+#month_grid table td.holidays:hover,
+#month_grid table td.calendar_today.holidays {
 	background: rgba(23, 110, 245, 0.2);
 }
-#main_grid table td.birthdays:hover, #month_grid table td.birthdays:hover, #month_grid table td.calendar_today.birthdays {
+#main_grid table td.birthdays:hover,
+#month_grid table td.birthdays:hover,
+#month_grid table td.calendar_today.birthdays {
 	background: rgba(153, 51, 255, 0.2);
 }
-#main_grid table td.days, #month_grid table td.days {
+#main_grid table td.days,
+#month_grid table td.days {
 	vertical-align: top;
 	text-align: left;
 	border-right: 1px solid #ddd;
 	border-bottom: 1px solid #ddd;
 }
 #main_grid table td.days {
-	padding: 10px;
+	padding: 5px;
 }
 #month_grid table td.days {
 	padding: 5px;
-	width: 14.28%;
+	width: 12.5%;
 	text-align: center;
 }
-#main_grid table tbody tr:nth-child(2) td.days, #month_grid table tbody tr:nth-child(2) {
+#main_grid table tbody tr:nth-child(2) td.days,
+#month_grid table tbody tr:nth-child(2) {
 	border-top: 1px solid #ddd;
 }
-#main_grid table tbody tr.days_wrapper > td:nth-child(2), #month_grid table tr.days_wrapper > td:nth-child(2) {
+#main_grid table tbody tr.days_wrapper > td:nth-child(2),
+#month_grid table tr.days_wrapper > td:nth-child(2) {
 	border-left: 1px solid #ddd;
 }
 #main_grid table tr.days_wrapper:nth-child(2) > td.weeks {
@@ -140,11 +166,16 @@
 #main_grid table:last-child td.weeks {
 	border-bottom: 1px solid #ddd;
 }
-#main_grid td#post_event {
+#main_grid tr:not(.days_wrapper) th,
+#main_grid tr:not(.days_wrapper) td {
+	height: 30px;
+}
+#post_event {
 	background: #e7eaef;
 	text-align: center;
-	padding-top: 12px;
-	margin-right: 0;
+}
+#calendar_navigation {
+	margin-top: 8px;
 }
 #main_grid .act_day {
 	font-size: 12pt;
@@ -181,7 +212,7 @@ span.hidelink {
 }
 /* Cheat and match this to the submit button. */
 #main_grid .buttonlist {
-	margin: -4px 12px 0 0;
+	margin: 0 12px 0 0;
 }
 #month_grid .compact {
 	padding: 2px;
@@ -189,14 +220,110 @@ span.hidelink {
 #month_grid .comfortable {
 	padding: 5px;
 }
-#main_grid .compact, .calendar_week .compact {
+#main_grid .compact,
+.calendar_week .compact {
 	height: 45px;
 }
-#main_grid .comfortable, .calendar_week .comfortable {
+#main_grid .comfortable,
+.calendar_week .comfortable {
 	height: 100px;
 	padding: 10px;
 }
-
 .modify_event:hover {
 	text-decoration: none;
+}
+
+/* Break long words in calendar table cells to avoid layout problems */
+#main_grid table td.days {
+	-webkit-hyphens: auto;
+	-ms-hyphens: auto;
+	hyphens: auto;
+	overflow-wrap: break-word;
+	word-wrap: break-word;
+}
+#chrome #main_grid table td.days {
+	word-break: break-word;
+}
+
+/* Make main calendar same height as the stack of mini calendars */
+@media (min-width: 1024px) {
+	#main_grid .calendar_table {
+		min-height: 650px;
+	}
+}
+
+/* At less than 1024px wide, #main_grid needs all the space it can get */
+@media (max-width: 1023px) {
+	#month_grid {
+		display: none;
+	}
+}
+
+/* Small screens get the calendar in a vertical list */
+@media (max-width: 665px) {
+	#main_grid table {
+		border: none;
+		background: none;
+	}
+	#main_grid tr:not(.days_wrapper) {
+		display: none;
+	}
+	#main_grid .days_wrapper {
+		display: block;
+	}
+	#main_grid td {
+		display: block;
+	}
+	
+	#main_grid .calendar_table .days {
+		margin-top: 0;
+		height: auto;
+	}
+	#main_grid .calendar_table .days:not(.disabled) {
+		min-height: 45px;
+	}
+	#main_grid .calendar_table .weeks a:before {
+		content: attr(title);
+		font-size: 0.65em;
+		margin: 0 0.5em;
+		vertical-align: top;
+	}
+	#main_grid .calendar_table tr:nth-of-type(2) .weeks {
+		margin-top: 0;
+	}
+	
+	#main_grid .calendar_week tr {
+		margin-bottom: 1em;
+		border: 1px solid #ddd !important;
+	}
+	#main_grid .calendar_week td {
+		margin: 0;
+		height: auto;
+		border: none !important;
+	}
+	#main_grid .calendar_week .event_col:before {
+		content: "Events: ";
+	}
+	#main_grid .calendar_week .holiday_col:before {
+		content: "Holidays: ";
+	}
+	#main_grid .calendar_week .birthday_col:before {
+		content: "Birthdays: ";
+	}
+	#main_grid .calendar_week .event_col:empty:before {
+		content: "Events: None";
+	}
+	#main_grid .calendar_week .holiday_col:empty {
+		display: none;
+	}
+	#main_grid .calendar_week .birthday_col:empty {
+		display: none;
+	}
+	div.week_add_event {
+		display: inline-block;
+	}
+	div.week_add_event > a {
+		font-size: 1em;
+		text-decoration: underline;
+	}
 }

--- a/Themes/default/css/calendar.css
+++ b/Themes/default/css/calendar.css
@@ -265,6 +265,9 @@ span.hidelink {
 		border: none;
 		background: none;
 	}
+	#main_grid tr {
+		margin-bottom: 1em;
+	}
 	#main_grid tr:not(.days_wrapper) {
 		display: none;
 	}
@@ -288,12 +291,11 @@ span.hidelink {
 		margin: 0 0.5em;
 		vertical-align: top;
 	}
-	#main_grid .calendar_table tr:nth-of-type(2) .weeks {
+	#main_grid .calendar_table .weeks {
 		margin-top: 0;
 	}
 	
 	#main_grid .calendar_week tr {
-		margin-bottom: 1em;
 		border: 1px solid #ddd !important;
 	}
 	#main_grid .calendar_week td {

--- a/Themes/default/css/calendar.css
+++ b/Themes/default/css/calendar.css
@@ -245,13 +245,6 @@ span.hidelink {
 	word-break: break-word;
 }
 
-/* Make main calendar same height as the stack of mini calendars */
-@media (min-width: 1024px) {
-	#main_grid .calendar_table {
-		min-height: 650px;
-	}
-}
-
 /* At less than 1024px wide, #main_grid needs all the space it can get */
 @media (max-width: 1023px) {
 	#month_grid {


### PR DESCRIPTION
- As the screen gets smaller, first we force the mini calendars to hide, then we switch the main calendar into a vertical list view. This involves manipulating the CSS to make all the table cells display as blocks and various other bits of CSS chicanery.
- To help avoid long words stretching table cells wider than we want, this also implements CSS hyphenation on browsers that support it, and word-breaking on browsers that don't. Note that to make hyphenation work, the lang attribute needs to be set on a parent element somewhere (see SimpleMachines#3351).
- This also does a bit of tidying in the CSS file.
- Removes some redundant classes in the template, adds some others where needed, and lightly rearranges a few elements. Also removes a couple of `<br class="clear">` elements that were no longer needed.
