### PR TITLE
Add index Support for Birthday task pg only

### DIFF
--- a/Sources/tasks/Birthday-Notify.php
+++ b/Sources/tasks/Birthday-Notify.php
@@ -40,7 +40,7 @@ class Birthday_Notify_Background extends SMF_BackgroundTask
 				AND MONTH(birthdate) = {int:month}
 				AND DAYOFMONTH(birthdate) = {int:day}
 				AND YEAR(birthdate) > {int:year}
-				' . ($smcFunc['db_title'] === POSTGRE_TITLE ? 'AND indexable_month_day(birthdate) = {date:bdate}' : ''),
+				' . ($smcFunc['db_title'] === POSTGRE_TITLE ? 'AND indexable_month_day(birthdate) = indexable_month_day({date:bdate})' : ''),
 			array(
 				'year' => 1,
 				'month' => $month,

--- a/Sources/tasks/Birthday-Notify.php
+++ b/Sources/tasks/Birthday-Notify.php
@@ -45,7 +45,7 @@ class Birthday_Notify_Background extends SMF_BackgroundTask
 				'year' => 1,
 				'month' => $month,
 				'day' => $day,
-				'bdate' => '2020-' . $month . '-' . $day,
+				'bdate' => '1004-' . $month . '-' . $day, // a random leap year is here needed
 			)
 		);
 

--- a/Sources/tasks/Birthday-Notify.php
+++ b/Sources/tasks/Birthday-Notify.php
@@ -39,11 +39,13 @@ class Birthday_Notify_Background extends SMF_BackgroundTask
 			WHERE is_activated < 10
 				AND MONTH(birthdate) = {int:month}
 				AND DAYOFMONTH(birthdate) = {int:day}
-				AND YEAR(birthdate) > {int:year}',
+				AND YEAR(birthdate) > {int:year}
+				' . ($smcFunc['db_title'] === POSTGRE_TITLE ? 'AND indexable_month_day(birthdate) = {date:bdate}' : ''),
 			array(
 				'year' => 1,
 				'month' => $month,
 				'day' => $day,
+				'bdate' => '2020-' . $month . '-' . $day,
 			)
 		);
 


### PR DESCRIPTION
Since i saw the query in the pr #5945 
i notice that this query didn't use the birthday index for pg,
so this fix it.

Query execution time goes down from 0.900 ms to 0.050 ms at 2014 entries.

Don't get confused by the year,
it's literaly random.