### PR TITLE
Keeps the autolinker up-to-date with the full list of top level domains

### DIFF
--- a/Sources/ScheduledTasks.php
+++ b/Sources/ScheduledTasks.php
@@ -1297,7 +1297,7 @@ function scheduled_birthdayemails()
  */
 function scheduled_weekly_maintenance()
 {
-	global $modSettings, $smcFunc;
+	global $modSettings, $smcFunc, $sourcedir;
 
 	// Delete some settings that needn't be set if they are otherwise empty.
 	$emptySettings = array(
@@ -1478,6 +1478,9 @@ function scheduled_weekly_maintenance()
 			'last_update' => time() - 86400,
 		)
 	);
+
+	require_once($sourcedir . '/Subs.php');
+	set_tld_regex(true);
 
 	return true;
 }

--- a/Sources/ScheduledTasks.php
+++ b/Sources/ScheduledTasks.php
@@ -1297,7 +1297,7 @@ function scheduled_birthdayemails()
  */
 function scheduled_weekly_maintenance()
 {
-	global $modSettings, $smcFunc, $sourcedir;
+	global $modSettings, $smcFunc;
 
 	// Delete some settings that needn't be set if they are otherwise empty.
 	$emptySettings = array(

--- a/Sources/ScheduledTasks.php
+++ b/Sources/ScheduledTasks.php
@@ -1479,8 +1479,11 @@ function scheduled_weekly_maintenance()
 		)
 	);
 
-	require_once($sourcedir . '/Subs.php');
-	set_tld_regex(true);
+	$smcFunc['db_insert']('insert', '{db_prefix}background_tasks',
+		array('task_file' => 'string-255', 'task_class' => 'string-255', 'task_data' => 'string', 'claimed_time' => 'int'),
+		array('$sourcedir/tasks/UpdateTldRegex.php', 'Update_TLD_Regex', '', 0), array()
+	);
+
 
 	return true;
 }

--- a/Sources/ScheduledTasks.php
+++ b/Sources/ScheduledTasks.php
@@ -1479,11 +1479,11 @@ function scheduled_weekly_maintenance()
 		)
 	);
 
+	// Update the regex of top level domains with the IANA's latest official list
 	$smcFunc['db_insert']('insert', '{db_prefix}background_tasks',
 		array('task_file' => 'string-255', 'task_class' => 'string-255', 'task_data' => 'string', 'claimed_time' => 'int'),
 		array('$sourcedir/tasks/UpdateTldRegex.php', 'Update_TLD_Regex', '', 0), array()
 	);
-
 
 	return true;
 }

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -1888,7 +1888,7 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 	|											#	or
 	www\d{0,3}[.]								# "www.", "www1.", "www2." … "www999."
 	|											#	or
-	[\p{L}\p{M}\p{N}.\-]+[.][\p{L}\p{M}]{2,4}/	# looks like domain name followed by a slash
+	[\p{L}\p{M}\p{N}.\-]+[.][\p{L}\p{M}]{2,63}/	# looks like domain name followed by a slash
 )
 (?:												# One or more:
 	[^\s()<>]+									# Run of non-space, non-()<>

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -5532,8 +5532,111 @@ function set_tld_regex($update = false)
 		$schedule_update = true;
 	}
 
-	// Punycode is for machines, not humans
-	$tlds = array_map('punycode_to_unicode', $tlds);
+	// Convert Punycode to Unicode
+	$tlds = array_map(function ($input) {
+		$prefix = 'xn--';
+		$safe_char = 0xFFFC;
+		$base = 36;
+		$tmin = 1;
+		$tmax = 26;
+		$skew = 38;
+		$damp = 700;
+		$output_parts = array();
+
+		$input = str_replace(strtoupper($prefix), $prefix, $input);
+
+		$enco_parts = (array) explode('.', $input);
+
+		foreach ($enco_parts as $encoded)
+		{
+			if (strpos($encoded,$prefix) !== 0 || strlen(trim(str_replace($prefix,'',$encoded))) == 0)
+			{
+				$output_parts[] = $encoded;
+				continue;
+			}
+
+			$is_first = true;
+			$bias = 72;
+			$idx = 0;
+			$char = 0x80;
+			$decoded = array();
+			$output='';
+			$delim_pos = strrpos($encoded, '-');
+
+			if ($delim_pos > strlen($prefix))
+			{
+				for ($k = strlen($prefix); $k < $delim_pos; ++$k)
+				{
+					$decoded[] = ord($encoded{$k});
+				}
+			}
+
+			$deco_len = count($decoded);
+			$enco_len = strlen($encoded);
+
+			for ($enco_idx = $delim_pos ? ($delim_pos + 1) : 0; $enco_idx < $enco_len; ++$deco_len)
+			{
+				for ($old_idx = $idx, $w = 1, $k = $base; 1 ; $k += $base)
+				{
+					$cp = ord($encoded{$enco_idx++});
+					$digit = ($cp - 48 < 10) ? $cp - 22 : (($cp - 65 < 26) ? $cp - 65 : (($cp - 97 < 26) ? $cp - 97 : $base));
+					$idx += $digit * $w;
+					$t = ($k <= $bias) ? $tmin : (($k >= $bias + $tmax) ? $tmax : ($k - $bias));
+
+					if ($digit < $t)
+						break;
+
+					$w = (int) ($w * ($base - $t));
+				}
+
+				$delta = $idx - $old_idx;
+				$delta = intval($is_first ? ($delta / $damp) : ($delta / 2));
+				$delta += intval($delta / ($deco_len + 1));
+
+				for ($k = 0; $delta > (($base - $tmin) * $tmax) / 2; $k += $base)
+					$delta = intval($delta / ($base - $tmin));
+
+				$bias = intval($k + ($base - $tmin + 1) * $delta / ($delta + $skew));
+				$is_first = false;
+				$char += (int) ($idx / ($deco_len + 1));
+				$idx %= ($deco_len + 1);
+
+				if ($deco_len > 0)
+				{
+					for ($i = $deco_len; $i > $idx; $i--)
+						$decoded[$i] = $decoded[($i - 1)];
+				}
+				$decoded[$idx++] = $char;
+			}
+
+			foreach ($decoded as $k => $v)
+			{
+				// 7bit are transferred literally
+				if ($v < 128)
+					$output .= chr($v);
+
+				// 2 bytes
+				elseif ($v < (1 << 11))
+					$output .= chr(192+($v >> 6)) . chr(128+($v & 63));
+
+				// 3 bytes
+				elseif ($v < (1 << 16))
+					$output .= chr(224+($v >> 12)) . chr(128+(($v >> 6) & 63)) . chr(128+($v & 63));
+
+				// 4 bytes
+				elseif ($v < (1 << 21))
+					$output .= chr(240+($v >> 18)) . chr(128+(($v >> 12) & 63)) . chr(128+(($v >> 6) & 63)) . chr(128+($v & 63));
+
+				//  'Conversion from UCS-4 to UTF-8 failed: malformed input at byte '.$k
+				else
+					$output .= $safe_char;
+			}
+
+			$output_parts[] = $output;
+		}
+
+		return implode('.', $output_parts);
+	}, $tlds);
 
 	// build_regex() returns an array. We only need the first item.
 	$tld_regex = array_shift(build_regex($tlds));
@@ -5552,121 +5655,6 @@ function set_tld_regex($update = false)
 
 	// Redundant repetition is redundant
 	$done = true;
-}
-
-/**
- * Converts Punycode to Unicode in a domain name.
- *
- * This function does not sanitize the input prior to processing. So, if you try to feed it a URL
- * or basically anything that isn't a domain name, it will choke and die.
- *
- * @param string $input A domain name or any part thereof (e.g.: 'com', 'subdomain.example.com').
- * @return string The domain name with any Punycode converted to human-readable UTF-8 characters.
- */
-function punycode_to_unicode($input)
-{
-	$prefix = 'xn--';
-	$safe_char = 0xFFFC;
-	$base = 36;
-	$tmin = 1;
-	$tmax = 26;
-	$skew = 38;
-	$damp = 700;
-	$output_parts = array();
-
-	$input = str_replace(strtoupper($prefix), $prefix, $input);
-
-	$enco_parts = (array) explode('.', $input);
-
-	foreach ($enco_parts as $encoded)
-	{
-		if (strpos($encoded,$prefix) !== 0 || strlen(trim(str_replace($prefix,'',$encoded))) == 0)
-		{
-			$output_parts[] = $encoded;
-			continue;
-		}
-
-		$is_first = true;
-		$bias = 72;
-		$idx = 0;
-		$char = 0x80;
-		$decoded = array();
-		$output='';
-		$delim_pos = strrpos($encoded, '-');
-
-		if ($delim_pos > strlen($prefix))
-		{
-			for ($k = strlen($prefix); $k < $delim_pos; ++$k)
-			{
-				$decoded[] = ord($encoded{$k});
-			}
-		}
-
-		$deco_len = count($decoded);
-		$enco_len = strlen($encoded);
-
-		for ($enco_idx = $delim_pos ? ($delim_pos + 1) : 0; $enco_idx < $enco_len; ++$deco_len)
-		{
-			for ($old_idx = $idx, $w = 1, $k = $base; 1 ; $k += $base)
-			{
-				$cp = ord($encoded{$enco_idx++});
-				$digit = ($cp - 48 < 10) ? $cp - 22 : (($cp - 65 < 26) ? $cp - 65 : (($cp - 97 < 26) ? $cp - 97 : $base));
-				$idx += $digit * $w;
-				$t = ($k <= $bias) ? $tmin : (($k >= $bias + $tmax) ? $tmax : ($k - $bias));
-
-				if ($digit < $t)
-					break;
-
-				$w = (int) ($w * ($base - $t));
-			}
-
-			$delta = $idx - $old_idx;
-			$delta = intval($is_first ? ($delta / $damp) : ($delta / 2));
-			$delta += intval($delta / ($deco_len + 1));
-
-			for ($k = 0; $delta > (($base - $tmin) * $tmax) / 2; $k += $base)
-				$delta = intval($delta / ($base - $tmin));
-
-			$bias = intval($k + ($base - $tmin + 1) * $delta / ($delta + $skew));
-			$is_first = false;
-			$char += (int) ($idx / ($deco_len + 1));
-			$idx %= ($deco_len + 1);
-
-			if ($deco_len > 0)
-			{
-				for ($i = $deco_len; $i > $idx; $i--)
-					$decoded[$i] = $decoded[($i - 1)];
-			}
-			$decoded[$idx++] = $char;
-		}
-
-		foreach ($decoded as $k => $v)
-		{
-			// 7bit are transferred literally
-			if ($v < 128)
-				$output .= chr($v);
-
-			// 2 bytes
-			elseif ($v < (1 << 11))
-				$output .= chr(192+($v >> 6)) . chr(128+($v & 63));
-
-			// 3 bytes
-			elseif ($v < (1 << 16))
-				$output .= chr(224+($v >> 12)) . chr(128+(($v >> 6) & 63)) . chr(128+($v & 63));
-
-			// 4 bytes
-			elseif ($v < (1 << 21))
-				$output .= chr(240+($v >> 18)) . chr(128+(($v >> 12) & 63)) . chr(128+(($v >> 6) & 63)) . chr(128+($v & 63));
-
-			//  'Conversion from UCS-4 to UTF-8 failed: malformed input at byte '.$k
-			else
-				$output .= $safe_char;
-		}
-
-		$output_parts[] = $output;
-	}
-
-	return implode('.', $output_parts);
 }
 
 /**

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -5688,25 +5688,28 @@ function punycode_to_unicode($input)
  *
  * @param array $strings An array of strings to make a regex for.
  * @param string $delim An optional delimiter character to pass to preg_quote().
- * @param string $encoding The character encoding of the input strings. Defaults to 'UTF-8'.
  * @return array An array of one or more regular expressions to match any of the input strings.
  */
-function build_regex($strings, $delim = null, $encoding = 'UTF-8')
+function build_regex($strings, $delim = null)
 {
 	global $smcFunc;
 
 	// The mb_* functions are faster than the $smcFunc ones, but may not be available
-	if (function_exists('mb_internal_encoding') && function_exists('mb_strlen') && function_exists('mb_substr'))
+	if (function_exists('mb_internal_encoding') && function_exists('mb_detect_encoding') && function_exists('mb_strlen') && function_exists('mb_substr'))
 	{
-		$current_encoding = mb_internal_encoding();
-		mb_internal_encoding($encoding);
+		if (($string_encoding = mb_detect_encoding(implode(' ', $strings))) !== false)
+		{
+			$current_encoding = mb_internal_encoding();
+			mb_internal_encoding($string_encoding);
+		}
+
 		$strlen = 'mb_strlen';
 		$substr = 'mb_substr';
 	}
 	else
 	{
-		$strlen &= $smcFunc['strlen'];
-		$substr &= $smcFunc['substr'];
+		$strlen = $smcFunc['strlen'];
+		$substr = $smcFunc['substr'];
 	}
 
 	// This recursive function creates the index array from the strings

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -1941,7 +1941,7 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 
 						# IRI path, query, and fragment (if present)
 						(?:
-							# If any of these parts exist, must start with a /
+							# If any of these parts exist, must start with a single /
 							/
 
 							# And then optionally:
@@ -1961,7 +1961,10 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 									\(([^\s()<>]+|(\([^\s()<>]+\)))*\)
 									| # or
 									# not a space or one of these punct char
-									[^\s`!()\[\]{};:\'".,<>?«»“”‘’]
+									[^\s`!()\[\]{};:\'".,<>?«»“”‘’/]
+									| # or
+									# a trailing slash (but not two in a row)
+									(?<!/)/
 								)
 							)?
 						)?

--- a/Sources/tasks/UpdateTldRegex.php
+++ b/Sources/tasks/UpdateTldRegex.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * This file initiates updates of $modSettings['tld_regex']
+ *
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines http://www.simplemachines.org
+ * @copyright 2016 Simple Machines and individual contributors
+ * @license http://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 2.1 Beta 3
+ */
+
+/**
+ * Class Update_TLD_Regex
+ */
+class Update_TLD_Regex extends SMF_BackgroundTask
+{
+    /**
+     * This executes the task. It just calls set_tld_regex() in Subs.php
+     * @return bool Always returns true
+     */
+	public function execute()
+ 	{
+		global $sourcedir;
+
+		require_once($sourcedir . '/Subs.php');
+		set_tld_regex(true);
+
+		return true;
+	}
+}
+
+?>


### PR DESCRIPTION
The `set_tld_regex()` function creates an optimized regex to match all known top level domains and stores it in $modSettings['tld_regex']. The regex is updated once per week (or possibly more often if necessary for some reason) using a cron job. If the regex is discovered to be missing or invalid during day-to-day use, it will be regenerated from a hard-coded list of basic TLDs for the short term, and a background update via cron will be scheduled to fix it properly in the near future.

This PR also tweaks `build_regex()` for cleaner handling of multibyte character encodings like UTF-8.

Finally, this PR also improves the regexes used for autolinking URLs and email address.