### PR TITLE
Checks MIME type of user-supplied avatar images

### DIFF
--- a/Sources/Attachments.php
+++ b/Sources/Attachments.php
@@ -255,9 +255,9 @@ class Attachments
 			if (empty($errors))
 			{
 				// The reported MIME type of the attachment might not be reliable.
-				// Fortunately, PHP 5.3+ lets us easily verify the real MIME type.
-				if (function_exists('mime_content_type'))
-					$_FILES['attachment']['type'][$n] = mime_content_type($_FILES['attachment']['tmp_name'][$n]);
+				$detected_mime_type = get_mime_type($_FILES['attachment']['tmp_name'][$n], true);
+				if ($detected_mime_type !== false)
+					$_FILES['attachment']['type'][$n] = $detected_mime_type;
 
 				$_SESSION['temp_attachments'][$attachID] = array(
 					'name' => $smcFunc['htmlspecialchars'](basename($_FILES['attachment']['name'][$n])),

--- a/Sources/Profile-Modify.php
+++ b/Sources/Profile-Modify.php
@@ -3458,13 +3458,15 @@ function profileSaveAvatarData(&$value)
 		removeAttachments(array('id_member' => $memID));
 
 		$profile_vars['avatar'] = str_replace(' ', '%20', preg_replace('~action(?:=|%3d)(?!dlattach)~i', 'action-', $_POST['userpicpersonal']));
+		$mime_valid = check_mime_type($profile_vars['avatar'], 'image/', true);
 
 		if ($profile_vars['avatar'] == 'http://' || $profile_vars['avatar'] == 'http:///')
 			$profile_vars['avatar'] = '';
 		// Trying to make us do something we'll regret?
 		elseif (substr($profile_vars['avatar'], 0, 7) != 'http://' && substr($profile_vars['avatar'], 0, 8) != 'https://')
 			return 'bad_avatar_invalid_url';
-
+		elseif (empty($mime_valid))
+			return 'bad_avatar';
 		// Should we check dimensions?
 		elseif (!empty($modSettings['avatar_max_height_external']) || !empty($modSettings['avatar_max_width_external']))
 		{
@@ -3513,7 +3515,8 @@ function profileSaveAvatarData(&$value)
 				$_FILES['attachment']['tmp_name'] = $new_filename;
 			}
 
-			$sizes = @getimagesize($_FILES['attachment']['tmp_name']);
+			$mime_valid = check_mime_type($_FILES['attachment']['tmp_name'], 'image/', true);
+			$sizes = empty($mime_valid) ? false : @getimagesize($_FILES['attachment']['tmp_name']);
 
 			// No size, then it's probably not a valid pic.
 			if ($sizes === false)

--- a/Sources/Subs-Attachments.php
+++ b/Sources/Subs-Attachments.php
@@ -425,9 +425,9 @@ function processAttachments()
 		if (empty($errors))
 		{
 			// The reported MIME type of the attachment might not be reliable.
-			// Fortunately, PHP 5.3+ lets us easily verify the real MIME type.
-			if (function_exists('mime_content_type'))
-				$_FILES['attachment']['type'][$n] = mime_content_type($_FILES['attachment']['tmp_name'][$n]);
+			$detected_mime_type = get_mime_type($_FILES['attachment']['tmp_name'][$n], true);
+			if ($detected_mime_type !== false)
+				$_FILES['attachment']['type'][$n] = $detected_mime_type;
 
 			$_SESSION['temp_attachments'][$attachID] = array(
 				'name' => $smcFunc['htmlspecialchars'](basename($_FILES['attachment']['name'][$n])),

--- a/Sources/Subs-Graphics.php
+++ b/Sources/Subs-Graphics.php
@@ -336,6 +336,10 @@ function resizeImageFile($source, $destination, $max_width, $max_height, $prefer
 	{
 		$fileContents = fetch_web_data($source);
 
+		$mime_valid = check_mime_type($fileContents, implode('|', array_map('image_type_to_mime_type', array_keys($default_formats))));
+		if (empty($mime_valid))
+			return false;
+
 		fwrite($fp_destination, $fileContents);
 		fclose($fp_destination);
 
@@ -343,6 +347,10 @@ function resizeImageFile($source, $destination, $max_width, $max_height, $prefer
 	}
 	elseif ($fp_destination)
 	{
+		$mime_valid = check_mime_type($source, implode('|', array_map('image_type_to_mime_type', array_keys($default_formats))), true);
+		if (empty($mime_valid))
+			return false;
+
 		$sizes = @getimagesize($source);
 
 		$fp_source = fopen($source, 'rb');

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -5563,16 +5563,6 @@ function check_mime_type($data, $type_pattern, $is_path = false)
 	$finfo_loaded = extension_loaded('fileinfo');
 	$exif_loaded = extension_loaded('exif') && function_exists('image_type_to_mime_type');
 
-	// On Windows, the Fileinfo extension may not be enabled by default.
-	if (!$finfo_loaded)
-	{
-		// Maybe we can load it dynamically? (Probably not, but give it a shot.)
-		$safe = ini_get('safe_mode');
-		$dl_ok = ini_get('enable_dl');
-		if (empty($safe) && !empty($dl_ok) && function_exists('dl'))
-			$finfo_loaded = @dl(((PHP_SHLIB_SUFFIX === 'dll') ? 'php_' : '') . 'fileinfo.' . PHP_SHLIB_SUFFIX);
-	}
-
 	// Oh well. We tried.
 	if (!$finfo_loaded && !$exif_loaded)
 		return 2;


### PR DESCRIPTION
This implements a more robust version of check_mime_type() than in 2.0.16, and puts it in Subs.php instead of Subs-Package.php to accompany fetch_web_data().

This is part of porting over some recent changes in 2.0.x to 2.1. It is an alternative to #5957.