### PR TITLE
Fix Unwatch Topic not working

### DIFF
--- a/Sources/Notify.php
+++ b/Sources/Notify.php
@@ -107,9 +107,6 @@ function TopicNotify()
 			$mode = (int) $_GET['mode'];
 			$alertPref = $mode <= 1 ? 0 : ($mode == 2 ? 1 : 3);
 
-			if (empty($mode))
-				$mode = 1;
-
 			$request = $smcFunc['db_query']('', '
 				SELECT id_member, id_topic, id_msg, unwatched
 				FROM {db_prefix}log_topics


### PR DESCRIPTION
There is already a similar test in line 132, this test here breaks the feature.

Before the fix:
If you mark the topic as "Not Following" it won't save that state, and the topic won't be added to the user's unwatched topics list. 