### PR TITLE
Better Coding Style for curl class

### DIFF
--- a/Sources/Class-CurlFetchWeb.php
+++ b/Sources/Class-CurlFetchWeb.php
@@ -57,6 +57,41 @@ class curl_fetch_web_data
 		CURLOPT_SSL_VERIFYHOST	=> 0, // stop cURL from verifying the peer's host
 		CURLOPT_POST			=> 0, // no post data unless its passed
 	);
+	
+	/**
+	 * @var int Maximum number of redirects
+	 */
+	public $max_redirect;
+	
+	/**
+	 * @var array An array of cURL options
+	 */
+	public $user_options = array();
+	
+	/**
+	 * @var array Any post data as form name => value
+	 */
+	public $post_data;
+	
+	/**
+	 * @var array An array of cURL options
+	 */
+	public $options;
+	
+	/**
+	 * @var int ???
+	 */
+	public $current_redirect;
+	
+	/**
+	 * @var array Stores responses (url, code, error, headers, body) in the response array
+	 */
+	public $response = array();
+	
+	/**
+	 * @var string The header
+	 */
+	public $headers;
 
 	/**
 	* Start the curl object
@@ -64,7 +99,6 @@ class curl_fetch_web_data
 	*
 	* @param array $options An array of cURL options
 	* @param int $max_redirect Maximum number of redirects
-	* @return void
 	*/
 	public function __construct($options = array(), $max_redirect = 3)
 	{

--- a/Sources/Class-CurlFetchWeb.php
+++ b/Sources/Class-CurlFetchWeb.php
@@ -69,7 +69,7 @@ class curl_fetch_web_data
 	public $user_options = array();
 	
 	/**
-	 * @var array Any post data as form name => value
+	 * @var string Any post data as form name => value
 	 */
 	public $post_data;
 	


### PR DESCRIPTION
Try to remove this findings: https://scrutinizer-ci.com/g/SimpleMachines/SMF2.1/issues/release-2.1/files/Sources/Class-CurlFetchWeb.php?orderField=path&order=asc&fileId=Sources%2FClass-CurlFetchWeb.php&honorSelectedPaths=0

in my eyes the curl class is broken,
three types of options
default_options, user_options and options
but to fix this is not target of this pr.