### PR TITLE
Handle spaces that are already encoded

### DIFF
--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -6533,6 +6533,11 @@ function iri_to_url($iri)
 {
 	global $sourcedir;
 
+	// First do a quick check to ensure there are no encoded values already
+	// These get mangled by rawurlencode()...
+	if (preg_match('~%\d{2}~', $iri) === 1)
+		return($iri);
+
 	$host = parse_url((strpos($iri, '://') === false ? 'http://' : '') . ltrim($iri, ':/'), PHP_URL_HOST);
 
 	if (empty($host))
@@ -6546,8 +6551,6 @@ function iri_to_url($iri)
 	$iri = substr_replace($iri, $encoded_host, $pos, strlen($host));
 
 	// Encode any disallowed characters in the rest of the URL
-	// First deal with spaces that may already be encoded...
-	$iri = strtr($iri, array('%20'=>' '));
 	$unescaped = array(
 		'%21'=>'!', '%23'=>'#', '%24'=>'$', '%26'=>'&',
 		'%27'=>"'", '%28'=>'(', '%29'=>')', '%2A'=>'*',

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -6533,11 +6533,6 @@ function iri_to_url($iri)
 {
 	global $sourcedir;
 
-	// First do a quick check to ensure there are no encoded values already
-	// These get mangled by rawurlencode()...
-	if (preg_match('~%\d{2}~', $iri) === 1)
-		return($iri);
-
 	$host = parse_url((strpos($iri, '://') === false ? 'http://' : '') . ltrim($iri, ':/'), PHP_URL_HOST);
 
 	if (empty($host))
@@ -6549,6 +6544,10 @@ function iri_to_url($iri)
 	$encoded_host = $Punycode->encode($host);
 	$pos = strpos($iri, $host);
 	$iri = substr_replace($iri, $encoded_host, $pos, strlen($host));
+
+	// Safety check...  Just in case anything is already pre-encoded...
+	// Don't want %20 to turn into %2520
+	$iri = rawurldecode($iri);
 
 	// Encode any disallowed characters in the rest of the URL
 	$unescaped = array(

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -6545,10 +6545,6 @@ function iri_to_url($iri)
 	$pos = strpos($iri, $host);
 	$iri = substr_replace($iri, $encoded_host, $pos, strlen($host));
 
-	// Safety check...  Just in case anything is already pre-encoded...
-	// Don't want %20 to turn into %2520
-	$iri = rawurldecode($iri);
-
 	// Encode any disallowed characters in the rest of the URL
 	$unescaped = array(
 		'%21'=>'!', '%23'=>'#', '%24'=>'$', '%26'=>'&',

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -6546,6 +6546,8 @@ function iri_to_url($iri)
 	$iri = substr_replace($iri, $encoded_host, $pos, strlen($host));
 
 	// Encode any disallowed characters in the rest of the URL
+	// First deal with spaces that may already be encoded...
+	$iri = strtr($iri, array('%20'=>' '));
 	$unescaped = array(
 		'%21'=>'!', '%23'=>'#', '%24'=>'$', '%26'=>'&',
 		'%27'=>"'", '%28'=>'(', '%29'=>')', '%2A'=>'*',

--- a/proxy.php
+++ b/proxy.php
@@ -89,9 +89,6 @@ class ProxyServer
 		if (md5($request . $this->secret) != $hash)
 			return false;
 
-		// Ensure any non-ASCII characters in the URL are encoded correctly
-		$request = iri_to_url($request);
-
 		// Attempt to cache the request if it doesn't exist
 		if (!$this->isCached($request))
 			return $this->cacheImage($request);


### PR DESCRIPTION
Fixes #5170 .   The image proxy was having issues with URLs that contained %20.  

I considered two solutions, the first was to simply remove the call to iri_to_url() from proxy.php.  That felt safest, and produced the same results during image proxy tests.  

But this solution is more in line with the intent of using iri_to_url() - to cleanse & standardize url usage.

Tested on both WAMP & Linux.  Solves a # of dropped image issues with the image proxy.  