### PR TITLE
Allow hooks to silently fail.

### DIFF
--- a/Sources/Packages.php
+++ b/Sources/Packages.php
@@ -1026,6 +1026,10 @@ function PackageInstall()
 			}
 			elseif ($action['type'] == 'hook' && isset($action['hook'], $action['function']))
 			{
+				// Set the system to ignore hooks, but only if it wasn't changed before.
+				if (!isset($context['ignore_hook_errors']))
+					$context['ignore_hook_errors'] = true;
+
 				if ($action['reverse'])
 					remove_integration_function($action['hook'], $action['function'], true, $action['include_file'], $action['object']);
 				else


### PR DESCRIPTION
This fixes #4926 by adding a context check to allow Package Manager to specify that we are silently ignoring this.  This is the simplest of fixes without complex changes to the code to do the correct fixes in preventing reloading settings from being called.