### PR TITLE
Dont exceed range

### DIFF
--- a/Sources/ManageSearchEngines.php
+++ b/Sources/ManageSearchEngines.php
@@ -558,7 +558,8 @@ function logSpider()
 		$date = strftime('%Y-%m-%d', forum_time(false));
 		$smcFunc['db_query']('', '
 			UPDATE {db_prefix}log_spider_stats
-			SET last_seen = {int:current_time}, page_hits = page_hits + 1
+			SET last_seen = {int:current_time},
+				page_hits = CASE WHEN page_hits + 1 > 65535 THEN 65535 ELSE page_hits + 1 END
 			WHERE id_spider = {int:current_spider}
 				AND stat_date = {date:current_date}',
 			array(
@@ -636,7 +637,7 @@ function consolidateSpiderStats()
 		$date = strftime('%Y-%m-%d', $stat['last_seen']);
 		$smcFunc['db_query']('', '
 			UPDATE {db_prefix}log_spider_stats
-			SET page_hits = page_hits + {int:hits},
+			SET page_hits = CASE WHEN page_hits + {int:hits} > 65535 THEN 65535 ELSE page_hits + {int:hits} END,
 				last_seen = CASE WHEN last_seen > {int:last_seen} THEN last_seen ELSE {int:last_seen} END
 			WHERE id_spider = {int:current_spider}
 				AND stat_date = {date:last_seen_date}',

--- a/Sources/ManageSearchEngines.php
+++ b/Sources/ManageSearchEngines.php
@@ -558,8 +558,7 @@ function logSpider()
 		$date = strftime('%Y-%m-%d', forum_time(false));
 		$smcFunc['db_query']('', '
 			UPDATE {db_prefix}log_spider_stats
-			SET last_seen = {int:current_time},
-				page_hits = CASE WHEN page_hits + 1 > 65535 THEN 65535 ELSE page_hits + 1 END
+			SET last_seen = {int:current_time}, page_hits = page_hits + 1
 			WHERE id_spider = {int:current_spider}
 				AND stat_date = {date:current_date}',
 			array(
@@ -637,7 +636,7 @@ function consolidateSpiderStats()
 		$date = strftime('%Y-%m-%d', $stat['last_seen']);
 		$smcFunc['db_query']('', '
 			UPDATE {db_prefix}log_spider_stats
-			SET page_hits = CASE WHEN page_hits + {int:hits} > 65535 THEN 65535 ELSE page_hits + {int:hits} END,
+			SET page_hits = page_hits + {int:hits},
 				last_seen = CASE WHEN last_seen > {int:last_seen} THEN last_seen ELSE {int:last_seen} END
 			WHERE id_spider = {int:current_spider}
 				AND stat_date = {date:last_seen_date}',

--- a/other/install_2-1_mysql.sql
+++ b/other/install_2-1_mysql.sql
@@ -601,7 +601,7 @@ CREATE TABLE {$db_prefix}log_spider_hits (
 
 CREATE TABLE {$db_prefix}log_spider_stats (
 	id_spider SMALLINT UNSIGNED DEFAULT '0',
-	page_hits SMALLINT UNSIGNED NOT NULL DEFAULT '0',
+	page_hits INT NOT NULL DEFAULT '0',
 	last_seen INT(10) UNSIGNED NOT NULL DEFAULT '0',
 	stat_date DATE DEFAULT '1004-01-01',
 	PRIMARY KEY (stat_date, id_spider)

--- a/other/install_2-1_postgresql.sql
+++ b/other/install_2-1_postgresql.sql
@@ -917,7 +917,7 @@ CREATE INDEX {$db_prefix}log_spider_hits_processed ON {$db_prefix}log_spider_hit
 
 CREATE TABLE {$db_prefix}log_spider_stats (
 	id_spider smallint NOT NULL DEFAULT '0',
-	page_hits smallint NOT NULL DEFAULT '0',
+	page_hits int NOT NULL DEFAULT '0',
 	last_seen bigint NOT NULL DEFAULT '0',
 	stat_date date NOT NULL DEFAULT '1004-01-01',
 	PRIMARY KEY (stat_date, id_spider)

--- a/other/upgrade_2-1_mysql.sql
+++ b/other/upgrade_2-1_mysql.sql
@@ -3073,3 +3073,11 @@ while ($row = $smcFunc['db_fetch_assoc']($request))
 }
 ---}
 ---#
+
+/******************************************************************************/
+--- Update log_spider_stats
+/******************************************************************************/
+---# Allow for hyper aggressive crawlers
+ALTER TABLE {$db_prefix}log_spider_stats CHANGE page_hits page_hits INT NOT NULL DEFAULT '0';
+---#
+

--- a/other/upgrade_2-1_postgresql.sql
+++ b/other/upgrade_2-1_postgresql.sql
@@ -3437,3 +3437,10 @@ VALUES ('Independence Day', '1004-07-04'),
 DROP INDEX IF EXISTS {$db_prefix}attachments_id_thumb;
 CREATE INDEX {$db_prefix}attachments_id_thumb ON {$db_prefix}attachments (id_thumb);
 ---#
+
+/******************************************************************************/
+--- Update log_spider_stats
+/******************************************************************************/
+---# Allow for hyper aggressive crawlers
+ALTER TABLE {$db_prefix}log_spider_stats ALTER COLUMN page_hits TYPE INT;
+---#


### PR DESCRIPTION
Hyper aggressive crawlers like MSN can flood the stats records.

Fixes #5890 

I am assuming we're not going to change the schema at this point.  

Note this does not work for pg, mainly because the pg smallint is signed & the max value is 32767, not 65535.  Open to input.  
