### PR TITLE
Pg cache

### DIFF
--- a/Sources/CacheAPI-pg.php
+++ b/Sources/CacheAPI-pg.php
@@ -1,0 +1,134 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines http://www.simplemachines.org
+ * @copyright 2017 Simple Machines and individual contributors
+ * @license http://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 2.1 Beta 3
+ */
+
+if (!defined('SMF'))
+	die('Hacking attempt...');
+
+/**
+ * PostgreSQL Cache API class
+ * @package cacheAPI
+ */
+class pg_cache extends cache_api
+{
+
+	public function __construct()
+	{
+		parent::__construct();
+
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function connect()
+	{
+		global $db_prefix, $smcFunc;
+
+		$request = $smcFunc['db_query']('','
+			SELECT 1 
+			FROM   pg_tables
+			WHERE  schemaname = {string:schema}
+			AND    tablename = {string:cache}
+			',
+			array(
+			'schema' => 'public',
+			'cache' => $db_prefix . 'cache',
+			)
+		);
+
+		if($smcFunc['db_num_rows']($request) === 0)		
+			$smcFunc['db_query']('',
+				'CREATE TABLE {db_prefix}cache (key text, value text, ttl bigint, PRIMARY KEY (key))',
+				array()
+			);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function isSupported($test = false)
+	{
+		global $smcFunc;
+		
+		if ($smcFunc['db_title'] === 'PostgreSQL')
+			return true;
+		else
+			return false;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function getData($key, $ttl = null)
+	{
+		global $smcFunc;
+		
+		$ttl = time() - $ttl;
+		$request = $smcFunc['db_query']('','
+			SELECT value FROM {db_prefix}cache WHERE key = {string:key} AND ttl >= {int:ttl} LIMIT 1
+			',
+			array(
+				'key' => $key,
+				'ttl' => $ttl,
+			)
+		);
+		if($smcFunc['db_num_rows']($request) === 0)
+			return null;
+		
+		$res = $smcFunc['db_fetch_assoc']($request);
+		
+		return $res['value'];
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function putData($key, $value, $ttl = null)
+	{
+		global $smcFunc;
+		
+                if(!isset($value))
+                    $value = '';
+                
+		$ttl = time() + $ttl;
+		$smcFunc['db_insert'](
+			'replace',
+			'{db_prefix}cache',
+			array('key' => 'string', 'value' => 'string', 'ttl' => 'int'),
+			array($key, $value, $ttl),
+			array('key')
+		);
+		
+		if ($smcFunc['db_affected_rows']() > 0)
+			return true;
+		else
+			return false;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function cleanCache($type = '')
+	{
+		global $smcFunc;
+		
+		$smcFunc['db_query']('',
+				'TRUNCATE TABLE {db_prefix}cache',
+				array()
+			);
+
+		return true;
+	}
+}
+
+?>

--- a/Sources/CacheAPI-postgres.php
+++ b/Sources/CacheAPI-postgres.php
@@ -8,7 +8,7 @@
  * @copyright 2017 Simple Machines and individual contributors
  * @license http://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 2.1 Beta 3
+ * @version 2.1 Beta 4
  */
 
 if (!defined('SMF'))

--- a/Sources/CacheAPI-postgres.php
+++ b/Sources/CacheAPI-postgres.php
@@ -42,7 +42,7 @@ class postgres_cache extends cache_api
 		$result = pg_execute($db_connection, '', array('public', $db_prefix . 'cache'));
 
 		if(pg_affected_rows($result) === 0)
-			pg_query($db_connection, 'CREATE TABLE {db_prefix}cache (key text, value text, ttl bigint, PRIMARY KEY (key))');			
+			pg_query($db_connection, 'CREATE UNLOGGED TABLE {db_prefix}cache (key text, value text, ttl bigint, PRIMARY KEY (key))');			
 	}
 
 	/**

--- a/Sources/CacheAPI-postgres.php
+++ b/Sources/CacheAPI-postgres.php
@@ -41,7 +41,7 @@ class postgres_cache extends cache_api
 
 		$result = pg_execute($db_connection, '', array('public', $db_prefix . 'cache'));
 
-		if(pg_affected_rows($result) === 0)
+		if (pg_affected_rows($result) === 0)
 			pg_query($db_connection, 'CREATE UNLOGGED TABLE {db_prefix}cache (key text, value text, ttl bigint, PRIMARY KEY (key))');			
 	}
 
@@ -59,7 +59,7 @@ class postgres_cache extends cache_api
 		$result = pg_query($db_connection, 'SHOW server_version_num');
 		$res = pg_fetch_assoc($result);
 		
-		if($res['server_version_num'] < 90500)
+		if ($res['server_version_num'] < 90500)
 			return false;
 		
 		return $test ? true : parent::isSupported();
@@ -77,7 +77,7 @@ class postgres_cache extends cache_api
 			
 		$result = pg_execute($db_connection, '', array($key, $ttl));
 		
-		if(pg_affected_rows($result) === 0)
+		if (pg_affected_rows($result) === 0)
 			return null;
 
 		$res = pg_fetch_assoc($result);
@@ -92,7 +92,7 @@ class postgres_cache extends cache_api
 	{
 		global  $db_prefix, $db_connection;
 
-		if(!isset($value))
+		if (!isset($value))
 			$value = '';
 
 		$ttl = time() + $ttl;

--- a/Sources/CacheAPI-postgres.php
+++ b/Sources/CacheAPI-postgres.php
@@ -21,6 +21,16 @@ if (!defined('SMF'))
 class postgres_cache extends cache_api
 {
 
+	/**
+	 * @var false|resource of the pg_prepare from get_data.
+	 */
+	private $pg_get_data_prep;
+	
+	/**
+	 * @var false|resource of the pg_prepare from put_data.
+	 */
+	private $pg_put_data_prep;
+
 	public function __construct()
 	{
 		parent::__construct();
@@ -71,12 +81,11 @@ class postgres_cache extends cache_api
 	public function getData($key, $ttl = null)
 	{
 		global $db_prefix, $db_connection;
-		static $pg_get_data_prep;
 
 		$ttl = time() - $ttl;
 		
-		if (empty($pg_get_data_prep))
-			$pg_get_data_prep = pg_prepare($db_connection, 'smf_cache_get_data', 'SELECT value FROM ' . $db_prefix . 'cache WHERE key = $1 AND ttl >= $2 LIMIT 1');
+		if (empty($this->pg_get_data_prep))
+			$this->pg_get_data_prep = pg_prepare($db_connection, 'smf_cache_get_data', 'SELECT value FROM ' . $db_prefix . 'cache WHERE key = $1 AND ttl >= $2 LIMIT 1');
 			
 		$result = pg_execute($db_connection, 'smf_cache_get_data', array($key, $ttl));
 		
@@ -94,15 +103,14 @@ class postgres_cache extends cache_api
 	public function putData($key, $value, $ttl = null)
 	{
 		global  $db_prefix, $db_connection;
-		static $pg_put_data_prep;
 
 		if (!isset($value))
 			$value = '';
 
 		$ttl = time() + $ttl;
 		
-		if (empty($pg_put_data_prep))
-			$pg_put_data_prep = pg_prepare($db_connection, 'smf_cache_put_data',
+		if (empty($this->pg_put_data_prep))
+			$this->pg_put_data_prep = pg_prepare($db_connection, 'smf_cache_put_data',
 				'INSERT INTO ' . $db_prefix . 'cache(key,value,ttl) VALUES($1,$2,$3)
 				ON CONFLICT(key) DO UPDATE SET value = excluded.value, ttl = excluded.ttl'
 			);

--- a/Sources/CacheAPI-postgres.php
+++ b/Sources/CacheAPI-postgres.php
@@ -18,7 +18,7 @@ if (!defined('SMF'))
  * PostgreSQL Cache API class
  * @package cacheAPI
  */
-class pg_cache extends cache_api
+class postgres_cache extends cache_api
 {
 
 	public function __construct()

--- a/Sources/CacheAPI-postgres.php
+++ b/Sources/CacheAPI-postgres.php
@@ -62,7 +62,7 @@ class postgres_cache extends cache_api
 		if($res['server_version_num'] < 90500)
 			return false;
 		
-		return true;
+		return $test ? true : parent::isSupported();
 	}
 
 	/**


### PR DESCRIPTION
I notice in my test env is no cache avaible by side of file cache and
this one is slow.

So I added this cache for postgresql and
again i notice that the smf db_* magic is to mutch overhead for a cache.

so i used native pg_* with prepared statment stuff to be safer as the other cache solution but be faster as
file cache solution.