### PR TITLE
Much faster timeformat

### DIFF
--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -741,6 +741,7 @@ function comma_format($number, $override_decimal_count = false)
  * @param int $log_time A timestamp
  * @param bool $show_today Whether to show "Today"/"Yesterday" or just a date
  * @param bool|string $offset_type If false, uses both user time offset and forum offset. If 'forum', uses only the forum offset. Otherwise no offset is applied.
+ * @param bool $process_safe activate setlocale check for changes at runtime -> slower this function 
  * @return string A formatted timestamp
  */
 function timeformat($log_time, $show_today = true, $offset_type = false, $process_safe = false)
@@ -791,7 +792,7 @@ function timeformat($log_time, $show_today = true, $offset_type = false, $proces
 	}
 
 	$str = !is_bool($show_today) ? $show_today : $user_info['time_format'];
-	
+
 	if (!isset($local_cache))
 		$local_cache = setlocale(LC_TIME, $txt['lang_locale']);
 

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -801,7 +801,7 @@ function timeformat($log_time, $show_today = true, $offset_type = false, $proces
 		//check if other process change the local
 		if ($process_safe === true)
 		{
-			if ( setlocale(LC_TIME, '0') != $local_cache )
+			if (setlocale(LC_TIME, '0') != $local_cache)
 				setlocale(LC_TIME, $txt['lang_locale']);
 		}
 

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -743,10 +743,11 @@ function comma_format($number, $override_decimal_count = false)
  * @param bool|string $offset_type If false, uses both user time offset and forum offset. If 'forum', uses only the forum offset. Otherwise no offset is applied.
  * @return string A formatted timestamp
  */
-function timeformat($log_time, $show_today = true, $offset_type = false)
+function timeformat($log_time, $show_today = true, $offset_type = false, $process_safe = false)
 {
 	global $context, $user_info, $txt, $modSettings;
 	static $non_twelve_hour;
+	static $local_cache;
 
 	// Offset the time.
 	if (!$offset_type)
@@ -790,9 +791,19 @@ function timeformat($log_time, $show_today = true, $offset_type = false)
 	}
 
 	$str = !is_bool($show_today) ? $show_today : $user_info['time_format'];
+	
+	if (!isset($local_cache))
+		$local_cache = setlocale(LC_TIME, $txt['lang_locale']);
 
-	if (setlocale(LC_TIME, $txt['lang_locale']))
+	if ($local_cache !== false)
 	{
+		//check if other process change the local
+		if ($process_safe === true)
+		{
+			if ( setlocale(LC_TIME, '0') != $local_cache )
+				setlocale(LC_TIME, $txt['lang_locale']);
+		}
+
 		if (!isset($non_twelve_hour))
 			$non_twelve_hour = trim(strftime('%p')) === '';
 		if ($non_twelve_hour && strpos($str, '%p') !== false)


### PR DESCRIPTION
Notice on calendar call that this function takes ~78% runtime,
issues was that the setlocal get called 13k times.

This changes reduce the call at one when process_safe is off (default) in
theory a different process can change setlocal and then our runtime is affected too.
But this is in my eyes less potential that this happen -> so i take the fast way.

left side old, right side new
![grafik](https://user-images.githubusercontent.com/1782906/27620945-91434768-5bcd-11e7-8cba-c2cfbb895158.png)

