### PR TITLE
HTTP Status Codes

### DIFF
--- a/Sources/Display.php
+++ b/Sources/Display.php
@@ -44,7 +44,7 @@ function Display()
 	if (isset($_SERVER['HTTP_X_MOZ']) && $_SERVER['HTTP_X_MOZ'] == 'prefetch')
 	{
 		ob_end_clean();
-		header('HTTP/1.1 403 Prefetch Forbidden');
+		header($_SERVER['SERVER_PROTOCOL'] . ' 403 Prefetch Forbidden');
 		die;
 	}
 

--- a/Sources/Display.php
+++ b/Sources/Display.php
@@ -44,7 +44,7 @@ function Display()
 	if (isset($_SERVER['HTTP_X_MOZ']) && $_SERVER['HTTP_X_MOZ'] == 'prefetch')
 	{
 		ob_end_clean();
-		header($_SERVER['SERVER_PROTOCOL'] . ' 403 Prefetch Forbidden');
+		send_http_status(403, 'Prefetch Forbidden');
 		die;
 	}
 

--- a/Sources/Errors.php
+++ b/Sources/Errors.php
@@ -499,7 +499,7 @@ function set_fatal_error_headers()
 	header('cache-control: no-cache');
 
 	// Send the right error codes.
-	header('HTTP/1.1 503 Service Temporarily Unavailable');
+	header($_SERVER['SERVER_PROTOCOL'] . ' 503 Service Temporarily Unavailable');
 	header('status: 503 Service Temporarily Unavailable');
 	header('retry-after: 3600');
 }

--- a/Sources/Errors.php
+++ b/Sources/Errors.php
@@ -499,7 +499,7 @@ function set_fatal_error_headers()
 	header('cache-control: no-cache');
 
 	// Send the right error codes.
-	header($_SERVER['SERVER_PROTOCOL'] . ' 503 Service Temporarily Unavailable');
+	send_http_status(503, 'Service Temporarily Unavailable');
 	header('status: 503 Service Temporarily Unavailable');
 	header('retry-after: 3600');
 }
@@ -567,23 +567,27 @@ function log_error_online($error, $sprintf = array())
 /**
  * Sends an appropriate HTTP status header based on a given status code
  * @param int $code The status code
+ * @param string $status The string for the status. Set automatically if not provided.
  */
-function send_http_status($code)
+function send_http_status($code, $status = '')
 {
 	$statuses = array(
+		206 => 'Partial Content',
+		304 => 'Not Modified',
+		400 => 'Bad Request',
 		403 => 'Forbidden',
 		404 => 'Not Found',
 		410 => 'Gone',
 		500 => 'Internal Server Error',
-		503 => 'Service Unavailable'
+		503 => 'Service Unavailable',
 	);
+	
+	$protocol = preg_match('~^\s*(HTTP/[12]\.\d)\s*$~i', $_SERVER['SERVER_PROTOCOL'], $matches) ? $matches[1] : 'HTTP/1.0';
 
-	$protocol = preg_match('~HTTP/1\.[01]~i', $_SERVER['SERVER_PROTOCOL']) ? $_SERVER['SERVER_PROTOCOL'] : 'HTTP/1.0';
-
-	if (!isset($statuses[$code]))
+	if (!isset($statuses[$code]) && empty($status))
 		header($protocol . ' 500 Internal Server Error');
 	else
-		header($protocol . ' ' . $code . ' ' . $statuses[$code]);
+		header($protocol . ' ' . $code . ' ' . !empty($status) ? $status : $statuses[$code]);
 }
 
 ?>

--- a/Sources/Errors.php
+++ b/Sources/Errors.php
@@ -564,30 +564,4 @@ function log_error_online($error, $sprintf = array())
 	$smcFunc['db_free_result']($request);
 }
 
-/**
- * Sends an appropriate HTTP status header based on a given status code
- * @param int $code The status code
- * @param string $status The string for the status. Set automatically if not provided.
- */
-function send_http_status($code, $status = '')
-{
-	$statuses = array(
-		206 => 'Partial Content',
-		304 => 'Not Modified',
-		400 => 'Bad Request',
-		403 => 'Forbidden',
-		404 => 'Not Found',
-		410 => 'Gone',
-		500 => 'Internal Server Error',
-		503 => 'Service Unavailable',
-	);
-	
-	$protocol = preg_match('~^\s*(HTTP/[12]\.\d)\s*$~i', $_SERVER['SERVER_PROTOCOL'], $matches) ? $matches[1] : 'HTTP/1.0';
-
-	if (!isset($statuses[$code]) && empty($status))
-		header($protocol . ' 500 Internal Server Error');
-	else
-		header($protocol . ' ' . $code . ' ' . !empty($status) ? $status : $statuses[$code]);
-}
-
 ?>

--- a/Sources/Load.php
+++ b/Sources/Load.php
@@ -1029,7 +1029,7 @@ function loadBoard()
 		if ((isset($_SERVER['HTTP_X_MOZ']) && $_SERVER['HTTP_X_MOZ'] == 'prefetch') || (!empty($_REQUEST['action']) && $_REQUEST['action'] === 'dlattach'))
 		{
 			ob_end_clean();
-			header($_SERVER['SERVER_PROTOCOL'] . ' 403 Forbidden');
+			send_http_status(403);
 			die;
 		}
 		elseif ($board_info['error'] == 'post_in_redirect')

--- a/Sources/Load.php
+++ b/Sources/Load.php
@@ -1029,7 +1029,7 @@ function loadBoard()
 		if ((isset($_SERVER['HTTP_X_MOZ']) && $_SERVER['HTTP_X_MOZ'] == 'prefetch') || (!empty($_REQUEST['action']) && $_REQUEST['action'] === 'dlattach'))
 		{
 			ob_end_clean();
-			header('HTTP/1.1 403 Forbidden');
+			header($_SERVER['SERVER_PROTOCOL'] . ' 403 Forbidden');
 			die;
 		}
 		elseif ($board_info['error'] == 'post_in_redirect')

--- a/Sources/MessageIndex.php
+++ b/Sources/MessageIndex.php
@@ -49,7 +49,7 @@ function MessageIndex()
 		if (isset($_SERVER['HTTP_X_MOZ']) && $_SERVER['HTTP_X_MOZ'] == 'prefetch')
 		{
 			ob_end_clean();
-			header($_SERVER['SERVER_PROTOCOL'] . ' 403 Prefetch Forbidden');
+			send_http_status(403, 'Prefetch Forbidden');
 			die;
 		}
 	}

--- a/Sources/MessageIndex.php
+++ b/Sources/MessageIndex.php
@@ -49,7 +49,7 @@ function MessageIndex()
 		if (isset($_SERVER['HTTP_X_MOZ']) && $_SERVER['HTTP_X_MOZ'] == 'prefetch')
 		{
 			ob_end_clean();
-			header('HTTP/1.1 403 Prefetch Forbidden');
+			header($_SERVER['SERVER_PROTOCOL'] . ' 403 Prefetch Forbidden');
 			die;
 		}
 	}

--- a/Sources/QueryString.php
+++ b/Sources/QueryString.php
@@ -64,7 +64,7 @@ function cleanRequest()
 	// It seems that sticking a URL after the query string is mighty common, well, it's evil - don't.
 	if (strpos($_SERVER['QUERY_STRING'], 'http') === 0)
 	{
-		header('HTTP/1.1 400 Bad Request');
+		header($_SERVER['SERVER_PROTOCOL'] . ' 400 Bad Request');
 		die;
 	}
 

--- a/Sources/QueryString.php
+++ b/Sources/QueryString.php
@@ -64,7 +64,7 @@ function cleanRequest()
 	// It seems that sticking a URL after the query string is mighty common, well, it's evil - don't.
 	if (strpos($_SERVER['QUERY_STRING'], 'http') === 0)
 	{
-		header($_SERVER['SERVER_PROTOCOL'] . ' 400 Bad Request');
+		send_http_status(400);
 		die;
 	}
 

--- a/Sources/Recent.php
+++ b/Sources/Recent.php
@@ -473,7 +473,7 @@ function UnreadTopics()
 	if (isset($_SERVER['HTTP_X_MOZ']) && $_SERVER['HTTP_X_MOZ'] == 'prefetch')
 	{
 		ob_end_clean();
-		header('HTTP/1.1 403 Forbidden');
+		header($_SERVER['SERVER_PROTOCOL'] . ' 403 Forbidden');
 		die;
 	}
 

--- a/Sources/Recent.php
+++ b/Sources/Recent.php
@@ -473,7 +473,7 @@ function UnreadTopics()
 	if (isset($_SERVER['HTTP_X_MOZ']) && $_SERVER['HTTP_X_MOZ'] == 'prefetch')
 	{
 		ob_end_clean();
-		header($_SERVER['SERVER_PROTOCOL'] . ' 403 Forbidden');
+		send_http_status(403);
 		die;
 	}
 

--- a/Sources/Register.php
+++ b/Sources/Register.php
@@ -830,7 +830,7 @@ function VerificationCode()
 		require_once($sourcedir . '/Subs-Graphics.php');
 
 		if (in_array('gd', get_loaded_extensions()) && !showCodeImage($code))
-			header($_SERVER['SERVER_PROTOCOL'] . ' 400 Bad Request');
+			send_http_status(400);
 
 		// Otherwise just show a pre-defined letter.
 		elseif (isset($_REQUEST['letter']))
@@ -855,7 +855,7 @@ function VerificationCode()
 		require_once($sourcedir . '/Subs-Sound.php');
 
 		if (!createWaveFile($code))
-			header($_SERVER['SERVER_PROTOCOL'] . ' 400 Bad Request');
+			send_http_status(400);
 	}
 
 	// We all die one day...

--- a/Sources/Register.php
+++ b/Sources/Register.php
@@ -830,7 +830,7 @@ function VerificationCode()
 		require_once($sourcedir . '/Subs-Graphics.php');
 
 		if (in_array('gd', get_loaded_extensions()) && !showCodeImage($code))
-			header('HTTP/1.1 400 Bad Request');
+			header($_SERVER['SERVER_PROTOCOL'] . ' 400 Bad Request');
 
 		// Otherwise just show a pre-defined letter.
 		elseif (isset($_REQUEST['letter']))
@@ -855,7 +855,7 @@ function VerificationCode()
 		require_once($sourcedir . '/Subs-Sound.php');
 
 		if (!createWaveFile($code))
-			header('HTTP/1.1 400 Bad Request');
+			header($_SERVER['SERVER_PROTOCOL'] . ' 400 Bad Request');
 	}
 
 	// We all die one day...

--- a/Sources/Search.php
+++ b/Sources/Search.php
@@ -266,7 +266,7 @@ function PlushSearch2()
 	if (isset($_SERVER['HTTP_X_MOZ']) && $_SERVER['HTTP_X_MOZ'] == 'prefetch')
 	{
 		ob_end_clean();
-		header($_SERVER['SERVER_PROTOCOL'] . ' 403 Forbidden');
+		send_http_status(403);
 		die;
 	}
 

--- a/Sources/Search.php
+++ b/Sources/Search.php
@@ -266,7 +266,7 @@ function PlushSearch2()
 	if (isset($_SERVER['HTTP_X_MOZ']) && $_SERVER['HTTP_X_MOZ'] == 'prefetch')
 	{
 		ob_end_clean();
-		header('HTTP/1.1 403 Forbidden');
+		header($_SERVER['SERVER_PROTOCOL'] . ' 403 Forbidden');
 		die;
 	}
 

--- a/Sources/Security.php
+++ b/Sources/Security.php
@@ -635,7 +635,7 @@ function checkSession($type = 'post', $from_action = '', $is_fatal = true)
 	if (isset($_SERVER['HTTP_X_MOZ']) && $_SERVER['HTTP_X_MOZ'] == 'prefetch')
 	{
 		ob_end_clean();
-		header($_SERVER['SERVER_PROTOCOL'] . ' 403 Forbidden');
+		send_http_status(403);
 		die;
 	}
 
@@ -693,7 +693,7 @@ function checkSession($type = 'post', $from_action = '', $is_fatal = true)
 		if (isset($_GET['xml']))
 		{
 			ob_end_clean();
-			header($_SERVER['SERVER_PROTOCOL'] . ' 403 Forbidden - Session timeout');
+			send_http_status(403, 'Forbidden - Session timeout');
 			die;
 		}
 		else

--- a/Sources/Security.php
+++ b/Sources/Security.php
@@ -635,7 +635,7 @@ function checkSession($type = 'post', $from_action = '', $is_fatal = true)
 	if (isset($_SERVER['HTTP_X_MOZ']) && $_SERVER['HTTP_X_MOZ'] == 'prefetch')
 	{
 		ob_end_clean();
-		header('HTTP/1.1 403 Forbidden');
+		header($_SERVER['SERVER_PROTOCOL'] . ' 403 Forbidden');
 		die;
 	}
 
@@ -693,7 +693,7 @@ function checkSession($type = 'post', $from_action = '', $is_fatal = true)
 		if (isset($_GET['xml']))
 		{
 			ob_end_clean();
-			header('HTTP/1.1 403 Forbidden - Session timeout');
+			header($_SERVER['SERVER_PROTOCOL'] . ' 403 Forbidden - Session timeout');
 			die;
 		}
 		else

--- a/Sources/ShowAttachments.php
+++ b/Sources/ShowAttachments.php
@@ -208,7 +208,7 @@ function showAttachment()
 			ob_end_clean();
 
 			// Answer the question - no, it hasn't been modified ;).
-			header('HTTP/1.1 304 Not Modified');
+			header($_SERVER['SERVER_PROTOCOL'] . ' 304 Not Modified');
 			exit;
 		}
 	}
@@ -219,7 +219,7 @@ function showAttachment()
 	{
 		ob_end_clean();
 
-		header('HTTP/1.1 304 Not Modified');
+		header($_SERVER['SERVER_PROTOCOL'] . ' 304 Not Modified');
 		exit;
 	}
 
@@ -301,7 +301,7 @@ function showAttachment()
 	// Multipart and resuming support
 	if (isset($_SERVER['HTTP_RANGE']))
 	{
-		header("HTTP/1.1 206 Partial Content");
+		header($_SERVER['SERVER_PROTOCOL'] . ' 206 Partial Content');
 		header("content-length: $new_length");
 		header("content-range: bytes $range-$range_end/$size");
 	}

--- a/Sources/ShowAttachments.php
+++ b/Sources/ShowAttachments.php
@@ -59,7 +59,7 @@ function showAttachment()
 	// We need a valid ID.
 	if (empty($attachId))
 	{
-		header('HTTP/1.0 404 File Not Found');
+		send_http_status(404, 'File Not Found');
 		die('404 File Not Found');
 	}
 
@@ -71,7 +71,7 @@ function showAttachment()
 	// No access in strict maintenance mode or you don't have permission to see attachments.
 	if ((!empty($maintenance) && $maintenance == 2) || !allowedTo('view_attachments'))
 	{
-		header('HTTP/1.0 404 File Not Found');
+		send_http_status(404, 'File Not Found');
 		die('404 File Not Found');
 	}
 
@@ -105,7 +105,7 @@ function showAttachment()
 		// No attachment has been found.
 		if ($smcFunc['db_num_rows']($request) == 0)
 		{
-			header('HTTP/1.0 404 File Not Found');
+			send_http_status(404, 'File Not Found');
 			die('404 File Not Found');
 		}
 
@@ -115,7 +115,7 @@ function showAttachment()
 		// If theres a message ID stored, we NEED a topic ID.
 		if (!empty($file['id_msg']) && empty($attachTopic) && empty($preview))
 		{
-			header('HTTP/1.0 404 File Not Found');
+			send_http_status(404, 'File Not Found');
 			die('404 File Not Found');
 		}
 
@@ -138,7 +138,7 @@ function showAttachment()
 			// The provided topic must match the one stored in the DB for this particular attachment, also.
 			if ($smcFunc['db_num_rows']($request2) == 0)
 			{
-				header('HTTP/1.0 404 File Not Found');
+				send_http_status(404, 'File Not Found');
 				die('404 File Not Found');
 			}
 
@@ -192,7 +192,7 @@ function showAttachment()
 	// No point in a nicer message, because this is supposed to be an attachment anyway...
 	if (!file_exists($file['filePath']))
 	{
-		header((preg_match('~HTTP/1\.[01]~i', $_SERVER['SERVER_PROTOCOL']) ? $_SERVER['SERVER_PROTOCOL'] : 'HTTP/1.0') . ' 404 Not Found');
+		send_http_status(404);
 		header('content-type: text/plain; charset=' . (empty($context['character_set']) ? 'ISO-8859-1' : $context['character_set']));
 
 		// We need to die like this *before* we send any anti-caching headers as below.
@@ -208,7 +208,7 @@ function showAttachment()
 			ob_end_clean();
 
 			// Answer the question - no, it hasn't been modified ;).
-			header($_SERVER['SERVER_PROTOCOL'] . ' 304 Not Modified');
+			send_http_status(304);
 			exit;
 		}
 	}
@@ -219,7 +219,7 @@ function showAttachment()
 	{
 		ob_end_clean();
 
-		header($_SERVER['SERVER_PROTOCOL'] . ' 304 Not Modified');
+		send_http_status(304);
 		exit;
 	}
 
@@ -301,7 +301,7 @@ function showAttachment()
 	// Multipart and resuming support
 	if (isset($_SERVER['HTTP_RANGE']))
 	{
-		header($_SERVER['SERVER_PROTOCOL'] . ' 206 Partial Content');
+		send_http_status(206);
 		header("content-length: $new_length");
 		header("content-range: bytes $range-$range_end/$size");
 	}

--- a/Sources/Subs-Auth.php
+++ b/Sources/Subs-Auth.php
@@ -238,7 +238,7 @@ function InMaintenance()
 	createToken('login');
 
 	// Send a 503 header, so search engines don't bother indexing while we're in maintenance mode.
-	header($_SERVER['SERVER_PROTOCOL'] . ' 503 Service Temporarily Unavailable');
+	send_http_status(503, 'Service Temporarily Unavailable');
 
 	// Basic template stuff..
 	$context['sub_template'] = 'maintenance';

--- a/Sources/Subs-Auth.php
+++ b/Sources/Subs-Auth.php
@@ -238,7 +238,7 @@ function InMaintenance()
 	createToken('login');
 
 	// Send a 503 header, so search engines don't bother indexing while we're in maintenance mode.
-	header('HTTP/1.1 503 Service Temporarily Unavailable');
+	header($_SERVER['SERVER_PROTOCOL'] . ' 503 Service Temporarily Unavailable');
 
 	// Basic template stuff..
 	$context['sub_template'] = 'maintenance';

--- a/Sources/Subs-Sound.php
+++ b/Sources/Subs-Sound.php
@@ -33,7 +33,7 @@ function createWaveFile($word)
 
 	// Allow max 2 requests per 20 seconds.
 	if (($ip = cache_get_data('wave_file/' . $user_info['ip'], 20)) > 2 || ($ip2 = cache_get_data('wave_file/' . $user_info['ip2'], 20)) > 2)
-		die(header($_SERVER['SERVER_PROTOCOL'] . ' 400 Bad Request'));
+		die(send_http_status(400));
 	cache_put_data('wave_file/' . $user_info['ip'], $ip ? $ip + 1 : 1, 20);
 	cache_put_data('wave_file/' . $user_info['ip2'], $ip2 ? $ip2 + 1 : 1, 20);
 

--- a/Sources/Subs-Sound.php
+++ b/Sources/Subs-Sound.php
@@ -33,7 +33,7 @@ function createWaveFile($word)
 
 	// Allow max 2 requests per 20 seconds.
 	if (($ip = cache_get_data('wave_file/' . $user_info['ip'], 20)) > 2 || ($ip2 = cache_get_data('wave_file/' . $user_info['ip2'], 20)) > 2)
-		die(header('HTTP/1.1 400 Bad Request'));
+		die(header($_SERVER['SERVER_PROTOCOL'] . ' 400 Bad Request'));
 	cache_put_data('wave_file/' . $user_info['ip'], $ip ? $ip + 1 : 1, 20);
 	cache_put_data('wave_file/' . $user_info['ip2'], $ip2 ? $ip2 + 1 : 1, 20);
 

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -6518,4 +6518,30 @@ function check_cron()
 	}
 }
 
+/**
+ * Sends an appropriate HTTP status header based on a given status code
+ * @param int $code The status code
+ * @param string $status The string for the status. Set automatically if not provided.
+ */
+function send_http_status($code, $status = '')
+{
+	$statuses = array(
+		206 => 'Partial Content',
+		304 => 'Not Modified',
+		400 => 'Bad Request',
+		403 => 'Forbidden',
+		404 => 'Not Found',
+		410 => 'Gone',
+		500 => 'Internal Server Error',
+		503 => 'Service Unavailable',
+	);
+	
+	$protocol = preg_match('~^\s*(HTTP/[12]\.\d)\s*$~i', $_SERVER['SERVER_PROTOCOL'], $matches) ? $matches[1] : 'HTTP/1.0';
+
+	if (!isset($statuses[$code]) && empty($status))
+		header($protocol . ' 500 Internal Server Error');
+	else
+		header($protocol . ' ' . $code . ' ' . !empty($status) ? $status : $statuses[$code]);
+}
+
 ?>

--- a/proxy.php
+++ b/proxy.php
@@ -116,7 +116,7 @@ class ProxyServer
 		if ($response === -1)
 		{
 			// Throw a 404
-			header('HTTP/1.0 404 Not Found');
+			header(send_http_status(404));
 			exit;
 		}
 		// Right, image not cached? Simply redirect, then.
@@ -139,7 +139,7 @@ class ProxyServer
 		$eTag = '"' . substr(sha1($request) . $cached['time'], 0, 64) . '"';
 		if (!empty($_SERVER['HTTP_IF_NONE_MATCH']) && strpos($_SERVER['HTTP_IF_NONE_MATCH'], $eTag) !== false)
 		{
-			header($_SERVER['SERVER_PROTOCOL'] . ' 304 Not Modified');
+			send_http_status(304);
 			exit;
 		}
 

--- a/proxy.php
+++ b/proxy.php
@@ -139,7 +139,7 @@ class ProxyServer
 		$eTag = '"' . substr(sha1($request) . $cached['time'], 0, 64) . '"';
 		if (!empty($_SERVER['HTTP_IF_NONE_MATCH']) && strpos($_SERVER['HTTP_IF_NONE_MATCH'], $eTag) !== false)
 		{
-			header('HTTP/1.1 304 Not Modified');
+			header($_SERVER['SERVER_PROTOCOL'] . ' 304 Not Modified');
 			exit;
 		}
 

--- a/proxy.php
+++ b/proxy.php
@@ -116,7 +116,7 @@ class ProxyServer
 		if ($response === -1)
 		{
 			// Throw a 404
-			header(send_http_status(404));
+			send_http_status(404);
 			exit;
 		}
 		// Right, image not cached? Simply redirect, then.


### PR DESCRIPTION
Makes sure all HTTP status codes provided HTTP response headers are correct for the version of HTTP being used.

Also utilises the centralised function send_http_status in Errors.php to make sure the HTTP version determining code is centralised.

Resolves #4832 