### PR TITLE
Generic fixes

### DIFF
--- a/Sources/Admin.php
+++ b/Sources/Admin.php
@@ -30,7 +30,7 @@ function AdminMain()
 	// Load the language and templates....
 	loadLanguage('Admin');
 	loadTemplate('Admin');
-	loadJavascriptFile('admin.js', array(), 'smf_admin');
+	loadJavaScriptFile('admin.js', array(), 'smf_admin');
 	loadCSSFile('admin.css', array(), 'smf_admin');
 
 	// No indexing evil stuff.
@@ -572,7 +572,7 @@ function AdminHome()
 	);
 
 	if ($context['admin_area'] == 'admin')
-		loadJavascriptFile('admin.js', array('defer' => false), 'smf_admin');
+		loadJavaScriptFile('admin.js', array('defer' => false), 'smf_admin');
 }
 
 /**

--- a/Sources/BoardIndex.php
+++ b/Sources/BoardIndex.php
@@ -138,7 +138,7 @@ function BoardIndex()
 
 	if (!empty($settings['show_newsfader']))
 	{
-		loadJavascriptFile('slippry.min.js', array(), 'smf_jquery_slippry');
+		loadJavaScriptFile('slippry.min.js', array(), 'smf_jquery_slippry');
 		loadCSSFile('slider.min.css', array(), 'smf_jquery_slider');
 	}
 }

--- a/Sources/DbPackages-mysql.php
+++ b/Sources/DbPackages-mysql.php
@@ -512,7 +512,7 @@ function smf_db_remove_index($table_name, $index_name, $parameters = array(), $e
 function smf_db_calculate_type($type_name, $type_size = null, $reverse = false)
 {
 	// MySQL is actually the generic baseline.
-	
+
 	$type_name = strtolower($type_name);
 	// Generic => Specific.
 	if (!$reverse)
@@ -527,7 +527,7 @@ function smf_db_calculate_type($type_name, $type_size = null, $reverse = false)
 			'varbinary' => 'inet',
 		);
 	}
-	
+
 	// Got it? Change it!
 	if (isset($types[$type_name]))
 	{
@@ -546,7 +546,7 @@ function smf_db_calculate_type($type_name, $type_size = null, $reverse = false)
 		else
 			$type_name = $types[$type_name];
 	}
-	
+
 	return array($type_name, $type_size);
 }
 

--- a/Sources/DbPackages-postgresql.php
+++ b/Sources/DbPackages-postgresql.php
@@ -680,11 +680,11 @@ function smf_db_calculate_type($type_name, $type_size = null, $reverse = false)
 			$type_size = 255;
 		$type_name = $types[$type_name];
 	}
-	
+
 	// Only char fields got size
 	if (strpos($type_name, 'char') === false)
 			$type_size = null;
-	
+
 
 	return array($type_name, $type_size);
 }

--- a/Sources/Display.php
+++ b/Sources/Display.php
@@ -1299,24 +1299,24 @@ function Display()
 
 	// Load the drafts js file
 	if ($context['drafts_autosave'])
-		loadJavascriptFile('drafts.js', array('defer' => false), 'smf_drafts');
+		loadJavaScriptFile('drafts.js', array('defer' => false), 'smf_drafts');
 
 	// Spellcheck
 	if ($context['show_spellchecking'])
-		loadJavascriptFile('spellcheck.js', array('defer' => false), 'smf_spellcheck');
+		loadJavaScriptFile('spellcheck.js', array('defer' => false), 'smf_spellcheck');
 
 	// topic.js
-	loadJavascriptFile('topic.js', array('defer' => false), 'smf_topic');
+	loadJavaScriptFile('topic.js', array('defer' => false), 'smf_topic');
 
 	// quotedText.js
-	loadJavascriptFile('quotedText.js', array('defer' => true), 'smf_quotedText');
+	loadJavaScriptFile('quotedText.js', array('defer' => true), 'smf_quotedText');
 
 	// Mentions
 	if (!empty($modSettings['enable_mentions']) && allowedTo('mention'))
 	{
-		loadJavascriptFile('jquery.atwho.min.js', array('defer' => true), 'smf_atwho');
-		loadJavascriptFile('jquery.caret.min.js', array('defer' => true), 'smf_caret');
-		loadJavascriptFile('mentions.js', array('defer' => true), 'smf_mentions');
+		loadJavaScriptFile('jquery.atwho.min.js', array('defer' => true), 'smf_atwho');
+		loadJavaScriptFile('jquery.caret.min.js', array('defer' => true), 'smf_caret');
+		loadJavaScriptFile('mentions.js', array('defer' => true), 'smf_mentions');
 	}
 }
 

--- a/Sources/Groups.php
+++ b/Sources/Groups.php
@@ -438,7 +438,7 @@ function MembergroupMembers()
 	createToken('mod-mgm');
 
 	if ($context['group']['assignable'])
-		loadJavascriptFile('suggest.js', array('defer' => false), 'smf_suggest');
+		loadJavaScriptFile('suggest.js', array('defer' => false), 'smf_suggest');
 }
 
 /**

--- a/Sources/Load.php
+++ b/Sources/Load.php
@@ -2116,29 +2116,29 @@ function loadTheme($id_theme = 0, $initialize = true)
 
 	// Add the JQuery library to the list of files to load.
 	if (isset($modSettings['jquery_source']) && $modSettings['jquery_source'] == 'cdn')
-		loadJavascriptFile('https://ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.min.js', array('external' => true), 'smf_jquery');
+		loadJavaScriptFile('https://ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.min.js', array('external' => true), 'smf_jquery');
 
 	elseif (isset($modSettings['jquery_source']) && $modSettings['jquery_source'] == 'local')
-		loadJavascriptFile('jquery-2.1.4.min.js', array('seed' => false), 'smf_jquery');
+		loadJavaScriptFile('jquery-2.1.4.min.js', array('seed' => false), 'smf_jquery');
 
 	elseif (isset($modSettings['jquery_source'], $modSettings['jquery_custom']) && $modSettings['jquery_source'] == 'custom')
-		loadJavascriptFile($modSettings['jquery_custom'], array(), 'smf_jquery');
+		loadJavaScriptFile($modSettings['jquery_custom'], array(), 'smf_jquery');
 
 	// Auto loading? template_javascript() will take care of the local half of this.
 	else
-		loadJavascriptFile('https://ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.min.js', array('external' => true), 'smf_jquery');
+		loadJavaScriptFile('https://ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.min.js', array('external' => true), 'smf_jquery');
 
 	// Queue our JQuery plugins!
-	loadJavascriptFile('smf_jquery_plugins.js', array('minimize' => true), 'smf_jquery_plugins');
+	loadJavaScriptFile('smf_jquery_plugins.js', array('minimize' => true), 'smf_jquery_plugins');
 	if (!$user_info['is_guest'])
 	{
-		loadJavascriptFile('jquery.custom-scrollbar.js', array(), 'smf_jquery_scrollbar');
+		loadJavaScriptFile('jquery.custom-scrollbar.js', array(), 'smf_jquery_scrollbar');
 		loadCSSFile('jquery.custom-scrollbar.css', array('force_current' => false, 'validate' => true), 'smf_scrollbar');
 	}
 
 	// script.js and theme.js, always required, so always add them! Makes index.template.php cleaner and all.
-	loadJavascriptFile('script.js', array('defer' => false, 'minimize' => true), 'smf_script');
-	loadJavascriptFile('theme.js', array('minimize' => true), 'smf_theme');
+	loadJavaScriptFile('script.js', array('defer' => false, 'minimize' => true), 'smf_script');
+	loadJavaScriptFile('theme.js', array('minimize' => true), 'smf_theme');
 
 	// If we think we have mail to send, let's offer up some possibilities... robots get pain (Now with scheduled task support!)
 	if ((!empty($modSettings['mail_next_send']) && $modSettings['mail_next_send'] < time() && empty($modSettings['mail_queue_use_cron'])) || empty($modSettings['next_task_time']) || $modSettings['next_task_time'] < time())
@@ -2159,7 +2159,7 @@ function loadTheme($id_theme = 0, $initialize = true)
 			$type = empty($modSettings['next_task_time']) || $modSettings['next_task_time'] < time() ? 'task' : 'mailq';
 			$ts = $type == 'mailq' ? $modSettings['mail_next_send'] : $modSettings['next_task_time'];
 
-			addInlineJavascript('
+			addInlineJavaScript('
 		function smfAutoTask()
 		{
 			$.get(smf_scripturl + "?scheduled=' . $type . ';ts=' . $ts . '");
@@ -2442,7 +2442,7 @@ function addInlineCss($css)
  *
  * @param string $id An ID to stick on the end of the filename
  */
-function loadJavascriptFile($fileName, $params = array(), $id = '')
+function loadJavaScriptFile($fileName, $params = array(), $id = '')
 {
 	global $settings, $context, $modSettings;
 
@@ -2508,7 +2508,7 @@ function loadJavascriptFile($fileName, $params = array(), $id = '')
  * @param string $value The value
  * @param bool $escape Whether or not to escape the value
  */
-function addJavascriptVar($key, $value, $escape = false)
+function addJavaScriptVar($key, $value, $escape = false)
 {
 	global $context;
 
@@ -2527,7 +2527,7 @@ function addJavascriptVar($key, $value, $escape = false)
  * @param bool $defer Whether the script should load in <head> or before the closing <html> tag
  * @return void|bool Adds the code to one of the $context['javascript_inline'] arrays or returns if no JS was specified
  */
-function addInlineJavascript($javascript, $defer = false)
+function addInlineJavaScript($javascript, $defer = false)
 {
 	global $context;
 

--- a/Sources/ManageBans.php
+++ b/Sources/ManageBans.php
@@ -579,7 +579,7 @@ function BanEdit()
 		}
 	}
 
-	loadJavascriptFile('suggest.js', array(), 'smf_suggest');
+	loadJavaScriptFile('suggest.js', array(), 'smf_suggest');
 	$context['sub_template'] = 'ban_edit';
 
 }
@@ -1601,7 +1601,7 @@ function BanEditTrigger()
 		redirectexit('action=admin;area=ban;sa=edit' . (!empty($ban_group) ? ';bg=' . $ban_group : ''));
 	}
 
-	loadJavascriptFile('suggest.js', array(), 'smf_suggest');
+	loadJavaScriptFile('suggest.js', array(), 'smf_suggest');
 
 	if (empty($ban_id))
 	{

--- a/Sources/ManageBoards.php
+++ b/Sources/ManageBoards.php
@@ -595,7 +595,7 @@ function EditBoard()
 	{
 		$context['sub_template'] = 'modify_board';
 		$context['page_title'] = $txt['boardsEdit'];
-		loadJavascriptFile('suggest.js', array('defer' => false), 'smf_suggest');
+		loadJavaScriptFile('suggest.js', array('defer' => false), 'smf_suggest');
 	}
 	else
 	{
@@ -874,7 +874,7 @@ function EditBoardSettings($return_config = false)
 	$context['sub_template'] = 'show_settings';
 
 	// Add some javascript stuff for the recycle box.
-	addInlineJavascript('
+	addInlineJavaScript('
 	document.getElementById("recycle_board").disabled = !document.getElementById("recycle_enable").checked;', true);
 
 	// Warn the admin against selecting the recycle topic without selecting a board.

--- a/Sources/ManageLanguages.php
+++ b/Sources/ManageLanguages.php
@@ -670,7 +670,7 @@ function ModifyLanguages()
 	);
 
 	// We want to highlight the selected language. Need some Javascript for this.
-	addInlineJavascript('
+	addInlineJavaScript('
 	function highlightSelected(box)
 	{
 		$("tr.highlight2").removeClass("highlight2");

--- a/Sources/ManageMaintenance.php
+++ b/Sources/ManageMaintenance.php
@@ -198,7 +198,7 @@ function MaintainMembers()
 	if (isset($_GET['done']) && $_GET['done'] == 'recountposts')
 		$context['maintenance_finished'] = $txt['maintain_recountposts'];
 
-	loadJavascriptFile('suggest.js', array('defer' => false), 'smf_suggest');
+	loadJavaScriptFile('suggest.js', array('defer' => false), 'smf_suggest');
 }
 
 /**

--- a/Sources/ManageMembergroups.php
+++ b/Sources/ManageMembergroups.php
@@ -1171,9 +1171,9 @@ function EditMembergroup()
 
 	// Insert our JS, if we have possible icons.
 	if (!empty($context['possible_icons']))
-		loadJavascriptFile('icondropdown.js', array('validate' => true), 'smf_icondropdown');
+		loadJavaScriptFile('icondropdown.js', array('validate' => true), 'smf_icondropdown');
 
-		loadJavascriptFile('suggest.js', array('defer' => false), 'smf_suggest');
+		loadJavaScriptFile('suggest.js', array('defer' => false), 'smf_suggest');
 
 	// Finally, get all the groups this could be inherited off.
 	$request = $smcFunc['db_query']('', '

--- a/Sources/ManageNews.php
+++ b/Sources/ManageNews.php
@@ -424,7 +424,7 @@ function SelectMailingMembers()
 
 	$context['can_send_pm'] = allowedTo('pm_send');
 
-	loadJavascriptFile('suggest.js', array('defer' => false), 'smf_suggest');
+	loadJavaScriptFile('suggest.js', array('defer' => false), 'smf_suggest');
 }
 
 /**
@@ -1087,7 +1087,7 @@ function ModifyNewsSettings($return_config = false)
 	$context['post_url'] = $scripturl . '?action=admin;area=news;save;sa=settings';
 
 	// Add some javascript at the bottom...
-	addInlineJavascript('
+	addInlineJavaScript('
 	document.getElementById("xmlnews_maxlen").disabled = !document.getElementById("xmlnews_enable").checked;', true);
 
 	// Saving the settings?

--- a/Sources/ManagePaid.php
+++ b/Sources/ManagePaid.php
@@ -126,7 +126,7 @@ function ModifySubscriptionSettings($return_config = false)
 		$context['settings_title'] = $txt['settings'];
 
 		// We want javascript for our currency options.
-		addInlineJavascript('
+		addInlineJavaScript('
 		function toggleOther()
 		{
 			var otherOn = document.getElementById("paid_currency").value == \'other\';
@@ -1361,7 +1361,7 @@ function ModifyUserSubscription()
 		$context['sub']['end']['last_day'] = (int) strftime('%d', mktime(0, 0, 0, $context['sub']['end']['month'] == 12 ? 1 : $context['sub']['end']['month'] + 1, 0, $context['sub']['end']['month'] == 12 ? $context['sub']['end']['year'] + 1 : $context['sub']['end']['year']));
 	}
 
-	loadJavascriptFile('suggest.js', array('defer' => false), 'smf_suggest');
+	loadJavaScriptFile('suggest.js', array('defer' => false), 'smf_suggest');
 }
 
 /**

--- a/Sources/ManageRegistration.php
+++ b/Sources/ManageRegistration.php
@@ -172,7 +172,7 @@ function AdminRegister()
 	$context['sub_template'] = 'admin_register';
 	$context['page_title'] = $txt['registration_center'];
 	createToken('admin-regc');
-	loadJavascriptFile('register.js', array('defer' => false), 'smf_register');
+	loadJavaScriptFile('register.js', array('defer' => false), 'smf_register');
 }
 
 /**

--- a/Sources/ManageSearchEngines.php
+++ b/Sources/ManageSearchEngines.php
@@ -146,7 +146,7 @@ function ManageSearchEngineSettings($return_config = false)
 	// Final settings...
 	$context['post_url'] = $scripturl . '?action=admin;area=sengines;save;sa=settings';
 	$context['settings_title'] = $txt['settings'];
-	addInlineJavascript($javascript_function, true);
+	addInlineJavaScript($javascript_function, true);
 
 	// Prepare the settings...
 	prepareDBSettingContext($config_vars);

--- a/Sources/ManageServer.php
+++ b/Sources/ManageServer.php
@@ -187,7 +187,7 @@ function ModifyGeneralSettings($return_config = false)
 	prepareServerSettingsContext($config_vars);
 
 	// Some javascript for SSL
-	addInlineJavascript('
+	addInlineJavaScript('
 $(function()
 {
 	$("#force_ssl").change(function()
@@ -291,7 +291,7 @@ function ModifyCookieSettings($return_config = false)
 		)), 'subtext' => $txt['tfa_mode_subtext'] . (empty($user_settings['tfa_secret']) ? '<br /><strong>' . $txt['tfa_mode_forced_help'] . '</strong>' : ''), 'tfa_mode'),
 	);
 
-	addInlineJavascript('
+	addInlineJavaScript('
 	function hideGlobalCookies()
 	{
 		var usingLocal = $("#localCookies").prop("checked");
@@ -309,7 +309,7 @@ function ModifyCookieSettings($return_config = false)
 	});', true);
 
 	if (empty($user_settings['tfa_secret']))
-		addInlineJavascript('');
+		addInlineJavaScript('');
 
 	call_integration_hook('integrate_cookie_settings', array(&$config_vars));
 

--- a/Sources/ManageSettings.php
+++ b/Sources/ManageSettings.php
@@ -634,7 +634,7 @@ function ModifyAntispamSettings($return_config = false)
 	}
 
 	// Thirdly, push some JavaScript for the form to make it work.
-	addInlineJavascript('
+	addInlineJavaScript('
 	var nextrow = ' . (!empty($context['question_answers']) ? max(array_keys($context['question_answers'])) + 1 : 1) . ';
 	$(".qa_link a").click(function() {
 		var id = $(this).parent().attr("id").substring(6);
@@ -2111,7 +2111,7 @@ function ModifyLogSettings($return_config = false)
 	if ($return_config)
 		return $config_vars;
 
-	addInlineJavascript('
+	addInlineJavaScript('
 	function togglePruned()
 	{
 		var newval = $("#pruningOptions").prop("checked");

--- a/Sources/Memberlist.php
+++ b/Sources/Memberlist.php
@@ -567,7 +567,7 @@ function MLSearch()
 		$context['old_search'] = isset($_GET['search']) ? $_GET['search'] : (isset($_POST['search']) ? $smcFunc['htmlspecialchars']($_POST['search']) : '');
 
 		// Since we're nice we also want to default focus on to the search field.
-		addInlineJavascript('
+		addInlineJavaScript('
 	$(\'input[name="search"]\').focus();', true);
 	}
 

--- a/Sources/Mentions.php
+++ b/Sources/Mentions.php
@@ -179,8 +179,14 @@ class Mentions
 	 */
 	protected static function getPossibleMentions($body)
 	{
+		global $smcFunc;
+
 		// preparse code does a few things which might mess with our parsing
 		$body = htmlspecialchars_decode(preg_replace('~<br\s*/?\>~', "\n", str_replace('&nbsp;', ' ', $body)), ENT_QUOTES);
+
+		// Remove quotes, we don't want to get double mentions.
+		while (preg_match('~\[quote[^\]]*\](.+?)\[\/quote\]~s', $body))
+			$body = preg_replace('~\[quote[^\]]*\](.+?)\[\/quote\]~s', '', $body);
 
 		$matches = array();
 		$string = str_split($body);
@@ -217,7 +223,7 @@ class Mentions
 			$match = preg_split('/([^\w])/', $match, -1, PREG_SPLIT_DELIM_CAPTURE);
 
 			for ($i = 1; $i <= count($match); $i++)
-				$names[] = htmlspecialchars(trim(implode('', array_slice($match, 0, $i))));
+				$names[] = $smcFunc['htmlspecialchars']($smcFunc['htmltrim'](implode('', array_slice($match, 0, $i))));
 		}
 
 		$names = array_unique($names);

--- a/Sources/MessageIndex.php
+++ b/Sources/MessageIndex.php
@@ -750,7 +750,7 @@ function MessageIndex()
 		);
 
 	// Javascript for inline editing.
-	loadJavascriptFile('topic.js', array('defer' => false), 'smf_topic');
+	loadJavaScriptFile('topic.js', array('defer' => false), 'smf_topic');
 
 	// Allow adding new buttons easily.
 	// Note: $context['normal_buttons'] is added for backward compatibility with 2.0, but is deprecated and should not be used

--- a/Sources/ModerationCenter.php
+++ b/Sources/ModerationCenter.php
@@ -248,7 +248,7 @@ function ModerationHome()
 	global $txt, $context, $options;
 
 	loadTemplate('ModerationCenter');
-	loadJavascriptFile('admin.js', array(), 'smf_admin');
+	loadJavaScriptFile('admin.js', array(), 'smf_admin');
 
 	$context['page_title'] = $txt['moderation_center'];
 	$context['sub_template'] = 'moderation_center';

--- a/Sources/PackageGet.php
+++ b/Sources/PackageGet.php
@@ -170,7 +170,7 @@ function PackageServers()
 		}
 	}
 
-	addInlineJavascript('
+	addInlineJavaScript('
 	$(\'.new_package_content\').hide();
 	$(\'.download_new_package\').on(\'click\', function() {
 		var collapseState = $(\'.new_package_content\').css(\'display\');

--- a/Sources/Packages.php
+++ b/Sources/Packages.php
@@ -83,7 +83,7 @@ function Packages()
 	);
 
 	if ($context['sub_action'] == 'browse')
-		loadJavascriptFile('suggest.js', array('defer' => false), 'smf_suggest');
+		loadJavaScriptFile('suggest.js', array('defer' => false), 'smf_suggest');
 
 	call_integration_hook('integrate_manage_packages', array(&$subActions));
 

--- a/Sources/PersonalMessage.php
+++ b/Sources/PersonalMessage.php
@@ -1727,8 +1727,8 @@ function MessagePost()
 	loadLanguage('PersonalMessage');
 	// Just in case it was loaded from somewhere else.
 	loadTemplate('PersonalMessage');
-	loadJavascriptFile('PersonalMessage.js', array('defer' => false), 'smf_pms');
-	loadJavascriptFile('suggest.js', array('defer' => false), 'smf_suggest');
+	loadJavaScriptFile('PersonalMessage.js', array('defer' => false), 'smf_pms');
+	loadJavaScriptFile('suggest.js', array('defer' => false), 'smf_suggest');
 	$context['sub_template'] = 'send';
 
 	// Extract out the spam settings - cause it's neat.
@@ -2038,8 +2038,8 @@ function messagePostError($error_types, $named_recipients, $recipient_ids = arra
 	if (!isset($_REQUEST['xml']))
 	{
 		$context['menu_data_' . $context['pm_menu_id']]['current_area'] = 'send';		$context['sub_template'] = 'send';
-		loadJavascriptFile('PersonalMessage.js', array('defer' => false), 'smf_pms');
-		loadJavascriptFile('suggest.js', array('defer' => false), 'smf_suggest');
+		loadJavaScriptFile('PersonalMessage.js', array('defer' => false), 'smf_pms');
+		loadJavaScriptFile('suggest.js', array('defer' => false), 'smf_suggest');
 	}
 	else
 		$context['sub_template'] = 'pm';

--- a/Sources/Post.php
+++ b/Sources/Post.php
@@ -1181,22 +1181,22 @@ function Post($post_errors = array())
 	// Mentions
 	if (!empty($modSettings['enable_mentions']) && allowedTo('mention'))
 	{
-		loadJavascriptFile('jquery.caret.min.js', array('defer' => true), 'smf_caret');
-		loadJavascriptFile('jquery.atwho.min.js', array('defer' => true), 'smf_atwho');
-		loadJavascriptFile('mentions.js', array('defer' => true), 'smf_mentions');
+		loadJavaScriptFile('jquery.caret.min.js', array('defer' => true), 'smf_caret');
+		loadJavaScriptFile('jquery.atwho.min.js', array('defer' => true), 'smf_atwho');
+		loadJavaScriptFile('mentions.js', array('defer' => true), 'smf_mentions');
 	}
 
 	// quotedText.js
-	loadJavascriptFile('quotedText.js', array('defer' => true), 'smf_quotedText');
+	loadJavaScriptFile('quotedText.js', array('defer' => true), 'smf_quotedText');
 
 	// Mock files to show already attached files.
-	addInlineJavascript('
+	addInlineJavaScript('
 	var current_attachments = [];', true);
 
 	if (!empty($context['current_attachments']))
 	{
 		foreach ($context['current_attachments'] as $key => $mock)
-			addInlineJavascript('
+			addInlineJavaScript('
 	current_attachments.push({
 		name: '. JavaScriptEscape($mock['name']) .',
 		size: '. $mock['size'] .',
@@ -1212,9 +1212,9 @@ function Post($post_errors = array())
 	{
 		$acceptedFiles = implode(',', array_map(function($val) use($smcFunc) { return '.'. $smcFunc['htmltrim']($val);} , explode(',', $context['allowed_extensions'])));
 
-		loadJavascriptFile('dropzone.min.js', array('defer' => true), 'smf_dropzone');
-		loadJavascriptFile('smf_fileUpload.js', array('defer' => true), 'smf_fileUpload');
-		addInlineJavascript('
+		loadJavaScriptFile('dropzone.min.js', array('defer' => true), 'smf_dropzone');
+		loadJavaScriptFile('smf_fileUpload.js', array('defer' => true), 'smf_fileUpload');
+		addInlineJavaScript('
 	$(function() {
 		smf_fileUpload({
 			dictDefaultMessage : '. JavaScriptEscape($txt['attach_drop_zone']) .',
@@ -1245,7 +1245,7 @@ function Post($post_errors = array())
 	}
 
 	// Knowing the current board ID might be handy.
-	addInlineJavascript('
+	addInlineJavaScript('
 	var current_board = '. (empty($context['current_board']) ? 'null' : $context['current_board']) .';', false);
 
 	// Finally, load the template.

--- a/Sources/Profile-Modify.php
+++ b/Sources/Profile-Modify.php
@@ -698,7 +698,7 @@ function setupProfileContext($fields)
 	}
 
 	// Some spicy JS.
-	addInlineJavascript('
+	addInlineJavaScript('
 	var form_handle = document.forms.creator;
 	createEventListener(form_handle);
 	'. (!empty($context['require_password']) ? '
@@ -714,11 +714,11 @@ function setupProfileContext($fields)
 
 	// Any onsubmit javascript?
 	if (!empty($context['profile_onsubmit_javascript']))
-		addInlineJavascript($context['profile_onsubmit_javascript'], true);
+		addInlineJavaScript($context['profile_onsubmit_javascript'], true);
 
 	// Any totally custom stuff?
 	if (!empty($context['profile_javascript']))
-		addInlineJavascript($context['profile_javascript'], true);
+		addInlineJavaScript($context['profile_javascript'], true);
 
 	// Free up some memory.
 	unset($profile_fields);
@@ -1306,7 +1306,7 @@ function editBuddyIgnoreLists($memID)
 		),
 	);
 
-	loadJavascriptFile('suggest.js', array('defer' => false), 'smf_suggest');
+	loadJavaScriptFile('suggest.js', array('defer' => false), 'smf_suggest');
 
 	// Pass on to the actual function.
 	$context['sub_template'] = $subActions[$context['list_area']][0];
@@ -1868,7 +1868,7 @@ function alert_configuration($memID)
 
 	// What options are set
 	loadThemeOptions($memID);
-	loadJavascriptFile('alertSettings.js', array(), 'smf_alertSettings');
+	loadJavaScriptFile('alertSettings.js', array(), 'smf_alertSettings');
 
 	// Now load all the values for this user.
 	require_once($sourcedir . '/Subs-Notify.php');
@@ -2952,7 +2952,7 @@ function profileLoadSignatureData()
 
 	// Load the spell checker?
 	if ($context['show_spellchecking'])
-		loadJavascriptFile('spellcheck.js', array('defer' => false), 'smf_spellcheck');
+		loadJavaScriptFile('spellcheck.js', array('defer' => false), 'smf_spellcheck');
 
 	return true;
 }

--- a/Sources/Profile-View.php
+++ b/Sources/Profile-View.php
@@ -379,7 +379,7 @@ function showAlerts($memID)
 	$context['pagination'] = constructPageIndex($scripturl . '?action=profile;area=showalerts;u=' . $memID, $start, $count, $maxIndex, false);
 
 	// Set some JavaScript for checking all alerts at once.
-	addInlineJavascript('
+	addInlineJavaScript('
 	$(function(){
 		$(\'#select_all\').on(\'change\', function() {
 			var checkboxes = $(\'ul.quickbuttons\').find(\':checkbox\');

--- a/Sources/Profile.php
+++ b/Sources/Profile.php
@@ -580,7 +580,7 @@ function ModifyProfile($post_errors = array())
 	$check_password = $context['user']['is_owner'] && in_array($profile_include_data['current_area'], $context['password_areas']);
 	$context['require_password'] = $check_password;
 
-	loadJavascriptFile('profile.js', array('defer' => false), 'smf_profile');
+	loadJavaScriptFile('profile.js', array('defer' => false), 'smf_profile');
 
 	// These will get populated soon!
 	$post_errors = array();

--- a/Sources/Register.php
+++ b/Sources/Register.php
@@ -91,7 +91,7 @@ function Register($reg_errors = array())
 
 	// Kinda need this.
 	if ($context['sub_template'] == 'registration_form')
-		loadJavascriptFile('register.js', array('defer' => false), 'smf_register');
+		loadJavaScriptFile('register.js', array('defer' => false), 'smf_register');
 
 	// Add the register chain to the link tree.
 	$context['linktree'][] = array(

--- a/Sources/Reminder.php
+++ b/Sources/Reminder.php
@@ -187,7 +187,7 @@ function setPassword()
 		'memID' => (int) $_REQUEST['u']
 	);
 
-	loadJavascriptFile('register.js', array('defer' => false), 'smf_register');
+	loadJavaScriptFile('register.js', array('defer' => false), 'smf_register');
 
 	// Tokens!
 	createToken('remind-sp');
@@ -321,7 +321,7 @@ function SecretAnswerInput()
 
 	$context['sub_template'] = 'ask';
 	createToken('remind-sai');
-	loadJavascriptFile('register.js', array('defer' => false), 'smf_register');
+	loadJavaScriptFile('register.js', array('defer' => false), 'smf_register');
 }
 
 /**

--- a/Sources/ReportToMod.php
+++ b/Sources/ReportToMod.php
@@ -131,7 +131,7 @@ function ReportToModerator()
 	loadLanguage('Post');
 	loadTemplate('ReportToMod');
 
-	addInlineJavascript('
+	addInlineJavaScript('
 	var error_box = $("#error_box");
 	$("#report_comment").keyup(function() {
 		var post_too_long = $("#error_post_too_long");

--- a/Sources/Search.php
+++ b/Sources/Search.php
@@ -47,7 +47,7 @@ function PlushSearch1()
 	if (!isset($_REQUEST['xml']))
 	{
 		loadTemplate('Search');
-		loadJavascriptFile('suggest.js', array('defer' => false), 'smf_suggest');
+		loadJavaScriptFile('suggest.js', array('defer' => false), 'smf_suggest');
 	}
 
 	// Check the user's permissions.

--- a/Sources/Stats.php
+++ b/Sources/Stats.php
@@ -75,7 +75,7 @@ function DisplayStats()
 
 	loadLanguage('Stats');
 	loadTemplate('Stats');
-	loadJavascriptFile('stats.js', array('default_theme' => true, 'defer' => false), 'smf_stats');
+	loadJavaScriptFile('stats.js', array('default_theme' => true, 'defer' => false), 'smf_stats');
 
 	// Build the link tree......
 	$context['linktree'][] = array(

--- a/Sources/Subs-Editor.php
+++ b/Sources/Subs-Editor.php
@@ -1606,23 +1606,23 @@ function create_control_richedit($editorOptions)
 		loadTemplate('GenericControls');
 
 		// JS makes the editor go round
-		loadJavascriptFile('editor.js', array(), 'smf_editor');
-		loadJavascriptFile('jquery.sceditor.bbcode.min.js', array(), 'smf_sceditor_bbcode');
-		loadJavascriptFile('jquery.sceditor.smf.js', array(), 'smf_sceditor_smf');
-		addInlineJavascript('
+		loadJavaScriptFile('editor.js', array(), 'smf_editor');
+		loadJavaScriptFile('jquery.sceditor.bbcode.min.js', array(), 'smf_sceditor_bbcode');
+		loadJavaScriptFile('jquery.sceditor.smf.js', array(), 'smf_sceditor_smf');
+		addInlineJavaScript('
 		var smf_smileys_url = \'' . $settings['smileys_url'] . '\';
 		var bbc_quote_from = \'' . addcslashes($txt['quote_from'], "'") . '\';
 		var bbc_quote = \'' . addcslashes($txt['quote'], "'") . '\';
 		var bbc_search_on = \'' . addcslashes($txt['search_on'], "'") . '\';');
 		// editor language file
 		if (!empty($txt['lang_locale']) && $txt['lang_locale'] != 'en_US')
-			loadJavascriptFile($scripturl . '?action=loadeditorlocale', array('external' => true), 'sceditor_language');
+			loadJavaScriptFile($scripturl . '?action=loadeditorlocale', array('external' => true), 'sceditor_language');
 
 		$context['shortcuts_text'] = $txt['shortcuts' . (!empty($context['drafts_save']) ? '_drafts' : '') . (isBrowser('is_firefox') ? '_firefox' : '')];
 		$context['show_spellchecking'] = !empty($modSettings['enableSpellChecking']) && (function_exists('pspell_new') || (function_exists('enchant_broker_init') && ($txt['lang_charset'] == 'UTF-8' || function_exists('iconv'))));
 		if ($context['show_spellchecking'])
 		{
-			loadJavascriptFile('spellcheck.js', array(), 'smf_spellcheck');
+			loadJavaScriptFile('spellcheck.js', array(), 'smf_spellcheck');
 
 			// Some hidden information is needed in order to make the spell checking work.
 			if (!isset($_REQUEST['xml']))
@@ -2032,7 +2032,7 @@ function create_control_verification(&$verificationOptions, $do_test = false)
 
 		// Some javascript ma'am?
 		if (!empty($verificationOptions['override_visual']) || (!empty($modSettings['visual_verification_type']) && !isset($verificationOptions['override_visual'])))
-			loadJavascriptFile('captcha.js', array(), 'smf_captcha');
+			loadJavaScriptFile('captcha.js', array(), 'smf_captcha');
 
 		$context['use_graphic_library'] = in_array('gd', get_loaded_extensions());
 

--- a/Sources/Subs-Post.php
+++ b/Sources/Subs-Post.php
@@ -1351,8 +1351,8 @@ function smtp_mail($mail_to_array, $subject, $message, $headers)
 	elseif (array_key_exists('SERVER_NAME',$_SERVER) && !empty($_SERVER['SERVER_NAME']))
 		$helo = $_SERVER['SERVER_NAME'];
 
-	if (empty($helo)) 
-		$helo	= $modSettings['smtp_host'];
+	if (empty($helo))
+		$helo = $modSettings['smtp_host'];
 
 	// SMTP = 1, SMTP - STARTTLS = 2
 	if (in_array($modSettings['mail_type'], array(1,2)) && $modSettings['smtp_username'] != '' && $modSettings['smtp_password'] != '')
@@ -1360,17 +1360,17 @@ function smtp_mail($mail_to_array, $subject, $message, $headers)
 		// EHLO could be understood to mean encrypted hello...
 		if (server_parse('EHLO ' . $helo, $socket, null, $response) == '250')
 		{
-			// Are we using STARTTLS and does the server support STARTTLS? 
-			if ($modSettings['mail_type'] == 2 && preg_match("~250( |-)STARTTLS~mi", $response)) 
+			// Are we using STARTTLS and does the server support STARTTLS?
+			if ($modSettings['mail_type'] == 2 && preg_match("~250( |-)STARTTLS~mi", $response))
 			{
 				// Send STARTTLS to enable encryption
-				if (!server_parse('STARTTLS', $socket, '220')) 
-					return false; 
+				if (!server_parse('STARTTLS', $socket, '220'))
+					return false;
 				// Enable the encryption
 				if (!@stream_socket_enable_crypto($socket, true, STREAM_CRYPTO_METHOD_TLS_CLIENT))
 					return false;
 				// Send the EHLO command again
-				if (!server_parse('EHLO ' . $helo, $socket, null) == '250') 
+				if (!server_parse('EHLO ' . $helo, $socket, null) == '250')
 					return false;
 			}
 
@@ -1457,7 +1457,7 @@ function server_parse($message, $socket, $code, &$response = null)
 	// No response yet.
 	$server_response = '';
 
-	while (substr($server_response, 3, 1) != ' ') 
+	while (substr($server_response, 3, 1) != ' ')
 	{
 		if (!($server_response = fgets($socket, 256)))
 		{
@@ -2108,17 +2108,39 @@ function modifyPost(&$msgOptions, &$topicOptions, &$posterOptions)
 		'id_msg' => $msgOptions['id'],
 	);
 
-	require_once($sourcedir . '/Mentions.php');
 	if (!empty($modSettings['enable_mentions']))
 	{
 		require_once($sourcedir . '/Mentions.php');
-		$mentions = Mentions::getMentionedMembers($msgOptions['body']);
-		if (!empty($mentions))
-		{
-			$msgOptions['body'] = Mentions::getBody($msgOptions['body'], $mentions);
-			$msgOptions['mentioned_members'] = $mentions;
 
-			// Queue this for notification
+		$oldmentions = array();
+
+		if (!empty($msgOptions['old_body']))
+		{
+			preg_match_all('/\[member\=([0-9]+)\]([^\[]*)\[\/member\]/U', $msgOptions['old_body'], $match);
+
+			if (isset($match[1]) && isset($match[2]) && is_array($match[1]) && is_array($match[2]))
+				foreach($match[1] as $i => $oldID)
+					$oldmentions[$oldID] = array('id' => $oldID, 'real_name' => $match[2][$i]);
+
+			if (empty($modSettings['search_custom_index_config']))
+				unset($msgOptions['old_body']);
+		}
+
+		$mentions = Mentions::getMentionedMembers($msgOptions['body']);
+		$messages_columns['body'] = $msgOptions['body'] = Mentions::getBody($msgOptions['body'], $mentions);
+
+		// Remove the poster.
+		if(isset($mentions[$user_info['id']]))
+			unset($mentions[$user_info['id']]);
+
+		if(isset($oldmentions[$user_info['id']]))
+			unset($oldmentions[$user_info['id']]);
+
+		if (is_array($mentions) && is_array($oldmentions) && count(array_diff_key($mentions, $oldmentions)) > 0 && count($mentions) > count($oldmentions))
+		{
+			// Queue this for notification.
+			$msgOptions['mentioned_members'] = array_diff_key($mentions, $oldmentions);
+
 			$smcFunc['db_insert']('',
 				'{db_prefix}background_tasks',
 				array('task_file' => 'string', 'task_class' => 'string', 'task_data' => 'string', 'claimed_time' => 'int'),

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -3034,7 +3034,7 @@ function setupThemeContext($forceload = false)
 
 	// 2.1+: Add the PM popup here instead. Theme authors can still override it simply by editing/removing the 'fPmPopup' in the array.
 	if ($context['show_pm_popup'])
-		addInlineJavascript('
+		addInlineJavaScript('
 		jQuery(document).ready(function($) {
 			new smc_Popup({
 				heading: ' . JavaScriptEscape($txt['show_personal_messages_heading']) . ',
@@ -3044,7 +3044,7 @@ function setupThemeContext($forceload = false)
 		});');
 
 	// Add a generic "Are you sure?" confirmation message.
-	addInlineJavascript('
+	addInlineJavaScript('
 	var smf_you_sure =' . JavaScriptEscape($txt['quickmod_confirm']) .';');
 
 	// Now add the capping code for avatars.
@@ -3068,7 +3068,7 @@ img.avatar { max-width: ' . $modSettings['avatar_max_width_external'] . 'px; max
 	$context['common_stats']['boardindex_total_posts'] = sprintf($txt['boardindex_total_posts'], $context['common_stats']['total_posts'], $context['common_stats']['total_topics'], $context['common_stats']['total_members']);
 
 	if (empty($settings['theme_version']))
-		addJavascriptVar('smf_scripturl', $scripturl);
+		addJavaScriptVar('smf_scripturl', $scripturl);
 
 	if (!isset($context['page_title']))
 		$context['page_title'] = '';
@@ -4009,12 +4009,12 @@ function setupMenuContext()
 	// There is some menu stuff we need to do if we're coming at this from a non-guest perspective.
 	if (!$context['user']['is_guest'])
 	{
-		addInlineJavascript('
+		addInlineJavaScript('
 	var user_menus = new smc_PopupMenu();
 	user_menus.add("profile", "' . $scripturl . '?action=profile;area=popup");
 	user_menus.add("alerts", "' . $scripturl . '?action=profile;area=alerts_popup;u='. $context['user']['id'] .'");', true);
 		if ($context['allow_pm'])
-			addInlineJavascript('
+			addInlineJavaScript('
 	user_menus.add("pm", "' . $scripturl . '?action=pm;sa=popup");', true);
 
 		if (!empty($modSettings['enable_ajax_alerts']))
@@ -4024,10 +4024,10 @@ function setupMenuContext()
 			$timeout = getNotifyPrefs($context['user']['id'], 'alert_timeout', true);
 			$timeout = empty($timeout) ? 10000 : $timeout[$context['user']['id']]['alert_timeout'] * 1000;
 
-			addInlineJavascript('
+			addInlineJavaScript('
 	var new_alert_title = "' . $context['forum_name'] . '";
 	var alert_timeout = ' . $timeout . ';');
-			loadJavascriptFile('alerts.js', array(), 'smf_alerts');
+			loadJavaScriptFile('alerts.js', array(), 'smf_alerts');
 		}
 	}
 

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -4398,7 +4398,7 @@ function add_integration_function($hook, $function, $permanent = true, $file = '
 
 	// Any files  to load?
 	if (!empty($file) && is_string($file))
-		$function = $file . '|' . $function;
+		$function = $file . (!empty($function) ? '|' . $function : '');
 
 	// Get the correct string.
 	$integration_call = $function;


### PR DESCRIPTION
- Prevent appending a function name if there isn't one.  Some hooks do not need a function name, this is mainly used when adding a hook like integrate_pre_include via the packager manager hook tag.
- Rename a few JavaScript functions to camelCase
- Prevents double mentions when quoting or editing a message,
