### PR TITLE
Fix undefined member_group when using minimal profile

### DIFF
--- a/Sources/Load.php
+++ b/Sources/Load.php
@@ -1275,7 +1275,7 @@ function loadMemberData($users, $is_name = false, $set = 'normal')
 				$row['avatar'] = get_proxied_url($row['avatar']);
 
 			// Keep track of the member's normal member group
-			$row['primary_group'] = $row['member_group'];
+			$row['primary_group'] = !empty($row['member_group']) ? $row['member_group'] : '';
 
 			if (isset($row['member_ip']))
 				$row['member_ip'] = inet_dtop($row['member_ip']);


### PR DESCRIPTION
If you load a profile as minimal you will receive a undefined index as we do not load the member_group column.  This simply does what the process would have done if it couldn't find a membergroup name and load a blank string

Signed-off-by: jdarwood007 <unmonitored+github@sleepycode.com>