### PR TITLE
Email template HTML support

### DIFF
--- a/Sources/ManageMembers.php
+++ b/Sources/ManageMembers.php
@@ -1125,7 +1125,7 @@ function AdminApprove()
 				);
 
 				$emaildata = loadEmailTemplate('admin_approve_accept', $replacements, $member['language']);
-				sendmail($member['email'], $emaildata['subject'], $emaildata['body'], null, 'accapp' . $member['id'], false, 0);
+				sendmail($member['email'], $emaildata['subject'], $emaildata['body'], null, 'accapp' . $member['id'], $emaildata['is_html'], 0);
 			}
 		}
 	}
@@ -1165,7 +1165,7 @@ function AdminApprove()
 			);
 
 			$emaildata = loadEmailTemplate('admin_approve_activation', $replacements, $member['language']);
-			sendmail($member['email'], $emaildata['subject'], $emaildata['body'], null, 'accact' . $member['id'], false, 0);
+			sendmail($member['email'], $emaildata['subject'], $emaildata['body'], null, 'accact' . $member['id'], $emaildata['is_html'], 0);
 		}
 	}
 	// Are we rejecting them?
@@ -1184,7 +1184,7 @@ function AdminApprove()
 				);
 
 				$emaildata = loadEmailTemplate('admin_approve_reject', $replacements, $member['language']);
-				sendmail($member['email'], $emaildata['subject'], $emaildata['body'], null, 'accrej', false, 1);
+				sendmail($member['email'], $emaildata['subject'], $emaildata['body'], null, 'accrej', $emaildata['is_html'], 1);
 			}
 		}
 	}
@@ -1204,7 +1204,7 @@ function AdminApprove()
 				);
 
 				$emaildata = loadEmailTemplate('admin_approve_delete', $replacements, $member['language']);
-				sendmail($member['email'], $emaildata['subject'], $emaildata['body'], null, 'accdel', false, 1);
+				sendmail($member['email'], $emaildata['subject'], $emaildata['body'], null, 'accdel', $emaildata['is_html'], 1);
 			}
 		}
 	}
@@ -1221,7 +1221,7 @@ function AdminApprove()
 			);
 
 			$emaildata = loadEmailTemplate('admin_approve_remind', $replacements, $member['language']);
-			sendmail($member['email'], $emaildata['subject'], $emaildata['body'], null, 'accrem' . $member['id'], false, 1);
+			sendmail($member['email'], $emaildata['subject'], $emaildata['body'], null, 'accrem' . $member['id'], $emaildata['is_html'], 1);
 		}
 	}
 

--- a/Sources/Post.php
+++ b/Sources/Post.php
@@ -2402,6 +2402,7 @@ function AnnouncementSend()
 			$announcements[$cur_language] = array(
 				'subject' => $emaildata['subject'],
 				'body' => $emaildata['body'],
+				'is_html' => $emaildata['is_html'],
 				'recipients' => array(),
 			);
 		}
@@ -2412,7 +2413,7 @@ function AnnouncementSend()
 
 	// For each language send a different mail - low priority...
 	foreach ($announcements as $lang => $mail)
-		sendmail($mail['recipients'], $mail['subject'], $mail['body'], null, 'ann-' . $lang, false, 5);
+		sendmail($mail['recipients'], $mail['subject'], $mail['body'], null, 'ann-' . $lang, $mail['is_html'], 5);
 
 	$context['percentage_done'] = round(100 * $context['start'] / $modSettings['latestMember'], 1);
 

--- a/Sources/Profile-Modify.php
+++ b/Sources/Profile-Modify.php
@@ -3658,7 +3658,7 @@ function profileSendActivation()
 
 	// Send off the email.
 	$emaildata = loadEmailTemplate('activate_reactivate', $replacements, empty($cur_profile['lngfile']) || empty($modSettings['userLanguage']) ? $language : $cur_profile['lngfile']);
-	sendmail($profile_vars['email_address'], $emaildata['subject'], $emaildata['body'], null, 'reactivate', false, 0);
+	sendmail($profile_vars['email_address'], $emaildata['subject'], $emaildata['body'], null, 'reactivate', $emaildata['is_html'], 0);
 
 	// Log the user out.
 	$smcFunc['db_query']('', '

--- a/Sources/Register.php
+++ b/Sources/Register.php
@@ -611,7 +611,7 @@ function Activate()
 
 		$emaildata = loadEmailTemplate('resend_activate_message', $replacements, empty($row['lngfile']) || empty($modSettings['userLanguage']) ? $language : $row['lngfile']);
 
-		sendmail($row['email_address'], $emaildata['subject'], $emaildata['body'], null, 'resendact', false, 0);
+		sendmail($row['email_address'], $emaildata['subject'], $emaildata['body'], null, 'resendact', $emaildata['is_html'], 0);
 
 		$context['page_title'] = $txt['invalid_activation_resend'];
 

--- a/Sources/Reminder.php
+++ b/Sources/Reminder.php
@@ -141,7 +141,7 @@ function RemindPick()
 		$emaildata = loadEmailTemplate('forgot_password', $replacements, empty($row['lngfile']) || empty($modSettings['userLanguage']) ? $language : $row['lngfile']);
 		$context['description'] = $txt['reminder_sent'];
 
-		sendmail($row['email_address'], $emaildata['subject'], $emaildata['body'], null, 'reminder', false, 1);
+		sendmail($row['email_address'], $emaildata['subject'], $emaildata['body'], null, 'reminder', $emaildata['is_html'], 1);
 
 		// Set the password in the database.
 		updateMemberData($row['id_member'], array('validation_code' => substr(md5($password), 0, 10)));

--- a/Sources/ScheduledTasks.php
+++ b/Sources/ScheduledTasks.php
@@ -367,7 +367,7 @@ function scheduled_approval_notification()
 		$emaildata = loadEmailTemplate('scheduled_approval', $replacements, $current_language);
 
 		// Send the actual email.
-		sendmail($member['email'], $emaildata['subject'], $emaildata['body'], null, 'schedapp', false, 2);
+		sendmail($member['email'], $emaildata['subject'], $emaildata['body'], null, 'schedapp', $emaildata['is_html'], 2);
 	}
 
 	// All went well!
@@ -1558,7 +1558,7 @@ function scheduled_paid_subscriptions()
 
 		// Send the actual email.
 		if ($notifyPrefs[$row['id_member']] & 0x02)
-			sendmail($row['email_address'], $emaildata['subject'], $emaildata['body'], null, 'paid_sub_remind', false, 2);
+			sendmail($row['email_address'], $emaildata['subject'], $emaildata['body'], null, 'paid_sub_remind', $emaildata['is_html'], 2);
 
 		if ($notifyPrefs[$row['id_member']] & 0x01)
 		{

--- a/Sources/Subs-Admin.php
+++ b/Sources/Subs-Admin.php
@@ -531,7 +531,7 @@ function emailAdmins($template, $replacements = array(), $additional_recipients 
 		$emaildata = loadEmailTemplate($template, $replacements, empty($row['lngfile']) || empty($modSettings['userLanguage']) ? $language : $row['lngfile']);
 
 		// Then send the actual email.
-		sendmail($row['email_address'], $emaildata['subject'], $emaildata['body'], null, $template, false, 1);
+		sendmail($row['email_address'], $emaildata['subject'], $emaildata['body'], null, $template, $emaildata['is_html'], 1);
 
 		// Track who we emailed so we don't do it twice.
 		$emails_sent[] = $row['email_address'];
@@ -553,7 +553,7 @@ function emailAdmins($template, $replacements = array(), $additional_recipients 
 			$emaildata = loadEmailTemplate($template, $replacements, empty($recipient['lang']) || empty($modSettings['userLanguage']) ? $language : $recipient['lang']);
 
 			// Send off the email.
-			sendmail($recipient['email'], $emaildata['subject'], $emaildata['body'], null, $template, false, 1);
+			sendmail($recipient['email'], $emaildata['subject'], $emaildata['body'], null, $template, $emaildata['is_html'], 1);
 		}
 }
 

--- a/Sources/Subs-Auth.php
+++ b/Sources/Subs-Auth.php
@@ -615,7 +615,7 @@ function resetPassword($memID, $username = null)
 	$emaildata = loadEmailTemplate('change_password', $replacements, empty($lngfile) || empty($modSettings['userLanguage']) ? $language : $lngfile);
 
 	// Send them the email informing them of the change - then we're done!
-	sendmail($email, $emaildata['subject'], $emaildata['body'], null, 'chgpass' . $memID, false, 0);
+	sendmail($email, $emaildata['subject'], $emaildata['body'], null, 'chgpass' . $memID, $emaildata['is_html'], 0);
 }
 
 /**

--- a/Sources/Subs-Members.php
+++ b/Sources/Subs-Members.php
@@ -751,7 +751,7 @@ function registerMember(&$regOptions, $return_errors = false)
 
 			$emaildata = loadEmailTemplate($email_message, $replacements);
 
-			sendmail($regOptions['email'], $emaildata['subject'], $emaildata['body'], null, $email_message . $memberID, false, 0);
+			sendmail($regOptions['email'], $emaildata['subject'], $emaildata['body'], null, $email_message . $memberID, $emaildata['is_html'], 0);
 		}
 
 		// All admins are finished here.
@@ -770,7 +770,7 @@ function registerMember(&$regOptions, $return_errors = false)
 				'FORGOTPASSWORDLINK' => $scripturl . '?action=reminder',
 			);
 			$emaildata = loadEmailTemplate('register_immediate', $replacements);
-			sendmail($regOptions['email'], $emaildata['subject'], $emaildata['body'], null, 'register', false, 0);
+			sendmail($regOptions['email'], $emaildata['subject'], $emaildata['body'], null, 'register', $emaildata['is_html'], 0);
 		}
 
 		// Send admin their notification.
@@ -799,7 +799,7 @@ function registerMember(&$regOptions, $return_errors = false)
 
 		$emaildata = loadEmailTemplate('register_' . ($regOptions['require'] == 'activation' ? 'activate' : 'coppa'), $replacements);
 
-		sendmail($regOptions['email'], $emaildata['subject'], $emaildata['body'], null, 'reg_' . $regOptions['require'] . $memberID, false, 0);
+		sendmail($regOptions['email'], $emaildata['subject'], $emaildata['body'], null, 'reg_' . $regOptions['require'] . $memberID, $emaildata['is_html'], 0);
 	}
 	// Must be awaiting approval.
 	else
@@ -813,7 +813,7 @@ function registerMember(&$regOptions, $return_errors = false)
 
 		$emaildata = loadEmailTemplate('register_pending', $replacements);
 
-		sendmail($regOptions['email'], $emaildata['subject'], $emaildata['body'], null, 'reg_pending', false, 0);
+		sendmail($regOptions['email'], $emaildata['subject'], $emaildata['body'], null, 'reg_pending', $emaildata['is_html'], 0);
 
 		// Admin gets informed here...
 		adminNotify('approval', $memberID, $regOptions['username']);

--- a/Sources/Subs-Post.php
+++ b/Sources/Subs-Post.php
@@ -1127,10 +1127,10 @@ function sendpm($recipients, $subject, $message, $store_outbox = false, $from = 
 
 	foreach ($notifications as $lang => $notification_list)
 	{
-		$mail = loadEmailTemplate($email_template, $replacements, $lang);
+		$emaildata = loadEmailTemplate($email_template, $replacements, $lang);
 
 		// Off the notification email goes!
-		sendmail($notification_list, $mail['subject'], $mail['body'], null, 'p' . $id_pm, false, 2, null, true);
+		sendmail($notification_list, $emaildata['subject'], $emaildata['body'], null, 'p' . $id_pm, $emaildata['is_html'], 2, null, true);
 	}
 
 	// Integrated After PMs
@@ -2670,6 +2670,7 @@ function loadEmailTemplate($template, $replacements = array(), $lang = '', $load
 	$ret = array(
 		'subject' => $txt[$template . '_subject'],
 		'body' => $txt[$template . '_body'],
+		'is_html' => !empty($txt[$template . '_html']),
 	);
 
 	// Add in the default replacements.

--- a/Sources/tasks/ApprovePost-Notify.php
+++ b/Sources/tasks/ApprovePost-Notify.php
@@ -77,7 +77,7 @@ class ApprovePost_Notify_Background extends SMF_BackgroundTask
 				);
 
 				$emaildata = loadEmailTemplate('alert_unapproved_post', $replacements, empty($data['lngfile']) || empty($modSettings['userLanguage']) ? $language : $data['lngfile']);
-				sendmail($data['email_address'], $emaildata['subject'], $emaildata['body'], null, 'm' . $topicOptions['id']);
+				sendmail($data['email_address'], $emaildata['subject'], $emaildata['body'], null, 'm' . $topicOptions['id'], $emaildata['is_html']);
 			}
 
 			if ($pref & 0x01)

--- a/Sources/tasks/ApproveReply-Notify.php
+++ b/Sources/tasks/ApproveReply-Notify.php
@@ -70,7 +70,7 @@ class ApproveReply_Notify_Background extends SMF_BackgroundTask
 				);
 
 				$emaildata = loadEmailTemplate('alert_unapproved_reply', $replacements, empty($data['lngfile']) || empty($modSettings['userLanguage']) ? $language : $data['lngfile']);
-				sendmail($data['email_address'], $emaildata['subject'], $emaildata['body'], null, 'm' . $topicOptions['id']);
+				sendmail($data['email_address'], $emaildata['subject'], $emaildata['body'], null, 'm' . $topicOptions['id'], $emaildata['is_html']);
 			}
 
 			if ($pref & 0x01)

--- a/Sources/tasks/Birthday-Notify.php
+++ b/Sources/tasks/Birthday-Notify.php
@@ -108,7 +108,7 @@ class Birthday_Notify_Background extends SMF_BackgroundTask
 					if ($pref & 0x02)
 					{
 						$emaildata = loadEmailTemplate('happy_birthday', $replacements, $lang, false);
-						sendmail($member['email'], $emaildata['subject'], $emaildata['body'], null, 'birthday', false, 4);
+						sendmail($member['email'], $emaildata['subject'], $emaildata['body'], null, 'birthday', $emaildata['is_html'], 4);
 					}
 				}
 			}

--- a/Sources/tasks/CreatePost-Notify.php
+++ b/Sources/tasks/CreatePost-Notify.php
@@ -158,7 +158,7 @@ class CreatePost_Notify_Background extends SMF_BackgroundTask
 				);
 
 				$emaildata = loadEmailTemplate($message_type, $replacements, empty($data['lngfile']) || empty($modSettings['userLanguage']) ? $language : $data['lngfile']);
-				sendmail($data['email_address'], $emaildata['subject'], $emaildata['body'], null, 'm' . $topicOptions['id']);
+				sendmail($data['email_address'], $emaildata['subject'], $emaildata['body'], null, 'm' . $topicOptions['id'], $emaildata['is_html']);
 			}
 
 			if ($pref & 0x01)
@@ -241,7 +241,7 @@ class CreatePost_Notify_Background extends SMF_BackgroundTask
 				);
 
 				$emaildata = loadEmailTemplate('msg_quote', $replacements, empty($member['lngfile']) || empty($modSettings['userLanguage']) ? $language : $member['lngfile']);
-				sendmail($member['email_address'], $emaildata['subject'], $emaildata['body'], null, 'msg_quote_' . $msgOptions['id'], false, 2);
+				sendmail($member['email_address'], $emaildata['subject'], $emaildata['body'], null, 'msg_quote_' . $msgOptions['id'], $emaildata['is_html'], 2);
 			}
 
 			if ($prefs[$id]['msg_quote'] & 0x01)
@@ -353,7 +353,7 @@ class CreatePost_Notify_Background extends SMF_BackgroundTask
 				);
 
 				$emaildata = loadEmailTemplate('msg_mention', $replacements, empty($member['lngfile']) || empty($modSettings['userLanguage']) ? $language : $member['lngfile']);
-				sendmail($member['email_address'], $emaildata['subject'], $emaildata['body'], null, 'msg_mention_' . $msgOptions['id'], false, 2);
+				sendmail($member['email_address'], $emaildata['subject'], $emaildata['body'], null, 'msg_mention_' . $msgOptions['id'], $emaildata['is_html'], 2);
 			}
 
 			if ($prefs[$id]['msg_mention'] & 0x01)

--- a/Sources/tasks/GroupAct-Notify.php
+++ b/Sources/tasks/GroupAct-Notify.php
@@ -137,7 +137,7 @@ class GroupAct_Notify_Background extends SMF_BackgroundTask
 
 					$emaildata = loadEmailTemplate($email_template_name, $replacements, $user['language']);
 
-					sendmail($user['email'], $emaildata['subject'], $emaildata['body'], null, $email_message_id_prefix . $user['rid'], false, 2);
+					sendmail($user['email'], $emaildata['subject'], $emaildata['body'], null, $email_message_id_prefix . $user['rid'], $emaildata['is_html'], 2);
 				}
 			}
 

--- a/Sources/tasks/GroupReq-Notify.php
+++ b/Sources/tasks/GroupReq-Notify.php
@@ -122,7 +122,7 @@ class GroupReq_Notify_Background extends SMF_BackgroundTask
 					);
 
 					$emaildata = loadEmailTemplate('request_membership', $replacements, empty($row['lngfile']) || empty($modSettings['userLanguage']) ? $language : $row['lngfile']);
-					sendmail($row['email_address'], $emaildata['subject'], $emaildata['body'], null, 'groupreq' . $this->_details['id_group'], false, 2);
+					sendmail($row['email_address'], $emaildata['subject'], $emaildata['body'], null, 'groupreq' . $this->_details['id_group'], $emaildata['is_html'], 2);
 				}
 			}
 		}

--- a/Sources/tasks/MemberReport-Notify.php
+++ b/Sources/tasks/MemberReport-Notify.php
@@ -130,7 +130,7 @@ class MemberReport_Notify_Background extends SMF_BackgroundTask
 
 				// And do the actual sending...
 				foreach ($recipients as $id_member => $email_address)
-					sendmail($email_address, $emaildata['subject'], $emaildata['body'], null, 'ureport' . $this->_details['report_id'], false, 2);
+					sendmail($email_address, $emaildata['subject'], $emaildata['body'], null, 'ureport' . $this->_details['report_id'], $emaildata['is_html'], 2);
 			}
 		}
 

--- a/Sources/tasks/MemberReportReply-Notify.php
+++ b/Sources/tasks/MemberReportReply-Notify.php
@@ -156,7 +156,7 @@ class MemberReportReply_Notify_Background extends SMF_BackgroundTask
 
 				// And do the actual sending...
 				foreach ($recipients as $id_member => $email_address)
-					sendmail($email_address, $emaildata['subject'], $emaildata['body'], null, 'urptrpy' . $this->_details['comment_id'], false, 3);
+					sendmail($email_address, $emaildata['subject'], $emaildata['body'], null, 'urptrpy' . $this->_details['comment_id'], $emaildata['is_html'], 3);
 			}
 		}
 

--- a/Sources/tasks/MsgReport-Notify.php
+++ b/Sources/tasks/MsgReport-Notify.php
@@ -178,7 +178,7 @@ class MsgReport_Notify_Background extends SMF_BackgroundTask
 
 				// And do the actual sending...
 				foreach ($recipients as $id_member => $email_address)
-					sendmail($email_address, $emaildata['subject'], $emaildata['body'], null, 'report' . $this->_details['report_id'], false, 2);
+					sendmail($email_address, $emaildata['subject'], $emaildata['body'], null, 'report' . $this->_details['report_id'], $emaildata['is_html'], 2);
 			}
 		}
 

--- a/Sources/tasks/MsgReportReply-Notify.php
+++ b/Sources/tasks/MsgReportReply-Notify.php
@@ -204,7 +204,7 @@ class MsgReportReply_Notify_Background extends SMF_BackgroundTask
 
 				// And do the actual sending...
 				foreach ($recipients as $id_member => $email_address)
-					sendmail($email_address, $emaildata['subject'], $emaildata['body'], null, 'rptrpy' . $this->_details['comment_id'], false, 3);
+					sendmail($email_address, $emaildata['subject'], $emaildata['body'], null, 'rptrpy' . $this->_details['comment_id'], $emaildata['is_html'], 3);
 			}
 		}
 

--- a/Sources/tasks/Register-Notify.php
+++ b/Sources/tasks/Register-Notify.php
@@ -127,7 +127,7 @@ class Register_Notify_Background extends SMF_BackgroundTask
 
 				// And do the actual sending...
 				foreach ($recipients as $id_member => $email_address)
-					sendmail($email_address, $emaildata['subject'], $emaildata['body'], null, 'newmember' . $this->_details['new_member_id'], false, 0);
+					sendmail($email_address, $emaildata['subject'], $emaildata['body'], null, 'newmember' . $this->_details['new_member_id'], $emaildata['is_html'], 0);
 			}
 		}
 


### PR DESCRIPTION
Signed-off-by: Alex Smith asmith_20002@yahoo.com

Followed by:
http://www.simplemachines.org/community/index.php?topic=542885.0

Example:

```
$txt['resend_pending_message_html'] = true;
$txt['resend_pending_message_subject'] = 'Welcome to {FORUMNAME}';
$txt['resend_pending_message_body']  = 'I support < strong>HTML content< /strong> now!';
```
