### PR TITLE
Fixes #3624

### DIFF
--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -1122,22 +1122,10 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 						$alt = !empty($params['{alt}']) ? ' alt="' . $params['{alt}'] . '"' : ' alt="' . $currentAttachment['name'] . '"';
 						$title = !empty($params['{title}']) ? ' title="' . $params['{alt}'] . '"' : '';
 
-						if (!empty($params['{width}']) && !empty($params['{height}']))
-						{
-							$width = ' width="' . $params['{width}'] . '"';
-							$height = ' height="' . $params['{height}'] . '"';
-						}
-						elseif (!empty($params['{width}']) && empty($params['{height}']))
-						{
-							$width = ' width="' . $params['{width}'] . '"';
-							$height = '';
-						}
-						elseif (empty($params['{width}']) && !empty($params['{height}']))
-						{
-							$width = '';
-							$height = ' height="' . $params['{height}'] . '"';
-						}
-						else
+						$width = !empty($params['{width}']) ? ' width="' . $params['{width}'] . '"' : '';
+						$height = !empty($params['{height}']) ? ' height="' . $params['{height}'] . '"' : '';
+
+						if (empty($width) && empty($height))
 						{
 							$width = ' width="' . $currentAttachment['width'] . '"';
 							$height = ' height="' . $currentAttachment['height'] . '"';

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -1144,11 +1144,9 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 						}
 
 						if ($currentAttachment['thumbnail']['has_thumb'] && empty($params['{width}']) && empty($params['{height}']))
-							$returnContext .= '
-													<a href="'. $currentAttachment['href']. ';image" id="link_'. $currentAttachment['id']. '" onclick="'. $currentAttachment['thumbnail']['javascript']. '"><img src="'. $currentAttachment['thumbnail']['href']. '" alt="' . $currentAttachment['name'] . '" id="thumb_'. $currentAttachment['id']. '"></a>';
+							$returnContext .= '<a href="'. $currentAttachment['href']. ';image" id="link_'. $currentAttachment['id']. '" onclick="'. $currentAttachment['thumbnail']['javascript']. '"><img src="'. $currentAttachment['thumbnail']['href']. '" alt="' . $currentAttachment['name'] . '" id="thumb_'. $currentAttachment['id']. '"></a>';
 						else
-							$returnContext .= '
-													<img src="' . $currentAttachment['href'] . ';image" alt="' . $currentAttachment['name'] . '"' . $width . $height . '/>';
+							$returnContext .= '<img src="' . $currentAttachment['href'] . ';image" alt="' . $currentAttachment['name'] . '"' . $width . $height . '/>';
 					}
 
 					// No image. Show a link.


### PR DESCRIPTION
Problem was the newlines inserted by the attach BBC validation function. Since parse_bbc() uses newlines as delimiters to decide where to parse smilies, these extra newlines were causing confusion.

