### PR TITLE
Ensures "deferred" inline scripts run after deferred external scripts

### DIFF
--- a/Sources/Calendar.php
+++ b/Sources/Calendar.php
@@ -476,8 +476,8 @@ function CalendarPost()
 		'name' => $context['page_title'],
 	);
 
-	loadCSSFile('jquery-ui.datepicker.css', array('defer' => false), 'smf_datepicker');
-	loadCSSFile('jquery.timepicker.css', array('defer' => false), 'smf_timepicker');
+	loadCSSFile('jquery-ui.datepicker.css', array(), 'smf_datepicker');
+	loadCSSFile('jquery.timepicker.css', array(), 'smf_timepicker');
 	loadJavaScriptFile('jquery-ui.datepicker.min.js', array('defer' => true), 'smf_datepicker');
 	loadJavaScriptFile('jquery.timepicker.min.js', array('defer' => true), 'smf_timepicker');
 	loadJavaScriptFile('datepair.min.js', array('defer' => true), 'smf_datepair');

--- a/Sources/Post.php
+++ b/Sources/Post.php
@@ -352,8 +352,8 @@ function Post($post_errors = array())
 			$context['all_timezones'] = array($context['event']['tz'] => fix_tz_abbrev($context['event']['tz'], date_format($d, 'T')) . ' - ' . $context['event']['tz'] . ' [UTC' . date_format($d, 'P') . ']') + $context['all_timezones'];
 		}
 
-		loadCSSFile('jquery-ui.datepicker.css', array('defer' => false), 'smf_datepicker');
-		loadCSSFile('jquery.timepicker.css', array('defer' => false), 'smf_timepicker');
+		loadCSSFile('jquery-ui.datepicker.css', array(), 'smf_datepicker');
+		loadCSSFile('jquery.timepicker.css', array(), 'smf_timepicker');
 		loadJavaScriptFile('jquery-ui.datepicker.min.js', array('defer' => true), 'smf_datepicker');
 		loadJavaScriptFile('jquery.timepicker.min.js', array('defer' => true), 'smf_timepicker');
 		loadJavaScriptFile('datepair.min.js', array('defer' => true), 'smf_datepair');

--- a/Sources/Subs-Calendar.php
+++ b/Sources/Subs-Calendar.php
@@ -703,7 +703,7 @@ function getCalendarList($start_date, $end_date, $calendarOptions)
 		}
 	}
 
-	loadCSSFile('jquery-ui.datepicker.css', array('defer' => false), 'smf_datepicker');
+	loadCSSFile('jquery-ui.datepicker.css', array(), 'smf_datepicker');
 	loadJavaScriptFile('jquery-ui.datepicker.min.js', array('defer' => true), 'smf_datepicker');
 	addInlineJavaScript('
 	$("#calendar_range .date_input").datepicker({

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -3642,12 +3642,14 @@ function template_javascript($do_deferred = false)
 		if (!empty($context['javascript_inline']['defer']) && $do_deferred)
 		{
 			echo '
-<script>';
+<script>
+window.addEventListener("DOMContentLoaded", function() {';
 
 			foreach ($context['javascript_inline']['defer'] as $js_code)
 				echo $js_code;
 
 			echo '
+});
 </script>';
 		}
 


### PR DESCRIPTION
Prior to #4640, when we deferred scripts merely by inserting them into the document right before the `</body>` tag, we always loaded the external scripts first and then the inline script after that. In #4640 we started loading the external scripts using the defer attribute instead. But the defer attribute causes a script not to be executed until after the DOMContentLoaded event. This is functionally equivalent to inserting the script after the closing `</html>`. But our deferred inline script was still being loaded and executed before the DOMContentLoaded event. That could cause problems if the inline script depended on the external script.

This PR solves the problem by simply ensuring the inline script isn't executed until after the DOMContentLoaded event. Because the external scripts with the defer attribute appeared earlier in the HTML, they will be executed before the content of the inline script. Thus the correct load order is maintained.