### PR TITLE
Fix missing global char set fix #3669

### DIFF
--- a/other/upgrade.php
+++ b/other/upgrade.php
@@ -3299,6 +3299,13 @@ function convertUtf8()
 	// First make sure they aren't already on UTF-8 before we go anywhere...
 	if ($db_type == 'postgresql' || ($db_character_set === 'utf8' && !empty($modSettings['global_character_set']) && $modSettings['global_character_set'] === 'UTF-8'))
 	{
+		$smcFunc['db_insert']('replace',
+			'{db_prefix}settings',
+			array('variable' => 'string', 'value' => 'string'),
+			array(array('global_character_set', 'UTF-8')),
+			array('variable')
+		);
+		
 		return true;
 	}
 	else


### PR DESCRIPTION
In the pg upgrade process this information was missing.
I think it's doesn't hurt to set this value everytime.

related issue #3669