### PR TITLE
Adds a list view to the calendar

### DIFF
--- a/Sources/Calendar.php
+++ b/Sources/Calendar.php
@@ -112,7 +112,7 @@ function CalendarMain()
 		$context['calendar_view'] = $modSettings['calendar_default_view'];
 
 	// Don't let search engines index the non-default calendar pages
-	if ($context$context['calendar_view'] !== $modSettings['calendar_default_view'])
+	if ($context['calendar_view'] !== $modSettings['calendar_default_view'])
 		$context['robot_no_index'] = true;
 
 	// Get the current day of month...

--- a/Sources/Calendar.php
+++ b/Sources/Calendar.php
@@ -79,6 +79,10 @@ function CalendarMain()
 				$_REQUEST['year'] = (int) $_REQUEST['year'];
 				$_REQUEST['month'] = (int) $_REQUEST['month'];
 
+				// We want month view.
+				if (empty($_GET['viewmonth']))
+					$_GET['viewmonth'] = true;
+
 				// And we definitely don't want weekly view.
 				unset ($_GET['viewweek']);
 
@@ -93,22 +97,80 @@ function CalendarMain()
 	// Set the page title to mention the calendar ;).
 	$context['page_title'] = $txt['calendar'];
 
-	// Is this a week view?
-	$context['view_week'] = isset($_GET['viewweek']);
+	// Ensure a default view is defined
+	if (empty($modSettings['calendar_default_view']))
+		$modSettings['calendar_default_view'] = 'view_list';
 
-	// Don't let search engines index weekly calendar pages.
-	if ($context['view_week'])
+	// What view do we want?
+	if (isset($_GET['viewweek']))
+		$context['calendar_view'] = 'view_week';
+	elseif (isset($_GET['viewmonth']))
+		$context['calendar_view'] = 'view_month';
+	elseif (isset($_GET['viewlist']))
+		$context['calendar_view'] = 'view_list';
+	else
+		$context['calendar_view'] = $modSettings['calendar_default_view'];
+
+	// Don't let search engines index the non-default calendar pages
+	if (!empty($context[$modSettings['calendar_default_view']]))
 		$context['robot_no_index'] = true;
 
 	// Get the current day of month...
 	require_once($sourcedir . '/Subs-Calendar.php');
 	$today = getTodayInfo();
 
-	// If the month and year are not passed in, use today's date as a starting point.
+	// Need a start date for all views
+	if (!empty($_REQUEST['start_date']))
+	{
+		$start_parsed = date_parse($_REQUEST['start_date']);
+		if (empty($start_parsed['error_count']) && empty($start_parsed['warning_count']))
+		{
+			$_REQUEST['year'] = $start_parsed['year'];
+			$_REQUEST['month'] = $start_parsed['month'];
+			$_REQUEST['day'] = $start_parsed['day'];
+		}
+	}
+	$year = !empty($_REQUEST['year']) ? (int) $_REQUEST['year'] : $today['year'];
+	$month = !empty($_REQUEST['month']) ? (int) $_REQUEST['month'] : $today['month'];
+	$day = !empty($_REQUEST['day']) ? (int) $_REQUEST['day'] : $today['day'];
+
+	$start_object = checkdate($month, $day, $year) === true ? date_create(implode('-', array($year, $month, $day))) : date_create(implode('-', array($today['year'], $today['month'], $today['day'])));
+
+	// Need an end date for the list view
+	if (!empty($_REQUEST['end_date']))
+	{
+		$end_parsed = date_parse($_REQUEST['end_date']);
+		if (empty($end_parsed['error_count']) && empty($end_parsed['warning_count']))
+		{
+			$_REQUEST['end_year'] = $end_parsed['year'];
+			$_REQUEST['end_month'] = $end_parsed['month'];
+			$_REQUEST['end_day'] = $end_parsed['day'];
+		}
+	}
+	$end_year = !empty($_REQUEST['end_year']) ? (int) $_REQUEST['end_year'] : null;
+	$end_month = !empty($_REQUEST['end_month']) ? (int) $_REQUEST['end_month'] : null;
+	$end_day = !empty($_REQUEST['end_day']) ? (int) $_REQUEST['end_day'] : null;
+
+	$end_object = checkdate($end_month, $end_day, $end_year) === true ? date_create(implode('-', array($end_year, $end_month, $end_day))) : null;
+
+	if (empty($end_object) || $start_object >= $end_object)
+	{
+		$num_days_shown = empty($modSettings['cal_days_for_index']) || $modSettings['cal_days_for_index'] < 1 ? 1 : $modSettings['cal_days_for_index'];
+
+		$end_object = date_create(date_format($start_object, 'Y-m-d'));
+
+		date_add($end_object, date_interval_create_from_date_string($num_days_shown . ' days'));
+	}
+
 	$curPage = array(
-		'day' => isset($_REQUEST['day']) ? (int) $_REQUEST['day'] : $today['day'],
-		'month' => isset($_REQUEST['month']) ? (int) $_REQUEST['month'] : $today['month'],
-		'year' => isset($_REQUEST['year']) ? (int) $_REQUEST['year'] : $today['year']
+		'year' => date_format($start_object, 'Y'),
+		'month' => date_format($start_object, 'n'),
+		'day' => date_format($start_object, 'j'),
+		'start_date' => date_format($start_object, 'Y-m-d'),
+		'end_year' => date_format($end_object, 'Y'),
+		'end_month' => date_format($end_object, 'n'),
+		'end_day' => date_format($end_object, 'j'),
+		'end_date' => date_format($end_object, 'Y-m-d'),
 	);
 
 	// Make sure the year and month are in valid ranges.
@@ -117,11 +179,10 @@ function CalendarMain()
 	if ($curPage['year'] < $modSettings['cal_minyear'] || $curPage['year'] > $modSettings['cal_maxyear'])
 		fatal_lang_error('invalid_year', false);
 	// If we have a day clean that too.
-	if ($context['view_week'])
+	if ($context['calendar_view'] != 'view_month')
 	{
-		// Note $isValid is -1 < PHP 5.1
-		$isValid = mktime(0, 0, 0, $curPage['month'], $curPage['day'], $curPage['year']);
-		if ($curPage['day'] > 31 || !$isValid || $isValid == -1)
+		$isValid = checkdate($curPage['month'], $curPage['day'], $curPage['year']);
+		if (!$isValid)
 			fatal_lang_error('invalid_day', false);
 	}
 
@@ -144,7 +205,9 @@ function CalendarMain()
 	);
 
 	// Load up the main view.
-	if ($context['view_week'])
+	if ($context['calendar_view'] == 'view_list')
+		$context['calendar_grid_main'] = getCalendarList($curPage['start_date'], $curPage['end_date'], $calendarOptions);
+	elseif ($context['calendar_view'] == 'view_week')
 		$context['calendar_grid_main'] = getCalendarWeek($curPage['month'], $curPage['year'], $curPage['day'], $calendarOptions);
 	else
 		$context['calendar_grid_main'] = getCalendarGrid($curPage['month'], $curPage['year'], $calendarOptions);
@@ -178,7 +241,8 @@ function CalendarMain()
 	$context['blocks_disabled'] = !empty($modSettings['cal_disable_prev_next']) ? 1 : 0;
 
 	// Set the page title to mention the month or week, too
-	$context['page_title'] .= ' - ' . ($context['view_week'] ? $context['calendar_grid_main']['week_title'] : $txt['months'][$context['current_month']] . ' ' . $context['current_year']);
+	if ($context['calendar_view'] != 'view_list')
+		$context['page_title'] .= ' - ' . ($context['calendar_view'] == 'view_week' ? $context['calendar_grid_main']['week_title'] : $txt['months'][$context['current_month']] . ' ' . $context['current_year']);
 
 	// Load up the linktree!
 	$context['linktree'][] = array(
@@ -191,7 +255,7 @@ function CalendarMain()
 		'name' => $txt['months'][$context['current_month']] . ' ' . $context['current_year']
 	);
 	// If applicable, add the current week to the linktree.
-	if ($context['view_week'])
+	if ($context['calendar_view'] == 'view_week')
 		$context['linktree'][] = array(
 			'url' => $scripturl . '?action=calendar;viewweek;year=' . $context['current_year'] . ';month=' . $context['current_month'] . ';day=' . $context['current_day'],
 			'name' => $context['calendar_grid_main']['week_title'],

--- a/Sources/Calendar.php
+++ b/Sources/Calendar.php
@@ -112,7 +112,7 @@ function CalendarMain()
 		$context['calendar_view'] = $modSettings['calendar_default_view'];
 
 	// Don't let search engines index the non-default calendar pages
-	if (!empty($context[$modSettings['calendar_default_view']]))
+	if ($context$context['calendar_view'] !== $modSettings['calendar_default_view'])
 		$context['robot_no_index'] = true;
 
 	// Get the current day of month...

--- a/Sources/ManageCalendar.php
+++ b/Sources/ManageCalendar.php
@@ -338,6 +338,7 @@ function ModifyCalendarSettings($return_config = false)
 				array('permissions', 'calendar_edit_any'),
 			'',
 				// How many days to show on board index, and where to display events etc?
+				array('select', 'calendar_default_view', array('view_list' => $txt['setting_cal_view_list'], 'view_month' => $txt['setting_cal_view_month']), 'view_week' => $txt['setting_cal_view_week'])),
 				array('int', 'cal_days_for_index', 6, 'postinput' => $txt['days_word']),
 				array('select', 'cal_showholidays', array(0 => $txt['setting_cal_show_never'], 1 => $txt['setting_cal_show_cal'], 3 => $txt['setting_cal_show_index'], 2 => $txt['setting_cal_show_all'])),
 				array('select', 'cal_showbdays', array(0 => $txt['setting_cal_show_never'], 1 => $txt['setting_cal_show_cal'], 3 => $txt['setting_cal_show_index'], 2 => $txt['setting_cal_show_all'])),

--- a/Sources/ManageCalendar.php
+++ b/Sources/ManageCalendar.php
@@ -338,7 +338,7 @@ function ModifyCalendarSettings($return_config = false)
 				array('permissions', 'calendar_edit_any'),
 			'',
 				// How many days to show on board index, and where to display events etc?
-				array('select', 'calendar_default_view', array('view_list' => $txt['setting_cal_view_list'], 'view_month' => $txt['setting_cal_view_month']), 'view_week' => $txt['setting_cal_view_week'])),
+				array('select', 'calendar_default_view', array('view_list' => $txt['setting_cal_view_list'], 'view_month' => $txt['setting_cal_view_month'], 'view_week' => $txt['setting_cal_view_week'])),
 				array('int', 'cal_days_for_index', 6, 'postinput' => $txt['days_word']),
 				array('select', 'cal_showholidays', array(0 => $txt['setting_cal_show_never'], 1 => $txt['setting_cal_show_cal'], 3 => $txt['setting_cal_show_index'], 2 => $txt['setting_cal_show_all'])),
 				array('select', 'cal_showbdays', array(0 => $txt['setting_cal_show_never'], 1 => $txt['setting_cal_show_cal'], 3 => $txt['setting_cal_show_index'], 2 => $txt['setting_cal_show_all'])),

--- a/Sources/Subs-Calendar.php
+++ b/Sources/Subs-Calendar.php
@@ -677,7 +677,7 @@ function getCalendarList($start_date, $end_date, $calendarOptions)
 	loadJavaScriptFile('jquery.timepicker.min.js', array('defer' => true), 'smf_timepicker');
 	loadJavaScriptFile('datepair.min.js', array('defer' => true), 'smf_datepair');
 	addInlineJavaScript('
-	$("#event_time_input .date_input").datepicker({
+	$("#calendar_range .date_input").datepicker({
 		dateFormat: "yy-mm-dd",
 		autoSize: true,
 		isRTL: ' . ($context['right_to_left'] ? 'true' : 'false') . ',
@@ -696,7 +696,7 @@ function getCalendarList($start_date, $end_date, $calendarOptions)
 		prevText: "' . $txt['prev_month'] . '",
 		nextText: "' . $txt['next_month'] . '",
 	});
-	var date_entry = document.getElementById("event_time_input");
+	var date_entry = document.getElementById("calendar_range");
 	var date_entry_pair = new Datepair(date_entry, {
 		dateClass: "date_input",
 		autoclose: true,

--- a/Themes/default/Calendar.template.php
+++ b/Themes/default/Calendar.template.php
@@ -93,7 +93,7 @@ function template_show_upcoming_list($grid_name)
 	}
 
 	// Give the user some controls to work with
-	template_caledar_top($calendar_data);
+	template_calendar_top($calendar_data);
 
 	// First, list any events
 	if (!empty($calendar_data['events']))
@@ -295,7 +295,7 @@ function template_show_month_grid($grid_name, $is_mini = false)
 
 	// Show the controls on main grids
 	if ($is_mini === false)
-		template_caledar_top($calendar_data);
+		template_calendar_top($calendar_data);
 
 	// Finally, the main calendar table.
 	echo '<table class="calendar_table">';
@@ -573,7 +573,7 @@ function template_show_week_grid($grid_name)
 				</div>';
 
 			// Show the controls
-			template_caledar_top($calendar_data);
+			template_calendar_top($calendar_data);
 		}
 
 		// Our actual month...
@@ -726,7 +726,7 @@ function template_show_week_grid($grid_name)
  *
  * @param array $calendar_data The data for the calendar grid that this is for
  */
-function template_caledar_top($calendar_data)
+function template_calendar_top($calendar_data)
 {
 	global $context, $scripturl, $txt;
 

--- a/Themes/default/Calendar.template.php
+++ b/Themes/default/Calendar.template.php
@@ -571,10 +571,10 @@ function template_show_week_grid($grid_name)
 					echo '
 					</h3>
 				</div>';
-		}
 
-		// Show the controls
-		template_caledar_top($calendar_data);
+			// Show the controls
+			template_caledar_top($calendar_data);
+		}
 
 		// Our actual month...
 		echo '

--- a/Themes/default/css/calendar.css
+++ b/Themes/default/css/calendar.css
@@ -8,6 +8,7 @@
 	box-shadow: none;
 	border-radius: 0;
 	box-sizing: content-box;
+	margin: 0;
 }
 /* Used to indicate the current day in the grid. */
 #main_grid .calendar_today span.day_text,
@@ -168,14 +169,17 @@ td.days:hover {
 }
 #main_grid tr:not(.days_wrapper) th,
 #main_grid tr:not(.days_wrapper) td {
-    min-height: 30px;
+	min-height: 30px;
 }
-#main_grid td.calendar_base {
-	background: #e7eaef;
-	text-align: center;
+.calendar_top .input_text {
+	width: 80px;
 }
+#calendar_range,
 #calendar_navigation {
-    margin-top: 8px;
+	padding: 5px 0;
+	text-align: center;
+	max-width: 50%;
+	margin: auto;
 }
 #main_grid .act_day {
 	font-size: 12pt;
@@ -209,10 +213,12 @@ span.hidelink {
 }
 #view_button {
 	margin-top: -2px;
+	margin-left: inherit;
 }
-/* Cheat and match this to the submit button. */
+#main_grid .buttonrow,
 #main_grid .buttonlist {
-	margin: 0 12px 0 0;
+	margin: 5px 0;
+	padding: 0
 }
 #month_grid .compact {
 	padding: 2px;
@@ -333,13 +339,26 @@ span.hidelink {
 		font-size: 1em;
 		text-decoration: underline;
 	}
-	#main_grid .buttonlist {
-		margin: 2px;
-		padding: 0;
+}
+
+@media (max-width: 639px) {
+	.calendar_top {
+		padding: 12px 8px;
 	}
+	#calendar_range,
 	#calendar_navigation {
-		float: left;
-		margin: 3px 2px;
-		padding: 0;
+		max-width: none;
+	}
+}
+@media (max-width: 539px) {
+	#calendar_range {
+		clear: both;
+		padding: 10px 0 0;
+	}
+}
+@media (max-width: 479px) {
+	#calendar_navigation {
+		clear: both;
+		padding: 10px 0 0;
 	}
 }

--- a/Themes/default/css/index.css
+++ b/Themes/default/css/index.css
@@ -944,7 +944,7 @@ img.sort, .sort {
 
 /* Styles for the standard button lists.
 ------------------------------------------------------- */
-.buttonlist {
+.buttonlist, .buttonrow {
 	z-index: 100;
 	padding: 5px 0 5px 0;
 	margin: 5px 0 5px 0;
@@ -993,6 +993,21 @@ img.sort, .sort {
 }
 .button.last {
 	margin-top: 9px;
+}
+/* In a .buttonrow, the buttons are joined together */
+.buttonrow {
+	margin-left: 5px;
+}
+.buttonrow .button {
+	display: table-cell;
+}
+.buttonrow .button:not(:first-child) {
+	border-top-left-radius: 0;
+	border-bottom-left-radius: 0;
+}
+.buttonrow .button:not(:last-child) {
+	border-top-right-radius: 0;
+	border-bottom-right-radius: 0;
 }
 
 /* Styles for the general looks of the theme.

--- a/Themes/default/languages/ManageCalendar.english.php
+++ b/Themes/default/languages/ManageCalendar.english.php
@@ -27,6 +27,10 @@ $txt['setting_cal_minyear'] = 'Minimum year';
 $txt['setting_cal_maxyear'] = 'Maximum year';
 $txt['setting_cal_maxspan'] = 'Max number of days an event can span';
 $txt['setting_cal_showInTopic'] = 'Show linked events in topic display';
+$txt['setting_calendar_default_view'] = 'Default view on calendar page';
+$txt['setting_cal_view_list'] = 'List view';
+$txt['setting_cal_view_month'] = 'Month view';
+$txt['setting_cal_view_week'] = 'Week view';
 
 $txt['setting_cal_display_type'] = 'Cell Display Type';
 $txt['setting_cal_display_comfortable'] = 'Comfortable';

--- a/Themes/default/languages/index.english.php
+++ b/Themes/default/languages/index.english.php
@@ -530,6 +530,7 @@ $txt['calendar_linked_events'] = 'Linked Events';
 $txt['calendar_click_all'] = 'click to see all %1$s';
 $txt['calendar_allday'] = 'All day';
 $txt['calendar_timezone'] = 'Time zone';
+$txt['calendar_list'] = 'List';
 
 $txt['movetopic_change_subject'] = 'Change the topic\'s subject';
 $txt['movetopic_new_subject'] = 'New subject';


### PR DESCRIPTION
Think of this PR as an addendum to #3530. It adds a list view to the calendar, so that the user can view the calendar in list, month, or week formats. [Live demo](http://stovell.noip.me/~jon/dev/index.php?action=calendar;viewlist;year=2017;month=1;day=5)

The list view is somewhat similar to the compact "Upcoming Calendar" block in the info centre on the board index, but it gives more fulsome info and lets the user specify date ranges that they want to view.

The main changes are:

- A couple new functions to gather and assemble calendar info for display on the list view
- A new UI screen to show the list view
- The date selection dropdown and post event button have been moved from the bottom to the top (just below the title bar), and buttons to switch between list, month, and week views have been added
- To allow the user to switch between list, month, and week views, the calendar action now handles `viewlist`, `viewmonth`, and `viewweek` URL parameters. (Previously, it only handled the presence or absence of `viewweek`.) If none of these are specified, the default is list view (since, IMHO, the list view is more helpful for the sort of things a forum calendar is used for).

