### PR TITLE
Fixes #2516

### DIFF
--- a/other/install.php
+++ b/other/install.php
@@ -1241,7 +1241,7 @@ function DatabasePopulation()
 		if (!empty($url_parts['host']) && (filter_var($url_parts['host'], FILTER_VALIDATE_IP) === false))
 		{
 			// www isn't really a subdomain in this sense, so strip it out
-			$url_parts['host'] = strtr($url_parts['host'], array('www.' => ''));
+			$url_parts['host'] = str_ireplace('www.', '', $url_parts['host']);
 			$pos1 = strrpos($url_parts['host'], '.');
 			if ($pos1 !== false)
 			{

--- a/other/install.php
+++ b/other/install.php
@@ -1237,7 +1237,8 @@ function DatabasePopulation()
 		unset($globalCookies, $globalCookiesDomain, $localCookies);
 
 		// Look for subdomain, if found, set globalCookie settings
-		if (!empty($url_parts['host']))
+		// Don't bother looking if you have an ip address for host
+		if (!empty($url_parts['host']) && (filter_var($url_parts['host'], FILTER_VALIDATE_IP) === false))
 		{
 			// www isn't really a subdomain in this sense, so strip it out
 			$url_parts['host'] = strtr($url_parts['host'], array('www.' => ''));


### PR DESCRIPTION
Fix cookie setting defaults in the installer:

- The old logic looked for a subdomain in $boardurl, and attempted to set globalCookies if found. Three issues: (A) due to a problem with the preg_match, it never detects a subdomain, (B) it should mirror the ACP logic and also set globalCookiesDomain with the top-level-domain (TLD) but it does not, & (C) it is hard-coded to only recognize certain subdomains (e.g., forum, community, board) which is an unnecessary constraint, and worse, will not work for non-english languages. All 3 issues are addressed in this PR.
- The old logic looked for a subfolder in $boardurl, and attempted to set localCookies if found. Due to an issue with the preg_match here, it will ONLY find sub-sub-folders (e.g., mysite.com/myboard will not be detected, but mysite.com/myboard/smf will be). This is addressed in this PR.

Tested in windows & linux, with subdomains & subfolders & without.