### PR TITLE
Abstracts adding <meta> tags to the output

### DIFF
--- a/Sources/Load.php
+++ b/Sources/Load.php
@@ -2529,23 +2529,6 @@ function addInlineJavascript($javascript, $defer = false)
 }
 
 /**
- * Add info for an Open Graph <meta> tag to include in the HTML head
- *
- * @param string $property The value for the meta tag's property attribute
- * @param string $content The value for the meta tag's content attribute
- * @return void|bool Adds the passed values to the $context['open_graph'] array or returns if either value is empty
- */
-function addOpenGraph($property, $content)
-{
-	global $context;
-
-	if (empty($property) || empty($content))
-		return false;
-
-	$context['open_graph'][$property] = $content;
-}
-
-/**
  * Load a language file.  Tries the current and default themes as well as the user and global languages.
  *
  * @param string $template_name The name of a template file

--- a/Sources/Load.php
+++ b/Sources/Load.php
@@ -306,6 +306,9 @@ function reloadSettings()
 		'bottom_poster',
 	);
 
+	// Define an array for content-related <meta> elements (e.g. description, keywords, Open Graph) for the HTML head.
+	$context['meta_tags'] = array();
+
 	// Define an array of allowed HTML tags.
 	$context['allowed_html_tags'] = array(
 		'<img>',

--- a/Sources/Load.php
+++ b/Sources/Load.php
@@ -2529,6 +2529,23 @@ function addInlineJavascript($javascript, $defer = false)
 }
 
 /**
+ * Add info for an Open Graph <meta> tag to include in the HTML head
+ *
+ * @param string $property The value for the meta tag's property attribute
+ * @param string $content The value for the meta tag's content attribute
+ * @return void|bool Adds the passed values to the $context['open_graph'] array or returns if either value is empty
+ */
+function addOpenGraph($property, $content)
+{
+	global $context;
+
+	if (empty($property) || empty($content))
+		return false;
+
+	$context['open_graph'][$property] = $content;
+}
+
+/**
  * Load a language file.  Tries the current and default themes as well as the user and global languages.
  *
  * @param string $template_name The name of a template file

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -3009,6 +3009,17 @@ img.avatar { max-width: ' . $modSettings['avatar_max_width_external'] . 'px; max
 	$context['page_title_html_safe'] = $smcFunc['htmlspecialchars'](un_htmlspecialchars($context['page_title'])) . (!empty($context['current_page']) ? ' - ' . $txt['page'] . ' ' . ($context['current_page'] + 1) : '');
 	$context['meta_keywords'] = !empty($modSettings['meta_keywords']) ? $smcFunc['htmlspecialchars']($modSettings['meta_keywords']) : '';
 
+	addOpenGraph('og:site_name', $context['forum_name']);
+	addOpenGraph('og:title', $context['page_title_html_safe']);
+	if (!empty($context['canonical_url']))
+		addOpenGraph('og:url', $context['canonical_url']);
+	if (!empty($settings['og_image']))
+		addOpenGraph('og:image', $settings['og_image']);
+	if (!empty($context['meta_description']))
+		addOpenGraph('og:description', $context['meta_description']);
+	else
+		addOpenGraph('og:description', $context['page_title_html_safe']);
+
 	call_integration_hook('integrate_theme_context');
 }
 

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -3009,16 +3009,29 @@ img.avatar { max-width: ' . $modSettings['avatar_max_width_external'] . 'px; max
 	$context['page_title_html_safe'] = $smcFunc['htmlspecialchars'](un_htmlspecialchars($context['page_title'])) . (!empty($context['current_page']) ? ' - ' . $txt['page'] . ' ' . ($context['current_page'] + 1) : '');
 	$context['meta_keywords'] = !empty($modSettings['meta_keywords']) ? $smcFunc['htmlspecialchars']($modSettings['meta_keywords']) : '';
 
-	addOpenGraph('og:site_name', $context['forum_name']);
-	addOpenGraph('og:title', $context['page_title_html_safe']);
+	// Content related meta tags, including Open Graph
+	$context['meta_tags'][] = array('property' => 'og:site_name', 'content' => $context['forum_name']);
+	$context['meta_tags'][] = array('property' => 'og:title', 'content' => $context['page_title_html_safe']);
+	
+	if (!empty($context['meta_keywords']))
+		$context['meta_tags'][] = array('name' => 'keywords', 'content' => $context['meta_keywords']);
+
 	if (!empty($context['canonical_url']))
-		addOpenGraph('og:url', $context['canonical_url']);
+		$context['meta_tags'][] = array('property' => 'og:url', 'content' => $context['canonical_url']);
+	
 	if (!empty($settings['og_image']))
-		addOpenGraph('og:image', $settings['og_image']);
+		$context['meta_tags'][] = array('property' => 'og:image', 'content' => $settings['og_image']);
+	
 	if (!empty($context['meta_description']))
-		addOpenGraph('og:description', $context['meta_description']);
+	{
+		$context['meta_tags'][] = array('property' => 'og:description', 'content' => $context['meta_description']);
+		$context['meta_tags'][] = array('name' => 'description', 'content' => $context['meta_description']);
+	}
 	else
-		addOpenGraph('og:description', $context['page_title_html_safe']);
+	{
+		$context['meta_tags'][] = array('property' => 'og:description', 'content' => $context['page_title_html_safe']);
+		$context['meta_tags'][] = array('name' => 'description', 'content' => $context['page_title_html_safe']);
+	}
 
 	call_integration_hook('integrate_theme_context');
 }

--- a/Themes/default/index.template.php
+++ b/Themes/default/index.template.php
@@ -108,12 +108,11 @@ function template_html_above()
 	<meta name="viewport" content="width=device-width, initial-scale=1">';
 
 	// Some Open Graph?
-	echo '
-	<meta property="og:site_name" content="', $mbname,'">
-	<meta property="og:title" content="', $context['page_title_html_safe'],'">
-	', !empty($context['canonical_url']) ? '<meta property="og:url" content="'. $context['canonical_url'].'">' : '',
-	!empty($settings['og_image']) ? '<meta property="og:image" content="'. $settings['og_image'].'">' : '','
-	<meta property="og:description" content="',!empty($context['meta_description']) ? $context['meta_description'] : $context['page_title_html_safe'],'">';
+	foreach ($context['open_graph'] as $og_property => $og_content)
+	{
+		echo '
+	<meta property="' . $og_property . '" content="' . $og_content . '">';
+	}
 
 	/* What is your Lollipop's color?
 	Theme Authors you can change here to make sure your theme's main color got visible on tab */

--- a/Themes/default/index.template.php
+++ b/Themes/default/index.template.php
@@ -102,16 +102,19 @@ function template_html_above()
 	template_javascript();
 
 	echo '
-	<meta name="description" content="', !empty($context['meta_description']) ? $context['meta_description'] : $context['page_title_html_safe'], '">', !empty($context['meta_keywords']) ? '
-	<meta name="keywords" content="' . $context['meta_keywords'] . '">' : '', '
 	<title>', $context['page_title_html_safe'], '</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1">';
 
-	// Some Open Graph?
-	foreach ($context['open_graph'] as $og_property => $og_content)
+	// Content related meta tags, like description, keywords, Open Graph stuff, etc...
+	foreach ($context['meta_tags'] as $meta_tag)
 	{
 		echo '
-	<meta property="' . $og_property . '" content="' . $og_content . '">';
+	<meta';
+
+		foreach ($meta_tag as $meta_key => $meta_value)
+			echo ' ', $meta_key, '="', $meta_value, '"';
+
+		echo '>';
 	}
 
 	/* What is your Lollipop's color?


### PR DESCRIPTION
~~The property and content values for the Open Graph <meta> tags are stored as key/value pairs in $context['open_graph']. Mods can add/overwrite OG tags either by calling `addOpenGraph()` directly, or by calling `call_integration_hook('integrate_theme_context')` and then editing the content of $context['open_graph'] themselves.~~

Moves all content related `<meta>` tag info into `$context['meta_tags']`. This will allow mods to add/edit/remove arbitrary meta info (e.g. Open Graph tags) simply by accessing `$context['meta_tags']`—ideally in a function that hooks into the `integrate_theme_context` hook, but theoretically anywhere.

