### PR TITLE
Permissions fixes

### DIFF
--- a/Sources/ManageBoards.php
+++ b/Sources/ManageBoards.php
@@ -866,9 +866,7 @@ function EditBoardSettings($return_config = false)
 	// Needed for the settings template.
 	require_once($sourcedir . '/ManageServer.php');
 
-	// Don't let guests have these permissions.
 	$context['post_url'] = $scripturl . '?action=admin;area=manageboards;save;sa=settings';
-	$context['permissions_excluded'] = array(-1);
 
 	$context['page_title'] = $txt['boards_and_cats'] . ' - ' . $txt['settings'];
 

--- a/Sources/ManageMembergroups.php
+++ b/Sources/ManageMembergroups.php
@@ -1230,9 +1230,6 @@ function ModifyMembergroupsettings()
 	// Needed for the settings functions.
 	require_once($sourcedir . '/ManageServer.php');
 
-	// Don't allow assignment of guests.
-	$context['permissions_excluded'] = array(-1);
-
 	// Only one thing here!
 	$config_vars = array(
 			array('permissions', 'manage_membergroups'),

--- a/Sources/ManageNews.php
+++ b/Sources/ManageNews.php
@@ -1085,7 +1085,6 @@ function ModifyNewsSettings($return_config = false)
 
 	// Wrap it all up nice and warm...
 	$context['post_url'] = $scripturl . '?action=admin;area=news;save;sa=settings';
-	$context['permissions_excluded'] = array(-1);
 
 	// Add some javascript at the bottom...
 	addInlineJavascript('

--- a/Sources/ManagePermissions.php
+++ b/Sources/ManagePermissions.php
@@ -2224,6 +2224,7 @@ function loadIllegalGuestPermissions()
 		'delete_replies',
 		'edit_news',
 		'issue_warning',
+		'likes_like',
 		'lock',
 		'make_sticky',
 		'manage_attachments',

--- a/Sources/ManagePermissions.php
+++ b/Sources/ManagePermissions.php
@@ -1772,6 +1772,9 @@ function init_inline_permissions($permissions, $excluded_groups = array())
 	}
 	$smcFunc['db_free_result']($request);
 
+	// Make sure we honor the "illegal guest permissions"
+	loadIllegalGuestPermissions();
+
 	// Some permissions cannot be given to certain groups. Remove the groups.
 	foreach ($excluded_groups as $group)
 	{
@@ -1780,6 +1783,14 @@ function init_inline_permissions($permissions, $excluded_groups = array())
 			if (isset($context[$permission][$group]))
 				unset($context[$permission][$group]);
 		}
+	}
+
+	// Are any of these permissions that guests can't have?
+	$non_guest_perms = array_intersect(str_replace(array('_any', '_own'), '', $permissions), $context['non_guest_permissions']);
+	foreach ($non_guest_perms as $permission)
+	{
+		if (isset($context[$permission][-1]))
+			unset($context[$permission][-1]);
 	}
 
 	// Create the token for the separate inline permission verification.

--- a/Sources/ManageSmileys.php
+++ b/Sources/ManageSmileys.php
@@ -156,7 +156,6 @@ function EditSmileySettings($return_config = false)
 
 	// Finish up the form...
 	$context['post_url'] = $scripturl . '?action=admin;area=smileys;save;sa=settings';
-	$context['permissions_excluded'] = array(-1);
 
 	// Saving the settings?
 	if (isset($_GET['save']))


### PR DESCRIPTION
The init_inline_permissions function doesn't respect permissions specified in loadIllegalGuestPermissions. This meant that you had to set `$context['permissions_excluded'] = array(-1);` everywhere you wanted to exclude guests, and this removed Guests from every permission, which wasn't always desired. This fix will ensure that Guests won't show up for any permission specified in loadIllegalGuestPermissions();

I've also added "likes_like" to the list of permissions guests can't have as it doesn't make sense to allow guests to like things - especially since we have no easy way to track that.
