### PR TITLE
Minify improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,9 +13,9 @@ Packages/*.zip
 Packages/*/
 attachments/
 /upgrade.php
-Themes/default/css/minified.css
-Themes/default/scripts/minified.js
-Themes/default/scripts/minified_deferred.js
+Themes/default/css/minified*.css
+Themes/default/scripts/minified*.js
+Themes/default/scripts/minified_deferred*.js
 
 # Compiled source #
 ###################

--- a/Sources/Load.php
+++ b/Sources/Load.php
@@ -2434,14 +2434,13 @@ function loadSubTemplate($sub_template_name, $fatal = false)
 function loadCSSFile($fileName, $params = array(), $id = '')
 {
 	global $settings, $context, $modSettings;
-	
-	if (empty($context['css_files_order'])) 
+
+	if (empty($context['css_files_order']))
 		$context['css_files_order'] = array();
 
 	$params['seed'] = (!array_key_exists('seed', $params) || (array_key_exists('seed', $params) && $params['seed'] === true)) ? (array_key_exists('browser_cache', $modSettings) ? $modSettings['browser_cache'] : '') : (is_string($params['seed']) ? ($params['seed'] = $params['seed'][0] === '?' ? $params['seed'] : '?' . $params['seed']) : '');
 	$params['force_current'] = isset($params['force_current']) ? $params['force_current'] : false;
 	$themeRef = !empty($params['default_theme']) ? 'default_theme' : 'theme';
-	$params['minimize'] = isset($params['minimize']) ? $params['minimize'] : false;
 	$params['external'] = isset($params['external']) ? $params['external'] : false;
 	$params['validate'] = isset($params['validate']) ? $params['validate'] : true;
 	$params['order_pos'] = isset($params['order_pos']) ? (int) $params['order_pos'] : 3000;

--- a/Sources/Load.php
+++ b/Sources/Load.php
@@ -2428,7 +2428,7 @@ function loadSubTemplate($sub_template_name, $fatal = false)
  *  - ['rtl'] (string): additional file to load in RTL mode
  *  - ['seed'] (true/false/string): if true or null, use cache stale, false do not, or used a supplied string
  *  - ['minimize'] boolean to add your file to the main minimized file. Useful when you have a file thats loaded everywhere and for everyone.
- *  - ['order_pos'] int define the load order, when not define it's loaded in the middle, before index = - 500, after index = 500, middle = 3000 end(after responsive) = 10000
+ *  - ['order_pos'] int define the load order, when not define it's loaded in the middle, before index.css = -500, after index.css = 500, middle = 3000, end (i.e. after responsive.css) = 10000
  * @param string $id An ID to stick on the end of the filename for caching purposes
  */
 function loadCSSFile($fileName, $params = array(), $id = '')
@@ -2441,6 +2441,7 @@ function loadCSSFile($fileName, $params = array(), $id = '')
 	$params['seed'] = (!array_key_exists('seed', $params) || (array_key_exists('seed', $params) && $params['seed'] === true)) ? (array_key_exists('browser_cache', $modSettings) ? $modSettings['browser_cache'] : '') : (is_string($params['seed']) ? ($params['seed'] = $params['seed'][0] === '?' ? $params['seed'] : '?' . $params['seed']) : '');
 	$params['force_current'] = isset($params['force_current']) ? $params['force_current'] : false;
 	$themeRef = !empty($params['default_theme']) ? 'default_theme' : 'theme';
+	$params['minimize'] = isset($params['minimize']) ? $params['minimize'] : true;
 	$params['external'] = isset($params['external']) ? $params['external'] : false;
 	$params['validate'] = isset($params['validate']) ? $params['validate'] : true;
 	$params['order_pos'] = isset($params['order_pos']) ? (int) $params['order_pos'] : 3000;

--- a/Sources/Load.php
+++ b/Sources/Load.php
@@ -2467,7 +2467,10 @@ function loadCSSFile($fileName, $params = array(), $id = '')
 			}
 
 			else
+			{
 				$fileUrl = false;
+				$filePath = false;
+			}
 		}
 
 		else

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -3636,13 +3636,20 @@ function template_css()
 	ksort($context['css_files_order']);
 	$context['css_files'] = array_merge(array_flip($context['css_files_order']), $context['css_files']);
 
+	// Need this in order to prevent responsive themes from breaking.
+	// THEME AUTHORS: Please always put your responsive CSS rules in a file named responsive.css
+	$minimize_below = isset($context['css_files']['smf_responsive']['options']['order_pos']) ? $context['css_files']['smf_responsive']['options']['order_pos'] : 1;
+
 	foreach ($context['css_files'] as $id => $file)
 	{
 		// Last minute call! allow theme authors to disable single files.
 		if (!empty($settings['disable_files']) && in_array($id, $settings['disable_files']))
 			continue;
 
-		// By default all files don't get minimized unless the file explicitly says so!
+		// Files loaded before responsive.css are minimized by default.
+		if (!isset($file['options']['minimize']) && $file['options']['order_pos'] <= $minimize_below)
+			$file['options']['minimize'] = true;
+
 		if (!empty($file['options']['minimize']) && !empty($modSettings['minimize_files']))
 		{
 			$toMinify[] = $file;

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -3566,7 +3566,7 @@ function template_javascript($do_deferred = false)
 				$toMinify[] = $js_file;
 
 			// Grab a random seed.
-			if (!isset($minSeed))
+			if (!isset($minSeed) && isset($js_file['options']['seed']))
 				$minSeed = $js_file['options']['seed'];
 		}
 
@@ -3583,7 +3583,7 @@ function template_javascript($do_deferred = false)
 
 		foreach ($result as $minFile)
 			echo '
-	<script src="', $minFile['fileUrl'], $minSuccessful ? $minSeed : '', '"', !empty($minFile['options']['async']) ? ' async="async"' : '', '></script>';
+	<script src="', $minFile['fileUrl'], $minSuccessful && isset($minSeed) ? $minSeed : '', '"', !empty($minFile['options']['async']) ? ' async="async"' : '', '></script>';
 
 	}
 
@@ -3633,18 +3633,14 @@ function template_css()
 	ksort($context['css_files_order']);
 	$context['css_files'] = array_merge(array_flip($context['css_files_order']), $context['css_files']);
 
-	// Need this in order to prevent responsive themes from breaking.
-	// THEME AUTHORS: Please always put your responsive CSS rules in a file named responsive.css
-	$minimize_below = isset($context['css_files']['smf_responsive']['options']['order_pos']) ? $context['css_files']['smf_responsive']['options']['order_pos'] : 1;
-
 	foreach ($context['css_files'] as $id => $file)
 	{
 		// Last minute call! allow theme authors to disable single files.
 		if (!empty($settings['disable_files']) && in_array($id, $settings['disable_files']))
 			continue;
 
-		// Files loaded before responsive.css are minimized by default.
-		if (!isset($file['options']['minimize']) && $file['options']['order_pos'] <= $minimize_below)
+		// Files are minimized unless they explicitly opt out.
+		if (!isset($file['options']['minimize']))
 			$file['options']['minimize'] = true;
 
 		if (!empty($file['options']['minimize']) && !empty($modSettings['minimize_files']))
@@ -3652,10 +3648,9 @@ function template_css()
 			$toMinify[] = $file;
 
 			// Grab a random seed.
-			if (!isset($minSeed))
+			if (!isset($minSeed) && isset($file['options']['seed']))
 				$minSeed = $file['options']['seed'];
 		}
-
 		else
 			$normal[] = $file['fileUrl'];
 	}
@@ -3668,7 +3663,7 @@ function template_css()
 
 		foreach ($result as $minFile)
 			echo '
-	<link rel="stylesheet" href="', $minFile['fileUrl'], $minSuccessful ? $minSeed : '', '">';
+	<link rel="stylesheet" href="', $minFile['fileUrl'], $minSuccessful && isset($minSeed) ? $minSeed : '', '">';
 	}
 
 	// Print the rest after the minified files.

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -2260,7 +2260,7 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 				continue;
 
 			$next_c = isset($message[$pos + 1 + $pt_strlen]) ? $message[$pos + 1 + $pt_strlen] : '';
-			
+
 			// A tag is the last char maybe
 			if ($next_c == '')
 				break;
@@ -3579,15 +3579,12 @@ function template_javascript($do_deferred = false)
 	{
 		$result = custMinify(($do_deferred ? $toMinifyDefer : $toMinify), 'js', $do_deferred);
 
-		// Minify process couldn't work, print each individual files.
-		if (!empty($result) && is_array($result))
-			foreach ($result as $minFailedFile)
-				echo '
-	<script src="', $minFailedFile['fileUrl'], '"', !empty($minFailedFile['options']['async']) ? ' async="async"' : '', '></script>';
+		$minSuccessful = array_keys($result) === array('smf_minified');
 
-		else
+		foreach ($result as $minFile)
 			echo '
-	<script src="', $settings['theme_url'] ,'/scripts/minified', ($do_deferred ? '_deferred' : '') ,'.js', $minSeed ,'"></script>';
+	<script src="', $minFile['fileUrl'], $minSuccessful ? $minSeed : '', '"', !empty($minFile['options']['async']) ? ' async="async"' : '', '></script>';
+
 	}
 
 	// Inline JavaScript - Actually useful some times!
@@ -3667,15 +3664,11 @@ function template_css()
 	{
 		$result = custMinify($toMinify, 'css');
 
-		// Minify process couldn't work, print each individual files.
-		if (!empty($result) && is_array($result))
-			foreach ($result as $minFailedFile)
-				echo '
-	<link rel="stylesheet" href="', $minFailedFile['fileUrl'], '">';
+		$minSuccessful = array_keys($result) === array('smf_minified');
 
-		else
+		foreach ($result as $minFile)
 			echo '
-	<link rel="stylesheet" href="', $settings['theme_url'] ,'/css/minified.css', $minSeed ,'">';
+	<link rel="stylesheet" href="', $minFile['fileUrl'], $minSuccessful ? $minSeed : '', '">';
 	}
 
 	// Print the rest after the minified files.
@@ -3726,8 +3719,11 @@ function custMinify($data, $type, $do_deferred = false)
 	if (empty($type) || empty($data))
 		return false;
 
+	// Different pages include different files, so we use a hash to label the different combinations
+	$hash = md5(implode(' ', array_keys($data)));
+
 	// Did we already did this?
-	$toCache = cache_get_data('minimized_'. $settings['theme_id'] .'_'. $type, 86400);
+	$toCache = cache_get_data('minimized_' . $settings['theme_id'] . '_' . $type . '_' . $hash, 86400);
 
 	// Already done?
 	if (!empty($toCache))
@@ -3737,30 +3733,36 @@ function custMinify($data, $type, $do_deferred = false)
 	$classType = 'MatthiasMullie\\Minify\\'. strtoupper($type);
 
 	// Temp path.
-	$cTempPath = $settings['theme_dir'] .'/'. ($type == 'css' ? 'css' : 'scripts') .'/';
+	$cTempPath = $settings['theme_dir'] . '/' . ($type == 'css' ? 'css' : 'scripts') . '/';
 
 	// What kind of file are we going to create?
-	$toCreate = $cTempPath .'minified'. ($do_deferred ? '_deferred' : '') .'.'. $type;
+	$toCreate = $cTempPath . 'minified' . ($do_deferred ? '_deferred' : '') . '_' . $hash . '.' . $type;
 
-	// File has to exists, if it isn't try to create it.
+	// File has to exist. If it doesn't, try to create it.
 	if ((!file_exists($toCreate) && @fopen($toCreate, 'w') === false) || !smf_chmod($toCreate))
 	{
 		loadLanguage('Errors');
 		log_error(sprintf($txt['file_not_created'], $toCreate), 'general');
-		cache_put_data('minimized_'. $settings['theme_id'] .'_'. $type, null);
+		cache_put_data('minimized_' . $settings['theme_id'] . '_' . $type . '_' . $hash, null);
 
-		// The process failed so roll back to print each individual file.
+		// The process failed, so roll back to print each individual file.
 		return $data;
 	}
 
 	$minifier = new $classType();
+
+	$async = $type === 'js';
 
 	foreach ($data as $file)
 	{
 		$tempFile = str_replace($file['options']['seed'], '', $file['filePath']);
 		$toAdd = file_exists($tempFile) ? $tempFile : false;
 
-		// The file couldn't be located so it won't be added, log this error.
+		// A minified script should only be loaded asynchronously if all its components wanted to be.
+		if (empty($file['options']['async']))
+			$async = false;
+
+		// The file couldn't be located so it won't be added. Log this error.
 		if (empty($toAdd))
 		{
 			loadLanguage('Errors');
@@ -3782,16 +3784,21 @@ function custMinify($data, $type, $do_deferred = false)
 	{
 		loadLanguage('Errors');
 		log_error(sprintf($txt['file_not_created'], $toCreate), 'general');
-		cache_put_data('minimized_'. $settings['theme_id'] .'_'. $type, null);
+		cache_put_data('minimized_' . $settings['theme_id'] . '_' . $type . '_' . $hash, null);
 
 		// The process failed so roll back to print each individual file.
 		return $data;
 	}
 
 	// And create a long lived cache entry.
-	cache_put_data('minimized_'. $settings['theme_id'] .'_'. $type, $toCreate, 86400);
+	cache_put_data('minimized_' . $settings['theme_id'] . '_' . $type . '_' . $hash, $toCreate, 86400);
 
-	return true;
+	return array('smf_minified' => array(
+		'fileUrl' => $settings['theme_url'] . '/' . ($type == 'css' ? 'css' : 'scripts') . '/' . basename($toCreate),
+		'filePath' => $toCreate,
+		'fileName' => basename($toCreate),
+		'options' => array('async' => $async),
+	));
 }
 
 /**

--- a/Themes/default/index.template.php
+++ b/Themes/default/index.template.php
@@ -103,10 +103,6 @@ function template_html_above()
 		This approach will let you take advantage of SMF's automatic CSS
 		minimization and other benefits. You can, of course, manually add any
 		other files you want after template_css() has been run.
-
-		If you are writing a theme that uses responsive design (and in this day
-		and age, you probably should be), please always put your responsive CSS
-		rules in a file named responsive.css.
 	*/
 
 	// load in any css from mods or themes so they can overwrite if wanted

--- a/Themes/default/index.template.php
+++ b/Themes/default/index.template.php
@@ -89,11 +89,24 @@ function template_html_above()
 <head>
 	<meta charset="', $context['character_set'], '">';
 
-	/*	You don't need to manually load index.css, this will be set up for you. You can, of course, add
-		any other files you want, after template_css() has been run. Note that RTL will also be loaded for you.
+	/*
+		You don't need to manually load index.css, this will be set up for you.
+		Note that RTL will also be loaded for you.
 
-		The most efficient way of writing multi themes is to use a master index.css plus variant.css files.
-		If you've set them up properly (through $settings['theme_variants'], loadCSSFile will load the variant files for you.
+		The most efficient way of writing multi themes is to use a master
+		index.css plus variant.css files. If you've set them up properly
+		(through $settings['theme_variants']), the variant files will be loaded
+		for you automatically.
+
+		If you want to load other CSS files, the best way is to use the
+		'integrate_load_theme' integration hook and the loadCSSFile() function.
+		This approach will let you take advantage of SMF's automatic CSS
+		minimization and other benefits. You can, of course, manually add any
+		other files you want after template_css() has been run.
+
+		If you are writing a theme that uses responsive design (and in this day
+		and age, you probably should be), please always put your responsive CSS
+		rules in a file named responsive.css.
 	*/
 
 	// load in any css from mods or themes so they can overwrite if wanted


### PR DESCRIPTION
- Minimizes ~CSS files loaded before responsive.css~ all CSS files by default
- Improves custMinify in several ways:
  - Now generates distinct minified files for different sets of input files. This allows us to serve up minified files that are tailored for different pages, which means we can freely include whatever files are necessary for a given page, without worrying that we are going to serve unnecessary bloat on other pages as a result.
  - Changes the return value so that it is always an array of relevant file info.
  - When minimizing JavaScript files, tries to preserve the async attribute if possible.

This is a follow-up to #4548 that helps to further fix #4544.