### PR TITLE
Uses json_encode instead of serialize on displayFields during upgrade

### DIFF
--- a/other/upgrade_2-1_mysql.sql
+++ b/other/upgrade_2-1_mysql.sql
@@ -1094,7 +1094,7 @@ ALTER TABLE `{$db_prefix}members`
 		$smcFunc['db_insert']('',
 			'{db_prefix}settings',
 			array('variable' => 'string', 'value' => 'string'),
-			array('displayFields', serialize($fields)),
+			array('displayFields', json_encode($fields)),
 			array('id_theme', 'id_member', 'variable')
 		);
 	}

--- a/other/upgrade_2-1_postgresql.sql
+++ b/other/upgrade_2-1_postgresql.sql
@@ -1070,7 +1070,7 @@ ALTER TABLE {$db_prefix}members
 		$smcFunc['db_insert']('',
 			'{db_prefix}settings',
 			array('variable' => 'string', 'value' => 'string'),
-			array('displayFields', serialize($fields)),
+			array('displayFields', json_encode($fields)),
 			array('id_theme', 'id_member', 'variable')
 		);
 	}


### PR DESCRIPTION
SMF now expects the value of $modSettings['displayFields'] to be JSON encoded, not serialized.
