### PR TITLE
CSS fixes

### DIFF
--- a/Themes/default/css/index.css
+++ b/Themes/default/css/index.css
@@ -3491,7 +3491,6 @@ h3.catbg .icon {
 	border: 1px solid #c5c5c5;
 	border-radius: 7px;
 	box-shadow: 0 -2px 2px rgba(0,0,0,0.1);
-	overflow: auto;
 }
 /* TitleBar & SubBar */
 .title_bar {

--- a/Themes/default/css/install.css
+++ b/Themes/default/css/install.css
@@ -68,7 +68,7 @@ h1.forumtitle {
 	margin: 0px 3px 0px 0px;
 }
 .overall_progress {
-	margin: -30px 5px 0 5px;
+	margin: -26px 5px 0 5px;
 }
 
 #step_progress {


### PR DESCRIPTION
Adjusting here some CSS aspects;
- The overflow property set to .roundframe caused to display the login box like this: http://bit.ly/2dFRNvT
- Adjusted top margin of .overall_progress on install to centralize it just a bit
