### PR TITLE
Remove wildcard on the fulltext search fixes #4606

### DIFF
--- a/Sources/SearchAPI-Fulltext.php
+++ b/Sources/SearchAPI-Fulltext.php
@@ -173,6 +173,9 @@ class fulltext_search extends search_api
 			$query_select['id_search'] = '{int:id_search}';
 
 		$count = 0;
+
+		$words['indexed_words'] = str_replace(array('*','%'),'',$words['indexed_words'] );
+
 		if (empty($modSettings['search_simple_fulltext']))
 			foreach ($words['words'] as $regularWord)
 			{


### PR DESCRIPTION
The fulltext operator of the rdbms didn't understand wildcards,
to provide a better result is the best to remove them.

fix  issue: #4606
#4605 is also fixed
when fulltext is used.