### PR TITLE
Seek for messages in topics

### DIFF
--- a/Sources/Display.php
+++ b/Sources/Display.php
@@ -876,15 +876,15 @@ function Display()
 		$start_char = null;
 
 	$limit = $context['messages_per_page'];
-	
+
 	$messages = array();
 	$all_posters = array();
-	
+
 	if (isset($start_char))
 	{
 		$firstIndex = 0;
 
-		if ($start_char === 'M' or $start_char === 'S' or $start_char === 'C')
+		if ($start_char === 'M' or $start_char === 'C')
 		{
 			$ascending = true;
 			$page_operator = '>=';
@@ -927,18 +927,18 @@ function Display()
 		{
 			while ($row = $smcFunc['db_fetch_assoc']($request))
 			{
-				if ($row['id_msg'] != $page_id || $start_char === 'C')
+				// Check if the start msg is in our result
+				if ($row['id_msg'] == $page_id)
+					$found_msg = true;
+
+				// Skip the the start msg if we not in mode C
+				if ($start_char === 'C' || $row['id_msg'] != $page_id)
 				{
 					if (!empty($row['id_member']))
 						$all_posters[$row['id_msg']] = $row['id_member'];
 
 					$messages[] = $row['id_msg'];
-
-					if ($start_char === 'C' && $row['id_msg'] == $page_id) // find the start message of current page
-						$found_msg = true;
 				}
-				else
-					$found_msg = true; // find the start message of next or before page
 			}
 
 			// page_id not found? -> fallback

--- a/Sources/Display.php
+++ b/Sources/Display.php
@@ -931,6 +931,7 @@ function Display()
 				{
 					if (!empty($row['id_member']))
 						$all_posters[$row['id_msg']] = $row['id_member'];
+
 					$messages[] = $row['id_msg'];
 
 					if ($start_char === 'C' && $row['id_msg'] == $page_id) // find the start message of current page
@@ -993,7 +994,7 @@ function Display()
 			$messages[] = $row['id_msg'];
 		}
 
-		// get the message in this order how they shown
+		// Sort the messages into the correct display order
 		if (!$ascending)
 			sort($messages);
 	}

--- a/Sources/Display.php
+++ b/Sources/Display.php
@@ -875,7 +875,7 @@ function Display()
 	{
 		$firstIndex = 0;
 		
-		if ($start_char === 'M' or $start_char === 'S')
+		if ($start_char === 'M' or $start_char === 'S' or $start_char === 'C')
 		{
 			$ascending = true;
 			$page_operator = '>=';

--- a/Sources/Display.php
+++ b/Sources/Display.php
@@ -842,45 +842,153 @@ function Display()
 		call_integration_hook('integrate_poll_buttons');
 	}
 
-	// Calculate the fastest way to get the messages!
-	$ascending = empty($options['view_newest_first']);
-	$start = $_REQUEST['start'];
-	$limit = $context['messages_per_page'];
-	$firstIndex = 0;
-	if ($start >= $context['total_visible_posts'] / 2 && $context['messages_per_page'] != -1)
+	// Check if we can use seek
+	if (isset($_SESSION['page_topic']) && isset($_SESSION['page_next_start']) && $_SESSION['page_topic'] == $topic && $_SESSION['page_next_start'] == $_REQUEST['start'])
 	{
-		$ascending = !$ascending;
-		$limit = $context['total_visible_posts'] <= $start + $limit ? $context['total_visible_posts'] - $start : $limit;
-		$start = $context['total_visible_posts'] <= $start + $limit ? 0 : $context['total_visible_posts'] - $start - $limit;
-		$firstIndex = $limit - 1;
+		$start_char = 'M'; //yes we call the next page
+		$page_id = $_SESSION['page_next_id'];
 	}
+	else if (isset($_SESSION['page_topic']) && isset($_SESSION['page_before_start']) && $_SESSION['page_topic'] == $topic && $_SESSION['page_before_start'] == $_REQUEST['start'] )
+	{
+		$start_char = 'L'; //yes we go backward
+		$page_id = $_SESSION['page_before_id'];
+	}
+	else if ($_REQUEST['start'] == 0) //special case start page
+	{
+		$start_char = 'S';
+		$page_id = $context['topicinfo']['id_first_msg'];
+	}
+	else
+		$start_char = null;
 
-	// Get each post and poster in this topic.
-	$request = $smcFunc['db_query']('', '
-		SELECT id_msg, id_member, approved
-		FROM {db_prefix}messages
-		WHERE id_topic = {int:current_topic}' . (!$modSettings['postmod_active'] || $approve_posts ? '' : '
-		AND (approved = {int:is_approved}' . ($user_info['is_guest'] ? '' : ' OR id_member = {int:current_member}') . ')') . '
-		ORDER BY id_msg ' . ($ascending ? '' : 'DESC') . ($context['messages_per_page'] == -1 ? '' : '
-		LIMIT {int:start}, {int:max}'),
-		array(
-			'current_member' => $user_info['id'],
-			'current_topic' => $topic,
-			'is_approved' => 1,
-			'blank_id_member' => 0,
-			'start' => $start,
-			'max' => $limit,
-		)
-	);
-
+	$limit = $context['messages_per_page'];
+	
 	$messages = array();
 	$all_posters = array();
-	while ($row = $smcFunc['db_fetch_assoc']($request))
+	
+	if (isset($start_char))
 	{
-		if (!empty($row['id_member']))
-			$all_posters[$row['id_msg']] = $row['id_member'];
-		$messages[] = $row['id_msg'];
+		$firstIndex = 0;
+		
+		if ($start_char === 'M' or $start_char === 'S')
+		{
+			$ascending = true;
+			$page_operator = '>=';
+		}
+		else
+		{
+			$ascending = false;
+			$page_operator = '<=';
+		}
+		
+		if ($start_char === 'S')
+			$limit_seek = $limit;
+		else
+			$limit_seek  = $limit + 1;
+		
+		$request = $smcFunc['db_query']('', '
+			SELECT id_msg, id_member, approved
+			FROM {db_prefix}messages
+			WHERE id_topic = {int:current_topic} 
+			AND id_msg '. $page_operator . ' {int:page_id}'. (!$modSettings['postmod_active'] || $approve_posts ? '' : '
+			AND (approved = {int:is_approved}' . ($user_info['is_guest'] ? '' : ' OR id_member = {int:current_member}') . ')') . '
+			ORDER BY id_msg ' . ($ascending ? '' : 'DESC') . ($context['messages_per_page'] == -1 ? '' : '
+			LIMIT {int:limit}'),
+			array(
+				'current_member' => $user_info['id'],
+				'current_topic' => $topic,
+				'is_approved' => 1,
+				'blank_id_member' => 0,
+				'limit' => $limit_seek,
+				'page_id' => $page_id,
+			)
+		);
+		
+		$found_msg = false;
+		
+		// the start msg can not be "lost"
+		if ($start_char === 'S')
+			$found_msg = true;
+		
+		// Fallback
+		if ($smcFunc['db_num_rows']($request) < 1)
+			unset($start_char);
+		else
+		{
+			while ($row = $smcFunc['db_fetch_assoc']($request))
+			{
+				if ($row['id_msg'] != $page_id || $found_msg)
+				{
+					if (!empty($row['id_member']))
+						$all_posters[$row['id_msg']] = $row['id_member'];
+					$messages[] = $row['id_msg'];
+				}
+				else
+					$found_msg = true;
+			}
+
+			//page_id not found? -> fallback
+			if (!$found_msg)
+			{
+				$messages = array();
+				$all_posters = array();
+				unset($start_char);
+			}
+		}
 	}
+
+	// Jump to page
+	if (empty($start_char))
+	{
+		// Calculate the fastest way to get the messages!
+		$ascending = empty($options['view_newest_first']);
+		$start = $_REQUEST['start'];
+		$firstIndex = 0;
+		if ($start >= $context['total_visible_posts'] / 2 && $context['messages_per_page'] != -1)
+		{
+			$ascending = !$ascending;
+			$limit = $context['total_visible_posts'] <= $start + $limit ? $context['total_visible_posts'] - $start : $limit;
+			$start = $context['total_visible_posts'] <= $start + $limit ? 0 : $context['total_visible_posts'] - $start - $limit;
+			$firstIndex = $limit - 1;
+		}
+
+		// Get each post and poster in this topic.
+		$request = $smcFunc['db_query']('', '
+			SELECT id_msg, id_member, approved
+			FROM {db_prefix}messages
+			WHERE id_topic = {int:current_topic}' . (!$modSettings['postmod_active'] || $approve_posts ? '' : '
+			AND (approved = {int:is_approved}' . ($user_info['is_guest'] ? '' : ' OR id_member = {int:current_member}') . ')') . '
+			ORDER BY id_msg ' . ($ascending ? '' : 'DESC') . ($context['messages_per_page'] == -1 ? '' : '
+			LIMIT {int:start}, {int:max}'),
+			array(
+				'current_member' => $user_info['id'],
+				'current_topic' => $topic,
+				'is_approved' => 1,
+				'blank_id_member' => 0,
+				'start' => $start,
+				'max' => $limit,
+			)
+		);
+
+		while ($row = $smcFunc['db_fetch_assoc']($request))
+		{
+			if (!empty($row['id_member']))
+				$all_posters[$row['id_msg']] = $row['id_member'];
+			$messages[] = $row['id_msg'];
+		}
+	}
+
+	// Before Page bring in the right order
+	if (!empty($start_char) && $start_char === 'L')
+		krsort($messages);
+	
+	// Save the next start of the next page and the end of the page before
+	$_SESSION['page_before_id'] = $messages[0];
+	$_SESSION['page_before_start'] = $_REQUEST['start'] - $limit;
+	$_SESSION['page_next_id'] = end($messages);
+	$_SESSION['page_next_start'] = $_REQUEST['start'] + $limit;
+	$_SESSION['page_topic'] = $topic;
+	
 	$smcFunc['db_free_result']($request);
 	$posters = array_unique($all_posters);
 

--- a/Sources/Display.php
+++ b/Sources/Display.php
@@ -999,7 +999,7 @@ function Display()
 			sort($messages);
 	}
 
-	// Save the next start of the next page and the end of the page before
+	// Remember the paging data for next time
 	$_SESSION['page_first_id'] = $messages[0];
 	$_SESSION['page_before_start'] = $_REQUEST['start'] - $limit;
 	$_SESSION['page_last_id'] = end($messages);

--- a/Sources/Display.php
+++ b/Sources/Display.php
@@ -842,23 +842,25 @@ function Display()
 		call_integration_hook('integrate_poll_buttons');
 	}
 
+	$start = $_REQUEST['start'];
+
 	// Check if we can use seek
-	if (isset($_SESSION['page_topic']) && isset($_SESSION['page_next_start']) && $_SESSION['page_topic'] == $topic && $_SESSION['page_next_start'] == $_REQUEST['start'])
+	if (isset($_SESSION['page_topic']) && isset($_SESSION['page_next_start']) && $_SESSION['page_topic'] == $topic && $_SESSION['page_next_start'] == $start)
 	{	// yes we call the next page
 		$start_char = 'M'; 
 		$page_id = $_SESSION['page_next_id'];
 	}
-	elseif (isset($_SESSION['page_topic']) && isset($_SESSION['page_before_start']) && $_SESSION['page_topic'] == $topic && $_SESSION['page_before_start'] == $_REQUEST['start'])
+	elseif (isset($_SESSION['page_topic']) && isset($_SESSION['page_before_start']) && $_SESSION['page_topic'] == $topic && $_SESSION['page_before_start'] == $start)
 	{	// yes we go backward
 		$start_char = 'L';
 		$page_id = $_SESSION['page_before_id'];
 	}
-	elseif (isset($_SESSION['page_topic']) && isset($_SESSION['page_current_start']) && $_SESSION['page_topic'] == $topic && $_SESSION['page_current_start'] == $_REQUEST['start'])
+	elseif (isset($_SESSION['page_topic']) && isset($_SESSION['page_current_start']) && $_SESSION['page_topic'] == $topic && $_SESSION['page_current_start'] == $start)
 	{	// refresh of current page
 		$start_char = 'C';
 		$page_id = $_SESSION['page_current_id'];
 	}
-	elseif ($_REQUEST['start'] == 0) //special case start page
+	elseif ($start == 0) //special case start page
 	{	// special case start page
 		$start_char = 'C';
 		$page_id = $context['topicinfo']['id_first_msg'];
@@ -946,7 +948,6 @@ function Display()
 	{
 		// Calculate the fastest way to get the messages!
 		$ascending = empty($options['view_newest_first']);
-		$start = $_REQUEST['start'];
 		$firstIndex = 0;
 		if ($start >= $context['total_visible_posts'] / 2 && $context['messages_per_page'] != -1)
 		{
@@ -988,11 +989,11 @@ function Display()
 	
 	// Save the next start of the next page and the end of the page before
 	$_SESSION['page_before_id'] = $messages[0];
-	$_SESSION['page_before_start'] = $_REQUEST['start'] - $limit;
+	$_SESSION['page_before_start'] = $start - $limit;
 	$_SESSION['page_next_id'] = end($messages);
-	$_SESSION['page_next_start'] = $_REQUEST['start'] + $limit;
+	$_SESSION['page_next_start'] = $start + $limit;
 	$_SESSION['page_current_id'] = $messages[0];
-	$_SESSION['page_current_start'] = $_REQUEST['start'];
+	$_SESSION['page_current_start'] = $start;
 	$_SESSION['page_topic'] = $topic;
 	
 	$smcFunc['db_free_result']($request);

--- a/Sources/Display.php
+++ b/Sources/Display.php
@@ -848,17 +848,17 @@ function Display()
 	if (isset($_SESSION['page_topic']) && isset($_SESSION['page_next_start']) && $_SESSION['page_topic'] == $topic && $_SESSION['page_next_start'] == $start)
 	{	// yes we call the next page
 		$start_char = 'M'; 
-		$page_id = $_SESSION['page_next_id'];
+		$page_id = $_SESSION['page_last_id'];
 	}
 	elseif (isset($_SESSION['page_topic']) && isset($_SESSION['page_before_start']) && $_SESSION['page_topic'] == $topic && $_SESSION['page_before_start'] == $start)
 	{	// yes we go backward
 		$start_char = 'L';
-		$page_id = $_SESSION['page_before_id'];
+		$page_id = $_SESSION['page_first_id'];
 	}
 	elseif (isset($_SESSION['page_topic']) && isset($_SESSION['page_current_start']) && $_SESSION['page_topic'] == $topic && $_SESSION['page_current_start'] == $start)
 	{	// refresh of current page
 		$start_char = 'C';
-		$page_id = $_SESSION['page_current_id'];
+		$page_id = $_SESSION['page_first_id'];
 	}
 	elseif ($start == 0) //special case start page
 	{	// special case start page
@@ -941,6 +941,10 @@ function Display()
 				unset($start_char);
 			}
 		}
+
+		// Before Page bring in the right order
+		if (!empty($start_char) && $start_char === 'L')
+			krsort($messages);
 	}
 
 	// Jump to page
@@ -981,21 +985,20 @@ function Display()
 				$all_posters[$row['id_msg']] = $row['id_member'];
 			$messages[] = $row['id_msg'];
 		}
+
+		// get the message in this order how they shown
+		if (!$ascending)
+			sort($messages);
 	}
 
-	// Before Page bring in the right order
-	if (!empty($start_char) && $start_char === 'L')
-		krsort($messages);
-	
 	// Save the next start of the next page and the end of the page before
-	$_SESSION['page_before_id'] = $messages[0];
-	$_SESSION['page_before_start'] = $start - $limit;
-	$_SESSION['page_next_id'] = end($messages);
-	$_SESSION['page_next_start'] = $start + $limit;
-	$_SESSION['page_current_id'] = $messages[0];
-	$_SESSION['page_current_start'] = $start;
+	$_SESSION['page_first_id'] = $messages[0];
+	$_SESSION['page_before_start'] = $_REQUEST['start'] - $limit;
+	$_SESSION['page_last_id'] = end($messages);
+	$_SESSION['page_next_start'] = $_REQUEST['start'] + $limit;
+	$_SESSION['page_current_start'] = $_REQUEST['start'];
 	$_SESSION['page_topic'] = $topic;
-	
+
 	$smcFunc['db_free_result']($request);
 	$posters = array_unique($all_posters);
 

--- a/Sources/Display.php
+++ b/Sources/Display.php
@@ -844,24 +844,31 @@ function Display()
 
 	$start = $_REQUEST['start'];
 
-	// Check if we can use seek
-	if (isset($_SESSION['page_topic']) && isset($_SESSION['page_next_start']) && $_SESSION['page_topic'] == $topic && $_SESSION['page_next_start'] == $start)
-	{	// yes we call the next page
-		$start_char = 'M'; 
-		$page_id = $_SESSION['page_last_id'];
+	// Check if we can use the seek method to speed things up
+	if (isset($_SESSION['page_topic']) && $_SESSION['page_topic'] == $topic)
+	{
+		// User moved to the next page
+		if (isset($_SESSION['page_next_start']) && $_SESSION['page_next_start'] == $start)
+		{	
+			$start_char = 'M'; 
+			$page_id = $_SESSION['page_last_id'];
+		}
+		// User moved to the previous page
+		elseif (isset($_SESSION['page_before_start']) && $_SESSION['page_before_start'] == $start)
+		{	
+			$start_char = 'L';
+			$page_id = $_SESSION['page_first_id'];
+		}
+		// User refreshed the current page
+		elseif (isset($_SESSION['page_current_start']) && $_SESSION['page_current_start'] == $start)
+		{
+			$start_char = 'C';
+			$page_id = $_SESSION['page_first_id'];
+		}
 	}
-	elseif (isset($_SESSION['page_topic']) && isset($_SESSION['page_before_start']) && $_SESSION['page_topic'] == $topic && $_SESSION['page_before_start'] == $start)
-	{	// yes we go backward
-		$start_char = 'L';
-		$page_id = $_SESSION['page_first_id'];
-	}
-	elseif (isset($_SESSION['page_topic']) && isset($_SESSION['page_current_start']) && $_SESSION['page_topic'] == $topic && $_SESSION['page_current_start'] == $start)
-	{	// refresh of current page
-		$start_char = 'C';
-		$page_id = $_SESSION['page_first_id'];
-	}
-	elseif ($start == 0) //special case start page
-	{	// special case start page
+	// Special case start page
+	elseif ($start == 0)
+	{
 		$start_char = 'C';
 		$page_id = $context['topicinfo']['id_first_msg'];
 	}

--- a/Sources/Display.php
+++ b/Sources/Display.php
@@ -844,23 +844,23 @@ function Display()
 
 	// Check if we can use seek
 	if (isset($_SESSION['page_topic']) && isset($_SESSION['page_next_start']) && $_SESSION['page_topic'] == $topic && $_SESSION['page_next_start'] == $_REQUEST['start'])
-	{	//yes we call the next page
+	{	// yes we call the next page
 		$start_char = 'M'; 
 		$page_id = $_SESSION['page_next_id'];
 	}
-	else if (isset($_SESSION['page_topic']) && isset($_SESSION['page_before_start']) && $_SESSION['page_topic'] == $topic && $_SESSION['page_before_start'] == $_REQUEST['start'])
-	{	//yes we go backward
+	elseif (isset($_SESSION['page_topic']) && isset($_SESSION['page_before_start']) && $_SESSION['page_topic'] == $topic && $_SESSION['page_before_start'] == $_REQUEST['start'])
+	{	// yes we go backward
 		$start_char = 'L';
 		$page_id = $_SESSION['page_before_id'];
 	}
-	else if (isset($_SESSION['page_topic']) && isset($_SESSION['page_current_start']) && $_SESSION['page_topic'] == $topic && $_SESSION['page_current_start'] == $_REQUEST['start'])
-	{	//refresh of corrent page
+	elseif (isset($_SESSION['page_topic']) && isset($_SESSION['page_current_start']) && $_SESSION['page_topic'] == $topic && $_SESSION['page_current_start'] == $_REQUEST['start'])
+	{	// refresh of current page
 		$start_char = 'C';
 		$page_id = $_SESSION['page_current_id'];
 	}
-	else if ($_REQUEST['start'] == 0) //special case start page
-	{
-		$start_char = 'S';
+	elseif ($_REQUEST['start'] == 0) //special case start page
+	{	// special case start page
+		$start_char = 'C';
 		$page_id = $context['topicinfo']['id_first_msg'];
 	}
 	else
@@ -874,7 +874,7 @@ function Display()
 	if (isset($start_char))
 	{
 		$firstIndex = 0;
-		
+
 		if ($start_char === 'M' or $start_char === 'S' or $start_char === 'C')
 		{
 			$ascending = true;
@@ -885,12 +885,12 @@ function Display()
 			$ascending = false;
 			$page_operator = '<=';
 		}
-		
-		if ($start_char === 'S' || $start_char === 'C')
+
+		if ($start_char === 'C')
 			$limit_seek = $limit;
 		else
 			$limit_seek  = $limit + 1;
-		
+
 		$request = $smcFunc['db_query']('', '
 			SELECT id_msg, id_member, approved
 			FROM {db_prefix}messages
@@ -908,13 +908,9 @@ function Display()
 				'page_id' => $page_id,
 			)
 		);
-		
+
 		$found_msg = false;
-		
-		// the start msg can not be "lost"
-		if ($start_char === 'S')
-			$found_msg = true;
-		
+
 		// Fallback
 		if ($smcFunc['db_num_rows']($request) < 1)
 			unset($start_char);
@@ -922,7 +918,7 @@ function Display()
 		{
 			while ($row = $smcFunc['db_fetch_assoc']($request))
 			{
-				if ($row['id_msg'] != $page_id || $found_msg || $start_char === 'C')
+				if ($row['id_msg'] != $page_id || $start_char === 'C')
 				{
 					if (!empty($row['id_member']))
 						$all_posters[$row['id_msg']] = $row['id_member'];


### PR DESCRIPTION
This is the next try to implement seek for pages in topics.
Handle four cases:
next page
before page
current page (when someone push refresh)
start page (it's mostly the same as current page)

@Sesquipedalian can you please look for issue of this version?