### PR TITLE
 Simplifies logic for manage_boards permission giving access to all boards

### DIFF
--- a/Sources/ManageBoards.php
+++ b/Sources/ManageBoards.php
@@ -663,15 +663,6 @@ function EditBoard2()
 					$boardOptions['deny_groups'][] = (int) $group;
 			}
 
-		// People with manage-boards are special.
-		require_once($sourcedir . '/Subs-Members.php');
-		$board_managers = groupsAllowedTo('manage_boards', null);
-		$board_managers = array_diff($board_managers['allowed'], array(1)); // We don't need to list admins anywhere.
-		// Firstly, we can't ever deny them.
-		$boardOptions['deny_groups'] = array_diff($boardOptions['deny_groups'], $board_managers);
-		// Secondly, make sure those with super cow powers (like apt-get, or in this case manage boards) are upgraded.
-		$boardOptions['access_groups'] = array_unique(array_merge($boardOptions['access_groups'], $board_managers));
-
 		if (strlen(implode(',', $boardOptions['access_groups'])) > 255 || strlen(implode(',', $boardOptions['deny_groups'])) > 255)
 			fatal_lang_error('too_many_groups', false);
 

--- a/Sources/ManageMembergroups.php
+++ b/Sources/ManageMembergroups.php
@@ -490,8 +490,8 @@ function AddMembergroup()
 
 				$smcFunc['db_query']('', '
 					DELETE FROM {db_prefix}board_permissions_view
-					WHERE id_board in({array_int:board_list}) 
-						AND id_group = {int:group_id} 
+					WHERE id_board IN ({array_int:board_list})
+						AND id_group = {int:group_id}
 						AND deny = {int:deny}',
 					array(
 						'board_list' => $changed_boards[$board_action],
@@ -776,20 +776,6 @@ function EditMembergroup()
 		if ($_REQUEST['group'] == 2 || $_REQUEST['group'] > 3)
 		{
 			$accesses = empty($_POST['boardaccess']) || !is_array($_POST['boardaccess']) ? array() : $_POST['boardaccess'];
-
-			// If they can manage boards, the rules are a bit different. They can see everything.
-			if ($context['can_manage_boards'])
-			{
-				$accesses = array();
-				$request = $smcFunc['db_query']('', '
-					SELECT id_board
-					FROM {db_prefix}boards'
-				);
-				while ($row = $smcFunc['db_fetch_assoc']($request))
-					$accesses[(int) $row['id_board']] = 'allow';
-
-				$smcFunc['db_free_result']($request);
-			}
 
 			$changed_boards['allow'] = array();
 			$changed_boards['deny'] = array();

--- a/Sources/Subs-Boards.php
+++ b/Sources/Subs-Boards.php
@@ -1380,23 +1380,30 @@ function getBoardTree()
 		'b.num_topics', 'b.deny_member_groups', 'c.id_cat', 'c.name AS cat_name',
 		'c.description AS cat_desc', 'c.cat_order', 'c.can_collapse',
 	);
+	$boardParameters = array();
+	$boardJoins = array();
+	$boardWhere = array();
+	$boardOrder = array('c.cat_order', 'b.child_level', 'b.board_order');
 
-	// Let mods add extra columns and parameters to the SELECT query
-	$extraBoardColumns = array();
-	$extraBoardParameters = array();
-	call_integration_hook('integrate_pre_boardtree', array(&$extraBoardColumns, &$extraBoardParameters));
+	// Let mods add extra columns, parameters, etc., to the SELECT query
+	call_integration_hook('integrate_pre_boardtree', array(&$boardColumns, &$boardParameters, &$boardJoins, &$boardWhere, &$boardOrder));
 
-	$boardColumns = array_unique(array_merge($boardColumns, $extraBoardColumns));
-	$boardParameters = array_unique($extraBoardParameters);
+	$boardColumns = array_unique($boardColumns);
+	$boardParameters = array_unique($boardParameters);
+	$boardJoins = array_unique($boardJoins);
+	$boardWhere = array_unique($boardWhere);
+	$boardOrder = array_unique($boardOrder);
 
 	// Getting all the board and category information you'd ever wanted.
 	$request = $smcFunc['db_query']('', '
 		SELECT
 			' . implode(', ', $boardColumns) . '
 		FROM {db_prefix}categories AS c
-			LEFT JOIN {db_prefix}boards AS b ON (b.id_cat = c.id_cat)
-		WHERE {query_see_board}
-		ORDER BY c.cat_order, b.child_level, b.board_order',
+			LEFT JOIN {db_prefix}boards AS b ON (b.id_cat = c.id_cat)' . implode('
+			', $boardJoins) . '
+		WHERE {query_see_board}' . (empty($boardWhere) ? '' : '
+			AND (' . implode(') AND (', $boardWhere) . ')') . '
+		ORDER BY ' . implode(', ', $boardOrder),
 		$boardParameters
 	);
 	$cat_tree = array();

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -6578,7 +6578,7 @@ function build_query_board($userid)
 	}
 
 	// Just build this here, it makes it easier to change/use - administrators can see all boards.
-	if ($is_admin)
+	if ($is_admin || allowedTo('manage_boards'))
 		$query_part['query_see_board'] = '1=1';
 	// Otherwise just the groups in $user_info['groups'].
 	else

--- a/Themes/default/languages/ManagePermissions.english.php
+++ b/Themes/default/languages/ManagePermissions.english.php
@@ -121,7 +121,7 @@ $txt['permissiongroup_maintenance'] = 'Forum administration';
 $txt['permissionname_admin_forum'] = 'Administrate forum and database';
 $txt['permissionhelp_admin_forum'] = 'This permission allows a user to:<ul class="normallist"><li>change forum, database and theme settings</li><li>manage packages</li><li>use the forum and database maintenance tools</li><li>view the error and mod logs</li></ul> Use this permission with caution, as it is very powerful.';
 $txt['permissionname_manage_boards'] = 'Manage boards and categories';
-$txt['permissionhelp_manage_boards'] = 'This permission allows creation, editing and removal of boards and categories.';
+$txt['permissionhelp_manage_boards'] = 'This permission allows creation, editing, and removal of boards and categories.<br><br>Users with this permission can see all boards.';
 $txt['permissionname_manage_attachments'] = 'Manage attachments and avatars';
 $txt['permissionhelp_manage_attachments'] = 'This permission allows access to the attachment center, where all forum attachments and avatars are listed and can be removed.';
 $txt['permissionname_manage_smileys'] = 'Manage smileys and message icons';

--- a/other/upgrade_2-1_mysql.sql
+++ b/other/upgrade_2-1_mysql.sql
@@ -631,61 +631,59 @@ VALUES
 ---#
 
 /******************************************************************************/
---- Updating board access rules
+--- Removing manage_boards permission from anyone who shouldn't have it
 /******************************************************************************/
----# Updating board access rules
+---# Removing manage_boards permission
 ---{
-$member_groups = array(
-	'allowed' => array(),
-	'denied' => array(),
-);
-
-$request = $smcFunc['db_query']('', '
-	SELECT id_group, add_deny
-	FROM {db_prefix}permissions
-	WHERE permission = {string:permission}',
-	array(
-		'permission' => 'manage_boards',
-	)
-);
-while ($row = $smcFunc['db_fetch_assoc']($request))
-	$member_groups[$row['add_deny'] === '1' ? 'allowed' : 'denied'][] = $row['id_group'];
-$smcFunc['db_free_result']($request);
-
-$member_groups = array_diff($member_groups['allowed'], $member_groups['denied']);
-
-if (!empty($member_groups))
+if (version_compare(@$modSettings['smfVersion'], '2.1', '<'))
 {
-	$count = count($member_groups);
-	$changes = array();
+	$board_managers = array();
 
 	$request = $smcFunc['db_query']('', '
-		SELECT id_board, member_groups
-		FROM {db_prefix}boards'
+		SELECT id_group
+		FROM {db_prefix}permissions
+		WHERE permission = {string:permission}',
+		array(
+			'permission' => 'manage_boards',
+		)
 	);
-	while ($row = $smcFunc['db_fetch_assoc']($request))
+	if ($smcFunc['db_num_rows']($request) != 0)
 	{
-		$current_groups = explode(',', $row['member_groups']);
-		if (count(array_intersect($current_groups, $member_groups)) != $count)
-		{
-			$new_groups = array_unique(array_merge($current_groups, $member_groups));
-			$changes[$row['id_board']] = implode(',', $new_groups);
-		}
+		while ($row = $smcFunc['db_fetch_assoc']($request))
+			$board_managers[$row['id_group']] = 0;
 	}
 	$smcFunc['db_free_result']($request);
 
-	if (!empty($changes))
+	$request = $smcFunc['db_query']('', '
+		SELECT member_groups
+		FROM {db_prefix}boards',
+		array()
+	);
+	$num_boards = $smcFunc['db_num_rows']($request);
+	while ($row = $smcFunc['db_fetch_assoc']($request))
 	{
-		foreach ($changes as $id_board => $member_groups)
-			$smcFunc['db_query']('', '
-				UPDATE {db_prefix}boards
-				SET member_groups = {string:member_groups}
-				WHERE id_board = {int:id_board}',
-				array(
-					'member_groups' => $member_groups,
-					'id_board' => $id_board,
-				)
-			);
+		$groups = explode($row['member_groups']);
+		foreach ($groups as $group)
+			++$board_managers[$group];
+	}
+	$smcFunc['db_free_result']($request);
+
+	$ex_board_managers = array();
+	foreach ($board_managers as $id_group => $board_count)
+		if ($board_count < $num_boards)
+			$ex_board_managers[] = $id_group;
+
+	if (!empty($ex_board_managers))
+	{
+		$smcFunc['db_query']('', '
+			DELETE FROM {db_prefix}permissions
+			WHERE permission = {string:permission}
+				AND id_group IN ({array_int:ex_board_managers})',
+			array(
+				'permission' => 'manage_boards',
+				'ex_board_managers' => $ex_board_managers,
+			)
+		);
 	}
 }
 ---}


### PR DESCRIPTION
Fixes #5002 
Closes #5459

This is an alternative to #5459. This PR continues with the change introduced in 2.1 that meant anyone with the manage_boards permission could see all boards, but also simplifies some logic regarding that behaviour. In particular, these lines in `build_query_board()` now grant anyone who can manage boards access to all boards:
https://github.com/SimpleMachines/SMF2.1/blob/1c530f0b0badea95818990ec2665d2c4bdb3ba4a/Sources/Subs.php#L6581-L6582

This approach has two advantages over the previous method:

1. It's simpler. Instead of needing to use workarounds in the `EditBoard2()` and `EditMembergroup()` functions in order to grant access to all boards to membergroups with the permission, this just cuts to the chase by checking for the permission in `build_query_board()`.
2. If the permission is later revoked from a membergroup, the group automatically reverts back to whatever board access it had before the permission was given. Under the previous method, if the permission was revoked after the workaround to explicitly grant access to all boards had succeeded, the membergroup would continue to have access to all boards until the admin edited its access.

In order to address the issue pointed out by @jdarwood007 in https://github.com/SimpleMachines/SMF2.1/pull/5396#issuecomment-465805040, this PR also adds some logic to the upgrader to remove the manage_boards permission from anyone who doesn't already have access to all boards. So, if the Global Moderator group has the permission on a 2.0.x forum, but does not have access to all boards in the forum, then the permission will be removed during the upgrade to 2.1. However, if the Global Moderator group does already have access to all boards, then it can retain the permission.