### PR TITLE
Fixing seeking by enabled descanding mode fixes #5561

### DIFF
--- a/Sources/Display.php
+++ b/Sources/Display.php
@@ -1017,9 +1017,9 @@ function Display()
 	}
 
 	// Remember the paging data for next time
-	$_SESSION['page_first_id'] = $ascending ? array_values($messages)[0] : end($messages);
+	$_SESSION['page_first_id'] = $ascending ? reset($messages) : end($messages);
 	$_SESSION['page_before_start'] = $_REQUEST['start'] - $limit;
-	$_SESSION['page_last_id'] = $ascending ? end($messages) : array_values($messages)[0];
+	$_SESSION['page_last_id'] = $ascending ? end($messages) : reset($messages);
 	$_SESSION['page_next_start'] = $_REQUEST['start'] + $limit;
 	$_SESSION['page_current_start'] = $_REQUEST['start'];
 	$_SESSION['page_topic'] = $topic;


### PR DESCRIPTION
I try to make to code a little bit easier,
in the way that $_SESSION['page_last_id'] got always the bottom message and
$_SESSION['page_first_id'] got always the top message id.

No strugle here anymore,
which one i had to take.

Second problem was in non seeking code the ascending got inverted 979,
leads me to the needs of $DBascending to get logic again easier i renamed $ascending_seeking to the same name
since it got the same meaning.

Thirt is that the $DBascending depends on the $ascending and $start_char,
in old code it's only depends on $start_char.

Issue: #5561