### PR TITLE
Suppress Phar handling alerts with open_basedir set

### DIFF
--- a/Sources/Subs-Package.php
+++ b/Sources/Subs-Package.php
@@ -251,8 +251,8 @@ function read_zip_file($file, $destination, $single_file = false, $overwrite = f
 			if (@rename($file, $file . '.zip'))
 				$file = $file . '.zip';
 
-		$archive = new PharData($file, RecursiveIteratorIterator::SELF_FIRST, null, Phar::ZIP);
-		$iterator = new RecursiveIteratorIterator($archive, RecursiveIteratorIterator::SELF_FIRST);
+		$archive = @new PharData($file, RecursiveIteratorIterator::SELF_FIRST, null, Phar::ZIP);
+		$iterator = @new RecursiveIteratorIterator($archive, RecursiveIteratorIterator::SELF_FIRST);
 
 		// go though each file in the archive
 		foreach ($iterator as $file_info)


### PR DESCRIPTION
If a host has set open_basedir restrictions we receive errors as shown in #3152 and https://www.simplemachines.org/community/index.php?topic=555537.0

PHP doesn't offer a way to catch warnings, only exceptions.  So the best solution here is to suppress errors when attempting to open the archive.

Fixes #3152

Signed-off-by: jdarwood007 <unmonitored+github@sleepycode.com>