### PR TITLE
 Simplifies min/max version range for search and cache APIs

### DIFF
--- a/Sources/Class-CacheAPI.php
+++ b/Sources/Class-CacheAPI.php
@@ -137,7 +137,7 @@ interface cache_api_interface
 	 * @access public
 	 * @return string the value of $key.
 	 */
-	public function getMiniumnVersion();
+	public function getMinimumVersion();
 
 	/**
 	 * Gets the Version of the Caching API.
@@ -163,14 +163,14 @@ interface cache_api_interface
 abstract class cache_api implements cache_api_interface
 {
 	/**
-	 * @var string The last version of SMF that this was tested on. Helps protect against API changes.
+	 * @var string The maximum SMF version that this will work with.
 	 */
-	protected $version_compatible = 'SMF 2.1 RC1';
+	protected $version_compatible = '2.1.999';
 
 	/**
-	 * @var string The minimum SMF version that this will work with
+	 * @var string The minimum SMF version that this will work with.
 	 */
-	protected $min_smf_version = 'SMF 2.1 RC1';
+	protected $min_smf_version = '2.1 RC1';
 
 	/**
 	 * @var string The prefix for all keys.
@@ -324,7 +324,7 @@ abstract class cache_api implements cache_api_interface
 	/**
 	 * {@inheritDoc}
 	 */
-	public function getMiniumnVersion()
+	public function getMinimumVersion()
 	{
 		return $this->min_smf_version;
 	}

--- a/Sources/Class-SearchAPI.php
+++ b/Sources/Class-SearchAPI.php
@@ -143,14 +143,14 @@ interface search_api_interface
 abstract class search_api implements search_api_interface
 {
 	/**
-	 * @var string The last version of SMF that this was tested on. Helps protect against API changes.
+	 * @var string The maximum SMF version that this will work with.
 	 */
-	public $version_compatible = 'SMF 2.1 RC1';
+	public $version_compatible = '2.1.999';
 
 	/**
-	 * @var string The minimum SMF version that this will work with
+	 * @var string The minimum SMF version that this will work with.
 	 */
-	public $min_smf_version = 'SMF 2.1 RC1';
+	public $min_smf_version = '2.1 RC1';
 
 	/**
 	 * @var bool Whether or not it's supported

--- a/Sources/Search.php
+++ b/Sources/Search.php
@@ -16,14 +16,6 @@
 if (!defined('SMF'))
 	die('No direct access...');
 
-// This defines two version types for checking the API's are compatible with this version of SMF.
-$GLOBALS['search_versions'] = array(
-	// @todo Probably unnecessary now that we use a constant instead of global $forum_version
-	'forum_version' => SMF_FULL_VERSION,
-	// This is the minimum version of SMF that an API could have been written for to work. (strtr to stop accidentally updating version on release)
-	'search_version' => strtr('SMF 2+1=Alpha=1', array('+' => '.', '=' => ' ')),
-);
-
 /**
  * Ask the user what they want to search for.
  * What it does:
@@ -2134,7 +2126,7 @@ function prepareSearchContext($reset = false)
  */
 function findSearchAPI()
 {
-	global $sourcedir, $modSettings, $search_versions, $searchAPI, $txt;
+	global $sourcedir, $modSettings, $searchAPI, $txt;
 
 	require_once($sourcedir . '/Subs-Package.php');
 	require_once($sourcedir . '/Class-SearchAPI.php');
@@ -2153,7 +2145,7 @@ function findSearchAPI()
 	$searchAPI = new $search_class_name();
 
 	// An invalid Search API.
-	if (!$searchAPI || !($searchAPI instanceof search_api_interface) || ($searchAPI->supportsMethod('isValid') && !$searchAPI->isValid()) || !matchPackageVersion($search_versions['forum_version'], $searchAPI->min_smf_version . '-' . $searchAPI->version_compatible))
+	if (!$searchAPI || !($searchAPI instanceof search_api_interface) || ($searchAPI->supportsMethod('isValid') && !$searchAPI->isValid()) || !matchPackageVersion(SMF_VERSION, $searchAPI->min_smf_version . '-' . $searchAPI->version_compatible))
 	{
 		// Log the error.
 		loadLanguage('Errors');


### PR DESCRIPTION
The previous way required us to update the `$version_compatible` strings in Class-SearchAPI.php and Class-CacheAPI.php with every release, in a misguided and ineffective attempt to future-proof against API changes.

Fixes #5558