### PR TITLE
Force the like index of messages for stat call

### DIFF
--- a/Sources/Stats.php
+++ b/Sources/Stats.php
@@ -537,7 +537,12 @@ function DisplayStats()
 		$max_liked_message = 1;
 		$liked_messages = $smcFunc['db_query']('', '
 			SELECT m.id_msg, m.subject, m.likes, m.id_board, m.id_topic, t.approved
-			FROM {db_prefix}messages as m
+			FROM (
+				SELECT n.id_msg, n.subject, n.likes, n.id_board, n.id_topic
+				FROM {db_prefix}messages as n
+				ORDER BY n.likes DESC
+				LIMIT 1000
+			) AS m
 				INNER JOIN {db_prefix}topics AS t ON (m.id_topic = t.id_topic)
 				INNER JOIN {db_prefix}boards AS b ON (b.id_board = t.id_board' . (!empty($modSettings['recycle_enable']) && $modSettings['recycle_board'] > 0 ? '
 					AND b.id_board != {int:recycle_board}' : '') . ')


### PR DESCRIPTION
Got the chance to lay my hands on a forum with 1.2 mio messages,
the stats view got a run time around 15 sec and
the query for the most like messages take ~ 14.8 sec.

By this optimization i was able to redurce the runtime of this query below 20ms.

The basic idea is collect the most 1k like messages,
with the hope that 10 of them get throw the join where statement part.

The chance is my eyes very low,
because non approved messages can't get likes and
that 1k most liked message get all in the recycle board is very less likly too.