### PR TITLE
Fix Possible bug in FulltextSearch

### DIFF
--- a/Sources/ManageSearch.php
+++ b/Sources/ManageSearch.php
@@ -236,6 +236,8 @@ function EditSearchMethod()
 				array()
 			);
 
+			$language_ftx = 'simple';
+
 			if ($request !== false && $smcFunc['db_num_rows']($request) == 1)
 			{
 				$row = $smcFunc['db_fetch_assoc']($request);


### PR DESCRIPTION
I don't know if this possible that $language_ftx could be empty,
but to protect this posibility i set an default value to this var.

So mostly the fix is easier as the thinking if this a real possible bug...