### PR TITLE
Adds some travis scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,6 @@ php:
 
 script:
   - if find . -name "*.php" ! -path "./vendor/*" -exec php -l {} 2>&1 \; | grep "syntax error, unexpected"; then exit 1; fi
+  - if php other/buildtools/check-signed-off.php | grep "Error:"; then exit 1; fi
+  - if find . -name "*.php" -exec php other/buildtools/check-smf-license.php {} 2>&1 \; | grep "Error:"; then exit 1; fi
+  - if find . -name "./Themes/default/languages/*.english.php" -exec php other/buildtools/check-smf-langauge.php {} 2>&1 \; | grep "Error:"; then exit 1; fi

--- a/other/buildtools/check-signed-off.php
+++ b/other/buildtools/check-signed-off.php
@@ -11,7 +11,7 @@
  * @version 2.1 Beta 3
  */
 
-$message = shell_exec('git show -s --format=%B ' . $hash . ' | tail -n 1');
+$message = shell_exec('git show -s --format=%B HEAD | tail -n 1');
 $result = stripos($message, 'Signed-off by:');
 if ($result === false)
 	die('Error: Signed-off by not found in commit message');

--- a/other/buildtools/check-signed-off.php
+++ b/other/buildtools/check-signed-off.php
@@ -22,5 +22,5 @@ if ($result === false)
 	// Try 2.
 	$result2 = stripos($lastLine, 'Signed by');
 	if ($result2 === false)
-		die('Error: Signed-off-by not found in commit message [' . $lastLine . ']' . "\n");
+		die('Error: Signed-off-by not found in commit message [' . $lastLine . ']' . '[' . $message . ']' . "\n");
 }

--- a/other/buildtools/check-signed-off.php
+++ b/other/buildtools/check-signed-off.php
@@ -16,6 +16,15 @@ $lines = explode("\n", trim(str_replace("\r", "\n", $message)));
 $lastLine = $lines[count($lines) - 1];
 var_dump($lines);
 
+// Did we find a merge?
+if (preg_match('~Merge ([A-Za-z0-9]{40}) into ([A-Za-z0-9]{40})~i', $lastLine, $merges))
+{
+	echo 'Message contains a merge, trying to find parent [' . $lastLine . ']' . '[' . $message . ']' . "\n";
+	$message = trim(shell_exec('git show -s --format=%B ' . $merges[1]));	
+	$lines = explode("\n", trim(str_replace("\r", "\n", $message)));
+	$lastLine = $lines[count($lines) - 1];
+}
+
 $result = stripos($lastLine, 'Signed-off-by:');
 if ($result === false)
 {

--- a/other/buildtools/check-signed-off.php
+++ b/other/buildtools/check-signed-off.php
@@ -11,7 +11,16 @@
  * @version 2.1 Beta 3
  */
 
-$message = shell_exec('git show -s --format=%B HEAD | tail -n 1');
-$result = stripos($message, 'Signed-off by:');
+$message = trim(shell_exec('git show -s --format=%B HEAD'));
+$lines = explode("\n", trim(str_replace("\r", "\n", $message)));
+$lastLine = $lines[count($lines) - 1];
+var_dump($lines);
+
+$result = stripos($lastLine, 'Signed-off-by:');
 if ($result === false)
-	die('Error: Signed-off by not found in commit message');
+{
+	// Try 2.
+	$result2 = stripos($lastLine, 'Signed by');
+	if ($result2 === false)
+		die('Error: Signed-off-by not found in commit message [' . $lastLine . ']' . "\n");
+}

--- a/other/buildtools/check-signed-off.php
+++ b/other/buildtools/check-signed-off.php
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines http://www.simplemachines.org
+ * @copyright 2017 Simple Machines and individual contributors
+ * @license http://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 2.1 Beta 3
+ */
+
+$message = shell_exec('git show -s --format=%B ' . $hash . ' | tail -n 1');
+$result = stripos($message, 'Signed-off by:');
+if ($result === false)
+	die('Error: Signed-off by not found in commit message');

--- a/other/buildtools/check-smf-languages.php
+++ b/other/buildtools/check-smf-languages.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines http://www.simplemachines.org
+ * @copyright 2017 Simple Machines and individual contributors
+ * @license http://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 2.1 Beta 3
+ */
+
+// Stuff we will ignore.
+$ignoreFiles = array(
+	'./Themes/default/languages/index\.php',
+);
+
+// No file? Thats bad.
+if (!isset($_SERVER['argv'], $_SERVER['argv'][1]))
+	die('Error: No File specified' . "\n");
+
+// The file has to exist.
+$currentFile = $_SERVER['argv'][1];
+if (!file_exists($currentFile))
+	die('Error: File does not exist' . "\n");
+
+// Is this ignored?
+foreach ($ignoreFiles as $if)
+	if (preg_match('~' . $if . '~i', $currentFile))
+		die;
+
+// Lets get the main index.php for $forum_version and $software_year.
+$upgradeFile = fopen('./other/upgrade.php', 'r');
+$upgradeContents = fread($upgradeFile, 500);
+
+if (!preg_match('~define\(\'SMF_LANG_VERSION\', \'([^\']+)\'\);~i', $upgradeContents, $versionResults))
+	die('Error: Could not locate SMF_LANG_VERSION' . "\n");
+$currentVersion = $versionResults[1];
+
+$file = fopen($currentFile, 'r');
+
+$contents = fread($file, 500);
+
+// Just see if the basic match is there.
+$match = '// Version: ' . $currentVersion;
+if (!preg_match('~' . $match . '~i', $contents))
+	die('Error: The version is missing or incorrect in ' . $currentFile . "\n");
+
+// Get the file prefix.
+preg_match('~([A-Za-z]+)\.english\.php~i', $currentFile, $fileMatch);
+if (empty($fileMatch))
+	die('Error: Could not locate locate the file name in ' . $currentFile . "\n");
+
+// Now match that prefix in a more strict mode.
+$match = '// Version: ' . $currentVersion . '; ' . $fileMatch[1];
+if (!preg_match('~' . $match . '~i', $contents))
+	die('Error: The version with file name is missing or incorrect in ' . $currentFile . "\n");

--- a/other/buildtools/check-smf-license.php
+++ b/other/buildtools/check-smf-license.php
@@ -1,0 +1,106 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines http://www.simplemachines.org
+ * @copyright 2017 Simple Machines and individual contributors
+ * @license http://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 2.1 Beta 3
+ */
+
+// Stuff we will ignore.
+$ignoreFiles = array(
+	// Index files.
+	'\./attachments/index\.php',
+	'\./avatars/index\.php',
+	'\./avatars/[A-Za-z0-9]+/index\.php',
+	'\./cache/index\.php',
+	'\./custom_avatar/index\.php',
+	'\./Packages/index\.php',
+	'\./Packages/backups/index\.php',
+	'\./Smileys/[A-Za-z0-9]+/index\.php',
+	'\./Smileys/index\.php',
+	'\./Sources/index\.php',
+	'\./Sources/tasks/index\.php',
+	'\./Themes/default/css/index\.php',
+	'\./Themes/default/fonts/index\.php',
+	'\./Themes/default/fonts/sound/index\.php',
+	'\./Themes/default/images/[A-Za-z0-9]+/index\.php',
+	'\./Themes/default/images/index\.php',
+	'\./Themes/default/index\.php',
+	'\./Themes/default/languages/index\.php',
+	'\./Themes/default/scripts/index\.php',
+	'\./Themes/index\.php',
+
+	// Minify Stuff.
+	'\./Sources/minify/[A-Za-z0-9/-]+\.php',
+
+	// ReCaptcha Stuff.
+	'\./Sources/ReCaptcha/[A-Za-z0-9]+\.php',
+	'\./Sources/ReCaptcha/RequestMethod/[A-Za-z0-9]+\.php',
+
+	// Language Files are ignored as they don't use the License format.
+	'./Themes/default/languages/[A-Za-z0-9]+\.english\.php',
+);
+
+// No file? Thats bad.
+if (!isset($_SERVER['argv'], $_SERVER['argv'][1]))
+	die('Error: No File specified' . "\n");
+
+// The file has to exist.
+$currentFile = $_SERVER['argv'][1];
+if (!file_exists($currentFile))
+	die('Error: File does not exist' . "\n");
+
+// Is this ignored?
+foreach ($ignoreFiles as $if)
+	if (preg_match('~' . $if . '~i', $currentFile))
+		die;
+
+// Lets get the main index.php for $forum_version and $software_year.
+$indexFile = fopen('./index.php', 'r');
+$indexContents = fread($indexFile, 850);
+
+if (!preg_match('~\$forum_version = \'SMF ([^\']+)\';~i', $indexContents, $versionResults))
+	die('Error: Could not locate $forum_version' . "\n");
+$currentVersion = $versionResults[1];
+
+if (!preg_match('~\$software_year = \'(\d{4})\';~i', $indexContents, $yearResults))
+	die('Error: Could not locate $software_year' . "\n");
+$currentSoftwareYear = (int) $yearResults[1];
+
+$file = fopen($currentFile, 'r');
+
+// Some files, *cough* ManageServer *cough* have lots of junk before the license, otherwise this could easily be 500.
+$contents = fread($file, 4000);
+
+// How the license file should look, in a regex type format.
+$match = array( 
+	0 => '\* Simple Machines Forum \(SMF\)' . '[\r]?\n',
+	1 => ' \*' . '[\r]?\n',
+	2 => ' \* @package SMF' . '[\r]?\n',
+	3 => ' \* @author Simple Machines http://www.simplemachines.org' . '[\r]?\n',
+	4 => ' \* @copyright \d{4} Simple Machines and individual contributors' . '[\r]?\n',
+	5 => ' \* @license http://www.simplemachines.org/about/smf/license.php BSD' . '[\r]?\n',
+	6 => ' \*' . '[\r]?\n',
+	7 => ' \* @version',
+);
+
+// Just see if the license is there.
+if (!preg_match('~' . implode('', $match) . '~i', $contents))
+	die('Error: License File is invalid or not found in ' . $currentFile . "\n");
+
+// Check the year is correct.
+$yearMatch = $match;
+$yearMatch[4] = ' \* @copyright ' . $currentSoftwareYear . ' Simple Machines and individual contributors' . '[\r]?\n';
+if (!preg_match('~' . implode('', $yearMatch) . '~i', $contents))
+	die('Error: The software year is incorrect in ' . $currentFile . "\n");
+
+// Check the version is correct.
+$versionMatch = $match;
+$versionMatch[7] = ' \* @version ' . $currentVersion . '[\r]?\n';
+if (!preg_match('~' . implode('', $versionMatch) . '~i', $contents))
+	die('Error: The version is incorrect in ' . $currentFile . "\n");


### PR DESCRIPTION
Add a travis script to check to make sure the commit was signed off
Add a travis script to check to make sure all SMF files contain a valid license/copyright and verify the software version and year from our index.php file.
Add a travis script to check to make sure that our languages have a valid header and version matches the upgrade script

I followed the format of the first travis script and it should exit as the other does if these fail.  These scripts are trying to find some simple checks like versions, copyright years, signed off commits, etc.

Signed-off-by: jdarwood007 <unmonitored+github@sleepycode.com>