### PR TITLE
Sanitizes settings; improves check_cron()

### DIFF
--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -6980,25 +6980,25 @@ function url_to_iri($url)
  */
 function check_cron()
 {
-	global $user_info, $modSettings, $smcFunc, $txt;
+	global $modSettings, $smcFunc, $txt;
 
-	if (empty($modSettings['cron_last_checked']))
-		$modSettings['cron_last_checked'] = 0;
-
-	if (!empty($modSettings['cron_is_real_cron']) && time() - $modSettings['cron_last_checked'] > 84600)
+	if (!empty($modSettings['cron_is_real_cron']) && time() - @intval($modSettings['cron_last_checked']) > 84600)
 	{
 		$request = $smcFunc['db_query']('', '
-			SELECT time_run
-			FROM {db_prefix}log_scheduled_tasks
-			ORDER BY id_log DESC
-			LIMIT 1',
-			array()
+			SELECT COUNT(*)
+			FROM {db_prefix}scheduled_tasks
+			WHERE disabled = {int:not_disabled}
+				AND next_time < {int:yesterday}',
+			array(
+				'not_disabled' => 0,
+				'yesterday' => time() - 84600,
+			)
 		);
-		list($time_run) = $smcFunc['db_fetch_row']($request);
+		list($overdue) = $smcFunc['db_fetch_row']($request);
 		$smcFunc['db_free_result']($request);
 
-		// If it's been more than 24 hours since the last task ran, cron must not be working
-		if (!empty($time_run) && time() - $time_run > 84600)
+		// If we have tasks more than a day overdue, cron isn't doing its job.
+		if (!empty($overdue))
 		{
 			loadLanguage('ManageScheduledTasks');
 			log_error($txt['cron_not_working']);

--- a/index.php
+++ b/index.php
@@ -40,6 +40,11 @@ foreach (array('db_character_set', 'cachedir') as $variable)
 // Load the settings...
 require_once(dirname(__FILE__) . '/Settings.php');
 
+// Ensure there are no trailing slashes in these variables.
+foreach (array('boardurl', 'boarddir', 'sourcedir', 'packagesdir', 'taskddir', 'cachedir') as $variable)
+	if (!empty($GLOBALS[$variable]))
+		$GLOBALS[$variable] = rtrim($GLOBALS[$variable], "\\/");
+
 // Make absolutely sure the cache directory is defined.
 if ((empty($cachedir) || !file_exists($cachedir)) && file_exists($boarddir . '/cache'))
 	$cachedir = $boarddir . '/cache';

--- a/index.php
+++ b/index.php
@@ -85,7 +85,6 @@ if (isset($_GET['scheduled']))
 
 // And important includes.
 require_once($sourcedir . '/Session.php');
-require_once($sourcedir . '/Errors.php');
 require_once($sourcedir . '/Logging.php');
 require_once($sourcedir . '/Security.php');
 require_once($sourcedir . '/Class-BrowserDetect.php');


### PR DESCRIPTION
- Trims trailing slashes from directory and URL variables early in index.php process, just in case the admin adds them in Settings.php by mistake.
- Removes a redundant `require_once($sourcedir . '/Errors.php')` in index.php.
- Prevents check_cron() from getting confused if the task log is emptied.