### PR TITLE
Remove the number of Field Order in the display

### DIFF
--- a/Sources/ManageSettings.php
+++ b/Sources/ManageSettings.php
@@ -1494,7 +1494,7 @@ function ShowCustomProfiles()
 				'data' => array(
 					'function' => function($rowData) use ($context, $txt, $scripturl)
 					{
-						$return = '<p class="centertext bold_text">' . $rowData['field_order'] . '<br>';
+						$return = '<p class="centertext bold_text">';
 
 						if ($rowData['field_order'] > 1)
 							$return .= '<a href="' . $scripturl . '?action=admin;area=featuresettings;sa=profileedit;fid=' . $rowData['id_field'] . ';move=up"><span class="toggle_up" title="' . $txt['custom_edit_order_move'] . ' ' . $txt['custom_edit_order_up'] . '"></span></a>';


### PR DESCRIPTION
![grafik](https://user-images.githubusercontent.com/1782906/50445873-df7b3b00-0911-11e9-834e-64533d2e2c72.png)
It's look cleaner and give the user less chance to get confused.

For compare the "old" one.
![grafik](https://user-images.githubusercontent.com/1156911/50427376-5676ec00-089e-11e9-9a05-31494bfacb27.png)