### PR TITLE
Remove defined E_STRICT check

### DIFF
--- a/SSI.php
+++ b/SSI.php
@@ -39,7 +39,7 @@ require_once(dirname(__FILE__) . '/Settings.php');
 if ((empty($cachedir) || !file_exists($cachedir)) && file_exists($boarddir . '/cache'))
 	$cachedir = $boarddir . '/cache';
 
-$ssi_error_reporting = error_reporting(defined('E_STRICT') ? E_ALL | E_STRICT : E_ALL);
+$ssi_error_reporting = error_reporting(E_ALL);
 /* Set this to one of three values depending on what you want to happen in the case of a fatal error.
 	false:	Default, will just load the error sub template and die - not putting any theme layers around it.
 	true:	Will load the error sub template AND put the SMF layers around it (Not useful if on total custom pages).

--- a/Sources/Errors.php
+++ b/Sources/Errors.php
@@ -225,8 +225,8 @@ function smf_error_handler($error_level, $error_string, $file, $line)
 {
 	global $settings, $modSettings, $db_show_debug;
 
-	// Ignore errors if we're ignoring them or they are strict notices from PHP 5 (which cannot be solved without breaking PHP 4.)
-	if (error_reporting() == 0 || (defined('E_STRICT') && $error_level == E_STRICT && !empty($modSettings['enableErrorLogging'])))
+	// Ignore errors if we're ignoring them or they are strict notices from PHP 5
+	if (error_reporting() == 0)
 		return;
 
 	if (strpos($file, 'eval()') !== false && !empty($settings['current_include_filename']))

--- a/cron.php
+++ b/cron.php
@@ -245,8 +245,8 @@ function smf_error_handler_cron($error_level, $error_string, $file, $line)
 {
 	global $modSettings;
 
-	// Ignore errors if we're ignoring them or they are strict notices from PHP 5 (which cannot be solved without breaking PHP 4.)
-	if (error_reporting() == 0 || (defined('E_STRICT') && $error_level == E_STRICT && !empty($modSettings['enableErrorLogging'])))
+	// Ignore errors if we're ignoring them or they are strict notices from PHP 5
+	if (error_reporting() == 0)
 		return;
 
 	$error_type = 'cron';

--- a/index.php
+++ b/index.php
@@ -25,7 +25,7 @@ $forum_version = 'SMF 2.1 Beta 4';
 
 // Get everything started up...
 define('SMF', 1);
-error_reporting(defined('E_STRICT') ? E_ALL | E_STRICT : E_ALL);
+error_reporting(E_ALL);
 $time_start = microtime(true);
 
 // This makes it so headers can be sent!


### PR DESCRIPTION
because since php 5.4 is E_STRICT in E_ALL included
http://php.net/manual/de/function.error-reporting.php

Would be also a good idea to not set the error_reporting level when not wanted (read the setting file),
but this not the scope of this pr.