### PR TITLE
Upgrade Added Load.php to WelcomeLogin()

### DIFF
--- a/other/upgrade.php
+++ b/other/upgrade.php
@@ -862,6 +862,8 @@ function WelcomeLogin()
 	if (checkLogin())
 		return true;
 
+	require_once($sourcedir . '/Load.php');
+	reloadSettings();	
 	$upcontext += createToken('login');
 
 	return false;


### PR DESCRIPTION
Fix issue: https://www.simplemachines.org/community/index.php?topic=563004.0
Since we make thinks now so differently with the call of the reloadsettings(when you look what ther is all done this could only break stufff...),
i could image many ways where a upgrade from 2.0 with php below 7.0 could get broken,
specialy on a mysql env...

@Sesquipedalian please have look