### PR TITLE
only multiselects should have an explicit size

### DIFF
--- a/Sources/ManageServer.php
+++ b/Sources/ManageServer.php
@@ -1124,6 +1124,8 @@ function prepareDBSettingContext(&$config_vars)
 					foreach ($config_var[2] as $key => $item)
 						$context['config_vars'][$config_var[1]]['data'][] = array($key, $item);
 				}
+				if (empty($config_var['size']) && !empty($config_var['multiple']))
+					$context['config_vars'][$config_var[1]]['size'] = max(4, count($config_var[2]));
 			}
 
 			// Finally allow overrides - and some final cleanups.

--- a/Themes/default/Admin.template.php
+++ b/Themes/default/Admin.template.php
@@ -881,10 +881,8 @@ function template_show_settings()
 				// Show a selection box.
 				elseif ($config_var['type'] == 'select')
 				{
-					$select_size = !empty($config_var['size']) ? $config_var['size'] : (!empty($config_var['data']) && (count($config_var['data']) <= 4) ? count($config_var['data']) : 4);
-
 					echo '
-										<select name="', $config_var['name'], '" id="', $config_var['name'], '" ', $javascript, $disabled, (!empty($config_var['multiple']) ? ' multiple="multiple"' : ''), (!empty($select_size) ? ' size="' . $select_size . '"' : ''), '>';
+										<select name="', $config_var['name'], '" id="', $config_var['name'], '" ', $javascript, $disabled, (!empty($config_var['multiple']) ? ' multiple="multiple"' : ''), ' size="', $config_var['size'], '">';
 
 					foreach ($config_var['data'] as $option)
 						echo '


### PR DESCRIPTION
may fix #5919 in passing; couldn't reproduce it

The size was applied to all selects before, making them listboxes

Bonus: This change is testable!