### PR TITLE
Improve secret q/a by using a more modern hashing method.

### DIFF
--- a/Sources/Profile-Modify.php
+++ b/Sources/Profile-Modify.php
@@ -433,9 +433,9 @@ function loadProfileFields($force_reload = false)
 			'postinput' => '<span class="smalltext"><a href="' . $scripturl . '?action=helpadmin;help=secret_why_blank" onclick="return reqOverlayDiv(this.href);"><span class="generic_icons help"></span> ' . $txt['secret_why_blank'] . '</a></span>',
 			'value' => '',
 			'permission' => 'profile_password',
-			'input_validate' => function(&$value)
+			'input_validate' => function(&$value) use ($cur_profile)
 			{
-				$value = $value != '' ? md5($value) : '';
+				$value = $value != '' ? hash_password($cur_profile['member_name'], $value) : '';
 				return true;
 			},
 		),

--- a/Sources/Reminder.php
+++ b/Sources/Reminder.php
@@ -357,7 +357,7 @@ function SecretAnswer2()
 	$smcFunc['db_free_result']($request);
 
 	// Check if the secret answer is correct.
-	if ($row['secret_question'] == '' || $row['secret_answer'] == '' || md5($_POST['secret_answer']) != $row['secret_answer'])
+	if ($row['secret_question'] == '' || $row['secret_answer'] == '' || (!hash_verify_password($row['member_name'], $_POST['secret_answer'], $row['secret_answer']) && md5($_POST['secret_answer']) != $row['secret_answer']))
 	{
 		log_error(sprintf($txt['reminder_error'], $row['member_name']), 'user');
 		fatal_lang_error('incorrect_answer', false);

--- a/Sources/Reminder.php
+++ b/Sources/Reminder.php
@@ -356,7 +356,12 @@ function SecretAnswer2()
 	$row = $smcFunc['db_fetch_assoc']($request);
 	$smcFunc['db_free_result']($request);
 
-	// Check if the secret answer is correct.
+	/*
+	 * Check if the secret answer is correct.
+	 * In 2.1 this was changed to use hash_(verify_)passsword, same as the password. The length of the hash is 60 characters.
+	 * Prior to 2.1 this was a simple md5.  The length of the hash is 32 charccters.
+	 * For compatibility with older answers, we still check if a match occurs on md5.  As there is a difference in the hash lengths, there isn't a possiblity of a cross match between the hashes.  This will ensure in future answer updates will prevent md5 methods from working.
+	*/
 	if ($row['secret_question'] == '' || $row['secret_answer'] == '' || (!hash_verify_password($row['member_name'], $_POST['secret_answer'], $row['secret_answer']) && md5($_POST['secret_answer']) != $row['secret_answer']))
 	{
 		log_error(sprintf($txt['reminder_error'], $row['member_name']), 'user');


### PR DESCRIPTION
Fixes #3117 by using hash_password.  We do not convert old answers as we have no way to verify them.  We accept both md5 and hash_password_verify.  Due to the varying lengths of the two methods, we don't need to try and figure out the length first.  This doesn't attempt to convert the secret question upon successful answers.