### PR TITLE
Allow [code] inside block level BBC (e.g. lists and tables)

### DIFF
--- a/Sources/Subs-Post.php
+++ b/Sources/Subs-Post.php
@@ -103,6 +103,8 @@ function preparsecode(&$message, $previewing = false)
 		}
 	}
 
+	$message = implode('', $parts);
+
 	// The regular expression non breaking space has many versions.
 	$non_breaking_space = $context['utf8'] ? '\x{A0}' : '\xA0';
 

--- a/Sources/Subs-Post.php
+++ b/Sources/Subs-Post.php
@@ -90,121 +90,130 @@ function preparsecode(&$message, $previewing = false)
 	// Now that we've fixed all the code tags, let's fix the img and url tags...
 	$parts = preg_split('~(\[/code\]|\[code(?:=[^\]]+)?\])~i', $message, -1, PREG_SPLIT_DELIM_CAPTURE);
 
-	// The regular expression non breaking space has many versions.
-	$non_breaking_space = $context['utf8'] ? '\x{A0}' : '\xA0';
-
-	// Only mess with stuff outside [code] tags.
+	// Replace code BBC with placeholders. We'll restore them at the end.
 	for ($i = 0, $n = count($parts); $i < $n; $i++)
 	{
 		// It goes 0 = outside, 1 = begin tag, 2 = inside, 3 = close tag, repeat.
-		if ($i % 4 == 0)
+		if ($i % 4 == 2)
 		{
-			fixTags($parts[$i]);
-
-			// Replace /me.+?\n with [me=name]dsf[/me]\n.
-			if (strpos($user_info['name'], '[') !== false || strpos($user_info['name'], ']') !== false || strpos($user_info['name'], '\'') !== false || strpos($user_info['name'], '"') !== false)
-				$parts[$i] = preg_replace('~(\A|\n)/me(?: |&nbsp;)([^\n]*)(?:\z)?~i', '$1[me=&quot;' . $user_info['name'] . '&quot;]$2[/me]', $parts[$i]);
-			else
-				$parts[$i] = preg_replace('~(\A|\n)/me(?: |&nbsp;)([^\n]*)(?:\z)?~i', '$1[me=' . $user_info['name'] . ']$2[/me]', $parts[$i]);
-
-			if (!$previewing && strpos($parts[$i], '[html]') !== false)
-			{
-				if (allowedTo('admin_forum'))
-					$parts[$i] = preg_replace('~\[html\](.+?)\[/html\]~ise', '\'[html]\' . strtr(un_htmlspecialchars(\'$1\'), array("\n" => \'&#13;\', \'  \' => \' &#32;\', \'[\' => \'&#91;\', \']\' => \'&#93;\')) . \'[/html]\'', $parts[$i]);
-
-				// We should edit them out, or else if an admin edits the message they will get shown...
-				else
-				{
-					while (strpos($parts[$i], '[html]') !== false)
-						$parts[$i] = preg_replace('~\[[/]?html\]~i', '', $parts[$i]);
-				}
-			}
-
-			// Let's look at the time tags...
-			$parts[$i] = preg_replace_callback('~\[time(?:=(absolute))*\](.+?)\[/time\]~i', function ($m) use ($modSettings, $user_info)
-			{
-				return "[time]" . (is_numeric("$m[2]") || @strtotime("$m[2]") == 0 ? "$m[2]" : strtotime("$m[2]") - ("$m[1]" == "absolute" ? 0 : (($modSettings["time_offset"] + $user_info["time_offset"]) * 3600))) . "[/time]";
-			}, $parts[$i]);
-
-			// Change the color specific tags to [color=the color].
-			$parts[$i] = preg_replace('~\[(black|blue|green|red|white)\]~', '[color=$1]', $parts[$i]);  // First do the opening tags.
-			$parts[$i] = preg_replace('~\[/(black|blue|green|red|white)\]~', '[/color]', $parts[$i]);   // And now do the closing tags
-
-			// Make sure all tags are lowercase.
-			$parts[$i] = preg_replace_callback('~\[([/]?)(list|li|table|tr|td)((\s[^\]]+)*)\]~i', function ($m)
-			{
-				return "[$m[1]" . strtolower("$m[2]") . "$m[3]]";
-			}, $parts[$i]);
-
-			$list_open = substr_count($parts[$i], '[list]') + substr_count($parts[$i], '[list ');
-			$list_close = substr_count($parts[$i], '[/list]');
-			if ($list_close - $list_open > 0)
-				$parts[$i] = str_repeat('[list]', $list_close - $list_open) . $parts[$i];
-			if ($list_open - $list_close > 0)
-				$parts[$i] = $parts[$i] . str_repeat('[/list]', $list_open - $list_close);
-
-			$mistake_fixes = array(
-				// Find [table]s not followed by [tr].
-				'~\[table\](?![\s' . $non_breaking_space . ']*\[tr\])~s' . ($context['utf8'] ? 'u' : '') => '[table][tr]',
-				// Find [tr]s not followed by [td].
-				'~\[tr\](?![\s' . $non_breaking_space . ']*\[td\])~s' . ($context['utf8'] ? 'u' : '') => '[tr][td]',
-				// Find [/td]s not followed by something valid.
-				'~\[/td\](?![\s' . $non_breaking_space . ']*(?:\[td\]|\[/tr\]|\[/table\]))~s' . ($context['utf8'] ? 'u' : '') => '[/td][/tr]',
-				// Find [/tr]s not followed by something valid.
-				'~\[/tr\](?![\s' . $non_breaking_space . ']*(?:\[tr\]|\[/table\]))~s' . ($context['utf8'] ? 'u' : '') => '[/tr][/table]',
-				// Find [/td]s incorrectly followed by [/table].
-				'~\[/td\][\s' . $non_breaking_space . ']*\[/table\]~s' . ($context['utf8'] ? 'u' : '') => '[/td][/tr][/table]',
-				// Find [table]s, [tr]s, and [/td]s (possibly correctly) followed by [td].
-				'~\[(table|tr|/td)\]([\s' . $non_breaking_space . ']*)\[td\]~s' . ($context['utf8'] ? 'u' : '') => '[$1]$2[_td_]',
-				// Now, any [td]s left should have a [tr] before them.
-				'~\[td\]~s' => '[tr][td]',
-				// Look for [tr]s which are correctly placed.
-				'~\[(table|/tr)\]([\s' . $non_breaking_space . ']*)\[tr\]~s' . ($context['utf8'] ? 'u' : '') => '[$1]$2[_tr_]',
-				// Any remaining [tr]s should have a [table] before them.
-				'~\[tr\]~s' => '[table][tr]',
-				// Look for [/td]s followed by [/tr].
-				'~\[/td\]([\s' . $non_breaking_space . ']*)\[/tr\]~s' . ($context['utf8'] ? 'u' : '') => '[/td]$1[_/tr_]',
-				// Any remaining [/tr]s should have a [/td].
-				'~\[/tr\]~s' => '[/td][/tr]',
-				// Look for properly opened [li]s which aren't closed.
-				'~\[li\]([^\[\]]+?)\[li\]~s' => '[li]$1[_/li_][_li_]',
-				'~\[li\]([^\[\]]+?)\[/list\]~s' => '[_li_]$1[_/li_][/list]',
-				'~\[li\]([^\[\]]+?)$~s' => '[li]$1[/li]',
-				// Lists - find correctly closed items/lists.
-				'~\[/li\]([\s' . $non_breaking_space . ']*)\[/list\]~s' . ($context['utf8'] ? 'u' : '') => '[_/li_]$1[/list]',
-				// Find list items closed and then opened.
-				'~\[/li\]([\s' . $non_breaking_space . ']*)\[li\]~s' . ($context['utf8'] ? 'u' : '') => '[_/li_]$1[_li_]',
-				// Now, find any [list]s or [/li]s followed by [li].
-				'~\[(list(?: [^\]]*?)?|/li)\]([\s' . $non_breaking_space . ']*)\[li\]~s' . ($context['utf8'] ? 'u' : '') => '[$1]$2[_li_]',
-				// Allow for sub lists.
-				'~\[/li\]([\s' . $non_breaking_space . ']*)\[list\]~' . ($context['utf8'] ? 'u' : '') => '[_/li_]$1[list]',
-				'~\[/list\]([\s' . $non_breaking_space . ']*)\[li\]~' . ($context['utf8'] ? 'u' : '') => '[/list]$1[_li_]',
-				// Any remaining [li]s weren't inside a [list].
-				'~\[li\]~' => '[list][li]',
-				// Any remaining [/li]s weren't before a [/list].
-				'~\[/li\]~' => '[/li][/list]',
-				// Put the correct ones back how we found them.
-				'~\[_(li|/li|td|tr|/tr)_\]~' => '[$1]',
-				// Images with no real url.
-				'~\[img\]https?://.{0,7}\[/img\]~' => '',
-			);
-
-			// Fix up some use of tables without [tr]s, etc. (it has to be done more than once to catch it all.)
-			for ($j = 0; $j < 3; $j++)
-				$parts[$i] = preg_replace(array_keys($mistake_fixes), $mistake_fixes, $parts[$i]);
-
-			// Remove empty bbc from the sections outside the code tags
-			$parts[$i] = preg_replace('~\[[bisu]\]\s*\[/[bisu]\]~', '', $parts[$i]);
-			$parts[$i] = preg_replace('~\[quote\]\s*\[/quote\]~', '', $parts[$i]);
-			$parts[$i] = preg_replace('~\[color=(?:#[\da-fA-F]{3}|#[\da-fA-F]{6}|[A-Za-z]{1,20}|rgb\(\d{1,3}, ?\d{1,3}, ?\d{1,3}\))\]\s*\[/color\]~', '', $parts[$i]);
+			$code_tag = $parts[$i - 1] . $parts[$i] . $parts[$i + 1];
+			$substitute = $parts[$i - 1] . $i . $parts[$i + 1];
+			$code_tags[$substitute] = $code_tag;
+			$parts[$i] = $i;
 		}
 	}
 
-	// Put it back together!
-	if (!$previewing)
-		$message = strtr(implode('', $parts), array('  ' => '&nbsp; ', "\n" => '<br>', $context['utf8'] ? "\xC2\xA0" : "\xA0" => '&nbsp;'));
+	// The regular expression non breaking space has many versions.
+	$non_breaking_space = $context['utf8'] ? '\x{A0}' : '\xA0';
+
+	fixTags($message);
+
+	// Replace /me.+?\n with [me=name]dsf[/me]\n.
+	if (strpos($user_info['name'], '[') !== false || strpos($user_info['name'], ']') !== false || strpos($user_info['name'], '\'') !== false || strpos($user_info['name'], '"') !== false)
+		$message = preg_replace('~(\A|\n)/me(?: |&nbsp;)([^\n]*)(?:\z)?~i', '$1[me=&quot;' . $user_info['name'] . '&quot;]$2[/me]', $message);
 	else
-		$message = strtr(implode('', $parts), array('  ' => '&nbsp; ', $context['utf8'] ? "\xC2\xA0" : "\xA0" => '&nbsp;'));
+		$message = preg_replace('~(\A|\n)/me(?: |&nbsp;)([^\n]*)(?:\z)?~i', '$1[me=' . $user_info['name'] . ']$2[/me]', $message);
+
+	if (!$previewing && strpos($message, '[html]') !== false)
+	{
+		if (allowedTo('admin_forum'))
+			$message = preg_replace('~\[html\](.+?)\[/html\]~ise', '\'[html]\' . strtr(un_htmlspecialchars(\'$1\'), array("\n" => \'&#13;\', \'  \' => \' &#32;\', \'[\' => \'&#91;\', \']\' => \'&#93;\')) . \'[/html]\'', $message);
+
+		// We should edit them out, or else if an admin edits the message they will get shown...
+		else
+		{
+			while (strpos($message, '[html]') !== false)
+				$message = preg_replace('~\[[/]?html\]~i', '', $message);
+		}
+	}
+
+	// Let's look at the time tags...
+	$message = preg_replace_callback('~\[time(?:=(absolute))*\](.+?)\[/time\]~i', function ($m) use ($modSettings, $user_info)
+	{
+		return "[time]" . (is_numeric("$m[2]") || @strtotime("$m[2]") == 0 ? "$m[2]" : strtotime("$m[2]") - ("$m[1]" == "absolute" ? 0 : (($modSettings["time_offset"] + $user_info["time_offset"]) * 3600))) . "[/time]";
+	}, $message);
+
+	// Change the color specific tags to [color=the color].
+	$message = preg_replace('~\[(black|blue|green|red|white)\]~', '[color=$1]', $message);  // First do the opening tags.
+	$message = preg_replace('~\[/(black|blue|green|red|white)\]~', '[/color]', $message);   // And now do the closing tags
+
+	// Make sure all tags are lowercase.
+	$message = preg_replace_callback('~\[([/]?)(list|li|table|tr|td)((\s[^\]]+)*)\]~i', function ($m)
+	{
+		return "[$m[1]" . strtolower("$m[2]") . "$m[3]]";
+	}, $message);
+
+	$list_open = substr_count($message, '[list]') + substr_count($message, '[list ');
+	$list_close = substr_count($message, '[/list]');
+	if ($list_close - $list_open > 0)
+		$message = str_repeat('[list]', $list_close - $list_open) . $message;
+	if ($list_open - $list_close > 0)
+		$message = $message . str_repeat('[/list]', $list_open - $list_close);
+
+	$mistake_fixes = array(
+		// Find [table]s not followed by [tr].
+		'~\[table\](?![\s' . $non_breaking_space . ']*\[tr\])~s' . ($context['utf8'] ? 'u' : '') => '[table][tr]',
+		// Find [tr]s not followed by [td].
+		'~\[tr\](?![\s' . $non_breaking_space . ']*\[td\])~s' . ($context['utf8'] ? 'u' : '') => '[tr][td]',
+		// Find [/td]s not followed by something valid.
+		'~\[/td\](?![\s' . $non_breaking_space . ']*(?:\[td\]|\[/tr\]|\[/table\]))~s' . ($context['utf8'] ? 'u' : '') => '[/td][/tr]',
+		// Find [/tr]s not followed by something valid.
+		'~\[/tr\](?![\s' . $non_breaking_space . ']*(?:\[tr\]|\[/table\]))~s' . ($context['utf8'] ? 'u' : '') => '[/tr][/table]',
+		// Find [/td]s incorrectly followed by [/table].
+		'~\[/td\][\s' . $non_breaking_space . ']*\[/table\]~s' . ($context['utf8'] ? 'u' : '') => '[/td][/tr][/table]',
+		// Find [table]s, [tr]s, and [/td]s (possibly correctly) followed by [td].
+		'~\[(table|tr|/td)\]([\s' . $non_breaking_space . ']*)\[td\]~s' . ($context['utf8'] ? 'u' : '') => '[$1]$2[_td_]',
+		// Now, any [td]s left should have a [tr] before them.
+		'~\[td\]~s' => '[tr][td]',
+		// Look for [tr]s which are correctly placed.
+		'~\[(table|/tr)\]([\s' . $non_breaking_space . ']*)\[tr\]~s' . ($context['utf8'] ? 'u' : '') => '[$1]$2[_tr_]',
+		// Any remaining [tr]s should have a [table] before them.
+		'~\[tr\]~s' => '[table][tr]',
+		// Look for [/td]s followed by [/tr].
+		'~\[/td\]([\s' . $non_breaking_space . ']*)\[/tr\]~s' . ($context['utf8'] ? 'u' : '') => '[/td]$1[_/tr_]',
+		// Any remaining [/tr]s should have a [/td].
+		'~\[/tr\]~s' => '[/td][/tr]',
+		// Look for properly opened [li]s which aren't closed.
+		'~\[li\]([^\[\]]+?)\[li\]~s' => '[li]$1[_/li_][_li_]',
+		'~\[li\]([^\[\]]+?)\[/list\]~s' => '[_li_]$1[_/li_][/list]',
+		'~\[li\]([^\[\]]+?)$~s' => '[li]$1[/li]',
+		// Lists - find correctly closed items/lists.
+		'~\[/li\]([\s' . $non_breaking_space . ']*)\[/list\]~s' . ($context['utf8'] ? 'u' : '') => '[_/li_]$1[/list]',
+		// Find list items closed and then opened.
+		'~\[/li\]([\s' . $non_breaking_space . ']*)\[li\]~s' . ($context['utf8'] ? 'u' : '') => '[_/li_]$1[_li_]',
+		// Now, find any [list]s or [/li]s followed by [li].
+		'~\[(list(?: [^\]]*?)?|/li)\]([\s' . $non_breaking_space . ']*)\[li\]~s' . ($context['utf8'] ? 'u' : '') => '[$1]$2[_li_]',
+		// Allow for sub lists.
+		'~\[/li\]([\s' . $non_breaking_space . ']*)\[list\]~' . ($context['utf8'] ? 'u' : '') => '[_/li_]$1[list]',
+		'~\[/list\]([\s' . $non_breaking_space . ']*)\[li\]~' . ($context['utf8'] ? 'u' : '') => '[/list]$1[_li_]',
+		// Any remaining [li]s weren't inside a [list].
+		'~\[li\]~' => '[list][li]',
+		// Any remaining [/li]s weren't before a [/list].
+		'~\[/li\]~' => '[/li][/list]',
+		// Put the correct ones back how we found them.
+		'~\[_(li|/li|td|tr|/tr)_\]~' => '[$1]',
+		// Images with no real url.
+		'~\[img\]https?://.{0,7}\[/img\]~' => '',
+	);
+
+	// Fix up some use of tables without [tr]s, etc. (it has to be done more than once to catch it all.)
+	for ($j = 0; $j < 3; $j++)
+		$message = preg_replace(array_keys($mistake_fixes), $mistake_fixes, $message);
+
+	// Remove empty bbc from the sections outside the code tags
+	$message = preg_replace('~\[[bisu]\]\s*\[/[bisu]\]~', '', $message);
+	$message = preg_replace('~\[quote\]\s*\[/quote\]~', '', $message);
+	$message = preg_replace('~\[color=(?:#[\da-fA-F]{3}|#[\da-fA-F]{6}|[A-Za-z]{1,20}|rgb\(\d{1,3}, ?\d{1,3}, ?\d{1,3}\))\]\s*\[/color\]~', '', $message);
+
+	// Restore code blocks
+	if (!empty($code_tags))
+		$message = str_replace(array_keys($code_tags), array_values($code_tags), $message);
+
+	// Restore white space entities
+	if (!$previewing)
+		$message = strtr($message, array('  ' => '&nbsp; ', "\n" => '<br>', $context['utf8'] ? "\xC2\xA0" : "\xA0" => '&nbsp;'));
+	else
+		$message = strtr($message, array('  ' => '&nbsp; ', $context['utf8'] ? "\xC2\xA0" : "\xA0" => '&nbsp;'));
 
 	// Now let's quickly clean up things that will slow our parser (which are common in posted code.)
 	$message = strtr($message, array('[]' => '&#91;]', '[&#039;' => '&#91;&#039;'));

--- a/Sources/Subs-Post.php
+++ b/Sources/Subs-Post.php
@@ -119,7 +119,9 @@ function preparsecode(&$message, $previewing = false)
 	if (!$previewing && strpos($message, '[html]') !== false)
 	{
 		if (allowedTo('admin_forum'))
-			$message = preg_replace('~\[html\](.+?)\[/html\]~ise', '\'[html]\' . strtr(un_htmlspecialchars(\'$1\'), array("\n" => \'&#13;\', \'  \' => \' &#32;\', \'[\' => \'&#91;\', \']\' => \'&#93;\')) . \'[/html]\'', $message);
+			$message = preg_replace_callback('~\[html\](.+?)\[/html\]~is', function ($m) {
+				return '[html]' . strtr(un_htmlspecialchars($m), array("\n" => '&#13;', '  ' => ' &#32;', '[' => '&#91;', ']' => '&#93;')) . '[/html]';
+			}, $message);
 
 		// We should edit them out, or else if an admin edits the message they will get shown...
 		else

--- a/Sources/Subs-Post.php
+++ b/Sources/Subs-Post.php
@@ -236,7 +236,7 @@ function un_preparsecode($message)
 	for ($i = 0, $n = count($parts); $i < $n; $i++)
 	{
 		// If $i is a multiple of four (0, 4, 8, ...) then it's not a code section...
-		if ($i % 4 == 0)
+		if ($i % 4 == 2)
 		{
 			$code_tag = $parts[$i - 1] . $parts[$i] . $parts[$i + 1];
 			$substitute = $parts[$i - 1] . $i . $parts[$i + 1];


### PR DESCRIPTION
Previously the preparser split the message at every `[code]` and `[/code]`, parsed BBC only within the parts outside the `[code]...[/code]`, and reassembled the string at the end. Now we substitute the content of a `[code]...[/code]` with a placeholder, and then restore the original content at the end. This allows the rest of the BBC preparsing to operate on the entire $message at once, and therefore allows `[code]...[/code]` to remain in place during preparsing and thus to be embedded within list items, table cells, etc.

Fixes #3106

