### PR TITLE
Some fixes to announcement options

### DIFF
--- a/Sources/Post.php
+++ b/Sources/Post.php
@@ -2704,6 +2704,7 @@ function AnnouncementSend()
 
 	foreach ($rows as $row)
 	{
+		$context['start'] = $row['id_member'];
 		// Force them to have it?
 		if (empty($prefs[$row['id_member']]['announcements']))
 			continue;
@@ -2730,7 +2731,6 @@ function AnnouncementSend()
 		}
 
 		$announcements[$cur_language]['recipients'][$row['id_member']] = $row['email_address'];
-		$context['start'] = $row['id_member'];
 	}
 
 	// For each language send a different mail - low priority...

--- a/Sources/Profile-Modify.php
+++ b/Sources/Profile-Modify.php
@@ -1976,6 +1976,7 @@ function alert_configuration($memID)
 		'alert_timeout' => isset($context['alert_prefs']['alert_timeout']) ? $context['alert_prefs']['alert_timeout'] : 10,
 		'notify_announcements' => isset($context['alert_prefs']['announcements']) ? $context['alert_prefs']['announcements'] : 0,
 	);
+	$context['can_disable_announce'] = $memID == 0 || !empty($modSettings['allow_disableAnnounce']);
 
 	// Now for the exciting stuff.
 	// We have groups of items, each item has both an alert and an email key as well as an optional help string.

--- a/Sources/Register.php
+++ b/Sources/Register.php
@@ -128,6 +128,13 @@ function Register($reg_errors = array())
 		}
 	}
 
+	if (!empty($modSettings['allow_disableAnnounce']))
+	{
+		require_once($sourcedir . '/Subs-Notify.php');
+		$prefs = getNotifyPrefs(0, 'announcements');
+		$context['notify_announcements'] = !empty($prefs[0]['announcements']);
+	}
+
 	if (!empty($modSettings['userLanguage']))
 	{
 		$selectedLanguage = empty($_SESSION['language']) ? $language : $_SESSION['language'];
@@ -507,15 +514,16 @@ function Register2()
 	spamProtection('register');
 
 	// Do they want to recieve announcements?
-	require_once($sourcedir . '/Subs-Notify.php');
-	$prefs = getNotifyPrefs($memberID, 'announcements', true);
-	$var = !empty($_POST['notify_announcements']);
-	$pref = !empty($prefs[$memberID]['announcements']);
-
-	// Don't update if the default is the same.
-	if ($var != $pref)
+	if (!empty($modSettings['allow_disableAnnounce']))
 	{
-		setNotifyPrefs($memberID, array('announcements' => (int) !empty($_POST['notify_announcements'])));
+		require_once($sourcedir . '/Subs-Notify.php');
+		$prefs = getNotifyPrefs($memberID, 'announcements', true);
+		$var = !empty($_POST['notify_announcements']);
+		$pref = !empty($prefs[$memberID]['announcements']);
+
+		// Don't update if the default is the same.
+		if ($var != $pref)
+			setNotifyPrefs($memberID, array('announcements' => (int) !empty($_POST['notify_announcements'])));
 	}
 
 	// We'll do custom fields after as then we get to use the helper function!

--- a/Themes/default/Profile.template.php
+++ b/Themes/default/Profile.template.php
@@ -1885,7 +1885,7 @@ function template_alert_configuration()
 				<dl class="settings">';
 
 	// Allow notification on announcements to be disabled?
-	if (!empty($modSettings['allow_disableAnnounce']))
+	if ($context['can_disable_announce'])
 		echo '
 					<dt>
 						<label for="notify_announcements">', $txt['notify_important_email'], '</label>

--- a/Themes/default/Register.template.php
+++ b/Themes/default/Register.template.php
@@ -133,7 +133,11 @@ function template_registration_form()
 								<span id="smf_autov_pwverify_img" class="main_icons valid"></span>
 							</span>
 						</dd>
-					</dl>
+					</dl>';
+
+	// Allow notification on announcements to be disabled?
+	if (!empty($modSettings['allow_disableAnnounce']))
+		echo '
 					<dl class="register_form" id="notify_announcements">
 						<dt>
 							<strong><label for="notify_announcements">', $txt['notify_announcements'], ':</label></strong>


### PR DESCRIPTION
-  hide the checkbox in the registration form if users cannot disable announcements
- only save the pref if said modsetting is on
- populate that checkbox with the admin pref
- always show that pref in the admin area