### PR TITLE
Clarifies logic for deciding not to send new topic/reply notifications

### DIFF
--- a/Sources/tasks/CreatePost-Notify.php
+++ b/Sources/tasks/CreatePost-Notify.php
@@ -143,8 +143,14 @@ class CreatePost_Notify_Background extends SMF_BackgroundTask
 			elseif ($notify_types == self::NOTIFY_TYPE_NOTHING)
 				continue;
 
-			if (empty($frequency) || $frequency > self::FREQUENCY_FIRST_UNREAD_MSG || $data['sent']
-				|| (!empty($this->_details['members_only']) && !in_array($member, $this->_details['members_only'])))
+			// Don't send a notification if they don't want any...
+			if (in_array($frequency, array(self::FREQUENCY_NOTHING, self::FREQUENCY_DAILY_DIGEST, self::FREQUENCY_WEEKLY_DIGEST)))
+				continue;
+			// ... or if we already sent one and they don't want more...
+			elseif ($frequency === self::FREQUENCY_FIRST_UNREAD_MSG && $data['sent'])
+				continue;
+			// ... or if they aren't on the bouncer's list.
+			elseif (!empty($this->_details['members_only']) && !in_array($member, $this->_details['members_only']))
 				continue;
 
 			// Watched topic?

--- a/Sources/tasks/CreatePost-Notify.php
+++ b/Sources/tasks/CreatePost-Notify.php
@@ -29,7 +29,7 @@ class CreatePost_Notify_Background extends SMF_BackgroundTask
 	const NOTIFY_TYPE_REPLY_AND_MODIFY = 1;
 	const NOTIFY_TYPE_REPLY_AND_TOPIC_START_FOLLOWING = 2;
 	const NOTIFY_TYPE_ONLY_REPLIES = 3;
-	const NOTIFY_TYPE_NOTHING = 3;
+	const NOTIFY_TYPE_NOTHING = 4;
 
 	/**
 	 * Constants for frequencies.


### PR DESCRIPTION
Possibly fixes #4966, and fixes a bug described in https://www.simplemachines.org/community/index.php?topic=561369.0.

Also sets NOTIFY_TYPE_NOTHING constant to correct value.