### PR TITLE
More speed calendar

### DIFF
--- a/Sources/Subs-Calendar.php
+++ b/Sources/Subs-Calendar.php
@@ -1591,14 +1591,12 @@ function buildEventDatetimes($row)
 	$end['iso_gmdate'] = gmdate('c', $end['timestamp']);
 
 	// Strings showing the datetimes in the user's preferred format, relative to the user's time zone
-	$test = timeformat($start['timestamp'], $date_format . ' § ' . $time_format);
-	$test_array = explode(' § ', timeformat($start['timestamp'], $date_format . ' § ' . $time_format));
-	list($start['date_local'], $start['time_local']) = explode('§', timeformat($start['timestamp'], $date_format . '§' . $time_format));
-	list($end['date_local'], $end['time_local']) = explode('||',timeformat($end['timestamp'], $date_format . '||' . $time_format));
+	list($start['date_local'], $start['time_local']) = explode(' § ', timeformat($start['timestamp'], $date_format . ' § ' . $time_format));
+	list($end['date_local'], $end['time_local']) = explode(' § ',timeformat($end['timestamp'], $date_format . ' § ' . $time_format));
 
 	// Strings showing the datetimes in the user's preferred format, relative to the event's time zone
-	list($start['date_orig'], $start['time_orig']) = explode('||',timeformat($start['timestamp'], $date_format . '||' . $time_format, 'none'));
-	list($end['date_orig'], $end['time_orig']) = explode('||',timeformat($end['timestamp'], $date_format . '' . $time_format, 'none'));
+	list($start['date_orig'], $start['time_orig']) = explode(' § ',timeformat($start['timestamp'], $date_format . ' § ' . $time_format, 'none'));
+	list($end['date_orig'], $end['time_orig']) = explode(' § ',timeformat($end['timestamp'], $date_format . ' § ' . $time_format, 'none'));
 
 	// The time zone identifier (e.g. 'Europe/London') and abbreviation (e.g. 'GMT')
 	$tz = date_format($start_object, 'e');

--- a/Sources/Subs-Calendar.php
+++ b/Sources/Subs-Calendar.php
@@ -130,7 +130,11 @@ function getBirthdayRange($low_date, $high_date)
 function getEventRange($low_date, $high_date, $use_permissions = true)
 {
 	global $scripturl, $modSettings, $user_info, $smcFunc, $context, $sourcedir;
+	static $timezone_array = array();
 	require_once($sourcedir . '/Subs.php');
+	
+	if (empty($timezone_array['default']))
+		$timezone_array['default'] = timezone_open(date_default_timezone_get());
 
 	$low_object = date_create($low_date);
 	$high_object = date_create($high_date);
@@ -165,16 +169,19 @@ function getEventRange($low_date, $high_date, $use_permissions = true)
 
 		// Get the various time and date properties for this event
 		list($start, $end, $allday, $span, $tz, $tz_abbrev) = buildEventDatetimes($row);
+		
+		if (empty($timezone_array[$tz]))
+			$timezone_array[$tz] = timezone_open($tz);
 
 		// Sanity check
 		if (!empty($start['error_count']) || !empty($start['warning_count']) || !empty($end['error_count']) || !empty($end['warning_count']))
 			continue;
 
 		// Get set up for the loop
-		$start_object = date_create($row['start_date'] . (!$allday ? ' ' . $row['start_time'] : ''), timezone_open($tz));
-		$end_object = date_create($row['end_date'] . (!$allday ? ' ' . $row['end_time'] : ''), timezone_open($tz));
-		date_timezone_set($start_object, timezone_open(date_default_timezone_get()));
-		date_timezone_set($end_object, timezone_open(date_default_timezone_get()));
+		$start_object = date_create($row['start_date'] . (!$allday ? ' ' . $row['start_time'] : ''), $timezone_array[$tz]);
+		$end_object = date_create($row['end_date'] . (!$allday ? ' ' . $row['end_time'] : ''), $timezone_array[$tz]);
+		date_timezone_set($start_object, $timezone_array['default']);
+		date_timezone_set($end_object, $timezone_array['default']);
 		date_time_set($start_object, 0, 0, 0);
 		date_time_set($end_object, 0, 0, 0);
 		$start_date_string = date_format($start_object, 'Y-m-d');
@@ -1534,6 +1541,9 @@ function buildEventDatetimes($row)
 {
 	global $sourcedir, $user_info;
 	require_once($sourcedir . '/Subs.php');
+	static $timezone_array = array();
+	
+	
 
 	// First, try to create a better date format, ignoring the "time" elements.
 	if (preg_match('~%[AaBbCcDdeGghjmuYy](?:[^%]*%[AaBbCcDdeGghjmuYy])*~', $user_info['time_format'], $matches) == 0 || empty($matches[0]))
@@ -1549,21 +1559,24 @@ function buildEventDatetimes($row)
 
 	// Should this be an all day event?
 	$allday = (empty($row['start_time']) || empty($row['end_time']) || empty($row['timezone']) || !in_array($row['timezone'], timezone_identifiers_list(DateTimeZone::ALL_WITH_BC))) ? true : false;
-
+	
 	// How many days does this event span?
 	$span = 1 + date_interval_format(date_diff(date_create($row['start_date']), date_create($row['end_date'])), '%d');
 
 	// We need to have a defined timezone in the steps below
 	if (empty($row['timezone']))
 		$row['timezone'] = getUserTimezone();
+	
+	if (empty($timezone_array[$row['timezone']]))
+		$timezone_array[$row['timezone']] = timezone_open($row['timezone']);
 
 	// Get most of the standard date information for the start and end datetimes
 	$start = date_parse($row['start_date'] . (!$allday ? ' ' . $row['start_time'] : ''));
 	$end = date_parse($row['end_date'] . (!$allday ? ' ' . $row['end_time'] : ''));
 
 	// But we also want more info, so make some DateTime objects we can use
-	$start_object = date_create($row['start_date'] . (!$allday ? ' ' . $row['start_time'] : ''), timezone_open($row['timezone']));
-	$end_object = date_create($row['end_date'] . (!$allday ? ' ' . $row['end_time'] : ''), timezone_open($row['timezone']));
+	$start_object = date_create($row['start_date'] . (!$allday ? ' ' . $row['start_time'] : ''), $timezone_array[$row['timezone']]);
+	$end_object = date_create($row['end_date'] . (!$allday ? ' ' . $row['end_time'] : ''), $timezone_array[$row['timezone']]);
 
 	// Unix timestamps are good
 	$start['timestamp'] = date_format($start_object, 'U');
@@ -1578,16 +1591,14 @@ function buildEventDatetimes($row)
 	$end['iso_gmdate'] = gmdate('c', $end['timestamp']);
 
 	// Strings showing the datetimes in the user's preferred format, relative to the user's time zone
-	$start['date_local'] = timeformat($start['timestamp'], $date_format);
-	$start['time_local'] = timeformat($start['timestamp'], $time_format);
-	$end['date_local'] = timeformat($end['timestamp'], $date_format);
-	$end['time_local'] = timeformat($end['timestamp'], $time_format);
+	$test = timeformat($start['timestamp'], $date_format . ' § ' . $time_format);
+	$test_array = explode(' § ', timeformat($start['timestamp'], $date_format . ' § ' . $time_format));
+	list($start['date_local'], $start['time_local']) = explode('§', timeformat($start['timestamp'], $date_format . '§' . $time_format));
+	list($end['date_local'], $end['time_local']) = explode('||',timeformat($end['timestamp'], $date_format . '||' . $time_format));
 
 	// Strings showing the datetimes in the user's preferred format, relative to the event's time zone
-	$start['date_orig'] = timeformat(strtotime(date_format($start_object, 'Y-m-d H:i:s')), $date_format, 'none');
-	$start['time_orig'] = timeformat(strtotime(date_format($start_object, 'Y-m-d H:i:s')), $time_format, 'none');
-	$end['date_orig'] = timeformat(strtotime(date_format($end_object, 'Y-m-d H:i:s')), $date_format, 'none');
-	$end['time_orig'] = timeformat(strtotime(date_format($end_object, 'Y-m-d H:i:s')), $time_format, 'none');
+	list($start['date_orig'], $start['time_orig']) = explode('||',timeformat($start['timestamp'], $date_format . '||' . $time_format, 'none'));
+	list($end['date_orig'], $end['time_orig']) = explode('||',timeformat($end['timestamp'], $date_format . '' . $time_format, 'none'));
 
 	// The time zone identifier (e.g. 'Europe/London') and abbreviation (e.g. 'GMT')
 	$tz = date_format($start_object, 'e');

--- a/Sources/Subs-Calendar.php
+++ b/Sources/Subs-Calendar.php
@@ -1542,8 +1542,6 @@ function buildEventDatetimes($row)
 	global $sourcedir, $user_info;
 	require_once($sourcedir . '/Subs.php');
 	static $timezone_array = array();
-	
-	
 
 	// First, try to create a better date format, ignoring the "time" elements.
 	if (preg_match('~%[AaBbCcDdeGghjmuYy](?:[^%]*%[AaBbCcDdeGghjmuYy])*~', $user_info['time_format'], $matches) == 0 || empty($matches[0]))
@@ -1559,14 +1557,14 @@ function buildEventDatetimes($row)
 
 	// Should this be an all day event?
 	$allday = (empty($row['start_time']) || empty($row['end_time']) || empty($row['timezone']) || !in_array($row['timezone'], timezone_identifiers_list(DateTimeZone::ALL_WITH_BC))) ? true : false;
-	
+
 	// How many days does this event span?
 	$span = 1 + date_interval_format(date_diff(date_create($row['start_date']), date_create($row['end_date'])), '%d');
 
 	// We need to have a defined timezone in the steps below
 	if (empty($row['timezone']))
 		$row['timezone'] = getUserTimezone();
-	
+
 	if (empty($timezone_array[$row['timezone']]))
 		$timezone_array[$row['timezone']] = timezone_open($row['timezone']);
 

--- a/Sources/Subs-Calendar.php
+++ b/Sources/Subs-Calendar.php
@@ -1590,11 +1590,11 @@ function buildEventDatetimes($row)
 
 	// Strings showing the datetimes in the user's preferred format, relative to the user's time zone
 	list($start['date_local'], $start['time_local']) = explode(' § ', timeformat($start['timestamp'], $date_format . ' § ' . $time_format));
-	list($end['date_local'], $end['time_local']) = explode(' § ',timeformat($end['timestamp'], $date_format . ' § ' . $time_format));
+	list($end['date_local'], $end['time_local']) = explode(' § ', timeformat($end['timestamp'], $date_format . ' § ' . $time_format));
 
 	// Strings showing the datetimes in the user's preferred format, relative to the event's time zone
-	list($start['date_orig'], $start['time_orig']) = explode(' § ',timeformat($start['timestamp'], $date_format . ' § ' . $time_format, 'none'));
-	list($end['date_orig'], $end['time_orig']) = explode(' § ',timeformat($end['timestamp'], $date_format . ' § ' . $time_format, 'none'));
+	list($start['date_orig'], $start['time_orig']) = explode(' § ', timeformat($start['timestamp'], $date_format . ' § ' . $time_format, 'none'));
+	list($end['date_orig'], $end['time_orig']) = explode(' § ', timeformat($end['timestamp'], $date_format . ' § ' . $time_format, 'none'));
 
 	// The time zone identifier (e.g. 'Europe/London') and abbreviation (e.g. 'GMT')
 	$tz = date_format($start_object, 'e');

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -829,6 +829,9 @@ function timeformat($log_time, $show_today = true, $offset_type = false, $proces
 	if ($context['server']['is_windows'] && strpos($str, '%e') !== false)
 		$str = str_replace('%e', ltrim(strftime('%d', $time), '0'), $str);
 
+	// fix unkown %l with %I
+	$str = str_replace('%l','%I',$str);
+
 	// Format any other characters..
 	return strftime($str, $time);
 }

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -829,9 +829,6 @@ function timeformat($log_time, $show_today = true, $offset_type = false, $proces
 	if ($context['server']['is_windows'] && strpos($str, '%e') !== false)
 		$str = str_replace('%e', ltrim(strftime('%d', $time), '0'), $str);
 
-	// fix unkown %l with %I
-	$str = str_replace('%l','%I',$str);
-
 	// Format any other characters..
 	return strftime($str, $time);
 }


### PR DESCRIPTION
For doesn't look that some one try to get the stuff better,
i try again.
The result is this pr,
which got the same/better runtime as the database solution.
~800 ms -> 400ms

One thing i don't understand from where and why we use %l instead of %I 
this small L didn't exists in strftime doc: http://php.net/manual/de/function.strftime.php

so i place a replace...

maybe @Sesquipedalian can explain this.

left old behavior right new bevhaior
![grafik](https://user-images.githubusercontent.com/1782906/28247922-04fa8fd8-6a3b-11e7-8d62-fd76e610236f.png)


