### PR TITLE
Preserves image attribs on attachments when toggling editor view

### DIFF
--- a/Themes/default/scripts/jquery.sceditor.smf.js
+++ b/Themes/default/scripts/jquery.sceditor.smf.js
@@ -310,17 +310,6 @@ $.sceditor.plugins.bbcode.bbcode.set(
 					return element.style ? element.style[name] : null;
 				};
 
-			// Is this an attachment?
-			if (element.attr('data-attachment'))
-			{
-				if (element.attr('name'))
-					attribs += ' name=' + element.attr('name');
-				if (element.attr('type'))
-					attribs += ' type=' + 	element.attr('type');
-
-				return '[attach' + attribs + ']' + element.attr('data-attachment') + '[/attach]';
-			}
-
 			// check if this is an emoticon image
 			if (typeof element.attr('data-sceditor-emoticon') !== "undefined")
 				return content;
@@ -334,6 +323,17 @@ $.sceditor.plugins.bbcode.bbcode.set(
 				attribs += " alt=" + element.attr('alt');
 			if (element.attr('title'))
 				attribs += " title=" + element.attr('title');
+
+			// Is this an attachment?
+			if (element.attr('data-attachment'))
+			{
+				if (element.attr('name'))
+					attribs += ' name=' + element.attr('name');
+				if (element.attr('type'))
+					attribs += ' type=' + 	element.attr('type');
+
+				return '[attach' + attribs + ']' + element.attr('data-attachment') + '[/attach]';
+			}
 
 			return '[img' + attribs + ']' + element.attr('src') + '[/img]';
 		},


### PR DESCRIPTION
Previously, if the text of a post contained something like `[attach width=600 name=outtosea.png type=image/png]4[/attach]`, toggling the editor between WYSIWYG and source views would remove the `width=600` parameter (same for height, title, and alt parameters). This fixes that.