### PR TITLE
Prevents resumed downloads from incrementing the download counter

### DIFF
--- a/Sources/ShowAttachments.php
+++ b/Sources/ShowAttachments.php
@@ -180,17 +180,6 @@ function showAttachment()
 			cache_put_data('attachment_lookup_id-' . $file['id_attach'], array($file, $thumbFile), mt_rand(850, 900));
 	}
 
-	// Update the download counter (unless it's a thumbnail).
-	if ($file['attachment_type'] != 3 && empty($showThumb))
-		$smcFunc['db_query']('attach_download_increase', '
-			UPDATE LOW_PRIORITY {db_prefix}attachments
-			SET downloads = downloads + 1
-			WHERE id_attach = {int:id_attach}',
-			array(
-				'id_attach' => $attachId,
-			)
-		);
-
 	// Replace the normal file with its thumbnail if it has one!
 	if (!empty($showThumb) && !empty($thumbFile))
 		$file = $thumbFile;
@@ -228,6 +217,30 @@ function showAttachment()
 		header('HTTP/1.1 304 Not Modified');
 		exit;
 	}
+
+	// If this is a partial download, we need to determine what data range to send
+	$range = 0;
+	$size = filesize($file['filePath']);
+	if (isset($_SERVER['HTTP_RANGE']))
+	{
+		list($a, $range) = explode("=", $_SERVER['HTTP_RANGE'], 2);
+		list($range) = explode(",", $range, 2);
+		list($range, $range_end) = explode("-", $range);
+		$range = intval($range);
+		$range_end = !$range_end ? $size - 1 : intval($range_end);
+		$new_length = $range_end - $range + 1;
+	}
+
+	// Update the download counter (unless it's a thumbnail or resuming an incomplete download).
+	if ($file['attachment_type'] != 3 && empty($showThumb) && $range === 0)
+		$smcFunc['db_query']('attach_download_increase', '
+			UPDATE LOW_PRIORITY {db_prefix}attachments
+			SET downloads = downloads + 1
+			WHERE id_attach = {int:id_attach}',
+			array(
+				'id_attach' => $attachId,
+			)
+		);
 
 	// Send the attachment headers.
 	header('Pragma: ');
@@ -281,17 +294,8 @@ function showAttachment()
 		header('Cache-Control: max-age=' . (525600 * 60) . ', private');
 
 	// Multipart and resuming support
-	$range = 0;
-	$size = filesize($file['filePath']);
 	if (isset($_SERVER['HTTP_RANGE']))
 	{
-		list($a, $range) = explode("=", $_SERVER['HTTP_RANGE'], 2);
-		list($range) = explode(",", $range, 2);
-		list($range, $range_end) = explode("-", $range);
-		$range = intval($range);
-		$range_end = !$range_end ? $size - 1 : intval($range_end);
-
-		$new_length = $range_end - $range + 1;
 		header("HTTP/1.1 206 Partial Content");
 		header("Content-Length: $new_length");
 		header("Content-Range: bytes $range-$range_end/$size");


### PR DESCRIPTION
(I should have included this in #4036, but I didn't catch it until too late.)

If the client requests the download in multiple parts, we don't want each request to count as another complete download. With this change, we only update when the requested range includes the start of the file or doesn't specify a range at all.

Also makes sure we don't increment the counter unless we actually serve up some data. Previously, we were incrementing it even if we only emitted a 304 or 404 header.