### PR TITLE
Remove unused code in ManageLanguages.php

### DIFF
--- a/Sources/ManageLanguages.php
+++ b/Sources/ManageLanguages.php
@@ -358,9 +358,6 @@ function DownloadLanguage()
 			// Add the context data to the main set.
 			$context['files']['lang'][] = $context_data;
 		}
-		elseif (in_array($extension, array('jpg', 'gif', 'jpeg', 'png'))) {
-		    $context['files']['images'][] = $context_data;
-        }
 		elseif ($extension == '.txt' && stripos($filename, 'agreement') !== false)
 		{
 			// Registration agreement is a primary file

--- a/Sources/ManageLanguages.php
+++ b/Sources/ManageLanguages.php
@@ -358,6 +358,9 @@ function DownloadLanguage()
 			// Add the context data to the main set.
 			$context['files']['lang'][] = $context_data;
 		}
+		elseif (in_array($extension, array('jpg', 'gif', 'jpeg', 'png'))) {
+		    $context['files']['images'][] = $context_data;
+        }
 		elseif ($extension == '.txt' && stripos($filename, 'agreement') !== false)
 		{
 			// Registration agreement is a primary file
@@ -372,71 +375,6 @@ function DownloadLanguage()
 		// Collect together all non-writable areas.
 		if (!$context_data['writable'])
 			$context['make_writable'][] = $context_data['destination'];
-	}
-
-	// So, I'm a perfectionist - let's get the theme names.
-	$theme_indexes = array();
-	foreach ($context['files']['images'] as $k => $dummy)
-		$indexes[] = $k;
-
-	$context['theme_names'] = array();
-	if (!empty($indexes))
-	{
-		$value_data = array(
-			'query' => array(),
-			'params' => array(),
-		);
-
-		foreach ($indexes as $k => $index)
-		{
-			$value_data['query'][] = 'value LIKE {string:value_' . $k . '}';
-			$value_data['params']['value_' . $k] = '%' . $index;
-		}
-
-		$request = $smcFunc['db_query']('', '
-			SELECT id_theme, value
-			FROM {db_prefix}themes
-			WHERE id_member = {int:no_member}
-				AND variable = {string:theme_dir}
-				AND (' . implode(' OR ', $value_data['query']) . ')',
-			array_merge($value_data['params'], array(
-				'no_member' => 0,
-				'theme_dir' => 'theme_dir',
-				'index_compare_explode' => 'value LIKE \'%' . implode('\' OR value LIKE \'%', $indexes) . '\'',
-			))
-		);
-		$themes = array();
-		while ($row = $smcFunc['db_fetch_assoc']($request))
-		{
-			// Find the right one.
-			foreach ($indexes as $index)
-				if (strpos($row['value'], $index) !== false)
-					$themes[$row['id_theme']] = $index;
-		}
-		$smcFunc['db_free_result']($request);
-
-		if (!empty($themes))
-		{
-			// Now we have the id_theme we can get the pretty description.
-			$request = $smcFunc['db_query']('', '
-				SELECT id_theme, value
-				FROM {db_prefix}themes
-				WHERE id_member = {int:no_member}
-					AND variable = {string:name}
-					AND id_theme IN ({array_int:theme_list})',
-				array(
-					'theme_list' => array_keys($themes),
-					'no_member' => 0,
-					'name' => 'name',
-				)
-			);
-			while ($row = $smcFunc['db_fetch_assoc']($request))
-			{
-				// Now we have it...
-				$context['theme_names'][$themes[$row['id_theme']]] = $row['value'];
-			}
-			$smcFunc['db_free_result']($request);
-		}
 	}
 
 	// Before we go to far can we make anything writable, eh, eh?


### PR DESCRIPTION
Fixes #3730.

`$context['theme_names']` is unused.
`$theme_indexes` is unused. 

I see no need for this logic to be here. 