### PR TITLE
Search API fatal error

### DIFF
--- a/Sources/ManageSearch.php
+++ b/Sources/ManageSearch.php
@@ -739,6 +739,9 @@ function loadSearchAPIs()
 {
 	global $sourcedir, $txt;
 
+	// Ensure we have class.
+	require_once($sourcedir . '/Class-SearchAPI.php');
+
 	$apis = array();
 	if ($dh = opendir($sourcedir))
 	{


### PR DESCRIPTION
Custom Searches use the Search API Class, ensure its loaded prior to loading up the APIs