### PR TITLE
Raise pg min version to 9.4

### DIFF
--- a/other/install.php
+++ b/other/install.php
@@ -51,7 +51,7 @@ $databases = array(
 	),
 	'postgresql' => array(
 		'name' => 'PostgreSQL',
-		'version' => '9.2',
+		'version' => '9.4',
 		'function_check' => 'pg_connect',
 		'version_check' => '$request = pg_query(\'SELECT version()\'); list ($version) = pg_fetch_row($request); list($pgl, $version) = explode(" ", $version); return $version;',
 		'supported' => function_exists('pg_connect'),

--- a/other/upgrade.php
+++ b/other/upgrade.php
@@ -37,7 +37,7 @@ $databases = array(
 	),
 	'postgresql' => array(
 		'name' => 'PostgreSQL',
-		'version' => '9.2',
+		'version' => '9.4',
 		'version_check' => '$version = pg_version(); return $version[\'client\'];',
 		'always_has_db' => true,
 	),


### PR DESCRIPTION
Postgresql 11 is now in the beta phase,
so it get release in the next months (before smf 2.1 get released).

Time for our yearly raise of supported pg version like the last one https://github.com/SimpleMachines/SMF2.1/pull/4201

since pg 9.3 is not well spreaded we can jump directly from 9.2 to 9.4,
i had to check whats is new stuff of 9.3 and 9.4 if ther features are ther which we could use.

This would be a different pr than.