### PR TITLE
Makes [url], not [iurl], when adding a link to selected text in editor

### DIFF
--- a/Themes/default/scripts/jquery.sceditor.smf.js
+++ b/Themes/default/scripts/jquery.sceditor.smf.js
@@ -217,7 +217,11 @@ sceditor.command.set(
 						'<a target="_blank" rel="noopener" href="' + url + '">' + text + '</a>'
 					);
 				} else {
-					editor.execCommand('createlink', url);
+					// Can't just use `editor.execCommand('createlink', url)`
+					// because we need to set the target attribute.
+					editor.wysiwygEditorInsertHtml(
+						'<a target="_blank" rel="noopener" href="' + url + '">', '</a>'
+					);
 				}
 			});
 		}


### PR DESCRIPTION
Fixes #4703

Please test this, @smfbigguy.