### PR TITLE
added return value to db_insert

### DIFF
--- a/Sources/Subs-Db-mysql.php
+++ b/Sources/Subs-Db-mysql.php
@@ -701,8 +701,10 @@ function smf_db_error($db_string, $connection = null)
  * @param array $keys The keys for the table
  * @param bool $disable_trans Whether to disable transactions
  * @param resource $connection The connection to use (if null, $db_connection is used)
+ * @param returnmode 0 = nothing(default), 1 = last row id, 2 = all rows id as array; every mode runs only with method = ''
+ * @return value of the first key, behavior based on returnmode
  */
-function smf_db_insert($method = 'replace', $table, $columns, $data, $keys, $disable_trans = false, $connection = null)
+function smf_db_insert($method = 'replace', $table, $columns, $data, $keys, $disable_trans = false, $connection = null, $returnmode = 0)
 {
 	global $smcFunc, $db_connection, $db_prefix;
 
@@ -754,6 +756,21 @@ function smf_db_insert($method = 'replace', $table, $columns, $data, $keys, $dis
 		),
 		$connection
 	);
+	
+	if(!empty($keys) && (count($keys) > 0) && $method == '' && $returnmode > 0)
+	{
+		if ($returnmode == 1)
+			$return_var = smf_db_insert_id($table, $keys[0]) + count($insertRows) - 1;
+		else if ($returnmode == 2)
+		{
+			$return_var = array();
+			$count = count($insertRows);
+			$start = smf_db_insert_id($table, $keys[0]);
+			for ($i = 0; $i < $count; $i++ )
+				$return_var[] = $start + $i;
+		}
+		return $return_var;
+	}
 }
 
 /**

--- a/Sources/Subs-Db-mysql.php
+++ b/Sources/Subs-Db-mysql.php
@@ -701,7 +701,7 @@ function smf_db_error($db_string, $connection = null)
  * @param array $keys The keys for the table
  * @param bool $disable_trans Whether to disable transactions
  * @param resource $connection The connection to use (if null, $db_connection is used)
- * @param returnmode 0 = nothing(default), 1 = last row id, 2 = all rows id as array; every mode runs only with method = ''
+ * @param int returnmode 0 = nothing(default), 1 = last row id, 2 = all rows id as array; every mode runs only with method = ''
  * @return value of the first key, behavior based on returnmode
  */
 function smf_db_insert($method = 'replace', $table, $columns, $data, $keys, $disable_trans = false, $connection = null, $returnmode = 0)

--- a/Sources/Subs-Db-mysqli.php
+++ b/Sources/Subs-Db-mysqli.php
@@ -759,8 +759,10 @@ function smf_db_error($db_string, $connection = null)
  * @param array $keys The keys for the table
  * @param bool $disable_trans Whether to disable transactions
  * @param object $connection The connection to use (if null, $db_connection is used)
+ * @param returnmode 0 = nothing(default), 1 = last row id, 2 = all rows id as array; every mode runs only with method = ''
+ * @return value of the first key, behavior based on returnmode
  */
-function smf_db_insert($method = 'replace', $table, $columns, $data, $keys, $disable_trans = false, $connection = null)
+function smf_db_insert($method = 'replace', $table, $columns, $data, $keys, $disable_trans = false, $connection = null, $returnmode = 0)
 {
 	global $smcFunc, $db_connection, $db_prefix;
 
@@ -812,6 +814,21 @@ function smf_db_insert($method = 'replace', $table, $columns, $data, $keys, $dis
 		),
 		$connection
 	);
+	
+	if(!empty($keys) && (count($keys) > 0) && $method == '' && $returnmode > 0)
+	{
+		if ($returnmode == 1)
+			$return_var = smf_db_insert_id($table, $keys[0]) + count($insertRows) - 1;
+		else if ($returnmode == 2)
+		{
+			$return_var = array();
+			$count = count($insertRows);
+			$start = smf_db_insert_id($table, $keys[0]);
+			for ($i = 0; $i < $count; $i++ )
+				$return_var[] = $start + $i;
+		}
+		return $return_var;
+	}
 }
 
 /**

--- a/Sources/Subs-Db-mysqli.php
+++ b/Sources/Subs-Db-mysqli.php
@@ -759,7 +759,7 @@ function smf_db_error($db_string, $connection = null)
  * @param array $keys The keys for the table
  * @param bool $disable_trans Whether to disable transactions
  * @param object $connection The connection to use (if null, $db_connection is used)
- * @param returnmode 0 = nothing(default), 1 = last row id, 2 = all rows id as array; every mode runs only with method = ''
+ * @param int returnmode 0 = nothing(default), 1 = last row id, 2 = all rows id as array; every mode runs only with method = ''
  * @return value of the first key, behavior based on returnmode
  */
 function smf_db_insert($method = 'replace', $table, $columns, $data, $keys, $disable_trans = false, $connection = null, $returnmode = 0)


### PR DESCRIPTION
I saw many places where after db_insert the db_insert_id is calling
and i realize that the db_insert function is able to insert multipe values at once but then the db_insert_id get then broken.

So with this pr I solve this issues your are able to get directly the id back and
when your insert multiple values your get multiple id's.

To handle this different needs I place different returnmods = 
0 do nothing (default)
1 return the id of the last row
2 return an array of all id of every row

The challange is here that mysql is less potential as pg.
in pg last insert id works on all insert mode, on all type of fields and unlimited number of fields in the table
in mysql last insert works only on normal insert (no replace or ignore), only on ai fields and only one field

The first limitation of mysql I implemented in pg that the return only works on method == ''
for the second I don't see any checks
the last one when multiple keys are provided I take the first one -> the first one needs to be the ai field.

When this pr is merged,
the next step would be to remove the places where db_insert_id is used.