### PR TITLE
Allows the $paid_debug hidden setting to actually work

### DIFF
--- a/Sources/Subscriptions-PayPal.php
+++ b/Sources/Subscriptions-PayPal.php
@@ -373,7 +373,7 @@ class paypal_payment
 	}
 
 	/**
-	 * Record the transaction reference and exit
+	 * Record the transaction reference to finish up.
 	 *
 	 */
 	public function close()
@@ -393,8 +393,6 @@ class paypal_payment
 				)
 			);
 		}
-
-		exit();
 	}
 
 	/**


### PR DESCRIPTION
This `exit();` was useless anyway, since the script ends right after the function returns (unless `$paid_debug` is true, of course).