### PR TITLE
Stuff

### DIFF
--- a/Sources/DbExtra-postgresql.php
+++ b/Sources/DbExtra-postgresql.php
@@ -91,9 +91,9 @@ function smf_db_optimize_table($table)
 	global $smcFunc, $db_prefix;
 
 	$table = str_replace('{db_prefix}', $db_prefix, $table);
-	
+
 	$pg_tables = array('pg_catalog','information_schema');
-	
+
 	$request = $smcFunc['db_query']('', '
 		SELECT pg_relation_size(C.oid) AS "size"
 		FROM pg_class C
@@ -105,10 +105,10 @@ function smf_db_optimize_table($table)
 			'pg_tables' => $pg_tables,
 		)
 	);
-	
+
 	$row = $smcFunc['db_fetch_assoc']($request);
 	$smcFunc['db_free_result']($request);
-	
+
 	$old_size = $row['size'];
 
 	//pg below 9.0.0 is very slow on full vacuum
@@ -132,7 +132,7 @@ function smf_db_optimize_table($table)
 				'table' => $table,
 			)
 		);
-	} 
+	}
 	else
 		$request = $smcFunc['db_query']('', '
 				VACUUM FULL ANALYZE {raw:table}',
@@ -140,10 +140,10 @@ function smf_db_optimize_table($table)
 					'table' => $table,
 				)
 			);
-			
+
 	if (!$request)
 		return -1;
-	
+
 	$request = $smcFunc['db_query']('', '
 		SELECT pg_relation_size(C.oid) AS "size"
 		FROM pg_class C
@@ -155,7 +155,7 @@ function smf_db_optimize_table($table)
 			'pg_tables' => $pg_tables,
 		)
 	);
-	
+
 
 	$row = $smcFunc['db_fetch_assoc']($request);
 	$smcFunc['db_free_result']($request);

--- a/Sources/DbSearch-postgresql.php
+++ b/Sources/DbSearch-postgresql.php
@@ -30,9 +30,9 @@ function db_search_init()
 			'db_create_word_search' => 'smf_db_create_word_search',
 			'db_support_ignore' => false,
 		);
-	
+
 	db_extend();
-	
+
 	//pg 9.5 got ignore support
 	$version = $smcFunc['db_get_version']();
 	// if we got a Beta Version
@@ -41,7 +41,7 @@ function db_search_init()
 	// or RC
 	if (stripos($version, 'rc') !== false)
 		$version = substr($version, 0, stripos($version, 'rc')).'.0';
-	
+
 	if (version_compare($version,'9.5.0','>='))
 		$smcFunc['db_support_ignore'] = true;
 }

--- a/Sources/Load.php
+++ b/Sources/Load.php
@@ -58,6 +58,9 @@ function reloadSettings()
 		if (empty($modSettings['defaultMaxListItems']) || $modSettings['defaultMaxListItems'] <= 0 || $modSettings['defaultMaxListItems'] > 999)
 			$modSettings['defaultMaxListItems'] = 15;
 
+		if (!is_array($modSettings['attachmentUploadDir']))
+			$modSettings['attachmentUploadDir'] = smf_json_decode($modSettings['attachmentUploadDir'], true);
+
 		if (!empty($cache_enable))
 			cache_put_data('modSettings', $modSettings, 90);
 	}

--- a/Sources/Load.php
+++ b/Sources/Load.php
@@ -1969,6 +1969,7 @@ function loadTheme($id_theme = 0, $initialize = true)
 		'xmlhttp',
 		'post2',
 		'suggest',
+		'stats',
 	);
 
 	call_integration_hook('integrate_simple_actions', array(&$simpleActions, &$simpleAreas, &$simpleSubActions, &$xmlActions));

--- a/Sources/ManageAttachments.php
+++ b/Sources/ManageAttachments.php
@@ -197,6 +197,9 @@ function ManageAttachmentSettings($return_config = false)
 	{
 		checkSession();
 
+		if (isset($_POST['attachmentUploadDir']))
+			unset($_POST['attachmentUploadDir']);
+
 		if (!empty($_POST['use_subdirectories_for_attachments']))
 		{
 			if (isset($_POST['use_subdirectories_for_attachments']) && empty($_POST['basedirectory_for_attachments']))

--- a/Sources/ManageAttachments.php
+++ b/Sources/ManageAttachments.php
@@ -53,6 +53,13 @@ function ManageAttachments()
 		'transfer' => 'TransferAttachments',
 	);
 
+	// This uses admin tabs - as it should!
+	$context[$context['admin_menu_name']]['tab_data'] = array(
+		'title' => $txt['attachments_avatars'],
+		'help' => 'manage_files',
+		'description' => $txt['attachments_desc'],
+	);
+
 	call_integration_hook('integrate_manage_attachments', array(&$subActions));
 
 	// Pick the correct sub-action.
@@ -63,13 +70,6 @@ function ManageAttachments()
 
 	// Default page title is good.
 	$context['page_title'] = $txt['attachments_avatars'];
-
-	// This uses admin tabs - as it should!
-	$context[$context['admin_menu_name']]['tab_data'] = array(
-		'title' => $txt['attachments_avatars'],
-		'help' => 'manage_files',
-		'description' => $txt['attachments_desc'],
-	);
 
 	// Finally fall through to what we are doing.
 	call_helper($subActions[$context['sub_action']]);
@@ -91,25 +91,21 @@ function ManageAttachmentSettings($return_config = false)
 
 	require_once($sourcedir . '/Subs-Attachments.php');
 
-	// Get the current attachment directory.
-	$modSettings['attachmentUploadDir'] = smf_json_decode($modSettings['attachmentUploadDir'], true);
 	$context['attachmentUploadDir'] = $modSettings['attachmentUploadDir'][$modSettings['currentAttachmentUploadDir']];
-
-	// First time here?
-	if (empty($modSettings['attachment_basedirectories']) && $modSettings['currentAttachmentUploadDir'] == 1 && count($modSettings['attachmentUploadDir']) == 1)
-		$modSettings['attachmentUploadDir'] = $modSettings['attachmentUploadDir'][1];
 
 	// If not set, show a default path for the base directory
 	if (!isset($_GET['save']) && empty($modSettings['basedirectory_for_attachments']))
 		if (is_dir($modSettings['attachmentUploadDir'][1]))
 			$modSettings['basedirectory_for_attachments'] = $modSettings['attachmentUploadDir'][1];
-		else
-			$modSettings['basedirectory_for_attachments'] = $context['attachmentUploadDir'];
+
+	else
+		$modSettings['basedirectory_for_attachments'] = $context['attachmentUploadDir'];
 
 	$context['valid_upload_dir'] = is_dir($context['attachmentUploadDir']) && is_writable($context['attachmentUploadDir']);
 
 	if (!empty($modSettings['automanage_attachments']))
 		$context['valid_basedirectory'] =  !empty($modSettings['basedirectory_for_attachments']) && is_writable($modSettings['basedirectory_for_attachments']);
+
 	else
 		$context['valid_basedirectory'] = true;
 
@@ -140,7 +136,7 @@ function ManageAttachmentSettings($return_config = false)
 			array('select', 'automanage_attachments', array(0 => $txt['attachments_normal'], 1 => $txt['attachments_auto_space'], 2 => $txt['attachments_auto_years'], 3 => $txt['attachments_auto_months'], 4 => $txt['attachments_auto_16'])),
 			array('check', 'use_subdirectories_for_attachments', 'subtext' => $txt['use_subdirectories_for_attachments_note']),
 			(empty($modSettings['attachment_basedirectories']) ? array('text', 'basedirectory_for_attachments', 40,) : array('var_message', 'basedirectory_for_attachments', 'message' => 'basedirectory_for_attachments_path', 'invalid' => empty($context['valid_basedirectory']), 'text_label' => (!empty($context['valid_basedirectory']) ? $txt['basedirectory_for_attachments_current'] : $txt['basedirectory_for_attachments_warning']))),
-			empty($modSettings['attachment_basedirectories']) && $modSettings['currentAttachmentUploadDir'] == 1 && count($modSettings['attachmentUploadDir']) == 1	? array('text', 'attachmentUploadDir', 'subtext' => $txt['attachmentUploadDir_multiple_configure'], 40, 'invalid' => !$context['valid_upload_dir']) : array('var_message', 'attach_current_directory', 'subtext' => $txt['attachmentUploadDir_multiple_configure'], 'message' => 'attachment_path', 'invalid' => empty($context['valid_upload_dir']), 'text_label' => (!empty($context['valid_upload_dir']) ? $txt['attach_current_dir'] : $txt['attach_current_dir_warning'])),
+			empty($modSettings['attachment_basedirectories']) && $modSettings['currentAttachmentUploadDir'] == 1 && count($modSettings['attachmentUploadDir']) == 1	? array('json', 'attachmentUploadDir', 'subtext' => $txt['attachmentUploadDir_multiple_configure'], 40, 'invalid' => !$context['valid_upload_dir'], 'disabled' => true) : array('var_message', 'attach_current_directory', 'subtext' => $txt['attachmentUploadDir_multiple_configure'], 'message' => 'attachment_path', 'invalid' => empty($context['valid_upload_dir']), 'text_label' => (!empty($context['valid_upload_dir']) ? $txt['attach_current_dir'] : $txt['attach_current_dir_warning'])),
 			array('int', 'attachmentDirFileLimit', 'subtext' => $txt['zero_for_no_limit'], 6),
 			array('int', 'attachmentDirSizeLimit', 'subtext' => $txt['zero_for_no_limit'], 6, 'postinput' => $txt['kilobyte']),
 			array('check', 'dont_show_attach_under_post', 'subtext' => $txt['dont_show_attach_under_post_sub']),
@@ -200,15 +196,6 @@ function ManageAttachmentSettings($return_config = false)
 	if (isset($_GET['save']))
 	{
 		checkSession();
-
-		if (isset($_POST['attachmentUploadDir']))
-		{
-			if (!empty($_POST['attachmentUploadDir']) && $modSettings['attachmentUploadDir'] != $_POST['attachmentUploadDir'])
-				rename($modSettings['attachmentUploadDir'], $_POST['attachmentUploadDir']);
-
-			$modSettings['attachmentUploadDir'] = array(1 => $_POST['attachmentUploadDir']);
-			$_POST['attachmentUploadDir'] = json_encode($modSettings['attachmentUploadDir']);
-		}
 
 		if (!empty($_POST['use_subdirectories_for_attachments']))
 		{
@@ -1348,9 +1335,6 @@ function RepairAttachments()
 						// Get the attachment name with out the folder.
 						$attachment_name = $row['id_attach'] . '_' . $row['file_hash'] .'.dat';
 
-						if (!is_array($modSettings['attachmentUploadDir']))
-							$modSettings['attachmentUploadDir'] = smf_json_decode($modSettings['attachmentUploadDir'], true);
-
 						// Loop through the other folders.
 						foreach ($modSettings['attachmentUploadDir'] as $id => $dir)
 							if (file_exists($dir . '/' . $attachment_name))
@@ -1596,9 +1580,6 @@ function RepairAttachments()
 	// What about files who are not recorded in the database?
 	if ($_GET['step'] <= 5)
 	{
-		// Just use the current path for temp files.
-		if (!is_array($modSettings['attachmentUploadDir']))
-			$modSettings['attachmentUploadDir'] = smf_json_decode($modSettings['attachmentUploadDir'], true);
 		$attach_dirs = $modSettings['attachmentUploadDir'];
 
 		$current_check = 0;
@@ -1917,10 +1898,9 @@ function ManageAttachmentPaths()
 	global $modSettings, $scripturl, $context, $txt, $sourcedir, $boarddir, $smcFunc, $settings;
 
 	// Since this needs to be done eventually.
-	if (!is_array($modSettings['attachmentUploadDir']))
-		$modSettings['attachmentUploadDir'] = smf_json_decode($modSettings['attachmentUploadDir'], true);
 	if (!isset($modSettings['attachment_basedirectories']))
 		$modSettings['attachment_basedirectories'] = array();
+
 	elseif (!is_array($modSettings['attachment_basedirectories']))
 		$modSettings['attachment_basedirectories'] = smf_json_decode($modSettings['attachment_basedirectories'], true);
 

--- a/Sources/ManageServer.php
+++ b/Sources/ManageServer.php
@@ -799,6 +799,9 @@ function prepareDBSettingContext(&$config_vars)
 					case 'select':
 						$value = $modSettings[$config_var[1]];
 						break;
+					case 'json':
+						$value = $smcFunc['htmlspecialchars'](json_encode($modSettings[$config_var[1]]));
+						break;
 					case 'boards':
 						$value = explode(',', $modSettings[$config_var[1]]);
 						break;

--- a/Sources/PersonalMessage.php
+++ b/Sources/PersonalMessage.php
@@ -698,7 +698,7 @@ function MessageFolder()
 					'pmsg' => isset($pmsg) ? (int) $pmsg : 0,
 				)
 		);
-		
+
 	}
 	// This is kinda simple!
 	else
@@ -1105,7 +1105,7 @@ function prepareMessageContext($type = 'subject', $reset = false)
 				default:
 					$output['custom_fields']['standard'][] = $custom;
 			}
-	
+
 	call_integration_hook('integrate_prepare_pm_context', array(&$output, &$message, $counter));
 
 	return $output;
@@ -1701,7 +1701,7 @@ function MessageSearch2()
 		}
 		$smcFunc['db_free_result']($request);
 	}
-	
+
 	call_integration_hook('integrate_search_pm_context');
 
 	// Finish off the context.
@@ -1998,7 +1998,7 @@ function MessagePost()
 		$context['require_verification'] = create_control_verification($verificationOptions);
 		$context['visual_verification_id'] = $verificationOptions['id'];
 	}
-	
+
 	call_integration_hook('integrate_pm_post');
 
 	// Register this form and get a sequence number in $context.
@@ -2196,7 +2196,7 @@ function messagePostError($error_types, $named_recipients, $recipient_ids = arra
 
 	$context['to_value'] = empty($named_recipients['to']) ? '' : '&quot;' . implode('&quot;, &quot;', $named_recipients['to']) . '&quot;';
 	$context['bcc_value'] = empty($named_recipients['bcc']) ? '' : '&quot;' . implode('&quot;, &quot;', $named_recipients['bcc']) . '&quot;';
-	
+
 	call_integration_hook('integrate_pm_error');
 
 	// No check for the previous submission is needed.

--- a/Sources/Post.php
+++ b/Sources/Post.php
@@ -1407,6 +1407,7 @@ function Post2()
 		{
 			if ($modSettings['postmod_active'] && allowedTo('post_unapproved_replies_any') && !allowedTo('post_reply_any'))
 				$becomesApproved = false;
+
 			else
 				isAllowedTo('post_reply_any');
 		}
@@ -1414,6 +1415,7 @@ function Post2()
 		{
 			if ($modSettings['postmod_active'] && allowedTo('post_unapproved_replies_own') && !allowedTo('post_reply_own'))
 				$becomesApproved = false;
+
 			else
 				isAllowedTo('post_reply_own');
 		}
@@ -1423,15 +1425,18 @@ function Post2()
 			// Nothing is changed to the lock.
 			if ((empty($topic_info['locked']) && empty($_POST['lock'])) || (!empty($_POST['lock']) && !empty($topic_info['locked'])))
 				unset($_POST['lock']);
+
 			// You're have no permission to lock this topic.
 			elseif (!allowedTo(array('lock_any', 'lock_own')) || (!allowedTo('lock_any') && $user_info['id'] != $topic_info['id_member_started']))
 				unset($_POST['lock']);
+
 			// You are allowed to (un)lock your own topic only.
 			elseif (!allowedTo('lock_any'))
 			{
 				// You cannot override a moderator lock.
 				if ($topic_info['locked'] == 1)
 					unset($_POST['lock']);
+
 				else
 					$_POST['lock'] = empty($_POST['lock']) ? 0 : 2;
 			}

--- a/Sources/QueryString.php
+++ b/Sources/QueryString.php
@@ -328,7 +328,7 @@ function isValidIPv6($ip)
 	//looking for :
 	if (strpos($ip , ':') === false )
 		return false;
-	
+
 	//check valid address
 	return inet_pton($ip);
 }

--- a/Sources/Security.php
+++ b/Sources/Security.php
@@ -745,7 +745,7 @@ function createToken($action, $type = 'post')
 	global $modSettings, $context;
 
 	$token = md5(mt_rand() . session_id() . (string) microtime() . $modSettings['rand_seed'] . $type);
-	$token_var = substr(preg_replace('~^\d+~', '', md5(mt_rand() . (string) microtime() . mt_rand())), 0, rand(7, 12));
+	$token_var = substr(preg_replace('~^\d+~', '', md5(mt_rand() . (string) microtime() . mt_rand())), 0, mt_rand(7, 12));
 
 	$_SESSION['token'][$type . '-' . $action] = array($token_var, md5($token . $_SERVER['HTTP_USER_AGENT']), time(), $token);
 

--- a/Sources/Session.php
+++ b/Sources/Session.php
@@ -84,7 +84,7 @@ function loadSession()
 	if (!isset($_SESSION['session_var']))
 	{
 		$_SESSION['session_value'] = md5(session_id() . mt_rand());
-		$_SESSION['session_var'] = substr(preg_replace('~^\d+~', '', sha1(mt_rand() . session_id() . mt_rand())), 0, rand(7, 12));
+		$_SESSION['session_var'] = substr(preg_replace('~^\d+~', '', sha1(mt_rand() . session_id() . mt_rand())), 0, mt_rand(7, 12));
 	}
 	$sc = $_SESSION['session_value'];
 }

--- a/Sources/Subs-Db-mysql.php
+++ b/Sources/Subs-Db-mysql.php
@@ -237,7 +237,7 @@ function smf_db_replacement__callback($matches)
 			//we don't use the native support of mysql > 5.6.2
 			return sprintf('unhex(\'%1$s\')', bin2hex(inet_pton($replacement)));
 		break;
-		
+
 		case 'array_inet':
 			if (is_array($replacement))
 			{

--- a/Sources/Subs-Db-mysqli.php
+++ b/Sources/Subs-Db-mysqli.php
@@ -261,7 +261,7 @@ function smf_db_replacement__callback($matches)
 			//we don't use the native support of mysql > 5.6.2
 			return sprintf('unhex(\'%1$s\')', bin2hex(inet_pton($replacement)));
 		break;
-		
+
 		case 'array_inet':
 			if (is_array($replacement))
 			{

--- a/Sources/Subs-Db-postgresql.php
+++ b/Sources/Subs-Db-postgresql.php
@@ -215,7 +215,7 @@ function smf_db_replacement__callback($matches)
 		case 'raw':
 			return $replacement;
 		break;
-		
+
 		case 'inet':
 			if ($replacement == 'null')
 				return 'null';
@@ -223,7 +223,7 @@ function smf_db_replacement__callback($matches)
 				smf_db_error_backtrace('Wrong value type sent to the database. IPv4 or IPv6 expected.(' . $matches[2] . ')', '', E_USER_ERROR, __FILE__, __LINE__);
 			return sprintf('\'%1$s\'::inet', pg_escape_string($replacement));
 		break;
-		
+
 		case 'array_inet':
 			if (is_array($replacement))
 			{
@@ -661,7 +661,7 @@ function smf_db_insert($method = 'replace', $table, $columns, $data, $keys, $dis
 	global $db_in_transact, $smcFunc, $db_connection, $db_prefix;
 
 	$connection = $connection === null ? $db_connection : $connection;
-	
+
 	$replace = '';
 
 	if (empty($data))
@@ -687,7 +687,7 @@ function smf_db_insert($method = 'replace', $table, $columns, $data, $keys, $dis
 		$col_str = '';
 		static $pg_version;
 		static $replace_support;
-		
+
 		if(empty($pg_version))
 		{
 			db_extend();
@@ -702,11 +702,11 @@ function smf_db_insert($method = 'replace', $table, $columns, $data, $keys, $dis
 
 			$replace_support = (version_compare($pg_version,'9.5.0','>=') ? true : false);
 		}
-		
+
 		$count = 0;
 		$where = '';
 		$count_pk = 0;
-		
+
 		If($replace_support)
 		{
 			foreach ($columns as $columnName => $type)
@@ -719,14 +719,14 @@ function smf_db_insert($method = 'replace', $table, $columns, $data, $keys, $dis
 					$count_pk++;
 				}
 				else //normal field
-				{					
+				{
 					$col_str .= ($count > 0 ? ',' : '');
 					$col_str .= $columnName.' = EXCLUDED.'.$columnName;
 					$count++;
 				}
 			}
 			$replace = ' ON CONFLICT ('.$key_str.') DO UPDATE SET '.$col_str;
-		} 
+		}
 		else
 		{
 			foreach ($columns as $columnName => $type)

--- a/Sources/Subs-Graphics.php
+++ b/Sources/Subs-Graphics.php
@@ -937,11 +937,11 @@ function showCodeImage($code)
 	// Some squares/rectanges for new extreme level
 	if ($noiseType == 'extreme')
 	{
-		for ($i = 0; $i < rand(1, 5); $i++)
+		for ($i = 0; $i < mt_rand(1, 5); $i++)
 		{
-			$x1 = rand(0, $total_width / 4);
+			$x1 = mt_rand(0, $total_width / 4);
 			$x2 = $x1 + round(rand($total_width / 4, $total_width));
-			$y1 = rand(0, $max_height);
+			$y1 = mt_rand(0, $max_height);
 			$y2 = $y1 + round(rand(0, $max_height / 3));
 			imagefilledrectangle($code_image, $x1, $y1, $x2, $y2, mt_rand(0, 1) ? $fg_color : $randomness_color);
 		}

--- a/Sources/Subs-Members.php
+++ b/Sources/Subs-Members.php
@@ -897,7 +897,7 @@ function isReservedName($name, $current_ID_MEMBER = 0, $is_name = true, $fatal =
 
 	// Get rid of any SQL parts of the reserved name...
 	$checkName = strtr($name, array('_' => '\\_', '%' => '\\%'));
-	
+
 	//when we got no wildcard we can use equal -> fast
 	$operator = (strpos($checkName, '%') || strpos($checkName, '_') ? 'LIKE' : '=' );
 
@@ -1455,7 +1455,7 @@ function populateDuplicateMembers(&$members)
 	while ($row = $smcFunc['db_fetch_assoc']($request))
 	{
 		$row['poster_ip'] = inet_dtop($row['poster_ip']);
-		
+
 		// Don't collect lots of the same.
 		if (isset($had_ips[$row['poster_ip']]) && in_array($row['id_member'], $had_ips[$row['poster_ip']]))
 			continue;

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -3108,11 +3108,8 @@ function template_header()
 
 			// We are already checking so many files...just few more doesn't make any difference! :P
 			if (!empty($modSettings['currentAttachmentUploadDir']))
-			{
-				if (!is_array($modSettings['attachmentUploadDir']))
-					$modSettings['attachmentUploadDir'] = smf_json_decode($modSettings['attachmentUploadDir'], true);
 				$path = $modSettings['attachmentUploadDir'][$modSettings['currentAttachmentUploadDir']];
-			}
+
 			else
 			{
 				$path = $modSettings['attachmentUploadDir'];
@@ -3542,11 +3539,8 @@ function getAttachmentFilename($filename, $attachment_id, $dir = null, $new = fa
 
 	// Are we using multiple directories?
 	if (!empty($modSettings['currentAttachmentUploadDir']))
-	{
-		if (!is_array($modSettings['attachmentUploadDir']))
-			$modSettings['attachmentUploadDir'] = smf_json_decode($modSettings['attachmentUploadDir'], true);
 		$path = $modSettings['attachmentUploadDir'][$dir];
-	}
+
 	else
 		$path = $modSettings['attachmentUploadDir'];
 
@@ -5248,11 +5242,11 @@ function smf_chmod($file, $value = 0)
 }
 
 /**
- * Wrapper function for smf_json_decode() with error handling.
+ * Wrapper function for json_decode() with error handling.
 
  * @param string $json The string to decode.
  * @param bool $returnAsArray To return the decoded string as an array or an object, SMF only uses Arrays but to keep on compatibility with json_decode its set to false as default.
- * @param bool $logIt To specify if the error will be logged if h}theres an error.
+ * @param bool $logIt To specify if the error will be logged if theres any.
  * @return array Either an empty array or the decoded data as an array.
  */
 function smf_json_decode($json, $returnAsArray = false, $logIt = true)

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -4969,13 +4969,6 @@ function inet_dtop($bin)
  * @author anthon (dot) pang (at) gmail (dot) com
  */
 
-/*
- * Arbitrary limits for safe_unserialize()
- */
-define('MAX_SERIALIZED_INPUT_LENGTH', 4096);
-define('MAX_SERIALIZED_ARRAY_LENGTH', 256);
-define('MAX_SERIALIZED_ARRAY_DEPTH', 3);
-
 /**
  * Safe serialize() replacement. Recursive
  * - output a strict subset of PHP's native serialized representation
@@ -5048,10 +5041,6 @@ function safe_serialize($value)
  */
 function _safe_unserialize($str)
 {
-	// Input exceeds MAX_SERIALIZED_INPUT_LENGTH.
-	if(strlen($str) > MAX_SERIALIZED_INPUT_LENGTH)
-		return false;
-
 	// Input  is not a string.
 	if(empty($str) || !is_string($str))
 		return false;
@@ -5098,7 +5087,7 @@ function _safe_unserialize($str)
 			$value = substr($matches[2], 0, (int)$matches[1]);
 			$str = substr($matches[2], (int)$matches[1] + 2);
 		}
-		else if($type == 'a' && preg_match('/^a:([0-9]+):{(.*)/s', $str, $matches) && $matches[1] < MAX_SERIALIZED_ARRAY_LENGTH)
+		else if($type == 'a' && preg_match('/^a:([0-9]+):{(.*)/s', $str, $matches))
 		{
 			$expectedLength = (int)$matches[1];
 			$str = $matches[2];
@@ -5113,10 +5102,6 @@ function _safe_unserialize($str)
 			case 3: // In array, expecting value or another array.
 				if($type == 'a')
 				{
-					// Array nesting exceeds MAX_SERIALIZED_ARRAY_DEPTH.
-					if(count($stack) >= MAX_SERIALIZED_ARRAY_DEPTH)
-						return false;
-
 					$stack[] = &$list;
 					$list[$key] = array();
 					$list = &$list[$key];
@@ -5156,10 +5141,6 @@ function _safe_unserialize($str)
 
 				if($type == 'i' || $type == 's')
 				{
-					// Array size exceeds MAX_SERIALIZED_ARRAY_LENGTH.
-					if(count($list) >= MAX_SERIALIZED_ARRAY_LENGTH)
-						return false;
-
 					// Array size exceeds expected length.
 					if(count($list) >= end($expected))
 						return false;
@@ -5176,10 +5157,6 @@ function _safe_unserialize($str)
 			case 0:
 				if($type == 'a')
 				{
-					// Array nesting exceeds MAX_SERIALIZED_ARRAY_DEPTH.
-					if(count($stack) >= MAX_SERIALIZED_ARRAY_DEPTH)
-						return false;
-
 					$data = array();
 					$list = &$data;
 					$expected[] = $expectedLength;

--- a/other/install.php
+++ b/other/install.php
@@ -1087,8 +1087,8 @@ function DatabasePopulation()
 			$replaces['START TRANSACTION;'] = '';
 			$replaces['COMMIT;'] = '';
 		}
-	} 
-	else 
+	}
+	else
 	{
 		$has_innodb = false;
 	}
@@ -1105,7 +1105,7 @@ function DatabasePopulation()
 				$pg_version = $row['server_version_num'];
 			$smcFunc['db_free_result']($result);
 		}
-		
+
 		if(isset($pg_version) && $pg_version >= 90100)
 			$replaces['{$unlogged}'] = 'UNLOGGED';
 		else
@@ -1288,11 +1288,11 @@ function DatabasePopulation()
 			}
 		}
 	}
-	
-	// MySQL specific stuff 
+
+	// MySQL specific stuff
 	if (substr($db_type, 0, 5) != 'mysql')
 		return false;
-	
+
 	// Find database user privileges.
 	$privs = array();
 	$get_privs = $smcFunc['db_query']('', 'SHOW PRIVILEGES', array());
@@ -1337,7 +1337,7 @@ function AdminAccount()
 	load_database();
 
 	require_once($sourcedir . '/Subs-Auth.php');
-	
+
 	require_once($sourcedir . '/Subs.php');
 
 	// We need this to properly hash the password for Admin

--- a/other/install.php
+++ b/other/install.php
@@ -36,10 +36,10 @@ $databases = array(
 		'utf8_default' => true,
 		'utf8_required' => true,
 		'alter_support' => true,
-		'validate_prefix' => create_function('&$value', '
-			$value = preg_replace(\'~[^A-Za-z0-9_\$]~\', \'\', $value);
+		'validate_prefix' => function(&$value) {
+			$value = preg_replace('~[^A-Za-z0-9_\$]~', '', $value);
 			return true;
-		'),
+		},
 	),
 	'mysql' => array(
 		'name' => 'MySQL',
@@ -56,10 +56,10 @@ $databases = array(
 		'utf8_default' => true,
 		'utf8_required' => true,
 		'alter_support' => true,
-		'validate_prefix' => create_function('&$value', '
-			$value = preg_replace(\'~[^A-Za-z0-9_\$]~\', \'\', $value);
+		'validate_prefix' => function(&$value){
+			$value = preg_replace('~[^A-Za-z0-9_\$]~', '', $value);
 			return true;
-		'),
+		},
 	),
 	'postgresql' => array(
 		'name' => 'PostgreSQL',
@@ -73,19 +73,19 @@ $databases = array(
 		'utf8_support' => true,
 		'utf8_version' => '8.0',
 		'utf8_version_check' => '$request = pg_query(\'SELECT version()\'); list ($version) = pg_fetch_row($request); list($pgl, $version) = explode(" ", $version); return $version;',
-		'validate_prefix' => create_function('&$value', '
-			$value = preg_replace(\'~[^A-Za-z0-9_\$]~\', \'\', $value);
+		'validate_prefix' => function(&$value){
+			$value = preg_replace('~[^A-Za-z0-9_\$]~', '', $value);
 
 			// Is it reserved?
-			if ($value == \'pg_\')
-				return $txt[\'error_db_prefix_reserved\'];
+			if ($value == 'pg_')
+				return $txt['error_db_prefix_reserved'];
 
 			// Is the prefix numeric?
-			if (preg_match(\'~^\d~\', $value))
-				return $txt[\'error_db_prefix_numeric\'];
+			if (preg_match('~^\d~', $value))
+				return $txt['error_db_prefix_numeric'];
 
 			return true;
-		'),
+		},
 	),
 );
 
@@ -1342,13 +1342,13 @@ function AdminAccount()
 
 	// We need this to properly hash the password for Admin
 	$smcFunc['strtolower'] = $db_character_set != 'utf8' && $txt['lang_character_set'] != 'UTF-8' ? 'strtolower' :
-		create_function('$string', '
+		function($string){
 			global $sourcedir;
-			if (function_exists(\'mb_strtolower\'))
-				return mb_strtolower($string, \'UTF-8\');
-			require_once($sourcedir . \'/Subs-Charset.php\');
+			if (function_exists('mb_strtolower'))
+				return mb_strtolower($string, 'UTF-8');
+			require_once($sourcedir . '/Subs-Charset.php');
 			return utf8_strtolower($string);
-		');
+		};
 
 	if (!isset($_POST['username']))
 		$_POST['username'] = '';
@@ -1607,13 +1607,13 @@ function DeleteInstall()
 
 	// This function is needed to do the updateStats('subject') call.
 	$smcFunc['strtolower'] = $db_character_set != 'utf8' && $txt['lang_character_set'] != 'UTF-8' ? 'strtolower' :
-		create_function('$string', '
+		function($string){
 			global $sourcedir;
-			if (function_exists(\'mb_strtolower\'))
-				return mb_strtolower($string, \'UTF-8\');
-			require_once($sourcedir . \'/Subs-Charset.php\');
+			if (function_exists('mb_strtolower'))
+				return mb_strtolower($string, 'UTF-8');
+			require_once($sourcedir . '/Subs-Charset.php');
 			return utf8_strtolower($string);
-		');
+		};
 
 	$request = $smcFunc['db_query']('', '
 		SELECT id_msg

--- a/other/upgrade_2-0_mysql.sql
+++ b/other/upgrade_2-0_mysql.sql
@@ -1515,7 +1515,7 @@ VALUES
 ---# Adding the simple machines scheduled task.
 ---{
 // Randomise the time.
-$randomTime = 82800 + rand(0, 86399);
+$randomTime = 82800 + mt_rand(0, 86399);
 upgrade_query("
 	INSERT IGNORE INTO {$db_prefix}scheduled_tasks
 		(next_time, time_offset, time_regularity, time_unit, disabled, task)


### PR DESCRIPTION
With this change the attachmentUploadDir text field shows the entire json string, it is disabled, basically its just there for reference as the attachments dirs should be edited on its own page.
- Moved the check on attachmentUploadDir to reloadsettings to avoid having it on multiple places.
- Adds a json type, basically the same as a string, it assumes the modSetting is an array already and encodes it.
- Replaces all calls to create_function and rand() for php 7.1 compatibility.
