### PR TITLE
Whilst parsing BBCode, support pre-2.1 br tag style during whitespace trim

### DIFF
--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -2643,7 +2643,7 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 				// See the comment at the end of the big loop - just eating whitespace ;).
 				$whitespace_regex = '';
 				if (!empty($tag['block_level']))
-					$whitespace_regex .= '(&nbsp;|\s)*(<br>)?';
+					$whitespace_regex .= '(&nbsp;|\s)*(<br\s*/?' . '>)?';
 				// Trim one line of whitespace after unnested tags, but all of it after nested ones
 				if (!empty($tag['trim']) && $tag['trim'] != 'inside')
 					$whitespace_regex .= empty($tag['require_parents']) ? '(&nbsp;|\s)*' : '(<br>|&nbsp;|\s)*';


### PR DESCRIPTION
I noticed whilst doing a test upgrade that topic messages with tables in them are displayed very poorly, and that the more line breaks in the BBCode source for the tables, the worse the problem was. I'll put an example in the following conversation.

Editing the table mostly cleans it up, but in a forum with many thousands of messages, this is obvoiusly impractical.

With this change, the messages renders correctly. An alternative to this patch would be to change all the instances of `<br />` in `smf_messages` (and possibly other tables) to `<br>`, but given that most of the treatment of these line breaks through the rest of the source code already accepts both styles, it seemed preferably to patch it here.

Signed-off-by: Dave 'Gizmo' Gymer <github@davegymer.org>