### PR TITLE
Cookie preg_match should check for json, not serialized strings

### DIFF
--- a/Sources/LogInOut.php
+++ b/Sources/LogInOut.php
@@ -173,7 +173,7 @@ function Login2()
 		redirectexit();
 
 	// Are you guessing with a script?
-	checkSession('login');
+	checkSession();
 	validateToken('login');
 	spamProtection('login');
 

--- a/Sources/LogInOut.php
+++ b/Sources/LogInOut.php
@@ -169,7 +169,7 @@ function Login2()
 		redirectexit();
 
 	// Are you guessing with a script?
-	checkSession();
+	checkSession('login');
 	validateToken('login');
 	spamProtection('login');
 

--- a/Sources/LogInOut.php
+++ b/Sources/LogInOut.php
@@ -97,13 +97,9 @@ function Login2()
 
 	if (isset($_GET['sa']) && $_GET['sa'] == 'salt' && !$user_info['is_guest'])
 	{
-		if (isset($_COOKIE[$cookiename]) && preg_match('~^a:[34]:\{i:0;i:\d{1,7};i:1;s:(0|128):"([a-fA-F0-9]{128})?";i:2;[id]:\d{1,14};(i:3;i:\d;)?\}$~', $_COOKIE[$cookiename]) === 1)
+		if (isset($_COOKIE[$cookiename]) && preg_match('~^\[\d{1,7},"([a-fA-F0-9]{128})?",\d{1,14}(,[0-3])?\]$~', $_COOKIE[$cookiename]) === 1)
 		{
 			list (,, $timeout) = $smcFunc['json_decode']($_COOKIE[$cookiename], true);
-
-			// That didn't work... Maybe it's using serialize?
-			if (is_null($timeout))
-				list (,, $timeout) = safe_unserialize($_COOKIE[$cookiename]);
 		}
 		elseif (isset($_SESSION['login_' . $cookiename]))
 		{

--- a/Sources/Security.php
+++ b/Sources/Security.php
@@ -593,11 +593,7 @@ function isBannedEmail($email, $restriction, $error)
  * Will check GET, POST, or REQUEST depending on the passed type.
  * Also optionally checks the referring action if passed. (note that the referring action must be by GET.)
  *
- * @param string $type The type of check (post, get, request, or login), where
- *      post - checks for a session timeout
- *      get - performs a strict session check
- *      request - performs a strict session check
- *      login - does none of the above, as they are not appropriate for logging in
+ * @param string $type The type of check (post, get, request)
  * @param string $from_action The action this is coming from
  * @param bool $is_fatal Whether to die with a fatal error if the check fails
  * @return string The error message if is_fatal is false.

--- a/Sources/Security.php
+++ b/Sources/Security.php
@@ -593,7 +593,11 @@ function isBannedEmail($email, $restriction, $error)
  * Will check GET, POST, or REQUEST depending on the passed type.
  * Also optionally checks the referring action if passed. (note that the referring action must be by GET.)
  *
- * @param string $type The type of check (post, get, request)
+ * @param string $type The type of check (post, get, request, or login), where
+ *      post - checks for a session timeout
+ *      get - performs a strict session check
+ *      request - performs a strict session check
+ *      login - does none of the above, as they are not appropriate for logging in
  * @param string $from_action The action this is coming from
  * @param bool $is_fatal Whether to die with a fatal error if the check fails
  * @return string The error message if is_fatal is false.

--- a/Sources/Subs-Auth.php
+++ b/Sources/Subs-Auth.php
@@ -38,9 +38,18 @@ function setLoginCookie($cookie_length, $id, $password = '')
 
 	// The cookie may already exist, and have been set with different options.
 	$cookie_state = (empty($modSettings['localCookies']) ? 0 : 1) | (empty($modSettings['globalCookies']) ? 0 : 2);
-	if (isset($_COOKIE[$cookiename]) && preg_match('~^\[\d{1,7},"([a-fA-F0-9]{128})?",\d{1,14}(,[0-3])?\]$~', $_COOKIE[$cookiename]) === 1)
+	if (isset($_COOKIE[$cookiename]))
 	{
-		$array = $smcFunc['json_decode']($_COOKIE[$cookiename], true);
+		// First check for 2.1 json-format cookie
+		if (preg_match('~^\[\d{1,7},"([a-fA-F0-9]{128})?",\d{1,14}(,[0-3])?\]$~', $_COOKIE[$cookiename]) === 1)
+		{
+			$array = $smcFunc['json_decode']($_COOKIE[$cookiename], true);		
+		}
+		// If necessary, fall back on checking for 2.0 serialized string cookie
+		elseif (preg_match('~^a:[34]:\{i:0;i:\d{1,7};i:1;s:(0|128):"([a-fA-F0-9]{128})?";i:2;[id]:\d{1,14};(i:3;i:\d;)?\}$~', $_COOKIE[$cookiename]) === 1)
+		{
+			$array = safe_unserialize($_COOKIE[$cookiename]);
+		}
 
 		// Out with the old, in with the new!
 		if (isset($array[3]) && $array[3] != $cookie_state)

--- a/Sources/Subs-Auth.php
+++ b/Sources/Subs-Auth.php
@@ -38,13 +38,9 @@ function setLoginCookie($cookie_length, $id, $password = '')
 
 	// The cookie may already exist, and have been set with different options.
 	$cookie_state = (empty($modSettings['localCookies']) ? 0 : 1) | (empty($modSettings['globalCookies']) ? 0 : 2);
-	if (isset($_COOKIE[$cookiename]) && preg_match('~^a:[34]:\{i:0;i:\d{1,7};i:1;s:(0|128):"([a-fA-F0-9]{128})?";i:2;[id]:\d{1,14};(i:3;i:\d;)?\}$~', $_COOKIE[$cookiename]) === 1)
+	if (isset($_COOKIE[$cookiename]) && preg_match('~^\[\d{1,7},"([a-fA-F0-9]{128})?",\d{1,14}(,[0-3])?\]$~', $_COOKIE[$cookiename]) === 1)
 	{
 		$array = $smcFunc['json_decode']($_COOKIE[$cookiename], true);
-
-		// Legacy format
-		if (is_null($array))
-			$array = safe_unserialize($_COOKIE[$cookiename]);
 
 		// Out with the old, in with the new!
 		if (isset($array[3]) && $array[3] != $cookie_state)


### PR DESCRIPTION
In the cookie/session handling logic, cookie values were being checked vs serialized strings; they need to be checked for json encoded strings.   Found & addressed 2 instances of preg_matches that needed to be updated

Two other changes:
 - No need to de-serialize the cookie string.  It can't get that far...
 - During login, session checks should not default to normal post/get session checks.  You're not posting a message, you're trying to login & create a new session.  

This is the last PR to address #4297 (login failures after cookie setting changes).  There has been existing logic in setLoginCookie to detect cookie state changes, but it was not being invoked due to the preg_match fail.  This is why the cookies/sessions were not re-established properly after cookie settings were changed by the admin.  
