### PR TITLE
Move post images size limit to css

### DIFF
--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -3221,11 +3221,11 @@ function setupThemeContext($forceload = false)
 	// Add max image limits
 	if (!empty($modSettings['max_image_width']))
 		addInlineCss('
-	.bbc_img { max-width: ' . $modSettings['max_image_width'] . 'px; }');
+	.postarea .bbc_img { max-width: ' . $modSettings['max_image_width'] . 'px; }');
 
 	if (!empty($modSettings['max_image_height']))
 		addInlineCss('
-	.bbc_img { max-height: ' . $modSettings['max_image_height'] . 'px; }');
+	.postarea .bbc_img { max-height: ' . $modSettings['max_image_height'] . 'px; }');
 
 	// This looks weird, but it's because BoardIndex.php references the variable.
 	$context['common_stats']['latest_member'] = array(

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -1928,28 +1928,7 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 						if (preg_match('~action(=|%3d)(?!dlattach)~i', $imgtag) != 0)
 							$imgtag = preg_replace('~action(?:=|%3d)(?!dlattach)~i', 'action-', $imgtag);
 
-						// Check if the image is larger than allowed.
-						if (!empty($modSettings['max_image_width']) && !empty($modSettings['max_image_height']))
-						{
-							list ($width, $height) = url_image_size($imgtag);
-
-							if (!empty($modSettings['max_image_width']) && $width > $modSettings['max_image_width'])
-							{
-								$height = (int) (($modSettings['max_image_width'] * $height) / $width);
-								$width = $modSettings['max_image_width'];
-							}
-
-							if (!empty($modSettings['max_image_height']) && $height > $modSettings['max_image_height'])
-							{
-								$width = (int) (($modSettings['max_image_height'] * $width) / $height);
-								$height = $modSettings['max_image_height'];
-							}
-
-							// Set the new image tag.
-							$replaces[$matches[0][$match]] = '[img width=' . $width . ' height=' . $height . $alt . ']' . $imgtag . '[/img]';
-						}
-						else
-							$replaces[$matches[0][$match]] = '[img' . $alt . ']' . $imgtag . '[/img]';
+						$replaces[$matches[0][$match]] = '[img' . $alt . ']' . $imgtag . '[/img]';
 					}
 
 					$data = strtr($data, $replaces);
@@ -3237,7 +3216,16 @@ function setupThemeContext($forceload = false)
 	// Now add the capping code for avatars.
 	if (!empty($modSettings['avatar_max_width_external']) && !empty($modSettings['avatar_max_height_external']) && !empty($modSettings['avatar_action_too_large']) && $modSettings['avatar_action_too_large'] == 'option_css_resize')
 		addInlineCss('
-img.avatar { max-width: ' . $modSettings['avatar_max_width_external'] . 'px; max-height: ' . $modSettings['avatar_max_height_external'] . 'px; }');
+	img.avatar { max-width: ' . $modSettings['avatar_max_width_external'] . 'px; max-height: ' . $modSettings['avatar_max_height_external'] . 'px; }');
+
+	// Add max image limits
+	if (!empty($modSettings['max_image_width']))
+		addInlineCss('
+	.bbc_img { max-width: ' . $modSettings['max_image_width'] . 'px; }');
+
+	if (!empty($modSettings['max_image_height']))
+		addInlineCss('
+	.bbc_img { max-height: ' . $modSettings['max_image_height'] . 'px; }');
 
 	// This looks weird, but it's because BoardIndex.php references the variable.
 	$context['common_stats']['latest_member'] = array(

--- a/Themes/default/css/index.css
+++ b/Themes/default/css/index.css
@@ -369,10 +369,6 @@ blockquote cite::before {
 .bbc_color a {
 	color: inherit;
 }
-.bbc_img, .atc_img {
-	border: 0;
-	height: auto;
-}
 .bbc_table {
 	font: inherit;
 	color: inherit;

--- a/Themes/default/css/index.css
+++ b/Themes/default/css/index.css
@@ -396,6 +396,15 @@ blockquote cite::before {
 	margin-left: 1em;
 	clear: right;
 }
+.postarea .bbc_img:hover {
+	cursor: pointer;
+}
+.bbc_img.original_size {
+	height: auto !important;
+	width: auto !important;
+	max-height: none;
+	max-width: 100%;
+}
 /* No image should have a border when linked. */
 a img {
 	border: 0;

--- a/Themes/default/scripts/theme.js
+++ b/Themes/default/scripts/theme.js
@@ -38,19 +38,12 @@ if (is_ie || is_webkit || is_ff)
 // Toggles the element height and width styles of an image.
 function smc_toggleImageDimensions()
 {
-	var images = $('img.bbc_img');
-
-	$.each(images, function(key, img)
+	$('.postarea .bbc_img').each(function(index, item)
 	{
-		if ($(img).hasClass('resized'))
+		$(item).click(function(e)
 		{
-			$(img).css({cursor: 'pointer'});
-			$(img).on('click', function()
-			{
-				var size = $(this)[0].style.width == 'auto' ? '' : 'auto';
-				$(this).css({width: size, height: size});
-			});
-		}
+			$(item).toggleClass('original_size');
+		});
 	});
 }
 


### PR DESCRIPTION
Fixes the host of issues with the old resize function. This does create one small conflict with the existing code: images that get resized through css will no longer have the "resized" class, so the "click to expand" function only works with manually resized images instead. I will make a separate PR to add a popup to expand images inside posts and perhaps for attachments as well.

The css removed fixes one additional issue with any manually defined height being ignored.

Fixes #1401 