### PR TITLE
Call less timeformat in boardindex

### DIFF
--- a/Sources/Subs-BoardIndex.php
+++ b/Sources/Subs-BoardIndex.php
@@ -353,11 +353,6 @@ function getBoardIndex($boardIndexOptions)
 		{
 			$this_last_post['href'] = $scripturl . '?topic=' . $row_board['id_topic'] . '.msg' . ($user_info['is_guest'] ? $row_board['id_msg'] : $row_board['new_from']) . (empty($row_board['is_read']) ? ';boardseen' : '') . '#new';
 			$this_last_post['link'] = '<a href="' . $this_last_post['href'] . '" title="' . $row_board['subject'] . '">' . $row_board['short_subject'] . '</a>';
-			/* The board's and children's 'last_post's have:
-			time, timestamp (a number that represents the time.), id (of the post), topic (topic id.),
-			link, href, subject, start (where they should go for the first unread post.),
-			and member. (which has id, name, link, href, username in it.) */
-			//$this_last_post['last_post_message'] = sprintf($txt['last_post_message'], $this_last_post['member']['link'], $this_last_post['link'], $this_last_post['time']);
 		}
 		else
 		{
@@ -391,6 +386,11 @@ function getBoardIndex($boardIndexOptions)
 			);
 	}
 	
+	/* The board's and children's 'last_post's have:
+	time, timestamp (a number that represents the time.), id (of the post), topic (topic id.),
+	link, href, subject, start (where they should go for the first unread post.),
+	and member. (which has id, name, link, href, username in it.) 
+	timeformat is a pricy call do it only for thos how get shown */
 	if ($boardIndexOptions['include_categories'])
 		foreach ($categories as &$category)
 		{

--- a/Sources/Subs-BoardIndex.php
+++ b/Sources/Subs-BoardIndex.php
@@ -327,7 +327,7 @@ function getBoardIndex($boardIndexOptions)
 		$row_board['short_subject'] = shorten_subject($row_board['subject'], 24);
 		$this_last_post = array(
 			'id' => $row_board['id_msg'],
-			'time' => $row_board['poster_time'] > 0 ? timeformat($row_board['poster_time']) : $txt['not_applicable'],
+			'time' => $row_board['poster_time'],
 			'timestamp' => forum_time(true, $row_board['poster_time']),
 			'subject' => $row_board['short_subject'],
 			'member' => array(
@@ -357,7 +357,7 @@ function getBoardIndex($boardIndexOptions)
 			time, timestamp (a number that represents the time.), id (of the post), topic (topic id.),
 			link, href, subject, start (where they should go for the first unread post.),
 			and member. (which has id, name, link, href, username in it.) */
-			$this_last_post['last_post_message'] = sprintf($txt['last_post_message'], $this_last_post['member']['link'], $this_last_post['link'], $this_last_post['time']);
+			//$this_last_post['last_post_message'] = sprintf($txt['last_post_message'], $this_last_post['member']['link'], $this_last_post['link'], $this_last_post['time']);
 		}
 		else
 		{
@@ -389,6 +389,16 @@ function getBoardIndex($boardIndexOptions)
 				'timestamp' => $row_board['poster_time'],
 				'ref' => &$this_category[$isChild ? $row_board['id_parent'] : $row_board['id_board']]['last_post'],
 			);
+	}
+	
+	foreach ($categories as &$category)
+	{
+		foreach ($category['boards'] as &$board )
+		{
+			if (empty($board['last_post']))
+				continue;
+			$board['last_post']['last_post_message'] = sprintf($txt['last_post_message'], $board['last_post']['member']['link'], $board['last_post']['link'], $board['last_post']['time'] > 0 ? timeformat($board['last_post']['time']) : $txt['not_applicable']);
+		}
 	}
 
 	// Fetch the board's moderators and moderator groups

--- a/Sources/Subs-BoardIndex.php
+++ b/Sources/Subs-BoardIndex.php
@@ -48,7 +48,7 @@ function getBoardIndex($boardIndexOptions)
 		$modSettings['boardindex_max_depth'] = 1;
 
 	// Find all boards and categories, as well as related information.  This will be sorted by the natural order of boards and categories, which we control.
-	if ($boardIndexOptions['parent_id'] != 0 && $smcFunc['db_cte_support']())
+	if ($boardIndexOptions['parent_id'] != 0 && $smcFunc['db_cte_support']() && false)
 		$result_boards = $smcFunc['db_query']('', '
 			WITH RECURSIVE 
 				boards_cte (child_level, id_board, name , description, redirect, num_posts, num_topics, unapproved_posts, unapproved_topics, id_parent, id_msg_updated, id_cat, id_last_msg, board_order)
@@ -391,15 +391,23 @@ function getBoardIndex($boardIndexOptions)
 			);
 	}
 	
-	foreach ($categories as &$category)
-	{
-		foreach ($category['boards'] as &$board )
+	if (!empty($categories))
+		foreach ($categories as &$category)
+		{
+			foreach ($category['boards'] as &$board )
+			{
+				if (empty($board['last_post']))
+					continue;
+				$board['last_post']['last_post_message'] = sprintf($txt['last_post_message'], $board['last_post']['member']['link'], $board['last_post']['link'], $board['last_post']['time'] > 0 ? timeformat($board['last_post']['time']) : $txt['not_applicable']);
+			}
+		}
+	else
+		foreach ($this_category as &$board )
 		{
 			if (empty($board['last_post']))
 				continue;
 			$board['last_post']['last_post_message'] = sprintf($txt['last_post_message'], $board['last_post']['member']['link'], $board['last_post']['link'], $board['last_post']['time'] > 0 ? timeformat($board['last_post']['time']) : $txt['not_applicable']);
 		}
-	}
 
 	// Fetch the board's moderators and moderator groups
 	$boards = array_unique($boards);

--- a/Sources/Subs-BoardIndex.php
+++ b/Sources/Subs-BoardIndex.php
@@ -391,73 +391,57 @@ function getBoardIndex($boardIndexOptions)
 	link, href, subject, start (where they should go for the first unread post.),
 	and member. (which has id, name, link, href, username in it.) 
 	timeformat is a pricy call do it only for thos how get shown */
-	if ($boardIndexOptions['include_categories'])
-		foreach ($categories as &$category)
-		{
-			foreach ($category['boards'] as &$board )
-			{
-				if (empty($board['last_post']))
-					continue;
-				$board['last_post']['last_post_message'] = sprintf($txt['last_post_message'], $board['last_post']['member']['link'], $board['last_post']['link'], $board['last_post']['time'] > 0 ? timeformat($board['last_post']['time']) : $txt['not_applicable']);
-			}
-		}
-	else
-		foreach ($this_category as &$board )
-		{
-			if (empty($board['last_post']))
-				continue;
-			$board['last_post']['last_post_message'] = sprintf($txt['last_post_message'], $board['last_post']['member']['link'], $board['last_post']['link'], $board['last_post']['time'] > 0 ? timeformat($board['last_post']['time']) : $txt['not_applicable']);
-		}
-
 	// Fetch the board's moderators and moderator groups
 	$boards = array_unique($boards);
 	$moderators = getBoardModerators($boards);
 	$groups = getBoardModeratorGroups($boards);
 	if ($boardIndexOptions['include_categories'])
-	{
-		foreach ($categories as $k => $category)
+		foreach ($categories as &$category)
 		{
-			foreach ($category['boards'] as $j => $board)
+			foreach ($category['boards'] as &$board )
 			{
 				if (!empty($moderators[$board['id']]))
 				{
-					$categories[$k]['boards'][$j]['moderators'] = $moderators[$board['id']];
+					$board['moderators'] = $moderators[$board['id']];
 					foreach ($moderators[$board['id']] as $moderator)
-						$categories[$k]['boards'][$j]['link_moderators'][] = $moderator['link'];
+						$board['link_moderators'][] = $moderator['link'];
 				}
 				if (!empty($groups[$board['id']]))
 				{
-					$categories[$k]['boards'][$j]['moderator_groups'] = $groups[$board['id']];
+					$board['moderator_groups'] = $groups[$board['id']];
 					foreach ($groups[$board['id']] as $group)
 					{
-						$categories[$k]['boards'][$j]['link_moderators'][] = $group['link'];
-						$categories[$k]['boards'][$j]['link_moderator_groups'][] = $group['link'];
+						$board['link_moderators'][] = $group['link'];
+						$board['link_moderator_groups'][] = $group['link'];
 					}
 				}
+				if (!empty($board['last_post']))
+					$board['last_post']['last_post_message'] = sprintf($txt['last_post_message'], $board['last_post']['member']['link'], $board['last_post']['link'], $board['last_post']['time'] > 0 ? timeformat($board['last_post']['time']) : $txt['not_applicable']);
 			}
 		}
-	}
 	else
-	{
-		foreach ($this_category as $k => $board)
+		foreach ($this_category as &$board )
 		{
 			if (!empty($moderators[$board['id']]))
 			{
-				$this_category[$k]['moderators'] = $moderators[$board['id']];
+				$board['moderators'] = $moderators[$board['id']];
 				foreach ($moderators[$board['id']] as $moderator)
-					$this_category[$k]['link_moderators'][] = $moderator['link'];
+					$board['link_moderators'][] = $moderator['link'];
 			}
 			if (!empty($groups[$board['id']]))
 			{
-				$this_category[$k]['moderator_groups'] = $groups[$board['id']];
+				$board['moderator_groups'] = $groups[$board['id']];
 				foreach ($groups[$board['id']] as $group)
 				{
-					$this_category[$k]['link_moderators'][] = $group['link'];
-					$this_category[$k]['link_moderator_groups'][] = $group['link'];
+					$board['link_moderators'][] = $group['link'];
+					$board['link_moderator_groups'][] = $group['link'];
 				}
 			}
+			if (!empty($board['last_post']))
+				$board['last_post']['last_post_message'] = sprintf($txt['last_post_message'], $board['last_post']['member']['link'], $board['last_post']['link'], $board['last_post']['time'] > 0 ? timeformat($board['last_post']['time']) : $txt['not_applicable']);
 		}
-	}
+
+	unset($category,$board);
 
 	if ($boardIndexOptions['include_categories'])
 		sortCategories($categories);

--- a/Sources/Subs-BoardIndex.php
+++ b/Sources/Subs-BoardIndex.php
@@ -48,7 +48,7 @@ function getBoardIndex($boardIndexOptions)
 		$modSettings['boardindex_max_depth'] = 1;
 
 	// Find all boards and categories, as well as related information.  This will be sorted by the natural order of boards and categories, which we control.
-	if ($boardIndexOptions['parent_id'] != 0 && $smcFunc['db_cte_support']() && false)
+	if ($boardIndexOptions['parent_id'] != 0 && $smcFunc['db_cte_support']())
 		$result_boards = $smcFunc['db_query']('', '
 			WITH RECURSIVE 
 				boards_cte (child_level, id_board, name , description, redirect, num_posts, num_topics, unapproved_posts, unapproved_topics, id_parent, id_msg_updated, id_cat, id_last_msg, board_order)
@@ -391,7 +391,7 @@ function getBoardIndex($boardIndexOptions)
 			);
 	}
 	
-	if (!empty($categories))
+	if ($boardIndexOptions['include_categories'])
 		foreach ($categories as &$category)
 		{
 			foreach ($category['boards'] as &$board )


### PR DESCRIPTION
Another pr from the category less call more speed,
this pr got as focus to reduce the calls of timeformat,
which is one of the pricy functions we got.

When we got board with many sub (not sub sub) boards,
than we call for everyone the timeformat function,
because it could be this one with the lasted post.

End of the day only one sub board (with his sub sub ... boards) can win -> we show only one,
this code move the logic for calling the timeformat at the end where we know how is the winner.

This pr is completed.