### PR TITLE
Makes sure user IDs flow as integers in loadMemberData()

### DIFF
--- a/Sources/Load.php
+++ b/Sources/Load.php
@@ -1298,6 +1298,7 @@ function loadMemberData($users, $is_name = false, $set = 'normal')
 				$row['member_ip'] = inet_dtop($row['member_ip']);
 			if (isset($row['member_ip2']))
 				$row['member_ip2'] = inet_dtop($row['member_ip2']);
+			$row['id_member'] = (int) $row['id_member'];
 			$new_loaded_ids[] = $row['id_member'];
 			$loaded_ids[] = $row['id_member'];
 			$row['options'] = array();

--- a/Sources/Profile.php
+++ b/Sources/Profile.php
@@ -55,6 +55,7 @@ function ModifyProfile($post_errors = array())
 
 	// If all went well, we have a valid member ID!
 	list ($memID) = $memberResult;
+	$memID = (int) $memID;
 	$context['id_member'] = $memID;
 	$cur_profile = $user_profile[$memID];
 


### PR DESCRIPTION
Fixes an edge case cause of issue SimpleMachines/SMF2.1#4716

Makes sure member IDs are loaded as integers in loadMemberData() - this may be [MySQL sepcific](https://stackoverflow.com/questions/5323146/mysql-integer-field-is-returned-as-string-in-php) as $row['id_member'] has type string when connected to MySQL (not checked on PostgreSQL).

This also makes the id_member produce an integer in anything relying on loadMemberData() which makes the return an array of ints as expected under the SMF 2.0 function DB, rather than an array of strings.

Signed-off-by: James Robson <git@sorck.net>