### PR TITLE
Implements boardurl token substitution

### DIFF
--- a/Sources/Subs-Db-mysql.php
+++ b/Sources/Subs-Db-mysql.php
@@ -527,9 +527,12 @@ function smf_db_fetch_assoc($request)
 
 	$row = mysqli_fetch_assoc($request);
 
-	array_walk($row, function(&$column) use ($boardurl) {
-		$column = str_replace('{$boardurl}', $boardurl, $column);
-	});
+	if (is_array($row))
+	{
+		array_walk($row, function(&$column) use ($boardurl) {
+			$column = str_replace('{$boardurl}', $boardurl, $column);
+		});
+	}
 
 	return $row;
 }
@@ -545,9 +548,12 @@ function smf_db_fetch_row($request)
 
 	$row = mysqli_fetch_row($request);
 
-	array_walk($row, function(&$column) use ($boardurl) {
-		$column = str_replace('{$boardurl}', $boardurl, $column);
-	});
+	if (is_array($row))
+	{
+		array_walk($row, function(&$column) use ($boardurl) {
+			$column = str_replace('{$boardurl}', $boardurl, $column);
+		});
+	}
 
 	return $row;
 }

--- a/Sources/Subs-Db-mysql.php
+++ b/Sources/Subs-Db-mysql.php
@@ -422,12 +422,12 @@ function smf_db_query($identifier, $db_string, $db_values = array(), $connection
 		// Inject the values passed to this function.
 		$db_string = preg_replace_callback('~{([a-z_]+)(?::([a-zA-Z0-9_-]+))?}~', 'smf_db_replacement__callback', $db_string);
 
-		// Replace $boardurl with a token (we restore it when we retrieve the value)
-		$db_string = str_replace($boardurl, '{$boardurl}', $db_string);
-
 		// This shouldn't be residing in global space any longer.
 		$db_callback = array();
 	}
+
+	// Replace $boardurl with a token (we restore it when we retrieve the value)
+	$db_string = str_replace($boardurl, '{$boardurl}', $db_string);
 
 	// Debugging.
 	if (isset($db_show_debug) && $db_show_debug === true)
@@ -528,11 +528,9 @@ function smf_db_fetch_assoc($request)
 	$row = mysqli_fetch_assoc($request);
 
 	if (is_array($row))
-	{
 		array_walk($row, function(&$column) use ($boardurl) {
 			$column = str_replace('{$boardurl}', $boardurl, $column);
 		});
-	}
 
 	return $row;
 }
@@ -549,11 +547,9 @@ function smf_db_fetch_row($request)
 	$row = mysqli_fetch_row($request);
 
 	if (is_array($row))
-	{
 		array_walk($row, function(&$column) use ($boardurl) {
 			$column = str_replace('{$boardurl}', $boardurl, $column);
 		});
-	}
 
 	return $row;
 }

--- a/Sources/Subs-Db-mysql.php
+++ b/Sources/Subs-Db-mysql.php
@@ -37,8 +37,8 @@ function smf_db_initiate($db_server, $db_name, $db_user, $db_passwd, $db_prefix,
 		$smcFunc += array(
 			'db_query'                  => 'smf_db_query',
 			'db_quote'                  => 'smf_db_quote',
-			'db_fetch_assoc'            => 'mysqli_fetch_assoc',
-			'db_fetch_row'              => 'mysqli_fetch_row',
+			'db_fetch_assoc'            => 'smf_db_fetch_assoc',
+			'db_fetch_row'              => 'smf_db_fetch_row',
 			'db_free_result'            => 'mysqli_free_result',
 			'db_insert'                 => 'smf_db_insert',
 			'db_insert_id'              => 'smf_db_insert_id',
@@ -350,7 +350,7 @@ function smf_db_quote($db_string, $db_values, $connection = null)
 function smf_db_query($identifier, $db_string, $db_values = array(), $connection = null)
 {
 	global $db_cache, $db_count, $db_connection, $db_show_debug, $time_start;
-	global $db_unbuffered, $db_callback, $modSettings;
+	global $db_unbuffered, $db_callback, $modSettings, $boardurl;
 
 	// Comments that are allowed in a query are preg_removed.
 	static $allowed_comments_from = array(
@@ -421,6 +421,9 @@ function smf_db_query($identifier, $db_string, $db_values = array(), $connection
 
 		// Inject the values passed to this function.
 		$db_string = preg_replace_callback('~{([a-z_]+)(?::([a-zA-Z0-9_-]+))?}~', 'smf_db_replacement__callback', $db_string);
+
+		// Replace $boardurl with a token (we restore it when we retrieve the value)
+		$db_string = str_replace($boardurl, '{$boardurl}', $db_string);
 
 		// This shouldn't be residing in global space any longer.
 		$db_callback = array();
@@ -511,6 +514,42 @@ function smf_db_query($identifier, $db_string, $db_values = array(), $connection
 		$db_cache[$db_count]['t'] = array_sum(explode(' ', microtime())) - array_sum(explode(' ', $st));
 
 	return $ret;
+}
+
+/**
+ * Wrapper for mysqli_fetch_assoc that restores {$boardurl} to $boardurl
+ * @param object $request A mysqli_result object from a previous query
+ * @return array An associative array that corresponds to the fetched row or NULL if there are no more rows
+ */
+function smf_db_fetch_assoc($request)
+{
+	global $boardurl;
+
+	$row = mysqli_fetch_assoc($request);
+
+	array_walk($row, function(&$column) use ($boardurl) {
+		$column = str_replace('{$boardurl}', $boardurl, $column);
+	});
+
+	return $row;
+}
+
+/**
+ * Wrapper for mysqli_fetch_row that restores {$boardurl} to $boardurl
+ * @param object $request A mysqli_result object from a previous query
+ * @return array An associative array that corresponds to the fetched row or NULL if there are no more rows
+ */
+function smf_db_fetch_row($request)
+{
+	global $boardurl;
+
+	$row = mysqli_fetch_row($request);
+
+	array_walk($row, function(&$column) use ($boardurl) {
+		$column = str_replace('{$boardurl}', $boardurl, $column);
+	});
+
+	return $row;
 }
 
 /**
@@ -773,7 +812,7 @@ function smf_db_insert($method = 'replace', $table, $columns, $data, $keys, $ret
 	global $smcFunc, $db_connection, $db_prefix;
 
 	$connection = $connection === null ? $db_connection : $connection;
-	
+
 	$return_var = null;
 
 	// With nothing to insert, simply return.
@@ -782,9 +821,9 @@ function smf_db_insert($method = 'replace', $table, $columns, $data, $keys, $ret
 
 	// Replace the prefix holder with the actual prefix.
 	$table = str_replace('{db_prefix}', $db_prefix, $table);
-	
+
 	$with_returning = false;
-	
+
 	if (!empty($keys) && (count($keys) > 0) && $returnmode > 0)
 	{
 		$with_returning = true;
@@ -841,7 +880,7 @@ function smf_db_insert($method = 'replace', $table, $columns, $data, $keys, $ret
 		for($i = 0; $i < $count; $i++)
 		{
 			$old_id = $smcFunc['db_insert_id']();
-			
+
 			$smcFunc['db_query']('', '
 				' . $queryTitle . ' INTO ' . $table . '(`' . implode('`, `', $indexed_columns) . '`)
 				VALUES
@@ -853,7 +892,7 @@ function smf_db_insert($method = 'replace', $table, $columns, $data, $keys, $ret
 				$connection
 			);
 			$new_id = $smcFunc['db_insert_id']();
-			
+
 			if ($last_id != $new_id) //the inserted value was new
 			{
 				$ai = $new_id;
@@ -874,21 +913,21 @@ function smf_db_insert($method = 'replace', $table, $columns, $data, $keys, $ret
 					WHERE ' . $where_string . ' LIMIT 1',
 					array()
 				);
-				
+
 				if ($request !== false && $smcFunc['db_num_rows']($request) == 1)
 				{
 					$row = $smcFunc['db_fetch_assoc']($request);
 					$ai = $row[$keys[0]];
 				}
 			}
-			
+
 			if ($returnmode == 1)
 				$return_var = $ai;
 			else if ($returnmode == 2)
 				$return_var[] = $ai;
 		}
 	}
-	
+
 
 	if ($with_returning)
 	{
@@ -997,7 +1036,7 @@ function smf_is_resource($result)
 }
 
 /**
- * Fetches all rows from a result as an array 
+ * Fetches all rows from a result as an array
  *
  * @param resource $request A MySQL result resource
  * @return array An array that contains all rows (records) in the result resource

--- a/Sources/Subs-Db-mysql.php
+++ b/Sources/Subs-Db-mysql.php
@@ -1045,8 +1045,17 @@ function smf_is_resource($result)
  */
 function smf_db_fetch_all($request)
 {
+	global $boardurl;
+
 	// Return the right row.
-	return mysqli_fetch_all($request);
+	$rows = mysqli_fetch_all($request);
+
+	if (is_array($rows))
+		array_walk_recursive($rows, function(&$column) use ($boardurl) {
+			$column = str_replace('{$boardurl}', $boardurl, $column);
+		});
+
+	return $rows
 }
 
 ?>

--- a/Sources/Subs-Db-postgresql.php
+++ b/Sources/Subs-Db-postgresql.php
@@ -389,12 +389,12 @@ function smf_db_query($identifier, $db_string, $db_values = array(), $connection
 		// Inject the values passed to this function.
 		$db_string = preg_replace_callback('~{([a-z_]+)(?::([a-zA-Z0-9_-]+))?}~', 'smf_db_replacement__callback', $db_string);
 
-		// Replace $boardurl with a token (we restore it when we retrieve the value)
-		$db_string = str_replace($boardurl, '{$boardurl}', $db_string);
-
 		// This shouldn't be residing in global space any longer.
 		$db_callback = array();
 	}
+
+	// Replace $boardurl with a token (we restore it when we retrieve the value)
+	$db_string = str_replace($boardurl, '{$boardurl}', $db_string);
 
 	// Debugging.
 	if (isset($db_show_debug) && $db_show_debug === true)

--- a/Sources/Subs-Db-postgresql.php
+++ b/Sources/Subs-Db-postgresql.php
@@ -995,8 +995,17 @@ function smf_db_escape_wildcard_string($string, $translate_human_wildcards = fal
  */
 function smf_db_fetch_all($request)
 {
+	global $boardurl;
+
 	// Return the right row.
-	return @pg_fetch_all($request);
+	$rows = @pg_fetch_all($request);
+
+	if (is_array($rows))
+		array_walk_recursive($rows, function(&$column) use ($boardurl) {
+			$column = str_replace('{$boardurl}', $boardurl, $column);
+		});
+
+	return $rows
 }
 
 ?>

--- a/Sources/Subs-Db-postgresql.php
+++ b/Sources/Subs-Db-postgresql.php
@@ -641,9 +641,12 @@ function smf_db_fetch_row($request, $counter = false)
 		$row = @pg_fetch_row($request, $db_row_count[(int) $request]++);
 	}
 
-	array_walk($row, function(&$column) use ($boardurl) {
-		$column = str_replace('{$boardurl}', $boardurl, $column);
-	});
+	if (is_array($row))
+	{
+		array_walk($row, function(&$column) use ($boardurl) {
+			$column = str_replace('{$boardurl}', $boardurl, $column);
+		});
+	}
 
 	return $row;
 }
@@ -672,9 +675,10 @@ function smf_db_fetch_assoc($request, $counter = false)
 		$row = @pg_fetch_assoc($request, $db_row_count[(int) $request]++);
 	}
 
-	array_walk($row, function(&$column) use ($boardurl) {
-		$column = str_replace('{$boardurl}', $boardurl, $column);
-	});
+	if (is_array($row))
+		array_walk($row, function(&$column) use ($boardurl) {
+			$column = str_replace('{$boardurl}', $boardurl, $column);
+		});
 
 	return $row;
 }

--- a/Sources/Subs-Db-postgresql.php
+++ b/Sources/Subs-Db-postgresql.php
@@ -626,7 +626,7 @@ function smf_db_error($db_string, $connection = null)
  */
 function smf_db_fetch_row($request, $counter = false)
 {
-	global $db_row_count;
+	global $db_row_count, $boardurl;
 
 	if ($counter !== false)
 		$row = pg_fetch_row($request, $counter);
@@ -660,7 +660,7 @@ function smf_db_fetch_row($request, $counter = false)
  */
 function smf_db_fetch_assoc($request, $counter = false)
 {
-	global $db_row_count;
+	global $db_row_count, $boardurl;
 
 	if ($counter !== false)
 		$row = pg_fetch_assoc($request, $counter);

--- a/Sources/Subs-Db-postgresql.php
+++ b/Sources/Subs-Db-postgresql.php
@@ -308,7 +308,7 @@ function smf_db_quote($db_string, $db_values, $connection = null)
 function smf_db_query($identifier, $db_string, $db_values = array(), $connection = null)
 {
 	global $db_cache, $db_count, $db_connection, $db_show_debug, $time_start;
-	global $db_callback, $db_last_result, $db_replace_result, $modSettings;
+	global $db_callback, $db_last_result, $db_replace_result, $modSettings, $boardurl;
 
 	// Decide which connection to use.
 	$connection = $connection === null ? $db_connection : $connection;
@@ -388,6 +388,9 @@ function smf_db_query($identifier, $db_string, $db_values = array(), $connection
 
 		// Inject the values passed to this function.
 		$db_string = preg_replace_callback('~{([a-z_]+)(?::([a-zA-Z0-9_-]+))?}~', 'smf_db_replacement__callback', $db_string);
+
+		// Replace $boardurl with a token (we restore it when we retrieve the value)
+		$db_string = str_replace($boardurl, '{$boardurl}', $db_string);
 
 		// This shouldn't be residing in global space any longer.
 		$db_callback = array();
@@ -480,7 +483,7 @@ function smf_db_query($identifier, $db_string, $db_values = array(), $connection
 		}
 
 		$db_string = $query_hints_set . $db_string;
-		
+
 		if (isset($db_show_debug) && $db_show_debug === true && $db_cache[$db_count]['q'] != '...')
 			$db_cache[$db_count]['q'] = "\t\t" . $db_string;
 	}
@@ -626,14 +629,23 @@ function smf_db_fetch_row($request, $counter = false)
 	global $db_row_count;
 
 	if ($counter !== false)
-		return pg_fetch_row($request, $counter);
+		$row = pg_fetch_row($request, $counter);
 
-	// Reset the row counter...
-	if (!isset($db_row_count[(int) $request]))
-		$db_row_count[(int) $request] = 0;
+	else
+	{
+		// Reset the row counter...
+		if (!isset($db_row_count[(int) $request]))
+			$db_row_count[(int) $request] = 0;
 
-	// Return the right row.
-	return @pg_fetch_row($request, $db_row_count[(int) $request]++);
+		// Get the right row.
+		$row = @pg_fetch_row($request, $db_row_count[(int) $request]++);
+	}
+
+	array_walk($row, function(&$column) use ($boardurl) {
+		$column = str_replace('{$boardurl}', $boardurl, $column);
+	});
+
+	return $row;
 }
 
 /**
@@ -648,14 +660,23 @@ function smf_db_fetch_assoc($request, $counter = false)
 	global $db_row_count;
 
 	if ($counter !== false)
-		return pg_fetch_assoc($request, $counter);
+		$row = pg_fetch_assoc($request, $counter);
 
-	// Reset the row counter...
-	if (!isset($db_row_count[(int) $request]))
-		$db_row_count[(int) $request] = 0;
+	else
+	{
+		// Reset the row counter...
+		if (!isset($db_row_count[(int) $request]))
+			$db_row_count[(int) $request] = 0;
 
-	// Return the right row.
-	return @pg_fetch_assoc($request, $db_row_count[(int) $request]++);
+		// Get the right row.
+		$row = @pg_fetch_assoc($request, $db_row_count[(int) $request]++);
+	}
+
+	array_walk($row, function(&$column) use ($boardurl) {
+		$column = str_replace('{$boardurl}', $boardurl, $column);
+	});
+
+	return $row;
 }
 
 /**
@@ -963,7 +984,7 @@ function smf_db_escape_wildcard_string($string, $translate_human_wildcards = fal
 }
 
 /**
- * Fetches all rows from a result as an array 
+ * Fetches all rows from a result as an array
  *
  * @param resource $request A PostgreSQL result resource
  * @return array An array that contains all rows (records) in the result resource

--- a/other/install.php
+++ b/other/install.php
@@ -1059,7 +1059,6 @@ function DatabasePopulation()
 		'{$db_prefix}' => $db_prefix,
 		'{$attachdir}' => json_encode(array(1 => $smcFunc['db_escape_string']($attachdir))),
 		'{$boarddir}' => $smcFunc['db_escape_string'](dirname(__FILE__)),
-		'{$boardurl}' => $boardurl,
 		'{$enableCompressedOutput}' => isset($_POST['compress']) ? '1' : '0',
 		'{$databaseSession_enable}' => isset($_POST['dbsession']) ? '1' : '0',
 		'{$smf_version}' => $GLOBALS['current_smf_version'],

--- a/other/upgrade_2-1_mysql.sql
+++ b/other/upgrade_2-1_mysql.sql
@@ -2066,14 +2066,6 @@ UPDATE {$db_prefix}personal_messages SET body = REPLACE(REPLACE(body, '[blue]', 
 ---#
 
 /******************************************************************************/
---- Tokenizing references to forum URL in posts and personal messages
-/******************************************************************************/
----# Replacing $boardurl with token
-UPDATE {$db_prefix}messages SET body = REPLACE(body, '{$boardurl}', CONCAT('{$', 'boardurl}')) WHERE body LIKE '%{$boardurl}%';
-UPDATE {$db_prefix}personal_messages SET body = REPLACE(body, '{$boardurl}', CONCAT('{$', 'boardurl}')) WHERE body LIKE '%{$boardurl}%';
----#
-
-/******************************************************************************/
 --- Remove redundant indexes
 /******************************************************************************/
 ---# Duplicates to messages_current_topic

--- a/other/upgrade_2-1_mysql.sql
+++ b/other/upgrade_2-1_mysql.sql
@@ -973,7 +973,7 @@ $request = $smcFunc['db_query']('', '
 		'theme_dir' => 'theme_dir',
 	)
 );
-// Check which themes exist in the filesystem & save off their IDs 
+// Check which themes exist in the filesystem & save off their IDs
 // Dont delete default theme(start with 1 in the array), & make sure to delete old core theme
 $known_themes = array('1');
 $core_dir = $GLOBALS['boarddir'] . '/Themes/core';
@@ -2066,6 +2066,14 @@ UPDATE {$db_prefix}personal_messages SET body = REPLACE(REPLACE(body, '[blue]', 
 ---#
 
 /******************************************************************************/
+--- Tokenizing references to forum URL in posts and personal messages
+/******************************************************************************/
+---# Replacing $boardurl with token
+UPDATE {$db_prefix}messages SET body = REPLACE(body, '{$boardurl}', CONCAT('{$', 'boardurl}')) WHERE body LIKE '%{$boardurl}%';
+UPDATE {$db_prefix}personal_messages SET body = REPLACE(body, '{$boardurl}', CONCAT('{$', 'boardurl}')) WHERE body LIKE '%{$boardurl}%';
+---#
+
+/******************************************************************************/
 --- Remove redundant indexes
 /******************************************************************************/
 ---# Duplicates to messages_current_topic
@@ -2462,6 +2470,6 @@ SET lngfile = REPLACE(lngfile, '-utf8', '');
 /******************************************************************************/
 --- Create index for messages likes
 /******************************************************************************/
----# Add Index for messages likes 
+---# Add Index for messages likes
 CREATE INDEX idx_likes ON {$db_prefix}messages (likes DESC);
 ---#

--- a/other/upgrade_2-1_postgresql.sql
+++ b/other/upgrade_2-1_postgresql.sql
@@ -2089,14 +2089,6 @@ UPDATE {$db_prefix}personal_messages SET body = REPLACE(REPLACE(body, '[blue]', 
 ---#
 
 /******************************************************************************/
---- Tokenizing references to forum URL in posts and personal messages
-/******************************************************************************/
----# Replacing $boardurl with token
-UPDATE {$db_prefix}messages SET body = REPLACE(body, '{$boardurl}', CONCAT('{$', 'boardurl}')) WHERE body LIKE '%{$boardurl}%';
-UPDATE {$db_prefix}personal_messages SET body = REPLACE(body, '{$boardurl}', CONCAT('{$', 'boardurl}')) WHERE body LIKE '%{$boardurl}%';
----#
-
-/******************************************************************************/
 --- optimization of members
 /******************************************************************************/
 

--- a/other/upgrade_2-1_postgresql.sql
+++ b/other/upgrade_2-1_postgresql.sql
@@ -998,7 +998,7 @@ $request = $smcFunc['db_query']('', '
 		'theme_dir' => 'theme_dir',
 	)
 );
-// Check which themes exist in the filesystem & save off their IDs 
+// Check which themes exist in the filesystem & save off their IDs
 // Dont delete default theme(start with 1 in the array), & make sure to delete old core theme
 $known_themes = array('1');
 $core_dir = $GLOBALS['boarddir'] . '/Themes/core';
@@ -2089,6 +2089,14 @@ UPDATE {$db_prefix}personal_messages SET body = REPLACE(REPLACE(body, '[blue]', 
 ---#
 
 /******************************************************************************/
+--- Tokenizing references to forum URL in posts and personal messages
+/******************************************************************************/
+---# Replacing $boardurl with token
+UPDATE {$db_prefix}messages SET body = REPLACE(body, '{$boardurl}', CONCAT('{$', 'boardurl}')) WHERE body LIKE '%{$boardurl}%';
+UPDATE {$db_prefix}personal_messages SET body = REPLACE(body, '{$boardurl}', CONCAT('{$', 'boardurl}')) WHERE body LIKE '%{$boardurl}%';
+---#
+
+/******************************************************************************/
 --- optimization of members
 /******************************************************************************/
 
@@ -2422,7 +2430,7 @@ CREATE INDEX {$db_prefix}members_birthdate2 ON {$db_prefix}members (indexable_mo
 /******************************************************************************/
 --- Create index for messages likes
 /******************************************************************************/
----# Add Index for messages likes 
+---# Add Index for messages likes
 DROP INDEX IF EXISTS {$db_prefix}messages_likes;
 CREATE INDEX {$db_prefix}messages_likes ON {$db_prefix}messages (likes DESC);
 ---#


### PR DESCRIPTION
As discussed in #3726, this commit implements seamless substitution of the value of $boardurl with a token when reading and writing to the database.

This approach solves a few problems:

* Activating or deactivating SSL will not break existing URLs in settings
* Changing the domain or path of the forum will not break existing URLs in settings
* Quotes and links in posts that refer to other posts will always use the proper value of $boardurl

It works by (1) replacing all occurrences of the value of $boardurl with the literal string `{$boardurl}` just before writing in smf_db_query(), and then (2) performing the opposite operation immediately after reading using smf_db_fetch_assoc() or smf_db_fetch_row().

Note:
1. During a fresh install, we no longer replace `{$boardurl}` in the install SQL files with the value of $boardurl, because we want to use that token in the database now.
2. During an upgrade to 2.1, we replace all literal references to the value of $boardurl in posts and personal messages with the token.

Fixes #3726