### PR TITLE
Fixes Posting Unapproved Messages

### DIFF
--- a/Sources/Post.php
+++ b/Sources/Post.php
@@ -78,8 +78,9 @@ function Post($post_errors = array())
 			array(
 				'msg' => (int) $_REQUEST['msg'],
 		));
-		if ($smcFunc['db_num_rows']($request) != 1)
+		if ($smcFunc['db_num_rows']($request) != 1) {
 			unset($_REQUEST['msg'], $_POST['msg'], $_GET['msg']);
+		}
 		else
 			list ($topic) = $smcFunc['db_fetch_row']($request);
 		$smcFunc['db_free_result']($request);
@@ -90,7 +91,7 @@ function Post($post_errors = array())
 	{
 		$request = $smcFunc['db_query']('', '
 			SELECT
-				t.locked, COALESCE(ln.id_topic, 0) AS notify, t.is_sticky, t.id_poll, t.id_last_msg, mf.id_member,
+				t.locked, t.approved, COALESCE(ln.id_topic, 0) AS notify, t.is_sticky, t.id_poll, t.id_last_msg, mf.id_member,
 				t.id_first_msg, mf.subject, ml.modified_reason,
 				CASE WHEN ml.poster_time > ml.modified_time THEN ml.poster_time ELSE ml.modified_time END AS last_post_time
 			FROM {db_prefix}topics AS t
@@ -104,7 +105,7 @@ function Post($post_errors = array())
 				'current_topic' => $topic,
 			)
 		);
-		list ($locked, $context['notify'], $sticky, $pollID, $context['topic_last_message'], $id_member_poster, $id_first_msg, $first_subject, $editReason, $lastPostTime) = $smcFunc['db_fetch_row']($request);
+		list ($locked, $topic_approved, $context['notify'], $sticky, $pollID, $context['topic_last_message'], $id_member_poster, $id_first_msg, $first_subject, $editReason, $lastPostTime) = $smcFunc['db_fetch_row']($request);
 		$smcFunc['db_free_result']($request);
 
 		// If this topic already has a poll, they sure can't add another.
@@ -182,7 +183,7 @@ function Post($post_errors = array())
 	$context['can_quote'] = empty($modSettings['disabledBBC']) || !in_array('quote', explode(',', $modSettings['disabledBBC']));
 
 	// Generally don't show the approval box... (Assume we want things approved)
-	$context['show_approval'] = allowedTo('approve_posts') && $context['becomes_approved'] ? 2 : (allowedTo('approve_posts') ? 1 : 0);
+	$context['show_approval'] = allowedTo('approve_posts') && $context['becomes_approved'] && (empty($topic) || !empty($topic_approved)) ? 2 : (allowedTo('approve_posts') ? 1 : 0);
 
 	// An array to hold all the attachments for this topic.
 	$context['current_attachments'] = array();

--- a/Sources/Post.php
+++ b/Sources/Post.php
@@ -1465,18 +1465,6 @@ function Post2()
 		// Did this topic suddenly move? Just checking...
 		if ($topic_info['id_board'] != $board)
 			fatal_lang_error('not_a_topic');
-	}
-
-	// Replying to a topic?
-	if (!empty($topic) && !isset($_REQUEST['msg']))
-	{
-		// Don't allow a post if it's locked.
-		if ($topic_info['locked'] != 0 && !allowedTo('moderate_board'))
-			fatal_lang_error('topic_locked', false);
-
-		// Sorry, multiple polls aren't allowed... yet.  You should stop giving me ideas :P.
-		if (isset($_REQUEST['poll']) && $topic_info['id_poll'] > 0)
-			unset($_REQUEST['poll']);
 
 		// Do the permissions and approval stuff...
 		$becomesApproved = true;
@@ -1493,6 +1481,18 @@ function Post2()
 			// Set a nice session var...
 			$_SESSION['becomesUnapproved'] = true;
 		}
+	}
+
+	// Replying to a topic?
+	if (!empty($topic) && !isset($_REQUEST['msg']))
+	{
+		// Don't allow a post if it's locked.
+		if ($topic_info['locked'] != 0 && !allowedTo('moderate_board'))
+			fatal_lang_error('topic_locked', false);
+
+		// Sorry, multiple polls aren't allowed... yet.  You should stop giving me ideas :P.
+		if (isset($_REQUEST['poll']) && $topic_info['id_poll'] > 0)
+			unset($_REQUEST['poll']);
 
 		elseif ($topic_info['id_member_started'] != $user_info['id'])
 		{
@@ -1703,7 +1703,8 @@ function Post2()
 
 		// Can they approve it?
 		$can_approve = allowedTo('approve_posts');
-		$becomesApproved = $modSettings['postmod_active'] ? ($can_approve && !$row['approved'] ? (!empty($_REQUEST['approve']) ? 1 : 0) : $row['approved']) : 1;
+		$approve_checked = (!empty($REQUEST['approve']) ? 1 : 0);
+		$becomesApproved = $modSettings['postmod_active'] ? ($can_approve && !$row['approved'] ? $approve_checked : $row['approved']) : 1;
 		$approve_has_changed = $row['approved'] != $becomesApproved;
 
 		if (!allowedTo('moderate_forum') || !$posterIsGuest)
@@ -1713,10 +1714,10 @@ function Post2()
 		}
 	}
 
-	// In case we want to override but still respect the unapproved topic rule.
-	if (allowedTo('approve_posts') && empty($topicAndMessageBothUnapproved))
+	// In case we have approval permissions and want to override.
+	if (allowedTo('approve_posts'))
 	{
-		$becomesApproved = !isset($_REQUEST['approve']) || !empty($_REQUEST['approve']) ? 1 : 0;
+		$becomesApproved = !empty($_REQUEST['approve']) ? 1 : 0;
 		$approve_has_changed = isset($row['approved']) ? $row['approved'] != $becomesApproved : false;
 	}
 

--- a/Sources/Post.php
+++ b/Sources/Post.php
@@ -78,9 +78,9 @@ function Post($post_errors = array())
 			array(
 				'msg' => (int) $_REQUEST['msg'],
 		));
-		if ($smcFunc['db_num_rows']($request) != 1) {
+		if ($smcFunc['db_num_rows']($request) != 1)
 			unset($_REQUEST['msg'], $_POST['msg'], $_GET['msg']);
-		}
+		
 		else
 			list ($topic) = $smcFunc['db_fetch_row']($request);
 		$smcFunc['db_free_result']($request);

--- a/Sources/Post.php
+++ b/Sources/Post.php
@@ -80,7 +80,6 @@ function Post($post_errors = array())
 		));
 		if ($smcFunc['db_num_rows']($request) != 1)
 			unset($_REQUEST['msg'], $_POST['msg'], $_GET['msg']);
-		
 		else
 			list ($topic) = $smcFunc['db_fetch_row']($request);
 		$smcFunc['db_free_result']($request);


### PR DESCRIPTION
Fixes #4390

Fixes issue of user who has approval permissions submitting the post form with the “approve this post” checkbox unchecked yet the post still being approved.

Removes weird logic of ignoring “approve this post” checkbox value after form submission to default to unapproving new replies to unapproved topics. This PR moves that logic to the template of deciding whether or not to load the Post form with the “Approve this post” checkbox defaulted to checked or unchecked. 
