### PR TITLE
Issue setlocale to enable utf8 processing in certain php functions

### DIFF
--- a/Sources/Load.php
+++ b/Sources/Load.php
@@ -2651,7 +2651,7 @@ function loadLanguage($template_name, $lang = '', $fatal = true, $force_reload =
 				$found = true;
 
 				// setlocale is required for basename() & pathinfo() to work properly on the selected language
-				setlocale(LC_CTYPE, $txt['lang_locale'] . '.' . $txt['lang_character_set']);
+				setlocale(LC_CTYPE, $txt['lang_locale'] . '.' . $modSettings['global_character_set']);
 				
 				break;
 			}

--- a/Sources/Load.php
+++ b/Sources/Load.php
@@ -74,9 +74,6 @@ function reloadSettings()
 	// UTF-8 ?
 	$utf8 = (empty($modSettings['global_character_set']) ? $txt['lang_character_set'] : $modSettings['global_character_set']) === 'UTF-8';
 
-	// setlocale is required for basename() & pathinfo() to work properly on files with utf8 characters in the names
-	setlocale(LC_CTYPE,'en_US.UTF-8');
-
 	// Set a list of common functions.
 	$ent_list = empty($modSettings['disableEntityCheck']) ? '&(#\d{1,7}|quot|amp|lt|gt|nbsp);' : '&(#021|quot|amp|lt|gt|nbsp);';
 	$ent_check = empty($modSettings['disableEntityCheck']) ? function($string)
@@ -2653,6 +2650,9 @@ function loadLanguage($template_name, $lang = '', $fatal = true, $force_reload =
 				// Note that we found it.
 				$found = true;
 
+				// setlocale is required for basename() & pathinfo() to work properly on the selected language
+				setlocale(LC_CTYPE, $txt['lang_locale'] . '.' . $txt['lang_character_set']);
+				
 				break;
 			}
 		}

--- a/Sources/Load.php
+++ b/Sources/Load.php
@@ -2651,7 +2651,8 @@ function loadLanguage($template_name, $lang = '', $fatal = true, $force_reload =
 				$found = true;
 
 				// setlocale is required for basename() & pathinfo() to work properly on the selected language
-				setlocale(LC_CTYPE, $txt['lang_locale'] . '.' . $modSettings['global_character_set']);
+				if (!empty($txt['lang_locale']) && !empty($modSettings['global_character_set']))
+					setlocale(LC_CTYPE, $txt['lang_locale'] . '.' . $modSettings['global_character_set']);
 				
 				break;
 			}

--- a/Sources/Load.php
+++ b/Sources/Load.php
@@ -74,6 +74,9 @@ function reloadSettings()
 	// UTF-8 ?
 	$utf8 = (empty($modSettings['global_character_set']) ? $txt['lang_character_set'] : $modSettings['global_character_set']) === 'UTF-8';
 
+	// setlocale is required for basename() & pathinfo() to work properly on files with utf8 characters in the names
+	setlocale(LC_CTYPE,'en_US.UTF-8');
+
 	// Set a list of common functions.
 	$ent_list = empty($modSettings['disableEntityCheck']) ? '&(#\d{1,7}|quot|amp|lt|gt|nbsp);' : '&(#021|quot|amp|lt|gt|nbsp);';
 	$ent_check = empty($modSettings['disableEntityCheck']) ? function($string)

--- a/Themes/default/languages/index.english.php
+++ b/Themes/default/languages/index.english.php
@@ -16,7 +16,7 @@ $txt['lang_dictionary'] = 'en';
 $txt['lang_spelling'] = 'american';
 
 // Ensure you remember to use uppercase for character set strings.
-$txt['lang_character_set'] = 'ISO-8859-1';
+$txt['lang_character_set'] = 'UTF-8';
 // Character set and right to left?
 $txt['lang_rtl'] = false;
 // Number format.

--- a/Themes/default/languages/index.english.php
+++ b/Themes/default/languages/index.english.php
@@ -16,7 +16,8 @@ $txt['lang_dictionary'] = 'en';
 $txt['lang_spelling'] = 'american';
 
 // Ensure you remember to use uppercase for character set strings.
-$txt['lang_character_set'] = 'UTF-8';
+// Leave this entry at ISO-8859-1 for the language editor
+$txt['lang_character_set'] = 'ISO-8859-1';
 // Character set and right to left?
 $txt['lang_rtl'] = false;
 // Number format.

--- a/Themes/default/languages/index.english.php
+++ b/Themes/default/languages/index.english.php
@@ -16,7 +16,6 @@ $txt['lang_dictionary'] = 'en';
 $txt['lang_spelling'] = 'american';
 
 // Ensure you remember to use uppercase for character set strings.
-// Leave this entry at ISO-8859-1 for the language editor
 $txt['lang_character_set'] = 'ISO-8859-1';
 // Character set and right to left?
 $txt['lang_rtl'] = false;


### PR DESCRIPTION
php functions such as basename() and pathinfo() require setlocale to be set in order to properly operate with the utf8 character set.  

basename() and pathinfo() are safe & preferred methods operate on uploaded files, and provide protection from file traversal attacks.  Both are used throughout SMF today.  This PR makes them utf8-friendly.

This PR negates the need to write our own version of pathinfo or basename, & replaces PR #3887 

Feedback welcome,