### PR TITLE
Remove not more supported mysql hints

### DIFF
--- a/Sources/ManageMaintenance.php
+++ b/Sources/ManageMaintenance.php
@@ -855,13 +855,13 @@ function AdminBoardRecount()
 			// Recount approved messages
 			$request = $smcFunc['db_query']('', '
 				SELECT t.id_topic, MAX(t.num_replies) AS num_replies,
-					CASE WHEN COUNT(ma.id_msg) >= 1 THEN COUNT(ma.id_msg) - 1 ELSE 0 END AS real_num_replies
+					GREATEST(COUNT(ma.id_msg) - 1, 0) AS real_num_replies
 				FROM {db_prefix}topics AS t
 					LEFT JOIN {db_prefix}messages AS ma ON (ma.id_topic = t.id_topic AND ma.approved = {int:is_approved})
 				WHERE t.id_topic > {int:start}
 					AND t.id_topic <= {int:max_id}
 				GROUP BY t.id_topic
-				HAVING CASE WHEN COUNT(ma.id_msg) >= 1 THEN COUNT(ma.id_msg) - 1 ELSE 0 END != MAX(t.num_replies)',
+				HAVING GREATEST(COUNT(ma.id_msg) - 1, 0) != MAX(t.num_replies)',
 				array(
 					'is_approved' => 1,
 					'start' => $_REQUEST['start'],

--- a/Sources/ManageMaintenance.php
+++ b/Sources/ManageMaintenance.php
@@ -410,7 +410,7 @@ function ConvertMsgBody()
 		while ($_REQUEST['start'] < $max_msgs)
 		{
 			$request = $smcFunc['db_query']('', '
-				SELECT /*!40001 SQL_NO_CACHE */ id_msg
+				SELECT id_msg
 				FROM {db_prefix}messages
 				WHERE id_msg BETWEEN {int:start} AND {int:start} + {int:increment}
 					AND LENGTH(body) > 65535',
@@ -854,7 +854,7 @@ function AdminBoardRecount()
 		{
 			// Recount approved messages
 			$request = $smcFunc['db_query']('', '
-				SELECT /*!40001 SQL_NO_CACHE */ t.id_topic, MAX(t.num_replies) AS num_replies,
+				SELECT t.id_topic, MAX(t.num_replies) AS num_replies,
 					CASE WHEN COUNT(ma.id_msg) >= 1 THEN COUNT(ma.id_msg) - 1 ELSE 0 END AS real_num_replies
 				FROM {db_prefix}topics AS t
 					LEFT JOIN {db_prefix}messages AS ma ON (ma.id_topic = t.id_topic AND ma.approved = {int:is_approved})
@@ -882,7 +882,7 @@ function AdminBoardRecount()
 
 			// Recount unapproved messages
 			$request = $smcFunc['db_query']('', '
-				SELECT /*!40001 SQL_NO_CACHE */ t.id_topic, MAX(t.unapproved_posts) AS unapproved_posts,
+				SELECT t.id_topic, MAX(t.unapproved_posts) AS unapproved_posts,
 					COUNT(mu.id_msg) AS real_unapproved_posts
 				FROM {db_prefix}topics AS t
 					LEFT JOIN {db_prefix}messages AS mu ON (mu.id_topic = t.id_topic AND mu.approved = {int:not_approved})
@@ -942,7 +942,7 @@ function AdminBoardRecount()
 		while ($_REQUEST['start'] < $max_topics)
 		{
 			$request = $smcFunc['db_query']('', '
-				SELECT /*!40001 SQL_NO_CACHE */ m.id_board, COUNT(*) AS real_num_posts
+				SELECT m.id_board, COUNT(*) AS real_num_posts
 				FROM {db_prefix}messages AS m
 				WHERE m.id_topic > {int:id_topic_min}
 					AND m.id_topic <= {int:id_topic_max}
@@ -998,7 +998,7 @@ function AdminBoardRecount()
 		while ($_REQUEST['start'] < $max_topics)
 		{
 			$request = $smcFunc['db_query']('', '
-				SELECT /*!40001 SQL_NO_CACHE */ t.id_board, COUNT(*) AS real_num_topics
+				SELECT t.id_board, COUNT(*) AS real_num_topics
 				FROM {db_prefix}topics AS t
 				WHERE t.approved = {int:is_approved}
 					AND t.id_topic > {int:id_topic_min}
@@ -1054,7 +1054,7 @@ function AdminBoardRecount()
 		while ($_REQUEST['start'] < $max_topics)
 		{
 			$request = $smcFunc['db_query']('', '
-				SELECT /*!40001 SQL_NO_CACHE */ m.id_board, COUNT(*) AS real_unapproved_posts
+				SELECT m.id_board, COUNT(*) AS real_unapproved_posts
 				FROM {db_prefix}messages AS m
 				WHERE m.id_topic > {int:id_topic_min}
 					AND m.id_topic <= {int:id_topic_max}
@@ -1110,7 +1110,7 @@ function AdminBoardRecount()
 		while ($_REQUEST['start'] < $max_topics)
 		{
 			$request = $smcFunc['db_query']('', '
-				SELECT /*!40001 SQL_NO_CACHE */ t.id_board, COUNT(*) AS real_unapproved_topics
+				SELECT t.id_board, COUNT(*) AS real_unapproved_topics
 				FROM {db_prefix}topics AS t
 				WHERE t.approved = {int:is_approved}
 					AND t.id_topic > {int:id_topic_min}
@@ -1155,7 +1155,7 @@ function AdminBoardRecount()
 	if ($_REQUEST['step'] <= 5)
 	{
 		$request = $smcFunc['db_query']('', '
-			SELECT /*!40001 SQL_NO_CACHE */ mem.id_member, COUNT(pmr.id_pm) AS real_num,
+			SELECT mem.id_member, COUNT(pmr.id_pm) AS real_num,
 				MAX(mem.instant_messages) AS instant_messages
 			FROM {db_prefix}members AS mem
 				LEFT JOIN {db_prefix}pm_recipients AS pmr ON (mem.id_member = pmr.id_member AND pmr.deleted = {int:is_not_deleted})
@@ -1170,7 +1170,7 @@ function AdminBoardRecount()
 		$smcFunc['db_free_result']($request);
 
 		$request = $smcFunc['db_query']('', '
-			SELECT /*!40001 SQL_NO_CACHE */ mem.id_member, COUNT(pmr.id_pm) AS real_num,
+			SELECT mem.id_member, COUNT(pmr.id_pm) AS real_num,
 				MAX(mem.unread_messages) AS unread_messages
 			FROM {db_prefix}members AS mem
 				LEFT JOIN {db_prefix}pm_recipients AS pmr ON (mem.id_member = pmr.id_member AND pmr.deleted = {int:is_not_deleted} AND pmr.is_read = {int:is_not_read})
@@ -1203,7 +1203,7 @@ function AdminBoardRecount()
 		while ($_REQUEST['start'] < $modSettings['maxMsgID'])
 		{
 			$request = $smcFunc['db_query']('', '
-				SELECT /*!40001 SQL_NO_CACHE */ t.id_board, m.id_msg
+				SELECT t.id_board, m.id_msg
 				FROM {db_prefix}messages AS m
 					INNER JOIN {db_prefix}topics AS t ON (t.id_topic = m.id_topic AND t.id_board != m.id_board)
 				WHERE m.id_msg > {int:id_msg_min}
@@ -1263,7 +1263,7 @@ function AdminBoardRecount()
 	$smcFunc['db_free_result']($request);
 
 	$request = $smcFunc['db_query']('', '
-		SELECT /*!40001 SQL_NO_CACHE */ id_board, id_parent, id_last_msg, child_level, id_msg_updated
+		SELECT id_board, id_parent, id_last_msg, child_level, id_msg_updated
 		FROM {db_prefix}boards',
 		array(
 		)
@@ -1740,7 +1740,7 @@ function MaintainRecountPosts()
 
 	// Lets get a group of members and determine their post count (from the boards that have post count enabled of course).
 	$request = $smcFunc['db_query']('', '
-		SELECT /*!40001 SQL_NO_CACHE */ m.id_member, COUNT(m.id_member) AS posts
+		SELECT m.id_member, COUNT(m.id_member) AS posts
 		FROM {db_prefix}messages AS m
 			INNER JOIN {db_prefix}boards AS b ON m.id_board = b.id_board
 		WHERE m.id_member != {int:zero}

--- a/Sources/ScheduledTasks.php
+++ b/Sources/ScheduledTasks.php
@@ -667,7 +667,7 @@ function ReduceMailQueue($number = false, $override_limit = false, $force_send =
 
 	// Now we know how many we're sending, let's send them.
 	$request = $smcFunc['db_query']('', '
-		SELECT /*!40001 SQL_NO_CACHE */ id_mail, recipient, body, subject, headers, send_html, time_sent, private
+		SELECT id_mail, recipient, body, subject, headers, send_html, time_sent, private
 		FROM {db_prefix}mail_queue
 		ORDER BY priority ASC, id_mail ASC
 		LIMIT {int:limit}',


### PR DESCRIPTION
With mysql 5.7 sql_no_cache got deptraced and with 8.0 got it removed.
src: https://dev.mysql.com/doc/refman/5.7/en/query-cache-in-select.html

I didn't change the hint handling in the db layer,
because maybe some mods use it.

https://github.com/SimpleMachines/SMF2.1/blob/e0848c82fbbc912b51789a2fefded6b6830f086f/Sources/Subs-Db-mysql.php#L367

https://github.com/SimpleMachines/SMF2.1/blob/e0848c82fbbc912b51789a2fefded6b6830f086f/Sources/Subs-Db-postgresql.php#L375

End of the day only the hint: "40000 USE INDEX" is used once:
https://github.com/SimpleMachines/SMF2.1/blob/e0848c82fbbc912b51789a2fefded6b6830f086f/Sources/Subs-Boards.php#L109
otherwise the queries are free from hints.