### PR TITLE
Fixes #4274

### DIFF
--- a/other/install.php
+++ b/other/install.php
@@ -150,8 +150,8 @@ function initialize_inputs()
 	if (!isset($_SERVER['PHP_SELF']))
 		$_SERVER['PHP_SELF'] = isset($GLOBALS['HTTP_SERVER_VARS']['PHP_SELF']) ? $GLOBALS['HTTP_SERVER_VARS']['PHP_SELF'] : 'install.php';
 
-	// Enable error reporting.
-	error_reporting(E_ALL);
+	// Enable error reporting for fatal errors.
+	error_reporting(E_ERROR | E_PARSE);
 
 	// Fun.  Low PHP version...
 	if (!isset($_GET))


### PR DESCRIPTION
Installer - Don't display warnings inline, only serious errors.
This will prevent warning messages (e.g., wrong db credentials) from displaying twice on the screen, once formatted & once raw.