### PR TITLE
Fix default notification preferences

### DIFF
--- a/Sources/Profile-Modify.php
+++ b/Sources/Profile-Modify.php
@@ -2184,12 +2184,12 @@ function alert_configuration($memID)
 			}
 		}
 
-		if (!empty($_POST['opt_alert_timeout']))
+		if (isset($_POST['opt_alert_timeout']))
 			$update_prefs['alert_timeout'] = $context['member']['alert_timeout'] = (int) $_POST['opt_alert_timeout'];
 		else
 			$update_prefs['alert_timeout'] = $context['alert_prefs']['alert_timeout'];
 
-		if (!empty($_POST['notify_announcements']))
+		if (isset($_POST['notify_announcements']))
 			$update_prefs['announcements'] = $context['member']['notify_announcements'] = (int) $_POST['notify_announcements'];
 		else
 			$update_prefs['announcements'] = $context['alert_prefs']['announcements'];

--- a/Sources/Profile-Modify.php
+++ b/Sources/Profile-Modify.php
@@ -2179,16 +2179,20 @@ function alert_configuration($memID)
 					if ($this_options[$type] == 'yes' && !empty($_POST[$type . '_' . $item_key]) || $this_options[$type] == 'always')
 						$this_value |= $bitvalue;
 				}
-				if (!isset($context['alert_prefs'][$item_key]) || $context['alert_prefs'][$item_key] != $this_value)
-					$update_prefs[$item_key] = $this_value;
+
+				$update_prefs[$item_key] = $this_value;
 			}
 		}
 
 		if (!empty($_POST['opt_alert_timeout']))
 			$update_prefs['alert_timeout'] = $context['member']['alert_timeout'] = (int) $_POST['opt_alert_timeout'];
+		else
+			$update_prefs['alert_timeout'] = $context['alert_prefs']['alert_timeout'];
 
 		if (!empty($_POST['notify_announcements']))
 			$update_prefs['announcements'] = $context['member']['notify_announcements'] = (int) $_POST['notify_announcements'];
+		else
+			$update_prefs['announcements'] = $context['alert_prefs']['announcements'];
 
 		setNotifyPrefs((int) $memID, $update_prefs);
 		foreach ($update_prefs as $pref => $value)


### PR DESCRIPTION
### Reference
https://www.simplemachines.org/community/index.php?topic=569527.msg4030683#msg4030683

### Issue
When a user saves their notification preferences, unchecked preferences are ignored and thus not saved to the database, example:

If the list of preferences looks like this
```
[1] => Array
        (
            [msg_auto_notify] => 1
            [msg_receive_body] => 0
            [msg_notify_pref] => 2
            [msg_notify_type] => 1
            [pm_notify] => 1
            [topic_notify] => 0
            [board_notify] => 0
            [msg_mention] => 1
            [msg_quote] => 0
            [msg_like] => 0
            [unapproved_reply] => 1
            [pm_new] => 0
            [pm_reply] => 0
            [groupr_approved] => 2
            [groupr_rejected] => 3
            [buddy_request] => 0
            [birthday] => 0
            [event_new] => 1
            [alert_timeout] => 10
            [announcements] => 0
        )
```

This is what gets saved to the db:
```
[1] => Array
        (
            [msg_auto_notify] => 1
            [msg_receive_body] => 0
            [msg_notify_pref] => 2
            [msg_notify_type] => 1
            [pm_notify] => 1
            [alert_timeout] => 10
        )
```

the software reads the rest if the prefs for users based on the default prefs saved in the db, the problem with that is, when the admin changes the default preferences, that applies to all the users as if they didn't save their unchecked preferences (because they actually didn't)

### What this PR does
Makes it so that whenever users edit their preferences, the default prefs are always saved to their profile, i.e when they save their preferences, they saves all the values even the unchecked prefs