### PR TITLE
Fix Child boards get marked new where their is a new post in a grand … fixes #1734

### DIFF
--- a/Sources/Subs-BoardIndex.php
+++ b/Sources/Subs-BoardIndex.php
@@ -98,7 +98,7 @@ function getBoardIndex($boardIndexOptions)
 		for($x = 0; $x < $count_ar; $x++)
 		{
 			$num = $row_lvl[$i][$x];
-			if ($row_boards[$num]['is_read'] == 0 && $row_boards[$num]['id_parent'] != 0 && isset($row_boards[$row_boards[$num]['id_parent']]))
+			if ($row_boards[$num]['is_read'] == 0 && $row_boards[$num]['id_parent'] != 0 && isset($row_boards[$row_boards[$num]['id_parent']]) && $row_boards[$num]['child_level'] > 1)
 				$row_boards[$row_boards[$num]['id_parent']]['is_read'] = 0;
 		}
 			

--- a/Sources/Subs-BoardIndex.php
+++ b/Sources/Subs-BoardIndex.php
@@ -89,19 +89,22 @@ function getBoardIndex($boardIndexOptions)
 			$row_lvl[$row_board['child_level']] = array();
 		$row_lvl[$row_board['child_level']][] =  $row_board['id_board'];
 	}
-	
-	$max_level = max(array_keys($row_lvl));
-	$min_level = min(array_keys($row_lvl));
-	for($i = $max_level; $i >= $min_level; $i--)
+
+	if (!empty($row_lvl))
 	{
-		$count_ar = count($row_lvl[$i]);
-		for($x = 0; $x < $count_ar; $x++)
+		$max_level = max(array_keys($row_lvl));
+		$min_level = min(array_keys($row_lvl));
+		for($i = $max_level; $i >= $min_level; $i--)
 		{
-			$num = $row_lvl[$i][$x];
-			if ($row_boards[$num]['is_read'] == 0 && $row_boards[$num]['id_parent'] != 0 && isset($row_boards[$row_boards[$num]['id_parent']]) && $row_boards[$num]['child_level'] > 1)
-				$row_boards[$row_boards[$num]['id_parent']]['is_read'] = 0;
+			$count_ar = count($row_lvl[$i]);
+			for($x = 0; $x < $count_ar; $x++)
+			{
+				$num = $row_lvl[$i][$x];
+				if ($row_boards[$num]['is_read'] == 0 && $row_boards[$num]['id_parent'] != 0 && isset($row_boards[$row_boards[$num]['id_parent']]) && $row_boards[$num]['child_level'] > 1)
+					$row_boards[$row_boards[$num]['id_parent']]['is_read'] = 0;
+			}
+
 		}
-			
 	}
 
 	// Run through the categories and boards (or only boards)....

--- a/Sources/Subs-Post.php
+++ b/Sources/Subs-Post.php
@@ -2617,20 +2617,6 @@ function updateLastMessages($setboards, $id_msg = 0)
 			$board_updates[$msg . '-' . $lastModified[$id]]['boards'][] = $id;
 	}
 
-	// Now commit the changes!
-	foreach ($parent_updates as $id_msg => $boards)
-	{
-		$smcFunc['db_query']('', '
-			UPDATE {db_prefix}boards
-			SET id_msg_updated = {int:id_msg_updated}
-			WHERE id_board IN ({array_int:board_list})
-				AND id_msg_updated < {int:id_msg_updated}',
-			array(
-				'board_list' => $boards,
-				'id_msg_updated' => $id_msg,
-			)
-		);
-	}
 	foreach ($board_updates as $board_data)
 	{
 		$smcFunc['db_query']('', '


### PR DESCRIPTION
…child that isn't visible

This pr do two things:
- don't update the the parent board with the new message id
- run from the bottom to the top to search for is_read false and mark all level above in the same way

@Sesquipedalian is that a good way?

issue #1734