### PR TITLE
Do the mb4 fix only when needed

### DIFF
--- a/Sources/Load.php
+++ b/Sources/Load.php
@@ -84,7 +84,7 @@ function reloadSettings()
 		{
 			return $string;
 		};
-	$fix_utf8mb4 = function($string) use ($utf8,$smcFunc)
+	$fix_utf8mb4 = function($string) use ($utf8, $smcFunc)
 	{
 		if (!$utf8 || $smcFunc['db_mb4'])
 			return $string;

--- a/Sources/Load.php
+++ b/Sources/Load.php
@@ -84,9 +84,9 @@ function reloadSettings()
 		{
 			return $string;
 		};
-	$fix_utf8mb4 = function($string) use ($utf8)
+	$fix_utf8mb4 = function($string) use ($utf8,$smcFunc)
 	{
-		if (!$utf8)
+		if (!$utf8 || $smcFunc['db_mb4'])
 			return $string;
 
 		$i = 0;

--- a/Sources/Subs-Db-mysql.php
+++ b/Sources/Subs-Db-mysql.php
@@ -57,6 +57,7 @@ function smf_db_initiate($db_server, $db_name, $db_user, $db_passwd, $db_prefix,
 			'db_case_sensitive'         => false,
 			'db_escape_wildcard_string' => 'smf_db_escape_wildcard_string',
 			'db_is_resource'            => 'smf_is_resource',
+			'db_mb4'                    => false,
 		);
 
 	if (!empty($db_options['persist']))

--- a/Sources/Subs-Db-postgresql.php
+++ b/Sources/Subs-Db-postgresql.php
@@ -58,6 +58,7 @@ function smf_db_initiate($db_server, $db_name, $db_user, $db_passwd, &$db_prefix
 			'db_case_sensitive' => true,
 			'db_escape_wildcard_string' => 'smf_db_escape_wildcard_string',
 			'db_is_resource' => 'is_resource',
+			'db_mb4' => true,
 		);
 
 	if (!empty($db_options['persist']))


### PR DESCRIPTION
Postgresql support from default the complet utf8,
in mysql is this related to the used collation when you use the newer one (utf8mb4_general_ci).

utf8mb4 collation exists with mysql 5.5+ and is recommand to use instead of uf8
but we support 5.1 so the default value is false for mb4 support.