### PR TITLE
Correctly processes BBCodes with all optional parameters

### DIFF
--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -2443,7 +2443,18 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 			// Do we want parameters?
 			elseif (!empty($possible['parameters']))
 			{
-				if ($next_c != ' ')
+				// Are all the parameters optional?
+				$param_required = false;
+				foreach ($possible['parameters'] as $param)
+				{
+					if (empty($param['optional']))
+					{
+						$param_required = true;
+						break;
+					}
+				}
+
+				if ($param_required && $next_c != ' ')
 					continue;
 			}
 			elseif (isset($possible['type']))


### PR DESCRIPTION
Previously, if a BBCode's parameters were all optional, parse_bbc() would nevertheless refuse to process it unless at least one parameter was specified in the post text. With this change, parse_bbc() will accept a BBCode with no parameters specified if all of its parameters are optional.