### PR TITLE
Catch Warning from mail()

### DIFF
--- a/Sources/Subs-Post.php
+++ b/Sources/Subs-Post.php
@@ -686,11 +686,29 @@ function sendmail($to, $subject, $message, $from = null, $message_id = null, $se
 
 		foreach ($to_array as $to)
 		{
-			if (!mail(strtr($to, array("\r" => '', "\n" => '')), $subject, $message, $headers))
+			set_error_handler(function($errno, $errstr, $errfile, $errline)
+				{
+					// error was suppressed with the @-operator
+					if (0 === error_reporting()) {
+						return false;
+					}
+
+					throw new ErrorException($errstr, 0, $errno, $errfile, $errline);
+				}
+			);
+			try
 			{
-				log_error(sprintf($txt['mail_send_unable'], $to));
-				$mail_result = false;
+				if (!mail(strtr($to, array("\r" => '', "\n" => '')), $subject, $message, $headers))
+				{
+					log_error(sprintf($txt['mail_send_unable'], $to));
+					$mail_result = false;
+				}
 			}
+			catch(ErrorException $e)
+			{
+				log_error($e->getMessage(), 'general', $e->getFile(), $e->getLine());
+			}
+			restore_error_handler();
 
 			// Wait, wait, I'm still sending here!
 			@set_time_limit(300);

--- a/Sources/Subs-Post.php
+++ b/Sources/Subs-Post.php
@@ -707,6 +707,8 @@ function sendmail($to, $subject, $message, $from = null, $message_id = null, $se
 			catch(ErrorException $e)
 			{
 				log_error($e->getMessage(), 'general', $e->getFile(), $e->getLine());
+				log_error(sprintf($txt['mail_send_unable'], $to));
+				$mail_result = false;
 			}
 			restore_error_handler();
 


### PR DESCRIPTION
By testing another error,
my test env remember me that i got no mail server setting up:
![grafik](https://user-images.githubusercontent.com/1782906/36682468-6f28a08e-1b1b-11e8-985c-9ca36539964b.png)
In my eyes to mutch information to a $random guy,
so i suppress the error message on user interface side but log this in the smf log.