### PR TITLE
Fix the select of Mysql Insert Returning fixes #5354

### DIFF
--- a/Sources/Subs-Db-mysql.php
+++ b/Sources/Subs-Db-mysql.php
@@ -804,7 +804,7 @@ function smf_db_insert($method = 'replace', $table, $columns, $data, $keys, $ret
 		$ai = 0;
 		for ($i = 0; $i < $count; $i++)
 		{
-			$old_id = $smcFunc['db_insert_id']();
+			$old_id = $smcFunc['db_insert_id']($table);
 
 			$smcFunc['db_query']('', '
 				' . $queryTitle . ' INTO ' . $table . '(`' . implode('`, `', $indexed_columns) . '`)
@@ -816,7 +816,7 @@ function smf_db_insert($method = 'replace', $table, $columns, $data, $keys, $ret
 				),
 				$connection
 			);
-			$new_id = $smcFunc['db_insert_id']();
+			$new_id = $smcFunc['db_insert_id']($table);
 
 			// the inserted value was new
 			if ($old_id != $new_id)

--- a/Sources/Subs-Db-mysql.php
+++ b/Sources/Subs-Db-mysql.php
@@ -827,10 +827,11 @@ function smf_db_insert($method = 'replace', $table, $columns, $data, $keys, $ret
 			else
 			{
 				$where_string = '';
-				$count2 = count($indexed_columns);
+				$count2 = count($keys);
 				for ($x = 0; $x < $count2; $x++)
 				{
-					$where_string .= key($indexed_columns[$x]) . ' = ' . $insertRows[$i][$x];
+					$keyPos = array_search($keys[$x], array_keys($columns));
+					$where_string .= $keys[$x] . ' = ' . $data[$i][$keyPos];
 					if (($x + 1) < $count2)
 						$where_string .= ' AND ';
 				}


### PR DESCRIPTION
Now it's work,
please had in mind because mysql is mysql...
this is not realy a fast way.

A normal insert(with ignore) is one query with many values.
In the case of returning(doesn't matter if mode1 or 2) you could got in the worst case
per row two query.

Issue: #5354

maybe the two query things is not needed..
to use returning with ignore or replace means in the common sense that one or more columns you insert,
are pk fields... so i could print them directly out without checking the db response.

Possible more compley would it be when you got on tables unique index,
when you look at smf 2.1 setup file ther are ~11 unqiue,
but the most are miss used only 5 are correctly and this around 4 tables --> not a common use case.

In short,
when you do a insert how is not using replace/ignore we need to look at the ai field on returning,
when replace or ignore is used we can return directly the index value from the $data array.