### PR TITLE
Show the pg optimization

### DIFF
--- a/Sources/Subs-Db-postgresql.php
+++ b/Sources/Subs-Db-postgresql.php
@@ -482,8 +482,10 @@ function smf_db_query($identifier, $db_string, $db_values = array(), $connection
 			$query_hints_set .= 'SET LOCAL enable_seqscan = ' . $query_hints['enable_seqscan'] . ';';
 		}
 
-		$db_string = $query_hints_set .'
-		' . $db_string;
+		$db_string = $query_hints_set . $db_string;
+		
+		if (isset($db_show_debug) && $db_show_debug === true && $db_cache[$db_count]['q'] != '...')
+			$db_cache[$db_count]['q'] = "\t\t" . $db_string;
 	}
 
 	$db_last_result = @pg_query($connection, $db_string);


### PR DESCRIPTION
This add the hints to query display:
https://snag.gy/y9MIux.jpg

issue that the explain function didn't work because the set statement got a ; and this let catch the hacking attemp...
but i think is more important to show the right query which we fire as support for this case the explain stuff.

i could also disable the hack protection in viewquery but i don't know if i open here a big hole...

