### PR TITLE
Displaying filter, Add/Remove buddy, unapproved Members amount

### DIFF
--- a/Sources/ManageMembers.php
+++ b/Sources/ManageMembers.php
@@ -1012,8 +1012,8 @@ function MembersAwaitingActivation()
 	if (!empty($context['show_filter']) && !empty($context['available_filters']))
 		$listOptions['additional_rows'][] = array(
 			'position' => 'above_column_headers',
-			'value' => '<strong>' . $txt['admin_browse_filter_show'] . ':</strong> ' . $context['available_filters'][0]['desc'],
-			'class' => 'smalltext floatright',
+			'value' => '<strong>' . $txt['admin_browse_filter_show'] . ':</strong> ' . ((isset($context['current_filter']) && isset($txt['admin_browse_filter_type_'.$context['current_filter']])) ? $txt['admin_browse_filter_type_'.$context['current_filter']] : $context['available_filters'][0]['desc']),
+			'class' => 'filter_row generic_list_wrapper smalltext',
 		);
 
 	// Now that we have all the options, create the list.

--- a/Sources/Profile-View.php
+++ b/Sources/Profile-View.php
@@ -30,7 +30,7 @@ function summary($memID)
 	$context += array(
 		'page_title' => sprintf($txt['profile_of_username'], $memberContext[$memID]['name']),
 		'can_send_pm' => allowedTo('pm_send'),
-		'can_have_buddy' => allowedTo('profile_identity_own') && !empty($modSettings['enable_buddylist']),
+		'can_have_buddy' => allowedTo('profile_extra_own') && !empty($modSettings['enable_buddylist']),
 		'can_issue_warning' => allowedTo('issue_warning') && $modSettings['warning_settings'][0] == 1,
 		'can_view_warning' => (allowedTo('moderate_forum') || allowedTo('issue_warning') || allowedTo('view_warning_any') || ($context['user']['is_owner'] && allowedTo('view_warning_own')) && $modSettings['warning_settings'][0] === 1)
 	);

--- a/Sources/Subs-Members.php
+++ b/Sources/Subs-Members.php
@@ -1255,7 +1255,7 @@ function BuddyListToggle()
 
 	checkSession('get');
 
-	isAllowedTo('profile_identity_own');
+	isAllowedTo('profile_extra_own');
 	is_not_guest();
 
 	$userReceiver = (int) !empty($_REQUEST['u']) ? $_REQUEST['u'] : 0;

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -108,7 +108,7 @@ function updateStats($type, $parameter1 = null, $parameter2 = null)
 					}
 
 					// What about unapproved COPPA registrations?
-					if (!empty($modSettings['coppaType']) && $modSettings['coppaType'] != 1)
+					if (!empty($modSettings['coppaType']) && $modSettings['coppaType'] != 0)
 					{
 						$result = $smcFunc['db_query']('', '
 						SELECT COUNT(*)
@@ -3326,7 +3326,7 @@ function setupThemeContext($forceload = false)
 		$_SESSION['unread_messages'] = $user_info['unread_messages'];
 
 		if (allowedTo('moderate_forum'))
-			$context['unapproved_members'] = (!empty($modSettings['registration_method']) && ($modSettings['registration_method'] == 2 || (!empty($modSettings['coppaType']) && $modSettings['coppaType'] == 2))) || !empty($modSettings['approveAccountDeletion']) ? $modSettings['unapprovedMembers'] : 0;
+			$context['unapproved_members'] = !empty($modSettings['unapprovedMembers']) ? $modSettings['unapprovedMembers'] : 0;
 
 		$context['user']['avatar'] = array();
 

--- a/Themes/default/css/index.css
+++ b/Themes/default/css/index.css
@@ -2970,7 +2970,7 @@ span.postby {
 
 /* MessageIndex */
 /* Start with description and other things */
-#description_board {
+#description_board, .filter_row {
 	padding: 8px 10px;
 	border-radius: 6px 6px 0 0;
 	border-bottom: none;


### PR DESCRIPTION
1. Fixes Displaying X filter #5009 
For example If you change the type of approval from new registrations to account deletions or underaged approvals the Displaying x filter message doesn't switch to the current filter
This pr also makes the display of current filter better.

2. Fixes Add/Remove Buddy link permission in profile #4998 
The buddy/ignore list section of the profile uses profile_extra_own perm, however the Buddy link in another person 's profile uses profile_identity_own perm, so they have to both use the same perm otherwise it doesn't make sense

3. Fix unapproved members logic #5008 
The logic used checks if the registration method is approval or profile deletions require approval in order to show the amount of unapproved member registrations/deletions which is wrong. If you have X unapproved members but then you change the registration method to anything other than approval AND you turn off profile deletion approval. You no longer get the amount of unapproved members.

It should just check if there's anything to approve at all and show how many, no needless checks