### PR TITLE
Fixes a Access-Control-Allow-Origin error with sub domains

### DIFF
--- a/cron.php
+++ b/cron.php
@@ -70,6 +70,10 @@ if (file_exists($cachedir . '/cron.lock'))
 // Before we go any further, if this is not a CLI request, we need to do some checking.
 if (!FROM_CLI)
 {
+	// When using sub-domains with SSI and ssi_themes set, browsers will receive a "Access-Control-Allow-Origin" error.
+	// * is not ideal but the best method to preventing this from occurring.
+	header('Access-Control-Allow-Origin: *');
+
 	// We will clean up $_GET shortly. But we want to this ASAP.
 	$ts = isset($_GET['ts']) ? (int) $_GET['ts'] : 0;
 	if ($ts <= 0 || $ts % 15 != 0 || time() - $ts < 0 || time() - $ts > 20)


### PR DESCRIPTION
This is a minor issue, but while testing SMF via SSI.php with $ssi_themes across subdomains (i.e. www.site.tld/forums is SMF and support.site.tld/ is the current page), the browser will send a error

> Access to XMLHttpRequest at 'https://www.site.tld/forums/cron.php?ts=1557074880' from origin 'https://support.site.tld' has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present on the requested resource.

To work around this, we are sending a header now in Cron.php to allow any.  This is allowed as long as cron.php does not specify credentials: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin

More information here: https://www.moesif.com/blog/technical/cors/Authoritative-Guide-to-CORS-Cross-Origin-Resource-Sharing-for-REST-APIs/
Which suggests that even *.site.tld is not allowed.  Meaning there is not easy way for us to fix this unless we check the referral and ensure it is in our domain.  Not something that can easily be done in cron.php without adding lots of code and assumptions due to lack of entire SMF loading.