### PR TITLE
Implement new logic for sorting fixes #5278

### DIFF
--- a/Sources/ManageSettings.php
+++ b/Sources/ManageSettings.php
@@ -1805,51 +1805,43 @@ function EditCustomProfiles()
 		);
 		$fields = array();
 		$new_sort = array();
-		
+
 		while($row = $smcFunc['db_fetch_assoc']($request))
-				$fields[$row['id_field']] = $row['field_order'];
+				$fields[] = $row['id_field'];
 		$smcFunc['db_free_result']($request);
 
+		$idx = array_search($context['fid'], $fields);
 
-		if ($_GET['move'] == 'up' && count($fields) -1 > $context['fid'] )
+		if ($_GET['move'] == 'down' && count($fields) - 1 > $idx )
 		{
-			if( count($fields) -1 > $context['fid'] ) {
-				$new_sort = array_slice($fields ,0 ,$context['fid'] ,true);
-				$new_sort[] = $fields[$context['fid'] + 1];
-				$new_sort[] = $fields[$context['fid']];
-				$new_sort += array_slice($fields ,$context['fid'] + 2 ,count($fields) ,true);
-			}
+				$new_sort = array_slice($fields ,0 ,$idx ,true);
+				$new_sort[] = $fields[$idx + 1];
+				$new_sort[] = $fields[$idx];
+				$new_sort += array_slice($fields ,$idx + 2 ,count($fields) ,true);
 		}
-		elseif ($context['fid'] > 0 and $context['fid'] < count($fields))
+		elseif ($context['fid'] > 0 and $idx < count($fields))
 		{
-				$new_sort = array_slice($fields ,0 ,($context['fid'] - 1) ,true);
-				$new_sort[] = $fields[$context['fid']];
-				$new_sort[] = $fields[$context['fid'] - 1];
-				$new_sort += array_slice($fields ,($context['fid'] + 1) ,count($fields) ,true);
+				$new_sort = array_slice($fields ,0 ,($idx - 1) ,true);
+				$new_sort[] = $fields[$idx];
+				$new_sort[] = $fields[$idx - 1];
+				$new_sort += array_slice($fields ,($idx + 1) ,count($fields) ,true);
 		}
 		else
 			redirectexit('action=admin;area=featuresettings;sa=profile'); // @todo implement an error handler
-		
-/*
-		// All good, proceed.
+
+		$sql_update = 'CASE ';
+		foreach ($new_sort as $orderKey => $PKid)
+		{
+			$sql_update .= 'WHEN id_field = ' . $PKid . ' THEN ' . ($orderKey + 1) . ' ';
+		}
+		$sql_update .= 'END';
+
 		$smcFunc['db_query']('', '
 			UPDATE {db_prefix}custom_fields
-			SET field_order = {int:old_order}
-			WHERE field_order = {int:new_order}',
-			array(
-				'new_order' => $new_order,
-				'old_order' => $context['field']['order'],
-			)
+			SET field_order = ' . $sql_update,
+				array()
 		);
-		$smcFunc['db_query']('', '
-			UPDATE {db_prefix}custom_fields
-			SET field_order = {int:new_order}
-			WHERE id_field = {int:id_field}',
-			array(
-				'new_order' => $new_order,
-				'id_field' => $context['fid'],
-			)
-		);*/
+
 		redirectexit('action=admin;area=featuresettings;sa=profile'); // @todo perhaps a nice confirmation message, dunno.
 	}
 


### PR DESCRIPTION
Since the pr is final,
some motivation the existing solution got two issues:

First it handle gabs between field_order very bad -> when between two fields a gab of 10 int is,
than you need to push 10 time the field up to be in front of
Secondly when two fields got the same field_order things get horrible wrong:
![grafik](https://user-images.githubusercontent.com/1782906/50448207-08a2c800-0920-11e9-84c0-5e5010e99f45.png)
In this case your are not able to get out of this corrupt state.

First issue get fixed because we generated for all field everytime the field_order,
so the admin/user had to click once and the field move in wanted direction.
Second issue get fixed by the same logic,
since we build the order everytime new,
the field_order get corrected after the update of one field.

To forbid(by using unique key) the case of doublicate field_order is my eyes not an option.

issue #5278

Since the numbers of field_order got less important work this pr very well with the pr  #5289