### PR TITLE
Fix utf8 template

### DIFF
--- a/Sources/Subs-Db-mysql.php
+++ b/Sources/Subs-Db-mysql.php
@@ -58,6 +58,7 @@ function smf_db_initiate($db_server, $db_name, $db_user, $db_passwd, $db_prefix,
 			'db_escape_wildcard_string' => 'smf_db_escape_wildcard_string',
 			'db_is_resource'            => 'smf_is_resource',
 			'db_mb4'                    => false,
+			'db_ping'                   => 'mysqli_ping',
 		);
 
 	if (!empty($db_options['persist']))

--- a/Sources/Subs-Db-postgresql.php
+++ b/Sources/Subs-Db-postgresql.php
@@ -59,6 +59,7 @@ function smf_db_initiate($db_server, $db_name, $db_user, $db_passwd, &$db_prefix
 			'db_escape_wildcard_string' => 'smf_db_escape_wildcard_string',
 			'db_is_resource' => 'is_resource',
 			'db_mb4' => true,
+			'db_ping' => 'pg_ping',
 		);
 
 	if (!empty($db_options['persist']))

--- a/other/upgrade.php
+++ b/other/upgrade.php
@@ -358,7 +358,11 @@ function upgradeExit($fallThrough = false)
 			if (!empty($upcontext['query_string']))
 				$upcontext['form_url'] .= $upcontext['query_string'];
 
-			call_user_func('template_' . $upcontext['sub_template']);
+			// Call the appropriate subtemplate
+			if (is_callable('template_' . $upcontext['sub_template']))
+				call_user_func('template_' . $upcontext['sub_template']);
+			else
+				die('Upgrade aborted!  Invalid template: template_' . $upcontext['sub_template']);
 		}
 
 		// Was there an error?

--- a/other/upgrade.php
+++ b/other/upgrade.php
@@ -458,7 +458,11 @@ function loadEssentialData()
 		require_once($sourcedir . '/Subs-Db-' . $db_type . '.php');
 
 		// Make the connection...
-		$db_connection = smf_db_initiate($db_server, $db_name, $db_user, $db_passwd, $db_prefix, array('non_fatal' => true));
+		if (empty($db_connection))
+			$db_connection = smf_db_initiate($db_server, $db_name, $db_user, $db_passwd, $db_prefix, array('non_fatal' => true));
+		else
+			// If we've returned here, ping/reconnect to be safe
+			$smcFunc['db_ping']($db_connection);
 
 		// Oh dear god!!
 		if ($db_connection === null)

--- a/other/upgrade.php
+++ b/other/upgrade.php
@@ -2756,7 +2756,7 @@ function ConvertUtf8()
 				$upcontext['previous_tables'][] = $table;
 
 		$upcontext['cur_table_num'] = $_GET['substep'];
-		$upcontext['cur_table_name'] = $queryTables[$_GET['substep']];
+		$upcontext['cur_table_name'] = str_replace($db_prefix, '', $queryTables[$_GET['substep']]);
 		$upcontext['step_progress'] = (int) (($upcontext['cur_table_num'] / $upcontext['table_count']) * 100);
 			
 		// Make sure we're ready & have painted the template before proceeding	
@@ -2766,9 +2766,9 @@ function ConvertUtf8()
 		}	
 			
 		// We want to start at the first table.
-		for ($substep = $_GET['substep']; $substep < $upcontext['table_count']; $substep++)
+		for ($substep = $_GET['substep'], $n = count($queryTables); $substep < $n; $substep++)
 		{
-			$table = $queryTables[$_GET['substep']];
+			$table = $queryTables[$substep];
 
 			$getTableStatus = $smcFunc['db_query']('', '
 				SHOW TABLE STATUS
@@ -2782,8 +2782,8 @@ function ConvertUtf8()
 			$table_info = $smcFunc['db_fetch_assoc']($getTableStatus);
 			$smcFunc['db_free_result']($getTableStatus);
 
-			$upcontext['cur_table_num'] = $_GET['substep'] + 1;
-			$upcontext['cur_table_name'] = $table_info['Name'];
+			$upcontext['cur_table_name'] = str_replace($db_prefix, '', (isset($queryTables[$substep + 1]) ? $queryTables[$substep + 1] : $queryTables[$substep]));
+			$upcontext['cur_table_num'] = $substep + 1;
 			$upcontext['step_progress'] = (int) (($upcontext['cur_table_num'] / $upcontext['table_count']) * 100);
 
 			// Do we need to pause?

--- a/other/upgrade_2-1_mysql.sql
+++ b/other/upgrade_2-1_mysql.sql
@@ -2140,7 +2140,7 @@ ADD COLUMN member_ip VARBINARY(16),
 ADD COLUMN member_ip2 VARBINARY(16);
 ---#
 
----# Create a ip index for old ips
+---# Create an ip index for old ips
 ---{
 $results = $smcFunc['db_list_columns']('{db_prefix}members');
 if (in_array('member_ip_old', $results))
@@ -2155,6 +2155,7 @@ if (in_array('member_ip_old', $results))
 ---{
 MySQLConvertOldIp('members','member_ip_old','member_ip');
 ---}
+---#
 
 ---# Convert member ips2
 ---{
@@ -2191,7 +2192,7 @@ if ($doChange)
 ALTER TABLE {$db_prefix}messages ADD COLUMN poster_ip VARBINARY(16);
 ---#
 
----# Create a ip index for old ips
+---# Create an ip index for old ips
 ---{
 $doChange = true;
 $results = $smcFunc['db_list_columns']('{db_prefix}members');

--- a/other/upgrade_2-1_mysql.sql
+++ b/other/upgrade_2-1_mysql.sql
@@ -1900,7 +1900,7 @@ ALTER TABLE {$db_prefix}members
 ADD tfa_backup VARCHAR(64) NOT NULL DEFAULT '';
 ---#
 
----# Force 2FA per membergroup?
+---# Force 2FA per membergroup
 ALTER TABLE {$db_prefix}membergroups
 ADD COLUMN tfa_required TINYINT(3) NOT NULL DEFAULT '0';
 ---#
@@ -2218,11 +2218,11 @@ DROP INDEX temp_old_poster_ip on {$db_prefix}messages;
 ALTER TABLE {$db_prefix}messages DROP COLUMN poster_ip_old;
 ---#
 
----# Add the index again to mesages poster ip topic
+---# Add the index again to messages poster ip topic
 CREATE INDEX {$db_prefix}messages_ip_index ON {$db_prefix}messages (poster_ip, id_topic);
 ---#
 
----# Add the index again to mesages poster ip msg
+---# Add the index again to messages poster ip msg
 CREATE INDEX {$db_prefix}messages_related_ip ON {$db_prefix}messages (id_member, poster_ip, id_msg);
 ---#
 

--- a/other/upgrade_2-1_postgresql.sql
+++ b/other/upgrade_2-1_postgresql.sql
@@ -1955,7 +1955,7 @@ ALTER TABLE {$db_prefix}members
 ADD COLUMN tfa_backup VARCHAR(64) NOT NULL DEFAULT '';
 ---#
 
----# Force 2FA per membergroup?
+---# Force 2FA per membergroup
 ALTER TABLE {$db_prefix}membergroups
 ADD COLUMN tfa_required smallint NOT NULL default '0';
 ---#


### PR DESCRIPTION
Several changes to get the template to display during the UTF8 conversion step.  While in there, I brought  some consistency across the templates, so the steps behave similarly (scrollbars, buttons, display etc).   

Addresses: UTF8 conversion - template not displayed #3996

While I was in there I also:
  -  Confirmed the subtemplate exists - part of the issue is that it had been calling a non-existent subtemplate...
  -  The connect was generating internal "out of sequence" warnings on subsequent calls; used a ping instead, as that will attempt a reconnect; I think this will be helpful during long-running upgrades
  -  SourceURL directives allow debugging of inline .js using your browser's debugger

Tested on large & small forums, with & without backups, with & without debug info displayed, and with & without a UTF8 conversion needed.  Testing combos was needed, because sometimes steps affected subsequent steps' behavior (another part of the reason the template didn't display)...  This PR resolves this. The only quirk outstanding is that the very first tablename is displayed (not executed, displayed) 2x if debug is enabled during UTF8 conversion...  I gave up on that one after spending WAY too much time on it...  