### PR TITLE
 Better handles forum's default timezone in smf_list_timezones()

### DIFF
--- a/Sources/Calendar.php
+++ b/Sources/Calendar.php
@@ -433,11 +433,31 @@ function CalendarPost()
 	// Need this so the user can select a timezone for the event.
 	$context['all_timezones'] = smf_list_timezones($context['event']['start_date']);
 
-	// If the event's timezone is not in SMF's standard list of time zones, prepend it to the list
-	if (!in_array($context['event']['tz'], array_keys($context['all_timezones'])))
+	// If the event's timezone is not in SMF's standard list of time zones, try to fix it.
+	if (!isset($context['all_timezones'][$context['event']['tz']]))
 	{
-		$d = date_create($context['event']['start_datetime'] . ' ' . $context['event']['tz']);
-		$context['all_timezones'] = array($context['event']['tz'] => '[UTC' . date_format($d, 'P') . '] - ' . $context['event']['tz']) + $context['all_timezones'];
+		$later = strtotime('@' . $context['event']['start_timestamp'] . ' + 1 year');
+		$tzinfo = timezone_transitions_get(timezone_open($context['event']['tz']), $context['event']['start_timestamp'], $later);
+
+		$found = false;
+		foreach ($context['all_timezones'] as $possible_tzid => $dummy)
+		{
+			$possible_tzinfo = timezone_transitions_get(timezone_open($possible_tzid), $context['event']['start_timestamp'], $later);
+
+			if ($tzinfo === $possible_tzinfo)
+			{
+				$context['event']['tz'] = $possible_tzid;
+				$found = true;
+				break;
+			}
+		}
+
+		// Hm. That's weird. Well, just prepend it to the list and let the user deal with it.
+		if (!$found)
+		{
+			$d = date_create($context['event']['start_datetime'] . ' ' . $context['event']['tz']);
+			$context['all_timezones'] = array($context['event']['tz'] => '[UTC' . date_format($d, 'P') . '] - ' . $context['event']['tz']) + $context['all_timezones'];
+		}
 	}
 
 	// Get list of boards that can be posted in.

--- a/Sources/Calendar.php
+++ b/Sources/Calendar.php
@@ -432,7 +432,6 @@ function CalendarPost()
 
 	// Need this so the user can select a timezone for the event.
 	$context['all_timezones'] = smf_list_timezones($context['event']['start_date']);
-	unset($context['all_timezones']['']);
 
 	// If the event's timezone is not in SMF's standard list of time zones, prepend it to the list
 	if (!in_array($context['event']['tz'], array_keys($context['all_timezones'])))

--- a/Sources/Post.php
+++ b/Sources/Post.php
@@ -344,7 +344,6 @@ function Post($post_errors = array())
 
 		// Need this so the user can select a timezone for the event.
 		$context['all_timezones'] = smf_list_timezones($context['event']['start_date']);
-		unset($context['all_timezones']['']);
 
 		// If the event's timezone is not in SMF's standard list of time zones, prepend it to the list
 		if (!in_array($context['event']['tz'], array_keys($context['all_timezones'])))

--- a/Sources/Profile-Modify.php
+++ b/Sources/Profile-Modify.php
@@ -600,6 +600,7 @@ function loadProfileFields($force_reload = false)
 			'disabled_options' => array_filter(array_keys(smf_list_timezones()), 'is_int'),
 			'permission' => 'profile_extra',
 			'label' => $txt['timezone'],
+			'value' => empty($cur_profile['timezone']) ? $modSettings['default_timezone'] : $cur_profile['timezone'],
 			'input_validate' => function($value)
 			{
 				$tz = smf_list_timezones();

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -5821,7 +5821,7 @@ function get_gravatar_url($email_address)
  */
 function smf_list_timezones($when = 'now')
 {
-	global $smcFunc, $modSettings, $tztxt, $txt;
+	global $smcFunc, $modSettings, $tztxt, $txt, $cur_profile;
 	static $timezones = null, $lastwhen = null;
 
 	// No point doing this over if we already did it once
@@ -5844,7 +5844,7 @@ function smf_list_timezones($when = 'now')
 
 	// We'll need these too
 	$date_when = date_create('@' . $when);
-	$later = (int) date_format(date_add($date_when, date_interval_create_from_date_string('1 year')), 'U');
+	$later = strtotime('@' . $when . ' + 1 year');
 
 	// Load up any custom time zone descriptions we might have
 	loadLanguage('Timezones');
@@ -5904,6 +5904,10 @@ function smf_list_timezones($when = 'now')
 		}
 		$offsets[$tzkey] = $tzinfo[0]['offset'];
 		$longitudes[$tzkey] = empty($longitudes[$tzkey]) ? $tzgeo['longitude'] : $longitudes[$tzkey];
+
+		// Remember this for later
+		if (isset($cur_profile['timezone']) && $cur_profile['timezone'] == $tzid)
+			$member_tzkey = $tzkey;
 	}
 
 	// Sort by offset then longitude
@@ -5930,6 +5934,10 @@ function smf_list_timezones($when = 'now')
 			$priority_timezones[$tzvalue['tzid']] = $desc;
 		else
 			$timezones[$tzvalue['tzid']] = $desc;
+
+		// Automatically fix orphaned timezones on the member profile page
+		if (isset($member_tzkey) && $member_tzkey == $tzkey)
+			$cur_profile['timezone'] = $tzvalue['tzid'];
 	}
 
 	if (!empty($priority_timezones))
@@ -5937,7 +5945,7 @@ function smf_list_timezones($when = 'now')
 
 	$timezones = array_merge(
 		$priority_timezones,
-		array('' => '(Forum Default)', 'UTC' => 'UTC - ' . $tztxt['UTC'], '-----'),
+		array('UTC' => 'UTC' . (!empty($tztxt['UTC']) ? ' - ' . $tztxt['UTC'] : ''), '-----'),
 		$timezones
 	);
 

--- a/Themes/default/Profile.template.php
+++ b/Themes/default/Profile.template.php
@@ -1537,7 +1537,7 @@ function template_edit_options()
 					if (is_array($field['options']))
 						foreach ($field['options'] as $value => $name)
 							echo '
-							<option', (!empty($field['disabled_options']) && is_array($field['disabled_options']) && in_array($value, $field['disabled_options'], true) ? ' disabled' : ''), ' value="' . $value . '"', $value == $field['value'] ? ' selected' : '', '>', $name, '</option>';
+							<option value="' . $value . '"', (!empty($field['disabled_options']) && is_array($field['disabled_options']) && in_array($value, $field['disabled_options'], true) ? ' disabled' : ($value == $field['value'] ? ' selected' : '')), '>', $name, '</option>';
 				}
 
 				echo '


### PR DESCRIPTION
Fixes #5290 by removing "(Forum default)" as an option in the select menu. That option was unhelpful anyway, since (1) it left the user having to guess/remember what the default was, and (2) meant that if the admin changed the forum's default time zone, then users' time zones would be changed automatically and quite unexpectedly (to them). Time zones, after all, should always be set explicitly.

Also handles unexpected event time zones more gracefully in the event editor. Instead of simply prepending time zones that don't appear in SMF's standard list to that list, we now try to correct the time zone on the fly. If the attempt fails, we fall back to the previous behaviour (i.e. prepending to the list).