### PR TITLE
Merge topics

### DIFF
--- a/Sources/MessageIndex.php
+++ b/Sources/MessageIndex.php
@@ -811,16 +811,22 @@ function QuickModeration()
 
 	if (!$user_info['is_guest'])
 		$possibleActions[] = 'markread';
+
 	if (!empty($boards_can['make_sticky']))
 		$possibleActions[] = 'sticky';
+
 	if (!empty($boards_can['move_any']) || !empty($boards_can['move_own']))
 		$possibleActions[] = 'move';
+
 	if (!empty($boards_can['remove_any']) || !empty($boards_can['remove_own']))
 		$possibleActions[] = 'remove';
+
 	if (!empty($boards_can['lock_any']) || !empty($boards_can['lock_own']))
 		$possibleActions[] = 'lock';
+
 	if (!empty($boards_can['merge_any']))
 		$possibleActions[] = 'merge';
+
 	if (!empty($boards_can['approve_posts']))
 		$possibleActions[] = 'approve';
 

--- a/Sources/SplitTopics.php
+++ b/Sources/SplitTopics.php
@@ -857,6 +857,7 @@ function MergeIndex()
 
 	if (!isset($_GET['from']))
 		fatal_lang_error('no_access', false);
+
 	$_GET['from'] = (int) $_GET['from'];
 
 	$_REQUEST['targetboard'] = isset($_REQUEST['targetboard']) ? (int) $_REQUEST['targetboard'] : $board;
@@ -868,6 +869,7 @@ function MergeIndex()
 		$can_approve_boards = boardsAllowedTo('approve_posts');
 		$onlyApproved = $can_approve_boards !== array(0) && !in_array($_REQUEST['targetboard'], $can_approve_boards);
 	}
+
 	else
 		$onlyApproved = false;
 
@@ -882,6 +884,7 @@ function MergeIndex()
 			'is_approved' => 1,
 		)
 	);
+
 	list ($topiccount) = $smcFunc['db_fetch_row']($request);
 	$smcFunc['db_free_result']($request);
 
@@ -903,8 +906,10 @@ function MergeIndex()
 			'is_approved' => 1,
 		)
 	);
+
 	if ($smcFunc['db_num_rows']($request) == 0)
 		fatal_lang_error('no_board');
+
 	list ($subject) = $smcFunc['db_fetch_row']($request);
 	$smcFunc['db_free_result']($request);
 

--- a/Themes/default/MoveTopic.template.php
+++ b/Themes/default/MoveTopic.template.php
@@ -246,7 +246,6 @@ function template_merge()
 
 		echo '
 					</ul>
-					<input type="submit" value="', $txt['merge'], '" class="button">
 				</div>
 				<div class="pagesection">
 					', $context['page_index'], '


### PR DESCRIPTION
Fixes #5902

That merge button belongs to the second option to merge a topic where you manually specify a topic ID.