### PR TITLE
Improvements to get_proxied_url() and general proxy handling

### DIFF
--- a/Sources/Load.php
+++ b/Sources/Load.php
@@ -514,7 +514,7 @@ function loadUserSettings()
 			$user_settings = $smcFunc['db_fetch_assoc']($request);
 			$smcFunc['db_free_result']($request);
 
-			if (!empty($user_settings['avatar']) && parse_url($data['avatar'], PHP_URL_SCHEME) !== null)
+			if (!empty($user_settings['avatar']))
 				$user_settings['avatar'] = get_proxied_url($user_settings['avatar']);
 
 			if (!empty($cache_enable) && $cache_enable >= 2)
@@ -1373,7 +1373,7 @@ function loadMemberData($users, $is_name = false, $set = 'normal')
 			$row['avatar_original'] = !empty($row['avatar']) ? $row['avatar'] : '';
 
 			// Take care of proxying avatar if required, do this here for maximum reach
-			if (!empty($row['avatar']) && parse_url($row['avatar'], PHP_URL_SCHEME) !== null)
+			if (!empty($row['avatar']))
 				$row['avatar'] = get_proxied_url($row['avatar']);
 
 			// Keep track of the member's normal member group

--- a/Sources/Load.php
+++ b/Sources/Load.php
@@ -509,7 +509,7 @@ function loadUserSettings()
 			$user_settings = $smcFunc['db_fetch_assoc']($request);
 			$smcFunc['db_free_result']($request);
 
-			if (!empty($modSettings['force_ssl']) && $image_proxy_enabled && stripos($user_settings['avatar'], 'http://') !== false && empty($user_info['possibly_robot']))
+			if (!empty($modSettings['force_ssl']) && $image_proxy_enabled && stripos($user_settings['avatar'], 'http://') !== false)
 				$user_settings['avatar'] = get_proxied_url($user_settings['avatar']);
 
 			if (!empty($cache_enable) && $cache_enable >= 2)
@@ -1368,7 +1368,7 @@ function loadMemberData($users, $is_name = false, $set = 'normal')
 			$row['avatar_original'] = !empty($row['avatar']) ? $row['avatar'] : '';
 
 			// Take care of proxying avatar if required, do this here for maximum reach
-			if ($image_proxy_enabled && !empty($row['avatar']) && stripos($row['avatar'], 'http://') !== false && empty($user_info['possibly_robot']))
+			if ($image_proxy_enabled && !empty($row['avatar']) && stripos($row['avatar'], 'http://') !== false)
 				$row['avatar'] = get_proxied_url($row['avatar']);
 
 			// Keep track of the member's normal member group
@@ -3669,7 +3669,7 @@ function set_avatar_data($data = array())
 			else
 			{
 				// Using ssl?
-				if (!empty($modSettings['force_ssl']) && $image_proxy_enabled && stripos($data['avatar'], 'http://') !== false && empty($user_info['possibly_robot']))
+				if (!empty($modSettings['force_ssl']) && $image_proxy_enabled && stripos($data['avatar'], 'http://') !== false)
 					$image = get_proxied_url($data['avatar']);
 
 				// Just a plain external url.

--- a/Sources/Load.php
+++ b/Sources/Load.php
@@ -445,7 +445,7 @@ function reloadSettings()
 function loadUserSettings()
 {
 	global $modSettings, $user_settings, $sourcedir, $smcFunc;
-	global $cookiename, $user_info, $language, $context, $image_proxy_enabled, $cache_enable;
+	global $cookiename, $user_info, $language, $context, $cache_enable;
 
 	// Check first the integration, then the cookie, and last the session.
 	if (count($integration_ids = call_integration_hook('integrate_verify_user')) > 0)
@@ -514,7 +514,7 @@ function loadUserSettings()
 			$user_settings = $smcFunc['db_fetch_assoc']($request);
 			$smcFunc['db_free_result']($request);
 
-			if (!empty($modSettings['force_ssl']) && $image_proxy_enabled && stripos($user_settings['avatar'], 'http://') !== false)
+			if (!empty($user_settings['avatar']) && parse_url($data['avatar'], PHP_URL_SCHEME) !== null)
 				$user_settings['avatar'] = get_proxied_url($user_settings['avatar']);
 
 			if (!empty($cache_enable) && $cache_enable >= 2)
@@ -1286,7 +1286,7 @@ function loadPermissions()
 function loadMemberData($users, $is_name = false, $set = 'normal')
 {
 	global $user_profile, $modSettings, $board_info, $smcFunc, $context;
-	global $image_proxy_enabled, $user_info, $cache_enable;
+	global $user_info, $cache_enable;
 
 	// Can't just look for no users :P.
 	if (empty($users))
@@ -1373,7 +1373,7 @@ function loadMemberData($users, $is_name = false, $set = 'normal')
 			$row['avatar_original'] = !empty($row['avatar']) ? $row['avatar'] : '';
 
 			// Take care of proxying avatar if required, do this here for maximum reach
-			if ($image_proxy_enabled && !empty($row['avatar']) && stripos($row['avatar'], 'http://') !== false)
+			if (!empty($row['avatar']) && parse_url($row['avatar'], PHP_URL_SCHEME) !== null)
 				$row['avatar'] = get_proxied_url($row['avatar']);
 
 			// Keep track of the member's normal member group
@@ -3631,7 +3631,7 @@ function clean_cache($type = '')
  */
 function set_avatar_data($data = array())
 {
-	global $modSettings, $smcFunc, $image_proxy_enabled, $user_info;
+	global $modSettings, $smcFunc, $user_info;
 
 	// Come on!
 	if (empty($data))
@@ -3668,15 +3668,7 @@ function set_avatar_data($data = array())
 
 			// External url.
 			else
-			{
-				// Using ssl?
-				if (!empty($modSettings['force_ssl']) && $image_proxy_enabled && stripos($data['avatar'], 'http://') !== false)
-					$image = get_proxied_url($data['avatar']);
-
-				// Just a plain external url.
-				else
-					$image = (stristr($data['avatar'], 'http://') || stristr($data['avatar'], 'https://')) ? $data['avatar'] : $modSettings['avatar_url'] . '/' . $data['avatar'];
-			}
+				$image = parse_url($data['avatar'], PHP_URL_SCHEME) !== null ? get_proxied_url($data['avatar']) : $modSettings['avatar_url'] . '/' . $data['avatar'];
 		}
 
 		// Perhaps this user has an attachment as avatar...

--- a/Sources/Load.php
+++ b/Sources/Load.php
@@ -23,6 +23,7 @@ function reloadSettings()
 {
 	global $modSettings, $boarddir, $smcFunc, $txt, $db_character_set;
 	global $cache_enable, $sourcedir, $context, $forum_version, $boardurl;
+	global $image_proxy_enabled;
 
 	// Most database systems have not set UTF-8 as their default input charset.
 	if (!empty($db_character_set))
@@ -91,6 +92,10 @@ function reloadSettings()
 	// Used to force browsers to download fresh CSS and JavaScript when necessary
 	$modSettings['browser_cache'] = !empty($modSettings['browser_cache']) ? (int) $modSettings['browser_cache'] : 0;
 	$context['browser_cache'] = '?' . preg_replace('~\W~', '', strtolower(SMF_FULL_VERSION)) . '_' . $modSettings['browser_cache'];
+
+	// Disable image proxy if we don't have SSL enabled
+	if (empty($modSettings['force_ssl']))
+		$image_proxy_enabled = false;
 
 	// UTF-8 ?
 	$utf8 = (empty($modSettings['global_character_set']) ? $txt['lang_character_set'] : $modSettings['global_character_set']) === 'UTF-8';
@@ -1818,7 +1823,7 @@ function loadTheme($id_theme = 0, $initialize = true)
 {
 	global $user_info, $user_settings, $board_info, $boarddir, $maintenance;
 	global $txt, $boardurl, $scripturl, $mbname, $modSettings;
-	global $context, $settings, $options, $sourcedir, $smcFunc, $language, $board, $image_proxy_enabled, $cache_enable;
+	global $context, $settings, $options, $sourcedir, $smcFunc, $language, $board, $cache_enable;
 
 	if (empty($id_theme))
 	{
@@ -1865,10 +1870,6 @@ function loadTheme($id_theme = 0, $initialize = true)
 	if (empty($settings['theme_id']) || $settings['theme_id'] != $id_theme)
 	{
 		$member = empty($user_info['id']) ? -1 : $user_info['id'];
-
-		// Disable image proxy if we don't have SSL enabled
-		if (empty($modSettings['force_ssl']))
-			$image_proxy_enabled = false;
 
 		if (!empty($cache_enable) && $cache_enable >= 2 && ($temp = cache_get_data('theme_settings-' . $id_theme . ':' . $member, 60)) != null && time() - 60 > $modSettings['settings_updated'])
 		{

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -3352,15 +3352,15 @@ function get_proxied_url($url)
 {
 	global $boardurl, $image_proxy_enabled, $image_proxy_secret, $user_info;
 
-	$parsedurl = parse_url($url);
-
-	// Only use the proxy if enabled and necessary (never for robots)
-	if (empty($image_proxy_enabled) || $parsedurl['scheme'] === 'https' || !empty($user_info['possibly_robot']))
+	// Only use the proxy if enabled, and never for robots
+	if (empty($image_proxy_enabled) || !empty($user_info['possibly_robot']))
 		return $url;
 
-	// Work around a parse_url() bug in old versions of PHP
-	if (empty($parsedurl['host']) && strpos($url, '//') === 0 && version_compare(PHP_VERSION, '5.4.7', '<'))
-		$parsedurl = parse_url('http://' . ltrim($url, ':/'));
+	$parsedurl = parse_url($url);
+
+	// Don't bother with HTTPS URLs, schemeless URLs, or obviously invalid URLs
+	if (empty($parsedurl['scheme']) || empty($parsedurl['host']) || empty($parsedurl['path']) || $parsedurl['scheme'] === 'https')
+		return $url;
 
 	// We don't need to proxy our own resources
 	if ($parsedurl['host'] === parse_url($boardurl, PHP_URL_HOST));

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -3347,7 +3347,7 @@ function get_proxied_url($url)
 		return $url;
 
 	// We don't need to proxy our own resources
-	if ($parsedurl['host'] === parse_url($boardurl, PHP_URL_HOST));
+	if ($parsedurl['host'] === parse_url($boardurl, PHP_URL_HOST))
 		return strtr($url, array('http://' => 'https://'));
 
 	// By default, use SMF's own image proxy script

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -1743,20 +1743,12 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 				'content' => '<img src="$1" alt="{alt}" title="{title}"{width}{height} class="bbc_img resized">',
 				'validate' => function(&$tag, &$data, $disabled)
 				{
-					global $image_proxy_enabled, $user_info;
-
 					$data = strtr($data, array('<br>' => ''));
-					$scheme = parse_url($data, PHP_URL_SCHEME);
-					if ($image_proxy_enabled)
-					{
-						if (empty($scheme))
-							$data = 'http://' . ltrim($data, ':/');
 
-						if ($scheme != 'https')
-							$data = get_proxied_url($data);
-					}
-					elseif (empty($scheme))
+					if (parse_url($data, PHP_URL_SCHEME) === null)
 						$data = '//' . ltrim($data, ':/');
+					
+					$data = get_proxied_url($data);
 				},
 				'disabled_content' => '($1)',
 			),
@@ -1766,20 +1758,12 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 				'content' => '<img src="$1" alt="" class="bbc_img">',
 				'validate' => function(&$tag, &$data, $disabled)
 				{
-					global $image_proxy_enabled, $user_info;
-
 					$data = strtr($data, array('<br>' => ''));
-					$scheme = parse_url($data, PHP_URL_SCHEME);
-					if ($image_proxy_enabled)
-					{
-						if (empty($scheme))
-							$data = 'http://' . ltrim($data, ':/');
 
-						if ($scheme != 'https')
-							$data = get_proxied_url($data);
-					}
-					elseif (empty($scheme))
+					if (parse_url($data, PHP_URL_SCHEME) === null)
 						$data = '//' . ltrim($data, ':/');
+					
+					$data = get_proxied_url($data);
 				},
 				'disabled_content' => '($1)',
 			),

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -3352,12 +3352,18 @@ function get_proxied_url($url)
 {
 	global $boardurl, $image_proxy_enabled, $image_proxy_secret, $user_info;
 
+	$parsedurl = parse_url($url);
+
 	// Only use the proxy if enabled and necessary (never for robots)
-	if (empty($image_proxy_enabled) || parse_url($url, PHP_URL_SCHEME) === 'https' || !empty($user_info['possibly_robot']))
+	if (empty($image_proxy_enabled) || $parsedurl['scheme'] === 'https' || !empty($user_info['possibly_robot']))
 		return $url;
 
+	// Work around a parse_url() bug in old versions of PHP
+	if (empty($parsedurl['host']) && strpos($url, '//') === 0 && version_compare(PHP_VERSION, '5.4.7', '<'))
+		$parsedurl = parse_url('http://' . ltrim($url, ':/'));
+
 	// We don't need to proxy our own resources
-	if (strpos(strtr($url, array('http://' => 'https://')), strtr($boardurl, array('http://' => 'https://'))) === 0)
+	if ($parsedurl['host'] === parse_url($boardurl, PHP_URL_HOST));
 		return strtr($url, array('http://' => 'https://'));
 
 	// By default, use SMF's own image proxy script

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -1747,8 +1747,8 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 
 					if (parse_url($data, PHP_URL_SCHEME) === null)
 						$data = '//' . ltrim($data, ':/');
-					
-					$data = get_proxied_url($data);
+					else
+						$data = get_proxied_url($data);
 				},
 				'disabled_content' => '($1)',
 			),
@@ -1762,8 +1762,8 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 
 					if (parse_url($data, PHP_URL_SCHEME) === null)
 						$data = '//' . ltrim($data, ':/');
-					
-					$data = get_proxied_url($data);
+					else
+						$data = get_proxied_url($data);
 				},
 				'disabled_content' => '($1)',
 			),

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -1749,9 +1749,6 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 					$scheme = parse_url($data, PHP_URL_SCHEME);
 					if ($image_proxy_enabled)
 					{
-						if (!empty($user_info['possibly_robot']))
-							return;
-
 						if (empty($scheme))
 							$data = 'http://' . ltrim($data, ':/');
 
@@ -1775,9 +1772,6 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 					$scheme = parse_url($data, PHP_URL_SCHEME);
 					if ($image_proxy_enabled)
 					{
-						if (!empty($user_info['possibly_robot']))
-							return;
-
 						if (empty($scheme))
 							$data = 'http://' . ltrim($data, ':/');
 
@@ -3356,10 +3350,10 @@ function highlight_php_code($code)
  */
 function get_proxied_url($url)
 {
-	global $boardurl, $image_proxy_enabled, $image_proxy_secret;
+	global $boardurl, $image_proxy_enabled, $image_proxy_secret, $user_info;
 
-	// Only use the proxy if enabled and necessary
-	if (empty($image_proxy_enabled) || parse_url($url, PHP_URL_SCHEME) === 'https')
+	// Only use the proxy if enabled and necessary (never for robots)
+	if (empty($image_proxy_enabled) || parse_url($url, PHP_URL_SCHEME) === 'https' || !empty($user_info['possibly_robot']))
 		return $url;
 
 	// We don't need to proxy our own resources


### PR DESCRIPTION
These changes make the rest of the code's interaction with the image proxy very clean and self-contained.

Also, this removes hardcoded assumptions that proxied file URLs will only use HTTP or HTTPS protocols.