### PR TITLE
Fix a undefined indexes when changing file permissions

### DIFF
--- a/Sources/Packages.php
+++ b/Sources/Packages.php
@@ -2650,6 +2650,8 @@ function PackagePermissionsAction()
 			if ($dont_chmod)
 			{
 				$context['total_files'] = $file_count;
+				$context['directory_list_encode'] = base64_encode($smcFunc['json_encode']($context['directory_list']));
+				$context['special_files_encode'] = base64_encode($smcFunc['json_encode']($context['special_files']));
 				return false;
 			}
 


### PR DESCRIPTION
Reproduce
1. ACP > Packages > File Permissions
2. Choose to use a predefined permission profile (any is fine)
3. Enter in any FTP details, doesn't need to be valid
4. Click Make Changes
5. When the timeout page opens, the undefined indexes are loaded.

As well I noticed the undefined indexes here are not logged.  Not sure why.

Signed-off-by: jdarwood007 <unmonitored+github@sleepycode.com>