### PR TITLE
Improves extraction of BBC params from message text

### DIFF
--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -1702,7 +1702,12 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 	$open_tags = array();
 	$message = strtr($message, array("\n" => '<br>'));
 	
-	$alltags_regex = implode("|", array_unique(array_map(function($code){return $code['tag'];}, $codes)));
+	foreach ($bbc_codes as $section) {
+		foreach ($section as $code) {
+			$alltags[] = $code['tag'];
+		}
+	}
+	$alltags_regex = implode("|", array_unique($alltags));
 
 	// The non-breaking-space looks a bit different each time.
 	$non_breaking_space = $context['utf8'] ? '\x{A0}' : '\xA0';

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -2034,9 +2034,8 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 			{
 				// Build a regular expression for each parameter for the current tag.
 				$preg = array();
-				foreach ($possible['parameters'] as $p => $info) {
+				foreach ($possible['parameters'] as $p => $info)
 					$preg[] = '(\s+' . $p . '=' . (empty($info['quoted']) ? '' : '&quot;') . (isset($info['match']) ? $info['match'] : '(.+?)') . (empty($info['quoted']) ? '' : '&quot;') . ')' . (empty($info['optional']) ? '' : '?');
-				}
 				
 				// Extract the string that potentially holds our parameters.
 				$blob = preg_split('~\[/?(?:' . $alltags_regex . ')~is', substr($message, $pos));

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -2035,7 +2035,7 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 				// Build a regular expression for each parameter for the current tag.
 				$preg = array();
 				foreach ($possible['parameters'] as $p => $info)
-					$preg[] = '(\s+' . $p . '=' . (empty($info['quoted']) ? '' : '&quot;') . (isset($info['match']) ? $info['match'] : '(.+?)') . (empty($info['quoted']) ? '' : '&quot;') . ')' . (empty($info['optional']) ? '' : '?');
+					$preg[] = '(\s+' . $p . '=' . (empty($info['quoted']) ? '' : '&quot;') . (isset($info['match']) ? $info['match'] : '(.+?)') . (empty($info['quoted']) ? '' : '&quot;') . '\s*)' . (empty($info['optional']) ? '' : '?');
 				
 				// Extract the string that potentially holds our parameters.
 				$blob = preg_split('~\[/?(?:' . $alltags_regex . ')~i', substr($message, $pos));
@@ -2049,7 +2049,7 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 					
 					$given_param_string = implode(']', array_slice($blobs, 0, $blob_counter++));
 					
-					$given_params = preg_split('~(\s|&nbsp;)+(?=(' . $splitters . '))~i', $given_param_string);
+					$given_params = preg_split('~\s(?=(' . $splitters . '))~i', $given_param_string);
 					sort($given_params, SORT_STRING);
 					
 					$match = preg_match('~^' . implode('', $preg) . '$~i', implode(' ', $given_params), $matches) !== 0;

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -2033,11 +2033,8 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 			if (!empty($possible['parameters']))
 			{
 				// Build a regular expression for each parameter for the current tag.
-				// ... And also an array for use in another regular expression in a moment.
 				$preg = array();
-				$splitters = array();
 				foreach ($possible['parameters'] as $p => $info) {
-					$splitters[] = $p . '=';
 					$preg[] = '(\s+' . $p . '=' . (empty($info['quoted']) ? '' : '&quot;') . (isset($info['match']) ? $info['match'] : '(.+?)') . (empty($info['quoted']) ? '' : '&quot;') . ')' . (empty($info['optional']) ? '' : '?');
 				}
 				
@@ -2045,13 +2042,15 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 				$blob = preg_split('~\[/?(?:' . $alltags_regex . ')~is', substr($message, $pos));
 				$blobs = preg_split('~\]~is', $blob[1]);
 				
+				$splitters = implode('=|', array_keys($possible['parameters'])) . '=';
+
 				// Progressively append more blobs until we find our parameters or run out of blobs
 				$blob_counter = 0;
 				while ($blob_counter <= count($blobs)) {
 					
 					$given_param_string = implode(']', array_slice($blobs, 0, $blob_counter++));
 					
-					$given_params = preg_split('~\s(?=(' . implode('|', $splitters) . '))~i', $given_param_string);
+					$given_params = preg_split('~\s(?=(' . $splitters . '))~i', $given_param_string);
 					sort($given_params, SORT_STRING);
 					
 					$match = preg_match('~^' . implode('', $preg) . '$~i', implode(' ', $given_params), $matches) !== 0;
@@ -2361,6 +2360,7 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 			if (isset($tag['quoted']))
 			{
 				$quoted = substr($message, $pos1, 6) == '&quot;';
+				echo '<pre>'; echo substr($message, $pos1, 6); echo '</pre>';
 				if ($tag['quoted'] != 'optional' && !$quoted)
 					continue;
 

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -1707,7 +1707,7 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 			$alltags[] = $code['tag'];
 		}
 	}
-	$alltags_regex = implode("|", array_unique($alltags));
+	$alltags_regex = '\b' . implode("\b|\b", array_unique($alltags)) . '\b';
 
 	// The non-breaking-space looks a bit different each time.
 	$non_breaking_space = $context['utf8'] ? '\x{A0}' : '\xA0';

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -2360,7 +2360,6 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 			if (isset($tag['quoted']))
 			{
 				$quoted = substr($message, $pos1, 6) == '&quot;';
-				echo '<pre>'; echo substr($message, $pos1, 6); echo '</pre>';
 				if ($tag['quoted'] != 'optional' && !$quoted)
 					continue;
 

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -2038,8 +2038,8 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 					$preg[] = '(\s+' . $p . '=' . (empty($info['quoted']) ? '' : '&quot;') . (isset($info['match']) ? $info['match'] : '(.+?)') . (empty($info['quoted']) ? '' : '&quot;') . ')' . (empty($info['optional']) ? '' : '?');
 				
 				// Extract the string that potentially holds our parameters.
-				$blob = preg_split('~\[/?(?:' . $alltags_regex . ')~is', substr($message, $pos));
-				$blobs = preg_split('~\]~is', $blob[1]);
+				$blob = preg_split('~\[/?(?:' . $alltags_regex . ')~i', substr($message, $pos));
+				$blobs = preg_split('~\]~i', $blob[1]);
 				
 				$splitters = implode('=|', array_keys($possible['parameters'])) . '=';
 
@@ -2049,7 +2049,7 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 					
 					$given_param_string = implode(']', array_slice($blobs, 0, $blob_counter++));
 					
-					$given_params = preg_split('~\s(?=(' . $splitters . '))~i', $given_param_string);
+					$given_params = preg_split('~(\s|&nbsp;)+(?=(' . $splitters . '))~i', $given_param_string);
 					sort($given_params, SORT_STRING);
 					
 					$match = preg_match('~^' . implode('', $preg) . '$~i', implode(' ', $given_params), $matches) !== 0;


### PR DESCRIPTION
The weak spot in #3345 was the part that extracted parameters. This version fixes its problems.
- No longer needs an alternative method to extract parameters from closed BBC.
- In the previous version, nested BBC could sometimes cause the parameter extraction to fail. This fixes that.
- Improves performance by eliminating regex recursion.
