### PR TITLE
Replace php_os with directory_separator to detect windows

### DIFF
--- a/Sources/Load.php
+++ b/Sources/Load.php
@@ -311,7 +311,7 @@ function reloadSettings()
 		'is_lighttpd' => isset($_SERVER['SERVER_SOFTWARE']) && strpos($_SERVER['SERVER_SOFTWARE'], 'lighttpd') !== false,
 		'is_nginx' => isset($_SERVER['SERVER_SOFTWARE']) && strpos($_SERVER['SERVER_SOFTWARE'], 'nginx') !== false,
 		'is_cgi' => isset($_SERVER['SERVER_SOFTWARE']) && strpos(php_sapi_name(), 'cgi') !== false,
-		'is_windows' => strpos(PHP_OS, 'WIN') === 0,
+		'is_windows' => DIRECTORY_SEPARATOR === '\\',
 		'iso_case_folding' => ord(strtolower(chr(138))) === 154,
 	);
 	// A bug in some versions of IIS under CGI (older ones) makes cookie setting not work with Location: headers.

--- a/Sources/ManageServer.php
+++ b/Sources/ManageServer.php
@@ -733,7 +733,7 @@ function ModifyLoadBalancingSettings($return_config = false)
 	$disabled = true;
 	$context['settings_message'] = $txt['loadavg_disabled_conf'];
 
-	if (stripos(PHP_OS, 'win') === 0)
+	if (DIRECTORY_SEPARATOR === '\\')
 	{
 		$context['settings_message'] = $txt['loadavg_disabled_windows'];
 		if (isset($_GET['save']))

--- a/Sources/Subs-Attachments.php
+++ b/Sources/Subs-Attachments.php
@@ -73,7 +73,7 @@ function automanage_attachments_check_directory()
 
 	$basedirectory = (!empty($modSettings['use_subdirectories_for_attachments']) ? ($modSettings['basedirectory_for_attachments']) : $boarddir);
 	//Just to be sure: I don't want directory separators at the end
-	$sep = (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') ? '\/' : DIRECTORY_SEPARATOR;
+	$sep = (DIRECTORY_SEPARATOR === '\\') ? '\/' : DIRECTORY_SEPARATOR;
 	$basedirectory = rtrim($basedirectory, $sep);
 
 	switch ($modSettings['automanage_attachments'])
@@ -171,7 +171,7 @@ function automanage_attachments_create_directory($updir)
 	if (!file_exists($directory . DIRECTORY_SEPARATOR . '.htaccess'))
 		secureDirectory($updir, true);
 
-	$sep = (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') ? '\/' : DIRECTORY_SEPARATOR;
+	$sep = (DIRECTORY_SEPARATOR === '\\') ? '\/' : DIRECTORY_SEPARATOR;
 	$updir = rtrim($updir, $sep);
 
 	// Only update if it's a new directory
@@ -206,7 +206,7 @@ function automanage_attachments_by_space()
 
 	$basedirectory = !empty($modSettings['use_subdirectories_for_attachments']) ? $modSettings['basedirectory_for_attachments'] : $boarddir;
 	// Just to be sure: I don't want directory separators at the end
-	$sep = (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') ? '\/' : DIRECTORY_SEPARATOR;
+	$sep = (DIRECTORY_SEPARATOR === '\\') ? '\/' : DIRECTORY_SEPARATOR;
 	$basedirectory = rtrim($basedirectory, $sep);
 
 	// Get the current base directory
@@ -256,7 +256,7 @@ function get_directory_tree_elements($directory)
 			* in Windows we need to explode for both \ and /
 			* while in linux should be safe to explode only for / (aka DIRECTORY_SEPARATOR)
 	*/
-	if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN')
+	if (DIRECTORY_SEPARATOR === '\\')
 		$tree = preg_split('#[\\\/]#', $directory);
 	else
 	{
@@ -280,7 +280,7 @@ function attachments_init_dir(&$tree, &$count)
 {
 	$directory = '';
 	// If on Windows servers the first part of the path is the drive (e.g. "C:")
-	if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN')
+	if (DIRECTORY_SEPARATOR === '\\')
 	{
 		 //Better be sure that the first part of the path is actually a drive letter...
 		 //...even if, I should check this in the admin page...isn't it?

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -849,7 +849,7 @@ function timeformat($log_time, $show_today = true, $offset_type = false, $proces
 		}
 
 		// Windows needs extra help if $timeformat contains something completely invalid, e.g. '%Q'
-		if (strtoupper(substr(PHP_OS, 0, 3)) == 'WIN')
+		if (DIRECTORY_SEPARATOR === '\\')
 			$timeformat = preg_replace('~%(?!' . implode('|', array_keys($strftimeFormatSubstitutions)) . ')~', '&#37;', $timeformat);
 
 		// Substitute unsupported formats with supported ones


### PR DESCRIPTION
php_os is the os where the php version was build, could lead in the wrong direction and it's slow
10k loop:
php_os 0.022707939147949
directory_separator: 0.0039470195770264

Signed-off-by: albertlast albertlast@hotmail.de