### PR TITLE
Allow \ and ' be part of db pw for pg

### DIFF
--- a/Sources/Subs-Db-postgresql.php
+++ b/Sources/Subs-Db-postgresql.php
@@ -72,6 +72,9 @@ function smf_db_initiate($db_server, $db_name, $db_user, $db_passwd, &$db_prefix
 	if (!function_exists('pg_pconnect'))
 		display_db_error();
 
+	// We need to escape ' and \
+	$db_passwd = str_replace(array('\\','\''), array('\\\\','\\\''), $db_passwd);
+
 	if (!empty($db_options['persist']))
 		$connection = @pg_pconnect((empty($db_server) ? '' : 'host=' . $db_server . ' ') . 'dbname=' . $db_name . ' user=\'' . $db_user . '\' password=\'' . $db_passwd . '\'' . (empty($db_options['port']) ? '' : ' port=\'' . $db_options['port'] . '\''));
 	else


### PR DESCRIPTION
i was not able to get a test case running for mysql,
so i need to believe the @live627 fix works for mysql.

Maybe to do this every time is not best way,
so would be better to place the convertion once in install process,
so that we got the right format directly in the settings.php