### PR TITLE
let's call the function of db_allow_persistent

### DIFF
--- a/Sources/DbExtra-mysql.php
+++ b/Sources/DbExtra-mysql.php
@@ -421,7 +421,7 @@ function smf_db_get_vendor()
 function smf_db_allow_persistent()
 {
 	$value = ini_get('mysqli.allow_persistent');
-	if ($value == 'on' || $value == 'true')
+	if (strtolower($value) == 'on' || strtolower($value) == 'true' || $value == '1')
 		return true;
 	else
 		return false;

--- a/Sources/DbExtra-postgresql.php
+++ b/Sources/DbExtra-postgresql.php
@@ -317,7 +317,7 @@ function smf_db_get_vendor()
 function smf_db_allow_persistent()
 {
 	$value = ini_get('pgsql.allow_persistent');
-	if ($value == 'on' || $value == 'true')
+	if (strtolower($value) == 'on' || strtolower($value) == 'true' || $value == '1')
 		return true;
 	else
 		return false;

--- a/Sources/ManageServer.php
+++ b/Sources/ManageServer.php
@@ -424,7 +424,7 @@ function ModifyDatabaseSettings($return_config = false)
 	$context['settings_title'] = $txt['database_settings'];
 	$context['save_disabled'] = $context['settings_not_writable'];
 
-	if (!$smcFunc['db_allow_persistent'])
+	if (!$smcFunc['db_allow_persistent']())
 		addInlineJavaScript('
 			$(function()
 			{


### PR DESCRIPTION
stupid php can return mostly everything here...
> Note: When querying boolean values
> 
> A boolean ini value of off will be returned as an empty string or "0" while a boolean ini value of on will be returned as "1". The function can also return the literal string of INI value. 