### PR TITLE
Fix "Hook call: The file at path: ... could not be loaded."

### DIFF
--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -5319,7 +5319,7 @@ function call_helper($string, $return = false)
  */
 function load_file($string)
 {
-	global $sourcedir, $txt, $boarddir, $settings;
+	global $sourcedir, $txt, $boarddir, $settings, $context;
 
 	if (empty($string))
 		return false;
@@ -5348,7 +5348,7 @@ function load_file($string)
 				require_once($absPath);
 
 			// Sorry, can't do much for you at this point.
-			else
+			elseif (empty($context['uninstalling']))
 			{
 				loadLanguage('Errors');
 				log_error(sprintf($txt['hook_fail_loading_file'], $absPath), 'general');


### PR DESCRIPTION
This pr fixes errors like this:
`
    Type of error: General
    Error message: Hook call: The file at path: ***.php could not be loaded.
    URL of the page causing the error: http://***/index.php?action=admin;area=packages;sa=uninstall2;package=***.zip;pid=***
`
This happens when you delete a hookable mod.

Signed-off-by: Bugo <bugo@dragomano.ru>