### PR TITLE
Removes HHVM from Travis, because HHVM no longer supports PHP

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,11 +12,6 @@ php:
   - 7.2
   - 7.3
 
-matrix:
-  include:
-    - php: hhvm
-      dist: trusty
-
 script:
   - sudo add-apt-repository ppa:git-core/ppa -y
   - sudo apt-get update


### PR DESCRIPTION
See https://hhvm.com/blog/2019/02/11/hhvm-4.0.0.html