### PR TITLE
Remove unneeded col alter of ip in log_online

### DIFF
--- a/other/upgrade_2-1_mysql.sql
+++ b/other/upgrade_2-1_mysql.sql
@@ -2316,25 +2316,6 @@ ALTER TABLE {$db_prefix}member_logins ADD COLUMN ip2 VARBINARY(16);
 ---#
 
 /******************************************************************************/
---- Update log_online ip with ipv6 support without converting
-/******************************************************************************/
----# Delete old column log banned ip
----{
-$doChange = true;
-$column_info = upgradeGetColumnInfo('{db_prefix}log_online', 'ip');
-if (stripos($column_info['type'], 'varbinary') !== false)
-	$doChange = false;
-
-if ($doChange)
-	upgrade_query("ALTER TABLE {$db_prefix}log_online DROP COLUMN ip;");
----}
----#
-
----# Add the new log banned ip
-ALTER TABLE {$db_prefix}log_online ADD COLUMN ip VARBINARY(16);
----#
-
-/******************************************************************************/
 --- Renaming the "profile_other" permission...
 /******************************************************************************/
 ---# Changing the "profile_other" permission to "profile_website"

--- a/other/upgrade_2-1_postgresql.sql
+++ b/other/upgrade_2-1_postgresql.sql
@@ -1745,13 +1745,6 @@ CREATE INDEX {$db_prefix}qanda_lngfile ON {$db_prefix}qanda (lngfile varchar_pat
 ---#
 
 /******************************************************************************/
---- Fixing log_online table
-/******************************************************************************/
----# Changing ip to bigint
-ALTER TABLE {$db_prefix}log_online ALTER ip TYPE bigint;
----#
-
-/******************************************************************************/
 --- Marking packages as uninstalled...
 /******************************************************************************/
 ---# Updating log_packages


### PR DESCRIPTION
To alter the column make no sense,
because later on we alter it again to inet and
this alter create a issue when you try to upgrade the upgrade.

In this case pg try to convert inet datatype of ip to bigint which is not possible.