### PR TITLE
Skip part of the loadTheme when possible

### DIFF
--- a/Sources/Load.php
+++ b/Sources/Load.php
@@ -1717,7 +1717,7 @@ function loadTheme($id_theme = 0, $initialize = true)
 	// The theme is the forum's default.
 	else
 		$id_theme = $modSettings['theme_guests'];
-	
+
 	// We already load the basic stuff?
 	if (empty($settings['theme_id']) || $settings['theme_id'] != $id_theme )
 	{


### PR DESCRIPTION
I notice on the query log that we call twice the theme load query,
the reason for this is.
That loadTheme got call twice
first here https://github.com/SimpleMachines/SMF2.1/blob/release-2.1/Sources/Load.php#L2818
without initialize
and then here https://github.com/SimpleMachines/SMF2.1/blob/release-2.1/index.php#L189
with initialize.

So this change do that we do the first step (with the query) do once when the theme_id is same as in the settings.