### PR TITLE
Localizes date display on quotes in editor

### DIFF
--- a/Themes/default/scripts/jquery.sceditor.smf.js
+++ b/Themes/default/scripts/jquery.sceditor.smf.js
@@ -647,7 +647,9 @@ $.sceditor.plugins.bbcode.bbcode.set(
 			if (typeof attrs.date !== "undefined" && attrs.date)
 			{
 				attr_date = attrs.date;
-				sDate = '<date timestamp="' + attr_date + '">' + new Date(attrs.date * 1000) + '</date>';
+				tDate = new Date(attrs.date * 1000);
+				sDate_string = tDate.toLocaleString();
+				sDate = '<date timestamp="' + attr_date + '">' + sDate_string + '</date>';
 			}
 
 			if (author == '' && sDate == '')

--- a/Themes/default/scripts/jquery.sceditor.smf.js
+++ b/Themes/default/scripts/jquery.sceditor.smf.js
@@ -647,7 +647,7 @@ $.sceditor.plugins.bbcode.bbcode.set(
 			if (typeof attrs.date !== "undefined" && attrs.date)
 			{
 				attr_date = attrs.date;
-				tDate = new Date(attrs.date * 1000);
+				tDate = new Date(attr_date * 1000);
 				sDate_string = tDate.toLocaleString();
 				sDate = '<date timestamp="' + attr_date + '">' + sDate_string + '</date>';
 			}


### PR DESCRIPTION
Instead of displaying dates in JavaScript's default date string format (e.g. `Wed Jun 14 2017 11:31:58 GMT-0600 (MDT)`), we display them in the format for the user's locale. This still isn't exactly the same as it appears it the post display, but at least it should be clearer and more easily understandable, especially to non-English speakers.

Inspired by code originally submitted by [PortaMx](https://github.com/PortaMx) in #3335

Fixes #3330 