### PR TITLE
Add smiley fixes

### DIFF
--- a/Sources/ManageSmileys.php
+++ b/Sources/ManageSmileys.php
@@ -778,7 +778,7 @@ function AddSmiley()
 				'code' => 'string-30', 'filename' => 'string-48', 'description' => 'string-80', 'hidden' => 'int', 'smiley_order' => 'int',
 			),
 			array(
-				$_POST['smiley_code'], $_POST['smiley_filename'], $_POST['smiley_description'], $_POST['smiley_location'], $smiley_order,
+				$_POST['smiley_code'], pathinfo($_POST['smiley_filename'], PATHINFO_FILENAME), $_POST['smiley_description'], $_POST['smiley_location'], $smiley_order,
 			),
 			array('id_smiley')
 		);

--- a/Sources/ManageSmileys.php
+++ b/Sources/ManageSmileys.php
@@ -702,8 +702,8 @@ function AddSmiley()
 					fatal_lang_error('smileys_upload_error_blank');
 
 				if (empty($newName))
-					$newName = basename($_FILES[$name]['name']);
-				elseif (basename($_FILES[$name]['name']) != $newName)
+					$newName = pathinfo($_FILES[$name]['name'], PATHINFO_FILENAME);
+				elseif (pathinfo($_FILES[$name]['name'], PATHINFO_FILENAME) != $newName)
 					fatal_lang_error('smileys_upload_error_name');
 			}
 

--- a/Sources/ManageSmileys.php
+++ b/Sources/ManageSmileys.php
@@ -709,7 +709,8 @@ function AddSmiley()
 
 			foreach ($context['smiley_sets'] as $i => $set)
 			{
-				$set['name'] = un_htmlspecialchars($set['name']);
+				// Name must be treated differently; it's used within a variable name & php converted spaces & periods to underscores
+				$set['name'] = strtr(un_htmlspecialchars($set['name']), ' .', '__');
 				$set['path'] = un_htmlspecialchars($set['path']);
 
 				if (!isset($_FILES['individual_' . $set['name']]['name']) || $_FILES['individual_' . $set['name']]['name'] == '')

--- a/Sources/ManageSmileys.php
+++ b/Sources/ManageSmileys.php
@@ -415,7 +415,6 @@ function EditSmileySets()
 				),
 				'sort' => array(
 					'default' => 'selected DESC',
-					'reverse' => 'selected',
 				),
 			),
 			'name' => array(

--- a/Sources/ManageSmileys.php
+++ b/Sources/ManageSmileys.php
@@ -710,7 +710,7 @@ function AddSmiley()
 			foreach ($context['smiley_sets'] as $i => $set)
 			{
 				// Name must be treated differently; it's used within a variable name & php converted spaces & periods to underscores
-				$set['name'] = strtr(un_htmlspecialchars($set['name']), ' .', '__');
+				$set['name'] = preg_replace('~[\x20\x2e\x5b\x80-\x9f]~', '_', un_htmlspecialchars($set['name']));
 				$set['path'] = un_htmlspecialchars($set['path']);
 
 				if (!isset($_FILES['individual_' . $set['name']]['name']) || $_FILES['individual_' . $set['name']]['name'] == '')

--- a/Sources/ManageSmileys.php
+++ b/Sources/ManageSmileys.php
@@ -415,6 +415,7 @@ function EditSmileySets()
 				),
 				'sort' => array(
 					'default' => 'selected DESC',
+					'reverse' => 'selected',
 				),
 			),
 			'name' => array(
@@ -733,6 +734,10 @@ function AddSmiley()
 				// Make sure they aren't trying to upload a nasty file - for their own good here!
 				if (in_array(strtolower($destName), $disabledFiles))
 					fatal_lang_error('smileys_upload_error_illegal');
+
+				// Only allow an upload of the proper extension for the set
+				if (pathinfo($_FILES['individual_' . $set['name']]['name'], PATHINFO_EXTENSION) != str_replace('.', '', $set['ext']))
+					fatal_lang_error('smileys_upload_error_exts');
 
 				// If the file exists - ignore it.
 				$smileyLocation = $context['smileys_dir'] . '/' . $set['path'] . '/' . $destName;

--- a/Themes/default/languages/Errors.english.php
+++ b/Themes/default/languages/Errors.english.php
@@ -276,6 +276,7 @@ $txt['smileys_upload_error'] = 'Failed to upload file.';
 $txt['smileys_upload_error_blank'] = 'All smiley sets must have an image.';
 $txt['smileys_upload_error_name'] = 'All smileys must have the same filename.';
 $txt['smileys_upload_error_illegal'] = 'Illegal Type.';
+$txt['smileys_upload_error_exts'] = 'Cannot mix file types within a smiley set.';
 
 $txt['search_invalid_weights'] = 'Search weights are not properly configured. At least one weight should be configure to be non-zero. Please report this error to an administrator.';
 $txt['unable_to_create_temporary'] = 'The search function was unable to create temporary tables. Please try again.';


### PR DESCRIPTION
Fixes #5331 - multi-extension add erroneous message
Fixes #5328 - upload new smiley issue

Also tightened edits to prevent uploading the wrong file/extension into a set's folder.

I have one question regarding the solution to a 'special characters' issue I discovered here, in this case, the space in "Alienine's Set" & "Fugue's Set".  Internally, this name is used within a variable name.  PHP doesn't let you use spaces or periods in variable names, & swaps them out with underscores unannounced.  Thus, some of the internal edits & processing were getting bypassed because it didn't get a hit on the set name.  I just swapped out dots & spaces with underscores on the _other_ field before the comparison to address.  

My question is - is there a php function to do this?  I couldn't find one.

It would be cleaner in the long term to use a supported function for the variable name conversion that is going on.  Good description of this conversion is in the answer here:
https://stackoverflow.com/questions/17092398/post-spaces-converted-in-underscores
