### PR TITLE
Sanitizes $_REQUEST['start'] for topic display in QueryString.php

### DIFF
--- a/Sources/QueryString.php
+++ b/Sources/QueryString.php
@@ -195,10 +195,38 @@ function cleanRequest()
 			list ($_REQUEST['topic'], $_REQUEST['start'], $_REQUEST['page_id']) = explode('.', $_REQUEST['topic'] . '.');
 		}
 
-		$topic = (int) $_REQUEST['topic'];
+		// Topic should always be an integer
+		$topic = $_GET['topic'] = $_REQUEST['topic'] = (int) $_REQUEST['topic'];
 
-		// Now make sure the online log gets the right number.
-		$_GET['topic'] = $topic;
+		// Start could be a lot of things...
+		// ... a simple number ...
+		if (is_numeric($_REQUEST['start']))
+		{
+			$_REQUEST['start'] = (int) $_REQUEST['start'];
+		}
+		// ... or a specific message ...
+		elseif (strpos($_REQUEST['start'], 'msg') === 0)
+		{
+			$virtual_msg = (int) substr($_REQUEST['start'], 3);
+			$_REQUEST['start'] = $virtual_msg === 0 ? 0 : 'msg' . $virtual_msg;
+		}
+		// ... or whatever is new ...
+		elseif (strpos($_REQUEST['start'], 'new') === 0)
+		{
+			$_REQUEST['start'] = 'new';
+		}
+		// ... or since a certain time ...
+		elseif (strpos($_REQUEST['start'], 'from') === 0)
+		{
+			$timestamp = (int) substr($_REQUEST['start'], 4);
+			$_REQUEST['start'] = $timestamp === 0 ? 0 : 'from' . $timestamp;
+		}
+		// ... or something invalid, in which case we reset it to 0.
+		else
+		{
+			$_REQUEST['start'] = 0;
+			unset($_REQUEST['page_id']);
+		}
 	}
 	else
 		$topic = 0;

--- a/Sources/QueryString.php
+++ b/Sources/QueryString.php
@@ -227,6 +227,15 @@ function cleanRequest()
 			$_REQUEST['start'] = 0;
 			unset($_REQUEST['page_id']);
 		}
+
+		if (isset($_REQUEST['page_id']))
+		{
+			$page_id_firstchar = substr($_REQUEST['page_id'], 0, 1);
+			if (in_array($page_id_firstchar, array('L', 'M')))
+				$_REQUEST['page_id'] = $page_id_firstchar . (int) substr($_REQUEST['page_id'], 1);
+			else
+				unset($_REQUEST['page_id']);
+		}
 	}
 	else
 		$topic = 0;

--- a/Sources/QueryString.php
+++ b/Sources/QueryString.php
@@ -223,19 +223,7 @@ function cleanRequest()
 		}
 		// ... or something invalid, in which case we reset it to 0.
 		else
-		{
 			$_REQUEST['start'] = 0;
-			unset($_REQUEST['page_id']);
-		}
-
-		if (isset($_REQUEST['page_id']))
-		{
-			$page_id_firstchar = substr($_REQUEST['page_id'], 0, 1);
-			if (in_array($page_id_firstchar, array('L', 'M')))
-				$_REQUEST['page_id'] = $page_id_firstchar . (int) substr($_REQUEST['page_id'], 1);
-			else
-				unset($_REQUEST['page_id']);
-		}
 	}
 	else
 		$topic = 0;


### PR DESCRIPTION
Plugs a potential security hole by making sure that `$_REQUEST['start']` is always a clean and expected value before Display.php ever even sees it. This ensures that any random cruft (or evil SQL appended by would-be hackers) is dropped before before the start value is passed to the database abstraction layer.

@albertlast will probably want to add something here to sanitize `$_REQUEST['page_id']` according to his expected values for that URL parameter.