### PR TITLE
Fix missing $db_persist global, fixes #4516

### DIFF
--- a/Sources/Subs-Db-mysql.php
+++ b/Sources/Subs-Db-mysql.php
@@ -374,7 +374,7 @@ function smf_db_query($identifier, $db_string, $db_values = array(), $connection
 	// Get a connection if we are shutting down, sometimes the link is closed before sessions are written
 	if (!is_object($connection))
 	{
-		global $db_server, $db_user, $db_passwd, $db_name, $db_show_debug, $ssi_db_user, $ssi_db_passwd;
+		global $db_server, $db_user, $db_passwd, $db_name, $db_show_debug, $ssi_db_user, $ssi_db_passwd, $db_persist;
 
 		// Are we in SSI mode?  If so try that username and password first
 		if (SMF == 'SSI' && !empty($ssi_db_user) && !empty($ssi_db_passwd))


### PR DESCRIPTION
Without this change, the 'persistent connection' setting doesn't really work; it just creates a new connection every time.  

With this change, you can see that subsequent connects use next to 0 resources.  Without this change, sessionWrite() always needs a new db connection, increasing overhead.   

**_This change is also needed in 2.0_**
![smf21_persist_compare](https://user-images.githubusercontent.com/23568484/35477809-2d2a71e6-0381-11e8-898f-b59c3406db82.JPG)
