### PR TITLE
Change the default session serialize_handler to php_serialize Fixes #4444

### DIFF
--- a/Sources/Session.php
+++ b/Sources/Session.php
@@ -63,7 +63,7 @@ function loadSession()
 		if (!empty($modSettings['databaseSession_enable']))
 		{
 			@ini_set('session.serialize_handler', 'php_serialize');
-			if(ini_get('session.serialize_handler') != 'php_serialize')
+			if (ini_get('session.serialize_handler') != 'php_serialize')
 				@ini_set('session.serialize_handler', 'php');
 			session_set_save_handler('sessionOpen', 'sessionClose', 'sessionRead', 'sessionWrite', 'sessionDestroy', 'sessionGC');
 			@ini_set('session.gc_probability', '1');

--- a/Sources/Session.php
+++ b/Sources/Session.php
@@ -63,7 +63,7 @@ function loadSession()
 		if (!empty($modSettings['databaseSession_enable']))
 		{
 			@ini_set('session.serialize_handler', 'php_serialize');
-			if(ini_get( 'session.serialize_handler') != 'php_serialize')
+			if(ini_get('session.serialize_handler') != 'php_serialize')
 				@ini_set('session.serialize_handler', 'php');
 			session_set_save_handler('sessionOpen', 'sessionClose', 'sessionRead', 'sessionWrite', 'sessionDestroy', 'sessionGC');
 			@ini_set('session.gc_probability', '1');

--- a/Sources/Session.php
+++ b/Sources/Session.php
@@ -62,7 +62,9 @@ function loadSession()
 		// Use database sessions? (they don't work in 4.1.x!)
 		if (!empty($modSettings['databaseSession_enable']))
 		{
-			@ini_set('session.serialize_handler', 'php');
+			@ini_set('session.serialize_handler', 'php_serialize');
+			if(ini_get( 'session.serialize_handler') != 'php_serialize')
+				@ini_set('session.serialize_handler', 'php');
 			session_set_save_handler('sessionOpen', 'sessionClose', 'sessionRead', 'sessionWrite', 'sessionDestroy', 'sessionGC');
 			@ini_set('session.gc_probability', '1');
 		}


### PR DESCRIPTION
by keeping run able on php 5.4
the full story you find in the issue: #4444 and related sm.org topic

i "copy" the logic from wikimedia: https://github.com/wikimedia/php-session-serializer/blob/master/src/Wikimedia/PhpSessionSerializer.php#L70