### PR TITLE
Merge login session expiration options

### DIFF
--- a/Themes/default/Login.template.php
+++ b/Themes/default/Login.template.php
@@ -51,13 +51,15 @@ function template_login()
 						</dd>
 					</dl>
 					<dl>
-						<dt>', $txt['mins_logged_in'], ':</dt>
+						<dt>', $txt['time_logged_in'], ':</dt>
 						<dd>
-							<input type="number" name="cookielength" size="4" maxlength="4" value="', $modSettings['cookieTime'], '"', $context['never_expire'] ? ' disabled' : '', ' min="1">
-						</dd>
-						<dt>', $txt['always_logged_in'], ':</dt>
-						<dd>
-							<input type="checkbox" name="cookieneverexp"', $context['never_expire'] ? ' checked' : '', ' onclick="this.form.cookielength.disabled = this.checked;">
+							<select name="cookielength" id="cookielength">
+								<option value="60"', $context['never_expire'] ? '' : ' selected', '>', $txt['one_hour'], '</option>
+								<option value="1440">', $txt['one_day'], '</option>
+								<option value="10080">', $txt['one_week'], '</option>
+								<option value="43200">', $txt['one_month'], '</option>
+								<option value="3153600"', $context['never_expire'] ? ' selected' : '', '>', $txt['always_logged_in'], '</option>
+							</select>
 						</dd>';
 
 	// If they have deleted their account, give them a chance to change their mind.
@@ -249,10 +251,16 @@ function template_kick_guest()
 					<dd><input type="text" name="user" size="20"></dd>
 					<dt>', $txt['password'], ':</dt>
 					<dd><input type="password" name="passwrd" size="20"></dd>
-					<dt>', $txt['mins_logged_in'], ':</dt>
-					<dd><input type="text" name="cookielength" size="4" maxlength="4" value="', $modSettings['cookieTime'], '"></dd>
-					<dt>', $txt['always_logged_in'], ':</dt>
-					<dd><input type="checkbox" name="cookieneverexp" onclick="this.form.cookielength.disabled = this.checked;"></dd>
+					<dt>', $txt['time_logged_in'], ':</dt>
+					<dd>
+						<select name="cookielength" id="cookielength">
+							<option value="60" selected>', $txt['one_hour'], '</option>
+							<option value="1440">', $txt['one_day'], '</option>
+							<option value="10080">', $txt['one_week'], '</option>
+							<option value="43200">', $txt['one_month'], '</option>
+							<option value="3153600">', $txt['always_logged_in'], '</option>
+						</select>
+					</dd>
 				</dl>
 				<p class="centertext">
 					<input type="submit" value="', $txt['login'], '" class="button">
@@ -301,10 +309,16 @@ function template_maintenance()
 					<dd><input type="text" name="user" size="20"></dd>
 					<dt>', $txt['password'], ':</dt>
 					<dd><input type="password" name="passwrd" size="20"></dd>
-					<dt>', $txt['mins_logged_in'], ':</dt>
-					<dd><input type="text" name="cookielength" size="4" maxlength="4" value="', $modSettings['cookieTime'], '"></dd>
-					<dt>', $txt['always_logged_in'], ':</dt>
-					<dd><input type="checkbox" name="cookieneverexp"></dd>
+					<dt>', $txt['time_logged_in'], ':</dt>
+					<dd>
+						<select name="cookielength" id="cookielength">
+							<option value="60" selected>', $txt['one_hour'], '</option>
+							<option value="1440">', $txt['one_day'], '</option>
+							<option value="10080">', $txt['one_week'], '</option>
+							<option value="43200">', $txt['one_month'], '</option>
+							<option value="3153600">', $txt['always_logged_in'], '</option>
+						</select>
+					</dd>
 				</dl>
 				<input type="submit" value="', $txt['login'], '" class="button">
 				<br class="clear">

--- a/Themes/default/languages/index.english.php
+++ b/Themes/default/languages/index.english.php
@@ -331,7 +331,7 @@ $txt['total_members'] = 'Total Members';
 $txt['total_posts'] = 'Total Posts';
 $txt['total_topics'] = 'Total Topics';
 
-$txt['mins_logged_in'] = 'Minutes to stay logged in';
+$txt['time_logged_in'] = 'Time to stay logged in';
 
 $txt['preview'] = 'Preview';
 $txt['always_logged_in'] = 'Always stay logged in';
@@ -410,6 +410,7 @@ $txt['poll_lock'] = 'Lock Voting';
 $txt['poll_unlock'] = 'Unlock Voting';
 $txt['poll_edit'] = 'Edit Poll';
 $txt['poll'] = 'Poll';
+$txt['one_hour'] = '1 Hour';
 $txt['one_day'] = '1 Day';
 $txt['one_week'] = '1 Week';
 $txt['two_weeks'] = '2 Weeks';
@@ -417,7 +418,6 @@ $txt['one_month'] = '1 Month';
 $txt['two_months'] = '2 Months';
 $txt['forever'] = 'Forever';
 $txt['quick_login_dec'] = 'Login with username, password and session length';
-$txt['one_hour'] = '1 Hour';
 $txt['moved'] = 'MOVED';
 $txt['move_why'] = 'Please enter a brief description as to<br>why this topic is being moved.';
 $txt['board'] = 'Board';


### PR DESCRIPTION
Anything we should do with` $modSettings['cookieTime'] `in that setup? 

Also, I noticed `$context['never_expire']` is only used in one of the logins, is that intentional?