### PR TITLE
Fixes minor visual glitch in blockquote CSS

### DIFF
--- a/Themes/default/css/index.css
+++ b/Themes/default/css/index.css
@@ -303,7 +303,8 @@ h3.largetext {
 	color: #aaa;
 	font-size: 22px;
 	content: '\275D';
-	margin: -5px 5px 0 -5px;
+	position: absolute;
+	left: 5px;
 }
 /* Remove the difference IE/Opera/Chrome/Firefox etc... */
 #firefox .bbc_standard_quote:before, #firefox .bbc_alternate_quote:before {
@@ -316,11 +317,12 @@ h3.largetext {
 }
 .bbc_standard_quote, .bbc_alternate_quote {
 	margin: 0 0 8px 0;
-	padding: 6px 10px;
+	padding: 6px 10px 6px 25px;
 	font-size: 0.9em;
 	border: 1px solid #d6dfe2;
 	border-left: 2px solid #aaa;
 	border-right: 2px solid #aaa;
+	position: relative;
 }
 /* Alternate blockquote stylings */
 .bbc_standard_quote {


### PR DESCRIPTION
Under the previous method, if the content of the blockquote started with a block level element (e.g. a list) a visual line break would appear between the :before pseudo-element and the blockquote content.
- Uses absolute positioning on the :before pseudo-element instead of margin adjustments
- Adds 15px padding to the left side of the blockquote

