### PR TITLE
Binary clock icons are reversed

### DIFF
--- a/Sources/Calendar.php
+++ b/Sources/Calendar.php
@@ -649,8 +649,8 @@ function clock()
 {
 	global $smcFunc, $settings, $context, $scripturl;
 
-	$context['onimg'] = $settings['images_url'] . '/bbc/bbc_bg.png';
-	$context['offimg'] = $settings['images_url'] . '/bbc/bbc_hoverbg.png';
+	$context['onimg'] = $settings['images_url'] . '/bbc/bbc_hoverbg.png';
+	$context['offimg'] = $settings['images_url'] . '/bbc/bbc_bg.png';
 
 	$context['page_title'] = 'Anyone know what time it is?';
 	$context['linktree'][] = array(


### PR DESCRIPTION
One would reasonably assume that blue is "on" and white is "off," but that's not how it is.

![imgur](https://i.imgur.com/n9xcc6T.png)

In the above image, reading the blue icons, the time would be 30:49:46 or 210:49:46, depending on how you want to add the second column. Reading the white icons yields a much more reasonable time of 15:36:39.

This affects both 2.0 and 2.1. The screenshot is from https://www.simplemachines.org/community/index.php?action=clock