### PR TITLE
Deny SMF.org scraping for guests or non-admins

### DIFF
--- a/Sources/Admin.php
+++ b/Sources/Admin.php
@@ -582,11 +582,11 @@ function AdminHome()
  */
 function DisplayAdminFile()
 {
-	global $context, $modSettings, $smcFunc;
+	global $context, $modSettings, $smcFunc, $user_info;
 
 	setMemoryLimit('32M');
 
-	if (empty($_REQUEST['filename']) || !is_string($_REQUEST['filename']))
+	if (empty($_REQUEST['filename']) || !is_string($_REQUEST['filename']) || empty($user_info['is_admin']))
 		fatal_lang_error('no_access', false);
 
 	// Strip off the forum cache part or we won't find it...

--- a/Sources/Admin.php
+++ b/Sources/Admin.php
@@ -962,4 +962,5 @@ function AdminEndSession()
 
 	redirectexit();
 }
+
 ?>

--- a/Sources/Admin.php
+++ b/Sources/Admin.php
@@ -962,5 +962,4 @@ function AdminEndSession()
 
 	redirectexit();
 }
-
 ?>


### PR DESCRIPTION
Gathering info from SMF.org for the admin section should be limited to admin access since this is only for admins to view
I had errors in my log showing guests accessing this info and when tested I was able to view this piped data as a guest.

Signed-off-by: Chen Zhen <github.underdog@gmail.com>