### PR TITLE
[WIP] Addressing hooks information

### DIFF
--- a/Sources/Likes.php
+++ b/Sources/Likes.php
@@ -413,7 +413,7 @@ class Likes
 		}
 
 		// Sometimes there might be other things that need updating after we do this like.
-		call_integration_hook('integrate_issue_like', array($this));
+		call_integration_hook('integrate_issue_like', array($this->_type, $this->_content, $this->_user['id'], $this->_alreadyLiked, $this->_validLikes));
 
 		// Now some clean up. This is provided here for any like handlers that want to do any cache flushing.
 		// This way a like handler doesn't need to explicitly declare anything in integrate_issue_like, but do so

--- a/Sources/Likes.php
+++ b/Sources/Likes.php
@@ -413,7 +413,7 @@ class Likes
 		}
 
 		// Sometimes there might be other things that need updating after we do this like.
-		call_integration_hook('integrate_issue_like', array($this->_type, $this->_content, $this->_user['id'], $this->_alreadyLiked, $this->_validLikes));
+		call_integration_hook('integrate_issue_like', array($this));
 
 		// Now some clean up. This is provided here for any like handlers that want to do any cache flushing.
 		// This way a like handler doesn't need to explicitly declare anything in integrate_issue_like, but do so

--- a/Sources/MessageIndex.php
+++ b/Sources/MessageIndex.php
@@ -313,8 +313,9 @@ function MessageIndex()
 	$message_index_selects = array();
 	$message_index_tables = array();
 	$message_index_wheres = array();
+	$message_index_topic_wheres = array();
 
-	call_integration_hook('integrate_message_index', array(&$message_index_selects, &$message_index_tables, &$message_index_parameters, &$message_index_wheres, &$topic_ids));
+	call_integration_hook('integrate_message_index', array(&$message_index_selects, &$message_index_tables, &$message_index_parameters, &$message_index_wheres, &$topic_ids, &$message_index_topic_wheres));
 
 	if (!empty($modSettings['enableParticipation']) && !$user_info['is_guest'])
 		$enableParticipation = true;
@@ -328,7 +329,8 @@ function MessageIndex()
 		' . (!empty($message_index_tables) ? implode("\n\t\t\t\t", $message_index_tables) : '') . '
 		WHERE t.id_board = {int:current_board} '
 			. (!$modSettings['postmod_active'] || $context['can_approve_posts'] ? '' : '
-			AND (t.approved = {int:is_approved}' . ($user_info['is_guest'] ? '' : ' OR t.id_member_started = {int:current_member}') . ')') . '
+			AND (t.approved = {int:is_approved}' . ($user_info['is_guest'] ? '' : ' OR t.id_member_started = {int:current_member}') . ')') . (!empty($message_index_topic_wheres) ? ' 
+			AND ' . implode("\n\t\t\t\tAND ", $message_index_topic_wheres) : ''). '
 		ORDER BY is_sticky' . ($fake_ascending ? '' : ' DESC') . ', ' . $_REQUEST['sort'] . ($ascending ? '' : ' DESC') . '
 		LIMIT {int:maxindex}
 			OFFSET {int:start} ';

--- a/Sources/Post.php
+++ b/Sources/Post.php
@@ -1566,7 +1566,7 @@ function Post2()
 	require_once($sourcedir . '/Subs-Post.php');
 	loadLanguage('Post');
 
-	call_integration_hook('integrate_post2_start');
+	call_integration_hook('integrate_post2_start', array(&$post_errors));
 
 	// Drafts enabled and needed?
 	if (!empty($modSettings['drafts_post_enabled']) && (isset($_POST['save_draft']) || isset($_POST['id_draft'])))

--- a/Sources/RemoveTopic.php
+++ b/Sources/RemoveTopic.php
@@ -984,10 +984,10 @@ function removeMessage($message, $decreasePostCount = true)
 			'id_msg' => $message,
 		);
 		removeAttachments($attachmentQuery);
-
-		// Allow mods to remove message related data of their own (likes, maybe?)
-		call_integration_hook('integrate_remove_message', array($message));
 	}
+
+	// Allow mods to remove message related data of their own (likes, maybe?)
+	call_integration_hook('integrate_remove_message', array($message, $row, $recycle));
 
 	// Update the pesky statistics.
 	updateStats('message');

--- a/Sources/RemoveTopic.php
+++ b/Sources/RemoveTopic.php
@@ -255,6 +255,9 @@ function removeTopics($topics, $decreasePostCount = true, $ignoreRecycling = fal
 
 	$recycle_board = !empty($modSettings['recycle_enable']) && !empty($modSettings['recycle_board']) ? (int) $modSettings['recycle_board'] : 0;
 
+	// Do something before?
+	call_integration_hook('integrate_remove_topics_before', array($topics, $recycle_board));
+
 	// Decrease the post counts.
 	if ($decreasePostCount)
 	{


### PR DESCRIPTION
Fixes some issues for #5780 

But needs more discussing still maybe.
And I have no clue how to approach loadBoard but doesn't seem like a big issue imo because usually $board_info is already available so we can get additional board info from different hooks.

For _integrate_remove_message_ I moved the hook outside of if statement because otherwise it's only invoked when there's no recycle bin. Also added _$row_ so we can get more info about this message in case it's gone forever. _$recycle_ suggested by Sycho as well.

For _integrate_remove_topics_ I would suggest adding a hook _before_ topics are deleted?