### PR TITLE
EOL to LF, even on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,5 @@
 # Force our line endings to be LF, even for Windows
-* text
+* text eol=lf
 
 # Set certain files to be binary
 *.png binary


### PR DESCRIPTION
After some research & experimentation, this is what keeps EOL at LF, in git, on WAMP systems.  Upon commit, CRLFs, if found, are converted to LF.  On checkout, LFs are preserved.  

Without this change, all files are converted to CRLF upon checkout in Windows.  This can impact testing & package builds - wherever code is expecting an LF but finds a CRLF instead.  

This does not take effect immediately.  Git only applies the EOL processing on checkout/commit.  Also, if no changes are detected on a file, it leaves the file alone.  To force everything in your working directory to be converted to LF after this change, there are some very complicated procedures out there...  I took a much simpler, brute force approach: I deleted all files & folders (except the hidden .git folder, where the repo is...), then issued a:
`git checkout release-2.1 --force`
Boom.  Git was forced to rebuild all the files in the working directory from the repo, honoring the new setting, and all EOLs became LFs, everywhere.  

Input welcome.