### PR TITLE
Don't forget custom_avatar_url

### DIFF
--- a/Sources/Load.php
+++ b/Sources/Load.php
@@ -1882,6 +1882,7 @@ function loadTheme($id_theme = 0, $initialize = true)
 			// And just a few mod settings :).
 			$modSettings['smileys_url'] = strtr($modSettings['smileys_url'], array($oldurl => $boardurl));
 			$modSettings['avatar_url'] = strtr($modSettings['avatar_url'], array($oldurl => $boardurl));
+			$modSettings['custom_avatar_url'] = strtr($modSettings['custom_avatar_url'], array($oldurl => $boardurl));
 
 			// Clean up after loadBoard().
 			if (isset($board_info['moderators']))


### PR DESCRIPTION
In loadTheme(), there is some logic that deals with alternate URLs.  These can include anything from detected https/http differences, to using an IP address to load the board, to using alias URLs.  

When a valid 'alternate' is detected, it updates all of the board URLs in $modSettings in memory prior to loading the theme.   It does not update custom_avatar_url.  

I believe that there will be instances, for example, when somebody invokes a page via http on an https forum or vice-versa, where this may cause avatar issues.