### PR TITLE
 Correctly handles unapproved messages and topics in search results and recent posts

### DIFF
--- a/SSI.php
+++ b/SSI.php
@@ -472,13 +472,15 @@ function ssi_queryPosts($query_where = '', $query_where_params = array(), $query
 			COALESCE(lt.id_msg, lmr.id_msg, 0) >= m.id_msg_modified AS is_read,
 			COALESCE(lt.id_msg, lmr.id_msg, -1) + 1 AS new_from') . ', ' . ($limit_body ? 'SUBSTRING(m.body, 1, 384) AS body' : 'm.body') . ', m.smileys_enabled
 		FROM {db_prefix}messages AS m
-			INNER JOIN {db_prefix}boards AS b ON (b.id_board = m.id_board)
+			INNER JOIN {db_prefix}boards AS b ON (b.id_board = m.id_board)' . ($modSettings['postmod_active'] ? '
+			INNER JOIN {db_prefix}topics AS t ON (t.id_topic = m.id_topic)' : '') . '
 			LEFT JOIN {db_prefix}members AS mem ON (mem.id_member = m.id_member)' . (!$user_info['is_guest'] ? '
 			LEFT JOIN {db_prefix}log_topics AS lt ON (lt.id_topic = m.id_topic AND lt.id_member = {int:current_member})
 			LEFT JOIN {db_prefix}log_mark_read AS lmr ON (lmr.id_board = m.id_board AND lmr.id_member = {int:current_member})' : '') . '
 		WHERE 1=1 ' . ($override_permissions ? '' : '
 			AND {query_wanna_see_board}') . ($modSettings['postmod_active'] ? '
-			AND m.approved = {int:is_approved}' : '') . '
+			AND m.approved = {int:is_approved}
+			AND t.approved = {int:is_approved}' : '') . '
 		' . (empty($query_where) ? '' : 'AND ' . $query_where) . '
 		ORDER BY ' . $query_order . '
 		' . ($query_limit == '' ? '' : 'LIMIT ' . $query_limit),

--- a/Sources/Load.php
+++ b/Sources/Load.php
@@ -801,9 +801,11 @@ function loadUserSettings()
 
 	$temp = build_query_board($user_info['id']);
 	$user_info['query_see_board'] = $temp['query_see_board'];
-	$user_info['query_wanna_see_board'] = $temp['query_wanna_see_board'];
 	$user_info['query_see_message_board'] = $temp['query_see_message_board'];
 	$user_info['query_see_topic_board'] = $temp['query_see_topic_board'];
+	$user_info['query_wanna_see_board'] = $temp['query_wanna_see_board'];
+	$user_info['query_wanna_see_message_board'] = $temp['query_wanna_see_message_board'];
+	$user_info['query_wanna_see_topic_board'] = $temp['query_wanna_see_topic_board'];
 
 	call_integration_hook('integrate_user_info');
 }

--- a/Sources/Recent.php
+++ b/Sources/Recent.php
@@ -33,10 +33,12 @@ function getLastPost()
 		SELECT ml.poster_time, ml.subject, ml.id_topic, ml.poster_name, SUBSTRING(ml.body, 1, 385) AS body,
 			ml.smileys_enabled
 		FROM {db_prefix}boards AS b
-			INNER JOIN {db_prefix}messages AS ml ON (ml.id_msg = b.id_last_msg)
+			INNER JOIN {db_prefix}messages AS ml ON (ml.id_msg = b.id_last_msg)' . (!empty($modSettings['postmod_active']) ? '
+			INNER JOIN {db_prefix}topics AS t ON (t.id_topic = m.id_topic)' : '') . '
 		WHERE {query_wanna_see_board}' . (!empty($modSettings['recycle_enable']) && $modSettings['recycle_board'] > 0 ? '
-			AND b.id_board != {int:recycle_board}' : '') . '
+			AND b.id_board != {int:recycle_board}' : '') . (!empty($modSettings['postmod_active']) ? '
 			AND ml.approved = {int:is_approved}
+			AND t.approved = {int:is_approved}' : '') . '
 		ORDER BY b.id_msg_updated DESC
 		LIMIT 1',
 		array(
@@ -285,9 +287,11 @@ function RecentPosts()
 			$request = $smcFunc['db_query']('', '
 				SELECT m.id_msg
 				FROM {db_prefix}messages AS m
-					INNER JOIN {db_prefix}boards AS b ON (b.id_board = m.id_board)
-				WHERE ' . $query_this_board . '
+					INNER JOIN {db_prefix}boards AS b ON (b.id_board = m.id_board)' . (!empty($modSettings['postmod_active']) ? '
+					INNER JOIN {db_prefix}topics AS t ON (t.id_topic = m.id_topic)' : '') . '
+				WHERE ' . $query_this_board . (!empty($modSettings['postmod_active']) ? '
 					AND m.approved = {int:is_approved}
+					AND t.approved = {int:is_approved}' : '') . '
 				ORDER BY m.id_msg DESC
 				LIMIT {int:offset}, {int:limit}',
 				array_merge($query_parameters, array(

--- a/Sources/Recent.php
+++ b/Sources/Recent.php
@@ -30,16 +30,15 @@ function getLastPost()
 
 	// Find it by the board - better to order by board than sort the entire messages table.
 	$request = $smcFunc['db_query']('substring', '
-		SELECT ml.poster_time, ml.subject, ml.id_topic, ml.poster_name, SUBSTRING(ml.body, 1, 385) AS body,
-			ml.smileys_enabled
-		FROM {db_prefix}boards AS b
-			INNER JOIN {db_prefix}messages AS ml ON (ml.id_msg = b.id_last_msg)' . (!empty($modSettings['postmod_active']) ? '
+		SELECT m.poster_time, m.subject, m.id_topic, m.poster_name, SUBSTRING(m.body, 1, 385) AS body,
+			m.smileys_enabled
+		FROM {db_prefix}messages AS m' . (!empty($modSettings['postmod_active']) ? '
 			INNER JOIN {db_prefix}topics AS t ON (t.id_topic = m.id_topic)' : '') . '
-		WHERE {query_wanna_see_board}' . (!empty($modSettings['recycle_enable']) && $modSettings['recycle_board'] > 0 ? '
-			AND b.id_board != {int:recycle_board}' : '') . (!empty($modSettings['postmod_active']) ? '
-			AND ml.approved = {int:is_approved}
+		WHERE {query_wanna_see_message_board}' . (!empty($modSettings['recycle_enable']) && $modSettings['recycle_board'] > 0 ? '
+			AND m.id_board != {int:recycle_board}' : '') . (!empty($modSettings['postmod_active']) ? '
+			AND m.approved = {int:is_approved}
 			AND t.approved = {int:is_approved}' : '') . '
-		ORDER BY b.id_msg_updated DESC
+		ORDER BY m.id_msg DESC
 		LIMIT 1',
 		array(
 			'recycle_board' => $modSettings['recycle_board'],
@@ -147,7 +146,7 @@ function RecentPosts()
 		if (empty($boards))
 			fatal_lang_error('error_no_boards_selected');
 
-		$query_this_board = 'b.id_board IN ({array_int:boards})';
+		$query_this_board = 'm.id_board IN ({array_int:boards})';
 		$query_parameters['boards'] = $boards;
 
 		// If this category has a significant number of posts in it...
@@ -191,7 +190,7 @@ function RecentPosts()
 		if (empty($boards))
 			fatal_lang_error('error_no_boards_selected');
 
-		$query_this_board = 'b.id_board IN ({array_int:boards})';
+		$query_this_board = 'm.id_board IN ({array_int:boards})';
 		$query_parameters['boards'] = $boards;
 
 		// If these boards have a significant number of posts in them...
@@ -225,7 +224,7 @@ function RecentPosts()
 			$context['is_redirect'] = true;
 		}
 
-		$query_this_board = 'b.id_board = {int:board}';
+		$query_this_board = 'm.id_board = {int:board}';
 		$query_parameters['board'] = $board;
 
 		// If this board has a significant number of posts in it...
@@ -240,14 +239,14 @@ function RecentPosts()
 	}
 	else
 	{
-		$query_this_board = '{query_wanna_see_board}' . (!empty($modSettings['recycle_enable']) && $modSettings['recycle_board'] > 0 ? '
-					AND b.id_board != {int:recycle_board}' : '') . '
+		$query_this_board = '{query_wanna_see_message_board}' . (!empty($modSettings['recycle_enable']) && $modSettings['recycle_board'] > 0 ? '
+					AND m.id_board != {int:recycle_board}' : '') . '
 					AND m.id_msg >= {int:max_id_msg}';
 		$query_parameters['max_id_msg'] = max(0, $modSettings['maxMsgID'] - 100 - $_REQUEST['start'] * 6);
 		$query_parameters['recycle_board'] = $modSettings['recycle_board'];
 
-		// "Borrow" some data from above...
-		$query_these_boards = str_replace('AND m.id_msg >= {int:max_id_msg}', '', $query_this_board);
+		$query_these_boards = '{query_wanna_see_board}' . (!empty($modSettings['recycle_enable']) && $modSettings['recycle_board'] > 0 ? '
+					AND b.id_board != {int:recycle_board}' : '');
 		$query_these_boards_params = $query_parameters;
 		unset($query_these_boards_params['max_id_msg']);
 
@@ -286,8 +285,7 @@ function RecentPosts()
 			// @todo SLOW This query is really slow still, probably?
 			$request = $smcFunc['db_query']('', '
 				SELECT m.id_msg
-				FROM {db_prefix}messages AS m
-					INNER JOIN {db_prefix}boards AS b ON (b.id_board = m.id_board)' . (!empty($modSettings['postmod_active']) ? '
+				FROM {db_prefix}messages AS m ' . (!empty($modSettings['postmod_active']) ? '
 					INNER JOIN {db_prefix}topics AS t ON (t.id_topic = m.id_topic)' : '') . '
 				WHERE ' . $query_this_board . (!empty($modSettings['postmod_active']) ? '
 					AND m.approved = {int:is_approved}

--- a/Sources/Search.php
+++ b/Sources/Search.php
@@ -971,7 +971,7 @@ function PlushSearch2()
 		$participants = array();
 		$searchArray = array();
 
-		$num_results = $searchAPI->searchQuery($query_params, $searchWords, $excludedIndexWords, $participants, $searchArray);
+		$searchAPI->searchQuery($query_params, $searchWords, $excludedIndexWords, $participants, $searchArray);
 	}
 
 	// Update the cache if the current search term is not yet cached.
@@ -1715,8 +1715,6 @@ function PlushSearch2()
 			$participants[$row['id_topic']] = false;
 		}
 		$smcFunc['db_free_result']($request);
-
-		$num_results = $_SESSION['search_cache']['num_results'];
 	}
 
 	if (!empty($context['topics']))
@@ -1792,8 +1790,11 @@ function PlushSearch2()
 			)
 		);
 
+		// How many results will the user be able to see?
+		$num_results = $smcFunc['db_num_rows']($messages_request);
+
 		// If there are no results that means the things in the cache got deleted, so pretend we have no topics anymore.
-		if ($smcFunc['db_num_rows']($messages_request) == 0)
+		if ($num_results == 0)
 			$context['topics'] = array();
 
 		// If we want to know who participated in what then load this now.

--- a/Sources/Search.php
+++ b/Sources/Search.php
@@ -1687,13 +1687,32 @@ function PlushSearch2()
 			}
 		}
 
+		if (!empty($modSettings['postmod_active']))
+		{
+			$approve_boards = boardsAllowedTo('approve_posts');
+
+			// Can approve everywhere, so search all topics.
+			if ($approve_boards === array(0))
+		 		$approve_query = '';
+
+		 	// Can't approve anywhere, so search ony their own topics and approved topics.
+		 	elseif (empty($approve_boards))
+		 		$approve_query = '
+				AND (t.approved = {int:is_approved} OR t.id_member_started = {int:current_member})';
+
+		 	// Can approve in some boards, so search own, approved, and approvable topics.
+		 	else
+		 		$approve_query = '
+				AND (t.approved = {int:is_approved} OR t.id_member_started = {int:current_member} OR t.id_board IN ({array_int:approve_boards}))';
+		}
+
 		// *** Retrieve the results to be shown on the page
 		$participants = array();
 		$request = $smcFunc['db_search_query']('', '
 			SELECT ' . (empty($search_params['topic']) ? 'lsr.id_topic' : $search_params['topic'] . ' AS id_topic') . ', lsr.id_msg, lsr.relevance, lsr.num_matches
-			FROM {db_prefix}log_search_results AS lsr' . ($search_params['sort'] == 'num_replies' ? '
+			FROM {db_prefix}log_search_results AS lsr' . ($search_params['sort'] == 'num_replies' || !empty($approve_query) ? '
 				INNER JOIN {db_prefix}topics AS t ON (t.id_topic = lsr.id_topic)' : '') . '
-			WHERE lsr.id_search = {int:id_search}
+			WHERE lsr.id_search = {int:id_search}' . $approve_query . '
 			ORDER BY {raw:sort} {raw:sort_dir}
 			LIMIT {int:start}, {int:max}',
 			array(
@@ -1702,6 +1721,9 @@ function PlushSearch2()
 				'sort_dir' => $search_params['sort_dir'],
 				'start' => $_REQUEST['start'],
 				'max' => $modSettings['search_results_per_page'],
+				'is_approved' => 1,
+				'current_member' => $user_info['id'],
+				'approve_boards' => !empty($approve_boards) ? $approve_boards : array(0),
 			)
 		);
 		while ($row = $smcFunc['db_fetch_assoc']($request))
@@ -1720,18 +1742,41 @@ function PlushSearch2()
 	if (!empty($context['topics']))
 	{
 		// Create an array for the permissions.
-		$boards_can = boardsAllowedTo(array('post_reply_own', 'post_reply_any'), true, false);
+		$perms = array('post_reply_own', 'post_reply_any');
+
+		if (!empty($options['display_quick_mod']))
+			$perms = array_merge($perms, array('lock_any', 'lock_own', 'make_sticky', 'move_any', 'move_own', 'remove_any', 'remove_own', 'merge_any'));
+
+		if (!empty($modSettings['postmod_active']) && !isset($approve_boards))
+			$perms[] = 'approve_posts';
+
+		$boards_can = boardsAllowedTo($perms, true, false);
 
 		// How's about some quick moderation?
 		if (!empty($options['display_quick_mod']))
 		{
-			$boards_can = array_merge($boards_can, boardsAllowedTo(array('lock_any', 'lock_own', 'make_sticky', 'move_any', 'move_own', 'remove_any', 'remove_own', 'merge_any'), true, false));
-
 			$context['can_lock'] = in_array(0, $boards_can['lock_any']);
 			$context['can_sticky'] = in_array(0, $boards_can['make_sticky']);
 			$context['can_move'] = in_array(0, $boards_can['move_any']);
 			$context['can_remove'] = in_array(0, $boards_can['remove_any']);
 			$context['can_merge'] = in_array(0, $boards_can['merge_any']);
+		}
+
+		if (!empty($modSettings['postmod_active']))
+		{
+			if (!isset($approve_boards))
+				$approve_boards = $boards_can['approve_posts'];
+
+			if ($approve_boards === array(0))
+		 		$approve_query = '';
+
+		 	elseif (empty($approve_boards))
+		 		$approve_query = '
+				AND (m.approved = {int:is_approved} OR m.id_member = {int:current_member})';
+
+		 	else
+		 		$approve_query = '
+				AND (m.approved = {int:is_approved} OR m.id_member = {int:current_member} OR m.id_board IN ({array_int:approve_boards}))';
 		}
 
 		// What messages are we using?
@@ -1779,13 +1824,14 @@ function PlushSearch2()
 				INNER JOIN {db_prefix}messages AS last_m ON (last_m.id_msg = t.id_last_msg)
 				LEFT JOIN {db_prefix}members AS first_mem ON (first_mem.id_member = first_m.id_member)
 				LEFT JOIN {db_prefix}members AS last_mem ON (last_mem.id_member = first_m.id_member)
-			WHERE m.id_msg IN ({array_int:message_list})' . ($modSettings['postmod_active'] ? '
-				AND m.approved = {int:is_approved}' : '') . '
+			WHERE m.id_msg IN ({array_int:message_list})' . $approve_query . '
 			ORDER BY ' . $smcFunc['db_custom_order']('m.id_msg', $msg_list) . '
 			LIMIT {int:limit}',
 			array(
 				'message_list' => $msg_list,
 				'is_approved' => 1,
+				'current_member' => $user_info['id'],
+				'approve_boards' => !empty($approve_boards) ? $approve_boards : array(0),
 				'limit' => count($context['topics']),
 			)
 		);

--- a/Sources/SearchAPI-Fulltext.php
+++ b/Sources/SearchAPI-Fulltext.php
@@ -64,7 +64,6 @@ class fulltext_search extends search_api
 			case 'searchSort':
 			case 'prepareIndexes':
 			case 'indexedWordQuery':
-			case 'postRemoved':
 				$return = true;
 				break;
 

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -6761,18 +6761,26 @@ function build_query_board($userid)
 			)';
 	}
 
+	$query_part['query_see_message_board'] = str_replace('b.', 'm.', $query_part['query_see_board']);
+	$query_part['query_see_topic_board'] = str_replace('b.', 't.', $query_part['query_see_board']);
+
 	// Build the list of boards they WANT to see.
 	// This will take the place of query_see_boards in certain spots, so it better include the boards they can see also
 
 	// If they aren't ignoring any boards then they want to see all the boards they can see
 	if (empty($ignoreboards))
+	{
 		$query_part['query_wanna_see_board'] = $query_part['query_see_board'];
+		$query_part['query_wanna_see_message_board'] = $query_part['query_see_message_board'];
+		$query_part['query_wanna_see_topic_board'] = $query_part['query_see_topic_board'];
+	}
 	// Ok I guess they don't want to see all the boards
 	else
+	{
 		$query_part['query_wanna_see_board'] = '(' . $query_part['query_see_board'] . ' AND b.id_board NOT IN (' . implode(',', $ignoreboards) . '))';
-
-	$query_part['query_see_message_board'] = str_replace('b.', 'm.', $query_part['query_see_board']);
-	$query_part['query_see_topic_board'] = str_replace('b.', 't.', $query_part['query_see_board']);
+		$query_part['query_wanna_see_message_board'] = '(' . $query_part['query_see_message_board'] . ' AND m.id_board NOT IN (' . implode(',', $ignoreboards) . '))';
+		$query_part['query_wanna_see_topic_board'] = '(' . $query_part['query_see_topic_board'] . ' AND t.id_board NOT IN (' . implode(',', $ignoreboards) . '))';
+	}
 
 	return $query_part;
 }


### PR DESCRIPTION
- Fixes #5534
- Closes #5539
- Adds `{query_wanna_see_message_board}` and `{query_wanna_see_topic_board}` for use in queries
- Uses these additions to improve performance when getting recent posts.
- Fixes a couple minor issues related to search