### PR TITLE
Docker setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM php:5.4-apache
+RUN apt-get update
+RUN apt-get install -y zip libxml2-dev libpng-dev
+RUN docker-php-ext-install mysql simplexml mbstring gd mysqli
+RUN pecl install xdebug-2.4.0 && docker-php-ext-enable xdebug
+RUN echo "xdebug.remote_enable=on" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
+RUN echo "xdebug.remote_connect_back=on" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
+# nasty hack to solve perms issues
+RUN chmod 777 /var/www/html
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '2'
+services:
+  smf:
+    build: .
+    ports:
+      - "8080:80"
+    volumes:
+      - ./:/var/www/html
+  database:
+    image: mysql
+    restart: always
+    ports:
+      - "3306:3306"
+    environment:
+      MYSQL_ROOT_PASSWORD: password


### PR DESCRIPTION
Apache, PHP 5.4  (with xdebug), MySql

I choose PHP 5.4 as this is the minimum version for SMF, so we should be testing everything on PHP 5.4.

Does someone want to give it a go?

Instructions:

docker-compose up -d
docker-compose logs -f (if you want to see the build logs)

Copy files from other folder (we could do this as part of the setup).
http://localhost:8080/install.php
In the DB settings, you can use the database container name (smf21_database_1).
