### PR TITLE
Upgrader - fix writable check

### DIFF
--- a/other/upgrade-helper.php
+++ b/other/upgrade-helper.php
@@ -99,6 +99,10 @@ function makeFilesWritable(&$files)
 
 		foreach ($files as $k => $file)
 		{
+			// Some files won't exist, try to address up front
+			if (!file_exists($file))
+				@touch($file);
+			// NOW do the writable check...
 			if (!is_writable($file))
 			{
 				@chmod($file, 0755);
@@ -288,6 +292,12 @@ function makeFilesWritable(&$files)
  */
 function quickFileWritable($file)
 {
+
+	// Some files won't exist, try to address up front
+	if (!file_exists($file))
+		@touch($file);
+
+	// NOW do the writable check...
 	if (is_writable($file))
 		return true;
 

--- a/other/upgrade.php
+++ b/other/upgrade.php
@@ -2365,14 +2365,19 @@ Usage: /path/to/php -f ' . basename(__FILE__) . ' -- [OPTION]...
 		print_error('Error: Some files have not yet been updated properly.');
 
 	// Make sure Settings.php is writable.
-		quickFileWritable($boarddir . '/Settings.php');
+	quickFileWritable($boarddir . '/Settings.php');
 	if (!is_writable($boarddir . '/Settings.php'))
 		print_error('Error: Unable to obtain write access to "Settings.php".', true);
 
 	// Make sure Settings_bak.php is writable.
-		quickFileWritable($boarddir . '/Settings_bak.php');
+	quickFileWritable($boarddir . '/Settings_bak.php');
 	if (!is_writable($boarddir . '/Settings_bak.php'))
 		print_error('Error: Unable to obtain write access to "Settings_bak.php".');
+
+	// Make sure db_last_error.php is writable.
+	quickFileWritable($boarddir . '/db_last_error.php');
+	if (!is_writable($boarddir . '/db_last_error.php'))
+		print_error('Error: Unable to obtain write access to "db_last_error.php".');
 
 	if (isset($modSettings['agreement']) && (!is_writable($boarddir) || file_exists($boarddir . '/agreement.txt')) && !is_writable($boarddir . '/agreement.txt'))
 		print_error('Error: Unable to obtain write access to "agreement.txt".');


### PR DESCRIPTION
Fixes:  Beta 3 Installer: Step 2 Writable Check #4175   But for the UPGRADER this time...    

The basic problem is that the upgrader is erroneously reporting files as non-writable when they just don't exist yet...  

Also checked the same files in the command line as the browser.

Tested in Windows & Linux, issues had been only in Linux