### PR TITLE
[PG] Remove the limit of delete drafts

### DIFF
--- a/Sources/Drafts.php
+++ b/Sources/Drafts.php
@@ -532,8 +532,7 @@ function showProfileDrafts($memID, $draft_type = 0)
 			DELETE FROM {db_prefix}user_drafts
 			WHERE id_draft = {int:id_draft}
 				AND id_member = {int:id_member}
-				AND type = {int:draft_type}
-			LIMIT 1',
+				AND type = {int:draft_type}',
 			array(
 				'id_draft' => $id_delete,
 				'id_member' => $memID,


### PR DESCRIPTION
Since in where part is the primary key field mention the amount of rows which could be deletet,
are 1 or 0 so the limit make no sense.
Btw postgres didn't allow a limit directly in the delete: https://stackoverflow.com/questions/5170546/how-do-i-delete-a-fixed-number-of-rows-with-sorting-in-postgresql

issue: https://www.simplemachines.org/community/index.php?topic=560151.0
