### PR TITLE
Marks alerts about a topic as read when the topic is viewed

### DIFF
--- a/Sources/Display.php
+++ b/Sources/Display.php
@@ -1139,7 +1139,7 @@ function Display()
 		$smcFunc['db_query']('', '
 			UPDATE {db_prefix}user_alerts
 			SET is_read = {int:now}
-			WHERE id_member = {int:current_member}
+			WHERE is_read = 0 AND id_member = {int:current_member}
 				AND
 				(
 					(content_id IN ({array_int:messages}) AND content_type = {string:msg})

--- a/Sources/Display.php
+++ b/Sources/Display.php
@@ -1136,28 +1136,31 @@ function Display()
 		}
 
 		// Mark any alerts about this topic or the posts on this page as read.
-		$smcFunc['db_query']('', '
-			UPDATE {db_prefix}user_alerts
-			SET is_read = {int:now}
-			WHERE is_read = 0 AND id_member = {int:current_member}
-				AND
-				(
-					(content_id IN ({array_int:messages}) AND content_type = {string:msg})
-					OR
-					(content_id = {int:current_topic} AND (content_type = {string:topic} OR (content_type = {string:board} AND content_action = {string:topic})))
-				)',
-			array(
-				'topic' => 'topic',
-				'board' => 'board',
-				'msg' => 'msg',
-				'current_member' => $user_info['id'],
-				'current_topic' => $topic,
-				'messages' => $messages,
-				'now' => time(),
-			)
-		);
-		$user_info['alerts'] = $user_info['alerts'] - $smcFunc['db_affected_rows']();
-		updateMemberData($user_info['id'], array('alerts' => $user_info['alerts']));
+		if (!empty($user_info['alerts']))
+		{
+			$smcFunc['db_query']('', '
+				UPDATE {db_prefix}user_alerts
+				SET is_read = {int:now}
+				WHERE is_read = 0 AND id_member = {int:current_member}
+					AND
+					(
+						(content_id IN ({array_int:messages}) AND content_type = {string:msg})
+						OR
+						(content_id = {int:current_topic} AND (content_type = {string:topic} OR (content_type = {string:board} AND content_action = {string:topic})))
+					)',
+				array(
+					'topic' => 'topic',
+					'board' => 'board',
+					'msg' => 'msg',
+					'current_member' => $user_info['id'],
+					'current_topic' => $topic,
+					'messages' => $messages,
+					'now' => time(),
+				)
+			);
+			$user_info['alerts'] = $user_info['alerts'] - $smcFunc['db_affected_rows']();
+			updateMemberData($user_info['id'], array('alerts' => $user_info['alerts']));
+		}
 	}
 
 	// Get notification preferences

--- a/Sources/Display.php
+++ b/Sources/Display.php
@@ -1158,7 +1158,7 @@ function Display()
 					'now' => time(),
 				)
 			);
-			$user_info['alerts'] = $user_info['alerts'] - $smcFunc['db_affected_rows']();
+			$user_info['alerts'] = $user_info['alerts'] - max(0, $smcFunc['db_affected_rows']());
 			updateMemberData($user_info['id'], array('alerts' => $user_info['alerts']));
 		}
 	}

--- a/Sources/Display.php
+++ b/Sources/Display.php
@@ -1134,6 +1134,30 @@ function Display()
 				array('id_member', 'id_board')
 			);
 		}
+
+		// Mark any alerts about this topic or the posts on this page as read.
+		$smcFunc['db_query']('', '
+			UPDATE {db_prefix}user_alerts
+			SET is_read = {int:now}
+			WHERE id_member = {int:current_member}
+				AND
+				(
+					(content_id IN ({array_int:messages}) AND content_type = {string:msg})
+					OR
+					(content_id = {int:current_topic} AND (content_type = {string:topic} OR (content_type = {string:board} AND content_action = {string:topic})))
+				)',
+			array(
+				'topic' => 'topic',
+				'board' => 'board',
+				'msg' => 'msg',
+				'current_member' => $user_info['id'],
+				'current_topic' => $topic,
+				'messages' => $messages,
+				'now' => time(),
+			)
+		);
+		$user_info['alerts'] = $user_info['alerts'] - $smcFunc['db_affected_rows']();
+		updateMemberData($user_info['id'], array('alerts' => $user_info['alerts']));
 	}
 
 	// Get notification preferences


### PR DESCRIPTION
Previously, we only marked the alert as read if you visited the topic via the alert. If you nevigated there via other means, the alert would still show as unread. This required the user to manually mark the alert as read after reading the topic itself, which quickly becomes unmanageable on an active forum.