### PR TITLE
Handles unsupported strftime formats more robustly

### DIFF
--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -792,7 +792,7 @@ function timeformat($log_time, $show_today = true, $offset_type = false, $proces
 			// Time and Date Stamps
 			'c' => '%F %T', 'D' => '%m/%d/%y', 'F' => '%Y-%m-%d', 's' => '&#37;s', 'x' => '%F',
 			// Miscellaneous
-			'n' => "\n", 't' => "\t", '%' => '%%',
+			'n' => "\n", 't' => "\t", '%' => '&#37;',
 		);
 
 		// No need to do this part again if we already did it once

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -720,6 +720,7 @@ function timeformat($log_time, $show_today = true, $offset_type = false, $proces
 {
 	global $context, $user_info, $txt, $modSettings;
 	static $non_twelve_hour, $locale_cache;
+	static $unsupportedFormats, $finalizedFormats;
 
 	// Offset the time.
 	if (!$offset_type)
@@ -764,8 +765,11 @@ function timeformat($log_time, $show_today = true, $offset_type = false, $proces
 
 	$str = !is_bool($show_today) ? $show_today : $user_info['time_format'];
 
-	$finalizedFormats = cache_get_data('timeformatstrings', 86400);
+	// Use the cached formats if available
+	if (is_null($finalizedFormats))
+		$finalizedFormats = (array) cache_get_data('timeformatstrings', 86400);
 
+	// Make a supported version for this format if we don't already have one
 	if (empty($finalizedFormats[$str]))
 	{
 		$timeformat = $str;
@@ -792,7 +796,8 @@ function timeformat($log_time, $show_today = true, $offset_type = false, $proces
 		);
 
 		// No need to do this part again if we already did it once
-		$unsupportedFormats = cache_get_data('unsupportedtimeformats', 86400);
+		if (is_null($unsupportedFormats))
+			$unsupportedFormats = (array) cache_get_data('unsupportedtimeformats', 86400);
 		if (empty($unsupportedFormats))
 		{
 			foreach($strftimeFormatSubstitutions as $format => $substitution)

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -713,13 +713,13 @@ function comma_format($number, $override_decimal_count = false)
  * @param int $log_time A timestamp
  * @param bool $show_today Whether to show "Today"/"Yesterday" or just a date
  * @param bool|string $offset_type If false, uses both user time offset and forum offset. If 'forum', uses only the forum offset. Otherwise no offset is applied.
- * @param bool $process_safe activate setlocale check for changes at runtime -> slower this function
+ * @param bool $process_safe Activate setlocale check for changes at runtime. Slower, but safer.
  * @return string A formatted timestamp
  */
 function timeformat($log_time, $show_today = true, $offset_type = false, $process_safe = false)
 {
 	global $context, $user_info, $txt, $modSettings;
-	static $non_twelve_hour, $local_cache;
+	static $non_twelve_hour, $locale_cache;
 	static $unsupportedFormats = array(), $finalizedFormats = array();
 
 	// Offset the time.
@@ -819,17 +819,14 @@ function timeformat($log_time, $show_today = true, $offset_type = false, $proces
 
 	$str = $finalizedFormats[$str];
 
-	if (!isset($local_cache))
-		$local_cache = setlocale(LC_TIME, $txt['lang_locale']);
+	if (!isset($locale_cache))
+		$locale_cache = setlocale(LC_TIME, $txt['lang_locale']);
 
-	if ($local_cache !== false)
+	if ($locale_cache !== false)
 	{
-		//check if other process change the local
-		if ($process_safe === true)
-		{
-			if (setlocale(LC_TIME, '0') != $local_cache)
-				setlocale(LC_TIME, $txt['lang_locale']);
-		}
+		// Check if another process changed the locale
+		if ($process_safe === true && setlocale(LC_TIME, '0') != $locale_cache)
+			setlocale(LC_TIME, $txt['lang_locale']);
 
 		if (!isset($non_twelve_hour))
 			$non_twelve_hour = trim(strftime('%p')) === '';

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -819,7 +819,7 @@ function timeformat($log_time, $show_today = true, $offset_type = false, $proces
 		// Substitute unsupported formats with supported ones
 		if (!empty($unsupportedFormats))
 			while (preg_match('~%(' . implode('|', $unsupportedFormats) . ')~', $timeformat, $matches))
-				$timeformat = preg_replace('~' . $matches[0] . '~', $strftimeFormatSubstitutions[$matches[1]], $timeformat);
+				$timeformat = str_replace($matches[0], $strftimeFormatSubstitutions[$matches[1]], $timeformat);
 
 		// Remember this so we don't need to do it again
 		$finalizedFormats[$str] = $timeformat;

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -720,7 +720,6 @@ function timeformat($log_time, $show_today = true, $offset_type = false, $proces
 {
 	global $context, $user_info, $txt, $modSettings;
 	static $non_twelve_hour, $locale_cache;
-	static $unsupportedFormats = array(), $finalizedFormats = array();
 
 	// Offset the time.
 	if (!$offset_type)
@@ -765,6 +764,8 @@ function timeformat($log_time, $show_today = true, $offset_type = false, $proces
 
 	$str = !is_bool($show_today) ? $show_today : $user_info['time_format'];
 
+	$finalizedFormats = cache_get_data('timeformatstrings', 86400);
+
 	if (empty($finalizedFormats[$str]))
 	{
 		$timeformat = $str;
@@ -791,6 +792,7 @@ function timeformat($log_time, $show_today = true, $offset_type = false, $proces
 		);
 
 		// No need to do this part again if we already did it once
+		$unsupportedFormats = cache_get_data('unsupportedtimeformats', 86400);
 		if (empty($unsupportedFormats))
 		{
 			foreach($strftimeFormatSubstitutions as $format => $substitution)
@@ -802,6 +804,7 @@ function timeformat($log_time, $show_today = true, $offset_type = false, $proces
 				if ($value === false || $value === $format)
 					$unsupportedFormats[] = $format;
 			}
+			cache_put_data('unsupportedtimeformats', $unsupportedFormats, 86400);
 		}
 
 		// Windows needs extra help if $timeformat contains something completely invalid, e.g. '%Q'
@@ -815,6 +818,7 @@ function timeformat($log_time, $show_today = true, $offset_type = false, $proces
 
 		// Remember this so we don't need to do it again
 		$finalizedFormats[$str] = $timeformat;
+		cache_put_data('timeformatstrings', $finalizedFormats, 86400);
 	}
 
 	$str = $finalizedFormats[$str];


### PR DESCRIPTION
This seems to work well on my *nix systems. I don't have Windows, though, so if someone (maybe @albertlast?) could test it there, that'd be good.