### PR TITLE
When the setting name does not contain a direct $txt entry and instea…

### DIFF
--- a/Sources/Admin.php
+++ b/Sources/Admin.php
@@ -769,7 +769,7 @@ function AdminSearchInternal()
 
 		foreach ($config_vars as $var)
 			if (!empty($var[1]) && !in_array($var[0], array('permissions', 'switch', 'desc')))
-				$search_data['settings'][] = array($var[(isset($var[2]) && in_array($var[2], array('file', 'db'))) ? 0 : 1], $setting_area[1]);
+				$search_data['settings'][] = array($var[(isset($var[2]) && in_array($var[2], array('file', 'db'))) ? 0 : 1], $setting_area[1], 'alttxt' => (isset($var[2]) && in_array($var[2], array('file', 'db'))) || isset($var[3]) ? (in_array($var[2], array('file', 'db')) ? $var[1] : $var[3]) : '');
 	}
 
 	$context['page_title'] = $txt['admin_search_results'];
@@ -796,7 +796,7 @@ function AdminSearchInternal()
 			if ($found)
 			{
 				// Format the name - and remove any descriptions the entry may have.
-				$name = isset($txt[$found]) ? $txt[$found] : (isset($txt['setting_' . $found]) ? $txt['setting_' . $found] : $found);
+				$name = isset($txt[$found]) ? $txt[$found] : (isset($txt['setting_' . $found]) ? $txt['setting_' . $found] : (!empty($item['alttxt']) ? $item['alttxt'] : $found));
 				$name = preg_replace('~<(?:div|span)\sclass="smalltext">.+?</(?:div|span)>~', '', $name);
 
 				$context['search_results'][] = array(


### PR DESCRIPTION
…d uses a different name, it is possible that the admin search will not be able to locate a $txt entry.  In this case we are attempting to read the txt entry provided directly in the $config_vars already and output it instead.

Signed-off-by: jdarwood007 <unmonitored+github@sleepycode.com>