### PR TITLE
Reduce the amount of attachment queries fixes #5492

### DIFF
--- a/Sources/Display.php
+++ b/Sources/Display.php
@@ -1040,10 +1040,10 @@ function Display()
 		foreach ($messages as $key => $value) {
 			$msgIDs[] = $value;
 		}
-		
+
 		prepareAttachsByMsg($msgIDs);
 	}
-	
+
 	call_integration_hook('integrate_display_message_list', array(&$messages, &$posters));
 
 	// Guests can't mark topics read or for notifications, just can't sorry.

--- a/Sources/Display.php
+++ b/Sources/Display.php
@@ -1026,6 +1026,24 @@ function Display()
 	$smcFunc['db_free_result']($request);
 	$posters = array_unique($all_posters);
 
+	// BBC and the entire attachments feature is enabled
+	$disabled = array();
+
+	$temp = !empty($modSettings['disabledBBC']) ? explode(',', strtolower($modSettings['disabledBBC'])) : [];
+
+	foreach ($temp as $tag)
+		$disabled[trim($tag)] = true;
+	if (!empty($modSettings['attachmentEnable']) && empty($disabled['attach']))
+	{
+		require_once($sourcedir . '/Subs-Attachments.php');
+		$msgIDs = array();
+		foreach ($messages as $key => $value) {
+			$msgIDs[] = $value;
+		}
+		
+		prepareAttachsByMsg($msgIDs);
+	}
+	
 	call_integration_hook('integrate_display_message_list', array(&$messages, &$posters));
 
 	// Guests can't mark topics read or for notifications, just can't sorry.

--- a/Sources/Display.php
+++ b/Sources/Display.php
@@ -1029,7 +1029,7 @@ function Display()
 	// BBC and the entire attachments feature is enabled
 	$disabled = array();
 
-	$temp = !empty($modSettings['disabledBBC']) ? explode(',', strtolower($modSettings['disabledBBC'])) : [];
+	$temp = !empty($modSettings['disabledBBC']) ? explode(',', strtolower($modSettings['disabledBBC'])) : array();
 
 	foreach ($temp as $tag)
 		$disabled[trim($tag)] = true;

--- a/Sources/Subs-Attachments.php
+++ b/Sources/Subs-Attachments.php
@@ -1101,16 +1101,15 @@ function getAttachMsgInfo($attachID)
 	{
 		if (empty($msgRows[$attachID]))
 			continue;
-		
+
 		$row = array(
 			'msg' => $msgRows[$attachID]['id_msg'],
 			'topic' => $msgRows[$attachID]['topic'],
 			'board' => $msgRows[$attachID]['board'],
 			);
-		
+
 		return $row;
 	}
-	
 
 	$request = $smcFunc['db_query']('', '
 		SELECT a.id_msg AS msg, m.id_topic AS topic, m.id_board AS board
@@ -1366,18 +1365,18 @@ function loadAttachmentContext($id_msg, $attachments)
 }
 
 /**
- * Gets attachment info associated with a message ID
+ * prepare the Attachment api for all messages
  *
- * @param int $msgID the message ID to load info from.
+ * @param int array $msgIDs the message ID to load info from.
  *
- * @return array.
+ * @return void.
  */
 function prepareAttachsByMsg($msgIDs)
 {
 	global $context, $modSettings, $smcFunc, $user_info, $cacheMsgID;
 	if(!isset($cacheMsgID))
 		$cacheMsgID = [];
-	
+
 	// remove all $msgIDs which we already cached
 	$msgIDs = array_flip(array_diff_key(array_flip($msgIDs), $cacheMsgID)) ;
 
@@ -1401,7 +1400,7 @@ function prepareAttachsByMsg($msgIDs)
 		$temp = array();
 		$rows = $smcFunc['db_fetch_all']($request);
 		$smcFunc['db_free_result']($request);
-		
+
 		foreach ($rows as $value)
 		{
 			if(empty($cacheMsgID[$value['id_msg']]))

--- a/Sources/Subs-Attachments.php
+++ b/Sources/Subs-Attachments.php
@@ -1106,7 +1106,7 @@ function getAttachMsgInfo($attachID)
 			'msg' => $msgRows[$attachID]['id_msg'],
 			'topic' => $msgRows[$attachID]['topic'],
 			'board' => $msgRows[$attachID]['board'],
-			);
+		);
 
 		return $row;
 	}
@@ -1146,7 +1146,7 @@ function getAttachsByMsg($msgID)
 	if (!isset($attached[$msgID]))
 	{
 		if (empty($cacheMsgID[$msgID]))
-			prepareAttachsByMsg (array($msgID));
+			prepareAttachsByMsg(array($msgID));
 
 		$temp = array();
 		$rows = $cacheMsgID[$msgID];
@@ -1358,6 +1358,7 @@ function loadAttachmentContext($id_msg, $attachments)
 function prepareAttachsByMsg($msgIDs)
 {
 	global $context, $modSettings, $smcFunc, $user_info, $cacheMsgID;
+
 	if(!isset($cacheMsgID))
 		$cacheMsgID = array();
 
@@ -1388,7 +1389,7 @@ function prepareAttachsByMsg($msgIDs)
 		foreach ($rows as $value)
 		{
 			if(empty($cacheMsgID[$value['id_msg']]))
-				$cacheMsgID[$value['id_msg']] = [];
+				$cacheMsgID[$value['id_msg']] = array();
 			$cacheMsgID[$value['id_msg']][$value['id_attach']] = $value;
 		}
 	}

--- a/Sources/Subs-Attachments.php
+++ b/Sources/Subs-Attachments.php
@@ -1146,24 +1146,8 @@ function getAttachsByMsg($msgID)
 	if (!isset($attached[$msgID]))
 	{
 		if (empty($cacheMsgID[$msgID]))
-			prepareAttachsByMsg ([$msgID]);
-/*
-		$request = $smcFunc['db_query']('', '
-			SELECT
-				a.id_attach, a.id_folder, a.id_msg, a.filename, a.file_hash, COALESCE(a.size, 0) AS filesize, a.downloads, a.approved, m.id_topic AS topic, m.id_board AS board, m.id_member,
-				a.width, a.height' . (empty($modSettings['attachmentShowImages']) || empty($modSettings['attachmentThumbnails']) ? '' : ',
-				COALESCE(thumb.id_attach, 0) AS id_thumb, thumb.width AS thumb_width, thumb.height AS thumb_height') . '
-			FROM {db_prefix}attachments AS a' . (empty($modSettings['attachmentShowImages']) || empty($modSettings['attachmentThumbnails']) ? '' : '
-				LEFT JOIN {db_prefix}attachments AS thumb ON (thumb.id_attach = a.id_thumb)') . '
-				LEFT JOIN {db_prefix}messages AS m ON (m.id_msg = a.id_msg)
-			WHERE a.attachment_type = {int:attachment_type}
-				AND a.id_msg ' . (!empty($context['preview_message']) ? 'IN (0, {int:message_id})' : '= {int:message_id}'),
-			array(
-				'message_id' => $msgID,
-				'attachment_type' => 0,
-			)
-		);
- */
+			prepareAttachsByMsg (array($msgID));
+
 		$temp = array();
 		$rows = $cacheMsgID[$msgID];
 		foreach ($rows as $row)
@@ -1375,7 +1359,7 @@ function prepareAttachsByMsg($msgIDs)
 {
 	global $context, $modSettings, $smcFunc, $user_info, $cacheMsgID;
 	if(!isset($cacheMsgID))
-		$cacheMsgID = [];
+		$cacheMsgID = array();
 
 	// remove all $msgIDs which we already cached
 	$msgIDs = array_flip(array_diff_key(array_flip($msgIDs), $cacheMsgID)) ;

--- a/Sources/Subs-Attachments.php
+++ b/Sources/Subs-Attachments.php
@@ -1092,10 +1092,25 @@ function getRawAttachInfo($attachIDs)
  */
 function getAttachMsgInfo($attachID)
 {
-	global $smcFunc;
+	global $smcFunc, $cacheMsgID;
 
 	if (empty($attachID))
 		return array();
+
+	foreach ($cacheMsgID as $msgRows)
+	{
+		if (empty($msgRows[$attachID]))
+			continue;
+		
+		$row = array(
+			'msg' => $msgRows[$attachID]['id_msg'],
+			'topic' => $msgRows[$attachID]['topic'],
+			'board' => $msgRows[$attachID]['board'],
+			);
+		
+		return $row;
+	}
+	
 
 	$request = $smcFunc['db_query']('', '
 		SELECT a.id_msg AS msg, m.id_topic AS topic, m.id_board AS board
@@ -1126,11 +1141,14 @@ function getAttachMsgInfo($attachID)
  */
 function getAttachsByMsg($msgID)
 {
-	global $context, $modSettings, $smcFunc, $user_info;
+	global $context, $modSettings, $smcFunc, $user_info, $cacheMsgID;
 	static $attached = array();
 
 	if (!isset($attached[$msgID]))
 	{
+		if (empty($cacheMsgID[$msgID]))
+			prepareAttachsByMsg ([$msgID]);
+/*
 		$request = $smcFunc['db_query']('', '
 			SELECT
 				a.id_attach, a.id_folder, a.id_msg, a.filename, a.file_hash, COALESCE(a.size, 0) AS filesize, a.downloads, a.approved, m.id_topic AS topic, m.id_board AS board, m.id_member,
@@ -1146,15 +1164,16 @@ function getAttachsByMsg($msgID)
 				'attachment_type' => 0,
 			)
 		);
+ */
 		$temp = array();
-		while ($row = $smcFunc['db_fetch_assoc']($request))
+		$rows = $cacheMsgID[$msgID];
+		foreach ($rows as $row)
 		{
 			if (!$row['approved'] && $modSettings['postmod_active'] && !allowedTo('approve_posts') && $row['id_member'] != $user_info['id'])
 				continue;
 
 			$temp[$row['id_attach']] = $row;
 		}
-		$smcFunc['db_free_result']($request);
 
 		// This is better than sorting it with the query...
 		ksort($temp);
@@ -1344,6 +1363,52 @@ function loadAttachmentContext($id_msg, $attachments)
 		});
 
 	return $attachmentData;
+}
+
+/**
+ * Gets attachment info associated with a message ID
+ *
+ * @param int $msgID the message ID to load info from.
+ *
+ * @return array.
+ */
+function prepareAttachsByMsg($msgIDs)
+{
+	global $context, $modSettings, $smcFunc, $user_info, $cacheMsgID;
+	if(!isset($cacheMsgID))
+		$cacheMsgID = [];
+	
+	// remove all $msgIDs which we already cached
+	$msgIDs = array_flip(array_diff_key(array_flip($msgIDs), $cacheMsgID)) ;
+
+	if (!empty($msgIDs))
+	{
+		$request = $smcFunc['db_query']('', '
+			SELECT
+				a.id_attach, a.id_folder, a.id_msg, a.filename, a.file_hash, COALESCE(a.size, 0) AS filesize, a.downloads, a.approved, m.id_topic AS topic, m.id_board AS board, m.id_member,
+				a.width, a.height' . (empty($modSettings['attachmentShowImages']) || empty($modSettings['attachmentThumbnails']) ? '' : ',
+				COALESCE(thumb.id_attach, 0) AS id_thumb, thumb.width AS thumb_width, thumb.height AS thumb_height') . '
+			FROM {db_prefix}attachments AS a' . (empty($modSettings['attachmentShowImages']) || empty($modSettings['attachmentThumbnails']) ? '' : '
+				LEFT JOIN {db_prefix}attachments AS thumb ON (thumb.id_attach = a.id_thumb)') . '
+				LEFT JOIN {db_prefix}messages AS m ON (m.id_msg = a.id_msg)
+			WHERE a.attachment_type = {int:attachment_type}
+				AND a.id_msg ' . (!empty($context['preview_message']) ? 'IN (0, {array_int:message_id})' : 'IN ({array_int:message_id})'),
+			array(
+				'message_id' => $msgIDs,
+				'attachment_type' => 0,
+			)
+		);
+		$temp = array();
+		$rows = $smcFunc['db_fetch_all']($request);
+		$smcFunc['db_free_result']($request);
+		
+		foreach ($rows as $value)
+		{
+			if(empty($cacheMsgID[$value['id_msg']]))
+				$cacheMsgID[$value['id_msg']] = [];
+			$cacheMsgID[$value['id_msg']][$value['id_attach']] = $value;
+		}
+	}
 }
 
 ?>

--- a/Sources/Subs-Recent.php
+++ b/Sources/Subs-Recent.php
@@ -24,7 +24,7 @@ if (!defined('SMF'))
  */
 function getLastPosts($latestPostOptions)
 {
-	global $scripturl, $modSettings, $smcFunc;
+	global $scripturl, $modSettings, $smcFunc, $sourcedir;
 
 	// Find all the posts.  Newer ones will have higher IDs.  (assuming the last 20 * number are accessible...)
 	// @todo SLOW This query is now slow, NEEDS to be fixed.  Maybe break into two?
@@ -51,8 +51,29 @@ function getLastPosts($latestPostOptions)
 			'is_approved' => 1,
 		)
 	);
+	
+	$rows = $smcFunc['db_fetch_all']($request);
+	
+	// BBC and the entire attachments feature is enabled
+	$disabled = array();
+
+	$temp = !empty($modSettings['disabledBBC']) ? explode(',', strtolower($modSettings['disabledBBC'])) : [];
+
+	foreach ($temp as $tag)
+		$disabled[trim($tag)] = true;
+	if (!empty($modSettings['attachmentEnable']) && empty($disabled['attach']))
+	{
+		require_once($sourcedir . '/Subs-Attachments.php');
+		$msgIDs = array();
+		foreach ($rows as $key => $value) {
+			$msgIDs[] = $value['id_msg'];
+		}
+		
+		prepareAttachsByMsg($msgIDs);
+	}
+		
 	$posts = array();
-	while ($row = $smcFunc['db_fetch_assoc']($request))
+	foreach ($rows as $key => $row)
 	{
 		// Censor the subject and post for the preview ;).
 		censorText($row['subject']);

--- a/Sources/Subs-Recent.php
+++ b/Sources/Subs-Recent.php
@@ -57,7 +57,7 @@ function getLastPosts($latestPostOptions)
 	// BBC and the entire attachments feature is enabled
 	$disabled = array();
 
-	$temp = !empty($modSettings['disabledBBC']) ? explode(',', strtolower($modSettings['disabledBBC'])) : [];
+	$temp = !empty($modSettings['disabledBBC']) ? explode(',', strtolower($modSettings['disabledBBC'])) : array();
 
 	foreach ($temp as $tag)
 		$disabled[trim($tag)] = true;

--- a/Sources/Subs-Recent.php
+++ b/Sources/Subs-Recent.php
@@ -51,9 +51,9 @@ function getLastPosts($latestPostOptions)
 			'is_approved' => 1,
 		)
 	);
-	
+
 	$rows = $smcFunc['db_fetch_all']($request);
-	
+
 	// BBC and the entire attachments feature is enabled
 	$disabled = array();
 
@@ -68,10 +68,10 @@ function getLastPosts($latestPostOptions)
 		foreach ($rows as $key => $value) {
 			$msgIDs[] = $value['id_msg'];
 		}
-		
+
 		prepareAttachsByMsg($msgIDs);
 	}
-		
+
 	$posts = array();
 	foreach ($rows as $key => $row)
 	{


### PR DESCRIPTION
It's redurce the amount of to one for all attachment.

Idea is to "prepare" the attachment api with the needed data.

@Sesquipedalian i guess you should look into this.

issue: #5492

in my test env the amount of quries get down from 28 to 15.