### PR TITLE
Fixes a undefined error when running the upgrader multiple times.

### DIFF
--- a/Themes/default/languages/Install.english.php
+++ b/Themes/default/languages/Install.english.php
@@ -262,6 +262,8 @@ $txt['upgrade_username'] = 'Username:';
 $txt['upgrade_wrong_username'] = 'Username Incorrect';
 $txt['upgrade_password'] = 'Password:';
 $txt['upgrade_wrong_password'] = 'Password Incorrect';
+$txt['upgrade_script_timeout_minutes'] = 'This upgrade script cannot be run until %1$s has been inactive for at least %2$d minutes';
+$txt['upgrade_script_timeout_seconds'] = 'This upgrade script cannot be run until %1$s has been inactive for at least %2$d seconds';
 
 $txt['upgrade_wait'] = 'Please wait while a backup is created. For large forums this may take some time!';
 $txt['upgrade_wait2'] = 'Please wait while your database is converted to UTF-8. For large forums this may take some time!';

--- a/other/upgrade.php
+++ b/other/upgrade.php
@@ -3979,9 +3979,12 @@ function template_welcome_message()
 		if ($updated > $upcontext['inactive_timeout'])
 			echo '
 						<p>', $txt['upgrade_run'], '</p>';
+		elseif ($upcontext['inactive_timeout'] > 120)
+			echo '
+						<p>', sprintf($txt['upgrade_script_timeout_minutes'], $upcontext['user']['name'], round($upcontext['inactive_timeout'] / 60, 1)), '</p>';
 		else
 			echo '
-						<p>', $txt['upgrade_script_timeout'], ' ', $upcontext['user']['name'], ' ', $txt['upgrade_script_timeout2'], ' ', ($upcontext['inactive_timeout'] > 120 ? round($upcontext['inactive_timeout'] / 60, 1) . ' minutes!' : $upcontext['inactive_timeout'] . ' seconds!'), '</p>';
+						<p>', sprintf($txt['upgrade_script_timeout_seconds'], $upcontext['user']['name'], $upcontext['inactive_timeout']), '</p>';
 
 		echo '
 					</div>';


### PR DESCRIPTION
Noticed this while testing #5953 

To reproduce this run the upgrader all the way to the end, don't delete the upgrade.php then start it again fresh.  A undefined error will occur.  Oddly enough refreshing the page a second time fixes it because $updated became greater than the timeout.  So this will only occur if you run the entire upgrader before the timeout occurs.