### PR TITLE
Lock on writing cache

### DIFF
--- a/Sources/CacheAPI-smf.php
+++ b/Sources/CacheAPI-smf.php
@@ -111,7 +111,7 @@ class smf_cache extends cache_api
 			// Write out the cache file, check that the cache write was successful; all the data must be written
 			$fileSize = $this->filePutWithLock($file_name, $cache_data);
 
-			// Check the file againts what its suppose to have in it.
+			// Check the file against what its suppose to have in it.
 			if ($fileSize === strlen($cache_data))
 				$file_created = true;
 

--- a/Sources/CacheAPI-smf.php
+++ b/Sources/CacheAPI-smf.php
@@ -215,6 +215,26 @@ class smf_cache extends cache_api
 	{
 		return SMF_VERSION;
 	}
+
+	/**
+	 * @param string $file_name
+	 * @param string $cache_data
+	 * @return int
+	 */
+	protected function filePutWithLock($file_name, $cache_data)
+	{
+		$saved_file = 0;
+		$tmp_lock_file = $this->cachedir . '/tmp/'. str_replace('.php', '.lock', $file_name);
+
+		if (mkdir($tmp_lock_file, 0700)) {
+
+			$saved_file = file_put_contents( $file_name, $cache_data, LOCK_EX);
+
+			rmdir($tmp_lock_file);
+		}
+
+		return $saved_file;
+	}
 }
 
 ?>

--- a/Sources/CacheAPI-smf.php
+++ b/Sources/CacheAPI-smf.php
@@ -86,19 +86,20 @@ class smf_cache extends cache_api
 	public function putData($key, $value, $ttl = null)
 	{
 		$key = $this->prefix . strtr($key, ':/', '-_');
-		$file_name = $this->cachedir . '/data_' . $key . '.php';
+		$file_name = '/data_' . $key . '.php';
+		$file_path = $this->cachedir . $file_name;
 
 		// Work around Zend's opcode caching (PHP 5.5+), they would cache older files for a couple of seconds
 		// causing newer files to take effect a while later.
 		if (function_exists('opcache_invalidate'))
-			opcache_invalidate($file_name, true);
+			opcache_invalidate($file_path, true);
 
 		if (function_exists('apc_delete_file'))
-			@apc_delete_file($file_name);
+			@apc_delete_file($file_path);
 
 		// Otherwise custom cache?
 		if ($value === null)
-			@unlink($file_name);
+			@unlink($file_path);
 
 		else
 		{
@@ -224,9 +225,9 @@ class smf_cache extends cache_api
 	protected function filePutWithLock($file_name, $cache_data)
 	{
 		$saved_file = 0;
-		$tmp_lock_file = $this->cachedir . '/tmp/'. str_replace('.php', '.lock', $file_name);
+		$tmp_lock_file = $this->cachedir . '/tmp'. str_replace('.php', '.lock', $file_name);
 
-		if (mkdir($tmp_lock_file, 0700)) {
+		if (mkdir($tmp_lock_file, 0700, true)) {
 
 			$saved_file = file_put_contents( $file_name, $cache_data, LOCK_EX);
 

--- a/Sources/CacheAPI-smf.php
+++ b/Sources/CacheAPI-smf.php
@@ -229,7 +229,7 @@ class smf_cache extends cache_api
 
 		if (mkdir($tmp_lock_file, 0700, true)) {
 
-			$saved_file = file_put_contents( $file_name, $cache_data, LOCK_EX);
+			$saved_file = file_put_contents( $this->cachedir . $file_name, $cache_data, LOCK_EX);
 
 			rmdir($tmp_lock_file);
 		}


### PR DESCRIPTION
This is my approach to fixes #5826

It uses  rather simple method to lock a file while its been created, taking advantage of directories been able to be created and deleted but not overwritten we can bypass the race condition created when two or more process attempt to modify the same cache entry.

The function as it is return false when theres a lock on the file and thus the cache entry won't be created, it can be changed to do a re-attempt either via recursiveness or other mechanisms.