### PR TITLE
Always parses BBC using the recipent's language in email notifications

### DIFF
--- a/Sources/Subs-Post.php
+++ b/Sources/Subs-Post.php
@@ -1149,11 +1149,7 @@ function sendpm($recipients, $subject, $message, $store_outbox = false, $from = 
 		if (empty($notification_texts[$lang]))
 		{
 			if ($lang != $user_info['language'])
-			{
-				$user_txt = $txt;
-				$txt = array();
-				loadLanguage('index', $lang, false, true);
-			}
+				loadLanguage('index+Modifications', $lang, false);
 
 			$notification_texts[$lang]['subject'] = $subject;
 			censorText($notification_texts[$lang]['subject']);
@@ -1171,7 +1167,7 @@ function sendpm($recipients, $subject, $message, $store_outbox = false, $from = 
 
 
 			if ($lang != $user_info['language'])
-				$txt = $user_txt;
+				loadLanguage('index+Modifications', $user_info['language'], false);
 		}
 
 		$replacements['SUBJECT'] = $notification_texts[$lang]['subject'];

--- a/Sources/Subs-Post.php
+++ b/Sources/Subs-Post.php
@@ -1116,15 +1116,6 @@ function sendpm($recipients, $subject, $message, $store_outbox = false, $from = 
 		);
 	}
 
-	censorText($subject);
-	if (empty($modSettings['disallow_sendBody']))
-	{
-		censorText($message);
-		$message = trim(un_htmlspecialchars(strip_tags(strtr(parse_bbc($smcFunc['htmlspecialchars']($message), false), array('<br>' => "\n", '</div>' => "\n", '</li>' => "\n", '&#91;' => '[', '&#93;' => ']')))));
-	}
-	else
-		$message = '';
-
 	$to_names = array();
 	if (count($to_list) > 1)
 	{
@@ -1150,8 +1141,42 @@ function sendpm($recipients, $subject, $message, $store_outbox = false, $from = 
 	);
 	$email_template = 'new_pm' . (empty($modSettings['disallow_sendBody']) ? '_body' : '') . (!empty($to_names) ? '_tolist' : '');
 
+	$notification_texts = array();
+
 	foreach ($notifications as $lang => $notification_list)
 	{
+		// Censor and parse BBC in the receiver's language. Only do each language once.
+		if (empty($notification_texts[$lang]))
+		{
+			if ($lang != $user_info['language'])
+			{
+				$user_txt = $txt;
+				$txt = array();
+				loadLanguage('index', $lang, false, true);
+			}
+
+			$notification_texts[$lang]['subject'] = $subject;
+			censorText($notification_texts[$lang]['subject']);
+
+			if (empty($modSettings['disallow_sendBody']))
+			{
+				$notification_texts[$lang]['body'] = $message;
+
+				censorText($notification_texts[$lang]['body']);
+
+				$notification_texts[$lang]['body'] = trim(un_htmlspecialchars(strip_tags(strtr(parse_bbc($notification_texts[$lang]['body'], false), array('<br>' => "\n", '</div>' => "\n", '</li>' => "\n", '&#91;' => '[', '&#93;' => ']')))));
+			}
+			else
+				$notification_texts[$lang]['body'] = '';
+
+
+			if ($lang != $user_info['language'])
+				$txt = $user_txt;
+		}
+
+		$replacements['SUBJECT'] = $notification_texts[$lang]['subject'];
+		$replacements['MESSAGE'] = $notification_texts[$lang]['body'];
+
 		$emaildata = loadEmailTemplate($email_template, $replacements, $lang);
 
 		// Off the notification email goes!
@@ -1622,12 +1647,6 @@ function sendNotifications($topics, $type, $exclude = array(), $members_only = a
 	$task_rows = array();
 	while ($row = $smcFunc['db_fetch_assoc']($result))
 	{
-		// Clean it up.
-		censorText($row['subject']);
-		censorText($row['body']);
-		$row['subject'] = un_htmlspecialchars($row['subject']);
-		$row['body'] = trim(un_htmlspecialchars(strip_tags(strtr(parse_bbc($row['body'], false, $row['id_last_msg']), array('<br>' => "\n", '</div>' => "\n", '</li>' => "\n", '&#91;' => '[', '&#93;' => ']')))));
-
 		$task_rows[] = array(
 			'$sourcedir/tasks/CreatePost-Notify.php', 'CreatePost_Notify_Background', $smcFunc['json_encode'](array(
 				'msgOptions' => array(

--- a/Sources/Subs-Post.php
+++ b/Sources/Subs-Post.php
@@ -1164,7 +1164,7 @@ function sendpm($recipients, $subject, $message, $store_outbox = false, $from = 
 
 				censorText($notification_texts[$lang]['body']);
 
-				$notification_texts[$lang]['body'] = trim(un_htmlspecialchars(strip_tags(strtr(parse_bbc($notification_texts[$lang]['body'], false), array('<br>' => "\n", '</div>' => "\n", '</li>' => "\n", '&#91;' => '[', '&#93;' => ']')))));
+				$notification_texts[$lang]['body'] = trim(un_htmlspecialchars(strip_tags(strtr(parse_bbc($smcFunc['htmlspecialchars']($notification_texts[$lang]['body']), false), array('<br>' => "\n", '</div>' => "\n", '</li>' => "\n", '&#91;' => '[', '&#93;' => ']')))));
 			}
 			else
 				$notification_texts[$lang]['body'] = '';

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -1060,11 +1060,8 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 		$bbc_codes = array();
 
 	// If we are not doing every tag then we don't cache this run.
-	if (!empty($parse_tags) && !empty($bbc_codes))
-	{
-		$temp_bbc = $bbc_codes;
+	if (!empty($parse_tags))
 		$bbc_codes = array();
-	}
 
 	// Ensure $modSettings['tld_regex'] contains a valid regex for the autolinker
 	if (!empty($modSettings['autoLinkUrls']))
@@ -1932,8 +1929,6 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 		// This is mainly for the bbc manager, so it's easy to add tags above.  Custom BBC should be added above this line.
 		if ($message === false)
 		{
-			if (isset($temp_bbc))
-				$bbc_codes = $temp_bbc;
 			usort($codes, function($a, $b)
 			{
 				return strcmp($a['tag'], $b['tag']);
@@ -2977,23 +2972,10 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 	// If this was a force parse revert if needed.
 	if (!empty($parse_tags))
 	{
-		if (empty($temp_bbc))
-			$bbc_codes = array();
-		else
-		{
-			$bbc_codes = $temp_bbc;
-			unset($temp_bbc);
-		}
-
-		if (empty($real_alltags_regex))
-			$alltags_regex = '';
-		else
-		{
-			$alltags_regex = $real_alltags_regex;
-			unset($real_alltags_regex);
-		}
+		$alltags_regex = empty($real_alltags_regex) ? '' : $real_alltags_regex;
+		unset($real_alltags_regex);
 	}
-	else
+	elseif (!empty($bbc_codes))
 		$bbc_lang_locales[$txt['lang_locale']] = $bbc_codes;
 
 	return $message;

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -1021,7 +1021,7 @@ function permute($array)
 function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = array())
 {
 	global $smcFunc, $txt, $scripturl, $context, $modSettings, $user_info, $sourcedir;
-	static $bbc_codes = array(), $itemcodes = array(), $no_autolink_tags = array();
+	static $bbc_lang_locales = array(), $itemcodes = array(), $no_autolink_tags = array();
 	static $disabled, $alltags_regex = '', $param_regexes = array();
 
 	// Don't waste cycles
@@ -1052,6 +1052,12 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 
 		return $message;
 	}
+
+	// If we already have a version of the BBCodes for the current language, use that. Otherwise, make one.
+	if (!empty($bbc_lang_locales[$txt['lang_locale']]))
+		$bbc_codes = $bbc_lang_locales[$txt['lang_locale']];
+	else
+		$bbc_codes = array();
 
 	// If we are not doing every tag then we don't cache this run.
 	if (!empty($parse_tags) && !empty($bbc_codes))
@@ -2987,6 +2993,8 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 			unset($real_alltags_regex);
 		}
 	}
+	else
+		$bbc_lang_locales[$txt['lang_locale']] = $bbc_codes;
 
 	return $message;
 }

--- a/Sources/tasks/CreatePost-Notify.php
+++ b/Sources/tasks/CreatePost-Notify.php
@@ -211,8 +211,9 @@ class CreatePost_Notify_Background extends SMF_BackgroundTask
 
 				censorText($parsed_message[$receiver_lang]['subject']);
 				censorText($parsed_message[$receiver_lang]['body']);
+
 				$parsed_message[$receiver_lang]['subject'] = un_htmlspecialchars($parsed_message[$receiver_lang]['subject']);
-				$parsed_message[$receiver_lang]['body'] = trim(un_htmlspecialchars(strip_tags(strtr(parse_bbc($parsed_message[$receiver_lang]['body'], false), array('<br>' => "\n", '</div>' => "\n", '</li>' => "\n", '&#91;' => '[', '&#93;' => ']')))));
+				$parsed_message[$receiver_lang]['body'] = trim(un_htmlspecialchars(strip_tags(strtr(parse_bbc($parsed_message[$receiver_lang]['body'], false), array('<br>' => "\n", '</div>' => "\n", '</li>' => "\n", '&#91;' => '[', '&#93;' => ']', '&#39;' => '\'')))));
 			}
 
 			// Bitwise check: Receiving a email notification?
@@ -222,7 +223,7 @@ class CreatePost_Notify_Background extends SMF_BackgroundTask
 					'TOPICSUBJECT' => $parsed_message[$receiver_lang]['subject'],
 					'POSTERNAME' => un_htmlspecialchars($posterOptions['name']),
 					'TOPICLINK' => $scripturl . '?topic=' . $topicOptions['id'] . '.new#new',
-					'MESSAGE' => trim(un_htmlspecialchars(strip_tags(strtr(parse_bbc(un_preparsecode($parsed_message[$receiver_lang]['body']), false), array('<br>' => "\n", '</div>' => "\n", '</li>' => "\n", '&#91;' => '[', '&#93;' => ']', '&#39;' => '\''))))),
+					'MESSAGE' => $parsed_message[$receiver_lang]['body'],
 					'UNSUBSCRIBELINK' => $scripturl . '?action=notifyboard;board=' . $topicOptions['board'] . '.0',
 				);
 

--- a/Sources/tasks/CreatePost-Notify.php
+++ b/Sources/tasks/CreatePost-Notify.php
@@ -204,7 +204,7 @@ class CreatePost_Notify_Background extends SMF_BackgroundTask
 			// Censor and parse BBC in the receiver's language. Only do each language once.
 			if (empty($parsed_message[$receiver_lang]))
 			{
-				loadLanguage('index', $receiver_lang, false);
+				loadLanguage('index+Modifications', $receiver_lang, false);
 
 				$parsed_message[$receiver_lang]['subject'] = $msgOptions['subject'];
 				$parsed_message[$receiver_lang]['body'] = $msgOptions['body'];

--- a/Sources/tasks/CreatePost-Notify.php
+++ b/Sources/tasks/CreatePost-Notify.php
@@ -40,12 +40,14 @@ class CreatePost_Notify_Background extends SMF_BackgroundTask
 	 */
 	public function execute()
 	{
-		global $smcFunc, $sourcedir, $scripturl, $language, $modSettings, $user_info;
+		global $smcFunc, $sourcedir, $scripturl, $language, $modSettings;
 
 		require_once($sourcedir . '/Subs-Post.php');
 		require_once($sourcedir . '/Mentions.php');
 		require_once($sourcedir . '/Subs-Notify.php');
 		require_once($sourcedir . '/Subs.php');
+		require_once($sourcedir . '/ScheduledTasks.php');
+		loadEssentialThemeData();
 
 		$msgOptions = $this->_details['msgOptions'];
 		$topicOptions = $this->_details['topicOptions'];
@@ -202,8 +204,7 @@ class CreatePost_Notify_Background extends SMF_BackgroundTask
 			// Censor and parse BBC in the receiver's language. Only do each language once.
 			if (empty($parsed_message[$receiver_lang]))
 			{
-				if ($receiver_lang != $user_info['language'])
-					loadLanguage('index', $receiver_lang, false);
+				loadLanguage('index', $receiver_lang, false);
 
 				$parsed_message[$receiver_lang]['subject'] = $msgOptions['subject'];
 				$parsed_message[$receiver_lang]['body'] = $msgOptions['body'];
@@ -212,9 +213,6 @@ class CreatePost_Notify_Background extends SMF_BackgroundTask
 				censorText($parsed_message[$receiver_lang]['body']);
 				$parsed_message[$receiver_lang]['subject'] = un_htmlspecialchars($parsed_message[$receiver_lang]['subject']);
 				$parsed_message[$receiver_lang]['body'] = trim(un_htmlspecialchars(strip_tags(strtr(parse_bbc($parsed_message[$receiver_lang]['body'], false), array('<br>' => "\n", '</div>' => "\n", '</li>' => "\n", '&#91;' => '[', '&#93;' => ']')))));
-
-				if ($receiver_lang != $user_info['language'])
-					loadLanguage('index', $user_info['language'], false);
 			}
 
 			// Bitwise check: Receiving a email notification?


### PR DESCRIPTION
Doing this requires using `parse_bbc()` in the langauge of the recipient of the email notification rather than in the language of the current user.

Main changes:
- `parse_bbc()` can now remember versions of the $bbc_codes array for multiple languages.
- For new post notifications, the body text of the message is now censored and parsed in CreatePost-Notify.php rather than in Subs-Post.php's `sendNotifications()`. This allows us to tailor the output of `parse_bbc()` depending on the recipient's language.
- Similarly, some code has been moved around and modified in the `sendpm()` function of Subs-Post.php.

~TODO: This code temporarily resets `$txt` to a blank slate, populates it with the contents of the index language file for the recipient's language, and then restores `$txt` to its original state when we are done. This is fine for parsing standard BBC, but it will know nothing about `$txt` strings stored in other files, e.g. in those added by mods. Should probably do something about that...~ ← Done.

Fixes #1407 (which dates all the way back to 2006: http://dev.simplemachines.org/mantis/view.php?id=52)