### PR TITLE
Use UTF-8 in setup and index Fixes #4454

### DIFF
--- a/Themes/default/languages/Install.english.php
+++ b/Themes/default/languages/Install.english.php
@@ -2,7 +2,7 @@
 // Version: 2.1 Beta 4; Install
 
 // These should be the same as those in index.language.php.
-$txt['lang_character_set'] = 'ISO-8859-1';
+$txt['lang_character_set'] = 'UTF-8';
 $txt['lang_rtl'] = false;
 
 $txt['install_step_welcome'] = 'Welcome';

--- a/Themes/default/languages/index.english.php
+++ b/Themes/default/languages/index.english.php
@@ -16,7 +16,7 @@ $txt['lang_dictionary'] = 'en';
 $txt['lang_spelling'] = 'american';
 
 // Ensure you remember to use uppercase for character set strings.
-$txt['lang_character_set'] = 'ISO-8859-1';
+$txt['lang_character_set'] = 'UTF-8';
 // Character set and right to left?
 $txt['lang_rtl'] = false;
 // Number format.


### PR DESCRIPTION
With this change your able to use utf chars in the middle of install process,now.
Which i think is good specialy for the case when no lang pack exists for your language.

issue: #4454