### PR TITLE
Allows URLs to contain [ ] and makes parse_bbc() generally smarter

### DIFF
--- a/Sources/Subs-Post.php
+++ b/Sources/Subs-Post.php
@@ -412,7 +412,12 @@ function fixTag(&$message, $myTag, $protocols, $embeddedUrl = false, $hasEqualSi
 
 	$replaces = array();
 
-	if ($hasEqualSign)
+	if ($hasEqualSign && $embeddedUrl)
+	{
+		$quoted = preg_match('~\[(' . $myTag . ')=&quot;~', $message);
+		preg_match_all('~\[(' . $myTag . ')=' . ($quoted ? '&quot;(.*?)&quot;' : '([^\]]*?)') . '\](?:(.+?)\[/(' . $myTag . ')\])?~is', $message, $matches);
+	}
+	elseif ($hasEqualSign)
 		preg_match_all('~\[(' . $myTag . ')=([^\]]*?)\](?:(.+?)\[/(' . $myTag . ')\])?~is', $message, $matches);
 	else
 		preg_match_all('~\[(' . $myTag . ($hasExtra ? '(?:[^\]]*?)' : '') . ')\](.+?)\[/(' . $myTag . ')\]~is', $message, $matches);
@@ -453,7 +458,7 @@ function fixTag(&$message, $myTag, $protocols, $embeddedUrl = false, $hasEqualSi
 			$replace = $protocols[0] . '://' . $replace;
 
 		if ($hasEqualSign && $embeddedUrl)
-			$replaces[$matches[0][$k]] = '[' . $this_tag . '=' . $replace . ']' . (empty($matches[4][$k]) ? '' : $matches[3][$k] . '[/' . $this_close . ']');
+			$replaces[$matches[0][$k]] = '[' . $this_tag . '=&quot;' . $replace . '&quot;]' . (empty($matches[4][$k]) ? '' : $matches[3][$k] . '[/' . $this_close . ']');
 		elseif ($hasEqualSign)
 			$replaces['[' . $matches[1][$k] . '=' . $matches[2][$k] . ']'] = '[' . $this_tag . '=' . $replace . ']';
 		elseif ($embeddedUrl)

--- a/Sources/Subs-Post.php
+++ b/Sources/Subs-Post.php
@@ -270,7 +270,7 @@ function fixTags(&$message)
 		array(
 			'tag' => 'url',
 			'protocols' => array('http', 'https'),
-			'embeddedUrl' => true,
+			'embeddedUrl' => false,
 			'hasEqualSign' => false,
 		),
 		// [url=http://...]name[/url]
@@ -284,7 +284,7 @@ function fixTags(&$message)
 		array(
 			'tag' => 'iurl',
 			'protocols' => array('http', 'https'),
-			'embeddedUrl' => true,
+			'embeddedUrl' => false,
 			'hasEqualSign' => false,
 		),
 		// [iurl=http://...]name[/iurl]
@@ -298,7 +298,7 @@ function fixTags(&$message)
 		array(
 			'tag' => 'ftp',
 			'protocols' => array('ftp', 'ftps'),
-			'embeddedUrl' => true,
+			'embeddedUrl' => false,
 			'hasEqualSign' => false,
 		),
 		// [ftp=ftp://...]name[/ftp]

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -1275,7 +1275,7 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 				{
 					if (isset($disabled['url']))
 						$tag['content'] = '$1';
-					if (empty(parse_url($data, PHP_URL_SCHEME)))
+					if (empty(parse_url($data[0], PHP_URL_SCHEME)))
 						$data[0] = 'http://' . ltrim($data[0], ':/');
 				},
 				'disabled_content' => '<a href="$1" target="_blank" class="new_win">$1</a>',

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -1276,7 +1276,7 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 					if (isset($disabled['url']))
 						$tag['content'] = '$1';
 					if (empty(parse_url($data, PHP_URL_SCHEME)))
-						$data[0] = 'http://' . $data[0];
+						$data[0] = 'http://' . ltrim($data[0], ':/');
 				},
 				'disabled_content' => '<a href="$1" target="_blank" class="new_win">$1</a>',
 			),

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -1913,10 +1913,13 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 
 									// Time to do the deed
 									if (parse_url($fullUrl, PHP_URL_SCHEME) == 'mailto')
-										if (!isset($disabled['email']))
-											return '[email]' . str_replace('mailto:', '', $url) . '[/email]';
+									{
+										$email_address = str_replace('mailto:', '', $url);
+										if (!isset($disabled['email']) && filter_var($email_address, FILTER_VALIDATE_EMAIL) !== false)
+											return '[email=' . $url . ']' . $url . '[/email]';
 										else
 											return $url;
+									}
 									else
 										return '[url=&quot;' . str_replace(array('[', ']'), array('&#91;', '&#93;'), $fullUrl) . '&quot;]' . $url . '[/url]';
 								}, $data);

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -1275,7 +1275,7 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 				{
 					if (isset($disabled['url']))
 						$tag['content'] = '$1';
-					elseif (strpos($data[0], 'http://') !== 0 && strpos($data[0], 'https://') !== 0)
+					if (empty(parse_url($data, PHP_URL_SCHEME)))
 						$data[0] = 'http://' . $data[0];
 				},
 				'disabled_content' => '<a href="$1" target="_blank" class="new_win">$1</a>',
@@ -1320,7 +1320,7 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 					global $image_proxy_enabled, $image_proxy_secret, $boardurl;
 
 					$data = strtr($data, array('<br>' => ''));
-					if (strpos($data, 'http://') !== 0 && strpos($data, 'https://') !== 0)
+					if (empty(parse_url($data, PHP_URL_SCHEME)))
 						$data = 'http://' . $data;
 
 					if (substr($data, 0, 8) != 'https://' && $image_proxy_enabled)
@@ -1337,7 +1337,7 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 					global $image_proxy_enabled, $image_proxy_secret, $boardurl;
 
 					$data = strtr($data, array('<br>' => ''));
-					if (strpos($data, 'http://') !== 0 && strpos($data, 'https://') !== 0)
+					if (empty(parse_url($data, PHP_URL_SCHEME)))
 						$data = 'http://' . $data;
 
 					if (substr($data, 0, 8) != 'https://' && $image_proxy_enabled)
@@ -1352,7 +1352,7 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 				'validate' => function (&$tag, &$data, $disabled)
 				{
 					$data = strtr($data, array('<br>' => ''));
-					if (strpos($data, 'http://') !== 0 && strpos($data, 'https://') !== 0)
+					if (empty(parse_url($data, PHP_URL_SCHEME)))
 						$data = 'http://' . $data;
 				},
 			),
@@ -1366,7 +1366,7 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 				{
 					if (substr($data, 0, 1) == '#')
 						$data = '#post_' . substr($data, 1);
-					elseif (strpos($data, 'http://') !== 0 && strpos($data, 'https://') !== 0)
+					if (empty(parse_url($data, PHP_URL_SCHEME)))
 						$data = 'http://' . $data;
 				},
 				'disallow_children' => array('email', 'ftp', 'url', 'iurl'),

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -1321,7 +1321,7 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 
 					$data = strtr($data, array('<br>' => ''));
 					if (empty(parse_url($data, PHP_URL_SCHEME)))
-						$data = 'http://' . $data;
+						$data = 'http://' . ltrim($data, ':/');
 
 					if (substr($data, 0, 8) != 'https://' && $image_proxy_enabled)
 						$data = $boardurl . '/proxy.php?request=' . urlencode($data) . '&hash=' . md5($data . $image_proxy_secret);
@@ -1338,7 +1338,7 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 
 					$data = strtr($data, array('<br>' => ''));
 					if (empty(parse_url($data, PHP_URL_SCHEME)))
-						$data = 'http://' . $data;
+						$data = 'http://' . ltrim($data, ':/');
 
 					if (substr($data, 0, 8) != 'https://' && $image_proxy_enabled)
 						$data = $boardurl . '/proxy.php?request=' . urlencode($data) . '&hash=' . md5($data . $image_proxy_secret);
@@ -1353,7 +1353,7 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 				{
 					$data = strtr($data, array('<br>' => ''));
 					if (empty(parse_url($data, PHP_URL_SCHEME)))
-						$data = 'http://' . $data;
+						$data = 'http://' . ltrim($data, ':/');
 				},
 			),
 			array(
@@ -1367,7 +1367,7 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 					if (substr($data, 0, 1) == '#')
 						$data = '#post_' . substr($data, 1);
 					if (empty(parse_url($data, PHP_URL_SCHEME)))
-						$data = 'http://' . $data;
+						$data = 'http://' . ltrim($data, ':/');
 				},
 				'disallow_children' => array('email', 'ftp', 'url', 'iurl'),
 				'disabled_after' => ' ($1)',

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -1752,7 +1752,7 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 	{
 		$last_pos = isset($last_pos) ? max($pos, $last_pos) : $pos;
 		preg_match('~\[/?(?=' . $alltags_regex . ')~', $message, $matches, PREG_OFFSET_CAPTURE, $pos + 1);
-		$pos = !empty($matches[0][1]) ? $matches[0][1] : false;
+		$pos = isset($matches[0][1]) ? $matches[0][1] : false;
 
 		// Failsafe.
 		if ($pos === false || $last_pos > $pos)

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -1913,7 +1913,10 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 
 									// Time to do the deed
 									if (parse_url($fullUrl, PHP_URL_SCHEME) == 'mailto')
-										return '[email]' . str_replace('mailto:', '', $url) . '[/email]';
+										if (!isset($disabled['email']))
+											return '[email]' . str_replace('mailto:', '', $url) . '[/email]';
+										else
+											return $url;
 									else
 										return '[url=&quot;' . str_replace(array('[', ']'), array('&#91;', '&#93;'), $fullUrl) . '&quot;]' . $url . '[/url]';
 								}, $data);

--- a/Themes/default/scripts/jquery.sceditor.smf.js
+++ b/Themes/default/scripts/jquery.sceditor.smf.js
@@ -180,7 +180,7 @@ $.sceditor.command.set(
 			if (url)
 			{
 				var text	= prompt(this._("Enter the displayed text:"), display || url) || url;
-				this.insertText("[url=" + url + "]" + text + "[/url]");
+				this.insertText("[url=\"" + url + "\"]" + text + "[/url]");
 			}
 		}
 	}
@@ -436,12 +436,9 @@ $.sceditor.plugins.bbcode.bbcode.set(
 			// make sure this link is not an e-mail, if it is return e-mail BBCode
 			if (url.substr(0, 7) === 'mailto:')
 				return '[email=' + url.substr(7) + ']' + content + '[/email]';
-			// make sure this link is not an ftp, if it is return ftp BBCode
-			else if (url.substr(0, 3) === 'ftp')
-				return '[ftp=' +  url + ']' + content + '[/ftp]';
 
 			if (element.attr('target') !== undefined)
-				return '[url=' + decodeURI(url) + ']' + content + '[/url]';
+				return '[url=\"' + decodeURI(url) + '\"]' + content + '[/url]';
 			// Is this an attachment?
 			else if (element.attr('data-attachment') !== "undefined")
 			{
@@ -454,7 +451,7 @@ $.sceditor.plugins.bbcode.bbcode.set(
 				return '[attach'+attribs+']'+content+'[/attach]';
 			}
 			else
-				return '[iurl=' + decodeURI(url) + ']' + content + '[/iurl]';
+				return '[iurl=\"' + decodeURI(url) + '\"]' + content + '[/iurl]';
 		},
 		html: function (token, attrs, content) {
 			if (typeof attrs.defaultattr === "undefined" || attrs.defaultattr.length === 0)


### PR DESCRIPTION
- The [url] and [iurl] BBCodes optionally allow the URL to be quoted (e.g. `[url="http://www.example.com"]`). This required changes in both Subs.php's `parse_bbc()` function and Subs-Post.php's `fixTag()` function.
- The [url] and [iurl] BBCodes have smarter validation functions in parse_bbc(). Previously, `http://` was blindly prepended to any string that didn't begin with `http://` or `https://`. Now, we check if a valid URI scheme is present (even if it isn't an http one), and only prepend `http://` if there really and truly is no valid scheme present.
- Autolinking uses a smarter (and much more legible) regex to detect plain text URLs.
- Autolinking now uses the form `[url="http://www.example.com"]http://www.example.com[/url]` to wrap detected URLs.
- parse_bbc() is now smarter about how it detects BBCodes as it moves through a message. Previously, the parser broke up the message text at evey `[` character, which meant that random square brackets could interfere with the parser in some cases (e.g. when trying to detect and autolink URLs that include square brackets in the URL's query parameters).  Now we use a regex to detect where the next actually valid BBCode begins, and jump straight to that position. This means the parser doesn't need to concern itself with `[` and `]` characters that are not part of a valid BBCode.
- jquery.sceditor.smf.js has been updated to handle creating url BBCodes with a quoted parameter. However, jquery.sceditor.bbcode.min.js does not understand how to translate a BBCode with the form `[url="http://example.com/index.php?var[]=value"]foo[/url]` into an HTML element with the form `<a href="http://www.example.com/index.php?var[]=value">foo</a>`, so toggling the editor between source mode and WYSIWYG mode will cause such [url] BBCodes not to render as beautifully in the editor's WYSIWYG mode. Fortunately, this is a merely aesthetic issue, and does not cause any problems with the message text itself or with how it will be parsed and displayed by SMF afterwards. It would be nice if jquery.sceditor.bbcode.min.js were updated to fix this, but that would need to be done by the fine folks at SCEditor, rather than by us.

Fixes #3366
Fixes #1187

At some point, it would be a good idea to write some code to periodically grab the latest list of valid TLDs from http://data.iana.org/TLD/tlds-alpha-by-domain.txt to use at the relevant place in parse_bbc(). That's a job for another PR, though.
