### PR TITLE
Change default behavior of affected rows fix #3499

### DIFF
--- a/Sources/Subs-Db-mysql.php
+++ b/Sources/Subs-Db-mysql.php
@@ -61,11 +61,13 @@ function smf_db_initiate($db_server, $db_name, $db_user, $db_passwd, $db_prefix,
 
 	if (!empty($db_options['port']))
 		$db_server .= ':' . $db_options['port'];
+	
+	$flags = 2; //#define CLIENT_FOUND_ROWS 2 /* Found instead of affected rows */
 
 	if (!empty($db_options['persist']))
-		$connection = @mysql_pconnect($db_server, $db_user, $db_passwd);
+		$connection = @mysql_pconnect($db_server, $db_user, $db_passwd, $flags);
 	else
-		$connection = @mysql_connect($db_server, $db_user, $db_passwd);
+		$connection = @mysql_connect($db_server, $db_user, $db_passwd, false, $flags);
 
 	// Something's wrong, show an error if its fatal (which we assume it is)
 	if (!$connection)

--- a/Sources/Subs-Db-mysqli.php
+++ b/Sources/Subs-Db-mysqli.php
@@ -66,6 +66,8 @@ function smf_db_initiate($db_server, $db_name, $db_user, $db_passwd, $db_prefix,
 	
 	$flags = MYSQLI_CLIENT_FOUND_ROWS;
 	
+	$success = false;
+	
 	if ($connection) {
 		if (!empty($db_options['port']))
 			$success = mysqli_real_connect($connection, $db_server, $db_user, $db_passwd, '', $db_options['port'] , null ,$flags);
@@ -74,7 +76,7 @@ function smf_db_initiate($db_server, $db_name, $db_user, $db_passwd, $db_prefix,
 	}
 
 	// Something's wrong, show an error if its fatal (which we assume it is)
-	if (!$connection || $success)
+	if ($success === false)
 	{
 		if (!empty($db_options['non_fatal']))
 			return null;

--- a/Sources/Subs-Db-mysqli.php
+++ b/Sources/Subs-Db-mysqli.php
@@ -62,13 +62,19 @@ function smf_db_initiate($db_server, $db_name, $db_user, $db_passwd, $db_prefix,
 	if (!empty($db_options['persist']))
 		$db_server = 'p:' . $db_server;
 
-	if (!empty($db_options['port']))
-		$connection = @mysqli_connect($db_server, $db_user, $db_passwd, '', $db_options['port']);
-	else
-		$connection = @mysqli_connect($db_server, $db_user, $db_passwd);
+	$connection = mysqli_init();
+	
+	$flags = MYSQLI_CLIENT_FOUND_ROWS;
+	
+	if ($connection) {
+		if (!empty($db_options['port']))
+			$success = mysqli_real_connect($connection, $db_server, $db_user, $db_passwd, '', $db_options['port'] , null ,$flags);
+		else
+			$success = mysqli_real_connect($connection, $db_server, $db_user, $db_passwd,'', 0, null, $flags);
+	}
 
 	// Something's wrong, show an error if its fatal (which we assume it is)
-	if (!$connection)
+	if (!$connection || $success)
 	{
 		if (!empty($db_options['non_fatal']))
 			return null;


### PR DESCRIPTION
The default behavior by mysql is,
when you update a dataset it's return the number of affected rows (how many are changed).
When the dataset got already the value the affected row = 0
Problem is now when you got the return value affected row 0
could this mean two things:
The dataset didn't exists or
the dataset already got the right value
this behavior is bad and as far i know not sql standard.

With this change mysql return the numbers of rows which are selected by the where statement in the update statement.
This fix the issue https://github.com/SimpleMachines/SMF2.1/issues/3499
and sync the behavior with pg.
