### PR TITLE
Board category parse desc

### DIFF
--- a/Sources/Load.php
+++ b/Sources/Load.php
@@ -3641,8 +3641,6 @@ function cache_quick_get($key, $file, $function, $params, $level = 1)
 {
 	global $modSettings, $sourcedir, $cache_enable;
 
-	// @todo Why are we doing this if caching is disabled?
-
 	if (function_exists('call_integration_hook'))
 		call_integration_hook('pre_cache_quick_get', array(&$key, &$file, &$function, &$params, &$level));
 
@@ -3720,7 +3718,7 @@ function cache_put_data($key, $value, $ttl = 120)
  *
  * @param string $key The key for the value to retrieve
  * @param int $ttl The maximum age of the cached data
- * @return string|null The cached data or null if nothing was loaded
+ * @return array|null The cached data or null if nothing was loaded
  */
 function cache_get_data($key, $ttl = 120)
 {
@@ -3728,7 +3726,7 @@ function cache_get_data($key, $ttl = 120)
 	global $cache_hits, $cache_count, $cache_misses, $cache_count_misses, $db_show_debug;
 
 	if (empty($cache_enable) || empty($cacheAPI))
-		return;
+		return null;
 
 	$cache_count = isset($cache_count) ? $cache_count + 1 : 1;
 	if (isset($db_show_debug) && $db_show_debug === true)

--- a/Sources/ManageBoards.php
+++ b/Sources/ManageBoards.php
@@ -318,6 +318,7 @@ function EditCategory2()
 	validateToken('admin-bc-' . $_REQUEST['cat']);
 
 	require_once($sourcedir . '/Subs-Categories.php');
+	require_once($sourcedir . '/Subs-BoardIndex.php');
 	require_once($sourcedir . '/Subs-Editor.php');
 
 	$_POST['cat'] = (int) $_POST['cat'];

--- a/Sources/ManageBoards.php
+++ b/Sources/ManageBoards.php
@@ -341,12 +341,14 @@ function EditCategory2()
 		else
 			modifyCategory($_POST['cat'], $catOptions);
 	}
+
 	// If they want to delete - first give them confirmation.
 	elseif (isset($_POST['delete']) && !isset($_POST['confirmation']) && !isset($_POST['empty']))
 	{
 		EditCategory();
 		return;
 	}
+
 	// Delete the category!
 	elseif (isset($_POST['delete']))
 	{
@@ -358,6 +360,7 @@ function EditCategory2()
 
 			deleteCategories(array($_POST['cat']), (int) $_POST['cat_to']);
 		}
+
 		else
 			deleteCategories(array($_POST['cat']));
 	}

--- a/Sources/ManageBoards.php
+++ b/Sources/ManageBoards.php
@@ -671,9 +671,25 @@ function EditBoard2()
 		if (strlen(implode(',', $boardOptions['access_groups'])) > 255 || strlen(implode(',', $boardOptions['deny_groups'])) > 255)
 			fatal_lang_error('too_many_groups', false);
 
-		// Try and get any valid HTML to BBC first, add a naive attempt to strip it off, htmlspecialchars for the rest, parse it on display
-		$boardOptions['board_name'] = $smcFunc['htmlspecialchars'](strip_tags(html_to_bbc($_POST['board_name'])));
-		$boardOptions['board_description'] = $smcFunc['htmlspecialchars'](strip_tags(html_to_bbc($_POST['desc'])));
+		// Parse and cache the new content
+		$parsed_descriptions = setParsedDescriptions(array(
+			$boardOptions['target_category'] => array(
+				'boards' => array(
+					$_POST['boardid'] => array(
+						'name' => $_POST['board_name'],
+						'description' => $_POST['desc'],
+					)
+				)
+			),
+		));
+
+		foreach ($parsed_descriptions as $id_cat => $category)
+			foreach ($category['boards'] as $id_board => $board)
+				if ($_POST['boardid'] == $id_board)
+				{
+					$boardOptions['board_name'] = $board['name'];
+					$boardOptions['board_description'] = $board['description'];
+				}
 
 		$boardOptions['moderator_string'] = $_POST['moderators'];
 

--- a/Sources/ManageBoards.php
+++ b/Sources/ManageBoards.php
@@ -330,8 +330,8 @@ function EditCategory2()
 		if (isset($_POST['cat_order']))
 			$catOptions['move_after'] = (int) $_POST['cat_order'];
 
-		// Try and get any valid HTML to BBC first, add a naive attempt to strip it off, htmlspecialchars for the rest, parse it on display
-		$catOptions['cat_name'] = $smcFunc['htmlspecialchars'](strip_tags(html_to_bbc($_POST['cat_name'])));
+		// Try and get any valid HTML to BBC first, add a naive attempt to strip it off, htmlspecialchars for the rest
+		$catOptions['cat_name'] = $smcFunc['htmlspecialchars'](strip_tags($_POST['cat_name']));
 		$catOptions['cat_desc'] = $smcFunc['htmlspecialchars'](strip_tags(html_to_bbc($_POST['cat_desc'])));
 		$catOptions['is_collapsible'] = isset($_POST['collapse']);
 
@@ -669,7 +669,7 @@ function EditBoard2()
 			fatal_lang_error('too_many_groups', false);
 
 		// Try and get any valid HTML to BBC first, add a naive attempt to strip it off, htmlspecialchars for the rest
-		$boardOptions['board_name'] = $smcFunc['htmlspecialchars'](strip_tags(html_to_bbc($_POST['board_name'])));
+		$boardOptions['board_name'] = $smcFunc['htmlspecialchars'](strip_tags($_POST['board_name']));
 		$boardOptions['board_description'] = $smcFunc['htmlspecialchars'](strip_tags(html_to_bbc($_POST['desc'])));
 
 		$boardOptions['moderator_string'] = $_POST['moderators'];

--- a/Sources/ManageBoards.php
+++ b/Sources/ManageBoards.php
@@ -668,7 +668,7 @@ function EditBoard2()
 		if (strlen(implode(',', $boardOptions['access_groups'])) > 255 || strlen(implode(',', $boardOptions['deny_groups'])) > 255)
 			fatal_lang_error('too_many_groups', false);
 
-		// Try and get any valid HTML to BBC first, add a naive attempt to strip it off, htmlspecialchars for the rest, parse it on display
+		// Try and get any valid HTML to BBC first, add a naive attempt to strip it off, htmlspecialchars for the rest
 		$boardOptions['board_name'] = $smcFunc['htmlspecialchars'](strip_tags(html_to_bbc($_POST['board_name'])));
 		$boardOptions['board_description'] = $smcFunc['htmlspecialchars'](strip_tags(html_to_bbc($_POST['desc'])));
 

--- a/Sources/ManageBoards.php
+++ b/Sources/ManageBoards.php
@@ -679,6 +679,7 @@ function EditBoard2()
 			$moderators = array();
 			foreach ($_POST['moderator_list'] as $moderator)
 				$moderators[(int) $moderator] = (int) $moderator;
+
 			$boardOptions['moderators'] = $moderators;
 		}
 
@@ -703,25 +704,29 @@ function EditBoard2()
 		if (!empty($_POST['boardid']))
 		{
 			$request = $smcFunc['db_query']('', '
-				SELECT redirect, num_posts
+				SELECT redirect, num_posts, id_cat
 				FROM {db_prefix}boards
 				WHERE id_board = {int:current_board}',
 				array(
 					'current_board' => $_POST['boardid'],
 				)
 			);
-			list ($oldRedirect, $numPosts) = $smcFunc['db_fetch_row']($request);
+			list ($oldRedirect, $numPosts, $old_id_cat) = $smcFunc['db_fetch_row']($request);
 			$smcFunc['db_free_result']($request);
 
 			// If we're turning redirection on check the board doesn't have posts in it - if it does don't make it a redirection board.
 			if ($boardOptions['redirect'] && empty($oldRedirect) && $numPosts)
 				unset($boardOptions['redirect']);
+
 			// Reset the redirection count when switching on/off.
 			elseif (empty($boardOptions['redirect']) != empty($oldRedirect))
 				$boardOptions['num_posts'] = 0;
+
 			// Resetting the count?
 			elseif ($boardOptions['redirect'] && !empty($_POST['reset_redirect']))
 				$boardOptions['num_posts'] = 0;
+
+			$boardOptions['old_id_cat'] = $old_id_cat;
 		}
 
 		// Create a new board...

--- a/Sources/ManageBoards.php
+++ b/Sources/ManageBoards.php
@@ -333,6 +333,22 @@ function EditCategory2()
 		// Try and get any valid HTML to BBC first, add a naive attempt to strip it off, htmlspecialchars for the rest, parse it on display
 		$catOptions['cat_name'] = $smcFunc['htmlspecialchars'](strip_tags(html_to_bbc($_POST['cat_name'])));
 		$catOptions['cat_desc'] = $smcFunc['htmlspecialchars'](strip_tags(html_to_bbc($_POST['cat_desc'])));
+
+		// Parse and cache the new category content
+		$parsed_descriptions = setParsedDescriptions(array(
+			$_POST['cat'] => array(
+				'name' => $_POST['cat_name'],
+				'description' => $_POST['cat_desc'],
+			),
+		));
+
+		foreach ($parsed_descriptions as $id_cat => $category)
+			if ($_POST['cat'] == $id_cat)
+			{
+				$catOptions['cat_name'] = $category['name'];
+				$catOptions['cat_desc'] = $category['description'];
+			}
+
 		$catOptions['is_collapsible'] = isset($_POST['collapse']);
 
 		if (isset($_POST['add']))

--- a/Sources/ManageBoards.php
+++ b/Sources/ManageBoards.php
@@ -318,7 +318,6 @@ function EditCategory2()
 	validateToken('admin-bc-' . $_REQUEST['cat']);
 
 	require_once($sourcedir . '/Subs-Categories.php');
-	require_once($sourcedir . '/Subs-BoardIndex.php');
 	require_once($sourcedir . '/Subs-Editor.php');
 
 	$_POST['cat'] = (int) $_POST['cat'];
@@ -334,22 +333,6 @@ function EditCategory2()
 		// Try and get any valid HTML to BBC first, add a naive attempt to strip it off, htmlspecialchars for the rest, parse it on display
 		$catOptions['cat_name'] = $smcFunc['htmlspecialchars'](strip_tags(html_to_bbc($_POST['cat_name'])));
 		$catOptions['cat_desc'] = $smcFunc['htmlspecialchars'](strip_tags(html_to_bbc($_POST['cat_desc'])));
-
-		// Parse and cache the new category content
-		$parsed_descriptions = setParsedDescriptions(array(
-			$_POST['cat'] => array(
-				'name' => $_POST['cat_name'],
-				'description' => $_POST['cat_desc'],
-			),
-		));
-
-		foreach ($parsed_descriptions as $id_cat => $category)
-			if ($_POST['cat'] == $id_cat)
-			{
-				$catOptions['cat_name'] = $category['name'];
-				$catOptions['cat_desc'] = $category['description'];
-			}
-
 		$catOptions['is_collapsible'] = isset($_POST['collapse']);
 
 		if (isset($_POST['add']))
@@ -358,14 +341,12 @@ function EditCategory2()
 		else
 			modifyCategory($_POST['cat'], $catOptions);
 	}
-
 	// If they want to delete - first give them confirmation.
 	elseif (isset($_POST['delete']) && !isset($_POST['confirmation']) && !isset($_POST['empty']))
 	{
 		EditCategory();
 		return;
 	}
-
 	// Delete the category!
 	elseif (isset($_POST['delete']))
 	{
@@ -377,7 +358,6 @@ function EditCategory2()
 
 			deleteCategories(array($_POST['cat']), (int) $_POST['cat_to']);
 		}
-
 		else
 			deleteCategories(array($_POST['cat']));
 	}
@@ -688,25 +668,9 @@ function EditBoard2()
 		if (strlen(implode(',', $boardOptions['access_groups'])) > 255 || strlen(implode(',', $boardOptions['deny_groups'])) > 255)
 			fatal_lang_error('too_many_groups', false);
 
-		// Parse and cache the new content
-		$parsed_descriptions = setParsedDescriptions(array(
-			$boardOptions['target_category'] => array(
-				'boards' => array(
-					$_POST['boardid'] => array(
-						'name' => $_POST['board_name'],
-						'description' => $_POST['desc'],
-					)
-				)
-			),
-		));
-
-		foreach ($parsed_descriptions as $id_cat => $category)
-			foreach ($category['boards'] as $id_board => $board)
-				if ($_POST['boardid'] == $id_board)
-				{
-					$boardOptions['board_name'] = $board['name'];
-					$boardOptions['board_description'] = $board['description'];
-				}
+		// Try and get any valid HTML to BBC first, add a naive attempt to strip it off, htmlspecialchars for the rest, parse it on display
+		$boardOptions['board_name'] = $smcFunc['htmlspecialchars'](strip_tags(html_to_bbc($_POST['board_name'])));
+		$boardOptions['board_description'] = $smcFunc['htmlspecialchars'](strip_tags(html_to_bbc($_POST['desc'])));
 
 		$boardOptions['moderator_string'] = $_POST['moderators'];
 

--- a/Sources/MessageIndex.php
+++ b/Sources/MessageIndex.php
@@ -60,14 +60,11 @@ function MessageIndex()
 
 	if (!isset($boards_parsed_data[$board_info['id']]))
 		$boards_parsed_data = setBoardParsedDescription($board_info['cat']['id'], array(
-			$board_info['id'] => array(
-				'name' => $board_info['name'],
-				'description' => $board_info['description'],
-			)
+			$board_info['id'] => $board_info['description']
 		));
 
-	$context['name'] = $boards_parsed_data[$board_info['id']]['name'];
-	$context['description'] = $boards_parsed_data[$board_info['id']]['description'];
+	$context['name'] = $board_info['name'];
+	$context['description'] = $boards_parsed_data[$board_info['id']];
 
 	if (!empty($board_info['description']))
 		$context['meta_description'] = strip_tags($board_info['description']);

--- a/Sources/MessageIndex.php
+++ b/Sources/MessageIndex.php
@@ -25,6 +25,8 @@ function MessageIndex()
 	global $txt, $scripturl, $board, $modSettings, $context;
 	global $options, $settings, $board_info, $user_info, $smcFunc, $sourcedir;
 
+	require_once($sourcedir . '/Subs-Boards.php');
+
 	// If this is a redirection board head off.
 	if ($board_info['redirect'])
 	{
@@ -54,8 +56,19 @@ function MessageIndex()
 		}
 	}
 
-	$context['name'] = $board_info['name'];
-	$context['description'] = $board_info['description'];
+	$boards_parsed_data = getBoardsParsedDescription($board_info['cat']['id']);
+
+	if (!isset($boards_parsed_data[$board_info['id']]))
+		$boards_parsed_data = setBoardParsedDescription($board_info['cat']['id'], array(
+			$board_info['id'] => array(
+				'name' => $board_info['name'],
+				'description' => $board_info['description'],
+			)
+		));
+
+	$context['name'] = $boards_parsed_data[$board_info['id']]['name'];
+	$context['description'] = $boards_parsed_data[$board_info['id']]['description'];
+
 	if (!empty($board_info['description']))
 		$context['meta_description'] = strip_tags($board_info['description']);
 

--- a/Sources/Subs-BoardIndex.php
+++ b/Sources/Subs-BoardIndex.php
@@ -570,6 +570,9 @@ function getBoardIndex($board_index_options)
 		call_integration_hook('integrate_getboardtree', array($board_index_options, &$this_category));
 	}
 
+	// I took my time, I hurried up, the choice was mine I didn't think enough
+	setparsedDescriptions($to_parse);
+
 	return $board_index_options['include_categories'] ? $categories : $this_category;
 }
 

--- a/Sources/Subs-BoardIndex.php
+++ b/Sources/Subs-BoardIndex.php
@@ -640,11 +640,12 @@ function setParsedDescriptions($dataToParse = array())
 					'boards' => array(),
 				);
 
-				foreach ($category['boards'] as $board)
-					$already_parsed_data[$cat_id]['boards'] = array(
-						'name' => $board['name'],
-						'description' => $board['description'],
-					);
+				if (!empty($category['boards']))
+					foreach ($category['boards'] as $board)
+						$already_parsed_data[$cat_id]['boards'] = array(
+							'name' => $board['name'],
+							'description' => $board['description'],
+						);
 
 				cache_put_data('parsed_cat_description_'. $cat_id, $already_parsed_data[$cat_id], 864000);
 			}

--- a/Sources/Subs-BoardIndex.php
+++ b/Sources/Subs-BoardIndex.php
@@ -133,6 +133,7 @@ function getBoardIndex($board_index_options)
 	// Start with an empty array.
 	if ($board_index_options['include_categories'])
 		$categories = array();
+
 	else
 		$this_category = array();
 

--- a/Sources/Subs-BoardIndex.php
+++ b/Sources/Subs-BoardIndex.php
@@ -110,7 +110,7 @@ function getBoardIndex($board_index_options)
 	else
 		$result_boards = $smcFunc['db_query']('', '
 			SELECT' . ($board_index_options['include_categories'] ? '
-				b.id_cat, c.name AS cat_name, c.description AS cat_desc,' : 'b.id_cat,') . '
+				c.id_cat, c.name AS cat_name, c.description AS cat_desc,' : 'b.id_cat,') . '
 				' . (!empty($board_index_selects) ? implode(', ', $board_index_selects) : '') . ',
 				COALESCE(m.poster_time, 0) AS poster_time, COALESCE(mem.member_name, m.poster_name) AS poster_name,
 				m.subject, m.id_topic, COALESCE(mem.real_name, m.poster_name) AS real_name,

--- a/Sources/Subs-BoardIndex.php
+++ b/Sources/Subs-BoardIndex.php
@@ -607,18 +607,20 @@ function setParsedDescriptions($dataToParse = array())
 	$already_parsed_data = array();
 
 	// If you're here it means your data isn't cached... or so the theory dictates...
-	foreach ($dataToParse as $cat_id => $data)
+	foreach ($dataToParse as $cat_id => $category)
 	{
-		$to_cache[$cat_id] = array(
-			'name' => parse_bbc($data['name'], false, '', $context['description_allowed_tags']),
-			'description' => parse_bbc($data['description'], false, '', $context['description_allowed_tags']),
-			'boards' => array(),
-		);
+		// Sometimes we just want to update boards
+		if (!empty($category['name']))
+			$to_cache[$cat_id] = array(
+				'name' => parse_bbc($category['name'], false, '', $context['description_allowed_tags']),
+				'description' => parse_bbc($category['description'], false, '', $context['description_allowed_tags']),
+				'boards' => array(),
+			);
 
-		foreach ($data['boards'] as $id => $board)
+		foreach ($category['boards'] as $board_id => $board)
 		{
-			$to_cache[$cat_id]['boards'][$id]['name'] = parse_bbc($board['name'], false, '', $context['description_allowed_tags']);
-			$to_cache[$cat_id]['boards'][$id]['description'] = parse_bbc($board['description'], false, '', $context['description_allowed_tags']);
+			$to_cache[$cat_id]['boards'][$board_id]['name'] = parse_bbc($board['name'], false, '', $context['description_allowed_tags']);
+			$to_cache[$cat_id]['boards'][$board_id]['description'] = parse_bbc($board['description'], false, '', $context['description_allowed_tags']);
 		}
 
 		// Let's have some fun shall we?
@@ -628,12 +630,12 @@ function setParsedDescriptions($dataToParse = array())
 		{
 			// Append data!
 			$already_parsed_data[$cat_id] = array(
-				'name' => $data['name'],
-				'description' => $data['description'],
+				'name' => $category['name'],
+				'description' => $category['description'],
 				'boards' => array(),
 			);
 
-			foreach ($data['boards'] as $board)
+			foreach ($category['boards'] as $board)
 				$already_parsed_data[$cat_id]['boards'] = array(
 					'name' => $board['name'],
 					'description' => $board['description'],

--- a/Sources/Subs-BoardIndex.php
+++ b/Sources/Subs-BoardIndex.php
@@ -57,7 +57,8 @@ function getBoardIndex($board_index_options)
 		'b.num_topics',
 		'b.unapproved_posts',
 		'b.unapproved_topics',
-		'b.id_parent'
+		'b.id_parent',
+		'b.id_cat'
 	);
 
 	$board_index_parameters = array(
@@ -110,7 +111,7 @@ function getBoardIndex($board_index_options)
 	else
 		$result_boards = $smcFunc['db_query']('', '
 			SELECT' . ($board_index_options['include_categories'] ? '
-				c.id_cat, c.name AS cat_name, c.description AS cat_desc,' : 'b.id_cat,') . '
+				c.id_cat, c.name AS cat_name, c.description AS cat_desc,' : '') . '
 				' . (!empty($board_index_selects) ? implode(', ', $board_index_selects) : '') . ',
 				COALESCE(m.poster_time, 0) AS poster_time, COALESCE(mem.member_name, m.poster_name) AS poster_name,
 				m.subject, m.id_topic, COALESCE(mem.real_name, m.poster_name) AS real_name,
@@ -162,10 +163,6 @@ function getBoardIndex($board_index_options)
 	}
 
 	$smcFunc['db_free_result']($result_boards);
-
-	// mmmm memory, delicious!
-	$parsed_descriptions = getParsedDescriptions($categories_ids);
-	$to_parse = array();
 
 	// Run through the categories and boards (or only boards)....
 	// Done like this so the modified values can be used.

--- a/Sources/Subs-BoardIndex.php
+++ b/Sources/Subs-BoardIndex.php
@@ -496,6 +496,12 @@ function getBoardIndex($board_index_options)
 		{
 			foreach ($category['boards'] as &$board)
 			{
+				if (isset($boards_parsed_data[$category['id']][$board['id']]))
+				{
+					$board['name'] = $boards_parsed_data[$category['id']][$board['id']]['name'];
+					$board['description'] = $boards_parsed_data[$category['id']][$board['id']]['description'];
+				}
+
 				if (!empty($moderators[$board['id']]))
 				{
 					$board['moderators'] = $moderators[$board['id']];

--- a/Sources/Subs-BoardIndex.php
+++ b/Sources/Subs-BoardIndex.php
@@ -175,27 +175,8 @@ function getBoardIndex($board_index_options)
 			// Haven't set this category yet.
 			if (empty($categories[$row_board['id_cat']]))
 			{
-				// Is this your lucky day?
-				if (!empty($parsed_descriptions) && !empty($parsed_descriptions[$row_board['id_cat']]))
-				{
-					$name = $parsed_descriptions[$row_board['id_cat']]['name'];
-					$description = $parsed_descriptions[$row_board['id_cat']]['description'];
-				}
-
-				// No? take one for the team then
-				else
-				{
-					$to_parse[$row_board['id_cat']] = array(
-						'name' => $row_board['cat_name'],
-						'description' => $row_board['cat_desc'],
-					);
-
-					if (!isset($to_parse[$row_board['id_cat']]['boards']))
-						$to_parse[$row_board['id_cat']]['boards'] = array();
-
-					$name = $row_board['cat_name'];
-					$description = $row_board['cat_desc'];
-				}
+				$name = parse_bbc($row_board['cat_name'], false, '', $context['description_allowed_tags']);
+				$description = parse_bbc($row_board['cat_desc'], false, '', $context['description_allowed_tags']);
 
 				$categories[$row_board['id_cat']] = array(
 					'id' => $row_board['id_cat'],
@@ -236,30 +217,8 @@ function getBoardIndex($board_index_options)
 				if (!isset($this_category[$row_board['id_board']]))
 					$this_category[$row_board['id_board']] = array();
 
-				$parsed_board_vars = $parsed_descriptions[$row_board['id_cat']]['boards'][$row_board['id_board']];
-
-				// Quid pro quo Clarice...
-				if (!empty($parsed_descriptions) && !empty($parsed_board_vars))
-				{
-					$board_name = $parsed_board_vars['name'];
-					$board_description = $parsed_board_vars['description'];
-				}
-
-				// Yes or no, Clarice? Poor little Catherine is waiting.
-				else
-				{
-					$board_name = $row_board['board_name'];
-					$board_description = $row_board['description'];
-
-					// Always buckle up your kids!
-					if (!isset($to_parse[$row_board['id_cat']]['boards']))
-						$to_parse[$row_board['id_cat']]['boards'] = array();
-
-					$to_parse[$row_board['id_cat']]['boards'][$row_board['id_board']] = array(
-						'name' => $board_name,
-						'description' => $board_description
-					);
-				}
+				$board_name = parse_bbc($row_board['board_name'], false, '', $context['description_allowed_tags']);
+				$board_description = parse_bbc($row_board['description'], false, '', $context['description_allowed_tags']);
 
 				$this_category[$row_board['id_board']] += array(
 					'new' => empty($row_board['is_read']),
@@ -322,27 +281,8 @@ function getBoardIndex($board_index_options)
 					'board_class' => 'off'
 				);
 
-			// Is this your lucky day?
-			if (!empty($parsed_descriptions) && !empty($parsed_descriptions[$row_board['id_cat']]))
-			{
-				$board_name = $parsed_descriptions[$row_board['id_cat']]['name'];
-				$board_description = $parsed_descriptions[$row_board['id_cat']]['description'];
-			}
-
-			// No? take one for the team then
-			else
-			{
-				$to_parse[$row_board['id_cat']] = array(
-					'name' => $row_board['cat_name'],
-					'description' => $row_board['cat_desc'],
-				);
-
-				if (!isset($to_parse[$row_board['id_cat']]['boards']))
-					$to_parse[$row_board['id_cat']]['boards'] = array();
-
-				$board_name = $row_board['cat_name'];
-				$board_description = $row_board['cat_desc'];
-			}
+			$board_name = parse_bbc($row_board['board_name'], false, '', $context['description_allowed_tags']);
+			$board_description = parse_bbc($row_board['description'], false, '', $context['description_allowed_tags']);
 
 			$this_category[$row_board['id_parent']]['children'][$row_board['id_board']] = array(
 				'id' => $row_board['id_board'],
@@ -469,8 +409,8 @@ function getBoardIndex($board_index_options)
 		if (!$isChild && !empty($row_board['poster_time'])
 			&& (empty($this_category[$row_board['id_board']]['last_post']['timestamp'])
 				|| $this_category[$row_board['id_board']]['last_post']['timestamp'] < forum_time(true, $row_board['poster_time'])
-				)
 			)
+		)
 			$this_category[$row_board['id_board']]['last_post'] = $this_last_post;
 
 		// Just in the child...?

--- a/Sources/Subs-BoardIndex.php
+++ b/Sources/Subs-BoardIndex.php
@@ -178,8 +178,8 @@ function getBoardIndex($board_index_options)
 				// Is this your lucky day?
 				if (!empty($parsed_descriptions) && !empty($parsed_descriptions[$row_board['id_cat']]))
 				{
-					$name = parse_bbc($row_board['cat_name'], false, '', $context['description_allowed_tags']);
-					$description = parse_bbc($row_board['cat_desc'], false, '', $context['description_allowed_tags']);
+					$name = $parsed_descriptions[$row_board['id_cat']]['name'];
+					$description = $parsed_descriptions[$row_board['id_cat']]['description'];
 				}
 
 				// No? take one for the team then
@@ -192,6 +192,9 @@ function getBoardIndex($board_index_options)
 
 					if (!isset($to_parse[$row_board['id_cat']]['boards']))
 						$to_parse[$row_board['id_cat']]['boards'] = array();
+
+					$name = $row_board['cat_name'];
+					$description = $row_board['cat_desc'];
 				}
 
 				$categories[$row_board['id_cat']] = array(
@@ -233,8 +236,21 @@ function getBoardIndex($board_index_options)
 				if (!isset($this_category[$row_board['id_board']]))
 					$this_category[$row_board['id_board']] = array();
 
-				$board_name = parse_bbc($row_board['board_name'], false, '', $context['description_allowed_tags']);
-				$board_description = parse_bbc($row_board['description'], false, '', $context['description_allowed_tags']);
+				$parsed_board_vars = $parsed_descriptions[$row_board['id_cat']]['boards'][$row_board['id_board']];
+
+				// Quid pro quo Clarice...
+				if (!empty($parsed_descriptions) && !empty($parsed_board_vars))
+				{
+					$board_name = $parsed_board_vars['name'];
+					$board_description = $parsed_board_vars['description'];
+				}
+
+				// Yes or no, Clarice? Poor little Catherine is waiting.
+				else
+				{
+					$board_name = $row_board['board_name'];
+					$board_description = $row_board['description'];
+				}
 
 				$this_category[$row_board['id_board']] += array(
 					'new' => empty($row_board['is_read']),

--- a/Sources/Subs-BoardIndex.php
+++ b/Sources/Subs-BoardIndex.php
@@ -195,8 +195,8 @@ function getBoardIndex($board_index_options)
 				);
 
 				$categories[$row_board['id_cat']]['link'] = '<a id="c' . $row_board['id_cat'] . '"></a>' . (!$context['user']['is_guest'] ?
-                        '<a href="' . $scripturl . '?action=unread;c=' . $row_board['id_cat'] . '" title="' . sprintf($txt['new_posts_in_category'], $row_board['cat_name']) . '">' . $row_board['cat_name'] . '</a>' :
-                        $row_board['cat_name']);
+						'<a href="' . $scripturl . '?action=unread;c=' . $row_board['id_cat'] . '" title="' . sprintf($txt['new_posts_in_category'], $row_board['cat_name']) . '">' . $row_board['cat_name'] . '</a>' :
+						$row_board['cat_name']);
 
 			}
 
@@ -234,7 +234,7 @@ function getBoardIndex($board_index_options)
 					$this_category[$row_board['id_board']] = array();
 
 				if (isset($boards_parsed_data[$row_board['id_board']]))
-                    $row_board['description'] = $boards_parsed_data[$row_board['id_board']];
+					$row_board['description'] = $boards_parsed_data[$row_board['id_board']];
 
 				else
 					$to_parse_boards_info[$row_board['id_cat']][$row_board['id_board']] = $row_board['description'];
@@ -302,7 +302,7 @@ function getBoardIndex($board_index_options)
 				);
 
 			if (isset($boards_parsed_data[$row_board['id_board']]))
-                $row_board['description'] = $boards_parsed_data[$row_board['id_board']];
+				$row_board['description'] = $boards_parsed_data[$row_board['id_board']];
 
 			else
 				$to_parse_boards_info[$row_board['id_cat']][$row_board['id_board']] = $row_board['description'];
@@ -449,30 +449,30 @@ function getBoardIndex($board_index_options)
 	}
 
 	// There are some categories still unparsed.
-    $to_parse_categories_description = array_filter($to_parse_categories_description);
+	$to_parse_categories_description = array_filter($to_parse_categories_description);
 
 	if (!empty($to_parse_categories_description))
 	{
 		$already_parsed_categories = setCategoryParsedDescription($to_parse_categories_description);
 
 		foreach ($to_parse_categories_description as $category_id => $category_description)
-		    $categories[$category_id]['description'] = $already_parsed_categories[$category_id];
+			$categories[$category_id]['description'] = $already_parsed_categories[$category_id];
 	}
 
 	// Some boards didn't get their info cached, it is done on a per category basis.
-    $boards_parsed_data_by_cat_id = array();
+	$boards_parsed_data_by_cat_id = array();
 
 	if (!empty($to_parse_boards_info))
 		foreach ($to_parse_boards_info as $unparsed_category_id => $board_unparsed_description)
 		{
-		    if (empty($board_unparsed_description))
-		        continue;
+			if (empty($board_unparsed_description))
+			continue;
 
-            $boards_parsed_data_by_cat_id[$unparsed_category_id] = setBoardParsedDescription(
-                $unparsed_category_id,
-                $board_unparsed_description
-            );
-        }
+			$boards_parsed_data_by_cat_id[$unparsed_category_id] = setBoardParsedDescription(
+				$unparsed_category_id,
+				$board_unparsed_description
+			);
+		}
 
 	/* The board's and children's 'last_post's have:
 	time, timestamp (a number that represents the time.), id (of the post), topic (topic id.),

--- a/Sources/Subs-BoardIndex.php
+++ b/Sources/Subs-BoardIndex.php
@@ -173,7 +173,6 @@ function getBoardIndex($board_index_options)
 			// Haven't set this category yet.
 			if (empty($categories[$row_board['id_cat']]))
 			{
-				$category_name = $row_board['cat_name'];
 				$category_description = $row_board['cat_desc'];
 
 				if (isset($parsed_categories_description[$row_board['id_cat']]))
@@ -184,7 +183,7 @@ function getBoardIndex($board_index_options)
 
 				$categories[$row_board['id_cat']] = array(
 					'id' => $row_board['id_cat'],
-					'name' => $category_name,
+					'name' => $row_board['cat_name'],
 					'description' => $category_description,
 					'is_collapsed' => isset($row_board['can_collapse']) && $row_board['can_collapse'] == 1 &&
 						!empty($options['collapse_category_' . $row_board['id_cat']]),
@@ -195,7 +194,9 @@ function getBoardIndex($board_index_options)
 					'css_class' => ''
 				);
 
-				$categories[$row_board['id_cat']]['link'] = '<a id="c' . $row_board['id_cat'] . '"></a>' . (!$context['user']['is_guest'] ? '<a href="' . $scripturl . '?action=unread;c=' . $row_board['id_cat'] . '" title="' . sprintf($txt['new_posts_in_category'], $category_name) . '">' . $category_name . '</a>' : $category_name);
+				$categories[$row_board['id_cat']]['link'] = '<a id="c' . $row_board['id_cat'] . '"></a>' . (!$context['user']['is_guest'] ?
+                        '<a href="' . $scripturl . '?action=unread;c=' . $row_board['id_cat'] . '" title="' . sprintf($txt['new_posts_in_category'], $row_board['cat_name']) . '">' . $row_board['cat_name'] . '</a>' :
+                        $row_board['cat_name']);
 
 			}
 
@@ -448,12 +449,14 @@ function getBoardIndex($board_index_options)
 	}
 
 	// There are some categories still unparsed.
+    $to_parse_categories_description = array_filter($to_parse_categories_description);
+
 	if (!empty($to_parse_categories_description))
 	{
 		$already_parsed_categories = setCategoryParsedDescription($to_parse_categories_description);
 
 		foreach ($to_parse_categories_description as $category_id => $category_description)
-			$categories[$category_id]['description'] = $already_parsed_categories[$category_id];
+		    $categories[$category_id]['description'] = $already_parsed_categories[$category_id];
 	}
 
 	// Some boards didn't get their info cached, it is done on a per category basis.

--- a/Sources/Subs-BoardIndex.php
+++ b/Sources/Subs-BoardIndex.php
@@ -301,12 +301,14 @@ function getBoardIndex($board_index_options)
 					$this_category[$row_board['id_board']]['board_class'] = 'on';
 					$this_category[$row_board['id_board']]['board_tooltip'] = $txt['new_posts'];
 				}
+
 				else
 				{
 					$this_category[$row_board['id_board']]['board_tooltip'] = $txt['old_posts'];
 				}
 			}
 		}
+
 		// This is a child board.
 		elseif (isset($row_boards[$row_board['id_parent']]['id_parent']) && $row_boards[$row_board['id_parent']]['id_parent'] == $board_index_options['parent_id'])
 		{
@@ -320,8 +322,27 @@ function getBoardIndex($board_index_options)
 					'board_class' => 'off'
 				);
 
-			$board_name = parse_bbc($row_board['board_name'], false, '', $context['description_allowed_tags']);
-			$board_description = parse_bbc($row_board['description'], false, '', $context['description_allowed_tags']);
+			// Is this your lucky day?
+			if (!empty($parsed_descriptions) && !empty($parsed_descriptions[$row_board['id_cat']]))
+			{
+				$board_name = $parsed_descriptions[$row_board['id_cat']]['name'];
+				$board_description = $parsed_descriptions[$row_board['id_cat']]['description'];
+			}
+
+			// No? take one for the team then
+			else
+			{
+				$to_parse[$row_board['id_cat']] = array(
+					'name' => $row_board['cat_name'],
+					'description' => $row_board['cat_desc'],
+				);
+
+				if (!isset($to_parse[$row_board['id_cat']]['boards']))
+					$to_parse[$row_board['id_cat']]['boards'] = array();
+
+				$board_name = $row_board['cat_name'];
+				$board_description = $row_board['cat_desc'];
+			}
 
 			$this_category[$row_board['id_parent']]['children'][$row_board['id_board']] = array(
 				'id' => $row_board['id_board'],

--- a/Sources/Subs-BoardIndex.php
+++ b/Sources/Subs-BoardIndex.php
@@ -380,6 +380,7 @@ function getBoardIndex($board_index_options)
 			// This is easier to use in many cases for the theme....
 			$this_category[$row_board['id_parent']]['link_children'][] = &$this_category[$row_board['id_parent']]['children'][$row_board['id_board']]['link'];
 		}
+
 		// A further descendent (grandchild, great-grandchild, etc.)
 		else
 		{
@@ -451,6 +452,7 @@ function getBoardIndex($board_index_options)
 			$this_last_post['href'] = $scripturl . '?topic=' . $row_board['id_topic'] . '.msg' . ($user_info['is_guest'] ? $row_board['id_msg'] : $row_board['new_from']) . (empty($row_board['is_read']) ? ';boardseen' : '') . '#new';
 			$this_last_post['link'] = '<a href="' . $this_last_post['href'] . '" title="' . $row_board['subject'] . '">' . $row_board['short_subject'] . '</a>';
 		}
+
 		else
 		{
 			$this_last_post['href'] = '';
@@ -552,15 +554,21 @@ function getBoardIndex($board_index_options)
 		$context['latest_post'] = $latest_post['ref'];
 	}
 
+	// I took my time, I hurried up, the choice was mine I didn't think enough
+	$parsed_descriptions = setparsedDescriptions($to_parse);
+
 	// I can't remember why but trying to make a ternary to get this all in one line is actually a Very Bad Idea.
 	if ($board_index_options['include_categories'])
+	{
+		$categories = appendCategoriesParsedDescriptions($categories, $parsed_descriptions);
 		call_integration_hook('integrate_getboardtree', array($board_index_options, &$categories));
+	}
 
 	else
+	{
+		$this_category = appendBoardsParsedDescriptions($this_category, $parsed_descriptions);
 		call_integration_hook('integrate_getboardtree', array($board_index_options, &$this_category));
-
-	// I took my time, I hurried up, the choice was mine I didn't think enough
-	setparsedDescriptions($to_parse);
+	}
 
 	return $board_index_options['include_categories'] ? $categories : $this_category;
 }
@@ -633,6 +641,47 @@ function setParsedDescriptions($dataToParse = array())
 	}
 
 	return $already_parsed_data;
+}
+
+/**
+ * @param array $categories
+ * @param array $parsed_descriptions
+ *
+ * @return array
+ */
+function appendCategoriesParsedDescriptions($categories = array(), $parsed_descriptions = array())
+{
+	if (empty($categories) || empty($parsed_description))
+		return $categories;
+
+	foreach ($parsed_descriptions as $id_cat => $parsed_description)
+	{
+		$categories[$id_cat]['name'] = $parsed_description['name'];
+		$categories[$id_cat]['description'] = $parsed_description['description'];
+	}
+
+	return $categories;
+}
+
+/**
+ * @param $this_category
+ * @param $parsed_descriptions
+ *
+ * @return array
+ */
+function appendBoardsParsedDescriptions($this_category = array(), $parsed_descriptions = array())
+{
+	if (empty($this_category) || empty($parsed_descriptions))
+		return $this_category;
+
+	foreach ($parsed_descriptions as $id_cat => $parsed_description)
+		foreach ($parsed_description['boards'] as $id_board => $board)
+		{
+			$this_category[$id_board]['name'] = $board['name'];
+			$this_category[$id_board]['description'] = $board['description'];
+		}
+
+	return $this_category;
 }
 
 ?>

--- a/Sources/Subs-BoardIndex.php
+++ b/Sources/Subs-BoardIndex.php
@@ -563,7 +563,7 @@ function getParsedDescriptions($cat_ids = array())
 
 /**
  * @param array $dataToParse
- * @return array
+ * @return array Parsed data
  */
 function setParsedDescriptions($dataToParse = array())
 {
@@ -607,7 +607,7 @@ function setParsedDescriptions($dataToParse = array())
 					'description' => $board['description'],
 				);
 
-			cache_put_data('parsed_cat_description_'. $cat_id, $already_parsed_data, 864000);
+			cache_put_data('parsed_cat_description_'. $cat_id, $already_parsed_data[$cat_id], 864000);
 		}
 	}
 

--- a/Sources/Subs-BoardIndex.php
+++ b/Sources/Subs-BoardIndex.php
@@ -132,35 +132,25 @@ function getBoardIndex($board_index_options)
 		);
 
 	// Start with an empty array.
+	$categories = array();
+	$this_category = array();
+	$parsed_categories_description = array();
+	$to_parse_categories_description = array();
+
 	if ($board_index_options['include_categories'])
 	{
 		require_once $sourcedir . '/Subs-Categories.php';
 
-		$categories = array();
 		$parsed_categories_description = getCategoriesParsedDescription();
-		$to_parse_categories_description = array();
-	}
-
-	else
-	{
-		$this_category = array();
-		$parsed_categories_description = array();
-		$to_parse_categories_description = array();
 	}
 
 	$boards = array();
-	$boards_ids = array();
-	$categories_ids = array();
 
 	// Children can affect parents, so we need to gather all the boards first and then process them after.
 	$row_boards = array();
 
 	foreach ($smcFunc['db_fetch_all']($result_boards) as $row)
-	{
 		$row_boards[$row['id_board']] = $row;
-		$boards_ids[] = $row['id_board'];
-		$categories_ids[] = $row['id_cat'];
-	}
 
 	$smcFunc['db_free_result']($result_boards);
 
@@ -180,8 +170,6 @@ function getBoardIndex($board_index_options)
 
 		if ($board_index_options['include_categories'])
 		{
-			require_once $sourcedir . '/Subs-Categories.php';
-
 			// Haven't set this category yet.
 			if (empty($categories[$row_board['id_cat']]))
 			{
@@ -536,6 +524,13 @@ function getBoardIndex($board_index_options)
 			{
 				$board['name'] = $boards_parsed_data[$board['id_cat']][$board['id']]['name'];
 				$board['description'] = $boards_parsed_data[$board['id_cat']][$board['id']]['description'];
+
+				if (isset($board['children']))
+					foreach ($board['children'] as &$child_board)
+					{
+						$child_board['name'] = $boards_parsed_data[$board['id_cat']][$board['id']]['name'];
+						$child_board['description'] = $boards_parsed_data[$board['id_cat']][$board['id']]['description'];
+					}
 			}
 
 			if (!empty($moderators[$board['id']]))

--- a/Sources/Subs-BoardIndex.php
+++ b/Sources/Subs-BoardIndex.php
@@ -222,6 +222,15 @@ function getBoardIndex($board_index_options)
 			$this_category = &$categories[$row_board['id_cat']]['boards'];
 		}
 
+		if (empty($boards_parsed_data))
+			$boards_parsed_data = getBoardsParsedDescription($row_board['id_cat']);
+
+		if (empty($to_parse_boards_info))
+			$to_parse_boards_info = array();
+
+		if (empty($to_parse_boards_info[$row_board['id_cat']]))
+			$to_parse_boards_info[$row_board['id_cat']] = array();
+
 		// This is a parent board.
 		if ($row_board['id_parent'] == $board_index_options['parent_id'])
 		{
@@ -230,15 +239,6 @@ function getBoardIndex($board_index_options)
 			{
 				// Not a child.
 				$isChild = false;
-
-				if (empty($boards_parsed_data))
-					$boards_parsed_data = getBoardsParsedDescription($row_board['id_cat']);
-
-				if (empty($to_parse_boards_info))
-					$to_parse_boards_info = array();
-
-				if (empty($to_parse_boards_info[$row_board['id_cat']]))
-					$to_parse_boards_info[$row_board['id_cat']] = array();
 
 				// We might or might not have already added this board, so...
 				if (!isset($this_category[$row_board['id_board']]))

--- a/Sources/Subs-BoardIndex.php
+++ b/Sources/Subs-BoardIndex.php
@@ -174,13 +174,13 @@ function getBoardIndex($board_index_options)
 			if (empty($categories[$row_board['id_cat']]))
 			{
 				$category_name = $row_board['cat_name'];
-				$category_description = $parsed_categories_description[$row_board['id_cat']];
+				$category_description = $row_board['cat_desc'];
 
-				if (!isset($category_description))
-				{
+				if (isset($parsed_categories_description[$row_board['id_cat']]))
+					$category_description = $parsed_categories_description[$row_board['id_cat']];
+
+				else
 					$to_parse_categories_description[$row_board['id_cat']] = $row_board['cat_desc'];
-					$category_description = $row_board['cat_desc'];
-				}
 
 				$categories[$row_board['id_cat']] = array(
 					'id' => $row_board['id_cat'],

--- a/Sources/Subs-BoardIndex.php
+++ b/Sources/Subs-BoardIndex.php
@@ -609,6 +609,8 @@ function setParsedDescriptions($dataToParse = array())
 	// If you're here it means your data isn't cached... or so the theory dictates...
 	foreach ($dataToParse as $cat_id => $category)
 	{
+		$to_cache = array();
+
 		// Sometimes we just want to update boards
 		if (!empty($category['name']))
 			$to_cache[$cat_id] = array(
@@ -617,11 +619,12 @@ function setParsedDescriptions($dataToParse = array())
 				'boards' => array(),
 			);
 
-		foreach ($category['boards'] as $board_id => $board)
-		{
-			$to_cache[$cat_id]['boards'][$board_id]['name'] = parse_bbc($board['name'], false, '', $context['description_allowed_tags']);
-			$to_cache[$cat_id]['boards'][$board_id]['description'] = parse_bbc($board['description'], false, '', $context['description_allowed_tags']);
-		}
+		if (!empty($category['boards']))
+			foreach ($category['boards'] as $board_id => $board)
+			{
+				$to_cache[$cat_id]['boards'][$board_id]['name'] = parse_bbc($board['name'], false, '', $context['description_allowed_tags']);
+				$to_cache[$cat_id]['boards'][$board_id]['description'] = parse_bbc($board['description'], false, '', $context['description_allowed_tags']);
+			}
 
 		// Let's have some fun shall we?
 		$already_parsed_data[$cat_id] = cache_get_data('parsed_cat_description_'. $cat_id);

--- a/Sources/Subs-BoardIndex.php
+++ b/Sources/Subs-BoardIndex.php
@@ -627,24 +627,27 @@ function setParsedDescriptions($dataToParse = array())
 			}
 
 		// Let's have some fun shall we?
-		$already_parsed_data[$cat_id] = cache_get_data('parsed_cat_description_'. $cat_id);
-
-		foreach ($to_cache as $to_cache_cat_id => $to_cache_data)
+		if (!empty($cat_id))
 		{
-			// Append data!
-			$already_parsed_data[$cat_id] = array(
-				'name' => $category['name'],
-				'description' => $category['description'],
-				'boards' => array(),
-			);
+			$already_parsed_data[$cat_id] = cache_get_data('parsed_cat_description_'. $cat_id);
 
-			foreach ($category['boards'] as $board)
-				$already_parsed_data[$cat_id]['boards'] = array(
-					'name' => $board['name'],
-					'description' => $board['description'],
+			foreach ($to_cache as $to_cache_cat_id => $to_cache_data)
+			{
+				// Append data!
+				$already_parsed_data[$cat_id] = array(
+					'name' => $category['name'],
+					'description' => $category['description'],
+					'boards' => array(),
 				);
 
-			cache_put_data('parsed_cat_description_'. $cat_id, $already_parsed_data[$cat_id], 864000);
+				foreach ($category['boards'] as $board)
+					$already_parsed_data[$cat_id]['boards'] = array(
+						'name' => $board['name'],
+						'description' => $board['description'],
+					);
+
+				cache_put_data('parsed_cat_description_'. $cat_id, $already_parsed_data[$cat_id], 864000);
+			}
 		}
 	}
 

--- a/Sources/Subs-Boards.php
+++ b/Sources/Subs-Boards.php
@@ -1553,40 +1553,31 @@ function isChildOf($child, $parent)
 	return isChildOf($boards[$child]['parent'], $parent);
 }
 
-function setBoardParsedDescription($category_id = 0, $board_info = array())
+function setBoardParsedDescription($category_id = 0, $boards_info = array())
 {
 	global $cache_enable, $context;
 
 	if (empty($category_id) || empty($board_info))
-		return array(
-			'name' => '',
-			'description' => '',
-		);;
+		return array();
 
 	// Get the data we already parsed
 	$already_parsed_boards = getBoardsParsedDescription($category_id);
 
-	$parsed_board_info = array(
-		'name' => !empty($board_info['name']) ?
-			parse_bbc($board_info['name'], false, '', $context['description_allowed_tags']) : '',
-		'description' => !empty($board_info['description']) ?
-			parse_bbc($board_info['description'], false, '', $context['description_allowed_tags']) : '',
-	);
-
-	if (!empty($already_parsed_boards))
-		$already_parsed_boards[$category_id][$board_id] = $parsed_board_info;
-
-	else
-	{
+	if (null === $already_parsed_boards)
 		$already_parsed_boards = array();
-		$already_parsed_boards[$category_id] = array();
-		$already_parsed_boards[$category_id][$board_id] = $parsed_board_info;
-	}
+
+	foreach ($boards_info as $board_id => $board_data)
+		$already_parsed_boards[$board_id] = array(
+			'name' => !empty($board_data['name']) ?
+				parse_bbc($board_data['name'], false, '', $context['description_allowed_tags']) : '',
+			'description' => !empty($board_data['description']) ?
+				parse_bbc($board_data['description'], false, '', $context['description_allowed_tags']) : '',
+		);
 
 	if(!empty($cache_enable))
 		cache_put_data('parsed_boards_descriptions_'. $category_id, $already_parsed_boards, 864000);
 
-	return $parsed_board_info;
+	return $already_parsed_boards;
 }
 
 function getBoardsParsedDescription($category_id = 0)

--- a/Sources/Subs-Boards.php
+++ b/Sources/Subs-Boards.php
@@ -1579,7 +1579,6 @@ function setBoardParsedDescription($category_id = 0, $board_id = 0, $board_info 
 	return $already_parsed_boards;
 }
 
-
 function getBoardsParsedDescription($category_id = 0)
 {
 	global $cache_enable;
@@ -1588,5 +1587,21 @@ function getBoardsParsedDescription($category_id = 0)
 		return null;
 
 	return cache_get_data('parsed_boards_descriptions_' . $category_id, 864000);
+}
+
+function getBoardsParsedDescriptionById($category_id = 0, $board_id = 0)
+{
+	global $cache_enable;
+
+	if (empty($board_id) || empty($category_id) || empty($cache_enable))
+		return null;
+
+	// Get the data we already parsed
+	$already_parsed_boards = getBoardsParsedDescription($category_id);
+
+	if (null === $already_parsed_boards || !isset($already_parsed_boards[$category_id]) || !isset($already_parsed_boards[$category_id][$board_id]))
+		return null;
+
+	return $already_parsed_boards[$category_id][$board_id];
 }
 ?>

--- a/Sources/Subs-Boards.php
+++ b/Sources/Subs-Boards.php
@@ -1613,4 +1613,5 @@ function getBoardParsedDescriptionById($category_id = 0, $board_id = 0)
 
 	return $already_parsed_boards[$category_id][$board_id];
 }
+
 ?>

--- a/Sources/Subs-Boards.php
+++ b/Sources/Subs-Boards.php
@@ -1559,7 +1559,7 @@ function setBoardParsedDescription($category_id = 0, $boards_info = array())
 {
 	global $cache_enable, $context;
 
-	if (empty($category_id) || empty($board_info))
+	if (empty($category_id) || empty($boards_info))
 		return array();
 
 	// Get the data we already parsed

--- a/Sources/Subs-Boards.php
+++ b/Sources/Subs-Boards.php
@@ -840,14 +840,14 @@ function modifyBoard($board_id, &$boardOptions)
 
 	$parsed_boards_cat_id = isset($id_cat) ? $id_cat : $boardOptions['old_id_cat'];
     $already_parsed_boards = getBoardsParsedDescription($parsed_boards_cat_id);
-    $already_parsed_boards[$board_id] = array(
-        'name' => isset($boardOptions['board_name']) ?
-            parse_bbc($boardOptions['board_name'], false, '', $context['description_allowed_tags']) :
+
+    if (isset($boardOptions['board_description']))
+        $already_parsed_boards[$board_id] = parse_bbc(
+            $boardOptions['board_description'],
+            false,
+
             '',
-        'description' => isset($boardOptions['board_description']) ?
-            parse_bbc($boardOptions['board_description'], false, '', $context['description_allowed_tags']) :
-            ''
-    );
+            $context['description_allowed_tags']);
 
 	clean_cache('data');
 
@@ -1571,13 +1571,13 @@ function setBoardParsedDescription($category_id = 0, $boards_info = array())
 	// Get the data we already parsed
 	$already_parsed_boards = getBoardsParsedDescription($category_id);
 
-	foreach ($boards_info as $board_id => $board_data)
-		$already_parsed_boards[$board_id] = array(
-			'name' => !empty($board_data['name']) ?
-				parse_bbc($board_data['name'], false, '', $context['description_allowed_tags']) : '',
-			'description' => !empty($board_data['description']) ?
-				parse_bbc($board_data['description'], false, '', $context['description_allowed_tags']) : '',
-		);
+	foreach ($boards_info as $board_id => $board_description)
+        $already_parsed_boards[$board_id] = parse_bbc(
+            $board_description,
+            false,
+            '',
+            $context['description_allowed_tags']
+        );
 
     cache_put_data('parsed_boards_descriptions_'. $category_id, $already_parsed_boards, 864000);
 

--- a/Sources/Subs-Boards.php
+++ b/Sources/Subs-Boards.php
@@ -1579,4 +1579,14 @@ function setBoardParsedDescription($category_id = 0, $board_id = 0, $board_info 
 	return $already_parsed_boards;
 }
 
+
+function getBoardsParsedDescription($category_id = 0)
+{
+	global $cache_enable;
+
+	if (empty($category_id) || empty($cache_enable))
+		return null;
+
+	return cache_get_data('parsed_boards_descriptions_' . $category_id, 864000);
+}
 ?>

--- a/Sources/Subs-Boards.php
+++ b/Sources/Subs-Boards.php
@@ -645,13 +645,6 @@ function modifyBoard($board_id, &$boardOptions)
 		$boardUpdateParameters['num_posts'] = (int) $boardOptions['num_posts'];
 	}
 
-	setBoardParsedDescription((isset($id_cat) ? $id_cat : $boardOptions['old_id_cat']), array(
-		$board_id => array(
-			'name' => isset($boardOptions['board_name']) ? $boardOptions['board_name'] : '',
-			'description' => isset($boardOptions['board_description']) ? $boardOptions['board_description'] : ''
-		)
-	));
-
 	$id = $board_id;
 	call_integration_hook('integrate_modify_board', array($id, $boardOptions, &$boardUpdates, &$boardUpdateParameters));
 
@@ -846,6 +839,13 @@ function modifyBoard($board_id, &$boardOptions)
 		reorderBoards();
 
 	clean_cache('data');
+
+    setBoardParsedDescription((isset($id_cat) ? $id_cat : $boardOptions['old_id_cat']), array(
+        $board_id => array(
+            'name' => isset($boardOptions['board_name']) ? $boardOptions['board_name'] : '',
+            'description' => isset($boardOptions['board_description']) ? $boardOptions['board_description'] : ''
+        )
+    ));
 
 	if (empty($boardOptions['dont_log']))
 		logAction('edit_board', array('board' => $board_id), 'admin');

--- a/Sources/Subs-Boards.php
+++ b/Sources/Subs-Boards.php
@@ -645,7 +645,7 @@ function modifyBoard($board_id, &$boardOptions)
 		$boardUpdateParameters['num_posts'] = (int) $boardOptions['num_posts'];
 	}
 
-	setBoardParsedDescription($boardOptions['target_category'], $board_id, array(
+	setBoardParsedDescription((isset($id_cat) ? $id_cat : $boardOptions['old_id_cat']), $board_id, array(
 		'name' => isset($boardOptions['board_name']) ? $boardOptions['board_name'] : '',
 		'description' => isset($boardOptions['board_description']) ? $boardOptions['board_description'] : ''
 	));
@@ -1558,7 +1558,10 @@ function setBoardParsedDescription($category_id = 0, $board_id = 0, $board_info 
 	global $cache_enable, $context;
 
 	if (empty($cache_enable) || empty($category_id) || empty($board_id) || empty($board_info))
-		return null;
+		return array(
+			'name' => '',
+			'description' => '',
+		);;
 
 	// Get the data we already parsed
 	$already_parsed_boards = getBoardsParsedDescription($category_id);
@@ -1582,7 +1585,7 @@ function setBoardParsedDescription($category_id = 0, $board_id = 0, $board_info 
 
 	cache_put_data('parsed_boards_descriptions_'. $category_id, $already_parsed_boards, 864000);
 
-	return $already_parsed_boards;
+	return $parsed_board_info;
 }
 
 function getBoardsParsedDescription($category_id = 0)

--- a/Sources/Subs-Boards.php
+++ b/Sources/Subs-Boards.php
@@ -1595,7 +1595,7 @@ function getBoardsParsedDescription($category_id = 0)
 	return cache_get_data('parsed_boards_descriptions_' . $category_id, 864000);
 }
 
-function getBoardsParsedDescriptionById($category_id = 0, $board_id = 0)
+function getBoardParsedDescriptionById($category_id = 0, $board_id = 0)
 {
 	global $cache_enable;
 

--- a/Sources/Subs-Boards.php
+++ b/Sources/Subs-Boards.php
@@ -1553,11 +1553,11 @@ function isChildOf($child, $parent)
 	return isChildOf($boards[$child]['parent'], $parent);
 }
 
-function setBoardParsedDescription($category_id = 0, $board_id = 0, $board_info = array())
+function setBoardParsedDescription($category_id = 0, $board_info = array())
 {
 	global $cache_enable, $context;
 
-	if (empty($cache_enable) || empty($category_id) || empty($board_id) || empty($board_info))
+	if (empty($category_id) || empty($board_info))
 		return array(
 			'name' => '',
 			'description' => '',
@@ -1583,7 +1583,8 @@ function setBoardParsedDescription($category_id = 0, $board_id = 0, $board_info 
 		$already_parsed_boards[$category_id][$board_id] = $parsed_board_info;
 	}
 
-	cache_put_data('parsed_boards_descriptions_'. $category_id, $already_parsed_boards, 864000);
+	if(!empty($cache_enable))
+		cache_put_data('parsed_boards_descriptions_'. $category_id, $already_parsed_boards, 864000);
 
 	return $parsed_board_info;
 }

--- a/Sources/Subs-Boards.php
+++ b/Sources/Subs-Boards.php
@@ -839,19 +839,19 @@ function modifyBoard($board_id, &$boardOptions)
 		reorderBoards();
 
 	$parsed_boards_cat_id = isset($id_cat) ? $id_cat : $boardOptions['old_id_cat'];
-    $already_parsed_boards = getBoardsParsedDescription($parsed_boards_cat_id);
+	$already_parsed_boards = getBoardsParsedDescription($parsed_boards_cat_id);
 
-    if (isset($boardOptions['board_description']))
-        $already_parsed_boards[$board_id] = parse_bbc(
-            $boardOptions['board_description'],
-            false,
+	if (isset($boardOptions['board_description']))
+		$already_parsed_boards[$board_id] = parse_bbc(
+			$boardOptions['board_description'],
+			false,
 
-            '',
-            $context['description_allowed_tags']);
+			'',
+			$context['description_allowed_tags']);
 
 	clean_cache('data');
 
-    cache_put_data('parsed_boards_descriptions_'. $parsed_boards_cat_id, $already_parsed_boards, 864000);
+	cache_put_data('parsed_boards_descriptions_'. $parsed_boards_cat_id, $already_parsed_boards, 864000);
 
 	if (empty($boardOptions['dont_log']))
 		logAction('edit_board', array('board' => $board_id), 'admin');
@@ -1572,14 +1572,14 @@ function setBoardParsedDescription($category_id = 0, $boards_info = array())
 	$already_parsed_boards = getBoardsParsedDescription($category_id);
 
 	foreach ($boards_info as $board_id => $board_description)
-        $already_parsed_boards[$board_id] = parse_bbc(
-            $board_description,
-            false,
-            '',
-            $context['description_allowed_tags']
-        );
+		$already_parsed_boards[$board_id] = parse_bbc(
+			$board_description,
+			false,
+			'',
+			$context['description_allowed_tags']
+		);
 
-    cache_put_data('parsed_boards_descriptions_'. $category_id, $already_parsed_boards, 864000);
+	cache_put_data('parsed_boards_descriptions_'. $category_id, $already_parsed_boards, 864000);
 
 	return $already_parsed_boards;
 }

--- a/Sources/Subs-Boards.php
+++ b/Sources/Subs-Boards.php
@@ -1565,9 +1565,6 @@ function setBoardParsedDescription($category_id = 0, $boards_info = array())
 	// Get the data we already parsed
 	$already_parsed_boards = getBoardsParsedDescription($category_id);
 
-	if (null === $already_parsed_boards)
-		$already_parsed_boards = array();
-
 	foreach ($boards_info as $board_id => $board_data)
 		$already_parsed_boards[$board_id] = array(
 			'name' => !empty($board_data['name']) ?
@@ -1587,7 +1584,7 @@ function getBoardsParsedDescription($category_id = 0)
 	global $cache_enable;
 
 	if (empty($category_id) || empty($cache_enable))
-		return null;
+		return array();
 
 	return cache_get_data('parsed_boards_descriptions_' . $category_id, 864000);
 }

--- a/Sources/Subs-Boards.php
+++ b/Sources/Subs-Boards.php
@@ -645,9 +645,11 @@ function modifyBoard($board_id, &$boardOptions)
 		$boardUpdateParameters['num_posts'] = (int) $boardOptions['num_posts'];
 	}
 
-	setBoardParsedDescription((isset($id_cat) ? $id_cat : $boardOptions['old_id_cat']), $board_id, array(
-		'name' => isset($boardOptions['board_name']) ? $boardOptions['board_name'] : '',
-		'description' => isset($boardOptions['board_description']) ? $boardOptions['board_description'] : ''
+	setBoardParsedDescription((isset($id_cat) ? $id_cat : $boardOptions['old_id_cat']), array(
+		$board_id => array(
+			'name' => isset($boardOptions['board_name']) ? $boardOptions['board_name'] : '',
+			'description' => isset($boardOptions['board_description']) ? $boardOptions['board_description'] : ''
+		)
 	));
 
 	$id = $board_id;

--- a/Sources/Subs-Boards.php
+++ b/Sources/Subs-Boards.php
@@ -1592,20 +1592,4 @@ function getBoardsParsedDescription($category_id = 0)
 	return cache_get_data('parsed_boards_descriptions_' . $category_id, 864000);
 }
 
-function getBoardParsedDescriptionById($category_id = 0, $board_id = 0)
-{
-	global $cache_enable;
-
-	if (empty($board_id) || empty($category_id) || empty($cache_enable))
-		return null;
-
-	// Get the data we already parsed
-	$already_parsed_boards = getBoardsParsedDescription($category_id);
-
-	if (null === $already_parsed_boards || !isset($already_parsed_boards[$category_id]) || !isset($already_parsed_boards[$category_id][$board_id]))
-		return null;
-
-	return $already_parsed_boards[$category_id][$board_id];
-}
-
 ?>

--- a/Sources/Subs-Boards.php
+++ b/Sources/Subs-Boards.php
@@ -645,6 +645,11 @@ function modifyBoard($board_id, &$boardOptions)
 		$boardUpdateParameters['num_posts'] = (int) $boardOptions['num_posts'];
 	}
 
+	setBoardParsedDescription($boardOptions['target_category'], $board_id, array(
+		'name' => isset($boardOptions['board_name']) ? $boardOptions['board_name'] : '',
+		'description' => isset($boardOptions['board_description']) ? $boardOptions['board_description'] : ''
+	));
+
 	$id = $board_id;
 	call_integration_hook('integrate_modify_board', array($id, $boardOptions, &$boardUpdates, &$boardUpdateParameters));
 
@@ -1558,20 +1563,21 @@ function setBoardParsedDescription($category_id = 0, $board_id = 0, $board_info 
 	// Get the data we already parsed
 	$already_parsed_boards = getBoardsParsedDescription($category_id);
 
+	$parsed_board_info = array(
+		'name' => !empty($board_info['name']) ?
+			parse_bbc($board_info['name'], false, '', $context['description_allowed_tags']) : '',
+		'description' => !empty($board_info['description']) ?
+			parse_bbc($board_info['description'], false, '', $context['description_allowed_tags']) : '',
+	);
+
 	if (!empty($already_parsed_boards))
-		$already_parsed_boards[$category_id][$board_id] = array(
-			'name' => parse_bbc($board_info['name'], false, '', $context['description_allowed_tags']),
-			'description' => parse_bbc($board_info['description'], false, '', $context['description_allowed_tags']),
-		);
+		$already_parsed_boards[$category_id][$board_id] = $parsed_board_info;
 
 	else
 	{
 		$already_parsed_boards = array();
 		$already_parsed_boards[$category_id] = array();
-		$already_parsed_boards[$category_id][$board_id] = array(
-			'name' => parse_bbc($board_info['name'], false, '', $context['description_allowed_tags']),
-			'description' => parse_bbc($board_info['description'], false, '', $context['description_allowed_tags']),
-		);
+		$already_parsed_boards[$category_id][$board_id] = $parsed_board_info;
 	}
 
 	cache_put_data('parsed_boards_descriptions_'. $category_id, $already_parsed_boards, 864000);

--- a/Sources/Subs-Categories.php
+++ b/Sources/Subs-Categories.php
@@ -272,8 +272,8 @@ function setCategoryParsedDescription($category_info = array())
 	$already_parsed_categories = getCategoriesParsedDescription();
 
 	foreach ($category_info as $category_id => $category_description)
-		$already_parsed_categories[$category_id] = !empty($category_description) ?
-				parse_bbc($category_description, false, '', $context['description_allowed_tags']) : '';
+    $already_parsed_categories[$category_id] = !empty($category_description) ?
+        parse_bbc($category_description, false, '', $context['description_allowed_tags']) : '';
 
 	if (!empty($cache_enable))
 		cache_put_data('parsed_category_descriptions', $already_parsed_categories, 864000);

--- a/Sources/Subs-Categories.php
+++ b/Sources/Subs-Categories.php
@@ -265,8 +265,8 @@ function setCategoryParsedDescription($category_info = array())
 {
 	global $cache_enable, $context;
 
-	if (empty($cache_enable) || empty($category_info))
-		return array();
+	if (empty($category_info))
+		return $category_info;
 
 	// Get the data we already parsed
 	$already_parsed_categories = getCategoriesParsedDescription();
@@ -278,7 +278,8 @@ function setCategoryParsedDescription($category_info = array())
 		$already_parsed_categories[$category_id] = !empty($category_description) ?
 				parse_bbc($category_description, false, '', $context['description_allowed_tags']) : '';
 
-	cache_put_data('parsed_category_descriptions', $already_parsed_categories, 864000);
+	if (!empty($cache_enable))
+		cache_put_data('parsed_category_descriptions', $already_parsed_categories, 864000);
 
 	return $already_parsed_categories;
 }

--- a/Sources/Subs-Categories.php
+++ b/Sources/Subs-Categories.php
@@ -129,6 +129,7 @@ function modifyCategory($category_id, $catOptions)
  * returns the ID of the newly created category.
  *
  * @param array $catOptions An array of data and settings related to the new category. Should have at least 'cat_name' and can also have 'cat_desc', 'move_after' and 'is_collapsable'
+ * @return mixed
  */
 function createCategory($catOptions)
 {
@@ -141,10 +142,13 @@ function createCategory($catOptions)
 	// Set default values.
 	if (!isset($catOptions['cat_desc']))
 		$catOptions['cat_desc'] = '';
+
 	if (!isset($catOptions['move_after']))
 		$catOptions['move_after'] = 0;
+
 	if (!isset($catOptions['is_collapsible']))
 		$catOptions['is_collapsible'] = true;
+
 	// Don't log an edit right after.
 	$catOptions['dont_log'] = true;
 

--- a/Sources/Subs-Categories.php
+++ b/Sources/Subs-Categories.php
@@ -272,8 +272,8 @@ function setCategoryParsedDescription($category_info = array())
 	$already_parsed_categories = getCategoriesParsedDescription();
 
 	foreach ($category_info as $category_id => $category_description)
-    $already_parsed_categories[$category_id] = !empty($category_description) ?
-        parse_bbc($category_description, false, '', $context['description_allowed_tags']) : '';
+	$already_parsed_categories[$category_id] = !empty($category_description) ?
+		parse_bbc($category_description, false, '', $context['description_allowed_tags']) : '';
 
 	if (!empty($cache_enable))
 		cache_put_data('parsed_category_descriptions', $already_parsed_categories, 864000);

--- a/Sources/Subs-Categories.php
+++ b/Sources/Subs-Categories.php
@@ -276,6 +276,14 @@ function setCategoryParsedDescription($category_id = 0, $category_description = 
 	return $parsed_description;
 }
 
+function getCategoryParsedDescription($category_id = 0)
+{
+	global $cache_enable;
 
+	if (empty($category_id) || empty($cache_enable))
+		return null;
+
+	return cache_get_data('parsed_cat_description_' . $category_id, 864000);
+}
 
 ?>

--- a/Sources/Subs-Categories.php
+++ b/Sources/Subs-Categories.php
@@ -271,9 +271,6 @@ function setCategoryParsedDescription($category_info = array())
 	// Get the data we already parsed
 	$already_parsed_categories = getCategoriesParsedDescription();
 
-	if (null === $already_parsed_categories)
-		$already_parsed_categories = array();
-
 	foreach ($category_info as $category_id => $category_description)
 		$already_parsed_categories[$category_id] = !empty($category_description) ?
 				parse_bbc($category_description, false, '', $context['description_allowed_tags']) : '';
@@ -289,7 +286,7 @@ function getCategoriesParsedDescription()
 	global $cache_enable;
 
 	if (empty($cache_enable))
-		return null;
+		return array();
 
 	return cache_get_data('parsed_category_descriptions', 864000);
 }

--- a/Sources/Subs-Categories.php
+++ b/Sources/Subs-Categories.php
@@ -96,7 +96,7 @@ function modifyCategory($category_id, $catOptions)
 
 		$parsed_description = getCategoryParsedDescription($category_id);
 
-		if (is_null($parsed_description))
+		if (null === $parsed_description)
 			setCategoryParsedDescription($category_id, $catOptions['cat_desc']);
 	}
 
@@ -262,7 +262,7 @@ function deleteCategories($categories, $moveBoardsTo = null)
 	reorderBoards();
 }
 
-function setCategoryParsedDescription($category_id = 0, $category_description = 0)
+function setCategoryParsedDescription($category_id = 0, $category_description = '')
 {
 	global $cache_enable, $context;
 

--- a/Sources/Subs-Categories.php
+++ b/Sources/Subs-Categories.php
@@ -94,10 +94,7 @@ function modifyCategory($category_id, $catOptions)
 		$catUpdates[] = 'description = {string:cat_desc}';
 		$catParameters['cat_desc'] = $catOptions['cat_desc'];
 
-		$parsed_description = getCategoryParsedDescription($category_id);
-
-		if (null === $parsed_description)
-			setCategoryParsedDescription($category_id, $catOptions['cat_desc']);
+		setCategoryParsedDescription($category_id, $catOptions['cat_desc']);
 	}
 
 	// Can a user collapse this category or is it too important?

--- a/Sources/Subs-Categories.php
+++ b/Sources/Subs-Categories.php
@@ -57,8 +57,10 @@ function modifyCategory($category_id, $catOptions)
 		{
 			if ($row['id_cat'] != $category_id)
 				$cats[] = $row['id_cat'];
+
 			if ($row['id_cat'] == $catOptions['move_after'])
 				$cats[] = $category_id;
+
 			$cat_order[$row['id_cat']] = $row['cat_order'];
 		}
 		$smcFunc['db_free_result']($request);
@@ -91,6 +93,11 @@ function modifyCategory($category_id, $catOptions)
 	{
 		$catUpdates[] = 'description = {string:cat_desc}';
 		$catParameters['cat_desc'] = $catOptions['cat_desc'];
+
+		$parsed_description = getCategoryParsedDescription($category_id);
+
+		if (is_null($parsed_description))
+			setCategoryParsedDescription($category_id, $catOptions['cat_desc']);
 	}
 
 	// Can a user collapse this category or is it too important?
@@ -254,5 +261,21 @@ function deleteCategories($categories, $moveBoardsTo = null)
 	// Get all boards back into the right order.
 	reorderBoards();
 }
+
+function setCategoryParsedDescription($category_id = 0, $category_description = 0)
+{
+	global $cache_enable, $context;
+
+	if (empty($category_description) || empty($category_id) || empty($cache_enable))
+		return $category_description;
+
+	$parsed_description = parse_bbc($category_description, false, '', $context['description_allowed_tags']);
+
+	cache_put_data('parsed_cat_description_'. $category_id, $parsed_description, 864000);
+
+	return $parsed_description;
+}
+
+
 
 ?>

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -5315,6 +5315,7 @@ function call_helper($string, $return = false)
 	// We can't call this helper, but we want to silently ignore this.
 	if (!is_callable($func, false, $callable_name) && !empty($context['ignore_hook_errors']))
 		return false;
+
 	// Right, we got what we need, time to do some checks.
 	elseif (!is_callable($func, false, $callable_name))
 	{


### PR DESCRIPTION
Fixes #5734

Made a refactor on how to parse and save the parsed content on the cache.

Its a somehow atomic approach, the get and set operations are done on a per category and per board basis, this means an user who can only see a subset of the total boards won't get the load of parsing all of them.

Tested with filebased and SQLite3