### PR TITLE
Makes sure we don't show an alert counter with a value of zero

### DIFF
--- a/Themes/default/scripts/alerts.js
+++ b/Themes/default/scripts/alerts.js
@@ -86,6 +86,10 @@ var updateAlerts = function ()
 		user_menus.add("alerts", smf_scripturl + "?action=profile;area=alerts_popup;u=" + smf_member_id);
 	});
 
+	// A counter showing zero looks silly
+	if (unreadAlerts === 0)
+		$('#alerts_menu_top > .amt:first').remove();
+
 	setTimeout(updateAlerts, pingTime);
 }
 


### PR DESCRIPTION
This could happen if the user had multiple browser windows open and marked all alerts as read in one of them.