### PR TITLE
Html bbc fix

### DIFF
--- a/Sources/Subs-Post.php
+++ b/Sources/Subs-Post.php
@@ -117,7 +117,7 @@ function preparsecode(&$message, $previewing = false)
 	{
 		if (allowedTo('admin_forum'))
 			$message = preg_replace_callback('~\[html\](.+?)\[/html\]~is', function($m) {
-				return '[html]' . strtr(un_htmlspecialchars($m), array("\n" => '&#13;', '  ' => ' &#32;', '[' => '&#91;', ']' => '&#93;')) . '[/html]';
+				return '[html]' . strtr(un_htmlspecialchars($m[1]), array("\n" => '&#13;', '  ' => ' &#32;', '[' => '&#91;', ']' => '&#93;')) . '[/html]';
 			}, $message);
 
 		// We should edit them out, or else if an admin edits the message they will get shown...

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -1281,7 +1281,7 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 			array(
 				'tag' => 'html',
 				'type' => 'unparsed_content',
-				'content' => '$1',
+				'content' => '<div>$1</div>',
 				'block_level' => true,
 				'disabled_content' => '$1',
 			),


### PR DESCRIPTION
Fixes #3794
Also, wraps the content of the [html] BBC in a `<div>`, since, after all, that BBC is supposed to be a block level one.