### PR TITLE
Date fixes

### DIFF
--- a/Sources/Load.php
+++ b/Sources/Load.php
@@ -1463,7 +1463,7 @@ function loadMemberContext($user, $display_custom_fields = false)
 				'title' => $profile['website_title'],
 				'url' => $profile['website_url'],
 			),
-			'birth_date' => empty($profile['birthdate']) || $profile['birthdate'] === '1001-01-01' ? '0000-00-00' : (substr($profile['birthdate'], 0, 4) === '0004' ? '0000' . substr($profile['birthdate'], 4) : $profile['birthdate']),
+			'birth_date' => empty($profile['birthdate']) || $profile['birthdate'] === '1001-01-01' ? '1001-01-01' : (substr($profile['birthdate'], 0, 4) === '0004' ? '1001' . substr($profile['birthdate'], 4) : $profile['birthdate']),
 			'signature' => $profile['signature'],
 			'real_posts' => $profile['posts'],
 			'posts' => $profile['posts'] > 500000 ? $txt['geek'] : comma_format($profile['posts']),

--- a/Sources/Load.php
+++ b/Sources/Load.php
@@ -1463,7 +1463,7 @@ function loadMemberContext($user, $display_custom_fields = false)
 				'title' => $profile['website_title'],
 				'url' => $profile['website_url'],
 			),
-			'birth_date' => empty($profile['birthdate']) || $profile['birthdate'] === '1001-01-01' ? '1001-01-01' : (substr($profile['birthdate'], 0, 4) === '0004' ? '1001' . substr($profile['birthdate'], 4) : $profile['birthdate']),
+			'birth_date' => empty($profile['birthdate']) || $profile['birthdate'] === '1000-01-01' ? '1000-01-01' : (substr($profile['birthdate'], 0, 4) === '0004' ? '1000' . substr($profile['birthdate'], 4) : $profile['birthdate']),
 			'signature' => $profile['signature'],
 			'real_posts' => $profile['posts'],
 			'posts' => $profile['posts'] > 500000 ? $txt['geek'] : comma_format($profile['posts']),

--- a/Sources/Load.php
+++ b/Sources/Load.php
@@ -1463,7 +1463,7 @@ function loadMemberContext($user, $display_custom_fields = false)
 				'title' => $profile['website_title'],
 				'url' => $profile['website_url'],
 			),
-			'birth_date' => empty($profile['birthdate']) || $profile['birthdate'] === '0001-01-01' ? '0000-00-00' : (substr($profile['birthdate'], 0, 4) === '0004' ? '0000' . substr($profile['birthdate'], 4) : $profile['birthdate']),
+			'birth_date' => empty($profile['birthdate']) || $profile['birthdate'] === '1001-01-01' ? '0000-00-00' : (substr($profile['birthdate'], 0, 4) === '0004' ? '0000' . substr($profile['birthdate'], 4) : $profile['birthdate']),
 			'signature' => $profile['signature'],
 			'real_posts' => $profile['posts'],
 			'posts' => $profile['posts'] > 500000 ? $txt['geek'] : comma_format($profile['posts']),

--- a/Sources/Load.php
+++ b/Sources/Load.php
@@ -1463,7 +1463,7 @@ function loadMemberContext($user, $display_custom_fields = false)
 				'title' => $profile['website_title'],
 				'url' => $profile['website_url'],
 			),
-			'birth_date' => empty($profile['birthdate']) || $profile['birthdate'] === '1000-01-01' ? '1000-01-01' : (substr($profile['birthdate'], 0, 4) === '0004' ? '1000' . substr($profile['birthdate'], 4) : $profile['birthdate']),
+			'birth_date' => empty($profile['birthdate']) ? '1004-01-01' : (substr($profile['birthdate'], 0, 4) === '0004' ? '1004' . substr($profile['birthdate'], 4) : $profile['birthdate']),
 			'signature' => $profile['signature'],
 			'real_posts' => $profile['posts'],
 			'posts' => $profile['posts'] > 500000 ? $txt['geek'] : comma_format($profile['posts']),

--- a/Sources/ManageCalendar.php
+++ b/Sources/ManageCalendar.php
@@ -139,7 +139,7 @@ function ModifyHolidays()
 					'function' => function ($rowData) use ($txt)
 					{
 						// Recurring every year or just a single year?
-						$year = $rowData['year'] == '1001' ? sprintf('(%1$s)', $txt['every_year']) : $rowData['year'];
+						$year = $rowData['year'] == '1004' ? sprintf('(%1$s)', $txt['every_year']) : $rowData['year'];
 
 						// Construct the date.
 						return sprintf('%1$d %2$s %3$s', $rowData['day'], $txt['months'][(int) $rowData['month']], $year);
@@ -231,7 +231,7 @@ function EditHoliday()
 			);
 		else
 		{
-			$date = strftime($_REQUEST['year'] <= 4 ? '1001-%m-%d' : '%Y-%m-%d', mktime(0, 0, 0, $_REQUEST['month'], $_REQUEST['day'], $_REQUEST['year']));
+			$date = strftime($_REQUEST['year'] <= 1004 ? '1004-%m-%d' : '%Y-%m-%d', mktime(0, 0, 0, $_REQUEST['month'], $_REQUEST['day'], $_REQUEST['year']));
 			if (isset($_REQUEST['edit']))
 				$smcFunc['db_query']('', '
 					UPDATE {db_prefix}calendar_holidays

--- a/Sources/ManageCalendar.php
+++ b/Sources/ManageCalendar.php
@@ -139,7 +139,7 @@ function ModifyHolidays()
 					'function' => function ($rowData) use ($txt)
 					{
 						// Recurring every year or just a single year?
-						$year = $rowData['year'] == '0004' ? sprintf('(%1$s)', $txt['every_year']) : $rowData['year'];
+						$year = $rowData['year'] == '1001' ? sprintf('(%1$s)', $txt['every_year']) : $rowData['year'];
 
 						// Construct the date.
 						return sprintf('%1$d %2$s %3$s', $rowData['day'], $txt['months'][(int) $rowData['month']], $year);
@@ -231,7 +231,7 @@ function EditHoliday()
 			);
 		else
 		{
-			$date = strftime($_REQUEST['year'] <= 4 ? '0004-%m-%d' : '%Y-%m-%d', mktime(0, 0, 0, $_REQUEST['month'], $_REQUEST['day'], $_REQUEST['year']));
+			$date = strftime($_REQUEST['year'] <= 4 ? '1001-%m-%d' : '%Y-%m-%d', mktime(0, 0, 0, $_REQUEST['month'], $_REQUEST['day'], $_REQUEST['year']));
 			if (isset($_REQUEST['edit']))
 				$smcFunc['db_query']('', '
 					UPDATE {db_prefix}calendar_holidays

--- a/Sources/Profile-Modify.php
+++ b/Sources/Profile-Modify.php
@@ -89,9 +89,9 @@ function loadProfileFields($force_reload = false)
 			'preload' => function() use ($cur_profile, &$context)
 			{
 				// Split up the birthdate....
-				list ($uyear, $umonth, $uday) = explode('-', empty($cur_profile['birthdate']) || $cur_profile['birthdate'] == '1000-01-01' ? '0000-00-00' : $cur_profile['birthdate']);
+				list ($uyear, $umonth, $uday) = explode('-', empty($cur_profile['birthdate']) ? '1004-01-01' : $cur_profile['birthdate']);
 				$context['member']['birth_date'] = array(
-					'year' => $uyear == '0004' ? '0000' : $uyear,
+					'year' => $uyear,
 					'month' => $umonth,
 					'day' => $uday,
 				);
@@ -104,12 +104,12 @@ function loadProfileFields($force_reload = false)
 				{
 					// Set to blank?
 					if ((int) $_POST['bday3'] == 1 && (int) $_POST['bday2'] == 1 && (int) $value == 1)
-						$value = '1000-01-01';
+						$value = '1004-01-01';
 					else
-						$value = checkdxate($value, $_POST['bday2'], $_POST['bday3'] < 1001 ? 1001 : $_POST['bday3']) ? sprintf('%04d-%02d-%02d', $_POST['bday3'] < 1001 ? 1001 : $_POST['bday3'], $_POST['bday1'], $_POST['bday2']) : '1000-01-01';
+						$value = checkdxate($value, $_POST['bday2'], $_POST['bday3'] < 1004 ? 1004 : $_POST['bday3']) ? sprintf('%04d-%02d-%02d', $_POST['bday3'] < 1004 ? 1004 : $_POST['bday3'], $_POST['bday1'], $_POST['bday2']) : '1004-01-01';
 				}
 				else
-					$value = '1000-01-01';
+					$value = '1004-01-01';
 
 				$profile_vars['birthdate'] = $value;
 				$cur_profile['birthdate'] = $value;
@@ -125,12 +125,12 @@ function loadProfileFields($force_reload = false)
 				// @todo Should we check for this year and tell them they made a mistake :P? (based on coppa at least?)
 				if (preg_match('/(\d{4})[\-\., ](\d{2})[\-\., ](\d{2})/', $value, $dates) === 1)
 				{
-					$value = checkdate($dates[2], $dates[3], $dates[1] < 4 ? 4 : $dates[1]) ? sprintf('%04d-%02d-%02d', $dates[1] < 4 ? 4 : $dates[1], $dates[2], $dates[3]) : '1000-01-01';
+$value = checkdate($dates[2], $dates[3], $dates[1] < 4 ? 4 : $dates[1]) ? sprintf('%04d-%02d-%02d', $dates[1] < 4 ? 4 : $dates[1], $dates[2], $dates[3]) : '1004-01-01';
 					return true;
 				}
 				else
 				{
-					$value = empty($cur_profile['birthdate']) ? '1000-01-01' : $cur_profile['birthdate'];
+					$value = empty($cur_profile['birthdate']) ? '1004-01-01' : $cur_profile['birthdate'];
 					return false;
 				}
 			},

--- a/Sources/Profile-Modify.php
+++ b/Sources/Profile-Modify.php
@@ -106,7 +106,7 @@ function loadProfileFields($force_reload = false)
 					if ((int) $_POST['bday3'] == 1 && (int) $_POST['bday2'] == 1 && (int) $value == 1)
 						$value = '1001-01-01';
 					else
-						$value = checkdate($value, $_POST['bday2'], $_POST['bday3'] < 4 ? 4 : $_POST['bday3']) ? sprintf('%04d-%02d-%02d', $_POST['bday3'] < 4 ? 4 : $_POST['bday3'], $_POST['bday1'], $_POST['bday2']) : '1001-01-01';
+						$value = checkdxate($value, $_POST['bday2'], $_POST['bday3'] < 1001 ? 1001 : $_POST['bday3']) ? sprintf('%04d-%02d-%02d', $_POST['bday3'] < 1001 ? 1001 : $_POST['bday3'], $_POST['bday1'], $_POST['bday2']) : '1001-01-01';
 				}
 				else
 					$value = '1001-01-01';
@@ -130,8 +130,7 @@ function loadProfileFields($force_reload = false)
 				}
 				else
 				{
-					$value = empty($cur_profile['birthdate']) ? '1
-					001-01-01' : $cur_profile['birthdate'];
+					$value = empty($cur_profile['birthdate']) ? '1001-01-01' : $cur_profile['birthdate'];
 					return false;
 				}
 			},

--- a/Sources/Profile-Modify.php
+++ b/Sources/Profile-Modify.php
@@ -106,7 +106,7 @@ function loadProfileFields($force_reload = false)
 					if ((int) $_POST['bday3'] == 1 && (int) $_POST['bday2'] == 1 && (int) $value == 1)
 						$value = '1004-01-01';
 					else
-						$value = checkdxate($value, $_POST['bday2'], $_POST['bday3'] < 1004 ? 1004 : $_POST['bday3']) ? sprintf('%04d-%02d-%02d', $_POST['bday3'] < 1004 ? 1004 : $_POST['bday3'], $_POST['bday1'], $_POST['bday2']) : '1004-01-01';
+						$value = checkdate($value, $_POST['bday2'], $_POST['bday3'] < 1004 ? 1004 : $_POST['bday3']) ? sprintf('%04d-%02d-%02d', $_POST['bday3'] < 1004 ? 1004 : $_POST['bday3'], $_POST['bday1'], $_POST['bday2']) : '1004-01-01';
 				}
 				else
 					$value = '1004-01-01';

--- a/Sources/Profile-Modify.php
+++ b/Sources/Profile-Modify.php
@@ -89,7 +89,7 @@ function loadProfileFields($force_reload = false)
 			'preload' => function() use ($cur_profile, &$context)
 			{
 				// Split up the birthdate....
-				list ($uyear, $umonth, $uday) = explode('-', empty($cur_profile['birthdate']) || $cur_profile['birthdate'] == '1001-01-01' ? '0000-00-00' : $cur_profile['birthdate']);
+				list ($uyear, $umonth, $uday) = explode('-', empty($cur_profile['birthdate']) || $cur_profile['birthdate'] == '1000-01-01' ? '0000-00-00' : $cur_profile['birthdate']);
 				$context['member']['birth_date'] = array(
 					'year' => $uyear == '0004' ? '0000' : $uyear,
 					'month' => $umonth,
@@ -104,12 +104,12 @@ function loadProfileFields($force_reload = false)
 				{
 					// Set to blank?
 					if ((int) $_POST['bday3'] == 1 && (int) $_POST['bday2'] == 1 && (int) $value == 1)
-						$value = '1001-01-01';
+						$value = '1000-01-01';
 					else
-						$value = checkdxate($value, $_POST['bday2'], $_POST['bday3'] < 1001 ? 1001 : $_POST['bday3']) ? sprintf('%04d-%02d-%02d', $_POST['bday3'] < 1001 ? 1001 : $_POST['bday3'], $_POST['bday1'], $_POST['bday2']) : '1001-01-01';
+						$value = checkdxate($value, $_POST['bday2'], $_POST['bday3'] < 1001 ? 1001 : $_POST['bday3']) ? sprintf('%04d-%02d-%02d', $_POST['bday3'] < 1001 ? 1001 : $_POST['bday3'], $_POST['bday1'], $_POST['bday2']) : '1000-01-01';
 				}
 				else
-					$value = '1001-01-01';
+					$value = '1000-01-01';
 
 				$profile_vars['birthdate'] = $value;
 				$cur_profile['birthdate'] = $value;
@@ -125,12 +125,12 @@ function loadProfileFields($force_reload = false)
 				// @todo Should we check for this year and tell them they made a mistake :P? (based on coppa at least?)
 				if (preg_match('/(\d{4})[\-\., ](\d{2})[\-\., ](\d{2})/', $value, $dates) === 1)
 				{
-					$value = checkdate($dates[2], $dates[3], $dates[1] < 4 ? 4 : $dates[1]) ? sprintf('%04d-%02d-%02d', $dates[1] < 4 ? 4 : $dates[1], $dates[2], $dates[3]) : '1001-01-01';
+					$value = checkdate($dates[2], $dates[3], $dates[1] < 4 ? 4 : $dates[1]) ? sprintf('%04d-%02d-%02d', $dates[1] < 4 ? 4 : $dates[1], $dates[2], $dates[3]) : '1000-01-01';
 					return true;
 				}
 				else
 				{
-					$value = empty($cur_profile['birthdate']) ? '1001-01-01' : $cur_profile['birthdate'];
+					$value = empty($cur_profile['birthdate']) ? '1000-01-01' : $cur_profile['birthdate'];
 					return false;
 				}
 			},

--- a/Sources/Profile-Modify.php
+++ b/Sources/Profile-Modify.php
@@ -89,7 +89,7 @@ function loadProfileFields($force_reload = false)
 			'preload' => function() use ($cur_profile, &$context)
 			{
 				// Split up the birthdate....
-				list ($uyear, $umonth, $uday) = explode('-', empty($cur_profile['birthdate']) || $cur_profile['birthdate'] == '0001-01-01' ? '0000-00-00' : $cur_profile['birthdate']);
+				list ($uyear, $umonth, $uday) = explode('-', empty($cur_profile['birthdate']) || $cur_profile['birthdate'] == '1001-01-01' ? '0000-00-00' : $cur_profile['birthdate']);
 				$context['member']['birth_date'] = array(
 					'year' => $uyear == '0004' ? '0000' : $uyear,
 					'month' => $umonth,
@@ -104,12 +104,12 @@ function loadProfileFields($force_reload = false)
 				{
 					// Set to blank?
 					if ((int) $_POST['bday3'] == 1 && (int) $_POST['bday2'] == 1 && (int) $value == 1)
-						$value = '0001-01-01';
+						$value = '1001-01-01';
 					else
-						$value = checkdate($value, $_POST['bday2'], $_POST['bday3'] < 4 ? 4 : $_POST['bday3']) ? sprintf('%04d-%02d-%02d', $_POST['bday3'] < 4 ? 4 : $_POST['bday3'], $_POST['bday1'], $_POST['bday2']) : '0001-01-01';
+						$value = checkdate($value, $_POST['bday2'], $_POST['bday3'] < 4 ? 4 : $_POST['bday3']) ? sprintf('%04d-%02d-%02d', $_POST['bday3'] < 4 ? 4 : $_POST['bday3'], $_POST['bday1'], $_POST['bday2']) : '1001-01-01';
 				}
 				else
-					$value = '0001-01-01';
+					$value = '1001-01-01';
 
 				$profile_vars['birthdate'] = $value;
 				$cur_profile['birthdate'] = $value;
@@ -125,12 +125,13 @@ function loadProfileFields($force_reload = false)
 				// @todo Should we check for this year and tell them they made a mistake :P? (based on coppa at least?)
 				if (preg_match('/(\d{4})[\-\., ](\d{2})[\-\., ](\d{2})/', $value, $dates) === 1)
 				{
-					$value = checkdate($dates[2], $dates[3], $dates[1] < 4 ? 4 : $dates[1]) ? sprintf('%04d-%02d-%02d', $dates[1] < 4 ? 4 : $dates[1], $dates[2], $dates[3]) : '0001-01-01';
+					$value = checkdate($dates[2], $dates[3], $dates[1] < 4 ? 4 : $dates[1]) ? sprintf('%04d-%02d-%02d', $dates[1] < 4 ? 4 : $dates[1], $dates[2], $dates[3]) : '1001-01-01';
 					return true;
 				}
 				else
 				{
-					$value = empty($cur_profile['birthdate']) ? '0001-01-01' : $cur_profile['birthdate'];
+					$value = empty($cur_profile['birthdate']) ? '1
+					001-01-01' : $cur_profile['birthdate'];
 					return false;
 				}
 			},

--- a/Sources/Profile-Modify.php
+++ b/Sources/Profile-Modify.php
@@ -125,7 +125,7 @@ function loadProfileFields($force_reload = false)
 				// @todo Should we check for this year and tell them they made a mistake :P? (based on coppa at least?)
 				if (preg_match('/(\d{4})[\-\., ](\d{2})[\-\., ](\d{2})/', $value, $dates) === 1)
 				{
-$value = checkdate($dates[2], $dates[3], $dates[1] < 4 ? 4 : $dates[1]) ? sprintf('%04d-%02d-%02d', $dates[1] < 4 ? 4 : $dates[1], $dates[2], $dates[3]) : '1004-01-01';
+					$value = checkdate($dates[2], $dates[3], $dates[1] < 4 ? 4 : $dates[1]) ? sprintf('%04d-%02d-%02d', $dates[1] < 4 ? 4 : $dates[1], $dates[2], $dates[3]) : '1004-01-01';
 					return true;
 				}
 				else

--- a/Sources/Profile-View.php
+++ b/Sources/Profile-View.php
@@ -76,7 +76,7 @@ function summary($memID)
 		list ($birth_year, $birth_month, $birth_day) = sscanf($context['member']['birth_date'], '%d-%d-%d');
 		$datearray = getdate(forum_time());
 		$context['member'] += array(
-			'age' => $birth_year <= 1001 ? $txt['not_applicable'] : $datearray['year'] - $birth_year - (($datearray['mon'] > $birth_month || ($datearray['mon'] == $birth_month && $datearray['mday'] >= $birth_day)) ? 0 : 1),
+			'age' => $birth_year <= 1000 ? $txt['not_applicable'] : $datearray['year'] - $birth_year - (($datearray['mon'] > $birth_month || ($datearray['mon'] == $birth_month && $datearray['mday'] >= $birth_day)) ? 0 : 1),
 			'today_is_birthday' => $datearray['mon'] == $birth_month && $datearray['mday'] == $birth_day
 		);
 	}

--- a/Sources/Profile-View.php
+++ b/Sources/Profile-View.php
@@ -76,7 +76,7 @@ function summary($memID)
 		list ($birth_year, $birth_month, $birth_day) = sscanf($context['member']['birth_date'], '%d-%d-%d');
 		$datearray = getdate(forum_time());
 		$context['member'] += array(
-			'age' => $birth_year <= 1000 ? $txt['not_applicable'] : $datearray['year'] - $birth_year - (($datearray['mon'] > $birth_month || ($datearray['mon'] == $birth_month && $datearray['mday'] >= $birth_day)) ? 0 : 1),
+			'age' => $birth_year <= 1004 ? $txt['not_applicable'] : $datearray['year'] - $birth_year - (($datearray['mon'] > $birth_month || ($datearray['mon'] == $birth_month && $datearray['mday'] >= $birth_day)) ? 0 : 1),
 			'today_is_birthday' => $datearray['mon'] == $birth_month && $datearray['mday'] == $birth_day
 		);
 	}

--- a/Sources/Profile-View.php
+++ b/Sources/Profile-View.php
@@ -64,7 +64,7 @@ function summary($memID)
 		$context['member']['posts_per_day'] = comma_format($context['member']['real_posts'] / $days_registered, 3);
 
 	// Set the age...
-	if (empty($context['member']['birth_date']))
+	if (empty($context['member']['birth_date']) || substr($context['member']['birthdate'], 0, 4) < 1002)
 	{
 		$context['member'] += array(
 			'age' => $txt['not_applicable'],
@@ -76,7 +76,7 @@ function summary($memID)
 		list ($birth_year, $birth_month, $birth_day) = sscanf($context['member']['birth_date'], '%d-%d-%d');
 		$datearray = getdate(forum_time());
 		$context['member'] += array(
-			'age' => $birth_year <= 4 ? $txt['not_applicable'] : $datearray['year'] - $birth_year - (($datearray['mon'] > $birth_month || ($datearray['mon'] == $birth_month && $datearray['mday'] >= $birth_day)) ? 0 : 1),
+			'age' => $birth_year <= 1001 ? $txt['not_applicable'] : $datearray['year'] - $birth_year - (($datearray['mon'] > $birth_month || ($datearray['mon'] == $birth_month && $datearray['mday'] >= $birth_day)) ? 0 : 1),
 			'today_is_birthday' => $datearray['mon'] == $birth_month && $datearray['mday'] == $birth_day
 		);
 	}

--- a/Sources/Subs-Calendar.php
+++ b/Sources/Subs-Calendar.php
@@ -78,7 +78,7 @@ function getBirthdayRange($low_date, $high_date)
 				'is_activated' => 1,
 				'no_month' => 0,
 				'no_day' => 0,
-				'year_one' => '0001',
+				'year_one' => '1001',
 				'year_low' => $year_low . '-%m-%d',
 				'year_high' => $year_high . '-%m-%d',
 				'year_low_low_date' => $low_date,
@@ -99,7 +99,7 @@ function getBirthdayRange($low_date, $high_date)
 		$bday[$age_year . substr($row['birthdate'], 4)][] = array(
 			'id' => $row['id_member'],
 			'name' => $row['real_name'],
-			'age' => $row['birth_year'] > 4 && $row['birth_year'] <= $age_year ? $age_year - $row['birth_year'] : null,
+			'age' => $row['birth_year'] > 1001 && $row['birth_year'] <= $age_year ? $age_year - $row['birth_year'] : null,
 			'is_last' => false
 		);
 	}

--- a/Sources/Subs-Calendar.php
+++ b/Sources/Subs-Calendar.php
@@ -52,7 +52,7 @@ function getBirthdayRange($low_date, $high_date)
 				'is_activated' => 1,
 				'no_month' => 0,
 				'no_day' => 0,
-				'year_one' => '1001',
+				'year_one' => '1000',
 				'year_low' => $year_low . '-%m-%d',
 				'year_high' => $year_high . '-%m-%d',
 				'low_date' => $low_date,
@@ -78,7 +78,7 @@ function getBirthdayRange($low_date, $high_date)
 				'is_activated' => 1,
 				'no_month' => 0,
 				'no_day' => 0,
-				'year_one' => '1001',
+				'year_one' => '1000',
 				'year_low' => $year_low . '-%m-%d',
 				'year_high' => $year_high . '-%m-%d',
 				'year_low_low_date' => $low_date,
@@ -99,7 +99,7 @@ function getBirthdayRange($low_date, $high_date)
 		$bday[$age_year . substr($row['birthdate'], 4)][] = array(
 			'id' => $row['id_member'],
 			'name' => $row['real_name'],
-			'age' => $row['birth_year'] > 1001 && $row['birth_year'] <= $age_year ? $age_year - $row['birth_year'] : null,
+			'age' => $row['birth_year'] > 1000 && $row['birth_year'] <= $age_year ? $age_year - $row['birth_year'] : null,
 			'is_last' => false
 		);
 	}
@@ -298,10 +298,10 @@ function getHolidayRange($low_date, $high_date)
 		array(
 			'low_date' => $low_date,
 			'high_date' => $high_date,
-			'all_year_low' => '1001' . substr($low_date, 4),
-			'all_year_high' => '1001' . substr($high_date, 4),
-			'all_year_jan' => '1001-01-01',
-			'all_year_dec' => '1001-12-31',
+			'all_year_low' => '1000' . substr($low_date, 4),
+			'all_year_high' => '1000' . substr($high_date, 4),
+			'all_year_jan' => '1000-01-01',
+			'all_year_dec' => '1000-12-31',
 		)
 	);
 	$holidays = array();

--- a/Sources/Subs-Calendar.php
+++ b/Sources/Subs-Calendar.php
@@ -52,7 +52,7 @@ function getBirthdayRange($low_date, $high_date)
 				'is_activated' => 1,
 				'no_month' => 0,
 				'no_day' => 0,
-				'year_one' => '0001',
+				'year_one' => '1001',
 				'year_low' => $year_low . '-%m-%d',
 				'year_high' => $year_high . '-%m-%d',
 				'low_date' => $low_date,
@@ -298,10 +298,10 @@ function getHolidayRange($low_date, $high_date)
 		array(
 			'low_date' => $low_date,
 			'high_date' => $high_date,
-			'all_year_low' => '0004' . substr($low_date, 4),
-			'all_year_high' => '0004' . substr($high_date, 4),
-			'all_year_jan' => '0004-01-01',
-			'all_year_dec' => '0004-12-31',
+			'all_year_low' => '1001' . substr($low_date, 4),
+			'all_year_high' => '1001' . substr($high_date, 4),
+			'all_year_jan' => '1001-01-01',
+			'all_year_dec' => '1001-12-31',
 		)
 	);
 	$holidays = array();

--- a/Sources/Subs-Calendar.php
+++ b/Sources/Subs-Calendar.php
@@ -52,7 +52,7 @@ function getBirthdayRange($low_date, $high_date)
 				'is_activated' => 1,
 				'no_month' => 0,
 				'no_day' => 0,
-				'year_one' => '1000',
+				'year_one' => '1004',
 				'year_low' => $year_low . '-%m-%d',
 				'year_high' => $year_high . '-%m-%d',
 				'low_date' => $low_date,
@@ -78,7 +78,7 @@ function getBirthdayRange($low_date, $high_date)
 				'is_activated' => 1,
 				'no_month' => 0,
 				'no_day' => 0,
-				'year_one' => '1000',
+				'year_one' => '1004',
 				'year_low' => $year_low . '-%m-%d',
 				'year_high' => $year_high . '-%m-%d',
 				'year_low_low_date' => $low_date,
@@ -99,7 +99,7 @@ function getBirthdayRange($low_date, $high_date)
 		$bday[$age_year . substr($row['birthdate'], 4)][] = array(
 			'id' => $row['id_member'],
 			'name' => $row['real_name'],
-			'age' => $row['birth_year'] > 1000 && $row['birth_year'] <= $age_year ? $age_year - $row['birth_year'] : null,
+			'age' => $row['birth_year'] > 1004 && $row['birth_year'] <= $age_year ? $age_year - $row['birth_year'] : null,
 			'is_last' => false
 		);
 	}
@@ -298,10 +298,10 @@ function getHolidayRange($low_date, $high_date)
 		array(
 			'low_date' => $low_date,
 			'high_date' => $high_date,
-			'all_year_low' => '1000' . substr($low_date, 4),
-			'all_year_high' => '1000' . substr($high_date, 4),
-			'all_year_jan' => '1000-01-01',
-			'all_year_dec' => '1000-12-31',
+			'all_year_low' => '1004' . substr($low_date, 4),
+			'all_year_high' => '1004' . substr($high_date, 4),
+			'all_year_jan' => '1004-01-01',
+			'all_year_dec' => '1004-12-31',
 		)
 	);
 	$holidays = array();

--- a/other/install_2-1_mysql.sql
+++ b/other/install_2-1_mysql.sql
@@ -151,8 +151,8 @@ CREATE TABLE {$db_prefix}boards (
 
 CREATE TABLE {$db_prefix}calendar (
   id_event SMALLINT UNSIGNED AUTO_INCREMENT,
-  start_date date NOT NULL DEFAULT '1001-01-01',
-  end_date date NOT NULL DEFAULT '1001-01-01',
+  start_date date NOT NULL DEFAULT '1000-01-01',
+  end_date date NOT NULL DEFAULT '1000-01-01',
   id_board SMALLINT UNSIGNED NOT NULL DEFAULT '0',
   id_topic MEDIUMINT UNSIGNED NOT NULL DEFAULT '0',
   title VARCHAR(255) NOT NULL DEFAULT '',
@@ -173,7 +173,7 @@ CREATE TABLE {$db_prefix}calendar (
 
 CREATE TABLE {$db_prefix}calendar_holidays (
   id_holiday SMALLINT UNSIGNED AUTO_INCREMENT,
-  event_date date NOT NULL DEFAULT '1001-01-01',
+  event_date date NOT NULL DEFAULT '1000-01-01',
   title VARCHAR(255) NOT NULL DEFAULT '',
   PRIMARY KEY (id_holiday),
   INDEX idx_event_date (event_date)
@@ -589,7 +589,7 @@ CREATE TABLE {$db_prefix}log_spider_stats (
   id_spider SMALLINT UNSIGNED DEFAULT '0',
   page_hits SMALLINT UNSIGNED NOT NULL DEFAULT '0',
   last_seen INT(10) UNSIGNED NOT NULL DEFAULT '0',
-  stat_date DATE DEFAULT '1001-01-01',
+  stat_date DATE DEFAULT '1000-01-01',
   PRIMARY KEY (stat_date, id_spider)
 ) ENGINE={$engine};
 
@@ -694,7 +694,7 @@ CREATE TABLE {$db_prefix}members (
   passwd VARCHAR(64) NOT NULL DEFAULT '',
   email_address VARCHAR(255) NOT NULL DEFAULT '',
   personal_text VARCHAR(255) NOT NULL DEFAULT '',
-  birthdate date NOT NULL DEFAULT '1001-01-01',
+  birthdate date NOT NULL DEFAULT '1000-01-01',
   website_title VARCHAR(255) NOT NULL DEFAULT '',
   website_url VARCHAR(255) NOT NULL DEFAULT '',
   show_online TINYINT NOT NULL DEFAULT '1',

--- a/other/install_2-1_mysql.sql
+++ b/other/install_2-1_mysql.sql
@@ -151,8 +151,8 @@ CREATE TABLE {$db_prefix}boards (
 
 CREATE TABLE {$db_prefix}calendar (
   id_event SMALLINT UNSIGNED AUTO_INCREMENT,
-  start_date date NOT NULL DEFAULT '0001-01-01',
-  end_date date NOT NULL DEFAULT '0001-01-01',
+  start_date date NOT NULL DEFAULT '1001-01-01',
+  end_date date NOT NULL DEFAULT '1001-01-01',
   id_board SMALLINT UNSIGNED NOT NULL DEFAULT '0',
   id_topic MEDIUMINT UNSIGNED NOT NULL DEFAULT '0',
   title VARCHAR(255) NOT NULL DEFAULT '',
@@ -173,7 +173,7 @@ CREATE TABLE {$db_prefix}calendar (
 
 CREATE TABLE {$db_prefix}calendar_holidays (
   id_holiday SMALLINT UNSIGNED AUTO_INCREMENT,
-  event_date date NOT NULL DEFAULT '0001-01-01',
+  event_date date NOT NULL DEFAULT '1001-01-01',
   title VARCHAR(255) NOT NULL DEFAULT '',
   PRIMARY KEY (id_holiday),
   INDEX idx_event_date (event_date)
@@ -589,7 +589,7 @@ CREATE TABLE {$db_prefix}log_spider_stats (
   id_spider SMALLINT UNSIGNED DEFAULT '0',
   page_hits SMALLINT UNSIGNED NOT NULL DEFAULT '0',
   last_seen INT(10) UNSIGNED NOT NULL DEFAULT '0',
-  stat_date DATE DEFAULT '0001-01-01',
+  stat_date DATE DEFAULT '1001-01-01',
   PRIMARY KEY (stat_date, id_spider)
 ) ENGINE={$engine};
 
@@ -694,7 +694,7 @@ CREATE TABLE {$db_prefix}members (
   passwd VARCHAR(64) NOT NULL DEFAULT '',
   email_address VARCHAR(255) NOT NULL DEFAULT '',
   personal_text VARCHAR(255) NOT NULL DEFAULT '',
-  birthdate date NOT NULL DEFAULT '0001-01-01',
+  birthdate date NOT NULL DEFAULT '1001-01-01',
   website_title VARCHAR(255) NOT NULL DEFAULT '',
   website_url VARCHAR(255) NOT NULL DEFAULT '',
   show_online TINYINT NOT NULL DEFAULT '1',

--- a/other/install_2-1_mysql.sql
+++ b/other/install_2-1_mysql.sql
@@ -151,8 +151,8 @@ CREATE TABLE {$db_prefix}boards (
 
 CREATE TABLE {$db_prefix}calendar (
   id_event SMALLINT UNSIGNED AUTO_INCREMENT,
-  start_date date NOT NULL DEFAULT '1000-01-01',
-  end_date date NOT NULL DEFAULT '1000-01-01',
+  start_date date NOT NULL DEFAULT '1004-01-01',
+  end_date date NOT NULL DEFAULT '1004-01-01',
   id_board SMALLINT UNSIGNED NOT NULL DEFAULT '0',
   id_topic MEDIUMINT UNSIGNED NOT NULL DEFAULT '0',
   title VARCHAR(255) NOT NULL DEFAULT '',
@@ -173,7 +173,7 @@ CREATE TABLE {$db_prefix}calendar (
 
 CREATE TABLE {$db_prefix}calendar_holidays (
   id_holiday SMALLINT UNSIGNED AUTO_INCREMENT,
-  event_date date NOT NULL DEFAULT '1000-01-01',
+  event_date date NOT NULL DEFAULT '1004-01-01',
   title VARCHAR(255) NOT NULL DEFAULT '',
   PRIMARY KEY (id_holiday),
   INDEX idx_event_date (event_date)
@@ -589,7 +589,7 @@ CREATE TABLE {$db_prefix}log_spider_stats (
   id_spider SMALLINT UNSIGNED DEFAULT '0',
   page_hits SMALLINT UNSIGNED NOT NULL DEFAULT '0',
   last_seen INT(10) UNSIGNED NOT NULL DEFAULT '0',
-  stat_date DATE DEFAULT '1000-01-01',
+  stat_date DATE DEFAULT '1004-01-01',
   PRIMARY KEY (stat_date, id_spider)
 ) ENGINE={$engine};
 
@@ -694,7 +694,7 @@ CREATE TABLE {$db_prefix}members (
   passwd VARCHAR(64) NOT NULL DEFAULT '',
   email_address VARCHAR(255) NOT NULL DEFAULT '',
   personal_text VARCHAR(255) NOT NULL DEFAULT '',
-  birthdate date NOT NULL DEFAULT '1000-01-01',
+  birthdate date NOT NULL DEFAULT '1004-01-01',
   website_title VARCHAR(255) NOT NULL DEFAULT '',
   website_url VARCHAR(255) NOT NULL DEFAULT '',
   show_online TINYINT NOT NULL DEFAULT '1',

--- a/other/install_2-1_postgresql.sql
+++ b/other/install_2-1_postgresql.sql
@@ -69,7 +69,7 @@ CREATE OR REPLACE FUNCTION DATE_FORMAT (timestamp, text) RETURNS text AS '
 LANGUAGE 'sql';
 
 CREATE OR REPLACE FUNCTION TO_DAYS (timestamp) RETURNS integer AS
-  'SELECT DATE_PART(''DAY'', $1 - ''0001-01-01bc'')::integer AS result'
+  'SELECT DATE_PART(''DAY'', $1 - ''1001-01-01bc'')::integer AS result'
 LANGUAGE 'sql';
 
 CREATE OR REPLACE FUNCTION INSTR (text, text) RETURNS integer AS
@@ -303,8 +303,8 @@ CREATE SEQUENCE {$db_prefix}calendar_seq;
 
 CREATE TABLE {$db_prefix}calendar (
   id_event smallint default nextval('{$db_prefix}calendar_seq'),
-  start_date date NOT NULL default '0001-01-01',
-  end_date date NOT NULL default '0001-01-01',
+  start_date date NOT NULL default '1001-01-01',
+  end_date date NOT NULL default '1001-01-01',
   id_board smallint NOT NULL default '0',
   id_topic int NOT NULL default '0',
   title varchar(255) NOT NULL default '',
@@ -336,7 +336,7 @@ CREATE SEQUENCE {$db_prefix}calendar_holidays_seq;
 
 CREATE TABLE {$db_prefix}calendar_holidays (
   id_holiday smallint default nextval('{$db_prefix}calendar_holidays_seq'),
-  event_date date NOT NULL default '0001-01-01',
+  event_date date NOT NULL default '1001-01-01',
   title varchar(255) NOT NULL default '',
   PRIMARY KEY (id_holiday)
 );
@@ -456,7 +456,7 @@ CREATE INDEX {$db_prefix}log_actions_id_topic_id_log ON {$db_prefix}log_actions 
 #
 
 CREATE TABLE {$db_prefix}log_activity (
-  date date NOT NULL default '0001-01-01',
+  date date NOT NULL default '1001-01-01',
   hits int NOT NULL default '0',
   topics smallint NOT NULL default '0',
   posts smallint NOT NULL default '0',
@@ -905,7 +905,7 @@ CREATE TABLE {$db_prefix}log_spider_stats (
   id_spider smallint NOT NULL default '0',
   page_hits smallint NOT NULL default '0',
   last_seen bigint NOT NULL default '0',
-  stat_date date NOT NULL default '0001-01-01',
+  stat_date date NOT NULL default '1001-01-01',
   PRIMARY KEY (stat_date, id_spider)
 );
 
@@ -1054,7 +1054,7 @@ CREATE TABLE {$db_prefix}members (
   passwd varchar(64) NOT NULL default '',
   email_address varchar(255) NOT NULL DEFAULT '',
   personal_text varchar(255) NOT NULL DEFAULT '',
-  birthdate date NOT NULL default '0001-01-01',
+  birthdate date NOT NULL default '1001-01-01',
   website_title varchar(255) NOT NULL DEFAULT '',
   website_url varchar(255) NOT NULL DEFAULT '',
   show_online smallint NOT NULL default '1',

--- a/other/install_2-1_postgresql.sql
+++ b/other/install_2-1_postgresql.sql
@@ -303,8 +303,8 @@ CREATE SEQUENCE {$db_prefix}calendar_seq;
 
 CREATE TABLE {$db_prefix}calendar (
   id_event smallint default nextval('{$db_prefix}calendar_seq'),
-  start_date date NOT NULL default '1001-01-01',
-  end_date date NOT NULL default '1001-01-01',
+  start_date date NOT NULL default '1000-01-01',
+  end_date date NOT NULL default '1000-01-01',
   id_board smallint NOT NULL default '0',
   id_topic int NOT NULL default '0',
   title varchar(255) NOT NULL default '',
@@ -336,7 +336,7 @@ CREATE SEQUENCE {$db_prefix}calendar_holidays_seq;
 
 CREATE TABLE {$db_prefix}calendar_holidays (
   id_holiday smallint default nextval('{$db_prefix}calendar_holidays_seq'),
-  event_date date NOT NULL default '1001-01-01',
+  event_date date NOT NULL default '1000-01-01',
   title varchar(255) NOT NULL default '',
   PRIMARY KEY (id_holiday)
 );
@@ -456,7 +456,7 @@ CREATE INDEX {$db_prefix}log_actions_id_topic_id_log ON {$db_prefix}log_actions 
 #
 
 CREATE TABLE {$db_prefix}log_activity (
-  date date NOT NULL default '1001-01-01',
+  date date NOT NULL default '1000-01-01',
   hits int NOT NULL default '0',
   topics smallint NOT NULL default '0',
   posts smallint NOT NULL default '0',
@@ -905,7 +905,7 @@ CREATE TABLE {$db_prefix}log_spider_stats (
   id_spider smallint NOT NULL default '0',
   page_hits smallint NOT NULL default '0',
   last_seen bigint NOT NULL default '0',
-  stat_date date NOT NULL default '1001-01-01',
+  stat_date date NOT NULL default '1000-01-01',
   PRIMARY KEY (stat_date, id_spider)
 );
 
@@ -1054,7 +1054,7 @@ CREATE TABLE {$db_prefix}members (
   passwd varchar(64) NOT NULL default '',
   email_address varchar(255) NOT NULL DEFAULT '',
   personal_text varchar(255) NOT NULL DEFAULT '',
-  birthdate date NOT NULL default '1001-01-01',
+  birthdate date NOT NULL default '1000-01-01',
   website_title varchar(255) NOT NULL DEFAULT '',
   website_url varchar(255) NOT NULL DEFAULT '',
   show_online smallint NOT NULL default '1',

--- a/other/install_2-1_postgresql.sql
+++ b/other/install_2-1_postgresql.sql
@@ -69,7 +69,7 @@ CREATE OR REPLACE FUNCTION DATE_FORMAT (timestamp, text) RETURNS text AS '
 LANGUAGE 'sql';
 
 CREATE OR REPLACE FUNCTION TO_DAYS (timestamp) RETURNS integer AS
-  'SELECT DATE_PART(''DAY'', $1 - ''1001-01-01bc'')::integer AS result'
+  'SELECT DATE_PART(''DAY'', $1 - ''0001-01-01bc'')::integer AS result'
 LANGUAGE 'sql';
 
 CREATE OR REPLACE FUNCTION INSTR (text, text) RETURNS integer AS

--- a/other/install_2-1_postgresql.sql
+++ b/other/install_2-1_postgresql.sql
@@ -303,8 +303,8 @@ CREATE SEQUENCE {$db_prefix}calendar_seq;
 
 CREATE TABLE {$db_prefix}calendar (
   id_event smallint default nextval('{$db_prefix}calendar_seq'),
-  start_date date NOT NULL default '1000-01-01',
-  end_date date NOT NULL default '1000-01-01',
+  start_date date NOT NULL default '1004-01-01',
+  end_date date NOT NULL default '1004-01-01',
   id_board smallint NOT NULL default '0',
   id_topic int NOT NULL default '0',
   title varchar(255) NOT NULL default '',
@@ -336,7 +336,7 @@ CREATE SEQUENCE {$db_prefix}calendar_holidays_seq;
 
 CREATE TABLE {$db_prefix}calendar_holidays (
   id_holiday smallint default nextval('{$db_prefix}calendar_holidays_seq'),
-  event_date date NOT NULL default '1000-01-01',
+  event_date date NOT NULL default '1004-01-01',
   title varchar(255) NOT NULL default '',
   PRIMARY KEY (id_holiday)
 );
@@ -456,7 +456,7 @@ CREATE INDEX {$db_prefix}log_actions_id_topic_id_log ON {$db_prefix}log_actions 
 #
 
 CREATE TABLE {$db_prefix}log_activity (
-  date date NOT NULL default '1000-01-01',
+  date date NOT NULL default '1004-01-01',
   hits int NOT NULL default '0',
   topics smallint NOT NULL default '0',
   posts smallint NOT NULL default '0',
@@ -905,7 +905,7 @@ CREATE TABLE {$db_prefix}log_spider_stats (
   id_spider smallint NOT NULL default '0',
   page_hits smallint NOT NULL default '0',
   last_seen bigint NOT NULL default '0',
-  stat_date date NOT NULL default '1000-01-01',
+  stat_date date NOT NULL default '1004-01-01',
   PRIMARY KEY (stat_date, id_spider)
 );
 
@@ -1054,7 +1054,7 @@ CREATE TABLE {$db_prefix}members (
   passwd varchar(64) NOT NULL default '',
   email_address varchar(255) NOT NULL DEFAULT '',
   personal_text varchar(255) NOT NULL DEFAULT '',
-  birthdate date NOT NULL default '1000-01-01',
+  birthdate date NOT NULL default '1004-01-01',
   website_title varchar(255) NOT NULL DEFAULT '',
   website_url varchar(255) NOT NULL DEFAULT '',
   show_online smallint NOT NULL default '1',

--- a/other/upgrade_2-1_mysql.sql
+++ b/other/upgrade_2-1_mysql.sql
@@ -1,6 +1,38 @@
 /* ATTENTION: You don't need to run or use this file!  The upgrade.php script does everything for you! */
 
 /******************************************************************************/
+--- Fixing dates...
+/******************************************************************************/
+
+--# Updating old values
+UPDATE {$db_prefix}calendar
+SET start_date = '1001-01-01'
+WHERE start_date < '1001-01-01';
+
+UPDATE {$db_prefix}calendar
+SET end_date = '1001-01-01'
+WHERE end_date < '1001-01-01';
+
+UPDATE {$db_prefix}calendar_holidays
+SET event_date = '1001-01-01'
+WHERE event_date < '1001-01-01';
+
+UPDATE {$db_prefix}log_spider_stats
+SET stat_date = '1001-01-01'
+WHERE stat_date < '1001-01-01';
+
+UPDATE {$db_prefix}members
+SET birthdate = '1001-01-01'
+WHERE birthdate < '1001-01-01';
+
+--# Changing default values
+ALTER TABLE {$db_prefix}calendar CHANGE start_date start_date date NOT NULL DEFAULT '1001-01-01';
+ALTER TABLE {$db_prefix}calendar CHANGE end_date end_date date NOT NULL DEFAULT '1001-01-01';
+ALTER TABLE {$db_prefix}calendar_holidays CHANGE event_date event_date date NOT NULL DEFAULT '1001-01-01';
+ALTER TABLE {$db_prefix}log_spider_stats CHANGE stat_date stat_date date NOT NULL DEFAULT '1001-01-01';
+ALTER TABLE {$db_prefix}members CHANGE birthdate birthdate date NOT NULL DEFAULT '1001-01-01';
+
+/******************************************************************************/
 --- Adding new settings...
 /******************************************************************************/
 

--- a/other/upgrade_2-1_mysql.sql
+++ b/other/upgrade_2-1_mysql.sql
@@ -6,23 +6,23 @@
 
 ---# Updating old values
 UPDATE {$db_prefix}calendar
-SET start_date = '1001-01-01'
-WHERE start_date < '1001-01-01';
+SET start_date = DATE(CONCAT(1001, '-', MONTH(start_date), '-', DAY(start_date)))
+WHERE YEAR(start_date) < 1000;
 
 UPDATE {$db_prefix}calendar
-SET end_date = '1001-01-01'
-WHERE end_date < '1001-01-01';
+SET end_date = DATE(CONCAT(1001, '-', MONTH(end_date), '-', DAY(end_date)))
+WHERE YEAR(end_date) < 1000;
 
 UPDATE {$db_prefix}calendar_holidays
-SET event_date = '1001-01-01'
-WHERE event_date < '1001-01-01';
+SET event_date = DATE(CONCAT(1001, '-', MONTH(event_date), '-', DAY(event_date)))
+WHERE YEAR(event_date) < 1000;
 
 UPDATE {$db_prefix}log_spider_stats
-SET stat_date = '1001-01-01'
-WHERE stat_date < '1001-01-01';
+SET stat_date = DATE(CONCAT(1001, '-', MONTH(stat_date), '-', DAY(stat_date)))
+WHERE YEAR(stat_date) < 1000;
 
 UPDATE {$db_prefix}members
-SET birthdate = '1001-01-01'
+SET birthdate = DATE(CONCAT(IF(YEAR(birthdate) < 1001, 1001, YEAR(birthdate)), '-', IF(MONTH(birthdate) < 1, 1, MONTH(birthdate)), '-', IF(DAY(birthdate) < 1, 1, DAY(birthdate))))
 WHERE birthdate < '1001-01-01';
 ---#
 

--- a/other/upgrade_2-1_mysql.sql
+++ b/other/upgrade_2-1_mysql.sql
@@ -6,32 +6,32 @@
 
 ---# Updating old values
 UPDATE {$db_prefix}calendar
-SET start_date = DATE(CONCAT(1000, '-', MONTH(start_date), '-', DAY(start_date)))
-WHERE YEAR(start_date) < 1000;
+SET start_date = DATE(CONCAT(1004, '-', MONTH(start_date), '-', DAY(start_date)))
+WHERE YEAR(start_date) < 1004;
 
 UPDATE {$db_prefix}calendar
-SET end_date = DATE(CONCAT(1000, '-', MONTH(end_date), '-', DAY(end_date)))
-WHERE YEAR(end_date) < 1000;
+SET end_date = DATE(CONCAT(1004, '-', MONTH(end_date), '-', DAY(end_date)))
+WHERE YEAR(end_date) < 1004;
 
 UPDATE {$db_prefix}calendar_holidays
-SET event_date = DATE(CONCAT(1000, '-', MONTH(event_date), '-', DAY(event_date)))
-WHERE YEAR(event_date) < 1000;
+SET event_date = DATE(CONCAT(1004, '-', MONTH(event_date), '-', DAY(event_date)))
+WHERE YEAR(event_date) < 1004;
 
 UPDATE {$db_prefix}log_spider_stats
-SET stat_date = DATE(CONCAT(1000, '-', MONTH(stat_date), '-', DAY(stat_date)))
-WHERE YEAR(stat_date) < 1000;
+SET stat_date = DATE(CONCAT(1004, '-', MONTH(stat_date), '-', DAY(stat_date)))
+WHERE YEAR(stat_date) < 1004;
 
 UPDATE {$db_prefix}members
-SET birthdate = DATE(CONCAT(IF(YEAR(birthdate) < 1000, 1000, YEAR(birthdate)), '-', IF(MONTH(birthdate) < 1, 1, MONTH(birthdate)), '-', IF(DAY(birthdate) < 1, 1, DAY(birthdate))))
-WHERE YEAR(birthdate) < 1000;
+SET birthdate = DATE(CONCAT(IF(YEAR(birthdate) < 1004, 1004, YEAR(birthdate)), '-', IF(MONTH(birthdate) < 1, 1, MONTH(birthdate)), '-', IF(DAY(birthdate) < 1, 1, DAY(birthdate))))
+WHERE YEAR(birthdate) < 1004;
 ---#
 
 ---# Changing default values
-ALTER TABLE {$db_prefix}calendar CHANGE start_date start_date date NOT NULL DEFAULT '1000-01-01';
-ALTER TABLE {$db_prefix}calendar CHANGE end_date end_date date NOT NULL DEFAULT '1000-01-01';
-ALTER TABLE {$db_prefix}calendar_holidays CHANGE event_date event_date date NOT NULL DEFAULT '1000-01-01';
-ALTER TABLE {$db_prefix}log_spider_stats CHANGE stat_date stat_date date NOT NULL DEFAULT '1000-01-01';
-ALTER TABLE {$db_prefix}members CHANGE birthdate birthdate date NOT NULL DEFAULT '1000-01-01';
+ALTER TABLE {$db_prefix}calendar CHANGE start_date start_date date NOT NULL DEFAULT '1004-01-01';
+ALTER TABLE {$db_prefix}calendar CHANGE end_date end_date date NOT NULL DEFAULT '1004-01-01';
+ALTER TABLE {$db_prefix}calendar_holidays CHANGE event_date event_date date NOT NULL DEFAULT '1004-01-01';
+ALTER TABLE {$db_prefix}log_spider_stats CHANGE stat_date stat_date date NOT NULL DEFAULT '1004-01-01';
+ALTER TABLE {$db_prefix}members CHANGE birthdate birthdate date NOT NULL DEFAULT '1004-01-01';
 ---#
 
 /******************************************************************************/

--- a/other/upgrade_2-1_mysql.sql
+++ b/other/upgrade_2-1_mysql.sql
@@ -23,7 +23,7 @@ WHERE YEAR(stat_date) < 1000;
 
 UPDATE {$db_prefix}members
 SET birthdate = DATE(CONCAT(IF(YEAR(birthdate) < 1001, 1001, YEAR(birthdate)), '-', IF(MONTH(birthdate) < 1, 1, MONTH(birthdate)), '-', IF(DAY(birthdate) < 1, 1, DAY(birthdate))))
-WHERE birthdate < '1001-01-01';
+WHERE YEAR(birthdate) < 1000;
 ---#
 
 ---# Changing default values

--- a/other/upgrade_2-1_mysql.sql
+++ b/other/upgrade_2-1_mysql.sql
@@ -4,7 +4,7 @@
 --- Fixing dates...
 /******************************************************************************/
 
---# Updating old values
+---# Updating old values
 UPDATE {$db_prefix}calendar
 SET start_date = '1001-01-01'
 WHERE start_date < '1001-01-01';
@@ -24,13 +24,15 @@ WHERE stat_date < '1001-01-01';
 UPDATE {$db_prefix}members
 SET birthdate = '1001-01-01'
 WHERE birthdate < '1001-01-01';
+---#
 
---# Changing default values
+---# Changing default values
 ALTER TABLE {$db_prefix}calendar CHANGE start_date start_date date NOT NULL DEFAULT '1001-01-01';
 ALTER TABLE {$db_prefix}calendar CHANGE end_date end_date date NOT NULL DEFAULT '1001-01-01';
 ALTER TABLE {$db_prefix}calendar_holidays CHANGE event_date event_date date NOT NULL DEFAULT '1001-01-01';
 ALTER TABLE {$db_prefix}log_spider_stats CHANGE stat_date stat_date date NOT NULL DEFAULT '1001-01-01';
 ALTER TABLE {$db_prefix}members CHANGE birthdate birthdate date NOT NULL DEFAULT '1001-01-01';
+---#
 
 /******************************************************************************/
 --- Adding new settings...

--- a/other/upgrade_2-1_mysql.sql
+++ b/other/upgrade_2-1_mysql.sql
@@ -6,32 +6,32 @@
 
 ---# Updating old values
 UPDATE {$db_prefix}calendar
-SET start_date = DATE(CONCAT(1001, '-', MONTH(start_date), '-', DAY(start_date)))
+SET start_date = DATE(CONCAT(1000, '-', MONTH(start_date), '-', DAY(start_date)))
 WHERE YEAR(start_date) < 1000;
 
 UPDATE {$db_prefix}calendar
-SET end_date = DATE(CONCAT(1001, '-', MONTH(end_date), '-', DAY(end_date)))
+SET end_date = DATE(CONCAT(1000, '-', MONTH(end_date), '-', DAY(end_date)))
 WHERE YEAR(end_date) < 1000;
 
 UPDATE {$db_prefix}calendar_holidays
-SET event_date = DATE(CONCAT(1001, '-', MONTH(event_date), '-', DAY(event_date)))
+SET event_date = DATE(CONCAT(1000, '-', MONTH(event_date), '-', DAY(event_date)))
 WHERE YEAR(event_date) < 1000;
 
 UPDATE {$db_prefix}log_spider_stats
-SET stat_date = DATE(CONCAT(1001, '-', MONTH(stat_date), '-', DAY(stat_date)))
+SET stat_date = DATE(CONCAT(1000, '-', MONTH(stat_date), '-', DAY(stat_date)))
 WHERE YEAR(stat_date) < 1000;
 
 UPDATE {$db_prefix}members
-SET birthdate = DATE(CONCAT(IF(YEAR(birthdate) < 1001, 1001, YEAR(birthdate)), '-', IF(MONTH(birthdate) < 1, 1, MONTH(birthdate)), '-', IF(DAY(birthdate) < 1, 1, DAY(birthdate))))
+SET birthdate = DATE(CONCAT(IF(YEAR(birthdate) < 1000, 1000, YEAR(birthdate)), '-', IF(MONTH(birthdate) < 1, 1, MONTH(birthdate)), '-', IF(DAY(birthdate) < 1, 1, DAY(birthdate))))
 WHERE YEAR(birthdate) < 1000;
 ---#
 
 ---# Changing default values
-ALTER TABLE {$db_prefix}calendar CHANGE start_date start_date date NOT NULL DEFAULT '1001-01-01';
-ALTER TABLE {$db_prefix}calendar CHANGE end_date end_date date NOT NULL DEFAULT '1001-01-01';
-ALTER TABLE {$db_prefix}calendar_holidays CHANGE event_date event_date date NOT NULL DEFAULT '1001-01-01';
-ALTER TABLE {$db_prefix}log_spider_stats CHANGE stat_date stat_date date NOT NULL DEFAULT '1001-01-01';
-ALTER TABLE {$db_prefix}members CHANGE birthdate birthdate date NOT NULL DEFAULT '1001-01-01';
+ALTER TABLE {$db_prefix}calendar CHANGE start_date start_date date NOT NULL DEFAULT '1000-01-01';
+ALTER TABLE {$db_prefix}calendar CHANGE end_date end_date date NOT NULL DEFAULT '1000-01-01';
+ALTER TABLE {$db_prefix}calendar_holidays CHANGE event_date event_date date NOT NULL DEFAULT '1000-01-01';
+ALTER TABLE {$db_prefix}log_spider_stats CHANGE stat_date stat_date date NOT NULL DEFAULT '1000-01-01';
+ALTER TABLE {$db_prefix}members CHANGE birthdate birthdate date NOT NULL DEFAULT '1000-01-01';
 ---#
 
 /******************************************************************************/

--- a/other/upgrade_2-1_postgresql.sql
+++ b/other/upgrade_2-1_postgresql.sql
@@ -3,7 +3,7 @@
 /******************************************************************************/
 --- Fixing dates...
 /******************************************************************************/
---# Updating old values
+---# Updating old values
 UPDATE {$db_prefix}calendar
 SET start_date = '1001-01-01'
 WHERE start_date < '1001-01-01';
@@ -23,13 +23,15 @@ WHERE stat_date < '1001-01-01';
 UPDATE {$db_prefix}members
 SET birthdate = '1001-01-01'
 WHERE birthdate < '1001-01-01';
+---#
 
---# Changing default values
-ALTER TABLE {$db_prefix}calendar CHANGE start_date start_date date NOT NULL DEFAULT '1001-01-01';
-ALTER TABLE {$db_prefix}calendar CHANGE end_date end_date date NOT NULL DEFAULT '1001-01-01';
-ALTER TABLE {$db_prefix}calendar_holidays CHANGE event_date event_date date NOT NULL DEFAULT '1001-01-01';
-ALTER TABLE {$db_prefix}log_spider_stats CHANGE stat_date stat_date date NOT NULL DEFAULT '1001-01-01';
-ALTER TABLE {$db_prefix}members CHANGE birthdate birthdate date NOT NULL DEFAULT '1001-01-01';
+---# Changing default values
+ALTER TABLE {$db_prefix}calendar ALTER COLUMN start_date SET DEFAULT '1001-01-01'::date;
+ALTER TABLE {$db_prefix}calendar ALTER COLUMN end_date SET DEFAULT '1001-01-01'::date;
+ALTER TABLE {$db_prefix}calendar_holidays ALTER COLUMN event_date SET DEFAULT '1001-01-01'::date;
+ALTER TABLE {$db_prefix}log_spider_stats ALTER COLUMN state_date SET DEFAULT '1001-01-01'::date;
+ALTER TABLE {$db_prefix}members ALTER COLUMN birthdate SET DEFAULT '1001-01-01'::date;
+---#
 
 /******************************************************************************/
 --- Adding new settings...

--- a/other/upgrade_2-1_postgresql.sql
+++ b/other/upgrade_2-1_postgresql.sql
@@ -5,24 +5,24 @@
 /******************************************************************************/
 ---# Updating old values
 UPDATE {$db_prefix}calendar
-SET start_date = '1001-01-01'
-WHERE start_date < '1001-01-01';
+SET start_date = concat_ws('-', CASE WHEN EXTRACT(YEAR FROM start_date) < 1001 THEN 1001 END, EXTRACT(MONTH FROM start_date), EXTRACT(DAY FROM start_date))::date
+WHERE EXTRACT(YEAR FROM start_date) < 1001;
 
 UPDATE {$db_prefix}calendar
-SET end_date = '1001-01-01'
-WHERE end_date < '1001-01-01';
+SET end_date = concat_ws('-', CASE WHEN EXTRACT(YEAR FROM end_date) < 1001 THEN 1001 END, EXTRACT(MONTH FROM end_date), EXTRACT(DAY FROM end_date))::date
+WHERE EXTRACT(YEAR FROM end_date) < 1001;
 
 UPDATE {$db_prefix}calendar_holidays
-SET event_date = '1001-01-01'
-WHERE event_date < '1001-01-01';
+SET event_date = concat_ws('-', CASE WHEN EXTRACT(YEAR FROM event_date) < 1001 THEN 1001 END, EXTRACT(MONTH FROM event_date), EXTRACT(DAY FROM event_date))::date
+WHERE EXTRACT(YEAR FROM event_date) < 1001;
 
 UPDATE {$db_prefix}log_spider_stats
-SET stat_date = '1001-01-01'
-WHERE stat_date < '1001-01-01';
+SET stat_date = concat_ws('-', CASE WHEN EXTRACT(YEAR FROM stat_date) < 1001 THEN 1001 END, EXTRACT(MONTH FROM stat_date), EXTRACT(DAY FROM stat_date))::date
+WHERE EXTRACT(YEAR FROM stat_date) < 1001;
 
 UPDATE {$db_prefix}members
-SET birthdate = '1001-01-01'
-WHERE birthdate < '1001-01-01';
+SET birthdate = concat_ws('-', CASE WHEN EXTRACT(YEAR FROM start_date) < 1001 THEN 1001 END, CASE WHEN EXTRACT(MONTH FROM birthdate) < 1 THEN 1 ELSE EXTRACT(MONTH FROM birthdate) END, CASE WHEN EXTRACT(DAY FROM birthdate) < 1 THEN 1 ELSE EXTRACT(DAY FROM birthdate) END)::date
+WHERE birthdate EXTRACT(YEAR FROM birthdate) < 1001;
 ---#
 
 ---# Changing default values

--- a/other/upgrade_2-1_postgresql.sql
+++ b/other/upgrade_2-1_postgresql.sql
@@ -21,8 +21,8 @@ SET stat_date = concat_ws('-', CASE WHEN EXTRACT(YEAR FROM stat_date) < 1000 THE
 WHERE EXTRACT(YEAR FROM stat_date) < 1000;
 
 UPDATE {$db_prefix}members
-SET birthdate = concat_ws('-', CASE WHEN EXTRACT(YEAR FROM birthdate) < 1000 THEN 1000 END, CASE WHEN EXTRACT(MONTH FROM birthdate) < 1 THEN 1 ELSE EXTRACT(MONTH FROM birthdate) END, CASE WHEN EXTRACT(DAY FROM birthdate) < 1 THEN 1 ELSE EXTRACT(DAY FROM birthdate) END)::date
-WHERE EXTRACT(YEAR FROM birthdate) < 1000;
+SET birthdate = concat_ws('-', CASE WHEN EXTRACT(YEAR FROM birthdate) < 1004 THEN 1004 END, CASE WHEN EXTRACT(MONTH FROM birthdate) < 1 THEN 1 ELSE EXTRACT(MONTH FROM birthdate) END, CASE WHEN EXTRACT(DAY FROM birthdate) < 1 THEN 1 ELSE EXTRACT(DAY FROM birthdate) END)::date
+WHERE EXTRACT(YEAR FROM birthdate) < 1004;
 ---#
 
 ---# Changing default values

--- a/other/upgrade_2-1_postgresql.sql
+++ b/other/upgrade_2-1_postgresql.sql
@@ -5,20 +5,20 @@
 /******************************************************************************/
 ---# Updating old values
 UPDATE {$db_prefix}calendar
-SET start_date = concat_ws('-', CASE WHEN EXTRACT(YEAR FROM start_date) < 1000 THEN 1000 END, EXTRACT(MONTH FROM start_date), EXTRACT(DAY FROM start_date))::date
-WHERE EXTRACT(YEAR FROM start_date) < 1000;
+SET start_date = concat_ws('-', CASE WHEN EXTRACT(YEAR FROM start_date) < 1004 THEN 1004 END, EXTRACT(MONTH FROM start_date), EXTRACT(DAY FROM start_date))::date
+WHERE EXTRACT(YEAR FROM start_date) < 1004;
 
 UPDATE {$db_prefix}calendar
-SET end_date = concat_ws('-', CASE WHEN EXTRACT(YEAR FROM end_date) < 1000 THEN 1000 END, EXTRACT(MONTH FROM end_date), EXTRACT(DAY FROM end_date))::date
-WHERE EXTRACT(YEAR FROM end_date) < 1000;
+SET end_date = concat_ws('-', CASE WHEN EXTRACT(YEAR FROM end_date) < 1004 THEN 1004 END, EXTRACT(MONTH FROM end_date), EXTRACT(DAY FROM end_date))::date
+WHERE EXTRACT(YEAR FROM end_date) < 1004;
 
 UPDATE {$db_prefix}calendar_holidays
-SET event_date = concat_ws('-', CASE WHEN EXTRACT(YEAR FROM event_date) < 1000 THEN 1000 END, EXTRACT(MONTH FROM event_date), EXTRACT(DAY FROM event_date))::date
-WHERE EXTRACT(YEAR FROM event_date) < 1000;
+SET event_date = concat_ws('-', CASE WHEN EXTRACT(YEAR FROM event_date) < 1004 THEN 1004 END, EXTRACT(MONTH FROM event_date), EXTRACT(DAY FROM event_date))::date
+WHERE EXTRACT(YEAR FROM event_date) < 1004;
 
 UPDATE {$db_prefix}log_spider_stats
-SET stat_date = concat_ws('-', CASE WHEN EXTRACT(YEAR FROM stat_date) < 1000 THEN 1000 END, EXTRACT(MONTH FROM stat_date), EXTRACT(DAY FROM stat_date))::date
-WHERE EXTRACT(YEAR FROM stat_date) < 1000;
+SET stat_date = concat_ws('-', CASE WHEN EXTRACT(YEAR FROM stat_date) < 1004 THEN 1004 END, EXTRACT(MONTH FROM stat_date), EXTRACT(DAY FROM stat_date))::date
+WHERE EXTRACT(YEAR FROM stat_date) < 1004;
 
 UPDATE {$db_prefix}members
 SET birthdate = concat_ws('-', CASE WHEN EXTRACT(YEAR FROM birthdate) < 1004 THEN 1004 END, CASE WHEN EXTRACT(MONTH FROM birthdate) < 1 THEN 1 ELSE EXTRACT(MONTH FROM birthdate) END, CASE WHEN EXTRACT(DAY FROM birthdate) < 1 THEN 1 ELSE EXTRACT(DAY FROM birthdate) END)::date
@@ -26,11 +26,11 @@ WHERE EXTRACT(YEAR FROM birthdate) < 1004;
 ---#
 
 ---# Changing default values
-ALTER TABLE {$db_prefix}calendar ALTER COLUMN start_date SET DEFAULT '1000-01-01'::date;
-ALTER TABLE {$db_prefix}calendar ALTER COLUMN end_date SET DEFAULT '1000-01-01'::date;
-ALTER TABLE {$db_prefix}calendar_holidays ALTER COLUMN event_date SET DEFAULT '1000-01-01'::date;
-ALTER TABLE {$db_prefix}log_spider_stats ALTER COLUMN state_date SET DEFAULT '1000-01-01'::date;
-ALTER TABLE {$db_prefix}members ALTER COLUMN birthdate SET DEFAULT '1000-01-01'::date;
+ALTER TABLE {$db_prefix}calendar ALTER COLUMN start_date SET DEFAULT '1004-01-01'::date;
+ALTER TABLE {$db_prefix}calendar ALTER COLUMN end_date SET DEFAULT '1004-01-01'::date;
+ALTER TABLE {$db_prefix}calendar_holidays ALTER COLUMN event_date SET DEFAULT '1004-01-01'::date;
+ALTER TABLE {$db_prefix}log_spider_stats ALTER COLUMN state_date SET DEFAULT '1004-01-01'::date;
+ALTER TABLE {$db_prefix}members ALTER COLUMN birthdate SET DEFAULT '1004-01-01'::date;
 ---#
 
 /******************************************************************************/

--- a/other/upgrade_2-1_postgresql.sql
+++ b/other/upgrade_2-1_postgresql.sql
@@ -5,32 +5,32 @@
 /******************************************************************************/
 ---# Updating old values
 UPDATE {$db_prefix}calendar
-SET start_date = concat_ws('-', CASE WHEN EXTRACT(YEAR FROM start_date) < 1001 THEN 1001 END, EXTRACT(MONTH FROM start_date), EXTRACT(DAY FROM start_date))::date
-WHERE EXTRACT(YEAR FROM start_date) < 1001;
+SET start_date = concat_ws('-', CASE WHEN EXTRACT(YEAR FROM start_date) < 1000 THEN 1000 END, EXTRACT(MONTH FROM start_date), EXTRACT(DAY FROM start_date))::date
+WHERE EXTRACT(YEAR FROM start_date) < 1000;
 
 UPDATE {$db_prefix}calendar
-SET end_date = concat_ws('-', CASE WHEN EXTRACT(YEAR FROM end_date) < 1001 THEN 1001 END, EXTRACT(MONTH FROM end_date), EXTRACT(DAY FROM end_date))::date
-WHERE EXTRACT(YEAR FROM end_date) < 1001;
+SET end_date = concat_ws('-', CASE WHEN EXTRACT(YEAR FROM end_date) < 1000 THEN 1000 END, EXTRACT(MONTH FROM end_date), EXTRACT(DAY FROM end_date))::date
+WHERE EXTRACT(YEAR FROM end_date) < 1000;
 
 UPDATE {$db_prefix}calendar_holidays
-SET event_date = concat_ws('-', CASE WHEN EXTRACT(YEAR FROM event_date) < 1001 THEN 1001 END, EXTRACT(MONTH FROM event_date), EXTRACT(DAY FROM event_date))::date
-WHERE EXTRACT(YEAR FROM event_date) < 1001;
+SET event_date = concat_ws('-', CASE WHEN EXTRACT(YEAR FROM event_date) < 1000 THEN 1000 END, EXTRACT(MONTH FROM event_date), EXTRACT(DAY FROM event_date))::date
+WHERE EXTRACT(YEAR FROM event_date) < 1000;
 
 UPDATE {$db_prefix}log_spider_stats
-SET stat_date = concat_ws('-', CASE WHEN EXTRACT(YEAR FROM stat_date) < 1001 THEN 1001 END, EXTRACT(MONTH FROM stat_date), EXTRACT(DAY FROM stat_date))::date
-WHERE EXTRACT(YEAR FROM stat_date) < 1001;
+SET stat_date = concat_ws('-', CASE WHEN EXTRACT(YEAR FROM stat_date) < 1000 THEN 1000 END, EXTRACT(MONTH FROM stat_date), EXTRACT(DAY FROM stat_date))::date
+WHERE EXTRACT(YEAR FROM stat_date) < 1000;
 
 UPDATE {$db_prefix}members
-SET birthdate = concat_ws('-', CASE WHEN EXTRACT(YEAR FROM start_date) < 1001 THEN 1001 END, CASE WHEN EXTRACT(MONTH FROM birthdate) < 1 THEN 1 ELSE EXTRACT(MONTH FROM birthdate) END, CASE WHEN EXTRACT(DAY FROM birthdate) < 1 THEN 1 ELSE EXTRACT(DAY FROM birthdate) END)::date
-WHERE birthdate EXTRACT(YEAR FROM birthdate) < 1001;
+SET birthdate = concat_ws('-', CASE WHEN EXTRACT(YEAR FROM start_date) < 1000 THEN 1000 END, CASE WHEN EXTRACT(MONTH FROM birthdate) < 1 THEN 1 ELSE EXTRACT(MONTH FROM birthdate) END, CASE WHEN EXTRACT(DAY FROM birthdate) < 1 THEN 1 ELSE EXTRACT(DAY FROM birthdate) END)::date
+WHERE birthdate EXTRACT(YEAR FROM birthdate) < 1000;
 ---#
 
 ---# Changing default values
-ALTER TABLE {$db_prefix}calendar ALTER COLUMN start_date SET DEFAULT '1001-01-01'::date;
-ALTER TABLE {$db_prefix}calendar ALTER COLUMN end_date SET DEFAULT '1001-01-01'::date;
-ALTER TABLE {$db_prefix}calendar_holidays ALTER COLUMN event_date SET DEFAULT '1001-01-01'::date;
-ALTER TABLE {$db_prefix}log_spider_stats ALTER COLUMN state_date SET DEFAULT '1001-01-01'::date;
-ALTER TABLE {$db_prefix}members ALTER COLUMN birthdate SET DEFAULT '1001-01-01'::date;
+ALTER TABLE {$db_prefix}calendar ALTER COLUMN start_date SET DEFAULT '1000-01-01'::date;
+ALTER TABLE {$db_prefix}calendar ALTER COLUMN end_date SET DEFAULT '1000-01-01'::date;
+ALTER TABLE {$db_prefix}calendar_holidays ALTER COLUMN event_date SET DEFAULT '1000-01-01'::date;
+ALTER TABLE {$db_prefix}log_spider_stats ALTER COLUMN state_date SET DEFAULT '1000-01-01'::date;
+ALTER TABLE {$db_prefix}members ALTER COLUMN birthdate SET DEFAULT '1000-01-01'::date;
 ---#
 
 /******************************************************************************/

--- a/other/upgrade_2-1_postgresql.sql
+++ b/other/upgrade_2-1_postgresql.sql
@@ -21,8 +21,8 @@ SET stat_date = concat_ws('-', CASE WHEN EXTRACT(YEAR FROM stat_date) < 1000 THE
 WHERE EXTRACT(YEAR FROM stat_date) < 1000;
 
 UPDATE {$db_prefix}members
-SET birthdate = concat_ws('-', CASE WHEN EXTRACT(YEAR FROM start_date) < 1000 THEN 1000 END, CASE WHEN EXTRACT(MONTH FROM birthdate) < 1 THEN 1 ELSE EXTRACT(MONTH FROM birthdate) END, CASE WHEN EXTRACT(DAY FROM birthdate) < 1 THEN 1 ELSE EXTRACT(DAY FROM birthdate) END)::date
-WHERE birthdate EXTRACT(YEAR FROM birthdate) < 1000;
+SET birthdate = concat_ws('-', CASE WHEN EXTRACT(YEAR FROM birthdate) < 1000 THEN 1000 END, CASE WHEN EXTRACT(MONTH FROM birthdate) < 1 THEN 1 ELSE EXTRACT(MONTH FROM birthdate) END, CASE WHEN EXTRACT(DAY FROM birthdate) < 1 THEN 1 ELSE EXTRACT(DAY FROM birthdate) END)::date
+WHERE EXTRACT(YEAR FROM birthdate) < 1000;
 ---#
 
 ---# Changing default values

--- a/other/upgrade_2-1_postgresql.sql
+++ b/other/upgrade_2-1_postgresql.sql
@@ -1,6 +1,37 @@
 /* ATTENTION: You don't need to run or use this file! The upgrade.php script does everything for you! */
 
 /******************************************************************************/
+--- Fixing dates...
+/******************************************************************************/
+--# Updating old values
+UPDATE {$db_prefix}calendar
+SET start_date = '1001-01-01'
+WHERE start_date < '1001-01-01';
+
+UPDATE {$db_prefix}calendar
+SET end_date = '1001-01-01'
+WHERE end_date < '1001-01-01';
+
+UPDATE {$db_prefix}calendar_holidays
+SET event_date = '1001-01-01'
+WHERE event_date < '1001-01-01';
+
+UPDATE {$db_prefix}log_spider_stats
+SET stat_date = '1001-01-01'
+WHERE stat_date < '1001-01-01';
+
+UPDATE {$db_prefix}members
+SET birthdate = '1001-01-01'
+WHERE birthdate < '1001-01-01';
+
+--# Changing default values
+ALTER TABLE {$db_prefix}calendar CHANGE start_date start_date date NOT NULL DEFAULT '1001-01-01';
+ALTER TABLE {$db_prefix}calendar CHANGE end_date end_date date NOT NULL DEFAULT '1001-01-01';
+ALTER TABLE {$db_prefix}calendar_holidays CHANGE event_date event_date date NOT NULL DEFAULT '1001-01-01';
+ALTER TABLE {$db_prefix}log_spider_stats CHANGE stat_date stat_date date NOT NULL DEFAULT '1001-01-01';
+ALTER TABLE {$db_prefix}members CHANGE birthdate birthdate date NOT NULL DEFAULT '1001-01-01';
+
+/******************************************************************************/
 --- Adding new settings...
 /******************************************************************************/
 


### PR DESCRIPTION
Per the MySQL manual, MySQL 5.7 only "supports" date values as low as 1001-01-01, though other values may work as well. This PR updates SMF's usage of 0001-01-01 to compensate for this.