### PR TITLE
Implements permissions for BBCodes

### DIFF
--- a/Sources/Load.php
+++ b/Sources/Load.php
@@ -377,7 +377,11 @@ function reloadSettings()
 	$context['legacy_bbc'] = array(
 		'acronym', 'bdo', 'black', 'blue', 'flash', 'ftp', 'glow',
 		'green', 'move', 'red', 'shadow', 'tt', 'white',
+	);
 
+	// Define a list of BBC tags that require permissions to use
+	$context['restricted_bbc'] = array(
+		'html',
 	);
 
 	// Call pre load integration functions.

--- a/Sources/ManagePermissions.php
+++ b/Sources/ManagePermissions.php
@@ -1833,6 +1833,10 @@ function init_inline_permissions($permissions, $excluded_groups = array())
 			if (isset($context[$permission][$group]))
 				unset($context[$permission][$group]);
 		}
+
+		// There's no point showing a form with nobody in it
+		if (empty($context[$permission]))
+			unset($context['config_vars'][$permission], $context[$permission]);
 	}
 
 	// Create the token for the separate inline permission verification.

--- a/Sources/ManagePermissions.php
+++ b/Sources/ManagePermissions.php
@@ -1819,7 +1819,7 @@ function init_inline_permissions($permissions, $excluded_groups = array())
 			});
 
 		foreach ($permissions as $permission)
-			$context['permissions_excluded'][$permission][] = array_unique(array_merge($context['permissions_excluded'][$permission], $excluded_groups));
+			$context['permissions_excluded'][$permission] = array_unique(array_merge($context['permissions_excluded'][$permission], $excluded_groups));
 	}
 
 	// Some permissions cannot be given to certain groups. Remove the groups.

--- a/Sources/ManageServer.php
+++ b/Sources/ManageServer.php
@@ -1142,7 +1142,7 @@ function prepareDBSettingContext(&$config_vars)
 	if (!empty($inlinePermissions) && allowedTo('manage_permissions'))
 	{
 		require_once($sourcedir . '/ManagePermissions.php');
-		init_inline_permissions($inlinePermissions, isset($context['permissions_excluded']) ? $context['permissions_excluded'] : array());
+		init_inline_permissions($inlinePermissions);
 	}
 
 	if ($board_list)

--- a/Sources/ManageSettings.php
+++ b/Sources/ManageSettings.php
@@ -309,16 +309,10 @@ function ModifyBBCSettings($return_config = false)
 
 	// Permissions for restricted BBC
 	if (!empty($context['restricted_bbc']))
-	{
 		$config_vars[] = '';
-		foreach ($context['restricted_bbc'] as $bbc)
-		{
-			$config_vars[] = array('permissions', 'bbc_' . $bbc, 'text_label' => sprintf($txt['groups_can_use'], '[' . $bbc . ']'));
-		}
 
-		// The rank and file cannot be trusted with this one
-		$context['permissions_excluded']['bbc_html'] = array(0);
-	}
+	foreach ($context['restricted_bbc'] as $bbc)
+		$config_vars[] = array('permissions', 'bbc_' . $bbc, 'text_label' => sprintf($txt['groups_can_use'], '[' . $bbc . ']'));
 
 	$context['settings_post_javascript'] = '
 		toggleBBCDisabled(\'disabledBBC\', ' . (empty($modSettings['enableBBC']) ? 'true' : 'false') . ');

--- a/Sources/ManageSettings.php
+++ b/Sources/ManageSettings.php
@@ -307,6 +307,19 @@ function ModifyBBCSettings($return_config = false)
 		array('bbc', 'legacyBBC', 'help' => 'legacy_bbc'),
 	);
 
+	// Permissions for restricted BBC
+	if (!empty($context['restricted_bbc']))
+	{
+		$config_vars[] = '';
+		foreach ($context['restricted_bbc'] as $bbc)
+		{
+			$config_vars[] = array('permissions', 'bbc_' . $bbc, 'text_label' => sprintf($txt['groups_can_use'], '[' . $bbc . ']'));
+		}
+
+		// The rank and file cannot be trusted with this one
+		$context['permissions_excluded']['bbc_html'] = array(0);
+	}
+
 	$context['settings_post_javascript'] = '
 		toggleBBCDisabled(\'disabledBBC\', ' . (empty($modSettings['enableBBC']) ? 'true' : 'false') . ');
 		toggleBBCDisabled(\'legacyBBC\', ' . (empty($modSettings['enableBBC']) ? 'true' : 'false') . ');';

--- a/Sources/PersonalMessage.php
+++ b/Sources/PersonalMessage.php
@@ -2367,7 +2367,7 @@ function MessagePost2()
 		preparsecode($message);
 
 		// Make sure there's still some content left without the tags.
-		if ($smcFunc['htmltrim'](strip_tags(parse_bbc($smcFunc['htmlspecialchars']($message, ENT_QUOTES), false), '<img>')) === '' && (!allowedTo('admin_forum') || strpos($message, '[html]') === false))
+		if ($smcFunc['htmltrim'](strip_tags(parse_bbc($smcFunc['htmlspecialchars']($message, ENT_QUOTES), false), '<img>')) === '' && (!allowedTo('bbc_html') || strpos($message, '[html]') === false))
 			$post_errors[] = 'no_message';
 	}
 

--- a/Sources/Post.php
+++ b/Sources/Post.php
@@ -1889,7 +1889,7 @@ function Post2()
 		preparsecode($_POST['message']);
 
 		// Let's see if there's still some content left without the tags.
-		if ($smcFunc['htmltrim'](strip_tags(parse_bbc($_POST['message'], false), implode('', $context['allowed_html_tags']))) === '' && (!allowedTo('admin_forum') || strpos($_POST['message'], '[html]') === false))
+		if ($smcFunc['htmltrim'](strip_tags(parse_bbc($_POST['message'], false), implode('', $context['allowed_html_tags']))) === '' && (!allowedTo('bbc_html') || strpos($_POST['message'], '[html]') === false))
 			$post_errors[] = 'no_message';
 
 	}

--- a/Sources/Reports.php
+++ b/Sources/Reports.php
@@ -710,6 +710,9 @@ function GroupPermissionsReport()
 		if (in_array($row['permission'], $disabled_permissions))
 			continue;
 
+		if (strpos($row['permission'], 'bbc_') === 0)
+			$txt['group_perms_name_' . $row['permission']] = sprintf($txt['group_perms_name_bbc'], substr($row['permission'], 4));
+
 		// If this is a new permission flush the last row.
 		if ($row['permission'] != $lastPermission)
 		{

--- a/Sources/Subs-Post.php
+++ b/Sources/Subs-Post.php
@@ -121,7 +121,6 @@ function preparsecode(&$message, $previewing = false)
 	if (!$previewing && strpos($message, '[html]') !== false)
 	{
 		if (allowedTo('bbc_html'))
-			$message = preg_replace_callback('~\[html\](.+?)\[/html\]~is', function($m) {
 			$message = preg_replace_callback('~\[html\](.+?)\[/html\]~is', function($m)
 			{
 				return '[html]' . strtr(un_htmlspecialchars($m[1]), array("\n" => '&#13;', '  ' => ' &#32;', '[' => '&#91;', ']' => '&#93;')) . '[/html]';

--- a/Sources/Subs-Post.php
+++ b/Sources/Subs-Post.php
@@ -30,7 +30,7 @@ function preparsecode(&$message, $previewing = false)
 {
 	global $user_info, $modSettings, $context, $sourcedir;
 
-	static $tags_regex, $legacy_bbc_regex;
+	static $tags_regex, $disallowed_tags_regex;
 
 	// This line makes all languages *theoretically* work even with the wrong charset ;).
 	if (empty($context['utf8']))
@@ -117,7 +117,7 @@ function preparsecode(&$message, $previewing = false)
 
 	if (!$previewing && strpos($message, '[html]') !== false)
 	{
-		if (allowedTo('admin_forum'))
+		if (allowedTo('bbc_html'))
 			$message = preg_replace_callback('~\[html\](.+?)\[/html\]~is', function($m) {
 				return '[html]' . strtr(un_htmlspecialchars($m[1]), array("\n" => '&#13;', '  ' => ' &#32;', '[' => '&#91;', ']' => '&#93;')) . '[/html]';
 			}, $message);
@@ -140,9 +140,26 @@ function preparsecode(&$message, $previewing = false)
 	$message = preg_replace('~\[(black|blue|green|red|white)\]~', '[color=$1]', $message); // First do the opening tags.
 	$message = preg_replace('~\[/(black|blue|green|red|white)\]~', '[/color]', $message); // And now do the closing tags
 
-	// Legacy BBC are only retained for historical reasons. They're not for use in new posts.
-	$legacy_bbc_regex = empty($legacy_bbc_regex) ? build_regex(array_unique($context['legacy_bbc']), '~') : $legacy_bbc_regex;
-	$message = preg_replace('~\[(/?)(' . $legacy_bbc_regex . ')\b([^\]]*)\]~i', '&#91;$1$2$3&#93;', $message);
+	// Neutralize any BBC tags this member isn't permitted to use.
+	if (empty($disallowed_tags_regex))
+	{
+		// Legacy BBC are only retained for historical reasons. They're not for use in new posts.
+		$disallowed_bbc = $context['legacy_bbc'];
+
+		// Some BBC require permissions.
+		foreach ($context['restricted_bbc'] as $bbc)
+		{
+			// Skip html, since we handled it separately above.
+			if ($bbc === 'html')
+				continue;
+			if (!allowedTo('bbc_' . $bbc))
+				$disallowed_bbc[] = $bbc;
+		}
+
+		$disallowed_tags_regex = build_regex(array_unique($disallowed_bbc), '~');
+	}
+	if (!empty($disallowed_tags_regex))
+		$message = preg_replace('~\[(?=/?' . $disallowed_tags_regex . '\b)~i', '&#91;', $message);
 
 	// Make sure all tags are lowercase.
 	$message = preg_replace_callback('~\[(/?)(list|li|table|tr|td)\b([^\]]*)\]~i', function($m)

--- a/Themes/default/Admin.template.php
+++ b/Themes/default/Admin.template.php
@@ -975,9 +975,10 @@ function template_show_settings()
 								<dl class="settings">';
 			else
 				echo '
-									<dd>
+									<dt>
 										<strong>' . $config_var . '</strong>
-									</dd>';
+									</dt>
+									<dd></dd>';
 		}
 	}
 

--- a/Themes/default/Admin.template.php
+++ b/Themes/default/Admin.template.php
@@ -740,6 +740,28 @@ function template_show_settings()
 		echo '
 							<div class="information">', $context['settings_message'], '</div>';
 
+	// Filter out any redundant separators before we start the loop
+	$context['config_vars'] = array_filter($context['config_vars'], function ($v) use ($context)
+		{
+			static $config_vars, $prev;
+
+			$at_start = is_null($config_vars);
+			$config_vars = $at_start ? $context['config_vars'] : $config_vars;
+
+			$next = next($config_vars);
+			$at_end = key($config_vars) === null;
+
+			if (!$at_start && !$at_end)
+			{
+				$div_types = array('title', 'desc');
+				$at_start = isset($prev['type']) && in_array($prev['type'], $div_types);
+				$at_end = isset($next['type']) && in_array($next['type'], $div_types);
+			}
+
+			$prev = $v;
+			return ($v === '' && ($at_start || $at_end || $v === $next)) ? false : true;
+		});
+
 	// Now actually loop through all the variables.
 	$is_open = false;
 	foreach ($context['config_vars'] as $config_var)

--- a/Themes/default/ManagePermissions.template.php
+++ b/Themes/default/ManagePermissions.template.php
@@ -594,7 +594,11 @@ function template_modify_group_display($type)
 							<td>
 								', $permission['show_help'] ? '<a href="' . $scripturl . '?action=helpadmin;help=permissionhelp_' . $permission['id'] . '" onclick="return reqOverlayDiv(this.href);" class="help"><span class="main_icons help" title="' . $txt['help'] . '"></span></a>' : '', '
 							</td>
-							<td class="lefttext full_width">', $permission['name'], '</td><td>';
+							<td class="lefttext full_width">
+								', $permission['name'], (!empty($permission['note']) ? '<br>
+								<strong class="smalltext">' . $permission['note'] . '</strong>' : ''), '
+							</td>
+							<td>';
 
 					if ($permission['has_own_any'])
 					{

--- a/Themes/default/languages/Admin.english.php
+++ b/Themes/default/languages/Admin.english.php
@@ -579,6 +579,7 @@ $txt['legacyBBC'] = 'Legacy BBC tags';
 $txt['bbcTagsToUse'] = 'Enabled BBC tags';
 $txt['enabled_bbc_select'] = 'Select the tags allowed to be used';
 $txt['enabled_bbc_select_all'] = 'Select all tags';
+$txt['groups_can_use'] = 'Membergroups allowed to use %1$s';
 
 $txt['enableParticipation'] = 'Enable participation icons';
 $txt['oldTopicDays'] = 'Time before topic is warned as old on reply';

--- a/Themes/default/languages/ManagePermissions.english.php
+++ b/Themes/default/languages/ManagePermissions.english.php
@@ -324,4 +324,9 @@ $txt['auto_approve_topics'] = 'Post new topics, without requiring approval';
 $txt['auto_approve_replies'] = 'Post replies to topics, without requiring approval';
 $txt['auto_approve_attachments'] = 'Post attachments, without requiring approval';
 
+$txt['permissiongroup_bbc'] = 'BBCode';
+$txt['permissionname_bbc'] = 'Use the [%1$s] BBCode';
+$txt['permissionhelp_bbc_html'] = 'This permission allows a member to use the [html] BBCode to embed arbitrary HTML in posts, personal messages, etc.<br><br><strong>Embedding arbitrary HTML can break your site and create major security risks. <u>Do not grant this permission to anyone unless you completely trust them not to break your website!</u></strong>';
+$txt['permissionnote_bbc_html'] = 'Creates a security risk!';
+
 ?>

--- a/Themes/default/languages/Reports.english.php
+++ b/Themes/default/languages/Reports.english.php
@@ -136,6 +136,7 @@ $txt['group_perms_name_profile_forum_own'] = 'Allow Forum own Profile edits';
 $txt['group_perms_name_profile_password_own'] = 'Change own password';
 $txt['group_perms_name_profile_signature_own'] = 'Edit own signature';
 $txt['group_perms_name_profile_website_own'] = 'Edit own website';
+$txt['group_perms_name_bbc'] = 'Use the [%1$s] BBCode';
 
 $txt['report_error_too_many_staff'] = 'You have too many staff members. The report will not work with more than 300 staff members.';
 $txt['report_staff_position'] = 'Position';


### PR DESCRIPTION
- To impose permissions restrictions for a given BBC, the BBC tag simply needs to be appended to the $context['restricted_bbc'] array via the integrate_pre_load hook.
- The admin panel UI will show options to grant permission to use the restricted BBC on the main permissions page for each membergroup, as well as showing an inline permissions form for each restricted BBC at the bottom of the BBC settings page.
- The permission to use a restricted BBC is saved in the permissions table as `bbc_*`, where `*` is the tag for the BBC. For example, permission to use SMF's standard [html] BBC is stored as `bbc_html`.
- Mods adding their own restricted BBC do not need to add language strings for use on the permissions forms. Basic strings for that task are taken care of automatically. However, if a mod wants to add a $helptxt string for an individual BBC, it is free to do so.