### PR TITLE
Fix regular members board permission

### DIFF
--- a/Sources/Subs-Boards.php
+++ b/Sources/Subs-Boards.php
@@ -668,7 +668,7 @@ function modifyBoard($board_id, &$boardOptions)
 	);
 
 	// Do permission sync
-	if (!empty($boardUpdateParameters['deny_groups']))
+	if (!empty($boardOptions['deny_groups']))
 	{
 		$insert = array();
 		foreach ($boardOptions['deny_groups'] as $value)
@@ -682,7 +682,7 @@ function modifyBoard($board_id, &$boardOptions)
 		);
 	}
 
-	if (!empty($boardUpdateParameters['member_groups']))
+	if (!empty($boardOptions['access_groups']))
 	{
 		$insert = array();
 		foreach ($boardOptions['access_groups'] as $value)


### PR DESCRIPTION
Fixes #5514

regular members group id = 0
$boardUpdateParameters['member_groups'] is a string containing group ids seperated by commas, so if we only check regular members we get 0 which doesn't pass the test for empty()