### PR TITLE
Skip approval when not active fixes #4421

### DIFF
--- a/Sources/Post.php
+++ b/Sources/Post.php
@@ -1715,7 +1715,7 @@ function Post2()
 	}
 
 	// In case we have approval permissions and want to override.
-	if (allowedTo('approve_posts'))
+	if (allowedTo('approve_posts') && $modSettings['postmod_active'])
 	{
 		$becomesApproved = !empty($_REQUEST['approve']) ? 1 : 0;
 		$approve_has_changed = isset($row['approved']) ? $row['approved'] != $becomesApproved : false;


### PR DESCRIPTION
Since the pr #4398
new post got not approved eaven the postmod was not active which leads in unwanted behavior.
Like in the issue #4421 notice.

I place a skip when the postmod is not active.
When you got problem like the issue,
you can approve all message by going in permission activate and deactivate the post moderation