### PR TITLE
Unbind the click event each time the function is called

### DIFF
--- a/Themes/default/scripts/quotedText.js
+++ b/Themes/default/scripts/quotedText.js
@@ -118,6 +118,9 @@ $(function() {
 			msgID : $(this).data('msgid'),
 		};
 
+		// Revome any 'click' event to the button.
+		$(document).off('click', '#quoteSelected_' + oSelected.msgID + ' a');
+
 		// If the button is already visible, hide it!
 		$('#quoteSelected_' + oSelected.msgID).hide();
 


### PR DESCRIPTION
Fix #4084

It also remove the ability to select nonadjacent parts of text on firefox.
Chrome, IE and Edge don't support this so no problems.

Signed-off-by: Blober <contact@blober.net>