### PR TITLE
More RSS improvements

### DIFF
--- a/Sources/News.php
+++ b/Sources/News.php
@@ -579,14 +579,8 @@ function dumpTags($data, $i, $tag = null, $xml_format = '', $forceCdataKeys = ar
 		if ($key === null || ($val === null && $attrs === null))
 			continue;
 
-		// If the value should maybe be CDATA, do that now.
-		if (!is_array($val) && in_array($key, $keysToCdata))
-		{
-			$forceCdata = in_array($key, $forceCdataKeys);
-			$ns = !empty($nsKeys[$key]) ? $nsKeys[$key] : '';
-
-			$val = cdata_parse($val, $ns, $forceCdata);
-		}
+		$forceCdata = in_array($key, $forceCdataKeys);
+		$ns = !empty($nsKeys[$key]) ? $nsKeys[$key] : '';
 
 		// First let's indent!
 		echo "\n", str_repeat("\t", $i);
@@ -618,10 +612,10 @@ function dumpTags($data, $i, $tag = null, $xml_format = '', $forceCdataKeys = ar
 			}
 			// A string with returns in it.... show this as a multiline element.
 			elseif (strpos($val, "\n") !== false)
-				echo "\n", fix_possible_url($val), "\n", str_repeat("\t", $i);
+				echo "\n", in_array($key, $keysToCdata) ? cdata_parse(fix_possible_url($val), $ns, $forceCdata) : fix_possible_url($val), "\n", str_repeat("\t", $i);
 			// A simple string.
 			else
-				echo fix_possible_url($val);
+				echo in_array($key, $keysToCdata) ? cdata_parse(fix_possible_url($val), $ns, $forceCdata) : fix_possible_url($val);
 
 			// Ending tag.
 			echo '</', $key, '>';

--- a/Sources/News.php
+++ b/Sources/News.php
@@ -360,7 +360,7 @@ function ShowXmlFeed()
 	<icon>' . $feed_meta['icon'] . '</icon>' : '',
 	!empty($feed_meta['author']) ? '
 	<author>
-		<name>', $feed_meta['author'], '</name>
+		<name>' . $feed_meta['author'] . '</name>
 	</author>' : '',
 	!empty($feed_meta['rights']) ? '
 	<rights>' . $feed_meta['rights'] . '</rights>' : '';
@@ -687,7 +687,7 @@ function getXmlMembers($xml_format)
 		elseif ($xml_format == 'rdf')
 			$data[] = array(
 				'tag' => 'item',
-				'attributes' => array('rdf:about' => $scripturl . '?action=profile;u=' . $row['id_member'])),
+				'attributes' => array('rdf:about' => $scripturl . '?action=profile;u=' . $row['id_member']),
 				'content' => array(
 					array(
 						'tag' => 'dc:format',
@@ -940,7 +940,7 @@ function getXmlNews($xml_format)
 		{
 			$data[] = array(
 				'tag' => 'item',
-				'attributes' => array('rdf:about' => $scripturl . '?topic=' . $row['id_topic'] . '.0')),
+				'attributes' => array('rdf:about' => $scripturl . '?topic=' . $row['id_topic'] . '.0'),
 				'content' => array(
 					array(
 						'tag' => 'dc:format',
@@ -1350,7 +1350,7 @@ function getXmlRecent($xml_format)
 		{
 			$data[] = array(
 				'tag' => 'item',
-				'attributes' => array('rdf:about' => $scripturl . '?topic=' . $row['id_topic'] . '.msg' . $row['id_msg'] . '#msg' . $row['id_msg'])),
+				'attributes' => array('rdf:about' => $scripturl . '?topic=' . $row['id_topic'] . '.msg' . $row['id_msg'] . '#msg' . $row['id_msg']),
 				'content' => array(
 					array(
 						'tag' => 'dc:format',
@@ -1654,7 +1654,7 @@ function getXmlProfile($xml_format)
 	{
 		$data[] = array(
 			'tag' => 'item',
-			'attributes' => array('rdf:about' => $scripturl . '?action=profile;u=' . $profile['id'])),
+			'attributes' => array('rdf:about' => $scripturl . '?action=profile;u=' . $profile['id']),
 			'content' => array(
 				array(
 					'tag' => 'dc:format',


### PR DESCRIPTION
I found a few final improvements to make. Mostly just some bulletproofing.

- Fixes two small bugs in fix_possible_url()
	- Now fixes URLs anywhere in the string, not just at the start
	- Passes the correct delimiter character to preg_quote()
- Enforces consistent sanitization for all element attributes and values
- Ensures required feed elements are not empty
- Adds default support for icons and copyright notices to RSS and Atom feeds, because why not?
- Consolidates a few stray bits of redundant code