### PR TITLE
Specify admin quick search input field type as "search"

### DIFF
--- a/Themes/default/Admin.template.php
+++ b/Themes/default/Admin.template.php
@@ -1609,7 +1609,7 @@ function template_admin_quick_search()
 		echo '
 								<span class="floatright">
 									<span class="generic_icons filter centericon"></span>
-									<input type="text" name="search_term" value="', $txt['admin_search'], '" onclick="if (this.value == \'', $txt['admin_search'], '\') this.value = \'\';" class="input_text">
+									<input type="search" name="search_term" value="', $txt['admin_search'], '" onclick="if (this.value == \'', $txt['admin_search'], '\') this.value = \'\';" class="input_text">
 									<select name="search_type">
 										<option value="internal"', (empty($context['admin_preferences']['sb']) || $context['admin_preferences']['sb'] == 'internal' ? ' selected' : ''), '>', $txt['admin_search_type_internal'], '</option>
 										<option value="member"', (!empty($context['admin_preferences']['sb']) && $context['admin_preferences']['sb'] == 'member' ? ' selected' : ''), '>', $txt['admin_search_type_member'], '</option>


### PR DESCRIPTION
Better semantics, and more consistent with template_admin_search_results()

