### PR TITLE
Fixed option "show shildren"

### DIFF
--- a/Themes/default/MessageIndex.template.php
+++ b/Themes/default/MessageIndex.template.php
@@ -26,7 +26,7 @@ function template_main()
 			</div>';
 	}
 
-	if (!empty($context['boards']) && (!empty($options['show_children']) || $context['start'] == 0))
+	if (!empty($context['boards']) && (!empty($options['show_children']) && $context['start'] == 0))
 	{
 		echo '
 	<div id="board_', $context['current_board'], '_childboards" class="boardindex_table">


### PR DESCRIPTION
Option "show shildren", It does not work because operation logic OR (||), and I change OR (||) to AND (&&).

Topic: http://www.simplemachines.org/community/index.php?topic=551289.0

Signed-off-by: José jsdotx3@gmail.com