### PR TITLE
[pg] Ignore conflict on upgrade calendar settings

### DIFF
--- a/other/upgrade_2-1_postgresql.sql
+++ b/other/upgrade_2-1_postgresql.sql
@@ -2652,7 +2652,7 @@ VALUES
 	('cal_prev_next_links', '1'),
 	('cal_short_days', '0'),
 	('cal_short_months', '0'),
-	('cal_week_numbers', '0');
+	('cal_week_numbers', '0') ON CONFLICT DO NOTHING;
 ---#
 
 /******************************************************************************/


### PR DESCRIPTION
One insert miss the "on conflict do nothing" string.

the pr https://github.com/SimpleMachines/SMF2.1/pull/5800 is also needed to get the pg upgrade running again.