### PR TITLE
Cache allowedTo value

### DIFF
--- a/Sources/Security.php
+++ b/Sources/Security.php
@@ -897,6 +897,7 @@ function checkSubmitOnce($action, $is_fatal = true)
 function allowedTo($permission, $boards = null, $any = false)
 {
 	global $user_info, $smcFunc;
+	static $prem_cache = array();
 
 	// You're always allowed to do nothing. (unless you're a working man, MR. LAZY :P!)
 	if (empty($permission))
@@ -924,6 +925,9 @@ function allowedTo($permission, $boards = null, $any = false)
 	}
 	elseif (!is_array($boards))
 		$boards = array($boards);
+
+	if (!empty($prem_cache[hash('md5', $user_info['id'].implode($permission).implode($boards).$any)]))
+			return $prem_cache[hash('md5', $user_info['id'].implode($permission).implode($boards).$any)];
 
 	$request = $smcFunc['db_query']('', '
 		SELECT MIN(bp.add_deny) AS add_deny
@@ -955,18 +959,24 @@ function allowedTo($permission, $boards = null, $any = false)
 				break;
 		}
 		$smcFunc['db_free_result']($request);
+		$return = $result;
 		return $result;
 	}
 
 	// Make sure they can do it on all of the boards.
-	if ($smcFunc['db_num_rows']($request) != count($boards))
-		return false;
+	if ($smcFunc['db_num_rows']($request) != count($boards) && empty($return))
+		$return = false;
 
-	$result = true;
-	while ($row = $smcFunc['db_fetch_assoc']($request))
-		$result &= !empty($row['add_deny']);
-	$smcFunc['db_free_result']($request);
+	if (empty($return))
+	{
+		$result = true;
+		while ($row = $smcFunc['db_fetch_assoc']($request))
+			$result &= !empty($row['add_deny']);
+		$smcFunc['db_free_result']($request);
+		$return = $result;
+	}
 
+	$prem_cache[hash('md5', $user_info['id'].implode($permission).implode($boards).$any)] = $result;
 	// If the query returned 1, they can do it... otherwise, they can't.
 	return $result;
 }

--- a/Sources/Security.php
+++ b/Sources/Security.php
@@ -929,7 +929,7 @@ function allowedTo($permission, $boards = null, $any = false)
 	$cache_key = hash('md5', $user_info['id'] . '-' . implode(',', $permission) . '-' . implode(',', $boards) . '-' . $any);
 
 	if (isset($perm_cache[$cache_key]))
-			return $perm_cache[$cache_key];
+		return $perm_cache[$cache_key];
 
 	$request = $smcFunc['db_query']('', '
 		SELECT MIN(bp.add_deny) AS add_deny

--- a/Sources/Security.php
+++ b/Sources/Security.php
@@ -926,10 +926,10 @@ function allowedTo($permission, $boards = null, $any = false)
 	elseif (!is_array($boards))
 		$boards = array($boards);
 
-	$cache_key = $user_info['id'] . '-' . implode(',', $permission) . '-' . implode(',', $boards) . '-' . $any;
+	$cache_key = hash('md5', $user_info['id'] . '-' . implode(',', $permission) . '-' . implode(',', $boards) . '-' . $any);
 
-	if (isset($perm_cache[hash('md5', $cache_key)]))
-			return $perm_cache[hash('md5', $cache_key)];
+	if (isset($perm_cache[$cache_key]))
+			return $perm_cache[$cache_key];
 
 	$request = $smcFunc['db_query']('', '
 		SELECT MIN(bp.add_deny) AS add_deny
@@ -977,7 +977,7 @@ function allowedTo($permission, $boards = null, $any = false)
 		$return = $result;
 	}
 
-	$perm_cache[hash('md5', $cache_key)] = $result;
+	$perm_cache[$cache_key] = $result;
 
 	// If the query returned 1, they can do it... otherwise, they can't.
 	return $result;

--- a/Sources/Security.php
+++ b/Sources/Security.php
@@ -960,7 +960,6 @@ function allowedTo($permission, $boards = null, $any = false)
 		}
 		$smcFunc['db_free_result']($request);
 		$return = $result;
-		return $result;
 	}
 
 	// Make sure they can do it on all of the boards.

--- a/Sources/Security.php
+++ b/Sources/Security.php
@@ -926,7 +926,7 @@ function allowedTo($permission, $boards = null, $any = false)
 	elseif (!is_array($boards))
 		$boards = array($boards);
 
-	if (!empty($prem_cache[hash('md5', $user_info['id'].implode($permission).implode($boards).$any)]))
+	if (isset($prem_cache[hash('md5', $user_info['id'].implode($permission).implode($boards).$any)]))
 			return $prem_cache[hash('md5', $user_info['id'].implode($permission).implode($boards).$any)];
 
 	$request = $smcFunc['db_query']('', '
@@ -964,10 +964,10 @@ function allowedTo($permission, $boards = null, $any = false)
 	}
 
 	// Make sure they can do it on all of the boards.
-	if ($smcFunc['db_num_rows']($request) != count($boards) && empty($return))
+	if ($smcFunc['db_num_rows']($request) != count($boards) && !isset($return))
 		$return = false;
 
-	if (empty($return))
+	if (!isset($return))
 	{
 		$result = true;
 		while ($row = $smcFunc['db_fetch_assoc']($request))


### PR DESCRIPTION
Well this is an attempt to redurce the amount of queries produce by the allowedTo operation,
which can get high like in the issue #5492

Create a key(hash) based on the userid+input and safe the return value if the is a more complex check.

Fix partly #5492 instead of 4 quries per attachment we are now on 2.