### PR TITLE
Improves handling of attachment MIME types

### DIFF
--- a/Sources/Attachments.php
+++ b/Sources/Attachments.php
@@ -254,6 +254,11 @@ class Attachments
 			// No errors, YAY!
 			if (empty($errors))
 			{
+				// The reported MIME type of the attachment might not be reliable.
+				// Fortunately, PHP 5.3+ lets us easily verify the real MIME type.
+				if (function_exists('mime_content_type'))
+					$_FILES['attachment']['type'][$n] = mime_content_type($_FILES['attachment']['tmp_name'][$n]);
+
 				$_SESSION['temp_attachments'][$attachID] = array(
 					'name' => $smcFunc['htmlspecialchars'](basename($_FILES['attachment']['name'][$n])),
 					'tmp_name' => $destName,

--- a/Sources/Subs-Attachments.php
+++ b/Sources/Subs-Attachments.php
@@ -424,6 +424,11 @@ function processAttachments()
 		$destName = $context['attach_dir'] . '/' . $attachID;
 		if (empty($errors))
 		{
+			// The reported MIME type of the attachment might not be reliable.
+			// Fortunately, PHP 5.3+ lets us easily verify the real MIME type.
+			if (function_exists('mime_content_type'))
+				$_FILES['attachment']['type'][$n] = mime_content_type($_FILES['attachment']['tmp_name'][$n]);
+
 			$_SESSION['temp_attachments'][$attachID] = array(
 				'name' => $smcFunc['htmlspecialchars'](basename($_FILES['attachment']['name'][$n])),
 				'tmp_name' => $destName,

--- a/other/install_2-1_mysql.sql
+++ b/other/install_2-1_mysql.sql
@@ -44,7 +44,7 @@ CREATE TABLE {$db_prefix}attachments (
   downloads MEDIUMINT UNSIGNED NOT NULL DEFAULT '0',
   width MEDIUMINT UNSIGNED NOT NULL DEFAULT '0',
   height MEDIUMINT UNSIGNED NOT NULL DEFAULT '0',
-  mime_type VARCHAR(20) NOT NULL DEFAULT '',
+  mime_type VARCHAR(128) NOT NULL DEFAULT '',
   approved TINYINT NOT NULL DEFAULT '1',
   PRIMARY KEY (id_attach),
   UNIQUE idx_id_member (id_member, id_attach),

--- a/other/install_2-1_postgresql.sql
+++ b/other/install_2-1_postgresql.sql
@@ -152,7 +152,7 @@ CREATE TABLE {$db_prefix}attachments (
   downloads int NOT NULL default '0',
   width int NOT NULL default '0',
   height int NOT NULL default '0',
-  mime_type varchar(20) NOT NULL default '',
+  mime_type varchar(128) NOT NULL default '',
   approved smallint NOT NULL default '1',
   PRIMARY KEY (id_attach)
 );

--- a/other/upgrade_2-1_mysql.sql
+++ b/other/upgrade_2-1_mysql.sql
@@ -183,6 +183,11 @@ INSERT INTO {$db_prefix}settings (variable, value) VALUES ('defaultMaxListItems'
 --- Updating legacy attachments...
 /******************************************************************************/
 
+---# Adding more space to the mime_type column.
+ALTER TABLE {$db_prefix}attachments
+CHANGE `mime_type` `mime_type` VARCHAR(128) NOT NULL;
+---#
+
 ---# Converting legacy attachments.
 ---{
 // Need to know a few things first.

--- a/other/upgrade_2-1_postgresql.sql
+++ b/other/upgrade_2-1_postgresql.sql
@@ -163,6 +163,11 @@ INSERT INTO {$db_prefix}settings (variable, value) VALUES ('defaultMaxListItems'
 --- Updating legacy attachments...
 /******************************************************************************/
 
+---# Adding more space to the mime_type column.
+ALTER TABLE {$db_prefix}attachments
+CHANGE `mime_type` `mime_type` VARCHAR(128) NOT NULL;
+---#
+
 ---# Converting legacy attachments.
 ---{
 


### PR DESCRIPTION
Since SMF 2.1 requires PHP 5.3 as a minimum, we can use mime_content_type() to better identify an attachment's MIME type.

Also, a MIME type string can be up to 128 characters long, so this updates the length of the mime_types column in the attachments table to accommodate that.