### PR TITLE
Cut error url after 500 chars

### DIFF
--- a/Sources/Errors.php
+++ b/Sources/Errors.php
@@ -547,6 +547,9 @@ function log_error_online($error, $sprintf = array())
 		list ($url) = $smcFunc['db_fetch_row']($request);
 		$url = $smcFunc['json_decode']($url, true);
 		$url['error'] = $error;
+		// Url field got a max length of 1024 in db
+		if (strlen($url['error']) > 500)
+			$url['error'] = substr($url['error'],0,500);
 
 		if (!empty($sprintf))
 			$url['error_params'] = $sprintf;


### PR DESCRIPTION
While doing "stuff" i created a error which resulted in a endless loop,
the issue of the endless loop was that the $error length was bigger than the url was long,
which created the next error, which created the next error again...

To cut throw this i limited the error length at 500 chars,
because the field is 1024 chars long.

Alternative solution for pg would be to convert this varchar field to jsonb.