### PR TITLE
Remove uppercasing of words

### DIFF
--- a/Sources/Profile-Modify.php
+++ b/Sources/Profile-Modify.php
@@ -304,7 +304,7 @@ function loadProfileFields($force_reload = false)
 		),
 		'passwrd1' => array(
 			'type' => 'password',
-			'label' => ucwords($txt['choose_pass']),
+			'label' => $txt['choose_pass'],
 			'subtext' => $txt['password_strength'],
 			'size' => 20,
 			'value' => '',
@@ -337,7 +337,7 @@ function loadProfileFields($force_reload = false)
 		),
 		'passwrd2' => array(
 			'type' => 'password',
-			'label' => ucwords($txt['verify_pass']),
+			'label' => $txt['verify_pass'],
 			'size' => 20,
 			'value' => '',
 			'permission' => 'profile_password',

--- a/Themes/default/Register.template.php
+++ b/Themes/default/Register.template.php
@@ -115,7 +115,7 @@ function template_registration_form()
 						</dd>
 					</dl>
 					<dl class="register_form" id="password1_group">
-						<dt><strong><label for="smf_autov_pwmain">', ucwords($txt['choose_pass']), ':</label></strong></dt>
+						<dt><strong><label for="smf_autov_pwmain">', $txt['choose_pass'], ':</label></strong></dt>
 						<dd>
 							<input type="password" name="passwrd1" id="smf_autov_pwmain" size="50" tabindex="', $context['tabindex']++, '">
 							<span id="smf_autov_pwmain_div" style="display: none;">
@@ -125,7 +125,7 @@ function template_registration_form()
 					</dl>
 					<dl class="register_form" id="password2_group">
 						<dt>
-							<strong><label for="smf_autov_pwverify">', ucwords($txt['verify_pass']), ':</label></strong>
+							<strong><label for="smf_autov_pwverify">', $txt['verify_pass'], ':</label></strong>
 						</dt>
 						<dd>
 							<input type="password" name="passwrd2" id="smf_autov_pwverify" size="50" tabindex="', $context['tabindex']++, '">

--- a/Themes/default/languages/index.english.php
+++ b/Themes/default/languages/index.english.php
@@ -93,8 +93,8 @@ $txt['quick_modify'] = 'Modify inline';
 $txt['quick_modify_message'] = 'You have successfully modified this message.';
 $txt['reason_for_edit'] = 'Reason for editing';
 
-$txt['choose_pass'] = 'Choose password';
-$txt['verify_pass'] = 'Verify password';
+$txt['choose_pass'] = 'Choose Password';
+$txt['verify_pass'] = 'Verify Password';
 $txt['notify_announcements'] = 'Allow the administrators to send me important news by email';
 
 $txt['position'] = 'Position';


### PR DESCRIPTION
Since not all languages uses uppercasing of words it can't be done
in the code. If a langauge should have uppercasing it should be done
in the language string.

Signed-off-by: Oscar Rydhé <oscar.rydhe@gmail.com>