### PR TITLE
Fixes #4052

### DIFF
--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -2131,16 +2131,15 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 				$pos2 = $pos - 1;
 
 				// See the comment at the end of the big loop - just eating whitespace ;).
-				if (!empty($tag['block_level']) && substr($message, $pos, 4) == '<br>')
-					$message = substr($message, 0, $pos) . substr($message, $pos + 4);
+				$whitespace_regex = '';
+				if (!empty($tag['block_level']))
+					$whitespace_regex .= '(&nbsp;|\s)*<br>';
+				// Trim one line of whitespace after unnested tags, but all of it after nested ones
 				if (!empty($tag['trim']) && $tag['trim'] != 'inside')
-				{
-					// Trim one line of whitespace after unnested tags, but all of it after nested ones
-					$whitespace_regex = empty($tag['require_parents']) ?'(&nbsp;|\s)*(<br>)?(&nbsp;|\s)*' : '(<br>|&nbsp;|\s)*';
+					$whitespace_regex .= empty($tag['require_parents']) ? '(&nbsp;|\s)*' : '(<br>|&nbsp;|\s)*';
 
-					if (preg_match('~' . $whitespace_regex . '~', substr($message, $pos), $matches) != 0)
-						$message = substr($message, 0, $pos) . substr($message, $pos + strlen($matches[0]));
-				}
+				if (preg_match('~' . $whitespace_regex . '~', substr($message, $pos), $matches) != 0)
+					$message = substr($message, 0, $pos) . substr($message, $pos + strlen($matches[0]));
 			}
 
 			if (!empty($to_close))
@@ -2412,16 +2411,13 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 				$pos1 += $ot_strlen + 2;
 
 				// Trim or eat trailing stuff... see comment at the end of the big loop.
-				if (!empty($open_tags[$i]['block_level']) && substr($message, $pos, 4) == '<br>')
-					$message = substr($message, 0, $pos) . substr($message, $pos + 4);
-				if (!empty($open_tags[$i]['trim']) && $tag['trim'] != 'inside')
-				{
-					// Quotes only want one line trimed, but list items want all the white space trimmed
-					$whitespace_regex = empty($tag['require_parents']) ?'(&nbsp;|\s)*(<br>)?(&nbsp;|\s)*' : '(<br>|&nbsp;|\s)*';
-
-					if (preg_match('~' . $whitespace_regex . '~', substr($message, $pos), $matches) != 0)
-						$message = substr($message, 0, $pos) . substr($message, $pos + strlen($matches[0]));
-				}
+				$whitespace_regex = '';
+				if (!empty($tag['block_level']))
+					$whitespace_regex .= '(&nbsp;|\s)*<br>';
+				if (!empty($tag['trim']) && $tag['trim'] != 'inside')
+					$whitespace_regex .= empty($tag['require_parents']) ? '(&nbsp;|\s)*' : '(<br>|&nbsp;|\s)*';
+				if (preg_match('~' . $whitespace_regex . '~', substr($message, $pos), $matches) != 0)
+					$message = substr($message, 0, $pos) . substr($message, $pos + strlen($matches[0]));
 
 				array_pop($open_tags);
 			}

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -2133,8 +2133,14 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 				// See the comment at the end of the big loop - just eating whitespace ;).
 				if (!empty($tag['block_level']) && substr($message, $pos, 4) == '<br>')
 					$message = substr($message, 0, $pos) . substr($message, $pos + 4);
-				if (!empty($tag['trim']) && $tag['trim'] != 'inside' && preg_match('~(<br>|&nbsp;|\s)*~', substr($message, $pos), $matches) != 0)
-					$message = substr($message, 0, $pos) . substr($message, $pos + strlen($matches[0]));
+				if (!empty($tag['trim']) && $tag['trim'] != 'inside')
+				{
+					// Trim one line of whitespace after unnested tags, but all of it after nested ones
+					$whitespace_regex = empty($tag['require_parents']) ?'(&nbsp;|\s)*(<br>)?(&nbsp;|\s)*' : '(<br>|&nbsp;|\s)*';
+
+					if (preg_match('~' . $whitespace_regex . '~', substr($message, $pos), $matches) != 0)
+						$message = substr($message, 0, $pos) . substr($message, $pos + strlen($matches[0]));
+				}
 			}
 
 			if (!empty($to_close))
@@ -2408,8 +2414,14 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 				// Trim or eat trailing stuff... see comment at the end of the big loop.
 				if (!empty($open_tags[$i]['block_level']) && substr($message, $pos, 4) == '<br>')
 					$message = substr($message, 0, $pos) . substr($message, $pos + 4);
-				if (!empty($open_tags[$i]['trim']) && $tag['trim'] != 'inside' && preg_match('~(<br>|&nbsp;|\s)*~', substr($message, $pos), $matches) != 0)
-					$message = substr($message, 0, $pos) . substr($message, $pos + strlen($matches[0]));
+				if (!empty($open_tags[$i]['trim']) && $tag['trim'] != 'inside')
+				{
+					// Quotes only want one line trimed, but list items want all the white space trimmed
+					$whitespace_regex = empty($tag['require_parents']) ?'(&nbsp;|\s)*(<br>)?(&nbsp;|\s)*' : '(<br>|&nbsp;|\s)*';
+
+					if (preg_match('~' . $whitespace_regex . '~', substr($message, $pos), $matches) != 0)
+						$message = substr($message, 0, $pos) . substr($message, $pos + strlen($matches[0]));
+				}
 
 				array_pop($open_tags);
 			}

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -2138,7 +2138,7 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 				if (!empty($tag['trim']) && $tag['trim'] != 'inside')
 					$whitespace_regex .= empty($tag['require_parents']) ? '(&nbsp;|\s)*' : '(<br>|&nbsp;|\s)*';
 
-				if (preg_match('~' . $whitespace_regex . '~', substr($message, $pos), $matches) != 0)
+				if (!empty($whitespace_regex) && preg_match('~' . $whitespace_regex . '~', substr($message, $pos), $matches) != 0)
 					$message = substr($message, 0, $pos) . substr($message, $pos + strlen($matches[0]));
 			}
 
@@ -2416,7 +2416,7 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 					$whitespace_regex .= '(&nbsp;|\s)*<br>';
 				if (!empty($tag['trim']) && $tag['trim'] != 'inside')
 					$whitespace_regex .= empty($tag['require_parents']) ? '(&nbsp;|\s)*' : '(<br>|&nbsp;|\s)*';
-				if (preg_match('~' . $whitespace_regex . '~', substr($message, $pos), $matches) != 0)
+				if (!empty($whitespace_regex) && preg_match('~' . $whitespace_regex . '~', substr($message, $pos), $matches) != 0)
 					$message = substr($message, 0, $pos) . substr($message, $pos + strlen($matches[0]));
 
 				array_pop($open_tags);


### PR DESCRIPTION
After block level BBCs that trim outside whitespace but do not have required parents, such as [quote], [float], etc., we only want to trim one line of whitespace. But after ones that do have required parents, such as [li], [td], etc., we want to trim out all trailing whitespace and line breaks until we reach the next element. For reasons I haven't bothered to fully figure out, something about the way parse_bbc() worked in SMF 2.0.x made that work even though the code said to trim all the trailing whitespace regardless. At any rate, in 2.1 we need to state explicitly what we actually want to happen, so this PR does that.