### PR TITLE
Clean up prior attachment info when starting new message

### DIFF
--- a/Sources/Post.php
+++ b/Sources/Post.php
@@ -187,8 +187,12 @@ function Post($post_errors = array())
 
 	// An array to hold all the attachments for this topic.
 	$context['current_attachments'] = array();
-	unset($_SESSION['already_attached']);
 
+	// Clear out prior attachment activity when starting afresh
+	if (empty ($_REQUEST['message']) && empty ($_REQUEST['preview'])) {
+		unset($_SESSION['already_attached']);
+	}
+	
 	// Don't allow a post if it's locked and you aren't all powerful.
 	if ($locked && !allowedTo('moderate_board'))
 		fatal_lang_error('topic_locked', false);


### PR DESCRIPTION
Fixes: Attachments - discarded upon preview #3957

Needed to be a bit more selective when clearing out old $_SESSION attachment info.  