### PR TITLE
Set collation type consistently

### DIFF
--- a/other/upgrade.php
+++ b/other/upgrade.php
@@ -2914,7 +2914,7 @@ function ConvertUtf8()
 		}
 	}
 	$_GET['substep'] = 0;
-	return false;
+	return true;
 }
 
 function serialize_to_json()

--- a/other/upgrade.php
+++ b/other/upgrade.php
@@ -1329,7 +1329,7 @@ function DatabaseChanges()
 
 		return true;
 	}
-	return false;
+	return true;
 }
 
 
@@ -1638,7 +1638,7 @@ function parse_sql($filename)
 	// If we're on MySQL, set {db_collation}; this approach is used throughout upgrade_2-0_mysql.php to set new tables to utf8
 	// Note it is expected to be in the format: ENGINE=MyISAM{$db_collation};
 	if ($db_type == 'mysql')
-		$db_collation = ' ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci';
+		$db_collation = ' DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci';
 	else
 		$db_collation = '';
 

--- a/other/upgrade.php
+++ b/other/upgrade.php
@@ -1329,7 +1329,7 @@ function DatabaseChanges()
 
 		return true;
 	}
-	return true;
+	return false;
 }
 
 

--- a/other/upgrade.php
+++ b/other/upgrade.php
@@ -1635,43 +1635,11 @@ function parse_sql($filename)
 		}
 	);
 
-	// If we're on MySQL supporting collations then let's find out what the members table uses and put it in a global var - to allow upgrade script to match collations!
-	if (!empty($databases[$db_type]['utf8_support']) && version_compare($databases[$db_type]['utf8_version'], eval($databases[$db_type]['utf8_version_check']), '>'))
-	{
-		$request = $smcFunc['db_query']('', '
-			SHOW TABLE STATUS
-			LIKE {string:table_name}',
-			array(
-				'table_name' => "{$db_prefix}members",
-				'db_error_skip' => true,
-			)
-		);
-		if ($smcFunc['db_num_rows']($request) === 0)
-			die('Unable to find members table!');
-		$table_status = $smcFunc['db_fetch_assoc']($request);
-		$smcFunc['db_free_result']($request);
-
-		if (!empty($table_status['Collation']))
-		{
-			$request = $smcFunc['db_query']('', '
-				SHOW COLLATION
-				LIKE {string:collation}',
-				array(
-					'collation' => $table_status['Collation'],
-					'db_error_skip' => true,
-				)
-			);
-			// Got something?
-			if ($smcFunc['db_num_rows']($request) !== 0)
-				$collation_info = $smcFunc['db_fetch_assoc']($request);
-			$smcFunc['db_free_result']($request);
-
-			// Excellent!
-			if (!empty($collation_info['Collation']) && !empty($collation_info['Charset']))
-				$db_collation = ' CHARACTER SET ' . $collation_info['Charset'] . ' COLLATE ' . $collation_info['Collation'];
-		}
-	}
-	if (empty($db_collation))
+	// If we're on MySQL, set {db_collation}; this approach is used throughout upgrade_2-0_mysql.php to set new tables to utf8
+	// Note it is expected to be in the format: ENGINE=MyISAM{$db_collation};
+	if ($db_type == 'mysql')
+		$db_collation = ' ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci';
+	else
 		$db_collation = '';
 
 	$endl = $command_line ? "\n" : '<br>' . "\n";
@@ -1683,7 +1651,7 @@ function parse_sql($filename)
 	$substep = 0;
 	$last_step = '';
 
-	// Make sure all newly created tables will have the proper characters set.
+	// Make sure all newly created tables will have the proper characters set; this approach is used throughout upgrade_2-1_mysql.php
 	if (isset($db_character_set) && $db_character_set === 'utf8')
 		$lines = str_replace(') ENGINE=MyISAM;', ') ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci;', $lines);
 

--- a/other/upgrade_2-0_mysql.sql
+++ b/other/upgrade_2-0_mysql.sql
@@ -426,7 +426,7 @@ CREATE TABLE {$db_prefix}log_online (
 	PRIMARY KEY (session),
 	KEY log_time (log_time),
 	KEY id_member (id_member)
-) ENGINE=MyISAM;
+) ENGINE=MyISAM{$db_collation};
 ---#
 
 /******************************************************************************/

--- a/other/upgrade_2-0_mysql.sql
+++ b/other/upgrade_2-0_mysql.sql
@@ -426,7 +426,7 @@ CREATE TABLE {$db_prefix}log_online (
 	PRIMARY KEY (session),
 	KEY log_time (log_time),
 	KEY id_member (id_member)
-) ENGINE=MyISAM{$db_collation};
+) ENGINE=MyISAM;
 ---#
 
 /******************************************************************************/

--- a/other/upgrade_2-1_mysql.sql
+++ b/other/upgrade_2-1_mysql.sql
@@ -14,7 +14,7 @@ CREATE TABLE IF NOT EXISTS {$db_prefix}member_logins (
 	PRIMARY KEY id_login(id_login),
 	INDEX idx_id_member (id_member),
 	INDEX idx_time (time)
-) ENGINE=MyISAM{$db_collation};
+) ENGINE=MyISAM;
 ---#
 
 ---# Copying the current package backup setting...
@@ -1167,7 +1167,7 @@ CREATE TABLE IF NOT EXISTS {$db_prefix}user_drafts (
 	to_list VARCHAR(255) NOT NULL DEFAULT '',
 	PRIMARY KEY id_draft(id_draft),
 	INDEX idx_id_member (id_member, id_draft, type)
-) ENGINE=MyISAM{$db_collation};
+) ENGINE=MyISAM;
 ---#
 
 ---# Adding draft permissions...
@@ -1271,7 +1271,7 @@ CREATE TABLE IF NOT EXISTS {$db_prefix}moderator_groups (
 	id_board SMALLINT(5) UNSIGNED DEFAULT '0',
 	id_group SMALLINT(5) UNSIGNED DEFAULT '0',
 	PRIMARY KEY (id_board, id_group)
-) ENGINE=MyISAM{$db_collation};
+) ENGINE=MyISAM;
 ---#
 
 /******************************************************************************/
@@ -1397,7 +1397,7 @@ CREATE TABLE IF NOT EXISTS {$db_prefix}qanda (
 	answers TEXT NOT NULL,
 	PRIMARY KEY (id_question),
 	INDEX idx_lngfile (lngfile)
-) ENGINE=MyISAM{$db_collation};
+) ENGINE=MyISAM;
 ---#
 
 ---# Moving questions and answers to the new table


### PR DESCRIPTION
This addresses the issue where some tables were not built using the UTF8 charset.  

This sometimes happened when the DB had already been converted to UTF8 in 2.0.  The UTF8 conversion step gets bypassed, and new tables are built using the MySQL defaults, which may not be UTF8.

Fixes: Upgrader - collation set inconsistently, db may not be fully UTF8 #3992
