### PR TITLE
Show banned text on Login popup fixes #4603

### DIFF
--- a/Sources/Load.php
+++ b/Sources/Load.php
@@ -2199,7 +2199,7 @@ function loadTheme($id_theme = 0, $initialize = true)
 		'smf_member_id' => $context['user']['id'],
 		'ajax_notification_text' => JavaScriptEscape($txt['ajax_in_progress']),
 		'help_popup_heading_text' => JavaScriptEscape($txt['help_popup']),
-		'banned_text' => JavaScriptEscape(sprintf($txt['your_ban'],$context['user']['name'])),
+		'banned_text' => JavaScriptEscape(sprintf($txt['your_ban'], $context['user']['name'])),
 	);
 
 	// Add the JQuery library to the list of files to load.

--- a/Sources/Load.php
+++ b/Sources/Load.php
@@ -2199,6 +2199,7 @@ function loadTheme($id_theme = 0, $initialize = true)
 		'smf_member_id' => $context['user']['id'],
 		'ajax_notification_text' => JavaScriptEscape($txt['ajax_in_progress']),
 		'help_popup_heading_text' => JavaScriptEscape($txt['help_popup']),
+		'banned_text' => JavaScriptEscape(sprintf($txt['your_ban'],$context['user']['name'])),
 	);
 
 	// Add the JQuery library to the list of files to load.

--- a/Themes/default/scripts/script.js
+++ b/Themes/default/scripts/script.js
@@ -329,7 +329,10 @@ function reqOverlayDiv(desktopURL, sHeader, sIcon)
 		},
 		statusCode: {
 			500: function() {
-				oPopup_body.html(banned_text);
+				if (sHeader == 'Login')
+					oPopup_body.html(banned_text);
+				else
+					oPopup_body.html('500 Internal Server Error');
 			}
 		}
 	});

--- a/Themes/default/scripts/script.js
+++ b/Themes/default/scripts/script.js
@@ -326,6 +326,11 @@ function reqOverlayDiv(desktopURL, sHeader, sIcon)
 		},
 		error: function (xhr, textStatus, errorThrown) {
 			oPopup_body.html(textStatus);
+		},
+		statusCode: {
+			500: function() {
+			  oPopup_body.html(banned_text);
+			}
 		}
 	});
 	return false;

--- a/Themes/default/scripts/script.js
+++ b/Themes/default/scripts/script.js
@@ -329,7 +329,7 @@ function reqOverlayDiv(desktopURL, sHeader, sIcon)
 		},
 		statusCode: {
 			500: function() {
-			  oPopup_body.html(banned_text);
+				oPopup_body.html(banned_text);
 			}
 		}
 	});


### PR DESCRIPTION
Was unkown to me,
that we can catch status code.
![grafik](https://user-images.githubusercontent.com/1782906/39403405-6d398c62-4b7b-11e8-8646-fe1faea758a8.png)


The login form is not part of the xml response -> no chance to display this.

issue: #4603