### PR TITLE
Member search time warp

### DIFF
--- a/Sources/ManageMembers.php
+++ b/Sources/ManageMembers.php
@@ -340,7 +340,7 @@ function ViewMemberlist()
 					}
 					elseif ($search_params['types'][$param_name] == '-')
 					{
-						$query_parts[] = $param_info['db_fields'][0] . ' < ' . un_forum_time(true, $search_params[$param_name]) + 86400;
+						$query_parts[] = $param_info['db_fields'][0] . ' < ' . (un_forum_time(true, $search_params[$param_name]) + 86400);
 					}
 					else
 						$query_parts[] = $param_info['db_fields'][0] . ' ' . $range_trans[$search_params['types'][$param_name]] . ' ' . un_forum_time(true, $search_params[$param_name]);

--- a/Sources/ManageMembers.php
+++ b/Sources/ManageMembers.php
@@ -338,7 +338,7 @@ function ViewMemberlist()
 					{
 						$query_parts[] = $param_info['db_fields'][0] . ' >= ' . un_forum_time(true, $search_params[$param_name]) . ' AND ' . $param_info['db_fields'][0] . ' < ' . (un_forum_time(true, $search_params[$param_name]) + 86400);
 					}
-					elseif ($search_params['types'][$param_name] == '<=')
+					elseif ($search_params['types'][$param_name] == '-')
 					{
 						$query_parts[] = $param_info['db_fields'][0] . ' < ' . un_forum_time(true, $search_params[$param_name]) + 86400;
 					}

--- a/Sources/ManageMembers.php
+++ b/Sources/ManageMembers.php
@@ -334,10 +334,10 @@ function ViewMemberlist()
 				// Special case - equals a date.
 				elseif ($param_info['type'] == 'date' && $search_params['types'][$param_name] == '=')
 				{
-					$query_parts[] = $param_info['db_fields'][0] . ' > ' . $search_params[$param_name] . ' AND ' . $param_info['db_fields'][0] . ' < ' . ($search_params[$param_name] + 86400);
+					$query_parts[] = $param_info['db_fields'][0] . ' >= ' . un_forum_time(true, $search_params[$param_name]) . ' AND ' . $param_info['db_fields'][0] . ' < ' . (un_forum_time(true, $search_params[$param_name]) + 86400);
 				}
 				else
-					$query_parts[] = $param_info['db_fields'][0] . ' ' . $range_trans[$search_params['types'][$param_name]] . ' ' . $search_params[$param_name];
+					$query_parts[] = $param_info['db_fields'][0] . ' ' . $range_trans[$search_params['types'][$param_name]] . ' ' . un_forum_time(true, $search_params[$param_name]);
 			}
 			// Checkboxes.
 			elseif ($param_info['type'] == 'checkbox')

--- a/Sources/ManageMembers.php
+++ b/Sources/ManageMembers.php
@@ -336,20 +336,20 @@ function ViewMemberlist()
 				{
 					if ($search_params['types'][$param_name] == '=')
 					{
-						$query_parts[] = $param_info['db_fields'][0] . ' >= ' . un_forum_time(true, $search_params[$param_name]) . ' AND ' . $param_info['db_fields'][0] . ' < ' . (un_forum_time(true, $search_params[$param_name]) + 86400);
+						$query_parts[] = $param_info['db_fields'][0] . ' >= ' . forum_time(true, $search_params[$param_name], true) . ' AND ' . $param_info['db_fields'][0] . ' < ' . (forum_time(true, $search_params[$param_name], true) + 86400);
 					}
 					// Less than or equal to
 					elseif ($search_params['types'][$param_name] == '-')
 					{
-						$query_parts[] = $param_info['db_fields'][0] . ' < ' . (un_forum_time(true, $search_params[$param_name]) + 86400);
+						$query_parts[] = $param_info['db_fields'][0] . ' < ' . (forum_time(true, $search_params[$param_name], true) + 86400);
 					}
 					// Greater than
 					elseif ($search_params['types'][$param_name] == '++')
 					{
-						$query_parts[] = $param_info['db_fields'][0] . ' >= ' . (un_forum_time(true, $search_params[$param_name]) + 86400);
+						$query_parts[] = $param_info['db_fields'][0] . ' >= ' . (forum_time(true, $search_params[$param_name], true) + 86400);
 					}
 					else
-						$query_parts[] = $param_info['db_fields'][0] . ' ' . $range_trans[$search_params['types'][$param_name]] . ' ' . un_forum_time(true, $search_params[$param_name]);
+						$query_parts[] = $param_info['db_fields'][0] . ' ' . $range_trans[$search_params['types'][$param_name]] . ' ' . forum_time(true, $search_params[$param_name], true);
 				}
 				else
 					$query_parts[] = $param_info['db_fields'][0] . ' ' . $range_trans[$search_params['types'][$param_name]] . ' ' . $search_params[$param_name];

--- a/Sources/ManageMembers.php
+++ b/Sources/ManageMembers.php
@@ -332,12 +332,21 @@ function ViewMemberlist()
 					}
 				}
 				// Special case - equals a date.
-				elseif ($param_info['type'] == 'date' && $search_params['types'][$param_name] == '=')
+				elseif ($param_info['type'] == 'date')
 				{
-					$query_parts[] = $param_info['db_fields'][0] . ' >= ' . un_forum_time(true, $search_params[$param_name]) . ' AND ' . $param_info['db_fields'][0] . ' < ' . (un_forum_time(true, $search_params[$param_name]) + 86400);
+					if ($search_params['types'][$param_name] == '=')
+					{
+						$query_parts[] = $param_info['db_fields'][0] . ' >= ' . un_forum_time(true, $search_params[$param_name]) . ' AND ' . $param_info['db_fields'][0] . ' < ' . (un_forum_time(true, $search_params[$param_name]) + 86400);
+					}
+					elseif ($search_params['types'][$param_name] == '<=')
+					{
+						$query_parts[] = $param_info['db_fields'][0] . ' < ' . un_forum_time(true, $search_params[$param_name]) + 86400;
+					}
+					else
+						$query_parts[] = $param_info['db_fields'][0] . ' ' . $range_trans[$search_params['types'][$param_name]] . ' ' . un_forum_time(true, $search_params[$param_name]);
 				}
 				else
-					$query_parts[] = $param_info['db_fields'][0] . ' ' . $range_trans[$search_params['types'][$param_name]] . ' ' . un_forum_time(true, $search_params[$param_name]);
+					$query_parts[] = $param_info['db_fields'][0] . ' ' . $range_trans[$search_params['types'][$param_name]] . ' ' . $search_params[$param_name];
 			}
 			// Checkboxes.
 			elseif ($param_info['type'] == 'checkbox')

--- a/Sources/ManageMembers.php
+++ b/Sources/ManageMembers.php
@@ -338,9 +338,15 @@ function ViewMemberlist()
 					{
 						$query_parts[] = $param_info['db_fields'][0] . ' >= ' . un_forum_time(true, $search_params[$param_name]) . ' AND ' . $param_info['db_fields'][0] . ' < ' . (un_forum_time(true, $search_params[$param_name]) + 86400);
 					}
+					// Less than or equal to
 					elseif ($search_params['types'][$param_name] == '-')
 					{
 						$query_parts[] = $param_info['db_fields'][0] . ' < ' . (un_forum_time(true, $search_params[$param_name]) + 86400);
+					}
+					// Greater than
+					elseif ($search_params['types'][$param_name] == '++')
+					{
+						$query_parts[] = $param_info['db_fields'][0] . ' >= ' . (un_forum_time(true, $search_params[$param_name]) + 86400);
 					}
 					else
 						$query_parts[] = $param_info['db_fields'][0] . ' ' . $range_trans[$search_params['types'][$param_name]] . ' ' . un_forum_time(true, $search_params[$param_name]);

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -1153,9 +1153,9 @@ function forum_time($use_user_offset = true, $timestamp = null, $local_to_server
 			if ($dtz_user !== false)
 			{
 				$dt_user = new DateTime('@' . $timestamp);
-				$temp_offset = $dtz_user->getOffset($dt_user)/3600;
+				$temp_offset = $dtz_user->getOffset($dt_user);
 				if ($temp_offset !== false)
-					$user_offset = $temp_offset;
+					$user_offset = $temp_offset/3600;
 			}
 		}
 	}

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -1141,6 +1141,28 @@ function forum_time($use_user_offset = true, $timestamp = null)
 }
 
 /**
+ * The reverse of forum_time - given forum time, returns the server time.
+ * This is needed, for example, when users enter date parameters (in that user's forum time) that need to be compared to DB values.
+ *
+ * - always applies the offset in the time_offset setting.
+ *
+ * @param bool $use_user_offset Whether to apply the user's offset as well
+ * @param int $timestamp A timestamp (null to use current time)
+ * @return int Seconds since the unix epoch, with forum time offset and (optionally) user time offset applied
+ */
+function un_forum_time($use_user_offset = true, $timestamp = null)
+{
+	global $user_info, $modSettings;
+
+	if ($timestamp === null)
+		$timestamp = time();
+	elseif ($timestamp == 0)
+		return 0;
+
+	return $timestamp - ($modSettings['time_offset'] + ($use_user_offset ? $user_info['time_offset'] : 0)) * 3600;
+}
+
+/**
  * Calculates all the possible permutations (orders) of array.
  * should not be called on huge arrays (bigger than like 10 elements.)
  * returns an array containing each permutation.

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -734,16 +734,14 @@ function timeformat($log_time, $show_today = true, $offset_type = false, $proces
 	$unsupportedFormatsWindows = array('z', 'Z');
 
 	// Ensure required values are set
-	$user_info['time_offset'] = !empty($user_info['time_offset']) ? $user_info['time_offset'] : 0;
-	$modSettings['time_offset'] = !empty($modSettings['time_offset']) ? $modSettings['time_offset'] : 0;
 	$user_info['time_format'] = !empty($user_info['time_format']) ? $user_info['time_format'] : (!empty($modSettings['time_format']) ? $modSettings['time_format'] : '%F %H:%M');
 
 	// Offset the time.
 	if (!$offset_type)
-		$log_time = $log_time + ($user_info['time_offset'] + $modSettings['time_offset']) * 3600;
+		$log_time = forum_time(true, $log_time);
 	// Just the forum offset?
 	elseif ($offset_type == 'forum')
-		$log_time = $log_time + $modSettings['time_offset'] * 3600;
+		$log_time = forum_time(false, $log_time);
 
 	// We can't have a negative date (on Windows, at least.)
 	if ($log_time < 0)
@@ -1132,6 +1130,9 @@ function shorten_subject($subject, $len)
 function forum_time($use_user_offset = true, $timestamp = null, $local_to_server = false)
 {
 	global $user_info, $modSettings, $user_settings;
+
+	// Ensure required values are set
+	$modSettings['time_offset'] = !empty($modSettings['time_offset']) ? $modSettings['time_offset'] : 0;
 
 	if ($timestamp === null)
 		$timestamp = time();

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -1150,7 +1150,7 @@ function forum_time($use_user_offset = true, $timestamp = null)
  */
 function un_forum_time($use_user_offset = true, $timestamp = null)
 {
-	global $user_info, $modSettings;
+	global $user_info, $modSettings, $user_settings;
 
 	if ($timestamp === null)
 		$timestamp = time();
@@ -1167,10 +1167,11 @@ function un_forum_time($use_user_offset = true, $timestamp = null)
 		// But finding the user offset for the time in question is better
 		if (!empty($user_settings['timezone']))
 		{
-			$tz_user = new DateTimeZone($user_settings['timezone']);
-			if ($tz_user !== false)
+			$dtz_user = new DateTimeZone($user_settings['timezone']);
+			if ($dtz_user !== false)
 			{
-				$temp_offset = $tz_user->getOffset($timestamp);
+				$dt_user = new DateTime('@' . $timestamp);
+				$temp_offset = $dtz_user->getOffset($dt_user)/3600;
 				if ($temp_offset !== false)
 					$user_offset = $temp_offset;
 			}

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -1126,29 +1126,10 @@ function shorten_subject($subject, $len)
  *
  * @param bool $use_user_offset Whether to apply the user's offset as well
  * @param int $timestamp A timestamp (null to use current time)
+ * @param bool $local_to_server sometimes you need to go the other way - from user prompt to server time
  * @return int Seconds since the unix epoch, with forum time offset and (optionally) user time offset applied
  */
-function forum_time($use_user_offset = true, $timestamp = null)
-{
-	global $user_info, $modSettings;
-
-	if ($timestamp === null)
-		$timestamp = time();
-	elseif ($timestamp == 0)
-		return 0;
-
-	return $timestamp + ($modSettings['time_offset'] + ($use_user_offset ? $user_info['time_offset'] : 0)) * 3600;
-}
-
-/**
- * The reverse of forum_time - given forum time, returns the server time.
- * This is needed, for example, when users enter date parameters (in that user's forum time) that need to be compared to DB values.
- *
- * @param bool $use_user_offset Whether to apply the user's offset as well
- * @param int $timestamp A timestamp (null to use current time)
- * @return int Seconds since the unix epoch, with forum time offset and (optionally) user time offset applied
- */
-function un_forum_time($use_user_offset = true, $timestamp = null)
+function forum_time($use_user_offset = true, $timestamp = null, $local_to_server = false)
 {
 	global $user_info, $modSettings, $user_settings;
 
@@ -1178,7 +1159,10 @@ function un_forum_time($use_user_offset = true, $timestamp = null)
 		}
 	}
 
-	return $timestamp - ($modSettings['time_offset'] + $user_offset) * 3600;
+	if ($local_to_server)
+		return $timestamp - ($modSettings['time_offset'] + $user_offset) * 3600;
+	else
+		return $timestamp + ($modSettings['time_offset'] + $user_offset) * 3600;
 }
 
 /**

--- a/Themes/default/ManageMembers.template.php
+++ b/Themes/default/ManageMembers.template.php
@@ -80,7 +80,7 @@ function template_search_members()
 								</select>
 							</dt>
 							<dd>
-								<input type="date" name="reg_date" id="reg_date" value="" size="10"><span class="smalltext">', $txt['date_format'], '</span>
+								<input type="date" name="reg_date" id="reg_date" value="" size="10"><span class="smalltext"></span>
 							</dd>
 							<dt class="righttext">
 								<strong><label for="last_online">', $txt['viewmembers_online'], ':</label></strong>
@@ -93,7 +93,7 @@ function template_search_members()
 								</select>
 							</dt>
 							<dd>
-								<input type="date" name="last_online" id="last_online" value="" size="10"><span class="smalltext">', $txt['date_format'], '</span>
+								<input type="date" name="last_online" id="last_online" value="" size="10"><span class="smalltext"></span>
 							</dd>
 						</dl>
 					</div><!-- .msearch_details -->

--- a/Themes/default/languages/Admin.english.php
+++ b/Themes/default/languages/Admin.english.php
@@ -278,7 +278,6 @@ $txt['censor_whole_words'] = 'Check only whole words';
 $txt['admin_confirm_password'] = '(confirm)';
 $txt['admin_incorrect_password'] = 'Incorrect Password';
 
-$txt['date_format'] = '(YYYY-MM-DD)';
 $txt['age'] = 'User age';
 $txt['activation_status'] = 'Activation Status';
 $txt['activated'] = 'Activated';


### PR DESCRIPTION
Fixes #5274 

The problem is that the comparisons were all against fields in "db" time (GMT), but a user entering the field is thinking in terms of _their_ time zone...  We have functions that convert from "db" time to "user" time, but I couldn't find one to convert the other way around, so needed to add one.  

Also changed the comparison from > to >= as would be expected on the "date =" search; otherwise we may miss records that have had times truncated.  

Also got rid of the inaccurate prompt.
