### PR TITLE
Clean up old theme data

### DIFF
--- a/other/upgrade_2-1_mysql.sql
+++ b/other/upgrade_2-1_mysql.sql
@@ -924,13 +924,15 @@ foreach ($toMove as $move)
 /******************************************************************************/
 --- Cleaning up after old themes...
 /******************************************************************************/
----# Delete all theme data except for the current default
+---# Disabling old themes
 ---{
 $smcFunc['db_query']('', '
 	DELETE FROM {db_prefix}themes
-	WHERE id_theme != {int:default_theme}',
+	WHERE id_theme != {int:default_theme}
+	  AND variable IN ({array_string:remove_settings});',
 	array(
 		'default_theme' => 1,
+		'remove_settings' => array('theme_dir','theme_url'),
 	)
 );
 ---}
@@ -941,7 +943,7 @@ $smcFunc['db_query']('', '
 $smcFunc['db_query']('', '
 	UPDATE {db_prefix}settings
 	SET value = {string:default_theme}
-	WHERE variable = {string:known_themes}',
+	WHERE variable = {string:known_themes};',
 	array(
 		'default_theme' => '1',
 		'known_themes' => 'knownThemes',

--- a/other/upgrade_2-1_mysql.sql
+++ b/other/upgrade_2-1_mysql.sql
@@ -924,45 +924,29 @@ foreach ($toMove as $move)
 /******************************************************************************/
 --- Cleaning up after old themes...
 /******************************************************************************/
----# Checking for "core" and removing it if necessary...
+---# Delete all theme data except for the current default
 ---{
-// Do they have "core" installed?
-if (file_exists($GLOBALS['boarddir'] . '/Themes/core'))
-{
-	$core_dir = $GLOBALS['boarddir'] . '/Themes/core';
-	$theme_request = upgrade_query("
-		SELECT id_theme
-		FROM {$db_prefix}themes
-		WHERE variable = 'theme_dir'
-			AND value ='$core_dir'");
+$smcFunc['db_query']('', '
+	DELETE FROM {db_prefix}themes
+	WHERE id_theme != {int:default_theme}',
+	array(
+		'default_theme' => 1,
+	)
+);
+---}
+---#
 
-	// Don't do anything if this theme is already uninstalled
-	if ($smcFunc['db_num_rows']($theme_request) == 1)
-	{
-		// Only one row, so no loop needed
-		$row = $smcFunc['db_fetch_row']($theme_request);
-		$id_theme = $row[0];
-		$smcFunc['db_free_result']($theme_request);
-
-		$known_themes = explode(', ', $modSettings['knownThemes']);
-
-		// Remove this value...
-		$known_themes = array_diff($known_themes, array($id_theme));
-
-		// Change back to a string...
-		$known_themes = implode(', ', $known_themes);
-
-		// Update the database
-		upgrade_query("
-			REPLACE INTO {$db_prefix}settings (variable, value)
-			VALUES ('knownThemes', '$known_themes')");
-
-		// Delete any info about this theme
-		upgrade_query("
-			DELETE FROM {$db_prefix}themes
-			WHERE id_theme = $id_theme");
-	}
-}
+---# Setting knownThemes to current default
+---{
+$smcFunc['db_query']('', '
+	UPDATE {db_prefix}settings
+	SET value = {string:default_theme}
+	WHERE variable = {string:known_themes}',
+	array(
+		'default_theme' => '1',
+		'known_themes' => 'knownThemes',
+	)
+);
 ---}
 ---#
 

--- a/other/upgrade_2-1_postgresql.sql
+++ b/other/upgrade_2-1_postgresql.sql
@@ -950,44 +950,29 @@ foreach ($toMove as $move)
 /******************************************************************************/
 --- Cleaning up after old themes...
 /******************************************************************************/
----# Checking for "core" and removing it if necessary...
+---# Delete all theme data except for the current default
 ---{
-// Do they have "core" installed?
-if (file_exists($GLOBALS['boarddir'] . '/Themes/core'))
-{
-	$core_dir = $GLOBALS['boarddir'] . '/Themes/core';
-	$theme_request = upgrade_query("
-		SELECT id_theme
-		FROM {$db_prefix}themes
-		WHERE variable = 'theme_dir'
-			AND value ='$core_dir'");
+$smcFunc['db_query']('', '
+	DELETE FROM {db_prefix}themes
+	WHERE id_theme != {int:default_theme}',
+	array(
+		'default_theme' => 1,
+	)
+);
+---}
+---#
 
-	// Don't do anything if this theme is already uninstalled
-	if ($smcFunc['db_num_rows']($theme_request) == 1)
-	{
-		list($id_theme) = $smcFunc['db_fetch_row']($theme_request, 0);
-		$smcFunc['db_free_result']($theme_request);
-
-		$known_themes = explode(', ', $modSettings['knownThemes']);
-
-		// Remove this value...
-		$known_themes = array_diff($known_themes, array($id_theme));
-
-		// Change back to a string...
-		$known_themes = implode(', ', $known_themes);
-
-		// Update the database
-		upgrade_query("
-			UPDATE {$db_prefix}settings
-			SET value = '$known_themes'
-			WHERE variable = 'knownThemes'");
-
-		// Delete any info about this theme
-		upgrade_query("
-			DELETE FROM {$db_prefix}themes
-			WHERE id_theme = $id_theme");
-	}
-}
+---# Setting knownThemes to current default
+---{
+$smcFunc['db_query']('', '
+	UPDATE {db_prefix}settings
+	SET value = {string:default_theme}
+	WHERE variable = {string:known_themes}',
+	array(
+		'default_theme' => '1',
+		'known_themes' => 'knownThemes',
+	)
+);
 ---}
 ---#
 

--- a/other/upgrade_2-1_postgresql.sql
+++ b/other/upgrade_2-1_postgresql.sql
@@ -950,13 +950,15 @@ foreach ($toMove as $move)
 /******************************************************************************/
 --- Cleaning up after old themes...
 /******************************************************************************/
----# Delete all theme data except for the current default
+---# Disabling old themes
 ---{
 $smcFunc['db_query']('', '
 	DELETE FROM {db_prefix}themes
-	WHERE id_theme != {int:default_theme}',
+	WHERE id_theme != {int:default_theme}
+	  AND variable IN ({array_string:remove_settings});',
 	array(
 		'default_theme' => 1,
+		'remove_settings' => array('theme_dir','theme_url'),
 	)
 );
 ---}
@@ -967,7 +969,7 @@ $smcFunc['db_query']('', '
 $smcFunc['db_query']('', '
 	UPDATE {db_prefix}settings
 	SET value = {string:default_theme}
-	WHERE variable = {string:known_themes}',
+	WHERE variable = {string:known_themes};',
 	array(
 		'default_theme' => '1',
 		'known_themes' => 'knownThemes',

--- a/other/upgrade_2-1_postgresql.sql
+++ b/other/upgrade_2-1_postgresql.sql
@@ -950,29 +950,45 @@ foreach ($toMove as $move)
 /******************************************************************************/
 --- Cleaning up after old themes...
 /******************************************************************************/
----# Disabling old themes
+---# Clean up settings for unused themes
 ---{
-$smcFunc['db_query']('', '
-	DELETE FROM {db_prefix}themes
-	WHERE id_theme != {int:default_theme}
-	  AND variable IN ({array_string:remove_settings});',
+// Fetch list of theme directories
+$request = $smcFunc['db_query']('', '
+	SELECT id_theme, variable, value
+	  FROM {db_prefix}themes
+	WHERE variable = {string:theme_dir}
+	  AND id_theme != {int:default_theme};',
 	array(
 		'default_theme' => 1,
-		'remove_settings' => array('theme_dir','theme_url'),
+		'theme_dir' => 'theme_dir',
 	)
 );
----}
----#
-
----# Setting knownThemes to current default
----{
+// Check which themes exist in the filesystem & save off their IDs 
+// Dont delete default theme(start with 1 in the array), & make sure to delete old core theme
+$known_themes = array('1');
+$core_dir = $GLOBALS['boarddir'] . '/Themes/core';
+while ($row = $smcFunc['db_fetch_assoc']($request))	{
+	if ($row['value'] != $core_dir && is_dir($row['value'])) {
+		$known_themes[] = $row['id_theme'];
+	}
+}
+// Cleanup unused theme settings
+$smcFunc['db_query']('', '
+	DELETE FROM {db_prefix}themes
+	WHERE id_theme NOT IN ({array_int:known_themes});',
+	array(
+		'known_themes' => $known_themes,
+	)
+);
+// Set knownThemes
+$known_themes = implode(',', $known_themes);
 $smcFunc['db_query']('', '
 	UPDATE {db_prefix}settings
-	SET value = {string:default_theme}
-	WHERE variable = {string:known_themes};',
+	SET value = {string:known_themes}
+	WHERE variable = {string:known_theme_str};',
 	array(
-		'default_theme' => '1',
-		'known_themes' => 'knownThemes',
+		'known_theme_str' => 'knownThemes',
+		'known_themes' => $known_themes,
 	)
 );
 ---}


### PR DESCRIPTION
Fixes: Upgrader - remnants of old themes around, prevents package install #3962

Users must start afresh with themes upon upgrade due to the significant differences between 2.0 & 2.1.  This fixes the issue where old theme settings were left around in the themes table, and were reflected in the knownThemes settings in the settings table.  

The extra old theme settings were, for example, causing backups to fail, since references to old theme folders were found in the themes table, & the backup process iterates those when making backups.  

Test out OK, and fixes all issues reported in #3962 

I don't have pg, I simply copied the MySQL stuff over, I believe it's simple enough it should be supported.