### PR TITLE
Change BoardIndex Templates to be more flexible

### DIFF
--- a/Sources/Subs-BoardIndex.php
+++ b/Sources/Subs-BoardIndex.php
@@ -133,6 +133,7 @@ function getBoardIndex($boardIndexOptions)
 				$this_category[$row_board['id_board']] = array(
 					'new' => empty($row_board['is_read']),
 					'id' => $row_board['id_board'],
+					'type' => $row_board['is_redirect'] ? 'redirect' : 'board',
 					'name' => $row_board['board_name'],
 					'description' => $row_board['description'],
 					'moderators' => array(),

--- a/Themes/default/BoardIndex.template.php
+++ b/Themes/default/BoardIndex.template.php
@@ -132,7 +132,7 @@ function template_main()
 }
 
 /**
- * Outs the board icon for a standard board.
+ * Outputs the board icon for a standard board.
  *
  * @param array $board Current board information.
  */
@@ -145,7 +145,7 @@ function template_bi_board_icon($board)
 }
 
 /**
- * Outs the board icon for a redirect.
+ * Outputs the board icon for a redirect.
  *
  * @param array $board Current board information.
  */
@@ -158,7 +158,7 @@ function template_bi_redirect_icon($board)
 }
 
 /**
- * Outs the board info for a standard board or redirect.
+ * Outputs the board info for a standard board or redirect.
  *
  * @param array $board Current board information.
  */
@@ -187,7 +187,7 @@ function template_bi_board_info($board)
 }
 
 /**
- * Outs the board stats for a standard board.
+ * Outputs the board stats for a standard board.
  *
  * @param array $board Current board information.
  */
@@ -202,7 +202,7 @@ function template_bi_board_stats($board)
 }
 
 /**
- * Outs the board stats for a redirect.
+ * Outputs the board stats for a redirect.
  *
  * @param array $board Current board information.
  */
@@ -216,8 +216,8 @@ function template_bi_redirect_stats($board)
 }
 
 /**
- * Outs the board lastposts for a standard board or a redirect.
- * This gets hidden on mobile if $board['last_post']['id'] is empty by the main template.
+ * Outputs the board lastposts for a standard board or a redirect.
+ * When on a mobile device, this may be hidden if no last post exists.
  *
  * @param array $board Current board information.
  */
@@ -229,7 +229,7 @@ function template_bi_board_lastpost($board)
 }
 
 /**
- * Outs the board children for a standard board.
+ * Outputs the board children for a standard board.
  *
  * @param array $board Current board information.
  */

--- a/Themes/default/BoardIndex.template.php
+++ b/Themes/default/BoardIndex.template.php
@@ -95,69 +95,23 @@ function template_main()
 			{
 				echo '
 				<div id="board_', $board['id'], '" class="up_contain ', (!empty($board['css_class']) ? $board['css_class'] : ''), '">
-					<div class="board_icon">
-						<a href="', ($board['is_redirect'] || $context['user']['is_guest'] ? $board['href'] : $scripturl . '?action=unread;board=' . $board['id'] . '.0;children'), '" class="board_', $board['board_class'], '"', !empty($board['board_tooltip']) ? ' title="' . $board['board_tooltip'] . '"' : '', '></a>
+					<div class="board_icon">', function_exists('template_bi_' . $board['type'] . '_icon') ? call_user_func('template_bi_' . $board['type'] . '_icon', $board) : template_bi_board_icon($board), '
 					</div>
-					<div class="info">
-						<a class="subject mobile_subject" href="', $board['href'], '" id="b', $board['id'], '">
-							', $board['name'], '
-							<p class="board_description mobile_display">', $board['description'], '</p>
-						</a>';
-
-				// Has it outstanding posts for approval?
-				if ($board['can_approve_posts'] && ($board['unapproved_posts'] || $board['unapproved_topics']))
-					echo '
-						<a href="', $scripturl, '?action=moderate;area=postmod;sa=', ($board['unapproved_topics'] > 0 ? 'topics' : 'posts'), ';brd=', $board['id'], ';', $context['session_var'], '=', $context['session_id'], '" title="', sprintf($txt['unapproved_posts'], $board['unapproved_topics'], $board['unapproved_posts']), '" class="moderation_link">(!)</a>';
-
-				echo '
-						<p class="board_description">', $board['description'], '</p>';
-
-				// Show the "Moderators: ". Each has name, href, link, and id. (but we're gonna use link_moderators.)
-				if (!empty($board['link_moderators']))
-					echo '
-						<p class="moderators">', count($board['link_moderators']) == 1 ? $txt['moderator'] : $txt['moderators'], ': ', implode(', ', $board['link_moderators']), '</p>';
+					<div class="info">', function_exists('template_bi_' . $board['type'] . '_info') ? call_user_func('template_bi_' . $board['type'] . '_info', $board) : template_bi_board_info($board);
 
 				// Show some basic information about the number of posts, etc.
 					echo '
 					</div>
-					<div class="board_stats">
-						<p>', comma_format($board['posts']), ' ', $board['is_redirect'] ? $txt['redirects'] : $txt['posts'], '
-						', $board['is_redirect'] ? '' : '<br> ' . comma_format($board['topics']) . ' ' . $txt['board_topics'], '
-						</p>
+					<div class="board_stats">', function_exists('template_bi_' . $board['type'] . '_stats') ? call_user_func('template_bi_' . $board['type'] . '_stats', $board) : template_bi_board_stats($board), '
 					</div>
-					<div class="lastpost ',!empty($board['last_post']['id']) ? 'lpr_border' : 'hidden', '">';
-
-				if (!empty($board['last_post']['id']))
-					echo '
-						<p>', $board['last_post']['last_post_message'], '</p>';
-				echo '
+					<div class="lastpost ',!empty($board['last_post']['id']) ? 'lpr_border' : 'hidden', '">', function_exists('template_bi_' . $board['type'] . '_lastpost') ? call_user_func('template_bi_' . $board['type'] . '_lastpost', $board) : template_bi_board_lastpost($board), '
 					</div>';
-				// Show the "Child Boards: ". (there's a link_children but we're going to bold the new ones...)
-				if (!empty($board['children']))
-				{
-					// Sort the links into an array with new boards bold so it can be imploded.
-					$children = array();
-					/* Each child in each board's children has:
-							id, name, description, new (is it new?), topics (#), posts (#), href, link, and last_post. */
-					foreach ($board['children'] as $child)
-					{
-						if (!$child['is_redirect'])
-							$child['link'] = ''. ($child['new'] ? '<a href="' . $scripturl . '?action=unread;board=' . $child['id'] . '" title="' . $txt['new_posts'] . ' (' . $txt['board_topics'] . ': ' . comma_format($child['topics']) . ', ' . $txt['posts'] . ': ' . comma_format($child['posts']) . ')"><span class="new_posts">' . $txt['new'] . '</span></a>' : '') . '<a href="' . $child['href'] . '" ' . ($child['new'] ? 'class="board_new_posts" ' : '') . 'title="' . ($child['new'] ? $txt['new_posts'] : $txt['old_posts']) . ' (' . $txt['board_topics'] . ': ' . comma_format($child['topics']) . ', ' . $txt['posts'] . ': ' . comma_format($child['posts']) . ')">' . $child['name'] . '</a>';
-						else
-							$child['link'] = '<a href="' . $child['href'] . '" title="' . comma_format($child['posts']) . ' ' . $txt['redirects'] . ' - ' . $child['short_description'] . '">' . $child['name'] . '</a>';
 
-						// Has it posts awaiting approval?
-						if ($child['can_approve_posts'] && ($child['unapproved_posts'] || $child['unapproved_topics']))
-							$child['link'] .= ' <a href="' . $scripturl . '?action=moderate;area=postmod;sa=' . ($child['unapproved_topics'] > 0 ? 'topics' : 'posts') . ';brd=' . $child['id'] . ';' . $context['session_var'] . '=' . $context['session_id'] . '" title="' . sprintf($txt['unapproved_posts'], $child['unapproved_topics'], $child['unapproved_posts']) . '" class="moderation_link">(!)</a>';
-
-						$children[] = $child['new'] ? '<span class="strong">' . $child['link'] . '</span>' : '<span>' . $child['link'] . '</span>';
-					}
-
-				echo '
-					<div id="board_', $board['id'], '_children" class="children">
-						<p><strong id="child_list_', $board['id'], '">', $txt['sub_boards'], '</strong>', implode($children), '</p>
-					</div>';
-				}
+				// Won't somebody think of the children!
+				if (function_exists('template_bi_' . $board['type'] . '_children'))
+					call_user_func('template_bi_' . $board['type'] . '_children', $board);
+				else
+					template_bi_board_children($board);
 
 				echo '
 					</div>';
@@ -175,6 +129,140 @@ function template_main()
 	if ($context['user']['is_logged'] && !empty($context['categories']))
 		echo '
 		<div class="mark_read">', template_button_strip($context['mark_read_button'], 'right'), '</div>';
+}
+
+/**
+ * Outs the board icon for a standard board.
+ *
+ * @param array $board Current board information.
+ */
+function template_bi_board_icon($board)
+{
+	global $context, $scripturl;
+
+	echo '
+						<a href="', ($context['user']['is_guest'] ? $board['href'] : $scripturl . '?action=unread;board=' . $board['id'] . '.0;children'), '" class="board_', $board['board_class'], '"', !empty($board['board_tooltip']) ? ' title="' . $board['board_tooltip'] . '"' : '', '></a>';
+}
+
+/**
+ * Outs the board icon for a redirect.
+ *
+ * @param array $board Current board information.
+ */
+function template_bi_redirect_icon($board)
+{
+	global $context, $scripturl;
+
+	echo '
+						<a href="', $board['href'], '" class="board_', $board['board_class'], '"', !empty($board['board_tooltip']) ? ' title="' . $board['board_tooltip'] . '"' : '', '></a>';
+}
+
+/**
+ * Outs the board info for a standard board or redirect.
+ *
+ * @param array $board Current board information.
+ */
+function template_bi_board_info($board)
+{
+	global $context, $scripturl, $txt;
+
+	echo '
+						<a class="subject mobile_subject" href="', $board['href'], '" id="b', $board['id'], '">
+							', $board['name'], '
+							<p class="board_description mobile_display">', $board['description'], '</p>
+						</a>';
+
+	// Has it outstanding posts for approval?
+	if ($board['can_approve_posts'] && ($board['unapproved_posts'] || $board['unapproved_topics']))
+		echo '
+						<a href="', $scripturl, '?action=moderate;area=postmod;sa=', ($board['unapproved_topics'] > 0 ? 'topics' : 'posts'), ';brd=', $board['id'], ';', $context['session_var'], '=', $context['session_id'], '" title="', sprintf($txt['unapproved_posts'], $board['unapproved_topics'], $board['unapproved_posts']), '" class="moderation_link">(!)</a>';
+
+	echo '
+						<p class="board_description">', $board['description'], '</p>';
+
+	// Show the "Moderators: ". Each has name, href, link, and id. (but we're gonna use link_moderators.)
+	if (!empty($board['link_moderators']))
+		echo '
+						<p class="moderators">', count($board['link_moderators']) == 1 ? $txt['moderator'] : $txt['moderators'], ': ', implode(', ', $board['link_moderators']), '</p>';
+}
+
+/**
+ * Outs the board stats for a standard board.
+ *
+ * @param array $board Current board information.
+ */
+function template_bi_board_stats($board)
+{
+	global $txt;
+
+	echo '
+						<p>', comma_format($board['posts']), ' ', $txt['posts'], '
+						', '<br> ' . comma_format($board['topics']) . ' ' . $txt['board_topics'], '
+						</p>';
+}
+
+/**
+ * Outs the board stats for a redirect.
+ *
+ * @param array $board Current board information.
+ */
+function template_bi_redirect_stats($board)
+{
+	global $txt;
+
+	echo '
+						<p>', comma_format($board['posts']), ' ', $txt['redirects'], '
+						</p>';
+}
+
+/**
+ * Outs the board lastposts for a standard board or a redirect.
+ * This gets hidden on mobile if $board['last_post']['id'] is empty by the main template.
+ *
+ * @param array $board Current board information.
+ */
+function template_bi_board_lastpost($board)
+{
+	if (!empty($board['last_post']['id']))
+		echo '
+						<p>', $board['last_post']['last_post_message'], '</p>';
+}
+
+/**
+ * Outs the board children for a standard board.
+ *
+ * @param array $board Current board information.
+ */
+function template_bi_board_children($board)
+{
+	global $txt, $scripturl, $context;
+
+	// Show the "Child Boards: ". (there's a link_children but we're going to bold the new ones...)
+	if (!empty($board['children']))
+	{
+		// Sort the links into an array with new boards bold so it can be imploded.
+		$children = array();
+		/* Each child in each board's children has:
+				id, name, description, new (is it new?), topics (#), posts (#), href, link, and last_post. */
+		foreach ($board['children'] as $child)
+		{
+			if (!$child['is_redirect'])
+				$child['link'] = ''. ($child['new'] ? '<a href="' . $scripturl . '?action=unread;board=' . $child['id'] . '" title="' . $txt['new_posts'] . ' (' . $txt['board_topics'] . ': ' . comma_format($child['topics']) . ', ' . $txt['posts'] . ': ' . comma_format($child['posts']) . ')"><span class="new_posts">' . $txt['new'] . '</span></a>' : '') . '<a href="' . $child['href'] . '" ' . ($child['new'] ? 'class="board_new_posts" ' : '') . 'title="' . ($child['new'] ? $txt['new_posts'] : $txt['old_posts']) . ' (' . $txt['board_topics'] . ': ' . comma_format($child['topics']) . ', ' . $txt['posts'] . ': ' . comma_format($child['posts']) . ')">' . $child['name'] . '</a>';
+			else
+				$child['link'] = '<a href="' . $child['href'] . '" title="' . comma_format($child['posts']) . ' ' . $txt['redirects'] . ' - ' . $child['short_description'] . '">' . $child['name'] . '</a>';
+
+			// Has it posts awaiting approval?
+			if ($child['can_approve_posts'] && ($child['unapproved_posts'] || $child['unapproved_topics']))
+				$child['link'] .= ' <a href="' . $scripturl . '?action=moderate;area=postmod;sa=' . ($child['unapproved_topics'] > 0 ? 'topics' : 'posts') . ';brd=' . $child['id'] . ';' . $context['session_var'] . '=' . $context['session_id'] . '" title="' . sprintf($txt['unapproved_posts'], $child['unapproved_topics'], $child['unapproved_posts']) . '" class="moderation_link">(!)</a>';
+
+			$children[] = $child['new'] ? '<span class="strong">' . $child['link'] . '</span>' : '<span>' . $child['link'] . '</span>';
+		}
+
+	echo '
+					<div id="board_', $board['id'], '_children" class="children">
+						<p><strong id="child_list_', $board['id'], '">', $txt['sub_boards'], '</strong>', implode($children), '</p>
+					</div>';
+	}
 }
 
 /**


### PR DESCRIPTION
This technically adds a feature, but this feature prevents modifications from needing to modify the template if they need to inject a "fake" board.  This also allows us to more easily handle redirects differently than boards.

@Antes You may want to review this.
@Gwenwyfar Antes thinks you may be interested.

Signed-off-by: jdarwood007 <unmonitored+github@sleepycode.com>