### PR TITLE
Fix IP display bug that affected ~3% of the ips + 1 minor typo.

### DIFF
--- a/Sources/ManageBans.php
+++ b/Sources/ManageBans.php
@@ -2155,7 +2155,7 @@ function range2ip($low, $high)
 	$low = inet_dtop($low);
 	$high = inet_dtop($high);
 
-	if ($low == '255.255.255.255') return 'unkown';
+	if ($low == '255.255.255.255') return 'unknown';
 	if ($low == $high)
 	    return $low;
 	else

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -4847,12 +4847,14 @@ function inet_ptod($ip_address)
 }
 
 /**
- * @param binary $bin An IP address in IPv4, IPv6
+ * @param binary $bin An IP address in IPv4, IPv6 (Either string (postgresql) or binary (other databases))
  * @return string The IP address in presentation format or false on error
  */
 function inet_dtop($bin)
 {
-	if(strpos($bin,'.')!==false || strpos($bin,':')!==false)
+	global $db_type;
+
+	if ($db_type == 'postgresql')
 		return $bin;
 
 	$ip_address = inet_ntop($bin);


### PR DESCRIPTION
Due to the data being binary a dot or colon can occur in the binary data. Respectively the bug triggers in an IP address containing 46 and 58.
