### PR TITLE
Use the database directly on connection and use mysqli_query fixes #4516 partly

### DIFF
--- a/Sources/Subs-Db-mysql.php
+++ b/Sources/Subs-Db-mysql.php
@@ -73,11 +73,15 @@ function smf_db_initiate($db_server, $db_name, $db_user, $db_passwd, $db_prefix,
 
 	$success = false;
 
+	// Windows doesn't support socket
+	if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN' && $db_server == 'localhost')
+			$db_server = '127.0.0.1';
+
 	if ($connection) {
 		if (!empty($db_options['port']))
-			$success = mysqli_real_connect($connection, $db_server, $db_user, $db_passwd, $db_name, $db_options['port'], null, $flags);
+			$success = mysqli_real_connect($connection, $db_server, $db_user, $db_passwd, null, $db_options['port'], null, $flags);
 		else
-			$success = mysqli_real_connect($connection, $db_server, $db_user, $db_passwd, $db_name, 0, null, $flags);
+			$success = mysqli_real_connect($connection, $db_server, $db_user, $db_passwd, null, 0, null, $flags);
 	}
 
 	// Something's wrong, show an error if its fatal (which we assume it is)

--- a/Sources/Subs-Db-mysql.php
+++ b/Sources/Subs-Db-mysql.php
@@ -73,10 +73,6 @@ function smf_db_initiate($db_server, $db_name, $db_user, $db_passwd, $db_prefix,
 
 	$success = false;
 
-	// Windows doesn't support socket
-	if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN' && $db_server == 'localhost')
-			$db_server = '127.0.0.1';
-
 	if ($connection) {
 		if (!empty($db_options['port']))
 			$success = mysqli_real_connect($connection, $db_server, $db_user, $db_passwd, null, $db_options['port'], null, $flags);

--- a/Sources/Subs-Db-mysql.php
+++ b/Sources/Subs-Db-mysql.php
@@ -75,9 +75,9 @@ function smf_db_initiate($db_server, $db_name, $db_user, $db_passwd, $db_prefix,
 
 	if ($connection) {
 		if (!empty($db_options['port']))
-			$success = mysqli_real_connect($connection, $db_server, $db_user, $db_passwd, '', $db_options['port'], null, $flags);
+			$success = mysqli_real_connect($connection, $db_server, $db_user, $db_passwd, $db_name, $db_options['port'], null, $flags);
 		else
-			$success = mysqli_real_connect($connection, $db_server, $db_user, $db_passwd, '', 0, null, $flags);
+			$success = mysqli_real_connect($connection, $db_server, $db_user, $db_passwd, $db_name, 0, null, $flags);
 	}
 
 	// Something's wrong, show an error if its fatal (which we assume it is)
@@ -93,10 +93,7 @@ function smf_db_initiate($db_server, $db_name, $db_user, $db_passwd, $db_prefix,
 	if (empty($db_options['dont_select_db']) && !@mysqli_select_db($connection, $db_name) && empty($db_options['non_fatal']))
 		display_db_error();
 
-	$smcFunc['db_query']('', 'SET SESSION sql_mode = \'ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION\'',
-		array(),
-		false
-	);
+	mysqli_query($connection, 'SET SESSION sql_mode = \'ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION\'');
 
 	return $connection;
 }

--- a/Sources/Subs-Db-postgresql.php
+++ b/Sources/Subs-Db-postgresql.php
@@ -66,9 +66,9 @@ function smf_db_initiate($db_server, $db_name, $db_user, $db_passwd, &$db_prefix
 		);
 
 	if (!empty($db_options['persist']))
-		$connection = @pg_pconnect('host=' . $db_server . ' dbname=' . $db_name . ' user=\'' . $db_user . '\' password=\'' . $db_passwd . '\'' . (empty($db_options['port']) ? '' : ' port=\'' . $db_options['port'] . '\''));
+		$connection = @pg_pconnect((empty($db_server) ? '' : 'host=' . $db_server . ' ') . 'dbname=' . $db_name . ' user=\'' . $db_user . '\' password=\'' . $db_passwd . '\'' . (empty($db_options['port']) ? '' : ' port=\'' . $db_options['port'] . '\''));
 	else
-		$connection = @pg_connect('host=' . $db_server . ' dbname=' . $db_name . ' user=\'' . $db_user . '\' password=\'' . $db_passwd . '\'' . (empty($db_options['port']) ? '' : ' port=\'' . $db_options['port'] . '\''));
+		$connection = @pg_connect((empty($db_server) ? '' : 'host=' . $db_server . ' ') . 'dbname=' . $db_name . ' user=\'' . $db_user . '\' password=\'' . $db_passwd . '\'' . (empty($db_options['port']) ? '' : ' port=\'' . $db_options['port'] . '\''));
 
 	// Something's wrong, show an error if its fatal (which we assume it is)
 	if (!$connection)


### PR DESCRIPTION
instead of smcfunc query
Thanks to @sbulen i notice that mysql logic got a reconnect logic.
I used this new knowledg to check in which case a common smf 2.1 env call this.

Two reason are founded:
- mysql_real_connect needs a schema/database or will go fail
- in the smf_db_initiate is the call $smcFunc['db_query'] stupid because the $connection is not known at this point -> needs to be a mysqli_query

Whith this changes the issue #4516 get partly fixed -> no double connection call any more.