### PR TITLE
Do not re-encode data already utf8

### DIFF
--- a/other/upgrade.php
+++ b/other/upgrade.php
@@ -2818,7 +2818,7 @@ function ConvertUtf8()
 								$table_charsets[$charset] = array();
 
 							$table_charsets[$charset][] = $column_info;
-							}
+						}
 					}
 				}
 			}

--- a/other/upgrade.php
+++ b/other/upgrade.php
@@ -2812,13 +2812,13 @@ function ConvertUtf8()
 					{
 						list($charset) = explode('_', $collation);
 
-					// Build structure of columns to operate on organized by charset; only operate on columns not yet utf8
-					if ($charset != 'utf8') {
-						if (!isset($table_charsets[$charset]))
-							$table_charsets[$charset] = array();
+						// Build structure of columns to operate on organized by charset; only operate on columns not yet utf8
+						if ($charset != 'utf8') {
+							if (!isset($table_charsets[$charset]))
+								$table_charsets[$charset] = array();
 
-						$table_charsets[$charset][] = $column_info;
-						}
+							$table_charsets[$charset][] = $column_info;
+							}
 					}
 				}
 			}

--- a/other/upgrade.php
+++ b/other/upgrade.php
@@ -2812,17 +2812,20 @@ function ConvertUtf8()
 					{
 						list($charset) = explode('_', $collation);
 
+					// Build structure of columns to operate on organized by charset; only operate on columns not yet utf8
+					if ($charset != 'utf8') {
 						if (!isset($table_charsets[$charset]))
 							$table_charsets[$charset] = array();
 
 						$table_charsets[$charset][] = $column_info;
+						}
 					}
 				}
 			}
 			$smcFunc['db_free_result']($queryColumns);
 
-			// Only change the column if the data doesn't match the current charset.
-			if ((count($table_charsets) === 1 && key($table_charsets) !== $charsets[$upcontext['charset_detected']]) || count($table_charsets) > 1)
+			// Only change the non-utf8 columns identified above
+			if (count($table_charsets) > 0)
 			{
 				$updates_blob = '';
 				$updates_text = '';


### PR DESCRIPTION
This change ensures that individual columns are encoded to UTF8 ONLY if they aren't already UTF8...

Re-encoding UTF8 content that is already UTF8 causes it to be garbled.   We see this whenever:
  -  A site admin manually converts a site to UTF8, without using the SMF conversion function
  -  A prior UTF8 attempt conversion failed, leaving mixed charsets

These two scenarios are problematic because the system may not detect that the site has been converted to UTF8 (e.g., global_character_set may not be set).   So, it does the UTF8 conversion again...

Fixes: Problem reading arabic text after upgrading. #3972

_* Consider this change in 2.0 in ManageMaintenance.php as well... *_