### PR TITLE
Trim

### DIFF
--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -1040,13 +1040,9 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 			  not block level, and will not be implicitly closed as easily.
 			  One break following a block level tag may also be removed.
 
-			trim: if set to 'inside', whitespace after the begin tag will be
+			trim: if set, and 'inside' whitespace after the begin tag will be
 			  removed.  If set to 'outside', whitespace after the end tag will
-			  meet the same fate. If set to 'both', both will be done.
-
-			trim_breaks: if set to true, whitespace trimming after the end tag
-			  will trim as many <br> elements as it can. This is mostly useful
-			  for block_level tags.
+			  meet the same fate.
 
 			validate: except when type is missing or 'closed', a callback to
 			  validate the data as $data.  Depending on the tag's type, $data
@@ -1293,7 +1289,6 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 					$data = $class . $css;
 				},
 				'trim' => 'outside',
-				'trim_breaks' => true,
 				'block_level' => true,
 			),
 			array(
@@ -2141,7 +2136,7 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 					$whitespace_regex .= '(&nbsp;|\s)*(<br>)?';
 				// Trim one line of whitespace after unnested tags, but all of it after nested ones
 				if (!empty($tag['trim']) && $tag['trim'] != 'inside')
-					$whitespace_regex .= empty($tag['require_parents']) && empty($tag['trim_breaks']) ? '(&nbsp;|\s)*' : '(<br>|&nbsp;|\s)*';
+					$whitespace_regex .= empty($tag['require_parents']) ? '(&nbsp;|\s)*' : '(<br>|&nbsp;|\s)*';
 
 				if (!empty($whitespace_regex) && preg_match('~' . $whitespace_regex . '~', substr($message, $pos), $matches) != 0)
 					$message = substr($message, 0, $pos) . substr($message, $pos + strlen($matches[0]));
@@ -2420,7 +2415,7 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 				if (!empty($tag['block_level']))
 					$whitespace_regex .= '(&nbsp;|\s)*(<br>)?';
 				if (!empty($tag['trim']) && $tag['trim'] != 'inside')
-					$whitespace_regex .= empty($tag['require_parents']) && empty($tag['trim_breaks']) ? '(&nbsp;|\s)*' : '(<br>|&nbsp;|\s)*';
+					$whitespace_regex .= empty($tag['require_parents']) ? '(&nbsp;|\s)*' : '(<br>|&nbsp;|\s)*';
 				if (!empty($whitespace_regex) && preg_match('~' . $whitespace_regex . '~', substr($message, $pos), $matches) != 0)
 					$message = substr($message, 0, $pos) . substr($message, $pos + strlen($matches[0]));
 

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -2133,7 +2133,7 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 				// See the comment at the end of the big loop - just eating whitespace ;).
 				$whitespace_regex = '';
 				if (!empty($tag['block_level']))
-					$whitespace_regex .= '(&nbsp;|\s)*<br>';
+					$whitespace_regex .= '(&nbsp;|\s)*(<br>)?';
 				// Trim one line of whitespace after unnested tags, but all of it after nested ones
 				if (!empty($tag['trim']) && $tag['trim'] != 'inside')
 					$whitespace_regex .= empty($tag['require_parents']) ? '(&nbsp;|\s)*' : '(<br>|&nbsp;|\s)*';
@@ -2413,7 +2413,7 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 				// Trim or eat trailing stuff... see comment at the end of the big loop.
 				$whitespace_regex = '';
 				if (!empty($tag['block_level']))
-					$whitespace_regex .= '(&nbsp;|\s)*<br>';
+					$whitespace_regex .= '(&nbsp;|\s)*(<br>)?';
 				if (!empty($tag['trim']) && $tag['trim'] != 'inside')
 					$whitespace_regex .= empty($tag['require_parents']) ? '(&nbsp;|\s)*' : '(<br>|&nbsp;|\s)*';
 				if (!empty($whitespace_regex) && preg_match('~' . $whitespace_regex . '~', substr($message, $pos), $matches) != 0)

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -1040,9 +1040,13 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 			  not block level, and will not be implicitly closed as easily.
 			  One break following a block level tag may also be removed.
 
-			trim: if set, and 'inside' whitespace after the begin tag will be
+			trim: if set to 'inside', whitespace after the begin tag will be
 			  removed.  If set to 'outside', whitespace after the end tag will
-			  meet the same fate.
+			  meet the same fate. If set to 'both', both will be done.
+
+			trim_breaks: if set to true, whitespace trimming after the end tag
+			  will trim as many <br> elements as it can. This is mostly useful
+			  for block_level tags.
 
 			validate: except when type is missing or 'closed', a callback to
 			  validate the data as $data.  Depending on the tag's type, $data
@@ -1289,6 +1293,7 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 					$data = $class . $css;
 				},
 				'trim' => 'outside',
+				'trim_breaks' => true,
 				'block_level' => true,
 			),
 			array(
@@ -2136,7 +2141,7 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 					$whitespace_regex .= '(&nbsp;|\s)*(<br>)?';
 				// Trim one line of whitespace after unnested tags, but all of it after nested ones
 				if (!empty($tag['trim']) && $tag['trim'] != 'inside')
-					$whitespace_regex .= empty($tag['require_parents']) ? '(&nbsp;|\s)*' : '(<br>|&nbsp;|\s)*';
+					$whitespace_regex .= empty($tag['require_parents']) && empty($tag['trim_breaks']) ? '(&nbsp;|\s)*' : '(<br>|&nbsp;|\s)*';
 
 				if (!empty($whitespace_regex) && preg_match('~' . $whitespace_regex . '~', substr($message, $pos), $matches) != 0)
 					$message = substr($message, 0, $pos) . substr($message, $pos + strlen($matches[0]));
@@ -2415,7 +2420,7 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 				if (!empty($tag['block_level']))
 					$whitespace_regex .= '(&nbsp;|\s)*(<br>)?';
 				if (!empty($tag['trim']) && $tag['trim'] != 'inside')
-					$whitespace_regex .= empty($tag['require_parents']) ? '(&nbsp;|\s)*' : '(<br>|&nbsp;|\s)*';
+					$whitespace_regex .= empty($tag['require_parents']) && empty($tag['trim_breaks']) ? '(&nbsp;|\s)*' : '(<br>|&nbsp;|\s)*';
 				if (!empty($whitespace_regex) && preg_match('~' . $whitespace_regex . '~', substr($message, $pos), $matches) != 0)
 					$message = substr($message, 0, $pos) . substr($message, $pos + strlen($matches[0]));
 

--- a/Themes/default/css/jquery.sceditor.default.css
+++ b/Themes/default/css/jquery.sceditor.default.css
@@ -111,12 +111,6 @@ img {
 	clear: right;
 	margin: 0 0 1em 1em;
 }
-/* Prevent unnecessary line breaks after floats */
-.floatleft + div > br:first-child,
-.floatright + div > br:first-child {
-	display: none;
-}
-
 @media (max-width: 480px) {
 	.floatleft, .floatright {
 		max-width: 100% !important;


### PR DESCRIPTION
1. Fixes a bug with trimming breaks after block_level BBC.
Specifically, if a block level BBC was nested inside another block level, and the inner block level was NOT followed by a `<br>`, we might still trim off four characters after the inner BBC's closing tag.

2. ~Adds a 'trim_breaks' BBC param to help with layout for the float BBC
When 'trim' is set to 'outside' or 'both', 'trim_breaks' causes the whitespace trimming to always remove as many `<br>` elements as it can. This is the same thing that we already do for nested BBC like [li] and [tr] inside lists and tables, but now there is a way to specify it for other BBC that need it, such as the [float] BBC.~ Fixes a discrepancy between the editor's CSS and the standard display CSS.