### PR TITLE
Dont proxy images for bots, fixes #4448

### DIFF
--- a/Sources/Load.php
+++ b/Sources/Load.php
@@ -465,7 +465,7 @@ function loadUserSettings()
 			$user_settings = $smcFunc['db_fetch_assoc']($request);
 			$smcFunc['db_free_result']($request);
 
-			if (!empty($modSettings['force_ssl']) && $image_proxy_enabled && stripos($user_settings['avatar'], 'http://') !== false)
+			if (!empty($modSettings['force_ssl']) && $image_proxy_enabled && stripos($user_settings['avatar'], 'http://') !== false && empty($user_info['possibly_robot']))
 				$user_settings['avatar'] = strtr($boardurl, array('http://' => 'https://')) . '/proxy.php?request=' . urlencode($user_settings['avatar']) . '&hash=' . md5($user_settings['avatar'] . $image_proxy_secret);
 
 			if (!empty($modSettings['cache_enable']) && $modSettings['cache_enable'] >= 2)
@@ -1202,7 +1202,7 @@ function loadPermissions()
 function loadMemberData($users, $is_name = false, $set = 'normal')
 {
 	global $user_profile, $modSettings, $board_info, $smcFunc, $context;
-	global $image_proxy_enabled, $image_proxy_secret, $boardurl;
+	global $image_proxy_enabled, $image_proxy_secret, $boardurl, $user_info;
 
 	// Can't just look for no users :P.
 	if (empty($users))
@@ -1289,7 +1289,7 @@ function loadMemberData($users, $is_name = false, $set = 'normal')
 			$row['avatar_original'] = !empty($row['avatar']) ? $row['avatar'] : '';
 
 			// Take care of proxying avatar if required, do this here for maximum reach
-			if ($image_proxy_enabled && !empty($row['avatar']) && stripos($row['avatar'], 'http://') !== false)
+			if ($image_proxy_enabled && !empty($row['avatar']) && stripos($row['avatar'], 'http://') !== false && empty($user_info['possibly_robot']))
 				$row['avatar'] = $boardurl . '/proxy.php?request=' . urlencode($row['avatar']) . '&hash=' . md5($row['avatar'] . $image_proxy_secret);
 
 			// Keep track of the member's normal member group
@@ -3503,7 +3503,7 @@ function clean_cache($type = '')
  */
 function set_avatar_data($data = array())
 {
-	global $modSettings, $boardurl, $smcFunc, $image_proxy_enabled, $image_proxy_secret;
+	global $modSettings, $boardurl, $smcFunc, $image_proxy_enabled, $image_proxy_secret, $user_info;
 
 	// Come on!
 	if (empty($data))
@@ -3542,7 +3542,7 @@ function set_avatar_data($data = array())
 			else
 			{
 				// Using ssl?
-				if (!empty($modSettings['force_ssl']) && $image_proxy_enabled && stripos($data['avatar'], 'http://') !== false)
+				if (!empty($modSettings['force_ssl']) && $image_proxy_enabled && stripos($data['avatar'], 'http://') !== false && empty($user_info['possibly_robot']))
 					$image = strtr($boardurl, array('http://' => 'https://')) . '/proxy.php?request=' . urlencode($data['avatar']) . '&hash=' . md5($data['avatar'] . $image_proxy_secret);
 
 				// Just a plain external url.

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -1415,13 +1415,13 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 				{
 					global $image_proxy_enabled, $image_proxy_secret, $boardurl, $user_info;
 
-					if (!empty($user_info['possibly_robot']))
-						return;
-
 					$data = strtr($data, array('<br>' => ''));
 					$scheme = parse_url($data, PHP_URL_SCHEME);
 					if ($image_proxy_enabled)
 					{
+						if (!empty($user_info['possibly_robot']))
+							return;
+
 						if (empty($scheme))
 							$data = 'http://' . ltrim($data, ':/');
 
@@ -1441,13 +1441,13 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 				{
 					global $image_proxy_enabled, $image_proxy_secret, $boardurl, $user_info;
 
-					if (!empty($user_info['possibly_robot']))
-						return;
-
 					$data = strtr($data, array('<br>' => ''));
 					$scheme = parse_url($data, PHP_URL_SCHEME);
 					if ($image_proxy_enabled)
 					{
+						if (!empty($user_info['possibly_robot']))
+							return;
+
 						if (empty($scheme))
 							$data = 'http://' . ltrim($data, ':/');
 

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -1413,7 +1413,10 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 				'content' => '<img src="$1" alt="{alt}" title="{title}"{width}{height} class="bbc_img resized">',
 				'validate' => function (&$tag, &$data, $disabled)
 				{
-					global $image_proxy_enabled, $image_proxy_secret, $boardurl;
+					global $image_proxy_enabled, $image_proxy_secret, $boardurl, $user_info;
+
+					if (!empty($user_info['possibly_robot']))
+						return;
 
 					$data = strtr($data, array('<br>' => ''));
 					$scheme = parse_url($data, PHP_URL_SCHEME);
@@ -1436,7 +1439,10 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 				'content' => '<img src="$1" alt="" class="bbc_img">',
 				'validate' => function (&$tag, &$data, $disabled)
 				{
-					global $image_proxy_enabled, $image_proxy_secret, $boardurl;
+					global $image_proxy_enabled, $image_proxy_secret, $boardurl, $user_info;
+
+					if (!empty($user_info['possibly_robot']))
+						return;
 
 					$data = strtr($data, array('<br>' => ''));
 					$scheme = parse_url($data, PHP_URL_SCHEME);


### PR DESCRIPTION
Don't proxy images for bots.  

This fixes issues where site recrawls, even by good bots like Google, can cause your cache to grow by many GB of data & get completely randomized - useless as a cache.   

Also, bots probably should "see" the image's proper link anyway.  Give the image's original source page proper credit.

At this point in time, Google does not penalize sites for mixed-content pages (http & https), so this will not hurt Google's ranking of your forum's content.  