### PR TITLE
Fixes #4085

### DIFF
--- a/Themes/default/languages/Install.english.php
+++ b/Themes/default/languages/Install.english.php
@@ -26,6 +26,7 @@ $txt['good_luck'] = 'Good luck!<br>Simple Machines';
 
 $txt['install_welcome'] = 'Welcome';
 $txt['install_welcome_desc'] = 'Welcome to SMF. This script will guide you through the process for installing %1$s. We\'ll gather a few details about your forum over the next few steps, and after a couple of minutes your forum will be ready for use.';
+$txt['install_no_https'] = 'Your environment does not support https streams.  Certain functions, e.g., receiving updates from SimpleMachines.org, will not work.';
 $txt['install_all_lovely'] = 'We\'ve completed some initial tests on your server and everything appears to be in order. Simply click the &quot;Continue&quot; button below to get started.';
 
 $txt['user_refresh_install'] = 'Forum Refreshed';

--- a/other/install.php
+++ b/other/install.php
@@ -481,6 +481,11 @@ function Welcome()
 	if (!fixModSecurity() && !isset($_GET['overmodsecurity']))
 		$incontext['error'] = $txt['error_mod_security'] . '<br><br><a href="' . $installurl . '?overmodsecurity=true">' . $txt['error_message_click'] . '</a> ' . $txt['error_message_bad_try_again'];
 
+	// Check for https stream support.
+	$supported_streams = stream_get_wrappers();
+	if (!in_array('https', $supported_streams))
+		$incontext['warning'] = $txt['install_no_https'];
+
 	return false;
 }
 

--- a/other/install.php
+++ b/other/install.php
@@ -1346,7 +1346,7 @@ function DatabasePopulation()
 // Ask for the administrator login information.
 function AdminAccount()
 {
-	global $txt, $db_type, $smcFunc, $incontext, $db_prefix, $db_passwd, $sourcedir, $db_character_set;
+	global $txt, $db_type, $smcFunc, $incontext, $db_prefix, $db_passwd, $sourcedir, $db_character_set, $boardurl, $cachedir;
 
 	$incontext['sub_template'] = 'admin_account';
 	$incontext['page_title'] = $txt['user_settings'];
@@ -1364,6 +1364,10 @@ function AdminAccount()
 
 	require_once($sourcedir . '/Subs.php');
 
+	// Reload settings & set some global funcs
+	require_once($sourcedir . '/Load.php');
+	reloadSettings();
+	
 	// We need this to properly hash the password for Admin
 	$smcFunc['strtolower'] = $db_character_set != 'utf8' && $txt['lang_character_set'] != 'UTF-8' ? 'strtolower' : function($string) {
 			global $sourcedir;
@@ -1524,7 +1528,7 @@ function AdminAccount()
 function DeleteInstall()
 {
 	global $smcFunc, $db_character_set, $context, $txt, $incontext;
-	global $current_smf_version, $databases, $sourcedir, $forum_version, $modSettings, $user_info, $db_type, $boardurl;
+	global $current_smf_version, $databases, $sourcedir, $forum_version, $modSettings, $user_info, $db_type, $boardurl, $cachedir;
 
 	$incontext['page_title'] = $txt['congratulations'];
 	$incontext['sub_template'] = 'delete_install';
@@ -1542,6 +1546,9 @@ function DeleteInstall()
 	require_once($sourcedir . '/Security.php');
 	require_once($sourcedir . '/Subs-Auth.php');
 
+	// Reload settings & set some global funcs
+	reloadSettings();
+	
 	// Bring a warning over.
 	if (!empty($incontext['account_existed']))
 		$incontext['warning'] = $incontext['account_existed'];


### PR DESCRIPTION
This addresses: Installer - Undefined index & func name must be a string #4085

(1) Support for https streams is checked, and if not found, a warning is displayed.
(2) The error functions are properly loaded - for the last 2 steps anyway.  So, AT THE VERY LEAST, any error will appear in the error log and these screwy 'Notice: Undefined index: htmlspecialchars' messages should not be seen after database population.  

See screenshots below.
![no_https](https://user-images.githubusercontent.com/23568484/26914834-428409b4-4bd8-11e7-9d16-37c61cce8a1f.JPG)
![https_error](https://user-images.githubusercontent.com/23568484/26914837-462ae880-4bd8-11e7-9241-5f9f5f65169a.JPG)
