### PR TITLE
Don't hardcode the member URL in display

### DIFF
--- a/Themes/default/Display.template.php
+++ b/Themes/default/Display.template.php
@@ -466,7 +466,7 @@ function template_single_post($message)
 	if (!empty($modSettings['show_user_images']) && empty($options['show_no_avatars']) && !empty($message['member']['avatar']['image']))
 		echo '
 								<li class="avatar">
-									<a href="', $scripturl, '?action=profile;u=', $message['member']['id'], '">', $message['member']['avatar']['image'], '</a>
+									<a href="', $message['member']['href'], '">', $message['member']['avatar']['image'], '</a>
 								</li>';
 
 	// Are there any custom fields below the avatar?


### PR DESCRIPTION
There are mods that might want to alter the URL that the avatar points to - this should use $memberContext which is available to modders directly via hooks, and since it's already built there's no reason not to use it...

Signed-off-by: Arantor sleeping@myperch.org
