### PR TITLE
Preventing other profiles from crashing

### DIFF
--- a/Sources/Profile.php
+++ b/Sources/Profile.php
@@ -357,6 +357,7 @@ function ModifyProfile($post_errors = array())
 					'label' => $txt['report_profile'],
 					'custom_url' => $scripturl . '?action=reporttm;' . $context['session_var'] . '=' . $context['session_id'],
 					'icon' => 'warning',
+					'enabled' => allowedTo('profile_view'),
 					'permission' => array(
 						'own' => array(),
 						'any' => array('report_user'),
@@ -378,6 +379,7 @@ function ModifyProfile($post_errors = array())
 					'label' => $txt['profileBanUser'],
 					'custom_url' => $scripturl . '?action=admin;area=ban;sa=add',
 					'icon' => 'ban',
+					'enabled' => allowedTo('profile_view'),
 					'enabled' => $cur_profile['id_group'] != 1 && !in_array(1, explode(',', $cur_profile['additional_groups'])),
 					'permission' => array(
 						'own' => array(),

--- a/Sources/Profile.php
+++ b/Sources/Profile.php
@@ -379,7 +379,6 @@ function ModifyProfile($post_errors = array())
 					'label' => $txt['profileBanUser'],
 					'custom_url' => $scripturl . '?action=admin;area=ban;sa=add',
 					'icon' => 'ban',
-					'enabled' => allowedTo('profile_view'),
 					'enabled' => $cur_profile['id_group'] != 1 && !in_array(1, explode(',', $cur_profile['additional_groups'])),
 					'permission' => array(
 						'own' => array(),

--- a/Sources/Profile.php
+++ b/Sources/Profile.php
@@ -347,6 +347,7 @@ function ModifyProfile($post_errors = array())
 					'label' => $txt['profileSendIm'],
 					'custom_url' => $scripturl . '?action=pm;sa=send',
 					'icon' => 'personal_message',
+					'enabled' => allowedTo('profile_view'),
 					'permission' => array(
 						'own' => array(),
 						'any' => array('pm_send'),


### PR DESCRIPTION
This will prevent that the user gets an unexpected error (unable to load template) when viewing a different profile.
It only happens if the admin decided to disable permissions to view other profiles to a group and left the send pm options enabled.

Since it'd be the only button active the file would try to load a function to show something right before telling him he's not allowed to view other profiles.

Perhaps there's a better way to resolve this, but this one is the easiest for sure.