### PR TITLE
Stop Error loop fix #4349

### DIFF
--- a/Sources/Errors.php
+++ b/Sources/Errors.php
@@ -41,10 +41,10 @@ function log_error($error_message, $error_type = 'general', $file = null, $line 
 	// are we in a loop?
 	if($error_call > 2)
 	{
-		$backtrace = debug_backtrace();
 		if (!isset($db_show_debug) || $db_show_debug === false)
-			for ($i = 0; $i < count($backtrace); $i++)
-				unset($backtrace[$i]['args']);
+			$backtrace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
+		else
+			$backtrace = debug_backtrace();
 		var_dump($backtrace);
 		die('Error loop.');
 	}

--- a/Sources/Errors.php
+++ b/Sources/Errors.php
@@ -32,8 +32,22 @@ if (!defined('SMF'))
  */
 function log_error($error_message, $error_type = 'general', $file = null, $line = null)
 {
-	global $modSettings, $sc, $user_info, $smcFunc, $scripturl, $last_error, $context;
+	global $modSettings, $sc, $user_info, $smcFunc, $scripturl, $last_error, $context, $db_show_debug;
 	static $tried_hook = false;
+	static $error_call = 0;
+
+	$error_call++;
+
+	// are we in a loop?
+	if($error_call > 2)
+	{
+		$backtrace = debug_backtrace();
+		if (!isset($db_show_debug) || $db_show_debug === false)
+			for ($i = 0; $i < count($backtrace); $i++)
+				unset($backtrace[$i]['args']);
+		var_dump($backtrace);
+		die('Error loop.');
+	}
 
 	// Check if error logging is actually on.
 	if (empty($modSettings['enableErrorLogging']))
@@ -117,6 +131,9 @@ function log_error($error_message, $error_type = 'general', $file = null, $line 
 		// Increment our error count for the menu
 		$context['num_errors']++;
 	}
+
+	// reset error call
+	$error_call = 0;
 
 	// Return the message to make things simpler.
 	return $error_message;


### PR DESCRIPTION
I created some time error which get in a endless loop,
to prohibt that the user wait for ages this error loop stop try to stop on an early stage.

Since the 'args' information are "critical" i show them only when the $db_show_debug is true,
otherwise the backtrace show only the light information.

fix https://github.com/SimpleMachines/SMF2.1/issues/4349
