### PR TITLE
use star when you want to count the complet table

### DIFF
--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -4626,7 +4626,7 @@ function setupMenuContext()
 		if (!isset($context['num_errors']))
 		{
 			$query = $smcFunc['db_query']('', '
-				SELECT COUNT(id_error)
+				SELECT COUNT(*)
 				FROM {db_prefix}log_errors',
 				array()
 			);


### PR DESCRIPTION
Only a code style change, since id_error is pk, behavior keeps the same.