### PR TITLE
added new json pattern and right json_decode call fix #4357

### DIFF
--- a/Sources/Load.php
+++ b/Sources/Load.php
@@ -420,7 +420,7 @@ function loadUserSettings()
 	elseif (empty($id_member) && isset($_SESSION['login_' . $cookiename]) && ($_SESSION['USER_AGENT'] == $_SERVER['HTTP_USER_AGENT'] || !empty($modSettings['disableCheckUA'])))
 	{
 		// @todo Perhaps we can do some more checking on this, such as on the first octet of the IP?
-		$cookie_data = $smcFunc['json_decode']($_SESSION['login_' . $cookiename]);
+		$cookie_data = $smcFunc['json_decode']($_SESSION['login_' . $cookiename], true, false);
 
 		if (empty($cookie_data))
 			$cookie_data = safe_unserialize($_SESSION['login_' . $cookiename]);

--- a/Sources/LogInOut.php
+++ b/Sources/LogInOut.php
@@ -97,7 +97,11 @@ function Login2()
 
 	if (isset($_GET['sa']) && $_GET['sa'] == 'salt' && !$user_info['is_guest'])
 	{
-		if (isset($_COOKIE[$cookiename]) && preg_match('~^a:[34]:\{i:0;i:\d{1,7};i:1;s:(0|128):"([a-fA-F0-9]{128})?";i:2;[id]:\d{1,14};(i:3;i:\d;)?\}$~', $_COOKIE[$cookiename]) === 1)
+		if (isset($_COOKIE[$cookiename]) && (
+					preg_match('~^a:[34]:\{i:0;i:\d{1,7};i:1;s:(0|128):"([a-fA-F0-9]{128})?";i:2;[id]:\d{1,14};(i:3;i:\d;)?\}$~', $_COOKIE[$cookiename]) === 1 || // Serial
+					preg_match('~^{"0":\d{1,7},"1":"[0-9a-f]{0,128}","2":\d{1,14}(,"3":\d{1}(,"path"."\\\\/.*")?)?}$~' , $_COOKIE[$cookiename]) === 1 // JSON
+				)
+			)
 		{
 			list (,, $timeout) = $smcFunc['json_decode']($_COOKIE[$cookiename], true);
 

--- a/Sources/LogInOut.php
+++ b/Sources/LogInOut.php
@@ -99,7 +99,7 @@ function Login2()
 	{
 		if (isset($_COOKIE[$cookiename]) && (
 					preg_match('~^a:[34]:\{i:0;i:\d{1,7};i:1;s:(0|128):"([a-fA-F0-9]{128})?";i:2;[id]:\d{1,14};(i:3;i:\d;)?\}$~', $_COOKIE[$cookiename]) === 1 || // Serial
-					preg_match('~^{"0":\d{1,7},"1":"[0-9a-f]{0,128}","2":\d{1,14}(,"3":\d{1}(,"path"."\\\\/.*")?)?}$~' , $_COOKIE[$cookiename]) === 1 // JSON
+					preg_match('~^{"0":\d{1,7},"1":"[0-9a-f]{0,128}","2":\d{1,14}(,"3":\d{1}(,"path":"\\\\/.*")?)?}$~' , $_COOKIE[$cookiename]) === 1 // JSON
 				)
 			)
 		{

--- a/Sources/LogInOut.php
+++ b/Sources/LogInOut.php
@@ -97,11 +97,7 @@ function Login2()
 
 	if (isset($_GET['sa']) && $_GET['sa'] == 'salt' && !$user_info['is_guest'])
 	{
-		if (isset($_COOKIE[$cookiename]) && (
-					preg_match('~^a:[34]:\{i:0;i:\d{1,7};i:1;s:(0|128):"([a-fA-F0-9]{128})?";i:2;[id]:\d{1,14};(i:3;i:\d;)?\}$~', $_COOKIE[$cookiename]) === 1 || // Serial
-					preg_match('~^{"0":\d{1,7},"1":"[0-9a-f]{0,128}","2":\d{1,14}(,"3":\d{1}(,"path":"\\\\/.*")?)?}$~' , $_COOKIE[$cookiename]) === 1 // JSON
-				)
-			)
+		if (isset($_COOKIE[$cookiename]))
 		{
 			list (,, $timeout) = $smcFunc['json_decode']($_COOKIE[$cookiename], true);
 

--- a/Sources/Subs-Auth.php
+++ b/Sources/Subs-Auth.php
@@ -42,11 +42,7 @@ function setLoginCookie($cookie_length, $id, $password = '')
 
 	// The cookie may already exist, and have been set with different options.
 	$cookie_state = (empty($modSettings['localCookies']) ? 0 : 1) | (empty($modSettings['globalCookies']) ? 0 : 2);
-	if (isset($_COOKIE[$cookiename]) && (
-				preg_match('~^a:[34]:\{i:0;i:\d{1,7};i:1;s:(0|128):"([a-fA-F0-9]{128})?";i:2;[id]:\d{1,14};(i:3;i:\d;)?\}$~', $_COOKIE[$cookiename]) === 1 || // Serial
-				preg_match('~^{"0":\d{1,7},"1":"[0-9a-f]{0,128}","2":\d{1,14}(,"3":\d{1}(,"path":"\\\\/.*")?)?}$~' , $_COOKIE[$cookiename]) === 1 // JSON
-			)
-		)
+	if (isset($_COOKIE[$cookiename]))
 	{
 		$array = $smcFunc['json_decode']($_COOKIE[$cookiename], true);
 

--- a/Sources/Subs-Auth.php
+++ b/Sources/Subs-Auth.php
@@ -36,14 +36,14 @@ function setLoginCookie($cookie_length, $id, $password = '')
 	// If changing state force them to re-address some permission caching.
 	$_SESSION['mc']['time'] = 0;
 
-	// Get the path and check it
-	$cookie_url = url_parts(!empty($modSettings['localCookies']), !empty($modSettings['globalCookies']));
-	$pathWrong = empty($_COOKIE[$cookiename]['path']) || ($_COOKIE[$cookiename]['path'] != $cookie_url[1]);
-
 	// The cookie may already exist, and have been set with different options.
 	$cookie_state = (empty($modSettings['localCookies']) ? 0 : 1) | (empty($modSettings['globalCookies']) ? 0 : 2);
 	if (isset($_COOKIE[$cookiename]))
 	{
+		// Get the path and check it
+		$cookie_url = url_parts(!empty($modSettings['localCookies']), !empty($modSettings['globalCookies']));
+		$pathWrong = empty($_COOKIE[$cookiename]['path']) || ($_COOKIE[$cookiename]['path'] != $cookie_url[1]);
+
 		$array = $smcFunc['json_decode']($_COOKIE[$cookiename], true);
 
 		// Legacy format

--- a/Sources/Subs-Auth.php
+++ b/Sources/Subs-Auth.php
@@ -44,7 +44,7 @@ function setLoginCookie($cookie_length, $id, $password = '')
 	$cookie_state = (empty($modSettings['localCookies']) ? 0 : 1) | (empty($modSettings['globalCookies']) ? 0 : 2);
 	if (isset($_COOKIE[$cookiename]) && (
 				preg_match('~^a:[34]:\{i:0;i:\d{1,7};i:1;s:(0|128):"([a-fA-F0-9]{128})?";i:2;[id]:\d{1,14};(i:3;i:\d;)?\}$~', $_COOKIE[$cookiename]) === 1 || // Serial
-				preg_match('~^{"0":\d{1,7},"1":"[0-9a-f]{0,128}","2":\d{1,14}(,"3":\d{1}(,"path"."\\\\/.*")?)?}$~' , $_COOKIE[$cookiename]) === 1 // JSON
+				preg_match('~^{"0":\d{1,7},"1":"[0-9a-f]{0,128}","2":\d{1,14}(,"3":\d{1}(,"path":"\\\\/.*")?)?}$~' , $_COOKIE[$cookiename]) === 1 // JSON
 			)
 		)
 	{


### PR DESCRIPTION
In the last pr i changed the cookie format and i was unkown that we check the pattern of the cookie,
so this fix this issue and
since the last changes it can be happen that the user run into https://github.com/SimpleMachines/SMF2.1/blob/release-2.1/Sources/Load.php#L423
which never work because of the missing/wrong attribute for the function call.
@jdarwood007 or was this with intention?

Both issues are defined here: #4357

The pr: #4356 try to fix the first issue too (don't merge both)
