### PR TITLE
Fetch default alert prefs fix

### DIFF
--- a/Sources/Subs-Notify.php
+++ b/Sources/Subs-Notify.php
@@ -55,7 +55,10 @@ function getNotifyPrefs($members, $prefs = '', $process_default = false)
 	if ($process_default && isset($result[0]))
 	{
 		foreach ($members as $member)
-			$result[$member] += $result[0];
+			if (isset($result[$member]))
+				$result[$member] += $result[0];
+			else
+				$result[$member] = $result[0];
 
 		unset ($result[0]);
 	}

--- a/Sources/Subs-Notify.php
+++ b/Sources/Subs-Notify.php
@@ -49,16 +49,13 @@ function getNotifyPrefs($members, $prefs = '', $process_default = false)
 		)
 	);
 	while ($row = $smcFunc['db_fetch_assoc']($request))
-	{
 		$result[$row['id_member']][$row['alert_pref']] = $row['alert_value'];
-	}
 
 	// We may want to keep the default values separate from a given user's. Or we might not.
 	if ($process_default && isset($result[0]))
 	{
 		foreach ($members as $member)
-			if (!isset($result[$member]))
-				$result[$member] = $result[0];
+			$result[$member] += $result[0];
 
 		unset ($result[0]);
 	}


### PR DESCRIPTION
With this fix, the user prefs page will not go empty if a topic is being watched and no prefs have been set.

Also addresses https://www.simplemachines.org/community/index.php?topic=566866.0