### PR TITLE
Better Session Cookie handling fix #4297

### DIFF
--- a/Sources/Load.php
+++ b/Sources/Load.php
@@ -469,12 +469,17 @@ function loadUserSettings()
 
 			// Wrong password or not activated - either way, you're going nowhere.
 			$id_member = $check && ($user_settings['is_activated'] == 1 || $user_settings['is_activated'] == 11) ? (int) $user_settings['id_member'] : 0;
+			if ($id_member === 0 && isset($_COOKIE[$cookiename]))
+			{
+				setLoginCookie(-3600, 0);
+				$user_settings = array();
+			}
 		}
 		else
 			$id_member = 0;
 
 		// If we no longer have the member maybe they're being all hackey, stop brute force!
-		if (!$id_member)
+		if (!empty($id_member))
 		{
 			require_once($sourcedir . '/LogInOut.php');
 			validatePasswordFlood(
@@ -553,6 +558,10 @@ function loadUserSettings()
 
 			if ($row['total'] > 0 && !in_array($action, array('profile', 'logout')) || ($action == 'profile' && $area != 'tfasetup'))
 				redirectexit('action=profile;area=tfasetup;forced');
+		}
+		else if (!empty($user_settings) && empty($id_member))
+		{
+			$user_settings = array();
 		}
 	}
 

--- a/Sources/LogInOut.php
+++ b/Sources/LogInOut.php
@@ -809,9 +809,6 @@ function validatePasswordFlood($id_member, $member_name, $password_flood_value =
 	// Only if they're not validating for 2FA
 	if (!$tfa)
 	{
-		require_once($sourcedir . '/Subs-Auth.php');
-		setLoginCookie(-3600, 0);
-
 		if (isset($_SESSION['login_' . $cookiename]))
 			unset($_SESSION['login_' . $cookiename]);
 	}

--- a/Sources/Security.php
+++ b/Sources/Security.php
@@ -289,7 +289,7 @@ function is_not_banned($forceCheck = false)
 		{
 			require_once($sourcedir . '/Subs-Auth.php');
 			$cookie_url = url_parts(!empty($modSettings['localCookies']), !empty($modSettings['globalCookies']));
-			smf_setcookie($cookiename . '_', '', time() - 3600, $cookie_url[1], $cookie_url[0], false, false);
+			smf_setcookie($cookiename . '_', '', 1, $cookie_url[1], $cookie_url[0], false, false);
 		}
 	}
 

--- a/Sources/Subs-Auth.php
+++ b/Sources/Subs-Auth.php
@@ -52,7 +52,7 @@ function setLoginCookie($cookie_length, $id, $password = '')
 			$cookie_url = url_parts($array[3] & 1 > 0, $array[3] & 2 > 0);
 			if (isset($_COOKIE[$cookiename]['path']))
 				$cookie_url[1] = $_COOKIE[$cookiename]['path'];
-			smf_setcookie($cookiename, $smcFunc['json_encode'](array(0, '', 0, 'path' => $cookie_url[1])), time() - 3600, $cookie_url[1], $cookie_url[0]);
+			smf_setcookie($cookiename, $smcFunc['json_encode'](array(0, '', 0, 'path' => $cookie_url[1])), 1, $cookie_url[1], $cookie_url[0]);
 		}
 	}
 

--- a/Sources/Subs-Auth.php
+++ b/Sources/Subs-Auth.php
@@ -50,14 +50,17 @@ function setLoginCookie($cookie_length, $id, $password = '')
 		if (isset($array[3]) && $array[3] != $cookie_state)
 		{
 			$cookie_url = url_parts($array[3] & 1 > 0, $array[3] & 2 > 0);
-			smf_setcookie($cookiename, $smcFunc['json_encode'](array(0, '', 0)), time() - 3600, $cookie_url[1], $cookie_url[0]);
+			if (isset($_COOKIE[$cookiename]['path']))
+				$cookie_url[1] = $_COOKIE[$cookiename]['path'];
+			smf_setcookie($cookiename, $smcFunc['json_encode'](array(0, '', 0, 'path' => $cookie_url[1])), time() - 3600, $cookie_url[1], $cookie_url[0]);
 		}
 	}
 
 	// Get the data and path to set it on.
-	$data = $smcFunc['json_encode'](empty($id) ? array(0, '', 0) : array($id, $password, time() + $cookie_length, $cookie_state));
 	$cookie_url = url_parts(!empty($modSettings['localCookies']), !empty($modSettings['globalCookies']));
-
+	$dataAr = empty($id) ? array(0, '', 0, 'path' => $cookie_url[1]) : array($id, $password, time() + $cookie_length, $cookie_state,'path' => $cookie_url[1]);
+	$data = $smcFunc['json_encode']($dataAr);
+	
 	// Set the cookie, $_COOKIE, and session variable.
 	smf_setcookie($cookiename, $data, time() + $cookie_length, $cookie_url[1], $cookie_url[0]);
 
@@ -81,6 +84,9 @@ function setLoginCookie($cookie_length, $id, $password = '')
 
 			if ($cookie_url[0] == '')
 				$cookie_url[0] = strtok($alias, '/');
+			
+			$dataAr['path'] = $cookie_url[1];
+			$data = $smcFunc['json_encode']($dataAr);
 
 			smf_setcookie($cookiename, $data, time() + $cookie_length, $cookie_url[1], $cookie_url[0]);
 		}
@@ -130,8 +136,8 @@ function setTFACookie($cookie_length, $id, $secret, $preserve = false)
 		$cookie_length = 81600 * 30;
 
 	// Get the data and path to set it on.
-	$data = $smcFunc['json_encode'](empty($id) ? array(0, '', 0, $cookie_state, false) : array($id, $secret, time() + $cookie_length, $cookie_state, $preserve));
 	$cookie_url = url_parts(!empty($modSettings['localCookies']), !empty($modSettings['globalCookies']));
+	$data = $smcFunc['json_encode'](empty($id) ? array(0, '', 0, $cookie_state, false, 'path' => $cookie_url[1]) : array($id, $secret, time() + $cookie_length, $cookie_state, $preserve, 'path' => $cookie_url[1]));
 
 	// Set the cookie, $_COOKIE, and session variable.
 	smf_setcookie($identifier, $data, time() + $cookie_length, $cookie_url[1], $cookie_url[0]);


### PR DESCRIPTION
Since i saw for #4297 no pr and was able to produce the error number one,
i created this pr.

about case one,
i was only to create this case when i jump from my mysql env to pg and the other way around.

Main issue here was that validatePasswordFlood create a new session_id which get us to the point where
login session from the form and the actual running one are different.

after fixing this,
the next problem was that the load.php got the old cookie data and
recognized that member_id  + password doesn't match,
so it setted the $id_member at 0 without empty the usersetting and empty the cookie (so that we don't in the issue on the next call)
Load 472 - 476 handle now this case

Such for "backup" i also place another check in 562 of load that we can be sure that $user_setting is empty.

@sbulen do check your case

Also this pr fix the other two cases in the issue (they based on the first issue)

Side note, when you got multiple env like me,
it's important the cookie name are different OR the cookie setting are the same.