### PR TITLE
better error handling for inet_dtop

### DIFF
--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -4982,9 +4982,31 @@ function inet_dtop($bin)
 	if ($db_type == 'postgresql')
 		return $bin;
 
-	$ip_address = inet_ntop($bin);
+	//http://stackoverflow.com/questions/1241728/can-i-try-catch-a-warning
+	set_error_handler(function($errno, $errstr, $errfile, $errline, array $errcontext)
+		{
+			// error was suppressed with the @-operator
+			if (0 === error_reporting())
+			{
+				return false;
+			}
 
-	return $ip_address;
+			throw new ErrorException($errstr, 0, $errno, $errfile, $errline);
+		}
+	);
+
+	try
+	{
+	 $var = inet_ntop($bin);
+	 restore_error_handler();
+	 return $var;
+	}
+	catch(ErrorException $e)
+	{
+	    log_error($e->getMessage(),'general', $e->getFile(), $e->getLine());
+		restore_error_handler();
+		return false;
+	}
 }
 
 /**

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -4969,8 +4969,9 @@ function inet_ptod($ip_address)
 }
 
 /**
+ * Convert the ip field of a database output in a string
  * @param binary $bin An IP address in IPv4, IPv6 (Either string (postgresql) or binary (other databases))
- * @return string The IP address in presentation format or false on error
+ * @return string The IP address in presentation format, null will be an emtpy string or false on error
  */
 function inet_dtop($bin)
 {

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -5004,7 +5004,7 @@ function inet_dtop($bin)
 	}
 	catch(ErrorException $e)
 	{
-	    log_error($e->getMessage(),'general', $e->getFile(), $e->getLine());
+	    log_error($e->getMessage().'<br/>'.$e->getTraceAsString(),'general', $e->getFile(), $e->getLine());
 		restore_error_handler();
 		return false;
 	}


### PR DESCRIPTION
It's supress the warning and safe it in the smf log.
With less performance impact as #3570.

```
mysql bin ipv4           2.2889740467072
mysql bin ipv4 safe      4.1099700927734
postgresql bin ipv4      1.2278430461884
postgresql bin ipv4 safe 1.2439939975739
mysql bin ipv6           2.1695320606232
mysql bin ipv6 safe      4.0392029285431
postgresql bin ipv6      1.2550032138824
postgresql bin ipv6 safe 1.2721769809723
```

http://pastebin.com/ZraQt3eu
