### PR TITLE
Update all usages of json

### DIFF
--- a/Sources/Admin.php
+++ b/Sources/Admin.php
@@ -25,7 +25,7 @@ if (!defined('SMF'))
 function AdminMain()
 {
 	global $txt, $context, $scripturl, $modSettings, $settings;
-	global $sourcedir, $options, $boarddir;
+	global $smcFunc, $sourcedir, $options, $boarddir;
 
 	// Load the language and templates....
 	loadLanguage('Admin');
@@ -39,7 +39,7 @@ function AdminMain()
 	require_once($sourcedir . '/Subs-Menu.php');
 
 	// Some preferences.
-	$context['admin_preferences'] = !empty($options['admin_preferences']) ? smf_json_decode($options['admin_preferences'], true) : array();
+	$context['admin_preferences'] = !empty($options['admin_preferences']) ? $smcFunc['json_decode']($options['admin_preferences'], true) : array();
 
 	/** @var array $admin_areas Defines the menu structure for the admin center. See {@link Subs-Menu.php Subs-Menu.php} for details! */
 	$admin_areas = array(

--- a/Sources/Attachments.php
+++ b/Sources/Attachments.php
@@ -422,7 +422,7 @@ class Attachments
 
 	protected function sendResponse()
 	{
-		global $modSettings, $context;
+		global $smcFunc, $modSettings, $context;
 
 		ob_end_clean();
 
@@ -435,7 +435,7 @@ class Attachments
 		// Set the header.
 		header('Content-Type: application/json; charset='. $context['character_set'] .'');
 
-		echo json_encode($this->_response ? $this->_response : array());
+		echo $smcFunc['json_encode']($this->_response ? $this->_response : array());
 
 		// Done.
 		obExit(false);

--- a/Sources/Calendar.php
+++ b/Sources/Calendar.php
@@ -647,7 +647,7 @@ function iCalDownload()
  */
 function clock()
 {
-	global $settings, $context, $scripturl;
+	global $smcFunc, $settings, $context, $scripturl;
 
 	$context['onimg'] = $settings['images_url'] . '/bbc/bbc_bg.png';
 	$context['offimg'] = $settings['images_url'] . '/bbc/bbc_hoverbg.png';
@@ -668,19 +668,19 @@ function clock()
 	{
 		$context['sub_template'] = 'bcd';
 		$context['linktree'][] = array('url' => $scripturl . '?action=clock;bcd', 'name' => 'BCD');
-		$context['clockicons'] = smf_json_decode(base64_decode('eyJoMSI6WzIsMV0sImgyIjpbOCw0LDIsMV0sIm0xIjpbNCwyLDFdLCJtMiI6WzgsNCwyLDFdLCJzMSI6WzQsMiwxXSwiczIiOls4LDQsMiwxXX0='), true);
+		$context['clockicons'] = $smcFunc['json_decode'](base64_decode('eyJoMSI6WzIsMV0sImgyIjpbOCw0LDIsMV0sIm0xIjpbNCwyLDFdLCJtMiI6WzgsNCwyLDFdLCJzMSI6WzQsMiwxXSwiczIiOls4LDQsMiwxXX0='), true);
 	}
 	elseif (!$omfg && !isset($_REQUEST['time']))
 	{
 		$context['sub_template'] = 'hms';
 		$context['linktree'][] = array('url' => $scripturl . '?action=clock', 'name' => 'Binary');
-		$context['clockicons'] = smf_json_decode(base64_decode('eyJoIjpbMTYsOCw0LDIsMV0sIm0iOlszMiwxNiw4LDQsMiwxXSwicyI6WzMyLDE2LDgsNCwyLDFdfQ'), true);
+		$context['clockicons'] = $smcFunc['json_decode'](base64_decode('eyJoIjpbMTYsOCw0LDIsMV0sIm0iOlszMiwxNiw4LDQsMiwxXSwicyI6WzMyLDE2LDgsNCwyLDFdfQ'), true);
 	}
 	elseif ($omfg)
 	{
 		$context['sub_template'] = 'omfg';
 		$context['linktree'][] = array('url' => $scripturl . '?action=clock;omfg', 'name' => 'OMFG');
-		$context['clockicons'] = smf_json_decode(base64_decode('eyJ5ZWFyIjpbNjQsMzIsMTYsOCw0LDIsMV0sIm1vbnRoIjpbOCw0LDIsMV0sImRheSI6WzE2LDgsNCwyLDFdLCJob3VyIjpbMTYsOCw0LDIsMV0sIm1pbiI6WzMyLDE2LDgsNCwyLDFdLCJzZWMiOlszMiwxNiw4LDQsMiwxXX0='), true);
+		$context['clockicons'] = $smcFunc['json_decode'](base64_decode('eyJ5ZWFyIjpbNjQsMzIsMTYsOCw0LDIsMV0sIm1vbnRoIjpbOCw0LDIsMV0sImRheSI6WzE2LDgsNCwyLDFdLCJob3VyIjpbMTYsOCw0LDIsMV0sIm1pbiI6WzMyLDE2LDgsNCwyLDFdLCJzZWMiOlszMiwxNiw4LDQsMiwxXX0='), true);
 	}
 	elseif (isset($_REQUEST['time']))
 	{

--- a/Sources/Drafts.php
+++ b/Sources/Drafts.php
@@ -206,7 +206,7 @@ function SavePMDraft(&$post_errors, $recipientList)
 		$recipientList['bcc'] = isset($_POST['recipient_bcc']) ? explode(',', $_POST['recipient_bcc']) : array();
 	}
 	elseif (!empty($draft_info['to_list']) && empty($recipientList))
-		$recipientList = smf_json_decode($draft_info['to_list'], true);
+		$recipientList = $smcFunc['json_decode']($draft_info['to_list'], true);
 
 	// prepare the data we got from the form
 	$reply_id = empty($_POST['replied_to']) ? 0 : (int) $_POST['replied_to'];
@@ -238,7 +238,7 @@ function SavePMDraft(&$post_errors, $recipientList)
 				'subject' => $draft['subject'],
 				'body' => $draft['body'],
 				'id_pm_draft' => $id_pm_draft,
-				'to_list' => json_encode($recipientList),
+				'to_list' => $smcFunc['json_encode']($recipientList),
 			)
 		);
 
@@ -267,7 +267,7 @@ function SavePMDraft(&$post_errors, $recipientList)
 				$user_info['id'],
 				$draft['subject'],
 				$draft['body'],
-				json_encode($recipientList),
+				$smcFunc['json_encode']($recipientList),
 			),
 			array(
 				'id_draft'
@@ -366,7 +366,7 @@ function ReadDraft($id_draft, $type = 0, $check = true, $load = false)
 			$_REQUEST['message'] = !empty($draft_info['body']) ? str_replace('<br>', "\n", un_htmlspecialchars(stripslashes($draft_info['body']))) : '';
 			$_REQUEST['replied_to'] = !empty($draft_info['id_reply']) ? $draft_info['id_reply'] : 0;
 			$context['id_pm_draft'] = !empty($draft_info['id_draft']) ? $draft_info['id_draft'] : 0;
-			$recipients = smf_json_decode($draft_info['to_list'], true);
+			$recipients = $smcFunc['json_decode']($draft_info['to_list'], true);
 
 			// make sure we only have integers in this array
 			$recipients['to'] = array_map('intval', $recipients['to']);
@@ -785,7 +785,7 @@ function showPMDrafts($memID = -1)
 			'to' => array(),
 			'bcc' => array(),
 		);
-		$recipient_ids = (!empty($row['to_list'])) ? smf_json_decode($row['to_list'], true) : array();
+		$recipient_ids = (!empty($row['to_list'])) ? $smcFunc['json_decode']($row['to_list'], true) : array();
 
 		// @todo ... this is a bit ugly since it runs an extra query for every message, do we want this?
 		// at least its only for draft PM's and only the user can see them ... so not heavily used .. still

--- a/Sources/Errors.php
+++ b/Sources/Errors.php
@@ -502,8 +502,15 @@ function log_error_online($error, $sprintf = array())
 	);
 	if ($smcFunc['db_num_rows']($request) != 0)
 	{
+		// If this happened very early on in SMF startup, $smcFunc may not fully be defined.
+		if (!isset($smcFunc['json_decode']))
+		{
+			$smcFunc['json_decode'] = 'smf_json_decode';
+			$smcFunc['json_encode'] = 'json_encode';
+		}
+
 		list ($url) = $smcFunc['db_fetch_row']($request);
-		$url = smf_json_decode($url, true);
+		$url = $smcFunc['json_decode']($url, true);
 		$url['error'] = $error;
 
 		if (!empty($sprintf))
@@ -514,7 +521,7 @@ function log_error_online($error, $sprintf = array())
 			SET url = {string:url}
 			WHERE session = {string:session}',
 			array(
-				'url' => json_encode($url),
+				'url' => $smcFunc['json_encode']($url),
 				'session' => $session_id,
 			)
 		);

--- a/Sources/Groups.php
+++ b/Sources/Groups.php
@@ -527,7 +527,7 @@ function GroupRequests()
 			$smcFunc['db_free_result']($request);
 
 			// Add a background task to handle notifying people of this request
-			$data = json_encode(array('member_id' => $user_info['id'], 'member_ip' => $user_info['ip'], 'request_list' => $request_list, 'status' => $_POST['req_action'], 'reason' => isset($_POST['groupreason']) ? $_POST['groupreason'] : '', 'time' => time()));
+			$data = $smcFunc['json_encode'](array('member_id' => $user_info['id'], 'member_ip' => $user_info['ip'], 'request_list' => $request_list, 'status' => $_POST['req_action'], 'reason' => isset($_POST['groupreason']) ? $_POST['groupreason'] : '', 'time' => time()));
 			$smcFunc['db_insert']('insert', '{db_prefix}background_tasks',
 				array('task_file' => 'string-255', 'task_class' => 'string-255', 'task_data' => 'string', 'claimed_time' => 'int'),
 				array('$sourcedir/tasks/GroupAct-Notify.php', 'GroupAct_Notify_Background', $data, 0), array()

--- a/Sources/Likes.php
+++ b/Sources/Likes.php
@@ -326,7 +326,7 @@ class Likes
 			$smcFunc['db_insert']('insert',
 				'{db_prefix}background_tasks',
 				array('task_file' => 'string', 'task_class' => 'string', 'task_data' => 'string', 'claimed_time' => 'int'),
-				array('$sourcedir/tasks/Likes-Notify.php', 'Likes_Notify_Background', json_encode(array(
+				array('$sourcedir/tasks/Likes-Notify.php', 'Likes_Notify_Background', $smcFunc['json_encode'](array(
 					'content_id' => $content,
 					'content_type' => $type,
 					'sender_id' => $user['id'],
@@ -605,6 +605,8 @@ class Likes
 	 */
 	protected function jsonResponse()
 	{
+		global $smcFunc;
+
 		$print = array(
 			'data' => $this->_data,
 		);
@@ -622,7 +624,7 @@ class Likes
 		call_integration_hook('integrate_likes_json_response', array(&$print));
 
 		// Print the data.
-		smf_serverResponse(json_encode($print));
+		smf_serverResponse($smcFunc['json_encode']($print));
 		die;
 	}
 }

--- a/Sources/LogInOut.php
+++ b/Sources/LogInOut.php
@@ -99,7 +99,7 @@ function Login2()
 	{
 		if (isset($_COOKIE[$cookiename]) && preg_match('~^a:[34]:\{i:0;i:\d{1,7};i:1;s:(0|128):"([a-fA-F0-9]{128})?";i:2;[id]:\d{1,14};(i:3;i:\d;)?\}$~', $_COOKIE[$cookiename]) === 1)
 		{
-			list (,, $timeout) = smf_json_decode($_COOKIE[$cookiename], true);
+			list (,, $timeout) = $smcFunc['json_decode']($_COOKIE[$cookiename], true);
 
 			// That didn't work... Maybe it's using serialize?
 			if (is_null($timeout))
@@ -107,7 +107,7 @@ function Login2()
 		}
 		elseif (isset($_SESSION['login_' . $cookiename]))
 		{
-			list (,, $timeout) = smf_json_decode($_SESSION['login_' . $cookiename]);
+			list (,, $timeout) = $smcFunc['json_decode']($_SESSION['login_' . $cookiename]);
 
 			// Try for old format
 			if (is_null($timeout))
@@ -122,16 +122,12 @@ function Login2()
 		// Preserve the 2FA cookie?
 		if (!empty($modSettings['tfa_mode']) && !empty($_COOKIE[$cookiename . '_tfa']))
 		{
-			$tfadata = smf_json_decode($_COOKIE[$cookiename . '_tfa'], true);
-
-			// If that didn't work, try unserialize instead...
-			if (is_null($tfadata))
-				$tfadata = safe_unserialize($_COOKIE[$cookiename . '_tfa']);
+			$tfadata = $smcFunc['json_decode']($_COOKIE[$cookiename . '_tfa'], true);
 
 			list ($tfamember, $tfasecret, $exp, $state, $preserve) = $tfadata;
 
 			// If we're preserving the cookie, reset it with updated salt
-			if ($preserve && time() < $exp)
+			if (isset($tfamember, $tfasecret, $exp, $state, $preserve) && $preserve && time() < $exp)
 				setTFACookie(3153600, $user_info['password_salt'], hash_salt($user_settings['tfa_backup'], $user_settings['password_salt']), true);
 			else
 				setTFACookie(-3600, 0, '');

--- a/Sources/Logging.php
+++ b/Sources/Logging.php
@@ -81,7 +81,7 @@ function writeLog($force = false)
 			$context['session_var'] = $_SESSION['session_var'];
 
 		unset($encoded_get['sesc'], $encoded_get[$context['session_var']]);
-		$encoded_get = json_encode($encoded_get);
+		$encoded_get = $smcFunc['json_encode']($encoded_get);
 	}
 	else
 		$encoded_get = '';
@@ -541,7 +541,7 @@ function logActions($logs)
 
 		$inserts[] = array(
 			time(), $log_types[$log['log_type']], $memID, $user_info['ip'], $log['action'],
-			$board_id, $topic_id, $msg_id, json_encode($log['extra']),
+			$board_id, $topic_id, $msg_id, $smcFunc['json_encode']($log['extra']),
 		);
 	}
 

--- a/Sources/ManageAttachments.php
+++ b/Sources/ManageAttachments.php
@@ -87,7 +87,7 @@ function ManageAttachments()
 
 function ManageAttachmentSettings($return_config = false)
 {
-	global $txt, $modSettings, $scripturl, $context, $sourcedir, $boarddir;
+	global $smcFunc, $txt, $modSettings, $scripturl, $context, $sourcedir, $boarddir;
 
 	require_once($sourcedir . '/Subs-Attachments.php');
 
@@ -208,7 +208,7 @@ function ManageAttachmentSettings($return_config = false)
 			if (!empty($_POST['use_subdirectories_for_attachments']) && !empty($modSettings['attachment_basedirectories']))
 			{
 				if (!is_array($modSettings['attachment_basedirectories']))
-					$modSettings['attachment_basedirectories'] = smf_json_decode($modSettings['attachment_basedirectories'], true);
+					$modSettings['attachment_basedirectories'] = $smcFunc['json_decode']($modSettings['attachment_basedirectories'], true);
 			}
 			else
 				$modSettings['attachment_basedirectories'] = array();
@@ -227,12 +227,12 @@ function ManageAttachmentSettings($return_config = false)
 				{
 					$modSettings['attachment_basedirectories'][$modSettings['currentAttachmentUploadDir']] = $_POST['basedirectory_for_attachments'];
 					updateSettings(array(
-						'attachment_basedirectories' => json_encode($modSettings['attachment_basedirectories']),
+						'attachment_basedirectories' => $smcFunc['json_encode']($modSettings['attachment_basedirectories']),
 						'currentAttachmentUploadDir' => $currentAttachmentUploadDir,
 					));
 
 					$_POST['use_subdirectories_for_attachments'] = 1;
-					$_POST['attachmentUploadDir'] = json_encode($modSettings['attachmentUploadDir']);
+					$_POST['attachmentUploadDir'] = $smcFunc['json_encode']($modSettings['attachmentUploadDir']);
 
 				}
 			}
@@ -714,7 +714,7 @@ function MaintainFiles()
 
 	$context['sub_template'] = 'maintenance';
 
-	$attach_dirs = smf_json_decode($modSettings['attachmentUploadDir'], true);
+	$attach_dirs = $smcFunc['json_decode']($modSettings['attachmentUploadDir'], true);
 
 	// Get the number of attachments....
 	$request = $smcFunc['db_query']('', '
@@ -785,7 +785,7 @@ function MaintainFiles()
 
 	$context['attach_multiple_dirs'] = count($attach_dirs) > 1 ? true : false;
 	$context['attach_dirs'] = $attach_dirs;
-	$context['base_dirs'] = !empty($modSettings['attachment_basedirectories']) ? smf_json_decode($modSettings['attachment_basedirectories'], true) : array();
+	$context['base_dirs'] = !empty($modSettings['attachment_basedirectories']) ? $smcFunc['json_decode']($modSettings['attachment_basedirectories'], true) : array();
 	$context['checked'] = isset($_SESSION['checked']) ? $_SESSION['checked'] : true;
 	if (!empty($_SESSION['results']))
 	{
@@ -1909,7 +1909,7 @@ function ManageAttachmentPaths()
 		$modSettings['attachment_basedirectories'] = array();
 
 	elseif (!is_array($modSettings['attachment_basedirectories']))
-		$modSettings['attachment_basedirectories'] = smf_json_decode($modSettings['attachment_basedirectories'], true);
+		$modSettings['attachment_basedirectories'] = $smcFunc['json_decode']($modSettings['attachment_basedirectories'], true);
 
 	$errors = array();
 
@@ -1983,10 +1983,10 @@ function ManageAttachmentPaths()
 
 					$modSettings['attachment_basedirectories'][$id] = $path;
 					updateSettings(array(
-						'attachment_basedirectories' => json_encode($modSettings['attachment_basedirectories']),
+						'attachment_basedirectories' => $smcFunc['json_encode']($modSettings['attachment_basedirectories']),
 						'basedirectory_for_attachments' => $base,
 					));
-					$modSettings['attachment_basedirectories'] = smf_json_decode($modSettings['attachment_basedirectories'], true);
+					$modSettings['attachment_basedirectories'] = $smcFunc['json_decode']($modSettings['attachment_basedirectories'], true);
 				}
 			}
 
@@ -2047,8 +2047,8 @@ function ManageAttachmentPaths()
 						if (empty($error) && !empty($modSettings['attachment_basedirectories']))
 						{
 							unset($modSettings['attachment_basedirectories'][$id]);
-							updateSettings(array('attachment_basedirectories' => json_encode($modSettings['attachment_basedirectories'])));
-							$modSettings['attachment_basedirectories'] = smf_json_decode($modSettings['attachment_basedirectories'], true);
+							updateSettings(array('attachment_basedirectories' => $smcFunc['json_encode']($modSettings['attachment_basedirectories'])));
+							$modSettings['attachment_basedirectories'] = $smcFunc['json_decode']($modSettings['attachment_basedirectories'], true);
 						}
 					}
 					else
@@ -2081,7 +2081,7 @@ function ManageAttachmentPaths()
 		if ($_POST['current_dir'] != $modSettings['currentAttachmentUploadDir'] && !empty($modSettings['last_attachments_directory']) && (isset($modSettings['last_attachments_directory'][$_POST['current_dir']]) || isset($modSettings['last_attachments_directory'][0])))
 		{
 			if (!is_array($modSettings['last_attachments_directory']))
-				$modSettings['last_attachments_directory'] = smf_json_decode($modSettings['last_attachments_directory'], true);
+				$modSettings['last_attachments_directory'] = $smcFunc['json_decode']($modSettings['last_attachments_directory'], true);
 			$num = substr(strrchr($modSettings['attachmentUploadDir'][$_POST['current_dir']], '_'), 1);
 
 			if (is_numeric($num))
@@ -2104,7 +2104,7 @@ function ManageAttachmentPaths()
 				$modSettings['basedirectory_for_attachments'] = !empty($modSettings['basedirectory_for_attachments']) ? $modSettings['basedirectory_for_attachments'] : '';
 				$modSettings['use_subdirectories_for_attachments'] = !empty($modSettings['use_subdirectories_for_attachments']) ? $modSettings['use_subdirectories_for_attachments'] : 0;
 				updateSettings(array(
-					'last_attachments_directory' => json_encode($modSettings['last_attachments_directory']),
+					'last_attachments_directory' => $smcFunc['json_encode']($modSettings['last_attachments_directory']),
 					'basedirectory_for_attachments' => $bid == 0 ? $modSettings['basedirectory_for_attachments'] : $modSettings['attachment_basedirectories'][$bid],
 					'use_subdirectories_for_attachments' => $use_subdirectories_for_attachments,
 				));
@@ -2130,7 +2130,7 @@ function ManageAttachmentPaths()
 
 				$update = array(
 					'currentAttachmentUploadDir' => 1,
-					'attachmentUploadDir' => json_encode(array(1 => $dir)),
+					'attachmentUploadDir' => $smcFunc['json_encode'](array(1 => $dir)),
 				);
 			}
 		}
@@ -2139,7 +2139,7 @@ function ManageAttachmentPaths()
 			// Save it to the database.
 			$update = array(
 				'currentAttachmentUploadDir' => $_POST['current_dir'],
-				'attachmentUploadDir' => json_encode($new_dirs),
+				'attachmentUploadDir' => $smcFunc['json_encode']($new_dirs),
 			);
 		}
 
@@ -2178,8 +2178,8 @@ function ManageAttachmentPaths()
 						$modSettings['attachmentUploadDir'][$id] = $dir;
 						$modSettings['attachment_basedirectories'][$id] = $dir;
 						$update = (array(
-							'attachmentUploadDir' => json_encode($modSettings['attachmentUploadDir']),
-							'attachment_basedirectories' => json_encode($modSettings['attachment_basedirectories']),
+							'attachmentUploadDir' => $smcFunc['json_encode']($modSettings['attachmentUploadDir']),
+							'attachment_basedirectories' => $smcFunc['json_encode']($modSettings['attachment_basedirectories']),
 							'basedirectory_for_attachments' => $modSettings['attachmentUploadDir'][$_POST['current_base_dir']],
 						));
 					}
@@ -2195,7 +2195,7 @@ function ManageAttachmentPaths()
 
 					unset($modSettings['attachment_basedirectories'][$id]);
 					$update = (array(
-						'attachment_basedirectories' => json_encode($modSettings['attachment_basedirectories']),
+						'attachment_basedirectories' => $smcFunc['json_encode']($modSettings['attachment_basedirectories']),
 						'basedirectory_for_attachments' => $modSettings['attachmentUploadDir'][$_POST['current_base_dir']],
 					));
 				}
@@ -2222,7 +2222,7 @@ function ManageAttachmentPaths()
 			ksort($modSettings['attachment_basedirectories']);
 
 			$update = (array(
-				'attachment_basedirectories' => json_encode($modSettings['attachment_basedirectories']),
+				'attachment_basedirectories' => $smcFunc['json_encode']($modSettings['attachment_basedirectories']),
 				'basedirectory_for_attachments' => $_POST['new_base_dir'],
 				'currentAttachmentUploadDir' => $current_dir,
 			));
@@ -2603,9 +2603,9 @@ function TransferAttachments()
 
 	checkSession();
 
-	$modSettings['attachmentUploadDir'] = smf_json_decode($modSettings['attachmentUploadDir'], true);
+	$modSettings['attachmentUploadDir'] = $smcFunc['json_decode']($modSettings['attachmentUploadDir'], true);
 	if (!empty($modSettings['attachment_basedirectories']))
-		$modSettings['attachment_basedirectories'] = smf_json_decode($modSettings['attachment_basedirectories'], true);
+		$modSettings['attachment_basedirectories'] = $smcFunc['json_decode']($modSettings['attachment_basedirectories'], true);
 	else
 		$modSettings['basedirectory_for_attachments'] = array();
 

--- a/Sources/ManageMembers.php
+++ b/Sources/ManageMembers.php
@@ -269,7 +269,7 @@ function ViewMemberlist()
 
 		$search_params = array();
 		if ($context['sub_action'] == 'query' && !empty($_REQUEST['params']) && empty($_POST['types']))
-			$search_params = smf_json_decode(base64_decode($_REQUEST['params']), true);
+			$search_params = $smcFunc['json_decode'](base64_decode($_REQUEST['params']), true);
 		elseif (!empty($_POST))
 		{
 			$search_params['types'] = $_POST['types'];
@@ -278,7 +278,7 @@ function ViewMemberlist()
 					$search_params[$param_name] = $_POST[$param_name];
 		}
 
-		$search_url_params = isset($search_params) ? base64_encode(json_encode($search_params)) : null;
+		$search_url_params = isset($search_params) ? base64_encode($smcFunc['json_encode']($search_params)) : null;
 
 		// @todo Validate a little more.
 

--- a/Sources/ManagePaid.php
+++ b/Sources/ManagePaid.php
@@ -564,7 +564,7 @@ function ModifySubscription()
 			if (empty($_POST['cost_day']) && empty($_POST['cost_week']) && empty($_POST['cost_month']) && empty($_POST['cost_year']))
 				fatal_lang_error('paid_all_freq_blank');
 		}
-		$cost = json_encode($cost);
+		$cost = $smcFunc['json_encode']($cost);
 
 		// Having now validated everything that might throw an error, let's also now deal with the token.
 		validateToken('admin-pms');
@@ -699,7 +699,7 @@ function ModifySubscription()
 			$context['sub'] = array(
 				'name' => $row['name'],
 				'desc' => $row['description'],
-				'cost' => smf_json_decode($row['cost'], true),
+				'cost' => $smcFunc['json_decode']($row['cost'], true),
 				'span' => array(
 					'value' => $span_value,
 					'unit' => $span_unit,
@@ -1275,14 +1275,14 @@ function ModifyUserSubscription()
 		$context['pending_payments'] = array();
 		if (!empty($row['pending_details']))
 		{
-			$pending_details = smf_json_decode($row['pending_details'], true);
+			$pending_details = $smcFunc['json_decode']($row['pending_details'], true);
 			foreach ($pending_details as $id => $pending)
 			{
 				// Only this type need be displayed.
 				if ($pending[3] == 'payback')
 				{
 					// Work out what the options were.
-					$costs = smf_json_decode($context['current_subscription']['real_cost'], true);
+					$costs = $smcFunc['json_decode']($context['current_subscription']['real_cost'], true);
 
 					if ($context['current_subscription']['real_length'] == 'F')
 					{
@@ -1316,7 +1316,7 @@ function ModifyUserSubscription()
 							addSubscription($context['current_subscription']['id'], $row['id_member'], $context['current_subscription']['real_length'] == 'F' ? strtoupper(substr($pending[2], 0, 1)) : 0);
 						unset($pending_details[$id]);
 
-						$new_details = json_encode($pending_details);
+						$new_details = $smcFunc['json_encode']($pending_details);
 
 						// Update the entry.
 						$smcFunc['db_query']('', '
@@ -1844,7 +1844,7 @@ function loadSubscriptions()
 	while ($row = $smcFunc['db_fetch_assoc']($request))
 	{
 		// Pick a cost.
-		$costs = smf_json_decode($row['cost'], true);
+		$costs = $smcFunc['json_decode']($row['cost'], true);
 
 		if ($row['length'] != 'F' && !empty($modSettings['paid_currency_symbol']) && !empty($costs['fixed']))
 			$cost = sprintf($modSettings['paid_currency_symbol'], $costs['fixed']);

--- a/Sources/ManageSearch.php
+++ b/Sources/ManageSearch.php
@@ -516,7 +516,7 @@ function CreateMessageIndex()
 
 	if (isset($_REQUEST['resume']) && !empty($modSettings['search_custom_index_resume']))
 	{
-		$context['index_settings'] = smf_json_decode($modSettings['search_custom_index_resume'], true);
+		$context['index_settings'] = $smcFunc['json_decode']($modSettings['search_custom_index_resume'], true);
 		$context['start'] = (int) $context['index_settings']['resume_at'];
 		unset($context['index_settings']['resume_at']);
 		$context['step'] = 1;
@@ -649,7 +649,7 @@ function CreateMessageIndex()
 					break;
 				}
 				else
-					updateSettings(array('search_custom_index_resume' => json_encode(array_merge($context['index_settings'], array('resume_at' => $context['start'])))));
+					updateSettings(array('search_custom_index_resume' => $smcFunc['json_encode'](array_merge($context['index_settings'], array('resume_at' => $context['start'])))));
 			}
 
 			// Since there are still two steps to go, 80% is the maximum here.
@@ -714,7 +714,7 @@ function CreateMessageIndex()
 	{
 		$context['sub_template'] = 'create_index_done';
 
-		updateSettings(array('search_index' => 'custom', 'search_custom_index_config' => json_encode($context['index_settings'])));
+		updateSettings(array('search_index' => 'custom', 'search_custom_index_config' => $smcFunc['json_encode']($context['index_settings'])));
 		$smcFunc['db_query']('', '
 			DELETE FROM {db_prefix}settings
 			WHERE variable = {string:search_custom_index_resume}',

--- a/Sources/ManageSearchEngines.php
+++ b/Sources/ManageSearchEngines.php
@@ -589,7 +589,7 @@ function logSpider()
 		{
 			$url = $_GET + array('USER_AGENT' => $_SERVER['HTTP_USER_AGENT']);
 			unset($url['sesc'], $url[$context['session_var']]);
-			$url = json_encode($url);
+			$url = $smcFunc['json_encode']($url);
 		}
 		else
 			$url = '';
@@ -1109,7 +1109,7 @@ function recacheSpiderNames()
 		$spiders[$row['id_spider']] = $row['spider_name'];
 	$smcFunc['db_free_result']($request);
 
-	updateSettings(array('spider_name_cache' => json_encode($spiders)));
+	updateSettings(array('spider_name_cache' => $smcFunc['json_encode']($spiders)));
 }
 
 ?>

--- a/Sources/ManageServer.php
+++ b/Sources/ManageServer.php
@@ -830,7 +830,7 @@ function prepareDBSettingContext(&$config_vars)
 						$value = $modSettings[$config_var[1]];
 						break;
 					case 'json':
-						$value = $smcFunc['htmlspecialchars'](json_encode($modSettings[$config_var[1]]));
+						$value = $smcFunc['htmlspecialchars']($smcFunc['json_encode']($modSettings[$config_var[1]]));
 						break;
 					case 'boards':
 						$value = explode(',', $modSettings[$config_var[1]]);
@@ -849,7 +849,7 @@ function prepareDBSettingContext(&$config_vars)
 						$value = 0;
 						break;
 					case 'select':
-						$value = !empty($config_var['multiple']) ? json_encode(array()) : '';
+						$value = !empty($config_var['multiple']) ? $smcFunc['json_encode'](array()) : '';
 						break;
 					case 'boards':
 						$value = array();
@@ -898,7 +898,7 @@ function prepareDBSettingContext(&$config_vars)
 				if ($config_var[0] == 'select' && !empty($config_var['multiple']))
 				{
 					$context['config_vars'][$config_var[1]]['name'] .= '[]';
-					$context['config_vars'][$config_var[1]]['value'] = !empty($context['config_vars'][$config_var[1]]['value']) ? smf_json_decode($context['config_vars'][$config_var[1]]['value'], true) : array();
+					$context['config_vars'][$config_var[1]]['value'] = !empty($context['config_vars'][$config_var[1]]['value']) ? $smcFunc['json_decode']($context['config_vars'][$config_var[1]]['value'], true) : array();
 				}
 
 				// If it's associative
@@ -1172,7 +1172,7 @@ function saveDBSettings(&$config_vars)
 				if (in_array($invar, array_keys($var[2])))
 					$lOptions[] = $invar;
 
-			$setArray[$var[1]] = json_encode($lOptions);
+			$setArray[$var[1]] = $smcFunc['json_encode']($lOptions);
 		}
 		// List of boards!
 		elseif ($var[0] == 'boards')

--- a/Sources/ManageSettings.php
+++ b/Sources/ManageSettings.php
@@ -631,7 +631,7 @@ function ModifyAntispamSettings($return_config = false)
 		$context['question_answers'][$row['id_question']] = array(
 			'lngfile' => $lang,
 			'question' => $row['question'],
-			'answers' => smf_json_decode($row['answers'], true),
+			'answers' => $smcFunc['json_decode']($row['answers'], true),
 		);
 		$context['qa_by_lang'][$lang][] = $row['id_question'];
 	}
@@ -746,7 +746,7 @@ function ModifyAntispamSettings($return_config = false)
 							$changes['delete'][] = $q_id;
 						continue;
 					}
-					$answers = json_encode($answers);
+					$answers = $smcFunc['json_encode']($answers);
 
 					// At this point we know we have a question and some answers. What are we doing with it?
 					if (!isset($context['question_answers'][$q_id]))
@@ -2040,7 +2040,7 @@ function EditCustomProfiles()
 		}
 		$smcFunc['db_free_result']($request);
 
-		updateSettings(array('displayFields' => json_encode($fields)));
+		updateSettings(array('displayFields' => $smcFunc['json_encode']($fields)));
 		$_SESSION['adm-save'] = true;
 		redirectexit('action=admin;area=featuresettings;sa=profile');
 	}

--- a/Sources/ManageSmileys.php
+++ b/Sources/ManageSmileys.php
@@ -1606,7 +1606,7 @@ function InstallSmileySet()
 		package_flush_cache();
 
 		// Credits tag?
-		$credits_tag = (empty($credits_tag)) ? '' : json_encode($credits_tag);
+		$credits_tag = (empty($credits_tag)) ? '' : $smcFunc['json_encode']($credits_tag);
 		$smcFunc['db_insert']('',
 			'{db_prefix}log_packages',
 			array(

--- a/Sources/Memberlist.php
+++ b/Sources/Memberlist.php
@@ -178,7 +178,7 @@ function MLAll()
 	{
 		// Maybe there's something cached already.
 		if (!empty($modSettings['memberlist_cache']))
-			$memberlist_cache = smf_json_decode($modSettings['memberlist_cache'], true);
+			$memberlist_cache = $smcFunc['json_decode']($modSettings['memberlist_cache'], true);
 
 		// The chunk size for the cached index.
 		$cache_step_size = 500;
@@ -212,7 +212,7 @@ function MLAll()
 			$smcFunc['db_free_result']($request);
 
 			// Now we've got the cache...store it.
-			updateSettings(array('memberlist_cache' => json_encode($memberlist_cache)));
+			updateSettings(array('memberlist_cache' => $smcFunc['json_encode']($memberlist_cache)));
 		}
 
 		$context['num_members'] = $memberlist_cache['num_members'];

--- a/Sources/ModerationCenter.php
+++ b/Sources/ModerationCenter.php
@@ -23,7 +23,7 @@ if (!defined('SMF'))
  */
 function ModerationMain($dont_call = false)
 {
-	global $txt, $context, $scripturl, $modSettings, $user_info, $sourcedir, $options;
+	global $smcFunc, $txt, $context, $scripturl, $modSettings, $user_info, $sourcedir, $options;
 
 	// Don't run this twice... and don't conflict with the admin bar.
 	if (isset($context['admin_area']))
@@ -45,7 +45,7 @@ function ModerationMain($dont_call = false)
 	loadLanguage('ModerationCenter');
 	loadTemplate(false, 'admin');
 
-	$context['admin_preferences'] = !empty($options['admin_preferences']) ? smf_json_decode($options['admin_preferences'], true) : array();
+	$context['admin_preferences'] = !empty($options['admin_preferences']) ? $smcFunc['json_decode']($options['admin_preferences'], true) : array();
 	$context['robot_no_index'] = true;
 
 	// This is the menu structure - refer to Subs-Menu.php for the details.
@@ -245,7 +245,7 @@ function ModerationMain($dont_call = false)
  */
 function ModerationHome()
 {
-	global $txt, $context, $options;
+	global $smcFunc, $txt, $context, $options;
 
 	loadTemplate('ModerationCenter');
 	loadJavaScriptFile('admin.js', array(), 'smf_admin');
@@ -285,7 +285,7 @@ function ModerationHome()
 			$context['mod_blocks'][] = $block();
 	}
 
-	$context['admin_prefs'] = !empty($options['admin_preferences']) ? smf_json_decode($options['admin_preferences'], true) : array();
+	$context['admin_prefs'] = !empty($options['admin_preferences']) ? $smcFunc['json_decode']($options['admin_preferences'], true) : array();
 }
 
 /**
@@ -502,7 +502,7 @@ function ModBlockReportedPosts()
 	global $context, $user_info, $scripturl, $smcFunc;
 
 	// Got the info already?
-	$cachekey = md5(json_encode($user_info['mod_cache']['bq']));
+	$cachekey = md5($smcFunc['json_encode']($user_info['mod_cache']['bq']));
 	$context['reported_posts'] = array();
 	if ($user_info['mod_cache']['bq'] == '0=1')
 		return 'reported_posts_block';
@@ -616,7 +616,7 @@ function ModBlockReportedMembers()
 	global $context, $scripturl, $smcFunc;
 
 	// Got the info already?
-	$cachekey = md5(json_encode((int) allowedTo('moderate_forum')));
+	$cachekey = md5($smcFunc['json_encode']((int) allowedTo('moderate_forum')));
 	$context['reported_users'] = array();
 	if (!allowedTo('moderate_forum'))
 		return 'reported_users_block';
@@ -1425,7 +1425,7 @@ function ViewWarningLog()
 	if (!empty($_REQUEST['params']) && empty($_REQUEST['is_search']))
 	{
 		$search_params = base64_decode(strtr($_REQUEST['params'], array(' ' => '+')));
-		$search_params = smf_json_decode($search_params, true);
+		$search_params = $smcFunc['json_decode']($search_params, true);
 	}
 
 	// This array houses all the valid search types.
@@ -1461,7 +1461,7 @@ function ViewWarningLog()
 	$context['url_start'] = '?action=moderate;area=warnings;sa=log;sort=' . $context['order'];
 
 	// Setup the search context.
-	$context['search_params'] = empty($search_params['string']) ? '' : base64_encode(json_encode($search_params));
+	$context['search_params'] = empty($search_params['string']) ? '' : base64_encode($smcFunc['json_encode']($search_params));
 	$context['search'] = array(
 		'string' => $search_params['string'],
 		'type' => $search_params['type'],

--- a/Sources/Modlog.php
+++ b/Sources/Modlog.php
@@ -103,7 +103,7 @@ function ViewModlog()
 	if (!empty($_REQUEST['params']) && empty($_REQUEST['is_search']))
 	{
 		$search_params = base64_decode(strtr($_REQUEST['params'], array(' ' => '+')));
-		$search_params = smf_json_decode($search_params, true);
+		$search_params = $smcFunc['json_decode']($search_params, true);
 	}
 
 	// This array houses all the valid search types.
@@ -131,7 +131,7 @@ function ViewModlog()
 	);
 
 	// Setup the search context.
-	$context['search_params'] = empty($search_params['string']) ? '' : base64_encode(json_encode($search_params));
+	$context['search_params'] = empty($search_params['string']) ? '' : base64_encode($smcFunc['json_encode']($search_params));
 	$context['search'] = array(
 		'string' => $search_params['string'],
 		'type' => $search_params['type'],
@@ -399,7 +399,7 @@ function list_getModLogEntries($start, $items_per_page, $sort, $query_string = '
 	$entries = array();
 	while ($row = $smcFunc['db_fetch_assoc']($result))
 	{
-		$row['extra'] = smf_json_decode($row['extra'], true);
+		$row['extra'] = $smcFunc['json_decode']($row['extra'], true);
 
 		// Corrupt?
 		$row['extra'] = is_array($row['extra']) ? $row['extra'] : array();

--- a/Sources/News.php
+++ b/Sources/News.php
@@ -204,7 +204,7 @@ function ShowXmlFeed()
 	foreach (array('board', 'boards', 'c') as $var)
 		if (isset($_REQUEST[$var]))
 			$cachekey[] = $_REQUEST[$var];
-	$cachekey = md5(json_encode($cachekey) . (!empty($query_this_board) ? $query_this_board : ''));
+	$cachekey = md5($smcFunc['json_encode']($cachekey) . (!empty($query_this_board) ? $query_this_board : ''));
 	$cache_t = microtime();
 
 	// Get the associative array representing the xml.

--- a/Sources/Packages.php
+++ b/Sources/Packages.php
@@ -222,7 +222,7 @@ function PackageInstallTest()
 	{
 		$old_themes = explode(',', $row['themes_installed']);
 		$old_version = $row['version'];
-		$db_changes = empty($row['db_changes']) ? array() : smf_json_decode($row['db_changes'], true);
+		$db_changes = empty($row['db_changes']) ? array() : $smcFunc['json_decode']($row['db_changes'], true);
 	}
 	$smcFunc['db_free_result']($request);
 
@@ -729,7 +729,7 @@ function PackageInstallTest()
 								'type' => $txt['package_delete'] . ' ' . ($action_data['type'] == 'require-dir' ? $txt['package_tree'] : $txt['package_file']),
 								'action' => strtr($real_path, array('\\' => '/', $boarddir => '.')),
 								'description' => '',
-								'value' => base64_encode(json_encode(array('type' => $action_data['type'], 'orig' => $action_data['filename'], 'future' => $real_path, 'id' => $id))),
+								'value' => base64_encode($smcFunc['json_encode'](array('type' => $action_data['type'], 'orig' => $action_data['filename'], 'future' => $real_path, 'id' => $id))),
 								'not_mod' => true,
 							);
 						else
@@ -737,7 +737,7 @@ function PackageInstallTest()
 								'type' => $txt['package_extract'] . ' ' . ($action_data['type'] == 'require-dir' ? $txt['package_tree'] : $txt['package_file']),
 								'action' => strtr($real_path, array('\\' => '/', $boarddir => '.')),
 								'description' => '',
-								'value' => base64_encode(json_encode(array('type' => $action_data['type'], 'orig' => $action_data['destination'], 'future' => $real_path, 'id' => $id))),
+								'value' => base64_encode($smcFunc['json_encode'](array('type' => $action_data['type'], 'orig' => $action_data['destination'], 'future' => $real_path, 'id' => $id))),
 								'not_mod' => true,
 							);
 					}
@@ -873,7 +873,7 @@ function PackageInstall()
 		{
 			if (empty($change))
 				continue;
-			$theme_data = smf_json_decode(base64_decode($change), true);
+			$theme_data = $smcFunc['json_decode'](base64_decode($change), true);
 			if (empty($theme_data['type']))
 				continue;
 
@@ -921,7 +921,7 @@ function PackageInstall()
 	{
 		$old_themes = explode(',', $row['themes_installed']);
 		$old_version = $row['version'];
-		$db_changes = empty($row['db_changes']) ? array() : smf_json_decode($row['db_changes'], true);
+		$db_changes = empty($row['db_changes']) ? array() : $smcFunc['json_decode']($row['db_changes'], true);
 	}
 	$smcFunc['db_free_result']($request);
 
@@ -1114,7 +1114,7 @@ function PackageInstall()
 			else
 			{
 				$is_upgrade = true;
-				$old_db_changes = empty($row['db_changes']) ? array() : smf_json_decode($row['db_changes'], true);
+				$old_db_changes = empty($row['db_changes']) ? array() : $smcFunc['json_decode']($row['db_changes'], true);
 			}
 		}
 
@@ -1154,7 +1154,7 @@ function PackageInstall()
 					elseif (in_array($log[1], $tables))
 						unset($db_package_log[$k]);
 				}
-				$db_changes = json_encode($db_package_log);
+				$db_changes = $smcFunc['json_encode']($db_package_log);
 			}
 			else
 				$db_changes = '';
@@ -1164,7 +1164,7 @@ function PackageInstall()
 			$themes_installed = implode(',', $themes_installed);
 
 			// What failed steps?
-			$failed_step_insert = json_encode($failed_steps);
+			$failed_step_insert = $smcFunc['json_encode']($failed_steps);
 
 			// Un-sanitize things before we insert them...
 			$keys = array('filename', 'name', 'id', 'version');
@@ -1175,7 +1175,7 @@ function PackageInstall()
 			}
 
 			// Credits tag?
-			$credits_tag = (empty($credits_tag)) ? '' : json_encode($credits_tag);
+			$credits_tag = (empty($credits_tag)) ? '' : $smcFunc['json_encode']($credits_tag);
 			$smcFunc['db_insert']('',
 				'{db_prefix}log_packages',
 				array(
@@ -1509,7 +1509,7 @@ function PackageBrowse()
 	$smcFunc['db_free_result']($get_versions);
 
 	// Decode the data.
-	$items = smf_json_decode($data['data'], true);
+	$items = $smcFunc['json_decode']($data['data'], true);
 
 	$context['emulation_versions'] = preg_replace('~^SMF ~', '', $items);
 
@@ -2095,7 +2095,7 @@ function PackagePermissions()
 		unset($context['file_tree'][strtr($boarddir, array('\\' => '/'))]['contents']['attachments']);
 
 		if (!is_array($modSettings['attachmentUploadDir']))
-			$modSettings['attachmentUploadDir'] = smf_json_decode($modSettings['attachmentUploadDir'], true);
+			$modSettings['attachmentUploadDir'] = $smcFunc['json_decode']($modSettings['attachmentUploadDir'], true);
 
 		// @todo Should we suggest non-current directories be read only?
 		foreach ($modSettings['attachmentUploadDir'] as $dir)
@@ -2198,7 +2198,7 @@ function PackagePermissions()
 	// Have we got a load of back-catalogue trees to expand from a submit etc?
 	if (!empty($_GET['back_look']))
 	{
-		$potententialTrees = smf_json_decode(base64_decode($_GET['back_look']), true);
+		$potententialTrees = $smcFunc['json_decode'](base64_decode($_GET['back_look']), true);
 		foreach ($potententialTrees as $tree)
 			$context['look_for'][] = $tree;
 	}
@@ -2206,7 +2206,7 @@ function PackagePermissions()
 	if (!empty($_POST['back_look']))
 		$context['only_find'] = array_merge($context['only_find'], $_POST['back_look']);
 
-	$context['back_look_data'] = base64_encode(json_encode(array_slice($context['look_for'], 0, 15)));
+	$context['back_look_data'] = base64_encode($smcFunc['json_encode'](array_slice($context['look_for'], 0, 15)));
 
 	// Are we finding more files than first thought?
 	$context['file_offset'] = !empty($_REQUEST['fileoffset']) ? (int) $_REQUEST['fileoffset'] : 0;
@@ -2432,7 +2432,7 @@ function fetchPerms__recursive($path, &$data, $level)
  */
 function PackagePermissionsAction()
 {
-	global $context, $txt, $time_start, $package_ftp;
+	global $smcFunc, $context, $txt, $time_start, $package_ftp;
 
 	umask(0);
 
@@ -2456,7 +2456,7 @@ function PackagePermissionsAction()
 
 		// Continuing?
 		if (isset($_POST['toProcess']))
-			$_POST['permStatus'] = smf_json_decode(base64_decode($_POST['toProcess']), true);
+			$_POST['permStatus'] = $smcFunc['json_decode'](base64_decode($_POST['toProcess']), true);
 
 		if (isset($_POST['permStatus']))
 		{
@@ -2496,7 +2496,7 @@ function PackagePermissionsAction()
 
 			// Nothing to do?
 			if (empty($context['to_process']))
-				redirectexit('action=admin;area=packages;sa=perms' . (!empty($context['back_look_data']) ? ';back_look=' . base64_encode(json_encode($context['back_look_data'])) : '') . ';' . $context['session_var'] . '=' . $context['session_id']);
+				redirectexit('action=admin;area=packages;sa=perms' . (!empty($context['back_look_data']) ? ';back_look=' . base64_encode($smcFunc['json_encode']($context['back_look_data'])) : '') . ';' . $context['session_var'] . '=' . $context['session_id']);
 		}
 		// Should never get here,
 		else
@@ -2527,8 +2527,16 @@ function PackagePermissionsAction()
 
 			// See if we're out of time?
 			if (time() - array_sum(explode(' ', $time_start)) > $timeout_limit)
+			{
+				// Prepare template usage for to_process.
+				$context['to_process_encode'] = base64_encode($smcFunc['json_encode']($context['to_process']));
+
 				return false;
+			}
 		}
+
+		// Prepare template usage for to_process.
+		$context['to_process_encode'] = base64_encode($smcFunc['json_encode']($context['to_process']));
 	}
 	// If predefined this is a little different.
 	else
@@ -2536,7 +2544,7 @@ function PackagePermissionsAction()
 		$context['predefined_type'] = isset($_POST['predefined']) ? $_POST['predefined'] : 'restricted';
 
 		$context['total_items'] = isset($_POST['totalItems']) ? (int) $_POST['totalItems'] : 0;
-		$context['directory_list'] = isset($_POST['dirList']) ? smf_json_decode(base64_decode($_POST['dirList']), true) : array();
+		$context['directory_list'] = isset($_POST['dirList']) ? $smcFunc['json_decode'](base64_decode($_POST['dirList']), true) : array();
 
 		$context['file_offset'] = isset($_POST['fileOffset']) ? (int) $_POST['fileOffset'] : 0;
 
@@ -2611,7 +2619,7 @@ function PackagePermissionsAction()
 		elseif ($context['predefined_type'] == 'free')
 			$context['special_files'] = array();
 		else
-			$context['special_files'] = smf_json_decode(base64_decode($_POST['specialFiles']), true);
+			$context['special_files'] = $smcFunc['json_decode'](base64_decode($_POST['specialFiles']), true);
 
 		// Now we definitely know where we are, we need to go through again doing the chmod!
 		foreach ($context['directory_list'] as $path => $dummy)
@@ -2657,12 +2665,22 @@ function PackagePermissionsAction()
 
 			// See if we're out of time?
 			if (time() - array_sum(explode(' ', $time_start)) > $timeout_limit)
+			{
+				// Prepare this for usage on templates.
+				$context['directory_list_encode'] = base64_encode($smcFunc['json_encode']($context['directory_list']));
+				$context['special_files_encode'] = base64_encode($smcFunc['json_encode']($context['special_files']));
+
 				return false;
+			}
 		}
+
+		// Prepare this for usage on templates.
+		$context['directory_list_encode'] = base64_encode($smcFunc['json_encode']($context['directory_list']));
+		$context['special_files_encode'] = base64_encode($smcFunc['json_encode']($context['special_files']));
 	}
 
 	// If we're here we are done!
-	redirectexit('action=admin;area=packages;sa=perms' . (!empty($context['back_look_data']) ? ';back_look=' . base64_encode(json_encode($context['back_look_data'])) : '') . ';' . $context['session_var'] . '=' . $context['session_id']);
+	redirectexit('action=admin;area=packages;sa=perms' . (!empty($context['back_look_data']) ? ';back_look=' . base64_encode($smcFunc['json_encode']($context['back_look_data'])) : '') . ';' . $context['session_var'] . '=' . $context['session_id']);
 }
 
 /**

--- a/Sources/PersonalMessage.php
+++ b/Sources/PersonalMessage.php
@@ -3388,7 +3388,7 @@ function ManageLabels()
 						array(
 							'current_member' => $user_info['id'],
 							'id_rule' => $id,
-							'actions' => json_encode($context['rules'][$id]['actions']),
+							'actions' => $smcFunc['json_encode']($context['rules'][$id]['actions']),
 						)
 					);
 					unset($rule_changes[$k]);
@@ -3831,8 +3831,8 @@ function ManageRules()
 			fatal_lang_error('pm_rule_no_criteria', false);
 
 		// What are we storing?
-		$criteria = json_encode($criteria);
-		$actions = json_encode($actions);
+		$criteria = $smcFunc['json_encode']($criteria);
+		$actions = $smcFunc['json_encode']($actions);
 
 		// Create the rule?
 		if (empty($context['rid']))
@@ -4047,8 +4047,8 @@ function LoadRules($reload = false)
 		$context['rules'][$row['id_rule']] = array(
 			'id' => $row['id_rule'],
 			'name' => $row['rule_name'],
-			'criteria' => smf_json_decode($row['criteria'], true),
-			'actions' => smf_json_decode($row['actions'], true),
+			'criteria' => $smcFunc['json_decode']($row['criteria'], true),
+			'actions' => $smcFunc['json_decode']($row['actions'], true),
 			'delete' => $row['delete_pm'],
 			'logic' => $row['is_or'] ? 'or' : 'and',
 		);

--- a/Sources/Profile-Actions.php
+++ b/Sources/Profile-Actions.php
@@ -734,7 +734,7 @@ function subscriptions($memID)
 	foreach ($context['subscriptions'] as $id => $sub)
 	{
 		// Work out the costs.
-		$costs = smf_json_decode($sub['real_cost'], true);
+		$costs = $smcFunc['json_decode']($sub['real_cost'], true);
 
 		$cost_array = array();
 		if ($sub['real_length'] == 'F')
@@ -815,7 +815,7 @@ function subscriptions($memID)
 		if (isset($context['current'][$_GET['sub_id']]))
 		{
 			// What are the details like?
-			$current_pending = smf_json_decode($context['current'][$_GET['sub_id']]['pending_details'], true);
+			$current_pending = $smcFunc['json_decode']($context['current'][$_GET['sub_id']]['pending_details'], true);
 			if (!empty($current_pending))
 			{
 				$current_pending = array_reverse($current_pending);
@@ -830,7 +830,7 @@ function subscriptions($memID)
 				}
 
 				// Save the details back.
-				$pending_details = json_encode($current_pending);
+				$pending_details = $smcFunc['json_encode']($current_pending);
 
 				$smcFunc['db_query']('', '
 					UPDATE {db_prefix}log_subscribed
@@ -913,7 +913,7 @@ function subscriptions($memID)
 			// What are the details like?
 			$current_pending = array();
 			if ($context['current'][$context['sub']['id']]['pending_details'] != '')
-				$current_pending = smf_json_decode($context['current'][$context['sub']['id']]['pending_details'], true);
+				$current_pending = $smcFunc['json_decode']($context['current'][$context['sub']['id']]['pending_details'], true);
 			// Don't get silly.
 			if (count($current_pending) > 9)
 				$current_pending = array();
@@ -926,7 +926,7 @@ function subscriptions($memID)
 			if (!in_array($new_data, $current_pending))
 			{
 				$current_pending[] = $new_data;
-				$pending_details = json_encode($current_pending);
+				$pending_details = $smcFunc['json_encode']($current_pending);
 
 				$smcFunc['db_query']('', '
 					UPDATE {db_prefix}log_subscribed
@@ -946,7 +946,7 @@ function subscriptions($memID)
 		// Never had this before, lovely.
 		else
 		{
-			$pending_details = json_encode(array($new_data));
+			$pending_details = $smcFunc['json_encode'](array($new_data));
 			$smcFunc['db_insert']('',
 				'{db_prefix}log_subscribed',
 				array(

--- a/Sources/Profile-Modify.php
+++ b/Sources/Profile-Modify.php
@@ -3476,7 +3476,7 @@ function profileValidateSignature(&$value)
 			// Get all BBC tags...
 			preg_match_all('~\[img(\s+width=([\d]+))?(\s+height=([\d]+))?(\s+width=([\d]+))?\s*\](?:<br>)*([^<">]+?)(?:<br>)*\[/img\]~i', $unparsed_signature, $matches);
 			// ... and all HTML ones.
-			preg_match_all('~<img\s+src=(?:")?((?:http://|ftp://|https://|ftps://).+?)(?:")?(?:\s+alt=(?:")?(.*?)(?:")?)?(?:\s?/)?>~i', $unparsed_signature, $matches2, PREG_PATTERN_ORDER);
+			preg_match_all('~<img\s+src=(?:")?((?:http://|ftp://|https://|ftps://).+?)(?:")?(?:\s+alt=(?:")?(.*?)(?:")?)?(?:\s?/)?' . '>~i', $unparsed_signature, $matches2, PREG_PATTERN_ORDER);
 			// And stick the HTML in the BBC.
 			if (!empty($matches2))
 			{
@@ -3666,7 +3666,7 @@ function profileSendActivation()
 		)
 	);
 	$_SESSION['log_time'] = 0;
-	$_SESSION['login_' . $cookiename] = json_encode(array(0, '', 0));
+	$_SESSION['login_' . $cookiename] = $smcFunc['json_encode'](array(0, '', 0));
 
 	if (isset($_COOKIE[$cookiename]))
 		$_COOKIE[$cookiename] = '';
@@ -3941,7 +3941,7 @@ function groupMembership2($profile_vars, $post_errors, $memID)
 		);
 
 		// Set up some data for our background task...
-		$data = json_encode(array('id_member' => $memID, 'member_name' => $user_info['name'], 'id_group' => $group_id, 'group_name' => $group_name, 'reason' => $_POST['reason'], 'time' => time()));
+		$data = $smcFunc['json_encode'](array('id_member' => $memID, 'member_name' => $user_info['name'], 'id_group' => $group_id, 'group_name' => $group_name, 'reason' => $_POST['reason'], 'time' => time()));
 
 		// Add a background task to handle notifying people of this request
 		$smcFunc['db_insert']('insert', '{db_prefix}background_tasks',

--- a/Sources/Profile-View.php
+++ b/Sources/Profile-View.php
@@ -239,7 +239,7 @@ function fetch_alerts($memID, $all = false, $counter = 0, $pagination = array())
 	{
 		$id_alert = array_shift($row);
 		$row['time'] = timeformat($row['alert_time']);
-		$row['extra'] = !empty($row['extra']) ? smf_json_decode($row['extra'], true) : array();
+		$row['extra'] = !empty($row['extra']) ? $smcFunc['json_decode']($row['extra'], true) : array();
 		$alerts[$id_alert] = $row;
 
 		if (!empty($row['sender_id']))
@@ -2437,7 +2437,7 @@ function list_getProfileEdits($start, $items_per_page, $sort, $memID)
 	$members = array();
 	while ($row = $smcFunc['db_fetch_assoc']($request))
 	{
-		$extra = smf_json_decode($row['extra'], true);
+		$extra = $smcFunc['json_decode']($row['extra'], true);
 		if (!empty($extra['applicator']))
 			$members[] = $extra['applicator'];
 

--- a/Sources/Recent.php
+++ b/Sources/Recent.php
@@ -272,7 +272,7 @@ function RecentPosts()
 	if ($context['is_redirect'])
 		$messages = 0;
 
-	$key = 'recent-' . $user_info['id'] . '-' . md5(json_encode(array_diff_key($query_parameters, array('max_id_msg' => 0)))) . '-' . (int) $_REQUEST['start'];
+	$key = 'recent-' . $user_info['id'] . '-' . md5($smcFunc['json_decode'](array_diff_key($query_parameters, array('max_id_msg' => 0)))) . '-' . (int) $_REQUEST['start'];
 	if (!$context['is_redirect'] && (empty($modSettings['cache_enable']) || ($messages = cache_get_data($key, 120)) == null))
 	{
 		$done = false;

--- a/Sources/RemoveTopic.php
+++ b/Sources/RemoveTopic.php
@@ -478,7 +478,7 @@ function removeTopics($topics, $decreasePostCount = true, $ignoreRecycling = fal
 	// Delete possible search index entries.
 	if (!empty($modSettings['search_custom_index_config']))
 	{
-		$customIndexSettings = smf_json_decode($modSettings['search_custom_index_config'], true);
+		$customIndexSettings = $smcFunc['json_decode']($modSettings['search_custom_index_config'], true);
 
 		$words = array();
 		$messages = array();
@@ -962,7 +962,7 @@ function removeMessage($message, $decreasePostCount = true)
 
 		if (!empty($modSettings['search_custom_index_config']))
 		{
-			$customIndexSettings = smf_json_decode($modSettings['search_custom_index_config'], true);
+			$customIndexSettings = $smcFunc['json_decode']($modSettings['search_custom_index_config'], true);
 			$words = text2words($row['body'], $customIndexSettings['bytes_per_word'], true);
 			if (!empty($words))
 				$smcFunc['db_query']('', '

--- a/Sources/ReportToMod.php
+++ b/Sources/ReportToMod.php
@@ -326,7 +326,7 @@ function reportPost($msg, $reason)
 		$smcFunc['db_insert']('insert',
 			'{db_prefix}background_tasks',
 			array('task_file' => 'string', 'task_class' => 'string', 'task_data' => 'string', 'claimed_time' => 'int'),
-			array('$sourcedir/tasks/MsgReport-Notify.php', 'MsgReport_Notify_Background', json_encode(array(
+			array('$sourcedir/tasks/MsgReport-Notify.php', 'MsgReport_Notify_Background', $smcFunc['json_encode'](array(
 				'report_id' => $id_report,
 				'msg_id' => $_POST['msg'],
 				'topic_id' => $message['id_topic'],
@@ -447,7 +447,7 @@ function reportUser($id_member, $reason)
 		$smcFunc['db_insert']('insert',
 			'{db_prefix}background_tasks',
 			array('task_file' => 'string', 'task_class' => 'string', 'task_data' => 'string', 'claimed_time' => 'int'),
-			array('$sourcedir/tasks/MemberReport-Notify.php', 'MemberReport_Notify_Background', json_encode(array(
+			array('$sourcedir/tasks/MemberReport-Notify.php', 'MemberReport_Notify_Background', $smcFunc['json_encode'](array(
 				'report_id' => $id_report,
 				'user_id' => $user['id_member'],
 				'user_name' => $user_name,

--- a/Sources/ScheduledTasks.php
+++ b/Sources/ScheduledTasks.php
@@ -1562,7 +1562,7 @@ function scheduled_paid_subscriptions()
 				'content_id' => $row['id_sublog'],
 				'content_action' => 'expiring',
 				'is_read' => 0,
-				'extra' => json_encode(array(
+				'extra' => $smcFunc['json_encode'](array(
 					'subscription_name' => $row['name'],
 					'end_time' => strip_tags(timeformat($row['end_time'])),
 				)),
@@ -1602,13 +1602,13 @@ function scheduled_paid_subscriptions()
  */
 function scheduled_remove_temp_attachments()
 {
-	global $modSettings, $context, $txt;
+	global $smcFunc, $modSettings, $context, $txt;
 
 	// We need to know where this thing is going.
 	if (!empty($modSettings['currentAttachmentUploadDir']))
 	{
 		if (!is_array($modSettings['attachmentUploadDir']))
-			$modSettings['attachmentUploadDir'] = smf_json_decode($modSettings['attachmentUploadDir'], true);
+			$modSettings['attachmentUploadDir'] = $smcFunc['json_decode']($modSettings['attachmentUploadDir'], true);
 
 		// Just use the current path for temp files.
 		$attach_dirs = $modSettings['attachmentUploadDir'];

--- a/Sources/SearchAPI-Custom.php
+++ b/Sources/SearchAPI-Custom.php
@@ -45,7 +45,7 @@ class custom_search extends search_api
 	 */
 	public function __construct()
 	{
-		global $modSettings, $db_type;
+		global $smcFunc, $modSettings, $db_type;
 
 		// Is this database supported?
 		if (!in_array($db_type, $this->supported_databases))
@@ -57,7 +57,7 @@ class custom_search extends search_api
 		if (empty($modSettings['search_custom_index_config']))
 			return;
 
-		$this->indexSettings = smf_json_decode($modSettings['search_custom_index_config'], true);
+		$this->indexSettings = $smcFunc['json_decode']($modSettings['search_custom_index_config'], true);
 
 		$this->bannedWords = empty($modSettings['search_stopwords']) ? array() : explode(',', $modSettings['search_stopwords']);
 		$this->min_word_length = $this->indexSettings['bytes_per_word'];
@@ -232,7 +232,7 @@ class custom_search extends search_api
 	{
 		global $modSettings, $smcFunc;
 
-		$customIndexSettings = smf_json_decode($modSettings['search_custom_index_config'], true);
+		$customIndexSettings = $smcFunc['json_decode']($modSettings['search_custom_index_config'], true);
 
 		$inserts = array();
 		foreach (text2words($msgOptions['body'], $customIndexSettings['bytes_per_word'], true) as $word)
@@ -256,7 +256,7 @@ class custom_search extends search_api
 
 		if (isset($msgOptions['body']))
 		{
-			$customIndexSettings = smf_json_decode($modSettings['search_custom_index_config'], true);
+			$customIndexSettings = $smcFunc['json_decode']($modSettings['search_custom_index_config'], true);
 			$stopwords = empty($modSettings['search_stopwords']) ? array() : explode(',', $modSettings['search_stopwords']);
 			$old_body = isset($msgOptions['old_body']) ? $msgOptions['old_body'] : '';
 

--- a/Sources/Subs-Admin.php
+++ b/Sources/Subs-Admin.php
@@ -457,7 +457,7 @@ function updateAdminPreferences()
 		return false;
 
 	// This is what we'll be saving.
-	$options['admin_preferences'] = json_encode($context['admin_preferences']);
+	$options['admin_preferences'] = $smcFunc['json_encode']($context['admin_preferences']);
 
 	// Just check we haven't ended up with something theme exclusive somehow.
 	$smcFunc['db_query']('', '

--- a/Sources/Subs-Attachments.php
+++ b/Sources/Subs-Attachments.php
@@ -25,7 +25,7 @@ if (!defined('SMF'))
  */
 function automanage_attachments_check_directory()
 {
-	global $boarddir, $modSettings, $context;
+	global $smcFunc, $boarddir, $modSettings, $context;
 
 	// Not pretty, but since we don't want folders created for every post. It'll do unless a better solution can be found.
 	if (isset($_REQUEST['action']) && $_REQUEST['action'] == 'admin')
@@ -55,7 +55,7 @@ function automanage_attachments_check_directory()
 	if (!empty($modSettings['attachment_basedirectories']) && !empty($modSettings['use_subdirectories_for_attachments']))
 	{
 			if (!is_array($modSettings['attachment_basedirectories']))
-				$modSettings['attachment_basedirectories'] = smf_json_decode($modSettings['attachment_basedirectories'], true);
+				$modSettings['attachment_basedirectories'] = $smcFunc['json_decode']($modSettings['attachment_basedirectories'], true);
 			$base_dir = array_search($modSettings['basedirectory_for_attachments'], $modSettings['attachment_basedirectories']);
 	}
 	else
@@ -66,7 +66,7 @@ function automanage_attachments_check_directory()
 		if (!isset($modSettings['last_attachments_directory']))
 			$modSettings['last_attachments_directory'] = array();
 		if (!is_array($modSettings['last_attachments_directory']))
-			$modSettings['last_attachments_directory'] = smf_json_decode($modSettings['last_attachments_directory'], true);
+			$modSettings['last_attachments_directory'] = $smcFunc['json_decode']($modSettings['last_attachments_directory'], true);
 		if (!isset($modSettings['last_attachments_directory'][$base_dir]))
 			$modSettings['last_attachments_directory'][$base_dir] = 0;
 	}
@@ -98,7 +98,7 @@ function automanage_attachments_check_directory()
 	}
 
 	if (!is_array($modSettings['attachmentUploadDir']))
-		$modSettings['attachmentUploadDir'] = smf_json_decode($modSettings['attachmentUploadDir'], true);
+		$modSettings['attachmentUploadDir'] = $smcFunc['json_decode']($modSettings['attachmentUploadDir'], true);
 	if (!in_array($updir, $modSettings['attachmentUploadDir']) && !empty($updir))
 		$outputCreation = automanage_attachments_create_directory($updir);
 	elseif (in_array($updir, $modSettings['attachmentUploadDir']))
@@ -126,7 +126,7 @@ function automanage_attachments_check_directory()
  */
 function automanage_attachments_create_directory($updir)
 {
-	global $modSettings, $context, $boarddir;
+	global $smcFunc, $modSettings, $context, $boarddir;
 
 	$tree = get_directory_tree_elements($updir);
 	$count = count($tree);
@@ -181,10 +181,10 @@ function automanage_attachments_create_directory($updir)
 		$modSettings['attachmentUploadDir'][$modSettings['currentAttachmentUploadDir']] = $updir;
 
 		updateSettings(array(
-			'attachmentUploadDir' => json_encode($modSettings['attachmentUploadDir']),
+			'attachmentUploadDir' => $smcFunc['json_encode']($modSettings['attachmentUploadDir']),
 			'currentAttachmentUploadDir' => $modSettings['currentAttachmentUploadDir'],
 		), true);
-		$modSettings['attachmentUploadDir'] = smf_json_decode($modSettings['attachmentUploadDir'], true);
+		$modSettings['attachmentUploadDir'] = $smcFunc['json_decode']($modSettings['attachmentUploadDir'], true);
 	}
 
 	$context['attach_dir'] = $modSettings['attachmentUploadDir'][$modSettings['currentAttachmentUploadDir']];
@@ -199,7 +199,7 @@ function automanage_attachments_create_directory($updir)
  */
 function automanage_attachments_by_space()
 {
-	global $modSettings, $boarddir;
+	global $smcFunc, $modSettings, $boarddir;
 
 	if (!isset($modSettings['automanage_attachments']) || (!empty($modSettings['automanage_attachments']) && $modSettings['automanage_attachments'] != 1))
 		return;
@@ -229,10 +229,10 @@ function automanage_attachments_by_space()
 	{
 		$modSettings['currentAttachmentUploadDir'] = array_search($updir, $modSettings['attachmentUploadDir']);
 		updateSettings(array(
-			'last_attachments_directory' => json_encode($modSettings['last_attachments_directory']),
+			'last_attachments_directory' => $smcFunc['json_encode']($modSettings['last_attachments_directory']),
 			'currentAttachmentUploadDir' => $modSettings['currentAttachmentUploadDir'],
 		));
-		$modSettings['last_attachments_directory'] = smf_json_decode($modSettings['last_attachments_directory'], true);
+		$modSettings['last_attachments_directory'] = $smcFunc['json_decode']($modSettings['last_attachments_directory'], true);
 
 		return true;
 	}
@@ -307,7 +307,7 @@ function processAttachments()
 		automanage_attachments_check_directory();
 
 	if (!is_array($modSettings['attachmentUploadDir']))
-		$modSettings['attachmentUploadDir'] = smf_json_decode($modSettings['attachmentUploadDir'], true);
+		$modSettings['attachmentUploadDir'] = $smcFunc['json_decode']($modSettings['attachmentUploadDir'], true);
 
 	$context['attach_dir'] = $modSettings['attachmentUploadDir'][$modSettings['currentAttachmentUploadDir']];
 
@@ -700,7 +700,7 @@ function createAttachment(&$attachmentOptions)
 	call_integration_hook('integrate_createAttachment', array(&$attachmentOptions));
 
 	// Make sure the folder is valid...
-	$tmp = is_array($modSettings['attachmentUploadDir']) ? $modSettings['attachmentUploadDir'] : smf_json_decode($modSettings['attachmentUploadDir'], true);
+	$tmp = is_array($modSettings['attachmentUploadDir']) ? $modSettings['attachmentUploadDir'] : $smcFunc['json_decode']($modSettings['attachmentUploadDir'], true);
 	$folders = array_keys($tmp);
 	if (empty($attachmentOptions['id_folder']) || !in_array($attachmentOptions['id_folder'], $folders))
 		$attachmentOptions['id_folder'] = $modSettings['currentAttachmentUploadDir'];
@@ -1168,7 +1168,7 @@ function loadAttachmentContext($id_msg, $attachments)
 						if (!empty($modSettings['currentAttachmentUploadDir']))
 						{
 							if (!is_array($modSettings['attachmentUploadDir']))
-								$modSettings['attachmentUploadDir'] = smf_json_decode($modSettings['attachmentUploadDir'], true);
+								$modSettings['attachmentUploadDir'] = $smcFunc['json_decode']($modSettings['attachmentUploadDir'], true);
 							$id_folder_thumb = $modSettings['currentAttachmentUploadDir'];
 						}
 						else

--- a/Sources/Subs-Auth.php
+++ b/Sources/Subs-Auth.php
@@ -29,7 +29,7 @@ if (!defined('SMF'))
  */
 function setLoginCookie($cookie_length, $id, $password = '')
 {
-	global $cookiename, $boardurl, $modSettings, $sourcedir;
+	global $smcFunc, $cookiename, $boardurl, $modSettings, $sourcedir;
 
 	$id = (int) $id;
 
@@ -40,7 +40,7 @@ function setLoginCookie($cookie_length, $id, $password = '')
 	$cookie_state = (empty($modSettings['localCookies']) ? 0 : 1) | (empty($modSettings['globalCookies']) ? 0 : 2);
 	if (isset($_COOKIE[$cookiename]) && preg_match('~^a:[34]:\{i:0;i:\d{1,7};i:1;s:(0|128):"([a-fA-F0-9]{128})?";i:2;[id]:\d{1,14};(i:3;i:\d;)?\}$~', $_COOKIE[$cookiename]) === 1)
 	{
-		$array = smf_json_decode($_COOKIE[$cookiename], true);
+		$array = $smcFunc['json_decode']($_COOKIE[$cookiename], true);
 
 		// Legacy format
 		if (is_null($array))
@@ -50,12 +50,12 @@ function setLoginCookie($cookie_length, $id, $password = '')
 		if (isset($array[3]) && $array[3] != $cookie_state)
 		{
 			$cookie_url = url_parts($array[3] & 1 > 0, $array[3] & 2 > 0);
-			smf_setcookie($cookiename, json_encode(array(0, '', 0)), time() - 3600, $cookie_url[1], $cookie_url[0]);
+			smf_setcookie($cookiename, $smcFunc['json_encode'](array(0, '', 0)), time() - 3600, $cookie_url[1], $cookie_url[0]);
 		}
 	}
 
 	// Get the data and path to set it on.
-	$data = json_encode(empty($id) ? array(0, '', 0) : array($id, $password, time() + $cookie_length, $cookie_state));
+	$data = $smcFunc['json_encode'](empty($id) ? array(0, '', 0) : array($id, $password, time() + $cookie_length, $cookie_state));
 	$cookie_url = url_parts(!empty($modSettings['localCookies']), !empty($modSettings['globalCookies']));
 
 	// Set the cookie, $_COOKIE, and session variable.
@@ -121,7 +121,7 @@ function setLoginCookie($cookie_length, $id, $password = '')
  */
 function setTFACookie($cookie_length, $id, $secret, $preserve = false)
 {
-	global $modSettings, $cookiename;
+	global $smcFunc, $modSettings, $cookiename;
 
 	$identifier = $cookiename . '_tfa';
 	$cookie_state = (empty($modSettings['localCookies']) ? 0 : 1) | (empty($modSettings['globalCookies']) ? 0 : 2);
@@ -130,7 +130,7 @@ function setTFACookie($cookie_length, $id, $secret, $preserve = false)
 		$cookie_length = 81600 * 30;
 
 	// Get the data and path to set it on.
-	$data = json_encode(empty($id) ? array(0, '', 0, $cookie_state, false) : array($id, $secret, time() + $cookie_length, $cookie_state, $preserve));
+	$data = $smcFunc['json_encode'](empty($id) ? array(0, '', 0, $cookie_state, false) : array($id, $secret, time() + $cookie_length, $cookie_state, $preserve));
 	$cookie_url = url_parts(!empty($modSettings['localCookies']), !empty($modSettings['globalCookies']));
 
 	// Set the cookie, $_COOKIE, and session variable.

--- a/Sources/Subs-Calendar.php
+++ b/Sources/Subs-Calendar.php
@@ -1045,7 +1045,7 @@ function insertEvent(&$eventOptions)
 		$smcFunc['db_insert']('insert',
 			'{db_prefix}background_tasks',
 			array('task_file' => 'string', 'task_class' => 'string', 'task_data' => 'string', 'claimed_time' => 'int'),
-			array('$sourcedir/tasks/EventNew-Notify.php', 'EventNew_Notify_Background', json_encode(array(
+			array('$sourcedir/tasks/EventNew-Notify.php', 'EventNew_Notify_Background', $smcFunc['json_encode'](array(
 				'event_title' => $eventOptions['title'],
 				'event_id' => $eventOptions['id'],
 				'sender_id' => $eventOptions['member'],

--- a/Sources/Subs-Charset.php
+++ b/Sources/Subs-Charset.php
@@ -582,7 +582,7 @@ function fix_serialized_columns()
 					WHERE id_action = {int:current_action}',
 					array(
 						'current_action' => $row['id_action'],
-						'extra' => json_encode(safe_unserialize($temp)),
+						'extra' => $smcFunc['json_encode'](safe_unserialize($temp)),
 					)
 				);
 		}

--- a/Sources/Subs-Editor.php
+++ b/Sources/Subs-Editor.php
@@ -2091,7 +2091,7 @@ function create_control_verification(&$verificationOptions, $do_test = false)
 				$id_question = $row['id_question'];
 				unset ($row['id_question']);
 				// Make them all lowercase. We can't directly use $smcFunc['strtolower'] with array_walk, so do it manually, eh?
-				$row['answers'] = smf_json_decode($row['answers'], true);
+				$row['answers'] = $smcFunc['json_decode']($row['answers'], true);
 				foreach ($row['answers'] as $k => $v)
 					$row['answers'][$k] = $smcFunc['strtolower']($v);
 
@@ -2304,7 +2304,7 @@ function create_control_verification(&$verificationOptions, $do_test = false)
  */
 function AutoSuggestHandler($checkRegistered = null)
 {
-	global $context;
+	global $smcFunc, $context;
 
 	// These are all registered types.
 	$searchTypes = array(
@@ -2323,7 +2323,7 @@ function AutoSuggestHandler($checkRegistered = null)
 	loadTemplate('Xml');
 
 	// Any parameters?
-	$context['search_param'] = isset($_REQUEST['search_param']) ? smf_json_decode(base64_decode($_REQUEST['search_param']), true) : array();
+	$context['search_param'] = isset($_REQUEST['search_param']) ? $smcFunc['json_decode'](base64_decode($_REQUEST['search_param']), true) : array();
 
 	if (isset($_REQUEST['suggest_type'], $_REQUEST['search']) && isset($searchTypes[$_REQUEST['suggest_type']]))
 	{

--- a/Sources/Subs-Members.php
+++ b/Sources/Subs-Members.php
@@ -1278,7 +1278,7 @@ function BuddyListToggle()
 			$smcFunc['db_insert']('insert',
 				'{db_prefix}background_tasks',
 				array('task_file' => 'string', 'task_class' => 'string', 'task_data' => 'string', 'claimed_time' => 'int'),
-				array('$sourcedir/tasks/Buddy-Notify.php', 'Buddy_Notify_Background', json_encode(array(
+				array('$sourcedir/tasks/Buddy-Notify.php', 'Buddy_Notify_Background', $smcFunc['json_encode'](array(
 					'receiver_id' => $userReceiver,
 					'id_member' => $user_info['id'],
 					'member_name' => $user_info['username'],

--- a/Sources/Subs-MembersOnline.php
+++ b/Sources/Subs-MembersOnline.php
@@ -64,7 +64,7 @@ function getMembersOnlineStats($membersOnlineOptions)
 	$spiders = array();
 	$spider_finds = array();
 	if (!empty($modSettings['show_spider_online']) && ($modSettings['show_spider_online'] < 3 || allowedTo('admin_forum')) && !empty($modSettings['spider_name_cache']))
-		$spiders = smf_json_decode($modSettings['spider_name_cache'], true);
+		$spiders = $smcFunc['json_decode']($modSettings['spider_name_cache'], true);
 
 	// Load the users online right now.
 	$request = $smcFunc['db_query']('', '

--- a/Sources/Subs-Menu.php
+++ b/Sources/Subs-Menu.php
@@ -24,7 +24,7 @@ if (!defined('SMF'))
  */
 function createMenu($menuData, $menuOptions = array())
 {
-	global $context, $settings, $txt, $scripturl, $user_info;
+	global $smcFunc, $context, $settings, $txt, $scripturl, $user_info;
 
 	/* Note menuData is array of form:
 
@@ -122,7 +122,7 @@ function createMenu($menuData, $menuOptions = array())
 
 						// Does this area have its own icon?
 						if (!isset($area['force_menu_into_arms_of_another_menu']) && $user_info['name'] == 'iamanoompaloompa')
-							$menu_context['sections'][$section_id]['areas'][$area_id] = smf_json_decode(base64_decode('eyJsYWJlbCI6Ik9vbXBhIExvb21wYSIsInVybCI6Imh0dHBzOlwvXC9lbi53aWtpcGVkaWEub3JnXC93aWtpXC9Pb21wYV9Mb29tcGFzPyIsImljb24iOiI8aW1nIHNyYz1cImh0dHBzOlwvXC93d3cuc2ltcGxlbWFjaGluZXMub3JnXC9pbWFnZXNcL29vbXBhLmdpZlwiIGFsdD1cIkknbSBhbiBPb21wYSBMb29tcGFcIiBcLz4ifQ=='), true);
+							$menu_context['sections'][$section_id]['areas'][$area_id] = $smcFunc['json_decode'](base64_decode('eyJsYWJlbCI6Ik9vbXBhIExvb21wYSIsInVybCI6Imh0dHBzOlwvXC9lbi53aWtpcGVkaWEub3JnXC93aWtpXC9Pb21wYV9Mb29tcGFzPyIsImljb24iOiI8aW1nIHNyYz1cImh0dHBzOlwvXC93d3cuc2ltcGxlbWFjaGluZXMub3JnXC9pbWFnZXNcL29vbXBhLmdpZlwiIGFsdD1cIkknbSBhbiBPb21wYSBMb29tcGFcIiBcLz4ifQ=='), true);
 						elseif (isset($area['icon']) && file_exists($settings['theme_dir'] . '/images/admin/' . $area['icon']))
 							$menu_context['sections'][$section_id]['areas'][$area_id]['icon'] = '<img src="' . $settings['images_url'] . '/admin/' . $area['icon'] . '" alt="">';
 						elseif (isset($area['icon']) && file_exists($settings['default_theme_dir'] . '/images/admin/' . $area['icon']))

--- a/Sources/Subs-Post.php
+++ b/Sources/Subs-Post.php
@@ -922,7 +922,7 @@ function sendpm($recipients, $subject, $message, $store_outbox = false, $from = 
 	// Check whether we have to apply anything...
 	while ($row = $smcFunc['db_fetch_assoc']($request))
 	{
-		$criteria = smf_json_decode($row['criteria'], true);
+		$criteria = $smcFunc['json_decode']($row['criteria'], true);
 		// Note we don't check the buddy status, cause deletion from buddy = madness!
 		$delete = false;
 		foreach ($criteria as $criterium)
@@ -1614,7 +1614,7 @@ function sendNotifications($topics, $type, $exclude = array(), $members_only = a
 		$row['body'] = trim(un_htmlspecialchars(strip_tags(strtr(parse_bbc($row['body'], false, $row['id_last_msg']), array('<br>' => "\n", '</div>' => "\n", '</li>' => "\n", '&#91;' => '[', '&#93;' => ']')))));
 
 		$task_rows[] = array(
-			'$sourcedir/tasks/CreatePost-Notify.php', 'CreatePost_Notify_Background', json_encode(array(
+			'$sourcedir/tasks/CreatePost-Notify.php', 'CreatePost_Notify_Background', $smcFunc['json_encode'](array(
 				'msgOptions' => array(
 					'id' => $row['id_msg'],
 					'subject' => $row['subject'],
@@ -1942,7 +1942,7 @@ function createPost(&$msgOptions, &$topicOptions, &$posterOptions)
 			'{db_prefix}background_tasks',
 			array('task_file' => 'string', 'task_class' => 'string', 'task_data' => 'string', 'claimed_time' => 'int'),
 			array(
-				'$sourcedir/tasks/ApprovePost-Notify.php', 'ApprovePost_Notify_Background', json_encode(array(
+				'$sourcedir/tasks/ApprovePost-Notify.php', 'ApprovePost_Notify_Background', $smcFunc['json_encode'](array(
 					'msgOptions' => $msgOptions,
 					'topicOptions' => $topicOptions,
 					'posterOptions' => $posterOptions,
@@ -1990,7 +1990,7 @@ function createPost(&$msgOptions, &$topicOptions, &$posterOptions)
 			'{db_prefix}background_tasks',
 			array('task_file' => 'string', 'task_class' => 'string', 'task_data' => 'string', 'claimed_time' => 'int'),
 			array(
-				'$sourcedir/tasks/ApproveReply-Notify.php', 'ApproveReply_Notify_Background', json_encode(array(
+				'$sourcedir/tasks/ApproveReply-Notify.php', 'ApproveReply_Notify_Background', $smcFunc['json_encode'](array(
 					'msgOptions' => $msgOptions,
 					'topicOptions' => $topicOptions,
 					'posterOptions' => $posterOptions,
@@ -2033,7 +2033,7 @@ function createPost(&$msgOptions, &$topicOptions, &$posterOptions)
 		$smcFunc['db_insert']('',
 			'{db_prefix}background_tasks',
 			array('task_file' => 'string', 'task_class' => 'string', 'task_data' => 'string', 'claimed_time' => 'int'),
-			array('$sourcedir/tasks/CreatePost-Notify.php', 'CreatePost_Notify_Background', json_encode(array(
+			array('$sourcedir/tasks/CreatePost-Notify.php', 'CreatePost_Notify_Background', $smcFunc['json_encode'](array(
 				'msgOptions' => $msgOptions,
 				'topicOptions' => $topicOptions,
 				'posterOptions' => $posterOptions,
@@ -2146,7 +2146,7 @@ function modifyPost(&$msgOptions, &$topicOptions, &$posterOptions)
 			$smcFunc['db_insert']('',
 				'{db_prefix}background_tasks',
 				array('task_file' => 'string', 'task_class' => 'string', 'task_data' => 'string', 'claimed_time' => 'int'),
-				array('$sourcedir/tasks/CreatePost-Notify.php', 'CreatePost_Notify_Background', json_encode(array(
+				array('$sourcedir/tasks/CreatePost-Notify.php', 'CreatePost_Notify_Background', $smcFunc['json_encode'](array(
 					'msgOptions' => $msgOptions,
 					'topicOptions' => $topicOptions,
 					'posterOptions' => $posterOptions,
@@ -2446,7 +2446,7 @@ function approvePosts($msgs, $approve = true, $notify = true)
 		$task_rows = array();
 		foreach (array_merge($notification_topics, $notification_posts) as $topic)
 			$task_rows[] = array(
-				'$sourcedir/tasks/CreatePost-Notify.php', 'CreatePost_Notify_Background', json_encode(array(
+				'$sourcedir/tasks/CreatePost-Notify.php', 'CreatePost_Notify_Background', $smcFunc['json_encode'](array(
 					'msgOptions' => array(
 						'id' => $topic['msg'],
 						'body' => $topic['body'],
@@ -2721,7 +2721,7 @@ function adminNotify($type, $memberID, $member_name = null)
 	$smcFunc['db_insert']('insert',
 		'{db_prefix}background_tasks',
 		array('task_file' => 'string', 'task_class' => 'string', 'task_data' => 'string', 'claimed_time' => 'int'),
-		array('$sourcedir/tasks/Register-Notify.php', 'Register_Notify_Background', json_encode(array(
+		array('$sourcedir/tasks/Register-Notify.php', 'Register_Notify_Background', $smcFunc['json_encode'](array(
 			'new_member_id' => $memberID,
 			'new_member_name' => $member_name,
 			'notify_type' => $type,

--- a/Sources/Subs-ReportedContent.php
+++ b/Sources/Subs-ReportedContent.php
@@ -619,7 +619,7 @@ function saveModComment($report_id, $data)
 		$smcFunc['db_insert']('insert',
 			'{db_prefix}background_tasks',
 			array('task_file' => 'string', 'task_class' => 'string', 'task_data' => 'string', 'claimed_time' => 'int'),
-			array('$sourcedir/tasks/' . $prefix . 'ReportReply-Notify.php', $prefix . 'ReportReply_Notify_Background', json_encode($data), 0),
+			array('$sourcedir/tasks/' . $prefix . 'ReportReply-Notify.php', $prefix . 'ReportReply_Notify_Background', $smcFunc['json_encode']($data), 0),
 			array('id_task')
 		);
 }

--- a/Sources/Subs-Themes.php
+++ b/Sources/Subs-Themes.php
@@ -168,7 +168,7 @@ function get_all_themes($enable_only = false)
  */
 function get_theme_info($path)
 {
-	global $sourcedir, $forum_version, $txt, $scripturl, $context;
+	global $smcFunc, $sourcedir, $forum_version, $txt, $scripturl, $context;
 	global $explicit_images;
 
 	if (empty($path))
@@ -244,7 +244,7 @@ function get_theme_info($path)
 	}
 
 	if (!empty($theme_info_xml['extra']))
-		$xml_data += smf_json_decode($theme_info_xml['extra'], true);
+		$xml_data += $smcFunc['json_decode']($theme_info_xml['extra'], true);
 
 	return $xml_data;
 }

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -960,7 +960,7 @@ function permute($array)
  */
 function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = array())
 {
-	global $txt, $scripturl, $context, $modSettings, $user_info, $sourcedir;
+	global $smcFunce, $txt, $scripturl, $context, $modSettings, $user_info, $sourcedir;
 	static $bbc_codes = array(), $itemcodes = array(), $no_autolink_tags = array();
 	static $disabled;
 
@@ -1765,7 +1765,7 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 	if ($cache_id != '' && !empty($modSettings['cache_enable']) && (($modSettings['cache_enable'] >= 2 && isset($message[1000])) || isset($message[2400])) && empty($parse_tags))
 	{
 		// It's likely this will change if the message is modified.
-		$cache_key = 'parse:' . $cache_id . '-' . md5(md5($message) . '-' . $smileys . (empty($disabled) ? '' : implode(',', array_keys($disabled))) . json_encode($context['browser']) . $txt['lang_locale'] . $user_info['time_offset'] . $user_info['time_format']);
+		$cache_key = 'parse:' . $cache_id . '-' . md5(md5($message) . '-' . $smileys . (empty($disabled) ? '' : implode(',', array_keys($disabled))) . $smcFunc['json_encode']($context['browser']) . $txt['lang_locale'] . $user_info['time_offset'] . $user_info['time_format']);
 
 		if (($temp = cache_get_data($cache_key, 240)) != null)
 			return $temp;
@@ -4946,7 +4946,7 @@ function get_gravatar_url($email_address)
  */
 function smf_list_timezones($when = 'now')
 {
-	global $modSettings;
+	global $smcFunc, $modSettings;
 	static $timezones = null, $lastwhen = null;
 
 	// No point doing this over if we already did it once
@@ -5050,7 +5050,7 @@ function smf_list_timezones($when = 'now')
 
 		$tzinfo[0]['abbr'] = fix_tz_abbrev($tzid, $tzinfo[0]['abbr']);
 
-		$tzkey = json_encode($tzinfo);
+		$tzkey = $smcFunc['json_encode']($tzinfo);
 
 		// Next, get the geographic info for this tzid
 		$tzgeo = timezone_location_get($tz);
@@ -5079,7 +5079,7 @@ function smf_list_timezones($when = 'now')
 	foreach ($zones as $tzkey => $tzvalue)
 	{
 		// !!! TODO: Why encode this and then decode it here?
-		$tzinfo = smf_json_decode($tzkey, true);
+		$tzinfo = $smcFunc['json_decode']($tzkey, true);
 
 		date_timezone_set($date_when, timezone_open($tzvalue['tzid']));
 

--- a/Sources/Themes.php
+++ b/Sources/Themes.php
@@ -1627,13 +1627,13 @@ function SetJavaScript()
 	// If this is the admin preferences the passed value will just be an element of it.
 	if ($_GET['var'] == 'admin_preferences')
 	{
-		$options['admin_preferences'] = !empty($options['admin_preferences']) ? smf_json_decode($options['admin_preferences'], true) : array();
+		$options['admin_preferences'] = !empty($options['admin_preferences']) ? $smcFunc['json_decode']($options['admin_preferences'], true) : array();
 		// New thingy...
 		if (isset($_GET['admin_key']) && strlen($_GET['admin_key']) < 5)
 			$options['admin_preferences'][$_GET['admin_key']] = $_GET['val'];
 
 		// Change the value to be something nice,
-		$_GET['val'] = json_encode($options['admin_preferences']);
+		$_GET['val'] = $smcFunc['json_encode']($options['admin_preferences']);
 	}
 
 	// Update the option.

--- a/Sources/Who.php
+++ b/Sources/Who.php
@@ -155,7 +155,7 @@ function Who()
 	$url_data = array();
 	while ($row = $smcFunc['db_fetch_assoc']($request))
 	{
-		$actions = smf_json_decode($row['url'], true);
+		$actions = $smcFunc['json_decode']($row['url'], true);
 		if ($actions === false)
 			continue;
 
@@ -195,7 +195,7 @@ function Who()
 	$spiderContext = array();
 	if (!empty($modSettings['show_spider_online']) && ($modSettings['show_spider_online'] == 2 || allowedTo('admin_forum')) && !empty($modSettings['spider_name_cache']))
 	{
-		foreach (smf_json_decode($modSettings['spider_name_cache'], true) as $id => $name)
+		foreach ($smcFunc['json_decode']($modSettings['spider_name_cache'], true) as $id => $name)
 			$spiderContext[$id] = array(
 				'id' => 0,
 				'name' => $name,
@@ -306,7 +306,7 @@ function determineActions($urls, $preferred_prefix = false)
 	foreach ($url_list as $k => $url)
 	{
 		// Get the request parameters..
-		$actions = smf_json_decode($url[0], true);
+		$actions = $smcFunc['json_decode']($url[0], true);
 		if ($actions === false)
 			continue;
 
@@ -811,7 +811,7 @@ function Credits($in_admin = false)
 
 		while ($row = $smcFunc['db_fetch_assoc']($request))
 		{
-			$credit_info = smf_json_decode($row['credits'], true);
+			$credit_info = $smcFunc['json_decode']($row['credits'], true);
 
 			$copyright = empty($credit_info['copyright']) ? '' : $txt['credits_copyright'] . ' &copy; ' . $smcFunc['htmlspecialchars']($credit_info['copyright']);
 			$license = empty($credit_info['license']) ? '' : $txt['credits_license'] . ': ' . (!empty($credit_info['licenseurl']) ? '<a href="'. $smcFunc['htmlspecialchars']($credit_info['licenseurl']) .'">'. $smcFunc['htmlspecialchars']($credit_info['license']) .'</a>' : $smcFunc['htmlspecialchars']($credit_info['license']));

--- a/Sources/tasks/ApprovePost-Notify.php
+++ b/Sources/tasks/ApprovePost-Notify.php
@@ -91,7 +91,7 @@ class ApprovePost_Notify_Background extends SMF_BackgroundTask
 					'content_id' => $topicOptions['id'],
 					'content_action' => $type,
 					'is_read' => 0,
-					'extra' => json_encode(array(
+					'extra' => $smcFunc['json_encode'](array(
 						'topic' => $topicOptions['id'],
 						'board' => $topicOptions['board'],
 						'content_subject' => $msgOptions['subject'],

--- a/Sources/tasks/ApproveReply-Notify.php
+++ b/Sources/tasks/ApproveReply-Notify.php
@@ -84,7 +84,7 @@ class ApproveReply_Notify_Background extends SMF_BackgroundTask
 					'content_id' => $topicOptions['id'],
 					'content_action' => 'reply',
 					'is_read' => 0,
-					'extra' => json_encode(array(
+					'extra' => $smcFunc['json_encode'](array(
 						'topic' => $topicOptions['id'],
 						'board' => $topicOptions['board'],
 						'content_subject' => $msgOptions['subject'],

--- a/Sources/tasks/Birthday-Notify.php
+++ b/Sources/tasks/Birthday-Notify.php
@@ -100,7 +100,7 @@ class Birthday_Notify_Background extends SMF_BackgroundTask
 							'content_id' => 0,
 							'content_action' => 'msg',
 							'is_read' => 0,
-							'extra' => json_encode(array('happy_birthday' => $alertdata['body'])),
+							'extra' => $smcFunc['json_encode'](array('happy_birthday' => $alertdata['body'])),
 						);
 						updateMemberData($member_id, array('alerts' => '+'));
 					}

--- a/Sources/tasks/CreatePost-Notify.php
+++ b/Sources/tasks/CreatePost-Notify.php
@@ -177,7 +177,7 @@ class CreatePost_Notify_Background extends SMF_BackgroundTask
 					'content_id' => $topicOptions['id'],
 					'content_action' => $type,
 					'is_read' => 0,
-					'extra' => json_encode(array(
+					'extra' => $smcFunc['json_encode'](array(
 						'topic' => $topicOptions['id'],
 						'board' => $topicOptions['board'],
 						'content_subject' => $msgOptions['subject'],
@@ -226,7 +226,7 @@ class CreatePost_Notify_Background extends SMF_BackgroundTask
 
 	protected static function handleQuoteNotifications($msgOptions, $posterOptions, $quotedMembers, $prefs, &$done_members, &$alert_rows)
 	{
-		global $modSettings, $language, $scripturl;
+		global $smcFunc, $modSettings, $language, $scripturl;
 
 		foreach ($quotedMembers as $id => $member)
 		{
@@ -259,7 +259,7 @@ class CreatePost_Notify_Background extends SMF_BackgroundTask
 					'content_id' => $msgOptions['id'],
 					'content_action' => 'quote',
 					'is_read' => 0,
-					'extra' => json_encode(array(
+					'extra' => $smcFunc['json_encode'](array(
 						'content_subject' => $msgOptions['subject'],
 						'content_link' => $scripturl . '?msg=' . $msgOptions['id'],
 					)),
@@ -337,7 +337,7 @@ class CreatePost_Notify_Background extends SMF_BackgroundTask
 
 	protected static function handleMentionedNotifications($msgOptions, $members, $prefs, &$done_members, &$alert_rows)
 	{
-		global $scripturl, $language, $modSettings;
+		global $smcFunc, $scripturl, $language, $modSettings;
 
 		foreach ($members as $id => $member)
 		{
@@ -371,7 +371,7 @@ class CreatePost_Notify_Background extends SMF_BackgroundTask
 					'content_id' => $msgOptions['id'],
 					'content_action' => 'mention',
 					'is_read' => 0,
-					'extra' => json_encode(array(
+					'extra' => $smcFunc['json_encode'](array(
 						'content_subject' => $msgOptions['subject'],
 						'content_link' => $scripturl . '?msg=' . $msgOptions['id'],
 					)),

--- a/Sources/tasks/EventNew-Notify.php
+++ b/Sources/tasks/EventNew-Notify.php
@@ -80,7 +80,7 @@ class EventNew_Notify_Background extends SMF_BackgroundTask
 					'content_id' => $this->_details['event_id'],
 					'content_action' => empty($this->_details['sender_id']) ? 'new_guest' : 'new',
 					'is_read' => 0,
-					'extra' => json_encode(
+					'extra' => $smcFunc['json_encode'](
 					    array(
 					        "event_id" => $this->_details['event_id'],
 							"event_title" => $this->_details['event_title']

--- a/Sources/tasks/GroupAct-Notify.php
+++ b/Sources/tasks/GroupAct-Notify.php
@@ -114,7 +114,7 @@ class GroupAct_Notify_Background extends SMF_BackgroundTask
 						'content_id' => 0,
 						'content_action' => $pref_name,
 						'is_read' => 0,
-						'extra' => json_encode(array('group_name' => $user['group_name'], 'reason' => !empty($custom_reason) ? '<br><br>' . $custom_reason : '')),
+						'extra' => $smcFunc['json_encode'](array('group_name' => $user['group_name'], 'reason' => !empty($custom_reason) ? '<br><br>' . $custom_reason : '')),
 					);
 					updateMemberData($user['member_id'], array('alerts' => '+'));
 				}

--- a/Sources/tasks/GroupReq-Notify.php
+++ b/Sources/tasks/GroupReq-Notify.php
@@ -82,7 +82,7 @@ class GroupReq_Notify_Background extends SMF_BackgroundTask
 						'content_id' => 0,
 						'content_action' => 'group_request',
 						'is_read' => 0,
-						'extra' => json_encode(array('group_name' => $this->_details['group_name'])),
+						'extra' => $smcFunc['json_encode'](array('group_name' => $this->_details['group_name'])),
 					);
 				}
 

--- a/Sources/tasks/MemberReport-Notify.php
+++ b/Sources/tasks/MemberReport-Notify.php
@@ -67,7 +67,7 @@ class MemberReport_Notify_Background extends SMF_BackgroundTask
 					'content_id' => $this->_details['user_id'],
 					'content_action' => 'report',
 					'is_read' => 0,
-					'extra' => json_encode(
+					'extra' => $smcFunc['json_encode'](
 						array(
 							'report_link' => '?action=moderate;area=reportedmembers;report=' . $this->_details['report_id'], // We don't put $scripturl in these!
 							'user_name' => $this->_details['user_name'],

--- a/Sources/tasks/MemberReportReply-Notify.php
+++ b/Sources/tasks/MemberReportReply-Notify.php
@@ -94,7 +94,7 @@ class MemberReportReply_Notify_Background extends SMF_BackgroundTask
 					'content_id' => $this->_details['user_id'],
 					'content_action' => 'report_reply',
 					'is_read' => 0,
-					'extra' => json_encode(
+					'extra' => $smcFunc['json_encode'](
 						array(
 							'report_link' => '?action=moderate;area=reportedmembers;sa=details;rid=' . $this->_details['report_id'], // We don't put $scripturl in these!
 							'user_name' => $this->_details['user_name'],

--- a/Sources/tasks/MsgReport-Notify.php
+++ b/Sources/tasks/MsgReport-Notify.php
@@ -102,7 +102,7 @@ class MsgReport_Notify_Background extends SMF_BackgroundTask
 					'content_id' => $this->_details['msg_id'],
 					'content_action' => 'report',
 					'is_read' => 0,
-					'extra' => json_encode(
+					'extra' => $smcFunc['json_encode'](
 						array(
 							'report_link' => '?action=moderate;area=reportedposts;sa=details;rid=' . $this->_details['report_id'], // We don't put $scripturl in these!
 						)

--- a/Sources/tasks/MsgReportReply-Notify.php
+++ b/Sources/tasks/MsgReportReply-Notify.php
@@ -129,7 +129,7 @@ class MsgReportReply_Notify_Background extends SMF_BackgroundTask
 					'content_id' => $this->_details['msg_id'],
 					'content_action' => 'report_reply',
 					'is_read' => 0,
-					'extra' => json_encode(
+					'extra' => $smcFunc['json_encode'](
 						array(
 							'report_link' => '?action=moderate;area=reportedposts;sa=details;rid=' . $this->_details['report_id'], // We don't put $scripturl in these!
 						)

--- a/Themes/default/Packages.template.php
+++ b/Themes/default/Packages.template.php
@@ -1775,14 +1775,14 @@ function template_action_permissions()
 		echo '
 				<input type="hidden" name="custom_value" value="', $context['custom_value'], '">
 				<input type="hidden" name="totalItems" value="', $context['total_items'], '">
-				<input type="hidden" name="toProcess" value="', base64_encode(json_encode($context['to_process'])), '">';
+				<input type="hidden" name="toProcess" value="', $context['to_process_encode'], '">';
 	else
 		echo '
 				<input type="hidden" name="predefined" value="', $context['predefined_type'], '">
 				<input type="hidden" name="fileOffset" value="', $context['file_offset'], '">
 				<input type="hidden" name="totalItems" value="', $context['total_items'], '">
-				<input type="hidden" name="dirList" value="', base64_encode(json_encode($context['directory_list'])), '">
-				<input type="hidden" name="specialFiles" value="', base64_encode(json_encode($context['special_files'])), '">';
+				<input type="hidden" name="dirList" value="', $context['directory_list_encode'], '">
+				<input type="hidden" name="specialFiles" value="', $context['special_files_encode'], '">';
 
 	// Are we not using FTP for whatever reason.
 	if (!empty($context['skip_ftp']))

--- a/cron.php
+++ b/cron.php
@@ -181,7 +181,7 @@ function fetch_task()
  */
 function perform_task($task_details)
 {
-	global $sourcedir, $boarddir;
+	global $smcFunc, $sourcedir, $boarddir;
 
 	// This indicates the file to load.
 	if (!empty($task_details['task_file']))
@@ -201,7 +201,7 @@ function perform_task($task_details)
 	// All background tasks need to be classes.
 	elseif (class_exists($task_details['task_class']) && is_subclass_of($task_details['task_class'], 'SMF_BackgroundTask'))
 	{
-		$details = empty($task_details['task_data']) ? array() : json_decode($task_details['task_data'], true);
+		$details = empty($task_details['task_data']) ? array() : $smcFunc['json_decode']($task_details['task_data'], true);
 		$bgtask = new $task_details['task_class']($details);
 		return $bgtask->execute();
 	}

--- a/subscriptions.php
+++ b/subscriptions.php
@@ -180,14 +180,14 @@ if ($gatewayClass->isRefund())
 // Otherwise is it what we want, a purchase?
 elseif ($gatewayClass->isPayment() || $gatewayClass->isSubscription())
 {
-	$cost = json_decode($subscription_info['cost'], true);
+	$cost = $smcFunc['json_decode']($subscription_info['cost'], true);
 	$total_cost = $gatewayClass->getCost();
 	$notify = false;
 
 	// For one off's we want to only capture them once!
 	if (!$gatewayClass->isSubscription())
 	{
-		$real_details = json_decode($subscription_info['pending_details'], true);
+		$real_details = $smcFunc['json_decode']($subscription_info['pending_details'], true);
 		if (empty($real_details))
 			generateSubscriptionError(sprintf($txt['paid_count_not_find_outstanding_payment'], $member_id, $subscription_id));
 
@@ -201,7 +201,7 @@ elseif ($gatewayClass->isPayment() || $gatewayClass->isSubscription())
 			break;
 		}
 
-		$subscription_info['pending_details'] = empty($real_details) ? '' : json_encode($real_details);
+		$subscription_info['pending_details'] = empty($real_details) ? '' : $smcFunc['json_encode']($real_details);
 
 		$smcFunc['db_query']('', '
 			UPDATE {db_prefix}log_subscribed


### PR DESCRIPTION
Changed all json_(smf_de|en)code\(  to $smcFunc['json_\2code'](
Hopefully ensured $smcFunc is global in said functions

I have not tested this yet.  Getting it here for review and testing.  It should all work just fine though if I didn't miss a $smcFunc global somewhere.

I purposely did not change install or upgrade files because they only appear to load up a basic $smcFunc when they initialize the database.  Sometimes it loads up htmlspecialchars on its own.

Proxy.php can't be updated as it doesn't load SMF, so $smcFunc isn't around.

There is one call in Load.php that I didn't update, I added a comment for that which is because it happens prior to $smcFunc being populated with non database stuff.


Signed-off-by: jdarwood007 <unmonitored+github@sleepycode.com>

