### PR TITLE
Packman browse fixes

### DIFF
--- a/Sources/Packages.php
+++ b/Sources/Packages.php
@@ -1359,6 +1359,10 @@ function PackageBrowse()
 	$context['page_title'] .= ' - ' . $txt['browse_packages'];
 
 	$context['forum_version'] = SMF_FULL_VERSION;
+	$context['available_modification'] = array();
+	$context['available_avatar'] = array();
+	$context['available_language'] = array();
+	$context['available_unknown'] = array();
 	$context['modification_types'] = array('modification', 'avatar', 'language', 'unknown');
 
 	call_integration_hook('integrate_modification_types');
@@ -1491,13 +1495,6 @@ function PackageBrowse()
 
 	$context['sub_template'] = 'browse';
 	$context['default_list'] = 'packages_lists';
-
-	// Empty lists for now.
-	$context['available_mods'] = array();
-	$context['available_avatars'] = array();
-	$context['available_languages'] = array();
-	$context['available_other'] = array();
-	$context['available_all'] = array();
 
 	$get_versions = $smcFunc['db_query']('', '
 		SELECT data FROM {db_prefix}admin_info_files WHERE filename={string:versionsfile} AND path={string:smf}',

--- a/Sources/Packages.php
+++ b/Sources/Packages.php
@@ -1717,6 +1717,9 @@ function list_getPackages($start, $items_per_page, $sort, $params)
 					}
 				}
 
+				// Save some memory by not passing the xmlArray object into context.
+				unset($packageInfo['xml']);
+
 				if (isset($sort_id[$packageInfo['type']], $packages[$packageInfo['type']], $context['available_' . $packageInfo['type']]) && $params == $packageInfo['type'])
 				{
 					$sort_id[$packageInfo['type']]++;

--- a/Sources/Packages.php
+++ b/Sources/Packages.php
@@ -1723,14 +1723,14 @@ function list_getPackages($start, $items_per_page, $sort, $params)
 				if (isset($sort_id[$packageInfo['type']], $packages[$packageInfo['type']], $context['available_' . $packageInfo['type']]) && $params == $packageInfo['type'])
 				{
 					$sort_id[$packageInfo['type']]++;
-					$packages[$packageInfo['type']][strtolower($packageInfo[$sort])] = md5($package);
+					$packages[$packageInfo['type']][strtolower($packageInfo[$sort]) . '_' . $sort_id[$packageInfo['type']]] = md5($package);
 					$context['available_' . $packageInfo['type']][md5($package)] = $packageInfo;
 				}
 				elseif (!isset($sort_id[$packageInfo['type']], $packages[$packageInfo['type']], $context['available_' . $packageInfo['type']]) && $params == 'unknown')
 				{
 					$packageInfo['sort_id'] = $sort_id['unknown'];
 					$sort_id['unknown']++;
-					$packages['unknown'][strtolower($packageInfo[$sort])] = md5($package);
+					$packages['unknown'][strtolower($packageInfo[$sort]) . '_' . $sort_id['unknown']] = md5($package);
 					$context['available_unknown'][md5($package)] = $packageInfo;
 				}
 			}

--- a/Sources/Packages.php
+++ b/Sources/Packages.php
@@ -1725,6 +1725,7 @@ function list_getPackages($start, $items_per_page, $sort, $params)
 				}
 				elseif (!isset($sort_id[$packageInfo['type']], $packages[$packageInfo['type']], $context['available_' . $packageInfo['type']]) && $params == 'unknown')
 				{
+					$packageInfo['sort_id'] = $sort_id['unknown'];
 					$sort_id['unknown']++;
 					$packages['unknown'][strtolower($packageInfo[$sort])] = md5($package);
 					$context['available_unknown'][md5($package)] = $packageInfo;

--- a/Sources/Packages.php
+++ b/Sources/Packages.php
@@ -1586,15 +1586,10 @@ function list_getPackages($start, $items_per_page, $sort, $params)
 		$context['installed_mods'] = array_keys($installed_mods);
 	}
 
-	if (empty($packages))
-		foreach ($context['modification_types'] as $type)
-			$packages[$type] = array();
-
 	if ($dir = @opendir($packagesdir))
 	{
 		$dirs = array();
 		$sort_id = array(
-			'mod' => 1,
 			'modification' => 1,
 			'avatar' => 1,
 			'language' => 1,
@@ -1605,14 +1600,6 @@ function list_getPackages($start, $items_per_page, $sort, $params)
 		while ($package = readdir($dir))
 		{
 			if ($package == '.' || $package == '..' || $package == 'temp' || (!(is_dir($packagesdir . '/' . $package) && file_exists($packagesdir . '/' . $package . '/package-info.xml')) && substr(strtolower($package), -7) != '.tar.gz' && substr(strtolower($package), -4) != '.tgz' && substr(strtolower($package), -4) != '.zip'))
-				continue;
-
-			$skip = false;
-			foreach ($context['modification_types'] as $type)
-				if (isset($context['available_' . $type][md5($package)]))
-					$skip = true;
-
-			if ($skip)
 				continue;
 
 			// Skip directories or files that are named the same.
@@ -1733,37 +1720,13 @@ function list_getPackages($start, $items_per_page, $sort, $params)
 					}
 				}
 
-				// Modification.
-				if ($packageInfo['type'] == 'modification' || $packageInfo['type'] == 'mod')
-				{
-					$sort_id['modification']++;
-					$sort_id['mod']++;
-					$packages['modification'][strtolower($packageInfo[$sort]) . '_' . $sort_id['mod']] = md5($package);
-					$context['available_modification'][md5($package)] = $packageInfo;
-				}
-				// Avatar package.
-				elseif ($packageInfo['type'] == 'avatar')
-				{
-					$sort_id[$packageInfo['type']]++;
-					$packages['avatar'][strtolower($packageInfo[$sort])] = md5($package);
-					$context['available_avatar'][md5($package)] = $packageInfo;
-				}
-				// Language package.
-				elseif ($packageInfo['type'] == 'language')
-				{
-					$sort_id[$packageInfo['type']]++;
-					$packages['language'][strtolower($packageInfo[$sort])] = md5($package);
-					$context['available_language'][md5($package)] = $packageInfo;
-				}
-				// This might be a 3rd party section.
-				elseif (isset($sort_id[$packageInfo['type']], $packages[$packageInfo['type']], $context['available_' . $packageInfo['type']]))
+				if (isset($sort_id[$packageInfo['type']], $packages[$packageInfo['type']], $context['available_' . $packageInfo['type']]) && $params == $packageInfo['type'])
 				{
 					$sort_id[$packageInfo['type']]++;
 					$packages[$packageInfo['type']][strtolower($packageInfo[$sort])] = md5($package);
 					$context['available_' . $packageInfo['type']][md5($package)] = $packageInfo;
 				}
-				// Other stuff.
-				else
+				elseif (!isset($sort_id[$packageInfo['type']], $packages[$packageInfo['type']], $context['available_' . $packageInfo['type']]) && $params == 'unknown')
 				{
 					$sort_id['unknown']++;
 					$packages['unknown'][strtolower($packageInfo[$sort])] = md5($package);


### PR DESCRIPTION
- Download some random mods
- Download at least four avatar packs, install any two
- Sort by installed time, nothing happens
- Apply commits one and two. Sorting avatars works, except that some vanish.
- Apply the fifth commit. Sort avatars again. All four avatars now show.
- Download even more mods. Change their type to randomness. You can leave then unzipped.
- Observe the unknown packages all are enumerated as 1. The third commit fixes this.