### PR TITLE
Optimizing integration for who's online

### DIFF
--- a/Sources/Who.php
+++ b/Sources/Who.php
@@ -439,6 +439,12 @@ function determineActions($urls, $preferred_prefix = false)
 				if (!empty($integrate_action))
 				{
 					$data[$k] = $integrate_action;
+					if (isset($actions['topic']) && isset($topic_ids[(int) $actions['topic']][$k]))
+						$topic_ids[(int) $actions['topic']][$k] = $integrate_action;
+					if (isset($actions['board']) && isset($board_ids[(int) $actions['board']][$k]))
+						$board_ids[(int) $actions['board']][$k] = $integrate_action;
+					if (isset($actions['u']) && isset($profile_ids[(int) $actions['u']][$k]))
+						$profile_ids[(int) $actions['u']][$k] = $integrate_action;
 					break;
 				}
 			}


### PR DESCRIPTION
Who.php line 435:
If an integration hook for "integrate_whos_online" modifies a profile, board or topic, it will be completely ignored since SMF will overwrite it later with $topic_ids, $board_ids and $profile_ids.

I wanted to show which area of the profile the user is visiting and faced this limitation.

This fixes the problem without touching current SMF who's online logic.

Signed-off-by: Alex Smith asmith_20002@yahoo.com
