### PR TITLE
Fix user stats on PostgreSQL

### DIFF
--- a/other/install_2-1_postgresql.sql
+++ b/other/install_2-1_postgresql.sql
@@ -6,10 +6,6 @@
 # Some taken from http://www.xach.com/aolserver/mysql-functions.sql and http://pgfoundry.org/projects/mysqlcompat/.
 # IP Regex in inet_aton from https://www.mkyong.com/database/regular-expression-in-postgresql/.
 
-CREATE OR REPLACE FUNCTION FROM_UNIXTIME(integer) RETURNS timestamp AS
-	'SELECT timestamp ''epoch'' + $1 * interval ''1 second'' AS result'
-LANGUAGE 'sql';
-
 CREATE OR REPLACE FUNCTION FROM_UNIXTIME(bigint) RETURNS timestamp AS
 	'SELECT timestamp ''epoch'' + $1 * interval ''1 second'' AS result'
 LANGUAGE 'sql';

--- a/other/install_2-1_postgresql.sql
+++ b/other/install_2-1_postgresql.sql
@@ -10,6 +10,10 @@ CREATE OR REPLACE FUNCTION FROM_UNIXTIME(integer) RETURNS timestamp AS
 	'SELECT timestamp ''epoch'' + $1 * interval ''1 second'' AS result'
 LANGUAGE 'sql';
 
+CREATE OR REPLACE FUNCTION FROM_UNIXTIME(bigint) RETURNS timestamp AS
+	'SELECT timestamp ''epoch'' + $1 * interval ''1 second'' AS result'
+LANGUAGE 'sql';
+
 CREATE OR REPLACE FUNCTION FIND_IN_SET(needle text, haystack text) RETURNS integer AS '
 	SELECT i AS result
 	FROM generate_series(1, array_upper(string_to_array($2,'',''), 1)) AS g(i)

--- a/other/upgrade_2-1_postgresql.sql
+++ b/other/upgrade_2-1_postgresql.sql
@@ -2709,3 +2709,12 @@ INSERT INTO {$db_prefix}board_permissions_view (id_board, id_group, deny) SELECT
 FROM {$db_prefix}boards b
 where (FIND_IN_SET(0, b.deny_member_groups) != 0);
 ---#
+
+/******************************************************************************/
+--- Add new functions
+/******************************************************************************/
+---# Add FROM_UNIXTIME for bigint
+CREATE OR REPLACE FUNCTION FROM_UNIXTIME(bigint) RETURNS timestamp AS
+	'SELECT timestamp ''epoch'' + $1 * interval ''1 second'' AS result'
+LANGUAGE 'sql';
+---#

--- a/other/upgrade_2-1_postgresql.sql
+++ b/other/upgrade_2-1_postgresql.sql
@@ -2711,8 +2711,12 @@ where (FIND_IN_SET(0, b.deny_member_groups) != 0);
 ---#
 
 /******************************************************************************/
---- Add new functions
+--- FROM_UNIXTIME fix
 /******************************************************************************/
+---# Drop the old int version
+DROP FUNCTION IF EXISTS FROM_UNIXTIME(int);
+---#
+
 ---# Add FROM_UNIXTIME for bigint
 CREATE OR REPLACE FUNCTION FROM_UNIXTIME(bigint) RETURNS timestamp AS
 	'SELECT timestamp ''epoch'' + $1 * interval ''1 second'' AS result'


### PR DESCRIPTION
The function FROM_UNIXTIME is not defined for bigints, causing an error when trying to view user stats in PostgreSQL