### PR TITLE
Fixing Pg pool connection and empty ip field error handling

### DIFF
--- a/Sources/Subs-Db-postgresql.php
+++ b/Sources/Subs-Db-postgresql.php
@@ -975,6 +975,9 @@ function smf_db_error_insert($error_array)
 	if (empty($db_connection))
 		return;
 
+	if (filter_var($error_array[2], FILTER_VALIDATE_IP) === false)
+		$error_array[2] = null;
+
 	if(empty($db_persist))
 	{ // without pooling
 		if (empty($pg_error_data_prep))


### PR DESCRIPTION
Three things:
- Fix pool handling on pg cache
- Fix pool handling on pg insert error
- Fix empty/not valid ip address handling on pg insert error (take the solution from mysql part)

Since we use in cache and error handling prepared statements and
on pooling sutch prepared statement can survive between php executions,
issues got raised up.

When an error happen in a very very early stage the ip addresse can be empty,
an empty ip address needs to be null, like the mysql layer already do.