### PR TITLE
Removes DatePair script from calendar list view.

### DIFF
--- a/Sources/Subs-Calendar.php
+++ b/Sources/Subs-Calendar.php
@@ -698,7 +698,6 @@ function getCalendarList($start_date, $end_date, $calendarOptions)
 
 	loadCSSFile('jquery-ui.datepicker.css', array('defer' => false), 'smf_datepicker');
 	loadJavaScriptFile('jquery-ui.datepicker.min.js', array('defer' => true), 'smf_datepicker');
-	loadJavaScriptFile('jquery.timepicker.min.js', array('defer' => true), 'smf_timepicker');
 	addInlineJavaScript('
 	$("#calendar_range .date_input").datepicker({
 		dateFormat: "yy-mm-dd",

--- a/Sources/Subs-Calendar.php
+++ b/Sources/Subs-Calendar.php
@@ -699,7 +699,6 @@ function getCalendarList($start_date, $end_date, $calendarOptions)
 	loadCSSFile('jquery-ui.datepicker.css', array('defer' => false), 'smf_datepicker');
 	loadJavaScriptFile('jquery-ui.datepicker.min.js', array('defer' => true), 'smf_datepicker');
 	loadJavaScriptFile('jquery.timepicker.min.js', array('defer' => true), 'smf_timepicker');
-	loadJavaScriptFile('datepair.min.js', array('defer' => true), 'smf_datepair');
 	addInlineJavaScript('
 	$("#calendar_range .date_input").datepicker({
 		dateFormat: "yy-mm-dd",
@@ -721,17 +720,6 @@ function getCalendarList($start_date, $end_date, $calendarOptions)
 		nextText: "' . $txt['next_month'] . '",
 	});
 	var date_entry = document.getElementById("calendar_range");
-	var date_entry_pair = new Datepair(date_entry, {
-		dateClass: "date_input",
-		autoclose: true,
-		parseDate: function (el) {
-		    var utc = new Date($(el).datepicker("getDate"));
-		    return utc && new Date(utc.getTime() + (utc.getTimezoneOffset() * 60000));
-		},
-		updateDate: function (el, v) {
-		    $(el).datepicker("setDate", new Date(v.getTime() - (v.getTimezoneOffset() * 60000)));
-		}
-	});
 	', true);
 
 	return $calendarGrid;
@@ -1644,7 +1632,7 @@ function getUserTimezone($id_member = null)
 
 	if (is_null($id_member) && $user_info['is_guest'] == false)
 		$id_member = $context['user']['id'];
-	
+
 	//check if the cache got the data
 	if (isset($id_member) && isset($member_cache[$id_member]))
 	{
@@ -1670,7 +1658,7 @@ function getUserTimezone($id_member = null)
 
 	if (isset($id_member))
 		$member_cache[$id_member] = $timezone;
-	
+
 	return $timezone;
 }
 


### PR DESCRIPTION
DatePair automatically adjusts the end date when the start date changes so that the overall duration stays the same. That is a good thing when *creating* an event. But when the user is trying to adjust the *viewing* range, that's not helpful.