### PR TITLE
More method for db_insert returning id

### DIFF
--- a/Sources/Subs-Db-mysql.php
+++ b/Sources/Subs-Db-mysql.php
@@ -767,7 +767,7 @@ function smf_db_error($db_string, $connection = null)
  * @param array $columns An array of the columns we're inserting the data into. Should contain 'column' => 'datatype' pairs
  * @param array $data The data to insert
  * @param array $keys The keys for the table
- * @param int returnmode 0 = nothing(default), 1 = last row id, 2 = all rows id as array; every mode runs only with method = '' or 'insert'
+ * @param int returnmode 0 = nothing(default), 1 = last row id, 2 = all rows id as array; every mode runs only with method != 'ignore'
  * @param object $connection The connection to use (if null, $db_connection is used)
  * @return mixed value of the first key, behavior based on returnmode. null if no data.
  */
@@ -824,7 +824,7 @@ function smf_db_insert($method = 'replace', $table, $columns, $data, $keys, $ret
 		$connection
 	);
 
-	if(!empty($keys) && (count($keys) > 0) && ($method === '' || $method === 'insert') && $returnmode > 0)
+	if(!empty($keys) && (count($keys) > 0) && $method !== 'ignore' && $returnmode > 0)
 	{
 		if ($returnmode == 1)
 			$return_var = smf_db_insert_id($table, $keys[0]) + count($insertRows) - 1;

--- a/Sources/Subs-Db-mysql.php
+++ b/Sources/Subs-Db-mysql.php
@@ -777,7 +777,7 @@ function smf_db_insert($method = 'replace', $table, $columns, $data, $keys, $ret
 
 	$connection = $connection === null ? $db_connection : $connection;
 	
-	$return_var;
+	$return_var = null;
 
 	// With nothing to insert, simply return.
 	if (empty($data))

--- a/Sources/Subs-Db-postgresql.php
+++ b/Sources/Subs-Db-postgresql.php
@@ -764,7 +764,7 @@ function smf_db_insert($method = 'replace', $table, $columns, $data, $keys, $ret
 	$returning = '';
 	$with_returning = false;
 	// lets build the returning string, mysql allow only in normal mode
-	if(!empty($keys) && (count($keys) > 0) && $method !== 'ignore' && $returnmode > 0)
+	if (!empty($keys) && (count($keys) > 0) && $returnmode > 0)
 	{
 		// we only take the first key
 		$returning = ' RETURNING '.$keys[0];

--- a/Sources/Subs-Db-postgresql.php
+++ b/Sources/Subs-Db-postgresql.php
@@ -662,7 +662,7 @@ function smf_db_unescape_string($string)
  * @param array $columns An array of the columns we're inserting the data into. Should contain 'column' => 'datatype' pairs
  * @param array $data The data to insert
  * @param array $keys The keys for the table
- * @param int returnmode 0 = nothing(default), 1 = last row id, 2 = all rows id as array; every mode runs only with method = '' or 'insert'
+ * @param int returnmode 0 = nothing(default), 1 = last row id, 2 = all rows id as array; every mode runs only with method != 'ignore'
  * @param resource $connection The connection to use (if null, $db_connection is used)
  * @return mixed value of the first key, behavior based on returnmode. null if no data.
  */
@@ -764,7 +764,7 @@ function smf_db_insert($method = 'replace', $table, $columns, $data, $keys, $ret
 	$returning = '';
 	$with_returning = false;
 	// lets build the returning string, mysql allow only in normal mode
-	if(!empty($keys) && (count($keys) > 0) && ($method === '' || $method === 'insert') && $returnmode > 0)
+	if(!empty($keys) && (count($keys) > 0) && $method !== 'ignore' && $returnmode > 0)
 	{
 		// we only take the first key
 		$returning = ' RETURNING '.$keys[0];


### PR DESCRIPTION
Today i notice that i got a wrong understanding from replace method of mysql,
so i was able to add replace to supported method for returning the ai.
So only insert ingore keep unsupported,
i would try later this day to add also for ingore.