### PR TITLE
integrate_spam_protection was called a little late

### DIFF
--- a/Sources/Security.php
+++ b/Sources/Security.php
@@ -1160,13 +1160,13 @@ function spamProtection($error_type, $only_return_result = false)
 		'search' => !empty($modSettings['search_floodcontrol_time']) ? $modSettings['search_floodcontrol_time'] : 1,
 	);
 
+	call_integration_hook('integrate_spam_protection', array(&$timeOverrides));
+
 	// Moderators are free...
 	if (!allowedTo('moderate_board'))
 		$timeLimit = isset($timeOverrides[$error_type]) ? $timeOverrides[$error_type] : $modSettings['spamWaitTime'];
 	else
 		$timeLimit = 2;
-
-	call_integration_hook('integrate_spam_protection', array(&$timeOverrides, &$timeLimit));
 
 	// Delete old entries...
 	$smcFunc['db_query']('', '


### PR DESCRIPTION
-  `integrate_spam_protection` probably should be renamed to `integrate_floodcontrol so it matches everything else in the function
- Seems useless to pass `$timeLimit` through to integration