### PR TITLE
Tries using $smcFunc['random_bytes'] in Subs-Password.php

### DIFF
--- a/Sources/Subs-Password.php
+++ b/Sources/Subs-Password.php
@@ -38,7 +38,7 @@ namespace
 		 */
 		function password_hash($password, $algo, array $options = array())
 		{
-			global $smcFunc;
+			global $smcFunc, $sourcedir;
 
 			if (!function_exists('crypt'))
 			{
@@ -131,6 +131,23 @@ namespace
 						$buffer_valid = true;
 					}
 				}
+				if (!$buffer_valid && is_callable(@$smcFunc['random_bytes']))
+				{
+					$buffer = $smcFunc['random_bytes']($raw_salt_len);
+					if ($buffer)
+					{
+						$buffer_valid = true;
+					}
+				}
+				if (!$buffer_valid && file_exists((!empty($sourcedir) ? $sourcedir : __DIR__) . '/random_compat/random.php'))
+				{
+					require_once($sourcedir . '/random_compat/random.php');
+					$buffer = random_bytes($raw_salt_len);
+					if ($buffer)
+					{
+						$buffer_valid = true;
+					}
+				}
 				if (!$buffer_valid && function_exists('mcrypt_create_iv') && !defined('PHALANGER'))
 				{
 					$buffer = mcrypt_create_iv($raw_salt_len, MCRYPT_DEV_URANDOM);
@@ -164,16 +181,22 @@ namespace
 				}
 				if (!$buffer_valid || PasswordCompat\binary\_strlen($buffer) < $raw_salt_len)
 				{
+					if (function_exists('random_int'))
+						$random_int = 'random_int';
+					// This is bad, but we're out of options. Alternative would be to trigger an error, maybe?
+					else
+						$random_int = 'mt_rand';
+
 					$bl = PasswordCompat\binary\_strlen($buffer);
 					for ($i = 0; $i < $raw_salt_len; $i++)
 					{
 						if ($i < $bl)
 						{
-							$buffer[$i] = $buffer[$i] ^ chr($smcFunc['random_int'](0, 255));
+							$buffer[$i] = $buffer[$i] ^ chr($random_int(0, 255));
 						}
 						else
 						{
-							$buffer .= chr($smcFunc['random_int'](0, 255));
+							$buffer .= chr($random_int(0, 255));
 						}
 					}
 				}


### PR DESCRIPTION
This tries loading the random_compat library's `random_bytes()` function to generate a random salt in Subs-Password.php before falling back to other methods. It first tries using `$smcFunc['random_bytes']` to do the job. If that is unavailable, it attempts to load the library file directly. If both of those fail, it moves on to other options.

Also, in the last ditch attempt to generate a random salt, this no longer tries to call `$smcFunc['random_int']`. If that were going to work, then `$smcFunc['random_bytes']` already would have. Now it checks if PHP's native `random_int()` is available (in case it is but the native `random_bytes()` isn't for some strange reason), and then falls back to `mt_rand()` just like it did before we added the random_compat library. (I'd honestly prefer to trigger an error and return null at that point, but this seems more in line with the intended design of Subs-Password.php—and since we do include the random_compat library, it's a hypothetical question anyway.)