### PR TITLE
Better logic for [img] BBC re: schemeless URLs and image proxy

### DIFF
--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -1322,11 +1322,16 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 
 					$data = strtr($data, array('<br>' => ''));
 					$scheme = parse_url($data, PHP_URL_SCHEME);
-					if (empty($scheme))
-						$data = 'http://' . ltrim($data, ':/');
-
-					if ($scheme != 'https' && $image_proxy_enabled)
-						$data = $boardurl . '/proxy.php?request=' . urlencode($data) . '&hash=' . md5($data . $image_proxy_secret);
+					if ($image_proxy_enabled)
+					{
+						if (empty($scheme))
+							$data = 'http://' . ltrim($data, ':/');
+												
+						if ($scheme != 'https')
+							$data = $boardurl . '/proxy.php?request=' . urlencode($data) . '&hash=' . md5($data . $image_proxy_secret);
+					}
+					elseif (empty($scheme))
+						$data = '//' . ltrim($data, ':/');
 				},
 				'disabled_content' => '($1)',
 			),
@@ -1340,11 +1345,16 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 
 					$data = strtr($data, array('<br>' => ''));
 					$scheme = parse_url($data, PHP_URL_SCHEME);
-					if (empty($scheme))
+					if ($image_proxy_enabled)
+					{
+						if (empty($scheme))
+							$data = 'http://' . ltrim($data, ':/');
+												
+						if ($scheme != 'https')
+							$data = $boardurl . '/proxy.php?request=' . urlencode($data) . '&hash=' . md5($data . $image_proxy_secret);
+					}
+					elseif (empty($scheme))
 						$data = '//' . ltrim($data, ':/');
-
-					if (substr($data, 0, 8) != 'https://' && $image_proxy_enabled)
-						$data = $boardurl . '/proxy.php?request=' . urlencode($data) . '&hash=' . md5($data . $image_proxy_secret);
 				},
 				'disabled_content' => '($1)',
 			),


### PR DESCRIPTION
In b9a5018, I missed the second form of [img] entirely, and the code I used in the first form would never use a schemeless link even if we actually did want one (i.e. if the image proxy was not enabled). Now [img] will behave consistently in both forms, and will use schemeless URLs when appropriate.

