### PR TITLE
Permissions for Who's Online admin/mod centre

### DIFF
--- a/Sources/Who.php
+++ b/Sources/Who.php
@@ -273,20 +273,42 @@ function determineActions($urls, $preferred_prefix = false)
 		'ban' => array('manage_bans'),
 		'boardrecount' => array('admin_forum'),
 		'calendar' => array('calendar_view'),
+		'corefeatures' => array('admin_forum'),
 		'editnews' => array('edit_news'),
+		'featuresettings' => array('admin_forum'),
+		'languages' => array('admin_forum'),
+		'logs' => array('admin_forum'),
 		'mailing' => array('send_mail'),
+		'mailqueue' => array('admin_forum'),
 		'maintain' => array('admin_forum'),
 		'manageattachments' => array('manage_attachments'),
 		'manageboards' => array('manage_boards'),
+		'managecalendar' => array('admin_forum'),
+		'managesearch' => array('admin_forum'),
+		'managesmileys' => array('manage_smileys'),
+		'membergroups' => array('manage_membergroups'),
 		'mlist' => array('view_mlist'),
 		'moderate' => array('access_mod_center', 'moderate_forum', 'manage_membergroups'),
+		'modsettings' => array('admin_forum'),
+		'news' => array('edit_news', 'send_mail', 'admin_forum'),
 		'optimizetables' => array('admin_forum'),
+		'packages' => array('admin_forum'),
+		'paidsubscribe' => array('admin_forum'),
+		'permissions' => array('manage_permissions'),
+		'postsettings' => array('admin_forum'),
+		'regcenter' => array('admin_forum', 'moderate_forum'),
 		'repairboards' => array('admin_forum'),
+		'reports' => array('admin_forum'),
+		'scheduledtasks' => array('admin_forum'),
 		'search' => array('search_posts'),
 		'search2' => array('search_posts'),
+		'securitysettings' => array('admin_forum'),
+		'sengines' => array('admin_forum'),
+		'serversettings' => array('admin_forum'),
 		'setcensor' => array('moderate_forum'),
 		'setreserve' => array('moderate_forum'),
 		'stats' => array('view_stats'),
+		'theme' => array('admin_forum'),
 		'viewErrorLog' => array('admin_forum'),
 		'viewmembers' => array('moderate_forum'),
 	);
@@ -405,10 +427,6 @@ function determineActions($urls, $preferred_prefix = false)
 			{
 				if (allowedTo($allowedActions[$actions['action']]))
 					$data[$k] = $txt['whoallow_' . $actions['action']];
-				elseif (in_array('moderate_forum', $allowedActions[$actions['action']]))
-					$data[$k] = $txt['who_moderate'];
-				elseif (in_array('admin_forum', $allowedActions[$actions['action']]))
-					$data[$k] = $txt['who_admin'];
 				else
 					$data[$k] = $txt['who_hidden'];
 			}


### PR DESCRIPTION
Do not reveal admin and mod centre usage unless allowed to see it as per issue SimpleMachines/SMF2.1#4972

* Adds in all admin centre areas (except index) properly to the permissions checking array in Who.php
* Removes fallbacks that say something along the lines of 'using the admin panel' - only those with access to the admin panel should be able to see this.
* Does *not* add in the mod centre areas as they are harder to calculate permission for and have names that are likely to conflict with other actions.

Signed-off-by: James Robson <git@sorck.net>