### PR TITLE
If it cannot be cached, fall back to redirect

### DIFF
--- a/proxy.php
+++ b/proxy.php
@@ -197,7 +197,7 @@ class ProxyServer
 
 		// Looks like nobody was home
 		if (empty($image))
-			return -1;
+			return 0;
 
 		// What kind of file did they give us?
 		$finfo = finfo_open(FILEINFO_MIME_TYPE);


### PR DESCRIPTION
Fixes #5172 

There will be instances where fsockets & curl won't be allowed.  We need to still display those images when the proxy is enabled.  This PR treats them exactly like files that are too large - with a simple redirect.  

Without this change, a certain # of images will just disappear when the proxy is enabled.  