### PR TITLE
Fixed getBoardTree to use query_see_board instead of query_wanna_see_…

### DIFF
--- a/Sources/Subs-Boards.php
+++ b/Sources/Subs-Boards.php
@@ -1329,7 +1329,7 @@ function getBoardTree()
 			' . implode(', ', $boardColumns) . '
 		FROM {db_prefix}categories AS c
 			LEFT JOIN {db_prefix}boards AS b ON (b.id_cat = c.id_cat)
-		WHERE {query_wanna_see_board}
+		WHERE {query_see_board}
 		ORDER BY c.cat_order, b.child_level, b.board_order',
 		$boardParameters
 	);


### PR DESCRIPTION
…board

To reproduce this bug.
1. Install SMF
2. Ignore the default General Board
3. Go to Manage Boards
4. SMF claims no boards or categories exist.

Signed-off-by: jdarwood007 <unmonitored+github@sleepycode.com>