### PR TITLE
Remove php close tag

### DIFF
--- a/Packages/backups/index.php
+++ b/Packages/backups/index.php
@@ -5,5 +5,3 @@ if (file_exists(dirname(dirname(__FILE__)) . '/index.php'))
 	include (dirname(dirname(__FILE__)) . '/index.php');
 else
 	exit;
-
-?>

--- a/Packages/index.php
+++ b/Packages/index.php
@@ -14,5 +14,3 @@ if (file_exists(dirname(dirname(__FILE__)) . '/Settings.php'))
 // Can't find it... just forget it.
 else
 	exit;
-
-?>

--- a/SSI.php
+++ b/SSI.php
@@ -2354,5 +2354,3 @@ function ssi_recentAttachments($num_attachments = 10, $attachment_ext = array(),
 	echo '
 		</table>';
 }
-
-?>

--- a/Smileys/aaron/index.php
+++ b/Smileys/aaron/index.php
@@ -5,5 +5,3 @@ if (file_exists(dirname(dirname(__FILE__)) . '/index.php'))
 	include (dirname(dirname(__FILE__)) . '/index.php');
 else
 	exit;
-
-?>

--- a/Smileys/akyhne/index.php
+++ b/Smileys/akyhne/index.php
@@ -5,5 +5,3 @@ if (file_exists(dirname(dirname(__FILE__)) . '/index.php'))
 	include (dirname(dirname(__FILE__)) . '/index.php');
 else
 	exit;
-
-?>

--- a/Smileys/default/index.php
+++ b/Smileys/default/index.php
@@ -5,5 +5,3 @@ if (file_exists(dirname(dirname(__FILE__)) . '/index.php'))
 	include (dirname(dirname(__FILE__)) . '/index.php');
 else
 	exit;
-
-?>

--- a/Smileys/fugue/index.php
+++ b/Smileys/fugue/index.php
@@ -5,5 +5,3 @@ if (file_exists(dirname(dirname(__FILE__)) . '/index.php'))
 	include (dirname(dirname(__FILE__)) . '/index.php');
 else
 	exit;
-
-?>

--- a/Smileys/index.php
+++ b/Smileys/index.php
@@ -14,5 +14,3 @@ if (file_exists(dirname(dirname(__FILE__)) . '/Settings.php'))
 // Can't find it... just forget it.
 else
 	exit;
-
-?>

--- a/Sources/Admin.php
+++ b/Sources/Admin.php
@@ -961,5 +961,3 @@ function AdminEndSession()
 
 	redirectexit();
 }
-
-?>

--- a/Sources/Attachments.php
+++ b/Sources/Attachments.php
@@ -441,5 +441,3 @@ class Attachments
 		die;
 	}
 }
-
-?>

--- a/Sources/BoardIndex.php
+++ b/Sources/BoardIndex.php
@@ -142,5 +142,3 @@ function BoardIndex()
 		loadCSSFile('slider.min.css', array(), 'smf_jquery_slider');
 	}
 }
-
-?>

--- a/Sources/Calendar.php
+++ b/Sources/Calendar.php
@@ -760,5 +760,3 @@ function clock()
 			}
 	}
 }
-
-?>

--- a/Sources/Class-BrowserDetect.php
+++ b/Sources/Class-BrowserDetect.php
@@ -444,5 +444,3 @@ class browser_detector
 		);
 	}
 }
-
-?>

--- a/Sources/Class-CurlFetchWeb.php
+++ b/Sources/Class-CurlFetchWeb.php
@@ -343,5 +343,3 @@ class curl_fetch_web_data
 		return strlen($header);
 	}
 }
-
-?>

--- a/Sources/Class-Graphics.php
+++ b/Sources/Class-Graphics.php
@@ -700,5 +700,3 @@ if (!function_exists('smf_crc32'))
 {
 	require_once $sourcedir . '/Subs-Compat.php';
 }
-
-?>

--- a/Sources/Class-Package.php
+++ b/Sources/Class-Package.php
@@ -1201,5 +1201,3 @@ class ftp_connection
 		return true;
 	}
 }
-
-?>

--- a/Sources/Class-SearchAPI.php
+++ b/Sources/Class-SearchAPI.php
@@ -225,5 +225,3 @@ abstract class search_api implements search_api_interface
 	{
 	}
 }
-
-?>

--- a/Sources/Class-TOTP.php
+++ b/Sources/Class-TOTP.php
@@ -351,5 +351,3 @@ class Auth
 		return 'https://chart.googleapis.com/chart?chs=200x200&chld=M|0&cht=qr&chl=' . $urlencoded;
 	}
 }
-
-?>

--- a/Sources/DbExtra-mysql.php
+++ b/Sources/DbExtra-mysql.php
@@ -411,5 +411,3 @@ function smf_db_get_engine()
 
 	return 'MySQL';
 }
-
-?>

--- a/Sources/DbExtra-postgresql.php
+++ b/Sources/DbExtra-postgresql.php
@@ -314,5 +314,3 @@ function smf_db_get_engine()
 {
 	return 'PostgreSQL';
 }
-
-?>

--- a/Sources/DbPackages-mysql.php
+++ b/Sources/DbPackages-mysql.php
@@ -739,5 +739,3 @@ function smf_db_create_query_column($column)
 	// Now just put it together!
 	return '`' . $column['name'] . '` ' . $type . ' ' . (!empty($unsigned) ? $unsigned : '') . (!empty($column['null']) ? '' : 'NOT NULL') . ' ' . $default;
 }
-
-?>

--- a/Sources/DbPackages-postgresql.php
+++ b/Sources/DbPackages-postgresql.php
@@ -840,5 +840,3 @@ function smf_db_list_indexes($table_name, $detail = false, $parameters = array()
 
 	return $indexes;
 }
-
-?>

--- a/Sources/DbSearch-mysql.php
+++ b/Sources/DbSearch-mysql.php
@@ -73,5 +73,3 @@ function smf_db_create_word_search($size)
 		)
 	);
 }
-
-?>

--- a/Sources/DbSearch-postgresql.php
+++ b/Sources/DbSearch-postgresql.php
@@ -149,5 +149,3 @@ function smf_db_create_word_search($size)
 		)
 	);
 }
-
-?>

--- a/Sources/Display.php
+++ b/Sources/Display.php
@@ -1887,5 +1887,3 @@ function QuickInTopicModeration()
 
 	redirectexit(!empty($topicGone) ? 'board=' . $board : 'topic=' . $topic . '.' . $_REQUEST['start']);
 }
-
-?>

--- a/Sources/Drafts.php
+++ b/Sources/Drafts.php
@@ -838,5 +838,3 @@ function showPMDrafts($memID = -1)
 		'name' => $txt['drafts'],
 	);
 }
-
-?>

--- a/Sources/Errors.php
+++ b/Sources/Errors.php
@@ -543,5 +543,3 @@ function send_http_status($code)
 	else
 		header($protocol . ' ' . $code . ' ' . $statuses[$code]);
 }
-
-?>

--- a/Sources/Groups.php
+++ b/Sources/Groups.php
@@ -773,5 +773,3 @@ function list_getGroupRequests($start, $items_per_page, $sort, $where, $where_pa
 
 	return $group_requests;
 }
-
-?>

--- a/Sources/Help.php
+++ b/Sources/Help.php
@@ -165,5 +165,3 @@ function ShowAdminHelp()
 	if (preg_match('~%([0-9]+\$)?s\?~', $context['help_text'], $match))
 		$context['help_text'] = sprintf($context['help_text'], $scripturl, $context['session_id'], $context['session_var']);
 }
-
-?>

--- a/Sources/Likes.php
+++ b/Sources/Likes.php
@@ -684,5 +684,3 @@ function BookOfUnknown()
 
 	obExit(false);
 }
-
-?>

--- a/Sources/Load.php
+++ b/Sources/Load.php
@@ -3512,5 +3512,3 @@ function set_avatar_data($data = array())
 			'url' => '',
 		);
 }
-
-?>

--- a/Sources/LogInOut.php
+++ b/Sources/LogInOut.php
@@ -865,5 +865,3 @@ function validatePasswordFlood($id_member, $password_flood_value = false, $was_c
 	updateMemberData($id_member, array('passwd_flood' => $was_correct && $number_tries == 1 ? '' : $time_stamp . '|' . $number_tries));
 
 }
-
-?>

--- a/Sources/Logging.php
+++ b/Sources/Logging.php
@@ -535,5 +535,3 @@ function logActions($logs)
 
 	return $id_action;
 }
-
-?>

--- a/Sources/ManageAttachments.php
+++ b/Sources/ManageAttachments.php
@@ -2809,5 +2809,3 @@ function TransferAttachments()
 
 	redirectexit('action=admin;area=manageattachments;sa=maintenance#transfer');
 }
-
-?>

--- a/Sources/ManageBans.php
+++ b/Sources/ManageBans.php
@@ -2375,5 +2375,3 @@ function getMemberData($id)
 
 	return $suggestions;
 }
-
-?>

--- a/Sources/ManageBoards.php
+++ b/Sources/ManageBoards.php
@@ -898,5 +898,3 @@ function EditBoardSettings($return_config = false)
 	// Prepare the settings...
 	prepareDBSettingContext($config_vars);
 }
-
-?>

--- a/Sources/ManageCalendar.php
+++ b/Sources/ManageCalendar.php
@@ -413,5 +413,3 @@ function ModifyCalendarSettings($return_config = false)
 	// Prepare the settings...
 	prepareDBSettingContext($config_vars);
 }
-
-?>

--- a/Sources/ManageErrors.php
+++ b/Sources/ManageErrors.php
@@ -426,5 +426,3 @@ function ViewFile()
 	$context['sub_template'] = 'show_file';
 
 }
-
-?>

--- a/Sources/ManageLanguages.php
+++ b/Sources/ManageLanguages.php
@@ -1383,5 +1383,3 @@ function cleanLangString($string, $to_display = true)
 
 	return $new_string;
 }
-
-?>

--- a/Sources/ManageMail.php
+++ b/Sources/ManageMail.php
@@ -484,5 +484,3 @@ function time_since($time_diff)
 	else
 		return sprintf($time_diff == 1 ? $txt['mq_second'] : $txt['mq_seconds'], $time_diff);
 }
-
-?>

--- a/Sources/ManageMaintenance.php
+++ b/Sources/ManageMaintenance.php
@@ -2284,5 +2284,3 @@ function get_hook_info_from_raw($rawData)
 
 	return $hookData;
 }
-
-?>

--- a/Sources/ManageMembergroups.php
+++ b/Sources/ManageMembergroups.php
@@ -1245,5 +1245,3 @@ function ModifyMembergroupsettings()
 
 	prepareDBSettingContext($config_vars);
 }
-
-?>

--- a/Sources/ManageMembers.php
+++ b/Sources/ManageMembers.php
@@ -1284,5 +1284,3 @@ function jeffsdatediff($old)
 	// Divide out the seconds in a day to get the number of days.
 	return ceil($dis / (24 * 60 * 60));
 }
-
-?>

--- a/Sources/ManageNews.php
+++ b/Sources/ManageNews.php
@@ -1108,5 +1108,3 @@ function ModifyNewsSettings($return_config = false)
 
 	prepareDBSettingContext($config_vars);
 }
-
-?>

--- a/Sources/ManagePaid.php
+++ b/Sources/ManagePaid.php
@@ -1978,5 +1978,3 @@ function loadPaymentGateways()
 
 	return $gateways;
 }
-
-?>

--- a/Sources/ManagePermissions.php
+++ b/Sources/ManagePermissions.php
@@ -2473,5 +2473,3 @@ function ModifyPostModeration()
 
 	createToken('admin-mppm');
 }
-
-?>

--- a/Sources/ManagePosts.php
+++ b/Sources/ManagePosts.php
@@ -422,5 +422,3 @@ function ModifyDraftSettings($return_config = false)
 	// Prepare the settings...
 	prepareDBSettingContext($config_vars);
 }
-
-?>

--- a/Sources/ManageRegistration.php
+++ b/Sources/ManageRegistration.php
@@ -357,5 +357,3 @@ function ModifyRegistrationSettings($return_config = false)
 
 	prepareDBSettingContext($config_vars);
 }
-
-?>

--- a/Sources/ManageScheduledTasks.php
+++ b/Sources/ManageScheduledTasks.php
@@ -629,5 +629,3 @@ function list_getNumTaskLogEntries()
 
 	return $num_entries;
 }
-
-?>

--- a/Sources/ManageSearch.php
+++ b/Sources/ManageSearch.php
@@ -870,5 +870,3 @@ function detectFulltextIndex()
 		}
 	}
 }
-
-?>

--- a/Sources/ManageSearchEngines.php
+++ b/Sources/ManageSearchEngines.php
@@ -1111,5 +1111,3 @@ function recacheSpiderNames()
 
 	updateSettings(array('spider_name_cache' => json_encode($spiders)));
 }
-
-?>

--- a/Sources/ManageServer.php
+++ b/Sources/ManageServer.php
@@ -1320,5 +1320,3 @@ function loadCacheAPIs()
 
 	return $apis;
 }
-
-?>

--- a/Sources/ManageSettings.php
+++ b/Sources/ManageSettings.php
@@ -2271,4 +2271,3 @@ function ModifyAlertsSettings()
 	$context['description'] = $txt['notifications_desc'];
 	$context['sub_template'] = 'alert_configuration';
 }
-?>

--- a/Sources/ManageSmileys.php
+++ b/Sources/ManageSmileys.php
@@ -1995,5 +1995,3 @@ function list_getMessageIcons($start, $items_per_page, $sort)
 
 	return $message_icons;
 }
-
-?>

--- a/Sources/Memberlist.php
+++ b/Sources/Memberlist.php
@@ -706,5 +706,3 @@ function getCustFieldsMList()
 
 	return $cpf;
 }
-
-?>

--- a/Sources/Mentions.php
+++ b/Sources/Mentions.php
@@ -232,5 +232,3 @@ class Mentions
 		return $names;
 	}
 }
-
-?>

--- a/Sources/MessageIndex.php
+++ b/Sources/MessageIndex.php
@@ -1323,5 +1323,3 @@ function QuickModeration()
 
 	redirectexit($redirect_url);
 }
-
-?>

--- a/Sources/ModerationCenter.php
+++ b/Sources/ModerationCenter.php
@@ -2082,5 +2082,3 @@ function ModEndSession()
 
 	redirectexit();
 }
-
-?>

--- a/Sources/Modlog.php
+++ b/Sources/Modlog.php
@@ -647,5 +647,3 @@ function list_getModLogEntries($start, $items_per_page, $sort, $query_string = '
 	// Back we go!
 	return $entries;
 }
-
-?>

--- a/Sources/MoveTopic.php
+++ b/Sources/MoveTopic.php
@@ -729,5 +729,3 @@ function moveTopicConcurrence()
 		fatal_lang_error('topic_already_moved', false, array($topic_link, $board_link));
 	}
 }
-
-?>

--- a/Sources/News.php
+++ b/Sources/News.php
@@ -1810,5 +1810,3 @@ function getXmlProfile($xml_format)
 
 	return $data;
 }
-
-?>

--- a/Sources/Notify.php
+++ b/Sources/Notify.php
@@ -190,5 +190,3 @@ function TopicNotify()
 	else
 		redirectexit('topic=' . $topic . '.' . $_REQUEST['start']);
 }
-
-?>

--- a/Sources/PackageGet.php
+++ b/Sources/PackageGet.php
@@ -780,5 +780,3 @@ function PackageServerRemove()
 
 	redirectexit('action=admin;area=packages;get');
 }
-
-?>

--- a/Sources/Packages.php
+++ b/Sources/Packages.php
@@ -2697,5 +2697,3 @@ function PackageFTPTest()
 		),
 	);
 }
-
-?>

--- a/Sources/PersonalMessage.php
+++ b/Sources/PersonalMessage.php
@@ -4113,5 +4113,3 @@ function isAccessiblePM($pmID, $validFor = 'in_or_outbox')
 		break;
 	}
 }
-
-?>

--- a/Sources/Poll.php
+++ b/Sources/Poll.php
@@ -1005,5 +1005,3 @@ function RemovePoll()
 	// Take the moderator back to the topic.
 	redirectexit('topic=' . $topic . '.' . $_REQUEST['start']);
 }
-
-?>

--- a/Sources/Post.php
+++ b/Sources/Post.php
@@ -2937,5 +2937,3 @@ function JavaScriptModify()
 	else
 		obExit(false);
 }
-
-?>

--- a/Sources/PostModeration.php
+++ b/Sources/PostModeration.php
@@ -809,5 +809,3 @@ function removeMessages($messages, $messageDetails, $current_view = 'replies')
 		}
 	}
 }
-
-?>

--- a/Sources/Printpage.php
+++ b/Sources/Printpage.php
@@ -334,5 +334,3 @@ function PrintTopic()
 	// Set a canonical URL for this page.
 	$context['canonical_url'] = $scripturl . '?topic=' . $topic . '.0';
 }
-
-?>

--- a/Sources/Profile-Actions.php
+++ b/Sources/Profile-Actions.php
@@ -970,5 +970,3 @@ function subscriptions($memID)
 	else
 		$context['sub_template'] = 'user_subscription';
 }
-
-?>

--- a/Sources/Profile-Modify.php
+++ b/Sources/Profile-Modify.php
@@ -4086,5 +4086,3 @@ function tfasetup($memID)
 	else
 		redirectexit('action=profile;area=account;u=' . $memID);
 }
-
-?>

--- a/Sources/Profile-View.php
+++ b/Sources/Profile-View.php
@@ -2950,5 +2950,3 @@ function viewWarning($memID)
 		if ($context['member']['warning'] >= $limit)
 			$context['current_level'] = $limit;
 }
-
-?>

--- a/Sources/Profile.php
+++ b/Sources/Profile.php
@@ -987,5 +987,3 @@ function loadCustomFields($memID, $area = 'summary')
 
 	call_integration_hook('integrate_load_custom_profile_fields', array($memID, $area));
 }
-
-?>

--- a/Sources/QueryString.php
+++ b/Sources/QueryString.php
@@ -676,5 +676,3 @@ function ob_sessrewrite($buffer)
 	// Return the changed buffer.
 	return $buffer;
 }
-
-?>

--- a/Sources/ReCaptcha/RequestMethod/index.php
+++ b/Sources/ReCaptcha/RequestMethod/index.php
@@ -5,5 +5,3 @@ if (file_exists(dirname(dirname(__FILE__)) . '/index.php'))
 	include (dirname(dirname(__FILE__)) . '/index.php');
 else
 	exit;
-
-?>

--- a/Sources/ReCaptcha/index.php
+++ b/Sources/ReCaptcha/index.php
@@ -5,5 +5,3 @@ if (file_exists(dirname(dirname(__FILE__)) . '/index.php'))
 	include (dirname(dirname(__FILE__)) . '/index.php');
 else
 	exit;
-
-?>

--- a/Sources/Recent.php
+++ b/Sources/Recent.php
@@ -1426,5 +1426,3 @@ function UnreadTopics()
 	// Allow helpdesks and bug trackers and what not to add their own unread data (just add a template_layer to show custom stuff in the template!)
  	call_integration_hook('integrate_unread_list');
 }
-
-?>

--- a/Sources/Register.php
+++ b/Sources/Register.php
@@ -861,5 +861,3 @@ function SendActivation()
 	// We're gone!
 	obExit();
 }
-
-?>

--- a/Sources/Reminder.php
+++ b/Sources/Reminder.php
@@ -397,5 +397,3 @@ function SecretAnswer2()
 
 	createToken('login');
 }
-
-?>

--- a/Sources/RemoveTopic.php
+++ b/Sources/RemoveTopic.php
@@ -1518,5 +1518,3 @@ function removeDeleteConcurrence()
 
 	fatal_lang_error('post_already_deleted', false, array($confirm_url));
 }
-
-?>

--- a/Sources/RepairBoards.php
+++ b/Sources/RepairBoards.php
@@ -1865,5 +1865,3 @@ function createSalvageArea()
 	// Restore the user's language.
 	loadLanguage('Admin');
 }
-
-?>

--- a/Sources/ReportToMod.php
+++ b/Sources/ReportToMod.php
@@ -466,5 +466,3 @@ function reportUser($id_member, $reason)
 	// Back to the post we reported!
 	redirectexit('reportsent;action=profile;u=' . $id_member);
 }
-
-?>

--- a/Sources/ReportedContent.php
+++ b/Sources/ReportedContent.php
@@ -542,5 +542,3 @@ function HandleReport()
 	// Done!
 	redirectexit($scripturl . '?action=moderate;area=reported' . $context['report_type']);
 }
-
-?>

--- a/Sources/Reports.php
+++ b/Sources/Reports.php
@@ -1097,5 +1097,3 @@ function setKeys($method = 'rows', $keys = array(), $reverse = false)
 	// Rows or columns?
 	$context['key_method'] = $method == 'rows' ? 'rows' : 'cols';
 }
-
-?>

--- a/Sources/ScheduledTasks.php
+++ b/Sources/ScheduledTasks.php
@@ -1737,5 +1737,3 @@ function scheduled_remove_old_drafts()
 
 	return true;
 }
-
-?>

--- a/Sources/Search.php
+++ b/Sources/Search.php
@@ -2191,5 +2191,3 @@ function searchSort($a, $b)
 
 	return $searchAPI->searchSort($a, $b);
 }
-
-?>

--- a/Sources/SearchAPI-Custom.php
+++ b/Sources/SearchAPI-Custom.php
@@ -299,5 +299,3 @@ class custom_search extends search_api
 		}
 	}
 }
-
-?>

--- a/Sources/SearchAPI-Fulltext.php
+++ b/Sources/SearchAPI-Fulltext.php
@@ -289,5 +289,3 @@ class fulltext_search extends search_api
 		return $ignoreRequest;
 	}
 }
-
-?>

--- a/Sources/SearchAPI-Standard.php
+++ b/Sources/SearchAPI-Standard.php
@@ -28,5 +28,3 @@ class standard_search extends search_api
 		return false;
 	}
 }
-
-?>

--- a/Sources/Security.php
+++ b/Sources/Security.php
@@ -1290,5 +1290,3 @@ function frameOptionsHeader($override = null)
 	header('X-XSS-Protection: 1');
 	header('X-Content-Type-Options: nosniff');
 }
-
-?>

--- a/Sources/Session.php
+++ b/Sources/Session.php
@@ -231,5 +231,3 @@ function sessionGC($max_lifetime)
 
 	return ($smcFunc['db_affected_rows']() == 0 ? false : true);
 }
-
-?>

--- a/Sources/ShowAttachments.php
+++ b/Sources/ShowAttachments.php
@@ -307,4 +307,3 @@ function showAttachment()
 
 	die();
 }
-?>

--- a/Sources/SplitTopics.php
+++ b/Sources/SplitTopics.php
@@ -1769,5 +1769,3 @@ function MergeDone()
 	$context['page_title'] = $txt['merge'];
 	$context['sub_template'] = 'merge_done';
 }
-
-?>

--- a/Sources/Stats.php
+++ b/Sources/Stats.php
@@ -818,5 +818,3 @@ function SMStats()
 	// Die.
 	die('OK');
 }
-
-?>

--- a/Sources/Subs-Admin.php
+++ b/Sources/Subs-Admin.php
@@ -555,5 +555,3 @@ function emailAdmins($template, $replacements = array(), $additional_recipients 
 			sendmail($recipient['email'], $emaildata['subject'], $emaildata['body'], null, $template, $emaildata['is_html'], 1);
 		}
 }
-
-?>

--- a/Sources/Subs-Attachments.php
+++ b/Sources/Subs-Attachments.php
@@ -1280,5 +1280,3 @@ function loadAttachmentContext($id_msg, $attachments)
 
 	return $attachmentData;
 }
-
-?>

--- a/Sources/Subs-Auth.php
+++ b/Sources/Subs-Auth.php
@@ -915,5 +915,3 @@ function hash_benchmark($hashTime = 0.2)
 
 	return $cost;
 }
-
-?>

--- a/Sources/Subs-BoardIndex.php
+++ b/Sources/Subs-BoardIndex.php
@@ -384,5 +384,3 @@ function getBoardIndex($boardIndexOptions)
 
 	return $boardIndexOptions['include_categories'] ? $categories : $this_category;
 }
-
-?>

--- a/Sources/Subs-Boards.php
+++ b/Sources/Subs-Boards.php
@@ -1454,5 +1454,3 @@ function isChildOf($child, $parent)
 
 	return isChildOf($boards[$child]['parent'], $parent);
 }
-
-?>

--- a/Sources/Subs-Calendar.php
+++ b/Sources/Subs-Calendar.php
@@ -1707,5 +1707,3 @@ function removeHolidays($holiday_ids)
 		'calendar_updated' => time(),
 	));
 }
-
-?>

--- a/Sources/Subs-Categories.php
+++ b/Sources/Subs-Categories.php
@@ -250,5 +250,3 @@ function deleteCategories($categories, $moveBoardsTo = null)
 	// Get all boards back into the right order.
 	reorderBoards();
 }
-
-?>

--- a/Sources/Subs-Charset.php
+++ b/Sources/Subs-Charset.php
@@ -588,5 +588,3 @@ function fix_serialized_columns()
 	));
 
 }
-
-?>

--- a/Sources/Subs-Compat.php
+++ b/Sources/Subs-Compat.php
@@ -175,5 +175,3 @@ if (!function_exists('smf_crc32'))
 		return $crc;
 	}
 }
-
-?>

--- a/Sources/Subs-Db-mysql.php
+++ b/Sources/Subs-Db-mysql.php
@@ -919,5 +919,3 @@ function smf_is_resource($result)
 
 	return false;
 }
-
-?>

--- a/Sources/Subs-Db-postgresql.php
+++ b/Sources/Subs-Db-postgresql.php
@@ -921,5 +921,3 @@ function smf_db_escape_wildcard_string($string, $translate_human_wildcards = fal
 
 	return strtr($string, $replacements);
 }
-
-?>

--- a/Sources/Subs-Editor.php
+++ b/Sources/Subs-Editor.php
@@ -2481,5 +2481,3 @@ function AutoSuggest_Search_SMFVersions()
 
 	return $xml_data;
 }
-
-?>

--- a/Sources/Subs-Graphics.php
+++ b/Sources/Subs-Graphics.php
@@ -1156,5 +1156,3 @@ function showLetterImage($letter)
 	// Nothing more to come.
 	die();
 }
-
-?>

--- a/Sources/Subs-List.php
+++ b/Sources/Subs-List.php
@@ -253,5 +253,3 @@ function createList($listOptions)
 	// Make sure the template is loaded.
 	loadTemplate('GenericList');
 }
-
-?>

--- a/Sources/Subs-Membergroups.php
+++ b/Sources/Subs-Membergroups.php
@@ -821,5 +821,3 @@ function list_getMembergroups($start, $items_per_page, $sort, $membergroup_type)
 
 	return $groups;
 }
-
-?>

--- a/Sources/Subs-Members.php
+++ b/Sources/Subs-Members.php
@@ -1522,5 +1522,3 @@ function generateValidationCode()
 
 	return substr(preg_replace('/\W/', '', sha1(microtime() . mt_rand() . $dbRand . $modSettings['rand_seed'])), 0, 10);
 }
-
-?>

--- a/Sources/Subs-MembersOnline.php
+++ b/Sources/Subs-MembersOnline.php
@@ -261,5 +261,3 @@ function trackStatsUsersOnline($total_users_online)
 	if (!empty($settingsToUpdate))
 		updateSettings($settingsToUpdate);
 }
-
-?>

--- a/Sources/Subs-Menu.php
+++ b/Sources/Subs-Menu.php
@@ -302,5 +302,3 @@ function destroyMenu($menu_id = 'last')
 
 	unset($context[$menu_name]);
 }
-
-?>

--- a/Sources/Subs-MessageIndex.php
+++ b/Sources/Subs-MessageIndex.php
@@ -90,5 +90,3 @@ function getBoardList($boardListOptions = array())
 
 	return $return_value;
 }
-
-?>

--- a/Sources/Subs-Notify.php
+++ b/Sources/Subs-Notify.php
@@ -114,5 +114,3 @@ function deleteNotifyPrefs($memID, array $prefs)
 		)
 	);
 }
-
-?>

--- a/Sources/Subs-Package.php
+++ b/Sources/Subs-Package.php
@@ -3271,5 +3271,3 @@ if (!function_exists('smf_crc32'))
 		return $crc;
 	}
 }
-
-?>

--- a/Sources/Subs-Password.php
+++ b/Sources/Subs-Password.php
@@ -293,5 +293,3 @@ namespace PasswordCompat\binary {
 	}
 
 }
-
-?>

--- a/Sources/Subs-Post.php
+++ b/Sources/Subs-Post.php
@@ -2968,5 +2968,3 @@ function spell_suggest($dict, $word)
 		return pspell_suggest($dict, $word);
 	}
 }
-
-?>

--- a/Sources/Subs-Recent.php
+++ b/Sources/Subs-Recent.php
@@ -110,5 +110,3 @@ function cache_getLastPosts($latestPostOptions)
 			}',
 	);
 }
-
-?>

--- a/Sources/Subs-ReportedContent.php
+++ b/Sources/Subs-ReportedContent.php
@@ -673,5 +673,3 @@ function deleteModComment($comment_id)
 	);
 
 }
-
-?>

--- a/Sources/Subs-Sound.php
+++ b/Sources/Subs-Sound.php
@@ -111,5 +111,3 @@ function createWaveFile($word)
 	// Noting more to add.
 	die();
 }
-
-?>

--- a/Sources/Subs-Themes.php
+++ b/Sources/Subs-Themes.php
@@ -585,5 +585,3 @@ function get_file_listing($path, $relative)
 
 	return array_merge($listing1, $listing2);
 }
-
-?>

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -5827,5 +5827,3 @@ function build_regex($strings, $delim = null)
 
 	return $regexes;
 }
-
-?>

--- a/Sources/Subscriptions-PayPal.php
+++ b/Sources/Subscriptions-PayPal.php
@@ -450,5 +450,3 @@ class paypal_payment
 		$smcFunc['db_free_result']($request);
 	}
 }
-
-?>

--- a/Sources/Themes.php
+++ b/Sources/Themes.php
@@ -1979,5 +1979,3 @@ function CopyTemplate()
 
 	$context['sub_template'] = 'copy_template';
 }
-
-?>

--- a/Sources/Topic.php
+++ b/Sources/Topic.php
@@ -153,5 +153,3 @@ function Sticky()
 	// Take them back to the now stickied topic.
 	redirectexit('topic=' . $topic . '.' . $_REQUEST['start'] . ';moderate');
 }
-
-?>

--- a/Sources/ViewQuery.php
+++ b/Sources/ViewQuery.php
@@ -186,5 +186,3 @@ function ViewQuery()
 
 	obExit(false);
 }
-
-?>

--- a/Sources/Who.php
+++ b/Sources/Who.php
@@ -848,5 +848,3 @@ function Credits($in_admin = false)
 		$context['page_title'] = $txt['credits'];
 	}
 }
-
-?>

--- a/Sources/Xml.php
+++ b/Sources/Xml.php
@@ -304,5 +304,3 @@ function warning_preview()
 
 	$context['sub_template'] = 'warning';
 }
-
-?>

--- a/Sources/index.php
+++ b/Sources/index.php
@@ -14,5 +14,3 @@ if (file_exists(dirname(dirname(__FILE__)) . '/Settings.php'))
 // Can't find it... just forget it.
 else
 	exit;
-
-?>

--- a/Sources/minify/data/index.php
+++ b/Sources/minify/data/index.php
@@ -5,5 +5,3 @@ if (file_exists(dirname(dirname(__FILE__)) . '/index.php'))
 	include (dirname(dirname(__FILE__)) . '/index.php');
 else
 	exit;
-
-?>

--- a/Sources/minify/data/js/index.php
+++ b/Sources/minify/data/js/index.php
@@ -5,5 +5,3 @@ if (file_exists(dirname(dirname(__FILE__)) . '/index.php'))
 	include (dirname(dirname(__FILE__)) . '/index.php');
 else
 	exit;
-
-?>

--- a/Sources/minify/index.php
+++ b/Sources/minify/index.php
@@ -5,5 +5,3 @@ if (file_exists(dirname(dirname(__FILE__)) . '/index.php'))
 	include (dirname(dirname(__FILE__)) . '/index.php');
 else
 	exit;
-
-?>

--- a/Sources/minify/path-converter/index.php
+++ b/Sources/minify/path-converter/index.php
@@ -5,5 +5,3 @@ if (file_exists(dirname(dirname(__FILE__)) . '/index.php'))
 	include (dirname(dirname(__FILE__)) . '/index.php');
 else
 	exit;
-
-?>

--- a/Sources/minify/path-converter/src/index.php
+++ b/Sources/minify/path-converter/src/index.php
@@ -5,5 +5,3 @@ if (file_exists(dirname(dirname(__FILE__)) . '/index.php'))
 	include (dirname(dirname(__FILE__)) . '/index.php');
 else
 	exit;
-
-?>

--- a/Sources/minify/src/Exceptions/index.php
+++ b/Sources/minify/src/Exceptions/index.php
@@ -5,5 +5,3 @@ if (file_exists(dirname(dirname(__FILE__)) . '/index.php'))
 	include (dirname(dirname(__FILE__)) . '/index.php');
 else
 	exit;
-
-?>

--- a/Sources/minify/src/index.php
+++ b/Sources/minify/src/index.php
@@ -5,5 +5,3 @@ if (file_exists(dirname(dirname(__FILE__)) . '/index.php'))
 	include (dirname(dirname(__FILE__)) . '/index.php');
 else
 	exit;
-
-?>

--- a/Sources/tasks/ApprovePost-Notify.php
+++ b/Sources/tasks/ApprovePost-Notify.php
@@ -115,5 +115,3 @@ class ApprovePost_Notify_Background extends SMF_BackgroundTask
 		return true;
 	}
 }
-
-?>

--- a/Sources/tasks/ApproveReply-Notify.php
+++ b/Sources/tasks/ApproveReply-Notify.php
@@ -108,5 +108,3 @@ class ApproveReply_Notify_Background extends SMF_BackgroundTask
 		return true;
 	}
 }
-
-?>

--- a/Sources/tasks/Birthday-Notify.php
+++ b/Sources/tasks/Birthday-Notify.php
@@ -132,5 +132,3 @@ class Birthday_Notify_Background extends SMF_BackgroundTask
 		return true;
 	}
 }
-
-?>

--- a/Sources/tasks/Buddy-Notify.php
+++ b/Sources/tasks/Buddy-Notify.php
@@ -56,5 +56,3 @@ class Buddy_Notify_Background extends SMF_BackgroundTask
 		return true;
 	}
 }
-
-?>

--- a/Sources/tasks/CreatePost-Notify.php
+++ b/Sources/tasks/CreatePost-Notify.php
@@ -378,5 +378,3 @@ class CreatePost_Notify_Background extends SMF_BackgroundTask
 		}
 	}
 }
-
-?>

--- a/Sources/tasks/EventNew-Notify.php
+++ b/Sources/tasks/EventNew-Notify.php
@@ -103,5 +103,3 @@ class EventNew_Notify_Background extends SMF_BackgroundTask
 		}
 	}
 }
-
-?>

--- a/Sources/tasks/GroupAct-Notify.php
+++ b/Sources/tasks/GroupAct-Notify.php
@@ -156,5 +156,3 @@ class GroupAct_Notify_Background extends SMF_BackgroundTask
 		return true;
 	}
 }
-
-?>

--- a/Sources/tasks/GroupReq-Notify.php
+++ b/Sources/tasks/GroupReq-Notify.php
@@ -130,5 +130,3 @@ class GroupReq_Notify_Background extends SMF_BackgroundTask
 		return true;
 	}
 }
-
-?>

--- a/Sources/tasks/Likes-Notify.php
+++ b/Sources/tasks/Likes-Notify.php
@@ -121,5 +121,3 @@ class Likes_Notify_Background extends SMF_BackgroundTask
 		return true;
 	}
 }
-
-?>

--- a/Sources/tasks/MemberReport-Notify.php
+++ b/Sources/tasks/MemberReport-Notify.php
@@ -138,5 +138,3 @@ class MemberReport_Notify_Background extends SMF_BackgroundTask
 		return true;
 	}
 }
-
-?>

--- a/Sources/tasks/MemberReportReply-Notify.php
+++ b/Sources/tasks/MemberReportReply-Notify.php
@@ -164,5 +164,3 @@ class MemberReportReply_Notify_Background extends SMF_BackgroundTask
 		return true;
 	}
 }
-
-?>

--- a/Sources/tasks/MsgReport-Notify.php
+++ b/Sources/tasks/MsgReport-Notify.php
@@ -186,5 +186,3 @@ class MsgReport_Notify_Background extends SMF_BackgroundTask
 		return true;
 	}
 }
-
-?>

--- a/Sources/tasks/MsgReportReply-Notify.php
+++ b/Sources/tasks/MsgReportReply-Notify.php
@@ -212,5 +212,3 @@ class MsgReportReply_Notify_Background extends SMF_BackgroundTask
 		return true;
 	}
 }
-
-?>

--- a/Sources/tasks/Register-Notify.php
+++ b/Sources/tasks/Register-Notify.php
@@ -135,5 +135,3 @@ class Register_Notify_Background extends SMF_BackgroundTask
 		return true;
 	}
 }
-
-?>

--- a/Sources/tasks/UpdateTldRegex.php
+++ b/Sources/tasks/UpdateTldRegex.php
@@ -32,5 +32,3 @@ class Update_TLD_Regex extends SMF_BackgroundTask
 		return true;
 	}
 }
-
-?>

--- a/Sources/tasks/index.php
+++ b/Sources/tasks/index.php
@@ -5,5 +5,3 @@ if (file_exists(dirname(dirname(__FILE__)) . '/index.php'))
 	include (dirname(dirname(__FILE__)) . '/index.php');
 else
 	exit;
-
-?>

--- a/Themes/default/Admin.template.php
+++ b/Themes/default/Admin.template.php
@@ -1616,5 +1616,3 @@ function template_admin_quick_search()
 									<input type="submit" name="search_go" id="search_go" value="', $txt['admin_search_go'], '" class="button_submit">
 								</span>';
 }
-
-?>

--- a/Themes/default/BoardIndex.template.php
+++ b/Themes/default/BoardIndex.template.php
@@ -428,5 +428,3 @@ function template_ic_block_online()
 	echo '
 			</p>';
 }
-
-?>

--- a/Themes/default/Calendar.template.php
+++ b/Themes/default/Calendar.template.php
@@ -1208,5 +1208,3 @@ function template_thetime()
 			echo '
 		</table>';
 }
-
-?>

--- a/Themes/default/Display.template.php
+++ b/Themes/default/Display.template.php
@@ -1101,4 +1101,3 @@ function template_quickreply()
 					var oJumpAnchor = "quickreply";
 				</script>';
 }
-?>

--- a/Themes/default/Errors.template.php
+++ b/Themes/default/Errors.template.php
@@ -261,5 +261,3 @@ function template_attachment_errors()
 		</div>
 	</div>';
 }
-
-?>

--- a/Themes/default/GenericControls.template.php
+++ b/Themes/default/GenericControls.template.php
@@ -325,5 +325,3 @@ function template_control_verification($verify_id, $display_type = 'all', $reset
 	if ($display_type == 'single')
 		return true;
 }
-
-?>

--- a/Themes/default/GenericList.template.php
+++ b/Themes/default/GenericList.template.php
@@ -286,5 +286,3 @@ function template_create_list_menu($list_menu, $direction = 'top')
 		</table>';
 	}
 }
-
-?>

--- a/Themes/default/GenericMenu.template.php
+++ b/Themes/default/GenericMenu.template.php
@@ -277,5 +277,3 @@ function template_generic_menu_tabs(&$menu_context)
 
 	}
 }
-
-?>

--- a/Themes/default/Help.template.php
+++ b/Themes/default/Help.template.php
@@ -199,5 +199,3 @@ function template_terms()
 				', $txt['agreement_disabled'], '
 			</div>';
 }
-
-?>

--- a/Themes/default/Likes.template.php
+++ b/Themes/default/Likes.template.php
@@ -98,5 +98,3 @@ function template_generic()
 
 	echo $context['data'];
 }
-
-?>

--- a/Themes/default/Login.template.php
+++ b/Themes/default/Login.template.php
@@ -401,5 +401,3 @@ function template_resend()
 			</div>
 		</form>';
 }
-
-?>

--- a/Themes/default/ManageAttachments.template.php
+++ b/Themes/default/ManageAttachments.template.php
@@ -267,5 +267,3 @@ function template_attachment_paths()
 
 	template_show_list('attach_paths');
 }
-
-?>

--- a/Themes/default/ManageBans.template.php
+++ b/Themes/default/ManageBans.template.php
@@ -323,5 +323,3 @@ function template_ban_edit_trigger()
 		oAddMemberSuggest.registerCallback(\'onBeforeUpdate\', \'onUpdateName\');
 	</script>';
 }
-
-?>

--- a/Themes/default/ManageBoards.template.php
+++ b/Themes/default/ManageBoards.template.php
@@ -701,5 +701,3 @@ function template_confirm_board_delete()
 		</form>
 	</div>';
 }
-
-?>

--- a/Themes/default/ManageCalendar.template.php
+++ b/Themes/default/ManageCalendar.template.php
@@ -82,5 +82,3 @@ function template_edit_holiday()
 		</form>
 	</div>';
 }
-
-?>

--- a/Themes/default/ManageLanguages.template.php
+++ b/Themes/default/ManageLanguages.template.php
@@ -364,5 +364,3 @@ function template_add_language()
 		</form>
 	</div>';
 }
-
-?>

--- a/Themes/default/ManageMail.template.php
+++ b/Themes/default/ManageMail.template.php
@@ -38,5 +38,3 @@ function template_browse()
 	echo '
 	</div>';
 }
-
-?>

--- a/Themes/default/ManageMaintenance.template.php
+++ b/Themes/default/ManageMaintenance.template.php
@@ -608,5 +608,3 @@ function template_convert_msgbody()
 		</div>
 	</div>';
 }
-
-?>

--- a/Themes/default/ManageMembergroups.template.php
+++ b/Themes/default/ManageMembergroups.template.php
@@ -735,5 +735,3 @@ function template_group_request_reason()
 		</form>
 	</div>';
 }
-
-?>

--- a/Themes/default/ManageMembers.template.php
+++ b/Themes/default/ManageMembers.template.php
@@ -297,5 +297,3 @@ function template_admin_browse()
 	echo '
 	</div>';
 }
-
-?>

--- a/Themes/default/ManageNews.template.php
+++ b/Themes/default/ManageNews.template.php
@@ -449,5 +449,3 @@ function template_news_lists()
 
 	template_show_list('news_lists');
 }
-
-?>

--- a/Themes/default/ManagePaid.template.php
+++ b/Themes/default/ManagePaid.template.php
@@ -607,5 +607,3 @@ function template_paid_done()
 		</div>
 	</div>';
 }
-
-?>

--- a/Themes/default/ManagePermissions.template.php
+++ b/Themes/default/ManagePermissions.template.php
@@ -913,5 +913,3 @@ function template_postmod_permissions()
 	echo '
 					</div>';
 }
-
-?>

--- a/Themes/default/ManageScheduledTasks.template.php
+++ b/Themes/default/ManageScheduledTasks.template.php
@@ -114,5 +114,3 @@ function template_edit_scheduled_tasks()
 		</form>
 	</div>';
 }
-
-?>

--- a/Themes/default/ManageSearch.template.php
+++ b/Themes/default/ManageSearch.template.php
@@ -431,5 +431,3 @@ function template_show_spider_stats()
 		</form>
 	</div>';
 }
-
-?>

--- a/Themes/default/ManageSmileys.template.php
+++ b/Themes/default/ManageSmileys.template.php
@@ -474,5 +474,3 @@ function template_editicon()
 		</form>
 	</div>';
 }
-
-?>

--- a/Themes/default/Memberlist.template.php
+++ b/Themes/default/Memberlist.template.php
@@ -189,5 +189,3 @@ function template_search()
 		</div>
 	</form>';
 }
-
-?>

--- a/Themes/default/MessageIndex.template.php
+++ b/Themes/default/MessageIndex.template.php
@@ -436,5 +436,3 @@ function template_topic_legend()
 		</div>
 	</div>';
 }
-
-?>

--- a/Themes/default/ModerationCenter.template.php
+++ b/Themes/default/ModerationCenter.template.php
@@ -682,5 +682,3 @@ function template_warn_template()
 		}
 	</script>';
 }
-
-?>

--- a/Themes/default/MoveTopic.template.php
+++ b/Themes/default/MoveTopic.template.php
@@ -395,5 +395,3 @@ function template_merge_extra_options()
 		</form>
 	</div>';
 }
-
-?>

--- a/Themes/default/Notify.template.php
+++ b/Themes/default/Notify.template.php
@@ -51,5 +51,3 @@ function template_notify_board()
 			</p>
 		</div>';
 }
-
-?>

--- a/Themes/default/Packages.template.php
+++ b/Themes/default/Packages.template.php
@@ -1824,5 +1824,3 @@ function template_action_permissions()
 	</script>';
 
 }
-
-?>

--- a/Themes/default/PersonalMessage.template.php
+++ b/Themes/default/PersonalMessage.template.php
@@ -1958,5 +1958,3 @@ function template_showPMDrafts()
 			<span>', $context['page_index'], '</span>
 		</div>';
 }
-
-?>

--- a/Themes/default/Poll.template.php
+++ b/Themes/default/Poll.template.php
@@ -155,5 +155,3 @@ function template_main()
 		</form>
 	</div>';
 }
-
-?>

--- a/Themes/default/Post.template.php
+++ b/Themes/default/Post.template.php
@@ -1161,5 +1161,3 @@ function template_announcement_send()
 			}
 		</script>';
 }
-
-?>

--- a/Themes/default/Printpage.template.php
+++ b/Themes/default/Printpage.template.php
@@ -215,4 +215,3 @@ function template_print_options()
 		echo '
 			<strong><a href="', $url_text, '">', $txt['print_page_text'], '</a></strong> | <a href="', $url_images, '">', $txt['print_page_images'], '</a>';
 }
-?>

--- a/Themes/default/Profile.template.php
+++ b/Themes/default/Profile.template.php
@@ -3116,4 +3116,3 @@ function template_profile_tfa()
 	echo '
 							</dd>';
 }
-?>

--- a/Themes/default/Recent.template.php
+++ b/Themes/default/Recent.template.php
@@ -350,5 +350,3 @@ function template_replies()
 	if (empty($context['no_topic_listing']))
 		template_topic_legend();
 }
-
-?>

--- a/Themes/default/Register.template.php
+++ b/Themes/default/Register.template.php
@@ -702,5 +702,3 @@ function template_edit_reserved_words()
 			</div>
 		</form>';
 }
-
-?>

--- a/Themes/default/Reminder.template.php
+++ b/Themes/default/Reminder.template.php
@@ -199,5 +199,3 @@ function template_ask()
 </script>';
 
 }
-
-?>

--- a/Themes/default/ReportToMod.template.php
+++ b/Themes/default/ReportToMod.template.php
@@ -97,5 +97,3 @@ function template_main()
 		</form>
 	</div>';
 }
-
-?>

--- a/Themes/default/ReportedContent.template.php
+++ b/Themes/default/ReportedContent.template.php
@@ -578,5 +578,3 @@ function template_viewmemberreport()
 		</form>
 	</div>';
 }
-
-?>

--- a/Themes/default/Reports.template.php
+++ b/Themes/default/Reports.template.php
@@ -236,5 +236,3 @@ function template_print_below()
 	</body>
 </html>';
 }
-
-?>

--- a/Themes/default/Search.template.php
+++ b/Themes/default/Search.template.php
@@ -517,5 +517,3 @@ function template_results()
 		</script>';
 
 }
-
-?>

--- a/Themes/default/Settings.template.php
+++ b/Themes/default/Settings.template.php
@@ -208,5 +208,3 @@ function template_settings()
 		),
 	);
 }
-
-?>

--- a/Themes/default/SplitTopics.template.php
+++ b/Themes/default/SplitTopics.template.php
@@ -222,5 +222,3 @@ function template_select()
 		}
 	</script>';
 }
-
-?>

--- a/Themes/default/Stats.template.php
+++ b/Themes/default/Stats.template.php
@@ -261,5 +261,3 @@ function template_main()
 	</script>';
 	}
 }
-
-?>

--- a/Themes/default/Themes.template.php
+++ b/Themes/default/Themes.template.php
@@ -1231,5 +1231,3 @@ function template_edit_file()
 		</form>
 	</div>';
 }
-
-?>

--- a/Themes/default/Who.template.php
+++ b/Themes/default/Who.template.php
@@ -251,5 +251,3 @@ function template_credits()
 		</div>
 	</div>';
 }
-
-?>

--- a/Themes/default/Xml.template.php
+++ b/Themes/default/Xml.template.php
@@ -455,5 +455,3 @@ function template_generic_xml_recursive($xml_data, $parent_ident, $child_ident, 
 
 	echo "\n", str_repeat("\t", $level), '</', $parent_ident, '>';
 }
-
-?>

--- a/Themes/default/css/index.php
+++ b/Themes/default/css/index.php
@@ -5,5 +5,3 @@ if (file_exists(dirname(dirname(__FILE__)) . '/index.php'))
 	include (dirname(dirname(__FILE__)) . '/index.php');
 else
 	exit;
-
-?>

--- a/Themes/default/fonts/index.php
+++ b/Themes/default/fonts/index.php
@@ -5,5 +5,3 @@ if (file_exists(dirname(dirname(__FILE__)) . '/index.php'))
 	include (dirname(dirname(__FILE__)) . '/index.php');
 else
 	exit;
-
-?>

--- a/Themes/default/fonts/sound/index.php
+++ b/Themes/default/fonts/sound/index.php
@@ -5,5 +5,3 @@ if (file_exists(dirname(dirname(__FILE__)) . '/index.php'))
 	include (dirname(dirname(__FILE__)) . '/index.php');
 else
 	exit;
-
-?>

--- a/Themes/default/images/bbc/index.php
+++ b/Themes/default/images/bbc/index.php
@@ -5,5 +5,3 @@ if (file_exists(dirname(dirname(__FILE__)) . '/index.php'))
 	include (dirname(dirname(__FILE__)) . '/index.php');
 else
 	exit;
-
-?>

--- a/Themes/default/images/icons/index.php
+++ b/Themes/default/images/icons/index.php
@@ -5,5 +5,3 @@ if (file_exists(dirname(dirname(__FILE__)) . '/index.php'))
 	include (dirname(dirname(__FILE__)) . '/index.php');
 else
 	exit;
-
-?>

--- a/Themes/default/images/index.php
+++ b/Themes/default/images/index.php
@@ -5,5 +5,3 @@ if (file_exists(dirname(dirname(__FILE__)) . '/index.php'))
 	include (dirname(dirname(__FILE__)) . '/index.php');
 else
 	exit;
-
-?>

--- a/Themes/default/images/membericons/index.php
+++ b/Themes/default/images/membericons/index.php
@@ -5,5 +5,3 @@ if (file_exists(dirname(dirname(__FILE__)) . '/index.php'))
 	include (dirname(dirname(__FILE__)) . '/index.php');
 else
 	exit;
-
-?>

--- a/Themes/default/images/post/index.php
+++ b/Themes/default/images/post/index.php
@@ -5,5 +5,3 @@ if (file_exists(dirname(dirname(__FILE__)) . '/index.php'))
 	include (dirname(dirname(__FILE__)) . '/index.php');
 else
 	exit;
-
-?>

--- a/Themes/default/images/topic/index.php
+++ b/Themes/default/images/topic/index.php
@@ -5,5 +5,3 @@ if (file_exists(dirname(dirname(__FILE__)) . '/index.php'))
 	include (dirname(dirname(__FILE__)) . '/index.php');
 else
 	exit;
-
-?>

--- a/Themes/default/index.php
+++ b/Themes/default/index.php
@@ -5,5 +5,3 @@ if (file_exists(dirname(dirname(__FILE__)) . '/index.php'))
 	include (dirname(dirname(__FILE__)) . '/index.php');
 else
 	exit;
-
-?>

--- a/Themes/default/index.template.php
+++ b/Themes/default/index.template.php
@@ -619,5 +619,3 @@ function template_maint_warning_below()
 {
 
 }
-
-?>

--- a/Themes/default/languages/Admin.english.php
+++ b/Themes/default/languages/Admin.english.php
@@ -752,5 +752,3 @@ $txt['mention'] = 'Membergroups allowed to mention users';
 $txt['notifications'] = 'Notifications';
 $txt['notify_settings'] = 'Notification Settings';
 $txt['notifications_desc'] = 'This page allows you to set the default notification options for users.';
-
-?>

--- a/Themes/default/languages/Alerts.english.php
+++ b/Themes/default/languages/Alerts.english.php
@@ -42,5 +42,3 @@ $txt['alert_paidsubs_expiring'] = 'Your subscription to <a href="{scripturl}?act
 $txt['alert_buddy_buddy_request'] = '{member_link} added you as their buddy';
 $txt['alert_birthday_msg'] = '{happy_birthday}';
 $txt['alerts_none'] = 'You have no alerts.';
-
-?>

--- a/Themes/default/languages/Drafts.english.php
+++ b/Themes/default/languages/Drafts.english.php
@@ -35,5 +35,3 @@ $txt['drafts_pm_enabled'] = 'Enable the saving of PM drafts';
 $txt['drafts_post_enabled'] = 'Enable the saving of Post drafts';
 $txt['drafts_none'] = 'No Subject';
 $txt['drafts_saved'] = 'Draft was successfully saved';
-
-?>

--- a/Themes/default/languages/Editor.english.php
+++ b/Themes/default/languages/Editor.english.php
@@ -54,5 +54,3 @@ $editortxt['Preformatted Text'] = 'Preformatted Text';
 $editortxt['View source'] = 'View source';
 $editortxt['Pre'] = 'Preformatted text';
 $editortxt['flash'] = 'Insert Flash';
-
-?>

--- a/Themes/default/languages/EmailTemplates.english.php
+++ b/Themes/default/languages/EmailTemplates.english.php
@@ -1060,4 +1060,3 @@ We hope this message brought you cheer, and make it last, until same time same p
 
 {REGARDS}';
 $txtBirthdayEmails['karlbenson2_author'] = '<a href="http://www.simplemachines.org/community/?action=profile;u=63186">karlbenson</a>';
-?>

--- a/Themes/default/languages/Errors.english.php
+++ b/Themes/default/languages/Errors.english.php
@@ -444,4 +444,3 @@ $txt['json_JSON_ERROR_RECURSION'] = 'Json decode error: One or more recursive re
 $txt['json_JSON_ERROR_INF_OR_NAN'] = 'Json decode error: One or more NAN or INF values in the value to be encoded';
 $txt['json_JSON_ERROR_UNSUPPORTED_TYPE'] = 'Json decode error: A value of a type that cannot be encoded was given';
 $txt['json_unknown'] = 'Unknown error';
-?>

--- a/Themes/default/languages/Help.english.php
+++ b/Themes/default/languages/Help.english.php
@@ -616,4 +616,3 @@ $helptxt['force_ssl'] = '<b>Test SSL and HTTPS on your server properly before en
 $helptxt['image_proxy_enabled'] = 'Required for embedding external images when in full SSL';
 $helptxt['image_proxy_secret'] = 'Keep this a secret, protects your forum from hotlinking images. Change it in order to render current hotlinked images useless';
 $helptxt['image_proxy_maxsize'] = 'Maximum image size that the SSL image proxy will cache: bigger images will be not be cached. Cached images are stored in your SMF cache folder, so make sure you have enough free space.';
-?>

--- a/Themes/default/languages/Install.english.php
+++ b/Themes/default/languages/Install.english.php
@@ -262,5 +262,3 @@ $txt['force_ssl_label'] = 'Force SSL throughout the forum';
 $txt['force_ssl_info'] = '<b>Make sure SSL and HTTPS are supported throughout the forum, otherwise your forum may become inaccessible</b>';
 
 $txt['chmod_linux_info'] = 'If you have a shell account, the convenient below command can automatically correct permissions on these files';
-
-?>

--- a/Themes/default/languages/Login.english.php
+++ b/Themes/default/languages/Login.english.php
@@ -139,5 +139,3 @@ $txt['registration_password_no_match'] = 'Passwords do not match';
 $txt['registration_password_valid'] = 'Password is valid';
 
 $txt['registration_errors_occurred'] = 'The following errors were detected in your registration. Please correct them to continue:';
-
-?>

--- a/Themes/default/languages/ManageBoards.english.php
+++ b/Themes/default/languages/ManageBoards.english.php
@@ -98,5 +98,3 @@ $txt['mboards_cancel_moving'] = 'Cancel moving';
 $txt['mboards_move'] = 'move';
 
 $txt['mboards_no_cats'] = 'There are currently no categories or boards configured.';
-
-?>

--- a/Themes/default/languages/ManageCalendar.english.php
+++ b/Themes/default/languages/ManageCalendar.english.php
@@ -71,5 +71,3 @@ $txt['holidays_button_edit'] = 'Edit';
 $txt['holidays_button_remove'] = 'Remove';
 $txt['holidays_no_entries'] = 'There are currently no holidays configured.';
 $txt['every_year'] = 'Every Year';
-
-?>

--- a/Themes/default/languages/ManageMail.english.php
+++ b/Themes/default/languages/ManageMail.english.php
@@ -46,4 +46,3 @@ $txt['mq_mpriority_1'] = 'Very High';
 $txt['birthday_email'] = 'Birthday message to use';
 $txt['birthday_body'] = 'Email body';
 $txt['birthday_subject'] = 'Email subject';
-?>

--- a/Themes/default/languages/ManageMaintenance.english.php
+++ b/Themes/default/languages/ManageMaintenance.english.php
@@ -229,5 +229,3 @@ $txt['zipped_file'] = 'If you want you can create a compressed (zipped) backup.'
 $txt['plain_text'] = 'The best method to backup your database is to create a plain text file, a compressed package may not be completely reliable.';
 $txt['enable_maintenance1'] = 'Due to the size of your forum, it is recommended to place your forum in "maintenance mode" before you start the backup.';
 $txt['enable_maintenance2'] = 'To proceed, due to the size of your forum, please place your forum in "maintenance mode".';
-
-?>

--- a/Themes/default/languages/ManageMembers.english.php
+++ b/Themes/default/languages/ManageMembers.english.php
@@ -134,4 +134,3 @@ $txt['dont_check_for_duplicate'] = 'Don\'t check for duplicates';
 $txt['duplicates'] = 'Duplicates';
 
 $txt['not_activated'] = 'Not activated';
-?>

--- a/Themes/default/languages/ManagePaid.english.php
+++ b/Themes/default/languages/ManagePaid.english.php
@@ -214,5 +214,3 @@ $txt['pending_payments_desc'] = 'This member has attempted to make the following
 $txt['pending_payments_value'] = 'Value';
 $txt['pending_payments_accept'] = 'Accept';
 $txt['pending_payments_remove'] = 'Remove';
-
-?>

--- a/Themes/default/languages/ManagePermissions.english.php
+++ b/Themes/default/languages/ManagePermissions.english.php
@@ -324,5 +324,3 @@ $txt['permissions_post_moderation_group'] = 'Group';
 $txt['auto_approve_topics'] = 'Post new topics, without requiring approval';
 $txt['auto_approve_replies'] = 'Post replies to topics, without requiring approval';
 $txt['auto_approve_attachments'] = 'Post attachments, without requiring approval';
-
-?>

--- a/Themes/default/languages/ManageScheduledTasks.english.php
+++ b/Themes/default/languages/ManageScheduledTasks.english.php
@@ -61,5 +61,3 @@ $txt['scheduled_log_empty_log_confirm'] = 'Are you sure you want to completely c
 
 $txt['scheduled_task_remove_old_drafts'] = 'Remove old drafts';
 $txt['scheduled_task_desc_remove_old_drafts'] = 'Deletes drafts older than the number of days defined in the draft settings in the admin panel.';
-
-?>

--- a/Themes/default/languages/ManageSettings.english.php
+++ b/Themes/default/languages/ManageSettings.english.php
@@ -408,5 +408,3 @@ $txt['tfa_mode_forced_help'] = 'Please enable 2FA in your account in order to be
 $txt['tfa_mode_enabled'] = 'Enabled';
 $txt['tfa_mode_disabled'] = 'Disabled';
 $txt['tfa_mode_subtext'] = 'Allows users to have a second layer of security while logging in, users would need an app like Google Authenticator paired with their account';
-
-?>

--- a/Themes/default/languages/ManageSmileys.english.php
+++ b/Themes/default/languages/ManageSmileys.english.php
@@ -90,4 +90,3 @@ $txt['icons_location_after'] = 'After';
 $txt['icons_filename_all_gif'] = 'All files must be &quot;gif&quot; files';
 $txt['icons_filename_all_png'] = 'All files must be &quot;png&quot; files';
 $txt['icons_no_entries'] = 'There are currently no message icons configured.';
-?>

--- a/Themes/default/languages/Manual.english.php
+++ b/Themes/default/languages/Manual.english.php
@@ -34,4 +34,3 @@ $txt['manual_section_calendar_desc'] = 'Users can keep track of events, holidays
 $txt['manual_section_features_desc'] = 'Here is a list of the most popular features in SMF.';
 
 $txt['agreement_disabled'] = 'Registration agreement disabled';
-?>

--- a/Themes/default/languages/ModerationCenter.english.php
+++ b/Themes/default/languages/ModerationCenter.english.php
@@ -175,4 +175,3 @@ $txt['mc_add_note'] = 'Add';
 $txt['mc_reportedm_ignore_confirm'] = 'Are you sure you wish to ignore further reports about this user\'s profile?\\n\\nThis will turn off further reports for everyone.';
 $txt['mc_reported_members_title'] = 'Reported Members';
 $txt['mc_reported_members_desc'] = 'Allows you to view a list of all users whose profiles have been reported';
-?>

--- a/Themes/default/languages/Modlog.english.php
+++ b/Themes/default/languages/Modlog.english.php
@@ -112,5 +112,3 @@ $txt['modlog_ac_lock_poll'] = 'Locked voting in the poll in &quot;{topic}&quot;'
 $txt['modlog_ac_remove_poll'] = 'Removed the poll from &quot;{topic}&quot;';
 $txt['modlog_ac_reset_poll'] = 'Reset votes in the poll in &quot;{topic}&quot;';
 $txt['modlog_ac_unlock_poll'] = 'Unlocked voting in the poll in &quot;{topic}&quot;';
-
-?>

--- a/Themes/default/languages/Packages.english.php
+++ b/Themes/default/languages/Packages.english.php
@@ -277,5 +277,3 @@ $txt['package_license_default'] = 'Default';
 $txt['package_available_license_language'] = 'Available License Languages:';
 
 $txt['package_chmod_linux'] = 'If you have a shell account, the convenient below command can automatically correct permissions on these files';
-
-?>

--- a/Themes/default/languages/PersonalMessage.english.php
+++ b/Themes/default/languages/PersonalMessage.english.php
@@ -200,5 +200,3 @@ $txt['pm_readable_label'] = 'apply label &quot;{LABEL}&quot;';
 $txt['pm_readable_delete'] = 'delete the message';
 $txt['pm_readable_then'] = '<strong>then</strong>';
 $txt['pm_remove_message'] = 'Remove this message';
-
-?>

--- a/Themes/default/languages/Post.english.php
+++ b/Themes/default/languages/Post.english.php
@@ -208,5 +208,3 @@ $txt['ran_out_of_space'] = 'The upload directory is full. Please contact an admi
 $txt['attachments_no_write'] = 'The attachments upload directory is not writable. Your attachment or avatar cannot be saved.';
 $txt['attachments_no_create'] = 'Unable to create a new attachment directory. Your attachment or avatar cannot be saved.';
 $txt['attachments_limit_per_post'] = 'You may not upload more than %1$d attachments per post';
-
-?>

--- a/Themes/default/languages/Profile.english.php
+++ b/Themes/default/languages/Profile.english.php
@@ -563,4 +563,3 @@ $txt['tfa_preserve'] = 'Remember this computer for 30 days (not recommended on s
 $txt['tfa_backup_code'] = 'Backup code';
 $txt['tfa_backup_desc'] = 'In case you have lost your device or authentication app, you can use the backup code provided to you when 2FA was setup. In case you have lost that as well, please contact the administrator';
 $txt['tfa_wait'] = 'Please wait for about 2 minutes before attempting to log in via 2FA again';
-?>

--- a/Themes/default/languages/Reports.english.php
+++ b/Themes/default/languages/Reports.english.php
@@ -138,5 +138,3 @@ $txt['report_staff_posts'] = 'Posts';
 $txt['report_staff_last_login'] = 'Last Login';
 $txt['report_staff_all_boards'] = 'All boards';
 $txt['report_staff_no_boards'] = 'No boards';
-
-?>

--- a/Themes/default/languages/Search.english.php
+++ b/Themes/default/languages/Search.english.php
@@ -163,5 +163,3 @@ $txt['spider_logs_delete_confirm'] = 'Are you sure you wish to empty out all log
 $txt['spider_stats_select_month'] = 'Jump To Month';
 $txt['spider_stats_page_hits'] = 'Page Hits';
 $txt['spider_stats_no_entries'] = 'There are currently no spider statistics available.';
-
-?>

--- a/Themes/default/languages/Settings.english.php
+++ b/Themes/default/languages/Settings.english.php
@@ -5,5 +5,3 @@ global $settings;
 
 $txt['theme_thumbnail_href'] = $settings['images_url'] . '/thumbnail.png';
 $txt['theme_description'] = 'The default theme from Simple Machines.<br><br>Author: The Simple Machines Team';
-
-?>

--- a/Themes/default/languages/Stats.english.php
+++ b/Themes/default/languages/Stats.english.php
@@ -40,5 +40,3 @@ $txt['ssi_comments'] = 'comments';
 $txt['ssi_write_comment'] = 'Write Comment';
 $txt['ssi_no_guests'] = 'You cannot specify a board that doesn\'t allow guests. Please check the board ID before trying again.';
 $txt['xml_rss_desc'] = 'Live information from ' . $context['forum_name'];
-
-?>

--- a/Themes/default/languages/Themes.english.php
+++ b/Themes/default/languages/Themes.english.php
@@ -153,4 +153,3 @@ $txt['themeadmin_themelist_link'] = 'Show the list of themes';
 /* Open Graph */
 $txt['og_image'] = 'OG Image';
 $txt['og_image_desc'] = 'Link to your Open Graph optimized image, suggested size 175x175px<br><span class="smalltext">You can read more about here <a href="http://ogp.me/">Open Graph</a></span>';
-?>

--- a/Themes/default/languages/Who.english.php
+++ b/Themes/default/languages/Who.english.php
@@ -160,4 +160,3 @@ $txt['credits_groups_orignal_pm'] = 'Original Project Managers';
 
 // List of people who have made more than a token contribution to this translation. (blank for English)
 $txt['translation_credits'] = array();
-?>

--- a/Themes/default/languages/index.english.php
+++ b/Themes/default/languages/index.english.php
@@ -886,4 +886,3 @@ $txt['notify_board_3_desc'] = 'You will receive both alerts and e-mails for this
 $txt['mobile_action'] = 'User actions';
 $txt['mobile_moderation'] = 'Moderation';
 $txt['mobile_user_menu'] = 'Mobile Main Menu';
-?>

--- a/Themes/default/languages/index.php
+++ b/Themes/default/languages/index.php
@@ -5,5 +5,3 @@ if (file_exists(dirname(dirname(__FILE__)) . '/index.php'))
 	include (dirname(dirname(__FILE__)) . '/index.php');
 else
 	exit;
-
-?>

--- a/Themes/default/scripts/index.php
+++ b/Themes/default/scripts/index.php
@@ -5,5 +5,3 @@ if (file_exists(dirname(dirname(__FILE__)) . '/index.php'))
 	include (dirname(dirname(__FILE__)) . '/index.php');
 else
 	exit;
-
-?>

--- a/Themes/index.php
+++ b/Themes/index.php
@@ -12,5 +12,3 @@ if (file_exists(dirname(dirname(__FILE__)) . '/Settings.php'))
 // Can't find it... just forget it.
 else
 	exit;
-
-?>

--- a/attachments/index.php
+++ b/attachments/index.php
@@ -14,5 +14,3 @@ if (file_exists(dirname(dirname(__FILE__)) . '/Settings.php'))
 // Can't find it... just forget it.
 else
 	exit;
-
-?>

--- a/avatars/Oxygen/index.php
+++ b/avatars/Oxygen/index.php
@@ -5,5 +5,3 @@ if (file_exists(dirname(dirname(__FILE__)) . '/index.php'))
 	include (dirname(dirname(__FILE__)) . '/index.php');
 else
 	exit;
-
-?>

--- a/avatars/index.php
+++ b/avatars/index.php
@@ -14,5 +14,3 @@ if (file_exists(dirname(dirname(__FILE__)) . '/Settings.php'))
 // Can't find it... just forget it.
 else
 	exit;
-
-?>

--- a/cache/index.php
+++ b/cache/index.php
@@ -12,5 +12,3 @@ if (file_exists(dirname(dirname(__FILE__)) . '/Settings.php'))
 // Can't find it... just forget it.
 else
 	exit;
-
-?>

--- a/cron.php
+++ b/cron.php
@@ -300,4 +300,3 @@ abstract class SMF_BackgroundTask
 	 */
 	abstract public function execute();
 }
-?>

--- a/custom_avatar/index.php
+++ b/custom_avatar/index.php
@@ -14,5 +14,3 @@ if (file_exists(dirname(dirname(__FILE__)) . '/Settings.php'))
 // Can't find it... just forget it.
 else
 	exit;
-
-?>

--- a/index.php
+++ b/index.php
@@ -389,5 +389,3 @@ function smf_main()
 	// Do the right thing.
 	return call_helper($actionArray[$_REQUEST['action']][1], true);
 }
-
-?>

--- a/other/Settings.php
+++ b/other/Settings.php
@@ -208,5 +208,3 @@ if (!file_exists($sourcedir) && file_exists($boarddir . '/Sources'))
 	$sourcedir = $boarddir . '/Sources';
 if (!file_exists($cachedir) && file_exists($boarddir . '/cache'))
 	$cachedir = $boarddir . '/cache';
-
-?>

--- a/other/install.php
+++ b/other/install.php
@@ -2382,5 +2382,3 @@ function template_delete_install()
 		<br>
 		', $txt['good_luck'];
 }
-
-?>

--- a/other/upgrade.php
+++ b/other/upgrade.php
@@ -4639,5 +4639,3 @@ function MySQLConvertOldIp($targetTable, $oldCol, $newCol, $limit = 50000, $setS
 
 	unset($_GET['a']);
 }
-
-?>

--- a/subscriptions.php
+++ b/subscriptions.php
@@ -317,5 +317,3 @@ function generateSubscriptionError($text)
 
 	exit;
 }
-
-?>


### PR DESCRIPTION
Scrutinizer says:
> It is not recommended to use PHP's closing tag ?> in files other than templates.
>Using a closing tag in PHP files that only contain PHP code is not recommended as you might accidentally add whitespace after the closing tag which would then be output by PHP. This can cause severe problems, for example headers cannot be sent anymore.
>A simple precaution is to leave off the closing tag as it is not required, and it also has no negative effects whatsoever.

From the reason it's sound right to do so.

260 issues are fixed 