### PR TITLE
Fix fulltext search for pg

### DIFF
--- a/Sources/ManageSearch.php
+++ b/Sources/ManageSearch.php
@@ -402,11 +402,11 @@ function EditSearchMethod()
 	elseif ($db_type == 'postgresql')
 	{
 		// In order to report the sizes correctly we need to perform vacuum (optimize) on the tables we will be using.
-		db_extend();
-		$temp_tables = $smcFunc['db_list_tables']();
-		foreach ($temp_tables as $table)
-			if ($table == $db_prefix. 'messages' || $table == $db_prefix. 'log_search_words')
-				$smcFunc['db_optimize_table']($table);
+		//db_extend();
+		//$temp_tables = $smcFunc['db_list_tables']();
+		//foreach ($temp_tables as $table)
+		//	if ($table == $db_prefix. 'messages' || $table == $db_prefix. 'log_search_words')
+		//		$smcFunc['db_optimize_table']($table);
 
 		// PostGreSql has some hidden sizes.
 		$request = $smcFunc['db_query']('', '

--- a/Sources/SearchAPI-Fulltext.php
+++ b/Sources/SearchAPI-Fulltext.php
@@ -207,9 +207,23 @@ class fulltext_search extends search_api
 		if (!empty($modSettings['search_simple_fulltext']))
 		{
 			if($smcFunc['db_title'] == "PostgreSQL")
+			{
 				//we use the default language "default_text_search_config", otherwise we had to assgine the language here
 				//to_tsvector(body) -> to_tsvector($language,body) to_tsquery(...) -> to_tsquery($language,...)
-				$query_where[] = 'to_tsvector(body) @@ to_tsquery({string:body_match})';
+				$language_ftx = 'english';
+				$request = $smcFunc['db_query']('','
+					SHOW default_text_search_config',
+					array()
+				);
+
+				if ($request !== false && $smcFunc['db_num_rows']($request) == 1)
+				{
+					$row = $smcFunc['db_fetch_assoc']($request);
+					$language_ftx = $row['default_text_search_config'];
+				}
+				$query_where[] = 'to_tsvector({string:language_ftx},body) @@ to_tsquery({string:language_ftx},{string:body_match})';
+				$query_params['language_ftx'] = $language_ftx;
+			}
 			else
 				$query_where[] = 'MATCH (body) AGAINST ({string:body_match})';
 			$query_params['body_match'] = implode(' ', array_diff($words['indexed_words'], $query_params['excluded_index_words']));
@@ -238,9 +252,23 @@ class fulltext_search extends search_api
 			// if we have bool terms to search, add them in
 			if ($query_params['boolean_match']) {
 				if($smcFunc['db_title'] == "PostgreSQL")
+				{
 					//we use the default language "default_text_search_config", otherwise we had to assgine the language here
 					//to_tsvector(body) -> to_tsvector($language,body) to_tsquery(...) -> to_tsquery($language,...)
-					$query_where[] = 'to_tsvector(body) @@ to_tsquery({string:boolean_match})';
+					$language_ftx = 'english';
+					$request = $smcFunc['db_query']('','
+						SHOW default_text_search_config',
+						array()
+					);
+
+					if ($request !== false && $smcFunc['db_num_rows']($request) == 1)
+					{
+						$row = $smcFunc['db_fetch_assoc']($request);
+						$language_ftx = $row['default_text_search_config'];
+					}
+					$query_where[] = 'to_tsvector({string:language_ftx},body) @@ to_tsquery({string:language_ftx},{string:boolean_match})';
+					$query_params['language_ftx'] = $language_ftx;
+				}
 				else
 					$query_where[] = 'MATCH (body) AGAINST ({string:boolean_match} IN BOOLEAN MODE)';
 			}


### PR DESCRIPTION
deactivate the vacuum on the tables and
added default language to the ts query -> without that the gin index will be not used ... very slow without
