### PR TITLE
Fixes long delay in news slider

### DIFF
--- a/Themes/default/css/slider.min.css
+++ b/Themes/default/css/slider.min.css
@@ -62,7 +62,7 @@
 .sy-slide > a{margin:0;padding:0;display:block;width:100%}
 .sy-slide > a > img{margin:0;padding:0;display:block;max-width:100%;border:0}
 .sy-pager{overflow:hidden;*zoom:1;display:block;width:100%;margin:1em 0 0;padding:0;list-style:none;text-align:center}
-.sy-pager li{display:inline-block;width:1.2em;height:1.2em;margin:0 1em 0 0;-moz-border-radius:50%;-webkit-border-radius:50%;border-radius:50%}
+.sy-pager li{display:inline-block;width:1.2em;height:1.2em;margin:0 0.5em;-moz-border-radius:50%;-webkit-border-radius:50%;border-radius:50%}
 .sy-pager li.sy-active a{background-color:#557EA0}
 .sy-pager li a{width:100%;height:100%;display:block;background-color:#ccc;text-indent:-9999px;-moz-background-size:2em;-o-background-size:2em;-webkit-background-size:2em;background-size:2em;-moz-border-radius:50%;-webkit-border-radius:50%;border-radius:50%}
 .sy-pager li a:link,.sy-pager li a:visited{opacity:1}

--- a/Themes/default/css/slider.min.css
+++ b/Themes/default/css/slider.min.css
@@ -49,15 +49,15 @@
 .sy-slides-wrap{width:100%}
 .sy-slides-wrap:hover .sy-controls{display:block}
 .sy-slides-crop{width:100%;overflow:hidden}
-.sy-list{width:100%;list-style:none;margin:0;}
+.sy-list{width:100%;list-style:none;margin:0;padding:0;position:relative}
 .sy-list.horizontal{-moz-transition:left ease;-o-transition:left ease;-webkit-transition:left ease;transition:left ease}
 .sy-list.vertical{-moz-transition:top ease;-o-transition:top ease;-webkit-transition:top ease;transition:top ease}
-.sy-slide{width:100%;display: none;}
+.sy-slide{width:100%;padding:12px 16px;position: absolute;top: 0}
 .sy-slide.kenburns{width:140%;left:-20%}
 .sy-slide.kenburns.useCSS{-moz-transition-property:opacity;-o-transition-property:opacity;-webkit-transition-property:opacity;transition-property:opacity}
 .sy-slide.kenburns.useCSS.sy-ken:nth-child(1n){-webkit-animation-name:left-right;-webkit-animation-fill-mode:forwards;-moz-animation-name:left-right;-moz-animation-fill-mode:forwards;-o-animation-name:left-right;-o-animation-fill-mode:forwards;animation-name:left-right;animation-fill-mode:forwards}
 .sy-slide.kenburns.useCSS.sy-ken:nth-child(2n){-webkit-animation-name:right-left;-webkit-animation-fill-mode:forwards;-moz-animation-name:right-left;-moz-animation-fill-mode:forwards;-o-animation-name:right-left;-o-animation-fill-mode:forwards;animation-name:right-left;animation-fill-mode:forwards}
-.sy-slide.sy-active{display: block;z-index:3}
+.sy-slide.sy-active{position: relative;z-index:3}
 .sy-slide > img{margin:0;padding:0;display:block;max-width:100%;border:0}
 .sy-slide > a{margin:0;padding:0;display:block;width:100%}
 .sy-slide > a > img{margin:0;padding:0;display:block;max-width:100%;border:0}


### PR DESCRIPTION
At least on Safari 9.1.1, slippy.js would often have trouble transitioning from one news item to the next if:
1. the CSS for the list elements toggled between "display:none" and "display:block", and
2. there were three or more news items.
These changes maintain the same visual appearance, but avoid the display toggle so that the JS doesn't get stuck.

