### PR TITLE
remove the pm_email_notify fix #3724

### DIFF
--- a/Sources/Subs-Members.php
+++ b/Sources/Subs-Members.php
@@ -669,7 +669,7 @@ function registerMember(&$regOptions, $return_errors = false)
 	// Right, now let's prepare for insertion.
 	$knownInts = array(
 		'date_registered', 'posts', 'id_group', 'last_login', 'instant_messages', 'unread_messages',
-		'new_pm', 'pm_prefs', 'show_online', 'pm_email_notify',
+		'new_pm', 'pm_prefs', 'show_online',
 		'id_theme', 'is_activated', 'id_msg_last_visit', 'id_post_group', 'total_time_logged_in', 'warning',
 	);
 	$knownFloats = array(

--- a/other/upgrade_2-1_mysql.sql
+++ b/other/upgrade_2-1_mysql.sql
@@ -2455,3 +2455,10 @@ ALTER TABLE {$db_prefix}log_online ADD COLUMN ip VARBINARY(16);
 UPDATE {$db_prefix}permissions SET permission = 'profile_website_own' WHERE permission = 'profile_other_own';
 UPDATE {$db_prefix}permissions SET permission = 'profile_website_any' WHERE permission = 'profile_other_any';
 ---#
+
+/******************************************************************************/
+--- drop col pm_email_notify from members
+/******************************************************************************/
+---# drop column pm_email_notify on table members
+ALTER TABLE {$db_prefix}members DROP COLUMN pm_email_notify;
+---#

--- a/other/upgrade_2-1_postgresql.sql
+++ b/other/upgrade_2-1_postgresql.sql
@@ -2217,3 +2217,10 @@ CREATE INDEX {$db_prefix}boards_member_groups ON {$db_prefix}boards (member_grou
 DROP INDEX IF EXISTS {$db_prefix}log_comments_comment_type;
 CREATE INDEX {$db_prefix}log_comments_comment_type ON {$db_prefix}log_comments (comment_type varchar_pattern_ops);
 ---#
+
+/******************************************************************************/
+--- drop col pm_email_notify from members
+/******************************************************************************/
+---# drop column pm_email_notify on table members
+ALTER TABLE {$db_prefix}members DROP COLUMN IF EXISTS pm_email_notify;
+---#


### PR DESCRIPTION
Like i mention in #3724 i'm not 100% sure if this the right way.

The problem is mysql:
Because of the table lock,
the sql statement run on error if the col is already deleted.

The pg way is fast and run again a members table without the col will create no error message.