### PR TITLE
Show in search only approved message when needed fixes #5534

### DIFF
--- a/Sources/Recent.php
+++ b/Sources/Recent.php
@@ -322,6 +322,7 @@ function RecentPosts()
 		return;
 	}
 
+	$only_approved = $modSettings['postmod_active'] && !allowedTo('approve_posts') && !allowedTo('manage_boards');
 	// Get all the most recent posts.
 	$request = $smcFunc['db_query']('', '
 		SELECT
@@ -336,12 +337,14 @@ function RecentPosts()
 			INNER JOIN {db_prefix}messages AS m2 ON (m2.id_msg = t.id_first_msg)
 			LEFT JOIN {db_prefix}members AS mem ON (mem.id_member = m.id_member)
 			LEFT JOIN {db_prefix}members AS mem2 ON (mem2.id_member = m2.id_member)
-		WHERE m.id_msg IN ({array_int:message_list})
+		WHERE m.id_msg IN ({array_int:message_list}) ' . ($only_approved ? '
+			AND t.approved = {int:is_approved}' : '') . '
 		ORDER BY m.id_msg DESC
 		LIMIT {int:limit}',
 		array(
 			'message_list' => $messages,
 			'limit' => count($messages),
+			'is_approved' => 1,
 		)
 	);
 	$counter = $_REQUEST['start'] + 1;

--- a/Sources/Recent.php
+++ b/Sources/Recent.php
@@ -322,7 +322,7 @@ function RecentPosts()
 		return;
 	}
 
-	$only_approved = $modSettings['postmod_active'] && !allowedTo('approve_posts') && !allowedTo('manage_boards');
+	$only_approved = $modSettings['postmod_active'] && !allowedTo('approve_posts');
 	// Get all the most recent posts.
 	$request = $smcFunc['db_query']('', '
 		SELECT

--- a/Sources/Search.php
+++ b/Sources/Search.php
@@ -1704,7 +1704,7 @@ function PlushSearch2()
 		$request = $smcFunc['db_search_query']('', '
 			SELECT ' . (empty($search_params['topic']) ? 'lsr.id_topic' : $search_params['topic'] . ' AS id_topic') . ', lsr.id_msg, lsr.relevance, lsr.num_matches
 			FROM {db_prefix}log_search_results AS lsr' . ($join_topic ? '
-				INNER JOIN {db_prefix}topics AS t ON (t.id_topic = lsr.id_topic)' : '') . '	
+				INNER JOIN {db_prefix}topics AS t ON (t.id_topic = lsr.id_topic)' : '') . '
 			WHERE lsr.id_search = {int:id_search}
 			' . ($only_approved ? ' AND t.approved = {int:is_approved}' : '') . '
 			ORDER BY {raw:sort} {raw:sort_dir}

--- a/Sources/Search.php
+++ b/Sources/Search.php
@@ -1699,7 +1699,7 @@ function PlushSearch2()
 
 		// *** Retrieve the results to be shown on the page
 		$participants = array();
-		$only_approved = $modSettings['postmod_active'] && !allowedTo('approve_posts') && !allowedTo('manage_boards');
+		$only_approved = $modSettings['postmod_active'] && !allowedTo('approve_posts');
 		$join_topic = $only_approved || $search_params['sort'] == 'num_replies';
 		$request = $smcFunc['db_search_query']('', '
 			SELECT ' . (empty($search_params['topic']) ? 'lsr.id_topic' : $search_params['topic'] . ' AS id_topic') . ', lsr.id_msg, lsr.relevance, lsr.num_matches


### PR DESCRIPTION
The performance impact here is less big as expected.

Another suprise for me was,
that ``$modSettings['postmod_active'] && !allowedTo('approve_posts')``
was not enough.
Since the board manager can see now unapproval message too,
so i had to add him to the check.

issue: #5534