### PR TITLE
Add id_thumb index to Attachments

### DIFF
--- a/other/install_2-1_mysql.sql
+++ b/other/install_2-1_mysql.sql
@@ -49,7 +49,8 @@ CREATE TABLE {$db_prefix}attachments (
 	PRIMARY KEY (id_attach),
 	UNIQUE idx_id_member (id_member, id_attach),
 	INDEX idx_id_msg (id_msg),
-	INDEX idx_attachment_type (attachment_type)
+	INDEX idx_attachment_type (attachment_type),
+	INDEX id_thumb (id_thumb)
 ) ENGINE={$engine};
 
 #

--- a/other/install_2-1_mysql.sql
+++ b/other/install_2-1_mysql.sql
@@ -50,7 +50,7 @@ CREATE TABLE {$db_prefix}attachments (
 	UNIQUE idx_id_member (id_member, id_attach),
 	INDEX idx_id_msg (id_msg),
 	INDEX idx_attachment_type (attachment_type),
-	INDEX id_thumb (id_thumb)
+	INDEX idx_id_thumb (id_thumb)
 ) ENGINE={$engine};
 
 #

--- a/other/install_2-1_postgresql.sql
+++ b/other/install_2-1_postgresql.sql
@@ -163,6 +163,7 @@ CREATE TABLE {$db_prefix}attachments (
 CREATE UNIQUE INDEX {$db_prefix}attachments_id_member ON {$db_prefix}attachments (id_member, id_attach);
 CREATE INDEX {$db_prefix}attachments_id_msg ON {$db_prefix}attachments (id_msg);
 CREATE INDEX {$db_prefix}attachments_attachment_type ON {$db_prefix}attachments (attachment_type);
+CREATE INDEX {$db_prefix}attachments_id_thumb ON {$db_prefix}attachments (id_thumb);
 
 #
 # Sequence for table `background_tasks`

--- a/other/upgrade_2-1_mysql.sql
+++ b/other/upgrade_2-1_mysql.sql
@@ -2919,6 +2919,6 @@ VALUES ('Independence Day', '1004-07-04'),
 --- Add Attachments index
 /******************************************************************************/
 ---# Create new index on Attachments
-CREATE INDEX idx_id_thumb ON {$db_prefix}attachments(id_thumb);
+CREATE INDEX idx_id_thumb ON {$db_prefix}attachments (id_thumb);
 ---#
 

--- a/other/upgrade_2-1_mysql.sql
+++ b/other/upgrade_2-1_mysql.sql
@@ -2914,3 +2914,11 @@ VALUES ('Independence Day', '1004-07-04'),
 	('Labor Day', '2030-09-02'),
 	('D-Day', '1004-06-06');
 ---#
+
+/******************************************************************************/
+--- Add Attachments index
+/******************************************************************************/
+---# Create new index on Attachments
+CREATE INDEX idx_id_thumb ON {$db_prefix}attachments(id_thumb);
+---#
+

--- a/other/upgrade_2-1_postgresql.sql
+++ b/other/upgrade_2-1_postgresql.sql
@@ -3236,3 +3236,11 @@ VALUES ('Independence Day', '1004-07-04'),
 	('Labor Day', '2030-09-02'),
 	('D-Day', '1004-06-06');
 ---#
+
+/******************************************************************************/
+--- Add Attachments index
+/******************************************************************************/
+---# Create new index on Attachments
+DROP INDEX IF EXISTS {$db_prefix}attachments_id_thumb;
+CREATE INDEX {$db_prefix}attachments_id_thumb ON {$db_prefix}attachments (id_thumb);
+---#


### PR DESCRIPTION
In some statement is id_thumb part of where or join,
on bigger setup this type of query get very very slow: https://www.simplemachines.org/community/index.php?topic=564301.0

This pr fix this issue for 2.1

Since my target is that smf 2.1 is well designed for bigger setup,
are pr like this (small changes but big help for this kinds of setup) very important.