### PR TITLE
Support to search for ipaddress

### DIFF
--- a/Sources/ManageMembers.php
+++ b/Sources/ManageMembers.php
@@ -255,6 +255,14 @@ function ViewMemberlist()
 			'ip' => array(
 				'db_fields' => array('member_ip'),
 				'type' => 'inet'
+			),
+			'membergroups' => array(
+				'db_fields' => array('id_group'),
+				'type' => 'groups'
+			),
+			'postgroups' => array(
+				'db_fields' => array('id_group'),
+				'type' => 'groups'
 			)
 		);
 		$range_trans = array(
@@ -373,7 +381,7 @@ function ViewMemberlist()
 				}
 				
 			}
-			else
+			elseif ($param_info['type'] != 'groups')
 			{
 				// Replace the wildcard characters ('*' and '?') into MySQL ones.
 				$parameter = strtolower(strtr($smcFunc['htmlspecialchars']($search_params[$param_name], ENT_QUOTES), array('%' => '\%', '_' => '\_', '*' => '%', '?' => '_')));

--- a/Sources/ManageMembers.php
+++ b/Sources/ManageMembers.php
@@ -303,6 +303,12 @@ function ViewMemberlist()
 
 				$search_params[$param_name] = strtotime($search_params[$param_name]);
 			}
+			elseif ($param_info['type'] == 'inet')
+			{
+				$search_params[$param_name] = ip2range($search_params[$param_name]);
+				if (empty($search_params[$param_name]))
+					continue;
+			}
 
 			// Those values that are in some kind of range (<, <=, =, >=, >).
 			if (!empty($param_info['range']))
@@ -350,6 +356,22 @@ function ViewMemberlist()
 
 				$query_parts[] = ($param_info['db_fields'][0]) . ' IN ({array_string:' . $param_name . '_check})';
 				$where_params[$param_name . '_check'] = $search_params[$param_name];
+			}
+			// INET.
+			elseif ($param_info['type'] == 'inet')
+			{
+				if(count($search_params[$param_name]) === 1)
+				{
+					$query_parts[] = '(' . $param_info['db_fields'][0] . ' = {inet:' . $param_name . '})';
+					$where_params[$param_name] = $search_params[$param_name][0];
+				}
+				elseif (count($search_params[$param_name]) === 2)
+				{
+					$query_parts[] = '(' . $param_info['db_fields'][0] . ' <= {inet:' . $param_name . '_high} and ' . $param_info['db_fields'][0] . ' >= {inet:' . $param_name . '_low})';
+					$where_params[$param_name.'_low'] = $search_params[$param_name]['low'];
+					$where_params[$param_name.'_high'] = $search_params[$param_name]['high'];
+				}
+				
 			}
 			else
 			{


### PR DESCRIPTION
the search doesn't work without this.
Support the same syntax like ban mask:
- 127.0.0.1
- 127.*
- 127.0.0.1-127.0.0.100

only wildcard at the end supported

Thanks to the person how is to busy to write down this issue in github,
but got the time to write down in a random board.