### PR TITLE
 Always uses a fully qualified domain name in EHLO/HELO to SMTP host

### DIFF
--- a/Sources/Subs-Post.php
+++ b/Sources/Subs-Post.php
@@ -1322,22 +1322,9 @@ function smtp_mail($mail_to_array, $subject, $message, $headers)
 		elseif (function_exists('php_uname'))
 			$helo = php_uname('n');
 
-		// Local domains won't cut it, so look up the canonical one for $boardurl in DNS
+		// If the hostname isn't a fully qualified domain name, we can use the host name from $boardurl instead
 		if (empty($helo) || strpos($helo, '.') === false || substr_compare($helo, '.local', -6) === 0 || (!empty($modSettings['tld_regex']) && !preg_match('/\.' . $modSettings['tld_regex'] . '$/', $helo)))
-		{
 			$helo = parse_url($boardurl, PHP_URL_HOST);
-
-			if (function_exists('gethostbyaddr') && function_exists('dns_get_record'))
-			{
-				$dns_record = dns_get_record($helo, DNS_A);
-
-				if (empty($dns_record))
-					$dns_record = dns_get_record($helo, DNS_AAAA);
-
-				if (!empty($dns_record))
-					$helo = gethostbyaddr($dns_record['ip' . ($dns_record['type'] === 'AAAA' ? 'v6' : '')]);
-			}
-		}
 
 		// This is one of those situations where 'www.' is undesirable
 		if (strpos($helo, 'www.') === 0)

--- a/Sources/Subs-Post.php
+++ b/Sources/Subs-Post.php
@@ -1338,6 +1338,10 @@ function smtp_mail($mail_to_array, $subject, $message, $headers)
 					$helo = gethostbyaddr($dns_record['ip' . ($dns_record['type'] === 'AAAA' ? 'v6' : '')]);
 			}
 		}
+
+		// This is one of those situations where 'www.' is undesirable
+		if (strpos($helo, 'www.') === 0)
+			$helo = substr($helo, 4);
 	}
 
 	// SMTP = 1, SMTP - STARTTLS = 2

--- a/Sources/Subs-Post.php
+++ b/Sources/Subs-Post.php
@@ -1323,7 +1323,7 @@ function smtp_mail($mail_to_array, $subject, $message, $headers)
 			$helo = php_uname('n');
 
 		// If the hostname isn't a fully qualified domain name, we can use the host name from $boardurl instead
-		if (empty($helo) || strpos($helo, '.') === false || substr_compare($helo, '.local', -6) === 0 || (!empty($modSettings['tld_regex']) && !preg_match('/\.' . $modSettings['tld_regex'] . '$/', $helo)))
+		if (empty($helo) || strpos($helo, '.') === false || substr_compare($helo, '.local', -6) === 0 || (!empty($modSettings['tld_regex']) && !preg_match('/\.' . $modSettings['tld_regex'] . '$/u', $helo)))
 			$helo = parse_url($boardurl, PHP_URL_HOST);
 
 		// This is one of those situations where 'www.' is undesirable

--- a/Sources/Subs-Post.php
+++ b/Sources/Subs-Post.php
@@ -1327,8 +1327,17 @@ function smtp_mail($mail_to_array, $subject, $message, $headers)
 		{
 			$helo = parse_url($boardurl, PHP_URL_HOST);
 
-			if (function_exists('gethostbyaddr') && function_exists('gethostbyname'))
-				$helo = gethostbyaddr(gethostbyname($helo));
+			if (function_exists('gethostbyaddr') && function_exists('dns_get_record') && ($dns_record = dns_get_record($helo)))
+			{
+				foreach ($dns_record as $dns_rec)
+				{
+					if (in_array($dns_rec['type'], array('A', 'AAAA')))
+					{
+						$helo = gethostbyaddr($dns_rec['ip' . ($dns_rec['type'] === 'AAAA' ? 'v6' : '')]);
+						break;
+					}
+				}
+			}
 		}
 	}
 

--- a/Sources/Subs-Post.php
+++ b/Sources/Subs-Post.php
@@ -1323,7 +1323,7 @@ function smtp_mail($mail_to_array, $subject, $message, $headers)
 			$helo = php_uname('n');
 
 		// Local domains won't cut it, so look up the canonical one for $boardurl in DNS
-		if (empty($helo) || strpos($helo, '.') === false || substr_compare($helo, '.local', -6) === 0)
+		if (empty($helo) || strpos($helo, '.') === false || substr_compare($helo, '.local', -6) === 0 || (!empty($modSettings['tld_regex']) && !preg_match('/\.' . $modSettings['tld_regex'] . '$/', $helo)))
 		{
 			$helo = parse_url($boardurl, PHP_URL_HOST);
 

--- a/Sources/Subs-Post.php
+++ b/Sources/Subs-Post.php
@@ -1327,16 +1327,15 @@ function smtp_mail($mail_to_array, $subject, $message, $headers)
 		{
 			$helo = parse_url($boardurl, PHP_URL_HOST);
 
-			if (function_exists('gethostbyaddr') && function_exists('dns_get_record') && ($dns_record = dns_get_record($helo)))
+			if (function_exists('gethostbyaddr') && function_exists('dns_get_record'))
 			{
-				foreach ($dns_record as $dns_rec)
-				{
-					if (in_array($dns_rec['type'], array('A', 'AAAA')))
-					{
-						$helo = gethostbyaddr($dns_rec['ip' . ($dns_rec['type'] === 'AAAA' ? 'v6' : '')]);
-						break;
-					}
-				}
+				$dns_record = dns_get_record($helo, DNS_A);
+
+				if (empty($dns_record))
+					$dns_record = dns_get_record($helo, DNS_AAAA);
+
+				if (!empty($dns_record))
+					$helo = gethostbyaddr($dns_record['ip' . ($dns_record['type'] === 'AAAA' ? 'v6' : '')]);
 			}
 		}
 	}


### PR DESCRIPTION
Fixes #3997 by bringing our behaviour into compliance with [RFC 5321](https://tools.ietf.org/html/rfc5321).