### PR TITLE
Fix #4897: Implement jQuery smiley selector

### DIFF
--- a/Sources/Profile-Modify.php
+++ b/Sources/Profile-Modify.php
@@ -461,7 +461,7 @@ function loadProfileFields($force_reload = false)
 			'preload' => function() use ($modSettings, &$context, $txt, $cur_profile, $smcFunc)
 			{
 				$context['member']['smiley_set']['id'] = empty($cur_profile['smiley_set']) ? '' : $cur_profile['smiley_set'];
-				$context['smiley_sets'] = explode(',', 'none,,' . $modSettings['smiley_sets_known']);
+				$context['smiley_sets'] = explode(',', 'none,' . $modSettings['smiley_sets_default'] . ',' . $modSettings['smiley_sets_known']);
 				$set_names = explode("\n", $txt['smileys_none'] . "\n" . $txt['smileys_forum_board_default'] . "\n" . $modSettings['smiley_sets_names']);
 				foreach ($context['smiley_sets'] as $i => $set)
 				{

--- a/Themes/default/Profile.template.php
+++ b/Themes/default/Profile.template.php
@@ -3117,7 +3117,7 @@ function template_profile_smiley_pick()
 								<strong><label for="smiley_set">', $txt['smileys_current'], ':</label></strong>
 							</dt>
 							<dd>
-								<select name="smiley_set" id="smiley_set" onchange="document.getElementById(\'smileypr\').src = this.selectedIndex == 0 ? \'', $settings['images_url'], '/blank.png\' : \'', $modSettings['smileys_url'], '/\' + (this.selectedIndex != 1 ? this.options[this.selectedIndex].value : \'', !empty($settings['smiley_sets_default']) ? $settings['smiley_sets_default'] : $modSettings['smiley_sets_default'], '\') + \'/smiley.png\';">';
+								<select name="smiley_set" id="smiley_set">';
 
 	foreach ($context['smiley_sets'] as $set)
 		echo '

--- a/Themes/default/scripts/profile.js
+++ b/Themes/default/scripts/profile.js
@@ -282,3 +282,31 @@ function readfromUpload(input) {
 		reader.readAsDataURL(input.files[0]);
 	}
 }
+
+// The smiley set selector code
+$(document).on('change','#smiley_set', function ()
+{
+    let value = this.value;
+
+    let baseurl;
+    if (value === "none") {
+        baseurl = smf_images_url + "/blank.";
+	} else {
+        baseurl = smf_smileys_url + "/" + value + "/smiley.";
+    }
+    trySmileySetPreview(baseurl);
+});
+
+function trySmileySetPreview(baseurl, i = 0)
+{
+    let extensions = ["png", "gif", "jpg", "jpeg"];
+	$.ajax(baseurl + extensions[i])
+		.done(function ()
+		{
+            $("#smileypr").attr("src", baseurl + extensions[i]);
+		})
+		.fail(function ()
+		{
+			trySmileySetPreview(baseurl, ++i);
+		});
+}

--- a/Themes/default/scripts/profile.js
+++ b/Themes/default/scripts/profile.js
@@ -284,29 +284,25 @@ function readfromUpload(input) {
 }
 
 // The smiley set selector code
-$(document).on('change','#smiley_set', function ()
-{
+$(document).on('change', '#smiley_set', function () {
     let value = this.value;
 
     let baseurl;
     if (value === "none") {
         baseurl = smf_images_url + "/blank.";
-	} else {
+    } else {
         baseurl = smf_smileys_url + "/" + value + "/smiley.";
     }
     trySmileySetPreview(baseurl);
 });
 
-function trySmileySetPreview(baseurl, i = 0)
-{
+function trySmileySetPreview(baseurl, i = 0) {
     let extensions = ["png", "gif", "jpg", "jpeg"];
-	$.ajax(baseurl + extensions[i])
-		.done(function ()
-		{
+    $.ajax(baseurl + extensions[i])
+        .done(function () {
             $("#smileypr").attr("src", baseurl + extensions[i]);
-		})
-		.fail(function ()
-		{
-			trySmileySetPreview(baseurl, ++i);
-		});
+        })
+        .fail(function () {
+            trySmileySetPreview(baseurl, ++i);
+        });
 }


### PR DESCRIPTION
This selector iterates over the most common file extensions to find one that's available. Worked in my testing with Firefox.

Signed-off-by: NanoSector <rick.2889@gmail.com>