### PR TITLE
Does a better job declaring the lang attribute

### DIFF
--- a/Themes/default/index.template.php
+++ b/Themes/default/index.template.php
@@ -83,9 +83,9 @@ function template_html_above()
 {
 	global $context, $settings, $scripturl, $txt, $modSettings, $mbname;
 
-	// Show right to left and the character set for ease of translating.
+	// Show right to left, the language code, and the character set for ease of translating.
 	echo '<!DOCTYPE html>
-	<html', $context['right_to_left'] ? ' dir="rtl"' : '', !empty($txt['lang_locale']) ? ' lang="' . substr($txt['lang_locale'], 0, 2) . '"' : '' , '>
+	<html', $context['right_to_left'] ? ' dir="rtl"' : '', !empty($txt['lang_locale']) ? ' lang="' . str_replace("_", "-", substr($txt['lang_locale'], 0, strcspn($txt['lang_locale'], "."))) . '"' : '' , '>
 <head>
 	<meta charset="', $context['character_set'], '">';
 


### PR DESCRIPTION
- Doesn't assume that the primary language subtag is two characters long (there are many defined in BCP 47 that are three characters long). Also, keeps all subtags that are defined in the locale code, such as script and region tags. In some cases, the subtags are unnecessary but harmless (e.g. 'fr-FR') while in others they are very important (e.g. 'zh-Hans' vs. 'zh-Hant')
- TODO: As of 2016-03-21, several of SMF's language files use deprecated locale strings. These should be updated for SMF 2.1.

