### PR TITLE
Fix minor issues with Cry & Angel smileys

### DIFF
--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -3001,6 +3001,14 @@ function parsesmileys(&$message)
 			{
 				$smileyPregReplacements[$specialChars] = $smileyCode;
 				$searchParts[] = $specialChars;
+				
+				// Some 2.0 hex htmlchars are in there as 3 digits; allow for finding leading 0 or not
+				$specialChars2 = preg_replace('/&#(\d{2});/', '&#0$1;', $specialChars);
+				if ($specialChars2 != $specialChars)
+				{
+					$smileyPregReplacements[$specialChars2] = $smileyCode;
+					$searchParts[] = $specialChars2;
+				}
 			}
 		}
 

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -2927,7 +2927,7 @@ function parsesmileys(&$message)
 		// Use the default smileys if it is disabled. (better for "portability" of smileys.)
 		if (empty($modSettings['smiley_enable']))
 		{
-			$smileysfrom = array('>:D', ':D', '::)', '>:(', ':))', ':)', ';)', ';D', ':(', ':o', '8)', ':P', '???', ':-[', ':-X', ':-*', ':\'(', ':-\\', '^-^', 'O0', 'C:-)', '0:)');
+			$smileysfrom = array('>:D', ':D', '::)', '>:(', ':))', ':)', ';)', ';D', ':(', ':o', '8)', ':P', '???', ':-[', ':-X', ':-*', ':\'(', ':-\\', '^-^', 'O0', 'C:-)', 'O:-)');
 			$smileysto = array('evil.png', 'cheesy.png', 'rolleyes.png', 'angry.png', 'laugh.png', 'smiley.png', 'wink.png', 'grin.png', 'sad.png', 'shocked.png', 'cool.png', 'tongue.png', 'huh.png', 'embarrassed.png', 'lipsrsealed.png', 'kiss.png', 'cry.png', 'undecided.png', 'azn.png', 'afro.png', 'police.png', 'angel.png');
 			$smileysdescs = array('', $txt['icon_cheesy'], $txt['icon_rolleyes'], $txt['icon_angry'], '', $txt['icon_smiley'], $txt['icon_wink'], $txt['icon_grin'], $txt['icon_sad'], $txt['icon_shocked'], $txt['icon_cool'], $txt['icon_tongue'], $txt['icon_huh'], $txt['icon_embarrassed'], $txt['icon_lips'], $txt['icon_kiss'], $txt['icon_cry'], $txt['icon_undecided'], '', '', '', '');
 		}


### PR DESCRIPTION
Fixes #4918 .

The Angel smiley wasn't showing under some circumstances due to a different smiley code being used.  Made things consistent.   (This issue exists in 2.0.x as well.)

2.0 Cry smileys weren't showing up because they were stored as 3-digit hex html chars  - `:&#039;(` - where in 2.1 they were stored as 2-digit hex html chars - `:&#39;(`.   Added a 3-digit search pattern to support 2.0 legacy cry smileys.
