### PR TITLE
Set user_info language while install process fixes #4453

### DIFF
--- a/other/install.php
+++ b/other/install.php
@@ -325,7 +325,7 @@ function load_lang_file()
 	// And now include the actual language file itself.
 	require_once(dirname(__FILE__) . '/Themes/default/languages/' . $_SESSION['installer_temp_lang']);
 	
-	// Which language we load? And also assume that he like his language.
+	// Which language did we load? Assume that he likes his language.
 	preg_match('~^Install\.(.+[^-utf8])\.php$~', $_SESSION['installer_temp_lang'], $matches);
 	$user_info['language'] = $matches[1];
 }

--- a/other/install.php
+++ b/other/install.php
@@ -259,7 +259,7 @@ function initialize_inputs()
 // Load the list of language files, and the current language file.
 function load_lang_file()
 {
-	global $txt, $incontext;
+	global $txt, $incontext, $user_info;
 
 	$incontext['detected_languages'] = array();
 

--- a/other/install.php
+++ b/other/install.php
@@ -324,6 +324,10 @@ function load_lang_file()
 
 	// And now include the actual language file itself.
 	require_once(dirname(__FILE__) . '/Themes/default/languages/' . $_SESSION['installer_temp_lang']);
+	
+	// Which language we load? And also assume that he like his language.
+	preg_match('~^Install\.(.+[^-utf8])\.php$~', $_SESSION['installer_temp_lang'], $matches);
+	$user_info['language'] = $matches[1];
 }
 
 // This handy function loads some settings and the like.


### PR DESCRIPTION
In the last step we do scheduled_fetchSMfiles
while the process the loadLanguage() is called,
which didn't find any "loaded" language and try to guess which is loaded/or could be.
Which got than the issue we get a diffrent language is loaded as we use in the setup process.

So i extend the load_lang_file about the information which language we load (was suprised that is no otherwhere already known) and
set this language as $user_info['language'] so that the loadLanguage() know which language we like.

issue: #4453