### PR TITLE
Switch to OOP for memcache

### DIFF
--- a/Sources/ManageServer.php
+++ b/Sources/ManageServer.php
@@ -451,7 +451,7 @@ function ModifyCacheSettings($return_config = false)
 		$detected['apcu'] = $txt['apcu_cache'];
 	if (function_exists('output_cache_put') || function_exists('zend_shm_cache_store'))
 		$detected['zend'] = $txt['zend_cache'];
-	if (function_exists('memcache_set') || function_exists('memcached_set'))
+	if (class_exists('memcache') || class_exists('memcached'))
 		$detected['memcached'] = $txt['memcached_cache'];
 	if (function_exists('xcache_set'))
 		$detected['xcache'] = $txt['xcache_cache'];

--- a/Sources/Subs-Admin.php
+++ b/Sources/Subs-Admin.php
@@ -82,7 +82,7 @@ function getServerVersions($checkFor)
 		$versions['phpa'] = array('title' => 'ionCube PHP-Accelerator', 'version' => $_PHPA['VERSION']);
 	if (in_array('apc', $checkFor) && extension_loaded('apc'))
 		$versions['apc'] = array('title' => 'Alternative PHP Cache', 'version' => phpversion('apc'));
-	if (in_array('memcache', $checkFor) && function_exists('memcache_set'))
+	if (in_array('memcache', $checkFor) && (class_exists('memcache') || class_exists('memcached')))
 		$versions['memcache'] = array('title' => 'Memcached', 'version' => empty($memcached) ? '???' : memcache_get_version($memcached));
 	if (in_array('xcache', $checkFor) && function_exists('xcache_set'))
 		$versions['xcache'] = array('title' => 'XCache', 'version' => XCACHE_VERSION);

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -3968,7 +3968,7 @@ function clean_cache($type = '')
 	switch ($cache_accelerator)
 	{
 		case 'memcached':
-			if (function_exists('memcache_flush') || function_exists('memcached_flush') && isset($modSettings['cache_memcached']) && trim($modSettings['cache_memcached']) != '')
+			if (class_exists('memcache') || class_exists('memcached') && isset($modSettings['cache_memcached']) && trim($modSettings['cache_memcached']) != '')
 			{
 				// Not connected yet?
 				if (empty($memcached))
@@ -3977,10 +3977,7 @@ function clean_cache($type = '')
 					return;
 
 				// clear it out
-				if (function_exists('memcache_flush'))
-					memcache_flush($memcached);
-				else
-					memcached_flush($memcached);
+				$memcached->flush();
 			}
 			break;
 		case 'apc':


### PR DESCRIPTION
This commit changes all the procedural functions for memcache(d) to the OOP equivalents, per #3693. Note that I haven't tested any of this yet as I don't have memcache on my server.

Signed-off-by: Michael Eshom <oldiesmann@oldiesmann.us>