### PR TITLE
Doesn't try to use cache to track minified files

### DIFF
--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -4027,16 +4027,13 @@ function deleteAllMinified()
 		{
 			foreach (glob(rtrim($theme['dir'], '/') . '/' . ($type == 'css' ? 'css' : 'scripts') . '/minified*.' . $type) as $filename)
 			{
-				// Remove the cache entry
-				if (preg_match('~([a-zA-Z0-9]+)\.' . $type . '$~', $filename, $matches))
-					cache_put_data('minimized_' . $theme['id'] . '_' . $type . '_' . $matches[1], null);
-
 				// Try to delete the file. Add it to our error list if it fails.
 				if (!@unlink($filename))
 					$not_deleted[] = $filename;
 			}
 		}
 	}
+	$smcFunc['db_free_result']($request);
 
 	// If any of the files could not be deleted, log an error about it.
 	if (!empty($not_deleted))

--- a/Sources/minify/src/Minify.php
+++ b/Sources/minify/src/Minify.php
@@ -97,6 +97,9 @@ abstract class Minify
     {
         $content = $this->execute($path);
 
+        // These are not the droids you're looking for
+        $content = "/* Any changes to this file will be overwritten. To change the content\nof this file, edit the source files from which it was compiled. */\n" . $content;
+
         // save to path
         if ($path !== null) {
             $this->save($content, $path);


### PR DESCRIPTION
Fixes #5067

Using the cache wasn't working because:

1. It only told us if we'd **created** the minified file before, not whether it **exists** now.
2. It only worked if the cache was enabled, and would unnecessarily re-create the minified file every time if the cache was not enabled.

The only good solution to these problems is to check whether the file actually exists or not. But once we are doing that, there is no reason to use the cache at all. So this gets rid of all the cache-related logic in `custMinify()` (and `deleteAllMinified()`) and simply checks for the actual minified file. Some other lines of code have also been moved around as side effects of this change, but the underlying logic is the same.

Also fixes #5004 