### PR TITLE
Check for property exists in the error template Fixes #4836

### DIFF
--- a/Themes/default/Errors.template.php
+++ b/Themes/default/Errors.template.php
@@ -328,9 +328,9 @@ function template_show_backtrace()
 		foreach ($context['error_info']['backtrace'] as $key => $value)
 		{
 			//Check for existing
-			if (empty($value->file))
+			if (property_exists($value,'file') || empty($value->file))
 				$value->file = $txt['unknown'];
-			if (empty($value->line))
+			if (property_exists($value, 'line') || empty($value->line))
 				$value->line = -1;
 
 				echo '


### PR DESCRIPTION
First was my idea only to replace empty with property_exists,
but than i think maybe both checks are good here.
Issue: #4836

