### PR TITLE
Don't show the proxy-fied avatar URL when editing the profile

### DIFF
--- a/Sources/Load.php
+++ b/Sources/Load.php
@@ -1279,6 +1279,9 @@ function loadMemberData($users, $is_name = false, $set = 'normal')
 		$new_loaded_ids = array();
 		while ($row = $smcFunc['db_fetch_assoc']($request))
 		{
+			// If the image proxy is enabled, we still want the original URL when they're editing the profile...
+			$row['avatar_original'] = $row['avatar'];
+
 			// Take care of proxying avatar if required, do this here for maximum reach
 			if ($image_proxy_enabled && !empty($row['avatar']) && stripos($row['avatar'], 'http://') !== false)
 				$row['avatar'] = $boardurl . '/proxy.php?request=' . urlencode($row['avatar']) . '&hash=' . md5($row['avatar'] . $image_proxy_secret);

--- a/Sources/Profile-Modify.php
+++ b/Sources/Profile-Modify.php
@@ -2988,11 +2988,12 @@ function profileLoadAvatarData()
 		);
 		$context['member']['avatar']['href'] = empty($cur_profile['attachment_type']) ? $scripturl . '?action=dlattach;attach=' . $cur_profile['id_attach'] . ';type=avatar' : $modSettings['custom_avatar_url'] . '/' . $cur_profile['filename'];
 	}
+	// Use "avatar_original" here so we show what the user entered even if the image proxy is enabled
 	elseif ((stristr($cur_profile['avatar'], 'http://') || stristr($cur_profile['avatar'], 'https://')) && $context['member']['avatar']['allow_external'])
 		$context['member']['avatar'] += array(
 			'choice' => 'external',
 			'server_pic' => 'blank.png',
-			'external' => $cur_profile['avatar']
+			'external' => $cur_profile['avatar_original']
 		);
 	elseif ($cur_profile['avatar'] != '' && file_exists($modSettings['avatar_directory'] . '/' . $cur_profile['avatar']) && $context['member']['avatar']['allow_server_stored'])
 		$context['member']['avatar'] += array(


### PR DESCRIPTION
When the image proxy is enabled, SMF rewrites avatar URLs as necessary as soon as the user data is loaded. However, this causes the proxy-fied URL to show up in the avatar URL field later on when you go to edit your profile. While there's not really a security risk with this, it's not user-friendly and might cause some confusion. This change adds an extra "avatar_original" item in the user data array that stores the URL prior to it being rewritten, so we can use that in the profile instead (at least for display purposes).

Signed-off-by: Michael Eshom <oldiesmann@oldiesmann.us>