### PR TITLE
Dont clobber defaults

### DIFF
--- a/Sources/Themes.php
+++ b/Sources/Themes.php
@@ -413,7 +413,7 @@ function SetThemeOptions()
 				$smcFunc['db_query']('substring', '
 					DELETE FROM {db_prefix}themes
 					WHERE id_theme = {int:default_theme}
-						AND id_member != {int:no_member}
+						AND id_member > {int:no_member}
 						AND variable = SUBSTRING({string:option}, 1, 255)',
 					array(
 						'default_theme' => 1,
@@ -472,7 +472,7 @@ function SetThemeOptions()
 				$smcFunc['db_query']('substring', '
 					DELETE FROM {db_prefix}themes
 					WHERE id_theme = {int:current_theme}
-						AND id_member != {int:no_member}
+						AND id_member > {int:no_member}
 						AND variable = SUBSTRING({string:option}, 1, 255)',
 					array(
 						'current_theme' => $_GET['th'],

--- a/Themes/default/Themes.template.php
+++ b/Themes/default/Themes.template.php
@@ -325,7 +325,7 @@ function template_set_options()
 			<input type="hidden" name="who" value="', $context['theme_options_reset'] ? 1 : 0, '">
 			<div class="cat_bar">
 				<h3 class="catbg">
-					', $txt['theme_options_title'], ' - ', $context['theme_settings']['name'], '
+					', $context['theme_options_reset'] ? $txt['themeadmin_reset_options_title'] : $txt['theme_options_title'], ' - ', $context['theme_settings']['name'], '
 				</h3>
 			</div>
 			<div class="information noup">

--- a/Themes/default/languages/Themes.english.php
+++ b/Themes/default/languages/Themes.english.php
@@ -128,6 +128,7 @@ $txt['themeadmin_reset_options_info'] = 'The options below will reset options fo
 $txt['themeadmin_reset_options_change'] = 'Change';
 $txt['themeadmin_reset_options_none'] = 'Don\'t change';
 $txt['themeadmin_reset_options_default'] = 'Default';
+$txt['themeadmin_reset_options_title'] = 'Change or reset user options';
 
 $txt['themeadmin_edit_browse'] = 'Browse the templates and files in this theme.';
 $txt['themeadmin_edit_style'] = 'Edit this theme\'s stylesheets.';

--- a/other/install_2-1_mysql.sql
+++ b/other/install_2-1_mysql.sql
@@ -2223,12 +2223,12 @@ VALUES (1, 'name', '{$default_theme_name}'),
 	(1, 'show_stats_index', '1'),
 	(1, 'newsfader_time', '3000'),
 	(1, 'use_image_buttons', '1'),
-	(1, 'enable_news', '1'),
-	(1, 'drafts_show_saved_enabled', '1');
+	(1, 'enable_news', '1');
 
 INSERT INTO {$db_prefix}themes
 	(id_member, id_theme, variable, value)
 VALUES (-1, 1, 'posts_apply_ignore_list', '1'),
+	(-1, 1, 'drafts_show_saved_enabled', '1'),
 	(-1, 1, 'return_to_post', '1');
 # --------------------------------------------------------
 

--- a/other/install_2-1_postgresql.sql
+++ b/other/install_2-1_postgresql.sql
@@ -2770,12 +2770,12 @@ VALUES (1, 'name', '{$default_theme_name}'),
 	(1, 'show_stats_index', '1'),
 	(1, 'newsfader_time', '3000'),
 	(1, 'use_image_buttons', '1'),
-	(1, 'enable_news', '1'),
-	(1, 'drafts_show_saved_enabled', '1');
+	(1, 'enable_news', '1');
 
 INSERT INTO {$db_prefix}themes
 	(id_member, id_theme, variable, value)
 VALUES (-1, 1, 'posts_apply_ignore_list', '1'),
+	(-1, 1, 'drafts_show_saved_enabled', '1'),
 	(-1, 1, 'return_to_post', '1');
 # --------------------------------------------------------
 

--- a/other/upgrade_2-1_mysql.sql
+++ b/other/upgrade_2-1_mysql.sql
@@ -1318,9 +1318,9 @@ VALUES
 	('drafts_keep_days', '7');
 
 INSERT INTO {$db_prefix}themes
-	(id_theme, variable, value)
+	(id_member, id_theme, variable, value)
 VALUES
-	('1', 'drafts_show_saved_enabled', '1');
+	(-1, '1', 'drafts_show_saved_enabled', '1');
 ---#
 
 /******************************************************************************/

--- a/other/upgrade_2-1_postgresql.sql
+++ b/other/upgrade_2-1_postgresql.sql
@@ -1504,7 +1504,7 @@ INSERT INTO {$db_prefix}settings (variable, value) VALUES ('drafts_autosave_enab
 INSERT INTO {$db_prefix}settings (variable, value) VALUES ('drafts_show_saved_enabled', '1') ON CONFLICT DO NOTHING;
 INSERT INTO {$db_prefix}settings (variable, value) VALUES ('drafts_keep_days', '7') ON CONFLICT DO NOTHING;
 
-INSERT INTO {$db_prefix}themes (id_theme, variable, value) VALUES ('1', 'drafts_show_saved_enabled', '1') ON CONFLICT DO NOTHING;
+INSERT INTO {$db_prefix}themes (id_member, id_theme, variable, value) VALUES (-1, '1', 'drafts_show_saved_enabled', '1') ON CONFLICT DO NOTHING;
 ---#
 
 /******************************************************************************/


### PR DESCRIPTION
Fixes #5882 

 - don't delete defaults when making updates
 - improve confusing title of section where user settings are modified
 - a user default setting was being treated as a global setting (id_member should have been -1); note that as a result of this, draft selection now appears when posting by default as intended