### PR TITLE
Improve smiley visibility on load

### DIFF
--- a/Sources/Load.php
+++ b/Sources/Load.php
@@ -2208,6 +2208,7 @@ function loadTheme($id_theme = 0, $initialize = true)
 		'smf_default_theme_url' => '"' . $settings['default_theme_url'] . '"',
 		'smf_images_url' => '"' . $settings['images_url'] . '"',
 		'smf_smileys_url' => '"' . $modSettings['smileys_url'] . '"',
+		'smf_smiley_sets_default' => '"' . $modSettings['smiley_sets_default'] . '"',
 		'smf_scripturl' => '"' . $scripturl . '"',
 		'smf_iso_case_folding' => $context['server']['iso_case_folding'] ? 'true' : 'false',
 		'smf_charset' => '"' . $context['character_set'] . '"',

--- a/Sources/Profile-Modify.php
+++ b/Sources/Profile-Modify.php
@@ -461,7 +461,7 @@ function loadProfileFields($force_reload = false)
 			'preload' => function() use ($modSettings, &$context, $txt, $cur_profile, $smcFunc)
 			{
 				$context['member']['smiley_set']['id'] = empty($cur_profile['smiley_set']) ? '' : $cur_profile['smiley_set'];
-				$context['smiley_sets'] = explode(',', 'none,' . $modSettings['smiley_sets_default'] . ',' . $modSettings['smiley_sets_known']);
+				$context['smiley_sets'] = explode(',', 'none,,' . $modSettings['smiley_sets_known']);
 				$set_names = explode("\n", $txt['smileys_none'] . "\n" . $txt['smileys_forum_board_default'] . "\n" . $modSettings['smiley_sets_names']);
 				foreach ($context['smiley_sets'] as $i => $set)
 				{

--- a/Themes/default/scripts/profile.js
+++ b/Themes/default/scripts/profile.js
@@ -286,6 +286,22 @@ function readfromUpload(input) {
 // The smiley set selector code
 $(document).on('change', '#smiley_set', function () {
     let value = this.value;
+    if (value == "")
+        value = smf_smiley_sets_default;
+
+    let baseurl;
+    if (value === "none") {
+        baseurl = smf_images_url + "/blank.";
+    } else {
+        baseurl = smf_smileys_url + "/" + value + "/smiley.";
+    }
+    trySmileySetPreview(baseurl);
+});
+
+$(window).on('load', function () {
+    let value = $("#smiley_set").val();
+    if (value == "")
+        value = smf_smiley_sets_default;
 
     let baseurl;
     if (value === "none") {
@@ -303,6 +319,7 @@ function trySmileySetPreview(baseurl, i = 0) {
             $("#smileypr").attr("src", baseurl + extensions[i]);
         })
         .fail(function () {
-            trySmileySetPreview(baseurl, ++i);
+            if (i < extensions.length)
+                trySmileySetPreview(baseurl, ++i);
         });
 }


### PR DESCRIPTION
Fixes #4920 

Now displays icon upon initial page load
Stores blanks when forum default selected
Also added check to prevent infinite loops (e.g., if the admin removes your favorite smiley set)