### PR TITLE
align Backtrace message with error log message

### DIFF
--- a/Sources/ManageErrors.php
+++ b/Sources/ManageErrors.php
@@ -459,6 +459,8 @@ function ViewBacktrace()
 		$context['error_info']['url'] = $scripturl . $row['url'];
 		$context['error_info']['backtrace'] = $smcFunc['json_decode']($row['backtrace']);
 	}
+	$smcFunc['db_free_result']($request);
+
 	loadTemplate('Errors');
 	loadLanguage('ManageMaintenance');
 	$context['template_layers'] = array();

--- a/Sources/ManageErrors.php
+++ b/Sources/ManageErrors.php
@@ -461,6 +461,7 @@ function ViewBacktrace()
 	}
 	$smcFunc['db_free_result']($request);
 
+	loadCSSFile('admin.css', array(), 'smf_admin');
 	loadTemplate('Errors');
 	loadLanguage('ManageMaintenance');
 	$context['template_layers'] = array();

--- a/Themes/default/Errors.template.php
+++ b/Themes/default/Errors.template.php
@@ -272,8 +272,9 @@ function template_show_backtrace()
 <html', $context['right_to_left'] ? ' dir="rtl"' : '', '>
 	<head>
 		<meta charset="', $context['character_set'], '">
-		<title>Backtrace</title>
-		<link rel="stylesheet" href="', $settings['theme_url'], '/css/index', $context['theme_variant'], '.css', $context['browser_cache'], '">
+		<title>Backtrace</title>';
+	template_css();
+	echo '
 	</head>
 	<body class="padding">';
 
@@ -285,7 +286,7 @@ function template_show_backtrace()
 					', $txt['error'], '
 				</h3>
 			</div>
-			<div class="windowbg">
+			<div class="windowbg" id="backtrace">
 				<ul class="padding">';
 
 		if (!empty($context['error_info']['error_type']))
@@ -294,7 +295,7 @@ function template_show_backtrace()
 
 		if (!empty($context['error_info']['message']))
 			echo '
-					<li>', $txt['error_message'], ': ', $context['error_info']['message'], '</li>';
+					<li>', $txt['error_message'], ': <span class = "error_message">', $context['error_info']['message'], '</span></li>';
 
 		if (!empty($context['error_info']['file']))
 			echo '

--- a/Themes/default/css/admin.css
+++ b/Themes/default/css/admin.css
@@ -620,7 +620,7 @@ h3.grid_header {
 	float: left;
 	margin-right: 5px;
 }
-#error_log span.error_message {
+#error_log span.error_message, #backtrace span.error_message {
 	overflow: hidden; /* This changes how the text wraps around the float */
 	display: block;
 	white-space: pre-wrap;

--- a/Themes/default/css/index.css
+++ b/Themes/default/css/index.css
@@ -87,7 +87,7 @@ textarea {
 }
 
 /* Use a consistent monospace font everywhere */
-.monospace, .bbc_code, .phpcode, pre, #error_log span.error_message {
+.monospace, .bbc_code, .phpcode, pre, #error_log span.error_message, #backtrace span.error_message {
 	font-family: "DejaVu Sans Mono", Menlo, Monaco, Consolas, monospace;
 }
 


### PR DESCRIPTION
Align the output of the backtrace error message with the error log message.

![grafik](https://user-images.githubusercontent.com/1782906/59831748-b37dc700-9342-11e9-8239-80faea10f063.png)

old:
![grafik](https://user-images.githubusercontent.com/1782906/59831784-c42e3d00-9342-11e9-9547-323bf0437862.png)
