### PR TITLE
Fix point handling at identifier fixing #4075

### DIFF
--- a/Sources/Subs-Db-mysql.php
+++ b/Sources/Subs-Db-mysql.php
@@ -271,7 +271,13 @@ function smf_db_replacement__callback($matches)
 
 		case 'identifier':
 			// Backticks inside identifiers are supported as of MySQL 4.1. We don't need them for SMF.
-			return '`' . strtr($replacement, array('`' => '', '.' => '')) . '`';
+			$replacement = strtr($replacement, array('`' => ''));
+			if(strpos($replacement,'.') !== false)
+			{
+				$replacement = strstr($replacement, '.');
+				$replacement = substr($replacement, 1);
+			}
+			return '`' . $replacement . '`';
 		break;
 
 		case 'raw':

--- a/Sources/Subs-Db-postgresql.php
+++ b/Sources/Subs-Db-postgresql.php
@@ -226,7 +226,13 @@ function smf_db_replacement__callback($matches)
 		break;
 
 		case 'identifier':
-			return '"' . strtr($replacement, array('`' => '', '.' => '')) . '"';
+			$replacement = strtr($replacement, array('`' => ''));
+			if(strpos($replacement,'.') !== false)
+			{
+				$replacement = strstr($replacement, '.');
+				$replacement = substr($replacement, 1);
+			}
+			return '"' . $replacement . '"';
 		break;
 
 		case 'raw':


### PR DESCRIPTION
the existing solution remove only the point which create a wrong sql statement
order by "t.id_msg" -> order by "tid_msg"

two possible solutions:
- drop the alias
order by "t.id_msg" -> order by "id_msg"
- correct quote
order by "t.id_msg" -> order by "t"."id_msg"

i take the first route.
Fix the issue #4075