### PR TITLE
Improves CSS for .roundframe immediately after .cat_bar

### DIFF
--- a/Themes/default/Calendar.template.php
+++ b/Themes/default/Calendar.template.php
@@ -620,7 +620,7 @@ function template_event_post()
 	}
 
 	echo '
-			<div class="roundframe">
+			<div class="roundframe noup">
 				<fieldset id="event_main">
 					<legend><span', isset($context['post_error']['no_event']) ? ' class="error"' : '', '>', $txt['calendar_event_title'], '</span></legend>
 					<input type="hidden" name="calendar" value="1">

--- a/Themes/default/css/index.css
+++ b/Themes/default/css/index.css
@@ -3507,6 +3507,12 @@ h3.catbg .icon {
 	box-shadow: 0 -2px 2px rgba(0,0,0,0.1);
 	overflow: auto;
 }
+.cat_bar + .roundframe {
+	margin-top: 0;
+	border-top: 0;
+	border-top-left-radius: 0;
+	border-top-right-radius: 0;
+}
 /* TitleBar & SubBar */
 .title_bar {
 	border-right: 1px solid #ddd;

--- a/Themes/default/css/index.css
+++ b/Themes/default/css/index.css
@@ -3507,12 +3507,6 @@ h3.catbg .icon {
 	box-shadow: 0 -2px 2px rgba(0,0,0,0.1);
 	overflow: auto;
 }
-.cat_bar + .roundframe {
-	margin-top: 0;
-	border-top: 0;
-	border-top-left-radius: 0;
-	border-top-right-radius: 0;
-}
 /* TitleBar & SubBar */
 .title_bar {
 	border-right: 1px solid #ddd;


### PR DESCRIPTION
~~Specifically, causes a div.roundframe to hug up against a div.cat_bar similarly to how a div.information does. This helps when a .roundframe immediately follows a .cat_bar, such as on the event posting page (i.e. `$scripturl . '?action=calendar;sa=post'`)~~

Adds the 'noup' class to the event options div while creating an event in Calendar.template.php

