### PR TITLE
Database error "not exist: real_name_high"

### DIFF
--- a/Sources/Memberlist.php
+++ b/Sources/Memberlist.php
@@ -305,7 +305,7 @@ function MLAll()
 	if ($use_cache && $_REQUEST['sort'] === 'real_name' && !isset($_REQUEST['desc']))
 	{
 		$first_offset = $_REQUEST['start'] - ($_REQUEST['start'] % $cache_step_size);
-		$second_offset = ceil(($_REQUEST['start'] + $modSettings['defaultMaxMembers']) / $cache_step_size) * $cache_step_size;
+		$second_offset = floor(($_REQUEST['start'] + $modSettings['defaultMaxMembers']) / $cache_step_size) * $cache_step_size;
 
 		$where = 'mem.real_name BETWEEN {string:real_name_low} AND {string:real_name_high}';
 		$query_parameters['real_name_low'] = $memberlist_cache['index'][$first_offset];


### PR DESCRIPTION
Error message on Member list, default sort, last page:

http://my-forum.de/index.php?action=mlist;sort=real_name;start=13980
The database value you're trying to insert does not exist: real_name_high
Function: MLAll File: [smfRootFolder]/Sources/Memberlist.php
Line: 382

Run on smf V2.0.12