### PR TITLE
Fix new member alert errors

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -102,7 +102,6 @@ checks:
         side_effects_or_types: false
         no_mixed_inline_html: false
         require_braces_around_control_structures: false
-        php5_style_constructor: false
         no_global_keyword: false
         avoid_usage_of_logical_operators: false
         psr2_class_declaration: false

--- a/Sources/Profile-View.php
+++ b/Sources/Profile-View.php
@@ -219,7 +219,7 @@ function fetch_alerts($memID, $all = false, $counter = 0, $pagination = array(),
 	$query_see_board = $query_see_board['query_see_board'];
 
 	// are we someone else?
-	if (empty($user_info) || $user_info['id'] !== $memID)
+	if (empty($user_info) || $user_info['id'] != $memID)
 	{
 		$user_old = !empty($user_info) ? $user_info : null;
 		if (empty($user_profile[$memID]))
@@ -384,7 +384,7 @@ function fetch_alerts($memID, $all = false, $counter = 0, $pagination = array(),
 		}
 	}
 
-	$user_info = !empty($user_old) ? $user_old : null;
+	$user_info = !empty($user_old) ? $user_old : $user_info;
 
 	return $alerts;
 }


### PR DESCRIPTION
The function that retrieves alerts was setting $user_info to null in some cases, which is probably never what we want.

Fixes #4801