### PR TITLE
Fixes a bug when looking for optional BBC parameters

### DIFF
--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -2048,7 +2048,7 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 				$splitters = implode('=|', array_keys($possible['parameters'])) . '=';
 
 				// Progressively append more blobs until we find our parameters or run out of blobs
-				$blob_counter = 0;
+				$blob_counter = 1;
 				while ($blob_counter <= count($blobs))
 				{
 


### PR DESCRIPTION
- Partially fixes #3434 (the bit about img params)
- Previously, if all parameters for a BBC were optional, the regex to find the parameters would match against an empty string. By ensuring that we don't start with an empty string, we can avoid that situation.

