### PR TITLE
Clean up old security checks

### DIFF
--- a/Sources/Subs-Graphics.php
+++ b/Sources/Subs-Graphics.php
@@ -211,8 +211,9 @@ function checkImageContents($fileName, $extensiveCheck = false)
 		// Though not exhaustive lists, better safe than sorry.
 		if (!empty($extensiveCheck))
 		{
-			// Paranoid check. Some like it that way.
-			if (preg_match('~(iframe|\\<\\?|\\<%|html|eval|body|script\W|[CF]WS[\x01-\x0C])~i', $prev_chunk . $cur_chunk) === 1)
+			// Paranoid check.  Use this if you have reason to distrust your host's security config.
+			// Will result in MANY false positives, and is not suitable for photography sites.
+			if (preg_match('~(iframe|\\<\\?|\\<%|html|eval|body|script\W|(?-i)[CFZ]WS[\x01-\x0E])~i', $prev_chunk . $cur_chunk) === 1)
 			{
 				fclose($fp);
 				return false;
@@ -220,8 +221,9 @@ function checkImageContents($fileName, $extensiveCheck = false)
 		}
 		else
 		{
-			// Check for potential infection
-			if (preg_match('~(iframe|(?<!cellTextIs)html|eval|body|script\W|[CF]WS[\x01-\x0C])~i', $prev_chunk . $cur_chunk) === 1)
+			// Check for potential infection - focus on clues for inline php & flash.
+			// Will result in significantly fewer false positives than the paranoid check.
+			if (preg_match('~(\\<\\?php\s|(?-i)[CFZ]WS[\x01-\x0E])~i', $prev_chunk . $cur_chunk) === 1)
 			{
 				fclose($fp);
 				return false;


### PR DESCRIPTION
Our string search mechanism to find suspicious code in attachments is highly problematic, and rejects an extremely high percentage of valid photos.  

The existing security checks fall into 3 categories:
  -  <% and <? are the short form of inline php & js; these reflect older attack vectors that should be locked down by most hosts today
  -  [CFZ]WS is part of the pattern for inline flash
  -  flash, script, html, eval, etc - are paranoid checks looking for suspicious terms.  Some are tied to old forms of IE attacks, some I couldn't find any documentation for at all as valid, current vulnerabilities

In this PR, for the paranoid check, I left in all of the old checks.  I would suggest using this security option ONLY if you have extreme mistrust in your ISP's security config.

For the non-paranoid check, I was torn between removing it entirely, or leaving in minimal php & flash checks.  I eventually opted for keeping the php & flash checks, but making them more robust to significantly reduce false positives.  

SMF photo sharing sites have significant issues due to these edits in 2.0 and will continue to have issues in 2.1 without this change.  If approved, I suggest pushing these changes back into 2.0 as well.   

Discussion threads, for background:
  -  https://github.com/SimpleMachines/SMF2.1/issues/3928
  -  https://github.com/elkarte/Elkarte/issues/2874

This is a short-to-mid-term solution.  Long term, we should find a better approach, since ANY string search technique will return false positives sooner or later.  The goal should be to only filter out truly infected photos, not random photos...