### PR TITLE
[WIP] Added config_var type richedit to admin template

### DIFF
--- a/Themes/default/Admin.template.php
+++ b/Themes/default/Admin.template.php
@@ -897,6 +897,8 @@ function template_show_settings()
 				elseif ($config_var['type'] == 'large_text')
 					echo '
 										<textarea rows="', (!empty($config_var['size']) ? $config_var['size'] : (!empty($config_var['rows']) ? $config_var['rows'] : 4)), '" cols="', (!empty($config_var['cols']) ? $config_var['cols'] : 30), '" ', $javascript, $disabled, ' name="', $config_var['name'], '" id="', $config_var['name'], '">', $config_var['value'], '</textarea>';
+				elseif ($config_var['type'] == 'richedit')
+					echo template_control_richedit($context['post_box_name'], 'smileyBox_message', 'bbcBox_message');
 				// Permission group?
 				elseif ($config_var['type'] == 'permissions')
 					theme_inline_permissions($config_var['name']);


### PR DESCRIPTION
Was trying to use this in my privacy pr,
but my ideas are to complex to fit in the default admin template.
But maybe would be a good idea to provide this type of input field.

exp.
old: https://snag.gy/UwQihx.jpg
new: https://snag.gy/JmLCZt.jpg

needed code on code side
```
	require_once($sourcedir . '/Subs-Editor.php');

	// Now create the editor.
	$editorOptions = array(
		'id' => 'coppaPost',
		'value' => 'asdf',
		'height' => '250px',
		'width' => '100%',
		'labels' => array(
			'post_button' => 'go!!',
		),
		'preview_type' => 2,
		'required' => true,
	);
	create_control_richedit($editorOptions);
	// Store the ID for old compatibility.
	$context['post_box_name'] = $editorOptions['id'];
```