### PR TITLE
Fixes broken `<br/>` => `\n` replacement in un_preparsecode()

### DIFF
--- a/Sources/Post.php
+++ b/Sources/Post.php
@@ -2747,8 +2747,6 @@ function QuoteFast()
 		// Censor the message!
 		censorText($row['body']);
 
-		$row['body'] = preg_replace('~<br ?/?' . '>~i', "\n", $row['body']);
-
 		// Want to modify a single message by double clicking it?
 		if (isset($_REQUEST['modify']))
 		{

--- a/Sources/Subs-Post.php
+++ b/Sources/Subs-Post.php
@@ -274,7 +274,7 @@ function un_preparsecode($message)
 	}, $message);
 
 	if (!empty($code_tags))
-		$message = str_replace(array_keys($code_tags), array_values($code_tags), $message);
+		$message = strtr($message, $code_tags);
 
 	// Change breaks back to \n's and &nsbp; back to spaces.
 	return preg_replace('~<br\s*/?' . '>~', "\n", str_replace('&nbsp;', ' ', $message));

--- a/Sources/Subs-Post.php
+++ b/Sources/Subs-Post.php
@@ -277,7 +277,7 @@ function un_preparsecode($message)
 		$message = str_replace(array_keys($code_tags), array_values($code_tags), $message);
 
 	// Change breaks back to \n's and &nsbp; back to spaces.
-	return preg_replace('~<br( /)?' . '>~', "\n", str_replace('&nbsp;', ' ', $message));
+	return preg_replace('~<br\s*/?' . '>~', "\n", str_replace('&nbsp;', ' ', $message));
 }
 
 /**


### PR DESCRIPTION
Fixes #5334
Also removes a now redundant line in QuoteFast() that was doing this same replacement over again (using a better regex) because un_preparsecode() couldn't be trusted to have done it properly.