### PR TITLE
$db_port should be defined as a global var in SSI

### DIFF
--- a/SSI.php
+++ b/SSI.php
@@ -21,7 +21,7 @@ define('SMF', 'SSI');
 global $time_start, $maintenance, $msubject, $mmessage, $mbname, $language;
 global $boardurl, $boarddir, $sourcedir, $webmaster_email, $cookiename;
 global $db_type, $db_server, $db_name, $db_user, $db_prefix, $db_persist, $db_error_send, $db_last_error;
-global $db_connection, $modSettings, $context, $sc, $user_info, $topic, $board, $txt;
+global $db_connection, $db_port, $modSettings, $context, $sc, $user_info, $topic, $board, $txt;
 global $smcFunc, $ssi_db_user, $scripturl, $ssi_db_passwd, $db_passwd, $cachedir;
 
 // Remember the current configuration so it can be set back.


### PR DESCRIPTION
This most notably makes MariaDB work