### PR TITLE
Proxy servers bug fix, step 1

### DIFF
--- a/Sources/ManageServer.php
+++ b/Sources/ManageServer.php
@@ -406,7 +406,7 @@ function ModifyGeneralSecuritySettings($return_config = false)
 		'',
 			array('select', 'frame_security', array('SAMEORIGIN' => $txt['setting_frame_security_SAMEORIGIN'], 'DENY' => $txt['setting_frame_security_DENY'], 'DISABLE' => $txt['setting_frame_security_DISABLE'])),
 		'',
-			array('select', 'proxy_ip_header', array('disabled' => $txt['setting_proxy_ip_header_disabled'], 'autodetect' => $txt['setting_proxy_ip_header_autodetect'], 'HTTP_X_FORWARDED_FOR', 'HTTP_CLIENT_IP', 'HTTP_X_REAL_IP', 'CF-Connecting-IP')),
+			array('select', 'proxy_ip_header', array('disabled' => $txt['setting_proxy_ip_header_disabled'], 'autodetect' => $txt['setting_proxy_ip_header_autodetect'], 'HTTP_X_FORWARDED_FOR' => 'HTTP_X_FORWARDED_FOR', 'HTTP_CLIENT_IP' => 'HTTP_CLIENT_IP', 'HTTP_X_REAL_IP' => 'HTTP_X_REAL_IP', 'CF-Connecting-IP' => 'CF-Connecting-IP')),
 			array('text', 'proxy_ip_servers'),
 	);
 

--- a/Sources/QueryString.php
+++ b/Sources/QueryString.php
@@ -239,9 +239,9 @@ function cleanRequest()
 		$modSettings['proxy_ip_header'] = 'autodetect';
 
 	// Which headers are we going to check for Reverse Proxy IP headers?
-	if ($modSettings['proxy_ip_header'] = 'disabled')
+	if ($modSettings['proxy_ip_header'] == 'disabled')
 		$reverseIPheaders = array();
-	elseif ($modSettings['proxy_ip_header'] = 'autodetect')
+	elseif ($modSettings['proxy_ip_header'] == 'autodetect')
 		$reverseIPheaders = array('HTTP_X_FORWARDED_FOR', 'HTTP_CLIENT_IP');
 	else
 		$reverseIPheaders = array($modSettings['proxy_ip_header']);
@@ -249,7 +249,11 @@ function cleanRequest()
 	// Find the user's IP address. (but don't let it give you 'unknown'!)
 	foreach ($reverseIPheaders as $proxyIPheader)
 	{
-		if (isset($modSettings['proxy_ip_servers']))
+		// Ignore if this is not set.
+		if (!isset($_SERVER[$proxyIPheader]))
+			continue;
+
+		if (!empty($modSettings['proxy_ip_servers']))
 		{
 			foreach (explode(',', $modSettings['proxy_ip_servers']) as $proxy)
 				if ($proxy == $_SERVER['REMOTE_ADDR'] || matchIPtoCIDR($_SERVER['REMOTE_ADDR'], $proxy))


### PR DESCRIPTION
Fixes #3449

Tested on a live server behind proxy. (by the looks of the bug, it seems it was never tested before)

Now SMF successfully records member's real IP into member_ip2 column in member's table. However the member_ip1 still shows the proxy server IP which should be discussed further. (hence "step 1" in the title)

Signed-off-by: Alex Smith asmith_20002@yahoo.com
