### PR TITLE
Upgrader - various issues learned via CLI

### DIFF
--- a/Sources/Subs-Admin.php
+++ b/Sources/Subs-Admin.php
@@ -544,6 +544,7 @@ function updateSettingsFile($config_vars, $keep_quotes = null, $rebuild = false)
 			)),
 			'default' => null,
 			'auto_delete' => 1,
+			'type' => 'string',
 		),
 		'db_type' => array(
 			'text' => implode("\n", array(

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -4601,6 +4601,10 @@ function text2words($text, $max_chars = 20, $encrypt = false)
 {
 	global $smcFunc, $context;
 
+	// Upgrader may be working on old DBs...
+	if (!isset($context['utf8']))
+		$context['utf8'] = false;
+
 	// Step 1: Remove entities/things we don't consider words:
 	$words = preg_replace('~(?:[\x0B\0' . ($context['utf8'] ? '\x{A0}' : '\xA0') . '\t\r\s\n(){}\\[\\]<>!@$%^*.,:+=`\~\?/\\\\]+|&(?:amp|lt|gt|quot);)+~' . ($context['utf8'] ? 'u' : ''), ' ', strtr($text, array('<br>' => ' ')));
 

--- a/other/upgrade-helper.php
+++ b/other/upgrade-helper.php
@@ -49,7 +49,7 @@ function getMemberGroups()
 		return $member_groups;
 
 	$request = $smcFunc['db_query']('', '
-		SELECT group_name, id_group
+		SELECT groupName, id_group
 		FROM {db_prefix}membergroups
 		WHERE id_group = {int:admin_group} OR id_group > {int:old_group}',
 		array(

--- a/other/upgrade.php
+++ b/other/upgrade.php
@@ -2600,7 +2600,7 @@ function nextSubstep($substep)
 function cmdStep0()
 {
 	global $boarddir, $sourcedir, $modSettings, $start_time, $cachedir, $databases, $db_type, $smcFunc, $upcontext;
-	global $is_debug, $boardurl;
+	global $is_debug, $boardurl, $txt;
 	$start_time = time();
 
 	ob_end_clean();
@@ -2732,7 +2732,7 @@ Usage: /path/to/php -f ' . basename(__FILE__) . ' -- [OPTION]...
 	// Do we need to add this setting?
 	$need_settings_update = empty($modSettings['custom_avatar_dir']);
 
-	$custom_av_dir = !empty($modSettings['custom_avatar_dir']) ? $modSettings['custom_avatar_dir'] : $GLOBALS['boarddir'] . '/custom_avatar';
+	$custom_av_dir = !empty($modSettings['custom_avatar_dir']) ? $modSettings['custom_avatar_dir'] : $boarddir . '/custom_avatar';
 	$custom_av_url = !empty($modSettings['custom_avatar_url']) ? $modSettings['custom_avatar_url'] : $boardurl . '/custom_avatar';
 
 	// This little fellow has to cooperate...
@@ -2740,7 +2740,7 @@ Usage: /path/to/php -f ' . basename(__FILE__) . ' -- [OPTION]...
 
 	// Are we good now?
 	if (!is_writable($custom_av_dir))
-		return throw_error(sprintf($txt['error_dir_not_writable'], $custom_av_dir));
+		print_error(sprintf($txt['error_dir_not_writable'], $custom_av_dir));
 	elseif ($need_settings_update)
 	{
 		if (!function_exists('cache_put_data'))

--- a/other/upgrade.php
+++ b/other/upgrade.php
@@ -2744,8 +2744,12 @@ function ConvertUtf8()
 
 	// Done it already?
 	if (!empty($_POST['utf8_done']))
-		return true;
-
+	{
+		if ($command_line)
+			return DeleteUpgrade();
+		else
+			return true;
+	}
 	// First make sure they aren't already on UTF-8 before we go anywhere...
 	if ($db_type == 'postgresql' || ($db_character_set === 'utf8' && !empty($modSettings['global_character_set']) && $modSettings['global_character_set'] === 'UTF-8'))
 	{
@@ -2756,7 +2760,10 @@ function ConvertUtf8()
 			array('variable')
 		);
 
-		return true;
+		if ($command_line)
+			return DeleteUpgrade();
+		else
+			return true;
 	}
 	else
 	{
@@ -3246,6 +3253,11 @@ function ConvertUtf8()
 			flush();
 		}
 	}
+
+	// Make sure we move on!
+	if ($command_line)
+		return DeleteUpgrade();
+
 	$_GET['substep'] = 0;
 	return false;
 }

--- a/other/upgrade.php
+++ b/other/upgrade.php
@@ -1562,7 +1562,23 @@ function DatabaseChanges()
 			// Do we actually need to do this still?
 			if (!isset($modSettings['smfVersion']) || $modSettings['smfVersion'] < $file[1])
 			{
+				// Use STRICT mode on more recent steps
 				setSqlMode($file[3]);
+
+				// Reload modSettings to capture any adds/updates made along the way
+				$request = $smcFunc['db_query']('', '
+					SELECT variable, value
+					FROM {db_prefix}settings',
+					array(
+						'db_error_skip' => true,
+					)
+				);
+				$modSettings = array();
+				while ($row = $smcFunc['db_fetch_assoc']($request))
+					$modSettings[$row['variable']] = $row['value'];
+				$smcFunc['db_free_result']($request);
+
+				// Now process the file...
 				$nextFile = parse_sql(dirname(__FILE__) . '/' . $file[0]);
 				if ($nextFile)
 				{

--- a/other/upgrade.php
+++ b/other/upgrade.php
@@ -1917,12 +1917,14 @@ function parse_sql($filename)
 	db_extend('packages');
 
 	// Our custom error handler - does nothing but does stop public errors from XML!
+	// Note that php error suppression - @ - used heavily in the upgrader, calls the error handler
+	// but error_reporting() will return 0 as it does so.
 	set_error_handler(
 		function($errno, $errstr, $errfile, $errline) use ($support_js)
 		{
 			if ($support_js)
 				return true;
-			else
+			elseif (error_reporting() != 0)
 				echo 'Error: ' . $errstr . ' File: ' . $errfile . ' Line: ' . $errline;
 		}
 	);

--- a/other/upgrade.php
+++ b/other/upgrade.php
@@ -661,6 +661,17 @@ function loadEssentialData()
 		return random_int($min, $max);
 	};
 
+	// This is now needed for loadUserSettings()
+	$smcFunc['random_bytes'] = function($bytes)
+	{
+		global $sourcedir;
+
+		if (!is_callable('random_bytes'))
+			require_once($sourcedir . '/random_compat/random.php');
+
+		return random_bytes($bytes);
+	};
+
 	// We need this for authentication and some upgrade code
 	require_once($sourcedir . '/Subs-Auth.php');
 	require_once($sourcedir . '/Class-Package.php');

--- a/other/upgrade.php
+++ b/other/upgrade.php
@@ -1584,9 +1584,11 @@ function DatabaseChanges()
 						'db_error_skip' => true,
 					)
 				);
+
 				$modSettings = array();
 				while ($row = $smcFunc['db_fetch_assoc']($request))
 					$modSettings[$row['variable']] = $row['value'];
+
 				$smcFunc['db_free_result']($request);
 
 				// Some theme settings are in $modSettings
@@ -1606,8 +1608,10 @@ function DatabaseChanges()
 							'db_error_skip' => true,
 						)
 					);
+
 					while ($row = $smcFunc['db_fetch_assoc']($request))
 						$modSettings[$row['variable']] = $row['value'];
+
 					$smcFunc['db_free_result']($request);
 				}
 

--- a/other/upgrade.php
+++ b/other/upgrade.php
@@ -1792,9 +1792,11 @@ function convertSettingsToTheme()
 		'linktree_link' => @$GLOBALS['curposlinks'],
 		'show_profile_buttons' => @$GLOBALS['profilebutton'],
 		'show_mark_read' => @$GLOBALS['showmarkread'],
+		'show_board_desc' => @$GLOBALS['ShowBDescrip'],
 		'newsfader_time' => @$GLOBALS['fadertime'],
 		'use_image_buttons' => empty($GLOBALS['MenuType']) ? 1 : 0,
 		'enable_news' => @$GLOBALS['enable_news'],
+		'linktree_inline' => @$modSettings['enableInlineLinks'],
 		'return_to_post' => @$modSettings['returnToPost'],
 	);
 

--- a/other/upgrade.php
+++ b/other/upgrade.php
@@ -2600,7 +2600,7 @@ function nextSubstep($substep)
 function cmdStep0()
 {
 	global $boarddir, $sourcedir, $modSettings, $start_time, $cachedir, $databases, $db_type, $smcFunc, $upcontext;
-	global $is_debug;
+	global $is_debug, $boardurl;
 	$start_time = time();
 
 	ob_end_clean();
@@ -2727,6 +2727,27 @@ Usage: /path/to/php -f ' . basename(__FILE__) . ' -- [OPTION]...
 
 		// Otherwise include it!
 		require_once($modSettings['theme_dir'] . '/languages/Install.' . $upcontext['language'] . '.php');
+	}
+
+	// Do we need to add this setting?
+	$need_settings_update = empty($modSettings['custom_avatar_dir']);
+
+	$custom_av_dir = !empty($modSettings['custom_avatar_dir']) ? $modSettings['custom_avatar_dir'] : $GLOBALS['boarddir'] . '/custom_avatar';
+	$custom_av_url = !empty($modSettings['custom_avatar_url']) ? $modSettings['custom_avatar_url'] : $boardurl . '/custom_avatar';
+
+	// This little fellow has to cooperate...
+	quickFileWritable($custom_av_dir);
+
+	// Are we good now?
+	if (!is_writable($custom_av_dir))
+		return throw_error(sprintf($txt['error_dir_not_writable'], $custom_av_dir));
+	elseif ($need_settings_update)
+	{
+		if (!function_exists('cache_put_data'))
+			require_once($sourcedir . '/Load.php');
+
+		updateSettings(array('custom_avatar_dir' => $custom_av_dir));
+		updateSettings(array('custom_avatar_url' => $custom_av_url));
 	}
 
 	// Make sure we skip the HTML for login.


### PR DESCRIPTION
Fixes #5981 (in conjunction with #5986 )
Fixes #6001 

CLI, especially with 1.x, was generating scores of errors.  

Changes:
- The basic problem was that the '@' operator still invokes the error handler, and they get logged, even though they are OK.  Not a big deal, other than this was masking some REAL issues.  Note that although the @ operator still calls the error routine, it temporarily sets the error level to 0, so it is easy to test in the error handler.  So, the _real_ errors were...
 - Some true undefined errors were buried in there - and not visible via browser upgrades.
 - Fixed the utf8 template issue.
 - cmdstep0 is the cli version of WelcomeLogin (without a template) & needed to deal with custom_avatar

A subset of these changes are needed in 2.0 as well.

**_Testing completed..._**