### PR TITLE
Correct package backup prompt

### DIFF
--- a/Themes/default/languages/Packages.english.php
+++ b/Themes/default/languages/Packages.english.php
@@ -142,7 +142,7 @@ $txt['package_install_options_ftp_server'] = 'FTP Server';
 $txt['package_install_options_ftp_port'] = 'Port';
 $txt['package_install_options_ftp_user'] = 'Username';
 $txt['package_install_options_make_backups'] = 'Create Backup versions of replaced files with a tilde (~) on the end of their names.';
-$txt['package_install_options_make_full_backups'] = 'Create an entire backup (excluding smileys, avatars and attachments) of the SMF install.';
+$txt['package_install_options_make_full_backups'] = 'Create a backup of key SMF files when a package is installed, uninstalled or upgraded.';
 
 $txt['package_ftp_necessary'] = 'FTP Information Required';
 $txt['package_ftp_why'] = 'Some of the files the package manager needs to modify are not writable. This needs to be changed by logging into FTP and using it to chmod or create the files and directories. Your FTP information may be temporarily cached for proper operation of the package manager. Note you can also do this manually using an FTP client - to view a list of the affected files please click <a href="#" onclick="%1$s">here</a>.';


### PR DESCRIPTION
Fixes: Create an entire backup (excluding smileys, avatars and attachments) of the SMF install. #2182

Changed the setting label to be more accurate.
