### PR TITLE
Clean up after old UTF-8 languages

### DIFF
--- a/other/upgrade.php
+++ b/other/upgrade.php
@@ -908,7 +908,7 @@ function checkLogin()
 // Step 1: Do the maintenance and backup.
 function UpgradeOptions()
 {
-	global $db_prefix, $command_line, $modSettings, $is_debug, $smcFunc, $packagesdir, $tasksdir;
+	global $db_prefix, $command_line, $modSettings, $is_debug, $smcFunc, $packagesdir, $tasksdir, $language;
 	global $boarddir, $boardurl, $sourcedir, $maintenance, $cachedir, $upcontext, $db_type, $db_server, $db_last_error;
 
 	$upcontext['sub_template'] = 'upgrade_options';
@@ -1093,6 +1093,10 @@ function UpgradeOptions()
 	// Add support for $tasksdir var.
 	if (empty($tasksdir))
 		$changes['tasksdir'] = '\'' . fixRelativePath($sourcedir) . '/tasks\'';
+
+	// Make sure we fix the language as well.
+	if (stristr($language, '-utf8'))
+		$changes['language'] = str_ireplace('-utf8', '', $language);
 
 	// @todo Maybe change the cookie name if going to 1.1, too?
 

--- a/other/upgrade_2-1_mysql.sql
+++ b/other/upgrade_2-1_mysql.sql
@@ -2506,3 +2506,30 @@ ADD COLUMN timezone VARCHAR(80);
 ALTER TABLE {$db_prefix}calendar
 ADD COLUMN location VARCHAR(255) NOT NULL DEFAULT '';
 ---#
+
+/******************************************************************************/
+--- Cleaning up after old UTF-8 languages
+/******************************************************************************/
+---# Update the forum language list
+---(
+	$langlist = json_decode($modSettings['langList'], true);
+	$newlangs = array();
+
+	// Strip "-utf8" from any languages and change them to regular if necessary
+	foreach($langlist as $internal => $external)
+	{
+		// Make sure we won't end up with a duplicate here...
+		if (!array_key_exists(str_ireplace('-utf8', '', $internal), $newlangs))
+		{
+			$newlangs[str_ireplace('-utf8', '', $internal)] = str_ireplace(' UTF-8', '', $external);
+		}
+	}
+
+	updateSettings(array('langList' => json_encode($newlangs)));
+---}
+---#
+
+---# Update the members' languages
+UPDATE {$db__prefix}memberes
+SET lngfile = REPLACE(lngfile, '-utf8', '');
+---#

--- a/other/upgrade_2-1_postgresql.sql
+++ b/other/upgrade_2-1_postgresql.sql
@@ -2268,3 +2268,30 @@ CREATE INDEX {$db_prefix}log_comments_comment_type ON {$db_prefix}log_comments (
 ---# drop column pm_email_notify on table members
 ALTER TABLE {$db_prefix}members DROP COLUMN IF EXISTS pm_email_notify;
 ---#
+
+/******************************************************************************/
+--- Cleaning up after old UTF-8 languages
+/******************************************************************************/
+---# Update the forum language list
+---(
+	$langlist = json_decode($modSettings['langList'], true);
+	$newlangs = array();
+
+	// Strip "-utf8" from any languages and change them to regular if necessary
+	foreach($langlist as $internal => $external)
+	{
+		// Make sure we won't end up with a duplicate here...
+		if (!array_key_exists(str_ireplace('-utf8', '', $internal), $newlangs))
+		{
+			$newlangs[str_ireplace('-utf8', '', $internal)] = str_ireplace(' UTF-8', '', $external);
+		}
+	}
+
+	updateSettings(array('langList' => json_encode($newlangs)));
+---}
+---#
+
+---# Update the members' languages
+UPDATE {$db__prefix}memberes
+SET lngfile = REPLACE(lngfile, '-utf8', '');
+---#


### PR DESCRIPTION
This commit focuses on cleaning up language things for forums that were converted to UTF-8 prior to upgrading to 2.1. Specifically, it does three things:
1. Update the default forum language (dropping "-utf8" from the name)
2. Update the list of installed languages (dropping "-utf8" from the internal name and " UTF-8" from the external name, while also accounting for the possibility that the "regular" version of at least one language is already installed)
3. Update the language for each user (dropping "-utf8" from the language name)

Signed-off-by: Michael Eshom <oldiesmann@oldiesmann.us>