### PR TITLE
Converts global $time_start to constant TIME_START

### DIFF
--- a/SSI.php
+++ b/SSI.php
@@ -22,14 +22,14 @@ define('SMF_SOFTWARE_YEAR', '2020');
 define('JQUERY_VERSION', '3.4.1');
 
 // We're going to want a few globals... these are all set later.
-global $time_start, $maintenance, $msubject, $mmessage, $mbname, $language;
+global $maintenance, $msubject, $mmessage, $mbname, $language;
 global $boardurl, $boarddir, $sourcedir, $webmaster_email, $cookiename;
 global $db_type, $db_server, $db_name, $db_user, $db_prefix, $db_persist, $db_error_send, $db_last_error;
 global $db_connection, $db_port, $modSettings, $context, $sc, $user_info, $topic, $board, $txt;
 global $smcFunc, $ssi_db_user, $scripturl, $ssi_db_passwd, $db_passwd, $cache_enable, $cachedir;
 
 // Remember the current configuration so it can be set back.
-$time_start = microtime(true);
+define('TIME_START', microtime(true));
 
 // Just being safe...
 foreach (array('db_character_set', 'cachedir') as $variable)

--- a/SSI.php
+++ b/SSI.php
@@ -28,13 +28,12 @@ global $db_type, $db_server, $db_name, $db_user, $db_prefix, $db_persist, $db_er
 global $db_connection, $db_port, $modSettings, $context, $sc, $user_info, $topic, $board, $txt;
 global $smcFunc, $ssi_db_user, $scripturl, $ssi_db_passwd, $db_passwd, $cache_enable, $cachedir;
 
-// Remember the current configuration so it can be set back.
-define('TIME_START', microtime(true));
+if (!defined('TIME_START'))
+	define('TIME_START', microtime(true));
 
 // Just being safe...
 foreach (array('db_character_set', 'cachedir') as $variable)
-	if (isset($GLOBALS[$variable]))
-		unset($GLOBALS[$variable]);
+	unset($GLOBALS[$variable]);
 
 // Get the forum's settings for database and file paths.
 require_once(dirname(__FILE__) . '/Settings.php');

--- a/Sources/ManageAttachments.php
+++ b/Sources/ManageAttachments.php
@@ -1694,7 +1694,7 @@ function RepairAttachments()
  */
 function pauseAttachmentMaintenance($to_fix, $max_substep = 0)
 {
-	global $context, $txt, $time_start;
+	global $context, $txt;
 
 	// Try get more time...
 	@set_time_limit(600);
@@ -1702,7 +1702,7 @@ function pauseAttachmentMaintenance($to_fix, $max_substep = 0)
 		@apache_reset_timeout();
 
 	// Have we already used our maximum time?
-	if ((time() - $time_start) < 3 || $context['starting_substep'] == $_GET['substep'])
+	if ((time() - TIME_START) < 3 || $context['starting_substep'] == $_GET['substep'])
 		return;
 
 	$context['continue_get_data'] = '?action=admin;area=manageattachments;sa=repair' . (isset($_GET['fixErrors']) ? ';fixErrors' : '') . ';step=' . $_GET['step'] . ';substep=' . $_GET['substep'] . ';' . $context['session_var'] . '=' . $context['session_id'];

--- a/Sources/ManageMail.php
+++ b/Sources/ManageMail.php
@@ -425,7 +425,7 @@ function ClearMailQueue()
  */
 function pauseMailQueueClear()
 {
-	global $context, $txt, $time_start;
+	global $context, $txt;
 
 	// Try get more time...
 	@set_time_limit(600);
@@ -433,7 +433,7 @@ function pauseMailQueueClear()
 		@apache_reset_timeout();
 
 	// Have we already used our maximum time?
-	if ((time() - $time_start) < 5)
+	if ((time() - TIME_START) < 5)
 		return;
 
 	$context['continue_get_data'] = '?action=admin;area=mailqueue;sa=clear;te=' . $_GET['te'] . ';sent=' . $_GET['sent'] . ';' . $context['session_var'] . '=' . $context['session_id'];

--- a/Sources/ManageMaintenance.php
+++ b/Sources/ManageMaintenance.php
@@ -338,7 +338,7 @@ function Destroy()
 function ConvertMsgBody()
 {
 	global $scripturl, $context, $txt, $db_type;
-	global $modSettings, $smcFunc, $time_start;
+	global $modSettings, $smcFunc;
 
 	// Show me your badge!
 	isAllowedTo('admin_forum');
@@ -425,7 +425,7 @@ function ConvertMsgBody()
 
 			$_REQUEST['start'] += $increment;
 
-			if (microtime(true) - $time_start > 3)
+			if (microtime(true) - TIME_START > 3)
 			{
 				createToken('admin-convertMsg');
 				$context['continue_post_data'] = '
@@ -711,7 +711,7 @@ function ConvertEntities()
  */
 function OptimizeTables()
 {
-	global $db_prefix, $txt, $context, $smcFunc, $time_start;
+	global $db_prefix, $txt, $context, $smcFunc;
 
 	isAllowedTo('admin_forum');
 
@@ -757,7 +757,7 @@ function OptimizeTables()
 			break;
 
 		// Continue?
-		if (microtime(true) - $time_start > 10)
+		if (microtime(true) - TIME_START > 10)
 		{
 			$_REQUEST['start'] = $key;
 			$context['continue_get_data'] = '?action=admin;area=maintain;sa=database;activity=optimize;start=' . $_REQUEST['start'] . ';' . $context['session_var'] . '=' . $context['session_id'];
@@ -809,8 +809,7 @@ function OptimizeTables()
  */
 function AdminBoardRecount()
 {
-	global $txt, $context, $modSettings, $sourcedir;
-	global $time_start, $smcFunc;
+	global $txt, $context, $modSettings, $sourcedir, $smcFunc;
 
 	isAllowedTo('admin_forum');
 	checkSession('request');
@@ -910,7 +909,7 @@ function AdminBoardRecount()
 
 			$_REQUEST['start'] += $increment;
 
-			if (microtime(true) - $time_start > 3)
+			if (microtime(true) - TIME_START > 3)
 			{
 				createToken('admin-boardrecount');
 				$context['continue_post_data'] = '<input type="hidden" name="' . $context['admin-boardrecount_token_var'] . '" value="' . $context['admin-boardrecount_token'] . '">';
@@ -968,7 +967,7 @@ function AdminBoardRecount()
 
 			$_REQUEST['start'] += $increment;
 
-			if (microtime(true) - $time_start > 3)
+			if (microtime(true) - TIME_START > 3)
 			{
 				createToken('admin-boardrecount');
 				$context['continue_post_data'] = '<input type="hidden" name="' . $context['admin-boardrecount_token_var'] . '" value="' . $context['admin-boardrecount_token'] . '">';
@@ -1024,7 +1023,7 @@ function AdminBoardRecount()
 
 			$_REQUEST['start'] += $increment;
 
-			if (microtime(true) - $time_start > 3)
+			if (microtime(true) - TIME_START > 3)
 			{
 				createToken('admin-boardrecount');
 				$context['continue_post_data'] = '<input type="hidden" name="' . $context['admin-boardrecount_token_var'] . '" value="' . $context['admin-boardrecount_token'] . '">';
@@ -1080,7 +1079,7 @@ function AdminBoardRecount()
 
 			$_REQUEST['start'] += $increment;
 
-			if (microtime(true) - $time_start > 3)
+			if (microtime(true) - TIME_START > 3)
 			{
 				createToken('admin-boardrecount');
 				$context['continue_post_data'] = '<input type="hidden" name="' . $context['admin-boardrecount_token_var'] . '" value="' . $context['admin-boardrecount_token'] . '">';
@@ -1136,7 +1135,7 @@ function AdminBoardRecount()
 
 			$_REQUEST['start'] += $increment;
 
-			if (microtime(true) - $time_start > 3)
+			if (microtime(true) - TIME_START > 3)
 			{
 				createToken('admin-boardrecount');
 				$context['continue_post_data'] = '<input type="hidden" name="' . $context['admin-boardrecount_token_var'] . '" value="' . $context['admin-boardrecount_token'] . '">';
@@ -1185,7 +1184,7 @@ function AdminBoardRecount()
 			updateMemberData($row['id_member'], array('unread_messages' => $row['real_num']));
 		$smcFunc['db_free_result']($request);
 
-		if (microtime(true) - $time_start > 3)
+		if (microtime(true) - TIME_START > 3)
 		{
 			createToken('admin-boardrecount');
 			$context['continue_post_data'] = '<input type="hidden" name="' . $context['admin-boardrecount_token_var'] . '" value="' . $context['admin-boardrecount_token'] . '">';
@@ -1232,7 +1231,7 @@ function AdminBoardRecount()
 
 			$_REQUEST['start'] += $increment;
 
-			if (microtime(true) - $time_start > 3)
+			if (microtime(true) - TIME_START > 3)
 			{
 				createToken('admin-boardrecount');
 				$context['continue_post_data'] = '<input type="hidden" name="' . $context['admin-boardrecount_token_var'] . '" value="' . $context['admin-boardrecount_token'] . '">';

--- a/Sources/Packages.php
+++ b/Sources/Packages.php
@@ -2413,7 +2413,7 @@ function fetchPerms__recursive($path, &$data, $level)
  */
 function PackagePermissionsAction()
 {
-	global $smcFunc, $context, $txt, $time_start, $package_ftp;
+	global $smcFunc, $context, $txt, $package_ftp;
 
 	umask(0);
 
@@ -2507,7 +2507,7 @@ function PackagePermissionsAction()
 			unset($context['to_process'][$path]);
 
 			// See if we're out of time?
-			if ((time() - $time_start) > $timeout_limit)
+			if ((time() - TIME_START) > $timeout_limit)
 			{
 				// Prepare template usage for to_process.
 				$context['to_process_encode'] = base64_encode($smcFunc['json_encode']($context['to_process']));
@@ -2620,7 +2620,7 @@ function PackagePermissionsAction()
 				}
 
 				// See if we're out of time?
-				if (!$dont_chmod && (time() - $time_start) > $timeout_limit)
+				if (!$dont_chmod && (time() - TIME_START) > $timeout_limit)
 				{
 					$dont_chmod = true;
 					// Don't do this again.
@@ -2647,7 +2647,7 @@ function PackagePermissionsAction()
 			unset($context['directory_list'][$path]);
 
 			// See if we're out of time?
-			if ((time() - $time_start) > $timeout_limit)
+			if ((time() - TIME_START) > $timeout_limit)
 			{
 				// Prepare this for usage on templates.
 				$context['directory_list_encode'] = base64_encode($smcFunc['json_encode']($context['directory_list']));

--- a/Sources/RepairBoards.php
+++ b/Sources/RepairBoards.php
@@ -130,7 +130,7 @@ function RepairBoards()
  */
 function pauseRepairProcess($to_fix, $current_step_description, $max_substep = 0, $force = false)
 {
-	global $context, $txt, $time_start, $db_temp_cache, $db_cache;
+	global $context, $txt, $db_temp_cache, $db_cache;
 
 	// More time, I need more time!
 	@set_time_limit(600);
@@ -138,7 +138,7 @@ function pauseRepairProcess($to_fix, $current_step_description, $max_substep = 0
 		@apache_reset_timeout();
 
 	// Errr, wait.  How much time has this taken already?
-	if (!$force && (time() - $time_start) < 3)
+	if (!$force && (time() - TIME_START) < 3)
 		return;
 
 	// Restore the query cache if interested.

--- a/Sources/ScheduledTasks.php
+++ b/Sources/ScheduledTasks.php
@@ -21,7 +21,7 @@ if (!defined('SMF'))
  */
 function AutoTask()
 {
-	global $time_start, $smcFunc;
+	global $smcFunc;
 
 	// Special case for doing the mail queue.
 	if (isset($_GET['scheduled']) && $_GET['scheduled'] == 'mailq')
@@ -110,7 +110,7 @@ function AutoTask()
 				// Log that we did it ;)
 				if ($completed)
 				{
-					$total_time = round(microtime(true) - $time_start, 3);
+					$total_time = round(microtime(true) - TIME_START, 3);
 					$smcFunc['db_insert']('',
 						'{db_prefix}log_scheduled_tasks',
 						array(

--- a/Sources/Subs-Db-mysql.php
+++ b/Sources/Subs-Db-mysql.php
@@ -358,7 +358,7 @@ function smf_db_quote($db_string, $db_values, $connection = null)
  */
 function smf_db_query($identifier, $db_string, $db_values = array(), $connection = null)
 {
-	global $db_cache, $db_count, $db_connection, $db_show_debug, $time_start;
+	global $db_cache, $db_count, $db_connection, $db_show_debug;
 	global $db_unbuffered, $db_callback, $modSettings;
 
 	// Comments that are allowed in a query are preg_removed.
@@ -477,7 +477,7 @@ function smf_db_query($identifier, $db_string, $db_values = array(), $connection
 		$db_cache[$db_count]['q'] = $db_count < 50 ? $db_string : '...';
 		$db_cache[$db_count]['f'] = $file;
 		$db_cache[$db_count]['l'] = $line;
-		$db_cache[$db_count]['s'] = ($st = microtime(true)) - $time_start;
+		$db_cache[$db_count]['s'] = ($st = microtime(true)) - TIME_START;
 	}
 
 	if (empty($db_unbuffered))

--- a/Sources/Subs-Db-postgresql.php
+++ b/Sources/Subs-Db-postgresql.php
@@ -322,7 +322,7 @@ function smf_db_quote($db_string, $db_values, $connection = null)
  */
 function smf_db_query($identifier, $db_string, $db_values = array(), $connection = null)
 {
-	global $db_cache, $db_count, $db_connection, $db_show_debug, $time_start;
+	global $db_cache, $db_count, $db_connection, $db_show_debug;
 	global $db_callback, $db_last_result, $db_replace_result, $modSettings;
 
 	// Decide which connection to use.
@@ -486,7 +486,7 @@ function smf_db_query($identifier, $db_string, $db_values = array(), $connection
 		$db_cache[$db_count]['q'] = $db_count < 50 ? $db_string : '...';
 		$db_cache[$db_count]['f'] = $file;
 		$db_cache[$db_count]['l'] = $line;
-		$db_cache[$db_count]['s'] = ($st = microtime(true)) - $time_start;
+		$db_cache[$db_count]['s'] = ($st = microtime(true)) - TIME_START;
 	}
 
 	$db_last_result = @pg_query($connection, $db_string);

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -3992,11 +3992,11 @@ function theme_copyright()
  */
 function template_footer()
 {
-	global $context, $modSettings, $time_start, $db_count;
+	global $context, $modSettings, $db_count;
 
 	// Show the load time?  (only makes sense for the footer.)
 	$context['show_load_time'] = !empty($modSettings['timeLoadPageEnable']);
-	$context['load_time'] = round(microtime(true) - $time_start, 3);
+	$context['load_time'] = round(microtime(true) - TIME_START, 3);
 	$context['load_queries'] = $db_count;
 
 	if (!empty($context['template_layers']) && is_array($context['template_layers']))

--- a/cron.php
+++ b/cron.php
@@ -40,7 +40,7 @@ define('MAX_CRON_TIME', 10);
 define('MAX_CLAIM_THRESHOLD', 300);
 
 // We're going to want a few globals... these are all set later.
-global $time_start, $maintenance, $msubject, $mmessage, $mbname, $language;
+global $maintenance, $msubject, $mmessage, $mbname, $language;
 global $boardurl, $boarddir, $sourcedir, $webmaster_email;
 global $db_server, $db_name, $db_user, $db_prefix, $db_persist, $db_error_send, $db_last_error;
 global $db_connection, $modSettings, $context, $sc, $user_info, $txt;

--- a/cron.php
+++ b/cron.php
@@ -46,7 +46,8 @@ global $db_server, $db_name, $db_user, $db_prefix, $db_persist, $db_error_send, 
 global $db_connection, $modSettings, $context, $sc, $user_info, $txt;
 global $smcFunc, $ssi_db_user, $scripturl, $db_passwd, $cachedir;
 
-define('TIME_START', microtime(true));
+if (!defined('TIME_START'))
+	define('TIME_START', microtime(true));
 
 // Just being safe...
 foreach (array('db_character_set', 'cachedir') as $variable)

--- a/index.php
+++ b/index.php
@@ -32,7 +32,8 @@ define('MYSQL_TITLE', 'MySQL');
 define('SMF_USER_AGENT', 'Mozilla/5.0 (' . php_uname('s') . ' ' . php_uname('m') . ') AppleWebKit/605.1.15 (KHTML, like Gecko)  SMF/' . strtr(SMF_VERSION, ' ', '.'));
 
 error_reporting(E_ALL);
-define('TIME_START', microtime(true));
+if (!defined('TIME_START'))
+	define('TIME_START', microtime(true));
 
 // This makes it so headers can be sent!
 ob_start();

--- a/index.php
+++ b/index.php
@@ -32,7 +32,7 @@ define('MYSQL_TITLE', 'MySQL');
 define('SMF_USER_AGENT', 'Mozilla/5.0 (' . php_uname('s') . ' ' . php_uname('m') . ') AppleWebKit/605.1.15 (KHTML, like Gecko)  SMF/' . strtr(SMF_VERSION, ' ', '.'));
 
 error_reporting(E_ALL);
-$time_start = microtime(true);
+define('TIME_START', microtime(true));
 
 // This makes it so headers can be sent!
 ob_start();


### PR DESCRIPTION
Previously we were inconsistently using a constant in cron.php and a global variable elsewhere. Using a constant makes the most sense for this value.