### PR TITLE
Uses filename and content to create unique hash when minimizing files

### DIFF
--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -3744,7 +3744,7 @@ function custMinify($data, $type, $do_deferred = false)
 		return (array) $data;
 
 	// Different pages include different files, so we use a hash to label the different combinations
-	$hash = md5(implode(' ', array_keys($data)));
+	$hash = md5(implode(' ', array_map(function($file) { return $file['filePath'] . md5_file($file['filePath']); }, $data)));
 
 	// Did we already do this?
 	list($toCache, $async) = array_pad((array) cache_get_data('minimized_' . $settings['theme_id'] . '_' . $type . '_' . $hash, 86400), 2, null);


### PR DESCRIPTION
By using the filename and a hash of the file's content, we can ensure that if the content changes in a file to be minimized, we create a new minimized file with a new name to reflect that.

The reason to do this is to prevent browsers from using obsolete cached versions of our minified files. Without this change, if a mod altered the content of an existing CSS or JS file, our minimized file's name would include the same hash that it did before the change. The browser could then conclude that it should use its outdated, locally cached version of the minimized file rather than fetching the current version. With this change, that will no longer happen. If the content of one of the original CSS or JS file has been changed, the filename of our minimized file will change to reflect that, prompting the browser to fetch the current version if necessary.