### PR TITLE
Added wilcard to db_list_tables call - fixes UTF-8 conversion issue

### DIFF
--- a/other/upgrade.php
+++ b/other/upgrade.php
@@ -3922,7 +3922,7 @@ function convertUtf8()
 
 		// Get a list of table names ahead of time... This makes it easier to set our substep and such
 		db_extend();
-		$queryTables = $smcFunc['db_list_tables'](false, $db_prefix);
+		$queryTables = $smcFunc['db_list_tables'](false, $db_prefix . '%');
 
 		$upcontext['table_count'] = count($queryTables);
 		$file_steps = $upcontext['table_count'];


### PR DESCRIPTION
This fixes the issue with UTF-8 conversion.  Added the wildcard for the prefix back in (e.g smf_%) which was removed in a previous commit.
