### PR TITLE
Uses redirectexit and fixes #3798

### DIFF
--- a/proxy.php
+++ b/proxy.php
@@ -43,6 +43,8 @@ class ProxyServer
 
 		require_once(dirname(__FILE__) . '/Settings.php');
 		require_once($sourcedir . '/Class-CurlFetchWeb.php');
+        require_once($sourcedir . '/Subs.php');
+
 
 		// Turn off all error reporting; any extra junk makes for an invalid image.
 		error_reporting(0);
@@ -108,7 +110,7 @@ class ProxyServer
 
 		// Right, image not cached? Simply redirect, then.
 		if (!$this->checkRequest())
-			header('Location: ' . $request);
+            redirectexit($request);
 
 		// Make sure we're serving an image
 		$contentParts = explode('/', !empty($cached['content_type']) ? $cached['content_type'] : '');

--- a/proxy.php
+++ b/proxy.php
@@ -43,7 +43,7 @@ class ProxyServer
 
 		require_once(dirname(__FILE__) . '/Settings.php');
 		require_once($sourcedir . '/Class-CurlFetchWeb.php');
-        require_once($sourcedir . '/Subs.php');
+		require_once($sourcedir . '/Subs.php');
 
 
 		// Turn off all error reporting; any extra junk makes for an invalid image.
@@ -105,12 +105,12 @@ class ProxyServer
 			@unlink($cached_file);
 			if ($this->checkRequest())
 				$this->serve();
-            redirectexit($request);
+			redirectexit($request);
 		}
 
 		// Right, image not cached? Simply redirect, then.
 		if (!$this->checkRequest())
-            redirectexit($request);
+		    redirectexit($request);
 
 		// Make sure we're serving an image
 		$contentParts = explode('/', !empty($cached['content_type']) ? $cached['content_type'] : '');

--- a/proxy.php
+++ b/proxy.php
@@ -105,7 +105,7 @@ class ProxyServer
 			@unlink($cached_file);
 			if ($this->checkRequest())
 				$this->serve();
-			exit;
+            redirectexit($request);
 		}
 
 		// Right, image not cached? Simply redirect, then.


### PR DESCRIPTION
Use redirectexit instead of manually changing headers. Fixes #3798 

@jdarwood007 