### PR TITLE
Use cache folder for db_last_error

### DIFF
--- a/Sources/Logging.php
+++ b/Sources/Logging.php
@@ -183,29 +183,29 @@ function writeLog($force = false)
  */
 function logLastDatabaseError()
 {
-	global $boarddir;
+	global $boarddir, $cachedir;
 
 	// Make a note of the last modified time in case someone does this before us
-	$last_db_error_change = @filemtime($boarddir . '/db_last_error.php');
+	$last_db_error_change = @filemtime($cachedir . '/db_last_error.php');
 
 	// save the old file before we do anything
-	$file = $boarddir . '/db_last_error.php';
-	$dberror_backup_fail = !@is_writable($boarddir . '/db_last_error_bak.php') || !@copy($file, $boarddir . '/db_last_error_bak.php');
-	$dberror_backup_fail = !$dberror_backup_fail ? (!file_exists($boarddir . '/db_last_error_bak.php') || filesize($boarddir . '/db_last_error_bak.php') === 0) : $dberror_backup_fail;
+	$file = $cachedir . '/db_last_error.php';
+	$dberror_backup_fail = !@is_writable($cachedir . '/db_last_error_bak.php') || !@copy($file, $cachedir . '/db_last_error_bak.php');
+	$dberror_backup_fail = !$dberror_backup_fail ? (!file_exists($cachedir . '/db_last_error_bak.php') || filesize($cachedir . '/db_last_error_bak.php') === 0) : $dberror_backup_fail;
 
 	clearstatcache();
-	if (filemtime($boarddir . '/db_last_error.php') === $last_db_error_change)
+	if (filemtime($cachedir . '/db_last_error.php') === $last_db_error_change)
 	{
 		// Write the change
 		$write_db_change =  '<' . '?' . "php\n" . '$db_last_error = ' . time() . ';' . "\n" . '?' . '>';
-		$written_bytes = file_put_contents($boarddir . '/db_last_error.php', $write_db_change, LOCK_EX);
+		$written_bytes = file_put_contents($cachedir . '/db_last_error.php', $write_db_change, LOCK_EX);
 
 		// survey says ...
 		if ($written_bytes !== strlen($write_db_change) && !$dberror_backup_fail)
 		{
 			// Oops. maybe we have no more disk space left, or some other troubles, troubles...
 			// Copy the file back and run for your life!
-			@copy($boarddir . '/db_last_error_bak.php', $boarddir . '/db_last_error.php');
+			@copy($cachedir . '/db_last_error_bak.php', $cachedir . '/db_last_error.php');
 		}
 		else
 		{

--- a/Sources/Subs-Admin.php
+++ b/Sources/Subs-Admin.php
@@ -439,10 +439,10 @@ function updateSettingsFile($config_vars)
  */
 function updateDbLastError($time)
 {
-	global $boarddir;
+	global $boarddir, $cachedir;
 
 	// Write out the db_last_error file with the error timestamp
-	file_put_contents($boarddir . '/db_last_error.php', '<' . '?' . "php\n" . '$db_last_error = ' . $time . ';' . "\n" . '?' . '>', LOCK_EX);
+	file_put_contents($cachedir . '/db_last_error.php', '<' . '?' . "php\n" . '$db_last_error = ' . $time . ';' . "\n" . '?' . '>', LOCK_EX);
 	@touch($boarddir . '/' . 'Settings.php');
 }
 /**

--- a/other/Settings.php
+++ b/other/Settings.php
@@ -184,23 +184,6 @@ $packagesdir = dirname(__FILE__) . '/Packages';
  */
 $tasksdir = $sourcedir . '/tasks';
 
-########## Error-Catching ##########
-# Note: You shouldn't touch these settings.
-if (file_exists(dirname(__FILE__) . '/db_last_error.php'))
-	include(dirname(__FILE__) . '/db_last_error.php');
-
-if (!isset($db_last_error))
-{
-	// File does not exist so lets try to create it
-	file_put_contents(dirname(__FILE__) . '/db_last_error.php', '<' . '?' . "php\n" . '$db_last_error = 0;' . "\n" . '?' . '>');
-	$db_last_error = 0;
-}
-
-if (file_exists(dirname(__FILE__) . '/install.php'))
-{
-	header('Location: http' . (!empty($_SERVER['HTTPS']) && strtolower($_SERVER['HTTPS']) == 'on' ? 's' : '') . '://' . (empty($_SERVER['HTTP_HOST']) ? $_SERVER['SERVER_NAME'] . (empty($_SERVER['SERVER_PORT']) || $_SERVER['SERVER_PORT'] == '80' ? '' : ':' . $_SERVER['SERVER_PORT']) : $_SERVER['HTTP_HOST']) . (strtr(dirname($_SERVER['PHP_SELF']), '\\', '/') == '/' ? '' : strtr(dirname($_SERVER['PHP_SELF']), '\\', '/')) . '/install.php'); exit;
-}
-
 # Make sure the paths are correct... at least try to fix them.
 if (!file_exists($boarddir) && file_exists(dirname(__FILE__) . '/agreement.txt'))
 	$boarddir = dirname(__FILE__);
@@ -208,5 +191,22 @@ if (!file_exists($sourcedir) && file_exists($boarddir . '/Sources'))
 	$sourcedir = $boarddir . '/Sources';
 if (!file_exists($cachedir) && file_exists($boarddir . '/cache'))
 	$cachedir = $boarddir . '/cache';
+
+########## Error-Catching ##########
+# Note: You shouldn't touch these settings.
+if (file_exists($cachedir . '/db_last_error.php'))
+	include($cachedir . '/db_last_error.php');
+
+if (!isset($db_last_error))
+{
+	// File does not exist so lets try to create it
+	file_put_contents($cachedir . '/db_last_error.php', '<' . '?' . "php\n" . '$db_last_error = 0;' . "\n" . '?' . '>');
+	$db_last_error = 0;
+}
+
+if (file_exists(dirname(__FILE__) . '/install.php'))
+{
+	header('Location: http' . (!empty($_SERVER['HTTPS']) && strtolower($_SERVER['HTTPS']) == 'on' ? 's' : '') . '://' . (empty($_SERVER['HTTP_HOST']) ? $_SERVER['SERVER_NAME'] . (empty($_SERVER['SERVER_PORT']) || $_SERVER['SERVER_PORT'] == '80' ? '' : ':' . $_SERVER['SERVER_PORT']) : $_SERVER['HTTP_HOST']) . (strtr(dirname($_SERVER['PHP_SELF']), '\\', '/') == '/' ? '' : strtr(dirname($_SERVER['PHP_SELF']), '\\', '/')) . '/install.php'); exit;
+}
 
 ?>

--- a/other/install.php
+++ b/other/install.php
@@ -511,7 +511,6 @@ function CheckFilesWritable()
 		'agreement.txt',
 		'Settings.php',
 		'Settings_bak.php',
-		'db_last_error.php',
 	);
 
 	foreach ($incontext['detected_languages'] as $lang => $temp)
@@ -1797,8 +1796,13 @@ function updateSettingsFile($vars)
 
 function updateDbLastError()
 {
+	global $cachedir;
+
 	// Write out the db_last_error file with the error timestamp
-	file_put_contents(dirname(__FILE__) . '/db_last_error.php', '<' . '?' . "php\n" . '$db_last_error = 0;' . "\n" . '?' . '>');
+	if (!empty($cachedir) && is_writable($cachedir))
+		file_put_contents($cachedir . '/db_last_error.php', '<' . '?' . "php\n" . '$db_last_error = 0;' . "\n" . '?' . '>');
+	else
+		file_put_contents(dirname(__FILE__) . '/cache/db_last_error.php', '<' . '?' . "php\n" . '$db_last_error = 0;' . "\n" . '?' . '>');
 
 	return true;
 }

--- a/other/upgrade.php
+++ b/other/upgrade.php
@@ -661,11 +661,15 @@ function WelcomeLogin()
 	$writable_files = array(
 		$boarddir . '/Settings.php',
 		$boarddir . '/Settings_bak.php',
-		$boarddir . '/db_last_error.php',
-		$modSettings['theme_dir'] . '/css/minified.css',
-		$modSettings['theme_dir'] . '/scripts/minified.js',
-		$modSettings['theme_dir'] . '/scripts/minified_deferred.js',
 	);
+
+	// Only check for minified writable files if we have it enabled or not set.
+	if (!empty($modSettings['minimize_files']) || !isset($modSettings['minimize_files']))
+		$writable_files += array(
+			$modSettings['theme_dir'] . '/css/minified.css',
+			$modSettings['theme_dir'] . '/scripts/minified.js',
+			$modSettings['theme_dir'] . '/scripts/minified_deferred.js',
+		);
 
 	// Do we need to add this setting?
 	$need_settings_update = empty($modSettings['custom_avatar_dir']);
@@ -2387,11 +2391,6 @@ Usage: /path/to/php -f ' . basename(__FILE__) . ' -- [OPTION]...
 	if (!is_writable($boarddir . '/Settings_bak.php'))
 		print_error('Error: Unable to obtain write access to "Settings_bak.php".');
 
-	// Make sure db_last_error.php is writable.
-	quickFileWritable($boarddir . '/db_last_error.php');
-	if (!is_writable($boarddir . '/db_last_error.php'))
-		print_error('Error: Unable to obtain write access to "db_last_error.php".');
-
 	if (isset($modSettings['agreement']) && (!is_writable($boarddir) || file_exists($boarddir . '/agreement.txt')) && !is_writable($boarddir . '/agreement.txt'))
 		print_error('Error: Unable to obtain write access to "agreement.txt".');
 	elseif (isset($modSettings['agreement']))
@@ -2417,6 +2416,11 @@ Usage: /path/to/php -f ' . basename(__FILE__) . ' -- [OPTION]...
 
 	if (!is_writable($cachedir_temp))
 		print_error('Error: Unable to obtain write access to "cache".', true);
+
+	// Make sure db_last_error.php is writable.
+	quickFileWritable($cachedir_temp . '/db_last_error.php');
+	if (!is_writable($cachedir_temp . '/db_last_error.php'))
+		print_error('Error: Unable to obtain write access to "db_last_error.php".');
 
 	if (!file_exists($modSettings['theme_dir'] . '/languages/index.' . $upcontext['language'] . '.php') && !isset($modSettings['smfVersion']) && !isset($_GET['lang']))
 		print_error('Error: Unable to find language files!', true);


### PR DESCRIPTION
Also, Make sure we only verify minified files are writable if we have it enabled or have not set it yet.

Not all forums run with having world writable files in public folders.  This changes this to use the cache folder.  Which should be writable and per a admins configuration can be outside of the any public folders.

The only thing this doesn't cover it cleaning up Settings.php.  But so far none of the other changes done also cleanup Settings.php or prep it for a improved upgraded version.

Signed-off-by: jdarwood007 <unmonitored+github@sleepycode.com>