### PR TITLE
Fix minimized caching

### DIFF
--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -3997,7 +3997,7 @@ function custMinify($data, $type)
 	}
 
 	// And create a one day cache entry.
-	cache_put_data('minimized_' . $settings['theme_id'] . '_' . $type . '_' . $hash, array($toCache, $async, $defer), 86400);
+	cache_put_data('minimized_' . $settings['theme_id'] . '_' . $type . '_' . $hash, array($toCreate, $async, $defer), 86400);
 
 	return array('smf_minified' => array(
 		'fileUrl' => $settings['theme_url'] . '/' . ($type == 'css' ? 'css' : 'scripts') . '/' . basename($toCreate),

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -3915,7 +3915,7 @@ function custMinify($data, $type)
 	list($toCache, $async, $defer) = array_pad((array) cache_get_data('minimized_' . $settings['theme_id'] . '_' . $type . '_' . $hash, 86400), 3, null);
 
 	// Already done?
-	if (!empty($toCache))
+	if (!empty($toCache) && file_exists($toCache))
 		return array('smf_minified' => array(
 			'fileUrl' => $settings['theme_url'] . '/' . ($type == 'css' ? 'css' : 'scripts') . '/' . basename($toCache),
 			'filePath' => $toCache,


### PR DESCRIPTION
Look like the minimized never worked correctly...
two issue i found while looking at this.
First the path to the minimized files was never push down to the cache --> was always null:
![grafik](https://user-images.githubusercontent.com/1782906/47700179-dcb3e080-dc15-11e8-830c-a425a5d54aca.png)
Secondly the case was never checked when we get the file from the cache if the file is existing in the fs.

maybe related to: #5067

In general i didn't see the issue fixed by this,
because the dependency to the cache is not clear and without cache the minimized stuff make no sense.