### PR TITLE
Fixes #4011

### DIFF
--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -5989,12 +5989,13 @@ function build_regex($strings, $delim = null, $returnArray = false)
 	return $regex;
 }
 
-/*
-//*** Check if current domain has a cert
-// Adapted from: https://stackoverflow.com/questions/27689147/how-to-check-if-domain-has-ssl-certificate-or-not
-// * @param string $url to check, in $boardurl format (no trailing slash).
-*/ 
-function ssl_cert_found($url) {
+/**
+ * Check if the passed url has an SSL certificate.
+ *
+ * Returns true if a cert was found & false if not.
+ * @param string $url to check, in $boardurl format (no trailing slash).
+ */
+ function ssl_cert_found($url) {
 
 	// Ask for the headers for the passed url, but via https...
 	$url = str_ireplace('http://', 'https://', $url) . '/';
@@ -6009,10 +6010,12 @@ function ssl_cert_found($url) {
     return $result;
 }
 
-/* 
-//*** Check if $boardurl has a redirect to https:// by querying headers
-// * @param string $url to check, in $boardurl format (no trailing slash).
-*/ 
+/**
+ * Check if the passed url has a redirect to https:// by querying headers.
+ * 
+ * Returns true if a redirect was found & false if not.
+ * @param string $url to check, in $boardurl format (no trailing slash).
+ */
 function https_redirect_active($url) {
 
 	// Ask for the headers for the passed url, but via http...

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -5989,4 +5989,53 @@ function build_regex($strings, $delim = null, $returnArray = false)
 	return $regex;
 }
 
+/*
+//*** Check if current domain has a cert
+// Adapted from: https://stackoverflow.com/questions/27689147/how-to-check-if-domain-has-ssl-certificate-or-not
+// * @param string $url to check, in $boardurl format (no trailing slash).
+*/ 
+function ssl_cert_found($url) {
+
+	// Ask for the headers for the passed url, but via https...
+	$url = str_ireplace('http://', 'https://', $url) . '/';
+
+	$result = false;
+	$stream = stream_context_create (array("ssl" => array("capture_peer_cert" => true)));
+	$read = @fopen($url, "rb", false, $stream);
+	if ($read !== false) {
+		$cont = stream_context_get_params($read);
+		$result = isset($cont["options"]["ssl"]["peer_certificate"]) ? true : false;
+	}
+    return $result;
+}
+
+/* 
+//*** Check if $boardurl has a redirect to https:// by querying headers
+// * @param string $url to check, in $boardurl format (no trailing slash).
+*/ 
+function https_redirect_active($url) {
+
+	// Ask for the headers for the passed url, but via http...
+	// Need to add the trailing slash, or it puts it there & thinks there's a redirect when there isn't...
+	$url = str_ireplace('https://', 'http://', $url) . '/';
+	$headers = @get_headers($url);
+	if ($headers === false)
+		return false;
+
+	// Now to see if it came back https...   
+	// First check for a redirect status code in first row (301, 302, 307)
+	if (strstr($headers[0], '301') === false && strstr($headers[0], '302') === false && strstr($headers[0], '307') === false)
+		return false;
+	
+	// Search for the location entry to confirm https
+	$result = false;
+	foreach ($headers as $header) {
+		if (stristr($header, 'Location: https://') !== false) {
+			$result = true;
+			break;
+		}
+	}
+	return $result;		
+}
+
 ?>

--- a/other/install.php
+++ b/other/install.php
@@ -937,6 +937,23 @@ function ForumSettings()
 
 	$incontext['continue'] = 1;
 
+	// Setup the SSL checkbox...
+	$incontext['ssl_chkbx_protected'] = false;
+	$incontext['ssl_chkbx_checked'] = false;
+
+	// If redirect in effect, force ssl ON
+	require_once(dirname(__FILE__) . '/Sources/Subs.php');
+	if (https_redirect_active($incontext['detected_url'])) {
+		$incontext['ssl_chkbx_protected'] = true;
+		$incontext['ssl_chkbx_checked'] = true;
+		$_POST['force_ssl'] = true;
+	}
+	// If no cert, make sure ssl stays OFF
+	if (!ssl_cert_found($incontext['detected_url'])) {
+		$incontext['ssl_chkbx_protected'] = true;
+		$incontext['ssl_chkbx_checked'] = false;
+	}
+
 	// Submitting?
 	if (isset($_POST['boardurl']))
 	{
@@ -946,6 +963,12 @@ function ForumSettings()
 			$_POST['boardurl'] = substr($_POST['boardurl'], 0, -1);
 		if (substr($_POST['boardurl'], 0, 7) != 'http://' && substr($_POST['boardurl'], 0, 7) != 'file://' && substr($_POST['boardurl'], 0, 8) != 'https://')
 			$_POST['boardurl'] = 'http://' . $_POST['boardurl'];
+
+		//Make sure boardurl is aligned with ssl setting
+		if (empty($_POST['force_ssl']))
+			$_POST['boardurl'] = strtr($_POST['boardurl'], array('https://' => 'http://'));
+		else
+			$_POST['boardurl'] = strtr($_POST['boardurl'], array('http://' => 'https://'));		
 
 		// Save these variables.
 		$vars = array(
@@ -2286,7 +2309,8 @@ function template_forum_settings()
 			<tr>
 				<td class="textbox" style="vertical-align: top;">', $txt['force_ssl'], ':</td>
 				<td>
-					<input type="checkbox" name="force_ssl" id="force_ssl" />&nbsp;
+					<input type="checkbox" name="force_ssl" id="force_ssl"', $incontext['ssl_chkbx_checked'] ? ' checked' : '',
+					$incontext['ssl_chkbx_protected'] ? ' disabled' : '', ' />&nbsp;
 					<label for="force_ssl">', $txt['force_ssl_label'], '</label>
 					<br>
 					<div class="smalltext block">', $txt['force_ssl_info'], '</div>


### PR DESCRIPTION
If user selects to use SSL, ensures all URLs are https://. It does this by ensuring $boardurl is aligned with the SSL setting before setting any others, e.g., themes - everything else keys off of $boardurl.

Also ensures you cannot select SSL if you have no cert installed.

Further, ensures you MUST use SSL if you have an http:// => https:// redirect active.

If folks think it makes sense to add similar edits to the force_ssl setting in the admin control panel, I'll do so.