### PR TITLE
Set current key for custom multi option fields for profiles

### DIFF
--- a/Sources/Memberlist.php
+++ b/Sources/Memberlist.php
@@ -634,7 +634,8 @@ function printMemberListRows($request)
 
 				$value = $context['members'][$member]['options'][$key];
 				$currentKey = 0;
-				if (!empty($column['options'])) {
+				if (!empty($column['options']))
+				{
 					$fieldOptions = explode(',', $column['options']);
 					foreach ($fieldOptions as $k => $v)
 					{

--- a/Sources/Memberlist.php
+++ b/Sources/Memberlist.php
@@ -631,6 +631,18 @@ function printMemberListRows($request)
 		{
 			foreach ($context['custom_profile_fields']['columns'] as $key => $column)
 			{
+
+				$value = $context['members'][$member]['options'][$key];
+				$currentKey = 0;
+				if (!empty($column['options'])) {
+					$fieldOptions = explode(',', $column['options']);
+					foreach ($fieldOptions as $k => $v)
+					{
+						if (empty($currentKey))
+							$currentKey = $v === $value ? $k : 0;
+					}
+				}
+
 				// Don't show anything if there isn't anything to show.
 				if (!isset($context['members'][$member]['options'][$key]))
 				{
@@ -651,6 +663,7 @@ function printMemberListRows($request)
 						'{IMAGES_URL}' => $settings['images_url'],
 						'{DEFAULT_IMAGES_URL}' => $settings['default_images_url'],
 						'{INPUT}' => $context['members'][$member]['options'][$key],
+						'{KEY}' => $currentKey
 					));
 			}
 		}

--- a/Sources/Memberlist.php
+++ b/Sources/Memberlist.php
@@ -669,7 +669,7 @@ function getCustFieldsMList()
 	$cpf = array();
 
 	$request = $smcFunc['db_query']('', '
-		SELECT col_name, field_name, field_desc, field_type, bbc, enclose
+		SELECT col_name, field_name, field_desc, field_type, field_options, bbc, enclose
 		FROM {db_prefix}custom_fields
 		WHERE active = {int:active}
 			AND show_mlist = {int:show}
@@ -687,6 +687,7 @@ function getCustFieldsMList()
 		$cpf['columns'][$row['col_name']] = array(
 			'label' => $row['field_name'],
 			'type' => $row['field_type'],
+			'options' => $row['field_options'],
 			'bbc' => !empty($row['bbc']),
 			'enclose' => $row['enclose'],
 		);

--- a/Sources/Profile.php
+++ b/Sources/Profile.php
@@ -888,12 +888,13 @@ function loadCustomFields($memID, $area = 'summary')
 	{
 		$value = $user_profile[$memID]['options'][$row['col_name']];
 		$currentKey = 0;
-		if (!empty($row['field_options'])) {
+		if (!empty($row['field_options']))
+		{
 			$fieldOptions = explode(',', $row['field_options']);
-			foreach ($fieldOptions as $k => $v) {
-				if (empty($currentKey)) {
+			foreach ($fieldOptions as $k => $v)
+			{
+				if (empty($currentKey))
 					$currentKey = $v === $value ? $k : 0;
-				}
 			}
 		}
 

--- a/Sources/Profile.php
+++ b/Sources/Profile.php
@@ -886,6 +886,17 @@ function loadCustomFields($memID, $area = 'summary')
 	$context['custom_fields_required'] = false;
 	while ($row = $smcFunc['db_fetch_assoc']($request))
 	{
+	    $value = $user_profile[$memID]['options'][$row['col_name']];
+	    $currentKey = 0;
+	    if (!empty($row['field_options'])) {
+            $fieldOptions = explode(',', $row['field_options']);
+            foreach ($fieldOptions as $k => $v) {
+                if (empty($currentKey)) {
+                    $currentKey = $v === $value ? $k : 0;
+                }
+            }
+        }
+
 		// Shortcut.
 		$exists = $memID && isset($user_profile[$memID], $user_profile[$memID]['options'][$row['col_name']]);
 		$value = $exists ? $user_profile[$memID]['options'][$row['col_name']] : '';
@@ -961,6 +972,7 @@ function loadCustomFields($memID, $area = 'summary')
 				'{IMAGES_URL}' => $settings['images_url'],
 				'{DEFAULT_IMAGES_URL}' => $settings['default_images_url'],
 				'{INPUT}' => un_htmlspecialchars($output_html),
+				'{KEY}' => $currentKey
 			));
 
 		$context['custom_fields'][] = array(

--- a/Sources/Profile.php
+++ b/Sources/Profile.php
@@ -886,16 +886,16 @@ function loadCustomFields($memID, $area = 'summary')
 	$context['custom_fields_required'] = false;
 	while ($row = $smcFunc['db_fetch_assoc']($request))
 	{
-	    $value = $user_profile[$memID]['options'][$row['col_name']];
-	    $currentKey = 0;
-	    if (!empty($row['field_options'])) {
-            $fieldOptions = explode(',', $row['field_options']);
-            foreach ($fieldOptions as $k => $v) {
-                if (empty($currentKey)) {
-                    $currentKey = $v === $value ? $k : 0;
-                }
-            }
-        }
+		$value = $user_profile[$memID]['options'][$row['col_name']];
+		$currentKey = 0;
+		if (!empty($row['field_options'])) {
+			$fieldOptions = explode(',', $row['field_options']);
+			foreach ($fieldOptions as $k => $v) {
+				if (empty($currentKey)) {
+					$currentKey = $v === $value ? $k : 0;
+				}
+			}
+		}
 
 		// Shortcut.
 		$exists = $memID && isset($user_profile[$memID], $user_profile[$memID]['options'][$row['col_name']]);


### PR DESCRIPTION
Fixes #4451

Took a very similar approach to how loadMemberContext() does it for member profiles.  Same concept, check all the custom fields on the profile being loaded to see if they have options, match the option to a profile option, check if the values match and set a key.

Then added {KEY} to the output_html.