### PR TITLE
Uses smarter logic to decide whether to show the message icon for a post

### DIFF
--- a/Themes/default/Display.template.php
+++ b/Themes/default/Display.template.php
@@ -685,7 +685,7 @@ function template_single_post($message)
 
 	echo '
 								<h5>
-									<span class="messageicon" ', ($message['icon_url'] !== $settings['images_url'] . '/post/xx.png') ? '' : 'style="position: absolute; z-index: -1;"', '>
+									<span class="messageicon" ', ($message['icon_url'] === $settings['images_url'] . '/post/xx.png' && !$message['can_modify']) ? ' style="position: absolute; z-index: -1;"' : '', '>
 										<img src="', $message['icon_url'] . '" alt=""', $message['can_modify'] ? ' id="msg_icon_' . $message['id'] . '"' : '', '>
 									</span>
 									<a href="', $message['href'], '" rel="nofollow" title="', !empty($message['counter']) ? sprintf($txt['reply_number'], $message['counter'], ' - ') : '', $message['subject'], '" class="smalltext">', $message['time'], '</a>


### PR DESCRIPTION
With this change, a message's icon will be shown (1) if it is not the standard one, or (2) if the user has the ability to modify it. This allows the icon to be changed from within the topic display even if the icon is currently the standard one.

Fixes #5007