### PR TITLE
Fixes for paid subscriptions

### DIFF
--- a/Sources/Profile-Actions.php
+++ b/Sources/Profile-Actions.php
@@ -894,7 +894,7 @@ function subscriptions($memID)
 		$context['gateways'] = array();
 		foreach ($gateways as $id => $gateway)
 		{
-			$fields = $gateways[$id]->fetchGatewayFields($context['sub']['id'] . '+' . $memID, $context['sub'], $context['value'], $period, $scripturl . '?action=profile;u=' . $memID . ';area=subscriptions;sub_id=' . $context['sub']['id'] . ';done');
+			$fields = $gateways[$id]->fetchGatewayFields($context['sub']['id'] . '+' . $memID, $context['sub'], $context['value'], $period, $scripturl . '?action=profile&u=' . $memID . '&area=subscriptions&sub_id=' . $context['sub']['id'] . '&done');
 			if (!empty($fields['form']))
 				$context['gateways'][] = $fields;
 		}

--- a/Sources/Subscriptions-PayPal.php
+++ b/Sources/Subscriptions-PayPal.php
@@ -170,7 +170,7 @@ class paypal_payment
 			$_POST['business'] = $_POST['receiver_email'];
 
 		// Are we testing?
-		if (empty($modSettings['paidsubs_test']) && strtolower($modSettings['paypal_sandbox_email']) != strtolower($_POST['business']) && (empty($modSettings['paypal_additional_emails']) || !in_array(strtolower($_POST['business']), explode(',', strtolower($modSettings['paypal_additional_emails'])))))
+		if (!empty($modSettings['paidsubs_test']) && strtolower($modSettings['paypal_sandbox_email']) != strtolower($_POST['business']) && (empty($modSettings['paypal_additional_emails']) || !in_array(strtolower($_POST['business']), explode(',', strtolower($modSettings['paypal_additional_emails'])))))
 			return false;
 		elseif (strtolower($modSettings['paypal_email']) != strtolower($_POST['business']) && (empty($modSettings['paypal_additional_emails']) || !in_array(strtolower($_POST['business']), explode(',', $modSettings['paypal_additional_emails']))))
 			return false;

--- a/subscriptions.php
+++ b/subscriptions.php
@@ -285,18 +285,22 @@ else
 // In case we have anything specific to do.
 $gatewayClass->close();
 
+// Hidden setting to log the IPN info for debugging purposes.
+if (!empty($modSettings['paid_debug']))
+	generateSubscriptionError($txt['subscription'], true);
+
 /**
  * Log an error then exit
  *
  * @param string $text The error to log
  * @return void
  */
-function generateSubscriptionError($text)
+function generateSubscriptionError($text, $debug = false)
 {
 	global $modSettings, $notify_users, $smcFunc;
 
 	// Send an email?
-	if (!empty($modSettings['paid_email']))
+	if (!empty($modSettings['paid_email']) && !$debug)
 	{
 		$replacements = array(
 			'ERROR' => $text,

--- a/subscriptions.php
+++ b/subscriptions.php
@@ -14,6 +14,9 @@
  * @version 2.1 RC2
  */
 
+// Set this to true to always log $_POST info received from payment gateways.
+$paid_debug = false;
+
 // Start things rolling by getting SMF alive...
 $ssi_guest_access = true;
 if (!file_exists(dirname(__FILE__) . '/SSI.php'))
@@ -286,7 +289,7 @@ else
 $gatewayClass->close();
 
 // Hidden setting to log the IPN info for debugging purposes.
-if (!empty($modSettings['paid_debug']))
+if ($paid_debug === true)
 	generateSubscriptionError($txt['subscription'], true);
 
 /**


### PR DESCRIPTION
- Uses ampersands instead of semicolons for PayPal's return link. (This is a fix that was never ported from 2.0 to 2.1.)
- Fixes some broken logic in paypal_payment->isValid(). Specifically, a missing `!` caused us to check the sandbox info when we were not in sandbox mode, and vice versa.
- Adds a hidden debug setting to always log $_POST info received from payment gateways. Normally we only log that if there was an error, but when debugging it can be helpful to log it even on success.