### PR TITLE
Fix cloning of drafts when saving after a preview

### DIFF
--- a/Sources/PersonalMessage.php
+++ b/Sources/PersonalMessage.php
@@ -2305,7 +2305,10 @@ function MessagePost2()
 
 	// PM Drafts enabled and needed?
 	if ($context['drafts_pm_save'] && (isset($_POST['save_draft']) || isset($_POST['id_pm_draft'])))
+	{
+		$context['id_pm_draft'] = !empty($_POST['id_pm_draft']) ? (int) $_POST['id_pm_draft'] : 0;
 		require_once($sourcedir . '/Drafts.php');
+	}
 
 	loadLanguage('PersonalMessage', '', false);
 


### PR DESCRIPTION
Fixes #5874 

After investigating I found out that when previewing a pm draft the hidden input containing the value of `id_pm_draft` turns to 0 which results in the code treating it as a new draft when submitting, a simple line to remember the id of the draft after previewing fixes the issue.