### PR TITLE
Avoids AJAX error when changing topic notification options

### DIFF
--- a/Sources/Load.php
+++ b/Sources/Load.php
@@ -1980,6 +1980,7 @@ function loadTheme($id_theme = 0, $initialize = true)
 		'post2',
 		'suggest',
 		'stats',
+		'notifytopic',
 	);
 
 	call_integration_hook('integrate_simple_actions', array(&$simpleActions, &$simpleAreas, &$simpleSubActions, &$xmlActions));


### PR DESCRIPTION
The notifytopic action was failing with a 403 and the message "unable to load generic_xml template". See #3507 for a similar bug and fix.
