### PR TITLE
Fixes #4337

### DIFF
--- a/Sources/RepairBoards.php
+++ b/Sources/RepairBoards.php
@@ -354,7 +354,7 @@ function loadForumTests()
 				  LEFT JOIN {db_prefix}members AS m ON (m.id_member = t.id_member_started)
 				WHERE o.id_poll BETWEEN {STEP_LOW} AND {STEP_HIGH}
 				  AND p.id_poll IS NULL
-				GROUP BY o.id_poll
+				GROUP BY o.id_poll, t.id_topic
 				  ',
 			'fix_processing' => function ($row) use ($smcFunc, $txt)
 			{

--- a/Sources/RepairBoards.php
+++ b/Sources/RepairBoards.php
@@ -354,7 +354,7 @@ function loadForumTests()
 				  LEFT JOIN {db_prefix}members AS m ON (m.id_member = t.id_member_started)
 				WHERE o.id_poll BETWEEN {STEP_LOW} AND {STEP_HIGH}
 				  AND p.id_poll IS NULL
-				GROUP BY o.id_poll, t.id_topic
+				GROUP BY o.id_poll, t.id_topic, t.id_board, t.id_member_started, m.member_name
 				  ',
 			'fix_processing' => function ($row) use ($smcFunc, $txt)
 			{


### PR DESCRIPTION
Adds `t.id_topic` to the GROUP BY clause in the `check_query` of the `poll_options_missing_poll` test in `loadForumTests()`. This makes the query compatible with ONLY_FULL_GROUP_BY mode.

If @albertlast has any feedback, that'd be appreciated.