### PR TITLE
Keep order of poll choices consistent

### DIFF
--- a/Sources/Display.php
+++ b/Sources/Display.php
@@ -676,7 +676,8 @@ function Display()
 			SELECT pc.id_choice, pc.label, pc.votes, COALESCE(lp.id_choice, -1) AS voted_this
 			FROM {db_prefix}poll_choices AS pc
 				LEFT JOIN {db_prefix}log_polls AS lp ON (lp.id_choice = pc.id_choice AND lp.id_poll = {int:id_poll} AND lp.id_member = {int:current_member} AND lp.id_member != {int:not_guest})
-			WHERE pc.id_poll = {int:id_poll} ORDER by pc.id_choice',
+			WHERE pc.id_poll = {int:id_poll}
+			ORDER BY pc.id_choice',
 			array(
 				'current_member' => $user_info['id'],
 				'id_poll' => $context['topicinfo']['id_poll'],

--- a/Sources/Display.php
+++ b/Sources/Display.php
@@ -676,7 +676,7 @@ function Display()
 			SELECT pc.id_choice, pc.label, pc.votes, COALESCE(lp.id_choice, -1) AS voted_this
 			FROM {db_prefix}poll_choices AS pc
 				LEFT JOIN {db_prefix}log_polls AS lp ON (lp.id_choice = pc.id_choice AND lp.id_poll = {int:id_poll} AND lp.id_member = {int:current_member} AND lp.id_member != {int:not_guest})
-			WHERE pc.id_poll = {int:id_poll}',
+			WHERE pc.id_poll = {int:id_poll} ORDER by pc.id_choice',
 			array(
 				'current_member' => $user_info['id'],
 				'id_poll' => $context['topicinfo']['id_poll'],


### PR DESCRIPTION
This patch sorts poll choices the way they were input by the poll creator.

Before this, the poll choice order was inconsistent over time, see link below (in Postgres, the last-voted-on choices were shown last; I don't know or care about the details in MySQL, the patch is trivial enough that I don't expect issues on MySQL though).

Thanks to [Arantor, who did the searching that would have been the biggest part of my work for this patch](https://www.simplemachines.org/community/index.php?topic=569566.msg4036106#msg4036106).