### PR TITLE
Cache

### DIFF
--- a/Sources/Admin.php
+++ b/Sources/Admin.php
@@ -538,6 +538,7 @@ function AdminHome()
 		'db_server',
 		'phpa',
 		'apc',
+		'apcu',
 		'memcache',
 		'xcache',
 		'php',

--- a/Sources/Admin.php
+++ b/Sources/Admin.php
@@ -536,7 +536,6 @@ function AdminHome()
 		'gd',
 		'imagemagick',
 		'db_server',
-		'phpa',
 		'apc',
 		'apcu',
 		'memcache',

--- a/Sources/Admin.php
+++ b/Sources/Admin.php
@@ -540,6 +540,7 @@ function AdminHome()
 		'apc',
 		'apcu',
 		'memcache',
+		'memcached',
 		'xcache',
 		'php',
 		'server',

--- a/Sources/CacheAPI-apc.php
+++ b/Sources/CacheAPI-apc.php
@@ -56,7 +56,7 @@ class apc_cache extends cache_api
 		if ($value === null)
 			return apc_delete($key . 'smf');
 		else
-			return apc_store($key . 'smf', $value, $ttl);
+			return apc_store($key . 'smf', $value, $ttl !== null ? $ttl : $this->ttl);
 	}
 
 	/**

--- a/Sources/CacheAPI-apc.php
+++ b/Sources/CacheAPI-apc.php
@@ -40,7 +40,9 @@ class apc_cache extends cache_api
 	{
 		$key = $this->prefix . strtr($key, ':/', '-_');
 
-		return apc_fetch($key . 'smf');
+		$value = apc_fetch($key . 'smf');
+
+		return !empty($value) ? $value : null;
 	}
 
 	/**

--- a/Sources/CacheAPI-apcu.php
+++ b/Sources/CacheAPI-apcu.php
@@ -40,7 +40,9 @@ class apcu_cache extends cache_api
 	{
 		$key = $this->prefix . strtr($key, ':/', '-_');
 
-		return apcu_fetch($key . 'smf');
+		$value = apcu_fetch($key . 'smf');
+
+		return !empty($value) ? $value : null;
 	}
 
 	/**

--- a/Sources/CacheAPI-apcu.php
+++ b/Sources/CacheAPI-apcu.php
@@ -56,7 +56,7 @@ class apcu_cache extends cache_api
 		if ($value === null)
 			return apcu_delete($key . 'smf');
 		else
-			return apcu_store($key . 'smf', $value, $ttl);
+			return apcu_store($key . 'smf', $value, $ttl !== null ? $ttl : $this->ttl);
 	}
 
 	/**

--- a/Sources/CacheAPI-memcache.php
+++ b/Sources/CacheAPI-memcache.php
@@ -33,7 +33,7 @@ class memcache_cache extends cache_api
 	{
 		global $cache_memcached;
 
-		$supported = class_exists('memcache');
+		$supported = class_exists('Memcache');
 
 		if ($test)
 			return $supported;

--- a/Sources/CacheAPI-memcache.php
+++ b/Sources/CacheAPI-memcache.php
@@ -103,7 +103,7 @@ class memcache_cache extends cache_api
 	{
 		$key = $this->prefix . strtr($key, ':/', '-_');
 
-		return $this->memcache->set($key, $value, 0, $ttl);
+		return $this->memcache->set($key, $value, 0, $ttl !== null ? $ttl : $this->ttl);
 	}
 
 	/**

--- a/Sources/CacheAPI-memcached.php
+++ b/Sources/CacheAPI-memcached.php
@@ -33,7 +33,7 @@ class memcached_cache extends cache_api
 	{
 		global $cache_memcached;
 
-		$supported = class_exists('memcached');
+		$supported = class_exists('Memcached');
 
 		if ($test)
 			return $supported;

--- a/Sources/CacheAPI-memcached.php
+++ b/Sources/CacheAPI-memcached.php
@@ -21,10 +21,23 @@ if (!defined('SMF'))
  */
 class memcached_cache extends cache_api
 {
-	/**
-	 * @var \Memcached The memcache instance.
-	 */
+	/** @var Memcached The memcache instance. */
 	private $memcached = null;
+
+	/** @var string[] */
+	private $servers;
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function __construct()
+	{
+		global $cache_memcached;
+
+		$this->servers = explode(',', $cache_memcached);
+
+		parent::__construct();
+	}
 
 	/**
 	 * {@inheritDoc}

--- a/Sources/CacheAPI-memcached.php
+++ b/Sources/CacheAPI-memcached.php
@@ -104,7 +104,7 @@ class memcached_cache extends cache_api
 	{
 		$key = $this->prefix . strtr($key, ':/', '-_');
 
-		return $this->memcached->set($key, $value, $ttl);
+		return $this->memcached->set($key, $value, $ttl !== null ? $ttl : $this->ttl);
 	}
 
 	/**

--- a/Sources/CacheAPI-postgres.php
+++ b/Sources/CacheAPI-postgres.php
@@ -146,12 +146,7 @@ class postgres_cache extends cache_api
 	 */
 	public function cleanCache($type = '')
 	{
-		global $smcFunc;
-
-		$smcFunc['db_query']('', '
-			TRUNCATE TABLE {db_prefix}cache',
-			array()
-		);
+		pg_query($this->db_connection, 'TRUNCATE ' . $this->db_prefix . 'cache');
 
 		return true;
 	}

--- a/Sources/CacheAPI-postgres.php
+++ b/Sources/CacheAPI-postgres.php
@@ -108,12 +108,11 @@ class postgres_cache extends cache_api
 	 */
 	public function putData($key, $value, $ttl = null)
 	{
-		global $db_prefix, $db_connection, $db_persist;
+		$ttl = time() + (int) ($ttl !== null ? $ttl : $this->ttl);
 
 		if (!isset($value))
 			$value = '';
 
-		$ttl = time() + $ttl;
 
 		if (empty($this->pg_put_data_prep))
 		{

--- a/Sources/CacheAPI-postgres.php
+++ b/Sources/CacheAPI-postgres.php
@@ -161,9 +161,7 @@ class postgres_cache extends cache_api
 	 */
 	public function getVersion()
 	{
-		global $smcFunc;
-
-		return $smcFunc['db_server_info']();
+		return pg_version()['server'];
 	}
 
 	/**

--- a/Sources/CacheAPI-postgres.php
+++ b/Sources/CacheAPI-postgres.php
@@ -53,23 +53,21 @@ class postgres_cache extends cache_api
 		);
 
 		if (pg_affected_rows($result) === 0)
-		{
 			pg_query($this->db_connection, 'CREATE UNLOGGED TABLE ' . $this->db_prefix . 'cache (key text, value text, ttl bigint, PRIMARY KEY (key))');
 
-			$this->prepareQuery(
-				'smf_cache_get_data',
-				'SELECT value FROM ' . $this->db_prefix . 'cache WHERE key = $1 AND ttl >= $2 LIMIT 1'
-			);
-			$this->prepareQuery(
-				'smf_cache_put_data',
-				'INSERT INTO ' . $this->db_prefix . 'cache(key,value,ttl) VALUES($1,$2,$3)
-				ON CONFLICT(key) DO UPDATE SET value = $2, ttl = $3'
-			);
-			$this->prepareQuery(
-				'smf_cache_delete_data',
-				'DELETE FROM ' . $this->db_prefix . 'cache WHERE key = $1'
-			);
-		}
+		$this->prepareQuery(
+			'smf_cache_get_data',
+			'SELECT value FROM ' . $this->db_prefix . 'cache WHERE key = $1 AND ttl >= $2 LIMIT 1'
+		);
+		$this->prepareQuery(
+			'smf_cache_put_data',
+			'INSERT INTO ' . $this->db_prefix . 'cache(key,value,ttl) VALUES($1,$2,$3)
+			ON CONFLICT(key) DO UPDATE SET value = $2, ttl = $3'
+		);
+		$this->prepareQuery(
+			'smf_cache_delete_data',
+			'DELETE FROM ' . $this->db_prefix . 'cache WHERE key = $1'
+		);
 
 		return true;
 	}

--- a/Sources/CacheAPI-smf.php
+++ b/Sources/CacheAPI-smf.php
@@ -87,6 +87,7 @@ class smf_cache extends cache_api
 	{
 		$key = $this->prefix . strtr($key, ':/', '-_');
 		$cachedir = $this->cachedir;
+		$ttl = $ttl !== null ? $ttl : $this->ttl;
 
 		// Work around Zend's opcode caching (PHP 5.5+), they would cache older files for a couple of seconds
 		// causing newer files to take effect a while later.

--- a/Sources/CacheAPI-sqlite.php
+++ b/Sources/CacheAPI-sqlite.php
@@ -95,7 +95,10 @@ class sqlite_cache extends cache_api
 	public function putData($key, $value, $ttl = null)
 	{
 		$ttl = time() + (int) ($ttl !== null ? $ttl : $this->ttl);
-		$query = 'REPLACE INTO cache VALUES (\'' . $this->cacheDB->escapeString($key) . '\', \'' . $this->cacheDB->escapeString($value) . '\', ' . $this->cacheDB->escapeString($ttl) . ');';
+		if ($value === null)
+			$query = 'DELETE FROM cache WHERE key = \'' . $this->cacheDB->escapeString($key) . '\';';
+		else
+			$query = 'REPLACE INTO cache VALUES (\'' . $this->cacheDB->escapeString($key) . '\', \'' . $this->cacheDB->escapeString($value) . '\', ' . $ttl . ');';
 		$result = $this->cacheDB->exec($query);
 
 		return $result;

--- a/Sources/CacheAPI-sqlite.php
+++ b/Sources/CacheAPI-sqlite.php
@@ -94,7 +94,7 @@ class sqlite_cache extends cache_api
 	 */
 	public function putData($key, $value, $ttl = null)
 	{
-		$ttl = $this->cacheTime + $ttl;
+		$ttl = time() + (int) ($ttl !== null ? $ttl : $this->ttl);
 		$query = 'REPLACE INTO cache VALUES (\'' . $this->cacheDB->escapeString($key) . '\', \'' . $this->cacheDB->escapeString($value) . '\', ' . $this->cacheDB->escapeString($ttl) . ');';
 		$result = $this->cacheDB->exec($query);
 

--- a/Sources/CacheAPI-sqlite.php
+++ b/Sources/CacheAPI-sqlite.php
@@ -31,11 +31,6 @@ class sqlite_cache extends cache_api
 	 */
 	private $cacheDB = null;
 
-	/**
-	 * @var int
-	 */
-	private $cacheTime = 0;
-
 	public function __construct()
 	{
 		parent::__construct();
@@ -57,7 +52,6 @@ class sqlite_cache extends cache_api
 			$this->cacheDB->exec('CREATE TABLE cache (key text unique, value blob, ttl int);');
 			$this->cacheDB->exec('CREATE INDEX ttls ON cache(ttl);');
 		}
-		$this->cacheTime = time();
 	}
 
 	/**
@@ -78,8 +72,7 @@ class sqlite_cache extends cache_api
 	 */
 	public function getData($key, $ttl = null)
 	{
-		$ttl = time() - $ttl;
-		$query = 'SELECT value FROM cache WHERE key = \'' . $this->cacheDB->escapeString($key) . '\' AND ttl >= ' . $ttl . ' LIMIT 1';
+		$query = 'SELECT value FROM cache WHERE key = \'' . $this->cacheDB->escapeString($key) . '\' AND ttl >= ' . time() . ' LIMIT 1';
 		$result = $this->cacheDB->query($query);
 
 		$value = null;

--- a/Sources/Class-CacheAPI.php
+++ b/Sources/Class-CacheAPI.php
@@ -66,28 +66,33 @@ interface cache_api_interface
 	 * Gets the TTL as defined from set or the default.
 	 *
 	 * @access public
-	 * @return string the value of $ttl.
+	 * @return int the value of $ttl.
 	 */
 	public function getDefaultTTL();
 
 	/**
-	 * Gets data from the cache.
+	 * Retrieves an item from the cache.
 	 *
 	 * @access public
 	 * @param string $key The key to use, the prefix is applied to the key name.
-	 * @param string $ttl Overrides the default TTL.
+	 * @param int    $ttl Overrides the default TTL. Not really used anymore,
+	 *                    but is kept for backwards compatibility.
 	 * @return mixed The result from the cache, if there is no data or it is invalid, we return null.
+	 * @tddo Seprate existence checking into its own method
 	 */
 	public function getData($key, $ttl = null);
 
 	/**
-	 * Saves to data the cache.
+	 * Stores a value, regardless of whether or not the key already exists (in
+	 * which case it will overwrite the existing value for that key).
 	 *
 	 * @access public
-	 * @param string $key The key to use, the prefix is applied to the key name.
-	 * @param mixed $value The data we wish to save.
-	 * @param string $ttl Overrides the default TTL.
+	 * @param string $key   The key to use, the prefix is applied to the key name.
+	 * @param mixed  $value The data we wish to save. Use null to delete.
+	 * @param int    $ttl   How long (in seconds) the data should be cached for.
+	 *                      The default TTL will be used if this is null.
 	 * @return bool Whether or not we could save this to the cache.
+	 * @tddo Seprate deletion into its own method
 	 */
 	public function putData($key, $value, $ttl = null);
 

--- a/Sources/Class-CacheAPI.php
+++ b/Sources/Class-CacheAPI.php
@@ -189,7 +189,7 @@ abstract class cache_api implements cache_api_interface
 	 */
 	public function __construct()
 	{
-		$this->setPrefix('');
+		$this->setPrefix();
 	}
 
 	/**

--- a/Sources/Class-CacheAPI.php
+++ b/Sources/Class-CacheAPI.php
@@ -78,7 +78,7 @@ interface cache_api_interface
 	 * @param int    $ttl Overrides the default TTL. Not really used anymore,
 	 *                    but is kept for backwards compatibility.
 	 * @return mixed The result from the cache, if there is no data or it is invalid, we return null.
-	 * @tddo Seprate existence checking into its own method
+	 * @todo Seperate existence checking into its own method
 	 */
 	public function getData($key, $ttl = null);
 
@@ -92,7 +92,7 @@ interface cache_api_interface
 	 * @param int    $ttl   How long (in seconds) the data should be cached for.
 	 *                      The default TTL will be used if this is null.
 	 * @return bool Whether or not we could save this to the cache.
-	 * @tddo Seprate deletion into its own method
+	 * @todo Seperate deletion into its own method
 	 */
 	public function putData($key, $value, $ttl = null);
 

--- a/Sources/Class-CacheAPI.php
+++ b/Sources/Class-CacheAPI.php
@@ -110,7 +110,7 @@ interface cache_api_interface
 	 * Closes connections to the cache method.
 	 *
 	 * @access public
-	 * @return bool Whether or not we could close connections.
+	 * @return bool Whether the connections were closed.
 	 */
 	public function quit();
 

--- a/Sources/Class-CacheAPI.php
+++ b/Sources/Class-CacheAPI.php
@@ -208,6 +208,7 @@ abstract class cache_api implements cache_api_interface
 	 */
 	public function connect()
 	{
+		return true;
 	}
 
 	/**
@@ -282,6 +283,7 @@ abstract class cache_api implements cache_api_interface
 	 */
 	public function quit()
 	{
+		return true;
 	}
 
 	/**

--- a/Sources/Class-CacheAPI.php
+++ b/Sources/Class-CacheAPI.php
@@ -261,27 +261,6 @@ abstract class cache_api implements cache_api_interface
 	}
 
 	/**
-	 * {@inheritDoc}
-	 */
-	public function getData($key, $ttl = null)
-	{
-	}
-
-	/**
-	 * {@inheritDoc}
-	 */
-	public function putData($key, $value, $ttl = null)
-	{
-	}
-
-	/**
-	 * {@inheritDoc}
-	 */
-	public function cleanCache($type = '')
-	{
-	}
-
-	/**
 	 * Invalidate all cached data.
 	 *
 	 * @return bool Whether or not we could invalidate the cache.

--- a/Sources/Class-CacheAPI.php
+++ b/Sources/Class-CacheAPI.php
@@ -119,7 +119,6 @@ interface cache_api_interface
 	 *
 	 * @access public
 	 * @param array $config_vars Additional config_vars, see ManageSettings.php for usage.
-	 * @return void No return is needed.
 	 */
 	public function cacheSettings(array &$config_vars);
 

--- a/Sources/Class-CacheAPI.php
+++ b/Sources/Class-CacheAPI.php
@@ -23,8 +23,8 @@ interface cache_api_interface
 	 * Checks whether we can use the cache method performed by this API.
 	 *
 	 * @access public
-	 * @param boolean $test Test if this is supported or enabled.
-	 * @return boolean Whether or not the cache is supported
+	 * @param bool $test Test if this is supported or enabled.
+	 * @return bool Whether or not the cache is supported
 	 */
 	public function isSupported($test = false);
 
@@ -32,7 +32,7 @@ interface cache_api_interface
 	 * Connects to the cache method. This defines our $key. If this fails, we return false, otherwise we return true.
 	 *
 	 * @access public
-	 * @return boolean Whether or not the cache method was connected to.
+	 * @return bool Whether or not the cache method was connected to.
 	 */
 	public function connect();
 
@@ -41,7 +41,7 @@ interface cache_api_interface
 	 *
 	 * @access public
 	 * @param string $key The key to use
-	 * @return boolean If this was successful or not.
+	 * @return bool If this was successful or not.
 	 */
 	public function setPrefix($key = '');
 
@@ -58,7 +58,7 @@ interface cache_api_interface
 	 *
 	 * @access public
 	 * @param int $ttl The default TTL
-	 * @return boolean If this was successful or not.
+	 * @return bool If this was successful or not.
 	 */
 	public function setDefaultTTL($ttl = 120);
 

--- a/Sources/ManageServer.php
+++ b/Sources/ManageServer.php
@@ -685,6 +685,8 @@ function ModifyCacheSettings($return_config = false)
 
 	// Detect all available optimizers
 	$detected = loadCacheAPIs();
+	foreach ($detected as $api => $object)
+		$detected[$api] = isset($txt[$api . '_cache']) ? $txt[$api . '_cache'] : $api;
 
 	// set our values to show what, if anything, we found
 	if (empty($detected))

--- a/Sources/ManageServer.php
+++ b/Sources/ManageServer.php
@@ -1544,33 +1544,25 @@ function ShowPHPinfoSettings()
  */
 function loadCacheAPIs()
 {
-	global $sourcedir, $txt;
+	global $sourcedir;
 
 	// Make sure our class is in session.
 	require_once($sourcedir . '/Class-CacheAPI.php');
 
 	$apis = array();
-	if ($dh = opendir($sourcedir))
+	$classes = new GlobIterator($sourcedir . '/CacheAPI-*.php', FilesystemIterator::NEW_CURRENT_AND_KEY);
+
+	foreach ($classes as $file => $info)
 	{
-		while (($file = readdir($dh)) !== false)
-		{
-			if (is_file($sourcedir . '/' . $file) && preg_match('~^CacheAPI-([A-Za-z\d_]+)\.php$~', $file, $matches))
-			{
-				$tryCache = strtolower($matches[1]);
+		$tryCache = strtolower(explode('-', $info->getBasename('.php'))[1]);
 
-				require_once($sourcedir . '/' . $file);
-				$cache_class_name = $tryCache . '_cache';
-				$testAPI = new $cache_class_name();
+		require_once($sourcedir . '/' . $file);
+		$cache_class_name = $tryCache . '_cache';
+		$testAPI = new $cache_class_name();
 
-				// No Support?  NEXT!
-				if (!$testAPI->isSupported(true))
-					continue;
-
-				$apis[$tryCache] = isset($txt[$tryCache . '_cache']) ? $txt[$tryCache . '_cache'] : $tryCache;
-			}
-		}
+		if ($testAPI->isSupported(true) && $testAPI->connect())
+			$apis[$tryCache] = $testAPI;
 	}
-	closedir($dh);
 
 	return $apis;
 }

--- a/Sources/Subs-Admin.php
+++ b/Sources/Subs-Admin.php
@@ -66,11 +66,14 @@ function getServerVersions($checkFor)
 			trigger_error('getServerVersions(): you need to be connected to the database in order to get its server version', E_USER_NOTICE);
 		else
 		{
-			$versions['db_engine'] = array('title' => sprintf($txt['support_versions_db_engine'], $smcFunc['db_title']), 'version' => '');
-			$versions['db_engine']['version'] = $smcFunc['db_get_vendor']();
-
-			$versions['db_server'] = array('title' => sprintf($txt['support_versions_db'], $smcFunc['db_title']), 'version' => '');
-			$versions['db_server']['version'] = $smcFunc['db_get_version']();
+			$versions['db_engine'] = array(
+				'title' => sprintf($txt['support_versions_db_engine'], $smcFunc['db_title']),
+				'version' => $smcFunc['db_get_vendor'](),
+			);
+			$versions['db_server'] = array(
+				'title' => sprintf($txt['support_versions_db'], $smcFunc['db_title']),
+				'version' => $smcFunc['db_get_version'](),
+			);
 		}
 	}
 
@@ -85,10 +88,17 @@ function getServerVersions($checkFor)
 			);
 
 	if (in_array('php', $checkFor))
-		$versions['php'] = array('title' => 'PHP', 'version' => PHP_VERSION, 'more' => '?action=admin;area=serversettings;sa=phpinfo');
+		$versions['php'] = array(
+			'title' => 'PHP',
+			'version' => PHP_VERSION,
+			'more' => '?action=admin;area=serversettings;sa=phpinfo',
+		);
 
 	if (in_array('server', $checkFor))
-		$versions['server'] = array('title' => $txt['support_versions_server'], 'version' => $_SERVER['SERVER_SOFTWARE']);
+		$versions['server'] = array(
+			'title' => $txt['support_versions_server'],
+			'version' => $_SERVER['SERVER_SOFTWARE'],
+		);
 
 	return $versions;
 }


### PR DESCRIPTION
This unifies much of the behavior of the various cache methods. Also fixes version detection for memcached from the admin panel (credits section) because the object wasn't initialized and needs at least one server added. 

[`$memcached->getVersion()`](https://www.php.net/manual/en/memcached.getversion.php) returns an array of servers, the keys being the servers and the values are versions.  The code expects a string, so running the array through `current()` made it hunky dory again.

The previsions code would also only return a version string for memcached if it was selected as the current running cache.