### PR TITLE
Added language support for recaptcha fixes #4331

### DIFF
--- a/Themes/default/GenericControls.template.php
+++ b/Themes/default/GenericControls.template.php
@@ -295,11 +295,13 @@ function template_control_verification($verify_id, $display_type = 'all', $reset
 			}
 
 			if ($verify_context['can_recaptcha'])
+			{
 				$lang = (isset($txt['lang_recaptcha']) ? $txt['lang_recaptcha'] : $txt['lang_dictionary']); 
 				echo '
 				<div class="g-recaptcha centertext" data-sitekey="' . $verify_context['recaptcha_site_key'] . '" data-theme="' . $verify_context['recaptcha_theme'] . '"></div>
 				<br>
 				<script type="text/javascript" src="https://www.google.com/recaptcha/api.js?hl='.$lang.'"></script>';
+			}
 		}
 		else
 		{

--- a/Themes/default/GenericControls.template.php
+++ b/Themes/default/GenericControls.template.php
@@ -295,10 +295,11 @@ function template_control_verification($verify_id, $display_type = 'all', $reset
 			}
 
 			if ($verify_context['can_recaptcha'])
+				$lang = (isset($txt['recaptcha_lang']) ? $txt['recaptcha_lang'] : $txt['lang_dictionary']); 
 				echo '
 				<div class="g-recaptcha centertext" data-sitekey="' . $verify_context['recaptcha_site_key'] . '" data-theme="' . $verify_context['recaptcha_theme'] . '"></div>
 				<br>
-				<script type="text/javascript" src="https://www.google.com/recaptcha/api.js"></script>';
+				<script type="text/javascript" src="https://www.google.com/recaptcha/api.js?hl='.$lang.'"></script>';
 		}
 		else
 		{

--- a/Themes/default/GenericControls.template.php
+++ b/Themes/default/GenericControls.template.php
@@ -295,7 +295,7 @@ function template_control_verification($verify_id, $display_type = 'all', $reset
 			}
 
 			if ($verify_context['can_recaptcha'])
-				$lang = (isset($txt['recaptcha_lang']) ? $txt['recaptcha_lang'] : $txt['lang_dictionary']); 
+				$lang = (isset($txt['lang_recaptcha']) ? $txt['lang_recaptcha'] : $txt['lang_dictionary']); 
 				echo '
 				<div class="g-recaptcha centertext" data-sitekey="' . $verify_context['recaptcha_site_key'] . '" data-theme="' . $verify_context['recaptcha_theme'] . '"></div>
 				<br>

--- a/Themes/default/languages/index.english.php
+++ b/Themes/default/languages/index.english.php
@@ -785,6 +785,7 @@ $txt['visual_verification_hidden'] = 'Please leave this box empty';
 $txt['visual_verification_description'] = 'Type the letters shown in the picture';
 $txt['visual_verification_sound'] = 'Listen to the letters';
 $txt['visual_verification_request_new'] = 'Request another image';
+$txt['recaptcha_lang'] = 'en';
 
 // Sub menu labels
 $txt['summary'] = 'Summary';

--- a/Themes/default/languages/index.english.php
+++ b/Themes/default/languages/index.english.php
@@ -785,6 +785,7 @@ $txt['visual_verification_hidden'] = 'Please leave this box empty';
 $txt['visual_verification_description'] = 'Type the letters shown in the picture';
 $txt['visual_verification_sound'] = 'Listen to the letters';
 $txt['visual_verification_request_new'] = 'Request another image';
+//https://developers.google.com/recaptcha/docs/language
 $txt['recaptcha_lang'] = 'en';
 
 // Sub menu labels

--- a/Themes/default/languages/index.english.php
+++ b/Themes/default/languages/index.english.php
@@ -15,7 +15,7 @@ $txt['lang_locale'] = 'en_US';
 $txt['lang_dictionary'] = 'en';
 $txt['lang_spelling'] = 'american';
 //https://developers.google.com/recaptcha/docs/language
-$txt['recaptcha_lang'] = 'en';
+$txt['lang_recaptcha'] = 'en';
 
 // Ensure you remember to use uppercase for character set strings.
 $txt['lang_character_set'] = 'UTF-8';

--- a/Themes/default/languages/index.english.php
+++ b/Themes/default/languages/index.english.php
@@ -14,6 +14,8 @@ $txt['native_name'] = 'English';
 $txt['lang_locale'] = 'en_US';
 $txt['lang_dictionary'] = 'en';
 $txt['lang_spelling'] = 'american';
+//https://developers.google.com/recaptcha/docs/language
+$txt['recaptcha_lang'] = 'en';
 
 // Ensure you remember to use uppercase for character set strings.
 $txt['lang_character_set'] = 'UTF-8';
@@ -785,8 +787,6 @@ $txt['visual_verification_hidden'] = 'Please leave this box empty';
 $txt['visual_verification_description'] = 'Type the letters shown in the picture';
 $txt['visual_verification_sound'] = 'Listen to the letters';
 $txt['visual_verification_request_new'] = 'Request another image';
-//https://developers.google.com/recaptcha/docs/language
-$txt['recaptcha_lang'] = 'en';
 
 // Sub menu labels
 $txt['summary'] = 'Summary';


### PR DESCRIPTION
Since the language is commonly the dictory lang i place a fallback when recaptcha_lang didn't exists:
https://developers.google.com/recaptcha/docs/language
issue: #4331