### PR TITLE
Transfer function fixes

### DIFF
--- a/Sources/ManageAttachments.php
+++ b/Sources/ManageAttachments.php
@@ -722,7 +722,7 @@ function MaintainFiles()
 
 	$context['sub_template'] = 'maintenance';
 
-	$attach_dirs = $smcFunc['json_decode']($modSettings['attachmentUploadDir'], true);
+	$attach_dirs = $modSettings['attachmentUploadDir'];
 
 	// Get the number of attachments....
 	$request = $smcFunc['db_query']('', '
@@ -2615,7 +2615,6 @@ function TransferAttachments()
 
 	checkSession();
 
-	$modSettings['attachmentUploadDir'] = $smcFunc['json_decode']($modSettings['attachmentUploadDir'], true);
 	if (!empty($modSettings['attachment_basedirectories']))
 		$modSettings['attachment_basedirectories'] = $smcFunc['json_decode']($modSettings['attachment_basedirectories'], true);
 	else


### PR DESCRIPTION
Fixes #5685 

The attachment dir info is converted from JSON to an array in load.php, no need for these routines to do so.  