### PR TITLE
Fix undefined index for cookie login time

### DIFF
--- a/Sources/Load.php
+++ b/Sources/Load.php
@@ -700,6 +700,15 @@ function loadUserSettings()
 
 		// We don't know the offset...
 		$user_info['time_offset'] = 0;
+
+		// Login Cookie times. Format: time => txt
+		$context['login_cookie_times'] = array(
+			60 => 'one_hour',
+			1440 => 'one_day',
+			10080 => 'one_week',
+			43200 => 'one_month',
+			3153600 => 'always_logged_in',
+		);
 	}
 
 	// Set up the $user_info array.

--- a/Sources/LogInOut.php
+++ b/Sources/LogInOut.php
@@ -64,15 +64,6 @@ function Login()
 
 	// Create a one time token.
 	createToken('login');
-
-	// Login Cookie times. Format: time => txt
-	$context['login_cookie_times'] = array(
-		60 => 'one_hour',
-		1440 => 'one_day',
-		10080 => 'one_week',
-		43200 => 'one_month',
-		3153600 => 'always_logged_in',
-	);
 }
 
 /**
@@ -192,15 +183,6 @@ function Login2()
 		$modSettings['cookieTime'] = 3153600;
 	elseif (!empty($_POST['cookielength']) && ($_POST['cookielength'] >= 1 && $_POST['cookielength'] <= 3153600))
 		$modSettings['cookieTime'] = (int) $_POST['cookielength'];
-
-	// Login Cookie times. Format: time => txt
-	$context['login_cookie_times'] = array(
-		60 => 'one_hour',
-		1440 => 'one_day',
-		10080 => 'one_week',
-		43200 => 'one_month',
-		3153600 => 'always_logged_in',
-	);
 
 	loadLanguage('Login');
 	// Load the template stuff.

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -6683,7 +6683,7 @@ function send_http_status($code, $status = '')
 	if (!isset($statuses[$code]) && empty($status))
 		header($protocol . ' 500 Internal Server Error');
 	else
-		header($protocol . ' ' . $code . ' ' . !empty($status) ? $status : $statuses[$code]);
+		header($protocol . ' ' . $code . ' ' . (!empty($status) ? $status : $statuses[$code]));
 }
 
 ?>


### PR DESCRIPTION
This fixes #4886 by moving it to the Load.php for guests only.

As well fixed a issue related to #4833 where maintenance mode can cause a issue with HTTP/2.0 with the spdy protocol.