### PR TITLE
throw out $php_errormsg be php 7.2 ready

### DIFF
--- a/Sources/Load.php
+++ b/Sources/Load.php
@@ -3050,8 +3050,9 @@ function template_include($filename, $once = false)
 			require_once($sourcedir . '/Subs-Package.php');
 
 			$error = fetch_web_data($boardurl . strtr($filename, array($boarddir => '', strtr($boarddir, '\\', '/') => '')));
-			if (empty($error) && ini_get('track_errors') && !empty($php_errormsg))
-				$error = $php_errormsg;
+			$error_array = error_get_last();
+			if (empty($error) && ini_get('track_errors') && !empty($error_array))
+				$error = $error_array['message'];
 			if (empty($error))
 				$error = $txt['template_parse_errmsg'];
 


### PR DESCRIPTION
Deptracted feature: http://php.net/manual/en/reserved.variables.phperrormsg.php
recomandet replace: http://php.net/error_get_last
thanks @Antes for the list: https://wiki.php.net/rfc/deprecations_php_7_2