### PR TITLE
Avoids error if $modSettings['board_manager_groups'] is undefined

### DIFF
--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -6534,7 +6534,7 @@ function build_query_board($userid)
 		foreach ($groups as $k => $v)
 			$groups[$k] = (int) $v;
 
-		$can_see_all_boards = in_array(1, $groups) || count(array_intersect($groups, explode(',', $modSettings['board_manager_groups']))) > 0;
+		$can_see_all_boards = in_array(1, $groups) || (!empty($modSettings['board_manager_groups']) && count(array_intersect($groups, explode(',', $modSettings['board_manager_groups']))) > 0);
 
 		$ignoreboards = !empty($row['ignore_boards']) && !empty($modSettings['allow_ignore_boards']) ? explode(',', $row['ignore_boards']) : array();
 	}


### PR DESCRIPTION
Fixes #5541

I could have sworn I changed this in 9c540e0, but apparently I only got the ones in Load.php and missed the one in Subs.php.