### PR TITLE
Update Subs-Post.php

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,13 +1,5 @@
-# Autodetect text files
-* text=auto
-
-# ...Unless the name matches the following
-# overriding patterns
-
-# Definitively text files 
-*.txt text
-*.c text
-*.h text
+# Force our line endings to be LF, even for Windows
+* text
 
 # Set certain files to be binary
 *.png binary

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,13 @@
-# Force our line endings to be LF, even for Windows
-* text
+# Autodetect text files
+* text=auto
+
+# ...Unless the name matches the following
+# overriding patterns
+
+# Definitively text files 
+*.txt text
+*.c text
+*.h text
 
 # Set certain files to be binary
 *.png binary

--- a/Sources/Subs-Post.php
+++ b/Sources/Subs-Post.php
@@ -53,9 +53,7 @@ function preparsecode(&$message, $previewing = false)
 		$message = substr($message, 8);
 
 	// Find all code blocks, work out whether we'd be parsing them, then ensure they are all closed.
-	$in_tag = false;
-	$had_tag = false;
-	$codeopen = 0;
+	list($in_tag, $had_tag, $codeopen, $alltags, $codes) = array(false, false, 0, array(), array());
 	if (preg_match_all('~(\[(/)*code(?:=[^\]]+)?\])~is', $message, $matches))
 		foreach ($matches[0] as $index => $dummy)
 		{
@@ -210,7 +208,7 @@ function preparsecode(&$message, $previewing = false)
 
 	require_once($sourcedir . '/Subs.php');
 
-	foreach (($codes = parse_bbc(false)) as $code)
+	foreach ($codes as $code)
 		if (!in_array($code['tag'], $allowedEmpty))
 			$alltags[] = $code['tag'];
 


### PR DESCRIPTION
- create empty arrays prior to attempting to use them (using a one liner)
- parse_bbc(false) always returns an empty string therefore do not attempt to use it as an array in a for loop

If this (the 2nd edit) is supposed to be an attempt to filter $code['tag'] through the parse_bbc function then it should be done within the loop itself. If this is the intention then either change the code to do that or put a notation in this PR and I will make it as such.

Signed-off-by: Underdog-01 <github.underdog@gmail.com>