### PR TITLE
Fixes Javascript Error in WYSIWYG mode

### DIFF
--- a/Themes/default/GenericControls.template.php
+++ b/Themes/default/GenericControls.template.php
@@ -83,9 +83,12 @@ function template_control_richedit($editor_id, $smileyContainer = null, $bbcCont
 					}';
 		}
 		else
+		{
 			echo ',
 					emoticons:
-					{}';
+					{},
+					emoticonsEnabled:false';
+		}
 
 		if ($context['show_bbc'] && $bbcContainer !== null)
 		{

--- a/Themes/default/GenericControls.template.php
+++ b/Themes/default/GenericControls.template.php
@@ -83,12 +83,10 @@ function template_control_richedit($editor_id, $smileyContainer = null, $bbcCont
 					}';
 		}
 		else
-		{
 			echo ',
 					emoticons:
 					{},
 					emoticonsEnabled:false';
-		}
 
 		if ($context['show_bbc'] && $bbcContainer !== null)
 		{


### PR DESCRIPTION
If 'No Smileys' is selected in Theme Setting and the sceditor is in WYSIWYG mode, Javascript error occurs in Chrome browser when entering any text into the editor. 

Setting emoticonsEnabled option to false can fix the error.