### PR TITLE
Fixes #3393

### DIFF
--- a/SSI.php
+++ b/SSI.php
@@ -1924,7 +1924,6 @@ function ssi_boardNews($board = null, $limit = null, $start = null, $length = nu
 	if (!empty($modSettings['enable_likes']))
 	{
 		$context['can_like'] = allowedTo('likes_like');
-		$context['can_see_likes'] = allowedTo('likes_view');
 	}
 
 	// Find the post ids.
@@ -2068,7 +2067,7 @@ function ssi_boardNews($board = null, $limit = null, $start = null, $length = nu
 						<li class="like_button" id="msg_', $news['message_id'], '_likes"><a href="', $scripturl, '?action=likes;ltype=msg;sa=like;like=', $news['message_id'], ';', $context['session_var'], '=', $context['session_id'], '" class="msg_like"><span class="', $news['likes']['you'] ? 'unlike' : 'like', '"></span>', $news['likes']['you'] ? $txt['unlike'] : $txt['like'], '</a></li>';
 			}
 
-			if (!empty($news['likes']['count']) && !empty($context['can_see_likes']))
+			if (!empty($news['likes']['count']))
 			{
 				$context['some_likes'] = true;
 				$count = $news['likes']['count'];

--- a/Sources/Display.php
+++ b/Sources/Display.php
@@ -1251,7 +1251,6 @@ function Display()
 		'can_issue_warning' => 'issue_warning',
 		'can_restore_topic' => 'move_any',
 		'can_restore_msg' => 'move_any',
-		'can_see_likes' => 'likes_view',
 		'can_like' => 'likes_like',
 	);
 	foreach ($common_permissions as $contextual => $perm)

--- a/Sources/Likes.php
+++ b/Sources/Likes.php
@@ -58,9 +58,8 @@ class Likes
 
 	/**
 	 * @var array $_validLikes mostly used for external integration, needs to be filled as an array with the following keys:
-	 * => 'can_see' boolean|string whether or not the current user can see the like.
 	 * => 'can_like' boolean|string whether or not the current user can actually like your content.
-	 * for both can_like and can_see: Return a boolean true if the user can, otherwise return a string, the string will be used as key in a regular $txt language error var. The code assumes you already loaded your language file. If no value is returned or the $txt var isn't set, the code will use a generic error message.
+	 * for can_like: Return a boolean true if the user can, otherwise return a string, the string will be used as key in a regular $txt language error var. The code assumes you already loaded your language file. If no value is returned or the $txt var isn't set, the code will use a generic error message.
 	 * => 'redirect' string To add support for non JS users, It is highly encouraged to set a valid URL to redirect the user to, if you don't provide any, the code will redirect the user to the main page. The code only performs a light check to see if the redirect is valid so be extra careful while building it.
 	 * => 'type' string 6 letters or numbers. The unique identifier for your content, the code doesn't check for duplicate entries, if there are 2 or more exact hook calls, the code will take the first registered one so make sure you provide a unique identifier. Must match with what you sent in $_GET['ltype'].
 	 * => 'flush_cache' boolean this is optional, it tells the code to reset your like content's cache entry after a new entry has been inserted.
@@ -68,7 +67,6 @@ class Likes
 	 * => 'json' boolean optional defaults to false, if true the Like class will return a json object as response instead of HTML.
 	 */
 	protected $_validLikes = array(
-		'can_see' => false,
 		'can_like' => false,
 		'redirect' => '',
 		'type' => '',
@@ -221,7 +219,6 @@ class Likes
 			$this->_validLikes['type'] = 'msg';
 			$this->_validLikes['flush_cache'] = 'likes_topic_' . $this->_idTopic . '_' . $this->_user['id'];
 			$this->_validLikes['redirect'] = 'topic=' . $this->_idTopic . '.msg' . $this->_content . '#msg' . $this->_content;
-			$this->_validLikes['can_see'] = allowedTo('likes_view') ? true : 'cannot_view_likes';
 
 			$this->_validLikes['can_like'] = ($this->_user['id'] == $topicOwner ? 'cannot_like_content' : (allowedTo('likes_like') ? true : 'cannot_like_content'));
 		}
@@ -231,7 +228,7 @@ class Likes
 			// Modders: This will give you whatever the user offers up in terms of liking, e.g. $this->_type=msg, $this->_content=1
 			// When you hook this, check $this->_type first. If it is not something your mod worries about, return false.
 			// Otherwise, fill an array according to the docs for $this->_validLikes. Determine (however you need to) that the user can see and can_like the relevant liked content (and it exists) Remember that users can't like their own content.
-			// If the user cannot see it, return the appropriate key (can_see) as false. If the user can see it and can like it, you MUST return your type in the 'type' key back.
+			// If the user can like it, you MUST return your type in the 'type' key back.
 			// See also issueLike() for further notes.
 			$can_like = call_integration_hook('integrate_valid_likes', array($this->_type, $this->_content, $this->_sa, $this->_js, $this->_extra));
 
@@ -259,10 +256,6 @@ class Likes
 			if (!$found)
 				return $this->_error = 'cannot_';
 		}
-
-		// Does the user can see this?
-		if (isset($this->_validLikes['can_see']) && is_string($this->_validLikes['can_see']))
-			return $this->_error = $this->_validLikes['can_see'];
 
 		// Does the user can like this? Viewing a list of likes doesn't require this permission.
 			if ($this->_sa != 'view' && isset($this->_validLikes['can_like']) && is_string($this->_validLikes['can_like']))
@@ -434,7 +427,6 @@ class Likes
 			'id_content' => $this->_content,
 			'count' => $this->_numLikes,
 			'can_like' => $this->_validLikes['can_like'],
-			'can_see' => $this->_validLikes['can_see'],
 			'already_liked' => empty($this->_alreadyLiked),
 			'type' => $this->_type,
 		);

--- a/Sources/ManagePermissions.php
+++ b/Sources/ManagePermissions.php
@@ -1124,7 +1124,6 @@ function setPermissionLevel($level, $group, $profile = 'null')
 	// Standard - ie. members.  They can do anything Restrictive can.
 	$groupLevels['global']['standard'] = array_merge($groupLevels['global']['restrict'], array(
 		'view_mlist',
-		'likes_view',
 		'likes_like',
 		'mention',
 		'pm_read',
@@ -1486,7 +1485,6 @@ function loadAllPermissions()
 			'profile_password' => array(true, 'profile_account'),
 			'profile_remove' => array(true, 'profile_account'),
 			'view_warning' => array(true, 'profile_account'),
-			'likes_view' => array(false, 'likes'),
 			'likes_like' => array(false, 'likes'),
 			'mention' => array(false, 'mentions'),
 		),
@@ -1584,7 +1582,6 @@ function loadAllPermissions()
 	// Hide Likes/Mentions permissions...
 	if (empty($modSettings['enable_likes']))
 	{
-		$hiddenPermissions[] = 'likes_view';
 		$hiddenPermissions[] = 'likes_like';
 	}
 	if (empty($modSettings['enable_mentions']))

--- a/Sources/ManageSettings.php
+++ b/Sources/ManageSettings.php
@@ -373,7 +373,6 @@ function ModifyLikesSettings($return_config = false)
 
 	$config_vars = array(
 		array('check', 'enable_likes'),
-		array('permissions', 'likes_view'),
 		array('permissions', 'likes_like'),
 	);
 

--- a/Themes/default/Display.template.php
+++ b/Themes/default/Display.template.php
@@ -794,7 +794,7 @@ function template_single_post($message)
 	}
 
 	// And stuff below the attachments.
-	if ($context['can_report_moderator'] || !empty($context['can_like']) || $message['can_approve'] || $message['can_unapprove'] || $context['can_reply'] || $message['can_modify'] || $message['can_remove'] || $context['can_split'] || $context['can_restore_msg'] || $context['can_quote'])
+	if ($context['can_report_moderator'] || !empty($modSettings['enable_likes']) || $message['can_approve'] || $message['can_unapprove'] || $context['can_reply'] || $message['can_modify'] || $message['can_remove'] || $context['can_split'] || $context['can_restore_msg'] || $context['can_quote'])
 	echo '
 							<div class="under_message">';
 
@@ -913,7 +913,7 @@ function template_single_post($message)
 								</ul>';
 	}
 
-	if ($context['can_report_moderator'] || !empty($context['can_like']) || $message['can_approve'] || $message['can_unapprove'] || $context['can_reply'] || $message['can_modify'] || $message['can_remove'] || $context['can_split'] || $context['can_restore_msg'] || $context['can_quote'])
+	if ($context['can_report_moderator'] || !empty($modSettings['enable_likes']) || $message['can_approve'] || $message['can_unapprove'] || $context['can_reply'] || $message['can_modify'] || $message['can_remove'] || $context['can_split'] || $context['can_restore_msg'] || $context['can_quote'])
 	echo '
 							</div>';
 

--- a/Themes/default/Display.template.php
+++ b/Themes/default/Display.template.php
@@ -794,7 +794,7 @@ function template_single_post($message)
 	}
 
 	// And stuff below the attachments.
-	if ($context['can_report_moderator'] || !empty($context['can_see_likes']) || !empty($context['can_like']) || $message['can_approve'] || $message['can_unapprove'] || $context['can_reply'] || $message['can_modify'] || $message['can_remove'] || $context['can_split'] || $context['can_restore_msg'] || $context['can_quote'])
+	if ($context['can_report_moderator'] || !empty($context['can_like']) || $message['can_approve'] || $message['can_unapprove'] || $context['can_reply'] || $message['can_modify'] || $message['can_remove'] || $context['can_split'] || $context['can_restore_msg'] || $context['can_quote'])
 	echo '
 							<div class="under_message">';
 
@@ -817,7 +817,7 @@ function template_single_post($message)
 									<li class="like_button" id="msg_', $message['id'], '_likes"', $ignoring ? ' style="display:none;"' : '', '><a href="', $scripturl, '?action=likes;ltype=msg;sa=like;like=', $message['id'], ';', $context['session_var'], '=', $context['session_id'], '" class="msg_like"><span class="generic_icons ', $message['likes']['you'] ? 'unlike' : 'like', '"></span> ', $message['likes']['you'] ? $txt['unlike'] : $txt['like'], '</a></li>';
 		}
 
-		if (!empty($message['likes']['count']) && !empty($context['can_see_likes']))
+		if (!empty($message['likes']['count']))
 		{
 			$context['some_likes'] = true;
 			$count = $message['likes']['count'];
@@ -913,7 +913,7 @@ function template_single_post($message)
 								</ul>';
 	}
 
-	if ($context['can_report_moderator'] || !empty($context['can_see_likes']) || !empty($context['can_like']) || $message['can_approve'] || $message['can_unapprove'] || $context['can_reply'] || $message['can_modify'] || $message['can_remove'] || $context['can_split'] || $context['can_restore_msg'] || $context['can_quote'])
+	if ($context['can_report_moderator'] || !empty($context['can_like']) || $message['can_approve'] || $message['can_unapprove'] || $context['can_reply'] || $message['can_modify'] || $message['can_remove'] || $context['can_split'] || $context['can_restore_msg'] || $context['can_quote'])
 	echo '
 							</div>';
 

--- a/Themes/default/languages/Admin.english.php
+++ b/Themes/default/languages/Admin.english.php
@@ -745,7 +745,6 @@ $txt['board_perms_deny'] = 'Deny';
 $txt['all_boards_in_cat'] = 'All boards in this category';
 
 $txt['likes_like'] = 'Membergroups allowed to like posts';
-$txt['likes_view'] = 'Membergroups allowed to view likes';
 
 $txt['mention'] = 'Membergroups allowed to mention users';
 

--- a/Themes/default/languages/ManagePermissions.english.php
+++ b/Themes/default/languages/ManagePermissions.english.php
@@ -237,8 +237,6 @@ $txt['permissionname_report_any'] = 'Report posts to the moderators';
 $txt['permissionhelp_report_any'] = 'This permission adds a link to each message, allowing a user to report a post to a moderator. On reporting, all moderators on that board will receive an email with a link to the reported post and a description of the problem (as given by the reporting user).';
 
 $txt['permissiongroup_likes'] = 'Likes';
-$txt['permissionname_likes_view'] = 'View likes';
-$txt['permissionhelp_likes_view'] = 'This permission allows an user to view any likes. Without this permission, the user will only see the likes she/he has made.';
 $txt['permissionname_likes_like'] = 'Can like any content';
 $txt['permissionhelp_likes_like'] = 'This permission allows an user to like any content. Users aren\'t allowed to like their own content.';
 


### PR DESCRIPTION
All users even guests can see likes.

Note (1): I could not test the SSI function - would appreciate another set of eyes & /or testing by someone.  
Note (2): I kept the 'cannot_view_likes' error message, as it is used as a generic trap message in Likes logic.
