### PR TITLE
Revert Changes of Mysql Vendor and raise MySQL min version to 5.0.22 and 5.1.10 fixes #4441

### DIFF
--- a/Sources/DbExtra-mysql.php
+++ b/Sources/DbExtra-mysql.php
@@ -394,14 +394,7 @@ function smf_db_get_vendor()
 	if (!empty($db_type))
 		return $db_type;
 
-	$request = $smcFunc['db_query']('', 
-				'SELECT VARIABLE_VALUE
-				 FROM INFORMATION_SCHEMA.GLOBAL_VARIABLES
-				 WHERE variable_name = {string:var_name}',
-				array(
-					'var_name' => 'VERSION_COMMENT',
-				)
-			);
+	$request = $smcFunc['db_query']('', 'SELECT @@version_comment');
 	list ($comment) = $smcFunc['db_fetch_row']($request);
 	$smcFunc['db_free_result']($request);
 

--- a/other/install.php
+++ b/other/install.php
@@ -29,7 +29,7 @@ require_once('Sources/Class-Package.php');
 $databases = array(
 	'mysql' => array(
 		'name' => 'MySQL',
-		'version' => '5.0.3',
+		'version' => '5.0.22',
 		'version_check' => 'return min(mysqli_get_server_info($db_connection), mysqli_get_client_info());',
 		'supported' => function_exists('mysqli_connect'),
 		'default_user' => 'mysql.default_user',
@@ -39,7 +39,7 @@ $databases = array(
 		'utf8_support' => function() {
 			return true;
 		},
-		'utf8_version' => '5.0.3',
+		'utf8_version' => '5.0.22',
 		'utf8_version_check' => 'return mysqli_get_server_info($db_connection);',
 		'utf8_default' => true,
 		'utf8_required' => true,

--- a/other/upgrade.php
+++ b/other/upgrade.php
@@ -28,10 +28,10 @@ $GLOBALS['required_php_version'] = '5.4.0';
 $databases = array(
 	'mysql' => array(
 		'name' => 'MySQL',
-		'version' => '5.0.3',
+		'version' => '5.0.22',
 		'version_check' => 'global $db_connection; return min(mysqli_get_server_info($db_connection), mysqli_get_client_info());',
 		'utf8_support' => true,
-		'utf8_version' => '5.0.3',
+		'utf8_version' => '5.0.22',
 		'utf8_version_check' => 'global $db_connection; return mysqli_get_server_info($db_connection);',
 		'alter_support' => true,
 	),


### PR DESCRIPTION
The fix which i introduce got the issue that newer version of mysql didn't support any more.
See issue #4441 
since mysql 5.0.22/5.1.10 is this bug fixed on mysql side.

So instead placing a workaround for a very very old mysql version,
i think it's better to raise the min mysql version.
Since i can only define one version i choose the 5.0.22 but i'm also mean implicit that mysql version,
below 5.1.10 is not supported any more.

Personal i would like to go further but for this issue is not needed.