### PR TITLE
Avoids breaking stuff when the files and DB have mismatched versions

### DIFF
--- a/Sources/Load.php
+++ b/Sources/Load.php
@@ -74,7 +74,7 @@ function reloadSettings()
 	}
 
 	// Going anything further when the files don't match the database can make nasty messes (unless we're actively installing or upgrading)
-	if (!defined('SMF_INSTALLING') && !empty($modSettings['smfVersion']) && version_compare(strtolower(strtr($modSettings['smfVersion'], array('SMF ' => '', ' ' => '.'))), strtolower(strtr($forum_version, array('SMF ' => '', ' ' => '.'))), '!='))
+	if (!defined('SMF_INSTALLING') && (!isset($_REQUEST['action']) || $_REQUEST['action'] !== 'admin' || !isset($_REQUEST['area']) || $_REQUEST['area'] !== 'packages') && !empty($modSettings['smfVersion']) && version_compare(strtolower(strtr($modSettings['smfVersion'], array('SMF ' => '', ' ' => '.'))), strtolower(strtr($forum_version, array('SMF ' => '', ' ' => '.'))), '!='))
 	{
 		// Wipe the cached $modSettings values so they don't interfere with anything later
 		cache_put_data('modSettings', null);

--- a/other/install.php
+++ b/other/install.php
@@ -14,6 +14,7 @@
 define('SMF_VERSION', '2.1 RC1');
 define('DB_SCRIPT_VERSION', '2-1');
 define('SMF_SOFTWARE_YEAR', '2019');
+define('SMF_INSTALLING', 1);
 
 $GLOBALS['required_php_version'] = '5.4.0';
 

--- a/other/upgrade.php
+++ b/other/upgrade.php
@@ -15,6 +15,7 @@
 define('SMF_VERSION', '2.1 RC1');
 define('SMF_LANG_VERSION', '2.1 RC1');
 define('SMF_SOFTWARE_YEAR', '2019');
+define('SMF_INSTALLING', 1);
 
 /**
  * The minimum required PHP version.


### PR DESCRIPTION
Fixes #5123

Previously, if the admin uploaded an upgrade package, but then someone navigated to index.php before the admin finished the upgrade process, various errors and messes would be made. Among other things, `$modSettings['attachmentUploadDir']` could be corrupted, preventing custom avatars from being migrated correctly and generally causing havoc with attachments.

This commit does two things to fix the problem:

1. Adds some sanity checking when trying to json_decode the value of `$modSettings['attachmentUploadDir']` in `reloadSettings()`.
2. Detects when the SMF version defined in the PHP files doesn't match with the value of `$modSettings['smfVersion']` and, if so, redirects to the upgrader (unless the upgrader itself called `reloadSettings()`, in which case no intervention occurs). If upgrade.php doesn't exist in the expected location, dies with a message telling the admin to go get the upgrader package.