### PR TITLE
Small fix for hook (integrate_forum_stats)

### DIFF
--- a/Sources/Stats.php
+++ b/Sources/Stats.php
@@ -683,6 +683,9 @@ function DisplayStats()
 			$context['collapsed_years'][] = $year;
 	}
 
+	// Custom stats (just add a template_layer to add it to the template!)
+	call_integration_hook('integrate_forum_stats');
+
 	if (empty($_SESSION['expanded_stats']))
 		return;
 
@@ -701,9 +704,6 @@ function DisplayStats()
 		return;
 
 	getDailyStats(implode(' OR ', $condition_text), $condition_params);
-
-	// Custom stats (just add a template_layer to add it to the template!)
- 	call_integration_hook('integrate_forum_stats');
 }
 
 /**


### PR DESCRIPTION
integrate_forum_stats hook doesn't loaded if $_SESSION['expanded_stats'] is empty.