### PR TITLE
Generates the user's theme options list from Settings.template.php

### DIFF
--- a/Sources/Profile-Modify.php
+++ b/Sources/Profile-Modify.php
@@ -1794,6 +1794,9 @@ function theme($memID)
 {
 	global $txt, $context;
 
+	loadTemplate('Settings');
+	loadSubTemplate('options');
+
 	loadThemeOptions($memID);
 	if (allowedTo(array('profile_extra_own', 'profile_extra_any')))
 		loadCustomFields($memID, 'theme');

--- a/Sources/Themes.php
+++ b/Sources/Themes.php
@@ -592,6 +592,10 @@ function SetThemeOptions()
 
 	foreach ($context['options'] as $i => $setting)
 	{
+		// Just skip separators
+		if (!is_array($setting))
+			continue;
+
 		// Is this disabled?
 		if ($setting['id'] == 'calendar_start_day' && empty($modSettings['cal_enabled']))
 		{

--- a/Themes/default/Profile.template.php
+++ b/Themes/default/Profile.template.php
@@ -1632,157 +1632,98 @@ function template_profile_theme_settings()
 {
 	global $context, $modSettings, $txt;
 
-	echo '
-							<dt>
-								<label for="show_children">', $txt['show_children'], '</label>
-							</dt>
-							<dd>
-								<input type="hidden" name="default_options[show_children]" value="0">
-								<input type="checkbox" name="default_options[show_children]" id="show_children" value="1"', !empty($context['member']['options']['show_children']) ? ' checked' : '', ' class="input_check">
-							</dd>
-							<dt>
-								<label for="show_no_avatars">', $txt['show_no_avatars'], '</label>
-							</dt>
-							<dd>
-								<input type="hidden" name="default_options[show_no_avatars]" value="0">
-								<input type="checkbox" name="default_options[show_no_avatars]" id="show_no_avatars" value="1"', !empty($context['member']['options']['show_no_avatars']) ? ' checked' : '', ' class="input_check">
-							</dd>
-							<dt>
-								<label for="show_no_signatures">', $txt['show_no_signatures'], '</label>
-							</dt>
-							<dd>
-								<input type="hidden" name="default_options[show_no_signatures]" value="0">
-								<input type="checkbox" name="default_options[show_no_signatures]" id="show_no_signatures" value="1"', !empty($context['member']['options']['show_no_signatures']) ? ' checked' : '', ' class="input_check">
-							</dd>';
-
-	if (!empty($modSettings['allow_no_censored']))
-		echo '
-							<dt>
-								<label for="show_no_censored">' . $txt['show_no_censored'] . '</label>
-							</dt>
-							<dd>
-								<input type="hidden" name="default_options[show_no_censored]" value="0">
-								<input type="checkbox" name="default_options[show_no_censored]" id="show_no_censored" value="1"' . (!empty($context['member']['options']['show_no_censored']) ? ' checked' : '') . ' class="input_check">
-							</dd>';
-
-	echo '
-							<dt>
-								<label for="return_to_post">', $txt['return_to_post'], '</label>
-							</dt>
-							<dd>
-								<input type="hidden" name="default_options[return_to_post]" value="0">
-								<input type="checkbox" name="default_options[return_to_post]" id="return_to_post" value="1"', !empty($context['member']['options']['return_to_post']) ? ' checked' : '', ' class="input_check">
-							</dd>';
-
-	if (!empty($modSettings['enable_buddylist']))
-		echo '
-							<dt>
-								<label for="posts_apply_ignore_list">', $txt['posts_apply_ignore_list'], '</label>
-							</dt>
-							<dd>
-								<input type="hidden" name="default_options[posts_apply_ignore_list]" value="0">
-								<input type="checkbox" name="default_options[posts_apply_ignore_list]" id="posts_apply_ignore_list" value="1"', !empty($context['member']['options']['posts_apply_ignore_list']) ? ' checked' : '', ' class="input_check">
-							</dd>';
-
-	echo '
-							<dt>
-								<label for="view_newest_first">', $txt['recent_posts_at_top'], '</label>
-							</dt>
-							<dd>
-								<input type="hidden" name="default_options[view_newest_first]" value="0">
-								<input type="checkbox" name="default_options[view_newest_first]" id="view_newest_first" value="1"', !empty($context['member']['options']['view_newest_first']) ? ' checked' : '', ' class="input_check">
-							</dd>';
-
-	// Choose WYSIWYG settings?
-	if (empty($modSettings['disable_wysiwyg']))
-		echo '
-							<dt>
-								<label for="wysiwyg_default">', $txt['wysiwyg_default'], '</label>
-							</dt>
-							<dd>
-								<input type="hidden" name="default_options[wysiwyg_default]" value="0">
-								<input type="checkbox" name="default_options[wysiwyg_default]" id="wysiwyg_default" value="1"', !empty($context['member']['options']['wysiwyg_default']) ? ' checked' : '', ' class="input_check">
-							</dd>';
-
-	if (empty($modSettings['disableCustomPerPage']))
+	foreach ($context['theme_options'] as $i => $setting)
 	{
+		// Is this disabled?
+		if ($setting['id'] == 'calendar_start_day' && empty($modSettings['cal_enabled']))
+			continue;
+		elseif (($setting['id'] == 'topics_per_page' || $setting['id'] == 'messages_per_page') && !empty($modSettings['disableCustomPerPage']))
+			continue;
+		elseif ($setting['id'] == 'show_no_censored' && empty($modSettings['allow_no_censored']))
+			continue;
+		elseif ($setting['id'] == 'posts_apply_ignore_list' && empty($modSettings['enable_buddylist']))
+			continue;
+		elseif ($setting['id'] == 'wysiwyg_default' && !empty($modSettings['disable_wysiwyg']))
+			continue;
+		elseif ($setting['id'] == 'topics_per_page' && !empty($modSettings['disableCustomPerPage']))
+			continue;
+		elseif ($setting['id'] == 'drafts_autosave_enabled' && (empty($modSettings['drafts_autosave_enabled']) || (empty($modSettings['drafts_post_enabled']) && empty($modSettings['drafts_pm_enabled']))))
+			continue;
+		elseif ($setting['id'] == 'drafts_show_saved_enabled' && (empty($modSettings['drafts_show_saved_enabled']) || (empty($modSettings['drafts_post_enabled']) && empty($modSettings['drafts_pm_enabled']))))
+			continue;
+
+		if (!isset($setting['type']) || $setting['type'] == 'bool')
+			$setting['type'] = 'checkbox';
+		elseif ($setting['type'] == 'int' || $setting['type'] == 'integer')
+			$setting['type'] = 'number';
+		elseif ($setting['type'] == 'string')
+			$setting['type'] = 'text';
+
+		if (isset($setting['options']))
+			$setting['type'] = 'list';
+
 		echo '
-							<dt>
-								<label for="topics_per_page">', $txt['topics_per_page'], '</label>
-							</dt>
-							<dd>
-								<select name="default_options[topics_per_page]" id="topics_per_page">
-									<option value="0"', empty($context['member']['options']['topics_per_page']) ? ' selected' : '', '>', $txt['per_page_default'], ' (', $modSettings['defaultMaxTopics'], ')</option>
-									<option value="5"', !empty($context['member']['options']['topics_per_page']) && $context['member']['options']['topics_per_page'] == 5 ? ' selected' : '', '>5</option>
-									<option value="10"', !empty($context['member']['options']['topics_per_page']) && $context['member']['options']['topics_per_page'] == 10 ? ' selected' : '', '>10</option>
-									<option value="25"', !empty($context['member']['options']['topics_per_page']) && $context['member']['options']['topics_per_page'] == 25 ? ' selected' : '', '>25</option>
-									<option value="50"', !empty($context['member']['options']['topics_per_page']) && $context['member']['options']['topics_per_page'] == 50 ? ' selected' : '', '>50</option>
-								</select>
-							</dd>
-							<dt>
-								<label for="messages_per_page">', $txt['messages_per_page'], '</label>
-							</dt>
-							<dd>
-								<select name="default_options[messages_per_page]" id="messages_per_page">
-									<option value="0"', empty($context['member']['options']['messages_per_page']) ? ' selected' : '', '>', $txt['per_page_default'], ' (', $modSettings['defaultMaxMessages'], ')</option>
-									<option value="5"', !empty($context['member']['options']['messages_per_page']) && $context['member']['options']['messages_per_page'] == 5 ? ' selected' : '', '>5</option>
-									<option value="10"', !empty($context['member']['options']['messages_per_page']) && $context['member']['options']['messages_per_page'] == 10 ? ' selected' : '', '>10</option>
-									<option value="25"', !empty($context['member']['options']['messages_per_page']) && $context['member']['options']['messages_per_page'] == 25 ? ' selected' : '', '>25</option>
-									<option value="50"', !empty($context['member']['options']['messages_per_page']) && $context['member']['options']['messages_per_page'] == 50 ? ' selected' : '', '>50</option>
-								</select>
-							</dd>';
+					<dt>
+						<label for="', $setting['id'], '">', $setting['label'], '</label>';
+			if (isset($setting['description']))
+				echo '
+						<br><span class="smalltext">', $setting['description'], '</span>';
+			echo '
+					</dt>
+					<dd>';
+
+		// display checkbox options
+		if ($setting['type'] == 'checkbox')
+		{
+			echo '
+						<input type="hidden" name="default_options[' . $setting['id'] . ']" value="0">
+						<input type="checkbox" name="default_options[', $setting['id'], ']" id="', $setting['id'], '"', !empty($context['member']['options'][$setting['id']]) ? ' checked' : '', ' value="1" class="input_check">';
+		}
+		// how about selection lists, we all love them
+		elseif ($setting['type'] == 'list')
+		{
+			echo '
+						&nbsp;<select class="floatleft" name="default_options[', $setting['id'], ']" id="', $setting['id'], '"', '>';
+
+			foreach ($setting['options'] as $value => $label)
+			{
+				echo '
+							<option value="', $value, '"', $value == $context['member']['options'][$setting['id']] ? ' selected' : '', '>', $label, '</option>';
+			}
+
+			echo '
+						</select>';
+		}
+		// a textbox it is then
+		else
+		{
+			if (isset($setting['type']) && $setting['type'] == 'number')
+			{
+				$min = isset($setting['min']) ? ' min="' . $setting['min'] . '"' : ' min="0"';
+				$max = isset($setting['max']) ? ' max="' . $setting['max'] . '"' : '';
+				$step = isset($setting['step']) ? ' step="' . $setting['step'] . '"' : '';
+
+				echo '
+						<input type="number"', $min . $max . $step;
+			}
+			else if (isset($setting['type']) && $setting['type'] == 'url')
+			{
+				echo'
+						<input type="url"';
+			}
+			else
+			{
+				echo '
+						<input type="text"';
+			}
+
+			echo ' name="default_options[', $setting['id'], ']" id="', $setting['id'], '" value="', isset($context['member']['options'][$setting['id']]) ? $context['member']['options'][$setting['id']] : $setting['value'], '"', $setting['type'] == 'number' ? ' size="5"' : '', ' class="input_text">';
+		}
+
+		// end of this defintion
+		echo '
+					</dd>';
 	}
-
-	if (!empty($modSettings['cal_enabled']))
-		echo '
-							<dt>
-								<label for="calendar_start_day">', $txt['calendar_start_day'], ':</label>
-							</dt>
-							<dd>
-								<select name="default_options[calendar_start_day]" id="calendar_start_day">
-									<option value="0"', empty($context['member']['options']['calendar_start_day']) ? ' selected' : '', '>', $txt['days'][0], '</option>
-									<option value="1"', !empty($context['member']['options']['calendar_start_day']) && $context['member']['options']['calendar_start_day'] == 1 ? ' selected' : '', '>', $txt['days'][1], '</option>
-									<option value="6"', !empty($context['member']['options']['calendar_start_day']) && $context['member']['options']['calendar_start_day'] == 6 ? ' selected' : '', '>', $txt['days'][6], '</option>
-								</select>
-							</dd>';
-
-	if ((!empty($modSettings['drafts_post_enabled']) || !empty($modSettings['drafts_pm_enabled'])) && !empty($modSettings['drafts_autosave_enabled']))
-		echo '
-							<dt>
-								<label for="drafts_autosave_enabled">', $txt['drafts_autosave_enabled'], '</label>
-							</dt>
-							<dd>
-								<input type="hidden" name="default_options[drafts_autosave_enabled]" value="0">
-								<input type="checkbox" name="default_options[drafts_autosave_enabled]" id="drafts_autosave_enabled" value="1"', !empty($context['member']['options']['drafts_autosave_enabled']) ? ' checked' : '', ' class="input_check">
-							</dd>';
-	if ((!empty($modSettings['drafts_post_enabled']) || !empty($modSettings['drafts_pm_enabled'])) && !empty($modSettings['drafts_show_saved_enabled']))
-		echo '
-							<dt>
-								<label for="drafts_show_saved_enabled">', $txt['drafts_show_saved_enabled'], '</label>
-							</dt>
-							<dd>
-								<input type="hidden" name="default_options[drafts_show_saved_enabled]" value="0">
-								<input type="checkbox" name="default_options[drafts_show_saved_enabled]" id="drafts_show_saved_enabled" value="1"', !empty($context['member']['options']['drafts_show_saved_enabled']) ? ' checked' : '', ' class="input_check">
-							</dd>';
-
-	echo '
-							<dt>
-								<label for="use_editor_quick_reply">', $txt['use_editor_quick_reply'], '</label>
-							</dt>
-							<dd>
-								<input type="hidden" name="default_options[use_editor_quick_reply]" value="0">
-								<input type="checkbox" name="default_options[use_editor_quick_reply]" id="use_editor_quick_reply" value="1"', !empty($context['member']['options']['use_editor_quick_reply']) ? ' checked' : '', ' class="input_check">
-							</dd>
-							<dt>
-								<label for="display_quick_mod">', $txt['display_quick_mod'], ':</label>
-							</dt>
-							<dd>
-								<select name="default_options[display_quick_mod]" id="display_quick_mod">
-									<option value="0"', empty($context['member']['options']['display_quick_mod']) ? ' selected' : '', '>', $txt['display_quick_mod_none'], '</option>
-									<option value="1"', !empty($context['member']['options']['display_quick_mod']) && $context['member']['options']['display_quick_mod'] == 1 ? ' selected' : '', '>', $txt['display_quick_mod_check'], '</option>
-									<option value="2"', !empty($context['member']['options']['display_quick_mod']) && $context['member']['options']['display_quick_mod'] != 1 ? ' selected' : '', '>', $txt['display_quick_mod_image'], '</option>
-								</select>
-							</dd>';
 }
 
 /**

--- a/Themes/default/Profile.template.php
+++ b/Themes/default/Profile.template.php
@@ -1632,8 +1632,34 @@ function template_profile_theme_settings()
 {
 	global $context, $modSettings, $txt;
 
+	$first_option_key = array_shift(array_keys($context['theme_options']));
+	$titled_section = false;
+
 	foreach ($context['theme_options'] as $i => $setting)
 	{
+		// Just spit out separators and move on
+		if (!is_array($setting))
+		{
+			// Insert a separator (unless this is the first item in the list)
+			if ($i !== $first_option_key)
+				echo '
+				</dl>
+				<hr>
+				<dl class="settings flow_auto">';
+
+			// Should we give a name to this section?
+			if (is_string($setting) && !empty($setting))
+			{
+				$titled_section = true;
+				echo '
+					<dt><b>' . $setting . '</b></dt><dd></dd>';
+			}
+			else
+				$titled_section = false;
+
+			continue;
+		}
+
 		// Is this disabled?
 		if ($setting['id'] == 'calendar_start_day' && empty($modSettings['cal_enabled']))
 			continue;
@@ -1664,11 +1690,12 @@ function template_profile_theme_settings()
 
 		echo '
 					<dt>
-						<label for="', $setting['id'], '">', $setting['label'], '</label>';
-			if (isset($setting['description']))
-				echo '
-						<br><span class="smalltext">', $setting['description'], '</span>';
+						<label for="', $setting['id'], '">', !$titled_section ? '<b>' : '', $setting['label'], !$titled_section ? '</b>' : '', '</label>';
+
+		if (isset($setting['description']))
 			echo '
+						<br><span class="smalltext">', $setting['description'], '</span>';
+		echo '
 					</dt>
 					<dd>';
 

--- a/Themes/default/Profile.template.php
+++ b/Themes/default/Profile.template.php
@@ -268,7 +268,7 @@ function template_summary()
 
 	echo '
 		<div id="detailedinfo">
-			<dl>';
+			<dl class="settings">';
 
 	if ($context['user']['is_owner'] || $context['user']['is_admin'])
 		echo '
@@ -308,7 +308,7 @@ function template_summary()
 	if (!empty($context['print_custom_fields']['standard']))
 	{
 		echo '
-				<dl>';
+				<dl class="settings">';
 
 		foreach ($context['print_custom_fields']['standard'] as $field)
 			if (!empty($field['output_html']))
@@ -321,7 +321,7 @@ function template_summary()
 	}
 
 	echo '
-				<dl class="noborder">';
+				<dl class="settings noborder">';
 
 	// Can they view/issue a warning?
 	if ($context['can_view_warning'] && $context['member']['warning'])
@@ -903,7 +903,7 @@ function template_trackActivity()
 	// The last IP the user used.
 	echo '
 		<div id="tracking" class="windowbg2 noup">
-			<dl class="noborder">
+			<dl class="settings noborder">
 				<dt>', $txt['most_recent_ip'], ':
 					', (empty($context['last_ip2']) ? '' : '<br>
 					<span class="smalltext">(<a href="' . $scripturl . '?action=helpadmin;help=whytwoip" onclick="return reqOverlayDiv(this.href);">' . $txt['why_two_ip_address'] . '</a>)</span>'), '
@@ -1385,7 +1385,7 @@ function template_edit_options()
 
 	if (!empty($context['profile_fields']))
 		echo '
-				<dl>';
+				<dl class="settings">';
 
 	// Start the big old loop 'of love.
 	$lastItem = 'hr';
@@ -1401,7 +1401,7 @@ function template_edit_options()
 			echo '
 				</dl>
 				<hr>
-				<dl>';
+				<dl class="settings">';
 		}
 		elseif ($field['type'] == 'callback')
 		{
@@ -1499,7 +1499,7 @@ function template_edit_options()
 				<hr>';
 
 		echo '
-				<dl>';
+				<dl class="settings">';
 
 		foreach ($context['custom_fields'] as $field)
 		{
@@ -1526,7 +1526,7 @@ function template_edit_options()
 	// Only show the password box if it's actually needed.
 	if ($context['require_password'])
 		echo '
-				<dl>
+				<dl class="settings">
 					<dt>
 						<strong', isset($context['modify_error']['bad_password']) || isset($context['modify_error']['no_password']) ? ' class="error"' : '', '><label for="oldpasswrd">', $txt['current_password'], ': </label></strong><br>
 						<span class="smalltext">', $txt['required_security_reasons'], '</span>
@@ -1588,7 +1588,7 @@ function template_profile_pm_settings()
 								</dd>
 						</dl>
 						<hr>
-						<dl>
+						<dl class="settings">
 								<dt>
 										<label for="pm_receive_from">', $txt['pm_receive_from'], '</label>
 								</dt>
@@ -1614,7 +1614,7 @@ function template_profile_pm_settings()
 								</dd>
 						</dl>
 						<hr>
-						<dl>
+						<dl class="settings">
 								<dt>
 										<label for="pm_remove_inbox_label">', $txt['pm_remove_inbox_label'], '</label>
 								</dt>
@@ -1645,7 +1645,7 @@ function template_profile_theme_settings()
 				echo '
 				</dl>
 				<hr>
-				<dl class="settings flow_auto">';
+				<dl class="settings">';
 
 			// Should we give a name to this section?
 			if (is_string($setting) && !empty($setting))
@@ -2564,7 +2564,7 @@ function template_profile_save()
 	// Only show the password box if it's actually needed.
 	if ($context['require_password'])
 		echo '
-					<dl>
+					<dl class="settings">
 						<dt>
 							<strong', isset($context['modify_error']['bad_password']) || isset($context['modify_error']['no_password']) ? ' class="error"' : '', '>', $txt['current_password'], ': </strong><br>
 							<span class="smalltext">', $txt['required_security_reasons'], '</span>

--- a/Themes/default/Profile.template.php
+++ b/Themes/default/Profile.template.php
@@ -1638,7 +1638,7 @@ function template_profile_theme_settings()
 	foreach ($context['theme_options'] as $i => $setting)
 	{
 		// Just spit out separators and move on
-		if (!is_array($setting))
+		if (empty($setting) || !is_array($setting))
 		{
 			// Insert a separator (unless this is the first item in the list)
 			if ($i !== $first_option_key)

--- a/Themes/default/Profile.template.php
+++ b/Themes/default/Profile.template.php
@@ -1632,7 +1632,7 @@ function template_profile_theme_settings()
 {
 	global $context, $modSettings, $txt;
 
-	$first_option_key = array_shift(array_keys($context['theme_options']));
+	$first_option_key = array_shift($skeys = array_keys($context['theme_options']));
 	$titled_section = false;
 
 	foreach ($context['theme_options'] as $i => $setting)

--- a/Themes/default/Settings.template.php
+++ b/Themes/default/Settings.template.php
@@ -18,6 +18,7 @@ function template_options()
 	global $context, $txt;
 
 	$context['theme_options'] = array(
+		$txt['theme_opt_calendar'],
 		array(
 			'id' => 'calendar_start_day',
 			'label' => $txt['calendar_start_day'],
@@ -28,6 +29,7 @@ function template_options()
 			),
 			'default' => true,
 		),
+		$txt['theme_opt_display'],
 		array(
 			'id' => 'show_children',
 			'label' => $txt['show_children'],
@@ -77,6 +79,7 @@ function template_options()
 			'label' => $txt['posts_apply_ignore_list'],
 			'default' => false,
 		),
+		$txt['theme_opt_posting'],
 		array(
 			'id' => 'return_to_post',
 			'label' => $txt['return_to_post'],
@@ -107,6 +110,7 @@ function template_options()
 			'label'  => $txt['drafts_show_saved_enabled'],
 			'default' => true,
 		),
+		$txt['theme_opt_moderation'],
 		array(
 			'id' => 'display_quick_mod',
 			'label' => $txt['display_quick_mod'],
@@ -117,6 +121,7 @@ function template_options()
 			),
 			'default' => true,
 		),
+		$txt['theme_opt_personal_messages'],
 		array(
 			'id' => 'popup_messages',
 			'label' => $txt['popup_messages'],

--- a/Themes/default/Settings.template.php
+++ b/Themes/default/Settings.template.php
@@ -19,58 +19,18 @@ function template_options()
 
 	$context['theme_options'] = array(
 		array(
+			'id' => 'calendar_start_day',
+			'label' => $txt['calendar_start_day'],
+			'options' => array(
+				0 => $txt['days'][0],
+				1 => $txt['days'][1],
+				6 => $txt['days'][6],
+			),
+			'default' => true,
+		),
+		array(
 			'id' => 'show_children',
 			'label' => $txt['show_children'],
-			'default' => true,
-		),
-		array(
-			'id' => 'show_no_avatars',
-			'label' => $txt['show_no_avatars'],
-			'default' => true,
-		),
-		array(
-			'id' => 'show_no_signatures',
-			'label' => $txt['show_no_signatures'],
-			'default' => true,
-		),
-		array(
-			'id' => 'return_to_post',
-			'label' => $txt['return_to_post'],
-			'default' => true,
-		),
-		array(
-			'id' => 'view_newest_first',
-			'label' => $txt['recent_posts_at_top'],
-			'default' => true,
-		),
-		array(
-			'id' => 'view_newest_pm_first',
-			'label' => $txt['recent_pms_at_top'],
-			'default' => true,
-		),
-		array(
-			'id' => 'posts_apply_ignore_list',
-			'label' => $txt['posts_apply_ignore_list'],
-			'default' => false,
-		),
-		array(
-			'id' => 'wysiwyg_default',
-			'label' => $txt['wysiwyg_default'],
-			'default' => false,
-		),
-		array(
-			'id' => 'popup_messages',
-			'label' => $txt['popup_messages'],
-			'default' => true,
-		),
-		array(
-			'id' => 'pm_remove_inbox_label',
-			'label' => $txt['pm_remove_inbox_label'],
-			'default' => true,
-		),
-		array(
-			'id' => 'auto_notify',
-			'label' => $txt['auto_notify'],
 			'default' => true,
 		),
 		array(
@@ -98,18 +58,53 @@ function template_options()
 			'default' => true,
 		),
 		array(
-			'id' => 'calendar_start_day',
-			'label' => $txt['calendar_start_day'],
-			'options' => array(
-				0 => $txt['days'][0],
-				1 => $txt['days'][1],
-				6 => $txt['days'][6],
-			),
+			'id' => 'view_newest_first',
+			'label' => $txt['recent_posts_at_top'],
 			'default' => true,
+		),
+		array(
+			'id' => 'show_no_avatars',
+			'label' => $txt['show_no_avatars'],
+			'default' => true,
+		),
+		array(
+			'id' => 'show_no_signatures',
+			'label' => $txt['show_no_signatures'],
+			'default' => true,
+		),
+		array(
+			'id' => 'posts_apply_ignore_list',
+			'label' => $txt['posts_apply_ignore_list'],
+			'default' => false,
+		),
+		array(
+			'id' => 'return_to_post',
+			'label' => $txt['return_to_post'],
+			'default' => true,
+		),
+		array(
+			'id' => 'auto_notify',
+			'label' => $txt['auto_notify'],
+			'default' => true,
+		),
+		array(
+			'id' => 'wysiwyg_default',
+			'label' => $txt['wysiwyg_default'],
+			'default' => false,
 		),
 		array(
 			'id' => 'use_editor_quick_reply',
 			'label' => $txt['use_editor_quick_reply'],
+			'default' => true,
+		),
+		array(
+			'id' => 'drafts_autosave_enabled',
+			'label' => $txt['drafts_autosave_enabled'],
+			'default' => true,
+		),
+		array(
+			'id' => 'drafts_show_saved_enabled',
+			'label'  => $txt['drafts_show_saved_enabled'],
 			'default' => true,
 		),
 		array(
@@ -123,10 +118,20 @@ function template_options()
 			'default' => true,
 		),
 		array(
-			'id' => 'drafts_show_saved_enabled',
-			'label'  => $txt['drafts_show_saved_enabled'],
+			'id' => 'popup_messages',
+			'label' => $txt['popup_messages'],
 			'default' => true,
-		)
+		),
+		array(
+			'id' => 'view_newest_pm_first',
+			'label' => $txt['recent_pms_at_top'],
+			'default' => true,
+		),
+		array(
+			'id' => 'pm_remove_inbox_label',
+			'label' => $txt['pm_remove_inbox_label'],
+			'default' => true,
+		),
 	);
 }
 

--- a/Themes/default/Themes.template.php
+++ b/Themes/default/Themes.template.php
@@ -353,7 +353,7 @@ function template_set_options()
 	foreach ($context['options'] as $i => $setting)
 	{
 		// Just spit out separators and move on
-		if (!is_array($setting))
+		if (empty($setting) || !is_array($setting))
 		{
 			// Insert a separator (unless this is the first item in the list)
 			if ($i !== $first_option_key)
@@ -587,7 +587,7 @@ function template_set_settings()
 	foreach ($context['settings'] as $i => $setting)
 	{
 		// Is this a separator?
-		if (!is_array($setting))
+		if (empty($setting) || !is_array($setting))
 		{
 			// We don't need a separator before the first list element
 			if ($i !== $first_setting_key)

--- a/Themes/default/Themes.template.php
+++ b/Themes/default/Themes.template.php
@@ -347,8 +347,34 @@ function template_set_options()
 	echo '
 				<dl class="settings">';
 
-	foreach ($context['options'] as $setting)
+	$first_option_key = array_shift(array_keys($context['options']));
+	$titled_section = false;
+
+	foreach ($context['options'] as $i => $setting)
 	{
+		// Just spit out separators and move on
+		if (!is_array($setting))
+		{
+			// Insert a separator (unless this is the first item in the list)
+			if ($i !== $first_option_key)
+				echo '
+				</dl>
+				<hr>
+				<dl class="settings flow_auto">';
+
+			// Should we give a name to this section?
+			if (is_string($setting) && !empty($setting))
+			{
+				$titled_section = true;
+				echo '
+					<dt><b>' . $setting . '</b></dt><dd></dd>';
+			}
+			else
+				$titled_section = false;
+
+			continue;
+		}
+
 		echo '
 					<dt ', $context['theme_options_reset'] ? 'style="width:50%"' : '', '>';
 
@@ -365,11 +391,11 @@ function template_set_options()
 		if ($setting['type'] == 'checkbox')
 		{
 			echo '
-						<label for="options_', $setting['id'], '">', $setting['label'], '</label>';
+						<label for="options_', $setting['id'], '">', !$titled_section ? '<b>' : '', $setting['label'], !$titled_section ? '</b>' : '', '</label>';
 			if (isset($setting['description']))
 				echo '
 						<br><span class="smalltext">', $setting['description'], '</span>';
-		echo '
+			echo '
 					</dt>
 					<dd ', $context['theme_options_reset'] ? 'style="width:40%"' : '', '>
 						<input type="hidden" name="' . (!empty($setting['default']) ? 'default_' : '') . 'options[' . $setting['id'] . ']" value="0">
@@ -379,11 +405,11 @@ function template_set_options()
 		elseif ($setting['type'] == 'list')
 		{
 			echo '
-						<label for="options_', $setting['id'], '">', $setting['label'], '</label>';
+						<label for="options_', $setting['id'], '">', !$titled_section ? '<b>' : '', $setting['label'], !$titled_section ? '</b>' : '', '</label>';
 			if (isset($setting['description']))
 				echo '
 						<br><span class="smalltext">', $setting['description'], '</span>';
-		echo '
+			echo '
 					</dt>
 					<dd ', $context['theme_options_reset'] ? 'style="width:40%"' : '', '>
 						&nbsp;<select class="floatleft" name="', !empty($setting['default']) ? 'default_' : '', 'options[', $setting['id'], ']" id="options_', $setting['id'], '"', $context['theme_options_reset'] ? ' disabled' : '', '>';
@@ -401,11 +427,11 @@ function template_set_options()
 		else
 		{
 			echo '
-						<label for="options_', $setting['id'], '">', $setting['label'], '</label>';
+						<label for="options_', $setting['id'], '">', !$titled_section ? '<b>' : '', $setting['label'], !$titled_section ? '</b>' : '', '</label>';
 			if (isset($setting['description']))
 				echo '
 						<br><span class="smalltext">', $setting['description'], '</span>';
-		echo '
+			echo '
 					</dt>
 					<dd ', $context['theme_options_reset'] ? 'style="width:40%"' : '', '>';
 
@@ -565,22 +591,40 @@ function template_set_settings()
 			<div class="windowbg2 noup">
 				<dl class="settings flow_auto">';
 
-	foreach ($context['settings'] as $setting)
+	$first_setting_key = array_shift(array_keys($context['settings']));
+	$titled_section = false;
+
+	foreach ($context['settings'] as $i => $setting)
 	{
 		// Is this a separator?
-		if (empty($setting))
+		if (!is_array($setting))
 		{
-			echo '
+			// We don't need a separator before the first list element
+			if ($i !== $first_setting_key)
+				echo '
 				</dl>
 				<hr>
 				<dl class="settings flow_auto">';
+
+			// Add a fake heading?
+			if (is_string($setting) && !empty($setting))
+			{
+				$titled_section = true;
+				echo '
+					<dt><b>' . $setting . '</b></dt><dd></dd>';
+			}
+			else
+				$titled_section = false;
+
+			continue;
 		}
+
 		// A checkbox?
-		elseif ($setting['type'] == 'checkbox')
+		if ($setting['type'] == 'checkbox')
 		{
 			echo '
 					<dt>
-						<label for="', $setting['id'], '">', $setting['label'], '</label>:';
+						<label for="', $setting['id'], '">', !$titled_section ? '<b>' : '', $setting['label'], !$titled_section ? '</b>' : '', '</label>:';
 
 			if (isset($setting['description']))
 				echo '<br>
@@ -598,7 +642,7 @@ function template_set_settings()
 		{
 			echo '
 					<dt>
-						<label for="', $setting['id'], '">', $setting['label'], '</label>:';
+						<label for="', $setting['id'], '">', !$titled_section ? '<b>' : '', $setting['label'], !$titled_section ? '</b>' : '', '</label>:';
 
 			if (isset($setting['description']))
 				echo '<br>
@@ -622,7 +666,7 @@ function template_set_settings()
 		{
 			echo '
 					<dt>
-						<label for="', $setting['id'], '">', $setting['label'], '</label>:';
+						<label for="', $setting['id'], '">', !$titled_section ? '<b>' : '', $setting['label'], !$titled_section ? '</b>' : '', '</label>:';
 
 			if (isset($setting['description']))
 				echo '<br>
@@ -639,7 +683,7 @@ function template_set_settings()
 		{
 			echo '
 					<dt>
-						<label for="', $setting['id'], '">', $setting['label'], '</label>:';
+						<label for="', $setting['id'], '">', !$titled_section ? '<b>' : '', $setting['label'], !$titled_section ? '</b>' : '', '</label>:';
 
 			if (isset($setting['description']))
 				echo '<br>
@@ -661,7 +705,7 @@ function template_set_settings()
 			else if (isset($setting['type']) && $setting['type'] == 'url')
 			{
 				echo'
-						<input type="url"';	
+						<input type="url"';
 			}
 			else
 			{

--- a/Themes/default/Themes.template.php
+++ b/Themes/default/Themes.template.php
@@ -360,7 +360,7 @@ function template_set_options()
 				echo '
 				</dl>
 				<hr>
-				<dl class="settings flow_auto">';
+				<dl class="settings">';
 
 			// Should we give a name to this section?
 			if (is_string($setting) && !empty($setting))
@@ -589,7 +589,7 @@ function template_set_settings()
 				</h3>
 			</div>
 			<div class="windowbg2 noup">
-				<dl class="settings flow_auto">';
+				<dl class="settings">';
 
 	$first_setting_key = array_shift(array_keys($context['settings']));
 	$titled_section = false;
@@ -604,7 +604,7 @@ function template_set_settings()
 				echo '
 				</dl>
 				<hr>
-				<dl class="settings flow_auto">';
+				<dl class="settings">';
 
 			// Add a fake heading?
 			if (is_string($setting) && !empty($setting))

--- a/Themes/default/Themes.template.php
+++ b/Themes/default/Themes.template.php
@@ -387,16 +387,18 @@ function template_set_options()
 							<option value="2">', $txt['themeadmin_reset_options_default'], '</option>
 						</select>&nbsp;</span>';
 
+		echo '
+						<label for="options_', $setting['id'], '">', !$titled_section ? '<b>' : '', $setting['label'], !$titled_section ? '</b>' : '', '</label>';
+		if (isset($setting['description']))
+			echo '
+						<br><span class="smalltext">', $setting['description'], '</span>';
+		echo '
+					</dt>';
+
 		// display checkbox options
 		if ($setting['type'] == 'checkbox')
 		{
 			echo '
-						<label for="options_', $setting['id'], '">', !$titled_section ? '<b>' : '', $setting['label'], !$titled_section ? '</b>' : '', '</label>';
-			if (isset($setting['description']))
-				echo '
-						<br><span class="smalltext">', $setting['description'], '</span>';
-			echo '
-					</dt>
 					<dd ', $context['theme_options_reset'] ? 'style="width:40%"' : '', '>
 						<input type="hidden" name="' . (!empty($setting['default']) ? 'default_' : '') . 'options[' . $setting['id'] . ']" value="0">
 						<input type="checkbox" name="', !empty($setting['default']) ? 'default_' : '', 'options[', $setting['id'], ']" id="options_', $setting['id'], '"', !empty($setting['value']) ? ' checked' : '', $context['theme_options_reset'] ? ' disabled' : '', ' value="1" class="input_check floatleft">';
@@ -405,12 +407,6 @@ function template_set_options()
 		elseif ($setting['type'] == 'list')
 		{
 			echo '
-						<label for="options_', $setting['id'], '">', !$titled_section ? '<b>' : '', $setting['label'], !$titled_section ? '</b>' : '', '</label>';
-			if (isset($setting['description']))
-				echo '
-						<br><span class="smalltext">', $setting['description'], '</span>';
-			echo '
-					</dt>
 					<dd ', $context['theme_options_reset'] ? 'style="width:40%"' : '', '>
 						&nbsp;<select class="floatleft" name="', !empty($setting['default']) ? 'default_' : '', 'options[', $setting['id'], ']" id="options_', $setting['id'], '"', $context['theme_options_reset'] ? ' disabled' : '', '>';
 
@@ -427,12 +423,6 @@ function template_set_options()
 		else
 		{
 			echo '
-						<label for="options_', $setting['id'], '">', !$titled_section ? '<b>' : '', $setting['label'], !$titled_section ? '</b>' : '', '</label>';
-			if (isset($setting['description']))
-				echo '
-						<br><span class="smalltext">', $setting['description'], '</span>';
-			echo '
-					</dt>
 					<dd ', $context['theme_options_reset'] ? 'style="width:40%"' : '', '>';
 
 			if (isset($setting['type']) && $setting['type'] == 'number')
@@ -619,19 +609,21 @@ function template_set_settings()
 			continue;
 		}
 
+		echo '
+					<dt>
+						<label for="', $setting['id'], '">', !$titled_section ? '<b>' : '', $setting['label'], !$titled_section ? '</b>' : '', '</label>:';
+
+		if (isset($setting['description']))
+			echo '<br>
+						<span class="smalltext">', $setting['description'], '</span>';
+
+		echo '
+					</dt>';
+
 		// A checkbox?
 		if ($setting['type'] == 'checkbox')
 		{
 			echo '
-					<dt>
-						<label for="', $setting['id'], '">', !$titled_section ? '<b>' : '', $setting['label'], !$titled_section ? '</b>' : '', '</label>:';
-
-			if (isset($setting['description']))
-				echo '<br>
-						<span class="smalltext">', $setting['description'], '</span>';
-
-			echo '
-					</dt>
 					<dd>
 						<input type="hidden" name="', !empty($setting['default']) ? 'default_' : '', 'options[', $setting['id'], ']" value="0">
 						<input type="checkbox" name="', !empty($setting['default']) ? 'default_' : '', 'options[', $setting['id'], ']" id="', $setting['id'], '"', !empty($setting['value']) ? ' checked' : '', ' value="1" class="input_check">
@@ -641,15 +633,6 @@ function template_set_settings()
 		elseif ($setting['type'] == 'list')
 		{
 			echo '
-					<dt>
-						<label for="', $setting['id'], '">', !$titled_section ? '<b>' : '', $setting['label'], !$titled_section ? '</b>' : '', '</label>:';
-
-			if (isset($setting['description']))
-				echo '<br>
-						<span class="smalltext">', $setting['description'], '</span>';
-
-			echo '
-					</dt>
 					<dd>
 						<select name="', !empty($setting['default']) ? 'default_' : '', 'options[', $setting['id'], ']" id="', $setting['id'], '">';
 
@@ -665,14 +648,6 @@ function template_set_settings()
         	elseif ($setting['type'] == 'textarea')
 		{
 			echo '
-					<dt>
-						<label for="', $setting['id'], '">', !$titled_section ? '<b>' : '', $setting['label'], !$titled_section ? '</b>' : '', '</label>:';
-
-			if (isset($setting['description']))
-				echo '<br>
-						<span class="smalltext">', $setting['description'], '</span>';
-			echo '
-					</dt>
 					<dd>
 						<textarea rows="4" style="width: 95%;" cols="40" name="', !empty($setting['default']) ? 'default_' : '', 'options[', $setting['id'], ']" id="', $setting['id'], '">', $setting['value'], '</textarea>';
                 echo '
@@ -682,15 +657,6 @@ function template_set_settings()
 		else
 		{
 			echo '
-					<dt>
-						<label for="', $setting['id'], '">', !$titled_section ? '<b>' : '', $setting['label'], !$titled_section ? '</b>' : '', '</label>:';
-
-			if (isset($setting['description']))
-				echo '<br>
-						<span class="smalltext">', $setting['description'], '</span>';
-
-			echo '
-					</dt>
 					<dd>';
 
 			if (isset($setting['type']) && $setting['type'] == 'number')

--- a/Themes/default/Themes.template.php
+++ b/Themes/default/Themes.template.php
@@ -347,7 +347,7 @@ function template_set_options()
 	echo '
 				<dl class="settings">';
 
-	$first_option_key = array_shift(array_keys($context['options']));
+	$first_option_key = array_shift($skeys = array_keys($context['options']));
 	$titled_section = false;
 
 	foreach ($context['options'] as $i => $setting)
@@ -581,7 +581,7 @@ function template_set_settings()
 			<div class="windowbg2 noup">
 				<dl class="settings">';
 
-	$first_setting_key = array_shift(array_keys($context['settings']));
+	$first_setting_key = array_shift($skeys = array_keys($context['settings']));
 	$titled_section = false;
 
 	foreach ($context['settings'] as $i => $setting)

--- a/Themes/default/languages/Profile.english.php
+++ b/Themes/default/languages/Profile.english.php
@@ -564,4 +564,10 @@ $txt['tfa_backup_code'] = 'Backup code';
 $txt['tfa_backup_desc'] = 'In case you have lost your device or authentication app, you can use the backup code provided to you when 2FA was setup. In case you have lost that as well, please contact the administrator';
 $txt['tfa_wait'] = 'Please wait for about 2 minutes before attempting to log in via 2FA again';
 
+$txt['theme_opt_calendar'] = 'Calendar';
+$txt['theme_opt_display'] = 'Board and topic display';
+$txt['theme_opt_posting'] = 'Posting';
+$txt['theme_opt_moderation'] = 'Moderation';
+$txt['theme_opt_personal_messages'] = 'Personal Messages';
+
 ?>


### PR DESCRIPTION
- Previously, we were using hard-coded HTML in Profile.template.php, which defeated most of the purpose of `theme_options()` in Settings.template.php (namely, to allow themes to define their own sets of options). This PR changes that so that the user is shown a list of options according to what is defined in Settings.template.php. The new method is very similar to what is used to show the default options to the admin.
- This PR also rearranges the options in Settings.template.php into a more logical order.
- This PR also adds support for separators and titled sections in the theme settings/options.