### PR TITLE
More urlbbc

### DIFF
--- a/Sources/Subs-Post.php
+++ b/Sources/Subs-Post.php
@@ -439,7 +439,7 @@ function fixTag(&$message, $myTag, $protocols, $embeddedUrl = false, $hasEqualSi
 
 		if (!$found && $protocols[0] == 'http')
 		{
-			if (substr($replace, 0, 1) == '/')
+			if (substr($replace, 0, 1) == '/' && substr($replace, 0, 2) != '//')
 				$replace = $domain_url . $replace;
 			elseif (substr($replace, 0, 1) == '?')
 				$replace = $scripturl . $replace;

--- a/Sources/Subs-Post.php
+++ b/Sources/Subs-Post.php
@@ -449,7 +449,7 @@ function fixTag(&$message, $myTag, $protocols, $embeddedUrl = false, $hasEqualSi
 				$this_tag = 'iurl';
 				$this_close = 'iurl';
 			}
-			else
+			elseif (substr($replace, 0, 2) != '//')
 				$replace = $protocols[0] . '://' . $replace;
 		}
 		elseif (!$found && $protocols[0] == 'ftp')

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -1275,7 +1275,8 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 				{
 					if (isset($disabled['url']))
 						$tag['content'] = '$1';
-					if (empty(parse_url($data[0], PHP_URL_SCHEME)))
+					$scheme = parse_url($data[0], PHP_URL_SCHEME);
+					if (empty($scheme))
 						$data[0] = '//' . ltrim($data[0], ':/');
 				},
 				'disabled_content' => '<a href="$1" target="_blank" class="new_win">$1</a>',
@@ -1320,7 +1321,8 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 					global $image_proxy_enabled, $image_proxy_secret, $boardurl;
 
 					$data = strtr($data, array('<br>' => ''));
-					if (empty(parse_url($data, PHP_URL_SCHEME)))
+					$scheme = parse_url($data, PHP_URL_SCHEME);
+					if (empty($scheme))
 						$data = '//' . ltrim($data, ':/');
 
 					if (substr($data, 0, 8) != 'https://' && $image_proxy_enabled)
@@ -1337,7 +1339,8 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 					global $image_proxy_enabled, $image_proxy_secret, $boardurl;
 
 					$data = strtr($data, array('<br>' => ''));
-					if (empty(parse_url($data, PHP_URL_SCHEME)))
+					$scheme = parse_url($data, PHP_URL_SCHEME);
+					if (empty($scheme))
 						$data = '//' . ltrim($data, ':/');
 
 					if (substr($data, 0, 8) != 'https://' && $image_proxy_enabled)
@@ -1352,7 +1355,8 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 				'validate' => function (&$tag, &$data, $disabled)
 				{
 					$data = strtr($data, array('<br>' => ''));
-					if (empty(parse_url($data, PHP_URL_SCHEME)))
+					$scheme = parse_url($data, PHP_URL_SCHEME);
+					if (empty($scheme))
 						$data = '//' . ltrim($data, ':/');
 				},
 			),
@@ -1366,7 +1370,8 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 				{
 					if (substr($data, 0, 1) == '#')
 						$data = '#post_' . substr($data, 1);
-					if (empty(parse_url($data, PHP_URL_SCHEME)))
+					$scheme = parse_url($data, PHP_URL_SCHEME);
+					if (empty($scheme))
 						$data = '//' . ltrim($data, ':/');
 				},
 				'disallow_children' => array('email', 'ftp', 'url', 'iurl'),
@@ -1605,7 +1610,8 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 				'validate' => function (&$tag, &$data, $disabled)
 				{
 					$data = strtr($data, array('<br>' => ''));
-					if (empty(parse_url($data, PHP_URL_SCHEME)))
+					$scheme = parse_url($data, PHP_URL_SCHEME);
+					if (empty($scheme))
 						$data = '//' . ltrim($data, ':/');
 				},
 			),
@@ -1617,7 +1623,8 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 				'after' => '</a>',
 				'validate' => function (&$tag, &$data, $disabled)
 				{
-					if (empty(parse_url($data, PHP_URL_SCHEME)))
+					$scheme = parse_url($data, PHP_URL_SCHEME);
+					if (empty($scheme))
 						$data = '//' . ltrim($data, ':/');
 				},
 				'disallow_children' => array('email', 'ftp', 'url', 'iurl'),
@@ -1900,20 +1907,9 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 						$data = preg_replace_callback('~' . $url_regex . '~', function ($matches) {
 									$url = array_shift($matches);
 
-									// Are we linking a naked domain name (e.g. "example.com")?
-									if (empty(parse_url($url, PHP_URL_SCHEME)))
-									{
-										$fullUrl = 'http://' . ltrim($url, ':/');
-										$schemeless = true;
-									}
-									else
-									{
-										$fullUrl = $url;
-										$schemeless = false;
-									}
-									
-									// Time to do the deed
-									if (parse_url($fullUrl, PHP_URL_SCHEME) == 'mailto')
+									$scheme = parse_url($url, PHP_URL_SCHEME);
+
+									if ($scheme == 'mailto')
 									{
 										$email_address = str_replace('mailto:', '', $url);
 										if (!isset($disabled['email']) && filter_var($email_address, FILTER_VALIDATE_EMAIL) !== false)
@@ -1921,13 +1917,12 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 										else
 											return $url;
 									}
-									else
-									{
-										if ($schemeless)
-											$fullUrl = str_replace('http:', '', $fullUrl);
 
-										return '[url=&quot;' . str_replace(array('[', ']'), array('&#91;', '&#93;'), $fullUrl) . '&quot;]' . $url . '[/url]';
-									}
+									// Are we linking a schemeless URL or naked domain name (e.g. "example.com")?
+									if (empty($scheme))
+										$fullUrl = '//' . ltrim($url, ':/');
+
+									return '[url=&quot;' . str_replace(array('[', ']'), array('&#91;', '&#93;'), $fullUrl) . '&quot;]' . $url . '[/url]';
 								}, $data);
 					}
 

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -1276,7 +1276,7 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 					if (isset($disabled['url']))
 						$tag['content'] = '$1';
 					if (empty(parse_url($data[0], PHP_URL_SCHEME)))
-						$data[0] = 'http://' . ltrim($data[0], ':/');
+						$data[0] = '//' . ltrim($data[0], ':/');
 				},
 				'disabled_content' => '<a href="$1" target="_blank" class="new_win">$1</a>',
 			),
@@ -1321,7 +1321,7 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 
 					$data = strtr($data, array('<br>' => ''));
 					if (empty(parse_url($data, PHP_URL_SCHEME)))
-						$data = 'http://' . ltrim($data, ':/');
+						$data = '//' . ltrim($data, ':/');
 
 					if (substr($data, 0, 8) != 'https://' && $image_proxy_enabled)
 						$data = $boardurl . '/proxy.php?request=' . urlencode($data) . '&hash=' . md5($data . $image_proxy_secret);
@@ -1338,7 +1338,7 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 
 					$data = strtr($data, array('<br>' => ''));
 					if (empty(parse_url($data, PHP_URL_SCHEME)))
-						$data = 'http://' . ltrim($data, ':/');
+						$data = '//' . ltrim($data, ':/');
 
 					if (substr($data, 0, 8) != 'https://' && $image_proxy_enabled)
 						$data = $boardurl . '/proxy.php?request=' . urlencode($data) . '&hash=' . md5($data . $image_proxy_secret);
@@ -1353,7 +1353,7 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 				{
 					$data = strtr($data, array('<br>' => ''));
 					if (empty(parse_url($data, PHP_URL_SCHEME)))
-						$data = 'http://' . ltrim($data, ':/');
+						$data = '//' . ltrim($data, ':/');
 				},
 			),
 			array(
@@ -1367,7 +1367,7 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 					if (substr($data, 0, 1) == '#')
 						$data = '#post_' . substr($data, 1);
 					if (empty(parse_url($data, PHP_URL_SCHEME)))
-						$data = 'http://' . ltrim($data, ':/');
+						$data = '//' . ltrim($data, ':/');
 				},
 				'disallow_children' => array('email', 'ftp', 'url', 'iurl'),
 				'disabled_after' => ' ($1)',
@@ -1606,7 +1606,7 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 				{
 					$data = strtr($data, array('<br>' => ''));
 					if (empty(parse_url($data, PHP_URL_SCHEME)))
-						$data = 'http://' . ltrim($data, ':/');
+						$data = '//' . ltrim($data, ':/');
 				},
 			),
 			array(
@@ -1618,7 +1618,7 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 				'validate' => function (&$tag, &$data, $disabled)
 				{
 					if (empty(parse_url($data, PHP_URL_SCHEME)))
-						$data = 'http://' . ltrim($data, ':/');
+						$data = '//' . ltrim($data, ':/');
 				},
 				'disallow_children' => array('email', 'ftp', 'url', 'iurl'),
 				'disabled_after' => ' ($1)',
@@ -1857,9 +1857,12 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 						$tld_regex = '(?:com|net|org|edu|gov|mil|aero|asia|biz|cat|coop|info|int|jobs|mobi|museum|name|post|pro|tel|travel|xxx|ac|ad|ae|af|ag|ai|al|am|an|ao|aq|ar|as|at|au|aw|ax|az|ba|bb|bd|be|bf|bg|bh|bi|bj|bm|bn|bo|br|bs|bt|bv|bw|by|bz|ca|cc|cd|cf|cg|ch|ci|ck|cl|cm|cn|co|cr|cs|cu|cv|cx|cy|cz|dd|de|dj|dk|dm|do|dz|ec|ee|eg|eh|er|es|et|eu|fi|fj|fk|fm|fo|fr|ga|gb|gd|ge|gf|gg|gh|gi|gl|gm|gn|gp|gq|gr|gs|gt|gu|gw|gy|hk|hm|hn|hr|ht|hu|id|ie|il|im|in|io|iq|ir|is|it|ja|je|jm|jo|jp|ke|kg|kh|ki|km|kn|kp|kr|kw|ky|kz|la|lb|lc|li|lk|lr|ls|lt|lu|lv|ly|ma|mc|md|me|mg|mh|mk|ml|mm|mn|mo|mp|mq|mr|ms|mt|mu|mv|mw|mx|my|mz|na|nc|ne|nf|ng|ni|nl|no|np|nr|nu|nz|om|pa|pe|pf|pg|ph|pk|pl|pm|pn|pr|ps|pt|pw|py|qa|re|ro|rs|ru|rw|sa|sb|sc|sd|se|sg|sh|si|sj|sk|sl|sm|sn|so|sr|ss|st|su|sv|sx|sy|sz|tc|td|tf|tg|th|tj|tk|tl|tm|tn|to|tp|tr|tt|tv|tw|tz|ua|ug|uk|us|uy|uz|va|vc|ve|vg|vi|vn|vu|wf|ws|ye|yt|yu|za|zm|zw)';
 
 						$url_regex = '(?xi)
-\b
 (?:
-	[a-z][\w-]+:						# URL scheme and colon
+	(?:									# Either:
+		\b[a-z][\w-]+:					# URL scheme and colon
+		|								#  or
+		(?<=^|\W)(?=//)							# A boundary followed by two slashes (for schemaless URLs like "//example.com")
+	)						
 	(?:
 		/{1,3}							# 1-3 slashes
 		|								#	or
@@ -1885,7 +1888,7 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 |										# OR, the following to match naked domains:
 (?:
 	(?<!@)								# not preceded by a @, avoid matching foo@_gmail.com_
-	[a-z0-9]+
+	\b[a-z0-9]+
 	(?:[.\-][a-z0-9]+)*
 	[.]
 	'. $tld_regex . '
@@ -1903,9 +1906,15 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 									
 									// Are we linking a naked domain name (e.g. "example.com")?
 									if (empty(parse_url($url, PHP_URL_SCHEME)))
+									{
 										$fullUrl = 'http://' . ltrim($url, ':/');
+										$schemaless = true;
+									}
 									else
+									{
 										$fullUrl = $url;
+										$schemaless = false;
+									}
 									
 									// Make sure that $fullUrl really is a valid URL, including a valid host name
 									if (filter_var($fullUrl, FILTER_VALIDATE_URL, FILTER_FLAG_HOST_REQUIRED) === false)
@@ -1921,7 +1930,12 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 											return $url;
 									}
 									else
+									{
+										if ($schemaless)
+											$fullUrl = str_replace('http:', '', $fullUrl);
+
 										return '[url=&quot;' . str_replace(array('[', ']'), array('&#91;', '&#93;'), $fullUrl) . '&quot;]' . $url . '[/url]';
+									}
 								}, $data);
 					}
 

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -1916,7 +1916,7 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 									{
 										$email_address = str_replace('mailto:', '', $url);
 										if (!isset($disabled['email']) && filter_var($email_address, FILTER_VALIDATE_EMAIL) !== false)
-											return '[email=' . $url . ']' . $url . '[/email]';
+											return '[email=' . $email_address . ']' . $url . '[/email]';
 										else
 											return $url;
 									}

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -1370,9 +1370,12 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 				{
 					if (substr($data, 0, 1) == '#')
 						$data = '#post_' . substr($data, 1);
-					$scheme = parse_url($data, PHP_URL_SCHEME);
-					if (empty($scheme))
-						$data = '//' . ltrim($data, ':/');
+					else
+					{
+						$scheme = parse_url($data, PHP_URL_SCHEME);
+						if (empty($scheme))
+							$data = '//' . ltrim($data, ':/');
+					}
 				},
 				'disallow_children' => array('email', 'ftp', 'url', 'iurl'),
 				'disabled_after' => ' ($1)',

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -1323,9 +1323,9 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 					$data = strtr($data, array('<br>' => ''));
 					$scheme = parse_url($data, PHP_URL_SCHEME);
 					if (empty($scheme))
-						$data = '//' . ltrim($data, ':/');
+						$data = 'http://' . ltrim($data, ':/');
 
-					if (substr($data, 0, 8) != 'https://' && $image_proxy_enabled)
+					if ($scheme != 'https' && $image_proxy_enabled)
 						$data = $boardurl . '/proxy.php?request=' . urlencode($data) . '&hash=' . md5($data . $image_proxy_secret);
 				},
 				'disabled_content' => '($1)',

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -1858,52 +1858,48 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 
 						$url_regex = '(?xi)
 (?:
-	(?:									# Either:
-		\b[a-z][\w-]+:					# URL scheme and colon
-		|								#  or
+	(?:											# Either:
+		\b[a-z][\w-]+:							# URL scheme and colon
+		|										#  or
 		(?<=^|\W)(?=//)							# A boundary followed by two slashes (for schemeless URLs like "//example.com")
 	)						
 	(?:
-		/{1,3}							# 1-3 slashes
-		|								#	or
-		[a-z0-9%]						# Single letter or digit or "%"
-										# (Trying not to match e.g. "URI::Escape")
+		/{1,3}									# 1-3 slashes
+		|										#	or
+		[\p{L}\p{M}\p{N}%]						# Single letter or digit or "%"
+												# (Trying not to match e.g. "URI::Escape")
 	)
-	|									#	or
-	www\d{0,3}[.]						# "www.", "www1.", "www2." … "www999."
-	|									#	or
-	[a-z0-9.\-]+[.][a-z]{2,4}/			# looks like domain name followed by a slash
+	|											#	or
+	www\d{0,3}[.]								# "www.", "www1.", "www2." … "www999."
+	|											#	or
+	[\p{L}\p{M}\p{N}.\-]+[.][\p{L}\p{M}]{2,4}/	# looks like domain name followed by a slash
 )
-(?:										# One or more:
-	[^\s()<>]+							# Run of non-space, non-()<>
-	|									#	or
-	\(([^\s()<>]+|(\([^\s()<>]+\)))*\)	# balanced parens, up to 2 levels
+(?:												# One or more:
+	[^\s()<>]+									# Run of non-space, non-()<>
+	|											#	or
+	\(([^\s()<>]+|(\([^\s()<>]+\)))*\)			# balanced parens, up to 2 levels
 )+
-(?:										# End with:
-	\(([^\s()<>]+|(\([^\s()<>]+\)))*\)	# balanced parens, up to 2 levels
-	|									#	or
-	[^\s`!()\[\]{};:\'".,<>?«»“”‘’]		# not a space or one of these punct char
+(?:												# End with:
+	\(([^\s()<>]+|(\([^\s()<>]+\)))*\)			# balanced parens, up to 2 levels
+	|											#	or
+	[^\s`!()\[\]{};:\'".,<>?«»“”‘’]				# not a space or one of these punct char
 )
 
-|										# OR, the following to match naked domains:
+|												# OR, the following to match naked domains:
 (?:
-	(?<!@)								# not preceded by a @, avoid matching foo@_gmail.com_
-	\b[a-z0-9]+
-	(?:[.\-][a-z0-9]+)*
+	(?<!@)										# not preceded by a @, avoid matching foo@_gmail.com_
+	\b[\p{L}\p{M}\p{N}]+
+	(?:[.\-][\p{L}\p{M}\p{N}]+)*
 	[.]
 	'. $tld_regex . '
 	\b
 	/?
-	(?!@)								# not succeeded by a @, avoid matching "foo.na" in "foo.na@example.com"
+	(?!@)										# not succeeded by a @, avoid matching "foo.na" in "foo.na@example.com"
 )';
 
 						$data = preg_replace_callback('~' . $url_regex . '~', function ($matches) {
 									$url = array_shift($matches);
 
-									// If this isn't a clean URL, bail out
-									if ($url != filter_var($url, FILTER_SANITIZE_URL))
-										return $url;
-									
 									// Are we linking a naked domain name (e.g. "example.com")?
 									if (empty(parse_url($url, PHP_URL_SCHEME)))
 									{
@@ -1916,10 +1912,6 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 										$schemeless = false;
 									}
 									
-									// Make sure that $fullUrl really is a valid URL, including a valid host name
-									if (filter_var($fullUrl, FILTER_VALIDATE_URL, FILTER_FLAG_HOST_REQUIRED) === false)
-										return $url;
-
 									// Time to do the deed
 									if (parse_url($fullUrl, PHP_URL_SCHEME) == 'mailto')
 									{

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -1924,6 +1924,8 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 									// Are we linking a schemeless URL or naked domain name (e.g. "example.com")?
 									if (empty($scheme))
 										$fullUrl = '//' . ltrim($url, ':/');
+									else
+										$fullUrl = $url;
 
 									return '[url=&quot;' . str_replace(array('[', ']'), array('&#91;', '&#93;'), $fullUrl) . '&quot;]' . $url . '[/url]';
 								}, $data);

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -1861,7 +1861,7 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 	(?:									# Either:
 		\b[a-z][\w-]+:					# URL scheme and colon
 		|								#  or
-		(?<=^|\W)(?=//)							# A boundary followed by two slashes (for schemaless URLs like "//example.com")
+		(?<=^|\W)(?=//)							# A boundary followed by two slashes (for schemeless URLs like "//example.com")
 	)						
 	(?:
 		/{1,3}							# 1-3 slashes
@@ -1908,12 +1908,12 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 									if (empty(parse_url($url, PHP_URL_SCHEME)))
 									{
 										$fullUrl = 'http://' . ltrim($url, ':/');
-										$schemaless = true;
+										$schemeless = true;
 									}
 									else
 									{
 										$fullUrl = $url;
-										$schemaless = false;
+										$schemeless = false;
 									}
 									
 									// Make sure that $fullUrl really is a valid URL, including a valid host name
@@ -1931,7 +1931,7 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 									}
 									else
 									{
-										if ($schemaless)
+										if ($schemeless)
 											$fullUrl = str_replace('http:', '', $fullUrl);
 
 										return '[url=&quot;' . str_replace(array('[', ']'), array('&#91;', '&#93;'), $fullUrl) . '&quot;]' . $url . '[/url]';


### PR DESCRIPTION
1. Bug fixes
   - Fixes an unreported bug when autolinking `mailto:` URLs
   - Fixes #3575 
2. Supports schemeless URLs (Fixes #1565)
   - Raw domain names (e.g. `www.example.com`) and schemeless URLs (e.g. `//www.example.com`) are linked without specifying the `http:` scheme. This applies both in BBCode (e.g. `[url]` and `[iurl]`) and in the autolinker. 
3. Adds support for IRIs in the autolinker (Fixes #1389)
   - Changes the regex to permit Unicode characters in relevant parts of a detected URL. HTML5 supports IRIs, so it is perfectly valid to put UTF8 characters (without percent encoding them) into a web address in an HTML5 document. Whenever an IRI link is encountered, the browser will handle everything that needs to be handled. See http://www.w3.org/International/articles/idn-and-iri/ for more info.
   - Removes some calls to filter_var() because FILTER_SANITIZE_URL and FILTER_VALIDATE_URL only support URIs, not IRIs. Since we no longer have the filters in place as a secondary check for invalid URLs, we'll have to rely on the regex alone. But that should be fine; it's no different than the situation prior to commit 8db70d2.
