### PR TITLE
Added PG Hints and added one query

### DIFF
--- a/Sources/Load.php
+++ b/Sources/Load.php
@@ -850,7 +850,7 @@ function loadBoard()
 
 	if (empty($temp))
 	{
-		$request = $smcFunc['db_query']('', '
+		$request = $smcFunc['db_query']('load_board_info', '
 			SELECT
 				c.id_cat, b.name AS bname, b.description, b.num_topics, b.member_groups, b.deny_member_groups,
 				b.id_parent, c.name AS cname, COALESCE(mg.id_group, 0) AS id_moderator_group, mg.group_name,

--- a/Sources/Subs-Db-postgresql.php
+++ b/Sources/Subs-Db-postgresql.php
@@ -343,7 +343,7 @@ function smf_db_query($identifier, $db_string, $db_values = array(), $connection
 			'~COUNT\(\*\) \/ MAX\(b.num_posts\)~' => 'CAST(COUNT(*) AS DECIMAL) / CAST(b.num_posts AS DECIMAL)',
 		),
 	);
-	
+
 	// Special optimizer Hints
 	$query_opt = array(
 		'load_board_info' => array(
@@ -476,14 +476,13 @@ function smf_db_query($identifier, $db_string, $db_values = array(), $connection
 			$query_hints_set .= 'SET LOCAL join_collapse_limit = 1;';
 			$query_hints_undo .= 'SET LOCAL join_collapse_limit = default;';
 		}
-		
+
 		$db_string = $query_hints_set .'
 		' . $db_string;
-	
 	}
-		
+
 	$db_last_result = @pg_query($connection, $db_string);
-	
+
 	// Remove optimiz settings
 	if (isset($query_hints_undo))
 		@pg_query($connection, $query_hints_undo);


### PR DESCRIPTION
Sometime when the amount of joined tables is "high",
is better to run with an easy plan as waiting for the planer to find the "best" solution.

In this case the query run now in the half of time,
because the database optimizer is trying less to optimize the join stuff.

On Bechmark i got ~10% (5,5k -> 6,1k) more topic display.