### PR TITLE
View Warning permissions fix

### DIFF
--- a/Sources/Display.php
+++ b/Sources/Display.php
@@ -1576,7 +1576,7 @@ function prepareDisplayContext($reset = false)
 	else
 	{
 		// Define this here to make things a bit more readable
-		$can_view_warning = $context['user']['can_mod'] || allowedTo('view_warning_any') || ($message['id_member'] == $user_info['id'] && allowedTo('view_warning_own'));
+		$can_view_warning = allowedTo('moderate_forum') || allowedTo('view_warning_any') || ($message['id_member'] == $user_info['id'] && allowedTo('view_warning_own'));
 
 		$memberContext[$message['id_member']]['can_view_profile'] = allowedTo('profile_view') || ($message['id_member'] == $user_info['id'] && !$user_info['is_guest']);
 		$memberContext[$message['id_member']]['is_topic_starter'] = $message['id_member'] == $context['topic_starter_id'];

--- a/Sources/ManageSettings.php
+++ b/Sources/ManageSettings.php
@@ -574,7 +574,8 @@ function ModifyWarningSettings($return_config = false)
 				'warning_decrement',
 				'subtext' => $txt['setting_warning_decrement_note'] . ' ' . $txt['zero_to_disable']
 			),
-			array('permissions', 'view_warning'),
+			array('permissions', 'view_warning_any'),
+			array('permissions', 'view_warning_own'),
 		);
 
 	call_integration_hook('integrate_warning_settings', array(&$config_vars));

--- a/Themes/default/languages/ManageSettings.english.php
+++ b/Themes/default/languages/ManageSettings.english.php
@@ -223,7 +223,8 @@ $txt['setting_user_limit'] = 'Maximum user warning points per day';
 $txt['setting_user_limit_note'] = 'This value is the maximum amount of warning points a single moderator can assign to a user in a 24 hour period - 0 for no limit.';
 $txt['setting_warning_decrement'] = 'Warning points that are decreased every 24 hours';
 $txt['setting_warning_decrement_note'] = 'Only applies to users not warned within last 24 hours.';
-$txt['setting_view_warning'] = 'Users who can see warning status';
+$txt['setting_view_warning_any'] = 'Users who can see any warning status';
+$txt['setting_view_warning_own'] = 'Users who can see their own warning status';
 
 $txt['signature_settings'] = 'Signature Settings';
 $txt['signature_settings_desc'] = 'Use the settings on this page to decide how member signatures should be treated in SMF.';


### PR DESCRIPTION
Fixes #4695 

- Since there is only **view_warning_any** & **_own** I thought it'd be better to have both editable instead of one of them since it'd make things a bit confusing.
- **$context['user']['can_mod']** is true when the user is able to access the moderation center, that doesn't mean the user can moderate the forum, the second commit fixes it and matches the logic in profile view.