### PR TITLE
UX Improvements on board-index (board names)

### DIFF
--- a/Themes/default/BoardIndex.template.php
+++ b/Themes/default/BoardIndex.template.php
@@ -99,7 +99,10 @@ function template_main()
 						<a href="', ($board['is_redirect'] || $context['user']['is_guest'] ? $board['href'] : $scripturl . '?action=unread;board=' . $board['id'] . '.0;children'), '" class="board_', $board['board_class'], '"', !empty($board['board_tooltip']) ? ' title="' . $board['board_tooltip'] . '"' : '', '></a>
 					</div>
 					<div class="info">
-						<a class="subject" href="', $board['href'], '" id="b', $board['id'], '">', $board['name'], '</a>';
+						<a class="subject mobile_subject" href="', $board['href'], '" id="b', $board['id'], '">
+							', $board['name'], '
+							<p class="board_description mobile_display">', $board['description'] , '</p>
+						</a>';
 
 				// Has it outstanding posts for approval?
 				if ($board['can_approve_posts'] && ($board['unapproved_posts'] || $board['unapproved_topics']))
@@ -107,7 +110,6 @@ function template_main()
 						<a href="', $scripturl, '?action=moderate;area=postmod;sa=', ($board['unapproved_topics'] > 0 ? 'topics' : 'posts'), ';brd=', $board['id'], ';', $context['session_var'], '=', $context['session_id'], '" title="', sprintf($txt['unapproved_posts'], $board['unapproved_topics'], $board['unapproved_posts']), '" class="moderation_link">(!)</a>';
 
 				echo '
-
 						<p class="board_description">', $board['description'] , '</p>';
 
 				// Show the "Moderators: ". Each has name, href, link, and id. (but we're gonna use link_moderators.)

--- a/Themes/default/MessageIndex.template.php
+++ b/Themes/default/MessageIndex.template.php
@@ -42,7 +42,10 @@ function template_main()
 						<a href="', ($board['is_redirect'] || $context['user']['is_guest'] ? $board['href'] : $scripturl . '?action=unread;board=' . $board['id'] . '.0;children'), '" class="board_', $board['board_class'], '"', !empty($board['board_tooltip']) ? ' title="' . $board['board_tooltip'] . '"' : '', '></a>
 					</div>
 					<div class="info">
-						<a class="subject" href="', $board['href'], '" id="b', $board['id'], '">', $board['name'], '</a>';
+						<a class="subject mobile_subject" href="', $board['href'], '" id="b', $board['id'], '">
+							', $board['name'], '
+							<p class="board_description mobile_display">', $board['description'] , '</p>
+						</a>';
 
 			// Has it outstanding posts for approval?
 			if ($board['can_approve_posts'] && ($board['unapproved_posts'] || $board['unapproved_topics']))
@@ -65,7 +68,7 @@ function template_main()
 						', $board['is_redirect'] ? '' : comma_format($board['topics']) . ' ' . $txt['board_topics'], '
 						</p>
 					</div>
-					<div class="lastpost">';
+					<div class="lastpost lpr_border">';
 
 			if (!empty($board['last_post']['id']))
 				echo '

--- a/Themes/default/css/index.css
+++ b/Themes/default/css/index.css
@@ -3838,7 +3838,7 @@ p.attached_BBC a.insertBBC
 }
 
 /* Hide this from desktop users sshh... our little sekrit */
-.mobile_buttons {
+.mobile_buttons, .mobile_display {
 	display: none;
 }
 

--- a/Themes/default/css/responsive.css
+++ b/Themes/default/css/responsive.css
@@ -95,6 +95,21 @@
 		display: block;
 		width: 100%;
 	}
+	/* some new stuff for far better UX */
+	.mobile_subject {
+		display: block;
+		padding: 9px 0;
+		position: relative;
+	}
+	.mobile_subject .board_description {
+		display: block;
+		font-weight: normal;
+		font-size: 0.9em;
+		color: #222;
+	}
+	.board_description {
+		display: none;
+	}
 	/* Register Page */
 	#registration .button_submit {
 		font-size: 0.67em;
@@ -437,9 +452,6 @@
 	}
 
 	/* BoardIndex */
-	.board_icon {
-		margin-top: 10px;
-	}
 	.board_stats {
 		display: none;
 	}


### PR DESCRIPTION
Change cannot be explained with a screenshot properly, What changed is, board-name container element "a", enlarged with proper padding to make sure it contains all line so user can click anywhere on that place (excluding the board-icon it has different function) to get redirected to board.

If you want to see the difference

Before: https://smfgit.oldiesmann.us | After: http://next.mmobrowser.com
