### PR TITLE
Update install_2-1_postgresql.sql

### DIFF
--- a/other/install_2-1_postgresql.sql
+++ b/other/install_2-1_postgresql.sql
@@ -693,7 +693,7 @@ CREATE {$unlogged} TABLE {$db_prefix}log_online (
   log_time int NOT NULL default '0',
   id_member int NOT NULL default '0',
   id_spider smallint NOT NULL default '0',
-  ip inet,
+  ip varbinary(16),
   url varchar(1024) NOT NULL,
   PRIMARY KEY (session)
 );


### PR DESCRIPTION
- ip column in log_online table should be varbinary(16) for ipv4 & ipv6 support

Signed-off-by: -Underdog- github.underdog@gmail.com
