### PR TITLE
Consolidates & simplifies process of getting proxy urls; allows mods to add alternative proxies

### DIFF
--- a/Sources/Load.php
+++ b/Sources/Load.php
@@ -446,7 +446,7 @@ function loadUserSettings()
 			$smcFunc['db_free_result']($request);
 
 			if (!empty($modSettings['force_ssl']) && $image_proxy_enabled && stripos($user_settings['avatar'], 'http://') !== false && empty($user_info['possibly_robot']))
-				$user_settings['avatar'] = strtr($boardurl, array('http://' => 'https://')) . '/proxy.php?request=' . urlencode($user_settings['avatar']) . '&hash=' . md5($user_settings['avatar'] . $image_proxy_secret);
+				$user_settings['avatar'] = get_proxied_url($user_settings['avatar']);
 
 			if (!empty($modSettings['cache_enable']) && $modSettings['cache_enable'] >= 2)
 				cache_put_data('user_settings-' . $id_member, $user_settings, 60);
@@ -1272,7 +1272,7 @@ function loadMemberData($users, $is_name = false, $set = 'normal')
 
 			// Take care of proxying avatar if required, do this here for maximum reach
 			if ($image_proxy_enabled && !empty($row['avatar']) && stripos($row['avatar'], 'http://') !== false && empty($user_info['possibly_robot']))
-				$row['avatar'] = $boardurl . '/proxy.php?request=' . urlencode($row['avatar']) . '&hash=' . md5($row['avatar'] . $image_proxy_secret);
+				$row['avatar'] = get_proxied_url($row['avatar']);
 
 			// Keep track of the member's normal member group
 			$row['primary_group'] = $row['member_group'];
@@ -3543,7 +3543,7 @@ function set_avatar_data($data = array())
 			{
 				// Using ssl?
 				if (!empty($modSettings['force_ssl']) && $image_proxy_enabled && stripos($data['avatar'], 'http://') !== false && empty($user_info['possibly_robot']))
-					$image = strtr($boardurl, array('http://' => 'https://')) . '/proxy.php?request=' . urlencode($data['avatar']) . '&hash=' . md5($data['avatar'] . $image_proxy_secret);
+					$image = get_proxied_url($data['avatar']);
 
 				// Just a plain external url.
 				else

--- a/Sources/Load.php
+++ b/Sources/Load.php
@@ -376,7 +376,7 @@ function reloadSettings()
 function loadUserSettings()
 {
 	global $modSettings, $user_settings, $sourcedir, $smcFunc;
-	global $cookiename, $user_info, $language, $context, $image_proxy_enabled, $image_proxy_url, $image_proxy_secret, $boardurl;
+	global $cookiename, $user_info, $language, $context, $image_proxy_enabled, $image_proxy_secret, $boardurl;
 
 	// Check first the integration, then the cookie, and last the session.
 	if (count($integration_ids = call_integration_hook('integrate_verify_user')) > 0)
@@ -446,10 +446,7 @@ function loadUserSettings()
 			$smcFunc['db_free_result']($request);
 
 			if (!empty($modSettings['force_ssl']) && $image_proxy_enabled && stripos($user_settings['avatar'], 'http://') !== false && empty($user_info['possibly_robot']))
-				if ($image_proxy_enabled === 2 && !empty($image_proxy_url))
-					$user_settings['avatar'] = $image_proxy_url . $user_settings['avatar'];
-				else
-					$user_settings['avatar'] = strtr($boardurl, array('http://' => 'https://')) . '/proxy.php?request=' . urlencode($user_settings['avatar']) . '&hash=' . md5($user_settings['avatar'] . $image_proxy_secret);
+				$user_settings['avatar'] = strtr($boardurl, array('http://' => 'https://')) . '/proxy.php?request=' . urlencode($user_settings['avatar']) . '&hash=' . md5($user_settings['avatar'] . $image_proxy_secret);
 
 			if (!empty($modSettings['cache_enable']) && $modSettings['cache_enable'] >= 2)
 				cache_put_data('user_settings-' . $id_member, $user_settings, 60);
@@ -1187,7 +1184,7 @@ function loadPermissions()
 function loadMemberData($users, $is_name = false, $set = 'normal')
 {
 	global $user_profile, $modSettings, $board_info, $smcFunc, $context;
-	global $image_proxy_enabled, $image_proxy_url, $image_proxy_secret, $boardurl, $user_info;
+	global $image_proxy_enabled, $image_proxy_secret, $boardurl, $user_info;
 
 	// Can't just look for no users :P.
 	if (empty($users))
@@ -1275,10 +1272,7 @@ function loadMemberData($users, $is_name = false, $set = 'normal')
 
 			// Take care of proxying avatar if required, do this here for maximum reach
 			if ($image_proxy_enabled && !empty($row['avatar']) && stripos($row['avatar'], 'http://') !== false && empty($user_info['possibly_robot']))
-				if ($image_proxy_enabled === 2 && !empty($image_proxy_url))
-					$row['avatar'] = $image_proxy_url . $row['avatar'];
-				else
-					$row['avatar'] = $boardurl . '/proxy.php?request=' . urlencode($row['avatar']) . '&hash=' . md5($row['avatar'] . $image_proxy_secret);
+				$row['avatar'] = $boardurl . '/proxy.php?request=' . urlencode($row['avatar']) . '&hash=' . md5($row['avatar'] . $image_proxy_secret);
 
 			// Keep track of the member's normal member group
 			$row['primary_group'] = $row['member_group'];
@@ -3509,7 +3503,7 @@ function clean_cache($type = '')
  */
 function set_avatar_data($data = array())
 {
-	global $modSettings, $boardurl, $smcFunc, $image_proxy_enabled, $image_proxy_url, $image_proxy_secret, $user_info;
+	global $modSettings, $boardurl, $smcFunc, $image_proxy_enabled, $image_proxy_secret, $user_info;
 
 	// Come on!
 	if (empty($data))
@@ -3549,10 +3543,7 @@ function set_avatar_data($data = array())
 			{
 				// Using ssl?
 				if (!empty($modSettings['force_ssl']) && $image_proxy_enabled && stripos($data['avatar'], 'http://') !== false && empty($user_info['possibly_robot']))
-					if ($image_proxy_enabled === 2 && !empty($image_proxy_url))
-						$image = $image_proxy_url . urlencode($data['avatar']);
-					else
-						$image = strtr($boardurl, array('http://' => 'https://')) . '/proxy.php?request=' . urlencode($data['avatar']) . '&hash=' . md5($data['avatar'] . $image_proxy_secret);
+					$image = strtr($boardurl, array('http://' => 'https://')) . '/proxy.php?request=' . urlencode($data['avatar']) . '&hash=' . md5($data['avatar'] . $image_proxy_secret);
 
 				// Just a plain external url.
 				else

--- a/Sources/Load.php
+++ b/Sources/Load.php
@@ -447,7 +447,7 @@ function loadUserSettings()
 
 			if (!empty($modSettings['force_ssl']) && $image_proxy_enabled && stripos($user_settings['avatar'], 'http://') !== false && empty($user_info['possibly_robot']))
 				if ($image_proxy_enabled === 2 && !empty($image_proxy_url))
-					$user_settings['avatar'] = $image_proxy_url . urlencode($user_settings['avatar']);
+					$user_settings['avatar'] = $image_proxy_url . $user_settings['avatar'];
 				else
 					$user_settings['avatar'] = strtr($boardurl, array('http://' => 'https://')) . '/proxy.php?request=' . urlencode($user_settings['avatar']) . '&hash=' . md5($user_settings['avatar'] . $image_proxy_secret);
 

--- a/Sources/Load.php
+++ b/Sources/Load.php
@@ -376,7 +376,7 @@ function reloadSettings()
 function loadUserSettings()
 {
 	global $modSettings, $user_settings, $sourcedir, $smcFunc;
-	global $cookiename, $user_info, $language, $context, $image_proxy_enabled, $image_proxy_secret, $boardurl;
+	global $cookiename, $user_info, $language, $context, $image_proxy_enabled, $boardurl;
 
 	// Check first the integration, then the cookie, and last the session.
 	if (count($integration_ids = call_integration_hook('integrate_verify_user')) > 0)
@@ -1184,7 +1184,7 @@ function loadPermissions()
 function loadMemberData($users, $is_name = false, $set = 'normal')
 {
 	global $user_profile, $modSettings, $board_info, $smcFunc, $context;
-	global $image_proxy_enabled, $image_proxy_secret, $boardurl, $user_info;
+	global $image_proxy_enabled, $boardurl, $user_info;
 
 	// Can't just look for no users :P.
 	if (empty($users))
@@ -3503,7 +3503,7 @@ function clean_cache($type = '')
  */
 function set_avatar_data($data = array())
 {
-	global $modSettings, $boardurl, $smcFunc, $image_proxy_enabled, $image_proxy_secret, $user_info;
+	global $modSettings, $boardurl, $smcFunc, $image_proxy_enabled, $user_info;
 
 	// Come on!
 	if (empty($data))

--- a/Sources/Load.php
+++ b/Sources/Load.php
@@ -1276,7 +1276,7 @@ function loadMemberData($users, $is_name = false, $set = 'normal')
 			// Take care of proxying avatar if required, do this here for maximum reach
 			if ($image_proxy_enabled && !empty($row['avatar']) && stripos($row['avatar'], 'http://') !== false && empty($user_info['possibly_robot']))
 				if ($image_proxy_enabled === 2 && !empty($image_proxy_url))
-					$row['avatar'] = $image_proxy_url . urlencode($row['avatar']);
+					$row['avatar'] = $image_proxy_url . $row['avatar'];
 				else
 					$row['avatar'] = $boardurl . '/proxy.php?request=' . urlencode($row['avatar']) . '&hash=' . md5($row['avatar'] . $image_proxy_secret);
 

--- a/Sources/ManageServer.php
+++ b/Sources/ManageServer.php
@@ -223,7 +223,7 @@ $(function()
 		$("#image_proxy_secret").prop("disabled", mode);
 		$("#image_proxy_maxsize").prop("disabled", mode);
 	}).change();
-});');
+});', true);
 }
 
 /**

--- a/Sources/ManageServer.php
+++ b/Sources/ManageServer.php
@@ -166,10 +166,9 @@ function ModifyGeneralSettings($return_config = false)
 		array('disableHostnameLookup', $txt['disableHostnameLookup'], 'db', 'check', null, 'disableHostnameLookup'),
 		'',
 		array('force_ssl', $txt['force_ssl'], 'db', 'select', array($txt['force_ssl_off'], $txt['force_ssl_complete']), 'force_ssl', 'disabled' => $disable_force_ssl),
-		array('image_proxy_enabled', $txt['image_proxy_enabled'], 'file', 'select', array($txt['image_proxy_off'], $txt['image_proxy_internal'], $txt['image_proxy_external']), 'image_proxy_enabled'),
+		array('image_proxy_enabled', $txt['image_proxy_enabled'], 'file', 'check', null, 'image_proxy_enabled'),
 		array('image_proxy_secret', $txt['image_proxy_secret'], 'file', 'text', 30, 'image_proxy_secret'),
 		array('image_proxy_maxsize', $txt['image_proxy_maxsize'], 'file', 'int', null, 'image_proxy_maxsize'),
-		array('image_proxy_url', $txt['image_proxy_url'], 'file', 'text', 60, 'image_proxy_url'),
 		'',
 		array('enable_sm_stats', $txt['sm_state_setting'], 'db', 'check', null, 'enable_sm_stats'),
 	);
@@ -219,19 +218,12 @@ $(function()
 {
 	$("#force_ssl").change(function()
 	{
-		var mode = $(this).val() == 1 ? false : true;
+		var mode = $(this).val() == 2 ? false : true;
 		$("#image_proxy_enabled").prop("disabled", mode);
-		$("#image_proxy_enabled").trigger("change");
-	}).change();
-	$("#image_proxy_enabled").change(function()
-	{
-		var mode = $(this).val() == 1 && $("#force_ssl").val() == 1 ? false : true;
 		$("#image_proxy_secret").prop("disabled", mode);
 		$("#image_proxy_maxsize").prop("disabled", mode);
-		var mode2 = $(this).val() == 2 && $("#force_ssl").val() == 1 ? false : true;
-		$("#image_proxy_url").prop("disabled", mode2);
 	}).change();
-});', true);
+});');
 }
 
 /**
@@ -1222,18 +1214,16 @@ function saveSettings(&$config_vars)
 		'boarddir', 'sourcedir',
 		'cachedir', 'cachedir_sqlite', 'cache_accelerator', 'cache_memcached',
 		'image_proxy_secret',
-		'image_proxy_url',
 	);
 
 	// All the numeric variables.
 	$config_ints = array(
 		'cache_enable',
 		'image_proxy_maxsize',
-		'image_proxy_enabled',
 	);
 
 	// All the checkboxes
-	$config_bools = array('db_persist', 'db_error_send', 'maintenance');
+	$config_bools = array('db_persist', 'db_error_send', 'maintenance', 'image_proxy_enabled');
 
 	// Now sort everything into a big array, and figure out arrays and etc.
 	$new_settings = array();

--- a/Sources/ManageServer.php
+++ b/Sources/ManageServer.php
@@ -218,7 +218,7 @@ $(function()
 {
 	$("#force_ssl").change(function()
 	{
-		var mode = $(this).val() == 2 ? false : true;
+		var mode = $(this).val() == 1 ? false : true;
 		$("#image_proxy_enabled").prop("disabled", mode);
 		$("#image_proxy_secret").prop("disabled", mode);
 		$("#image_proxy_maxsize").prop("disabled", mode);

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -2875,7 +2875,7 @@ function highlight_php_code($code)
  */
 function get_proxied_url($url)
 {
-	global $boardurl, $modSettings, $image_proxy_enabled, $image_proxy_secret;
+	global $boardurl, $image_proxy_enabled, $image_proxy_secret;
 
 	// Only use the proxy if enabled and necessary
 	if (empty($image_proxy_enabled) || empty($modSettings['force_ssl']) || parse_url($url, PHP_URL_SCHEME) === 'https')

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -2866,7 +2866,7 @@ function highlight_php_code($code)
 
 function get_proxied_url($url)
 {
-	global $boardurl, $image_proxy_enabled, $image_proxy_secret;
+	global $boardurl, $modSettings, $image_proxy_enabled, $image_proxy_secret;
 
 	// Only use the proxy if enabled and necessary
 	if (empty($image_proxy_enabled) || empty($modSettings['force_ssl']) || parse_url($url, PHP_URL_SCHEME) === 'https')

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -2864,6 +2864,15 @@ function highlight_php_code($code)
 	return strtr($buffer, array('\'' => '&#039;', '<code>' => '', '</code>' => ''));
 }
 
+/**
+ * Gets the appropriate URL to use for images (or whatever) when using SSL
+ *
+ * The returned URL may or may not be a proxied URL, depending on the situation.
+ * Mods can implement alternative proxies using the 'integrate_proxy' hook.
+ *
+ * @param string $url The original URL of the requested resource
+ * @return string The URL to use
+ */
 function get_proxied_url($url)
 {
 	global $boardurl, $modSettings, $image_proxy_enabled, $image_proxy_secret;

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -2878,7 +2878,7 @@ function get_proxied_url($url)
 	global $boardurl, $image_proxy_enabled, $image_proxy_secret;
 
 	// Only use the proxy if enabled and necessary
-	if (empty($image_proxy_enabled) || empty($modSettings['force_ssl']) || parse_url($url, PHP_URL_SCHEME) === 'https')
+	if (empty($image_proxy_enabled) || parse_url($url, PHP_URL_SCHEME) === 'https')
 		return $url;
 
 	// We don't need to proxy our own resources

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -2869,7 +2869,7 @@ function get_proxied_url($url)
 	global $boardurl, $image_proxy_enabled, $image_proxy_secret;
 
 	// Only use the proxy if enabled and necessary
-	if (empty($image_proxy_enabled) || parse_url($url, PHP_URL_SCHEME) === 'https')
+	if (empty($image_proxy_enabled) || empty($modSettings['force_ssl']) || parse_url($url, PHP_URL_SCHEME) === 'https')
 		return $url;
 
 	// By default, use SMF's own image proxy script

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -2881,6 +2881,10 @@ function get_proxied_url($url)
 	if (empty($image_proxy_enabled) || empty($modSettings['force_ssl']) || parse_url($url, PHP_URL_SCHEME) === 'https')
 		return $url;
 
+	// We don't need to proxy our own resources
+	if (strpos(strtr($url, array('http://' => 'https://')), strtr($boardurl, array('http://' => 'https://'))) === 0)
+		return strtr($url, array('http://' => 'https://'));
+
 	// By default, use SMF's own image proxy script
 	$proxied_url = strtr($boardurl, array('http://' => 'https://')) . '/proxy.php?request=' . urlencode($url) . '&hash=' . md5($url . $image_proxy_secret);
 

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -1413,7 +1413,7 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 				'content' => '<img src="$1" alt="{alt}" title="{title}"{width}{height} class="bbc_img resized">',
 				'validate' => function (&$tag, &$data, $disabled)
 				{
-					global $image_proxy_enabled, $image_proxy_secret, $boardurl, $user_info, $image_proxy_url;
+					global $image_proxy_enabled, $image_proxy_secret, $boardurl, $user_info;
 
 					$data = strtr($data, array('<br>' => ''));
 					$scheme = parse_url($data, PHP_URL_SCHEME);
@@ -1426,10 +1426,7 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 							$data = 'http://' . ltrim($data, ':/');
 
 						if ($scheme != 'https')
-							if ($image_proxy_enabled === 2 && !empty($image_proxy_url))
-								$data = $image_proxy_url . urlencode($data);
-							else
-								$data = $boardurl . '/proxy.php?request=' . urlencode($data) . '&hash=' . md5($data . $image_proxy_secret);
+							$data = $boardurl . '/proxy.php?request=' . urlencode($data) . '&hash=' . md5($data . $image_proxy_secret);
 					}
 					elseif (empty($scheme))
 						$data = '//' . ltrim($data, ':/');
@@ -1442,7 +1439,7 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 				'content' => '<img src="$1" alt="" class="bbc_img">',
 				'validate' => function (&$tag, &$data, $disabled)
 				{
-					global $image_proxy_enabled, $image_proxy_secret, $boardurl, $image_proxy_url, $user_info;
+					global $image_proxy_enabled, $image_proxy_secret, $boardurl, $user_info;
 
 					$data = strtr($data, array('<br>' => ''));
 					$scheme = parse_url($data, PHP_URL_SCHEME);
@@ -1455,10 +1452,7 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 							$data = 'http://' . ltrim($data, ':/');
 
 						if ($scheme != 'https')
-							if ($image_proxy_enabled === 2 && !empty($image_proxy_url))
-								$data = $image_proxy_url . urlencode($data);
-							else
-								$data = $boardurl . '/proxy.php?request=' . urlencode($data) . '&hash=' . md5($data . $image_proxy_secret);
+							$data = $boardurl . '/proxy.php?request=' . urlencode($data) . '&hash=' . md5($data . $image_proxy_secret);
 					}
 					elseif (empty($scheme))
 						$data = '//' . ltrim($data, ':/');

--- a/Themes/default/languages/Help.english.php
+++ b/Themes/default/languages/Help.english.php
@@ -626,11 +626,7 @@ $helptxt['image_proxy_enabled'] = 'Required for embedding external images when i
 		</ul>';
 $helptxt['image_proxy_secret'] = 'Keep this a secret, protects your forum from hotlinking images. Change it in order to render current hotlinked images useless';
 $helptxt['image_proxy_maxsize'] = 'Maximum image size that the SSL image proxy will cache: bigger images will be not be cached. Cached images are stored in your SMF cache folder, so make sure you have enough free space.';
-$helptxt['image_proxy_url'] = 'Enter the URL for your external proxy <strong>exactly</strong> the way it should be accessed for the image file.<br>
-<br>
-For example, if your proxy serves files via <code>http://www.example.com/yourproxy.php?file=[URL of proxied file]</code>, enter <code>http://www.example.com/yourproxy.php?file=</code> here.<br>
-<br>
-If this field is left empty, SMF\'s internal proxy will be used.';
+$helptxt['image_proxy_url'] = 'Needs to be maintained with the proxy url, when empty the internal proxy will be used';
 
 $helptxt['enable_sm_stats'] = 'If enabled, this will allow Simple Machines to visit your site once a month to collect basic statistics. This will help us make decisions as to which configurations to optimize the software for. For more information please visit our <a href="https://www.simplemachines.org/about/stats.php" target="_blank" rel="noopener">info page</a>.';
 

--- a/Themes/default/languages/Help.english.php
+++ b/Themes/default/languages/Help.english.php
@@ -621,12 +621,12 @@ $helptxt['alert_event_new'] = 'This will send out an alert or email as requested
 $helptxt['force_ssl'] = '<strong>Test SSL and HTTPS on your server properly before enabling this, it may cause your forum to become inaccessible.</strong> Enable maintenance mode if you are unable to access the forum after enabling this.<br><br><strong>Changing this setting will update your forum\'s primary URL, as well as the URLs for your theme files and images, smileys, and avatars, setting them to either http: or https: based on your selection. Customized URLs will not be affected.</strong>';
 $helptxt['image_proxy_enabled'] = 'Required for embedding external images when in full SSL: <br>
 		<ul class="normallist"> 
-			<li>Internal Image Proxy uses the internal proxy.php</li>
-			<li>External Image Proxy uses a external proxy service</li>
+			<li>Internal Image Proxy use the internal proxy.php</li>
+			<li>External Image Proxy use a external proxy service</li>
 		</ul>';
 $helptxt['image_proxy_secret'] = 'Keep this a secret, protects your forum from hotlinking images. Change it in order to render current hotlinked images useless';
 $helptxt['image_proxy_maxsize'] = 'Maximum image size that the SSL image proxy will cache: bigger images will be not be cached. Cached images are stored in your SMF cache folder, so make sure you have enough free space.';
-$helptxt['image_proxy_url'] = 'Needs to be maintained with the proxy url, when empty the internal proxy will be used';
+$helptxt['image_proxy_url'] = 'Needs maintained with the proxy url, when empty the internal proxy will be used';
 
 $helptxt['enable_sm_stats'] = 'If enabled, this will allow Simple Machines to visit your site once a month to collect basic statistics. This will help us make decisions as to which configurations to optimize the software for. For more information please visit our <a href="https://www.simplemachines.org/about/stats.php" target="_blank" rel="noopener">info page</a>.';
 

--- a/Themes/default/languages/Help.english.php
+++ b/Themes/default/languages/Help.english.php
@@ -619,14 +619,9 @@ $helptxt['alert_pm_new'] = 'Notifications of new personal messages do not appear
 $helptxt['alert_event_new'] = 'This will send out an alert or email as requested if there is a new calendar event added. However, if that event is posted and a topic is added, you will not get an alert for the event if you\'re already following that board - the alert from following the board would cover this.';
 
 $helptxt['force_ssl'] = '<strong>Test SSL and HTTPS on your server properly before enabling this, it may cause your forum to become inaccessible.</strong> Enable maintenance mode if you are unable to access the forum after enabling this.<br><br><strong>Changing this setting will update your forum\'s primary URL, as well as the URLs for your theme files and images, smileys, and avatars, setting them to either http: or https: based on your selection. Customized URLs will not be affected.</strong>';
-$helptxt['image_proxy_enabled'] = 'Required for embedding external images when in full SSL: <br>
-		<ul class="normallist"> 
-			<li>Internal Image Proxy use the internal proxy.php</li>
-			<li>External Image Proxy use a external proxy service</li>
-		</ul>';
+$helptxt['image_proxy_enabled'] = 'Required for embedding external images when in full SSL';
 $helptxt['image_proxy_secret'] = 'Keep this a secret, protects your forum from hotlinking images. Change it in order to render current hotlinked images useless';
 $helptxt['image_proxy_maxsize'] = 'Maximum image size that the SSL image proxy will cache: bigger images will be not be cached. Cached images are stored in your SMF cache folder, so make sure you have enough free space.';
-$helptxt['image_proxy_url'] = 'Needs maintained with the proxy url, when empty the internal proxy will be used';
 
 $helptxt['enable_sm_stats'] = 'If enabled, this will allow Simple Machines to visit your site once a month to collect basic statistics. This will help us make decisions as to which configurations to optimize the software for. For more information please visit our <a href="https://www.simplemachines.org/about/stats.php" target="_blank" rel="noopener">info page</a>.';
 

--- a/Themes/default/languages/Help.english.php
+++ b/Themes/default/languages/Help.english.php
@@ -622,7 +622,7 @@ $helptxt['force_ssl'] = '<strong>Test SSL and HTTPS on your server properly befo
 $helptxt['image_proxy_enabled'] = 'Required for embedding external images when in full SSL: <br>
 		<ul class="normallist"> 
 			<li>Internal Image Proxy uses the internal proxy.php</li>
-			<li>External Image Proxy uses an external proxy service</li>
+			<li>External Image Proxy uses a external proxy service</li>
 		</ul>';
 $helptxt['image_proxy_secret'] = 'Keep this a secret, protects your forum from hotlinking images. Change it in order to render current hotlinked images useless';
 $helptxt['image_proxy_maxsize'] = 'Maximum image size that the SSL image proxy will cache: bigger images will be not be cached. Cached images are stored in your SMF cache folder, so make sure you have enough free space.';

--- a/Themes/default/languages/ManageSettings.english.php
+++ b/Themes/default/languages/ManageSettings.english.php
@@ -100,7 +100,7 @@ $txt['force_ssl_complete'] = 'Force SSL throughout the forum';
 $txt['image_proxy_off'] = 'Disable';
 $txt['image_proxy_internal'] = 'Internal';
 $txt['image_proxy_external'] = 'External';
-$txt['image_proxy_url'] = 'URL of external image proxy';
+$txt['image_proxy_url'] = 'URL of external Image Proxy';
 $txt['search_language'] = 'Fulltext Search Language';
 
 // Like settings.

--- a/Themes/default/languages/ManageSettings.english.php
+++ b/Themes/default/languages/ManageSettings.english.php
@@ -97,10 +97,6 @@ $txt['image_proxy_maxsize'] = 'Maximum file size of images to cache (in KB)';
 $txt['force_ssl'] = 'Forum SSL mode';
 $txt['force_ssl_off'] = 'Disable SSL';
 $txt['force_ssl_complete'] = 'Force SSL throughout the forum';
-$txt['image_proxy_off'] = 'Disable';
-$txt['image_proxy_internal'] = 'Internal';
-$txt['image_proxy_external'] = 'External';
-$txt['image_proxy_url'] = 'URL of external Image Proxy';
 $txt['search_language'] = 'Fulltext Search Language';
 
 // Like settings.

--- a/other/Settings.php
+++ b/other/Settings.php
@@ -145,10 +145,9 @@ $cachedir = dirname(__FILE__) . '/cache';
 # This is done entirely in Settings.php to avoid loading the DB while serving the images
 /**
  * Whether the proxy is enabled or not
- * 0 = disable 1 = proxy.php 2 = external proxy
- * @var int
+ * @var bool
  */
-$image_proxy_enabled = 1;
+$image_proxy_enabled = true;
 
 /**
  * Secret key to be used by the proxy
@@ -161,12 +160,6 @@ $image_proxy_secret = 'smfisawesome';
  * @var int
  */
 $image_proxy_maxsize = 5192;
-
-/**
- * Add the url of a external image proxy
- * @var string
- */
-$image_proxy_url = '';
 
 ########## Directories/Files ##########
 # Note: These directories do not have to be changed unless you move things.


### PR DESCRIPTION
The `get_proxied_url()` function will return the correct URL to use for URLs that may or may not require a proxy. If the proxy is disabled, we are not using SSL, or the requested URL is already an HTTPS url, then the original URL is returned. Otherwise, the proxied URL is returned.

Mods can easily implement any sort of alternative proxy they want via the 'integrate_proxy' hook. That hooks simply passes the `$url` and `$proxied_url` variables so that the mod can overwrite `$proxied_url` with whatever it wants based on `$url`.