### PR TITLE
Fix these two queries too work on PostgreSQL

### DIFF
--- a/Sources/Subs-Members.php
+++ b/Sources/Subs-Members.php
@@ -1220,24 +1220,38 @@ function reattributePosts($memID, $email = false, $membername = false, $post_cou
 	{
 		// First, check for updated topics.
 		$smcFunc['db_query']('', '
-			UPDATE {db_prefix}topics as t, {db_prefix}messages as m
-			SET t.id_member_started = {int:memID}
-			WHERE m.id_member = {int:memID}
-				AND t.id_first_msg = m.id_msg',
+			UPDATE {db_prefix}topics AS t
+			SET id_member_started = {int:memID}
+			WHERE t.id_first_msg = (
+				SELECT m.id_msg
+				FROM {db_prefix}messages m
+				WHERE m.id_member = {int:memID}
+					AND m.id_msg = t.id_first_msg
+					AND ' . $query . '
+				)',
 			array(
 				'memID' => $memID,
+				'email_address' => $email,
+				'member_name' => $membername,
 			)
 		);
 		$updated['topics'] = $smcFunc['db_affected_rows']();
 
 		// Second, check for updated reports.
 		$smcFunc['db_query']('', '
-			UPDATE {db_prefix}log_reported AS lr, {db_prefix}messages AS m
-			SET lr.id_member = {int:memID}
-			WHERE lr.id_msg = m.id_msg
-				AND m.id_member = {int:memID}',
+			UPDATE {db_prefix}log_reported AS lr
+			SET id_member = {int:memID}
+			WHERE lr.id_msg = (
+				SELECT m.id_msg
+				FROM {db_prefix}messages m
+				WHERE m.id_member = {int:memID}
+					AND m.id_msg = lr.id_msg
+					AND ' . $query . '
+				)',
 			array(
 				'memID' => $memID,
+				'email_address' => $email,
+				'member_name' => $membername,
 			)
 		);
 		$updated['reports'] = $smcFunc['db_affected_rows']();


### PR DESCRIPTION
A query that updates two or more tables throws an error
```
There was 1 error:

1) PHPTDD\MembersTest::testReattributePosts

Exception: ERROR:  syntax error at or near ","<br />

LINE 2:    UPDATE smf_topics as t, smf_messages as m<br />
                                 ^<br>File: /home/travis/build/live627/SMF2.1/Sources/Subs-Members.php<br>Line: 1221<br><br><br />
			UPDATE smf_topics as t, smf_messages as m<br />
			SET t.id_member_started = 2<br />
			WHERE m.id_member = 2<br />
				AND t.id_first_msg = m.id_msg

/home/travis/build/live627/SMF2.1/Sources/Errors.php:167
/home/travis/build/live627/SMF2.1/Sources/Subs-Db-postgresql.php:618
/home/travis/build/live627/SMF2.1/Sources/Subs-Db-postgresql.php:495
/home/travis/build/live627/SMF2.1/Sources/Subs-Members.php:1221
/home/travis/build/live627/SMF2.1/tests/MembersTest.php:127
```