### PR TITLE
Too many guesses and reminder broken in login pop-up.

### DIFF
--- a/Themes/default/Login.template.php
+++ b/Themes/default/Login.template.php
@@ -76,14 +76,23 @@ function template_login()
 								method: "POST",
 								data: form.serialize(),
 								success: function(data) {
-									if (data.indexOf("<bo" + "dy") > -1)
-										document.location = ', JavaScriptEscape(!empty($_SESSION['login_url']) ? $_SESSION['login_url'] : $scripturl), ';
-									else {
-										form.parent().html($(data).find(".roundframe").html());
+									if (data.indexOf("<bo" + "dy") > -1) {
+										document.open();
+										document.write(data);
+										document.close();
 									}
+									else
+										form.parent().html($(data).find(".roundframe").html());
 								},
-								error: function() {
-									document.location = ', JavaScriptEscape(!empty($_SESSION['login_url']) ? $_SESSION['login_url'] : $scripturl), ';
+								error: function(xhr) {
+									var data = xhr.responseText;
+									if (data.indexOf("<bo" + "dy") > -1) {
+										document.open();
+										document.write(data);
+										document.close();
+									}
+									else
+										form.parent().html($(data).filter("#fatal_error").html());
 								}
 							});
 

--- a/Themes/default/Login.template.php
+++ b/Themes/default/Login.template.php
@@ -78,14 +78,23 @@ function template_login()
 								method: "POST",
 								data: form.serialize(),
 								success: function(data) {
-									if (data.indexOf("<bo" + "dy") > -1)
-										document.location = ', JavaScriptEscape(!empty($_SESSION['login_url']) ? $_SESSION['login_url'] : $scripturl), ';
-									else {
-										form.parent().html($(data).find(".roundframe").html());
+									if (data.indexOf("<bo" + "dy") > -1) {
+										document.open();
+										document.write(data);
+										document.close();
 									}
+									else
+										form.parent().html($(data).find(".roundframe").html());
 								},
-								error: function() {
-									document.location = ', JavaScriptEscape(!empty($_SESSION['login_url']) ? $_SESSION['login_url'] : $scripturl), ';
+								error: function(xhr) {
+									var data = xhr.responseText;
+									if (data.indexOf("<bo" + "dy") > -1) {
+										document.open();
+										document.write(data);
+										document.close();
+									}
+									else
+										form.parent().html($(data).filter("#fatal_error").html());
 								}
 							});
 


### PR DESCRIPTION
Two types of errors during login were not handled properly:
1. fatal_lang_error messages such as 'failed_login_threshold' (too many password guesses).
2. The reminder page if you guessed the wrong password too many times.
In both cases it was just jumping back to the home page, leading the user to think they had successfully logged in - but they have no privileges.
We fix this by making it handle these cases better in handling the response to the ajax request.
