### PR TITLE
Fixes #4170

### DIFF
--- a/other/upgrade.php
+++ b/other/upgrade.php
@@ -451,7 +451,14 @@ function loadEssentialData()
 
 	// Get the database going!
 	if (empty($db_type) || $db_type == 'mysqli')
+	{
 		$db_type = 'mysql';
+		// If overriding $db_type, need to set its settings.php entry too
+		$changes = array();
+		$changes['db_type'] = '\'mysql\'';
+		require_once($sourcedir . '/Subs-Admin.php');
+		updateSettingsFile($changes);
+	}
 
 	if (file_exists($sourcedir . '/Subs-Db-' . $db_type . '.php'))
 	{
@@ -1086,10 +1093,6 @@ function UpgradeOptions()
 
 	if (empty($cachedir) || substr($cachedir, 0, 1) == '.')
 		$changes['cachedir'] = '\'' . fixRelativePath($boarddir) . '/cache\'';
-
-	// Not had the database type added before?
-	if (empty($db_type))
-		$changes['db_type'] = 'mysql';
 
 	// If they have a "host:port" setup for the host, split that into separate values
 	// You should never have a : in the hostname if you're not on MySQL, but better safe than sorry


### PR DESCRIPTION
Set $db_type if blank or 'mysqli'.  This impacts early beta testers that have a value of 'mysqli' in there.  

The existing logic sets $db_type early, because it needs to in order to connect.  Problem is that, as a result, it appears to be good later in the upgrade.  So it never gets set if it is blank or 'mysqli'. 