### PR TITLE
Use smf_scripturl for avatar fallback fixes #4684

### DIFF
--- a/Themes/default/scripts/script.js
+++ b/Themes/default/scripts/script.js
@@ -1657,7 +1657,7 @@ $(function() {
 function avatar_fallback(e) {
     var e = window.e || e;
 	var default_avatar = '/avatars/default.png';
-	var default_url = document.URL.substr(0,document.URL.lastIndexOf('/')) + default_avatar;
+	var default_url = document.URL.substr(0,smf_scripturl.lastIndexOf('/')) + default_avatar;
 
     if (e.target.tagName !== 'IMG' || !e.target.classList.contains('avatar') || e.target.src === default_url )
         return;


### PR DESCRIPTION
instead of using the dom url,
we better use the smf_scripturl

issue: #4684