### PR TITLE
Uses constants instead of variables for forum version and year

### DIFF
--- a/SSI.php
+++ b/SSI.php
@@ -251,6 +251,52 @@ function ssi_shutdown()
 }
 
 /**
+ * Show the SMF version.
+ */
+function ssi_version($output_method = 'echo')
+{
+	if ($output_method == 'echo')
+		echo SMF_VERSION;
+	else
+		return SMF_VERSION;
+}
+
+/**
+ * Show the full SMF version string.
+ */
+function ssi_full_version($output_method = 'echo')
+{
+	if ($output_method == 'echo')
+		echo SMF_FULL_VERSION;
+	else
+		return SMF_FULL_VERSION;
+}
+
+/**
+ * Show the SMF software year.
+ */
+function ssi_software_year($output_method = 'echo')
+{
+	if ($output_method == 'echo')
+		echo SMF_SOFTWARE_YEAR;
+	else
+		return SMF_SOFTWARE_YEAR;
+}
+
+/**
+ * Show the forum copyright. Only used in our ssi_examples files.
+ */
+function ssi_copyright($output_method = 'echo')
+{
+	global $forum_copyright;
+
+	if ($output_method == 'echo')
+		printf($forum_copyright, SMF_FULL_VERSION, SMF_SOFTWARE_YEAR);
+	else
+		return sprintf($forum_copyright, SMF_FULL_VERSION, SMF_SOFTWARE_YEAR);
+}
+
+/**
  * Display a welcome message, like: Hey, User, you have 0 messages, 0 are new.
  *
  * @param string $output_method The output method. If 'echo', will display everything. Otherwise returns an array of user info.

--- a/SSI.php
+++ b/SSI.php
@@ -16,6 +16,9 @@ if (defined('SMF'))
 	return true;
 
 define('SMF', 'SSI');
+define('SMF_VERSION', '2.1 RC1');
+define('SMF_FULL_VERSION', 'SMF ' . SMF_VERSION);
+define('SMF_SOFTWARE_YEAR', '2019');
 
 // We're going to want a few globals... these are all set later.
 global $time_start, $maintenance, $msubject, $mmessage, $mbname, $language;

--- a/Sources/Admin.php
+++ b/Sources/Admin.php
@@ -509,7 +509,7 @@ function AdminMain()
  */
 function AdminHome()
 {
-	global $sourcedir, $forum_version, $txt, $scripturl, $context, $user_info;
+	global $sourcedir, $txt, $scripturl, $context, $user_info;
 
 	// You have to be able to do at least one of the below to see this page.
 	isAllowedTo(array('admin_forum', 'manage_permissions', 'moderate_forum', 'manage_membergroups', 'manage_bans', 'send_mail', 'edit_news', 'manage_boards', 'manage_smileys', 'manage_attachments'));
@@ -528,7 +528,7 @@ function AdminHome()
 
 	// This makes it easier to get the latest news with your time format.
 	$context['time_format'] = urlencode($user_info['time_format']);
-	$context['forum_version'] = $forum_version;
+	$context['forum_version'] = SMF_FULL_VERSION;
 
 	// Get a list of current server versions.
 	require_once($sourcedir . '/Subs-Admin.php');

--- a/Sources/CacheAPI-smf.php
+++ b/Sources/CacheAPI-smf.php
@@ -210,9 +210,7 @@ class smf_cache extends cache_api
 	 */
 	public function getVersion()
 	{
-		global $forum_version;
-
-		return isset($forum_version) ? $forum_version : '2.1';
+		return SMF_VERSION;
 	}
 }
 

--- a/Sources/Calendar.php
+++ b/Sources/Calendar.php
@@ -539,7 +539,7 @@ function CalendarPost()
  */
 function iCalDownload()
 {
-	global $smcFunc, $sourcedir, $forum_version, $modSettings, $webmaster_email, $mbname;
+	global $smcFunc, $sourcedir, $modSettings, $webmaster_email, $mbname;
 
 	// You can't export if the calendar export feature is off.
 	if (empty($modSettings['cal_export']))
@@ -589,7 +589,7 @@ function iCalDownload()
 	$filecontents = '';
 	$filecontents .= 'BEGIN:VCALENDAR' . "\n";
 	$filecontents .= 'METHOD:PUBLISH' . "\n";
-	$filecontents .= 'PRODID:-//SimpleMachines//SMF ' . (empty($forum_version) ? 2.1 : strtr($forum_version, array('SMF ' => ''))) . '//EN' . "\n";
+	$filecontents .= 'PRODID:-//SimpleMachines//' . SMF_FULL_VERSION . '//EN' . "\n";
 	$filecontents .= 'VERSION:2.0' . "\n";
 	$filecontents .= 'BEGIN:VEVENT' . "\n";
 	// @TODO - Should be the members email who created the event rather than $webmaster_email.

--- a/Sources/Load.php
+++ b/Sources/Load.php
@@ -74,7 +74,7 @@ function reloadSettings()
 	}
 
 	// Going anything further when the files don't match the database can make nasty messes (unless we're actively installing or upgrading)
-	if (!defined('SMF_INSTALLING') && (!isset($_REQUEST['action']) || $_REQUEST['action'] !== 'admin' || !isset($_REQUEST['area']) || $_REQUEST['area'] !== 'packages') && !empty($modSettings['smfVersion']) && version_compare(strtolower(strtr($modSettings['smfVersion'], array('SMF ' => '', ' ' => '.'))), strtolower(strtr($forum_version, array('SMF ' => '', ' ' => '.'))), '!='))
+	if (!defined('SMF_INSTALLING') && (!isset($_REQUEST['action']) || $_REQUEST['action'] !== 'admin' || !isset($_REQUEST['area']) || $_REQUEST['area'] !== 'packages') && !empty($modSettings['smfVersion']) && version_compare(strtolower(strtr($modSettings['smfVersion'], array(' ' => '.'))), strtolower(strtr(SMF_VERSION, array(' ' => '.'))), '!='))
 	{
 		// Wipe the cached $modSettings values so they don't interfere with anything later
 		cache_put_data('modSettings', null);
@@ -83,14 +83,14 @@ function reloadSettings()
 		if (file_exists($boarddir . '/upgrade.php'))
 			header('location: ' . $boardurl . '/upgrade.php');
 
-		die('SMF file version (' . strtr($forum_version, array('SMF ' => '')) . ') does not match SMF database version (' . strtr($modSettings['smfVersion'], array('SMF ' => '')) . ').<br>Run the SMF upgrader to fix this.<br><a href="https://wiki.simplemachines.org/smf/Upgrading">More information</a>.');
+		die('SMF file version (' . SMF_VERSION . ') does not match SMF database version (' . $modSettings['smfVersion'] . ').<br>Run the SMF upgrader to fix this.<br><a href="https://wiki.simplemachines.org/smf/Upgrading">More information</a>.');
 	}
 
 	$modSettings['cache_enable'] = $cache_enable;
 
 	// Used to force browsers to download fresh CSS and JavaScript when necessary
 	$modSettings['browser_cache'] = !empty($modSettings['browser_cache']) ? (int) $modSettings['browser_cache'] : 0;
-	$context['browser_cache'] = '?' . preg_replace('~\W~', '', strtolower($forum_version)) . '_' . $modSettings['browser_cache'];
+	$context['browser_cache'] = '?' . preg_replace('~\W~', '', strtolower(SMF_FULL_VERSION)) . '_' . $modSettings['browser_cache'];
 
 	// UTF-8 ?
 	$utf8 = (empty($modSettings['global_character_set']) ? $txt['lang_character_set'] : $modSettings['global_character_set']) === 'UTF-8';

--- a/Sources/ManageLanguages.php
+++ b/Sources/ManageLanguages.php
@@ -141,10 +141,10 @@ function AddLanguage()
  */
 function list_getLanguagesList()
 {
-	global $forum_version, $context, $sourcedir, $smcFunc, $txt, $scripturl;
+	global $context, $sourcedir, $smcFunc, $txt, $scripturl;
 
 	// We're going to use this URL.
-	$url = 'https://download.simplemachines.org/fetch_language.php?version=' . urlencode(strtr($forum_version, array('SMF ' => '')));
+	$url = 'https://download.simplemachines.org/fetch_language.php?version=' . urlencode(SMF_VERSION);
 
 	// Load the class file and stick it into an array.
 	require_once($sourcedir . '/Class-Package.php');
@@ -194,7 +194,7 @@ function list_getLanguagesList()
  */
 function DownloadLanguage()
 {
-	global $context, $sourcedir, $forum_version, $boarddir, $txt, $scripturl, $modSettings;
+	global $context, $sourcedir, $boarddir, $txt, $scripturl, $modSettings;
 
 	loadLanguage('ManageSettings');
 	require_once($sourcedir . '/Subs-Package.php');
@@ -238,7 +238,7 @@ function DownloadLanguage()
 		// Otherwise, go go go!
 		elseif (!empty($install_files))
 		{
-			read_tgz_file('https://download.simplemachines.org/fetch_language.php?version=' . urlencode(strtr($forum_version, array('SMF ' => ''))) . ';fetch=' . urlencode($_GET['did']), $boarddir, false, true, $install_files);
+			read_tgz_file('https://download.simplemachines.org/fetch_language.php?version=' . urlencode(SMF_VERSION) . ';fetch=' . urlencode($_GET['did']), $boarddir, false, true, $install_files);
 
 			// Make sure the files aren't stuck in the cache.
 			package_flush_cache();
@@ -250,7 +250,7 @@ function DownloadLanguage()
 
 	// Open up the old china.
 	if (!isset($archive_content))
-		$archive_content = read_tgz_file('https://download.simplemachines.org/fetch_language.php?version=' . urlencode(strtr($forum_version, array('SMF ' => ''))) . ';fetch=' . urlencode($_GET['did']), null);
+		$archive_content = read_tgz_file('https://download.simplemachines.org/fetch_language.php?version=' . urlencode(SMF_VERSION) . ';fetch=' . urlencode($_GET['did']), null);
 
 	if (empty($archive_content))
 		fatal_error($txt['add_language_error_no_response']);

--- a/Sources/ManageMaintenance.php
+++ b/Sources/ManageMaintenance.php
@@ -1334,7 +1334,7 @@ function AdminBoardRecount()
  */
 function VersionDetail()
 {
-	global $forum_version, $txt, $sourcedir, $context;
+	global $txt, $sourcedir, $context;
 
 	isAllowedTo('admin_forum');
 
@@ -1359,7 +1359,7 @@ function VersionDetail()
 	);
 
 	// Make it easier to manage for the template.
-	$context['forum_version'] = $forum_version;
+	$context['forum_version'] = SMF_FULL_VERSION;
 
 	$context['sub_template'] = 'view_versions';
 	$context['page_title'] = $txt['admin_version_check'];

--- a/Sources/News.php
+++ b/Sources/News.php
@@ -34,7 +34,7 @@ if (!defined('SMF'))
 function ShowXmlFeed()
 {
 	global $board, $board_info, $context, $scripturl, $boardurl, $txt, $modSettings, $user_info;
-	global $query_this_board, $smcFunc, $forum_version, $settings;
+	global $query_this_board, $smcFunc, $settings;
 
 	// If it's not enabled, die.
 	if (empty($modSettings['xmlnews_enable']))
@@ -355,7 +355,7 @@ function ShowXmlFeed()
 	<updated>', gmstrftime('%Y-%m-%dT%H:%M:%SZ'), '</updated>
 	<id>', $feed_meta['source'], '</id>
 	<subtitle>', $feed_meta['desc'], '</subtitle>
-	<generator uri="https://www.simplemachines.org" version="', strtr($forum_version, array('SMF' => '')), '">SMF</generator>',
+	<generator uri="https://www.simplemachines.org" version="', SMF_VERSION, '">SMF</generator>',
 	!empty($feed_meta['icon']) ? '
 	<icon>' . $feed_meta['icon'] . '</icon>' : '',
 	!empty($feed_meta['author']) ? '

--- a/Sources/PackageGet.php
+++ b/Sources/PackageGet.php
@@ -198,7 +198,7 @@ function PackageServers()
  */
 function PackageGBrowse()
 {
-	global $txt, $context, $scripturl, $sourcedir, $forum_version, $smcFunc;
+	global $txt, $context, $scripturl, $sourcedir, $smcFunc;
 
 	if (isset($_GET['server']))
 	{
@@ -318,7 +318,7 @@ function PackageGBrowse()
 			$default_title = $smcFunc['htmlspecialchars']($listing->fetch('default-website/@title'));
 	}
 
-	$the_version = strtr($forum_version, array('SMF ' => ''));
+	$the_version = SMF_VERSION;
 	if (!empty($_SESSION['version_emulate']))
 		$the_version = $_SESSION['version_emulate'];
 

--- a/Sources/Packages.php
+++ b/Sources/Packages.php
@@ -1007,7 +1007,7 @@ function PackageInstall()
 			elseif ($action['type'] == 'code' && !empty($action['filename']))
 			{
 				// This is just here as reference for what is available.
-				global $txt, $boarddir, $sourcedir, $modSettings, $context, $settings, $forum_version, $smcFunc;
+				global $txt, $boarddir, $sourcedir, $modSettings, $context, $settings, $smcFunc;
 
 				// Now include the file and be done with it ;).
 				if (file_exists($packagesdir . '/temp/' . $context['base_path'] . $action['filename']))
@@ -1035,7 +1035,7 @@ function PackageInstall()
 			elseif ($action['type'] == 'database' && !empty($action['filename']) && (!$context['uninstalling'] || !empty($_POST['do_db_changes'])))
 			{
 				// These can also be there for database changes.
-				global $txt, $boarddir, $sourcedir, $modSettings, $context, $settings, $forum_version, $smcFunc;
+				global $txt, $boarddir, $sourcedir, $modSettings, $context, $settings, $smcFunc;
 				global $db_package_log;
 
 				// We'll likely want the package specific database functionality!
@@ -1354,11 +1354,11 @@ function PackageRemove()
  */
 function PackageBrowse()
 {
-	global $txt, $scripturl, $context, $forum_version, $sourcedir, $smcFunc;
+	global $txt, $scripturl, $context, $sourcedir, $smcFunc;
 
 	$context['page_title'] .= ' - ' . $txt['browse_packages'];
 
-	$context['forum_version'] = $forum_version;
+	$context['forum_version'] = SMF_FULL_VERSION;
 	$context['modification_types'] = array('modification', 'avatar', 'language', 'unknown');
 
 	call_integration_hook('integrate_modification_types');
@@ -1516,7 +1516,7 @@ function PackageBrowse()
 	$context['emulation_versions'] = preg_replace('~^SMF ~', '', $items);
 
 	// Current SMF version, which is selected by default
-	$context['default_version'] = preg_replace('~^SMF ~', '', $forum_version);
+	$context['default_version'] = SMF_VERSION;
 
 	$context['emulation_versions'][] = $context['default_version'];
 
@@ -1537,7 +1537,7 @@ function PackageBrowse()
  */
 function list_getPackages($start, $items_per_page, $sort, $params)
 {
-	global $scripturl, $packagesdir, $context, $forum_version;
+	global $scripturl, $packagesdir, $context;
 	static $packages, $installed_mods;
 
 	// Start things up
@@ -1548,7 +1548,7 @@ function list_getPackages($start, $items_per_page, $sort, $params)
 	if (!@is_writable($packagesdir))
 		create_chmod_control(array($packagesdir), array('destination_url' => $scripturl . '?action=admin;area=packages', 'crash_on_error' => true));
 
-	$the_version = strtr($forum_version, array('SMF ' => ''));
+	$the_version = SMF_VERSION;
 
 	// Here we have a little code to help those who class themselves as something of gods, version emulation ;)
 	if (isset($_GET['version_emulate']) && strtr($_GET['version_emulate'], array('SMF ' => '')) == $the_version)
@@ -1557,7 +1557,7 @@ function list_getPackages($start, $items_per_page, $sort, $params)
 	}
 	elseif (isset($_GET['version_emulate']))
 	{
-		if (($_GET['version_emulate'] === 0 || $_GET['version_emulate'] === $forum_version) && isset($_SESSION['version_emulate']))
+		if (($_GET['version_emulate'] === 0 || $_GET['version_emulate'] === SMF_FULL_VERSION) && isset($_SESSION['version_emulate']))
 			unset($_SESSION['version_emulate']);
 		elseif ($_GET['version_emulate'] !== 0)
 			$_SESSION['version_emulate'] = strtr($_GET['version_emulate'], array('-' => ' ', '+' => ' ', 'SMF ' => ''));

--- a/Sources/ScheduledTasks.php
+++ b/Sources/ScheduledTasks.php
@@ -1006,7 +1006,7 @@ function loadEssentialThemeData()
  */
 function scheduled_fetchSMfiles()
 {
-	global $sourcedir, $txt, $language, $forum_version, $modSettings, $smcFunc, $context;
+	global $sourcedir, $txt, $language, $modSettings, $smcFunc, $context;
 
 	// What files do we want to get
 	$request = $smcFunc['db_query']('', '
@@ -1023,7 +1023,7 @@ function scheduled_fetchSMfiles()
 		$js_files[$row['id_file']] = array(
 			'filename' => $row['filename'],
 			'path' => $row['path'],
-			'parameters' => sprintf($row['parameters'], $language, urlencode($modSettings['time_format']), urlencode($forum_version)),
+			'parameters' => sprintf($row['parameters'], $language, urlencode($modSettings['time_format']), urlencode(SMF_FULL_VERSION)),
 		);
 	}
 

--- a/Sources/Search.php
+++ b/Sources/Search.php
@@ -18,8 +18,8 @@ if (!defined('SMF'))
 
 // This defines two version types for checking the API's are compatible with this version of SMF.
 $GLOBALS['search_versions'] = array(
-	// This is the forum version but is repeated due to some people rewriting $forum_version.
-	'forum_version' => 'SMF 2.1 RC1',
+	// @todo Probably unnecessary now that we use a constant instead of global $forum_version
+	'forum_version' => SMF_FULL_VERSION,
 	// This is the minimum version of SMF that an API could have been written for to work. (strtr to stop accidentally updating version on release)
 	'search_version' => strtr('SMF 2+1=Alpha=1', array('+' => '.', '=' => ' ')),
 );

--- a/Sources/Stats.php
+++ b/Sources/Stats.php
@@ -754,7 +754,7 @@ function getDailyStats($condition_string, $condition_parameters = array())
  */
 function SMStats()
 {
-	global $modSettings, $user_info, $forum_version, $sourcedir;
+	global $modSettings, $user_info, $sourcedir;
 
 	// First, is it disabled?
 	if (empty($modSettings['enable_sm_stats']) || empty($modSettings['sm_stats_key']))
@@ -787,7 +787,7 @@ function SMStats()
 		'php_version' => $serverVersions['php']['version'],
 		'database_type' => strtolower($serverVersions['db_engine']['version']),
 		'database_version' => $serverVersions['db_server']['version'],
-		'smf_version' => $forum_version,
+		'smf_version' => SMF_FULL_VERSION,
 		'smfd_version' => $modSettings['smfVersion'],
 	);
 

--- a/Sources/Subs-Package.php
+++ b/Sources/Subs-Package.php
@@ -1140,7 +1140,7 @@ function packageRequireFTP($destination_url, $files = null, $return = false)
  */
 function parsePackageInfo(&$packageXML, $testing_only = true, $method = 'install', $previous_version = '')
 {
-	global $packagesdir, $forum_version, $context, $temp_path, $language, $smcFunc;
+	global $packagesdir, $context, $temp_path, $language, $smcFunc;
 
 	// Mayday!  That action doesn't exist!!
 	if (empty($packageXML) || !$packageXML->exists($method))
@@ -1148,7 +1148,7 @@ function parsePackageInfo(&$packageXML, $testing_only = true, $method = 'install
 
 	// We haven't found the package script yet...
 	$script = false;
-	$the_version = strtr($forum_version, array('SMF ' => ''));
+	$the_version = SMF_VERSION;
 
 	// Emulation support...
 	if (!empty($_SESSION['version_emulate']))

--- a/Sources/Subs-Themes.php
+++ b/Sources/Subs-Themes.php
@@ -170,7 +170,7 @@ function get_all_themes($enable_only = false)
  */
 function get_theme_info($path)
 {
-	global $smcFunc, $sourcedir, $forum_version, $txt, $scripturl, $context;
+	global $smcFunc, $sourcedir, $txt, $scripturl, $context;
 	global $explicit_images;
 
 	if (empty($path))
@@ -206,18 +206,18 @@ function get_theme_info($path)
 	if (!$theme_info_xml->exists('theme-info/install'))
 	{
 		remove_dir($path);
-		fatal_lang_error('package_get_error_theme_not_compatible', false, $forum_version);
+		fatal_lang_error('package_get_error_theme_not_compatible', false, SMF_FULL_VERSION);
 	}
 
 	// So, we have an install tag which is cool and stuff but we also need to check it and match your current SMF version...
-	$the_version = strtr($forum_version, array('SMF ' => ''));
+	$the_version = SMF_VERSION;
 	$install_versions = $theme_info_xml->path('theme-info/install/@for');
 
 	// The theme isn't compatible with the current SMF version.
 	if (!$install_versions || !matchPackageVersion($the_version, $install_versions))
 	{
 		remove_dir($path);
-		fatal_lang_error('package_get_error_theme_not_compatible', false, $forum_version);
+		fatal_lang_error('package_get_error_theme_not_compatible', false, SMF_FULL_VERSION);
 	}
 
 	$theme_info_xml = $theme_info_xml->path('theme-info[0]');

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -3778,14 +3778,14 @@ function template_header()
  */
 function theme_copyright()
 {
-	global $forum_copyright, $software_year, $forum_version;
+	global $forum_copyright;
 
 	// Don't display copyright for things like SSI.
-	if (!isset($forum_version) || !isset($software_year))
+	if (SMF !== 1)
 		return;
 
 	// Put in the version...
-	printf($forum_copyright, $forum_version, $software_year);
+	printf($forum_copyright, SMF_FULL_VERSION, SMF_SOFTWARE_YEAR);
 }
 
 /**

--- a/Sources/Themes.php
+++ b/Sources/Themes.php
@@ -1381,7 +1381,6 @@ function InstallFile()
 function InstallCopy()
 {
 	global $themedir, $themeurl, $settings, $smcFunc, $context;
-	global $forum_version;
 
 	// There's gotta be something to work with.
 	if (!isset($_REQUEST['copy']) || empty($_REQUEST['copy']))
@@ -1401,7 +1400,7 @@ function InstallCopy()
 		'name' => $name,
 		'images_url' => $themeurl . '/' . $name . '/images',
 		'version' => '1.0',
-		'install_for' => '2.1 - 2.1.99, ' . strtr($forum_version, array('SMF ' => '')),
+		'install_for' => '2.1 - 2.1.99, ' . SMF_VERSION,
 		'based_on' => '',
 		'based_on_dir' => $themedir . '/default',
 	);

--- a/Sources/Who.php
+++ b/Sources/Who.php
@@ -543,7 +543,7 @@ function determineActions($urls, $preferred_prefix = false)
  */
 function Credits($in_admin = false)
 {
-	global $context, $smcFunc, $forum_copyright, $forum_version, $software_year, $txt, $user_info;
+	global $context, $smcFunc, $forum_copyright, $txt, $user_info;
 
 	// Don't blink. Don't even blink. Blink and you're dead.
 	loadLanguage('Who');
@@ -843,7 +843,7 @@ function Credits($in_admin = false)
 	$context['credits_modifications'] = $mods;
 
 	$context['copyrights'] = array(
-		'smf' => sprintf($forum_copyright, $forum_version, $software_year),
+		'smf' => sprintf($forum_copyright, SMF_FULL_VERSION, SMF_SOFTWARE_YEAR),
 		/* Modification Authors:  You may add a copyright statement to this array for your mods.
 			Copyright statements should be in the form of a value only without a array key.  I.E.:
 				'Some Mod by Thantos © 2010',

--- a/index.php
+++ b/index.php
@@ -20,11 +20,12 @@
  * @version 2.1 RC1
  */
 
-$software_year = '2019';
-$forum_version = 'SMF 2.1 RC1';
-
 // Get everything started up...
 define('SMF', 1);
+define('SMF_VERSION', '2.1 RC1');
+define('SMF_FULL_VERSION', 'SMF ' . SMF_VERSION);
+define('SMF_SOFTWARE_YEAR', '2019');
+
 error_reporting(E_ALL);
 $time_start = microtime(true);
 

--- a/other/install.php
+++ b/other/install.php
@@ -12,6 +12,7 @@
  */
 
 define('SMF_VERSION', '2.1 RC1');
+define('SMF_FULL_VERSION', 'SMF ' . SMF_VERSION);
 define('DB_SCRIPT_VERSION', '2-1');
 define('SMF_SOFTWARE_YEAR', '2019');
 define('SMF_INSTALLING', 1);
@@ -1657,7 +1658,7 @@ function AdminAccount()
 function DeleteInstall()
 {
 	global $smcFunc, $db_character_set, $context, $txt, $incontext;
-	global $current_smf_version, $databases, $sourcedir, $forum_version, $modSettings, $user_info, $db_type, $boardurl;
+	global $databases, $sourcedir, $modSettings, $user_info, $db_type, $boardurl;
 
 	$incontext['page_title'] = $txt['congratulations'];
 	$incontext['sub_template'] = 'delete_install';
@@ -1785,13 +1786,12 @@ function DeleteInstall()
 	// Sanity check that they loaded earlier!
 	if (isset($modSettings['recycle_board']))
 	{
-		$forum_version = $current_smf_version; // The variable is usually defined in index.php so lets just use our variable to do it for us.
 		scheduled_fetchSMfiles(); // Now go get those files!
 
 		// We've just installed!
 		$user_info['ip'] = $_SERVER['REMOTE_ADDR'];
 		$user_info['id'] = isset($incontext['member_id']) ? $incontext['member_id'] : 0;
-		logAction('install', array('version' => $forum_version), 'admin');
+		logAction('install', array('version' => SMF_FULL_VERSION), 'admin');
 	}
 
 	// Disable the legacy BBC by default for new installs
@@ -2062,7 +2062,7 @@ function template_install_below()
 	</div><!-- #footerfix -->
 	<div id="footer">
 		<ul>
-			<li class="copyright"><a href="https://www.simplemachines.org/" title="Simple Machines Forum" target="_blank" rel="noopener">SMF &copy; ' . SMF_SOFTWARE_YEAR . ', Simple Machines</a></li>
+			<li class="copyright"><a href="https://www.simplemachines.org/" title="Simple Machines Forum" target="_blank" rel="noopener">' . SMF_FULL_VERSION . ' &copy; ' . SMF_SOFTWARE_YEAR . ', Simple Machines</a></li>
 		</ul>
 	</div>
 </body>
@@ -2075,7 +2075,7 @@ function template_welcome_message()
 	global $incontext, $txt;
 
 	echo '
-	<script src="https://www.simplemachines.org/smf/current-version.js?version=' . SMF_VERSION . '"></script>
+	<script src="https://www.simplemachines.org/smf/current-version.js?version=' . urlencode(SMF_VERSION) . '"></script>
 	<form action="', $incontext['form_url'], '" method="post">
 		<p>', sprintf($txt['install_welcome_desc'], SMF_VERSION), '</p>
 		<div id="version_warning" class="noticebox hidden">

--- a/other/upgrade.php
+++ b/other/upgrade.php
@@ -13,6 +13,7 @@
 
 // Version information...
 define('SMF_VERSION', '2.1 RC1');
+define('SMF_FULL_VERSION', 'SMF ' . SMF_VERSION);
 define('SMF_LANG_VERSION', '2.1 RC1');
 define('SMF_SOFTWARE_YEAR', '2019');
 define('SMF_INSTALLING', 1);
@@ -1573,7 +1574,7 @@ function DatabaseChanges()
 // Delete the damn thing!
 function DeleteUpgrade()
 {
-	global $command_line, $language, $upcontext, $sourcedir, $forum_version;
+	global $command_line, $language, $upcontext, $sourcedir;
 	global $user_info, $maintenance, $smcFunc, $db_type, $txt, $settings;
 
 	// Now it's nice to have some of the basic SMF source files.
@@ -1621,7 +1622,6 @@ function DeleteUpgrade()
 	else
 	{
 		require_once($sourcedir . '/ScheduledTasks.php');
-		$forum_version = SMF_VERSION; // The variable is usually defined in index.php so lets just use the constant to do it for us.
 		scheduled_fetchSMfiles(); // Now go get those files!
 		// This is needed in case someone invokes the upgrader using https when upgrading an http forum
 		if (httpsOn())
@@ -1641,7 +1641,7 @@ function DeleteUpgrade()
 		),
 		array(
 			time(), 3, $user_info['id'], $command_line ? '127.0.0.1' : $user_info['ip'], 'upgrade',
-			0, 0, 0, json_encode(array('version' => $forum_version, 'member' => $user_info['id'])),
+			0, 0, 0, json_encode(array('version' => SMF_FULL_VERSION, 'member' => $user_info['id'])),
 		),
 		array('id_action')
 	);
@@ -1667,7 +1667,7 @@ function DeleteUpgrade()
 // Just like the built in one, but setup for CLI to not use themes.
 function cli_scheduled_fetchSMfiles()
 {
-	global $sourcedir, $language, $forum_version, $modSettings, $smcFunc;
+	global $sourcedir, $language, $modSettings, $smcFunc;
 
 	if (empty($modSettings['time_format']))
 		$modSettings['time_format'] = '%B %d, %Y, %I:%M:%S %p';
@@ -1686,7 +1686,7 @@ function cli_scheduled_fetchSMfiles()
 		$js_files[$row['id_file']] = array(
 			'filename' => $row['filename'],
 			'path' => $row['path'],
-			'parameters' => sprintf($row['parameters'], $language, urlencode($modSettings['time_format']), urlencode($forum_version)),
+			'parameters' => sprintf($row['parameters'], $language, urlencode($modSettings['time_format']), urlencode(SMF_FULL_VERSION)),
 		);
 	}
 	$smcFunc['db_free_result']($request);

--- a/ssi_examples.php
+++ b/ssi_examples.php
@@ -33,7 +33,7 @@ if (isset($_GET['view']) && $_GET['view'] == 'home1')
 template_ssi_above();
 ?>
 			<h2>SMF SSI.php Functions</h2>
-			<p><strong>Current Version:</strong> 2.1 RC1</p>
+			<p><strong>Current Version:</strong> <?php echo SMF_VERSION; ?></p>
 			<p>This file is used to demonstrate the capabilities of SSI.php using PHP include functions. The examples show the include tag, then the results of it.</p>
 
 			<h2>Include Code</h2>
@@ -415,8 +415,8 @@ function template_ssi_above()
 	echo '<!DOCTYPE html>
 <html>
 	<head>
-		<title>SMF 2.1 RC1 SSI.php Examples</title>
-		<link rel="stylesheet" href="', $settings['default_theme_url'], '/css/index.css?alp21">
+		<title>', SMF_FULL_VERSION, ' SSI.php Examples</title>
+		<link rel="stylesheet" href="', $settings['default_theme_url'], '/css/index.css">
 		<script src="', $settings['default_theme_url'], '/scripts/script.js"></script>
 		<style>
 			#wrapper {
@@ -501,7 +501,7 @@ function template_ssi_above()
 	</head>
 	<body>
 		<div id="header">
-			<h1 class="forumtitle">SMF 2.1 RC1 SSI.php Examples</h1>
+			<h1 class="forumtitle">', SMF_FULL_VERSION, ' SSI.php Examples</h1>
 			<img id="smflogo" src="Themes/default/images/smflogo.svg" alt="Simple Machines Forum" title="Simple Machines Forum">
 		</div>
 		<div id="wrapper">
@@ -525,7 +525,7 @@ function template_ssi_below()
 				<a href="#header" id="bot" class="go_up"></a>
 				<ul>
 					<li class="copyright">
-						<span class="smalltext"><a href="https://www.simplemachines.org">Simple Machines Forum</a></span>
+						<span class="smalltext">', SMF_FULL_VERSION, ' &copy; ', SMF_SOFTWARE_YEAR, ', <a href="https://www.simplemachines.org">Simple Machines Forum</a></span>
 					</li>
 				</ul>
 			</div>

--- a/ssi_examples.php
+++ b/ssi_examples.php
@@ -525,7 +525,7 @@ function template_ssi_below()
 				<a href="#header" id="bot" class="go_up"></a>
 				<ul>
 					<li class="copyright">
-						<span class="smalltext">', SMF_FULL_VERSION, ' &copy; ', SMF_SOFTWARE_YEAR, ', <a href="https://www.simplemachines.org">Simple Machines Forum</a></span>
+						<span class="smalltext">', ssi_copyright(), '</span>
 					</li>
 				</ul>
 			</div>

--- a/ssi_examples.shtml
+++ b/ssi_examples.shtml
@@ -150,12 +150,12 @@
 		<br>
 		<br>
 		<span class="smalltext">
-			<a href="https://www.simplemachines.org/" title="Simple Machines Forum" target="_blank" rel="noopener">SMF &copy; 2018, Simple Machines</a>
+			<a href="https://www.simplemachines.org/" title="Simple Machines Forum" target="_blank" rel="noopener">SMF &copy; 2019, Simple Machines</a>
 		</span>
 		<br>
 		<br>
 		<span class="smalltext" style="color: #CCCCCC;">
-			*ssi_examples.shtml last modified on <!--#config timefmt="%m/%d/%y" --><!--#echo var="LAST_MODIFIED" -->
+			*ssi_examples.shtml last modified on <!--#config timefmt="%F" --><!--#echo var="LAST_MODIFIED" -->
 		</span>
 
 	</body>

--- a/ssi_examples.shtml
+++ b/ssi_examples.shtml
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html>
 	<head>
-		<title> &lt;&lt; :: SMF SSI.php 2.1 RC1 :: &gt;&gt; </title>
+		<title> &lt;&lt; :: SMF SSI.php <!--#include virtual="./SSI.php?ssi_function=version" --> :: &gt;&gt; </title>
 	</head>
 	<body style="font-family: Verdana, Arial, Helvetica, sans-serif; font-size: 10pt;">
 			<h1>SMF SSI.php Functions</h1>
-			Current Version 2.1 RC1<br>
+			Current Version <!--#include virtual="./SSI.php?ssi_function=version" --><br>
 			<br>
 			This file is used to demonstrate the capabilities of SSI.php using SHTML include functions.<br>
 			The examples the include tag, then the results of it. Examples are separated by horizontal rules.<br>
@@ -150,7 +150,7 @@
 		<br>
 		<br>
 		<span class="smalltext">
-			<a href="https://www.simplemachines.org/" title="Simple Machines Forum" target="_blank" rel="noopener">SMF &copy; 2019, Simple Machines</a>
+			<!--#include virtual="./SSI.php?ssi_function=copyright" -->
 		</span>
 		<br>
 		<br>


### PR DESCRIPTION
For the sake of improving developer sanity and making some things a bit simpler, this replaces variables like `$forum_version` and `$software_year` with some nice constants (specifically, `SMF_VERSION`, `SMF_FULL_VERSION`, and `SMF_SOFTWARE_YEAR`).

Given that these values are supposed to be constant, it makes sense to define them as constants. Not only does this let us eliminate silliness like `strtr($forum_version, array('SMF ' => ''))` from numerous places, but it also lets us get rid of a few silly workarounds that had to be put in place just in case a mod had clobbered the variables.

These changes do require an update to some of our buildTools scripts, so this PR will fail Travis and Scrutinizer for now. I've already written the changes for buildTools, but I won't push them to the buildTools repo until we decide to merge this.