### PR TITLE
Really check for 30 seconds

### DIFF
--- a/other/upgrade.php
+++ b/other/upgrade.php
@@ -47,7 +47,7 @@ $databases = array(
  * The maximum time a single substep may take, in seconds.
  * @var int
  */
-$timeLimitThreshold = 3;
+$timeLimitThreshold = 30;
 
 /**
  * The current path to the upgrade.php file.
@@ -4002,7 +4002,7 @@ function template_database_changes()
 				// We want to track this...
 				if (timeOutID)
 					clearTimeout(timeOutID);
-				timeOutID = window.setTimeout("retTimeout()", ', (10 * $timeLimitThreshold), '000);
+				timeOutID = window.setTimeout("retTimeout()", ', $timeLimitThreshold, '000);
 
 				getXMLDocument(\'', $upcontext['form_url'], '&xml&filecount=', $upcontext['file_count'], '&substep=\' + lastItem + getData, onItemUpdate);
 			}
@@ -4239,7 +4239,7 @@ function template_database_changes()
 				if (!attemptAgain)
 				{
 					document.getElementById("error_block").style.display = "";
-					setInnerHTML(document.getElementById("error_message"), "Server has not responded for ', ($timeLimitThreshold * 10), ' seconds. It may be worth waiting a little longer or otherwise please click <a href=\"#\" onclick=\"retTimeout(true); return false;\">here<" + "/a> to try this step again");
+					setInnerHTML(document.getElementById("error_message"), "Server has not responded for ', $timeLimitThreshold, ' seconds. It may be worth waiting a little longer or otherwise please click <a href=\"#\" onclick=\"retTimeout(true); return false;\">here<" + "/a> to try this step again");
 				}
 				else
 				{


### PR DESCRIPTION
Final PR for this set of issues:
Upgrader: Various issues impacting stability & performance #3901

It was really reporting errors when queries exceeded 3 seconds, not 30.  
