### PR TITLE
Fixes #1896

### DIFF
--- a/Sources/Security.php
+++ b/Sources/Security.php
@@ -465,26 +465,22 @@ function banPermissions()
 	}
 
 	// Now that we have the mod cache taken care of lets setup a cache for the number of mod reports still open
-	if (!empty($_SESSION['rc']['reports']) && $_SESSION['rc']['time'] > $modSettings['last_mod_report_action'] && $_SESSION['rc']['id'] == $user_info['id'])
+	if (!empty($_SESSION['rc']['reports']) && !empty($_SESSION['rc']['member_reports']) && $_SESSION['rc']['time'] > $modSettings['last_mod_report_action'] && $_SESSION['rc']['id'] == $user_info['id'])
+	{
 		$context['open_mod_reports'] = $_SESSION['rc']['reports'];
+		$context['open_member_reports'] = $_SESSION['rc']['member_reports'];
+	}
 	elseif ($_SESSION['mc']['bq'] != '0=1')
 	{
 		require_once($sourcedir . '/Subs-ReportedContent.php');
 		$context['open_mod_reports'] = recountOpenReports('posts');
-	}
-	else
-		$context['open_mod_reports'] = 0;
-
-	// Figure out how many reported members need attention
-	if (!empty($_SESSION['rc']['member_reports']) && $_SESSION['rc']['time'] > $modSettings['last_mod_report_action'] && $_SESSION['rc']['id'] == $user_info['id'])
-		$context['open_member_reports'] = $_SESSION['rc']['member_reports'];
-	elseif ($_SESSION['mc']['bq'] != '0=1')
-	{
-		require_once($sourcedir . '/Subs-ReportedContent.php');
 		$context['open_member_reports'] = recountOpenReports('members');
 	}
 	else
+	{
+		$context['open_mod_reports'] = 0;
 		$context['open_member_reports'] = 0;
+	}
 
 }
 

--- a/Sources/Security.php
+++ b/Sources/Security.php
@@ -465,22 +465,23 @@ function banPermissions()
 	}
 
 	// Now that we have the mod cache taken care of lets setup a cache for the number of mod reports still open
-	if (!empty($_SESSION['rc']) && $_SESSION['rc']['time'] > $modSettings['last_mod_report_action'] && $_SESSION['rc']['id'] == $user_info['id'])
+	if (!empty($_SESSION['rc']['reports']) && $_SESSION['rc']['time'] > $modSettings['last_mod_report_action'] && $_SESSION['rc']['id'] == $user_info['id'])
 		$context['open_mod_reports'] = $_SESSION['rc']['reports'];
 	elseif ($_SESSION['mc']['bq'] != '0=1')
 	{
 		require_once($sourcedir . '/Subs-ReportedContent.php');
-		recountOpenReports('posts');
+		$context['open_mod_reports'] = recountOpenReports('posts');
 	}
 	else
 		$context['open_mod_reports'] = 0;
 
-	if (!empty($_SESSION['rc']) && $_SESSION['rc']['time'] > $modSettings['last_mod_report_action'] && $_SESSION['rc']['id'] == $user_info['id'])
-		$context['open_member_reports'] = !empty($_SESSION['rc']['member_reports']) ? $_SESSION['rc']['member_reports'] : 0;
-	elseif (allowedTo('moderate_forum'))
+	// Figure out how many reported members need attention
+	if (!empty($_SESSION['rc']['member_reports']) && $_SESSION['rc']['time'] > $modSettings['last_mod_report_action'] && $_SESSION['rc']['id'] == $user_info['id'])
+		$context['open_member_reports'] = $_SESSION['rc']['member_reports'];
+	elseif ($_SESSION['mc']['bq'] != '0=1')
 	{
 		require_once($sourcedir . '/Subs-ReportedContent.php');
-		recountOpenReports('members');
+		$context['open_member_reports'] = recountOpenReports('members');
 	}
 	else
 		$context['open_member_reports'] = 0;

--- a/Sources/Security.php
+++ b/Sources/Security.php
@@ -465,7 +465,7 @@ function banPermissions()
 	}
 
 	// Now that we have the mod cache taken care of lets setup a cache for the number of mod reports still open
-	if (!empty($_SESSION['rc']['reports']) && !empty($_SESSION['rc']['member_reports']) && $_SESSION['rc']['time'] > $modSettings['last_mod_report_action'] && $_SESSION['rc']['id'] == $user_info['id'])
+	if (isset($_SESSION['rc']['reports']) && isset($_SESSION['rc']['member_reports']) && $_SESSION['rc']['time'] > $modSettings['last_mod_report_action'] && $_SESSION['rc']['id'] == $user_info['id'])
 	{
 		$context['open_mod_reports'] = $_SESSION['rc']['reports'];
 		$context['open_member_reports'] = $_SESSION['rc']['member_reports'];
@@ -481,7 +481,6 @@ function banPermissions()
 		$context['open_mod_reports'] = 0;
 		$context['open_member_reports'] = 0;
 	}
-
 }
 
 /**

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -4287,9 +4287,7 @@ function setupMenuContext()
 		$context['menu_buttons']['admin']['sub_buttons']['errorlog']['title'] .= ' <span class="amt">' . $context['num_errors'] . '</span>';
 	}
 
-	/**
-	 * @todo For some reason, $context['open_member_reports'] isn't getting set
-	 */
+	// Show number of reported members
 	if (!empty($context['open_member_reports']) && allowedTo('moderate_forum'))
 	{
 		$total_mod_reports += $context['open_member_reports'];


### PR DESCRIPTION
Fixed reported member count in mod menu.  

Main problem was that it needed to be more specific when checking the session variables, i.e., checking $_SESSION['rc']['member_reports'] instead of just $_SESSION['rc'].  Prior logic always ensured ['rc'] was set, so it was never empty...  Since it never thought it was empty, it was never recalculated via a call to recountOpenReports()...  

While in there, noted that the context variables weren't loaded when recountOpenReports() was called.  Thus it took multiple executions of this logic to get the menu entries right.  Now it can get them right the first time thru.  

Everything tests OK.

All this mod menu logic is buried in banPermissions(), which doesn't feel like a proper location for it...  I'll move if to a new location if desired.   Just tell me where...    
