### PR TITLE
Upgrader - 1.x issues - alt approach

### DIFF
--- a/other/upgrade-helper.php
+++ b/other/upgrade-helper.php
@@ -417,7 +417,7 @@ function smf_mysql_num_rows($rs)
 function smf_mysql_real_escape_string($string)
 {
 	global $db_connection;
-	mysqli_real_escape_string($db_connection, $string);
+	return mysqli_real_escape_string($db_connection, $string);
 }
 
 /**

--- a/other/upgrade.php
+++ b/other/upgrade.php
@@ -2196,6 +2196,9 @@ function upgrade_query($string, $unbuffered = false)
 			return false;
 		elseif ($mysqli_errno == 1050 && substr(trim($string), 0, 12) == 'RENAME TABLE')
 			return false;
+		// Testing for legacy tables or columns? Needed for 1.0 & 1.1 scripts.
+		elseif (in_array($mysqli_errno, array(1054, 1146)) && in_array(substr(trim($string), 0, 7), array('SELECT ', 'SHOW CO')))
+			return false;
 	}
 	// If a table already exists don't go potty.
 	else

--- a/other/upgrade.php
+++ b/other/upgrade.php
@@ -237,6 +237,14 @@ if (!isset($settings['default_theme_url']))
 if (!isset($settings['default_theme_dir']))
 	$settings['default_theme_dir'] = $modSettings['theme_dir'];
 
+// Old DBs won't have this
+if (!isset($modSettings['rand_seed']))
+{
+	if (!function_exists('cache_put_data'))
+		require_once($sourcedir . '/Load.php');
+	smf_seed_generator();
+}
+
 // This is needed in case someone invokes the upgrader using https when upgrading an http forum
 if (httpsOn())
 	$settings['default_theme_url'] = strtr($settings['default_theme_url'], array('http://' => 'https://'));

--- a/other/upgrade.php
+++ b/other/upgrade.php
@@ -1031,13 +1031,16 @@ function checkLogin()
 		$upcontext['username'] = $_POST['user'];
 
 		// Track whether javascript works!
-		if (!empty($_POST['js_works']))
+		if (isset($_POST['js_works']))
 		{
-			$upcontext['upgrade_status']['js'] = 1;
-			$support_js = 1;
+			if (!empty($_POST['js_works']))
+			{
+				$upcontext['upgrade_status']['js'] = 1;
+				$support_js = 1;
+			}
+			else
+				$support_js = 0;
 		}
-		else
-			$support_js = 0;
 
 		// Note down the version we are coming from.
 		if (!empty($modSettings['smfVersion']) && empty($upcontext['user']['version']))

--- a/other/upgrade.php
+++ b/other/upgrade.php
@@ -2149,7 +2149,7 @@ function upgrade_query($string, $unbuffered = false)
 	if ($db_type == 'mysql')
 	{
 		$mysqli_errno = mysqli_errno($db_connection);
-		$error_query = in_array(substr(trim($string), 0, 11), array('INSERT INTO', 'UPDATE IGNO', 'ALTER TABLE', 'DROP TABLE ', 'ALTER IGNOR'));
+		$error_query = in_array(substr(trim($string), 0, 11), array('INSERT INTO', 'UPDATE IGNO', 'ALTER TABLE', 'DROP TABLE ', 'ALTER IGNOR', 'INSERT IGNO'));
 
 		// Error numbers:
 		//    1016: Can't open file '....MYI'

--- a/other/upgrade.php
+++ b/other/upgrade.php
@@ -205,6 +205,10 @@ require_once($sourcedir . '/Subs.php');
 require_once($sourcedir . '/LogInOut.php');
 require_once($sourcedir . '/Subs-Editor.php');
 
+// Don't do security check if on Yabbse
+if (!isset($modSettings['smfVersion']))
+	$disable_security = true;
+
 // This only exists if we're on SMF ;)
 if (isset($modSettings['smfVersion']))
 {

--- a/other/upgrade.php
+++ b/other/upgrade.php
@@ -947,12 +947,8 @@ function checkLogin()
 	global $modSettings, $upcontext, $disable_security;
 	global $smcFunc, $db_type, $support_js, $sourcedir, $txt;
 
-	// Don't bother if the security is disabled.
-	if ($disable_security)
-		return true;
-
 	// Are we trying to login?
-	if (isset($_POST['contbutt']) && (!empty($_POST['user'])))
+	if (isset($_POST['contbutt']) && (!empty($_POST['user']) || $disable_security))
 	{
 		// If we've disabled security pick a suitable name!
 		if (empty($_POST['user']))

--- a/other/upgrade_1-0.sql
+++ b/other/upgrade_1-0.sql
@@ -1909,7 +1909,7 @@ upgrade_query("
 		('enableBBC', '" . (!isset($GLOBALS['enable_ubbc']) ? 1 : $GLOBALS['enable_ubbc']) . "'),
 		('max_messageLength', '" . (empty($GLOBALS['MaxMessLen']) ? 10000 : $GLOBALS['MaxMessLen']) . "'),
 		('max_signatureLength', '" . @$GLOBALS['MaxSigLen'] . "'),
-		('spamWaitTime', '" . @$GLOBALS['timeout'] . "'),
+		('spamWaitTime', '" . (empty($GLOBALS['timeout']) ? 5 : $GLOBALS['timeout']) . "'),
 		('avatar_directory', '" . (isset($GLOBALS['facesdir']) ? fixRelativePath($GLOBALS['facesdir']) : fixRelativePath('./avatars')) . "'),
 		('avatar_url', '" . @$GLOBALS['facesurl'] . "'),
 		('avatar_max_height_external', '" . @$GLOBALS['userpic_height'] . "'),
@@ -1919,7 +1919,7 @@ upgrade_query("
 		('defaultMaxMessages', '" . (empty($GLOBALS['maxmessagedisplay']) ? 15 : $GLOBALS['maxmessagedisplay']) . "'),
 		('defaultMaxTopics', '" . (empty($GLOBALS['maxdisplay']) ? 20 : $GLOBALS['maxdisplay']) . "'),
 		('defaultMaxMembers', '" . (empty($GLOBALS['MembersPerPage']) ? 20 : $GLOBALS['MembersPerPage']) . "'),
-		('time_offset', '" . @$GLOBALS['timeoffset'] . "'),
+		('time_offset', '" . (empty($GLOBALS['timeoffset']) ? 0 : $GLOBALS['timeoffset']) . "'),
 		('cookieTime', '" . (empty($GLOBALS['Cookie_Length']) ? 60 : $GLOBALS['Cookie_Length']) . "'),
 		('requireAgreement', '" . @$GLOBALS['RegAgree'] . "')");
 ---}

--- a/other/upgrade_1-0.sql
+++ b/other/upgrade_1-0.sql
@@ -2008,4 +2008,8 @@ FROM {$db_prefix}topics;
 REPLACE INTO {$db_prefix}settings
 	(variable, value)
 VALUES ('cal_today_updated', '00000000');
+
+REPLACE INTO {$db_prefix}settings
+	(variable, value)
+VALUES ('enable_password_conversion', '1');
 ---#

--- a/other/upgrade_1-1.sql
+++ b/other/upgrade_1-1.sql
@@ -377,7 +377,7 @@ if ((!isset($modSettings['smfVersion']) || $modSettings['smfVersion'] <= '1.1 RC
 // Do they have "classic" installed?
 if (file_exists($GLOBALS['boarddir'] . '/Themes/classic'))
 {
-	$classic_dir = $GLOBALS['boarddir'] . '/Themes/classic';
+	$classic_dir = smf_mysql_real_escape_string($GLOBALS['boarddir'] . '/Themes/classic');
 	$theme_request = upgrade_query("
 		SELECT ID_THEME
 		FROM {$db_prefix}themes
@@ -387,16 +387,16 @@ if (file_exists($GLOBALS['boarddir'] . '/Themes/classic'))
 	// Don't do anything if this theme is already uninstalled
 	if (smf_mysql_num_rows($theme_request) == 1)
 	{
-		$id_theme = mysql_result($theme_request, 0);
-		mysql_free_result($theme_request);
+		list($id_theme) = smf_mysql_fetch_row($theme_request);
+		smf_mysql_free_result($theme_request);
 
-		$known_themes = explode(', ', $modSettings['knownThemes']);
+		$known_themes = explode(',', $modSettings['knownThemes']);
 
 		// Remove this value...
 		$known_themes = array_diff($known_themes, array($id_theme));
 
 		// Change back to a string...
-		$known_themes = implode(', ', $known_themes);
+		$known_themes = implode(',', $known_themes);
 
 		// Update the database
 		upgrade_query("

--- a/other/upgrade_2-0_mysql.sql
+++ b/other/upgrade_2-0_mysql.sql
@@ -2763,7 +2763,7 @@ if (!isset($modSettings['attachment_thumb_png']))
 // Do they have "babylon" installed?
 if (file_exists($GLOBALS['boarddir'] . '/Themes/babylon'))
 {
-	$babylon_dir = $GLOBALS['boarddir'] . '/Themes/babylon';
+	$babylon_dir = smf_mysql_real_escape_string($GLOBALS['boarddir'] . '/Themes/babylon');
 	$theme_request = upgrade_query("
 		SELECT ID_THEME
 		FROM {$db_prefix}themes
@@ -2778,13 +2778,13 @@ if (file_exists($GLOBALS['boarddir'] . '/Themes/babylon'))
 		smf_mysql_free_result($theme_request);
 		unset($row);
 
-		$known_themes = explode(', ', $modSettings['knownThemes']);
+		$known_themes = explode(',', $modSettings['knownThemes']);
 
 		// Remove this value...
 		$known_themes = array_diff($known_themes, array($id_theme));
 
 		// Change back to a string...
-		$known_themes = implode(', ', $known_themes);
+		$known_themes = implode(',', $known_themes);
 
 		// Update the database
 		upgrade_query("

--- a/other/upgrade_2-0_mysql.sql
+++ b/other/upgrade_2-0_mysql.sql
@@ -2763,19 +2763,24 @@ if (!isset($modSettings['attachment_thumb_png']))
 // Do they have "babylon" installed?
 if (file_exists($GLOBALS['boarddir'] . '/Themes/babylon'))
 {
-	$babylon_dir = smf_mysql_real_escape_string($GLOBALS['boarddir'] . '/Themes/babylon');
-	$theme_request = upgrade_query("
-		SELECT ID_THEME
-		FROM {$db_prefix}themes
-		WHERE variable = 'theme_dir'
-			AND value ='$babylon_dir'");
+	$babylon_dir = $GLOBALS['boarddir'] . '/Themes/babylon';
+	$theme_request = $smcFunc['db_query']('', '
+		SELECT id_theme
+		FROM {db_prefix}themes
+		WHERE variable = {string:themedir}
+			AND value = {string:babylondir}',
+		array(
+			'themedir' => 'theme_dir',
+			'babylondir' => $babylon_dir,
+		)
+	);
 
 	// Don't do anything if this theme is already uninstalled
-	if (smf_mysql_num_rows($theme_request) == 1)
+	if ($smcFunc['db_num_rows']($theme_request) == 1)
 	{
-		$row = smf_mysql_fetch_row($theme_request);
+		$row = $smcFunc['db_fetch_row']($theme_request);
 		$id_theme = $row[0];
-		smf_mysql_free_result($theme_request);
+		$smcFunc['db_free_result']($theme_request);
 		unset($row);
 
 		$known_themes = explode(',', $modSettings['knownThemes']);
@@ -2787,9 +2792,12 @@ if (file_exists($GLOBALS['boarddir'] . '/Themes/babylon'))
 		$known_themes = implode(',', $known_themes);
 
 		// Update the database
-		upgrade_query("
-			REPLACE INTO {$db_prefix}settings (variable, value)
-			VALUES ('knownThemes', '$known_themes')");
+		$smcFunc['db_insert']('replace',
+			'{db_prefix}settings',
+			array('variable' => 'string', 'value' => 'string'),
+			array('knownThemes', $known_themes),
+			array('variable')
+		);
 
 		// Delete any info about this theme
 		upgrade_query("
@@ -2809,10 +2817,12 @@ if (file_exists($GLOBALS['boarddir'] . '/Themes/babylon'))
 
 		if ($modSettings['theme_guests'] == $id_theme)
 		{
-			upgrade_query("
-				REPLACE INTO {$db_prefix}settings
-				(variable, value)
-				VALUES('theme_guests', 0)");
+			$smcFunc['db_insert']('replace',
+				'{db_prefix}settings',
+				array('variable' => 'string', 'value' => 'string'),
+				array('theme_guests', 0),
+				array('variable')
+			);
 		}
 	}
 }

--- a/other/upgrade_2-0_mysql.sql
+++ b/other/upgrade_2-0_mysql.sql
@@ -1735,7 +1735,7 @@ if ($profileCount == 0)
 	// Update the board tables.
 	foreach ($board_updates as $profile => $boards)
 	{
-		if (empty($boards))
+		if (empty($boards) || empty($profile))
 			continue;
 
 		$boards = implode(',', $boards);

--- a/other/upgrade_2-0_postgresql.sql
+++ b/other/upgrade_2-0_postgresql.sql
@@ -926,19 +926,24 @@ if (!isset($modSettings['attachment_thumb_png']))
 // Do they have "babylon" installed?
 if (file_exists($GLOBALS['boarddir'] . '/Themes/babylon'))
 {
-	$babylon_dir = smf_mysql_real_escape_string($GLOBALS['boarddir'] . '/Themes/babylon');
-	$theme_request = upgrade_query("
-		SELECT ID_THEME
-		FROM {$db_prefix}themes
-		WHERE variable = 'theme_dir'
-			AND value ='$babylon_dir'");
+	$babylon_dir = $GLOBALS['boarddir'] . '/Themes/babylon';
+	$theme_request = $smcFunc['db_query']('', '
+		SELECT id_theme
+		FROM {db_prefix}themes
+		WHERE variable = {string:themedir}
+			AND value = {string:babylondir}',
+		array(
+			'themedir' => 'theme_dir',
+			'babylondir' => $babylon_dir,
+		)
+	);
 
 	// Don't do anything if this theme is already uninstalled
-	if (smf_mysql_num_rows($theme_request) == 1)
+	if ($smcFunc['db_num_rows']($theme_request) == 1)
 	{
-		$row = smf_mysql_fetch_row($theme_request);
+		$row = $smcFunc['db_fetch_row']($theme_request);
 		$id_theme = $row[0];
-		smf_mysql_free_result($theme_request);
+		$smcFunc['db_free_result']($theme_request);
 		unset($row);
 
 		$known_themes = explode(',', $modSettings['knownThemes']);
@@ -950,9 +955,12 @@ if (file_exists($GLOBALS['boarddir'] . '/Themes/babylon'))
 		$known_themes = implode(',', $known_themes);
 
 		// Update the database
-		upgrade_query("
-			REPLACE INTO {$db_prefix}settings (variable, value)
-			VALUES ('knownThemes', '$known_themes')");
+		$smcFunc['db_insert']('replace',
+			'{db_prefix}settings',
+			array('variable' => 'string', 'value' => 'string'),
+			array('knownThemes', $known_themes),
+			array('variable')
+		);
 
 		// Delete any info about this theme
 		upgrade_query("
@@ -972,10 +980,12 @@ if (file_exists($GLOBALS['boarddir'] . '/Themes/babylon'))
 
 		if ($modSettings['theme_guests'] == $id_theme)
 		{
-			upgrade_query("
-				REPLACE INTO {$db_prefix}settings
-				(variable, value)
-				VALUES('theme_guests', 0)");
+			$smcFunc['db_insert']('replace',
+				'{db_prefix}settings',
+				array('variable' => 'string', 'value' => 'string'),
+				array('theme_guests', 0),
+				array('variable')
+			);
 		}
 	}
 }

--- a/other/upgrade_2-0_postgresql.sql
+++ b/other/upgrade_2-0_postgresql.sql
@@ -918,192 +918,67 @@ if (!isset($modSettings['attachment_thumb_png']))
 ---#
 
 /******************************************************************************/
---- Installing new default theme...
+--- Cleaning up after old themes...
 /******************************************************************************/
 
----# Installing theme settings...
+---# Checking for "babylon" and removing it if necessary...
 ---{
-// This is Grudge's secret "I'm not a developer" theme install code - keep this quiet ;)
-
-// Firstly, I'm going out of my way to not do this twice!
-if ((!isset($modSettings['smfVersion']) || $modSettings['smfVersion'] <= '2.0 RC2') && empty($modSettings['dont_repeat_theme_core']))
+// Do they have "babylon" installed?
+if (file_exists($GLOBALS['boarddir'] . '/Themes/babylon'))
 {
-	// Check it's not already here, just in case.
+	$babylon_dir = smf_mysql_real_escape_string($GLOBALS['boarddir'] . '/Themes/babylon');
 	$theme_request = upgrade_query("
-		SELECT id_theme
+		SELECT ID_THEME
 		FROM {$db_prefix}themes
 		WHERE variable = 'theme_dir'
-			AND value LIKE '%core'");
-	// Only do the upgrade if it doesn't find the theme already.
-	if ($smcFunc['db_num_rows']($theme_request) == 0)
+			AND value ='$babylon_dir'");
+
+	// Don't do anything if this theme is already uninstalled
+	if (smf_mysql_num_rows($theme_request) == 1)
 	{
-		// Try to get some settings from the current default theme.
-		$request = upgrade_query("
-			SELECT t1.value AS theme_dir, t2.value AS theme_url, t3.value AS images_url
-			FROM ({$db_prefix}themes AS t1, {$db_prefix}themes AS t2, {$db_prefix}themes AS t3)
-			WHERE t1.id_theme = 1
-				AND t1.id_member = 0
-				AND t1.variable = 'theme_dir'
-				AND t2.id_theme = 1
-				AND t2.id_member = 0
-				AND t2.variable = 'theme_url'
-				AND t3.id_theme = 1
-				AND t3.id_member = 0
-				AND t3.variable = 'images_url'
-			LIMIT 1");
-		if ($smcFunc['db_num_rows']($request) != 0)
-		{
-			$curve = $smcFunc['db_fetch_assoc']($request);
+		$row = smf_mysql_fetch_row($theme_request);
+		$id_theme = $row[0];
+		smf_mysql_free_result($theme_request);
+		unset($row);
 
-			if (substr_count($curve['theme_dir'], 'default') === 1)
-				$core['theme_dir'] = strtr($curve['theme_dir'], array('default' => 'core'));
-			if (substr_count($curve['theme_url'], 'default') === 1)
-				$core['theme_url'] = strtr($curve['theme_url'], array('default' => 'core'));
-			if (substr_count($curve['images_url'], 'default') === 1)
-				$core['images_url'] = strtr($curve['images_url'], array('default' => 'core'));
-		}
-		$smcFunc['db_free_result']($request);
+		$known_themes = explode(',', $modSettings['knownThemes']);
 
-		if (!isset($core['theme_dir']))
-			$core['theme_dir'] = addslashes($GLOBALS['boarddir']) . '/Themes/core';
-		if (!isset($core['theme_url']))
-			$core['theme_url'] = $GLOBALS['boardurl'] . '/Themes/core';
-		if (!isset($core['images_url']))
-			$core['images_url'] = $GLOBALS['boardurl'] . '/Themes/core/images';
+		// Remove this value...
+		$known_themes = array_diff($known_themes, array($id_theme));
 
-		// Get an available id_theme first...
-		$request = upgrade_query("
-			SELECT MAX(id_theme) + 1
-			FROM {$db_prefix}themes");
-		list ($id_core_theme) = $smcFunc['db_fetch_row']($request);
-		$smcFunc['db_free_result']($request);
+		// Change back to a string...
+		$known_themes = implode(',', $known_themes);
 
-		// Insert the core theme into the tables.
-		$smcFunc['db_insert']('ignore',
-			'{db_prefix}themes',
-				array('id_member' => 'int', 'id_theme' => 'int', 'variable' => 'string-255', 'value' => 'string-255'),
-				array(
-					array(0, $id_core_theme, 'name', 'Core Theme'),
-					array(0, $id_core_theme, 'theme_url', $core['theme_url']),
-					array(0, $id_core_theme, 'images_url', $core['images_url']),
-					array(0, $id_core_theme, 'theme_dir', $core['theme_dir'])
-				),
-				array()
-		);
-
-		// Update the name of the default theme in the database.
+		// Update the database
 		upgrade_query("
-			UPDATE {$db_prefix}themes
-			SET value = 'SMF Default Theme - Curve'
-			WHERE id_theme = 1
-				AND variable = 'name'");
+			REPLACE INTO {$db_prefix}settings (variable, value)
+			VALUES ('knownThemes', '$known_themes')");
 
-		$newSettings = array();
-		// Now that we have the old theme details - switch anyone who used the default to it (Make sense?!)
-		if (!empty($modSettings['theme_default']) && $modSettings['theme_default'] == 1)
-			$newSettings[] = "('theme_default', $id_core_theme)";
-		// Did guests use to use the default?
-		if (!empty($modSettings['theme_guests']) && $modSettings['theme_guests'] == 1)
-			$newSettings[] = "('theme_guests', $id_core_theme)";
-
-		// If known themes aren't set, let's just pick all themes available.
-		if (empty($modSettings['knownThemes']))
-		{
-			$request = upgrade_query("
-				SELECT DISTINCT id_theme
-				FROM {$db_prefix}themes");
-			$themes = array();
-			while ($row = $smcFunc['db_fetch_assoc']($request))
-				$themes[] = $row['id_theme'];
-			$modSettings['knownThemes'] = implode(',', $themes);
-			upgrade_query("
-				UPDATE {$db_prefix}settings
-				SET value = '$modSettings[knownThemes]'
-				WHERE variable = 'knownThemes'");
-		}
-
-		// Known themes.
-		$allThemes = explode(',', $modSettings['knownThemes']);
-		$allThemes[] = $id_core_theme;
-		$newSettings[] = "('knownThemes', '" . implode(',', $allThemes) . "')";
-
-		// Since we want to do a replace, just delete the old settings and re-insert them
+		// Delete any info about this theme
 		upgrade_query("
-			DELETE FROM {$db_prefix}settings
-			WHERE variable IN ('theme_default', 'theme_guests', 'knownThemes')");
+			DELETE FROM {$db_prefix}themes
+			WHERE id_theme = $id_theme");
 
-		foreach ($new_settings AS $a_new_setting)
-		{
-			upgrade_query("
-				INSERT INTO {$db_prefix}settings
-				(variable, value)
-				VALUES " . implode(', ', $a_new_setting));
-		}
-
-		// What about members?
+		// Set any members or boards using this theme to the default
 		upgrade_query("
 			UPDATE {$db_prefix}members
-			SET id_theme = $id_core_theme
-			WHERE id_theme = 1");
+			SET id_theme = 0
+			WHERE id_theme = $id_theme");
 
-		// Boards?
 		upgrade_query("
 			UPDATE {$db_prefix}boards
-			SET id_theme = $id_core_theme
-			WHERE id_theme = 1");
+			SET id_theme = 0
+			WHERE id_theme = $id_theme");
 
-		// The other themes used to use core as their base theme.
-		if (isset($core['theme_dir']) && isset($core['theme_url']))
+		if ($modSettings['theme_guests'] == $id_theme)
 		{
-			$coreBasedThemes = array_diff($allThemes, array(1));
-
-			// Exclude the themes that already have a base_theme_dir.
-			$request = upgrade_query("
-				SELECT DISTINCT id_theme
-				FROM {$db_prefix}themes
-				WHERE variable = 'base_theme_dir'");
-			while ($row = $smcFunc['db_fetch_assoc']($request))
-				$coreBasedThemes = array_diff($coreBasedThemes, array($row['id_theme']));
-			$smcFunc['db_free_result']($request);
-
-			// Only base themes if there are templates that need a fall-back.
-			$insertRows = array();
-			$request = upgrade_query("
-				SELECT id_theme, value AS theme_dir
-				FROM {$db_prefix}themes
-				WHERE id_theme IN (" . implode(', ', $coreBasedThemes) . ")
-					AND id_member = 0
-					AND variable = 'theme_dir'");
-			while ($row = $smcFunc['db_fetch_assoc']($request))
-			{
-				if (!file_exists($row['theme_dir'] . '/BoardIndex.template.php') || !file_exists($row['theme_dir'] . '/Display.template.php') || !file_exists($row['theme_dir'] . '/index.template.php') || !file_exists($row['theme_dir'] . '/MessageIndex.template.php') || !file_exists($row['theme_dir'] . '/Settings.template.php'))
-				{
-					$insertRows[] = "(0, $row[id_theme], 'base_theme_dir', '" . addslashes($core['theme_dir']) . "')";
-					$insertRows[] = "(0, $row[id_theme], 'base_theme_url', '" . addslashes($core['theme_url']) . "')";
-				}
-			}
-			$smcFunc['db_free_result']($request);
-
-			if (!empty($insertRows))
-				upgrade_query("
-					INSERT INTO {$db_prefix}themes
-						(id_member, id_theme, variable, value)
-					VALUES
-						" . implode(',
-						', $insertRows). ' ON CONFLICT DO NOTHING');
+			upgrade_query("
+				REPLACE INTO {$db_prefix}settings
+				(variable, value)
+				VALUES('theme_guests', 0)");
 		}
 	}
-	$smcFunc['db_free_result']($theme_request);
-
-	// This ain't running twice either - not with the risk of log_tables timing us all out!
-	$smcFunc['db_insert']('replace',
-		'{db_prefix}settings',
-		array('variable' => 'string-255', 'value' => 'string-255'),
-		array('dont_repeat_theme_core', '1'),
-		array('variable')
-	);
 }
-
 ---}
 ---#
 

--- a/other/upgrade_2-1_mysql.sql
+++ b/other/upgrade_2-1_mysql.sql
@@ -212,7 +212,7 @@ INSERT INTO {$db_prefix}settings (variable, value) VALUES ('defaultMaxListItems'
 		'{db_prefix}settings',
 		array('variable' => 'string', 'value' => 'string'),
 		$inserts,
-		array('id_theme', 'id_member', 'variable')
+		array('variable')
 	);
 ---}
 ---#


### PR DESCRIPTION
Fixes #5741 
Fixes #5750 
Fixes #5751 
Fixes #5797 

This supersedes #5752 .  

I've tested the following variations of upgrades:
- yabbse 1.5.5 => 2.1
- 1.0.23 (vanilla) => 2.1
- 1.1.21 (vanilla) => 2.1
- 2.0.15 (vanilla) => 2.1
- 2.0.15 (test copy of my forum) => 2.1

In each of the following environments, including all updates thru 9/9/19:
- WAMP, PHP 7.2, MySQL 5.7
- Linux, PHP 5.4, MySQL 5.7

If others could test, that'd be welcome! Especially if you have a 1.0 or 1.1 environment with real data in it...

EDIT:  Notes on yabbse upgrades:
 - Tested with 1.5.5, I know 1.5.0 has  a completely different db structure & won't work
