### PR TITLE
Adjusting code tag and file content for RTL

### DIFF
--- a/Themes/default/css/jquery.sceditor.default.css
+++ b/Themes/default/css/jquery.sceditor.default.css
@@ -47,6 +47,7 @@ code {
 code, code:before {
 	display: block;
 	text-align: left;
+	direction: ltr;
 }
 blockquote {
 	margin: 0 0 8px 0;

--- a/Themes/default/css/rtl.css
+++ b/Themes/default/css/rtl.css
@@ -719,6 +719,7 @@ span.pages {
 }
 
 /* Code is a code do it LTR */
-code.bbc_code {
+code.bbc_code, pre.file_content {
 	text-align: left;
+	direction: ltr;
 }


### PR DESCRIPTION
Signed-off-by: Alex Smith asmith_20002@yahoo.com

Putting text-align: left won't just cut it for RTL languages.
The following codes illustrate the problem: (both of them are text-align: left;)

direction LTR:
`echo time();`

direction RTL:
`;()echo time`
