### PR TITLE
Align total progress with updates needed

### DIFF
--- a/other/upgrade_2-1_mysql.sql
+++ b/other/upgrade_2-1_mysql.sql
@@ -263,8 +263,9 @@ if ($custom_av_dir != $GLOBALS['boarddir'] .'/custom_avatar')
 }
 
 $request = upgrade_query("
-	SELECT MAX(id_attach)
-	FROM {$db_prefix}attachments");
+	SELECT COUNT(*)
+	FROM {$db_prefix}attachments
+	WHERE attachment_type != 1");
 list ($step_progress['total']) = $smcFunc['db_fetch_row']($request);
 $smcFunc['db_free_result']($request);
 

--- a/other/upgrade_2-1_postgresql.sql
+++ b/other/upgrade_2-1_postgresql.sql
@@ -243,8 +243,9 @@ if ($custom_av_dir != $GLOBALS['boarddir'] .'/custom_avatar')
 }
 
 $request = upgrade_query("
-	SELECT MAX(id_attach)
-	FROM {$db_prefix}attachments");
+	SELECT COUNT(*)
+	FROM {$db_prefix}attachments
+	WHERE attachment_type != 1");
 list ($step_progress['total']) = $smcFunc['db_fetch_row']($request);
 $smcFunc['db_free_result']($request);
 


### PR DESCRIPTION
Upgrader...  If you have had a lot of attachments deleted, or if you have a lot of avatars, max(id_attach) can overstate the number of attachments by as much as 20-30%.  This change makes the progress bar more accurate for this very long-running step, especially for forums with tens of thousands of attachments.  
