### PR TITLE
Inner Join breaks hooks using the attachment system.

### DIFF
--- a/Sources/ShowAttachments.php
+++ b/Sources/ShowAttachments.php
@@ -120,7 +120,7 @@ function showAttachment()
 		}
 
 		// Previews doesn't have this info.
-		if (empty($preview))
+		if (empty($preview) && is_resource($attachRequest))
 		{
 			$request2 = $smcFunc['db_query']('', '
 				SELECT a.id_msg


### PR DESCRIPTION
If a hook is using the attachment system and does not reference or has a id_msg, this will result in no rows being returned.  Two solutions are to use a left join or ignore this when $attachRequest from is a resource.