### PR TITLE
Remove old unused package_path setting

### DIFF
--- a/Sources/Subs-Package.php
+++ b/Sources/Subs-Package.php
@@ -596,7 +596,7 @@ function getPackageInfo($gzfilename)
  */
 function create_chmod_control($chmodFiles = array(), $chmodOptions = array(), $restore_write_status = false)
 {
-	global $context, $modSettings, $package_ftp, $boarddir, $txt, $sourcedir, $scripturl;
+	global $context, $modSettings, $package_ftp, $boarddir, $txt, $sourcedir, $scripturl, $packagesdir;
 
 	// If we're restoring the status of existing files prepare the data.
 	if ($restore_write_status && isset($_SESSION['pack_ftp']) && !empty($_SESSION['pack_ftp']['original_perms']))
@@ -828,9 +828,6 @@ function create_chmod_control($chmodFiles = array(), $chmodOptions = array(), $r
 				'connected' => true,
 			);
 
-			if (!isset($modSettings['package_path']) || $modSettings['package_path'] != $_POST['ftp_path'])
-				updateSettings(array('package_path' => $_POST['ftp_path']));
-
 			// This is now the primary connection.
 			$package_ftp = $ftp;
 		}
@@ -873,7 +870,7 @@ function create_chmod_control($chmodFiles = array(), $chmodOptions = array(), $r
 			if ($found_path)
 				$_POST['ftp_path'] = $detect_path;
 			elseif (!isset($_POST['ftp_path']))
-				$_POST['ftp_path'] = isset($modSettings['package_path']) ? $modSettings['package_path'] : $detect_path;
+				$_POST['ftp_path'] = isset($packagesdir) ? $packagesdir : $detect_path;
 
 			if (!isset($_POST['ftp_username']))
 				$_POST['ftp_username'] = $username;
@@ -1051,7 +1048,7 @@ function packageRequireFTP($destination_url, $files = null, $return = false)
 		if ($found_path)
 			$_POST['ftp_path'] = $detect_path;
 		elseif (!isset($_POST['ftp_path']))
-			$_POST['ftp_path'] = isset($modSettings['package_path']) ? $modSettings['package_path'] : $detect_path;
+			$_POST['ftp_path'] = isset($packagesdir) ? $packagesdir : $detect_path;
 
 		if (!isset($_POST['ftp_username']))
 			$_POST['ftp_username'] = $username;
@@ -1092,9 +1089,6 @@ function packageRequireFTP($destination_url, $files = null, $return = false)
 			'path' => $_POST['ftp_path'],
 			'root' => $ftp_root,
 		);
-
-		if (!isset($modSettings['package_path']) || $modSettings['package_path'] != $_POST['ftp_path'])
-			updateSettings(array('package_path' => $_POST['ftp_path']));
 
 		$files = packageRequireFTP($destination_url, $files, $return);
 	}

--- a/Sources/Subs-Package.php
+++ b/Sources/Subs-Package.php
@@ -912,7 +912,7 @@ function create_chmod_control($chmodFiles = array(), $chmodOptions = array(), $r
  */
 function packageRequireFTP($destination_url, $files = null, $return = false)
 {
-	global $context, $modSettings, $package_ftp, $boarddir, $txt, $sourcedir;
+	global $context, $modSettings, $package_ftp, $boarddir, $txt, $sourcedir, $packagesdir;
 
 	// Try to make them writable the manual way.
 	if ($files !== null)

--- a/other/upgrade_2-1_mysql.sql
+++ b/other/upgrade_2-1_mysql.sql
@@ -1339,7 +1339,7 @@ WHERE variable = 'avatar_action_too_large'
 
 ---# Cleaning up old settings.
 DELETE FROM {$db_prefix}settings
-WHERE variable IN ('enableStickyTopics', 'guest_hideContacts', 'notify_new_registration', 'attachmentEncryptFilenames', 'hotTopicPosts', 'hotTopicVeryPosts', 'fixLongWords', 'admin_features', 'topbottomEnable', 'simpleSearch', 'enableVBStyleLogin', 'admin_bbc', 'enable_unwatch');
+WHERE variable IN ('enableStickyTopics', 'guest_hideContacts', 'notify_new_registration', 'attachmentEncryptFilenames', 'hotTopicPosts', 'hotTopicVeryPosts', 'fixLongWords', 'admin_features', 'topbottomEnable', 'simpleSearch', 'enableVBStyleLogin', 'admin_bbc', 'enable_unwatch', 'package_path');
 ---#
 
 ---# Cleaning up old theme settings.

--- a/other/upgrade_2-1_postgresql.sql
+++ b/other/upgrade_2-1_postgresql.sql
@@ -1,4 +1,5 @@
 /* ATTENTION: You don't need to run or use this file! The upgrade.php script does everything for you! */
+/* ATTENTION: You don't need to run or use this file! The upgrade.php script does everything for you! */
 
 /******************************************************************************/
 --- Adding new settings...
@@ -1349,7 +1350,7 @@ WHERE variable = 'avatar_action_too_large'
 
 ---# Cleaning up old settings.
 DELETE FROM {$db_prefix}settings
-WHERE variable IN ('enableStickyTopics', 'guest_hideContacts', 'notify_new_registration', 'attachmentEncryptFilenames', 'hotTopicPosts', 'hotTopicVeryPosts', 'fixLongWords', 'admin_features', 'topbottomEnable', 'simpleSearch', 'enableVBStyleLogin', 'admin_bbc', 'enable_unwatch');
+WHERE variable IN ('enableStickyTopics', 'guest_hideContacts', 'notify_new_registration', 'attachmentEncryptFilenames', 'hotTopicPosts', 'hotTopicVeryPosts', 'fixLongWords', 'admin_features', 'topbottomEnable', 'simpleSearch', 'enableVBStyleLogin', 'admin_bbc', 'enable_unwatch', 'package_path');
 ---#
 
 ---# Cleaning up old theme settings.

--- a/other/upgrade_2-1_postgresql.sql
+++ b/other/upgrade_2-1_postgresql.sql
@@ -1,5 +1,4 @@
 /* ATTENTION: You don't need to run or use this file! The upgrade.php script does everything for you! */
-/* ATTENTION: You don't need to run or use this file! The upgrade.php script does everything for you! */
 
 /******************************************************************************/
 --- Adding new settings...


### PR DESCRIPTION
package_path is an legacy setting, but it still appears in subs-packages, and is populated with (old) path info in my 2.0 forum.   Replaced instances of package_path with its current version, $packagesdir, and removed the setting in the upgrader.  

Addresses: package_path lingers #3963

Testing, I was able to confirm the old setting is gone, & that package installation & de-installation still work fine.  

This may have addressed problems with FTP paths - it would be helpful if an FTP user could test that out.  