### PR TITLE
Ensure 'alltags' matching is case insensitive.

### DIFF
--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -1849,7 +1849,7 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 	while ($pos !== false)
 	{
 		$last_pos = isset($last_pos) ? max($pos, $last_pos) : $pos;
-		preg_match('~\[/?(?=' . $alltags_regex . ')~', $message, $matches, PREG_OFFSET_CAPTURE, $pos + 1);
+		preg_match('~\[/?(?=' . $alltags_regex . ')~i', $message, $matches, PREG_OFFSET_CAPTURE, $pos + 1);
 		$pos = isset($matches[0][1]) ? $matches[0][1] : false;
 
 		// Failsafe.


### PR DESCRIPTION
Otherwise, old posts in the form [URL=x]foo[/url] aren't parsed correctly.
This brings both uses of $alltags_regex into line.

Signed-off-by: Dave 'Gizmo' Gymer <github@davegymer.org>