### PR TITLE
improve boards category parse_bbc fixes #5734

### DIFF
--- a/Sources/Subs-BoardIndex.php
+++ b/Sources/Subs-BoardIndex.php
@@ -95,8 +95,8 @@ function getBoardIndex($boardIndexOptions)
 	else
 		$result_boards = $smcFunc['db_query']('', '
 			SELECT' . ($boardIndexOptions['include_categories'] ? '
-				c.id_cat, c.name AS cat_name, c.description AS cat_desc,' : '') . '
-				b.id_board, b.name AS board_name, b.description,
+				c.id_cat, c.name AS cat_name, c.name_disp AS cat_name_disp,c.description AS cat_desc, c.description_disp AS cat_desc_disp,' : '') . '
+				b.id_board, b.name AS board_name,b.name_disp AS board_name_disp, b.description, b.description_disp,
 				CASE WHEN b.redirect != {string:blank_string} THEN 1 ELSE 0 END AS is_redirect,
 				b.num_posts, b.num_topics, b.unapproved_posts, b.unapproved_topics, b.id_parent,
 				COALESCE(m.poster_time, 0) AS poster_time, COALESCE(mem.member_name, m.poster_name) AS poster_name,
@@ -157,8 +157,15 @@ function getBoardIndex($boardIndexOptions)
 			// Haven't set this category yet.
 			if (empty($categories[$row_board['id_cat']]))
 			{
-				$name = parse_bbc($row_board['cat_name'], false, '', $context['description_allowed_tags']);
-				$description = parse_bbc($row_board['cat_desc'], false, '', $context['description_allowed_tags']);
+				if (!empty($row_board['cat_name_disp']) || empty($row_board['cat_name']))
+					$name = $row_board['cat_name_disp'];
+				else
+					$name = parse_bbc($row_board['cat_name'], false, '', $context['description_allowed_tags']);
+				
+				if (!empty($row_board['cat_desc_disp']) || empty($row_board['cat_desc']))
+					$description = $row_board['cat_desc_disp'];
+				else
+					$description = parse_bbc($row_board['cat_desc'], false, '', $context['description_allowed_tags']);
 
 				$categories[$row_board['id_cat']] = array(
 					'id' => $row_board['id_cat'],
@@ -199,8 +206,15 @@ function getBoardIndex($boardIndexOptions)
 				if (!isset($this_category[$row_board['id_board']]))
 					$this_category[$row_board['id_board']] = array();
 
-				$board_name = parse_bbc($row_board['board_name'], false, '', $context['description_allowed_tags']);
-				$board_description = parse_bbc($row_board['description'], false, '', $context['description_allowed_tags']);
+				if (!empty($row_board['board_name_disp']) || empty($row_board['board_name']))
+					$board_name = $row_board['board_name_disp'];
+				else
+					$board_name = parse_bbc($row_board['board_name'], false, '', $context['description_allowed_tags']);
+				
+				if (!empty($row_board['description_disp']) || empty($row_board['description']))
+					$board_description = !empty($row_board['description_disp']) ? $row_board['description_disp'] : '';
+				else
+					$board_description = parse_bbc($row_board['description'], false, '', $context['description_allowed_tags']);
 
 				$this_category[$row_board['id_board']] += array(
 					'new' => empty($row_board['is_read']),
@@ -259,8 +273,15 @@ function getBoardIndex($boardIndexOptions)
 					'board_class' => 'off',
 				);
 
-			$board_name = parse_bbc($row_board['board_name'], false, '', $context['description_allowed_tags']);
-			$board_description = parse_bbc($row_board['description'], false, '', $context['description_allowed_tags']);
+				if (!empty($row_board['board_name_disp']) || empty($row_board['board_name']))
+					$board_name = $row_board['board_name_disp'];
+				else
+					$board_name = parse_bbc($row_board['board_name'], false, '', $context['description_allowed_tags']);
+				
+				if (!empty($row_board['description_disp']) || empty($row_board['description']))
+					$board_description = !empty($row_board['description_disp']) ? $row_board['description_disp'] : '';
+				else
+					$board_description = parse_bbc($row_board['description'], false, '', $context['description_allowed_tags']);
 
 			$this_category[$row_board['id_parent']]['children'][$row_board['id_board']] = array(
 				'id' => $row_board['id_board'],

--- a/other/install_2-1_mysql.sql
+++ b/other/install_2-1_mysql.sql
@@ -129,7 +129,9 @@ CREATE TABLE {$db_prefix}boards (
 	member_groups VARCHAR(255) NOT NULL DEFAULT '-1,0',
 	id_profile SMALLINT UNSIGNED NOT NULL DEFAULT '1',
 	name VARCHAR(255) NOT NULL DEFAULT '',
+	name_disp varchar(255) NOT NULL DEFAULT '',
 	description TEXT NOT NULL,
+	description_disp TEXT,
 	num_topics MEDIUMINT UNSIGNED NOT NULL DEFAULT '0',
 	num_posts MEDIUMINT UNSIGNED NOT NULL DEFAULT '0',
 	count_posts TINYINT NOT NULL DEFAULT '0',
@@ -200,7 +202,9 @@ CREATE TABLE {$db_prefix}categories (
 	id_cat TINYINT UNSIGNED AUTO_INCREMENT,
 	cat_order TINYINT NOT NULL DEFAULT '0',
 	name VARCHAR(255) NOT NULL DEFAULT '',
+	name_disp VARCHAR(255) NOT NULL DEFAULT '',
 	description TEXT NOT NULL,
+	description_disp TEXT,
 	can_collapse TINYINT NOT NULL DEFAULT '1',
 	PRIMARY KEY (id_cat)
 ) ENGINE={$engine};

--- a/other/install_2-1_postgresql.sql
+++ b/other/install_2-1_postgresql.sql
@@ -270,7 +270,9 @@ CREATE TABLE {$db_prefix}boards (
 	member_groups varchar(255) NOT NULL DEFAULT '-1,0',
 	id_profile smallint NOT NULL DEFAULT '1',
 	name varchar(255) NOT NULL DEFAULT '',
+	name_disp varchar(255) NOT NULL DEFAULT '',
 	description text NOT NULL,
+	description_disp text,
 	num_topics int NOT NULL DEFAULT '0',
 	num_posts int NOT NULL DEFAULT '0',
 	count_posts smallint NOT NULL DEFAULT '0',
@@ -374,7 +376,9 @@ CREATE TABLE {$db_prefix}categories (
 	id_cat smallint DEFAULT nextval('{$db_prefix}categories_seq'),
 	cat_order smallint NOT NULL DEFAULT '0',
 	name varchar(255) NOT NULL DEFAULT '',
+	name_disp varchar(255) NOT NULL DEFAULT '',
 	description text NOT NULL,
+	description_disp text,
 	can_collapse smallint NOT NULL DEFAULT '1',
 	PRIMARY KEY (id_cat)
 );

--- a/other/upgrade_2-1_mysql.sql
+++ b/other/upgrade_2-1_mysql.sql
@@ -117,7 +117,9 @@ if (version_compare(trim(strtolower(@$modSettings['smfVersion'])), '2.1.foo', '<
 
 ---# Parsing board descriptions and names
 ---{
-if (version_compare(trim(strtolower(@$modSettings['smfVersion'])), '2.1.foo', '<'))
+$table_columns = $smcFunc['db_list_columns']('{db_prefix}boards');
+
+if (!in_array('description_disp', $table_columns)))
 {
     $request = $smcFunc['db_query']('', '
         SELECT name, description, id_board
@@ -127,12 +129,21 @@ if (version_compare(trim(strtolower(@$modSettings['smfVersion'])), '2.1.foo', '<
 
     $smcFunc['db_free_result']($request);
 
+	$smcFunc['db_query'}('','
+		ALTER TABLE {db_prefix}boards
+			ADD COLUMN description_disp text');
+
+	$smcFunc['db_query'}('','
+		ALTER TABLE {db_prefix}boards
+			ADD COLUMN name_disp varchar(255) NOT NULL DEFAULT \'\'');
+
     while ($row = $smcFunc['db_fetch_assoc']($request))
     {
         $inserts[] = array(
             'name' => $smcFunc['htmlspecialchars'](strip_tags(html_to_bbc($row['name']))),
             'description' => $smcFunc['htmlspecialchars'](strip_tags(html_to_bbc($row['description']))),
             'id' => $row['id'],
+			'description_disp' => parse_bbc($smcFunc['htmlspecialchars'](strip_tags(html_to_bbc($row['description'])))),
         );
     }
 
@@ -142,13 +153,25 @@ if (version_compare(trim(strtolower(@$modSettings['smfVersion'])), '2.1.foo', '<
         {
             $smcFunc['db_query']('', '
                 UPDATE {db_prefix}boards
-                SET name = {string:name}, description = {string:description}
+                SET name = {string:name}, description = {string:description}, description_disp = {string:description_disp} 
                 WHERE id = {int:id}',
                 $insert
             );
         }
     }
 }
+
+$table_columns = $smcFunc['db_list_columns']('{db_prefix}categories');
+
+if (!in_array('description_disp', $table_columns)))
+	$smcFunc['db_query'}('','
+		ALTER TABLE {db_prefix}categories
+			ADD COLUMN description_disp text');
+
+if (!in_array('name_disp', $table_columns)))
+	$smcFunc['db_query'}('','
+		ALTER TABLE {db_prefix}categories
+			ADD COLUMN name_disp varchar(255) NOT NULL DEFAULT \'\'');
 ---}
 ---#
 

--- a/other/upgrade_2-1_postgresql.sql
+++ b/other/upgrade_2-1_postgresql.sql
@@ -308,7 +308,9 @@ if (version_compare(trim(strtolower(@$modSettings['smfVersion'])), '2.1.foo', '<
 
 ---# Parsing board descriptions and names
 ---{
-if (version_compare(trim(strtolower(@$modSettings['smfVersion'])), '2.1.foo', '<'))
+$table_columns = $smcFunc['db_list_columns']('{db_prefix}boards');
+
+if (!in_array('description_disp', $table_columns))
 {
     $request = $smcFunc['db_query']('', '
         SELECT name, description, id_board
@@ -318,12 +320,21 @@ if (version_compare(trim(strtolower(@$modSettings['smfVersion'])), '2.1.foo', '<
 
     $smcFunc['db_free_result']($request);
 
+	$smcFunc['db_query'}('','
+		ALTER TABLE {db_prefix}boards
+			ADD COLUMN description_disp text');
+
+	$smcFunc['db_query'}('','
+		ALTER TABLE {db_prefix}boards
+			ADD COLUMN name_disp varchar(255) NOT NULL DEFAULT \'\'');
+
     while ($row = $smcFunc['db_fetch_assoc']($request))
     {
         $inserts[] = array(
             'name' => $smcFunc['htmlspecialchars'](strip_tags(html_to_bbc($row['name']))),
             'description' => $smcFunc['htmlspecialchars'](strip_tags(html_to_bbc($row['description']))),
             'id' => $row['id'],
+			'description_disp' => parse_bbc($smcFunc['htmlspecialchars'](strip_tags(html_to_bbc($row['description'])))),
         );
     }
 
@@ -333,13 +344,25 @@ if (version_compare(trim(strtolower(@$modSettings['smfVersion'])), '2.1.foo', '<
         {
             $smcFunc['db_query']('', '
                 UPDATE {db_prefix}boards
-                SET name = {string:name}, description = {string:description}
+                SET name = {string:name}, description = {string:description}, description_disp = {string:description_disp} 
                 WHERE id = {int:id}',
                 $insert
             );
         }
     }
 }
+
+$table_columns = $smcFunc['db_list_columns']('{db_prefix}categories');
+
+if (!in_array('description_disp', $table_columns)))
+	$smcFunc['db_query'}('','
+		ALTER TABLE {db_prefix}categories
+			ADD COLUMN description_disp text');
+
+if (!in_array('name_disp', $table_columns)))
+	$smcFunc['db_query'}('','
+		ALTER TABLE {db_prefix}categories
+			ADD COLUMN name_disp varchar(255) NOT NULL DEFAULT \'\'');
 ---}
 ---#
 


### PR DESCRIPTION
the base idea is to build the best of two worlds,
on the one hand being able to modify the category name/description and board name/dscription with bbc,
on the other hand being fast to allow big board run in the same speed like small one.

since we do db changes in the process,
we can do a mutch better work on upgrade process check if the changes needs to run or not.

missing:
upgrade process is not final
edit logic is missing

issue: #5734