### PR TITLE
More rss improvements

### DIFF
--- a/Sources/News.php
+++ b/Sources/News.php
@@ -651,6 +651,9 @@ function getXmlMembers($xml_format)
 	$data = array();
 	while ($row = $smcFunc['db_fetch_assoc']($request))
 	{
+		// Create a GUID for each member using the tag URI scheme
+		$guid = 'tag:' . parse_url($scripturl, PHP_URL_HOST) . ',' . gmdate('Y-m-d', $row['poster_time']) . ':member=' . $row['id_member'];
+
 		// Make the data look rss-ish.
 		if ($xml_format == 'rss' || $xml_format == 'rss2')
 			$data[] = array(
@@ -674,7 +677,10 @@ function getXmlMembers($xml_format)
 					),
 					array(
 						'tag' => 'guid',
-						'content' => $scripturl . '?action=profile;u=' . $row['id_member'],
+						'content' => $guid,
+						'attributes' => array(
+							'isPermaLink' => 'false',
+						),
 					),
 				),
 			);
@@ -723,7 +729,7 @@ function getXmlMembers($xml_format)
 					),
 					array(
 						'tag' => 'id',
-						'content' => $scripturl . '?action=profile;u=' . $row['id_member'],
+						'content' => $guid,
 					),
 				),
 			);
@@ -872,6 +878,9 @@ function getXmlNews($xml_format)
 		else
 			$loaded_attachments = null;
 
+		// Create a GUID for this topic using the tag URI scheme
+		$guid = 'tag:' . parse_url($scripturl, PHP_URL_HOST) . ',' . gmdate('Y-m-d', $row['poster_time']) . ':topic=' . $row['id_topic'];
+
 		// Being news, this actually makes sense in rss format.
 		if ($xml_format == 'rss' || $xml_format == 'rss2')
 		{
@@ -921,7 +930,10 @@ function getXmlNews($xml_format)
 					),
 					array(
 						'tag' => 'guid',
-						'content' => $scripturl . '?topic=' . $row['id_topic'] . '.0',
+						'content' => $guid,
+						'attributes' => array(
+							'isPermaLink' => 'false',
+						),
 					),
 					array(
 						'tag' => 'enclosure',
@@ -1022,7 +1034,7 @@ function getXmlNews($xml_format)
 					),
 					array(
 						'tag' => 'id',
-						'content' => $scripturl . '?topic=' . $row['id_topic'] . '.0',
+						'content' => $guid,
 					),
 					array(
 						'tag' => 'link',
@@ -1282,6 +1294,9 @@ function getXmlRecent($xml_format)
 		else
 			$loaded_attachments = null;
 
+		// Create a GUID for this post using the tag URI scheme
+		$guid = 'tag:' . parse_url($scripturl, PHP_URL_HOST) . ',' . gmdate('Y-m-d', $row['poster_time']) . ':msg=' . $row['id_msg'];
+
 		// Doesn't work as well as news, but it kinda does..
 		if ($xml_format == 'rss' || $xml_format == 'rss2')
 		{
@@ -1331,7 +1346,10 @@ function getXmlRecent($xml_format)
 					),
 					array(
 						'tag' => 'guid',
-						'content' => $scripturl . '?topic=' . $row['id_topic'] . '.msg' . $row['id_msg'] . '#msg' . $row['id_msg'],
+						'content' => $guid,
+						'attributes' => array(
+							'isPermaLink' => 'false',
+						),
 					),
 					array(
 						'tag' => 'enclosure',
@@ -1432,7 +1450,7 @@ function getXmlRecent($xml_format)
 					),
 					array(
 						'tag' => 'id',
-						'content' => $scripturl . '?topic=' . $row['id_topic'] . '.msg' . $row['id_msg'] . '#msg' . $row['id_msg'],
+						'content' => $guid,
 					),
 					array(
 						'tag' => 'link',
@@ -1612,6 +1630,9 @@ function getXmlProfile($xml_format)
 	// Okay, I admit it, I'm lazy.  Stupid $_GET['u'] is long and hard to type.
 	$profile = &$memberContext[$_GET['u']];
 
+	// Create a GUID for this member using the tag URI scheme
+	$guid = 'tag:' . parse_url($scripturl, PHP_URL_HOST) . ',' . gmdate('Y-m-d', $user_profile[$profile['id']]['date_registered']) . ':member=' . $profile['id'];
+
 	if ($xml_format == 'rss' || $xml_format == 'rss2')
 	{
 		$data[] = array(
@@ -1639,7 +1660,10 @@ function getXmlProfile($xml_format)
 				),
 				array(
 					'tag' => 'guid',
-					'content' => $scripturl . '?action=profile;u=' . $profile['id'],
+					'content' => $guid,
+					'attributes' => array(
+						'isPermaLink' => 'false',
+					),
 				),
 			)
 		);
@@ -1718,7 +1742,7 @@ function getXmlProfile($xml_format)
 				),
 				array(
 					'tag' => 'id',
-					'content' => $scripturl . '?action=profile;u=' . $profile['id'],
+					'content' => $guid,
 				),
 			)
 		);

--- a/Sources/News.php
+++ b/Sources/News.php
@@ -181,7 +181,7 @@ function ShowXmlFeed()
 	}
 
 	// Show in rss or proprietary format?
-	$xml_format = isset($_GET['type']) && in_array($_GET['type'], array('smf', 'rss', 'rss2', 'atom', 'rdf')) ? $_GET['type'] : 'smf';
+	$xml_format = isset($_GET['type']) && in_array($_GET['type'], array('smf', 'rss', 'rss2', 'atom', 'rdf')) ? $_GET['type'] : 'rss2';
 
 	// @todo Birthdays?
 

--- a/Sources/News.php
+++ b/Sources/News.php
@@ -165,7 +165,7 @@ function ShowXmlFeed()
 		$smcFunc['db_free_result']($request);
 
 		$feed_meta['title'] = ' - ' . strip_tags($board_info['name']);
-		$feed_meta['source'] .= ';board=' . $board . '.0' ;
+		$feed_meta['source'] .= '?board=' . $board . '.0' ;
 
 		$query_this_board = 'b.id_board = ' . $board;
 

--- a/Sources/News.php
+++ b/Sources/News.php
@@ -259,17 +259,12 @@ function ShowXmlFeed()
 	call_integration_hook('integrate_xml_data', array(&$xml, &$feed_meta, &$namespaces, &$extraFeedTags, &$forceCdataKeys, &$nsKeys, $xml_format, $_GET['sa']));
 
 	// These can't be empty
-	$feed_meta['title'] = !empty($feed_meta['title']) ? $feed_meta['title'] : $orig_feed_meta['title'];
-	$feed_meta['desc'] = !empty($feed_meta['desc']) ? $feed_meta['desc'] : $orig_feed_meta['desc'];
-	$feed_meta['source'] = !empty($feed_meta['source']) ? $feed_meta['source'] : $orig_feed_meta['source'];
+	foreach (array('title', 'desc', 'source') as $mkey)
+		$feed_meta[$mkey] = !empty($feed_meta[$mkey]) ? $feed_meta[$mkey] : $orig_feed_meta[$mkey];
 
 	// Sanitize basic feed metadata values
-	$feed_meta['title'] = cdata_parse(strip_tags($feed_meta['title']));
-	$feed_meta['desc'] = cdata_parse(strip_tags($feed_meta['desc']));
-	$feed_meta['author'] = cdata_parse(strip_tags($feed_meta['author']));
-	$feed_meta['rights'] = cdata_parse(strip_tags($feed_meta['rights']));
-	$feed_meta['source'] = cdata_parse(strip_tags(fix_possible_url($feed_meta['source'])));
-	$feed_meta['icon'] = cdata_parse(strip_tags(fix_possible_url($feed_meta['icon'])));
+	foreach ($feed_meta as $mkey => $mvalue)
+		$feed_meta[$mkey] = cdata_parse(strip_tags(fix_possible_url($feed_meta[$mkey])));
 
 	$ns_string = '';
 	if (!empty($namespaces[$xml_format]))
@@ -281,8 +276,9 @@ function ShowXmlFeed()
 	$extraFeedTags_string = '';
 	if (!empty($extraFeedTags[$xml_format]))
 	{
+		$indent = "\t" . ($xml_format !== 'atom' ? "\t" : '');
 		foreach ($extraFeedTags[$xml_format] as $extraTag)
-			$extraFeedTags_string .= "\n\t\t" . $extraTag;
+			$extraFeedTags_string .= "\n" . $indent . $extraTag;
 	}
 
 	// This is an xml file....

--- a/Sources/News.php
+++ b/Sources/News.php
@@ -652,7 +652,7 @@ function getXmlMembers($xml_format)
 	while ($row = $smcFunc['db_fetch_assoc']($request))
 	{
 		// Create a GUID for each member using the tag URI scheme
-		$guid = 'tag:' . parse_url($scripturl, PHP_URL_HOST) . ',' . gmdate('Y-m-d', $row['poster_time']) . ':member=' . $row['id_member'];
+		$guid = 'tag:' . parse_url($scripturl, PHP_URL_HOST) . ',' . gmdate('Y-m-d', $row['date_registered']) . ':member=' . $row['id_member'];
 
 		// Make the data look rss-ish.
 		if ($xml_format == 'rss' || $xml_format == 'rss2')

--- a/Sources/News.php
+++ b/Sources/News.php
@@ -34,7 +34,7 @@ if (!defined('SMF'))
 function ShowXmlFeed()
 {
 	global $board, $board_info, $context, $scripturl, $boardurl, $txt, $modSettings, $user_info;
-	global $query_this_board, $smcFunc, $forum_version;
+	global $query_this_board, $smcFunc, $forum_version, $settings;
 
 	// If it's not enabled, die.
 	if (empty($modSettings['xmlnews_enable']))
@@ -52,6 +52,7 @@ function ShowXmlFeed()
 		'author' => $context['forum_name'],
 		'source' => $scripturl,
 		'rights' => '© ' . date('Y') . ' ' . $context['forum_name'],
+		'icon' => !empty($settings['og_image']) ? $settings['og_image'] : $boardurl . '/favicon.ico',
 		'language' => !empty($txt['lang_locale']) ? str_replace("_", "-", substr($txt['lang_locale'], 0, strcspn($txt['lang_locale'], "."))) : 'en',
 	);
 

--- a/Sources/News.php
+++ b/Sources/News.php
@@ -209,17 +209,17 @@ function ShowXmlFeed()
 
 	// Get the associative array representing the xml.
 	if (!empty($modSettings['cache_enable']) && (!$user_info['is_guest'] || $modSettings['cache_enable'] >= 3))
-		$xml = cache_get_data('xmlfeed-' . $xml_format . ':' . ($user_info['is_guest'] ? '' : $user_info['id'] . '-') . $cachekey, 240);
-	if (empty($xml))
+		$xml_data = cache_get_data('xmlfeed-' . $xml_format . ':' . ($user_info['is_guest'] ? '' : $user_info['id'] . '-') . $cachekey, 240);
+	if (empty($xml_data))
 	{
 		$call = call_helper($subActions[$_GET['sa']][0], true);
 
 		if (!empty($call))
-			$xml = call_user_func($call, $xml_format);
+			$xml_data = call_user_func($call, $xml_format);
 
 		if (!empty($modSettings['cache_enable']) && (($user_info['is_guest'] && $modSettings['cache_enable'] >= 3)
 		|| (!$user_info['is_guest'] && (array_sum(explode(' ', microtime())) - array_sum(explode(' ', $cache_t)) > 0.2))))
-			cache_put_data('xmlfeed-' . $xml_format . ':' . ($user_info['is_guest'] ? '' : $user_info['id'] . '-') . $cachekey, $xml, 240);
+			cache_put_data('xmlfeed-' . $xml_format . ':' . ($user_info['is_guest'] ? '' : $user_info['id'] . '-') . $cachekey, $xml_data, 240);
 	}
 
 	$feed_meta['title'] = $smcFunc['htmlspecialchars'](strip_tags($context['forum_name'])) . (isset($feed_meta['title']) ? $feed_meta['title'] : '');
@@ -255,8 +255,8 @@ function ShowXmlFeed()
 	$orig_feed_meta = $feed_meta;
 
 	// If mods want to do somthing with this feed, let them do that now.
-	// Provide the feed's data, title, format, content type, keys that need special handling, etc.
-	call_integration_hook('integrate_xml_data', array(&$xml, &$feed_meta, &$namespaces, &$extraFeedTags, &$forceCdataKeys, &$nsKeys, $xml_format, $_GET['sa']));
+	// Provide the feed's data, metadata, namespaces, extra feed-level tags, keys that need special handling, the feed format, and the requested subaction
+	call_integration_hook('integrate_xml_data', array(&$xml_data, &$feed_meta, &$namespaces, &$extraFeedTags, &$forceCdataKeys, &$nsKeys, $xml_format, $_GET['sa']));
 
 	// These can't be empty
 	foreach (array('title', 'desc', 'source') as $mkey)
@@ -334,7 +334,7 @@ function ShowXmlFeed()
 		echo $extraFeedTags_string;
 
 		// Output all of the associative array, start indenting with 2 tabs, and name everything "item".
-		dumpTags($xml, 2, null, $xml_format, $forceCdataKeys, $nsKeys);
+		dumpTags($xml_data, 2, null, $xml_format, $forceCdataKeys, $nsKeys);
 
 		// Output the footer of the xml.
 		echo '
@@ -367,7 +367,7 @@ function ShowXmlFeed()
 
 		echo $extraFeedTags_string;
 
-		dumpTags($xml, 1, null, $xml_format, $forceCdataKeys, $nsKeys);
+		dumpTags($xml_data, 1, null, $xml_format, $forceCdataKeys, $nsKeys);
 
 		echo '
 </feed>';
@@ -387,7 +387,7 @@ function ShowXmlFeed()
 		<items>
 			<rdf:Seq>';
 
-		foreach ($xml as $item)
+		foreach ($xml_data as $item)
 		{
 			$link = array_filter($item['content'], function ($e) { return ($e['tag'] == 'link'); });
 			$link = array_pop($link);
@@ -402,7 +402,7 @@ function ShowXmlFeed()
 	</channel>
 ';
 
-		dumpTags($xml, 1, null, $xml_format, $forceCdataKeys, $nsKeys);
+		dumpTags($xml_data, 1, null, $xml_format, $forceCdataKeys, $nsKeys);
 
 		echo '
 </rdf:RDF>';
@@ -417,7 +417,7 @@ function ShowXmlFeed()
 		echo $extraFeedTags_string;
 
 		// Dump out that associative array.  Indent properly.... and use the right names for the base elements.
-		dumpTags($xml, 1, $subActions[$_GET['sa']][1], $xml_format, $forceCdataKeys, $nsKeys);
+		dumpTags($xml_data, 1, $subActions[$_GET['sa']][1], $xml_format, $forceCdataKeys, $nsKeys);
 
 		echo '
 </smf:xml-feed>';

--- a/Sources/News.php
+++ b/Sources/News.php
@@ -165,6 +165,7 @@ function ShowXmlFeed()
 		$smcFunc['db_free_result']($request);
 
 		$feed_meta['title'] = ' - ' . strip_tags($board_info['name']);
+		$feed_meta['source'] .= ';board=' . $board . '.0' ;
 
 		$query_this_board = 'b.id_board = ' . $board;
 

--- a/Sources/News.php
+++ b/Sources/News.php
@@ -52,7 +52,7 @@ function ShowXmlFeed()
 		'author' => $context['forum_name'],
 		'source' => $scripturl,
 		'rights' => '© ' . date('Y') . ' ' . $context['forum_name'],
-		'icon' => $boardurl . '/favicon.ico',
+		'language' => !empty($txt['lang_locale']) ? str_replace("_", "-", substr($txt['lang_locale'], 0, strcspn($txt['lang_locale'], "."))) : 'en',
 	);
 
 	// Handle the cases where a board, boards, or category is asked for.
@@ -324,7 +324,9 @@ function ShowXmlFeed()
 			<link>' . $feed_meta['source'] . '</link>
 		</image>' : '',
 		!empty($feed_meta['rights']) ? '
-		<copyright>' . $feed_meta['rights'] . '</copyright>' : '';
+		<copyright>' . $feed_meta['rights'] . '</copyright>' : '',
+		!empty($feed_meta['language']) ? '
+		<language>' . $feed_meta['language'] . '</language>' : '';
 
 		// RSS2 calls for this.
 		if ($xml_format == 'rss2')
@@ -348,7 +350,7 @@ function ShowXmlFeed()
 				$url_parts[] = $var . '=' . (is_array($val) ? implode(',', $val) : $val);
 
 		echo '
-<feed', $ns_string, '>
+<feed', $ns_string, !empty($feed_meta['language']) ? ' xml:lang="' . $feed_meta['language'] . '"' : '', '>
 	<title>', $feed_meta['title'], '</title>
 	<link rel="alternate" type="text/html" href="', $feed_meta['source'], '" />
 	<link rel="self" type="application/atom+xml" href="', $scripturl, !empty($url_parts) ? '?' . implode(';', $url_parts) : '', '" />

--- a/Sources/News.php
+++ b/Sources/News.php
@@ -628,7 +628,7 @@ function dumpTags($data, $i, $tag = null, $xml_format = '', $forceCdataKeys = ar
  * The array will be generated to match the format.
  * @todo get the list of members from Subs-Members.
  *
- * @param string $xml_format The format to use. Can be 'atom', 'rdf', 'rss', 'rss2' or 'xml'
+ * @param string $xml_format The format to use. Can be 'atom', 'rdf', 'rss', 'rss2' or 'smf'
  * @return array An array of arrays of feed items. Each array has keys corresponding to the appropriate tags for the specified format.
  */
 function getXmlMembers($xml_format)
@@ -759,10 +759,10 @@ function getXmlMembers($xml_format)
 /**
  * Get the latest topics information from a specific board,
  * to display later.
- * The returned array will be generated to match the xmf_format.
+ * The returned array will be generated to match the xml_format.
  * @todo does not belong here
  *
- * @param $xml_format The XML format. Can be 'atom', 'rdf', 'rss', 'rss2' or 'xml'.
+ * @param $xml_format The XML format. Can be 'atom', 'rdf', 'rss', 'rss2' or 'smf'.
  * @return array An array of arrays of topic data for the feed. Each array has keys corresponding to the tags for the specified format.
  */
 function getXmlNews($xml_format)
@@ -1152,7 +1152,7 @@ function getXmlNews($xml_format)
  * The returned array will be generated to match the xml_format.
  * @todo does not belong here.
  *
- * @param string $xml_format The XML format. Can be 'atom', 'rdf', 'rss', 'rss2' or 'xml'
+ * @param string $xml_format The XML format. Can be 'atom', 'rdf', 'rss', 'rss2' or 'smf'
  * @return array An array of arrays containing data for the feed. Each array has keys corresponding to the appropriate tags for the specified format.
  */
 function getXmlRecent($xml_format)
@@ -1592,7 +1592,7 @@ function getXmlRecent($xml_format)
  * which will be generated to match the xml_format.
  * @todo refactor.
  *
- * @param $xml_format The XML format. Can be 'atom', 'rdf', 'rss', 'rss2' or 'xml'
+ * @param $xml_format The XML format. Can be 'atom', 'rdf', 'rss', 'rss2' or 'smf'
  * @return array An array profile data
  */
 function getXmlProfile($xml_format)

--- a/Themes/default/index.template.php
+++ b/Themes/default/index.template.php
@@ -141,8 +141,8 @@ function template_html_above()
 	// If RSS feeds are enabled, advertise the presence of one.
 	if (!empty($modSettings['xmlnews_enable']) && (!empty($modSettings['allow_guestAccess']) || $context['user']['is_logged']))
 		echo '
-	<link rel="alternate" type="application/rss+xml" title="', $context['forum_name_html_safe'], ' - ', $txt['rss'], '" href="', $scripturl, '?action=.xml;type=rss2', !empty($context['current_board']) ? ';board=' . $context['current_board'] : '', '">
-	<link rel="alternate" type="application/rss+xml" title="', $context['forum_name_html_safe'], ' - ', $txt['atom'], '" href="', $scripturl, '?action=.xml;type=atom', !empty($context['current_board']) ? ';board=' . $context['current_board'] : '', '">';
+	<link rel="alternate feed" type="application/rss+xml" title="', $context['forum_name_html_safe'], ' - ', $txt['rss'], '" href="', $scripturl, '?action=.xml;type=rss2', !empty($context['current_board']) ? ';board=' . $context['current_board'] : '', '">
+	<link rel="alternate feed" type="application/atom+xml" title="', $context['forum_name_html_safe'], ' - ', $txt['atom'], '" href="', $scripturl, '?action=.xml;type=atom', !empty($context['current_board']) ? ';board=' . $context['current_board'] : '', '">';
 
 	// If we're viewing a topic, these should be the previous and next topics, respectively.
 	if (!empty($context['links']['next']))

--- a/Themes/default/index.template.php
+++ b/Themes/default/index.template.php
@@ -141,8 +141,8 @@ function template_html_above()
 	// If RSS feeds are enabled, advertise the presence of one.
 	if (!empty($modSettings['xmlnews_enable']) && (!empty($modSettings['allow_guestAccess']) || $context['user']['is_logged']))
 		echo '
-	<link rel="alternate" type="application/rss+xml" title="', $context['forum_name_html_safe'], ' - ', $txt['rss'], '" href="', $scripturl, '?type=rss2;action=.xml">
-	<link rel="alternate" type="application/rss+xml" title="', $context['forum_name_html_safe'], ' - ', $txt['atom'], '" href="', $scripturl, '?type=atom;action=.xml">';
+	<link rel="alternate" type="application/rss+xml" title="', $context['forum_name_html_safe'], ' - ', $txt['rss'], '" href="', $scripturl, '?action=.xml;type=rss2', !empty($context['current_board']) ? ';board=' . $context['current_board'] : '', '">
+	<link rel="alternate" type="application/rss+xml" title="', $context['forum_name_html_safe'], ' - ', $txt['atom'], '" href="', $scripturl, '?action=.xml;type=atom', !empty($context['current_board']) ? ';board=' . $context['current_board'] : '', '">';
 
 	// If we're viewing a topic, these should be the previous and next topics, respectively.
 	if (!empty($context['links']['next']))
@@ -220,12 +220,12 @@ function template_body_above()
 	}
 	// Otherwise they're a guest. Ask them to either register or login.
 	else
-		if (empty($maintenance)) 
+		if (empty($maintenance))
 			echo '
 			<ul class="floatleft welcome">
 				<li>', sprintf($txt[$context['can_register'] ? 'welcome_guest_register' : 'welcome_guest'], $txt['guest_title'], $context['forum_name_html_safe'], $scripturl . '?action=login', 'return reqOverlayDiv(this.href, ' . JavaScriptEscape($txt['login']) . ');', $scripturl . '?action=signup'), '</li>
 			</ul>';
-		else 
+		else
 			//In maintenance mode, only login is allowed and don't show OverlayDiv
 			echo '
 			<ul class="floatleft welcome">
@@ -272,12 +272,12 @@ function template_body_above()
 		if (!empty($context['current_board']))
 			echo '
 				<option value="board"', ($selected == 'current_board' ? ' selected' : ''), '>', $txt['search_thisbrd'], '</option>';
-		
+
 		// Can't search for members if we can't see the memberlist
 		if (!empty($context['allow_memberlist']))
 			echo '
 				<option value="members"', ($selected == 'members' ? ' selected' : ''), '>', $txt['search_members'], ' </option>';
-				
+
 		echo '
 			</select>';
 


### PR DESCRIPTION
- Adds language declaration to RSS and Atom feeds
- Uses value of $settings['og_image'] for feed icon image, if available
- Appends board parameter to generated RSS links when appropriate
- Sets default feed format to RSS2 instead of SMF's proprietary format
- Tidies some code and corrects some documentation
- Use the [tag URI scheme](https://en.wikipedia.org/wiki/Tag_URI_scheme), which is designed and recommended for exactly this purpose, to generate GUIDs for feed items