### PR TITLE
Reduce the call of functions

### DIFF
--- a/Sources/Load.php
+++ b/Sources/Load.php
@@ -49,7 +49,8 @@ function reloadSettings()
 		if (!$request)
 			display_db_error();
 		$rows = $smcFunc['db_fetch_all']($request);
-		foreach ($rows as $row) {
+		foreach ($rows as $row)
+		{
 			$modSettings[$row['variable']] = $row['value'];
 		}
 		$smcFunc['db_free_result']($request);

--- a/Sources/Load.php
+++ b/Sources/Load.php
@@ -1809,8 +1809,7 @@ function loadTheme($id_theme = 0, $initialize = true)
 				)
 			);
 			// Pick between $settings and $options depending on whose data it is.
-			$rows = $smcFunc['db_fetch_all']($result);
-			foreach ($rows as $row)
+			foreach ($smcFunc['db_fetch_all']($result) as $row)
 			{
 				// There are just things we shouldn't be able to change as members.
 				if ($row['id_member'] != 0 && in_array($row['variable'], array('actual_theme_url', 'actual_images_url', 'base_theme_dir', 'base_theme_url', 'default_images_url', 'default_theme_dir', 'default_theme_url', 'default_template', 'images_url', 'number_recent_posts', 'smiley_sets_default', 'theme_dir', 'theme_id', 'theme_layers', 'theme_templates', 'theme_url')))
@@ -1825,7 +1824,6 @@ function loadTheme($id_theme = 0, $initialize = true)
 					$themeData[$row['id_member']][$row['variable']] = substr($row['variable'], 0, 5) == 'show_' ? $row['value'] == '1' : $row['value'];
 			}
 			$smcFunc['db_free_result']($result);
-			unset($rows);
 
 			if (!empty($themeData[-1]))
 				foreach ($themeData[-1] as $k => $v)

--- a/Sources/Load.php
+++ b/Sources/Load.php
@@ -48,13 +48,11 @@ function reloadSettings()
 		$modSettings = array();
 		if (!$request)
 			display_db_error();
-		$rows = $smcFunc['db_fetch_all']($request);
-		foreach ($rows as $row)
+		foreach ($smcFunc['db_fetch_all']($request) as $row)
 		{
 			$modSettings[$row['variable']] = $row['value'];
 		}
 		$smcFunc['db_free_result']($request);
-		unset($rows);
 
 		// Do a few things to protect against missing settings or settings with invalid values...
 		if (empty($modSettings['defaultMaxTopics']) || $modSettings['defaultMaxTopics'] <= 0 || $modSettings['defaultMaxTopics'] > 999)

--- a/Sources/Load.php
+++ b/Sources/Load.php
@@ -48,9 +48,14 @@ function reloadSettings()
 		$modSettings = array();
 		if (!$request)
 			display_db_error();
-		while ($row = $smcFunc['db_fetch_row']($request))
-			$modSettings[$row[0]] = $row[1];
+		$rows = $smcFunc['db_fetch_all']($request);
+		foreach ($rows as $row) {
+			$modSettings[$row['variable']] = $row['value'];
+		}
+		//while ($row = $smcFunc['db_fetch_row']($request))
+		//	$modSettings[$row[0]] = $row[1];
 		$smcFunc['db_free_result']($request);
+		unset($rows);
 
 		// Do a few things to protect against missing settings or settings with invalid values...
 		if (empty($modSettings['defaultMaxTopics']) || $modSettings['defaultMaxTopics'] <= 0 || $modSettings['defaultMaxTopics'] > 999)

--- a/Sources/Load.php
+++ b/Sources/Load.php
@@ -49,9 +49,7 @@ function reloadSettings()
 		if (!$request)
 			display_db_error();
 		foreach ($smcFunc['db_fetch_all']($request) as $row)
-		{
 			$modSettings[$row['variable']] = $row['value'];
-		}
 		$smcFunc['db_free_result']($request);
 
 		// Do a few things to protect against missing settings or settings with invalid values...

--- a/Sources/Load.php
+++ b/Sources/Load.php
@@ -1811,7 +1811,8 @@ function loadTheme($id_theme = 0, $initialize = true)
 				)
 			);
 			// Pick between $settings and $options depending on whose data it is.
-			while ($row = $smcFunc['db_fetch_assoc']($result))
+			$rows = $smcFunc['db_fetch_all']($result);
+			foreach ($rows as $row)
 			{
 				// There are just things we shouldn't be able to change as members.
 				if ($row['id_member'] != 0 && in_array($row['variable'], array('actual_theme_url', 'actual_images_url', 'base_theme_dir', 'base_theme_url', 'default_images_url', 'default_theme_dir', 'default_theme_url', 'default_template', 'images_url', 'number_recent_posts', 'smiley_sets_default', 'theme_dir', 'theme_id', 'theme_layers', 'theme_templates', 'theme_url')))
@@ -1826,6 +1827,7 @@ function loadTheme($id_theme = 0, $initialize = true)
 					$themeData[$row['id_member']][$row['variable']] = substr($row['variable'], 0, 5) == 'show_' ? $row['value'] == '1' : $row['value'];
 			}
 			$smcFunc['db_free_result']($result);
+			unset($rows);
 
 			if (!empty($themeData[-1]))
 				foreach ($themeData[-1] as $k => $v)

--- a/Sources/Load.php
+++ b/Sources/Load.php
@@ -52,8 +52,6 @@ function reloadSettings()
 		foreach ($rows as $row) {
 			$modSettings[$row['variable']] = $row['value'];
 		}
-		//while ($row = $smcFunc['db_fetch_row']($request))
-		//	$modSettings[$row[0]] = $row[1];
 		$smcFunc['db_free_result']($request);
 		unset($rows);
 

--- a/Sources/Subs-BoardIndex.php
+++ b/Sources/Subs-BoardIndex.php
@@ -130,8 +130,6 @@ function getBoardIndex($boardIndexOptions)
 
 	// Children can affect parents, so we need to gather all the boards first and then process them after.
 	$row_boards = array();
-	
-
 	foreach ($smcFunc['db_fetch_all']($result_boards) as $row)
 		$row_boards[$row['id_board']] = $row;
 	$smcFunc['db_free_result']($result_boards);;

--- a/Sources/Subs-BoardIndex.php
+++ b/Sources/Subs-BoardIndex.php
@@ -129,9 +129,14 @@ function getBoardIndex($boardIndexOptions)
 
 	// Children can affect parents, so we need to gather all the boards first and then process them after.
 	$row_boards = array();
-	while ($row_board = $smcFunc['db_fetch_assoc']($result_boards))
-		$row_boards[$row_board['id_board']] = $row_board;
+	$row_boards_fetch = $smcFunc['db_fetch_all']($result_boards);
+	foreach ($row_boards_fetch as $value) {
+		$row_boards[$value['id_board']] = $value;
+	}
+	//while ($row_board = $smcFunc['db_fetch_assoc']($result_boards))
+	//	$row_boards[$row_board['id_board']] = $row_board;
 	$smcFunc['db_free_result']($result_boards);
+	unset($row_boards_fetch);
 
 	// Run through the categories and boards (or only boards)....
 	for (reset($row_boards); key($row_boards)!==null; next($row_boards))

--- a/Sources/Subs-BoardIndex.php
+++ b/Sources/Subs-BoardIndex.php
@@ -130,15 +130,13 @@ function getBoardIndex($boardIndexOptions)
 
 	// Children can affect parents, so we need to gather all the boards first and then process them after.
 	$row_boards = array();
-	$row_boards_fetch = $smcFunc['db_fetch_all']($result_boards);
 	
-	if(is_array($row_boards_fetch))
-		foreach ($row_boards_fetch as $row)
-		{
-			$row_boards[$row['id_board']] = $row;
-		}
-	$smcFunc['db_free_result']($result_boards);
-	unset($row_boards_fetch);
+
+	foreach ($smcFunc['db_fetch_all']($result_boards) as $row)
+	{
+		$row_boards[$row['id_board']] = $row;
+	}
+	$smcFunc['db_free_result']($result_boards);;
 
 	// Run through the categories and boards (or only boards)....
 	for (reset($row_boards); key($row_boards)!==null; next($row_boards))

--- a/Sources/Subs-BoardIndex.php
+++ b/Sources/Subs-BoardIndex.php
@@ -131,11 +131,9 @@ function getBoardIndex($boardIndexOptions)
 	// Children can affect parents, so we need to gather all the boards first and then process them after.
 	$row_boards = array();
 	$row_boards_fetch = $smcFunc['db_fetch_all']($result_boards);
-	foreach ($row_boards_fetch as $value) {
-		$row_boards[$value['id_board']] = $value;
+	foreach ($row_boards_fetch as $row) {
+		$row_boards[$row['id_board']] = $row;
 	}
-	//while ($row_board = $smcFunc['db_fetch_assoc']($result_boards))
-	//	$row_boards[$row_board['id_board']] = $row_board;
 	$smcFunc['db_free_result']($result_boards);
 	unset($row_boards_fetch);
 

--- a/Sources/Subs-BoardIndex.php
+++ b/Sources/Subs-BoardIndex.php
@@ -133,9 +133,7 @@ function getBoardIndex($boardIndexOptions)
 	
 
 	foreach ($smcFunc['db_fetch_all']($result_boards) as $row)
-	{
 		$row_boards[$row['id_board']] = $row;
-	}
 	$smcFunc['db_free_result']($result_boards);;
 
 	// Run through the categories and boards (or only boards)....

--- a/Sources/Subs-BoardIndex.php
+++ b/Sources/Subs-BoardIndex.php
@@ -131,7 +131,8 @@ function getBoardIndex($boardIndexOptions)
 	// Children can affect parents, so we need to gather all the boards first and then process them after.
 	$row_boards = array();
 	$row_boards_fetch = $smcFunc['db_fetch_all']($result_boards);
-	foreach ($row_boards_fetch as $row) {
+	foreach ($row_boards_fetch as $row)
+	{
 		$row_boards[$row['id_board']] = $row;
 	}
 	$smcFunc['db_free_result']($result_boards);

--- a/Sources/Subs-BoardIndex.php
+++ b/Sources/Subs-BoardIndex.php
@@ -131,10 +131,12 @@ function getBoardIndex($boardIndexOptions)
 	// Children can affect parents, so we need to gather all the boards first and then process them after.
 	$row_boards = array();
 	$row_boards_fetch = $smcFunc['db_fetch_all']($result_boards);
-	foreach ($row_boards_fetch as $row)
-	{
-		$row_boards[$row['id_board']] = $row;
-	}
+	
+	if(is_array($row_boards_fetch))
+		foreach ($row_boards_fetch as $row)
+		{
+			$row_boards[$row['id_board']] = $row;
+		}
 	$smcFunc['db_free_result']($result_boards);
 	unset($row_boards_fetch);
 

--- a/Sources/Subs-BoardIndex.php
+++ b/Sources/Subs-BoardIndex.php
@@ -132,7 +132,7 @@ function getBoardIndex($boardIndexOptions)
 	$row_boards = array();
 	foreach ($smcFunc['db_fetch_all']($result_boards) as $row)
 		$row_boards[$row['id_board']] = $row;
-	$smcFunc['db_free_result']($result_boards);;
+	$smcFunc['db_free_result']($result_boards);
 
 	// Run through the categories and boards (or only boards)....
 	for (reset($row_boards); key($row_boards)!==null; next($row_boards))

--- a/Sources/Subs-Boards.php
+++ b/Sources/Subs-Boards.php
@@ -1158,13 +1158,21 @@ function getTreeOrder()
 		ORDER BY b.board_order',
 		array()
 	);
-	while ($row = $smcFunc['db_fetch_assoc']($request))
+	$rows = $smcFunc['db_fetch_all']($request);
+	foreach ($rows as $value)
 	{
-		if (!in_array($row['id_cat'], $tree_order['cats']))
-			$tree_order['cats'][] = $row['id_cat'];
-		$tree_order['boards'][] = $row['id_board'];
+		if (!in_array($value['id_cat'], $tree_order['cats']))
+			$tree_order['cats'][] = $value['id_cat'];
+		$tree_order['boards'][] = $value['id_board'];
 	}
+	//while ($row = $smcFunc['db_fetch_assoc']($request))
+	//{
+	//	if (!in_array($row['id_cat'], $tree_order['cats']))
+	//		$tree_order['cats'][] = $row['id_cat'];
+	//	$tree_order['boards'][] = $row['id_board'];
+	//}
 	$smcFunc['db_free_result']($request);
+	unset($rows);
 
 	cache_put_data('board_order', $tree_order, 86400);
 

--- a/Sources/Subs-Boards.php
+++ b/Sources/Subs-Boards.php
@@ -1226,15 +1226,14 @@ function getTreeOrder()
 		ORDER BY b.board_order',
 		array()
 	);
-	$rows = $smcFunc['db_fetch_all']($request);
-	foreach ($rows as $row)
+
+	foreach ($smcFunc['db_fetch_all']($request) as $row)
 	{
 		if (!in_array($row['id_cat'], $tree_order['cats']))
 			$tree_order['cats'][] = $row['id_cat'];
 		$tree_order['boards'][] = $row['id_board'];
 	}
 	$smcFunc['db_free_result']($request);
-	unset($rows);
 
 	cache_put_data('board_order', $tree_order, 86400);
 

--- a/Sources/Subs-Boards.php
+++ b/Sources/Subs-Boards.php
@@ -1227,18 +1227,12 @@ function getTreeOrder()
 		array()
 	);
 	$rows = $smcFunc['db_fetch_all']($request);
-	foreach ($rows as $value)
+	foreach ($rows as $row)
 	{
-		if (!in_array($value['id_cat'], $tree_order['cats']))
-			$tree_order['cats'][] = $value['id_cat'];
-		$tree_order['boards'][] = $value['id_board'];
+		if (!in_array($row['id_cat'], $tree_order['cats']))
+			$tree_order['cats'][] = $row['id_cat'];
+		$tree_order['boards'][] = $row['id_board'];
 	}
-	//while ($row = $smcFunc['db_fetch_assoc']($request))
-	//{
-	//	if (!in_array($row['id_cat'], $tree_order['cats']))
-	//		$tree_order['cats'][] = $row['id_cat'];
-	//	$tree_order['boards'][] = $row['id_board'];
-	//}
 	$smcFunc['db_free_result']($request);
 	unset($rows);
 

--- a/Sources/Subs-Db-mysql.php
+++ b/Sources/Subs-Db-mysql.php
@@ -967,7 +967,7 @@ function smf_is_resource($result)
 function smf_db_fetch_all($request)
 {
 	// Return the right row.
-	$return = mysqli_fetch_all($request);
+	$return = mysqli_fetch_all($request, MYSQLI_ASSOC);
 	return !empty($return) ? $return : array();
 }
 

--- a/Sources/Subs-Db-mysql.php
+++ b/Sources/Subs-Db-mysql.php
@@ -967,7 +967,8 @@ function smf_is_resource($result)
 function smf_db_fetch_all($request)
 {
 	// Return the right row.
-	return mysqli_fetch_all($request);
+	$return = mysqli_fetch_all($request);
+	return !empty($return) ? $return : array();
 }
 
 /**

--- a/Sources/Subs-Db-mysql.php
+++ b/Sources/Subs-Db-mysql.php
@@ -967,7 +967,14 @@ function smf_is_resource($result)
 function smf_db_fetch_all($request)
 {
 	// Return the right row.
-	$return = mysqli_fetch_all($request, MYSQLI_ASSOC);
+	if (function_exists('mysqli_fetch_all'))
+		$return = mysqli_fetch_all($request, MYSQLI_ASSOC);
+	else
+	{
+		$return = array();
+		while($row = mysqli_fetch_assoc($request))
+			$return[] = $row;
+	}
 	return !empty($return) ? $return : array();
 }
 

--- a/Sources/Subs-Db-postgresql.php
+++ b/Sources/Subs-Db-postgresql.php
@@ -40,11 +40,11 @@ function smf_db_initiate($db_server, $db_name, $db_user, $db_passwd, &$db_prefix
 			'db_quote'                  => 'smf_db_quote',
 			'db_insert'                 => 'smf_db_insert',
 			'db_insert_id'              => 'smf_db_insert_id',
-			'db_fetch_assoc'            => 'smf_db_fetch_assoc',
-			'db_fetch_row'              => 'smf_db_fetch_row',
+			'db_fetch_assoc'            => 'pg_fetch_assoc',
+			'db_fetch_row'              => 'pg_fetch_row',
 			'db_free_result'            => 'pg_free_result',
 			'db_num_rows'               => 'pg_num_rows',
-			'db_data_seek'              => 'smf_db_data_seek',
+			'db_data_seek'              => 'pg_result_seek',
 			'db_num_fields'             => 'pg_num_fields',
 			'db_escape_string'          => 'smf_db_escape_string',
 			'db_unescape_string'        => 'stripslashes',
@@ -615,42 +615,6 @@ function smf_db_error($db_string, $connection = null)
 
 	// It's already been logged... don't log it again.
 	fatal_error($context['error_message'], false);
-}
-
-/**
- * A PostgreSQL specific function for tracking the current row...
- *
- * @param resource $request A PostgreSQL result resource
- * @return array The contents of the row that was fetched
- */
-function smf_db_fetch_row($request)
-{
-	// Return the right row.
-	return @pg_fetch_row($request);
-}
-
-/**
- * Get an associative array
- *
- * @param resource $request A PostgreSQL result resource
- * @return array An associative array of row contents
- */
-function smf_db_fetch_assoc($request)
-{
-	// Return the right row.
-	return @pg_fetch_assoc($request);
-}
-
-/**
- * Reset the pointer...
- *
- * @param resource $request A PostgreSQL result resource
- * @param int $counter The counter
- * @return bool Always returns true
- */
-function smf_db_data_seek($request, $counter)
-{
-	return pg_result_seek($request, $counter);
 }
 
 /**

--- a/Sources/Subs-Db-postgresql.php
+++ b/Sources/Subs-Db-postgresql.php
@@ -955,7 +955,8 @@ function smf_db_escape_wildcard_string($string, $translate_human_wildcards = fal
 function smf_db_fetch_all($request)
 {
 	// Return the right row.
-	return @pg_fetch_all($request);
+	$return = @pg_fetch_all($request);
+	return !empty($return) ? $return : array();
 }
 
 /**

--- a/Sources/Subs-Db-postgresql.php
+++ b/Sources/Subs-Db-postgresql.php
@@ -621,44 +621,24 @@ function smf_db_error($db_string, $connection = null)
  * A PostgreSQL specific function for tracking the current row...
  *
  * @param resource $request A PostgreSQL result resource
- * @param bool|int $counter The row number in the result to fetch (false to fetch the next one)
  * @return array The contents of the row that was fetched
  */
-function smf_db_fetch_row($request, $counter = false)
+function smf_db_fetch_row($request)
 {
-	global $db_row_count;
-
-	if ($counter !== false)
-		return pg_fetch_row($request, $counter);
-
-	// Reset the row counter...
-	if (!isset($db_row_count[(int) $request]))
-		$db_row_count[(int) $request] = 0;
-
 	// Return the right row.
-	return @pg_fetch_row($request, $db_row_count[(int) $request]++);
+	return @pg_fetch_row($request);
 }
 
 /**
  * Get an associative array
  *
  * @param resource $request A PostgreSQL result resource
- * @param int|bool $counter The row to get. If false, returns the next row.
  * @return array An associative array of row contents
  */
-function smf_db_fetch_assoc($request, $counter = false)
+function smf_db_fetch_assoc($request)
 {
-	global $db_row_count;
-
-	if ($counter !== false)
-		return pg_fetch_assoc($request, $counter);
-
-	// Reset the row counter...
-	if (!isset($db_row_count[(int) $request]))
-		$db_row_count[(int) $request] = 0;
-
 	// Return the right row.
-	return @pg_fetch_assoc($request, $db_row_count[(int) $request]++);
+	return @pg_fetch_assoc($request);
 }
 
 /**
@@ -670,11 +650,7 @@ function smf_db_fetch_assoc($request, $counter = false)
  */
 function smf_db_data_seek($request, $counter)
 {
-	global $db_row_count;
-
-	$db_row_count[(int) $request] = $counter;
-
-	return true;
+	return pg_result_seek($request, $counter);
 }
 
 /**

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -741,7 +741,7 @@ function comma_format($number, $override_decimal_count = false)
 function timeformat($log_time, $show_today = true, $offset_type = false, $process_safe = false)
 {
 	global $context, $user_info, $txt, $modSettings;
-	static $non_twelve_hour, $locale_cache;
+	static $non_twelve_hour, $locale_cache, $now;
 	static $unsupportedFormats, $finalizedFormats;
 
 	$unsupportedFormatsWindows = array('z','Z');
@@ -768,10 +768,10 @@ function timeformat($log_time, $show_today = true, $offset_type = false, $proces
 	if ($modSettings['todayMod'] >= 1 && $show_today === true)
 	{
 		// Get the current time.
-		$nowtime = forum_time();
+		//$nowtime = forum_time();
 
 		$then = @getdate($time);
-		$now = @getdate($nowtime);
+		$now = (!empty($now) ? $now : @getdate(forum_time()));
 
 		// Try to make something of a time format string...
 		$s = strpos($user_info['time_format'], '%S') === false ? '' : ':%S';

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -767,9 +767,6 @@ function timeformat($log_time, $show_today = true, $offset_type = false, $proces
 	// Today and Yesterday?
 	if ($modSettings['todayMod'] >= 1 && $show_today === true)
 	{
-		// Get the current time.
-		//$nowtime = forum_time();
-
 		$then = @getdate($time);
 		$now = (!empty($now) ? $now : @getdate(forum_time()));
 


### PR DESCRIPTION
Well the idea less amount of context switch = faster,
but to be ownest my php env is so "fast" that i didn't measure any improvments.

What i notice in my profile data,
the smf_db_fetch_assoc  and smf_db_fetch_row take "big" amount of time in compare to the native part which is called internaly:
![grafik](https://user-images.githubusercontent.com/1782906/46882608-8f7ef300-ce4f-11e8-992e-fbe6c47411cb.png)

Since i believe the script runs long enough that a day switch is between,
I define $now as static -> again less amount of calls.