### PR TITLE
Added gui for pg fulltext index

### DIFF
--- a/Sources/DbSearch-postgresql.php
+++ b/Sources/DbSearch-postgresql.php
@@ -169,14 +169,16 @@ function smf_db_search_language()
 	else
 	{
 		$request = $smcFunc['db_query']('','
-			SHOW default_text_search_config',
-			array()
+			SELECT cfgname FROM pg_ts_config WHERE oid = current_setting({string:default_language})::regconfig',
+			array(
+			'default_language' => 'default_text_search_config'
+			)
 		);
 
 		if ($request !== false && $smcFunc['db_num_rows']($request) == 1)
 		{
 			$row = $smcFunc['db_fetch_assoc']($request);
-			$language_ftx = $row['default_text_search_config'];
+			$language_ftx = $row['cfgname'];
 
 			$smcFunc['db_insert']('replace',
 				'{db_prefix}settings',

--- a/Sources/ManageServer.php
+++ b/Sources/ManageServer.php
@@ -214,7 +214,7 @@ $(function()
  */
 function ModifyDatabaseSettings($return_config = false)
 {
-	global $scripturl, $context, $txt;
+	global $scripturl, $context, $txt, $smcFunc;
 
 	/* If you're writing a mod, it's a bad idea to add things here....
 		For each option:
@@ -229,6 +229,23 @@ function ModifyDatabaseSettings($return_config = false)
 		'',
 		array('autoFixDatabase', $txt['autoFixDatabase'], 'db', 'check', false, 'autoFixDatabase')
 	);
+	
+	// Add PG Stuff
+	if ($smcFunc['db_title'] == "PostgreSQL")
+	{
+		$request = $smcFunc['db_query']('', 'SELECT cfgname FROM pg_ts_config', array());
+		$fts_language = array();
+		
+		while ($row = $smcFunc['db_fetch_assoc']($request))
+			$fts_language[$row['cfgname']] = $row['cfgname'];
+		
+		$config_vars = array_merge ($config_vars, array(
+				'',
+				array('search_language', $txt['search_language'], 'db', 'select', $fts_language, 'pgFulltextSearch')
+			)
+		);
+	}
+		
 
 	call_integration_hook('integrate_database_settings', array(&$config_vars));
 

--- a/Themes/default/languages/Help.english.php
+++ b/Themes/default/languages/Help.english.php
@@ -1,7 +1,7 @@
 <?php
 // Version: 2.1 Beta 3; Help
 
-global $helptxt;
+global $helptxt, $scripturl;
 
 $txt['close_window'] = 'Close window';
 
@@ -403,10 +403,10 @@ $helptxt['customoptions'] = 'This defines the options that a user may choose fro
 	</ul>';
 
 $helptxt['autoFixDatabase'] = 'This will automatically fix broken tables and resume as if nothing happened. This can be useful, because the only way to fix it is to REPAIR the table, and this way your forum won\'t be down until you notice. It does email you when this happens.';
-$helptxt['pgFulltextSearch'] = 'This setting allow your to define the language wich is used for the fulltext search of postgresql, the language settings are independent from your smf settings and not related to the installed language for smf. <br/>
-When you change the language you need to rebuild the fulltext search index to find under Search -> Search Method. (Fulltext Index)<br/>
-The listed language based on the postgresql installation,
-when you miss a language ask your database admin.';
+$helptxt['pgFulltextSearch'] = 'This setting defines the language to use for PostgreSQL\'s fulltext search. Choose the language that most closely matches the language your forum actually uses. If your forum\'s language is not listed, or if your forum is multi-lingual, choose the "simple" option. <br/>
+This setting is independent of your main SMF language settings and not related to the installed language for SMF. <br/>
+When you change this setting you need to [url=' . $scripturl . '?action=admin;area=managesearch;sa=method]rebuild the fulltext search index[/url].<br/>
+If a language you need is not listed, ask your database admin to install PostgreSQL language support for that language.';
 
 $helptxt['enableParticipation'] = 'This shows a little icon on the topics the user has posted in.';
 

--- a/Themes/default/languages/Help.english.php
+++ b/Themes/default/languages/Help.english.php
@@ -403,6 +403,10 @@ $helptxt['customoptions'] = 'This defines the options that a user may choose fro
 	</ul>';
 
 $helptxt['autoFixDatabase'] = 'This will automatically fix broken tables and resume as if nothing happened. This can be useful, because the only way to fix it is to REPAIR the table, and this way your forum won\'t be down until you notice. It does email you when this happens.';
+$helptxt['pgFulltextSearch'] = 'This setting allow your to define the language wich is used for the fulltext search of postgresql, the language settings are independent from your smf settings and not related to the installed language for smf. <br/>
+When you change the language you need to rebuild the fulltext search index to find under Search -> Search Method. (Fulltext Index)<br/>
+The listed language based on the postgresql installation,
+when you miss a language ask your database admin.';
 
 $helptxt['enableParticipation'] = 'This shows a little icon on the topics the user has posted in.';
 

--- a/Themes/default/languages/ManageSettings.english.php
+++ b/Themes/default/languages/ManageSettings.english.php
@@ -98,6 +98,7 @@ $txt['force_ssl'] = 'Forum SSL mode';
 $txt['force_ssl_off'] = 'Disable SSL';
 $txt['force_ssl_auth'] = 'Enable SSL for Authentication (Login and Register)';
 $txt['force_ssl_complete'] = 'Force SSL throughout the forum';
+$txt['search_language'] = 'Fulltext Search Language';
 
 // Like settings.
 $txt['enable_likes'] = 'Enable likes';


### PR DESCRIPTION
It's frontend extension for the pr: https://github.com/SimpleMachines/SMF2.1/pull/4012

first i placed this setting under database stuff,
than i got the idea "would be cool in search setting"
moved and realize that there not select list exists,
that is the reason why this setting now again unter database settings.

plaese check the text stuff.
@Sesquipedalian maybe for your intresting

![grafik](https://cloud.githubusercontent.com/assets/1782906/26684929/e8b53154-46e8-11e7-80dc-898df7a6a9d6.png)
