### PR TITLE
Optimize the amount of queries for calendar

### DIFF
--- a/Sources/Subs-Calendar.php
+++ b/Sources/Subs-Calendar.php
@@ -1639,9 +1639,16 @@ function buildEventDatetimes($row)
 function getUserTimezone($id_member = null)
 {
 	global $smcFunc, $context, $sourcedir, $user_info, $modSettings;
+	static $member_cache = array();
 
 	if (is_null($id_member) && $user_info['is_guest'] == false)
 		$id_member = $context['user']['id'];
+	
+	//check if the cache got the data
+	if(isset($id_member) && isset($member_cache[$id_member]))
+	{
+		return $member_cache[$id_member];
+	}
 
 	if (isset($id_member))
 	{
@@ -1660,6 +1667,9 @@ function getUserTimezone($id_member = null)
 	if (empty($timezone) || !in_array($timezone, timezone_identifiers_list(DateTimeZone::ALL_WITH_BC)))
 		$timezone = isset($modSettings['default_timezone']) ? $modSettings['default_timezone'] : date_default_timezone_get();
 
+	if (isset($id_member))
+		$member_cache[$id_member] = $timezone;
+	
 	return $timezone;
 }
 

--- a/Sources/Subs-Calendar.php
+++ b/Sources/Subs-Calendar.php
@@ -33,7 +33,8 @@ function getBirthdayRange($low_date, $high_date)
 	$year_low = (int) substr($low_date, 0, 4);
 	$year_high = (int) substr($high_date, 0, 4);
 
-	if($smcFunc['db_title'] != "PostgreSQL") {
+	if ($smcFunc['db_title'] != "PostgreSQL")
+	{
 		// Collect all of the birthdays for this month.  I know, it's a painful query.
 		$result = $smcFunc['db_query']('birthday_array', '
 			SELECT id_member, real_name, YEAR(birthdate) AS birth_year, birthdate
@@ -81,8 +82,8 @@ function getBirthdayRange($low_date, $high_date)
 				'year_low' => $year_low . '-%m-%d',
 				'year_high' => $year_high . '-%m-%d',
 				'year_low_low_date' => $low_date,
-				'year_low_high_date' => ($year_low == $year_high ? $high_date : $year_low .'-12-31'),
-				'year_high_low_date' => ($year_low == $year_high ? $low_date : $year_high .'-01-01'),
+				'year_low_high_date' => ($year_low == $year_high ? $high_date : $year_low . '-12-31'),
+				'year_high_low_date' => ($year_low == $year_high ? $low_date : $year_high . '-01-01'),
 				'year_high_high_date' => $high_date,
 			)
 		);
@@ -1645,7 +1646,7 @@ function getUserTimezone($id_member = null)
 		$id_member = $context['user']['id'];
 	
 	//check if the cache got the data
-	if(isset($id_member) && isset($member_cache[$id_member]))
+	if (isset($id_member) && isset($member_cache[$id_member]))
 	{
 		return $member_cache[$id_member];
 	}


### PR DESCRIPTION
It could be happen that the same member got many event,
the query how get the timezone from the member is called once per event.

this code "cache" the result for every member.