### PR TITLE
Edited some CSS aspects

### DIFF
--- a/Themes/default/css/index.css
+++ b/Themes/default/css/index.css
@@ -946,6 +946,7 @@ img.sort, .sort {
 /* Keep a consistent size when wrapped in pagesection. */
 .pagesection .button {
 	font-size: 0.889em;
+	color: #346;
 }
 .button:hover {
 	color: #af6700;
@@ -1392,6 +1393,7 @@ ul li.greeting {
 }
 .quickbuttons li.post_options {
 	padding: 0 4px 0 4px;
+	cursor: pointer;
 }
 .quickbuttons li.post_options>a {
 	padding: 0 4px 0 4px;
@@ -2970,9 +2972,6 @@ span.postby {
 .icons, #messageindex .board_stats p, .lastpost p, #unread .board_stats p, #unreadreplies .board_stats p {
 	border: none;
 }
-.icons {
-	padding: 0 7px;
-}
 .moderation {
 	display: table-cell;
 	min-width: 35px;
@@ -3620,12 +3619,14 @@ p.information img {
 }
 .on {
 	background: #99FF66;
+	margin-bottom: 4px;
 }
 .off {
 	background: grey;
+	margin-bottom: 4px;
 }
 #userstatus .smalltext {
-	margin: 0 0 0 20px !important;
+	margin: 0 0 0 5px !important;
 }
 
 /* Styles for print media. */

--- a/Themes/default/css/index.css
+++ b/Themes/default/css/index.css
@@ -3619,11 +3619,12 @@ p.information img {
 }
 .on {
 	background: #99FF66;
-	margin-bottom: 4px;
 }
 .off {
 	background: grey;
-	margin-bottom: 4px;
+}
+#firefox .on, #firefox .off {
+	margin: 0 0 5px 0;
 }
 #userstatus .smalltext {
 	margin: 0 0 0 5px !important;


### PR DESCRIPTION
- I added some margin-bottom for on and off images to be aligned with the username (in the poster info) and with the user status (in the user profile).
  I reduced the margin-left of the user status text from 20px to 5px.
  I added "cursor: pointer" to the "More..." button of the quick buttons in topics.
  I changed the color of the button "button button_strip_notify" (next to print button) from Black to 346, as same as the other buttons.
  I deleted the padding property of the class "icons" to align the icons with the avatar and the rest of the items of poster info.
- It was a Firefox issue. I've added another commit to add the solution for Firefox and deleted the margin-bottom properties from on and off classes.
