### PR TITLE
Raise min PG Version to 9.2

### DIFF
--- a/other/install.php
+++ b/other/install.php
@@ -51,7 +51,7 @@ $databases = array(
 	),
 	'postgresql' => array(
 		'name' => 'PostgreSQL',
-		'version' => '9.1',
+		'version' => '9.2',
 		'function_check' => 'pg_connect',
 		'version_check' => '$request = pg_query(\'SELECT version()\'); list ($version) = pg_fetch_row($request); list($pgl, $version) = explode(" ", $version); return $version;',
 		'supported' => function_exists('pg_connect'),

--- a/other/upgrade.php
+++ b/other/upgrade.php
@@ -37,7 +37,7 @@ $databases = array(
 	),
 	'postgresql' => array(
 		'name' => 'PostgreSQL',
-		'version' => '9.1',
+		'version' => '9.2',
 		'version_check' => '$version = pg_version(); return $version[\'client\'];',
 		'always_has_db' => true,
 	),


### PR DESCRIPTION
I mean we got the discussion last year,
let's bring up the important points:
- the rule for me for smf is the oldest supported version - 1 -> 9.2 get eol sep 2017
- PG get ~once a year a new version when we release smf 2.1 we need to support the existing version (5 versions) + the first eol = 6 additionaly smf 2.1 will stay after release many year (once per year a new version) which get us for examp 5 year runtime 5 additional version of which we should support 
6 + 5 =11 to keep the support "easy" we should not go lower as one below supported
- i got the problem that me as mostly the main "maintainer" for pg support is not able to download/run eol version (i need to look in the documentation if something is supported)

here you find the supported/eol information: https://www.postgresql.org/support/versioning/

Good things:
- range datatypes (the start and the end are one field) -> posible improvment in calendar area https://wiki.postgresql.org/wiki/What%27s_new_in_PostgreSQL_9.2#Range_Types
- first tier of json support https://wiki.postgresql.org/wiki/What%27s_new_in_PostgreSQL_9.2#JSON_datatype