### PR TITLE
centralize the language setting for fulltext search

### DIFF
--- a/Sources/DbSearch-postgresql.php
+++ b/Sources/DbSearch-postgresql.php
@@ -29,6 +29,7 @@ function db_search_init()
 			'db_search_support' => 'smf_db_search_support',
 			'db_create_word_search' => 'smf_db_create_word_search',
 			'db_support_ignore' => false,
+			'db_search_language' => 'smf_db_search_language',
 		);
 
 	db_extend();
@@ -152,6 +153,41 @@ function smf_db_create_word_search($size)
 			'string_zero' => '0',
 		)
 	);
+}
+
+/**
+* Return the language for the textsearch index
+*/
+function smf_db_search_language()
+{
+	global $smcFunc, $modSettings;
+	
+	$language_ftx = 'english';
+	
+	if (!empty($modSettings['search_language']))
+		$language_ftx = $modSettings['search_language'];
+	else
+	{
+		$request = $smcFunc['db_query']('','
+			SHOW default_text_search_config',
+			array()
+		);
+
+		if ($request !== false && $smcFunc['db_num_rows']($request) == 1)
+		{
+			$row = $smcFunc['db_fetch_assoc']($request);
+			$language_ftx = $row['default_text_search_config'];
+
+			$smcFunc['db_insert']('replace',
+				'{db_prefix}settings',
+				array('variable' => 'string', 'value' => 'string'),
+				array('search_language', $language_ftx),
+				array('variable')
+			);
+		}
+	}
+
+	return $language_ftx;	
 }
 
 ?>

--- a/Sources/ManageSearch.php
+++ b/Sources/ManageSearch.php
@@ -231,19 +231,7 @@ function EditSearchMethod()
 				)
 			);
 
-			$request = $smcFunc['db_query']('', '
-				SHOW default_text_search_config',
-				array()
-			);
-
-			$language_ftx = 'simple';
-
-			if ($request !== false && $smcFunc['db_num_rows']($request) == 1)
-			{
-				$row = $smcFunc['db_fetch_assoc']($request);
-				$language_ftx = $row['default_text_search_config'];
-			}
-
+			$language_ftx = $smcFunc['db_search_language']();
 
 			$smcFunc['db_query']('', '
 				CREATE INDEX {db_prefix}messages_ftx ON {db_prefix}messages

--- a/Sources/SearchAPI-Fulltext.php
+++ b/Sources/SearchAPI-Fulltext.php
@@ -208,19 +208,8 @@ class fulltext_search extends search_api
 		{
 			if($smcFunc['db_title'] == "PostgreSQL")
 			{
-				//we use the default language "default_text_search_config", otherwise we had to assgine the language here
-				//to_tsvector(body) -> to_tsvector($language,body) to_tsquery(...) -> to_tsquery($language,...)
-				$language_ftx = 'english';
-				$request = $smcFunc['db_query']('','
-					SHOW default_text_search_config',
-					array()
-				);
-
-				if ($request !== false && $smcFunc['db_num_rows']($request) == 1)
-				{
-					$row = $smcFunc['db_fetch_assoc']($request);
-					$language_ftx = $row['default_text_search_config'];
-				}
+				$language_ftx = $smcFunc['db_search_language']();
+				
 				$query_where[] = 'to_tsvector({string:language_ftx},body) @@ to_tsquery({string:language_ftx},{string:body_match})';
 				$query_params['language_ftx'] = $language_ftx;
 			}
@@ -253,19 +242,8 @@ class fulltext_search extends search_api
 			if ($query_params['boolean_match']) {
 				if($smcFunc['db_title'] == "PostgreSQL")
 				{
-					//we use the default language "default_text_search_config", otherwise we had to assgine the language here
-					//to_tsvector(body) -> to_tsvector($language,body) to_tsquery(...) -> to_tsquery($language,...)
-					$language_ftx = 'english';
-					$request = $smcFunc['db_query']('','
-						SHOW default_text_search_config',
-						array()
-					);
-
-					if ($request !== false && $smcFunc['db_num_rows']($request) == 1)
-					{
-						$row = $smcFunc['db_fetch_assoc']($request);
-						$language_ftx = $row['default_text_search_config'];
-					}
+					$language_ftx = $smcFunc['db_search_language']();
+					
 					$query_where[] = 'to_tsvector({string:language_ftx},body) @@ to_tsquery({string:language_ftx},{string:boolean_match})';
 					$query_params['language_ftx'] = $language_ftx;
 				}


### PR DESCRIPTION
give the user/admin the option to change the fulltext search language by
changing the the search_language in the settings table