### PR TITLE
Prevent loading invalid attachments from hooks

### DIFF
--- a/Sources/ShowAttachments.php
+++ b/Sources/ShowAttachments.php
@@ -87,14 +87,13 @@ function showAttachment()
 		call_integration_hook('integrate_download_request', array(&$attachRequest));
 		if (!is_null($attachRequest) && $smcFunc['db_is_resource']($attachRequest))
 			$request = $attachRequest;
-
 		else
 		{
 			// Make sure this attachment is on this board and load its info while we are at it.
 			$request = $smcFunc['db_query']('', '
 				SELECT id_folder, filename, file_hash, fileext, id_attach, id_thumb, attachment_type, mime_type, approved, id_msg
 				FROM {db_prefix}attachments
-				WHERE id_attach = {int:attach}
+				WHERE id_attach = {int:attach} AND id_msg != 0
 				LIMIT 1',
 				array(
 					'attach' => $attachId,


### PR DESCRIPTION
When hooks are used to work with attachments, the id_msg is 0. 

This can sometimes cause the attachment to still be loaded.  Prevent us from directly loading attachments with id_msg = 0 unless a hook has handled this already.