### PR TITLE
Don't use the formated percent value for calculation

### DIFF
--- a/Themes/default/Profile.template.php
+++ b/Themes/default/Profile.template.php
@@ -1407,7 +1407,7 @@ function template_statPanel()
 			echo '
 					<dt>', $activity['link'], '</dt>
 					<dd>
-						<div class="profile_pie" style="background-position: -', ((int) ($activity['percent'] / 5) * 20), 'px 0;" title="', sprintf($txt['statPanel_topBoards_posts'], $activity['posts'], $activity['total_posts'], $activity['posts_percent']), '">
+						<div class="profile_pie" style="background-position: -', ((int) ($activity['posts_percent'] / 5) * 20), 'px 0;" title="', sprintf($txt['statPanel_topBoards_posts'], $activity['posts'], $activity['total_posts'], $activity['posts_percent']), '">
 							', sprintf($txt['statPanel_topBoards_posts'], $activity['posts'], $activity['total_posts'], $activity['posts_percent']), '
 						</div>
 						', $activity['percent'], '%


### PR DESCRIPTION
$activity['percent'] = formated output = bad for calculation stuff
$activity['posts_percent'] = float value = good for calculation stuff

issue: https://www.simplemachines.org/community/index.php?topic=565120.0