### PR TITLE
better join for display query

### DIFF
--- a/Sources/Display.php
+++ b/Sources/Display.php
@@ -163,7 +163,7 @@ function Display()
 			' . (!$user_info['is_guest'] ? ', COALESCE(lt.unwatched, 0) as unwatched' : '') . '
 		FROM {db_prefix}topics AS t
 			INNER JOIN {db_prefix}messages AS ms ON (ms.id_msg = t.id_first_msg)
-			LEFT JOIN {db_prefix}members AS mem on (mem.id_member = ms.id_member)' . ($user_info['is_guest'] ? '' : '
+			LEFT JOIN {db_prefix}members AS mem on (mem.id_member = t.id_member_started)' . ($user_info['is_guest'] ? '' : '
 			LEFT JOIN {db_prefix}log_topics AS lt ON (lt.id_topic = {int:current_topic} AND lt.id_member = {int:current_member})
 			LEFT JOIN {db_prefix}log_mark_read AS lmr ON (lmr.id_board = {int:current_board} AND lmr.id_member = {int:current_member})') . '
 			' . (!empty($topic_tables) ? implode("\n\t", $topic_tables) : '') . '


### PR DESCRIPTION
Take the id_member_started from topic instead of the id_messages -> easier join plan.
less time for queryplaner to find a good solution.
result:
in ...\Sources\Display.php line 171, which took 0.00295496 seconds at 0.04309702 into request.
in ...\Sources\Display.php line 171, which took 0.00209904 seconds at 0.04312682 into request.
