### PR TITLE
Adds some documentation of how to control where alerts take the user

### DIFF
--- a/Sources/Profile-View.php
+++ b/Sources/Profile-View.php
@@ -662,6 +662,13 @@ function showAlerts($memID)
 		$alerts = fetch_alerts($memID, $alert_id);
 		$alert = array_pop($alerts);
 
+		/* 
+		 * MOD AUTHORS: 
+		 * To control this redirect, use the 'integrate_fetch_alerts' hook to
+		 * set the value of $alert['extra']['content_link'], which will become
+		 * the value for $alert['target_href'].
+		 */
+		
 		// In case it failed to determine this alert's link
 		if (empty($alert['target_href']))
 			redirectexit('action=profile;area=showalerts');


### PR DESCRIPTION
Once upon a time there was an 'integrate_show_alert' hook that could override alert values when accessed via `?action=profile;area=showalerts;alert=12345`, but that hook has been removed because (1) it was redundant, and (2) it could lead to inconsistencies between the Alerts profile page and the Alerts popup menu.

This PR just adds some comments explaining how a mod can change the target link of an alert the right way by using the 'integrate_fetch_alerts' hook.