### PR TITLE
Package install backup fixes

### DIFF
--- a/Sources/Subs-Package.php
+++ b/Sources/Subs-Package.php
@@ -2980,7 +2980,7 @@ function package_create_backup($id = 'backup')
 
 	$files = array();
 
-	$base_files = array('index.php', 'SSI.php', 'agreement.txt', 'cron.php', 'ssi_examples.php', 'ssi_examples.shtml', 'subscriptions.php', 'settings.php');
+	$base_files = array('index.php', 'SSI.php', 'agreement.txt', 'cron.php', 'ssi_examples.php', 'ssi_examples.shtml', 'subscriptions.php');
 	foreach ($base_files as $file)
 	{
 		if (file_exists($boarddir . '/' . $file))

--- a/Sources/Subs-Package.php
+++ b/Sources/Subs-Package.php
@@ -2980,7 +2980,7 @@ function package_create_backup($id = 'backup')
 
 	$files = array();
 
-	$base_files = array('index.php', 'SSI.php', 'agreement.txt', 'cron.php', 'ssi_examples.php', 'ssi_examples.shtml', 'subscriptions.php');
+	$base_files = array('index.php', 'SSI.php', 'agreement.txt', 'cron.php', 'ssi_examples.php', 'ssi_examples.shtml', 'subscriptions.php', 'settings.php');
 	foreach ($base_files as $file)
 	{
 		if (file_exists($boarddir . '/' . $file))
@@ -3035,11 +3035,12 @@ function package_create_backup($id = 'backup')
 			package_chmod($packagesdir . '/backups');
 		$output_file = $packagesdir . '/backups/' . strftime('%Y-%m-%d_') . preg_replace('~[$\\\\/:<>|?*"\']~', '', $id);
 		$output_ext = '.tar';
-
-		if (file_exists($output_file . $output_ext))
+		$output_ext_target = '.tar.gz';
+		
+		if (file_exists($output_file . $output_ext_target))
 		{
 			$i = 2;
-			while (file_exists($output_file . '_' . $i . $output_ext))
+			while (file_exists($output_file . '_' . $i . $output_ext_target))
 				$i++;
 			$output_file = $output_file . '_' . $i . $output_ext;
 		}

--- a/Themes/default/languages/Packages.english.php
+++ b/Themes/default/languages/Packages.english.php
@@ -142,7 +142,7 @@ $txt['package_install_options_ftp_server'] = 'FTP Server';
 $txt['package_install_options_ftp_port'] = 'Port';
 $txt['package_install_options_ftp_user'] = 'Username';
 $txt['package_install_options_make_backups'] = 'Create Backup versions of replaced files with a tilde (~) on the end of their names.';
-$txt['package_install_options_make_full_backups'] = 'Create a backup of key SMF files when a package is installed, uninstalled or upgraded.';
+$txt['package_install_options_make_full_backups'] = 'Create a backup of key SMF files whenever a package is installed or uninstalled.';
 
 $txt['package_ftp_necessary'] = 'FTP Information Required';
 $txt['package_ftp_why'] = 'Some of the files the package manager needs to modify are not writable. This needs to be changed by logging into FTP and using it to chmod or create the files and directories. Your FTP information may be temporarily cached for proper operation of the package manager. Note you can also do this manually using an FTP client - to view a list of the affected files please click <a href="#" onclick="%1$s">here</a>.';


### PR DESCRIPTION
Addresses: Create an entire backup (excluding smileys, avatars and attachments) of the SMF install. #2182

3 changes:
  -  Made the backup prompt txt more accurate
  -  Added settings.php to backup
  -  Fixed glitch in backup filename dupe detection logic, in case package gets installed multiple times