### PR TITLE
Sync Db Schema from MySQL and Pg

### DIFF
--- a/other/install_2-1_mysql.sql
+++ b/other/install_2-1_mysql.sql
@@ -6,7 +6,7 @@
 #
 
 CREATE TABLE {$db_prefix}admin_info_files (
-  id_file TINYINT(4) UNSIGNED AUTO_INCREMENT,
+  id_file TINYINT UNSIGNED AUTO_INCREMENT,
   filename VARCHAR(255) NOT NULL DEFAULT '',
   path VARCHAR(255) NOT NULL DEFAULT '',
   parameters VARCHAR(255) NOT NULL DEFAULT '',
@@ -23,7 +23,7 @@ CREATE TABLE {$db_prefix}admin_info_files (
 CREATE TABLE {$db_prefix}approval_queue (
   id_msg INT(10) UNSIGNED NOT NULL DEFAULT '0',
   id_attach INT(10) UNSIGNED NOT NULL DEFAULT '0',
-  id_event SMALLINT(5) UNSIGNED NOT NULL DEFAULT '0'
+  id_event SMALLINT UNSIGNED NOT NULL DEFAULT '0'
 ) ENGINE={$engine};
 
 #
@@ -34,18 +34,18 @@ CREATE TABLE {$db_prefix}attachments (
   id_attach INT(10) UNSIGNED AUTO_INCREMENT,
   id_thumb INT(10) UNSIGNED NOT NULL DEFAULT '0',
   id_msg INT(10) UNSIGNED NOT NULL DEFAULT '0',
-  id_member MEDIUMINT(8) UNSIGNED NOT NULL DEFAULT '0',
-  id_folder TINYINT(3) NOT NULL DEFAULT '1',
-  attachment_type TINYINT(3) UNSIGNED NOT NULL DEFAULT '0',
+  id_member MEDIUMINT UNSIGNED NOT NULL DEFAULT '0',
+  id_folder TINYINT NOT NULL DEFAULT '1',
+  attachment_type TINYINT UNSIGNED NOT NULL DEFAULT '0',
   filename VARCHAR(255) NOT NULL DEFAULT '',
   file_hash VARCHAR(40) NOT NULL DEFAULT '',
   fileext VARCHAR(8) NOT NULL DEFAULT '',
   size INT(10) UNSIGNED NOT NULL DEFAULT '0',
-  downloads MEDIUMINT(8) UNSIGNED NOT NULL DEFAULT '0',
-  width MEDIUMINT(8) UNSIGNED NOT NULL DEFAULT '0',
-  height MEDIUMINT(8) UNSIGNED NOT NULL DEFAULT '0',
+  downloads MEDIUMINT UNSIGNED NOT NULL DEFAULT '0',
+  width MEDIUMINT UNSIGNED NOT NULL DEFAULT '0',
+  height MEDIUMINT UNSIGNED NOT NULL DEFAULT '0',
   mime_type VARCHAR(20) NOT NULL DEFAULT '',
-  approved TINYINT(3) NOT NULL DEFAULT '1',
+  approved TINYINT NOT NULL DEFAULT '1',
   PRIMARY KEY (id_attach),
   UNIQUE idx_id_member (id_member, id_attach),
   INDEX idx_id_msg (id_msg),
@@ -70,14 +70,14 @@ CREATE TABLE {$db_prefix}background_tasks (
 #
 
 CREATE TABLE {$db_prefix}ban_groups (
-  id_ban_group MEDIUMINT(8) UNSIGNED AUTO_INCREMENT,
+  id_ban_group MEDIUMINT UNSIGNED AUTO_INCREMENT,
   name VARCHAR(20) NOT NULL DEFAULT '',
   ban_time INT(10) UNSIGNED NOT NULL DEFAULT '0',
   expire_time INT(10) UNSIGNED,
-  cannot_access TINYINT(3) UNSIGNED NOT NULL DEFAULT '0',
-  cannot_register TINYINT(3) UNSIGNED NOT NULL DEFAULT '0',
-  cannot_post TINYINT(3) UNSIGNED NOT NULL DEFAULT '0',
-  cannot_login TINYINT(3) UNSIGNED NOT NULL DEFAULT '0',
+  cannot_access TINYINT UNSIGNED NOT NULL DEFAULT '0',
+  cannot_register TINYINT UNSIGNED NOT NULL DEFAULT '0',
+  cannot_post TINYINT UNSIGNED NOT NULL DEFAULT '0',
+  cannot_login TINYINT UNSIGNED NOT NULL DEFAULT '0',
   reason VARCHAR(255) NOT NULL DEFAULT '',
   notes TEXT NOT NULL,
   PRIMARY KEY (id_ban_group)
@@ -88,14 +88,14 @@ CREATE TABLE {$db_prefix}ban_groups (
 #
 
 CREATE TABLE {$db_prefix}ban_items (
-  id_ban MEDIUMINT(8) UNSIGNED AUTO_INCREMENT,
-  id_ban_group SMALLINT(5) UNSIGNED NOT NULL DEFAULT '0',
+  id_ban MEDIUMINT UNSIGNED AUTO_INCREMENT,
+  id_ban_group SMALLINT UNSIGNED NOT NULL DEFAULT '0',
   ip_low VARBINARY(16),
   ip_high VARBINARY(16),
   hostname VARCHAR(255) NOT NULL DEFAULT '',
   email_address VARCHAR(255) NOT NULL DEFAULT '',
-  id_member MEDIUMINT(8) UNSIGNED NOT NULL DEFAULT '0',
-  hits MEDIUMINT(8) UNSIGNED NOT NULL DEFAULT '0',
+  id_member MEDIUMINT UNSIGNED NOT NULL DEFAULT '0',
+  hits MEDIUMINT UNSIGNED NOT NULL DEFAULT '0',
   PRIMARY KEY (id_ban),
   INDEX idx_id_ban_group (id_ban_group),
   INDEX idx_id_ban_ip (ip_low,ip_high)
@@ -106,10 +106,10 @@ CREATE TABLE {$db_prefix}ban_items (
 #
 
 CREATE TABLE {$db_prefix}board_permissions (
-  id_group SMALLINT(5) DEFAULT '0',
-  id_profile SMALLINT(5) UNSIGNED DEFAULT '0',
+  id_group SMALLINT DEFAULT '0',
+  id_profile SMALLINT UNSIGNED DEFAULT '0',
   permission VARCHAR(30) DEFAULT '',
-  add_deny TINYINT(4) NOT NULL DEFAULT '1',
+  add_deny TINYINT NOT NULL DEFAULT '1',
   PRIMARY KEY (id_group, id_profile, permission)
 ) ENGINE={$engine};
 
@@ -118,24 +118,24 @@ CREATE TABLE {$db_prefix}board_permissions (
 #
 
 CREATE TABLE {$db_prefix}boards (
-  id_board SMALLINT(5) UNSIGNED AUTO_INCREMENT,
-  id_cat TINYINT(4) UNSIGNED NOT NULL DEFAULT '0',
-  child_level TINYINT(4) UNSIGNED NOT NULL DEFAULT '0',
-  id_parent SMALLINT(5) UNSIGNED NOT NULL DEFAULT '0',
-  board_order SMALLINT(5) NOT NULL DEFAULT '0',
+  id_board SMALLINT UNSIGNED AUTO_INCREMENT,
+  id_cat TINYINT UNSIGNED NOT NULL DEFAULT '0',
+  child_level TINYINT UNSIGNED NOT NULL DEFAULT '0',
+  id_parent SMALLINT UNSIGNED NOT NULL DEFAULT '0',
+  board_order SMALLINT NOT NULL DEFAULT '0',
   id_last_msg INT(10) UNSIGNED NOT NULL DEFAULT '0',
   id_msg_updated INT(10) UNSIGNED NOT NULL DEFAULT '0',
   member_groups VARCHAR(255) NOT NULL DEFAULT '-1,0',
-  id_profile SMALLINT(5) UNSIGNED NOT NULL DEFAULT '1',
+  id_profile SMALLINT UNSIGNED NOT NULL DEFAULT '1',
   name VARCHAR(255) NOT NULL DEFAULT '',
   description TEXT NOT NULL,
-  num_topics MEDIUMINT(8) UNSIGNED NOT NULL DEFAULT '0',
-  num_posts MEDIUMINT(8) UNSIGNED NOT NULL DEFAULT '0',
-  count_posts TINYINT(4) NOT NULL DEFAULT '0',
-  id_theme TINYINT(4) UNSIGNED NOT NULL DEFAULT '0',
-  override_theme TINYINT(4) UNSIGNED NOT NULL DEFAULT '0',
-  unapproved_posts SMALLINT(5) NOT NULL DEFAULT '0',
-  unapproved_topics SMALLINT(5) NOT NULL DEFAULT '0',
+  num_topics MEDIUMINT UNSIGNED NOT NULL DEFAULT '0',
+  num_posts MEDIUMINT UNSIGNED NOT NULL DEFAULT '0',
+  count_posts TINYINT NOT NULL DEFAULT '0',
+  id_theme TINYINT UNSIGNED NOT NULL DEFAULT '0',
+  override_theme TINYINT UNSIGNED NOT NULL DEFAULT '0',
+  unapproved_posts SMALLINT NOT NULL DEFAULT '0',
+  unapproved_topics SMALLINT NOT NULL DEFAULT '0',
   redirect VARCHAR(255) NOT NULL DEFAULT '',
   deny_member_groups VARCHAR(255) NOT NULL DEFAULT '',
   PRIMARY KEY (id_board),
@@ -150,13 +150,13 @@ CREATE TABLE {$db_prefix}boards (
 #
 
 CREATE TABLE {$db_prefix}calendar (
-  id_event SMALLINT(5) UNSIGNED AUTO_INCREMENT,
+  id_event SMALLINT UNSIGNED AUTO_INCREMENT,
   start_date date NOT NULL DEFAULT '0001-01-01',
   end_date date NOT NULL DEFAULT '0001-01-01',
-  id_board SMALLINT(5) UNSIGNED NOT NULL DEFAULT '0',
-  id_topic MEDIUMINT(8) UNSIGNED NOT NULL DEFAULT '0',
+  id_board SMALLINT UNSIGNED NOT NULL DEFAULT '0',
+  id_topic MEDIUMINT UNSIGNED NOT NULL DEFAULT '0',
   title VARCHAR(255) NOT NULL DEFAULT '',
-  id_member MEDIUMINT(8) UNSIGNED NOT NULL DEFAULT '0',
+  id_member MEDIUMINT UNSIGNED NOT NULL DEFAULT '0',
   PRIMARY KEY (id_event),
   INDEX idx_start_date (start_date),
   INDEX idx_end_date (end_date),
@@ -168,7 +168,7 @@ CREATE TABLE {$db_prefix}calendar (
 #
 
 CREATE TABLE {$db_prefix}calendar_holidays (
-  id_holiday SMALLINT(5) UNSIGNED AUTO_INCREMENT,
+  id_holiday SMALLINT UNSIGNED AUTO_INCREMENT,
   event_date date NOT NULL DEFAULT '0001-01-01',
   title VARCHAR(255) NOT NULL DEFAULT '',
   PRIMARY KEY (id_holiday),
@@ -180,11 +180,11 @@ CREATE TABLE {$db_prefix}calendar_holidays (
 #
 
 CREATE TABLE {$db_prefix}categories (
-  id_cat TINYINT(4) UNSIGNED AUTO_INCREMENT,
-  cat_order TINYINT(4) NOT NULL DEFAULT '0',
+  id_cat TINYINT UNSIGNED AUTO_INCREMENT,
+  cat_order TINYINT NOT NULL DEFAULT '0',
   name VARCHAR(255) NOT NULL DEFAULT '',
   description TEXT NOT NULL,
-  can_collapse TINYINT(1) NOT NULL DEFAULT '1',
+  can_collapse TINYINT NOT NULL DEFAULT '1',
   PRIMARY KEY (id_cat)
 ) ENGINE={$engine};
 
@@ -193,26 +193,26 @@ CREATE TABLE {$db_prefix}categories (
 #
 
 CREATE TABLE {$db_prefix}custom_fields (
-  id_field SMALLINT(5) AUTO_INCREMENT,
+  id_field SMALLINT AUTO_INCREMENT,
   col_name VARCHAR(12) NOT NULL DEFAULT '',
   field_name VARCHAR(40) NOT NULL DEFAULT '',
   field_desc VARCHAR(255) NOT NULL DEFAULT '',
   field_type VARCHAR(8) NOT NULL DEFAULT 'text',
-  field_length SMALLINT(5) NOT NULL DEFAULT '255',
+  field_length SMALLINT NOT NULL DEFAULT '255',
   field_options TEXT NOT NULL,
-  field_order TINYINT(3) NOT NULL DEFAULT '0',
+  field_order TINYINT NOT NULL DEFAULT '0',
   mask VARCHAR(255) NOT NULL DEFAULT '',
-  show_reg TINYINT(3) NOT NULL DEFAULT '0',
-  show_display TINYINT(3) NOT NULL DEFAULT '0',
-  show_mlist TINYINT(3) NOT NULL DEFAULT '0',
+  show_reg TINYINT NOT NULL DEFAULT '0',
+  show_display TINYINT NOT NULL DEFAULT '0',
+  show_mlist TINYINT NOT NULL DEFAULT '0',
   show_profile VARCHAR(20) NOT NULL DEFAULT 'forumprofile',
-  private TINYINT(3) NOT NULL DEFAULT '0',
-  active TINYINT(3) NOT NULL DEFAULT '1',
-  bbc TINYINT(3) NOT NULL DEFAULT '0',
-  can_search TINYINT(3) NOT NULL DEFAULT '0',
-  DEFAULT_value VARCHAR(255) NOT NULL DEFAULT '',
+  private TINYINT NOT NULL DEFAULT '0',
+  active TINYINT NOT NULL DEFAULT '1',
+  bbc TINYINT NOT NULL DEFAULT '0',
+  can_search TINYINT NOT NULL DEFAULT '0',
+  default_value VARCHAR(255) NOT NULL DEFAULT '',
   enclose TEXT NOT NULL,
-  placement TINYINT(3) NOT NULL DEFAULT '0',
+  placement TINYINT NOT NULL DEFAULT '0',
   PRIMARY KEY (id_field),
   UNIQUE idx_col_name (col_name)
 ) ENGINE={$engine};
@@ -222,8 +222,8 @@ CREATE TABLE {$db_prefix}custom_fields (
 #
 
 CREATE TABLE {$db_prefix}group_moderators (
-  id_group SMALLINT(5) UNSIGNED DEFAULT '0',
-  id_member MEDIUMINT(8) UNSIGNED DEFAULT '0',
+  id_group SMALLINT UNSIGNED DEFAULT '0',
+  id_member MEDIUMINT UNSIGNED DEFAULT '0',
   PRIMARY KEY (id_group, id_member)
 ) ENGINE={$engine};
 
@@ -233,13 +233,13 @@ CREATE TABLE {$db_prefix}group_moderators (
 
 CREATE TABLE {$db_prefix}log_actions (
   id_action INT(10) UNSIGNED AUTO_INCREMENT,
-  id_log TINYINT(3) UNSIGNED NOT NULL DEFAULT '1',
+  id_log TINYINT UNSIGNED NOT NULL DEFAULT '1',
   log_time INT(10) UNSIGNED NOT NULL DEFAULT '0',
-  id_member MEDIUMINT(8) UNSIGNED NOT NULL DEFAULT '0',
+  id_member MEDIUMINT UNSIGNED NOT NULL DEFAULT '0',
   ip VARBINARY(16),
   action VARCHAR(30) NOT NULL DEFAULT '',
-  id_board SMALLINT(5) UNSIGNED NOT NULL DEFAULT '0',
-  id_topic MEDIUMINT(8) UNSIGNED NOT NULL DEFAULT '0',
+  id_board SMALLINT UNSIGNED NOT NULL DEFAULT '0',
+  id_topic MEDIUMINT UNSIGNED NOT NULL DEFAULT '0',
   id_msg INT(10) UNSIGNED NOT NULL DEFAULT '0',
   extra TEXT NOT NULL,
   PRIMARY KEY (id_action),
@@ -257,11 +257,11 @@ CREATE TABLE {$db_prefix}log_actions (
 
 CREATE TABLE {$db_prefix}log_activity (
   date DATE DEFAULT '0001-01-01',
-  hits MEDIUMINT(8) UNSIGNED NOT NULL DEFAULT '0',
-  topics SMALLINT(5) UNSIGNED NOT NULL DEFAULT '0',
-  posts SMALLINT(5) UNSIGNED NOT NULL DEFAULT '0',
-  registers SMALLINT(5) UNSIGNED NOT NULL DEFAULT '0',
-  most_on SMALLINT(5) UNSIGNED NOT NULL DEFAULT '0',
+  hits MEDIUMINT UNSIGNED NOT NULL DEFAULT '0',
+  topics SMALLINT UNSIGNED NOT NULL DEFAULT '0',
+  posts SMALLINT UNSIGNED NOT NULL DEFAULT '0',
+  registers SMALLINT UNSIGNED NOT NULL DEFAULT '0',
+  most_on SMALLINT UNSIGNED NOT NULL DEFAULT '0',
   PRIMARY KEY (date)
 ) ENGINE={$engine};
 
@@ -270,8 +270,8 @@ CREATE TABLE {$db_prefix}log_activity (
 #
 
 CREATE TABLE {$db_prefix}log_banned (
-  id_ban_log MEDIUMINT(8) UNSIGNED AUTO_INCREMENT,
-  id_member MEDIUMINT(8) UNSIGNED NOT NULL DEFAULT '0',
+  id_ban_log MEDIUMINT UNSIGNED AUTO_INCREMENT,
+  id_member MEDIUMINT UNSIGNED NOT NULL DEFAULT '0',
   ip VARBINARY(16),
   email VARCHAR(255) NOT NULL DEFAULT '',
   log_time INT(10) UNSIGNED NOT NULL DEFAULT '0',
@@ -284,8 +284,8 @@ CREATE TABLE {$db_prefix}log_banned (
 #
 
 CREATE TABLE {$db_prefix}log_boards (
-  id_member MEDIUMINT(8) UNSIGNED DEFAULT '0',
-  id_board SMALLINT(5) UNSIGNED DEFAULT '0',
+  id_member MEDIUMINT UNSIGNED DEFAULT '0',
+  id_board SMALLINT UNSIGNED DEFAULT '0',
   id_msg INT(10) UNSIGNED NOT NULL DEFAULT '0',
   PRIMARY KEY (id_member, id_board)
 ) ENGINE={$engine};
@@ -295,15 +295,15 @@ CREATE TABLE {$db_prefix}log_boards (
 #
 
 CREATE TABLE {$db_prefix}log_comments (
-  id_comment MEDIUMINT(8) UNSIGNED AUTO_INCREMENT,
-  id_member MEDIUMINT(8) UNSIGNED NOT NULL DEFAULT '0',
+  id_comment MEDIUMINT UNSIGNED AUTO_INCREMENT,
+  id_member MEDIUMINT UNSIGNED NOT NULL DEFAULT '0',
   member_name VARCHAR(80) NOT NULL DEFAULT '',
   comment_type VARCHAR(8) NOT NULL DEFAULT 'warning',
-  id_recipient MEDIUMINT(8) UNSIGNED NOT NULL DEFAULT '0',
+  id_recipient MEDIUMINT UNSIGNED NOT NULL DEFAULT '0',
   recipient_name VARCHAR(255) NOT NULL DEFAULT '',
   log_time INT(10) NOT NULL DEFAULT '0',
-  id_notice MEDIUMINT(8) UNSIGNED NOT NULL DEFAULT '0',
-  counter TINYINT(3) NOT NULL DEFAULT '0',
+  id_notice MEDIUMINT UNSIGNED NOT NULL DEFAULT '0',
+  counter TINYINT NOT NULL DEFAULT '0',
   body TEXT NOT NULL,
   PRIMARY KEY (id_comment),
   INDEX idx_id_recipient (id_recipient),
@@ -316,11 +316,11 @@ CREATE TABLE {$db_prefix}log_comments (
 #
 
 CREATE TABLE {$db_prefix}log_digest (
-  id_topic MEDIUMINT(8) UNSIGNED NOT NULL,
+  id_topic MEDIUMINT UNSIGNED NOT NULL,
   id_msg INT(10) UNSIGNED NOT NULL,
   note_type VARCHAR(10) NOT NULL DEFAULT 'post',
-  daily TINYINT(3) UNSIGNED NOT NULL DEFAULT '0',
-  exclude MEDIUMINT(8) UNSIGNED NOT NULL DEFAULT '0'
+  daily TINYINT UNSIGNED NOT NULL DEFAULT '0',
+  exclude MEDIUMINT UNSIGNED NOT NULL DEFAULT '0'
 ) ENGINE={$engine};
 
 #
@@ -328,16 +328,16 @@ CREATE TABLE {$db_prefix}log_digest (
 #
 
 CREATE TABLE {$db_prefix}log_errors (
-  id_error MEDIUMINT(8) UNSIGNED AUTO_INCREMENT,
+  id_error MEDIUMINT UNSIGNED AUTO_INCREMENT,
   log_time INT(10) UNSIGNED NOT NULL DEFAULT '0',
-  id_member MEDIUMINT(8) UNSIGNED NOT NULL DEFAULT '0',
+  id_member MEDIUMINT UNSIGNED NOT NULL DEFAULT '0',
   ip VARBINARY(16),
   url TEXT NOT NULL,
   message TEXT NOT NULL,
   session CHAR(64) NOT NULL DEFAULT '                                                                ',
   error_type CHAR(15) NOT NULL DEFAULT 'general',
   file VARCHAR(255) NOT NULL DEFAULT '',
-  line MEDIUMINT(8) UNSIGNED NOT NULL DEFAULT '0',
+  line MEDIUMINT UNSIGNED NOT NULL DEFAULT '0',
   PRIMARY KEY (id_error),
   INDEX idx_log_time (log_time),
   INDEX idx_id_member (id_member),
@@ -360,13 +360,13 @@ CREATE TABLE {$db_prefix}log_floodcontrol (
 #
 
 CREATE TABLE {$db_prefix}log_group_requests (
-  id_request MEDIUMINT(8) UNSIGNED AUTO_INCREMENT,
-  id_member MEDIUMINT(8) UNSIGNED NOT NULL DEFAULT '0',
-  id_group SMALLINT(5) UNSIGNED NOT NULL DEFAULT '0',
+  id_request MEDIUMINT UNSIGNED AUTO_INCREMENT,
+  id_member MEDIUMINT UNSIGNED NOT NULL DEFAULT '0',
+  id_group SMALLINT UNSIGNED NOT NULL DEFAULT '0',
   time_applied INT(10) UNSIGNED NOT NULL DEFAULT '0',
   reason TEXT NOT NULL,
-  status TINYINT(3) UNSIGNED NOT NULL DEFAULT '0',
-  id_member_acted MEDIUMINT(8) UNSIGNED NOT NULL DEFAULT '0',
+  status TINYINT UNSIGNED NOT NULL DEFAULT '0',
+  id_member_acted MEDIUMINT UNSIGNED NOT NULL DEFAULT '0',
   member_name_acted VARCHAR(255) NOT NULL DEFAULT '',
   time_acted INT(10) UNSIGNED NOT NULL DEFAULT '0',
   act_reason TEXT NOT NULL,
@@ -379,8 +379,8 @@ CREATE TABLE {$db_prefix}log_group_requests (
 #
 
 CREATE TABLE {$db_prefix}log_mark_read (
-  id_member MEDIUMINT(8) UNSIGNED DEFAULT '0',
-  id_board SMALLINT(5) UNSIGNED DEFAULT '0',
+  id_member MEDIUMINT UNSIGNED DEFAULT '0',
+  id_board SMALLINT UNSIGNED DEFAULT '0',
   id_msg INT(10) UNSIGNED NOT NULL DEFAULT '0',
   PRIMARY KEY (id_member, id_board)
 ) ENGINE={$engine};
@@ -390,7 +390,7 @@ CREATE TABLE {$db_prefix}log_mark_read (
 #
 
 CREATE TABLE {$db_prefix}log_member_notices (
-  id_notice MEDIUMINT(8) UNSIGNED AUTO_INCREMENT,
+  id_notice MEDIUMINT UNSIGNED AUTO_INCREMENT,
   subject VARCHAR(255) NOT NULL DEFAULT '',
   body TEXT NOT NULL,
   PRIMARY KEY (id_notice)
@@ -401,10 +401,10 @@ CREATE TABLE {$db_prefix}log_member_notices (
 #
 
 CREATE TABLE {$db_prefix}log_notify (
-  id_member MEDIUMINT(8) UNSIGNED DEFAULT '0',
-  id_topic MEDIUMINT(8) UNSIGNED DEFAULT '0',
-  id_board SMALLINT(5) UNSIGNED DEFAULT '0',
-  sent TINYINT(1) UNSIGNED NOT NULL DEFAULT '0',
+  id_member MEDIUMINT UNSIGNED DEFAULT '0',
+  id_topic MEDIUMINT UNSIGNED DEFAULT '0',
+  id_board SMALLINT UNSIGNED DEFAULT '0',
+  sent TINYINT UNSIGNED NOT NULL DEFAULT '0',
   PRIMARY KEY (id_member, id_topic, id_board),
   INDEX idx_id_topic (id_topic, id_member)
 ) ENGINE={$engine};
@@ -416,8 +416,8 @@ CREATE TABLE {$db_prefix}log_notify (
 CREATE TABLE {$db_prefix}log_online (
   session VARCHAR(64) DEFAULT '',
   log_time INT(10) NOT NULL DEFAULT '0',
-  id_member MEDIUMINT(8) UNSIGNED NOT NULL DEFAULT '0',
-  id_spider SMALLINT(5) UNSIGNED NOT NULL DEFAULT '0',
+  id_member MEDIUMINT UNSIGNED NOT NULL DEFAULT '0',
+  id_spider SMALLINT UNSIGNED NOT NULL DEFAULT '0',
   ip VARBINARY(16),
   url VARCHAR(1024) NOT NULL,
   PRIMARY KEY (session),
@@ -435,13 +435,13 @@ CREATE TABLE {$db_prefix}log_packages (
   package_id VARCHAR(255) NOT NULL DEFAULT '',
   name VARCHAR(255) NOT NULL DEFAULT '',
   version VARCHAR(255) NOT NULL DEFAULT '',
-  id_member_installed MEDIUMINT(8) NOT NULL DEFAULT '0',
+  id_member_installed MEDIUMINT NOT NULL DEFAULT '0',
   member_installed VARCHAR(255) NOT NULL DEFAULT '',
   time_installed INT(10) NOT NULL DEFAULT '0',
-  id_member_removed MEDIUMINT(8) NOT NULL DEFAULT '0',
+  id_member_removed MEDIUMINT NOT NULL DEFAULT '0',
   member_removed VARCHAR(255) NOT NULL DEFAULT '',
   time_removed INT(10) NOT NULL DEFAULT '0',
-  install_state TINYINT(3) NOT NULL DEFAULT '1',
+  install_state TINYINT NOT NULL DEFAULT '1',
   failed_steps TEXT NOT NULL,
   themes_installed VARCHAR(255) NOT NULL DEFAULT '',
   db_changes TEXT NOT NULL,
@@ -455,9 +455,9 @@ CREATE TABLE {$db_prefix}log_packages (
 #
 
 CREATE TABLE {$db_prefix}log_polls (
-  id_poll MEDIUMINT(8) UNSIGNED DEFAULT '0',
-  id_member MEDIUMINT(8) UNSIGNED DEFAULT '0',
-  id_choice TINYINT(3) UNSIGNED DEFAULT '0',
+  id_poll MEDIUMINT UNSIGNED DEFAULT '0',
+  id_member MEDIUMINT UNSIGNED DEFAULT '0',
+  id_choice TINYINT UNSIGNED DEFAULT '0',
   INDEX idx_id_poll (id_poll, id_member, id_choice)
 ) ENGINE={$engine};
 
@@ -466,19 +466,19 @@ CREATE TABLE {$db_prefix}log_polls (
 #
 
 CREATE TABLE {$db_prefix}log_reported (
-  id_report MEDIUMINT(8) UNSIGNED AUTO_INCREMENT,
+  id_report MEDIUMINT UNSIGNED AUTO_INCREMENT,
   id_msg INT(10) UNSIGNED NOT NULL DEFAULT '0',
-  id_topic MEDIUMINT(8) UNSIGNED NOT NULL DEFAULT '0',
-  id_board SMALLINT(5) UNSIGNED NOT NULL DEFAULT '0',
-  id_member MEDIUMINT(8) UNSIGNED NOT NULL DEFAULT '0',
+  id_topic MEDIUMINT UNSIGNED NOT NULL DEFAULT '0',
+  id_board SMALLINT UNSIGNED NOT NULL DEFAULT '0',
+  id_member MEDIUMINT UNSIGNED NOT NULL DEFAULT '0',
   membername VARCHAR(255) NOT NULL DEFAULT '',
   subject VARCHAR(255) NOT NULL DEFAULT '',
   body MEDIUMTEXT NOT NULL,
   time_started INT(10) NOT NULL DEFAULT '0',
   time_updated INT(10) NOT NULL DEFAULT '0',
   num_reports MEDIUMINT(6) NOT NULL DEFAULT '0',
-  closed TINYINT(3) NOT NULL DEFAULT '0',
-  ignore_all TINYINT(3) NOT NULL DEFAULT '0',
+  closed TINYINT NOT NULL DEFAULT '0',
+  ignore_all TINYINT NOT NULL DEFAULT '0',
   PRIMARY KEY (id_report),
   INDEX idx_id_member (id_member),
   INDEX idx_id_topic (id_topic),
@@ -492,9 +492,9 @@ CREATE TABLE {$db_prefix}log_reported (
 #
 
 CREATE TABLE {$db_prefix}log_reported_comments (
-  id_comment MEDIUMINT(8) UNSIGNED AUTO_INCREMENT,
-  id_report MEDIUMINT(8) NOT NULL DEFAULT '0',
-  id_member MEDIUMINT(8) NOT NULL,
+  id_comment MEDIUMINT UNSIGNED AUTO_INCREMENT,
+  id_report MEDIUMINT NOT NULL DEFAULT '0',
+  id_member MEDIUMINT NOT NULL,
   membername VARCHAR(255) NOT NULL DEFAULT '',
   member_ip VARBINARY(16),
   comment VARCHAR(255) NOT NULL DEFAULT '',
@@ -510,8 +510,8 @@ CREATE TABLE {$db_prefix}log_reported_comments (
 #
 
 CREATE TABLE {$db_prefix}log_scheduled_tasks (
-  id_log MEDIUMINT(8) AUTO_INCREMENT,
-  id_task SMALLINT(5) NOT NULL DEFAULT '0',
+  id_log MEDIUMINT AUTO_INCREMENT,
+  id_task SMALLINT NOT NULL DEFAULT '0',
   time_run INT(10) NOT NULL DEFAULT '0',
   time_taken float NOT NULL DEFAULT '0',
   PRIMARY KEY (id_log)
@@ -522,7 +522,7 @@ CREATE TABLE {$db_prefix}log_scheduled_tasks (
 #
 
 CREATE TABLE {$db_prefix}log_search_messages (
-  id_search TINYINT(3) UNSIGNED DEFAULT '0',
+  id_search TINYINT UNSIGNED DEFAULT '0',
   id_msg INT(10) UNSIGNED DEFAULT '0',
   PRIMARY KEY (id_search, id_msg)
 ) ENGINE={$engine};
@@ -532,11 +532,11 @@ CREATE TABLE {$db_prefix}log_search_messages (
 #
 
 CREATE TABLE {$db_prefix}log_search_results (
-  id_search TINYINT(3) UNSIGNED DEFAULT '0',
-  id_topic MEDIUMINT(8) UNSIGNED DEFAULT '0',
+  id_search TINYINT UNSIGNED DEFAULT '0',
+  id_topic MEDIUMINT UNSIGNED DEFAULT '0',
   id_msg INT(10) UNSIGNED NOT NULL DEFAULT '0',
-  relevance SMALLINT(5) UNSIGNED NOT NULL DEFAULT '0',
-  num_matches SMALLINT(5) UNSIGNED NOT NULL DEFAULT '0',
+  relevance SMALLINT UNSIGNED NOT NULL DEFAULT '0',
+  num_matches SMALLINT UNSIGNED NOT NULL DEFAULT '0',
   PRIMARY KEY (id_search, id_topic)
 ) ENGINE={$engine};
 
@@ -546,7 +546,7 @@ CREATE TABLE {$db_prefix}log_search_results (
 
 CREATE TABLE {$db_prefix}log_search_subjects (
   word VARCHAR(20) DEFAULT '',
-  id_topic MEDIUMINT(8) UNSIGNED DEFAULT '0',
+  id_topic MEDIUMINT UNSIGNED DEFAULT '0',
   PRIMARY KEY (word, id_topic),
   INDEX idx_id_topic (id_topic)
 ) ENGINE={$engine};
@@ -556,8 +556,8 @@ CREATE TABLE {$db_prefix}log_search_subjects (
 #
 
 CREATE TABLE {$db_prefix}log_search_topics (
-  id_search TINYINT(3) UNSIGNED DEFAULT '0',
-  id_topic MEDIUMINT(8) UNSIGNED DEFAULT '0',
+  id_search TINYINT UNSIGNED DEFAULT '0',
+  id_topic MEDIUMINT UNSIGNED DEFAULT '0',
   PRIMARY KEY (id_search, id_topic)
 ) ENGINE={$engine};
 
@@ -567,10 +567,10 @@ CREATE TABLE {$db_prefix}log_search_topics (
 
 CREATE TABLE {$db_prefix}log_spider_hits (
   id_hit INT(10) UNSIGNED AUTO_INCREMENT,
-  id_spider SMALLINT(5) UNSIGNED NOT NULL DEFAULT '0',
+  id_spider SMALLINT UNSIGNED NOT NULL DEFAULT '0',
   log_time INT(10) UNSIGNED NOT NULL DEFAULT '0',
   url VARCHAR(1024) NOT NULL DEFAULT '',
-  processed TINYINT(3) NOT NULL DEFAULT '0',
+  processed TINYINT NOT NULL DEFAULT '0',
   PRIMARY KEY (id_hit),
   INDEX idx_id_spider(id_spider),
   INDEX idx_log_time(log_time),
@@ -582,8 +582,8 @@ CREATE TABLE {$db_prefix}log_spider_hits (
 #
 
 CREATE TABLE {$db_prefix}log_spider_stats (
-  id_spider SMALLINT(5) UNSIGNED DEFAULT '0',
-  page_hits SMALLINT(5) UNSIGNED NOT NULL DEFAULT '0',
+  id_spider SMALLINT UNSIGNED DEFAULT '0',
+  page_hits SMALLINT UNSIGNED NOT NULL DEFAULT '0',
   last_seen INT(10) UNSIGNED NOT NULL DEFAULT '0',
   stat_date DATE DEFAULT '0001-01-01',
   PRIMARY KEY (stat_date, id_spider)
@@ -595,15 +595,15 @@ CREATE TABLE {$db_prefix}log_spider_stats (
 
 CREATE TABLE {$db_prefix}log_subscribed (
   id_sublog INT(10) UNSIGNED AUTO_INCREMENT,
-  id_subscribe MEDIUMINT(8) UNSIGNED NOT NULL DEFAULT '0',
+  id_subscribe MEDIUMINT UNSIGNED NOT NULL DEFAULT '0',
   id_member INT(10) NOT NULL DEFAULT '0',
-  old_id_group SMALLINT(5) NOT NULL DEFAULT '0',
+  old_id_group SMALLINT NOT NULL DEFAULT '0',
   start_time INT(10) NOT NULL DEFAULT '0',
   end_time INT(10) NOT NULL DEFAULT '0',
-  status TINYINT(3) NOT NULL DEFAULT '0',
-  payments_pending TINYINT(3) NOT NULL DEFAULT '0',
+  status TINYINT NOT NULL DEFAULT '0',
+  payments_pending TINYINT NOT NULL DEFAULT '0',
   pending_details TEXT NOT NULL,
-  reminder_sent TINYINT(3) NOT NULL DEFAULT '0',
+  reminder_sent TINYINT NOT NULL DEFAULT '0',
   vendor_ref VARCHAR(255) NOT NULL DEFAULT '',
   PRIMARY KEY (id_sublog),
   UNIQUE KEY id_subscribe (id_subscribe, id_member),
@@ -619,10 +619,10 @@ CREATE TABLE {$db_prefix}log_subscribed (
 #
 
 CREATE TABLE {$db_prefix}log_topics (
-  id_member MEDIUMINT(8) UNSIGNED DEFAULT '0',
-  id_topic MEDIUMINT(8) UNSIGNED DEFAULT '0',
+  id_member MEDIUMINT UNSIGNED DEFAULT '0',
+  id_topic MEDIUMINT UNSIGNED DEFAULT '0',
   id_msg INT(10) UNSIGNED NOT NULL DEFAULT '0',
-  unwatched TINYINT(3) NOT NULL DEFAULT '0',
+  unwatched TINYINT NOT NULL DEFAULT '0',
   PRIMARY KEY (id_member, id_topic),
   INDEX idx_id_topic (id_topic)
 ) ENGINE={$engine};
@@ -638,9 +638,9 @@ CREATE TABLE {$db_prefix}mail_queue (
   body MEDIUMTEXT NOT NULL,
   subject VARCHAR(255) NOT NULL DEFAULT '',
   headers TEXT NOT NULL,
-  send_html TINYINT(3) NOT NULL DEFAULT '0',
-  priority TINYINT(3) NOT NULL DEFAULT '1',
-  private TINYINT(1) NOT NULL DEFAULT '0',
+  send_html TINYINT NOT NULL DEFAULT '0',
+  priority TINYINT NOT NULL DEFAULT '1',
+  private TINYINT NOT NULL DEFAULT '0',
   PRIMARY KEY  (id_mail),
   INDEX idx_time_sent (time_sent),
   INDEX idx_mail_priority (priority, id_mail)
@@ -651,17 +651,17 @@ CREATE TABLE {$db_prefix}mail_queue (
 #
 
 CREATE TABLE {$db_prefix}membergroups (
-  id_group SMALLINT(5) UNSIGNED AUTO_INCREMENT,
+  id_group SMALLINT UNSIGNED AUTO_INCREMENT,
   group_name VARCHAR(80) NOT NULL DEFAULT '',
   description TEXT NOT NULL,
   online_color VARCHAR(20) NOT NULL DEFAULT '',
   min_posts MEDIUMINT(9) NOT NULL DEFAULT '-1',
-  max_messages SMALLINT(5) UNSIGNED NOT NULL DEFAULT '0',
+  max_messages SMALLINT UNSIGNED NOT NULL DEFAULT '0',
   icons VARCHAR(255) NOT NULL DEFAULT '',
-  group_type TINYINT(3) NOT NULL DEFAULT '0',
-  hidden TINYINT(3) NOT NULL DEFAULT '0',
-  id_parent SMALLINT(5) NOT NULL DEFAULT '-2',
-  tfa_required TINYINT(3) NOT NULL DEFAULT '0',
+  group_type TINYINT NOT NULL DEFAULT '0',
+  hidden TINYINT NOT NULL DEFAULT '0',
+  id_parent SMALLINT NOT NULL DEFAULT '-2',
+  tfa_required TINYINT NOT NULL DEFAULT '0',
   PRIMARY KEY (id_group),
   INDEX idx_min_posts (min_posts)
 ) ENGINE={$engine};
@@ -671,21 +671,21 @@ CREATE TABLE {$db_prefix}membergroups (
 #
 
 CREATE TABLE {$db_prefix}members (
-  id_member MEDIUMINT(8) UNSIGNED AUTO_INCREMENT,
+  id_member MEDIUMINT UNSIGNED AUTO_INCREMENT,
   member_name VARCHAR(80) NOT NULL DEFAULT '',
   date_registered INT(10) UNSIGNED NOT NULL DEFAULT '0',
-  posts MEDIUMINT(8) UNSIGNED NOT NULL DEFAULT '0',
-  id_group SMALLINT(5) UNSIGNED NOT NULL DEFAULT '0',
+  posts MEDIUMINT UNSIGNED NOT NULL DEFAULT '0',
+  id_group SMALLINT UNSIGNED NOT NULL DEFAULT '0',
   lngfile VARCHAR(255) NOT NULL DEFAULT '',
   last_login INT(10) UNSIGNED NOT NULL DEFAULT '0',
   real_name VARCHAR(255) NOT NULL DEFAULT '',
-  instant_messages SMALLINT(5) NOT NULL DEFAULT 0,
-  unread_messages SMALLINT(5) NOT NULL DEFAULT 0,
-  new_pm TINYINT(3) UNSIGNED NOT NULL DEFAULT '0',
+  instant_messages SMALLINT NOT NULL DEFAULT 0,
+  unread_messages SMALLINT NOT NULL DEFAULT 0,
+  new_pm TINYINT UNSIGNED NOT NULL DEFAULT '0',
   alerts INT(10) UNSIGNED NOT NULL DEFAULT '0',
   buddy_list TEXT NOT NULL,
   pm_ignore_list VARCHAR(255) NOT NULL DEFAULT '',
-  pm_prefs MEDIUMINT(8) NOT NULL DEFAULT '0',
+  pm_prefs MEDIUMINT NOT NULL DEFAULT '0',
   mod_prefs VARCHAR(20) NOT NULL DEFAULT '',
   passwd VARCHAR(64) NOT NULL DEFAULT '',
   email_address VARCHAR(255) NOT NULL DEFAULT '',
@@ -693,8 +693,8 @@ CREATE TABLE {$db_prefix}members (
   birthdate date NOT NULL DEFAULT '0001-01-01',
   website_title VARCHAR(255) NOT NULL DEFAULT '',
   website_url VARCHAR(255) NOT NULL DEFAULT '',
-  hide_email TINYINT(4) NOT NULL DEFAULT '0',
-  show_online TINYINT(4) NOT NULL DEFAULT '1',
+  hide_email TINYINT NOT NULL DEFAULT '0',
+  show_online TINYINT NOT NULL DEFAULT '1',
   time_format VARCHAR(80) NOT NULL DEFAULT '',
   signature TEXT NOT NULL,
   time_offset float NOT NULL DEFAULT '0',
@@ -704,19 +704,19 @@ CREATE TABLE {$db_prefix}members (
   member_ip2 VARBINARY(16),
   secret_question VARCHAR(255) NOT NULL DEFAULT '',
   secret_answer VARCHAR(64) NOT NULL DEFAULT '',
-  id_theme TINYINT(4) UNSIGNED NOT NULL DEFAULT '0',
-  is_activated TINYINT(3) UNSIGNED NOT NULL DEFAULT '1',
+  id_theme TINYINT UNSIGNED NOT NULL DEFAULT '0',
+  is_activated TINYINT UNSIGNED NOT NULL DEFAULT '1',
   validation_code VARCHAR(10) NOT NULL DEFAULT '',
   id_msg_last_visit INT(10) UNSIGNED NOT NULL DEFAULT '0',
   additional_groups VARCHAR(255) NOT NULL DEFAULT '',
   smiley_set VARCHAR(48) NOT NULL DEFAULT '',
-  id_post_group SMALLINT(5) UNSIGNED NOT NULL DEFAULT '0',
+  id_post_group SMALLINT UNSIGNED NOT NULL DEFAULT '0',
   total_time_logged_in INT(10) UNSIGNED NOT NULL DEFAULT '0',
   password_salt VARCHAR(255) NOT NULL DEFAULT '',
   ignore_boards TEXT NOT NULL,
-  warning TINYINT(4) NOT NULL DEFAULT '0',
+  warning TINYINT NOT NULL DEFAULT '0',
   passwd_flood VARCHAR(12) NOT NULL DEFAULT '',
-  pm_receive_from TINYINT(4) UNSIGNED NOT NULL DEFAULT '1',
+  pm_receive_from TINYINT UNSIGNED NOT NULL DEFAULT '1',
   timezone VARCHAR(80) NOT NULL DEFAULT 'UTC',
   tfa_secret VARCHAR(24) NOT NULL DEFAULT '',
   tfa_backup VARCHAR(64) NOT NULL DEFAULT '',
@@ -742,7 +742,7 @@ CREATE TABLE {$db_prefix}members (
 
 CREATE TABLE {$db_prefix}member_logins (
   id_login INT(10) AUTO_INCREMENT,
-  id_member MEDIUMINT(8) NOT NULL DEFAULT '0',
+  id_member MEDIUMINT NOT NULL DEFAULT '0',
   time INT(10) NOT NULL DEFAULT '0',
   ip VARBINARY(16),
   ip2 VARBINARY(16),
@@ -756,11 +756,11 @@ CREATE TABLE {$db_prefix}member_logins (
 #
 
 CREATE TABLE {$db_prefix}message_icons (
-  id_icon SMALLINT(5) UNSIGNED AUTO_INCREMENT,
+  id_icon SMALLINT UNSIGNED AUTO_INCREMENT,
   title VARCHAR(80) NOT NULL DEFAULT '',
   filename VARCHAR(80) NOT NULL DEFAULT '',
-  id_board SMALLINT(5) UNSIGNED NOT NULL DEFAULT '0',
-  icon_order SMALLINT(5) UNSIGNED NOT NULL DEFAULT '0',
+  id_board SMALLINT UNSIGNED NOT NULL DEFAULT '0',
+  icon_order SMALLINT UNSIGNED NOT NULL DEFAULT '0',
   PRIMARY KEY (id_icon),
   INDEX idx_id_board (id_board)
 ) ENGINE={$engine};
@@ -771,23 +771,23 @@ CREATE TABLE {$db_prefix}message_icons (
 
 CREATE TABLE {$db_prefix}messages (
   id_msg INT(10) UNSIGNED AUTO_INCREMENT,
-  id_topic MEDIUMINT(8) UNSIGNED NOT NULL DEFAULT '0',
-  id_board SMALLINT(5) UNSIGNED NOT NULL DEFAULT '0',
+  id_topic MEDIUMINT UNSIGNED NOT NULL DEFAULT '0',
+  id_board SMALLINT UNSIGNED NOT NULL DEFAULT '0',
   poster_time INT(10) UNSIGNED NOT NULL DEFAULT '0',
-  id_member MEDIUMINT(8) UNSIGNED NOT NULL DEFAULT '0',
+  id_member MEDIUMINT UNSIGNED NOT NULL DEFAULT '0',
   id_msg_modified INT(10) UNSIGNED NOT NULL DEFAULT '0',
   subject VARCHAR(255) NOT NULL DEFAULT '',
   poster_name VARCHAR(255) NOT NULL DEFAULT '',
   poster_email VARCHAR(255) NOT NULL DEFAULT '',
   poster_ip VARBINARY(16),
-  smileys_enabled TINYINT(4) NOT NULL DEFAULT '1',
+  smileys_enabled TINYINT NOT NULL DEFAULT '1',
   modified_time INT(10) UNSIGNED NOT NULL DEFAULT '0',
   modified_name VARCHAR(255) NOT NULL DEFAULT '',
   modified_reason VARCHAR(255) NOT NULL DEFAULT '',
   body TEXT NOT NULL,
   icon VARCHAR(16) NOT NULL DEFAULT 'xx',
-  approved TINYINT(3) NOT NULL DEFAULT '1',
-  likes SMALLINT(5) UNSIGNED NOT NULL DEFAULT '0',
+  approved TINYINT NOT NULL DEFAULT '1',
+  likes SMALLINT UNSIGNED NOT NULL DEFAULT '0',
   PRIMARY KEY (id_msg),
   UNIQUE idx_id_board (id_board, id_msg),
   UNIQUE idx_id_member (id_member, id_msg),
@@ -805,8 +805,8 @@ CREATE TABLE {$db_prefix}messages (
 #
 
 CREATE TABLE {$db_prefix}moderators (
-  id_board SMALLINT(5) UNSIGNED DEFAULT '0',
-  id_member MEDIUMINT(8) UNSIGNED DEFAULT '0',
+  id_board SMALLINT UNSIGNED DEFAULT '0',
+  id_member MEDIUMINT UNSIGNED DEFAULT '0',
   PRIMARY KEY (id_board, id_member)
 ) ENGINE={$engine};
 
@@ -815,8 +815,8 @@ CREATE TABLE {$db_prefix}moderators (
 #
 
 CREATE TABLE {$db_prefix}moderator_groups (
-  id_board SMALLINT(5) UNSIGNED DEFAULT '0',
-  id_group SMALLINT(5) UNSIGNED DEFAULT '0',
+  id_board SMALLINT UNSIGNED DEFAULT '0',
+  id_group SMALLINT UNSIGNED DEFAULT '0',
   PRIMARY KEY (id_board, id_group)
 ) ENGINE={$engine};
 
@@ -825,7 +825,7 @@ CREATE TABLE {$db_prefix}moderator_groups (
 #
 
 CREATE TABLE {$db_prefix}package_servers (
-  id_server SMALLINT(5) UNSIGNED AUTO_INCREMENT,
+  id_server SMALLINT UNSIGNED AUTO_INCREMENT,
   name VARCHAR(255) NOT NULL DEFAULT '',
   url VARCHAR(255) NOT NULL DEFAULT '',
   PRIMARY KEY (id_server)
@@ -836,7 +836,7 @@ CREATE TABLE {$db_prefix}package_servers (
 #
 
 CREATE TABLE {$db_prefix}permission_profiles (
-  id_profile SMALLINT(5) AUTO_INCREMENT,
+  id_profile SMALLINT AUTO_INCREMENT,
   profile_name VARCHAR(255) NOT NULL DEFAULT '',
   PRIMARY KEY (id_profile)
 ) ENGINE={$engine};
@@ -846,9 +846,9 @@ CREATE TABLE {$db_prefix}permission_profiles (
 #
 
 CREATE TABLE {$db_prefix}permissions (
-  id_group SMALLINT(5) DEFAULT '0',
+  id_group SMALLINT DEFAULT '0',
   permission VARCHAR(30) DEFAULT '',
-  add_deny TINYINT(4) NOT NULL DEFAULT '1',
+  add_deny TINYINT NOT NULL DEFAULT '1',
   PRIMARY KEY (id_group, permission)
 ) ENGINE={$engine};
 
@@ -859,8 +859,8 @@ CREATE TABLE {$db_prefix}permissions (
 CREATE TABLE {$db_prefix}personal_messages (
   id_pm INT(10) UNSIGNED AUTO_INCREMENT,
   id_pm_head INT(10) UNSIGNED NOT NULL DEFAULT '0',
-  id_member_from MEDIUMINT(8) UNSIGNED NOT NULL DEFAULT '0',
-  deleted_by_sender TINYINT(3) UNSIGNED NOT NULL DEFAULT '0',
+  id_member_from MEDIUMINT UNSIGNED NOT NULL DEFAULT '0',
+  deleted_by_sender TINYINT UNSIGNED NOT NULL DEFAULT '0',
   from_name VARCHAR(255) NOT NULL DEFAULT '',
   msgtime INT(10) UNSIGNED NOT NULL DEFAULT '0',
   subject VARCHAR(255) NOT NULL DEFAULT '',
@@ -876,7 +876,7 @@ CREATE TABLE {$db_prefix}personal_messages (
 #
 CREATE TABLE {$db_prefix}pm_labels (
   id_label INT(10) UNSIGNED AUTO_INCREMENT,
-  id_member MEDIUMINT(8) UNSIGNED NOT NULL DEFAULT '0',
+  id_member MEDIUMINT UNSIGNED NOT NULL DEFAULT '0',
   name VARCHAR(30) NOT NULL DEFAULT '',
   PRIMARY KEY (id_label)
 ) ENGINE={$engine};
@@ -896,12 +896,12 @@ CREATE TABLE {$db_prefix}pm_labeled_messages (
 
 CREATE TABLE {$db_prefix}pm_recipients (
   id_pm INT(10) UNSIGNED DEFAULT '0',
-  id_member MEDIUMINT(8) UNSIGNED DEFAULT '0',
-  bcc TINYINT(3) UNSIGNED NOT NULL DEFAULT '0',
-  is_read TINYINT(3) UNSIGNED NOT NULL DEFAULT '0',
-  is_new TINYINT(3) UNSIGNED NOT NULL DEFAULT '0',
-  deleted TINYINT(3) UNSIGNED NOT NULL DEFAULT '0',
-  in_inbox TINYINT(3) UNSIGNED NOT NULL DEFAULT '1',
+  id_member MEDIUMINT UNSIGNED DEFAULT '0',
+  bcc TINYINT UNSIGNED NOT NULL DEFAULT '0',
+  is_read TINYINT UNSIGNED NOT NULL DEFAULT '0',
+  is_new TINYINT UNSIGNED NOT NULL DEFAULT '0',
+  deleted TINYINT UNSIGNED NOT NULL DEFAULT '0',
+  in_inbox TINYINT UNSIGNED NOT NULL DEFAULT '1',
   PRIMARY KEY (id_pm, id_member),
   UNIQUE idx_id_member (id_member, deleted, id_pm)
 ) ENGINE={$engine};
@@ -912,12 +912,12 @@ CREATE TABLE {$db_prefix}pm_recipients (
 
 CREATE TABLE {$db_prefix}pm_rules (
   id_rule INT(10) UNSIGNED AUTO_INCREMENT,
-  id_member INT(10) UNSIGNED NOT NULL DEFAULT '0',
+  id_member MEDIUMINT UNSIGNED NOT NULL DEFAULT '0',
   rule_name VARCHAR(60) NOT NULL,
   criteria TEXT NOT NULL,
   actions TEXT NOT NULL,
-  delete_pm TINYINT(3) UNSIGNED NOT NULL DEFAULT '0',
-  is_or TINYINT(3) UNSIGNED NOT NULL DEFAULT '0',
+  delete_pm TINYINT UNSIGNED NOT NULL DEFAULT '0',
+  is_or TINYINT UNSIGNED NOT NULL DEFAULT '0',
   PRIMARY KEY (id_rule),
   INDEX idx_id_member (id_member),
   INDEX idx_delete_pm (delete_pm)
@@ -928,17 +928,17 @@ CREATE TABLE {$db_prefix}pm_rules (
 #
 
 CREATE TABLE {$db_prefix}polls (
-  id_poll MEDIUMINT(8) UNSIGNED AUTO_INCREMENT,
+  id_poll MEDIUMINT UNSIGNED AUTO_INCREMENT,
   question VARCHAR(255) NOT NULL DEFAULT '',
-  voting_locked TINYINT(1) NOT NULL DEFAULT '0',
-  max_votes TINYINT(3) UNSIGNED NOT NULL DEFAULT '1',
+  voting_locked TINYINT NOT NULL DEFAULT '0',
+  max_votes TINYINT UNSIGNED NOT NULL DEFAULT '1',
   expire_time INT(10) UNSIGNED NOT NULL DEFAULT '0',
-  hide_results TINYINT(3) UNSIGNED NOT NULL DEFAULT '0',
-  change_vote TINYINT(3) UNSIGNED NOT NULL DEFAULT '0',
-  guest_vote TINYINT(3) UNSIGNED NOT NULL DEFAULT '0',
+  hide_results TINYINT UNSIGNED NOT NULL DEFAULT '0',
+  change_vote TINYINT UNSIGNED NOT NULL DEFAULT '0',
+  guest_vote TINYINT UNSIGNED NOT NULL DEFAULT '0',
   num_guest_voters INT(10) UNSIGNED NOT NULL DEFAULT '0',
   reset_poll INT(10) UNSIGNED NOT NULL DEFAULT '0',
-  id_member MEDIUMINT(8) NOT NULL DEFAULT '0',
+  id_member MEDIUMINT NOT NULL DEFAULT '0',
   poster_name VARCHAR(255) NOT NULL DEFAULT '',
   PRIMARY KEY (id_poll)
 ) ENGINE={$engine};
@@ -948,10 +948,10 @@ CREATE TABLE {$db_prefix}polls (
 #
 
 CREATE TABLE {$db_prefix}poll_choices (
-  id_poll MEDIUMINT(8) UNSIGNED DEFAULT '0',
-  id_choice TINYINT(3) UNSIGNED DEFAULT '0',
+  id_poll MEDIUMINT UNSIGNED DEFAULT '0',
+  id_choice TINYINT UNSIGNED DEFAULT '0',
   label VARCHAR(255) NOT NULL DEFAULT '',
-  votes SMALLINT(5) UNSIGNED NOT NULL DEFAULT '0',
+  votes SMALLINT UNSIGNED NOT NULL DEFAULT '0',
   PRIMARY KEY (id_poll, id_choice)
 ) ENGINE={$engine};
 
@@ -960,7 +960,7 @@ CREATE TABLE {$db_prefix}poll_choices (
 #
 
 CREATE TABLE {$db_prefix}qanda (
-  id_question SMALLINT(5) UNSIGNED AUTO_INCREMENT,
+  id_question SMALLINT UNSIGNED AUTO_INCREMENT,
   lngfile VARCHAR(255) NOT NULL DEFAULT '',
   question VARCHAR(255) NOT NULL DEFAULT '',
   answers TEXT NOT NULL,
@@ -973,12 +973,12 @@ CREATE TABLE {$db_prefix}qanda (
 #
 
 CREATE TABLE {$db_prefix}scheduled_tasks (
-  id_task SMALLINT(5) AUTO_INCREMENT,
+  id_task SMALLINT AUTO_INCREMENT,
   next_time INT(10) NOT NULL DEFAULT '0',
   time_offset INT(10) NOT NULL DEFAULT '0',
-  time_regularity SMALLINT(5) NOT NULL DEFAULT '0',
+  time_regularity SMALLINT NOT NULL DEFAULT '0',
   time_unit VARCHAR(1) NOT NULL DEFAULT 'h',
-  disabled TINYINT(3) NOT NULL DEFAULT '0',
+  disabled TINYINT NOT NULL DEFAULT '0',
   task VARCHAR(24) NOT NULL DEFAULT '',
   callable VARCHAR(60) NOT NULL DEFAULT '',
   PRIMARY KEY (id_task),
@@ -1013,13 +1013,13 @@ CREATE TABLE {$db_prefix}sessions (
 #
 
 CREATE TABLE {$db_prefix}smileys (
-  id_smiley SMALLINT(5) UNSIGNED AUTO_INCREMENT,
+  id_smiley SMALLINT UNSIGNED AUTO_INCREMENT,
   code VARCHAR(30) NOT NULL DEFAULT '',
   filename VARCHAR(48) NOT NULL DEFAULT '',
   description VARCHAR(80) NOT NULL DEFAULT '',
-  smiley_row TINYINT(4) UNSIGNED NOT NULL DEFAULT '0',
-  smiley_order SMALLINT(5) UNSIGNED NOT NULL DEFAULT '0',
-  hidden TINYINT(4) UNSIGNED NOT NULL DEFAULT '0',
+  smiley_row TINYINT UNSIGNED NOT NULL DEFAULT '0',
+  smiley_order SMALLINT UNSIGNED NOT NULL DEFAULT '0',
+  hidden TINYINT UNSIGNED NOT NULL DEFAULT '0',
   PRIMARY KEY (id_smiley)
 ) ENGINE={$engine};
 
@@ -1028,7 +1028,7 @@ CREATE TABLE {$db_prefix}smileys (
 #
 
 CREATE TABLE {$db_prefix}spiders (
-  id_spider SMALLINT(5) UNSIGNED AUTO_INCREMENT,
+  id_spider SMALLINT UNSIGNED AUTO_INCREMENT,
   spider_name VARCHAR(255) NOT NULL DEFAULT '',
   user_agent VARCHAR(255) NOT NULL DEFAULT '',
   ip_info VARCHAR(255) NOT NULL DEFAULT '',
@@ -1040,17 +1040,17 @@ CREATE TABLE {$db_prefix}spiders (
 #
 
 CREATE TABLE {$db_prefix}subscriptions(
-  id_subscribe MEDIUMINT(8) UNSIGNED AUTO_INCREMENT,
+  id_subscribe MEDIUMINT UNSIGNED AUTO_INCREMENT,
   name VARCHAR(60) NOT NULL DEFAULT '',
   description VARCHAR(255) NOT NULL DEFAULT '',
   cost TEXT NOT NULL,
   length VARCHAR(6) NOT NULL DEFAULT '',
-  id_group SMALLINT(5) NOT NULL DEFAULT '0',
+  id_group SMALLINT NOT NULL DEFAULT '0',
   add_groups VARCHAR(40) NOT NULL DEFAULT '',
-  active TINYINT(3) NOT NULL DEFAULT '1',
-  repeatable TINYINT(3) NOT NULL DEFAULT '0',
-  allow_partial TINYINT(3) NOT NULL DEFAULT '0',
-  reminder TINYINT(3) NOT NULL DEFAULT '0',
+  active TINYINT NOT NULL DEFAULT '1',
+  repeatable TINYINT NOT NULL DEFAULT '0',
+  allow_partial TINYINT NOT NULL DEFAULT '0',
+  reminder TINYINT NOT NULL DEFAULT '0',
   email_complete TEXT NOT NULL,
   PRIMARY KEY (id_subscribe),
   INDEX idx_active (active)
@@ -1061,8 +1061,8 @@ CREATE TABLE {$db_prefix}subscriptions(
 #
 
 CREATE TABLE {$db_prefix}themes (
-  id_member MEDIUMINT(8) DEFAULT '0',
-  id_theme TINYINT(4) UNSIGNED DEFAULT '1',
+  id_member MEDIUMINT DEFAULT '0',
+  id_theme TINYINT UNSIGNED DEFAULT '1',
   variable VARCHAR(255) DEFAULT '',
   value TEXT NOT NULL,
   PRIMARY KEY (id_theme, id_member, variable(30)),
@@ -1074,23 +1074,23 @@ CREATE TABLE {$db_prefix}themes (
 #
 
 CREATE TABLE {$db_prefix}topics (
-  id_topic MEDIUMINT(8) UNSIGNED AUTO_INCREMENT,
-  is_sticky TINYINT(4) NOT NULL DEFAULT '0',
-  id_board SMALLINT(5) UNSIGNED NOT NULL DEFAULT '0',
+  id_topic MEDIUMINT UNSIGNED AUTO_INCREMENT,
+  is_sticky TINYINT NOT NULL DEFAULT '0',
+  id_board SMALLINT UNSIGNED NOT NULL DEFAULT '0',
   id_first_msg INT(10) UNSIGNED NOT NULL DEFAULT '0',
   id_last_msg INT(10) UNSIGNED NOT NULL DEFAULT '0',
-  id_member_started MEDIUMINT(8) UNSIGNED NOT NULL DEFAULT '0',
-  id_member_updated MEDIUMINT(8) UNSIGNED NOT NULL DEFAULT '0',
-  id_poll MEDIUMINT(8) UNSIGNED NOT NULL DEFAULT '0',
-  id_previous_board SMALLINT(5) NOT NULL DEFAULT '0',
-  id_previous_topic MEDIUMINT(8) NOT NULL DEFAULT '0',
+  id_member_started MEDIUMINT UNSIGNED NOT NULL DEFAULT '0',
+  id_member_updated MEDIUMINT UNSIGNED NOT NULL DEFAULT '0',
+  id_poll MEDIUMINT UNSIGNED NOT NULL DEFAULT '0',
+  id_previous_board SMALLINT NOT NULL DEFAULT '0',
+  id_previous_topic MEDIUMINT NOT NULL DEFAULT '0',
   num_replies INT(10) UNSIGNED NOT NULL DEFAULT '0',
   num_views INT(10) UNSIGNED NOT NULL DEFAULT '0',
-  locked TINYINT(4) NOT NULL DEFAULT '0',
+  locked TINYINT NOT NULL DEFAULT '0',
   redirect_expires INT(10) UNSIGNED NOT NULL DEFAULT '0',
-  id_redirect_topic MEDIUMINT(8) UNSIGNED NOT NULL DEFAULT '0',
-  unapproved_posts SMALLINT(5) NOT NULL DEFAULT '0',
-  approved TINYINT(3) NOT NULL DEFAULT '1',
+  id_redirect_topic MEDIUMINT UNSIGNED NOT NULL DEFAULT '0',
+  unapproved_posts SMALLINT NOT NULL DEFAULT '0',
+  approved TINYINT NOT NULL DEFAULT '1',
   PRIMARY KEY (id_topic),
   UNIQUE idx_last_message (id_last_msg, id_board),
   UNIQUE idx_first_message (id_first_msg, id_board),
@@ -1109,8 +1109,8 @@ CREATE TABLE {$db_prefix}topics (
 CREATE TABLE {$db_prefix}user_alerts (
   id_alert INT(10) UNSIGNED AUTO_INCREMENT,
   alert_time INT(10) UNSIGNED NOT NULL DEFAULT '0',
-  id_member MEDIUMINT(10) UNSIGNED NOT NULL DEFAULT '0',
-  id_member_started MEDIUMINT(10) UNSIGNED NOT NULL DEFAULT '0',
+  id_member MEDIUMINT UNSIGNED NOT NULL DEFAULT '0',
+  id_member_started MEDIUMINT UNSIGNED NOT NULL DEFAULT '0',
   member_name VARCHAR(255) NOT NULL DEFAULT '',
   content_type VARCHAR(255) NOT NULL DEFAULT '',
   content_id INT(10) UNSIGNED NOT NULL DEFAULT '0',
@@ -1127,9 +1127,9 @@ CREATE TABLE {$db_prefix}user_alerts (
 #
 
 CREATE TABLE {$db_prefix}user_alerts_prefs (
-  id_member MEDIUMINT(8) UNSIGNED DEFAULT '0',
+  id_member MEDIUMINT UNSIGNED DEFAULT '0',
   alert_pref VARCHAR(32) DEFAULT '',
-  alert_value TINYINT(3) NOT NULL DEFAULT '0',
+  alert_value TINYINT NOT NULL DEFAULT '0',
   PRIMARY KEY (id_member, alert_pref)
 ) ENGINE={$engine};
 
@@ -1139,18 +1139,18 @@ CREATE TABLE {$db_prefix}user_alerts_prefs (
 
 CREATE TABLE {$db_prefix}user_drafts (
   id_draft INT(10) UNSIGNED AUTO_INCREMENT,
-  id_topic MEDIUMINT(8) UNSIGNED NOT NULL DEFAULT '0',
-  id_board SMALLINT(5) UNSIGNED NOT NULL DEFAULT '0',
+  id_topic MEDIUMINT UNSIGNED NOT NULL DEFAULT '0',
+  id_board SMALLINT UNSIGNED NOT NULL DEFAULT '0',
   id_reply INT(10) UNSIGNED NOT NULL DEFAULT '0',
-  type TINYINT(4) NOT NULL DEFAULT '0',
+  type TINYINT NOT NULL DEFAULT '0',
   poster_time INT(10) UNSIGNED NOT NULL DEFAULT '0',
-  id_member MEDIUMINT(8) UNSIGNED NOT NULL DEFAULT '0',
+  id_member MEDIUMINT UNSIGNED NOT NULL DEFAULT '0',
   subject VARCHAR(255) NOT NULL DEFAULT '',
-  smileys_enabled TINYINT(4) NOT NULL DEFAULT '1',
+  smileys_enabled TINYINT NOT NULL DEFAULT '1',
   body MEDIUMTEXT NOT NULL,
   icon VARCHAR(16) NOT NULL DEFAULT 'xx',
-  locked TINYINT(4) NOT NULL DEFAULT '0',
-  is_sticky TINYINT(4) NOT NULL DEFAULT '0',
+  locked TINYINT NOT NULL DEFAULT '0',
+  is_sticky TINYINT NOT NULL DEFAULT '0',
   to_list VARCHAR(255) NOT NULL DEFAULT '',
   PRIMARY KEY (id_draft),
   UNIQUE idx_id_member (id_member, id_draft, type)
@@ -1161,7 +1161,7 @@ CREATE TABLE {$db_prefix}user_drafts (
 #
 
 CREATE TABLE {$db_prefix}user_likes (
-  id_member MEDIUMINT(8) UNSIGNED DEFAULT '0',
+  id_member MEDIUMINT UNSIGNED DEFAULT '0',
   content_type CHAR(6) DEFAULT '',
   content_id INT(10) UNSIGNED DEFAULT '0',
   like_time INT(10) UNSIGNED NOT NULL DEFAULT '0',
@@ -1177,7 +1177,7 @@ CREATE TABLE {$db_prefix}mentions (
   content_id INT DEFAULT '0',
   content_type VARCHAR(10) DEFAULT '',
   id_mentioned INT DEFAULT 0,
-  id_member INT NOT NULL DEFAULT 0,
+  id_member INT(10) UNSIGNED NOT NULL DEFAULT 0,
   `time` INT NOT NULL DEFAULT 0,
   PRIMARY KEY (content_id, content_type, id_mentioned),
   INDEX content (content_id, content_type),

--- a/other/install_2-1_postgresql.sql
+++ b/other/install_2-1_postgresql.sql
@@ -127,11 +127,11 @@ CREATE SEQUENCE {$db_prefix}admin_info_files_seq START WITH 8;
 
 CREATE TABLE {$db_prefix}admin_info_files (
   id_file smallint default nextval('{$db_prefix}admin_info_files_seq'),
-  filename varchar(255) NOT NULL,
-  path varchar(255) NOT NULL,
-  parameters varchar(255) NOT NULL,
+  filename varchar(255) NOT NULL DEFAULT '',
+  path varchar(255) NOT NULL DEFAULT '',
+  parameters varchar(255) NOT NULL DEFAULT '',
   data text NOT NULL,
-  filetype varchar(255) NOT NULL,
+  filetype varchar(255) NOT NULL DEFAULT '',
   PRIMARY KEY (id_file)
 );
 
@@ -146,8 +146,8 @@ CREATE INDEX {$db_prefix}admin_info_files_filename ON {$db_prefix}admin_info_fil
 #
 
 CREATE TABLE {$db_prefix}approval_queue (
-  id_msg int NOT NULL default '0',
-  id_attach int NOT NULL default '0',
+  id_msg bigint NOT NULL default '0',
+  id_attach bigint NOT NULL default '0',
   id_event smallint NOT NULL default '0'
 );
 
@@ -162,13 +162,13 @@ CREATE SEQUENCE {$db_prefix}attachments_seq;
 #
 
 CREATE TABLE {$db_prefix}attachments (
-  id_attach int default nextval('{$db_prefix}attachments_seq'),
-  id_thumb int NOT NULL default '0',
-  id_msg int NOT NULL default '0',
+  id_attach bigint default nextval('{$db_prefix}attachments_seq'),
+  id_thumb bigint NOT NULL default '0',
+  id_msg bigint NOT NULL default '0',
   id_member int NOT NULL default '0',
   id_folder smallint NOT NULL default '1',
   attachment_type smallint NOT NULL default '0',
-  filename varchar(255) NOT NULL,
+  filename varchar(255) NOT NULL DEFAULT '',
   file_hash varchar(40) NOT NULL default '',
   fileext varchar(8) NOT NULL default '',
   size int NOT NULL default '0',
@@ -199,7 +199,7 @@ CREATE SEQUENCE {$db_prefix}background_tasks_seq;
 #
 
 CREATE TABLE {$db_prefix}background_tasks (
-  id_task int default nextval('{$db_prefix}background_tasks_seq'),
+  id_task bigint default nextval('{$db_prefix}background_tasks_seq'),
   task_file varchar(255) NOT NULL default '',
   task_class varchar(255) NOT NULL default '',
   task_data text NOT NULL,
@@ -220,8 +220,8 @@ CREATE SEQUENCE {$db_prefix}ban_groups_seq;
 CREATE TABLE {$db_prefix}ban_groups (
   id_ban_group int default nextval('{$db_prefix}ban_groups_seq'),
   name varchar(20) NOT NULL default '',
-  ban_time int NOT NULL default '0',
-  expire_time int,
+  ban_time bigint NOT NULL default '0',
+  expire_time bigint,
   cannot_access smallint NOT NULL default '0',
   cannot_register smallint NOT NULL default '0',
   cannot_post smallint NOT NULL default '0',
@@ -246,10 +246,10 @@ CREATE TABLE {$db_prefix}ban_items (
   id_ban_group smallint NOT NULL default '0',
   ip_low inet,
   ip_high inet,
-  hostname varchar(255) NOT NULL,
-  email_address varchar(255) NOT NULL,
+  hostname varchar(255) NOT NULL DEFAULT '',
+  email_address varchar(255) NOT NULL DEFAULT '',
   id_member int NOT NULL default '0',
-  hits int NOT NULL default '0',
+  hits bigint NOT NULL default '0',
   PRIMARY KEY (id_ban)
 );
 
@@ -288,11 +288,11 @@ CREATE TABLE {$db_prefix}boards (
   child_level smallint NOT NULL default '0',
   id_parent smallint NOT NULL default '0',
   board_order smallint NOT NULL default '0',
-  id_last_msg int NOT NULL default '0',
-  id_msg_updated int NOT NULL default '0',
+  id_last_msg bigint NOT NULL default '0',
+  id_msg_updated bigint NOT NULL default '0',
   member_groups varchar(255) NOT NULL default '-1,0',
   id_profile smallint NOT NULL default '1',
-  name varchar(255) NOT NULL,
+  name varchar(255) NOT NULL DEFAULT '',
   description text NOT NULL,
   num_topics int NOT NULL default '0',
   num_posts int NOT NULL default '0',
@@ -380,7 +380,7 @@ CREATE SEQUENCE {$db_prefix}categories_seq START WITH 2;
 CREATE TABLE {$db_prefix}categories (
   id_cat smallint default nextval('{$db_prefix}categories_seq'),
   cat_order smallint NOT NULL default '0',
-  name varchar(255) NOT NULL,
+  name varchar(255) NOT NULL DEFAULT '',
   description text NOT NULL,
   can_collapse smallint NOT NULL default '1',
   PRIMARY KEY (id_cat)
@@ -400,12 +400,12 @@ CREATE TABLE {$db_prefix}custom_fields (
   id_field smallint default nextval('{$db_prefix}custom_fields_seq'),
   col_name varchar(12) NOT NULL default '',
   field_name varchar(40) NOT NULL default '',
-  field_desc varchar(255) NOT NULL,
+  field_desc varchar(255) NOT NULL DEFAULT '',
   field_type varchar(8) NOT NULL default 'text',
   field_length smallint NOT NULL default '255',
   field_options text NOT NULL,
   field_order smallint NOT NULL default '0',
-  mask varchar(255) NOT NULL,
+  mask varchar(255) NOT NULL DEFAULT '',
   show_reg smallint NOT NULL default '0',
   show_display smallint NOT NULL default '0',
   show_mlist smallint NOT NULL default '0',
@@ -414,7 +414,7 @@ CREATE TABLE {$db_prefix}custom_fields (
   active smallint NOT NULL default '1',
   bbc smallint NOT NULL default '0',
   can_search smallint NOT NULL default '0',
-  default_value varchar(255) NOT NULL,
+  default_value varchar(255) NOT NULL DEFAULT '',
   enclose text NOT NULL,
   placement smallint NOT NULL default '0',
   PRIMARY KEY (id_field)
@@ -447,15 +447,15 @@ CREATE SEQUENCE {$db_prefix}log_actions_seq;
 #
 
 CREATE TABLE {$db_prefix}log_actions (
-  id_action int default nextval('{$db_prefix}log_actions_seq'),
+  id_action bigint default nextval('{$db_prefix}log_actions_seq'),
   id_log smallint NOT NULL default '1',
-  log_time int NOT NULL default '0',
+  log_time bigint NOT NULL default '0',
   id_member int NOT NULL default '0',
   ip inet,
   action varchar(30) NOT NULL default '',
   id_board smallint NOT NULL default '0',
   id_topic int NOT NULL default '0',
-  id_msg int NOT NULL default '0',
+  id_msg bigint NOT NULL default '0',
   extra text NOT NULL,
   PRIMARY KEY (id_action)
 );
@@ -499,8 +499,8 @@ CREATE TABLE {$db_prefix}log_banned (
   id_ban_log int default nextval('{$db_prefix}log_banned_seq'),
   id_member int NOT NULL default '0',
   ip inet,
-  email varchar(255) NOT NULL,
-  log_time int NOT NULL default '0',
+  email varchar(255) NOT NULL DEFAULT '',
+  log_time bigint NOT NULL default '0',
   PRIMARY KEY (id_ban_log)
 );
 
@@ -517,7 +517,7 @@ CREATE INDEX {$db_prefix}log_banned_log_time ON {$db_prefix}log_banned (log_time
 CREATE TABLE {$db_prefix}log_boards (
   id_member int NOT NULL default '0',
   id_board smallint NOT NULL default '0',
-  id_msg int NOT NULL default '0',
+  id_msg bigint NOT NULL default '0',
   PRIMARY KEY (id_member, id_board)
 );
 
@@ -537,8 +537,8 @@ CREATE TABLE {$db_prefix}log_comments (
   member_name varchar(80) NOT NULL default '',
   comment_type varchar(8) NOT NULL default 'warning',
   id_recipient int NOT NULL default '0',
-  recipient_name varchar(255) NOT NULL,
-  log_time int NOT NULL default '0',
+  recipient_name varchar(255) NOT NULL DEFAULT '',
+  log_time bigint NOT NULL default '0',
   id_notice int NOT NULL default '0',
   counter smallint NOT NULL default '0',
   body text NOT NULL,
@@ -559,7 +559,7 @@ CREATE INDEX {$db_prefix}log_comments_comment_type ON {$db_prefix}log_comments (
 
 CREATE TABLE {$db_prefix}log_digest (
   id_topic int NOT NULL,
-  id_msg int NOT NULL,
+  id_msg bigint NOT NULL,
   note_type varchar(10) NOT NULL default 'post',
   daily smallint NOT NULL default '0',
   exclude int NOT NULL default '0'
@@ -577,14 +577,14 @@ CREATE SEQUENCE {$db_prefix}log_errors_seq;
 
 CREATE TABLE {$db_prefix}log_errors (
   id_error int default nextval('{$db_prefix}log_errors_seq'),
-  log_time int NOT NULL default '0',
+  log_time bigint NOT NULL default '0',
   id_member int NOT NULL default '0',
   ip inet,
   url text NOT NULL,
   message text NOT NULL,
   session char(64) NOT NULL default '                                                                ',
   error_type varchar(15) NOT NULL default 'general',
-  file varchar(255) NOT NULL,
+  file varchar(255) NOT NULL DEFAULT '',
   line int NOT NULL default '0',
   PRIMARY KEY (id_error)
 );
@@ -603,7 +603,7 @@ CREATE INDEX {$db_prefix}log_errors_ip ON {$db_prefix}log_errors (ip);
 
 CREATE {$unlogged} TABLE {$db_prefix}log_floodcontrol (
   ip inet,
-  log_time int NOT NULL default '0',
+  log_time bigint NOT NULL default '0',
   log_type varchar(8) NOT NULL default 'post',
   PRIMARY KEY (ip, log_type)
 );
@@ -622,12 +622,12 @@ CREATE TABLE {$db_prefix}log_group_requests (
   id_request int default nextval('{$db_prefix}log_group_requests_seq'),
   id_member int NOT NULL default '0',
   id_group smallint NOT NULL default '0',
-  time_applied int NOT NULL default '0',
+  time_applied bigint NOT NULL default '0',
   reason text NOT NULL,
   status smallint NOT NULL default '0',
   id_member_acted int NOT NULL default '0',
-  member_name_acted varchar(255) NOT NULL,
-  time_acted int NOT NULL default '0',
+  member_name_acted varchar(255) NOT NULL DEFAULT '',
+  time_acted bigint NOT NULL default '0',
   act_reason text NOT NULL,
   PRIMARY KEY (id_request)
 );
@@ -645,7 +645,7 @@ CREATE INDEX {$db_prefix}log_group_requests_id_member ON {$db_prefix}log_group_r
 CREATE TABLE {$db_prefix}log_mark_read (
   id_member int NOT NULL default '0',
   id_board smallint NOT NULL default '0',
-  id_msg int NOT NULL default '0',
+  id_msg bigint NOT NULL default '0',
   PRIMARY KEY (id_member, id_board)
 );
 
@@ -661,7 +661,7 @@ CREATE SEQUENCE {$db_prefix}log_member_notices_seq;
 
 CREATE TABLE {$db_prefix}log_member_notices (
   id_notice int default nextval('{$db_prefix}log_member_notices_seq'),
-  subject varchar(255) NOT NULL,
+  subject varchar(255) NOT NULL DEFAULT '',
   body text NOT NULL,
   PRIMARY KEY (id_notice)
 );
@@ -690,7 +690,7 @@ CREATE INDEX {$db_prefix}log_notify_id_topic ON {$db_prefix}log_notify (id_topic
 
 CREATE {$unlogged} TABLE {$db_prefix}log_online (
   session varchar(64) NOT NULL default '',
-  log_time int NOT NULL default '0',
+  log_time bigint NOT NULL default '0',
   id_member int NOT NULL default '0',
   id_spider smallint NOT NULL default '0',
   ip inet,
@@ -717,10 +717,10 @@ CREATE SEQUENCE {$db_prefix}log_packages_seq;
 
 CREATE TABLE {$db_prefix}log_packages (
   id_install int default nextval('{$db_prefix}log_packages_seq'),
-  filename varchar(255) NOT NULL,
-  package_id varchar(255) NOT NULL,
-  name varchar(255) NOT NULL,
-  version varchar(255) NOT NULL,
+  filename varchar(255) NOT NULL DEFAULT '',
+  package_id varchar(255) NOT NULL DEFAULT '',
+  name varchar(255) NOT NULL DEFAULT '',
+  version varchar(255) NOT NULL DEFAULT '',
   id_member_installed int NOT NULL default '0',
   member_installed varchar(255) NOT NULL,
   time_installed int NOT NULL default '0',
@@ -729,9 +729,9 @@ CREATE TABLE {$db_prefix}log_packages (
   time_removed int NOT NULL default '0',
   install_state smallint NOT NULL default '1',
   failed_steps text NOT NULL,
-  themes_installed varchar(255) NOT NULL,
+  themes_installed varchar(255) NOT NULL DEFAULT '',
   db_changes text NOT NULL,
-  credits varchar(255) NOT NULL,
+  credits varchar(255) NOT NULL DEFAULT '',
   PRIMARY KEY (id_install)
 );
 
@@ -769,12 +769,12 @@ CREATE SEQUENCE {$db_prefix}log_reported_seq;
 
 CREATE TABLE {$db_prefix}log_reported (
   id_report int default nextval('{$db_prefix}log_reported_seq'),
-  id_msg int NOT NULL default '0',
+  id_msg bigint NOT NULL default '0',
   id_topic int NOT NULL default '0',
   id_board smallint NOT NULL default '0',
   id_member int NOT NULL default '0',
-  membername varchar(255) NOT NULL,
-  subject varchar(255) NOT NULL,
+  membername varchar(255) NOT NULL DEFAULT '',
+  subject varchar(255) NOT NULL DEFAULT '',
   body text NOT NULL,
   time_started int NOT NULL default '0',
   time_updated int NOT NULL default '0',
@@ -808,9 +808,9 @@ CREATE TABLE {$db_prefix}log_reported_comments (
   id_comment int default nextval('{$db_prefix}log_reported_comments_seq'),
   id_report int NOT NULL default '0',
   id_member int NOT NULL,
-  membername varchar(255) NOT NULL,
+  membername varchar(255) NOT NULL DEFAULT '',
   member_ip inet,
-  comment varchar(255) NOT NULL,
+  comment varchar(255) NOT NULL DEFAULT '',
   time_sent int NOT NULL,
   PRIMARY KEY (id_comment)
 );
@@ -847,7 +847,7 @@ CREATE TABLE {$db_prefix}log_scheduled_tasks (
 
 CREATE TABLE {$db_prefix}log_search_messages (
   id_search smallint NOT NULL default '0',
-  id_msg int NOT NULL default '0',
+  id_msg bigint NOT NULL default '0',
   PRIMARY KEY (id_search, id_msg)
 );
 
@@ -858,7 +858,7 @@ CREATE TABLE {$db_prefix}log_search_messages (
 CREATE TABLE {$db_prefix}log_search_results (
   id_search smallint NOT NULL default '0',
   id_topic int NOT NULL default '0',
-  id_msg int NOT NULL default '0',
+  id_msg bigint NOT NULL default '0',
   relevance smallint NOT NULL default '0',
   num_matches smallint NOT NULL default '0',
   PRIMARY KEY (id_search, id_topic)
@@ -901,10 +901,10 @@ CREATE SEQUENCE {$db_prefix}log_spider_hits_seq;
 #
 
 CREATE TABLE {$db_prefix}log_spider_hits (
-  id_hit int default nextval('{$db_prefix}log_spider_hits_seq'),
+  id_hit bigint default nextval('{$db_prefix}log_spider_hits_seq'),
   id_spider smallint NOT NULL default '0',
-  log_time int NOT NULL default '0',
-  url varchar(1024) NOT NULL,
+  log_time bigint NOT NULL default '0',
+  url varchar(1024) NOT NULL default '',
   processed smallint NOT NULL default '0',
   PRIMARY KEY (id_hit)
 );
@@ -924,7 +924,7 @@ CREATE INDEX {$db_prefix}log_spider_hits_processed ON {$db_prefix}log_spider_hit
 CREATE TABLE {$db_prefix}log_spider_stats (
   id_spider smallint NOT NULL default '0',
   page_hits smallint NOT NULL default '0',
-  last_seen int NOT NULL default '0',
+  last_seen bigint NOT NULL default '0',
   stat_date date NOT NULL default '0001-01-01',
   PRIMARY KEY (stat_date, id_spider)
 );
@@ -940,7 +940,7 @@ CREATE SEQUENCE {$db_prefix}log_subscribed_seq;
 #
 
 CREATE TABLE {$db_prefix}log_subscribed (
-  id_sublog int default nextval('{$db_prefix}log_subscribed_seq'),
+  id_sublog bigint default nextval('{$db_prefix}log_subscribed_seq'),
   id_subscribe smallint NOT NULL default '0',
   id_member int NOT NULL default '0',
   old_id_group int NOT NULL default '0',
@@ -948,7 +948,7 @@ CREATE TABLE {$db_prefix}log_subscribed (
   end_time int NOT NULL default '0',
   payments_pending smallint NOT NULL default '0',
   status smallint NOT NULL default '0',
-  pending_details text NOT NULL default '',
+  pending_details text NOT NULL,
   reminder_sent smallint NOT NULL default '0',
   vendor_ref varchar(255) NOT NULL default '',
   PRIMARY KEY (id_sublog)
@@ -972,7 +972,7 @@ CREATE INDEX {$db_prefix}log_subscribed_id_member ON {$db_prefix}log_subscribed 
 CREATE TABLE {$db_prefix}log_topics (
   id_member int NOT NULL default '0',
   id_topic int NOT NULL default '0',
-  id_msg int NOT NULL default '0',
+  id_msg bigint NOT NULL default '0',
   unwatched int NOT NULL default '0',
   PRIMARY KEY (id_member, id_topic)
 );
@@ -994,11 +994,11 @@ CREATE SEQUENCE {$db_prefix}mail_queue_seq;
 #
 
 CREATE TABLE {$db_prefix}mail_queue (
-  id_mail int default nextval('{$db_prefix}mail_queue_seq'),
+  id_mail bigint default nextval('{$db_prefix}mail_queue_seq'),
   time_sent int NOT NULL default '0',
-  recipient varchar(255) NOT NULL,
+  recipient varchar(255) NOT NULL DEFAULT '',
   body text NOT NULL,
-  subject varchar(255) NOT NULL,
+  subject varchar(255) NOT NULL DEFAULT '',
   headers text NOT NULL,
   send_html smallint NOT NULL default '0',
   priority smallint NOT NULL default '1',
@@ -1030,7 +1030,7 @@ CREATE TABLE {$db_prefix}membergroups (
   online_color varchar(20) NOT NULL default '',
   min_posts int NOT NULL default '-1',
   max_messages smallint NOT NULL default '0',
-  icons varchar(255) NOT NULL,
+  icons varchar(255) NOT NULL DEFAULT '',
   group_type smallint NOT NULL default '0',
   hidden smallint NOT NULL default '0',
   id_parent smallint NOT NULL default '-2',
@@ -1057,45 +1057,45 @@ CREATE SEQUENCE {$db_prefix}members_seq;
 CREATE TABLE {$db_prefix}members (
   id_member int default nextval('{$db_prefix}members_seq'),
   member_name varchar(80) NOT NULL default '',
-  date_registered int NOT NULL default '0',
+  date_registered bigint NOT NULL default '0',
   posts int NOT NULL default '0',
   id_group smallint NOT NULL default '0',
-  lngfile varchar(255) NOT NULL,
-  last_login int NOT NULL default '0',
-  real_name varchar(255) NOT NULL,
+  lngfile varchar(255) NOT NULL DEFAULT '',
+  last_login bigint NOT NULL default '0',
+  real_name varchar(255) NOT NULL  DEFAULT '',
   instant_messages smallint NOT NULL default 0,
   unread_messages smallint NOT NULL default 0,
   new_pm smallint NOT NULL default '0',
-  alerts int NOT NULL default '0',
+  alerts bigint NOT NULL default '0',
   buddy_list text NOT NULL,
-  pm_ignore_list varchar(255) NOT NULL,
+  pm_ignore_list varchar(255) NOT NULL DEFAULT '',
   pm_prefs int NOT NULL default '0',
   mod_prefs varchar(20) NOT NULL default '',
   passwd varchar(64) NOT NULL default '',
-  email_address varchar(255) NOT NULL,
-  personal_text varchar(255) NOT NULL,
+  email_address varchar(255) NOT NULL DEFAULT '',
+  personal_text varchar(255) NOT NULL DEFAULT '',
   birthdate date NOT NULL default '0001-01-01',
-  website_title varchar(255) NOT NULL,
-  website_url varchar(255) NOT NULL,
+  website_title varchar(255) NOT NULL DEFAULT '',
+  website_url varchar(255) NOT NULL DEFAULT '',
   hide_email smallint NOT NULL default '0',
   show_online smallint NOT NULL default '1',
   time_format varchar(80) NOT NULL default '',
   signature text NOT NULL,
   time_offset float NOT NULL default '0',
-  avatar varchar(255) NOT NULL,
-  usertitle varchar(255) NOT NULL,
+  avatar varchar(255) NOT NULL DEFAULT '',
+  usertitle varchar(255) NOT NULL DEFAULT '',
   member_ip inet,
   member_ip2 inet,
-  secret_question varchar(255) NOT NULL,
+  secret_question varchar(255) NOT NULL DEFAULT '',
   secret_answer varchar(64) NOT NULL default '',
   id_theme smallint NOT NULL default '0',
   is_activated smallint NOT NULL default '1',
   validation_code varchar(10) NOT NULL default '',
   id_msg_last_visit int NOT NULL default '0',
-  additional_groups varchar(255) NOT NULL,
+  additional_groups varchar(255) NOT NULL DEFAULT '',
   smiley_set varchar(48) NOT NULL default '',
   id_post_group smallint NOT NULL default '0',
-  total_time_logged_in int NOT NULL default '0',
+  total_time_logged_in bigint NOT NULL default '0',
   password_salt varchar(255) NOT NULL default '',
   ignore_boards text NOT NULL,
   warning smallint NOT NULL default '0',
@@ -1180,6 +1180,51 @@ CREATE TABLE {$db_prefix}message_icons (
 CREATE INDEX {$db_prefix}message_icons_id_board ON {$db_prefix}message_icons (id_board);
 
 #
+# Sequence for table `messages`
+#
+
+CREATE SEQUENCE {$db_prefix}messages_seq START WITH 2;
+
+#
+# Table structure for table `messages`
+#
+
+CREATE TABLE {$db_prefix}messages (
+  id_msg bigint default nextval('{$db_prefix}messages_seq'),
+  id_topic int NOT NULL default '0',
+  id_board smallint NOT NULL default '0',
+  poster_time bigint NOT NULL default '0',
+  id_member int NOT NULL default '0',
+  id_msg_modified int NOT NULL default '0',
+  subject varchar(255) NOT NULL DEFAULT '',
+  poster_name varchar(255) NOT NULL DEFAULT '',
+  poster_email varchar(255) NOT NULL DEFAULT '',
+  poster_ip inet,
+  smileys_enabled smallint NOT NULL default '1',
+  modified_time int NOT NULL default '0',
+  modified_name varchar(255) NOT NULL,
+  modified_reason varchar(255) NOT NULL default '',
+  body text NOT NULL,
+  icon varchar(16) NOT NULL default 'xx',
+  approved smallint NOT NULL default '1',
+  likes smallint NOT NULL default '0',
+  PRIMARY KEY (id_msg)
+);
+
+#
+# Indexes for table `messages`
+#
+
+CREATE UNIQUE INDEX {$db_prefix}messages_id_board ON {$db_prefix}messages (id_board, id_msg);
+CREATE UNIQUE INDEX {$db_prefix}messages_id_member ON {$db_prefix}messages (id_member, id_msg);
+CREATE INDEX {$db_prefix}messages_approved ON {$db_prefix}messages (approved);
+CREATE INDEX {$db_prefix}messages_ip_index ON {$db_prefix}messages (poster_ip, id_topic);
+CREATE INDEX {$db_prefix}messages_participation ON {$db_prefix}messages (id_member, id_topic);
+CREATE INDEX {$db_prefix}messages_show_posts ON {$db_prefix}messages (id_member, id_board);
+CREATE INDEX {$db_prefix}messages_id_member_msg ON {$db_prefix}messages (id_member, approved, id_msg);
+CREATE INDEX {$db_prefix}messages_current_topic ON {$db_prefix}messages (id_topic, id_msg, id_member, approved);
+CREATE INDEX {$db_prefix}messages_related_ip ON {$db_prefix}messages (id_member, poster_ip, id_msg);
+#
 # Table structure for table `moderators`
 #
 
@@ -1211,56 +1256,11 @@ CREATE SEQUENCE {$db_prefix}package_servers_seq;
 
 CREATE TABLE {$db_prefix}package_servers (
   id_server smallint default nextval('{$db_prefix}package_servers_seq'),
-  name varchar(255) NOT NULL,
-  url varchar(255) NOT NULL,
+  name varchar(255) NOT NULL DEFAULT '',
+  url varchar(255) NOT NULL DEFAULT '',
   PRIMARY KEY (id_server)
 );
 
-#
-# Sequence for table `messages`
-#
-
-CREATE SEQUENCE {$db_prefix}messages_seq START WITH 2;
-
-#
-# Table structure for table `messages`
-#
-
-CREATE TABLE {$db_prefix}messages (
-  id_msg int default nextval('{$db_prefix}messages_seq'),
-  id_topic int NOT NULL default '0',
-  id_board smallint NOT NULL default '0',
-  poster_time int NOT NULL default '0',
-  id_member int NOT NULL default '0',
-  id_msg_modified int NOT NULL default '0',
-  subject varchar(255) NOT NULL,
-  poster_name varchar(255) NOT NULL,
-  poster_email varchar(255) NOT NULL,
-  poster_ip inet,
-  smileys_enabled smallint NOT NULL default '1',
-  modified_time int NOT NULL default '0',
-  modified_name varchar(255) NOT NULL,
-  modified_reason varchar(255) NOT NULL default '',
-  body text NOT NULL,
-  icon varchar(16) NOT NULL default 'xx',
-  approved smallint NOT NULL default '1',
-  likes smallint NOT NULL default '0',
-  PRIMARY KEY (id_msg)
-);
-
-#
-# Indexes for table `messages`
-#
-
-CREATE UNIQUE INDEX {$db_prefix}messages_id_board ON {$db_prefix}messages (id_board, id_msg);
-CREATE UNIQUE INDEX {$db_prefix}messages_id_member ON {$db_prefix}messages (id_member, id_msg);
-CREATE INDEX {$db_prefix}messages_approved ON {$db_prefix}messages (approved);
-CREATE INDEX {$db_prefix}messages_ip_index ON {$db_prefix}messages (poster_ip, id_topic);
-CREATE INDEX {$db_prefix}messages_participation ON {$db_prefix}messages (id_member, id_topic);
-CREATE INDEX {$db_prefix}messages_show_posts ON {$db_prefix}messages (id_member, id_board);
-CREATE INDEX {$db_prefix}messages_id_member_msg ON {$db_prefix}messages (id_member, approved, id_msg);
-CREATE INDEX {$db_prefix}messages_current_topic ON {$db_prefix}messages (id_topic, id_msg, id_member, approved);
-CREATE INDEX {$db_prefix}messages_related_ip ON {$db_prefix}messages (id_member, poster_ip, id_msg);
 
 #
 # Sequence for table `permission_profiles`
@@ -1274,7 +1274,7 @@ CREATE SEQUENCE {$db_prefix}permission_profiles_seq START WITH 5;
 
 CREATE TABLE {$db_prefix}permission_profiles (
   id_profile smallint default nextval('{$db_prefix}permission_profiles_seq'),
-  profile_name varchar(255) NOT NULL,
+  profile_name varchar(255) NOT NULL DEFAULT '',
   PRIMARY KEY (id_profile)
 );
 
@@ -1300,13 +1300,13 @@ CREATE SEQUENCE {$db_prefix}personal_messages_seq;
 #
 
 CREATE TABLE {$db_prefix}personal_messages (
-  id_pm int default nextval('{$db_prefix}personal_messages_seq'),
-  id_pm_head int NOT NULL default '0',
+  id_pm bigint default nextval('{$db_prefix}personal_messages_seq'),
+  id_pm_head bigint NOT NULL default '0',
   id_member_from int NOT NULL default '0',
   deleted_by_sender smallint NOT NULL default '0',
   from_name varchar(255) NOT NULL,
-  msgtime int NOT NULL default '0',
-  subject varchar(255) NOT NULL,
+  msgtime bigint NOT NULL default '0',
+  subject varchar(255) NOT NULL DEFAULT '',
   body text NOT NULL,
   PRIMARY KEY (id_pm)
 );
@@ -1330,7 +1330,7 @@ CREATE SEQUENCE {$db_prefix}pm_labels_seq;
 #
 
 CREATE TABLE {$db_prefix}pm_labels (
-  id_label int NOT NULL default nextval('{$db_prefix}pm_labels_seq'),
+  id_label bigint NOT NULL default nextval('{$db_prefix}pm_labels_seq'),
   id_member int NOT NULL default '0',
   name varchar(30) NOT NULL default '',
   PRIMARY KEY (id_label)
@@ -1341,8 +1341,8 @@ CREATE TABLE {$db_prefix}pm_labels (
 #
 
 CREATE TABLE {$db_prefix}pm_labeled_messages (
-  id_label int NOT NULL default '0',
-  id_pm int NOT NULL default '0',
+  id_label bigint NOT NULL default '0',
+  id_pm bigint NOT NULL default '0',
   PRIMARY KEY (id_label, id_pm)
 );
 
@@ -1351,9 +1351,8 @@ CREATE TABLE {$db_prefix}pm_labeled_messages (
 #
 
 CREATE TABLE {$db_prefix}pm_recipients (
-  id_pm int NOT NULL default '0',
+  id_pm bigint NOT NULL default '0',
   id_member int NOT NULL default '0',
-  labels varchar(60) NOT NULL default '-1',
   bcc smallint NOT NULL default '0',
   is_read smallint NOT NULL default '0',
   is_new smallint NOT NULL default '0',
@@ -1379,7 +1378,7 @@ CREATE SEQUENCE {$db_prefix}pm_rules_seq;
 #
 
 CREATE TABLE {$db_prefix}pm_rules (
-  id_rule int default nextval('{$db_prefix}pm_rules_seq'),
+  id_rule bigint default nextval('{$db_prefix}pm_rules_seq'),
   id_member int NOT NULL default '0',
   rule_name varchar(60) NOT NULL,
   criteria text NOT NULL,
@@ -1408,7 +1407,7 @@ CREATE SEQUENCE {$db_prefix}polls_seq;
 
 CREATE TABLE {$db_prefix}polls (
   id_poll int default nextval('{$db_prefix}polls_seq'),
-  question varchar(255) NOT NULL,
+  question varchar(255) NOT NULL DEFAULT '',
   voting_locked smallint NOT NULL default '0',
   max_votes smallint NOT NULL default '1',
   expire_time int NOT NULL default '0',
@@ -1429,7 +1428,7 @@ CREATE TABLE {$db_prefix}polls (
 CREATE TABLE {$db_prefix}poll_choices (
   id_poll int NOT NULL default '0',
   id_choice smallint NOT NULL default '0',
-  label varchar(255) NOT NULL,
+  label varchar(255) NOT NULL  DEFAULT '',
   votes smallint NOT NULL default '0',
   PRIMARY KEY (id_poll, id_choice)
 );
@@ -1493,7 +1492,7 @@ CREATE UNIQUE INDEX {$db_prefix}scheduled_tasks_task ON {$db_prefix}scheduled_ta
 #
 
 CREATE TABLE {$db_prefix}settings (
-  variable varchar(255) NOT NULL,
+  variable varchar(255) NOT NULL DEFAULT '',
   value text NOT NULL,
   PRIMARY KEY (variable)
 );
@@ -1504,7 +1503,7 @@ CREATE TABLE {$db_prefix}settings (
 
 CREATE {$unlogged} TABLE {$db_prefix}sessions (
   session_id char(64) NOT NULL,
-  last_update int NOT NULL,
+  last_update bigint NOT NULL,
   data text NOT NULL,
   PRIMARY KEY (session_id)
 );
@@ -1542,9 +1541,9 @@ CREATE SEQUENCE {$db_prefix}spiders_seq;
 
 CREATE TABLE {$db_prefix}spiders (
   id_spider smallint NOT NULL default nextval('{$db_prefix}spiders_seq'),
-  spider_name varchar(255) NOT NULL,
-  user_agent varchar(255) NOT NULL,
-  ip_info varchar(255) NOT NULL,
+  spider_name varchar(255) NOT NULL DEFAULT '',
+  user_agent varchar(255) NOT NULL DEFAULT '',
+  ip_info varchar(255) NOT NULL DEFAULT '',
   PRIMARY KEY (id_spider)
 );
 
@@ -1559,13 +1558,13 @@ CREATE SEQUENCE {$db_prefix}subscriptions_seq;
 #
 
 CREATE TABLE {$db_prefix}subscriptions(
-  id_subscribe smallint NOT NULL default nextval('{$db_prefix}subscriptions_seq'),
-  name varchar(60) NOT NULL,
-  description varchar(255) NOT NULL,
+  id_subscribe int NOT NULL default nextval('{$db_prefix}subscriptions_seq'),
+  name varchar(60) NOT NULL DEFAULT '',
+  description varchar(255) NOT NULL DEFAULT '',
   cost text NOT NULL,
-  length varchar(6) NOT NULL,
+  length varchar(6) NOT NULL DEFAULT '',
   id_group int NOT NULL default '0',
-  add_groups varchar(40) NOT NULL,
+  add_groups varchar(40) NOT NULL DEFAULT '',
   active smallint NOT NULL default '1',
   repeatable smallint NOT NULL default '0',
   allow_partial smallint NOT NULL default '0',
@@ -1585,9 +1584,9 @@ CREATE INDEX {$db_prefix}subscriptions_active ON {$db_prefix}subscriptions (acti
 #
 
 CREATE TABLE {$db_prefix}themes (
-  id_member int NOT NULL default '0',
-  id_theme smallint NOT NULL default '1',
-  variable varchar(255) NOT NULL,
+  id_member int default '0',
+  id_theme smallint  default '1',
+  variable varchar(255) DEFAULT '',
   value text NOT NULL,
   PRIMARY KEY (id_theme, id_member, variable)
 );
@@ -1613,17 +1612,17 @@ CREATE TABLE {$db_prefix}topics (
   is_sticky smallint NOT NULL default '0',
   id_board smallint NOT NULL default '0',
   id_first_msg int NOT NULL default '0',
-  id_last_msg int NOT NULL default '0',
+  id_last_msg bigint NOT NULL default '0',
   id_member_started int NOT NULL default '0',
   id_member_updated int NOT NULL default '0',
   id_poll int NOT NULL default '0',
   id_previous_board smallint NOT NULL default '0',
   id_previous_topic int NOT NULL default '0',
-  num_replies int NOT NULL default '0',
-  num_views int NOT NULL default '0',
+  num_replies bigint NOT NULL default '0',
+  num_views bigint NOT NULL default '0',
   locked smallint NOT NULL default '0',
   redirect_expires int NOT NULL default '0',
-  id_redirect_topic int NOT NULL default '0',
+  id_redirect_topic bigint NOT NULL default '0',
   unapproved_posts smallint NOT NULL default '0',
   approved smallint NOT NULL default '1',
   PRIMARY KEY (id_topic)
@@ -1653,15 +1652,15 @@ CREATE SEQUENCE {$db_prefix}user_alerts_seq;
 #
 
 CREATE TABLE {$db_prefix}user_alerts (
-  id_alert int default nextval('{$db_prefix}user_alerts_seq'),
-  alert_time int NOT NULL default '0',
+  id_alert bigint default nextval('{$db_prefix}user_alerts_seq'),
+  alert_time bigint NOT NULL default '0',
   id_member int NOT NULL default '0',
-  id_member_started int NOT NULL default '0',
+  id_member_started bigint NOT NULL default '0',
   member_name varchar(255) NOT NULL default '',
   content_type varchar(255) NOT NULL default '',
-  content_id int NOT NULL default '0',
+  content_id bigint NOT NULL default '0',
   content_action varchar(255) NOT NULL default '',
-  is_read int NOT NULL default '0',
+  is_read bigint NOT NULL default '0',
   extra text NOT NULL,
   PRIMARY KEY (id_alert)
 );
@@ -1695,10 +1694,10 @@ CREATE SEQUENCE {$db_prefix}user_drafts_seq;
 #
 
 CREATE TABLE {$db_prefix}user_drafts (
-  id_draft int default nextval('{$db_prefix}user_drafts_seq'),
+  id_draft bigint default nextval('{$db_prefix}user_drafts_seq'),
   id_topic int NOT NULL default '0',
   id_board smallint NOT NULL default '0',
-  id_reply int NOT NULL default '0',
+  id_reply bigint NOT NULL default '0',
   type smallint NOT NULL default '0',
   poster_time int NOT NULL default '0',
   id_member int NOT NULL default '0',
@@ -1741,9 +1740,9 @@ CREATE INDEX {$db_prefix}user_likes_liker ON {$db_prefix}user_likes (id_member);
 # Table structure for `mentions`
 #
 CREATE TABLE {$db_prefix}mentions (
-  content_id int NOT NULL default '0',
+  content_id int default '0',
   content_type varchar(10) default '',
-  id_mentioned int NOT NULL default 0,
+  id_mentioned int default 0,
   id_member int NOT NULL default 0,
   time int NOT NULL default 0,
   PRIMARY KEY (content_id, content_type, id_mentioned)


### PR DESCRIPTION
mysql was the leading platform for the pg defintion
but i changed also the mysql more cleaner way

What I did:
- Remove useless information in mysql code like
  mediumint(8) --> mediumint -- mysql ingnore the information of (8) when the datatype is mediumint, smallint or tinyint
- set in pg code the same default value as there are in mysql
- try to set in pg a datatype which match the mysql datatype int(10) unsinged -> bigint
- sync not null

found in pg in table pm_recipients a col which didn't exists in mysql (labels) and
reorder sometable so that they in the same order like mysql file are. 
