### PR TITLE
Stats Get the right top topic starter

### DIFF
--- a/Sources/Stats.php
+++ b/Sources/Stats.php
@@ -441,7 +441,7 @@ function DisplayStats()
 		SELECT id_member, real_name
 		FROM {db_prefix}members
 		WHERE id_member IN ({array_int:member_list})
-		LIMIT 10',
+		LIMIT 20',
 		array(
 			'member_list' => array_keys($members),
 		)
@@ -464,6 +464,10 @@ function DisplayStats()
 	}
 	ksort($context['stats_blocks']['starters']);
 	$smcFunc['db_free_result']($members_result);
+
+	// remove alle not top 10
+	for($i = 10; $i < 20; $i++)
+		unset($context['stats_blocks']['starters'][$i]);
 
 	foreach ($context['stats_blocks']['starters'] as $i => $topic)
 	{

--- a/Sources/Stats.php
+++ b/Sources/Stats.php
@@ -450,6 +450,10 @@ function DisplayStats()
 	while ($row_members = $smcFunc['db_fetch_assoc']($members_result))
 	{
 		$i = array_search($row_members['id_member'], array_keys($members));
+		// skip all not top 10
+		if ($i >= 10)
+			continue;
+
 		$context['stats_blocks']['starters'][$i] = array(
 			'name' => $row_members['real_name'],
 			'id' => $row_members['id_member'],
@@ -463,10 +467,6 @@ function DisplayStats()
 	}
 	ksort($context['stats_blocks']['starters']);
 	$smcFunc['db_free_result']($members_result);
-
-	// remove alle not top 10
-	for($i = 10; $i < count($members); $i++)
-		unset($context['stats_blocks']['starters'][$i]);
 
 	foreach ($context['stats_blocks']['starters'] as $i => $topic)
 	{

--- a/Sources/Stats.php
+++ b/Sources/Stats.php
@@ -440,8 +440,7 @@ function DisplayStats()
 	$members_result = $smcFunc['db_query']('', '
 		SELECT id_member, real_name
 		FROM {db_prefix}members
-		WHERE id_member IN ({array_int:member_list})
-		LIMIT 20',
+		WHERE id_member IN ({array_int:member_list})',
 		array(
 			'member_list' => array_keys($members),
 		)
@@ -466,7 +465,7 @@ function DisplayStats()
 	$smcFunc['db_free_result']($members_result);
 
 	// remove alle not top 10
-	for($i = 10; $i < 20; $i++)
+	for($i = 10; $i < count($members); $i++)
 		unset($context['stats_blocks']['starters'][$i]);
 
 	foreach ($context['stats_blocks']['starters'] as $i => $topic)


### PR DESCRIPTION
In 2.1 i remove the order from 441 query for performance reason,
but forgot to adjust the limit.

This should now help to get the right top 10 users.

@live627 maybe you got another approache.