### PR TITLE
Adds a hook before returning XML output in JavaScriptModify()

### DIFF
--- a/Sources/Post.php
+++ b/Sources/Post.php
@@ -3152,6 +3152,9 @@ function JavaScriptModify()
 					$context['message']['errors'][] = $txt['error_' . $post_error];
 			}
 		}
+
+		// Allow mods to do something with $context before we return.
+		call_integration_hook('integrate_jsmodify_xml');
 	}
 	else
 		obExit(false);


### PR DESCRIPTION
Just a simple hook. It is chiefly of interest for mods that use the `integrate_prepare_display_context` hook in `prepareDisplayContext()`, so that they can apply the same changes to the message content returned after using the Quick Edit button.