### PR TITLE
Safer way to create a tsquery

### DIFF
--- a/Sources/SearchAPI-Fulltext.php
+++ b/Sources/SearchAPI-Fulltext.php
@@ -213,7 +213,7 @@ class fulltext_search extends search_api
 			{
 				$language_ftx = $smcFunc['db_search_language']();
 
-				$query_where[] = 'to_tsvector({string:language_ftx},body) @@ to_tsquery({string:language_ftx},{string:body_match})';
+				$query_where[] = 'to_tsvector({string:language_ftx},body) @@ plainto_tsquery({string:language_ftx},{string:body_match})';
 				$query_params['language_ftx'] = $language_ftx;
 			}
 			else
@@ -247,7 +247,7 @@ class fulltext_search extends search_api
 				{
 					$language_ftx = $smcFunc['db_search_language']();
 
-					$query_where[] = 'to_tsvector({string:language_ftx},body) @@ to_tsquery({string:language_ftx},{string:boolean_match})';
+					$query_where[] = 'to_tsvector({string:language_ftx},body) @@ plainto_tsquery({string:language_ftx},{string:boolean_match})';
 					$query_params['language_ftx'] = $language_ftx;
 				}
 				else


### PR DESCRIPTION
By using the test string from issue #4444 
i found an issue on pg fulltextsearch side,
this pr fix this.
But it didn't fix the issue from #4444.