### PR TITLE
Improves loading of JavaScript regarding async and defer

### DIFF
--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -3818,7 +3818,7 @@ function custMinify($data, $type)
 		if (empty($toAdd))
 		{
 			loadLanguage('Errors');
-			log_error(sprintf($txt['file_minimize_fail'], (!empty($file['fileName']) ? $file['fileName']) : $id), 'general');
+			log_error(sprintf($txt['file_minimize_fail'], !empty($file['fileName']) ? $file['fileName'] : $id), 'general');
 			continue;
 		}
 


### PR DESCRIPTION
All our supported browsers fully support the async and defer attributes for loading JavaScript files, and the best performance comes from loading all the scripts in the head and using those attributes. Why? This way the browser can download the JS files while simultaneously parsing the HTML into the DOM. In contrast, putting the script files at the end of the document means the browser only starts to download the scripts after it is done parsing the HTML.

(Well, the last sentence above may not be 100% true for all modern browsers. Apparently some scan the HTML looking for JS files to pre-fetch. But that is just an attempt to mimick the best practices that this change implements properly.)

For a handy explanation of the reasons for this, see https://bitsofco.de/async-vs-defer. For a comparative demo, see http://contentloaded.com/async-defer