### PR TITLE
Uses $context['posting_fields'] for all fields in post form header

### DIFF
--- a/Sources/Post.php
+++ b/Sources/Post.php
@@ -1326,20 +1326,19 @@ function Post($post_errors = array())
 	);
 
 	// Icons are fun.
-	$message_icon_select = '<select name="icon" id="icon" onchange="showimage()">';
+	$context['posting_fields']['icon'] = array(
+		'dt' => $txt['message_icon'],
+		'dd' => '<select name="icon" id="icon" onchange="showimage()">',
+	);
 	foreach ($context['icons'] as $icon)
 	{
-		$message_icon_select .= '
+		$context['posting_fields']['icon']['dd'] .= '
 							<option value="' . $icon['value'] . '"' . ($icon['value'] == $context['icon'] ? ' selected' : '') . '>' . $icon['name'] . '</option>';
 	}
-	$message_icon_select .= '
+	$context['posting_fields']['icon']['dd'] .= '
 						</select>
 						<img id="icons" src="' . $context['icon_url'] . '">';
 
-	$context['posting_fields']['icon'] = array(
-		'dt' => $txt['message_icon'],
-		'dd' => $message_icon_select,
-	);
 
 	// Finally, load the template.
 	if (!isset($_REQUEST['xml']))

--- a/Sources/Post.php
+++ b/Sources/Post.php
@@ -1305,15 +1305,15 @@ function Post($post_errors = array())
 	// Guests must supply their name and email.
 	if (isset($context['name']) && isset($context['email']))
 	{
-		$context['posting_fields']['guest_name'] = array(
-			'dt' => '<span' . (isset($context['post_error']['long_name']) || isset($context['post_error']['no_name']) || isset($context['post_error']['bad_name']) ? ' class="error"' : '') . ' id="caption_guestname">' . $txt['name'] . ':</span>',
-			'dd' => '<input type="text" name="guestname" size="25" value="' . $context['name'] . '" class="input_text">',
+		$context['posting_fields']['guestname'] = array(
+			'dt' => '<span id="caption_guestname"' .  (isset($context['post_error']['long_name']) || isset($context['post_error']['no_name']) || isset($context['post_error']['bad_name']) ? ' class="error"' : '') . '>' . $txt['name'] . '</span>',
+			'dd' => '<input type="text" name="guestname" size="25" value="' . $context['name'] . '" class="input_text" required>',
 		);
 
 		if (empty($modSettings['guest_post_no_email']))
 		{
-			$context['posting_fields']['guest_email'] = array(
-				'dt' => '<span' . (isset($context['post_error']['no_email']) || isset($context['post_error']['bad_email']) ? ' class="error"' : '') . ' id="caption_email">' . $txt['email'] . ':</span>',
+			$context['posting_fields']['email'] = array(
+				'dt' => '<span id="caption_email"' .  (isset($context['post_error']['no_email']) || isset($context['post_error']['bad_email']) ? ' class="error"' : '') . '>' . $txt['email'] . '</span>',
 				'dd' => '<input type="email" name="email" size="25" value="' . $context['email'] . '" class="input_text" required>',
 			);
 		}
@@ -1321,8 +1321,8 @@ function Post($post_errors = array())
 
 	// Gotta have a subject.
 	$context['posting_fields']['subject'] = array(
-		'dt' => '<span' . (isset($context['post_error']['no_subject']) ? ' class="error"' : '') . ' id="caption_subject">' . $txt['subject'] . ':</span>',
-		'dd' => '<input type="text" name="subject" value="' . $context['subject'] . '" size="80" maxlength="80" class="' . (isset($context['post_error']['no_subject']) ? 'error' : 'input_text') . '" required>',
+		'dt' => '<span id="caption_subject"' . (isset($context['post_error']['no_subject']) ? ' class="error"' : '') . '>' . $txt['subject'] . '</span>',
+		'dd' => '<input type="text" name="subject" value="' . $context['subject'] . '" size="80" maxlength="80" class="input_text" required>',
 	);
 
 	// Icons are fun.
@@ -1334,9 +1334,9 @@ function Post($post_errors = array())
 	}
 	$message_icon_select .= '
 						</select>
-						<img src="' . $context['icon_url'] . '" id="icons">';
+						<img id="icons" src="' . $context['icon_url'] . '">';
 
-	$context['posting_fields']['message_icon'] = array(
+	$context['posting_fields']['icon'] = array(
 		'dt' => $txt['message_icon'],
 		'dd' => $message_icon_select,
 	);

--- a/Themes/default/Post.template.php
+++ b/Themes/default/Post.template.php
@@ -142,7 +142,7 @@ function template_main()
 							', $pf['dt'], '
 						</dt>
 						<dd', !is_numeric($pfid) ? ' class="pf_' . $pfid . '"' : '', '>
-							', preg_replace('~<(input|select)\b~', '<$1 tabindex="' . $context['tabindex']++ . '"', $pf['dd']), '
+							', preg_replace('~<(input|select|textarea|button|area|a|object)\b~', '<$1 tabindex="' . $context['tabindex']++ . '"', $pf['dd']), '
 						</dd>';
 
 	echo '

--- a/Themes/default/Post.template.php
+++ b/Themes/default/Post.template.php
@@ -134,7 +134,8 @@ function template_main()
 	echo '
 					<dl id="post_header">';
 
-	// All the posting fields.
+	// All the posting fields (subject, message icon, guest name & email, etc.)
+	// Mod & theme authors can use the 'integrate_post_end' hook to modify $context['posting_fields']
 	if (!empty($context['posting_fields']) && is_array($context['posting_fields']))
 		foreach ($context['posting_fields'] as $pfid => $pf)
 			echo '

--- a/Themes/default/Post.template.php
+++ b/Themes/default/Post.template.php
@@ -136,12 +136,12 @@ function template_main()
 
 	// All the posting fields.
 	if (!empty($context['posting_fields']) && is_array($context['posting_fields']))
-		foreach ($context['posting_fields'] as $pf)
+		foreach ($context['posting_fields'] as $pfid => $pf)
 			echo '
-						<dt class="clear">
+						<dt class="clear', !is_numeric($pfid) ? ' pf_' . $pfid : '', '">
 							', $pf['dt'], '
 						</dt>
-						<dd>
+						<dd', !is_numeric($pfid) ? ' class="pf_' . $pfid . '"' : '', '>
 							', preg_replace('~<(input|select)\b~', '<$1 tabindex="' . $context['tabindex']++ . '"', $pf['dd']), '
 						</dd>';
 

--- a/Themes/default/Post.template.php
+++ b/Themes/default/Post.template.php
@@ -135,9 +135,11 @@ function template_main()
 					<dl id="post_header">';
 
 	// All the posting fields (subject, message icon, guest name & email, etc.)
-	// Mod & theme authors can use the 'integrate_post_end' hook to modify $context['posting_fields']
+	// Mod & theme authors can use the 'integrate_post_end' hook to modify or add to these (see Post.php)
 	if (!empty($context['posting_fields']) && is_array($context['posting_fields']))
+	{
 		foreach ($context['posting_fields'] as $pfid => $pf)
+		{
 			echo '
 						<dt class="clear', !is_numeric($pfid) ? ' pf_' . $pfid : '', '">
 							', $pf['dt'], '
@@ -145,6 +147,8 @@ function template_main()
 						<dd', !is_numeric($pfid) ? ' class="pf_' . $pfid . '"' : '', '>
 							', preg_replace('~<(input|select|textarea|button|area|a|object)\b~', '<$1 tabindex="' . $context['tabindex']++ . '"', $pf['dd']), '
 						</dd>';
+		}
+	}
 
 	echo '
 					</dl>';

--- a/Themes/default/Post.template.php
+++ b/Themes/default/Post.template.php
@@ -134,62 +134,18 @@ function template_main()
 	echo '
 					<dl id="post_header">';
 
-	// Custom posting fields.
+	// All the posting fields.
 	if (!empty($context['posting_fields']) && is_array($context['posting_fields']))
 		foreach ($context['posting_fields'] as $pf)
 			echo '
-						<dt>
-							', $pf['dt'] ,'
-						</dt>
-						<dd>
-							', $pf['dd'] ,'
-						</dd>';
-
-
-	// Guests have to put in their name and email...
-	if (isset($context['name']) && isset($context['email']))
-	{
-		echo '
-						<dt>
-							<span', isset($context['post_error']['long_name']) || isset($context['post_error']['no_name']) || isset($context['post_error']['bad_name']) ? ' class="error"' : '', ' id="caption_guestname">', $txt['name'], ':</span>
-						</dt>
-						<dd>
-							<input type="text" name="guestname" size="25" value="', $context['name'], '" tabindex="', $context['tabindex']++, '" class="input_text">
-						</dd>';
-
-		if (empty($modSettings['guest_post_no_email']))
-			echo '
-						<dt>
-							<span', isset($context['post_error']['no_email']) || isset($context['post_error']['bad_email']) ? ' class="error"' : '', ' id="caption_email">', $txt['email'], ':</span>
-						</dt>
-						<dd>
-							<input type="email" name="email" size="25" value="', $context['email'], '" tabindex="', $context['tabindex']++, '" class="input_text" required>
-						</dd>';
-	}
-
-	// Now show the subject box for this post.
-	echo '
 						<dt class="clear">
-							<span', isset($context['post_error']['no_subject']) ? ' class="error"' : '', ' id="caption_subject">', $txt['subject'], ':</span>
+							', $pf['dt'], '
 						</dt>
 						<dd>
-							<input type="text" name="subject"', $context['subject'] == '' ? '' : ' value="' . $context['subject'] . '"', ' tabindex="', $context['tabindex']++, '" size="80" maxlength="80"', isset($context['post_error']['no_subject']) ? ' class="error"' : ' class="input_text"', ' required>
-						</dd>
-						<dt class="clear_left">
-							', $txt['message_icon'], ':
-						</dt>
-						<dd>
-							<select name="icon" id="icon" onchange="showimage()">';
-
-	// Loop through each message icon allowed, adding it to the drop down list.
-	foreach ($context['icons'] as $icon)
-		echo '
-								<option value="', $icon['value'], '"', $icon['value'] == $context['icon'] ? ' selected' : '', '>', $icon['name'], '</option>';
+							', preg_replace('~<(input|select)\b~', '<$1 tabindex="' . $context['tabindex']++ . '"', $pf['dd']), '
+						</dd>';
 
 	echo '
-							</select>
-							<img src="', $context['icon_url'], '" id="icons" alt="">
-						</dd>
 					</dl>';
 
 	// Are you posting a calendar event?


### PR DESCRIPTION
Benefits:

1. The logic for setting up these fields is handled in source rather than in the theme
2. It is easier to ensure uniform formatting for all fields
3. Mods can add custom fields above, below, or between standard fields using nothing but the 'integrate_post_end' hook
4. Every dt/dd pair in the list is automatically assigned a unique `pf_*` CSS class