### PR TITLE
Fix upgrade ipv6 check for pg and do a more passive way of upgrade

### DIFF
--- a/other/upgrade_2-1_mysql.sql
+++ b/other/upgrade_2-1_mysql.sql
@@ -834,12 +834,7 @@ ALTER TABLE {$db_prefix}members
 /******************************************************************************/
 ---# Adding new column to log_topics...
 ALTER TABLE {$db_prefix}log_topics
-ADD COLUMN unwatched TINYINT NOT NULL DEFAULT '0';
----#
-
----# Initializing new column in log_topics...
-UPDATE {$db_prefix}log_topics
-SET unwatched = 0;
+ADD COLUMN unwatched TINYINT NOT NULL DEFAULT 0;
 ---#
 
 ---# Fixing column name change...

--- a/other/upgrade_2-1_postgresql.sql
+++ b/other/upgrade_2-1_postgresql.sql
@@ -1039,12 +1039,7 @@ ALTER TABLE {$db_prefix}members
 /******************************************************************************/
 ---# Adding new column to log_topics...
 ALTER TABLE {$db_prefix}log_topics
-ADD COLUMN unwatched int NOT NULL DEFAULT '0';
----#
-
----# Initializing new column in log_topics...
-UPDATE {$db_prefix}log_topics
-SET unwatched = 0;
+ADD COLUMN unwatched int NOT NULL DEFAULT 0;
 ---#
 
 ---# Fixing column name change...
@@ -2298,7 +2293,7 @@ DROP INDEX IF EXISTS {$db_prefix}topics_id_board;
 ---# upgrade check
 ---{
 $table_columns = $smcFunc['db_list_columns']('{db_prefix}ban_items');
-$upcontext['skip_db_substeps'] = !in_array('ip_low', $table_columns);
+$upcontext['skip_db_substeps'] = in_array('ip_low', $table_columns);
 ---}
 ---#
 


### PR DESCRIPTION
I did the column check in a wrong way in pg upgrade and
we add a colum with a default value, which is fine,
we run after this a update command,which harm the process.

Because when the table got added then all values are 0 already and
when the table got not added it change already existing values.