### PR TITLE
fix: allow $listOptions['get_count'] to get an int 

### DIFF
--- a/Sources/Subs-List.php
+++ b/Sources/Subs-List.php
@@ -73,11 +73,18 @@ function createList($listOptions)
 	else
 	{
 		// First get an impression of how many items to expect.
-		if (isset($listOptions['get_count']['file']))
-			require_once($listOptions['get_count']['file']);
+		if (ctype_digit($listOptions['get_count']['function']))
+			$list_context['total_num_items'] = $listOptions['get_count']['function'];
 
-		$call = call_helper($listOptions['get_count']['function'], true);
-		$list_context['total_num_items'] = call_user_func_array($call, empty($listOptions['get_count']['params']) ? array() : $listOptions['get_count']['params']);
+		else
+		{
+			if (isset($listOptions['get_count']['file']))
+				require_once($listOptions['get_count']['file']);
+
+			$call = call_helper($listOptions['get_count']['function'], true);
+			$list_context['total_num_items'] = call_user_func_array($call, empty($listOptions['get_count']['params']) ? array() : $listOptions['get_count']['params']);
+		}
+
 
 		// Default the start to the beginning...sounds logical.
 		$list_context['start'] = isset($_REQUEST[$list_context['start_var_name']]) ? (int) $_REQUEST[$list_context['start_var_name']] : 0;

--- a/Sources/Subs-List.php
+++ b/Sources/Subs-List.php
@@ -28,7 +28,7 @@ function createList($listOptions)
 	assert(isset($listOptions['columns']));
 	assert(is_array($listOptions['columns']));
 
-	if (!isset($listOptions['get_count']['value']) && !ctype_digit($listOptions['get_count']['value']))
+	if (!isset($listOptions['get_count']['value']))
 		assert((empty($listOptions['items_per_page']) ||
 			(isset($listOptions['get_count']['function'], $listOptions['base_href']) &&
 				is_numeric($listOptions['items_per_page']

--- a/Sources/Subs-List.php
+++ b/Sources/Subs-List.php
@@ -27,7 +27,13 @@ function createList($listOptions)
 	assert(isset($listOptions['id']));
 	assert(isset($listOptions['columns']));
 	assert(is_array($listOptions['columns']));
-	assert((empty($listOptions['items_per_page']) || (isset($listOptions['get_count']['function'], $listOptions['base_href']) && is_numeric($listOptions['items_per_page']))));
+
+	if (!isset($listOptions['get_count']['value']) && !ctype_digit($listOptions['get_count']['value']))
+		assert((empty($listOptions['items_per_page']) ||
+			(isset($listOptions['get_count']['function'], $listOptions['base_href']) &&
+				is_numeric($listOptions['items_per_page']
+		))));
+
 	assert((empty($listOptions['default_sort_col']) || isset($listOptions['columns'][$listOptions['default_sort_col']])));
 	assert((!isset($listOptions['form']) || isset($listOptions['form']['href'])));
 
@@ -73,8 +79,8 @@ function createList($listOptions)
 	else
 	{
 		// First get an impression of how many items to expect.
-		if (ctype_digit($listOptions['get_count']['function']))
-			$list_context['total_num_items'] = $listOptions['get_count']['function'];
+		if (!empty($listOptions['get_count']['value']) && ctype_digit($listOptions['get_count']['value']))
+			$list_context['total_num_items'] = $listOptions['get_count']['value'];
 
 		else
 		{


### PR DESCRIPTION
Right now to pass the total number of items you can pass a callable and the creatList option will call it.

But sometimes you already have that info in which case the only way to pass it is to use an anonymous function:


```php
'get_count' => [
		        'function' => function () use ($maxIndex)
		        {
		        	return $maxIndex;
		        },
		    ],
```

Which seems unnecessary and overkill.

This PR modifies createList() to allow it to directly accept an int and thus avoiding the need to execute the callable.

Its done in the "function" key rather than a new key to keep compatibility with 2.0.
