### PR TITLE
installer mysql remove mysql_errno call fixes  #5055

### DIFF
--- a/other/install.php
+++ b/other/install.php
@@ -1199,13 +1199,9 @@ function DatabasePopulation()
 
 		if ($smcFunc['db_query']('', $current_statement, array('security_override' => true, 'db_error_skip' => true), $db_connection) === false)
 		{
-			// Use the appropriate function based on the DB type
-			if ($db_type == 'mysql' || $db_type == 'mysqli')
-				$db_errorno = $db_type . '_errno';
-
 			// Error 1050: Table already exists!
 			// @todo Needs to be made better!
-			if ((($db_type != 'mysql' && $db_type != 'mysqli') || $db_errorno($db_connection) == 1050) && preg_match('~^\s*CREATE TABLE ([^\s\n\r]+?)~', $current_statement, $match) == 1)
+			if ((($db_type != 'mysql' && $db_type != 'mysqli') || mysqli_errno($db_connection) == 1050) && preg_match('~^\s*CREATE TABLE ([^\s\n\r]+?)~', $current_statement, $match) == 1)
 			{
 				$exists[] = $match[1];
 				$incontext['sql_results']['table_dups']++;


### PR DESCRIPTION
This place called the mysql_errno,
in my php 7.2 env is that deadly.

fixed by removing the check, call always mysqli_errno.

issue:  #5055