### PR TITLE
Fix Security, Check the attachment id

### DIFF
--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -3676,6 +3676,9 @@ function getAttachmentFilename($filename, $attachment_id, $dir = null, $new = fa
 	// Just make up a nice hash...
 	if ($new)
 		return sha1(md5($filename . time()) . mt_rand());
+	
+	// Just make sure that attachment id is only a int
+	$attachment_id = (int) $attachment_id;
 
 	// Grab the file hash if it wasn't added.
 	// Left this for legacy.


### PR DESCRIPTION
we pipe on many places $_REQUEST['attach'] directly into getAttachmentFilename as attachment_id without testing if there only integer value.
so instead of change on everycall i place a check in the function