### PR TITLE
Removed loop in db replace

### DIFF
--- a/Sources/Subs-Db-mysql.php
+++ b/Sources/Subs-Db-mysql.php
@@ -170,11 +170,8 @@ function smf_db_replacement__callback($matches)
 	if ($matches[1] === 'db_prefix')
 		return $db_prefix;
 
-	if (!empty($user_info) && strpos($matches[1],'query_') !== false)
-	{
-		if (isset($user_info[$matches[1]]))
-			return $user_info[$matches[1]];
-	}
+	if (isset($user_info[$matches[1]]) && strpos($matches[1], 'query_') !== false)
+		return $user_info[$matches[1]];
 
 	if ($matches[1] === 'empty')
 		return '\'\'';

--- a/Sources/Subs-Db-mysql.php
+++ b/Sources/Subs-Db-mysql.php
@@ -170,11 +170,10 @@ function smf_db_replacement__callback($matches)
 	if ($matches[1] === 'db_prefix')
 		return $db_prefix;
 
-	if (!empty($user_info))
+	if (!empty($user_info) && strpos($matches[1],'query_') !== false)
 	{
-		foreach (array_keys($user_info) as $key)
-			if (strpos($key, 'query_') !== false && $key === $matches[1])
-				return $user_info[$matches[1]];
+		if (isset($user_info[$matches[1]]))
+			return $user_info[$matches[1]];
 	}
 
 	if ($matches[1] === 'empty')

--- a/Sources/Subs-Db-postgresql.php
+++ b/Sources/Subs-Db-postgresql.php
@@ -128,11 +128,8 @@ function smf_db_replacement__callback($matches)
 	if ($matches[1] === 'db_prefix')
 		return $db_prefix;
 
-	if (!empty($user_info) && strpos($matches[1],'query_') !== false)
-	{
-		if (isset($user_info[$matches[1]]))
-			return $user_info[$matches[1]];
-	}
+	if (isset($user_info[$matches[1]]) && strpos($matches[1], 'query_') !== false)
+		return $user_info[$matches[1]];
 
 	if ($matches[1] === 'empty')
 		return '\'\'';

--- a/Sources/Subs-Db-postgresql.php
+++ b/Sources/Subs-Db-postgresql.php
@@ -128,11 +128,10 @@ function smf_db_replacement__callback($matches)
 	if ($matches[1] === 'db_prefix')
 		return $db_prefix;
 
-	if (!empty($user_info))
+	if (!empty($user_info) && strpos($matches[1],'query_') !== false)
 	{
-		foreach (array_keys($user_info) as $key)
-			if (strpos($key, 'query_') !== false && $key === $matches[1])
-				return $user_info[$matches[1]];
+		if (isset($user_info[$matches[1]]))
+			return $user_info[$matches[1]];
 	}
 
 	if ($matches[1] === 'empty')


### PR DESCRIPTION
i notice in the display benchmark,
that 30 % of the runtime getlost in the replace stuff.

the user_info stuff was essential the issue,
without understand what it do i try to do i revamp the idea in a more faster way

left old right new
![grafik](https://user-images.githubusercontent.com/1782906/27643678-fb04f5d0-5c21-11e7-8703-f08c816eeaef.png)

maybe @Sesquipedalian can comment if the code keep doing the same.