### PR TITLE
Links directly to messages in permalinks on topic display

### DIFF
--- a/Sources/Display.php
+++ b/Sources/Display.php
@@ -1587,7 +1587,7 @@ function prepareDisplayContext($reset = false)
 	$output = array(
 		'attachment' => loadAttachmentContext($message['id_msg'], $context['loaded_attachments']),
 		'id' => $message['id_msg'],
-		'href' => $scripturl . '?topic=' . $topic . '.msg' . $message['id_msg'] . '#msg' . $message['id_msg'],
+		'href' => $scripturl . '?msg=' . $message['id_msg'],
 		'link' => '<a href="' . $scripturl . '?msg=' . $message['id_msg'] . '" rel="nofollow">' . $message['subject'] . '</a>',
 		'member' => &$memberContext[$message['id_member']],
 		'icon' => $message['icon'],

--- a/Themes/default/Display.template.php
+++ b/Themes/default/Display.template.php
@@ -680,7 +680,7 @@ function template_single_post($message)
 	// Some people don't want subject... The div is still required or quick edit breaks.
 	echo '
 								<div id="subject_', $message['id'], '" class="subject_title', (empty($modSettings['subject_toggle']) ? ' subject_hidden' : ''), '">
-									<a href="', $message['href'], '" rel="nofollow">', $message['subject'], '</a>
+									', $message['link'], '
 								</div>';
 
 	echo '


### PR DESCRIPTION
In 54683d86e, @Oldiesmann rightly changed the URL in `$message['link']` to `$scripturl . '?msg=' . $message['id_msg']` in order to "prevent things from breaking if a post is moved, etc." This implements the same change for `$message['href']`.