### PR TITLE
overhaul of proxy.php

### DIFF
--- a/proxy.php
+++ b/proxy.php
@@ -31,6 +31,9 @@ class ProxyServer
 
 	/** @var string The cache directory */
 	protected $cache;
+	
+	/** @var int time() value */
+	protected $time;
 
 	/**
 	 * Constructor, loads up the Settings for the proxy
@@ -109,10 +112,7 @@ class ProxyServer
 			$this::redirectexit($request);
 		}
 
-		$old_timezone = date_default_timezone_get();
-		date_default_timezone_set('UTC');
-		$time = time();
-		date_default_timezone_set($old_timezone);
+		$time = $this->getTime();
 
 		// Is the cache expired?
 		if (!$cached || $time - $cached['time'] > (5 * 86400))
@@ -193,12 +193,9 @@ class ProxyServer
 		// Validate the filesize
 		if ($response['size'] > ($this->maxSize * 1024))
 			return 0;
-		
-		$old_timezone = date_default_timezone_get();
-		date_default_timezone_set('UTC');
-		$time = time();
-		date_default_timezone_set($old_timezone);
-		
+
+		$time = $this->getTime();
+
 		return file_put_contents($dest, json_encode(array(
 			'content_type' => $headers['content-type'],
 			'size' => $response['size'],
@@ -218,6 +215,24 @@ class ProxyServer
 	{
 		header('Location: ' . $request, false, 301);
 		exit;
+	}
+	
+	/**
+	 * Helper function to call time() once with the right logic
+	 * 
+	 * @return int
+	 */
+	protected function getTime()
+	{
+		if (empty($this->time))
+		{
+			$old_timezone = date_default_timezone_get();
+			date_default_timezone_set('UTC');
+			$this->time = time();
+			date_default_timezone_set($old_timezone);
+		}
+
+		return $this->time;
 	}
 }
 

--- a/proxy.php
+++ b/proxy.php
@@ -136,11 +136,11 @@ class ProxyServer
 			exit;
 
 		$max_age = $time - $cached['time'] + (5 * 86400);
-		header('Content-type: ' . $cached['content_type']);
-		header('Content-length: ' . $cached['size']);
-		header('Cache-Control: public, max-age=' . $max_age );
-		header('Last-Modified: ' . gmdate('D, d M Y H:i:s', $cached['time']) . ' UTC');
-		header('ETag: ' . $eTag);
+		header('content-type: ' . $cached['content_type']);
+		header('content-length: ' . $cached['size']);
+		header('cache-control: public, max-age=' . $max_age );
+		header('last-modified: ' . gmdate('D, d M Y H:i:s', $cached['time']) . ' UTC');
+		header('etag: ' . $eTag);
 		echo base64_decode($cached['body']);
 	}
 

--- a/proxy.php
+++ b/proxy.php
@@ -102,13 +102,15 @@ class ProxyServer
 
 		// Did we get an error when trying to fetch the image
 		$response = $this->checkRequest();
-		if ($response === -1) {
+		if ($response === -1)
+		{
 			// Throw a 404
 			header('HTTP/1.0 404 Not Found');
 			exit;
 		}
 		// Right, image not cached? Simply redirect, then.
-		if ($response === 0) {
+		if ($response === 0)
+		{
 			$this::redirectexit($request);
 		}
 
@@ -183,7 +185,8 @@ class ProxyServer
 		$responseCode = $curl_request->result('code');
 		$response = $curl_request->result();
 
-		if (empty($response) || $responseCode != 200) {
+		if (empty($response) || $responseCode != 200)
+		{
 			return -1;
 		}
 

--- a/proxy.php
+++ b/proxy.php
@@ -122,6 +122,13 @@ class ProxyServer
 				$this->serve();
 			$this::redirectexit($request);
 		}
+		
+		$eTag = '"' . substr(sha1($request) . $cached['time'], 0, 64) . '"';
+		if (!empty($_SERVER['HTTP_IF_NONE_MATCH']) && strpos($_SERVER['HTTP_IF_NONE_MATCH'], $eTag) !== false)
+		{
+			header('HTTP/1.1 304 Not Modified');
+			exit;
+		}
 
 		// Make sure we're serving an image
 		$contentParts = explode('/', !empty($cached['content_type']) ? $cached['content_type'] : '');
@@ -133,6 +140,7 @@ class ProxyServer
 		header('Content-length: ' . $cached['size']);
 		header('Cache-Control: public, max-age=' . $max_age );
 		header('Last-Modified: ' . gmdate('D, d M Y H:i:s', $cached['time']) . ' UTC');
+		header('ETag: ' . $eTag);
 		echo base64_decode($cached['body']);
 	}
 

--- a/proxy.php
+++ b/proxy.php
@@ -31,7 +31,7 @@ class ProxyServer
 
 	/** @var string The cache directory */
 	protected $cache;
-	
+
 	/** @var int time() value */
 	protected $time;
 
@@ -122,7 +122,7 @@ class ProxyServer
 				$this->serve();
 			$this::redirectexit($request);
 		}
-		
+
 		$eTag = '"' . substr(sha1($request) . $cached['time'], 0, 64) . '"';
 		if (!empty($_SERVER['HTTP_IF_NONE_MATCH']) && strpos($_SERVER['HTTP_IF_NONE_MATCH'], $eTag) !== false)
 		{
@@ -173,7 +173,7 @@ class ProxyServer
 	 *
 	 * @access protected
 	 * @param string $request The image to cache/validate
-	 * @return int -1 error, 0 to big, 1 is good
+	 * @return int -1 error, 0 too big, 1 valid image
 	 */
 	protected function cacheImage($request)
 	{
@@ -183,11 +183,7 @@ class ProxyServer
 		$responseCode = $curl_request->result('code');
 		$response = $curl_request->result();
 
-		if (empty($response)) {
-			return -1;
-		}
-
-		if ($responseCode != 200) {
+		if (empty($response) || $responseCode != 200) {
 			return -1;
 		}
 
@@ -224,7 +220,7 @@ class ProxyServer
 		header('Location: ' . $request, false, 301);
 		exit;
 	}
-	
+
 	/**
 	 * Helper function to call time() once with the right logic
 	 * 

--- a/proxy.php
+++ b/proxy.php
@@ -141,7 +141,7 @@ class ProxyServer
 		header('content-type: ' . $cached['content_type']);
 		header('content-length: ' . $cached['size']);
 		header('cache-control: public, max-age=' . $max_age );
-		header('last-modified: ' . gmdate('D, d M Y H:i:s', $cached['time']) . ' UTC');
+		header('last-modified: ' . gmdate('D, d M Y H:i:s', $cached['time']) . ' GMT');
 		header('etag: ' . $eTag);
 		echo base64_decode($cached['body']);
 	}
@@ -234,7 +234,7 @@ class ProxyServer
 		if (empty($this->time))
 		{
 			$old_timezone = date_default_timezone_get();
-			date_default_timezone_set('UTC');
+			date_default_timezone_set('GMT');
 			$this->time = time();
 			date_default_timezone_set($old_timezone);
 		}


### PR DESCRIPTION
Based on the idea/code from https://www.simplemachines.org/community/index.php?topic=558395.0
i decide to look more deeply in the code.
And did major changes:
- Removed subs.php -> better performance
- added request check of http/https (dunno why this make it but it doesn't hurt)
- stream line the return value of cacheImage to int
- define 3 return values -1 bad, 0 to big, 1 good
- based on this we can do different things
- define utc as default timezone for caching stuff no issue with daylight saving time
- added the header data that this is a cache and the browser can cache the data by his self for the same ttl like we got -> the proxy cache is less called

Since the proxy file works also with smf 2.0.x i guess @sbulen could maybe test this version and
comment on issue around this.