### PR TITLE
Generic quickbuttons template

### DIFF
--- a/Sources/Display.php
+++ b/Sources/Display.php
@@ -1691,7 +1691,7 @@ function prepareDisplayContext($reset = false)
 			),
 			'remove_topic' => array(
 				'label' => $txt['remove_topic'],
-				'href' => $scripturl.'?action=removetopic2;topic='.$context['current_topic'].'.'.$context['start'].';'.$context['session_var'], '='.$context['session_id'],
+				'href' => $scripturl.'?action=removetopic2;topic='.$context['current_topic'].'.'.$context['start'].';'.$context['session_var'].'='.$context['session_id'],
 				'javascript' => 'data-confirm="'.$txt['are_sure_remove_topic'].'" class="you_sure"',
 				'icon' => 'remove_button',
 				'show' => $context['can_delete'] && ($context['topic_first_message'] == $output['id'])
@@ -1717,7 +1717,7 @@ function prepareDisplayContext($reset = false)
 			),
 			'warn' => array(
 				'label' => $txt['issue_warning'],
-				'href' => $scripturl, '?action=profile;area=issuewarning;u=', $output['member']['id'], ';msg='.$output['id'],
+				'href' => $scripturl, '?action=profile;area=issuewarning;u='.$output['member']['id'].';msg='.$output['id'],
 				'icon' => 'warn_button',
 				'show' => $context['can_issue_warning'] && !$output['is_message_author'] && !$output['member']['is_guest']
 			),
@@ -1729,13 +1729,13 @@ function prepareDisplayContext($reset = false)
 			),
 			'approve' => array(
 				'label' => $txt['approve'],
-				'href' => $scripturl.'?action=moderate;area=postmod;sa=approve;topic='.$context['current_topic'], '.'.$context['start'], ';msg='.$output['id'], ';'.$context['session_var'], '='.$context['session_id'],
+				'href' => $scripturl.'?action=moderate;area=postmod;sa=approve;topic='.$context['current_topic'].'.'.$context['start'].';msg='.$output['id'].';'.$context['session_var'].'='.$context['session_id'],
 				'icon' => 'approve_button',
 				'show' => $output['can_approve']
 			),
 			'unapprove' => array(
 				'label' => $txt['unapprove'],
-				'href' => $scripturl.'?action=moderate;area=postmod;sa=approve;topic='.$context['current_topic'].'.'.$context['start'].';msg='.$output['id'].';'.$context['session_var'], '='.$context['session_id'],
+				'href' => $scripturl.'?action=moderate;area=postmod;sa=approve;topic='.$context['current_topic'].'.'.$context['start'].';msg='.$output['id'].';'.$context['session_var'].'='.$context['session_id'],
 				'icon' => 'unapprove_button',
 				'show' => $output['can_unapprove']
 			),

--- a/Sources/Display.php
+++ b/Sources/Display.php
@@ -1398,16 +1398,16 @@ function Display()
 	$context['normal_buttons'] = array();
 
 	if ($context['can_reply'])
-		$context['normal_buttons']['reply'] = array('text' => 'reply', 'image' => 'reply.png', 'url' => $scripturl . '?action=post;topic=' . $context['current_topic'] . '.' . $context['start'] . ';last_msg=' . $context['topic_last_message'], 'active' => true);
+		$context['normal_buttons']['reply'] = array('text' => 'reply', 'url' => $scripturl . '?action=post;topic=' . $context['current_topic'] . '.' . $context['start'] . ';last_msg=' . $context['topic_last_message'], 'active' => true);
 
 	if ($context['can_add_poll'])
-		$context['normal_buttons']['add_poll'] = array('text' => 'add_poll', 'image' => 'add_poll.png', 'url' => $scripturl . '?action=editpoll;add;topic=' . $context['current_topic'] . '.' . $context['start']);
+		$context['normal_buttons']['add_poll'] = array('text' => 'add_poll', 'url' => $scripturl . '?action=editpoll;add;topic=' . $context['current_topic'] . '.' . $context['start']);
 
 	if ($context['can_mark_unread'])
-		$context['normal_buttons']['mark_unread'] = array('text' => 'mark_unread', 'image' => 'markunread.png', 'url' => $scripturl . '?action=markasread;sa=topic;t=' . $context['mark_unread_time'] . ';topic=' . $context['current_topic'] . '.' . $context['start'] . ';' . $context['session_var'] . '=' . $context['session_id']);
+		$context['normal_buttons']['mark_unread'] = array('text' => 'mark_unread', 'url' => $scripturl . '?action=markasread;sa=topic;t=' . $context['mark_unread_time'] . ';topic=' . $context['current_topic'] . '.' . $context['start'] . ';' . $context['session_var'] . '=' . $context['session_id']);
 
 	if ($context['can_print'])
-		$context['normal_buttons']['print'] = array('text' => 'print', 'image' => 'print.png', 'custom' => 'rel="nofollow"', 'url' => $scripturl . '?action=printpage;topic=' . $context['current_topic'] . '.0');
+		$context['normal_buttons']['print'] = array('text' => 'print', 'custom' => 'rel="nofollow"', 'url' => $scripturl . '?action=printpage;topic=' . $context['current_topic'] . '.0');
 
 	if ($context['can_set_notify'])
 		$context['normal_buttons']['notify'] = array(
@@ -1437,26 +1437,26 @@ function Display()
 	$context['mod_buttons'] = array();
 
 	if ($context['can_move'])
-		$context['mod_buttons']['move'] = array('text' => 'move_topic', 'image' => 'admin_move.png', 'url' => $scripturl . '?action=movetopic;current_board=' . $context['current_board'] . ';topic=' . $context['current_topic'] . '.0');
+		$context['mod_buttons']['move'] = array('text' => 'move_topic', 'url' => $scripturl . '?action=movetopic;current_board=' . $context['current_board'] . ';topic=' . $context['current_topic'] . '.0');
 
 	if ($context['can_delete'])
-		$context['mod_buttons']['delete'] = array('text' => 'remove_topic', 'image' => 'admin_rem.png', 'custom' => 'data-confirm="' . $txt['are_sure_remove_topic'] . '"', 'class' => 'you_sure', 'url' => $scripturl . '?action=removetopic2;topic=' . $context['current_topic'] . '.0;' . $context['session_var'] . '=' . $context['session_id']);
+		$context['mod_buttons']['delete'] = array('text' => 'remove_topic', 'custom' => 'data-confirm="' . $txt['are_sure_remove_topic'] . '"', 'class' => 'you_sure', 'url' => $scripturl . '?action=removetopic2;topic=' . $context['current_topic'] . '.0;' . $context['session_var'] . '=' . $context['session_id']);
 
 	if ($context['can_lock'])
-		$context['mod_buttons']['lock'] = array('text' => empty($context['is_locked']) ? 'set_lock' : 'set_unlock', 'image' => 'admin_lock.png', 'url' => $scripturl . '?action=lock;topic=' . $context['current_topic'] . '.' . $context['start'] . ';sa=' . ($context['is_locked'] ? 'unlock' : 'lock') . ';' . $context['session_var'] . '=' . $context['session_id']);
+		$context['mod_buttons']['lock'] = array('text' => empty($context['is_locked']) ? 'set_lock' : 'set_unlock', 'url' => $scripturl . '?action=lock;topic=' . $context['current_topic'] . '.' . $context['start'] . ';sa=' . ($context['is_locked'] ? 'unlock' : 'lock') . ';' . $context['session_var'] . '=' . $context['session_id']);
 
 	if ($context['can_sticky'])
-		$context['mod_buttons']['sticky'] = array('text' => empty($context['is_sticky']) ? 'set_sticky' : 'set_nonsticky', 'image' => 'admin_sticky.png', 'url' => $scripturl . '?action=sticky;topic=' . $context['current_topic'] . '.' . $context['start'] . ';sa=' . ($context['is_sticky'] ? 'nonsticky' : 'sticky') . ';' . $context['session_var'] . '=' . $context['session_id']);
+		$context['mod_buttons']['sticky'] = array('text' => empty($context['is_sticky']) ? 'set_sticky' : 'set_nonsticky', 'url' => $scripturl . '?action=sticky;topic=' . $context['current_topic'] . '.' . $context['start'] . ';sa=' . ($context['is_sticky'] ? 'nonsticky' : 'sticky') . ';' . $context['session_var'] . '=' . $context['session_id']);
 
 	if ($context['can_merge'])
-		$context['mod_buttons']['merge'] = array('text' => 'merge', 'image' => 'merge.png', 'url' => $scripturl . '?action=mergetopics;board=' . $context['current_board'] . '.0;from=' . $context['current_topic']);
+		$context['mod_buttons']['merge'] = array('text' => 'merge', 'url' => $scripturl . '?action=mergetopics;board=' . $context['current_board'] . '.0;from=' . $context['current_topic']);
 
 	if ($context['calendar_post'])
-		$context['mod_buttons']['calendar'] = array('text' => 'calendar_link', 'image' => 'linktocal.png', 'url' => $scripturl . '?action=post;calendar;msg=' . $context['topic_first_message'] . ';topic=' . $context['current_topic'] . '.0');
+		$context['mod_buttons']['calendar'] = array('text' => 'calendar_link', 'url' => $scripturl . '?action=post;calendar;msg=' . $context['topic_first_message'] . ';topic=' . $context['current_topic'] . '.0');
 
 	// Restore topic. eh?  No monkey business.
 	if ($context['can_restore_topic'])
-		$context['mod_buttons']['restore_topic'] = array('text' => 'restore_topic', 'image' => '', 'url' => $scripturl . '?action=restoretopic;topics=' . $context['current_topic'] . ';' . $context['session_var'] . '=' . $context['session_id']);
+		$context['mod_buttons']['restore_topic'] = array('text' => 'restore_topic', 'url' => $scripturl . '?action=restoretopic;topics=' . $context['current_topic'] . ';' . $context['session_var'] . '=' . $context['session_id']);
 
 	// Show a message in case a recently posted message became unapproved.
 	$context['becomesUnapproved'] = !empty($_SESSION['becomesUnapproved']);
@@ -1657,6 +1657,96 @@ function prepareDisplayContext($reset = false)
 	if (!empty($memberContext[$message['id_member']]['custom_fields']))
 		foreach ($memberContext[$message['id_member']]['custom_fields'] as $custom)
 			$output['custom_fields'][$context['cust_profile_fields_placement'][$custom['placement']]][] = $custom;
+
+	$output['quickbuttons'] = array(
+		'quote' => array(
+			'label' => $txt['quote_action'],
+			'href' => $scripturl.'?action=post;quote='.$output['id'].';topic='.$context['current_topic'], '.'.$context['start'].';last_msg='.$context['topic_last_message'],
+			'javascript' => 'onclick="return oQuickReply.quote('.$output['id'].');"',
+			'icon' => 'quote',
+			'show' => $context['can_quote']
+		),
+		'quote_selected' => array(
+			'label' => $txt['quote_selected_action'],
+			'id' => 'quoteSelected_'. $output['id'],
+			'href' => 'javascript:void(0)',
+			'custom' => 'style="display:none"',
+			'icon' => 'quote_selected',
+			'show' => $context['can_quote']
+		),
+		'quick_edit' => array(
+			'label' => $txt['quick_edit'],
+			'class' => 'quick_edit',
+			'id' =>' modify_button_'. $output['id'],
+			'custom' => 'onclick="oQuickModify.modifyMsg(\''.$output['id'].'\', \''.!empty($modSettings['toggle_subject']).'\')"',
+			'icon' => 'quick_edit_button',
+			'show' => $output['can_modify']
+		),
+		'more' => array(
+			'modify' => array(
+				'label' => $txt['modify'],
+				'href' => $scripturl.'?action=post;msg='.$output['id'].';topic='.$context['current_topic'].'.'.$context['start'],
+				'icon' => 'modify_button',
+				'show' => $output['can_modify']
+			),
+			'remove_topic' => array(
+				'label' => $txt['remove_topic'],
+				'href' => $scripturl.'?action=removetopic2;topic='.$context['current_topic'].'.'.$context['start'].';'.$context['session_var'], '='.$context['session_id'],
+				'javascript' => 'data-confirm="'.$txt['are_sure_remove_topic'].'" class="you_sure"',
+				'icon' => 'remove_button',
+				'show' => $context['can_delete'] && ($context['topic_first_message'] == $output['id'])
+			),
+			'remove' => array(
+				'label' => $txt['remove'],
+				'href' => $scripturl.'?action=deletemsg;topic='.$context['current_topic'].'.'.$context['start'].';msg='.$output['id'].';'.$context['session_var'].'='.$context['session_id'],
+				'javascript' => 'data-confirm="'.$txt['remove_message_question'].'" class="you_sure"',
+				'icon' => 'remove_button',
+				'show' => $output['can_remove'] && ($context['topic_first_message'] != $output['id'])
+			),
+			'split' => array(
+				'label' => $txt['split'],
+				'href' => $scripturl.'?action=splittopics;topic='.$context['current_topic'].'.0;at='.$output['id'],
+				'icon' => 'split_button',
+				'show' => $context['can_split'] && !empty($context['real_num_replies'])
+			),
+			'report' => array(
+				'label' => $txt['report_to_mod'],
+				'href' => $scripturl.'?action=reporttm;topic='.$context['current_topic'].'.'.$output['counter'].';msg='.$output['id'],
+				'icon' => 'error',
+				'show' => $context['can_report_moderator']
+			),
+			'warn' => array(
+				'label' => $txt['issue_warning'],
+				'href' => $scripturl, '?action=profile;area=issuewarning;u=', $output['member']['id'], ';msg='.$output['id'],
+				'icon' => 'warn_button',
+				'show' => $context['can_issue_warning'] && !$output['is_message_author'] && !$output['member']['is_guest']
+			),
+			'restore' => array(
+				'label' => $txt['restore_message'],
+				'href' => $scripturl.'?action=restoretopic;msgs='.$output['id'].';'.$context['session_var'].'='.$context['session_id'],
+				'icon' => 'restore_button',
+				'show' => $context['can_restore_msg']
+			),
+			'approve' => array(
+				'label' => $txt['approve'],
+				'href' => $scripturl.'?action=moderate;area=postmod;sa=approve;topic='.$context['current_topic'], '.'.$context['start'], ';msg='.$output['id'], ';'.$context['session_var'], '='.$context['session_id'],
+				'icon' => 'approve_button',
+				'show' => $output['can_approve']
+			),
+			'unapprove' => array(
+				'label' => $txt['unapprove'],
+				'href' => $scripturl.'?action=moderate;area=postmod;sa=approve;topic='.$context['current_topic'].'.'.$context['start'].';msg='.$output['id'].';'.$context['session_var'], '='.$context['session_id'],
+				'icon' => 'unapprove_button',
+				'show' => $output['can_unapprove']
+			),
+		),
+		'quickmod' => array(
+			'id' => 'in_topic_mod_check_'. $output['id'],
+			'custom' => 'style="display: none;"',
+			'content' => '',
+			'show' => !empty($options['display_quick_mod']) && $options['display_quick_mod'] == 1 && $output['can_remove'],
+		)
+	);
 
 	if (empty($options['view_newest_first']))
 		$counter++;

--- a/Sources/Drafts.php
+++ b/Sources/Drafts.php
@@ -642,6 +642,19 @@ function showProfileDrafts($memID, $draft_type = 0)
 			'id_draft' => $row['id_draft'],
 			'locked' => $row['locked'],
 			'sticky' => $row['is_sticky'],
+			'quickbuttons' => array(
+				'edit' => array(
+					'label' => $txt['draft_edit'],
+					'href' => $scripturl.'?action=post;'.(empty($row['id_topic']) ? 'board='.$row['id_board'] : 'topic='.$row['id_topic']).'.0;id_draft='.$row['id_draft'],
+					'icon' => 'modify_button'
+				),
+				'delete' => array(
+					'label' => $txt['draft_delete'],
+					'href' => $scripturl.'?action=profile;u='.$context['member']['id'].';area=showdrafts;delete='.$row['id_draft'].';'.$context['session_var'].'='.$context['session_id'],
+					'javascript' => 'data-confirm="'.$txt['draft_remove'].'" class="you_sure"',
+					'icon' => 'remove_button'
+				),
+			),
 		);
 	}
 	$smcFunc['db_free_result']($request);
@@ -821,6 +834,19 @@ function showPMDrafts($memID = -1)
 			'recipients' => $recipients,
 			'age' => floor((time() - $row['poster_time']) / 86400),
 			'remaining' => (!empty($modSettings['drafts_keep_days']) ? floor($modSettings['drafts_keep_days'] - ((time() - $row['poster_time']) / 86400)) : 0),
+			'quickbuttons' => array(
+				'edit' => array(
+					'label' => $txt['draft_edit'],
+					'href' => $scripturl.'?action=pm;sa=showpmdrafts;id_draft='.$row['id_draft'].';'.$context['session_var'].'='.$context['session_id'],
+					'icon' => 'modify_button'
+				),
+				'delete' => array(
+					'label' => $txt['draft_delete'],
+					'href' => $scripturl.'?action=pm;sa=showpmdrafts;delete='.$row['id_draft'].';'.$context['session_var'].'='.$context['session_id'],
+					'javascript' => 'data-confirm="'.$txt['draft_remove'].'?" class="you_sure"',
+					'icon' => 'remove_button'
+				),
+			),
 		);
 	}
 	$smcFunc['db_free_result']($request);

--- a/Sources/PersonalMessage.php
+++ b/Sources/PersonalMessage.php
@@ -1101,6 +1101,51 @@ function prepareMessageContext($type = 'subject', $reset = false)
 
 	call_integration_hook('integrate_prepare_pm_context', array(&$output, &$message, $counter));
 
+	$output['quickbuttons'] = array(
+		'reply_to_all' => array(
+			'label' => $txt['reply_to_all'],
+			'href' => $scripturl.'?action=pm;sa=send;f='.$context['folder'].($context['current_label_id'] != -1 ? ';l=' .$context['current_label_id'] : '').';pmsg='.$output['id'].';quote;u=all',
+			'icon' => 'reply_all_button',
+			'show' => $context['can_send_pm'] && !$output['member']['is_guest'] && $output['number_recipients'] > 1
+		),
+		'reply' => array(
+			'label' => $txt['reply'],
+			'href' => $scripturl.'?action=pm;sa=send;f='.$context['folder'].($context['current_label_id'] != -1 ? ';l=' .$context['current_label_id'] : '').';pmsg='.$output['id'].';u='.$output['member']['id'],
+			'icon' => 'reply_button',
+			'show' => $context['can_send_pm'] && !$output['member']['is_guest']
+		),
+		'quote' => array(
+			'label' => $txt['quote_action'],
+			'href' => $scripturl.'?action=pm;sa=send;f='.$context['folder'].($context['current_label_id'] != -1 ? ';l=' .$context['current_label_id'] : '').';pmsg='.$output['id'].';quote'.($context['folder'] == 'sent' ? '' : ';u=' .$output['member']['id']),
+			'icon' => 'quote',
+			'show' => $context['can_send_pm'] && !$output['member']['is_guest']
+		),
+		'reply_quote' => array(
+			'label' => $txt['reply_quote'],
+			'href' => $scripturl.'?action=pm;sa=send;f='.$context['folder'].($context['current_label_id'] != -1 ? ';l=' .$context['current_label_id'] : '').';pmsg='.$output['id'].';quote',
+			'icon' => 'quote',
+			'show' => $context['can_send_pm'] && $output['member']['is_guest']
+		),
+		'delete' => array(
+			'label' => $txt['delete'],
+			'href' => $scripturl.'?action=pm;sa=pmactions;pm_actions%5b'.$output['id'].'%5D=delete;f='.$context['folder'].';start='.$context['start'].($context['current_label_id'] != -1 ? ';l=' .$context['current_label_id'] : '').';'.$context['session_var'].'='.$context['session_id'],
+			'javascript' => 'data-confirm="'.addslashes($txt['remove_message_question']).'" class="you_sure"',
+			'icon' => 'remove_button',
+		),
+		'more' => array(
+			'report' => array(
+				'label' => $txt['pm_report_to_admin'],
+				'href' => $scripturl .'?action=pm;sa=report;l=' .$context['current_label_id'] .';pmsg=' .$output['id'],
+				'icon' => 'error',
+				'show' => $output['can_report']
+			),
+		),
+		'quickmod' => array(
+			'content' => '<input type="checkbox" name="pms[]" id="deletedisplay'.$output['id'].'" value="'.$output['id'].'" onclick="document.getElementById(\'deletelisting'.$output['id'].'\').checked = this.checked;">',
+			'show' => empty($context['display_mode'])
+		)
+	);
+
 	return $output;
 }
 

--- a/Sources/Profile-View.php
+++ b/Sources/Profile-View.php
@@ -477,6 +477,28 @@ function showAlerts($memID)
 			});
 		});', true);
 
+	// The quickbuttons
+	foreach ($context['alerts'] as $id => $alert)
+	{
+		$context['alerts'][$id]['quickbuttons'] = array(
+			'delete' => array(
+				'label' => $txt['delete'],
+				'href' => $scripturl.'?action=profile;u='.$context['id_member'].';area=showalerts;do=remove;aid='.$id.';'.$context['session_var'].'='.$context['session_id'],
+				'javascript' => 'class="you_sure"',
+				'icon' => 'remove_button'
+			),
+			'mark' => array(
+				'label' => $alert['is_read'] != 0 ? $txt['mark_unread'] : $txt['mark_read_short'],
+				'href' => $scripturl.'?action=profile;u='.$context['id_member'].';area=showalerts;do='.($alert['is_read'] != 0 ? 'unread' : 'read').';aid='.$id.';'.$context['session_var'].'='.$context['session_id'],
+				'icon' => $alert['is_read'] != 0 ? 'unread_button' : 'read_button',
+			),
+			'quickmod' => array(
+				'content' => '<input type="checkbox" name="mark['.$id.']" value="'.$id.'">',
+				'show' => $context['showCheckboxes']
+			)
+		);
+	}
+
 	// Set a nice message.
 	if (!empty($_SESSION['update_message']))
 	{
@@ -874,6 +896,31 @@ function showPosts($memID)
 
 	// Allow last minute changes.
 	call_integration_hook('integrate_profile_showPosts');
+
+	foreach ($context['posts'] as $key => $post)
+	{
+		$context['posts'][$key]['quickbuttons'] = array(
+			'reply' => array(
+				'label' => $txt['reply'],
+				'href' => $scripturl.'?action=post;topic='.$post['topic'].'.'.$post['start'],
+				'icon' => 'reply_button',
+				'show' => $post['can_reply']
+			),
+			'quote' => array(
+				'label' => $txt['quote_action'],
+				'href' => $scripturl.'?action=post;topic='.$post['topic'].'.'.$post['start'].';quote='.$post['id'],
+				'icon' => 'quote',
+				'show' => $post['can_quote']
+			),
+			'remove' => array(
+				'label' => $txt['remove'],
+				'href' => $scripturl.'?action=deletemsg;msg='.$post['id'].';topic='.$post['topic'].';profile;u='.$context['member']['id'].';start='.$context['start'].';'.$context['session_var'].'='.$context['session_id'],
+				'javascript' => 'data-confirm="'.$txt['remove_message'].'" class="you_sure"',
+				'icon' => 'remove_button',
+				'show' => $post['can_delete']
+			)
+		);
+	}
 }
 
 /**

--- a/Sources/Recent.php
+++ b/Sources/Recent.php
@@ -454,9 +454,6 @@ function RecentPosts()
 		$context['posts'][$counter]['can_quote'] = $context['posts'][$counter]['can_reply'] && $quote_enabled;
 	}
 
-	// Allow last minute changes.
-	call_integration_hook('integrate_recent_RecentPosts');
-
 	// Last but not least, the quickbuttons
 	foreach ($context['posts'] as $key => $post)
 	{
@@ -482,6 +479,9 @@ function RecentPosts()
 			),
 		);
 	}
+
+	// Allow last minute changes.
+	call_integration_hook('integrate_recent_RecentPosts');
 }
 
 /**

--- a/Sources/Recent.php
+++ b/Sources/Recent.php
@@ -456,6 +456,32 @@ function RecentPosts()
 
 	// Allow last minute changes.
 	call_integration_hook('integrate_recent_RecentPosts');
+
+	// Last but not least, the quickbuttons
+	foreach ($context['posts'] as $key => $post)
+	{
+		$context['posts'][$key]['quickbuttons'] = array(
+			'reply' => array(
+				'label' => $txt['reply'],
+				'href' => $scripturl.'?action=post;topic='.$post['topic'].'.'.$post['start'],
+				'icon' => 'reply_button',
+				'show' => $post['can_reply']
+			),
+			'quote' => array(
+				'label' => $txt['quote_action'],
+				'href' => $scripturl.'?action=post;topic='.$post['topic'].'.'.$post['start'].';quote='.$post['id'],
+				'icon' => 'quote',
+				'show' => $post['can_quote']
+			),
+			'delete' => array(
+				'label' => $txt['remove'],
+				'href' => $scripturl.'?action=deletemsg;msg='.$post['id'].';topic='.$post['topic'].';recent;'.$context['session_var'].'='.$context['session_id'],
+				'javascript' => 'data-confirm="'.$txt['remove_message'].'" class="you_sure"',
+				'icon' => 'remove_button',
+				'show' => $post['can_delete']
+			),
+		);
+	}
 }
 
 /**

--- a/Sources/ReportedContent.php
+++ b/Sources/ReportedContent.php
@@ -27,7 +27,7 @@ if (!defined('SMF'))
 function ReportedContent()
 {
 	global $txt, $context, $user_info, $smcFunc;
-	global $sourcedir;
+	global $sourcedir, $scripturl;
 
 	// First order of business - what are these reports about?
 	// area=reported{type}
@@ -78,6 +78,62 @@ function ReportedContent()
 
 	// Hi Ho Silver Away!
 	call_helper($subActions[$context['sub_action']]);
+
+	// If we're showing a list of reports
+	if ($context['sub_action'] == 'show' || $context['sub_action'] == 'closed')
+	{
+		// Quickbuttons for each report
+		foreach ($context['reports'] as $key => $report)
+		{
+			$context['reports'][$key]['quickbuttons'] = array(
+				'details' => array(
+					'label' => $txt['mc_reportedp_details'],
+					'href' => $report['report_href'],
+					'icon' => 'details',
+				),
+				'ignore' => array(
+					'label' => $report['ignore'] ? $txt['mc_reportedp_unignore'] : $txt['mc_reportedp_ignore'],
+					'href' => $scripturl.'?action=moderate;area=reported'.$context['report_type'].';sa=handle;ignore='.(int)!$report['ignore'].';rid='.$report['id'].';start='.$context['start'].';'.$context['session_var'].'='.$context['session_id'].';'.$context['mod-report-ignore_token_var'].'='.$context['mod-report-ignore_token'],
+					'javascript' => !$report['ignore'] ? ' class="you_sure" data-confirm="' . $txt['mc_reportedp_ignore_confirm'] . '"' : '',
+					'icon' => 'ignore'
+				),
+				'close' => array(
+					'label' => $context['view_closed'] ? $txt['mc_reportedp_open'] : $txt['mc_reportedp_close'],
+					'href' => $scripturl.'?action=moderate;area=reported'.$context['report_type'].';sa=handle;closed='.(int)!$report['closed'].';rid='.$report['id'].';start='.$context['start'].';'.$context['session_var'].'='.$context['session_id'].';'.$context['mod-report-closed_token_var'].'='.$context['mod-report-closed_token'],
+					'icon' => $context['view_closed'] ? 'folder' : 'close',
+				),
+			);
+
+			// Only reported posts can be deleted
+			if ($context['report_type'] == 'posts')
+				$context['reports'][$key]['quickbuttons']['delete'] = array(
+					'label' => $txt['mc_reportedp_delete'],
+					'href' => $scripturl.'?action=deletemsg;topic='.$report['topic']['id'].'.0;msg='.$report['topic']['id_msg'].';modcenter;'.$context['session_var'].'='.$context['session_id'],
+					'javascript' => 'data-confirm="'.$txt['mc_reportedp_delete_confirm'].'" class="you_sure"',
+					'icon' => 'delete',
+					'show' => !$report['closed'] && (is_array($context['report_remove_any_boards']) && in_array($report['topic']['id_board'], $context['report_remove_any_boards']))
+				);
+
+			// Ban reported member/post author link
+			if ($context['report_type'] == 'members')
+				$ban_link = $scripturl.'?action=admin;area=ban;sa=add;u='.$report['user']['id'].';'.$context['session_var'].'='.$context['session_id'];
+			else
+				$ban_link = $scripturl.'?action=admin;area=ban;sa=add'.(!empty($report['author']['id']) ? ';u='.$report['author']['id'] : ';msg='.$report['topic']['id_msg']).';'.$context['session_var'].'='.$context['session_id'];
+
+			$context['reports'][$key]['quickbuttons'] += array(
+				'ban' => array(
+					'label' => $txt['mc_reportedp_ban'],
+					'href' => $ban_link,
+					'icon' => 'error',
+					'show' => !$report['closed'] && !empty($context['report_manage_bans']) && ($context['report_type'] == 'posts' || $context['report_type'] == 'members' && !empty($report['user']['id']))
+				),
+				'quickmod' => array(
+					'content' => '<input type="checkbox" name="close[]" value="'.$report['id'].'">',
+					'show' => !$context['view_closed']
+				)
+			);
+		}
+	}
 }
 
 /**

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -4408,32 +4408,6 @@ function text2words($text, $max_chars = 20, $encrypt = false)
 }
 
 /**
- * Creates an image/text button
- *
- * @param string $name The name of the button (should be a main_icons class or the name of an image)
- * @param string $alt The alt text
- * @param string $label The $txt string to use as the label
- * @param string $custom Custom text/html to add to the img tag (only when using an actual image)
- * @param boolean $force_use Whether to force use of this when template_create_button is available
- * @return string The HTML to display the button
- */
-function create_button($name, $alt, $label = '', $custom = '', $force_use = false)
-{
-	global $settings, $txt;
-
-	// Does the current loaded theme have this and we are not forcing the usage of this function?
-	if (function_exists('template_create_button') && !$force_use)
-		return template_create_button($name, $alt, $label = '', $custom = '');
-
-	if (!$settings['use_image_buttons'])
-		return $txt[$alt];
-	elseif (!empty($settings['use_buttons']))
-		return '<span class="main_icons ' . $name . '" alt="' . $txt[$alt] . '"></span>' . ($label != '' ? '&nbsp;<strong>' . $txt[$label] . '</strong>' : '');
-	else
-		return '<img src="' . $settings['lang_images_url'] . '/' . $name . '" alt="' . $txt[$alt] . '" ' . $custom . '>';
-}
-
-/**
  * Sets up all of the top menu buttons
  * Saves them in the cache if it is available and on
  * Places the results in $context

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -4408,6 +4408,33 @@ function text2words($text, $max_chars = 20, $encrypt = false)
 }
 
 /**
+ * Creates an image/text button
+ *
+ * @deprecated since 2.1
+ * @param string $name The name of the button (should be a main_icons class or the name of an image)
+ * @param string $alt The alt text
+ * @param string $label The $txt string to use as the label
+ * @param string $custom Custom text/html to add to the img tag (only when using an actual image)
+ * @param boolean $force_use Whether to force use of this when template_create_button is available
+ * @return string The HTML to display the button
+ */
+function create_button($name, $alt, $label = '', $custom = '', $force_use = false)
+{
+	global $settings, $txt;
+
+	// Does the current loaded theme have this and we are not forcing the usage of this function?
+	if (function_exists('template_create_button') && !$force_use)
+		return template_create_button($name, $alt, $label = '', $custom = '');
+
+	if (!$settings['use_image_buttons'])
+		return $txt[$alt];
+	elseif (!empty($settings['use_buttons']))
+		return '<span class="main_icons ' . $name . '" alt="' . $txt[$alt] . '"></span>' . ($label != '' ? '&nbsp;<strong>' . $txt[$label] . '</strong>' : '');
+	else
+		return '<img src="' . $settings['lang_images_url'] . '/' . $name . '" alt="' . $txt[$alt] . '" ' . $custom . '>';
+}
+
+/**
  * Sets up all of the top menu buttons
  * Saves them in the cache if it is available and on
  * Places the results in $context

--- a/Themes/default/Display.template.php
+++ b/Themes/default/Display.template.php
@@ -820,19 +820,8 @@ function template_single_post($message)
 							</div><!-- #msg_[id]_footer -->';
 	}
 
-	// And stuff below the attachments.
-	if ($context['can_report_moderator'] || !empty($modSettings['enable_likes']) || $message['can_approve'] || $message['can_unapprove'] || $context['can_reply'] || $message['can_modify'] || $message['can_remove'] || $context['can_split'] || $context['can_restore_msg'] || $context['can_quote'])
-		echo '
+	echo '
 							<div class="under_message">';
-
-	// Maybe they want to report this post to the moderator(s)?
-	if ($context['can_report_moderator'])
-		echo '
-								<ul class="floatright smalltext">
-									<li class="report_link">
-										<a href="', $scripturl, '?action=reporttm;topic=', $context['current_topic'], '.', $message['counter'], ';msg=', $message['id'], '">', $txt['report_to_mod'], '</a>
-									</li>
-								</ul>';
 
 	// What about likes?
 	if (!empty($modSettings['enable_likes']))
@@ -873,91 +862,10 @@ function template_single_post($message)
 	}
 
 	// Show the quickbuttons, for various operations on posts.
-	if ($message['can_approve'] || $message['can_unapprove'] || $context['can_reply'] || $message['can_modify'] || $message['can_remove'] || $context['can_split'] || $context['can_restore_msg'] || $context['can_quote'])
-	{
-		echo '
-								<ul class="quickbuttons">';
-
-		// Can they quote? if so they can select and quote as well!
-		if ($context['can_quote'])
-			echo '
-									<li><a href="', $scripturl, '?action=post;quote=', $message['id'], ';topic=', $context['current_topic'], '.', $context['start'], ';last_msg=', $context['topic_last_message'], '" onclick="return oQuickReply.quote(', $message['id'], ');"><span class="main_icons quote"></span>', $txt['quote_action'], '</a></li>
-									<li style="display:none;" id="quoteSelected_', $message['id'], '">
-										<a href="javascript:void(0)"><span class="main_icons quote_selected"></span>', $txt['quote_selected_action'], '</a>
-									</li>';
-
-		// Can the user modify the contents of this post? Show the modify inline image.
-		if ($message['can_modify'])
-			echo '
-									<li class="quick_edit">
-										<a title="', $txt['modify_msg'], '" class="modifybutton" id="modify_button_', $message['id'], '" onclick="oQuickModify.modifyMsg(\'', $message['id'], '\', \'', !empty($modSettings['toggle_subject']), '\')"><span class="main_icons quick_edit_button"></span>', $txt['quick_edit'], '</a>
-									</li>';
-
-		if ($message['can_approve'] || $message['can_unapprove'] || $message['can_modify'] || $message['can_remove'] || $context['can_split'] || $context['can_restore_msg'])
-			echo '
-									<li class="post_options">', $txt['post_options'];
-
-		echo '
-										<ul>';
-
-		// Can the user modify the contents of this post?
-		if ($message['can_modify'])
-			echo '
-											<li><a href="', $scripturl, '?action=post;msg=', $message['id'], ';topic=', $context['current_topic'], '.', $context['start'], '"><span class="main_icons modify_button"></span>', $txt['modify'], '</a></li>';
-
-		// How about... even... remove it entirely?!
-		if ($context['can_delete'] && ($context['topic_first_message'] == $message['id']))
-			echo '
-											<li><a href="', $scripturl, '?action=removetopic2;topic=', $context['current_topic'], '.', $context['start'], ';', $context['session_var'], '=', $context['session_id'], '" data-confirm="', $txt['are_sure_remove_topic'], '" class="you_sure"><span class="main_icons remove_button"></span>', $txt['remove_topic'], '</a></li>';
-
-		elseif ($message['can_remove'] && ($context['topic_first_message'] != $message['id']))
-			echo '
-											<li><a href="', $scripturl, '?action=deletemsg;topic=', $context['current_topic'], '.', $context['start'], ';msg=', $message['id'], ';', $context['session_var'], '=', $context['session_id'], '" data-confirm="', $txt['remove_message_question'], '" class="you_sure"><span class="main_icons remove_button"></span>', $txt['remove'], '</a></li>';
-
-		// What about splitting it off the rest of the topic?
-		if ($context['can_split'] && !empty($context['real_num_replies']))
-			echo '
-											<li><a href="', $scripturl, '?action=splittopics;topic=', $context['current_topic'], '.0;at=', $message['id'], '"><span class="main_icons split_button"></span>', $txt['split'], '</a></li>';
-
-		// Can we issue a warning because of this post? Remember, we can't give guests warnings.
-		if ($context['can_issue_warning'] && !$message['is_message_author'] && !$message['member']['is_guest'])
-			echo '
-											<li><a href="', $scripturl, '?action=profile;area=issuewarning;u=', $message['member']['id'], ';msg=', $message['id'], '"><span class="main_icons warn_button"></span>', $txt['issue_warning'], '</a></li>';
-
-		// Can we restore topics?
-		if ($context['can_restore_msg'])
-			echo '
-											<li><a href="', $scripturl, '?action=restoretopic;msgs=', $message['id'], ';', $context['session_var'], '=', $context['session_id'], '"><span class="main_icons restore_button"></span>', $txt['restore_message'], '</a></li>';
-
-		// Maybe we can approve it, maybe we should?
-		if ($message['can_approve'])
-			echo '
-											<li><a href="', $scripturl, '?action=moderate;area=postmod;sa=approve;topic=', $context['current_topic'], '.', $context['start'], ';msg=', $message['id'], ';', $context['session_var'], '=', $context['session_id'], '"><span class="main_icons approve_button"></span>', $txt['approve'], '</a></li>';
-
-		// Maybe we can unapprove it?
-		if ($message['can_unapprove'])
-			echo '
-											<li><a href="', $scripturl, '?action=moderate;area=postmod;sa=approve;topic=', $context['current_topic'], '.', $context['start'], ';msg=', $message['id'], ';', $context['session_var'], '=', $context['session_id'], '"><span class="main_icons unapprove_button"></span>', $txt['unapprove'], '</a></li>';
-
-		echo '
-										</ul>
-									</li>';
-
-		// Show a checkbox for quick moderation?
-		if (!empty($options['display_quick_mod']) && $options['display_quick_mod'] == 1 && $message['can_remove'])
-			echo '
-									<li style="display: none;" id="in_topic_mod_check_', $message['id'], '"></li>';
-
-		if ($message['can_approve'] || $context['can_reply'] || $message['can_modify'] || $message['can_remove'] || $context['can_split'] || $context['can_restore_msg'])
-			echo '
-								</ul><!-- .quickbuttons -->';
-	}
-
-	if ($context['can_report_moderator'] || !empty($modSettings['enable_likes']) || $message['can_approve'] || $message['can_unapprove'] || $context['can_reply'] || $message['can_modify'] || $message['can_remove'] || $context['can_split'] || $context['can_restore_msg'] || $context['can_quote'])
-		echo '
-							</div><!-- .under_message -->';
+	template_quickbuttons($message['quickbuttons'], 'post');
 
 	echo '
+							</div><!-- .under_message -->
 						</div><!-- .postarea -->
 						<div class="moderatorbar">';
 

--- a/Themes/default/ModerationCenter.template.php
+++ b/Themes/default/ModerationCenter.template.php
@@ -373,10 +373,6 @@ function template_unapproved_posts()
 				<h3 class="catbg">', $txt['mc_unapproved_posts'], '</h3>
 			</div>';
 
-	// Make up some buttons
-	$approve_button = create_button('approve', 'approve', 'approve');
-	$remove_button = create_button('delete', 'remove_message', 'remove');
-
 	// No posts?
 	if (empty($context['unapproved_items']))
 		echo '
@@ -393,6 +389,24 @@ function template_unapproved_posts()
 
 	foreach ($context['unapproved_items'] as $item)
 	{
+		// The buttons
+		$quickbuttons = array(
+			'approve' => array(
+				'label' => $txt['approve'],
+				'href' => $scripturl.'?action=moderate;area=postmod;sa='.$context['current_view'].';start='.$context['start'].';'.$context['session_var'].'='.$context['session_id'].';approve='.$item['id'],
+				'icon' => 'approve',
+			),
+			'delete' => array(
+				'label' => $txt['remove'],
+				'href' => $scripturl.'?action=moderate;area=postmod;sa='.$context['current_view'].';start='.$context['start'].';'.$context['session_var'].'='.$context['session_id'].';delete='.$item['id'],
+				'icon' => 'remove_button',
+				'show' => $item['can_delete']
+			),
+			'quickmod' => array(
+				'content' => '<input type="checkbox" name="item[]" value="'.$item['id'].'" checked>',
+				'show' => !empty($options['display_quick_mod']) && $options['display_quick_mod'] == 1
+			),
+		);
 		echo '
 			<div class="windowbg clear">
 				<div class="counter">', $item['counter'], '</div>
@@ -405,20 +419,7 @@ function template_unapproved_posts()
 				<div class="list_posts">
 					<div class="post">', $item['body'], '</div>
 				</div>
-				<span class="floatright">
-					<a href="', $scripturl, '?action=moderate;area=postmod;sa=', $context['current_view'], ';start=', $context['start'], ';', $context['session_var'], '=', $context['session_id'], ';approve=', $item['id'], '">', $approve_button, '</a>';
-
-		if ($item['can_delete'])
-			echo '
-					', $context['menu_separator'], '
-					<a href="', $scripturl, '?action=moderate;area=postmod;sa=', $context['current_view'], ';start=', $context['start'], ';', $context['session_var'], '=', $context['session_id'], ';delete=', $item['id'], '">', $remove_button, '</a>';
-
-		if (!empty($options['display_quick_mod']) && $options['display_quick_mod'] == 1)
-			echo '
-					<input type="checkbox" name="item[]" value="', $item['id'], '" checked> ';
-
-		echo '
-				</span>
+				', template_quickbuttons($quickbuttons, 'unapproved_posts'), '
 			</div><!-- .windowbg -->';
 	}
 
@@ -462,10 +463,21 @@ function template_user_watch_post_callback($post)
 {
 	global $scripturl, $context, $txt, $delete_button;
 
-	// We'll have a delete please bob.
+	// We'll have a delete and a checkbox please bob.
 	// @todo Discuss this with the team and rewrite if required.
-	if (empty($delete_button))
-		$delete_button = create_button('delete', 'remove_message', 'remove', 'class="centericon"');
+	$quickbuttons = array(
+		'delete' => array(
+			'label' => $txt['remove_message'],
+			'href' => $scripturl.'?action=moderate;area=userwatch;sa=post;delete='.$post['id'].';start='.$context['start'].';'.$context['session_var'].'='.$context['session_id'],
+			'javascript' => 'data-confirm="' . $txt['mc_watched_users_delete_post'] . '" class="you_sure"',
+			'icon' => 'remove_button',
+			'show' => $post['can_delete']
+		),
+		'quickmod' => array(
+			'content' => '<input type="checkbox" name="delete[]" value="' . $post['id'] . '">',
+			'show' => $post['can_delete']
+		)
+	);
 
 	$output_html = '
 					<div>
@@ -474,10 +486,7 @@ function template_user_watch_post_callback($post)
 						</div>
 						<div class="floatright">';
 
-	if ($post['can_delete'])
-		$output_html .= '
-							<a href="' . $scripturl . '?action=moderate;area=userwatch;sa=post;delete=' . $post['id'] . ';start=' . $context['start'] . ';' . $context['session_var'] . '=' . $context['session_id'] . '" data-confirm="' . $txt['mc_watched_users_delete_post'] . '" class="you_sure">' . $delete_button . '</a>
-							<input type="checkbox" name="delete[]" value="' . $post['id'] . '">';
+	$output_html .= template_quickbuttons($quickbuttons, 'user_watch_post', 'return');
 
 	$output_html .= '
 						</div>

--- a/Themes/default/MoveTopic.template.php
+++ b/Themes/default/MoveTopic.template.php
@@ -237,12 +237,10 @@ function template_merge()
 				<div class="windowbg">
 					<ul class="merge_topics">';
 
-		$merge_button = create_button('merge', 'merge', '');
-
 		foreach ($context['topics'] as $topic)
 			echo '
 						<li>
-							<a href="', $scripturl, '?action=mergetopics;sa=options;board=', $context['current_board'], '.0;from=', $context['origin_topic'], ';to=', $topic['id'], ';', $context['session_var'], '=', $context['session_id'], '">', $merge_button, '</a>
+							<a href="', $scripturl, '?action=mergetopics;sa=options;board=', $context['current_board'], '.0;from=', $context['origin_topic'], ';to=', $topic['id'], ';', $context['session_var'], '=', $context['session_id'], '"><span class="main_icons merge"></span></a>
 							<a href="', $scripturl, '?topic=', $topic['id'], '.0" target="_blank" rel="noopener">', $topic['subject'], '</a> ', $txt['started_by'], ' ', $topic['poster']['link'], '
 						</li>';
 

--- a/Themes/default/PersonalMessage.template.php
+++ b/Themes/default/PersonalMessage.template.php
@@ -891,9 +891,7 @@ function template_search_results()
 					<span class="floatright">', $txt['search_on'], ': ', $message['time'], '</span>
 					<span class="floatleft">', $message['counter'], '&nbsp;&nbsp;<a href="', $message['href'], '">', $message['subject'], '</a></span>
 				</h3>
-			</div>
-			<div class="cat_bar">
-				<h3 class="catbg">', $txt['from'], ': ', $message['member']['link'], ', ', $txt['to'], ': ';
+				<div class="desc">', $txt['from'], ': ', $message['member']['link'], ', ', $txt['to'], ': ';
 
 			// Show the recipients.
 			// @todo This doesn't deal with the sent item searching quite right for bcc.
@@ -905,6 +903,7 @@ function template_search_results()
 				echo '(', $txt['pm_undisclosed_recipients'], ')';
 
 			echo '
+					</div>
 				</h3>
 			</div>
 			<div class="windowbg">
@@ -913,19 +912,28 @@ function template_search_results()
 
 			if ($context['can_send_pm'])
 			{
-				$quote_button = create_button('quote.png', 'reply_quote', 'reply_quote', 'class="centericon"');
-				$reply_button = create_button('im_reply.png', 'reply', 'reply', 'class="centericon"');
-
-				// You can only reply if they are not a guest...
-				if (!$message['member']['is_guest'])
-					echo '
-					<a href="', $scripturl, '?action=pm;sa=send;f=', $context['folder'], $context['current_label_id'] != -1 ? ';l=' . $context['current_label_id'] : '', ';pmsg=', $message['id'], ';quote;u=', $context['folder'] == 'sent' ? '' : $message['member']['id'], '">', $quote_button, '</a>', $context['menu_separator'], '
-					<a href="', $scripturl, '?action=pm;sa=send;f=', $context['folder'], $context['current_label_id'] != -1 ? ';l=' . $context['current_label_id'] : '', ';pmsg=', $message['id'], ';u=', $message['member']['id'], '">', $reply_button, '</a> ', $context['menu_separator'];
-
-				// This is for "forwarding" - even if the member is gone.
-				else
-					echo '
-					<a href="', $scripturl, '?action=pm;sa=send;f=', $context['folder'], $context['current_label_id'] != -1 ? ';l=' . $context['current_label_id'] : '', ';pmsg=', $message['id'], ';quote">', $quote_button, '</a>', $context['menu_separator'];
+				$quickbuttons = array(
+					'quote' => array(
+						'label' => $txt['reply_quote'],
+						'href' => $scripturl.'?action=pm;sa=send;f='.$context['folder'].($context['current_label_id'] != -1 ? ';l=' . $context['current_label_id'] : '').';pmsg='.$message['id'].';quote;u='.($context['folder'] == 'sent' ? '' : $message['member']['id']),
+						'icon' => 'quote',
+						'show' => !$message['member']['is_guest']
+					),
+					'reply' => array(
+						'label' => $txt['reply'],
+						'href' => $scripturl.'?action=pm;sa=send;f='.$context['folder'].($context['current_label_id'] != -1 ? ';l=' . $context['current_label_id'] : '').';pmsg='.$message['id'].';u='.$message['member']['id'],
+						'icon' => 'reply_button',
+						'show' => !$message['member']['is_guest']
+					),
+					'reply_quote' => array(
+						'label' => $txt['reply_quote'],
+						'href' => $scripturl.'?action=pm;sa=send;f='.$context['folder'].($context['current_label_id'] != -1 ? ';l=' . $context['current_label_id'] : '').';pmsg='.$message['id'].';quote',
+						'icon' => 'quote',
+						'show' => $message['member']['is_guest']
+					)
+				);
+				// Show the quickbuttons
+				template_quickbuttons($quickbuttons, 'pm_search_results');
 			}
 
 			echo '

--- a/Themes/default/PersonalMessage.template.php
+++ b/Themes/default/PersonalMessage.template.php
@@ -441,51 +441,13 @@ function template_folder()
 					<div class="post">
 						<div class="inner" id="msg_', $message['id'], '"', '>
 							', $message['body'], '
-						</div>';
-
-			if ($message['can_report'] || $context['can_send_pm'])
-				echo '
+						</div>
 						<div class="under_message">';
 
-			if ($message['can_report'])
-				echo '
-							<a href="' . $scripturl . '?action=pm;sa=report;l=' . $context['current_label_id'] . ';pmsg=' . $message['id'] . '" class="floatright">' . $txt['pm_report_to_admin'] . '</a>';
+			// Message options
+			template_quickbuttons($message['quickbuttons'], 'pm');
 
 			echo '
-							<ul class="quickbuttons">';
-
-			// Show reply buttons if you have the permission to send PMs.
-			if ($context['can_send_pm'])
-			{
-				// You can't really reply if the member is gone.
-				if (!$message['member']['is_guest'])
-				{
-					// Is there than more than one recipient you can reply to?
-					if ($message['number_recipients'] > 1)
-						echo '
-								<li><a href="', $scripturl, '?action=pm;sa=send;f=', $context['folder'], $context['current_label_id'] != -1 ? ';l=' . $context['current_label_id'] : '', ';pmsg=', $message['id'], ';quote;u=all"><span class="main_icons reply_all_button"></span>', $txt['reply_to_all'], '</a></li>';
-
-					echo '
-								<li><a href="', $scripturl, '?action=pm;sa=send;f=', $context['folder'], $context['current_label_id'] != -1 ? ';l=' . $context['current_label_id'] : '', ';pmsg=', $message['id'], ';u=', $message['member']['id'], '"><span class="main_icons reply_button"></span>', $txt['reply'], '</a></li>
-								<li><a href="', $scripturl, '?action=pm;sa=send;f=', $context['folder'], $context['current_label_id'] != -1 ? ';l=' . $context['current_label_id'] : '', ';pmsg=', $message['id'], ';quote', $context['folder'] == 'sent' ? '' : ';u=' . $message['member']['id'], '"><span class="main_icons quote"></span>', $txt['quote_action'], '</a></li>';
-				}
-				// This is for "forwarding" - even if the member is gone.
-				else
-					echo '
-								<li><a href="', $scripturl, '?action=pm;sa=send;f=', $context['folder'], $context['current_label_id'] != -1 ? ';l=' . $context['current_label_id'] : '', ';pmsg=', $message['id'], ';quote"><span class="main_icons quote"></span>', $txt['reply_quote'], '</a></li>';
-			}
-			echo '
-								<li><a href="', $scripturl, '?action=pm;sa=pmactions;pm_actions%5b', $message['id'], '%5D=delete;f=', $context['folder'], ';start=', $context['start'], $context['current_label_id'] != -1 ? ';l=' . $context['current_label_id'] : '', ';', $context['session_var'], '=', $context['session_id'], '" data-confirm="', addslashes($txt['remove_message_question']), '" class="you_sure"><span class="main_icons remove_button"></span>', $txt['delete'], '</a></li>';
-
-			if (empty($context['display_mode']))
-				echo '
-								<li><input type="checkbox" name="pms[]" id="deletedisplay', $message['id'], '" value="', $message['id'], '" onclick="document.getElementById(\'deletelisting', $message['id'], '\').checked = this.checked;"></li>';
-
-			echo '
-							</ul>';
-
-			if ($message['can_report'] || $context['can_send_pm'])
-				echo '
 						</div><!-- .under_message -->';
 
 			// Are there any custom profile fields for above the signature?
@@ -1980,20 +1942,28 @@ function template_showPMDrafts()
 		<div class="windowbg">
 			<div class="counter">', $draft['counter'], '</div>
 			<div class="topic_details">
+				<div class="floatright smalltext righttext">
+					<div class="recipient_to">&#171;&nbsp;<strong>', $txt['to'], ':</strong> ', implode(', ', $draft['recipients']['to']), '&nbsp;&#187;</div>';
+
+			if(!empty($draft['recipients']['bcc']))
+				echo'
+					<div class="pm_bbc">&#171;&nbsp;<strong>', $txt['pm_bcc'], ':</strong> ', implode(', ', $draft['recipients']['bcc']), '&nbsp;&#187;</div>';
+
+			echo '
+				</div>
 				<h5>
 					<strong>', $draft['subject'], '</strong>
 				</h5>
 				<span class="smalltext">&#171;&nbsp;<strong>', $txt['draft_saved_on'], ':</strong> ', sprintf($txt['draft_days_ago'], $draft['age']), (!empty($draft['remaining']) ? ', ' . sprintf($txt['draft_retain'], $draft['remaining']) : ''), '&#187;</span><br>
-				<span class="smalltext">&#171;&nbsp;<strong>', $txt['to'], ':</strong> ', implode(', ', $draft['recipients']['to']), '&nbsp;&#187;</span><br>
-				<span class="smalltext">&#171;&nbsp;<strong>', $txt['pm_bcc'], ':</strong> ', implode(', ', $draft['recipients']['bcc']), '&nbsp;&#187;</span>
 			</div>
 			<div class="list_posts">
 				', $draft['body'], '
-			</div>
-			<ul class="quickbuttons">
-				<li><a href="', $scripturl, '?action=pm;sa=showpmdrafts;id_draft=', $draft['id_draft'], ';', $context['session_var'], '=', $context['session_id'], '"><span class="main_icons modifybutton"></span>', $txt['draft_edit'], '</a></li>
-				<li><a href="', $scripturl, '?action=pm;sa=showpmdrafts;delete=', $draft['id_draft'], ';', $context['session_var'], '=', $context['session_id'], '" data-confirm="', $txt['draft_remove'], '?" class="you_sure"><span class="main_icons remove_button"></span>', $txt['draft_delete'], '</a></li>
-			</ul>
+			</div>';
+
+			// Draft buttons
+			template_quickbuttons($draft['quickbuttons'], 'pm_drafts');
+
+			echo '
 		</div><!-- .windowbg -->';
 		}
 	}

--- a/Themes/default/PersonalMessage.template.php
+++ b/Themes/default/PersonalMessage.template.php
@@ -178,7 +178,7 @@ function template_folder()
 		</script>';
 
 	echo '
-		<form class="flow_hidden" action="', $scripturl, '?action=pm;sa=pmactions;', $context['display_mode'] == 2 ? 'conversation;' : '', 'f=', $context['folder'], ';start=', $context['start'], $context['current_label_id'] != -1 ? ';l=' . $context['current_label_id'] : '', '" method="post" accept-charset="', $context['character_set'], '" name="pmFolder">';
+		<form class="flow_hidden" action="', $scripturl, '?action=pm;sa=pmactions;', $context['display_mode'] == 2 ? 'conversation;' : '', 'f=', $context['folder'], ';start=', $context['start'], $context['current_label_id'] != -1 ? ';l=' . $context['current_label_id'] : '', '" method="post" accept-charset="', $context['character_set'], '" name="pmFolder" id="pmFolder">';
 
 	// If we are not in single display mode show the subjects on the top!
 	if ($context['display_mode'] != 1)
@@ -219,38 +219,39 @@ function template_folder()
 		{
 			echo '
 			<div class="windowbg">
-				<div class="poster">';
+				<div class="post_wrapper">
+					<div class="poster">';
 
 			// Are there any custom fields above the member name?
 			if (!empty($message['custom_fields']['above_member']))
 			{
 				echo '
-					<div class="custom_fields_above_member">
-						<ul class="nolist">';
+						<div class="custom_fields_above_member">
+							<ul class="nolist">';
 
 				foreach ($message['custom_fields']['above_member'] as $custom)
 					echo '
-							<li class="custom ', $custom['col_name'], '">', $custom['value'], '</li>';
+								<li class="custom ', $custom['col_name'], '">', $custom['value'], '</li>';
 
 				echo '
-						</ul>
-					</div>';
+							</ul>
+						</div>';
 			}
 
 			echo '
-					<h4>
-						<a id="msg', $message['id'], '"></a>';
+						<h4>
+							<a id="msg', $message['id'], '"></a>';
 
 			// Show online and offline buttons?
 			if (!empty($modSettings['onlineEnable']) && !$message['member']['is_guest'])
 				echo '
-						<span class="' . ($message['member']['online']['is_online'] == 1 ? 'on' : 'off') . '" title="' . $message['member']['online']['text'] . '"></span>';
+							<span class="' . ($message['member']['online']['is_online'] == 1 ? 'on' : 'off') . '" title="' . $message['member']['online']['text'] . '"></span>';
 
 			// Custom fields BEFORE the username?
 			if (!empty($message['custom_fields']['before_member']))
 				foreach ($message['custom_fields']['before_member'] as $custom)
 					echo '
-						<span class="custom ', $custom['col_name'], '">', $custom['value'], '</span>';
+							<span class="custom ', $custom['col_name'], '">', $custom['value'], '</span>';
 
 			// Show a link to the member's profile.
 			echo '
@@ -260,39 +261,39 @@ function template_folder()
 			if (!empty($message['custom_fields']['after_member']))
 				foreach ($message['custom_fields']['after_member'] as $custom)
 					echo '
-						<span class="custom ', $custom['col_name'], '">', $custom['value'], '</span>';
+							<span class="custom ', $custom['col_name'], '">', $custom['value'], '</span>';
 
 			echo '
-					</h4>';
+						</h4>';
 
 			echo '
-					<ul class="user_info">';
+						<ul class="user_info">';
 
 			// Show the user's avatar.
 			if (!empty($modSettings['show_user_images']) && empty($options['show_no_avatars']) && !empty($message['member']['avatar']['image']))
 				echo '
-						<li class="avatar">
-							<a href="', $scripturl, '?action=profile;u=', $message['member']['id'], '">', $message['member']['avatar']['image'], '</a>
-						</li>';
+							<li class="avatar">
+								<a href="', $scripturl, '?action=profile;u=', $message['member']['id'], '">', $message['member']['avatar']['image'], '</a>
+							</li>';
 
 			// Are there any custom fields below the avatar?
 			if (!empty($message['custom_fields']['below_avatar']))
 				foreach ($message['custom_fields']['below_avatar'] as $custom)
 					echo '
-						<li class="custom ', $custom['col_name'], '">', $custom['value'], '</li>';
+							<li class="custom ', $custom['col_name'], '">', $custom['value'], '</li>';
 
 			if (!$message['member']['is_guest'])
 				echo '
-						<li class="icons">', $message['member']['group_icons'], '</li>';
+							<li class="icons">', $message['member']['group_icons'], '</li>';
 			// Show the member's primary group (like 'Administrator') if they have one.
 			if (isset($message['member']['group']) && $message['member']['group'] != '')
 				echo '
-						<li class="membergroup">', $message['member']['group'], '</li>';
+							<li class="membergroup">', $message['member']['group'], '</li>';
 
 			// Show the member's custom title, if they have one.
 			if (isset($message['member']['title']) && $message['member']['title'] != '')
 				echo '
-						<li class="title">', $message['member']['title'], '</li>';
+							<li class="title">', $message['member']['title'], '</li>';
 
 			// Don't show these things for guests.
 			if (!$message['member']['is_guest'])
@@ -300,119 +301,119 @@ function template_folder()
 				// Show the post group if and only if they have no other group or the option is on, and they are in a post group.
 				if ((empty($modSettings['hide_post_group']) || $message['member']['group'] == '') && $message['member']['post_group'] != '')
 					echo '
-						<li class="postgroup">', $message['member']['post_group'], '</li>';
+							<li class="postgroup">', $message['member']['post_group'], '</li>';
 
 				// Show how many posts they have made.
 				if (!isset($context['disabled_fields']['posts']))
 					echo '
-						<li class="postcount">', $txt['member_postcount'], ': ', $message['member']['posts'], '</li>';
+							<li class="postcount">', $txt['member_postcount'], ': ', $message['member']['posts'], '</li>';
 
 				// Show their personal text?
 				if (!empty($modSettings['show_blurb']) && $message['member']['blurb'] != '')
 					echo '
-						<li class="blurb">', $message['member']['blurb'], '</li>';
+							<li class="blurb">', $message['member']['blurb'], '</li>';
 
 				// Any custom fields to show as icons?
 				if (!empty($message['custom_fields']['icons']))
 				{
 					echo '
-						<li class="im_icons">
-							<ol>';
+							<li class="im_icons">
+								<ol>';
 
 					foreach ($message['custom_fields']['icons'] as $custom)
 						echo '
-								<li class="custom ', $custom['col_name'], '">', $custom['value'], '</li>';
+									<li class="custom ', $custom['col_name'], '">', $custom['value'], '</li>';
 
 					echo '
-							</ol>
-						</li>';
+								</ol>
+							</li>';
 				}
 
 				// Show the IP to this user for this post - because you can moderate?
 				if (!empty($context['can_moderate_forum']) && !empty($message['member']['ip']))
 					echo '
-						<li class="poster_ip">
-							<a href="', $scripturl, '?action=', !empty($message['member']['is_guest']) ? 'trackip' : 'profile;area=tracking;sa=ip;u=' . $message['member']['id'], ';searchip=', $message['member']['ip'], '">', $message['member']['ip'], '</a> <a href="', $scripturl, '?action=helpadmin;help=see_admin_ip" onclick="return reqOverlayDiv(this.href);" class="help">(?)</a>
-						</li>';
+							<li class="poster_ip">
+								<a href="', $scripturl, '?action=', !empty($message['member']['is_guest']) ? 'trackip' : 'profile;area=tracking;sa=ip;u=' . $message['member']['id'], ';searchip=', $message['member']['ip'], '">', $message['member']['ip'], '</a> <a href="', $scripturl, '?action=helpadmin;help=see_admin_ip" onclick="return reqOverlayDiv(this.href);" class="help">(?)</a>
+							</li>';
 
 				// Or, should we show it because this is you?
 				elseif ($message['can_see_ip'])
 					echo '
-						<li class="poster_ip">
-							<a href="', $scripturl, '?action=helpadmin;help=see_member_ip" onclick="return reqOverlayDiv(this.href);" class="help">', $message['member']['ip'], '</a>
-						</li>';
+							<li class="poster_ip">
+								<a href="', $scripturl, '?action=helpadmin;help=see_member_ip" onclick="return reqOverlayDiv(this.href);" class="help">', $message['member']['ip'], '</a>
+							</li>';
 
 				// Okay, you are logged in, then we can show something about why IPs are logged...
 				else
 					echo '
-						<li class="poster_ip">
-							<a href="', $scripturl, '?action=helpadmin;help=see_member_ip" onclick="return reqOverlayDiv(this.href);" class="help">', $txt['logged'], '</a>
-						</li>';
+							<li class="poster_ip">
+								<a href="', $scripturl, '?action=helpadmin;help=see_member_ip" onclick="return reqOverlayDiv(this.href);" class="help">', $txt['logged'], '</a>
+							</li>';
 
 				// Show the profile, website, email address, and personal message buttons.
 				if ($message['member']['show_profile_buttons'])
 				{
 					echo '
-						<li class="profile">
-							<ol class="profile_icons">';
+							<li class="profile">
+								<ol class="profile_icons">';
 
 					// Show the profile button
 					if ($message['member']['can_view_profile'])
 						echo '
-								<li><a href="', $message['member']['href'], '">', ($settings['use_image_buttons'] ? '<img src="' . $settings['images_url'] . '/icons/profile_sm.png" alt="' . $txt['view_profile'] . '" title="' . $txt['view_profile'] . '">' : $txt['view_profile']), '</a></li>';
+									<li><a href="', $message['member']['href'], '">', ($settings['use_image_buttons'] ? '<img src="' . $settings['images_url'] . '/icons/profile_sm.png" alt="' . $txt['view_profile'] . '" title="' . $txt['view_profile'] . '">' : $txt['view_profile']), '</a></li>';
 
 					// Don't show an icon if they haven't specified a website.
 					if ($message['member']['website']['url'] != '' && !isset($context['disabled_fields']['website']))
 						echo '
-								<li><a href="', $message['member']['website']['url'], '" title="' . $message['member']['website']['title'] . '" target="_blank" rel="noopener">', ($settings['use_image_buttons'] ? '<span class="main_icons www centericon" title="' . $message['member']['website']['title'] . '"></span>' : $txt['www']), '</a></li>';
+									<li><a href="', $message['member']['website']['url'], '" title="' . $message['member']['website']['title'] . '" target="_blank" rel="noopener">', ($settings['use_image_buttons'] ? '<span class="main_icons www centericon" title="' . $message['member']['website']['title'] . '"></span>' : $txt['www']), '</a></li>';
 
 					// Don't show the email address if they want it hidden.
 					if ($message['member']['show_email'])
 						echo '
-								<li><a href="mailto:', $message['member']['email'], '" rel="nofollow">', ($settings['use_image_buttons'] ? '<span class="main_icons mail centericon" title="' . $txt['email'] . '"></span>' : $txt['email']), '</a></li>';
+									<li><a href="mailto:', $message['member']['email'], '" rel="nofollow">', ($settings['use_image_buttons'] ? '<span class="main_icons mail centericon" title="' . $txt['email'] . '"></span>' : $txt['email']), '</a></li>';
 
 					// Since we know this person isn't a guest, you *can* message them.
 					if ($context['can_send_pm'])
 						echo '
-								<li><a href="', $scripturl, '?action=pm;sa=send;u=', $message['member']['id'], '" title="', $message['member']['online']['is_online'] ? $txt['pm_online'] : $txt['pm_offline'], '">', $settings['use_image_buttons'] ? '<span class="main_icons im_' . ($message['member']['online']['is_online'] ? 'on' : 'off') . ' centericon" title="' . ($message['member']['online']['is_online'] ? $txt['pm_online'] : $txt['pm_offline']) . '"></span> ' : ($message['member']['online']['is_online'] ? $txt['pm_online'] : $txt['pm_offline']), '</a></li>';
+									<li><a href="', $scripturl, '?action=pm;sa=send;u=', $message['member']['id'], '" title="', $message['member']['online']['is_online'] ? $txt['pm_online'] : $txt['pm_offline'], '">', $settings['use_image_buttons'] ? '<span class="main_icons im_' . ($message['member']['online']['is_online'] ? 'on' : 'off') . ' centericon" title="' . ($message['member']['online']['is_online'] ? $txt['pm_online'] : $txt['pm_offline']) . '"></span> ' : ($message['member']['online']['is_online'] ? $txt['pm_online'] : $txt['pm_offline']), '</a></li>';
 
 					echo '
-							</ol>
-						</li>';
+								</ol>
+							</li>';
 				}
 
 				// Any custom fields for standard placement?
 				if (!empty($message['custom_fields']['standard']))
 					foreach ($message['custom_fields']['standard'] as $custom)
 						echo '
-						<li class="custom ', $custom['col_name'], '">', $custom['title'], ': ', $custom['value'], '</li>';
+							<li class="custom ', $custom['col_name'], '">', $custom['title'], ': ', $custom['value'], '</li>';
 
 				// Are we showing the warning status?
 				if ($message['member']['can_see_warning'])
 					echo '
-						<li class="warning">', $context['can_issue_warning'] ? '<a href="' . $scripturl . '?action=profile;area=issuewarning;u=' . $message['member']['id'] . '">' : '', '<span class="main_icons warning_', $message['member']['warning_status'], '"></span>', $context['can_issue_warning'] ? '</a>' : '', '<span class="warn_', $message['member']['warning_status'], '">', $txt['warn_' . $message['member']['warning_status']], '</span></li>';
+							<li class="warning">', $context['can_issue_warning'] ? '<a href="' . $scripturl . '?action=profile;area=issuewarning;u=' . $message['member']['id'] . '">' : '', '<span class="main_icons warning_', $message['member']['warning_status'], '"></span>', $context['can_issue_warning'] ? '</a>' : '', '<span class="warn_', $message['member']['warning_status'], '">', $txt['warn_' . $message['member']['warning_status']], '</span></li>';
 
 				// Are there any custom fields to show at the bottom of the poster info?
 				if (!empty($message['custom_fields']['bottom_poster']))
 					foreach ($message['custom_fields']['bottom_poster'] as $custom)
 						echo '
-						<li class="custom ', $custom['col_name'], '">', $custom['value'], '</li>';
+							<li class="custom ', $custom['col_name'], '">', $custom['value'], '</li>';
 			}
 
 			// Done with the information about the poster... on to the post itself.
 			echo '
-					</ul>
-				</div><!-- .poster -->
-				<div class="postarea">
-					<div class="flow_hidden">
-						<div class="keyinfo">
-							<h5 id="subject_', $message['id'], '">
-								', $message['subject'], '
-							</h5>';
+						</ul>
+					</div><!-- .poster -->
+					<div class="postarea">
+						<div class="flow_hidden">
+							<div class="keyinfo">
+								<h5 id="subject_', $message['id'], '">
+									', $message['subject'], '
+								</h5>';
 
 			// Show who the message was sent to.
 			echo '
-							<span class="smalltext">&#171; <strong> ', $txt['sent_to'], ':</strong> ';
+								<span class="smalltext">&#171; <strong> ', $txt['sent_to'], ':</strong> ';
 
 			// People it was sent directly to....
 			if (!empty($message['recipients']['to']))
@@ -423,32 +424,35 @@ function template_folder()
 				echo '(', $txt['pm_undisclosed_recipients'], ')';
 
 			echo '
-								<strong> ', $txt['on'], ':</strong> ', $message['time'], ' &#187;
-							</span>';
+									<strong> ', $txt['on'], ':</strong> ', $message['time'], ' &#187;
+								</span>';
 
 			// If we're in the sent items, show who it was sent to besides the "To:" people.
 			if (!empty($message['recipients']['bcc']))
 				echo '<br>
-							<span class="smalltext">&#171; <strong> ', $txt['pm_bcc'], ':</strong> ', implode(', ', $message['recipients']['bcc']), ' &#187;</span>';
+								<span class="smalltext">&#171; <strong> ', $txt['pm_bcc'], ':</strong> ', implode(', ', $message['recipients']['bcc']), ' &#187;</span>';
 
 			if (!empty($message['is_replied_to']))
 				echo '<br>
-							<span class="smalltext">&#171; ', $context['folder'] == 'sent' ? $txt['pm_sent_is_replied_to'] : $txt['pm_is_replied_to'], ' &#187;</span>';
+								<span class="smalltext">&#171; ', $context['folder'] == 'sent' ? $txt['pm_sent_is_replied_to'] : $txt['pm_is_replied_to'], ' &#187;</span>';
 
 			echo '
-						</div><!-- .keyinfo -->
-					</div><!-- .flow_hidden -->
-					<div class="post">
-						<div class="inner" id="msg_', $message['id'], '"', '>
-							', $message['body'], '
-						</div>
+							</div><!-- .keyinfo -->
+						</div><!-- .flow_hidden -->
+						<div class="post">
+							<div class="inner" id="msg_', $message['id'], '"', '>
+								', $message['body'], '
+							</div>
+						</div><!-- .post -->
 						<div class="under_message">';
 
 			// Message options
 			template_quickbuttons($message['quickbuttons'], 'pm');
 
 			echo '
-						</div><!-- .under_message -->';
+						</div><!-- .under_message -->
+					</div><!-- .postarea -->
+					<div class="moderatorbar">';
 
 			// Are there any custom profile fields for above the signature?
 			if (!empty($message['custom_fields']['above_signature']))
@@ -536,9 +540,8 @@ function template_folder()
 			}
 
 			echo '
-					</div><!-- .post -->
-				</div><!-- .postarea -->
-				<div class="moderatorbar"></div>
+					</div><!-- .moderatorbar -->
+				</div><!-- .post_wrapper -->
 			</div><!-- .windowbg -->';
 		}
 

--- a/Themes/default/Profile.template.php
+++ b/Themes/default/Profile.template.php
@@ -520,30 +520,8 @@ function template_showPosts()
 				</div>
 			</div><!-- .post -->';
 
-			if ($post['can_reply'] || $post['can_quote'] || $post['can_delete'])
-				echo '
-			<div class="under_message">
-				<ul class="quickbuttons">';
-
-			// If they *can* reply?
-			if ($post['can_reply'])
-				echo '
-					<li><a href="', $scripturl, '?action=post;topic=', $post['topic'], '.', $post['start'], '"><span class="main_icons reply_button"></span>', $txt['reply'], '</a></li>';
-
-			// If they *can* quote?
-			if ($post['can_quote'])
-				echo '
-					<li><a href="', $scripturl . '?action=post;topic=', $post['topic'], '.', $post['start'], ';quote=', $post['id'], '"><span class="main_icons quote"></span>', $txt['quote_action'], '</a></li>';
-
-			// How about... even... remove it entirely?!
-			if ($post['can_delete'])
-				echo '
-					<li><a href="', $scripturl, '?action=deletemsg;msg=', $post['id'], ';topic=', $post['topic'], ';profile;u=', $context['member']['id'], ';start=', $context['start'], ';', $context['session_var'], '=', $context['session_id'], '" data-confirm="', $txt['remove_message'], '" class="you_sure"><span class="main_icons remove_button"></span>', $txt['remove'], '</a></li>';
-
-			if ($post['can_reply'] || $post['can_quote'] || $post['can_delete'])
-				echo '
-				</ul>
-			</div><!-- .under_message -->';
+			// Post options
+			template_quickbuttons($post['quickbuttons'], 'profile_showposts');
 
 			echo '
 		</div><!-- .', $post['css_class'], ' -->';
@@ -613,17 +591,12 @@ function template_showAlerts()
 						<span class="alert_inline_time"><span class="main_icons time_online"></span> ', $alert['time'], '</span>
 					</td>
 					<td class="alert_time">', $alert['time'], '</td>
-					<td class="alert_buttons">
-						<ul class="quickbuttons">
-							<li><a href="', $scripturl, '?action=profile;u=', $context['id_member'], ';area=showalerts;do=remove;aid=', $id, ';', $context['session_var'], '=', $context['session_id'], '" class="you_sure"><span class="main_icons remove_button"></span>', $txt['delete'], '</a></li>
-							<li><a href="', $scripturl, '?action=profile;u=', $context['id_member'], ';area=showalerts;do=', ($alert['is_read'] != 0 ? 'unread' : 'read'), ';aid=', $id, ';', $context['session_var'], '=', $context['session_id'], '"><span class="main_icons ', $alert['is_read'] != 0 ? 'unread_button' : 'read_button', '"></span>', ($alert['is_read'] != 0 ? $txt['mark_unread'] : $txt['mark_read_short']), '</a></li>';
+					<td class="alert_buttons">';
 
-			if ($context['showCheckboxes'])
-				echo '
-							<li><input type="checkbox" name="mark[', $id, ']" value="', $id, '"></li>';
+			// Alert options
+			template_quickbuttons($alert['quickbuttons'], 'profile_alerts');
 
 			echo '
-						</ul>
 					</td>
 				</tr>';
 		}
@@ -707,11 +680,12 @@ function template_showDrafts()
 			<div class="list_posts">
 				', $draft['body'], '
 			</div>
-			<div class="floatright">
-				<ul class="quickbuttons">
-						<li><a href="', $scripturl, '?action=post;', (empty($draft['topic']['id']) ? 'board=' . $draft['board']['id'] : 'topic=' . $draft['topic']['id']), '.0;id_draft=', $draft['id_draft'], '"><span class="main_icons reply_button"></span>', $txt['draft_edit'], '</a></li>
-						<li><a href="', $scripturl, '?action=profile;u=', $context['member']['id'], ';area=showdrafts;delete=', $draft['id_draft'], ';', $context['session_var'], '=', $context['session_id'], '" data-confirm="', $txt['draft_remove'], '" class="you_sure"><span class="main_icons remove_button"></span>', $txt['draft_delete'], '</a></li>
-				</ul>
+			<div class="floatright">';
+
+			// Draft buttons
+			template_quickbuttons($draft['quickbuttons'], 'profile_drafts');
+
+			echo '
 			</div><!-- .floatright -->
 		</div><!-- .windowbg -->';
 		}

--- a/Themes/default/Recent.template.php
+++ b/Themes/default/Recent.template.php
@@ -41,28 +41,30 @@ function template_recent()
 			</div>
 			<div class="list_posts">', $post['message'], '</div>';
 
-		if ($post['can_reply'] || $post['can_quote'] || $post['can_delete'])
-			echo '
-			<ul class="quickbuttons">';
+		$quickbuttons = array(
+			'reply' => array(
+				'label' => $txt['reply'],
+				'href' => $scripturl.'?action=post;topic='.$post['topic'].'.'.$post['start'],
+				'icon' => 'reply_button',
+				'show' => $post['can_reply']
+			),
+			'quote' => array(
+				'label' => $txt['quote_action'],
+				'href' => $scripturl.'?action=post;topic='.$post['topic'].'.'.$post['start'].';quote='.$post['id'],
+				'icon' => 'quote',
+				'show' => $post['can_quote']
+			),
+			'delete' => array(
+				'label' => $txt['remove'],
+				'href' => $scripturl.'?action=deletemsg;msg='.$post['id'].';topic='.$post['topic'].';recent;'.$context['session_var'].'='.$context['session_id'],
+				'javascript' => 'data-confirm="'.$txt['remove_message'].'" class="you_sure"',
+				'icon' => 'remove_button',
+				'show' => $post['can_delete']
+			),
+		);
 
-		// If they *can* reply?
-		if ($post['can_reply'])
-			echo '
-				<li><a href="', $scripturl, '?action=post;topic=', $post['topic'], '.', $post['start'], '"><span class="main_icons reply_button"></span>', $txt['reply'], '</a></li>';
-
-		// If they *can* quote?
-		if ($post['can_quote'])
-			echo '
-				<li><a href="', $scripturl, '?action=post;topic=', $post['topic'], '.', $post['start'], ';quote=', $post['id'], '"><span class="main_icons quote"></span>', $txt['quote_action'], '</a></li>';
-
-		// How about... even... remove it entirely?!
-		if ($post['can_delete'])
-			echo '
-				<li><a href="', $scripturl, '?action=deletemsg;msg=', $post['id'], ';topic=', $post['topic'], ';recent;', $context['session_var'], '=', $context['session_id'], '" data-confirm="', $txt['remove_message'], '" class="you_sure"><span class="main_icons remove_button"></span>', $txt['remove'], '</a></li>';
-
-		if ($post['can_reply'] || $post['can_quote'] || $post['can_delete'])
-			echo '
-			</ul>';
+		// Post options
+		template_quickbuttons($quickbuttons, 'recent');
 
 		echo '
 		</div><!-- $post[css_class] -->';

--- a/Themes/default/Recent.template.php
+++ b/Themes/default/Recent.template.php
@@ -41,30 +41,8 @@ function template_recent()
 			</div>
 			<div class="list_posts">', $post['message'], '</div>';
 
-		$quickbuttons = array(
-			'reply' => array(
-				'label' => $txt['reply'],
-				'href' => $scripturl.'?action=post;topic='.$post['topic'].'.'.$post['start'],
-				'icon' => 'reply_button',
-				'show' => $post['can_reply']
-			),
-			'quote' => array(
-				'label' => $txt['quote_action'],
-				'href' => $scripturl.'?action=post;topic='.$post['topic'].'.'.$post['start'].';quote='.$post['id'],
-				'icon' => 'quote',
-				'show' => $post['can_quote']
-			),
-			'delete' => array(
-				'label' => $txt['remove'],
-				'href' => $scripturl.'?action=deletemsg;msg='.$post['id'].';topic='.$post['topic'].';recent;'.$context['session_var'].'='.$context['session_id'],
-				'javascript' => 'data-confirm="'.$txt['remove_message'].'" class="you_sure"',
-				'icon' => 'remove_button',
-				'show' => $post['can_delete']
-			),
-		);
-
 		// Post options
-		template_quickbuttons($quickbuttons, 'recent');
+		template_quickbuttons($post['quickbuttons'], 'recent');
 
 		echo '
 		</div><!-- $post[css_class] -->';

--- a/Themes/default/ReportedContent.template.php
+++ b/Themes/default/ReportedContent.template.php
@@ -197,8 +197,8 @@ function template_viewmodreport()
 		)
 	);
 
-					// Report buttons 
-					template_button_strip($report_buttons, 'right');
+	// Report buttons 
+	template_button_strip($report_buttons, 'right');
 
 	echo '
 				</h3>
@@ -477,8 +477,9 @@ function template_viewmemberreport()
 		)
 	);
 
-					// Report buttons
-					template_button_strip($report_buttons, 'right');
+	// Report buttons
+	template_button_strip($report_buttons, 'right');
+
 	echo '
 				</h3>
 			</div>

--- a/Themes/default/ReportedContent.template.php
+++ b/Themes/default/ReportedContent.template.php
@@ -32,14 +32,6 @@ function template_reported_posts()
 			</h3>
 		</div>';
 
-	// Make the buttons.
-	$close_button = create_button($context['view_closed'] ? 'folder' : 'close', $context['view_closed'] ? 'mc_reportedp_open' : 'mc_reportedp_close', $context['view_closed'] ? 'mc_reportedp_open' : 'mc_reportedp_close');
-	$details_button = create_button('details', 'mc_reportedp_details', 'mc_reportedp_details');
-	$ignore_button = create_button('ignore', 'mc_reportedp_ignore', 'mc_reportedp_ignore');
-	$unignore_button = create_button('ignore', 'mc_reportedp_unignore', 'mc_reportedp_unignore');
-	$ban_button = create_button('error', 'mc_reportedp_ban', 'mc_reportedp_ban');
-	$delete_button = create_button('delete', 'mc_reportedp_delete', 'mc_reportedp_delete');
-
 	foreach ($context['reports'] as $report)
 	{
 		echo '
@@ -60,30 +52,12 @@ function template_reported_posts()
 			</div>
 			<hr>
 			', $report['body'], '
-			<br>
-			<ul class="quickbuttons">
-				<li>
-					<a href="', $report['report_href'], '">', $details_button, '</a>
-				</li>
-				<li><a href="', $scripturl, '?action=moderate;area=reportedposts;sa=handle;ignore=', (int) !$report['ignore'], ';rid=', $report['id'], ';start=', $context['start'], ';', $context['session_var'], '=', $context['session_id'], ';', $context['mod-report-ignore_token_var'], '=', $context['mod-report-ignore_token'], '" ', (!$report['ignore'] ? ' class="you_sure" data-confirm="' . $txt['mc_reportedp_ignore_confirm'] . '"' : ''), '>', $report['ignore'] ? $unignore_button : $ignore_button, '</a></li>
-				<li><a href="', $scripturl, '?action=moderate;area=reportedposts;sa=handle;closed=', (int) !$report['closed'], ';rid=', $report['id'], ';start=', $context['start'], ';', $context['session_var'], '=', $context['session_id'], ';', $context['mod-report-closed_token_var'], '=', $context['mod-report-closed_token'], '">', $close_button, '</a></li>';
+			<br>';
 
-		// Delete message button.
-		if (!$report['closed'] && (is_array($context['report_remove_any_boards']) && in_array($report['topic']['id_board'], $context['report_remove_any_boards'])))
-			echo '
-				<li><a href="', $scripturl, '?action=deletemsg;topic=', $report['topic']['id'], '.0;msg=', $report['topic']['id_msg'], ';modcenter;', $context['session_var'], '=', $context['session_id'], '" data-confirm="', $txt['mc_reportedp_delete_confirm'], '" class="you_sure">', $delete_button, '</a></li>';
-
-		// Ban this user button.
-		if (!$report['closed'] && !empty($context['report_manage_bans']))
-			echo '
-				<li><a href="', $scripturl, '?action=admin;area=ban;sa=add', (!empty($report['author']['id']) ? ';u=' . $report['author']['id'] : ';msg=' . $report['topic']['id_msg']), ';', $context['session_var'], '=', $context['session_id'], '">', $ban_button, '</a></li>';
-
-		if (!$context['view_closed'])
-			echo '
-				<li><input type="checkbox" name="close[]" value="' . $report['id'] . '"></li>';
+		// Reported post options
+		template_quickbuttons($report['quickbuttons'], 'reported_posts');
 
 		echo '
-			</ul>
 		</div><!-- .windowbg -->';
 	}
 
@@ -206,18 +180,27 @@ function template_viewmodreport()
 				<h3 class="titlebg">
 					<span class="floatleft">
 						', sprintf($txt['mc_modreport_summary'], $context['report']['num_reports'], $context['report']['last_updated']), '
-					</span>
-					<span class="floatright">';
+					</span>';
 
-	// Make the buttons.
-	$close_button = create_button('close', $context['report']['closed'] ? 'mc_reportedp_open' : 'mc_reportedp_close', $context['report']['closed'] ? 'mc_reportedp_open' : 'mc_reportedp_close');
-	$ignore_button = create_button('ignore', 'mc_reportedp_ignore', 'mc_reportedp_ignore');
-	$unignore_button = create_button('ignore', 'mc_reportedp_unignore', 'mc_reportedp_unignore');
+	$report_buttons = array(
+		'ignore' => array(
+			'text' => !$context['report']['ignore'] ? 'mc_reportedp_ignore' : 'mc_reportedp_unignore',
+			'url' => $scripturl.'?action=moderate;area=reportedposts;sa=handle;ignore='.(int) !$context['report']['ignore'].';rid='.$context['report']['id'].';'.$context['session_var'].'='.$context['session_id'].';'.$context['mod-report-ignore_token_var'].'='.$context['mod-report-ignore_token'],
+			'class' => !$context['report']['ignore'] ? ' you_sure' : '',
+			'custom' => !$context['report']['ignore'] ? ' data-confirm="' . $txt['mc_reportedp_ignore_confirm'] . '"' : '',
+			'icon' => 'ignore'
+		),
+		'close' => array(
+			'text' => $context['report']['closed'] ? 'mc_reportedp_open' : 'mc_reportedp_close',
+			'url' => $scripturl.'?action=moderate;area=reportedposts;sa=handle;closed='.(int) !$context['report']['closed'].';rid='.$context['report']['id'].';'.$context['session_var'].'='.$context['session_id'].';'.$context['mod-report-closed_token_var'].'='.$context['mod-report-closed_token'],
+			'icon' => 'close'
+		)
+	);
+
+					// Report buttons 
+					template_button_strip($report_buttons, 'right');
 
 	echo '
-						<a href="', $scripturl, '?action=moderate;area=reportedposts;sa=handle;ignore=', (int) !$context['report']['ignore'], ';rid=', $context['report']['id'], ';', $context['session_var'], '=', $context['session_id'], ';', $context['mod-report-ignore_token_var'], '=', $context['mod-report-ignore_token'], '" class="button', (!$context['report']['ignore'] ? ' you_sure' : ''), '"', (!$context['report']['ignore'] ? ' data-confirm="' . $txt['mc_reportedp_ignore_confirm'] . '"' : ''), '>', $context['report']['ignore'] ? $unignore_button : $ignore_button, '</a>
-						<a href="', $scripturl, '?action=moderate;area=reportedposts;sa=handle;closed=', (int) !$context['report']['closed'], ';rid=', $context['report']['id'], ';', $context['session_var'], '=', $context['session_id'], ';', $context['mod-report-closed_token_var'], '=', $context['mod-report-closed_token'], '"  class="button">', $close_button, '</a>
-					</span>
 				</h3>
 			</div><!-- .title_bar -->
 			<div class="windowbg">
@@ -410,13 +393,6 @@ function template_reported_members()
 			<div class="pagelinks">', $context['page_index'], '</div>
 		</div>';
 
-	// Make the buttons.
-	$close_button = create_button('close', $context['view_closed'] ? 'mc_reportedp_open' : 'mc_reportedp_close', $context['view_closed'] ? 'mc_reportedp_open' : 'mc_reportedp_close');
-	$details_button = create_button('details', 'mc_reportedp_details', 'mc_reportedp_details');
-	$ignore_button = create_button('ignore', 'mc_reportedp_ignore', 'mc_reportedp_ignore');
-	$unignore_button = create_button('ignore', 'mc_reportedp_unignore', 'mc_reportedp_unignore');
-	$ban_button = create_button('close', 'mc_reportedp_ban', 'mc_reportedp_ban');
-
 	foreach ($context['reports'] as $report)
 	{
 		echo '
@@ -436,22 +412,7 @@ function template_reported_members()
 				', $txt['mc_reportedp_reported_by'], ': ', implode(', ', $comments), '
 			</div>
 			<hr>
-			<ul class="quickbuttons">
-				<li><a href="', $report['report_href'], '">', $details_button, '</a></li>
-				<li><a href="', $scripturl, '?action=moderate;area=reportedmembers;sa=handle;ignore=', (int) !$report['ignore'], ';rid=', $report['id'], ';start=', $context['start'], ';', $context['session_var'], '=', $context['session_id'], ';', $context['mod-report-ignore_token_var'], '=', $context['mod-report-ignore_token'], '" ', (!$report['ignore'] ? ' class="you_sure"  data-confirm="' . $txt['mc_reportedp_ignore_confirm'] . '"' : ''), '>', $report['ignore'] ? $unignore_button : $ignore_button, '</a></li>
-				<li><a href="', $scripturl, '?action=moderate;area=reportedmembers;sa=handle;closed=', (int) !$report['closed'], ';rid=', $report['id'], ';start=', $context['start'], ';', $context['session_var'], '=', $context['session_id'], ';', $context['mod-report-closed_token_var'], '=', $context['mod-report-closed_token'], '">', $close_button, '</a></li>';
-
-		// Ban this user button.
-		if (!$report['closed'] && !empty($context['report_manage_bans']) && !empty($report['user']['id']))
-			echo '
-				<li><a href="', $scripturl, '?action=admin;area=ban;sa=add;u=', $report['user']['id'], ';', $context['session_var'], '=', $context['session_id'], '">', $ban_button, '</a></li>';
-
-		if (!$context['view_closed'])
-			echo '
-				<li><input type="checkbox" name="close[]" value="' . $report['id'] . '"></li>';
-
-		echo '
-			</ul>
+			', template_quickbuttons($report['quickbuttons'], 'reported_members'), '
 		</div><!-- .generic_list_wrapper -->';
 	}
 
@@ -499,18 +460,26 @@ function template_viewmemberreport()
 				<h3 class="titlebg">
 					<span class="floatleft">
 						', sprintf($txt['mc_memberreport_summary'], $context['report']['num_reports'], $context['report']['last_updated']), '
-					</span>
-					<span class="floatright">';
+					</span>';
 
-	// Make the buttons.
-	$close_button = create_button('close', $context['report']['closed'] ? 'mc_reportedp_open' : 'mc_reportedp_close', $context['report']['closed'] ? 'mc_reportedp_open' : 'mc_reportedp_close');
-	$ignore_button = create_button('ignore', 'mc_reportedp_ignore', 'mc_reportedp_ignore');
-	$unignore_button = create_button('ignore', 'mc_reportedp_unignore', 'mc_reportedp_unignore');
+	$report_buttons = array(
+		'ignore' => array(
+			'text' => !$context['report']['ignore'] ? 'mc_reportedp_ignore' : 'mc_reportedp_unignore',
+			'url' => $scripturl.'?action=moderate;area=reportedmembers;sa=handle;ignore='.(int)!$context['report']['ignore'].';rid='.$context['report']['id'].';'.$context['session_var'].'='.$context['session_id'].';'.$context['mod-report-ignore_token_var'].'='.$context['mod-report-ignore_token'],
+			'class' => !$context['report']['ignore'] ? ' you_sure' : '',
+			'custom' => !$context['report']['ignore'] ? ' data-confirm="' . $txt['mc_reportedp_ignore_confirm'] . '"' : '',
+			'icon' => 'ignore'
+		),
+		'close' => array(
+			'text' => $context['report']['closed'] ? 'mc_reportedp_open' : 'mc_reportedp_close',
+			'url' => $scripturl.'?action=moderate;area=reportedmembers;sa=handle;closed='.(int)!$context['report']['closed'].';rid='.$context['report']['id'].';'.$context['session_var'].'='.$context['session_id'].';'.$context['mod-report-closed_token_var'].'='.$context['mod-report-closed_token'],
+			'icon' => 'close'
+		)
+	);
 
+					// Report buttons
+					template_button_strip($report_buttons, 'right');
 	echo '
-						<a href="', $scripturl, '?action=moderate;area=reportedmembers;sa=handle;ignore=', (int) !$context['report']['ignore'], ';rid=', $context['report']['id'], ';', $context['session_var'], '=', $context['session_id'], ';', $context['mod-report-ignore_token_var'], '=', $context['mod-report-ignore_token'], '" class="button', (!$context['report']['ignore'] ? ' you_sure' : ''), '"', (!$context['report']['ignore'] ? ' data-confirm="' . $txt['mc_reportedp_ignore_confirm'] . '"' : ''), '>', $context['report']['ignore'] ? $unignore_button : $ignore_button, '</a>
-						<a href="', $scripturl, '?action=moderate;area=reportedmembers;sa=handle;closed=', (int) !$context['report']['closed'], ';rid=', $context['report']['id'], ';', $context['session_var'], '=', $context['session_id'], ';', $context['mod-report-closed_token_var'], '=', $context['mod-report-closed_token'], '"  class="button">', $close_button, '</a>
-					</span>
 				</h3>
 			</div>
 			<br>

--- a/Themes/default/css/index.css
+++ b/Themes/default/css/index.css
@@ -1018,6 +1018,11 @@ img.sort, .sort {
 	border-right: none;
 	box-shadow: -1px 0 0 rgba(255, 255, 255, 0.7);
 }
+/* in a titlebg, the buttonlist is of small height */
+.titlebg .buttonlist {
+	margin: 0;
+	padding: 0;
+}
 
 /* Styles for the general looks of the theme.
 ------------------------------------------------------- */
@@ -1681,7 +1686,7 @@ tr.windowbg td, tr.bg td, .table_grid tr td {
 }
 
 /* Small fix for topics */
-.quickbuttons span.main_icons {
+.quickbuttons span.main_icons, .button span.main_icons {
 	margin: -3px 3px 0 1px;
 }
 .quickbuttons span.main_icons.quote,
@@ -2320,7 +2325,6 @@ dl {
 	float: left;
 }
 .topic_details {
-	width: 94%;
 	padding: 0 4px 4px 4px;
 }
 .list_posts {
@@ -3537,6 +3541,9 @@ h3.catbg .main_icons::before, h3.catbg .icon {
 	border-top-left-radius: 0;
 	border-top-right-radius: 0;
 }
+.cat_bar + .title_bar {
+	margin-top: 0;
+}
 /* Roundframe */
 .roundframe {
 	margin: 10px 0 0 0;
@@ -3577,6 +3584,11 @@ h3.titlebg, h4.titlebg, .titlebg, h3.subbg, h4.subbg, .subbg {
 	background: none;
 	color: #555;
 	text-decoration: none;
+}
+.title_bar + .windowbg, .title_bar + .roundframe {
+	margin-top: -1px;
+	border-top-left-radius: 0;
+	border-top-right-radius: 0;
 }
 
 /* Other */
@@ -3784,9 +3796,6 @@ h3.profile_hd {
 #reported_posts .quickbuttons li a,
 #reported_members .quickbuttons li a {
 	background: none;
-}
-#modcenter .main_icons {
-	margin: -3px -3px 0 0;
 }
 
 /* Some colors for generic usage */

--- a/Themes/default/css/index.css
+++ b/Themes/default/css/index.css
@@ -2766,7 +2766,7 @@ tr.windowbg:hover {
 }
 
 /* Special treatment for #forumposts area */
-#forumposts .windowbg, #forumposts .approvebg, #forumposts .approvebg2 {
+#forumposts .windowbg, #forumposts .approvebg, #forumposts .approvebg2, #pmFolder .windowbg {
 	overflow: visible;
 }
 /* Nobody wants locked topics to stand out much. */

--- a/Themes/default/index.template.php
+++ b/Themes/default/index.template.php
@@ -611,7 +611,7 @@ function template_button_strip($button_strip, $direction = '', $strip_options = 
  * @param array $list_items An array with info for displaying the strip
  * @param string $list_id unique list id, used for integration hooks
  */
-function template_quickbuttons($list_items, $list_id = null)
+function template_quickbuttons($list_items, $list_id = null, $output_method = 'echo')
 {
 	global $txt;
 
@@ -633,14 +633,8 @@ function template_quickbuttons($list_items, $list_id = null)
 				unset($list_items[$key]);
 		}
 		// A normal list item
-		else
-		{
-			if (isset($li['show']) && !$li['show'])
-				unset($list_items[$key]);
-
-			if (empty($li['sublist']))
-				continue;
-		}
+		elseif (isset($li['show']) && !$li['show'])
+			unset($list_items[$key]);
 	}
 
 	// Now check if there are any items left
@@ -648,23 +642,27 @@ function template_quickbuttons($list_items, $list_id = null)
 		return;
 
 	// Print the quickbuttons
-	echo '
-		<ul', !empty($list_id) ? ' id="quickbuttons_'.$list_id.'"' : '', ' class="quickbuttons">';
+	$output = '
+		<ul' . (!empty($list_id) ? ' id="quickbuttons_'.$list_id.'"' : '') . ' class="quickbuttons">';
 
-	$list_item_format = function($li) {
-		echo '
-			<li', !empty($li['class']) ? ' class="'.$li['class'].'"' : '', '', !empty($li['id']) ? ' id="'.$li['id'].'"' : '', '', !empty($li['custom']) ? $li['custom'] : '', '>';
+	// This is used for a list item or a sublist item
+	$list_item_format = function($li)
+	{
+		$html = '
+			<li' . (!empty($li['class']) ? ' class="'.$li['class'].'"' : '') . (!empty($li['id']) ? ' id="'.$li['id'].'"' : '') . (!empty($li['custom']) ? $li['custom'] : '') . '>';
 
 		if(isset($li['content']))
-			echo $li['content'];
+			$html .= $li['content'];
 		else
-			echo '
-				<a', !empty($li['href']) ? ' href="'.$li['href'].'"' : '', '', !empty($li['javascript']) ? $li['javascript'] : '', '>
-					', !empty($li['icon']) ? '<span class="main_icons '.$li['icon'].'"></span>' : '', '', !empty($li['label']) ? $li['label'] : '', '
+			$html .= '
+				<a' . (!empty($li['href']) ? ' href="'.$li['href'].'"' : '') . (!empty($li['javascript']) ? $li['javascript'] : '') . '>
+					' . (!empty($li['icon']) ? '<span class="main_icons '.$li['icon'].'"></span>' : '') . (!empty($li['label']) ? $li['label'] : '') . '
 				</a>';
 
-		echo '
+		$html .= '
 			</li>';
+
+		return $html;
 	};
 
 	foreach ($list_items as $key => $li)
@@ -672,24 +670,30 @@ function template_quickbuttons($list_items, $list_id = null)
 		// Handle the sublist
 		if($key == 'more')
 		{
-			echo '
-			<li class="post_options">', $txt['post_options'], '
+			$output .= '
+			<li class="post_options">' . $txt['post_options'] . '
 				<ul>';
 
 			foreach ($li as $subli)
-				$list_item_format($subli);
+				$output .= $list_item_format($subli);
 
-			echo '
+			$output .= '
 				</ul>
 			</li>';
 		}
 		// Ordinary list item
 		else
-			$list_item_format($li);
+			$output .= $list_item_format($li);
 	}
 
-	echo '
+	$output .= '
 		</ul><!-- .quickbuttons -->';
+
+	// There are a few spots where the result needs to be returned
+	if($output_method == 'echo')
+		echo $output;
+	else
+		return $output;
 }
 
 /**

--- a/Themes/default/index.template.php
+++ b/Themes/default/index.template.php
@@ -566,7 +566,7 @@ function template_button_strip($button_strip, $direction = '', $strip_options = 
 				$value['id'] = $key;
 
 			$button = '
-				<a class="button button_strip_' . $key . (!empty($value['active']) ? ' active' : '') . (isset($value['class']) ? ' ' . $value['class'] : '') . '" ' . (!empty($value['url']) ? 'href="' . $value['url'] . '"' : '') . ' ' . (isset($value['custom']) ? ' ' . $value['custom'] : '') . '>' . $txt[$value['text']] . '</a>';
+				<a class="button button_strip_' . $key . (!empty($value['active']) ? ' active' : '') . (isset($value['class']) ? ' ' . $value['class'] : '') . '" ' . (!empty($value['url']) ? 'href="' . $value['url'] . '"' : '') . ' ' . (isset($value['custom']) ? ' ' . $value['custom'] : '') . '>'.(!empty($value['icon']) ? '<span class="main_icons '.$value['icon'].'"></span>' : '').'' . $txt[$value['text']] . '</a>';
 
 			if (!empty($value['sub_buttons']))
 			{
@@ -603,6 +603,93 @@ function template_button_strip($button_strip, $direction = '', $strip_options = 
 		<div class="buttonlist', !empty($direction) ? ' float' . $direction : '', '"', (empty($buttons) ? ' style="display: none;"' : ''), (!empty($strip_options['id']) ? ' id="' . $strip_options['id'] . '"' : ''), '>
 			', implode('', $buttons), '
 		</div>';
+}
+
+/**
+ * Generate a list of quickbuttons.
+ *
+ * @param array $list_items An array with info for displaying the strip
+ * @param string $list_id unique list id, used for integration hooks
+ */
+function template_quickbuttons($list_items, $list_id = null)
+{
+	global $txt;
+
+	// Enable manipulation with hooks
+	if(!empty($list_id))
+		call_integration_hook('integrate_' . $list_id . '_quickbuttons', array(&$list_items));
+
+	// Make sure the list has at least one shown item
+	foreach ($list_items as $key => $li)
+	{
+		// Is there a sublist, and does it have any shown items
+		if ($key == 'more')
+		{
+			foreach ($li as $subkey => $subli)
+				if (isset($subli['show']) && !$subli['show'])
+					unset($list_items[$key][$subkey]);
+
+			if (empty($list_items[$key]))
+				unset($list_items[$key]);
+		}
+		// A normal list item
+		else
+		{
+			if (isset($li['show']) && !$li['show'])
+				unset($list_items[$key]);
+
+			if (empty($li['sublist']))
+				continue;
+		}
+	}
+
+	// Now check if there are any items left
+	if (empty($list_items))
+		return;
+
+	// Print the quickbuttons
+	echo '
+		<ul', !empty($list_id) ? ' id="quickbuttons_'.$list_id.'"' : '', ' class="quickbuttons">';
+
+	$list_item_format = function($li) {
+		echo '
+			<li', !empty($li['class']) ? ' class="'.$li['class'].'"' : '', '', !empty($li['id']) ? ' id="'.$li['id'].'"' : '', '', !empty($li['custom']) ? $li['custom'] : '', '>';
+
+		if(isset($li['content']))
+			echo $li['content'];
+		else
+			echo '
+				<a', !empty($li['href']) ? ' href="'.$li['href'].'"' : '', '', !empty($li['javascript']) ? $li['javascript'] : '', '>
+					', !empty($li['icon']) ? '<span class="main_icons '.$li['icon'].'"></span>' : '', '', !empty($li['label']) ? $li['label'] : '', '
+				</a>';
+
+		echo '
+			</li>';
+	};
+
+	foreach ($list_items as $key => $li)
+	{
+		// Handle the sublist
+		if($key == 'more')
+		{
+			echo '
+			<li class="post_options">', $txt['post_options'], '
+				<ul>';
+
+			foreach ($li as $subli)
+				$list_item_format($subli);
+
+			echo '
+				</ul>
+			</li>';
+		}
+		// Ordinary list item
+		else
+			$list_item_format($li);
+	}
+
+	echo '
+		</ul><!-- .quickbuttons -->';
 }
 
 /**

--- a/Themes/default/index.template.php
+++ b/Themes/default/index.template.php
@@ -47,9 +47,6 @@ function template_init()
 	// The version this template/theme is for. This should probably be the version of SMF it was created for.
 	$settings['theme_version'] = '2.1';
 
-	// Use plain buttons - as opposed to text buttons?
-	$settings['use_buttons'] = true;
-
 	// Set the following variable to true if this theme requires the optional theme strings file to be loaded.
 	$settings['require_theme_strings'] = false;
 


### PR DESCRIPTION
I'm not sure this is a good change at this stage, but that's for you devs to decide.

Here's what this PR does
* Adds a generic template for the quickbuttons layout and adds a hook for each set of quickbuttons array to enable manipulation without modifications.
* Removes the **create_button** function, it is only used in a few spots in the moderation section to remove icons using the **use_buttons** template setting.
* Removes the **use_button** template setting, there is no use in a setting that only makes a difference in a couple sections of the forum.