### PR TITLE
Clear out attachment info for new posts

### DIFF
--- a/Sources/Post.php
+++ b/Sources/Post.php
@@ -187,13 +187,7 @@ function Post($post_errors = array())
 
 	// An array to hold all the attachments for this topic.
 	$context['current_attachments'] = array();
-
-	// If there are attachments already uploaded, pass them to the current attachments array.
-	if (!empty($_SESSION['already_attached']))
-	{
-		require_once($sourcedir . '/Subs-Attachments.php');
-		$context['current_attachments'] = getRawAttachInfo($_SESSION['already_attached']);
-	}
+	unset($_SESSION['already_attached']);
 
 	// Don't allow a post if it's locked and you aren't all powerful.
 	if ($locked && !allowedTo('moderate_board'))


### PR DESCRIPTION
Deal with first issue in Attachments - orphaned file issues #3827
Basically when starting a new post clear out prior attachment info.
When posts are abandoned, there may be spurious info in there, & it's confusing to start a new post & see content in there.  