### PR TITLE
Ensures $num_results is always defined in PlushSearch2()

### DIFF
--- a/Sources/Search.php
+++ b/Sources/Search.php
@@ -1739,6 +1739,7 @@ function PlushSearch2()
 		$smcFunc['db_free_result']($request);
 	}
 
+	$num_results = 0;
 	if (!empty($context['topics']))
 	{
 		// Create an array for the permissions.


### PR DESCRIPTION
Without this change, we could sometimes end up passing an undefined variable to `constructPageIndex()` [here](https://github.com/Sesquipedalian/SMF2.1/blob/9e7462820b3965e18ea8b46a0a6e84259707e9e1/Sources/Search.php#L1871).