### PR TITLE
Check if the ascending is changed between calls fixes #5486

### DIFF
--- a/Sources/Display.php
+++ b/Sources/Display.php
@@ -864,7 +864,7 @@ function Display()
 	$ascending = empty($options['view_newest_first']);
 
 	// Check if we can use the seek method to speed things up
-	if (isset($_SESSION['page_topic']) && $_SESSION['page_topic'] == $topic)
+	if (isset($_SESSION['page_topic']) && $_SESSION['page_topic'] == $topic && $_SESSION['page_ascending'] == $ascending)
 	{
 		// User moved to the next page
 		if (isset($_SESSION['page_next_start']) && $_SESSION['page_next_start'] == $start)
@@ -1022,6 +1022,7 @@ function Display()
 	$_SESSION['page_next_start'] = $_REQUEST['start'] + $limit;
 	$_SESSION['page_current_start'] = $_REQUEST['start'];
 	$_SESSION['page_topic'] = $topic;
+	$_SESSION['page_ascending'] = $ascending;
 
 	$smcFunc['db_free_result']($request);
 	$posters = array_unique($all_posters);


### PR DESCRIPTION
I'm not 100% sure if a isset check should be placed too,
normaly the var should be setted in the same moment when $_SESSION['page_topic'] is setted.
So when $_SESSION['page_topic'] is not setted the $_SESSION['page_ascending'] var should be also not setted and
vice versa.

issue: #5486