### PR TITLE
Newsletter fixes

### DIFF
--- a/Sources/ManageNews.php
+++ b/Sources/ManageNews.php
@@ -1008,7 +1008,7 @@ function SendMailing($clean_only = false)
 			$message = str_replace($from_member,
 				array(
 					$row['email_address'],
-					!empty($_POST['send_html']) ? '<a href="' . $scripturl . '?action=profile;u=' . $row['id_member'] . '">' . $cleanMemberName . '</a>' : ($context['send_pm'] ? '[url=' . $scripturl . '?action=profile;u=' . $row['id_member'] . ']' . $cleanMemberName . '[/url]' : $cleanMemberName),
+					!empty($_POST['send_html']) ? '<a href="' . $scripturl . '?action=profile;u=' . $row['id_member'] . '">' . $cleanMemberName . '</a>' : ($context['send_pm'] ? '[url=' . $scripturl . '?action=profile;u=' . $row['id_member'] . ']' . $cleanMemberName . '[/url]' : $scripturl . '?action=profile;u=' . $row['id_member']),
 					$row['id_member'],
 					$cleanMemberName,
 				), $_POST['message']);

--- a/Sources/ManageNews.php
+++ b/Sources/ManageNews.php
@@ -985,7 +985,7 @@ function SendMailing($clean_only = false)
 		foreach ($rows as $row)
 		{
 			// Force them to have it?
-			if (empty($context['email_force']) || empty($prefs[$row['id_member']]['announcements']))
+			if (empty($context['email_force']) && empty($prefs[$row['id_member']]['announcements']))
 				continue;
 
 			// What groups are we looking at here?

--- a/Sources/ManageNews.php
+++ b/Sources/ManageNews.php
@@ -786,7 +786,8 @@ function SendMailing($clean_only = false)
 			foreach ($_POST['exclude_groups'] as $group => $dummy)
 				$context['recipients']['exclude_groups'][] = (int) $group;
 		}
-		else
+		// Ignore an empty string - we don't want to exclude "Regular Members" unless it's specifically selected
+		elseif ($_POST['exclude_groups'] != '')
 		{
 			$groups = explode(',', $_POST['exclude_groups']);
 			foreach ($groups as $group)
@@ -861,7 +862,7 @@ function SendMailing($clean_only = false)
 		array(
 			!empty($_POST['send_html']) ? '<a href="' . $scripturl . '">' . $scripturl . '</a>' : $scripturl,
 			timeformat(forum_time(), false),
-			!empty($_POST['send_html']) ? '<a href="' . $scripturl . '?action=profile;u=' . $modSettings['latestMember'] . '">' . $cleanLatestMember . '</a>' : ($context['send_pm'] ? '[url=' . $scripturl . '?action=profile;u=' . $modSettings['latestMember'] . ']' . $cleanLatestMember . '[/url]' : $cleanLatestMember),
+			!empty($_POST['send_html']) ? '<a href="' . $scripturl . '?action=profile;u=' . $modSettings['latestMember'] . '">' . $cleanLatestMember . '</a>' : ($context['send_pm'] ? '[url=' . $scripturl . '?action=profile;u=' . $modSettings['latestMember'] . ']' . $cleanLatestMember . '[/url]' : $scripturl . '?action=profile;u=' . $modSettings['latestMember']),
 			$modSettings['latestMember'],
 			$cleanLatestMember
 		), $_POST['message']);


### PR DESCRIPTION
This addresses a couple of issues:
- Always include a link for {$member.link} even when not sending via HTML (fixes #4116)
- Flawed logic in the code caused the newsletter to not get sent in most cases