### PR TITLE
More space in top_menu

### DIFF
--- a/Themes/default/css/index.css
+++ b/Themes/default/css/index.css
@@ -846,7 +846,7 @@ img.sort, .sort {
 }
 /* The profile/pm menus are declared off .dropmenu li ul for consistency but have other characteristics. */
 .top_menu {
-	width: 25em;
+	width: 30em;
 }
 .top_menu .login {
 	width: 100%;


### PR DESCRIPTION
It is needed for Russian language, as example.
![normal_view](https://user-images.githubusercontent.com/229402/40883913-9109e274-6721-11e8-877a-0231bdd92f06.png)
