### PR TITLE
Show original size of resized images only

### DIFF
--- a/Themes/default/css/index.css
+++ b/Themes/default/css/index.css
@@ -395,7 +395,7 @@ blockquote cite::before {
 	margin-left: 1em;
 	clear: right;
 }
-.postarea .bbc_img:hover {
+.postarea .bbc_img.resized:hover {
 	cursor: pointer;
 }
 .bbc_img.original_size {

--- a/Themes/default/scripts/theme.js
+++ b/Themes/default/scripts/theme.js
@@ -38,7 +38,7 @@ if (is_ie || is_webkit || is_ff)
 // Toggles the element height and width styles of an image.
 function smc_toggleImageDimensions()
 {
-	$('.postarea .bbc_img').each(function(index, item)
+	$('.postarea .bbc_img.resized').each(function(index, item)
 	{
 		$(item).click(function(e)
 		{


### PR DESCRIPTION
No point in trying to show an original size of an unchanged size of an image, also when the cursor points to images which nothing happens when clicked is annoying.

Signed-off-by: SychO <sychocouldy@gmail.com>