### PR TITLE
Use pg_version instead of select

### DIFF
--- a/Sources/DbExtra-postgresql.php
+++ b/Sources/DbExtra-postgresql.php
@@ -287,12 +287,13 @@ function smf_db_table_sql($tableName)
  */
 function smf_db_get_version()
 {
+	global $db_connection;
 	static $ver;
 
 	if(!empty($ver))
 		return $ver;
 
-	$ver = pg_version()['server'];
+	$ver = pg_version($db_connection)['server'];
 
 	return $ver;
 }

--- a/Sources/DbExtra-postgresql.php
+++ b/Sources/DbExtra-postgresql.php
@@ -292,15 +292,7 @@ function smf_db_get_version()
 	if(!empty($ver))
 		return $ver;
 
-	global $smcFunc;
-
-	$request = $smcFunc['db_query']('', '
-		SHOW server_version',
-		array(
-		)
-	);
-	list ($ver) = $smcFunc['db_fetch_row']($request);
-	$smcFunc['db_free_result']($request);
+	$ver = pg_version()['server'];
 
 	return $ver;
 }


### PR DESCRIPTION
Reason: it's faster
in mysql we can't use it because of the bug on windows env.