### PR TITLE
Disable autocomplete on text validation field

### DIFF
--- a/Themes/default/GenericControls.template.php
+++ b/Themes/default/GenericControls.template.php
@@ -290,7 +290,7 @@ function template_control_verification($verify_id, $display_type = 'all', $reset
 				<div class="smalltext" style="margin: 4px 0 8px 0;">
 					<a href="', $verify_context['image_href'], ';sound" id="visual_verification_', $verify_id, '_sound" rel="nofollow">', $txt['visual_verification_sound'], '</a> / <a href="#visual_verification_', $verify_id, '_refresh" id="visual_verification_', $verify_id, '_refresh">', $txt['visual_verification_request_new'], '</a>', $display_type != 'quick_reply' ? '<br>' : '', '<br>
 					', $txt['visual_verification_description'], ':', $display_type != 'quick_reply' ? '<br>' : '', '
-					<input type="text" name="', $verify_id, '_vv[code]" value="', !empty($verify_context['text_value']) ? $verify_context['text_value'] : '', '" size="30" tabindex="', $context['tabindex']++, '" required>
+					<input type="text" name="', $verify_id, '_vv[code]" value="', !empty($verify_context['text_value']) ? $verify_context['text_value'] : '', '" size="30" tabindex="', $context['tabindex']++, '" autocomplete="off" required>
 				</div>';
 			}
 


### PR DESCRIPTION
The input field where you had to enter the code from the image (registration),
got no autocomplete off,
and in my eyes it's make no sense.
