### PR TITLE
Fix issues with attachment critical error processing

### DIFF
--- a/Sources/Attachments.php
+++ b/Sources/Attachments.php
@@ -331,10 +331,11 @@ class Attachments
 				'mime_type' => isset($attachment['type']) ? $attachment['type'] : '',
 				'id_folder' => isset($attachment['id_folder']) ? $attachment['id_folder'] : $modSettings['currentAttachmentUploadDir'],
 				'approved' => !$modSettings['postmod_active'] || allowedTo('post_attachment'),
-				'errors' => $attachment['errors'],
+				'errors' => array(),
 			);
 
 			if (empty($attachment['errors']))
+			{	
 				if (createAttachment($attachmentOptions))
 				{
 					// Avoid JS getting confused.
@@ -349,13 +350,13 @@ class Attachments
 					if ($this->_msg)
 						assignAttachments($_SESSION['already_attached'], $this->_msg);
 				}
-
-			elseif (!empty($attachmentOptions['errors']))
+			}
+			else
 			{
 				// Sort out the errors for display and delete any associated files.
 				$log_these = array('attachments_no_create', 'attachments_no_write', 'attach_timeout', 'ran_out_of_space', 'cant_access_upload_path', 'attach_0_byte_file');
 
-				foreach ($attachmentOptions['errors'] as $error)
+				foreach ($attachment['errors'] as $error)
 				{
 					$attachmentOptions['errors'][] = vsprintf($txt['attach_warning'], $attachment['name']);
 


### PR DESCRIPTION
Addresses some of the issues noted here: Attachments - orphaned file issues #3827

Specifically, these issues are addressed:
(2) Set your max attachment directory space to something low like 4000K. Add a bunch of attachments & exceed this. Upload what you can, & press Post.
2A - It will not log a critical error or notify the administrators that the directory is full.
2B - It will leave post_tmp* files in your file system. The only way to remove these files is at the file system level. They are not visible when using "Browse Files" and they are not cleaned up when you run the Attachment Integrity Check.
2C - It displays the wrong errors to the user - it will use the 'internal' errors, not the user friendly translated errors. E.g., the error will state "ran_out_of_space".