### PR TITLE
Log backtrace on error

### DIFF
--- a/Sources/Errors.php
+++ b/Sources/Errors.php
@@ -115,8 +115,11 @@ function log_error($error_message, $error_type = 'general', $file = null, $line 
 	// Make sure the category that was specified is a valid one
 	$error_type = in_array($error_type, $known_error_types) && $error_type !== true ? $error_type : 'general';
 
+	// Collect backtrace
+	$backtrace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 10);
+
 	// Don't log the same error countless times, as we can get in a cycle of depression...
-	$error_info = array($user_info['id'], time(), $user_info['ip'], $query_string, $error_message, (string) $sc, $error_type, $file, $line);
+	$error_info = array($user_info['id'], time(), $user_info['ip'], $query_string, $error_message, (string) $sc, $error_type, $file, $line, $backtrace);
 	if (empty($last_error) || $last_error != $error_info)
 	{
 		// Insert the error into the database.

--- a/Sources/Errors.php
+++ b/Sources/Errors.php
@@ -115,8 +115,10 @@ function log_error($error_message, $error_type = 'general', $file = null, $line 
 	// Make sure the category that was specified is a valid one
 	$error_type = in_array($error_type, $known_error_types) && $error_type !== true ? $error_type : 'general';
 
-	// Collect backtrace
+	// Collect backtrace and remove himself
 	$backtrace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 10);
+	array_shift($backtrace);
+	$backtrace = json_encode($backtrace);
 
 	// Don't log the same error countless times, as we can get in a cycle of depression...
 	$error_info = array($user_info['id'], time(), $user_info['ip'], $query_string, $error_message, (string) $sc, $error_type, $file, $line, $backtrace);

--- a/Sources/Errors.php
+++ b/Sources/Errors.php
@@ -118,7 +118,7 @@ function log_error($error_message, $error_type = 'general', $file = null, $line 
 	// Collect a backtrace (but leave out the call to log_error)
 	$backtrace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 20);
 	array_shift($backtrace);
-	$backtrace = json_encode($backtrace);
+	$backtrace = !empty($smcFunc['json_encode']) ? $smcFunc['json_encode']($backtrace) : json_encode($backtrace);
 
 	// Don't log the same error countless times, as we can get in a cycle of depression...
 	$error_info = array($user_info['id'], time(), $user_info['ip'], $query_string, $error_message, (string) $sc, $error_type, $file, $line, $backtrace);

--- a/Sources/Errors.php
+++ b/Sources/Errors.php
@@ -115,7 +115,7 @@ function log_error($error_message, $error_type = 'general', $file = null, $line 
 	// Make sure the category that was specified is a valid one
 	$error_type = in_array($error_type, $known_error_types) && $error_type !== true ? $error_type : 'general';
 
-	// Collect backtrace and remove himself
+	// Collect a backtrace (but leave out the call to log_error)
 	$backtrace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 20);
 	array_shift($backtrace);
 	$backtrace = json_encode($backtrace);

--- a/Sources/Errors.php
+++ b/Sources/Errors.php
@@ -116,7 +116,7 @@ function log_error($error_message, $error_type = 'general', $file = null, $line 
 	$error_type = in_array($error_type, $known_error_types) && $error_type !== true ? $error_type : 'general';
 
 	// Collect backtrace and remove himself
-	$backtrace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 10);
+	$backtrace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 20);
 	array_shift($backtrace);
 	$backtrace = json_encode($backtrace);
 

--- a/Sources/Errors.php
+++ b/Sources/Errors.php
@@ -38,13 +38,15 @@ function log_error($error_message, $error_type = 'general', $file = null, $line 
 
 	$error_call++;
 
+	// Collect a backtrace
+	if (!isset($db_show_debug) || $db_show_debug === false)
+		$backtrace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
+	else
+		$backtrace = debug_backtrace();
+
 	// are we in a loop?
 	if($error_call > 2)
 	{
-		if (!isset($db_show_debug) || $db_show_debug === false)
-			$backtrace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
-		else
-			$backtrace = debug_backtrace();
 		var_dump($backtrace);
 		die('Error loop.');
 	}
@@ -115,8 +117,7 @@ function log_error($error_message, $error_type = 'general', $file = null, $line 
 	// Make sure the category that was specified is a valid one
 	$error_type = in_array($error_type, $known_error_types) && $error_type !== true ? $error_type : 'general';
 
-	// Collect a backtrace (but leave out the call to log_error)
-	$backtrace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 20);
+	// leave out the call to log_error
 	array_shift($backtrace);
 	$backtrace = !empty($smcFunc['json_encode']) ? $smcFunc['json_encode']($backtrace) : json_encode($backtrace);
 

--- a/Sources/ManageErrors.php
+++ b/Sources/ManageErrors.php
@@ -447,12 +447,16 @@ function ViewBacktrace()
 	$request = $smcFunc['db_query']('',
 			'SELECT backtrace
 				FROM {db_prefix}log_errors
-				WHERE id_error = {int:id_error',
+				WHERE id_error = {int:id_error}',
 			array(
 				'id_error' => $id_error,
 				)
 			);
 
+	while ($row = $smcFunc['db_fetch_assoc']($request))
+	{
+		$context['error_backtrace'] = $smcFunc['json_decode']($row['backtrace']);
+	}
 	loadTemplate('Errors');
 	$context['template_layers'] = array();
 	$context['sub_template'] = 'show_backtrace';

--- a/Sources/ManageErrors.php
+++ b/Sources/ManageErrors.php
@@ -32,7 +32,7 @@ function ViewErrorLog()
 	// Viewing contents of a file?
 	if (isset($_GET['file']))
 		return ViewFile();
-	
+
 	// Viewing contents of a backtrace?
 	if (isset($_GET['backtrace']))
 		return ViewBacktrace();

--- a/Sources/ManageErrors.php
+++ b/Sources/ManageErrors.php
@@ -32,6 +32,10 @@ function ViewErrorLog()
 	// Viewing contents of a file?
 	if (isset($_GET['file']))
 		return ViewFile();
+	
+	// Viewing contents of a backtrace?
+	if (isset($_GET['backtrace']))
+		return ViewBacktrace();
 
 	// Check for the administrative permission to do this.
 	isAllowedTo('admin_forum');
@@ -424,6 +428,34 @@ function ViewFile()
 	loadTemplate('Errors');
 	$context['template_layers'] = array();
 	$context['sub_template'] = 'show_file';
+
+}
+
+/**
+ * View a backtrace specified in $_REQUEST['backtrace'], with php highlighting on it
+ * Preconditions:
+ *  - user must have admin_forum permission.
+ */
+function ViewBacktrace()
+{
+	global $context, $boarddir, $sourcedir, $cachedir, $smcFunc;
+
+	// Check for the administrative permission to do this.
+	isAllowedTo('admin_forum');
+
+	$id_error = (int) $_REQUEST['backtrace'];
+	$request = $smcFunc['db_query']('',
+			'SELECT backtrace
+				FROM {db_prefix}log_errors
+				WHERE id_error = {int:id_error',
+			array(
+				'id_error' => $id_error,
+				)
+			);
+
+	loadTemplate('Errors');
+	$context['template_layers'] = array();
+	$context['sub_template'] = 'show_backtrace';
 
 }
 

--- a/Sources/Stats.php
+++ b/Sources/Stats.php
@@ -91,7 +91,7 @@ function DisplayStats()
 		SELECT
 			SUM(posts) AS posts, SUM(topics) AS topics, SUM(registers) AS registers,
 			SUM(most_on) AS most_on, MIN(date) AS date, SUM(hits) AS hits
-		FROM {db_prefix}log_activity',
+		FROM {db_prefix}log_activity where {string:asd}',
 		array(
 		)
 	);

--- a/Sources/Stats.php
+++ b/Sources/Stats.php
@@ -91,7 +91,7 @@ function DisplayStats()
 		SELECT
 			SUM(posts) AS posts, SUM(topics) AS topics, SUM(registers) AS registers,
 			SUM(most_on) AS most_on, MIN(date) AS date, SUM(hits) AS hits
-		FROM {db_prefix}log_activity where {string:asd}',
+		FROM {db_prefix}log_activity',
 		array(
 		)
 	);

--- a/Sources/Subs-Db-mysql.php
+++ b/Sources/Subs-Db-mysql.php
@@ -974,8 +974,8 @@ function smf_db_error_insert($error_array)
 
 	if (empty($mysql_error_data_prep))
 			$mysql_error_data_prep = mysqli_prepare($db_connection,
-				'INSERT INTO ' . $db_prefix . 'log_errors(id_member, log_time, ip, url, message, session, error_type, file, line)
-													VALUES(		?,		?,		unhex(?), ?, 		?,		?,			?,		?,	?)'
+				'INSERT INTO ' . $db_prefix . 'log_errors(id_member, log_time, ip, url, message, session, error_type, file, line, backtrace)
+													VALUES(		?,		?,		unhex(?), ?, 		?,		?,			?,		?,	?, ?)'
 			);
 
 	if (filter_var($error_array[2], FILTER_VALIDATE_IP) !== false)

--- a/Sources/Subs-Db-postgresql.php
+++ b/Sources/Subs-Db-postgresql.php
@@ -973,8 +973,8 @@ function smf_db_error_insert($error_array)
 
 	if (empty($pg_error_data_prep))
 			$pg_error_data_prep = pg_prepare($db_connection, 'smf_log_errors',
-				'INSERT INTO ' . $db_prefix . 'log_errors(id_member, log_time, ip, url, message, session, error_type, file, line)
-													VALUES(		$1,		$2,		$3, $4, 	$5,		$6,			$7,		$8,	$9)'
+				'INSERT INTO ' . $db_prefix . 'log_errors(id_member, log_time, ip, url, message, session, error_type, file, line, backtrace)
+													VALUES(		$1,		$2,		$3, $4, 	$5,		$6,			$7,		$8,	$9, $10)'
 			);
 
 	pg_execute($db_connection, 'smf_log_errors', $error_array);

--- a/Themes/default/Errors.template.php
+++ b/Themes/default/Errors.template.php
@@ -271,7 +271,9 @@ function template_show_backtrace()
 		<link rel="stylesheet" href="', $settings['theme_url'], '/css/index', $context['theme_variant'], '.css', $modSettings['browser_cache'], '">
 	</head>
 	<body>
-	', var_dump(!empty($context['error_backtrace'])? $context['error_backtrace'] : ''),'
+		<pre class="backtrace">
+		', print_r(!empty($context['error_backtrace']) ? $context['error_backtrace'] : ''),'
+		</pre>
 	</body>
 </html>';
 }

--- a/Themes/default/Errors.template.php
+++ b/Themes/default/Errors.template.php
@@ -145,11 +145,7 @@ function template_error_log()
 
 		echo '
 							<a href="', $scripturl, '?action=admin;area=logs;sa=errorlog', $context['sort_direction'] == 'down' ? ';desc' : '', ';filter=error_type;value=', $error['error_type']['type'], '" title="', $txt['apply_filter'], ': ', $txt['filter_only_type'], '"><span class="generic_icons filter centericon"></span></a>
-							', $txt['error_type'], ': ', $error['error_type']['name'], ' <a><span class="generic_icons details" onclick="smc_Popup({
-				heading: \'backtrace\',
-				content: \'asdf\' ,
-				icon_class: \'generic_icons mail_new\'
-			});"></span></a><br>
+							', $txt['error_type'], ': ', $error['error_type']['name'], ' <a href ="', $scripturl, '?action=admin;area=logs;sa=errorlog;backtrace=', $error['id'], '" onclick="return reqWin(this.href, 600, 480, false);"><span class="generic_icons details"></span></a><br>
 							<a class="error_message" href="', $scripturl, '?action=admin;area=logs;sa=errorlog', $context['sort_direction'] == 'down' ? ';desc' : '', ';filter=message;value=', $error['message']['href'], '" title="', $txt['apply_filter'], ': ', $txt['filter_only_message'], '"><span class="generic_icons filter"></span></a>
 							<span class="error_message">', $error['message']['html'], '</span>
 							<a href="', $scripturl, '?action=admin;area=logs;sa=errorlog', $context['sort_direction'] == 'down' ? ';desc' : '', ';filter=url;value=', $error['url']['href'], '" title="', $txt['apply_filter'], ': ', $txt['filter_only_url'], '"><span class="generic_icons filter"></span></a>
@@ -258,6 +254,39 @@ function template_attachment_errors()
 			</div>
 		</div>
 	</div>';
+}
+
+/**
+ * This template shows a backtrace of the given error
+ */
+function template_show_backtrace()
+{
+	global $context, $settings, $modSettings;
+
+	echo '<!DOCTYPE html>
+<html', $context['right_to_left'] ? ' dir="rtl"' : '', '>
+	<head>
+		<meta charset="', $context['character_set'], '">
+		<title>', $context['file_data']['file'], '</title>
+		<link rel="stylesheet" href="', $settings['theme_url'], '/css/index', $context['theme_variant'], '.css', $modSettings['browser_cache'], '">
+	</head>
+	<body>
+		<table class="errorfile_table">';
+	foreach ($context['file_data']['contents'] as $index => $line)
+	{
+		$line_num = $index + $context['file_data']['min'];
+		$is_target = $line_num == $context['file_data']['target'];
+
+		echo '
+			<tr>
+				<td class="file_line', $is_target ? ' current">==&gt;' : '">', $line_num, ':</td>
+				<td ', $is_target ? 'class="current"' : '', '>', $line, '</td>
+			</tr>';
+	}
+	echo '
+		</table>
+	</body>
+</html>';
 }
 
 ?>

--- a/Themes/default/Errors.template.php
+++ b/Themes/default/Errors.template.php
@@ -145,7 +145,11 @@ function template_error_log()
 
 		echo '
 							<a href="', $scripturl, '?action=admin;area=logs;sa=errorlog', $context['sort_direction'] == 'down' ? ';desc' : '', ';filter=error_type;value=', $error['error_type']['type'], '" title="', $txt['apply_filter'], ': ', $txt['filter_only_type'], '"><span class="generic_icons filter centericon"></span></a>
-							', $txt['error_type'], ': ', $error['error_type']['name'], '<br>
+							', $txt['error_type'], ': ', $error['error_type']['name'], ' <a><span class="generic_icons details" onclick="smc_Popup({
+				heading: \'backtrace\',
+				content: \'asdf\' ,
+				icon_class: \'generic_icons mail_new\'
+			});"></span></a><br>
 							<a class="error_message" href="', $scripturl, '?action=admin;area=logs;sa=errorlog', $context['sort_direction'] == 'down' ? ';desc' : '', ';filter=message;value=', $error['message']['href'], '" title="', $txt['apply_filter'], ': ', $txt['filter_only_message'], '"><span class="generic_icons filter"></span></a>
 							<span class="error_message">', $error['message']['html'], '</span>
 							<a href="', $scripturl, '?action=admin;area=logs;sa=errorlog', $context['sort_direction'] == 'down' ? ';desc' : '', ';filter=url;value=', $error['url']['href'], '" title="', $txt['apply_filter'], ': ', $txt['filter_only_url'], '"><span class="generic_icons filter"></span></a>

--- a/Themes/default/Errors.template.php
+++ b/Themes/default/Errors.template.php
@@ -267,24 +267,11 @@ function template_show_backtrace()
 <html', $context['right_to_left'] ? ' dir="rtl"' : '', '>
 	<head>
 		<meta charset="', $context['character_set'], '">
-		<title>', $context['file_data']['file'], '</title>
+		<title>Backtrace</title>
 		<link rel="stylesheet" href="', $settings['theme_url'], '/css/index', $context['theme_variant'], '.css', $modSettings['browser_cache'], '">
 	</head>
 	<body>
-		<table class="errorfile_table">';
-	foreach ($context['file_data']['contents'] as $index => $line)
-	{
-		$line_num = $index + $context['file_data']['min'];
-		$is_target = $line_num == $context['file_data']['target'];
-
-		echo '
-			<tr>
-				<td class="file_line', $is_target ? ' current">==&gt;' : '">', $line_num, ':</td>
-				<td ', $is_target ? 'class="current"' : '', '>', $line, '</td>
-			</tr>';
-	}
-	echo '
-		</table>
+	', var_dump(!empty($context['error_backtrace'])? $context['error_backtrace'] : ''),'
 	</body>
 </html>';
 }

--- a/other/install_2-1_mysql.sql
+++ b/other/install_2-1_mysql.sql
@@ -342,6 +342,7 @@ CREATE TABLE {$db_prefix}log_errors (
   error_type CHAR(15) NOT NULL DEFAULT 'general',
   file VARCHAR(255) NOT NULL DEFAULT '',
   line MEDIUMINT UNSIGNED NOT NULL DEFAULT '0',
+  backtrace VARCHAR(10000) NOT NULL DEFAULT '',
   PRIMARY KEY (id_error),
   INDEX idx_log_time (log_time),
   INDEX idx_id_member (id_member),

--- a/other/install_2-1_postgresql.sql
+++ b/other/install_2-1_postgresql.sql
@@ -566,6 +566,7 @@ CREATE TABLE {$db_prefix}log_errors (
   error_type varchar(15) NOT NULL DEFAULT 'general',
   file varchar(255) NOT NULL DEFAULT '',
   line int NOT NULL DEFAULT '0',
+  backtrace text NOT NULL DEFAULT '',
   PRIMARY KEY (id_error)
 );
 

--- a/other/upgrade_2-1_mysql.sql
+++ b/other/upgrade_2-1_mysql.sql
@@ -2638,3 +2638,11 @@ UPDATE {$db_prefix}settings
 SET value = replace (value, '\n{$default_fugue_smileyset_name', '')
 WHERE variable = 'smiley_sets_names';
 ---#
+
+/******************************************************************************/
+--- Change log_erros add backtrace
+/******************************************************************************/
+---# add backtrace column
+ALTER TABLE {$db_prefix}log_error
+ADD COLUMN backtrace varchar(10000) NOT NULL DEFAULT '';
+---#

--- a/other/upgrade_2-1_mysql.sql
+++ b/other/upgrade_2-1_mysql.sql
@@ -2640,7 +2640,7 @@ WHERE variable = 'smiley_sets_names';
 ---#
 
 /******************************************************************************/
---- Change log_erros add backtrace
+--- Add backtrace to log_error
 /******************************************************************************/
 ---# add backtrace column
 ALTER TABLE {$db_prefix}log_error

--- a/other/upgrade_2-1_postgresql.sql
+++ b/other/upgrade_2-1_postgresql.sql
@@ -2465,7 +2465,7 @@ WHERE variable = 'smiley_sets_names';
 ---#
 
 /******************************************************************************/
---- Change log_erros add backtrace
+--- Add backtrace to log_error
 /******************************************************************************/
 ---# add backtrace column
 ALTER TABLE {$db_prefix}log_error

--- a/other/upgrade_2-1_postgresql.sql
+++ b/other/upgrade_2-1_postgresql.sql
@@ -2463,3 +2463,11 @@ UPDATE {$db_prefix}settings
 SET value = replace (value, '\n{$default_fugue_smileyset_name', '')
 WHERE variable = 'smiley_sets_names';
 ---#
+
+/******************************************************************************/
+--- Change log_erros add backtrace
+/******************************************************************************/
+---# add backtrace column
+ALTER TABLE {$db_prefix}log_error
+ADD COLUMN backtrace text NOT NULL default '';
+---#


### PR DESCRIPTION
Issue like that: https://www.simplemachines.org/community/index.php?topic=559941.0
show me that we need more information from where the issue came,
to get the information i added backtrace to error log:

added a new icon to the error log
![grafik](https://user-images.githubusercontent.com/1782906/39405080-93fdaa04-4b9e-11e8-84ba-264179c3d2b9.png)
and this is the popup
![grafik](https://user-images.githubusercontent.com/1782906/39405085-b243a504-4b9e-11e8-99ff-a62a6448f00e.png)
