### PR TITLE
Revert "Really check for 30 seconds"

### DIFF
--- a/other/upgrade.php
+++ b/other/upgrade.php
@@ -47,7 +47,7 @@ $databases = array(
  * The maximum time a single substep may take, in seconds.
  * @var int
  */
-$timeLimitThreshold = 30;
+$timeLimitThreshold = 3;
 
 /**
  * The current path to the upgrade.php file.
@@ -4040,7 +4040,7 @@ function template_database_changes()
 				// We want to track this...
 				if (timeOutID)
 					clearTimeout(timeOutID);
-				timeOutID = window.setTimeout("retTimeout()", ', $timeLimitThreshold, '000);
+				timeOutID = window.setTimeout("retTimeout()", ', (10 * $timeLimitThreshold), '000);
 
 				getXMLDocument(\'', $upcontext['form_url'], '&xml&filecount=', $upcontext['file_count'], '&substep=\' + lastItem + getData, onItemUpdate);
 			}
@@ -4277,7 +4277,7 @@ function template_database_changes()
 				if (!attemptAgain)
 				{
 					document.getElementById("error_block").style.display = "";
-					setInnerHTML(document.getElementById("error_message"), "Server has not responded for ', $timeLimitThreshold, ' seconds. It may be worth waiting a little longer or otherwise please click <a href=\"#\" onclick=\"retTimeout(true); return false;\">here<" + "/a> to try this step again");
+					setInnerHTML(document.getElementById("error_message"), "Server has not responded for ', ($timeLimitThreshold * 10), ' seconds. It may be worth waiting a little longer or otherwise please click <a href=\"#\" onclick=\"retTimeout(true); return false;\">here<" + "/a> to try this step again");
 				}
 				else
 				{


### PR DESCRIPTION
PR #3924 , needs to be reverted.  It screwed up the display of the upgrader substep progress bar.  

The field "timeLimitThreshold" is actually a MINIMUM value to allow a substep to execute.  By setting it = to the actual threshold values of ~30 secs, it effectively stopped display of the substep progress bar until a timeout was reached.  A nice low value of 3 seconds updates the status bar nicely, interacts with the screen, and thus prevents the 30 sec .js threshold (enforced in the template...) from being reached when things are running smoothly. 

My bad...  