### PR TITLE
Improve the Query "Posting activity by time"

### DIFF
--- a/Sources/Profile-View.php
+++ b/Sources/Profile-View.php
@@ -1401,12 +1401,13 @@ function statPanel($memID)
 			SELECT poster_time, id_msg 
 			FROM {db_prefix}messages WHERE id_member = {int:current_member}
 			ORDER BY id_msg DESC
-			LIMIT 10000
+			LIMIT {int:max_messages}
 		) a
 		GROUP BY hour',
 		array(
 			'current_member' => $memID,
 			'time_offset' => (($user_info['time_offset'] + $modSettings['time_offset']) * 3600),
+			'max_messages' => 1001,
 		)
 	);
 	$maxPosts = $realPosts = 0;

--- a/Sources/Profile-View.php
+++ b/Sources/Profile-View.php
@@ -1397,13 +1397,15 @@ function statPanel($memID)
 		SELECT
 			HOUR(FROM_UNIXTIME(poster_time + {int:time_offset})) AS hour,
 			COUNT(*) AS post_count
-		FROM {db_prefix}messages
-		WHERE id_member = {int:current_member}' . ($modSettings['totalMessages'] > 100000 ? '
-			AND id_topic > {int:top_ten_thousand_topics}' : '') . '
+		FROM (
+			SELECT poster_time, id_msg 
+			FROM {db_prefix}messages WHERE id_member = {int:current_member}
+			ORDER BY id_msg DESC
+			LIMIT 10000
+		) a
 		GROUP BY hour',
 		array(
 			'current_member' => $memID,
-			'top_ten_thousand_topics' => $modSettings['totalTopics'] - 10000,
 			'time_offset' => (($user_info['time_offset'] + $modSettings['time_offset']) * 3600),
 		)
 	);


### PR DESCRIPTION
The problem mention here: https://www.simplemachines.org/community/index.php?topic=563957.0
is right in my eyes,
the mention solution is wrong.

To limit the readed amount of data i used a subquery,
important step is to use the id_msg for sorting(not poster_time),
which allowed newer mysql version (8.0+) and postgres to do a backwards index scan. 

I'm not sure if 10k messages maybe not to high,
from a statistic pov 1001 message should be enough.