### PR TITLE
Clean up some Serialized strings

### DIFF
--- a/Sources/Calendar.php
+++ b/Sources/Calendar.php
@@ -668,19 +668,19 @@ function clock()
 	{
 		$context['sub_template'] = 'bcd';
 		$context['linktree'][] = array('url' => $scripturl . '?action=clock;bcd', 'name' => 'BCD');
-		$context['clockicons'] = safe_unserialize(base64_decode('YTo2OntzOjI6ImgxIjthOjI6e2k6MDtpOjI7aToxO2k6MTt9czoyOiJoMiI7YTo0OntpOjA7aTo4O2k6MTtpOjQ7aToyO2k6MjtpOjM7aToxO31zOjI6Im0xIjthOjM6e2k6MDtpOjQ7aToxO2k6MjtpOjI7aToxO31zOjI6Im0yIjthOjQ6e2k6MDtpOjg7aToxO2k6NDtpOjI7aToyO2k6MztpOjE7fXM6MjoiczEiO2E6Mzp7aTowO2k6NDtpOjE7aToyO2k6MjtpOjE7fXM6MjoiczIiO2E6NDp7aTowO2k6ODtpOjE7aTo0O2k6MjtpOjI7aTozO2k6MTt9fQ=='));
+		$context['clockicons'] = smf_json_decode(base64_decode('eyJoMSI6WzIsMV0sImgyIjpbOCw0LDIsMV0sIm0xIjpbNCwyLDFdLCJtMiI6WzgsNCwyLDFdLCJzMSI6WzQsMiwxXSwiczIiOls4LDQsMiwxXX0='), true);
 	}
 	elseif (!$omfg && !isset($_REQUEST['time']))
 	{
 		$context['sub_template'] = 'hms';
 		$context['linktree'][] = array('url' => $scripturl . '?action=clock', 'name' => 'Binary');
-		$context['clockicons'] = safe_unserialize(base64_decode('YTozOntzOjE6ImgiO2E6NTp7aTowO2k6MTY7aToxO2k6ODtpOjI7aTo0O2k6MztpOjI7aTo0O2k6MTt9czoxOiJtIjthOjY6e2k6MDtpOjMyO2k6MTtpOjE2O2k6MjtpOjg7aTozO2k6NDtpOjQ7aToyO2k6NTtpOjE7fXM6MToicyI7YTo2OntpOjA7aTozMjtpOjE7aToxNjtpOjI7aTo4O2k6MztpOjQ7aTo0O2k6MjtpOjU7aToxO319'));
+		$context['clockicons'] = smf_json_decode(base64_decode('eyJoIjpbMTYsOCw0LDIsMV0sIm0iOlszMiwxNiw4LDQsMiwxXSwicyI6WzMyLDE2LDgsNCwyLDFdfQ'), true);
 	}
 	elseif ($omfg)
 	{
 		$context['sub_template'] = 'omfg';
 		$context['linktree'][] = array('url' => $scripturl . '?action=clock;omfg', 'name' => 'OMFG');
-		$context['clockicons'] = safe_unserialize(base64_decode('YTo2OntzOjQ6InllYXIiO2E6Nzp7aTowO2k6NjQ7aToxO2k6MzI7aToyO2k6MTY7aTozO2k6ODtpOjQ7aTo0O2k6NTtpOjI7aTo2O2k6MTt9czo1OiJtb250aCI7YTo0OntpOjA7aTo4O2k6MTtpOjQ7aToyO2k6MjtpOjM7aToxO31zOjM6ImRheSI7YTo1OntpOjA7aToxNjtpOjE7aTo4O2k6MjtpOjQ7aTozO2k6MjtpOjQ7aToxO31zOjQ6ImhvdXIiO2E6NTp7aTowO2k6MTY7aToxO2k6ODtpOjI7aTo0O2k6MztpOjI7aTo0O2k6MTt9czozOiJtaW4iO2E6Njp7aTowO2k6MzI7aToxO2k6MTY7aToyO2k6ODtpOjM7aTo0O2k6NDtpOjI7aTo1O2k6MTt9czozOiJzZWMiO2E6Njp7aTowO2k6MzI7aToxO2k6MTY7aToyO2k6ODtpOjM7aTo0O2k6NDtpOjI7aTo1O2k6MTt9fQ=='));
+		$context['clockicons'] = smf_json_decode(base64_decode('eyJ5ZWFyIjpbNjQsMzIsMTYsOCw0LDIsMV0sIm1vbnRoIjpbOCw0LDIsMV0sImRheSI6WzE2LDgsNCwyLDFdLCJob3VyIjpbMTYsOCw0LDIsMV0sIm1pbiI6WzMyLDE2LDgsNCwyLDFdLCJzZWMiOlszMiwxNiw4LDQsMiwxXX0='), true);
 	}
 	elseif (isset($_REQUEST['time']))
 	{

--- a/Sources/Load.php
+++ b/Sources/Load.php
@@ -490,12 +490,9 @@ function loadUserSettings()
 				{
 					$tfa_data = smf_json_decode($_COOKIE[$tfacookie]);
 
-					if (is_null($tfa_data))
-						$tfa_data = safe_unserialize($_COOKIE[$tfacookie]);
-
 					list ($tfamember, $tfasecret) = $tfa_data;
 
-					if ((int) $tfamember != $id_member)
+					if (!isset($tfamember, $tfasecret) || (int) $tfamember != $id_member)
 						$tfasecret = null;
 				}
 
@@ -647,12 +644,9 @@ function loadUserSettings()
 		{
 			$tfa_data = smf_json_decode($_COOKIE[$cookiename . '_tfa'], true);
 
-			if (is_null($tfa_data))
-				$tfa_data = safe_unserialize($_COOKIE[$cookiename . '_tfa']);
-
 			list ($id, $user, $exp, $state, $preserve) = $tfa_data;
 
-			if (!$preserve || time() > $exp)
+			if (!isset($id, $user, $exp, $state, $preserve) || !$preserve || time() > $exp)
 			{
 				$_COOKIE[$cookiename . '_tfa'] = '';
 				setTFACookie(-3600, 0, '');

--- a/Sources/LogInOut.php
+++ b/Sources/LogInOut.php
@@ -694,14 +694,10 @@ function Logout($internal = false, $redirect = true)
 	{
 		$tfadata = smf_json_decode($_COOKIE[$cookiename . '_tfa'], true);
 
-		// If that failed, try the old method
-		if (is_null($tfadata))
-			$tfadata = safe_unserialize($_COOKIE[$cookiename . '_tfa']);
-
 		list ($tfamember, $tfasecret, $exp, $state, $preserve) = $tfadata;
 
 		// If we're preserving the cookie, reset it with updated salt
-		if ($preserve && time() < $exp)
+		if (isset($tfamember, $tfasecret, $exp, $state, $preserve) && $preserve && time() < $exp)
 			setTFACookie(3153600, $user_info['id'], hash_salt($user_settings['tfa_backup'], $salt), true);
 		else
 			setTFACookie(-3600, 0, '');

--- a/Sources/Logging.php
+++ b/Sources/Logging.php
@@ -74,17 +74,17 @@ function writeLog($force = false)
 
 	if (!empty($modSettings['who_enabled']))
 	{
-		$serialized = truncateArray($_GET) + array('USER_AGENT' => $_SERVER['HTTP_USER_AGENT']);
+		$encoded_get = truncateArray($_GET) + array('USER_AGENT' => $_SERVER['HTTP_USER_AGENT']);
 
 		// In the case of a dlattach action, session_var may not be set.
 		if (!isset($context['session_var']))
 			$context['session_var'] = $_SESSION['session_var'];
 
-		unset($serialized['sesc'], $serialized[$context['session_var']]);
-		$serialized = json_encode($serialized);
+		unset($encoded_get['sesc'], $encoded_get[$context['session_var']]);
+		$encoded_get = json_encode($encoded_get);
 	}
 	else
-		$serialized = '';
+		$encoded_get = '';
 
 	// Guests use 0, members use their session ID.
 	$session_id = $user_info['is_guest'] ? 'ip' . $user_info['ip'] : session_id();
@@ -118,7 +118,7 @@ function writeLog($force = false)
 			array(
 				'log_time' => time(),
 				'ip' => $user_info['ip'],
-				'url' => $serialized,
+				'url' => $encoded_get,
 				'session' => $session_id,
 			)
 		);
@@ -146,7 +146,7 @@ function writeLog($force = false)
 		$smcFunc['db_insert']($do_delete ? 'ignore' : 'replace',
 			'{db_prefix}log_online',
 			array('session' => 'string', 'id_member' => 'int', 'id_spider' => 'int', 'log_time' => 'int', 'ip' => 'inet', 'url' => 'string'),
-			array($session_id, $user_info['id'], empty($_SESSION['id_robot']) ? 0 : $_SESSION['id_robot'], time(), $user_info['ip'], $serialized),
+			array($session_id, $user_info['id'], empty($_SESSION['id_robot']) ? 0 : $_SESSION['id_robot'], time(), $user_info['ip'], $encoded_get),
 			array('session')
 		);
 	}

--- a/Sources/Subs-Menu.php
+++ b/Sources/Subs-Menu.php
@@ -122,7 +122,7 @@ function createMenu($menuData, $menuOptions = array())
 
 						// Does this area have its own icon?
 						if (!isset($area['force_menu_into_arms_of_another_menu']) && $user_info['name'] == 'iamanoompaloompa')
-							$menu_context['sections'][$section_id]['areas'][$area_id] = safe_unserialize(base64_decode('YTozOntzOjU6ImxhYmVsIjtzOjEyOiJPb21wYSBMb29tcGEiO3M6MzoidXJsIjtzOjQzOiJodHRwOi8vZW4ud2lraXBlZGlhLm9yZy93aWtpL09vbXBhX0xvb21wYXM/IjtzOjQ6Imljb24iO3M6ODY6IjxpbWcgc3JjPSJodHRwOi8vd3d3LnNpbXBsZW1hY2hpbmVzLm9yZy9pbWFnZXMvb29tcGEuZ2lmIiBhbHQ9IkknbSBhbiBPb21wYSBMb29tcGEiIC8+Ijt9'));
+							$menu_context['sections'][$section_id]['areas'][$area_id] = smf_json_decode(base64_decode('eyJsYWJlbCI6Ik9vbXBhIExvb21wYSIsInVybCI6Imh0dHBzOlwvXC9lbi53aWtpcGVkaWEub3JnXC93aWtpXC9Pb21wYV9Mb29tcGFzPyIsImljb24iOiI8aW1nIHNyYz1cImh0dHBzOlwvXC93d3cuc2ltcGxlbWFjaGluZXMub3JnXC9pbWFnZXNcL29vbXBhLmdpZlwiIGFsdD1cIkknbSBhbiBPb21wYSBMb29tcGFcIiBcLz4ifQ=='), true);
 						elseif (isset($area['icon']) && file_exists($settings['theme_dir'] . '/images/admin/' . $area['icon']))
 							$menu_context['sections'][$section_id]['areas'][$area_id]['icon'] = '<img src="' . $settings['images_url'] . '/admin/' . $area['icon'] . '" alt="">';
 						elseif (isset($area['icon']) && file_exists($settings['default_theme_dir'] . '/images/admin/' . $area['icon']))

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -5050,7 +5050,7 @@ function smf_list_timezones($when = 'now')
 
 		$tzinfo[0]['abbr'] = fix_tz_abbrev($tzid, $tzinfo[0]['abbr']);
 
-		$tzkey = serialize($tzinfo);
+		$tzkey = json_encode($tzinfo);
 
 		// Next, get the geographic info for this tzid
 		$tzgeo = timezone_location_get($tz);
@@ -5078,7 +5078,8 @@ function smf_list_timezones($when = 'now')
 	$timezones = array();
 	foreach ($zones as $tzkey => $tzvalue)
 	{
-		$tzinfo = unserialize($tzkey);
+		// !!! TODO: Why encode this and then decode it here?
+		$tzinfo = smf_json_decode($tzkey, true);
 
 		date_timezone_set($date_when, timezone_open($tzvalue['tzid']));
 


### PR DESCRIPTION
For TFA which was introduced in 2.1, we shouldn’t need to keep the backup serialized fallback for the cookie.  2.1 is in dev and the cookies should all be expired.
A slight naming change for Logging.php to not say serialized
A possibly unused section of code we are making sure to convert it over to json for a charset issue
Remove a usage of serialized in Subs for timezone data

Signed-off-by: jdarwood007 <unmonitored+github@sleepycode.com>