### PR TITLE
Adds code to build optimized regexes from arrays of strings

### DIFF
--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -5482,7 +5482,7 @@ function build_regex($strings, $delim = null)
 	$index = array();
 	$regexes = array();
 
-	$add_string_to_index = function ($str, $index, $delim = null, $depth = 0) use ($smcFunc, &$add_string_to_index)
+	$add_string_to_index = function ($str, $index, $delim = null, $depth = 0) use (&$smcFunc, &$add_string_to_index)
 	{
 		$strlen = function_exists('mb_strlen') ? 'mb_strlen' : $smcFunc['strlen'];
 		$substr = function_exists('mb_substr') ? 'mb_substr' : $smcFunc['substr'];
@@ -5495,14 +5495,14 @@ function build_regex($strings, $delim = null)
 		if ($strlen($str) > 1 && $depth > 99)
 			$index[$first][$substr($str, 1)] = '';
 		elseif ($strlen($str) > 1)
-			$index[$first] =  $add_string_to_index($substr($str, 1), $index[$first], $delim, $depth + 1);
+			$index[$first] = $add_string_to_index($substr($str, 1), $index[$first], $delim, $depth + 1);
 		else
 			$index[$first][''] = '';
 
 		return $index;
 	};
 
-	$index_to_regex = function (&$index, $depth = 0) use ($smcFunc, &$index_to_regex)
+	$index_to_regex = function (&$index, $depth = 0) use (&$smcFunc, &$index_to_regex)
 	{
 		// Absolute max length is 32768, but we might need wiggle room
 		$max_length = 30000;
@@ -5542,7 +5542,7 @@ function build_regex($strings, $delim = null)
 		}
 		
 		// Sort by length (not including any subgroups) and then alphabetically
-		usort($regex, function($val1, $val2) use ($smcFunc) {
+		usort($regex, function($val1, $val2) use (&$smcFunc) {
 			$strlen = function_exists('mb_strlen') ? 'mb_strlen' : $smcFunc['strlen'];
 			$strpos = function_exists('mb_strpos') ? 'mb_strpos' : $smcFunc['strpos'];
 			$substr = function_exists('mb_substr') ? 'mb_substr' : $smcFunc['substr'];

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -5500,7 +5500,7 @@ function build_regex($strings)
  * @param array $index The index array that we want to incorporate the string into.
  * @return array An alphabetically keyed array that incorporates $str.
  */
-function add_string_to_index($str, $index)
+function add_string_to_index($str, $index, $depth = 0)
 {
 	global $smcFunc;
 
@@ -5513,7 +5513,7 @@ function add_string_to_index($str, $index)
 		$index[$first] = array();
 
 	if ($strlen($str) > 1)
-		$index[$first] = add_string_to_index($substr($str, 1), $index[$first]);
+		$index[$first] = $depth > 99 ? $substr($str, 1) : add_string_to_index($substr($str, 1), $index[$first], $depth + 1);
 	else
 		$index[$first][''] = '';
 

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -5495,7 +5495,7 @@ function build_regex($strings, $delim = null)
 		if ($strlen($str) > 1 && $depth > 99)
 			$index[$first][$substr($str, 1)] = '';
 		elseif ($strlen($str) > 1)
-			$index[$first] =  add_string_to_index($substr($str, 1), $index[$first], $delim, $depth + 1);
+			$index[$first] =  $add_string_to_index($substr($str, 1), $index[$first], $delim, $depth + 1);
 		else
 			$index[$first][''] = '';
 
@@ -5518,12 +5518,12 @@ function build_regex($strings, $delim = null)
 			}
 			elseif (count(array_keys($value)) == 1)
 			{
-				$sub_regex = index_to_regex($value, $depth + 1);
+				$sub_regex = $index_to_regex($value, $depth + 1);
 				$key_regex = $key . $sub_regex;
 			}
 			else
 			{
-				$sub_regex = '(?' . '>' . index_to_regex($value, $depth + 1) . ')';
+				$sub_regex = '(?' . '>' . $index_to_regex($value, $depth + 1) . ')';
 				$key_regex = $key . $sub_regex;
 			}
 

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -5547,9 +5547,9 @@ function build_regex($strings, $delim = null)
 			$strpos = function_exists('mb_strpos') ? 'mb_strpos' : $smcFunc['strpos'];
 			$substr = function_exists('mb_substr') ? 'mb_substr' : $smcFunc['substr'];
 
-			if (($l1 = $strpos($val1, '(?' . '>')) == false)
+			if (($l1 = $strpos($val1, '(?' . '>')) === false)
 				$l1 = $strlen($val1);
-			if (($l2 = $strpos($val2, '(?' . '>')) == false)
+			if (($l2 = $strpos($val2, '(?' . '>')) === false)
 				$l2 = $strlen($val2);
 			
 			if ($l1 == $l2)

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -5586,9 +5586,7 @@ function index_to_regex(&$index, $depth = 0)
 			$l2 = $strlen($val2);
 		
 		if ($l1 == $l2)
-		{
 			return strcmp($substr($val1, 0, $l1), $substr($val2, 0, $l2)) > 0 ? 1 : -1;
-		}
 		else
 			return $l1 > $l2 ? -1 : 1;
 	});

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -5512,8 +5512,10 @@ function add_string_to_index($str, $index, $depth = 0)
 	if (empty($index[$first]))
 		$index[$first] = array();
 
-	if ($strlen($str) > 1)
-		$index[$first] = $depth > 99 ? $substr($str, 1) : add_string_to_index($substr($str, 1), $index[$first], $depth + 1);
+	if ($strlen($str) > 1 && $depth > 99)
+		$index[$first][$substr($str, 1)] = '';
+	elseif ($strlen($str) > 1)
+		$index[$first] =  add_string_to_index($substr($str, 1), $index[$first], $depth + 1);
 	else
 		$index[$first][''] = '';
 

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -5482,7 +5482,7 @@ function build_regex($strings, $delim = null)
 	$index = array();
 	$regexes = array();
 
-	$add_string_to_index = function ($str, $index, $delim = null, $depth = 0) use (&$smcFunc, &$add_string_to_index)
+	$add_string_to_index = function ($str, $index, $delim, $depth = 0) use (&$smcFunc, &$add_string_to_index)
 	{
 		$strlen = function_exists('mb_strlen') ? 'mb_strlen' : $smcFunc['strlen'];
 		$substr = function_exists('mb_substr') ? 'mb_substr' : $smcFunc['substr'];

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -5479,7 +5479,7 @@ function build_regex($strings)
 	global $smcFunc;
 
 	$index = array();
-	$regexes = '';
+	$regexes = array();
 	
 	foreach ($strings as $string)
 		$index = add_string_to_index($string, $index);

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -5482,20 +5482,20 @@ function build_regex($strings, $delim = null)
 	$index = array();
 	$regexes = array();
 
-	$add_string_to_index = function ($str, $index, $depth = 0) use (&$smcFunc, &$add_string_to_index)
+	$add_string_to_index = function ($string, $index, $depth = 0) use (&$smcFunc, &$add_string_to_index)
 	{
 		$strlen = function_exists('mb_strlen') ? 'mb_strlen' : $smcFunc['strlen'];
 		$substr = function_exists('mb_substr') ? 'mb_substr' : $smcFunc['substr'];
 
-		$first = $substr($str, 0, 1);
+		$first = $substr($string, 0, 1);
 
 		if (empty($index[$first]))
 			$index[$first] = array();
 
-		if ($strlen($str) > 1 && $depth > 99)
-			$index[$first][$substr($str, 1)] = '';
-		elseif ($strlen($str) > 1)
-			$index[$first] = $add_string_to_index($substr($str, 1), $index[$first], $depth + 1);
+		if ($strlen($string) > 1 && $depth > 99)
+			$index[$first][$substr($string, 1)] = '';
+		elseif ($strlen($string) > 1)
+			$index[$first] = $add_string_to_index($substr($string, 1), $index[$first], $depth + 1);
 		else
 			$index[$first][''] = '';
 

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -5547,9 +5547,9 @@ function build_regex($strings, $delim = null)
 			$strpos = function_exists('mb_strpos') ? 'mb_strpos' : $smcFunc['strpos'];
 			$substr = function_exists('mb_substr') ? 'mb_substr' : $smcFunc['substr'];
 
-			if (($l1 = $strpos($val1, '(')) == false)
+			if (($l1 = $strpos($val1, '(?' . '>')) == false)
 				$l1 = $strlen($val1);
-			if (($l2 = $strpos($val2, '(')) == false)
+			if (($l2 = $strpos($val2, '(?' . '>')) == false)
 				$l2 = $strlen($val2);
 			
 			if ($l1 == $l2)

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -5472,9 +5472,10 @@ function smf_serverResponse($data = '', $type = 'Content-Type: application/json'
  * whatever you are trying to do with these giant regexes.)
  *
  * @param array $strings An array of strings to make a regex for.
+ * @param string $delim An optional delimiter character to pass to preg_quote().
  * @return array An array of one or more regular expressions to match any of the input strings.
  */
-function build_regex($strings)
+function build_regex($strings, $delim = null)
 {
 	global $smcFunc;
 
@@ -5482,7 +5483,7 @@ function build_regex($strings)
 	$regexes = array();
 	
 	foreach ($strings as $string)
-		$index = add_string_to_index($string, $index);
+		$index = add_string_to_index($string, $index, $delim);
 
 	while (!empty($index))
 		$regexes[] = '(?' . '>' . index_to_regex($index) . ')';
@@ -5498,17 +5499,18 @@ function build_regex($strings)
  *
  * @param string $str The string we want to incorporate into the index array.
  * @param array $index The index array that we want to incorporate the string into.
+ * @param string $delim An optional delimiter character to pass to preg_quote().
  * @param int $depth Indicates how many levels of recursion the function is currently at.
  * @return array An alphabetically keyed array that incorporates $str.
  */
-function add_string_to_index($str, $index, $depth = 0)
+function add_string_to_index($str, $index, $delim = null, $depth = 0)
 {
 	global $smcFunc;
 
 	$strlen = function_exists('mb_strlen') ? 'mb_strlen' : $smcFunc['strlen'];
 	$substr = function_exists('mb_substr') ? 'mb_substr' : $smcFunc['substr'];
 
-	$first = $substr($str, 0, 1);
+	$first = preg_quote($substr($str, 0, 1), $delim);
 
 	if (empty($index[$first]))
 		$index[$first] = array();
@@ -5516,7 +5518,7 @@ function add_string_to_index($str, $index, $depth = 0)
 	if ($strlen($str) > 1 && $depth > 99)
 		$index[$first][$substr($str, 1)] = '';
 	elseif ($strlen($str) > 1)
-		$index[$first] =  add_string_to_index($substr($str, 1), $index[$first], $depth + 1);
+		$index[$first] =  add_string_to_index($substr($str, 1), $index[$first], $delim, $depth + 1);
 	else
 		$index[$first][''] = '';
 

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -5479,11 +5479,11 @@ function build_regex($strings, $delim = null)
 {
 	global $smcFunc;
 
-	$index = array();
-	$regexes = array();
-
-	$add_string_to_index = function ($string, $index, $depth = 0) use (&$smcFunc, &$add_string_to_index)
+	// This function builds the index array from the strings
+	function add_string_to_index($string, $index, $depth = 0)
 	{
+		global $smcFunc;
+		
 		$strlen = function_exists('mb_strlen') ? 'mb_strlen' : $smcFunc['strlen'];
 		$substr = function_exists('mb_substr') ? 'mb_substr' : $smcFunc['substr'];
 
@@ -5495,16 +5495,19 @@ function build_regex($strings, $delim = null)
 		if ($strlen($string) > 1 && $depth > 99)
 			$index[$first][$substr($string, 1)] = '';
 		elseif ($strlen($string) > 1)
-			$index[$first] = $add_string_to_index($substr($string, 1), $index[$first], $depth + 1);
+			$index[$first] = add_string_to_index($substr($string, 1), $index[$first], $depth + 1);
 		else
 			$index[$first][''] = '';
 
 		return $index;
 	};
 
-	$index_to_regex = function (&$index, $delim, $depth = 0) use (&$smcFunc, &$index_to_regex)
+	// This one turns the index array into a regular expression
+	function index_to_regex(&$index, $delim, $depth = 0)
 	{
-		// Absolute max length is 32768, but we might need wiggle room
+		global $smcFunc;
+		
+		// Absolute max length for a regex is 32768, but we might need wiggle room
 		$max_length = 30000;
 
 		$regex = array();
@@ -5520,13 +5523,13 @@ function build_regex($strings, $delim = null)
 			}
 			elseif (count(array_keys($value)) == 1)
 			{
-				$sub_regex = $index_to_regex($value, $delim, $depth + 1);
+				$sub_regex = index_to_regex($value, $delim, $depth + 1);
 				$key_regex = preg_quote($key, $delim);
 				$new_key = $key . explode('(?'.'>', $sub_regex)[0];
 			}
 			else
 			{
-				$sub_regex = '(?'.'>' . $index_to_regex($value, $delim, $depth + 1) . ')';
+				$sub_regex = '(?'.'>' . index_to_regex($value, $delim, $depth + 1) . ')';
 				$key_regex = preg_quote($key, $delim);
 				$new_key = $key;
 			}
@@ -5546,7 +5549,7 @@ function build_regex($strings, $delim = null)
 		}
 		
 		// Sort by key length and then alphabetically
-		uksort($regex, function($k1, $k2) use (&$smcFunc, $delim) {
+		uksort($regex, function($k1, $k2) use (&$smcFunc) {
 			$strlen = function_exists('mb_strlen') ? 'mb_strlen' : $smcFunc['strlen'];
 
 			$l1 = $strlen($k1);
@@ -5560,13 +5563,16 @@ function build_regex($strings, $delim = null)
 
 		return implode('|', $regex);
 	};
-
 	
+	// Now that the functions are defined, let's do this thing
+	$index = array();
+	$regexes = array();
+
 	foreach ($strings as $string)
-		$index = $add_string_to_index($string, $index, $delim);
+		$index = add_string_to_index($string, $index, $delim);
 
 	while (!empty($index))
-		$regexes[] = '(?'.'>' . $index_to_regex($index, $delim) . ')';
+		$regexes[] = '(?'.'>' . index_to_regex($index, $delim) . ')';
 
 	return $regexes;
 }

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -5498,6 +5498,7 @@ function build_regex($strings)
  *
  * @param string $str The string we want to incorporate into the index array.
  * @param array $index The index array that we want to incorporate the string into.
+ * @param int $depth Indicates how many levels of recursion the function is currently at.
  * @return array An alphabetically keyed array that incorporates $str.
  */
 function add_string_to_index($str, $index, $depth = 0)

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -5454,4 +5454,143 @@ function smf_serverResponse($data = '', $type = 'Content-Type: application/json'
 	obExit(false);
 }
 
+/**
+ * Creates optimized regular expressions from an array of strings.
+ *
+ * An optimized regex built using this function will be much faster than a simple regex built using
+ * `implode('|', $strings)` --- anywhere from several times to several orders of magnitude faster.
+ *
+ * However, the time required to build the optimized regex is approximately equal to the time it
+ * takes to execute the simple regex. Therefore, it is only worth calling this function if the
+ * resulting regex will be used more than once.
+ *
+ * Because PHP places an upper limit on the allowed length of a regex, very large arrays may be
+ * split and returned as multiple regexes. In such cases, you will need to iterate through all
+ * elements of the returned array in order to test all possible matches. (Note: if your array of
+ * alternative strings is large enough to require multiple regexes to accomodate it all, it is
+ * probably time to reconsider your coding choices. There is almost certainly a better way to do
+ * whatever you are trying to do with these giant regexes.)
+ *
+ * @param array $strings An array of strings to make a regex for.
+ * @return array An array of one or more regular expressions to match any of the input strings.
+ */
+function build_regex($strings)
+{
+	global $smcFunc;
+
+	$index = array();
+	$regexes = '';
+	
+	foreach ($strings as $string)
+		$index = add_string_to_index($string, $index);
+
+	while (!empty($index))
+		$regexes[] = '(?' . '>' . index_to_regex($index) . ')';
+
+	return $regexes;
+}
+
+/**
+ * Splits up a string and adds it into an alphabetically keyed multdimensional array.
+ *
+ * This is a recursive helper function for build_regex(). You probably don't want to call this
+ * function directly.
+ *
+ * @param string $str The string we want to incorporate into the index array.
+ * @param array $index The index array that we want to incorporate the string into.
+ * @return array An alphabetically keyed array that incorporates $str.
+ */
+function add_string_to_index($str, $index)
+{
+	global $smcFunc;
+
+	$strlen = function_exists('mb_strlen') ? 'mb_strlen' : $smcFunc['strlen'];
+	$substr = function_exists('mb_substr') ? 'mb_substr' : $smcFunc['substr'];
+
+	$first = $substr($str, 0, 1);
+
+	if (empty($index[$first]))
+		$index[$first] = array();
+
+	if ($strlen($str) > 1)
+		$index[$first] = add_string_to_index($substr($str, 1), $index[$first]);
+	else
+		$index[$first][''] = '';
+
+	return $index;
+}
+
+/**
+ * Converts an alphabetically keyed multidimensional array into an optimized regular expression.
+ *
+ * This is a recursive helper function for build_regex(). You probably don't want to call this
+ * function directly.
+ *
+ * @param array $index An alphabetically keyed array created using add_string_to_index().
+ * @param int $depth Indicates how many levels of recursion the function is currently at.
+ * @return string A regular expression.
+ */
+function index_to_regex(&$index, $depth = 0)
+{
+	global $smcFunc;
+
+	// Absolute max length is 32768, but we might need wiggle room
+	$max_length = 30000;
+
+	$regex = array();
+	$length = 0;
+
+	foreach ($index as $key => $value)
+	{
+		if (empty($value))
+		{
+			$key_regex = $key;
+		}
+		elseif (count(array_keys($value)) == 1)
+		{
+			$sub_regex = index_to_regex($value, $depth + 1);
+			$key_regex = $key . $sub_regex;
+		}
+		else
+		{
+			$sub_regex = '(?' . '>' . index_to_regex($value, $depth + 1) . ')';
+			$key_regex = $key . $sub_regex;
+		}
+
+		if ($depth > 0)
+			$regex[] = $key_regex;
+		else
+		{
+			if (($length += strlen($key_regex) + 1) < $max_length || empty($regex))
+			{
+				$regex[] = $key_regex;
+				unset($index[$key]);
+			}
+			else
+				break;
+		}
+	}
+	
+	// Sort by length (not including any subgroups) and then alphabetically
+	usort($regex, function($val1, $val2) use ($smcFunc) {
+		$strlen = function_exists('mb_strlen') ? 'mb_strlen' : $smcFunc['strlen'];
+		$strpos = function_exists('mb_strpos') ? 'mb_strpos' : $smcFunc['strpos'];
+		$substr = function_exists('mb_substr') ? 'mb_substr' : $smcFunc['substr'];
+
+		if (($l1 = $strpos($val1, '(')) == false)
+			$l1 = $strlen($val1);
+		if (($l2 = $strpos($val2, '(')) == false)
+			$l2 = $strlen($val2);
+		
+		if ($l1 == $l2)
+		{
+			return strcmp($substr($val1, 0, $l1), $substr($val2, 0, $l2)) > 0 ? 1 : -1;
+		}
+		else
+			return $l1 > $l2 ? -1 : 1;
+	});
+
+	return implode('|', $regex);
+}
+
 ?>


### PR DESCRIPTION
The `build_regex()` function creates optimized regular expressions from an array of strings.

An optimized regex built using this function will be much faster than a simple regex built using `implode('|', $strings)` --- anywhere from several times to several orders of magnitude faster.

However, the time required to build the optimized regex is approximately equal to the time it takes to execute the simple regex. Therefore, it is only worth calling this function if the resulting regex will be used more than once.

Because PHP places an upper limit on the allowed length of a regex, very large arrays may be split and returned as multiple regexes. In such cases, you will need to iterate through all elements of the returned array in order to test all possible matches.