### PR TITLE
Prevent autocomplete in password fields

### DIFF
--- a/SSI.php
+++ b/SSI.php
@@ -1198,7 +1198,7 @@ function ssi_login($redirect_to = '', $output_method = 'echo')
 					<td><input type="text" id="user" name="user" size="9" value="', $user_info['username'], '" class="input_text"></td>
 				</tr><tr>
 					<td style="text-align: right; border-spacing: 1"><label for="passwrd">', $txt['password'], ':</label>&nbsp;</td>
-					<td><input type="password" name="passwrd" id="passwrd" size="9" class="input_password"></td>
+					<td><input type="password" name="passwrd" id="passwrd" size="9" class="input_password" autocomplete="off"></td>
 				</tr>
 				<tr>
 					<td>

--- a/Themes/default/Admin.template.php
+++ b/Themes/default/Admin.template.php
@@ -846,8 +846,8 @@ function template_show_settings()
 				// Escape (via htmlspecialchars.) the text box.
 				elseif ($config_var['type'] == 'password')
 					echo '
-										<input type="password"', $disabled, $javascript, ' name="', $config_var['name'], '[0]"', ($config_var['size'] ? ' size="' . $config_var['size'] . '"' : ''), ' value="*#fakepass#*" onfocus="this.value = \'\'; this.form.', $config_var['name'], '.disabled = false;" class="input_password"><br>
-										<input type="password" disabled id="', $config_var['name'], '" name="', $config_var['name'], '[1]"', ($config_var['size'] ? ' size="' . $config_var['size'] . '"' : ''), ' class="input_password">';
+										<input type="password"', $disabled, $javascript, ' name="', $config_var['name'], '[0]"', ($config_var['size'] ? ' size="' . $config_var['size'] . '"' : ''), ' value="*#fakepass#*" onfocus="this.value = \'\'; this.form.', $config_var['name'], '.disabled = false;" class="input_password" autocomplete="off"><br>
+										<input type="password" disabled id="', $config_var['name'], '" name="', $config_var['name'], '[1]"', ($config_var['size'] ? ' size="' . $config_var['size'] . '"' : ''), ' class="input_password" autocomplete="off">';
 				// Show a selection box.
 				elseif ($config_var['type'] == 'select')
 				{

--- a/Themes/default/Login.template.php
+++ b/Themes/default/Login.template.php
@@ -43,7 +43,7 @@ function template_login()
 						<dt>', $txt['username'], ':</dt>
 						<dd><input type="text" id="', !empty($context['from_ajax']) ? 'ajax_' : '', 'loginuser" name="user" size="20" value="', $context['default_username'], '" class="input_text"></dd>
 						<dt>', $txt['password'], ':</dt>
-						<dd><input type="password" id="', !empty($context['from_ajax']) ? 'ajax_' : '', 'loginpass" name="passwrd" value="', $context['default_password'], '" size="20" class="input_password"></dd>
+						<dd><input type="password" id="', !empty($context['from_ajax']) ? 'ajax_' : '', 'loginpass" name="passwrd" value="', $context['default_password'], '" size="20" class="input_password" autocomplete="off"></dd>
 					</dl>
 					<dl>
 						<dt>', $txt['mins_logged_in'], ':</dt>
@@ -223,7 +223,7 @@ function template_kick_guest()
 					<dt>', $txt['username'], ':</dt>
 					<dd><input type="text" name="user" size="20" class="input_text"></dd>
 					<dt>', $txt['password'], ':</dt>
-					<dd><input type="password" name="passwrd" size="20" class="input_password"></dd>
+					<dd><input type="password" name="passwrd" size="20" class="input_password" autocomplete="off"></dd>
 					<dt>', $txt['mins_logged_in'], ':</dt>
 					<dd><input type="text" name="cookielength" size="4" maxlength="4" value="', $modSettings['cookieTime'], '" class="input_text"></dd>
 					<dt>', $txt['always_logged_in'], ':</dt>
@@ -271,7 +271,7 @@ function template_maintenance()
 				<dt>', $txt['username'], ':</dt>
 				<dd><input type="text" name="user" size="20" class="input_text"></dd>
 				<dt>', $txt['password'], ':</dt>
-				<dd><input type="password" name="passwrd" size="20" class="input_password"></dd>
+				<dd><input type="password" name="passwrd" size="20" class="input_password" autocomplete="off"></dd>
 				<dt>', $txt['mins_logged_in'], ':</dt>
 				<dd><input type="text" name="cookielength" size="4" maxlength="4" value="', $modSettings['cookieTime'], '" class="input_text"></dd>
 				<dt>', $txt['always_logged_in'], ':</dt>
@@ -311,7 +311,7 @@ function template_admin_login()
 
 	echo '
 			<strong>', $txt['password'], ':</strong>
-			<input type="password" name="', $context['sessionCheckType'], '_pass" size="24" class="input_password">
+			<input type="password" name="', $context['sessionCheckType'], '_pass" size="24" class="input_password" autocomplete="off">
 			<a href="', $scripturl, '?action=helpadmin;help=securityDisable_why" onclick="return reqOverlayDiv(this.href);" class="help"><span class="generic_icons help" title="', $txt['help'],'"></span></a><br>
 			<input type="hidden" name="', $context['session_var'], '" value="', $context['session_id'], '">
 			<input type="hidden" name="', $context['admin-login_token_var'], '" value="', $context['admin-login_token'], '">
@@ -385,7 +385,7 @@ function template_resend()
 					<dt>', $txt['invalid_activation_new_email'], ':</dt>
 					<dd><input type="text" name="new_email" size="40" class="input_text"></dd>
 					<dt>', $txt['invalid_activation_password'], ':</dt>
-					<dd><input type="password" name="passwd" size="30" class="input_password"></dd>
+					<dd><input type="password" name="passwd" size="30" class="input_password" autocomplete="off"></dd>
 				</dl>';
 
 	if ($context['can_activate'])

--- a/Themes/default/ManageLanguages.template.php
+++ b/Themes/default/ManageLanguages.template.php
@@ -101,7 +101,7 @@ function template_download_language()
 						<label for="ftp_password">', $txt['package_ftp_password'], ':</label>
 					</dt>
 					<dd>
-						<input type="password" size="50" name="ftp_password" id="ftp_password" style="width: 99%;" class="input_text">
+						<input type="password" size="50" name="ftp_password" id="ftp_password" style="width: 99%;" class="input_text" autocomplete="off">
 					</dd>
 
 					<dt>

--- a/Themes/default/Packages.template.php
+++ b/Themes/default/Packages.template.php
@@ -745,7 +745,7 @@ function template_servers()
 							<label for="ftp_password">', $txt['package_ftp_password'], ':</label>
 						</dt>
 						<dd>
-							<input type="password" size="50" name="ftp_password" id="ftp_password" style="width: 99%;" class="input_password">
+							<input type="password" size="50" name="ftp_password" id="ftp_password" style="width: 99%;" class="input_password" autocomplete="off">
 						</dd>
 						<dt>
 							<label for="ftp_path">', $txt['package_ftp_path'], ':</label>
@@ -1164,7 +1164,7 @@ function template_control_chmod()
 							<label for="ftp_password">', $txt['package_ftp_password'], ':</label>
 						</dt>
 						<dd>
-							<input type="password" size="50" name="ftp_password" id="ftp_password" style="width: 98%;" class="input_password">
+							<input type="password" size="50" name="ftp_password" id="ftp_password" style="width: 98%;" class="input_password" autocomplete="off">
 						</dd>
 						<dt>
 							<label for="ftp_path">', $txt['package_ftp_path'], ':</label>

--- a/Themes/default/Profile.template.php
+++ b/Themes/default/Profile.template.php
@@ -1356,7 +1356,7 @@ function template_edit_options()
 
 	echo '
 		<form action="', $url, '" method="post" accept-charset="', $context['character_set'], '" name="creator" id="creator" enctype="multipart/form-data"', ($context['menu_item_selected'] == 'account' ? ' autocomplete="off"' : ''), '>
-			<div style="position:absolute; top:-100px;"><input type="text" id="autocompleteFakeName"/><input type="password" id="autocompleteFakePassword"/></div>
+			<div style="position:absolute; top:-100px;"><input type="text" id="autocompleteFakeName"/><input type="password" id="autocompleteFakePassword" autocomplete="off"/></div>
 			<div class="cat_bar">
 				<h3 class="catbg profile_hd">';
 
@@ -1534,7 +1534,7 @@ function template_edit_options()
 						<span class="smalltext">', $txt['required_security_reasons'], '</span>
 					</dt>
 					<dd>
-						<input type="password" name="oldpasswrd" id="oldpasswrd" size="20" style="margin-right: 4ex;" class="input_password">
+						<input type="password" name="oldpasswrd" id="oldpasswrd" size="20" style="margin-right: 4ex;" class="input_password" autocomplete="off">
 					</dd>
 				</dl>';
 
@@ -2525,7 +2525,7 @@ function template_deleteAccount()
 				<div class="alert">', $txt['own_profile_confirm'], '</div>
 				<div>
 					<strong', (isset($context['modify_error']['bad_password']) || isset($context['modify_error']['no_password']) ? ' class="error"' : ''), '>', $txt['current_password'], ': </strong>
-					<input type="password" name="oldpasswrd" size="20" class="input_password">&nbsp;&nbsp;&nbsp;&nbsp;
+					<input type="password" name="oldpasswrd" size="20" class="input_password" autocomplete="off">&nbsp;&nbsp;&nbsp;&nbsp;
 					<input type="submit" value="', $txt['yes'], '" class="button_submit">';
 
 		if (!empty($context['token_check']))
@@ -2607,7 +2607,7 @@ function template_profile_save()
 							<span class="smalltext">', $txt['required_security_reasons'], '</span>
 						</dt>
 						<dd>
-							<input type="password" name="oldpasswrd" size="20" style="margin-right: 4ex;" class="input_password">
+							<input type="password" name="oldpasswrd" size="20" style="margin-right: 4ex;" class="input_password" autocomplete="off">
 						</dd>
 					</dl>';
 
@@ -3045,7 +3045,7 @@ function template_tfasetup()
 											<div class="title_top">
 												<strong>', $txt['tfa_step1'], '</strong><br />
 												', !empty($context['tfa_pass_error']) ? '<div class="error smalltext">' . $txt['tfa_pass_invalid'] . '</div>' : '', '
-												<input type="password" name="passwd" style="width: 200px;"', !empty($context['tfa_pass_error']) ? ' class="error"' : '', !empty($context['tfa_pass_value']) ? ' value="' . $context['tfa_pass_value'] . '"' : '' ,'>
+												<input type="password" name="passwd" autocomplete="off" style="width: 200px;"', !empty($context['tfa_pass_error']) ? ' class="error"' : '', !empty($context['tfa_pass_value']) ? ' value="' . $context['tfa_pass_value'] . '"' : '' ,'>
 											</div>
 											<div class="title_top">
 												<strong>', $txt['tfa_step2'], '</strong>

--- a/Themes/default/Register.template.php
+++ b/Themes/default/Register.template.php
@@ -114,7 +114,7 @@ function template_registration_form()
 					<dl class="register_form" id="password1_group">
 						<dt><strong><label for="smf_autov_pwmain">', ucwords($txt['choose_pass']), ':</label></strong></dt>
 						<dd>
-							<input type="password" name="passwrd1" id="smf_autov_pwmain" size="30" tabindex="', $context['tabindex']++, '" class="input_password">
+							<input type="password" name="passwrd1" id="smf_autov_pwmain" size="30" tabindex="', $context['tabindex']++, '" class="input_password" autocomplete="off">
 							<span id="smf_autov_pwmain_div" style="display: none;">
 								<span id="smf_autov_pwmain_img" class="generic_icons invalid"></span>
 							</span>
@@ -123,7 +123,7 @@ function template_registration_form()
 					<dl class="register_form" id="password2_group">
 						<dt><strong><label for="smf_autov_pwverify">', ucwords($txt['verify_pass']), ':</label></strong></dt>
 						<dd>
-							<input type="password" name="passwrd2" id="smf_autov_pwverify" size="30" tabindex="', $context['tabindex']++, '" class="input_password">
+							<input type="password" name="passwrd2" id="smf_autov_pwverify" size="30" tabindex="', $context['tabindex']++, '" class="input_password" autocomplete="off">
 							<span id="smf_autov_pwverify_div" style="display: none;">
 								<span id="smf_autov_pwverify_img" class="generic_icons valid"></span>
 							</span>
@@ -511,7 +511,7 @@ function template_admin_register()
 							<span class="smalltext">', $txt['admin_register_password_desc'], '</span>
 						</dt>
 						<dd>
-							<input type="password" name="password" id="password_input" tabindex="', $context['tabindex']++, '" size="30" class="input_password" onchange="onCheckChange();">
+							<input type="password" name="password" id="password_input" tabindex="', $context['tabindex']++, '" size="30" class="input_password" onchange="onCheckChange();" autocomplete="off">
 						</dd>';
 
 	if (!empty($context['member_groups']))

--- a/Themes/default/Reminder.template.php
+++ b/Themes/default/Reminder.template.php
@@ -109,14 +109,14 @@ function template_set_password()
 				<dl>
 					<dt>', $txt['choose_pass'], ': </dt>
 					<dd>
-						<input type="password" name="passwrd1" id="smf_autov_pwmain" size="22" class="input_password">
+						<input type="password" name="passwrd1" id="smf_autov_pwmain" size="22" class="input_password" autocomplete="off">
 						<span id="smf_autov_pwmain_div" style="display: none;">
 							<span id="smf_autov_pwmain_img" class="generic_icons invalid"></span>
 						</span>
 					</dd>
 					<dt>', $txt['verify_pass'], ': </dt>
 					<dd>
-						<input type="password" name="passwrd2" id="smf_autov_pwverify" size="22" class="input_password">
+						<input type="password" name="passwrd2" id="smf_autov_pwverify" size="22" class="input_password" autocomplete="off">
 						<span id="smf_autov_pwverify_div" style="display: none;">
 							<span id="smf_autov_pwverify_img" class="generic_icons invalid"></span>
 						</span>
@@ -165,14 +165,14 @@ function template_ask()
 					<dd><input type="text" name="secret_answer" size="22" class="input_text"></dd>
 					<dt>', $txt['choose_pass'], ': </dt>
 					<dd>
-						<input type="password" name="passwrd1" id="smf_autov_pwmain" size="22" class="input_password">
+						<input type="password" name="passwrd1" id="smf_autov_pwmain" size="22" class="input_password" autocomplete="off">
 						<span id="smf_autov_pwmain_div" style="display: none;">
 							<span id="smf_autov_pwmain_img" class="generic_icons invalid"></span>
 						</span>
 					</dd>
 					<dt>', $txt['verify_pass'], ': </dt>
 					<dd>
-						<input type="password" name="passwrd2" id="smf_autov_pwverify" size="22" class="input_password">
+						<input type="password" name="passwrd2" id="smf_autov_pwverify" size="22" class="input_password" autocomplete="off">
 						<span id="smf_autov_pwverify_div" style="display: none;">
 							<span id="smf_autov_pwverify_img" class="generic_icons valid"></span>
 						</span>

--- a/other/install.php
+++ b/other/install.php
@@ -2036,7 +2036,7 @@ function template_chmod_files()
 				</tr><tr>
 					<td width="26%" valign="top" class="textbox"><label for="ftp_password">', $txt['ftp_password'], ':</label></td>
 					<td>
-						<input type="password" size="50" name="ftp_password" id="ftp_password" style="width: 99%;" class="input_password" />
+						<input type="password" size="50" name="ftp_password" id="ftp_password" style="width: 99%;" class="input_password" autocomplete="off" />
 						<div class="smalltext block">', $txt['ftp_password_info'], '</div>
 					</td>
 				</tr><tr>
@@ -2117,7 +2117,7 @@ function template_database_settings()
 			</tr><tr id="db_passwd_contain">
 				<td valign="top" class="textbox"><label for="db_passwd_input">', $txt['db_settings_password'], ':</label></td>
 				<td>
-					<input type="password" name="db_passwd" id="db_passwd_input" value="', $incontext['db']['pass'], '" size="30" class="input_password" /><br>
+					<input type="password" name="db_passwd" id="db_passwd_input" value="', $incontext['db']['pass'], '" size="30" class="input_password" autocomplete="off" /><br>
 					<div class="smalltext block">', $txt['db_settings_password_info'], '</div>
 				</td>
 			</tr><tr id="db_name_contain">
@@ -2316,13 +2316,13 @@ function template_admin_account()
 			</tr><tr>
 				<td valign="top" class="textbox"><label for="password1">', $txt['user_settings_password'], ':</label></td>
 				<td>
-					<input type="password" name="password1" id="password1" size="40" class="input_password" />
+					<input type="password" name="password1" id="password1" size="40" class="input_password" autocomplete="off" />
 					<div class="smalltext block">', $txt['user_settings_password_info'], '</div>
 				</td>
 			</tr><tr>
 				<td valign="top" class="textbox"><label for="password2">', $txt['user_settings_again'], ':</label></td>
 				<td>
-					<input type="password" name="password2" id="password2" size="40" class="input_password" />
+					<input type="password" name="password2" id="password2" size="40" class="input_password" autocomplete="off" />
 					<div class="smalltext block">', $txt['user_settings_again_info'], '</div>
 				</td>
 			</tr><tr>
@@ -2346,7 +2346,7 @@ function template_admin_account()
 		<p>', $txt['user_settings_database_info'], '</p>
 
 		<div style="margin-bottom: 2ex; padding-', $txt['lang_rtl'] == false ? 'left' : 'right', ': 50px;">
-			<input type="password" name="password3" size="30" class="input_password" />
+			<input type="password" name="password3" size="30" class="input_password" autocomplete="off" />
 		</div>';
 }
 

--- a/other/upgrade.php
+++ b/other/upgrade.php
@@ -4135,7 +4135,7 @@ function template_chmod()
 			</tr><tr>
 				<td width="26%" valign="top" class="textbox"><label for="ftp_password">', $txt['ftp_password'], ':</label></td>
 				<td>
-					<input type="password" size="50" name="ftp_password" id="ftp_password" style="width: 99%;" class="input_password">
+					<input type="password" size="50" name="ftp_password" id="ftp_password" style="width: 99%;" class="input_password" autocomplete="off">
 					<div class="smalltext block">', $txt['ftp_password_info'], '</div>
 				</td>
 			</tr><tr>
@@ -4478,7 +4478,7 @@ function template_welcome_message()
 				<tr valign="top">
 					<td><strong ', $disable_security ? 'style="color: gray;"' : '', '>Password:</strong></td>
 					<td>
-						<input type="password" name="passwrd" value=""', $disable_security ? ' disabled' : '', ' class="input_password">
+						<input type="password" name="passwrd" value=""', $disable_security ? ' disabled' : '', ' class="input_password" autocomplete="off">
 						<input type="hidden" name="hash_passwrd" value="">';
 
 	if (!empty($upcontext['password_failed']))


### PR DESCRIPTION
Best security practice is to have password fields set to not autocomplete. This PR updates all found password fields to have the autocomplete="off" attribute/value.

Signed-off-by: Luis Cruz <sprak3000+github@gmail.com>
