### PR TITLE
Drop handling of old "-utf8" languages from getLanguages()

### DIFF
--- a/Sources/ManageLanguages.php
+++ b/Sources/ManageLanguages.php
@@ -505,7 +505,7 @@ function ModifyLanguages()
 		checkSession();
 		validateToken('admin-lang');
 
-		getLanguages(true, false);
+		getLanguages();
 		$lang_exists = false;
 		foreach ($context['languages'] as $lang)
 		{
@@ -636,7 +636,7 @@ function ModifyLanguages()
  */
 function list_getNumLanguages()
 {
-	return count(getLanguages(true, false));
+	return count(getLanguages());
 }
 
 /**
@@ -658,7 +658,7 @@ function list_getLanguages()
 
 	// Override these for now.
 	$settings['actual_theme_dir'] = $settings['base_theme_dir'] = $settings['default_theme_dir'];
-	getLanguages(true, false);
+	getLanguages();
 
 	// Put them back.
 	$settings['actual_theme_dir'] = $backup_actual_theme_dir;
@@ -743,10 +743,10 @@ function ModifyLanguageSettings($return_config = false)
 	if ($return_config)
 		return $config_vars;
 
-	// Get our languages. No cache and use utf8.
-	getLanguages(false, false);
+	// Get our languages. No cache
+	getLanguages(false);
 	foreach ($context['languages'] as $lang)
-		$config_vars['language'][4][$lang['filename']] = array($lang['filename'], strtr($lang['name'], array('-utf8' => ' (UTF-8)')));
+		$config_vars['language'][4][$lang['filename']] = array($lang['filename'], $lang['name']);
 
 	// Saving settings?
 	if (isset($_REQUEST['save']))
@@ -928,7 +928,6 @@ function ModifyLanguage()
 		if (!empty($modSettings['cache_enable']))
 		{
 			cache_put_data('known_languages', null, !empty($modSettings['cache_enable']) && $modSettings['cache_enable'] < 1 ? 86400 : 3600);
-			cache_put_data('known_languages_all', null, !empty($modSettings['cache_enable']) && $modSettings['cache_enable'] < 1 ? 86400 : 3600);
 		}
 
 		// Sixth, if we deleted the default language, set us back to english?


### PR DESCRIPTION
Since everything is UTF-8 now, there's no need to specify whether we want to favor UTF-8. This also updates the file-matching regex to prevent matching any "index.language-utf8.php" files just in case there are any still lingering around.

Signed-off-by: Michael Eshom <oldiesmann@oldiesmann.us>