### PR TITLE
Engine to vendor

### DIFF
--- a/Sources/DbExtra-mysql.php
+++ b/Sources/DbExtra-mysql.php
@@ -394,7 +394,14 @@ function smf_db_get_engine()
 	if (!empty($db_type))
 		return $db_type;
 
-	$request = $smcFunc['db_query']('', 'SELECT @@version_comment');
+	$request = $smcFunc['db_query']('', 
+				'SELECT VARIABLE_VALUE
+				 FROM INFORMATION_SCHEMA.GLOBAL_VARIABLES
+				 WHERE variable_name = {string:var_name}',
+				array(
+					'var_name' => 'VERSION_COMMENT',
+				)
+			);
 	list ($comment) = $smcFunc['db_fetch_row']($request);
 	$smcFunc['db_free_result']($request);
 

--- a/Sources/DbExtra-mysql.php
+++ b/Sources/DbExtra-mysql.php
@@ -30,7 +30,7 @@ function db_extra_init()
 			'db_table_sql' => 'smf_db_table_sql',
 			'db_list_tables' => 'smf_db_list_tables',
 			'db_get_version' => 'smf_db_get_version',
-			'db_get_engine' => 'smf_db_get_engine',
+			'db_get_vendor' => 'smf_db_get_vendor',
 		);
 }
 
@@ -386,7 +386,7 @@ function smf_db_get_version()
  *
  * @return string The database engine we are using
 */
-function smf_db_get_engine()
+function smf_db_get_vendor()
 {
 	global $smcFunc;
 	static $db_type;

--- a/Sources/DbExtra-postgresql.php
+++ b/Sources/DbExtra-postgresql.php
@@ -30,7 +30,7 @@ function db_extra_init()
 			'db_table_sql' => 'smf_db_table_sql',
 			'db_list_tables' => 'smf_db_list_tables',
 			'db_get_version' => 'smf_db_get_version',
-			'db_get_engine' => 'smf_db_get_engine',
+			'db_get_vendor' => 'smf_db_get_vendor',
 		);
 }
 
@@ -303,7 +303,7 @@ function smf_db_get_version()
  *
  * @return string The database engine we are using
 */
-function smf_db_get_engine()
+function smf_db_get_vendor()
 {
 	return 'PostgreSQL';
 }

--- a/Sources/Subs-Admin.php
+++ b/Sources/Subs-Admin.php
@@ -66,7 +66,7 @@ function getServerVersions($checkFor)
 		else
 		{
 			$versions['db_engine'] = array('title' => sprintf($txt['support_versions_db_engine'], $smcFunc['db_title']), 'version' => '');
-			$versions['db_engine']['version'] = $smcFunc['db_get_engine']();
+			$versions['db_engine']['version'] = $smcFunc['db_get_vendor']();
 
 			$versions['db_server'] = array('title' => sprintf($txt['support_versions_db'], $smcFunc['db_title']), 'version' => '');
 			$versions['db_server']['version'] = $smcFunc['db_get_version']();


### PR DESCRIPTION
This PR is a spin off pr: #4391
Since i don't know for sure if this change get merge.

The word "engine" is in mysql context clear defined as storage engine and storage engine are
myisam, innodb, xtradb, blackhole etc.
but this function didn't return the engines it return the vendor of the db -> right name would be vendor. 