### PR TITLE
log_banned with ipv6 support

### DIFF
--- a/Sources/ManageBans.php
+++ b/Sources/ManageBans.php
@@ -2107,7 +2107,10 @@ function list_getBanLogEntries($start, $items_per_page, $sort)
 	);
 	$log_entries = array();
 	while ($row = $smcFunc['db_fetch_assoc']($request))
+	{
+		$row['ip'] = $row['ip'] === '-'? '-' : inet_dtop($row['ip']);
 		$log_entries[] = $row;
+	}
 	$smcFunc['db_free_result']($request);
 
 	return $log_entries;

--- a/Sources/Security.php
+++ b/Sources/Security.php
@@ -504,7 +504,7 @@ function log_ban($ban_ids = array(), $email = null)
 
 	$smcFunc['db_insert']('',
 		'{db_prefix}log_banned',
-		array('id_member' => 'int', 'ip' => 'string-16', 'email' => 'string', 'log_time' => 'int'),
+		array('id_member' => 'int', 'ip' => 'inet', 'email' => 'string', 'log_time' => 'int'),
 		array($user_info['id'], $user_info['ip'], ($email === null ? ($user_info['is_guest'] ? '' : $user_info['email']) : $email), time()),
 		array('id_ban_log')
 	);

--- a/other/install_2-1_mysql.sql
+++ b/other/install_2-1_mysql.sql
@@ -272,7 +272,7 @@ CREATE TABLE {$db_prefix}log_activity (
 CREATE TABLE {$db_prefix}log_banned (
   id_ban_log MEDIUMINT(8) UNSIGNED AUTO_INCREMENT,
   id_member MEDIUMINT(8) UNSIGNED NOT NULL DEFAULT '0',
-  ip CHAR(16) NOT NULL DEFAULT '                ',
+  ip VARBINARY(16),
   email VARCHAR(255) NOT NULL DEFAULT '',
   log_time INT(10) UNSIGNED NOT NULL DEFAULT '0',
   PRIMARY KEY (id_ban_log),

--- a/other/install_2-1_postgresql.sql
+++ b/other/install_2-1_postgresql.sql
@@ -498,7 +498,7 @@ CREATE SEQUENCE {$db_prefix}log_banned_seq;
 CREATE TABLE {$db_prefix}log_banned (
   id_ban_log int default nextval('{$db_prefix}log_banned_seq'),
   id_member int NOT NULL default '0',
-  ip char(16) NOT NULL default '                ',
+  ip inet,
   email varchar(255) NOT NULL,
   log_time int NOT NULL default '0',
   PRIMARY KEY (id_ban_log)

--- a/other/upgrade_2-1_mysql.sql
+++ b/other/upgrade_2-1_mysql.sql
@@ -1926,3 +1926,14 @@ DROP ip_high2,
 DROP ip_high3,
 DROP ip_high4;
 ---#
+
+/******************************************************************************/
+--- update log_banned ip with ipv6 support without converting
+/******************************************************************************/
+---# delete old columns
+ALTER TABLE {$db_prefix}log_banned DROP COLUMN ip;
+---#
+
+---# add the new one
+ALTER TABLE {$db_prefix}log_banned ADD COLUMN ip VARBINARY(16);
+---#

--- a/other/upgrade_2-1_postgresql.sql
+++ b/other/upgrade_2-1_postgresql.sql
@@ -2042,3 +2042,13 @@ WHERE ip_low1 > 0;
 CREATE INDEX {$db_prefix}ban_items_id_ban_ip ON {$db_prefix}ban_items (ip_low,ip_high);
 ---#
 
+/******************************************************************************/
+--- update log_banned ip with ipv6 support without converting
+/******************************************************************************/
+---# delete old columns
+ALTER TABLE {$db_prefix}log_banned DROP COLUMN ip;
+---#
+
+---# add the new one
+ALTER TABLE {$db_prefix}log_banned ADD COLUMN ip inet;
+---#


### PR DESCRIPTION
The pr give the log_banned.ip field ipv6 support,
the upgrade script is without converting the old stuff.(the old ip information are lost)

Reason, without converting this part is able to run more than one time,
this is needed for this: https://github.com/SimpleMachines/SMF2.1/issues/3309

related to issue: https://github.com/SimpleMachines/SMF2.1/issues/3291
