### PR TITLE
Fix who page error printing

### DIFF
--- a/Sources/Who.php
+++ b/Sources/Who.php
@@ -441,6 +441,8 @@ function determineActions($urls, $preferred_prefix = false)
 
 		if (isset($actions['error']))
 		{
+			loadLanguage('Errors');
+
 			if (isset($txt[$actions['error']]))
 				$error_message = str_replace('"', '&quot;', empty($actions['who_error_params']) ? $txt[$actions['error']] : vsprintf($txt[$actions['error']], $actions['who_error_params']));
 			elseif ($actions['error'] == 'guest_login')


### PR DESCRIPTION
It seems like some if not all errors don't get printed in the online list because the error strings are absent at the time

Reference: https://www.simplemachines.org/community/index.php?topic=569094