### PR TITLE
implement seek-method for display of topic

### DIFF
--- a/Sources/Display.php
+++ b/Sources/Display.php
@@ -442,7 +442,6 @@ function Display()
 		$_REQUEST['start'] = -1;
 
 	// Construct allowing for the .START method...
-	//$context['page_index'] = constructPageIndex($scripturl . '?topic=' . $topic . '.%1$d', $_REQUEST['start'], $context['total_visible_posts'], $context['messages_per_page'], true);
 	$context['start'] = $_REQUEST['start'];
 
 	// This is information about which page is current, and which page we're on - in case you don't like the constructed page index. (again, wireles..)
@@ -461,23 +460,6 @@ function Display()
 			'last' => $_REQUEST['start'] + $context['messages_per_page'] < $context['total_visible_posts'] ? $scripturl . '?topic=' . $topic . '.' . (floor($context['total_visible_posts'] / $context['messages_per_page']) * $context['messages_per_page']) : '',
 			'up' => $scripturl . '?board=' . $board . '.0'
 		);
-	}
-
-	// If they are viewing all the posts, show all the posts, otherwise limit the number.
-	if ($can_show_all)
-	{
-		if (isset($_REQUEST['all']))
-		{
-			// No limit! (actually, there is a limit, but...)
-			$context['messages_per_page'] = -1;
-			$context['page_index'] .= empty($modSettings['compactTopicPagesEnable']) ? '<strong>' . $txt['all'] . '</strong> ' : '[<strong>' . $txt['all'] . '</strong>] ';
-
-			// Set start back to 0...
-			$_REQUEST['start'] = 0;
-		}
-		// They aren't using it, but the *option* is there, at least.
-		else
-			$context['page_index'] .= '&nbsp;<a href="' . $scripturl . '?topic=' . $topic . '.0;all">' . $txt['all'] . '</a> ';
 	}
 
 	// Build the link tree.
@@ -939,6 +921,23 @@ function Display()
 		'max_id' => end($messages),
 	);
 	$context['page_index'] = constructPageIndex($scripturl . '?topic=' . $topic . '.%1$d', $_REQUEST['start'], $context['total_visible_posts'], $context['messages_per_page'], true, true, $page_options);
+	
+	// If they are viewing all the posts, show all the posts, otherwise limit the number.
+	if ($can_show_all)
+	{
+		if (isset($_REQUEST['all']))
+		{
+			// No limit! (actually, there is a limit, but...)
+			$context['messages_per_page'] = -1;
+			$context['page_index'] .= empty($modSettings['compactTopicPagesEnable']) ? '<strong>' . $txt['all'] . '</strong> ' : '[<strong>' . $txt['all'] . '</strong>] ';
+
+			// Set start back to 0...
+			$_REQUEST['start'] = 0;
+		}
+		// They aren't using it, but the *option* is there, at least.
+		else
+			$context['page_index'] .= '&nbsp;<a href="' . $scripturl . '?topic=' . $topic . '.0;all">' . $txt['all'] . '</a> ';
+	}
 	
 	$smcFunc['db_free_result']($request);
 	$posters = array_unique($all_posters);

--- a/Sources/QueryString.php
+++ b/Sources/QueryString.php
@@ -191,7 +191,7 @@ function cleanRequest()
 			list ($_REQUEST['topic'], $_REQUEST['start']) = explode('/', $_REQUEST['topic']);
 		// Dots are useful and fun ;).  This is ?topic=1.15.
 		elseif (strpos($_REQUEST['topic'], '.') !== false)
-			list ($_REQUEST['topic'], $_REQUEST['start']) = explode('.', $_REQUEST['topic']);
+			list ($_REQUEST['topic'], $_REQUEST['start'], $_REQUEST['page_id']) = explode('.', $_REQUEST['topic']);
 
 		$topic = (int) $_REQUEST['topic'];
 

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -543,16 +543,22 @@ function updateSettings($changeArray, $update = false)
  * @param int $num_per_page The number of items to be displayed on a given page. $start will be forced to be a multiple of this value.
  * @param bool $flexible_start Whether a ;start=x component should be introduced into the URL automatically (see above)
  * @param bool $show_prevnext Whether the Previous and Next links should be shown (should be on only when navigating the list)
+ * @param null|array $options Provide max_id and low_id to evade paging by next page jump
  *
  * @return string The complete HTML of the page index that was requested, formatted by the template.
  */
-function constructPageIndex($base_url, &$start, $max_value, $num_per_page, $flexible_start = false, $show_prevnext = true)
+function constructPageIndex($base_url, &$start, $max_value, $num_per_page, $flexible_start = false, $show_prevnext = true, $options = null)
 {
 	global $modSettings, $context, $smcFunc, $settings, $txt;
 
 	// Save whether $start was less than 0 or not.
 	$start = (int) $start;
 	$start_invalid = $start < 0;
+	
+	if (!empty($options['low_id']))
+		$low_id = $options['low_id'];
+	if (!empty($options['max_id']))
+		$max_id = $options['max_id'];
 
 	// Make sure $start is a proper variable - not less than 0.
 	if ($start_invalid)
@@ -582,14 +588,19 @@ function constructPageIndex($base_url, &$start, $max_value, $num_per_page, $flex
 	}
 
 	$base_link = strtr($settings['page_index']['page'], array('{URL}' => $flexible_start ? $base_url : strtr($base_url, array('%' => '%%')) . ';start=%1$d'));
+	$base_url_page = $base_url . '.%3$s';
+	$base_link_page = strtr($settings['page_index']['page'], array('{URL}' => $flexible_start ? $base_url_page : strtr($base_url_page, array('%' => '%%')) . ';start=%1$d'));
 	$pageindex = $settings['page_index']['extra_before'];
 
 	// Compact pages is off or on?
 	if (empty($modSettings['compactTopicPagesEnable']))
 	{
 		// Show the left arrow.
-		$pageindex .= $start == 0 ? ' ' : sprintf($base_link, $start - $num_per_page, $settings['page_index']['previous_page']);
-
+		if (empty($low_id))
+			$pageindex .= $start == 0 ? ' ' : sprintf($base_link, $start - $num_per_page, $settings['page_index']['previous_page']);
+		else
+			$pageindex .= $start == 0 ? ' ' : sprintf($base_link_page, ($start - $num_per_page), $settings['page_index']['previous_page'], 'L'.$low_id);
+		
 		// Show all the pages.
 		$display_page = 1;
 		for ($counter = 0; $counter < $max_value; $counter += $num_per_page)
@@ -597,8 +608,13 @@ function constructPageIndex($base_url, &$start, $max_value, $num_per_page, $flex
 
 		// Show the right arrow.
 		$display_page = ($start + $num_per_page) > $max_value ? $max_value : ($start + $num_per_page);
-		if ($start != $counter - $max_value && !$start_invalid)
-			$pageindex .= $display_page > $counter - $num_per_page ? ' ' : sprintf($base_link, $display_page, $settings['page_index']['next_page']);
+		if ($start != $counter - $max_value && !$start_invalid){
+			if (empty($max_id))
+				$pageindex .= $display_page > $counter - $num_per_page ? ' ' : sprintf($base_link, $display_page, $settings['page_index']['next_page']);
+			else
+				$pageindex .= $display_page > $counter - $num_per_page ? ' ' : sprintf($base_link_page, $display_page , $settings['page_index']['next_page'], 'M'.$max_id);
+		}
+			
 	}
 	else
 	{
@@ -607,7 +623,10 @@ function constructPageIndex($base_url, &$start, $max_value, $num_per_page, $flex
 
 		// Show the "prev page" link. (>prev page< 1 ... 6 7 [8] 9 10 ... 15 next page)
 		if (!empty($start) && $show_prevnext)
-			$pageindex .= sprintf($base_link, $start - $num_per_page, $settings['page_index']['previous_page']);
+			if (empty($low_id))
+				$pageindex .= sprintf($base_link, $start - $num_per_page, $settings['page_index']['previous_page']);
+			else
+				$pageindex .= sprintf($base_link_page, $start - $num_per_page, $settings['page_index']['previous_page'], 'L'.$low_id);
 		else
 			$pageindex .= '';
 
@@ -629,7 +648,10 @@ function constructPageIndex($base_url, &$start, $max_value, $num_per_page, $flex
 			if ($start >= $num_per_page * $nCont)
 			{
 				$tmpStart = $start - $num_per_page * $nCont;
-				$pageindex .= sprintf($base_link, $tmpStart, $tmpStart / $num_per_page + 1);
+				if($nCont != 1 || empty($low_id))
+					$pageindex .= sprintf($base_link, $tmpStart, $tmpStart / $num_per_page + 1);
+				else
+					$pageindex .= sprintf($base_link_page, $tmpStart, $tmpStart / $num_per_page + 1, 'L'.$low_id);
 			}
 
 		// Show the current page. (prev page 1 ... 6 7 >[8]< 9 10 ... 15 next page)
@@ -644,7 +666,10 @@ function constructPageIndex($base_url, &$start, $max_value, $num_per_page, $flex
 			if ($start + $num_per_page * $nCont <= $tmpMaxPages)
 			{
 				$tmpStart = $start + $num_per_page * $nCont;
-				$pageindex .= sprintf($base_link, $tmpStart, $tmpStart / $num_per_page + 1);
+				if($nCont != 1 || empty($max_id))
+					$pageindex .= sprintf($base_link, $tmpStart, $tmpStart / $num_per_page + 1);
+				else
+					$pageindex .= sprintf($base_link_page, $tmpStart, $tmpStart / $num_per_page + 1, 'M'.$max_id);
 			}
 
 		// Show the '...' part near the end. (prev page 1 ... 6 7 [8] 9 10 >...< 15 next page)
@@ -662,7 +687,10 @@ function constructPageIndex($base_url, &$start, $max_value, $num_per_page, $flex
 
 		// Show the "next page" link. (prev page 1 ... 6 7 [8] 9 10 ... 15 >next page<)
 		if ($start != $tmpMaxPages && $show_prevnext)
-			$pageindex .= sprintf($base_link, $start + $num_per_page, $settings['page_index']['next_page']);
+			if (empty($max_id))
+				$pageindex .= sprintf($base_link, $start + $num_per_page, $settings['page_index']['next_page']);
+			else
+				$pageindex .= sprintf($base_link_page, $start + $num_per_page, $settings['page_index']['next_page'], 'M'.$max_id);
 	}
 	$pageindex .= $settings['page_index']['extra_after'];
 


### PR DESCRIPTION
Well it database world you try to evade paging
so somthing like that: 
select * from messages LIMIT 15, 3000
is curse.

one of the common case where can evade this is,
when you jump from page to page,
here you can use the seek method which garantee the same run time on every page no different if you call the first page or the 300th.

For this stuff i had to two things:
build a base (subs.php and querystring.php) and
then implement this for board display topics.

example when you normale call a topic thr url look like that:
index.php?topic=123364.30
ther is no change but when you now try to access the next page:
index.php?topic=123364.45.M993457
M means next page/upper limit/max
993457 the id of the message

similiar it's look when you try the page before:
http://localhost/SMF2.1/index.php?topic=123364.15.L993457
L means before page/lower limit/min
993457 the id of the message

The effect old:
         SELECT id_msg, id_member, approved
         FROM smf_messages
         WHERE id_topic = 123364
         ORDER BY id_msg DESC
      LIMIT 15 OFFSET 2905
   in ...\Sources\Display.php line 866, which took 0.00132585 

         SELECT id_msg, id_member, approved
         FROM smf_messages
         WHERE id_topic = 123364
         AND id_msg < 996414
         ORDER BY id_msg DESC
         LIMIT 15
   in ...\Sources\Display.php line 899, which took 0.0003171
