### PR TITLE
Fix registration no access error

### DIFF
--- a/other/upgrade_2-1_mysql.sql
+++ b/other/upgrade_2-1_mysql.sql
@@ -1537,7 +1537,7 @@ $get_questions = upgrade_query("
 	WHERE comment_type = 'ver_test'");
 
 	while ($row = $smcFunc['db_fetch_assoc']($get_questions))
-		$questions[] = array($language, $row['question'], serialize(array($row['answer'])));
+		$questions[] = array($upcontext['language'], $row['question'], serialize(array($row['answer'])));
 
 	$smcFunc['db_free_result']($get_questions);
 

--- a/other/upgrade_2-1_postgresql.sql
+++ b/other/upgrade_2-1_postgresql.sql
@@ -1759,7 +1759,7 @@ CREATE INDEX {$db_prefix}qanda_lngfile ON {$db_prefix}qanda (lngfile varchar_pat
 		WHERE comment_type = 'ver_test'");
 
 	while ($row = $smcFunc['db_fetch_assoc']($get_questions))
-		$questions[] = array($language, $row['question'], serialize(array($row['answer'])));
+		$questions[] = array($upcontext['language'], $row['question'], serialize(array($row['answer'])));
 
 	$smcFunc['db_free_result']($get_questions);
 


### PR DESCRIPTION
Fixes #5582

So the issue was that, when a 2.0 installation has Anti-Spam questions and a "*Number of verification questions user must answer*" during the upgrade when those questions get moved to the **qanda** table the lngfile column ends up empty for all questions because **$language** is undefined at that point (not added to globals)

Which means that these questions don't show up on the registration page or in the admin panel page, so when the user registers without being able to answer, error no_access happens.