### PR TITLE
Address upgrader performance issue

### DIFF
--- a/other/upgrade.php
+++ b/other/upgrade.php
@@ -4528,8 +4528,10 @@ function MySQLConvertOldIp($targetTable, $oldCol, $newCol, $limit = 50000, $setS
 
 	$current_substep = $_GET['substep'];
 
+	if (empty($_GET['a']))
+		$_GET['a'] = 0;
 	$step_progress['name'] = 'Converting ips';
-	$step_progress['current'] = !empty($_GET['a']) ? $_GET['a'] : 0;
+	$step_progress['current'] = $_GET['a'];
 
 	// Skip this if we don't have the column
 	$request = $smcFunc['db_query']('', '
@@ -4555,6 +4557,8 @@ function MySQLConvertOldIp($targetTable, $oldCol, $newCol, $limit = 50000, $setS
 	{
 		// Keep looping at the current step.
 		nextSubStep($current_substep);
+
+		$arIp = array();
 
 		$request = $smcFunc['db_query']('', '
 			SELECT DISTINCT {raw:old_col}

--- a/other/upgrade_2-1_mysql.sql
+++ b/other/upgrade_2-1_mysql.sql
@@ -2209,6 +2209,10 @@ MySQLConvertOldIp('messages','poster_ip_old','poster_ip');
 ---}
 ---#
 
+---# Remove the temporary ip indexes
+DROP INDEX temp_old_poster_ip on {$db_prefix}messages;
+---#
+
 ---# Drop old column to messages
 ALTER TABLE {$db_prefix}messages DROP COLUMN poster_ip_old;
 ---#
@@ -2219,10 +2223,6 @@ CREATE INDEX {$db_prefix}messages_ip_index ON {$db_prefix}messages (poster_ip, i
 
 ---# Add the index again to mesages poster ip msg
 CREATE INDEX {$db_prefix}messages_related_ip ON {$db_prefix}messages (id_member, poster_ip, id_msg);
----#
-
----# Remove the temporary ip indexes
-DROP INDEX temp_old_poster_ip on {$db_prefix}messages;
 ---#
 
 /******************************************************************************/


### PR DESCRIPTION
Addresses performance issues (a runaway loop) & a minor internal error.
(1) arIp array needed to be reset within the loop, otherwise it just grew & ran thru timeout/next substep.
(2) get['a'] was uninitialized, resulting in an internal warning.
(3) delete index before column; spread the workload.

This PR addresses one of the issues noted in this thread:  UTF8 conversion - template not displayed #3996