### PR TITLE
Fixes errors with bad IPs

### DIFF
--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -5990,17 +5990,16 @@ function inet_ptod($ip_address)
  */
 function inet_dtop($bin)
 {
-	if (empty($bin))
-		return '';
-
 	global $db_type;
 
-	if ($db_type == 'postgresql')
+	if (empty($bin))
+		return '';
+	elseif ($db_type == 'postgresql')
 		return $bin;
-
-	$ip_address = inet_ntop($bin);
-
-	return $ip_address;
+	// Already a String?
+	elseif (isValidIP($bin))
+		return $bin;
+	return inet_ntop($bin);
 }
 
 /**


### PR DESCRIPTION
If bad data exists in the database for a binary IP, SMF will generate a error:
Warning: inet_ntop(): Invalid in_addr value in /Sources/Subs.php on line 6001

This simply tests if its a valid IP already and sends it back on through.

This doesn't fix the issue (as it doesn't know the source) and won't prevent areas that may be broken from compare operations.