### PR TITLE
Fix "strpos() expects parameter 1 to be string, array given"

### DIFF
--- a/Sources/ManageBans.php
+++ b/Sources/ManageBans.php
@@ -1791,11 +1791,11 @@ function BanBrowseTriggers()
 		$listOptions['columns']['banned_entity']['data'] = array(
 			'function' => function ($rowData)
 			{
-				return range2ip(array(
+				return range2ip(
 					$rowData['ip_low']
-				), array(
+				,
 					$rowData['ip_high']
-				));
+				);
 			},
 		);
 		$listOptions['columns']['banned_entity']['sort'] = array(


### PR DESCRIPTION
This error happen when you visit the "browse ban trigger" page
