### PR TITLE
Avoid using fopen when checking cert - sometimes disabled - Fixes #4407

### DIFF
--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -6022,7 +6022,7 @@ function build_regex($strings, $delim = null, $returnArray = false)
 	
 	// Next, check the ssl stream context for certificate info 
 	$result = false;
-	$context = stream_context_create (array("ssl" => array("capture_peer_cert" => true, "verify_peer" => true, "allow_self_signed" => true)));
+	$context = stream_context_create(array("ssl" => array("capture_peer_cert" => true, "verify_peer" => true, "allow_self_signed" => true)));
 	$stream = @stream_socket_client($url, $errno, $errstr, 30, STREAM_CLIENT_CONNECT, $context);
 	if ($stream !== false)
 	{


### PR DESCRIPTION
Modified the ssl_cert_found routine to avoid using fopen.
Some hosts may have allow_url_fopen disabled in php.ini.

Feedback welcome.  

Tested with allow_url_fopen enabled & disabled.
Tested on wamp & linux.
Tested with & without certs.  