### PR TITLE
Don't require Settings_bak.php on fresh install

### DIFF
--- a/other/install.php
+++ b/other/install.php
@@ -502,9 +502,11 @@ function CheckFilesWritable()
 		'Smileys',
 		'Themes',
 		'agreement.txt',
-		'Settings.php',
-		'Settings_bak.php'
+		'Settings.php'
 	);
+	if (file_exists(dirname(__FILE__) . '/Settings_bak.php'))
+		$writable_files[] = 'Settings_bak.php';
+	
 	foreach ($incontext['detected_languages'] as $lang => $temp)
 		$extra_files[] = 'Themes/default/languages/' . $lang;
 


### PR DESCRIPTION
- is_writable() fails on non-existent files, but on a fresh install there is no Settings_bak.php yet.

