### PR TITLE
Better detect a working temp directory

### DIFF
--- a/Sources/Subs-Admin.php
+++ b/Sources/Subs-Admin.php
@@ -2181,9 +2181,25 @@ function emailAdmins($template, $replacements = array(), $additional_recipients 
 		}
 }
 
-/**
+/*
  * Locates the most appropriate temp directory.
- */
+ *
+ * Systems using `open_basedir` restrictions may receive errors with
+ * `sys_get_temp_dir()` due to misconfigurations on servers. Other
+ * cases sys_temp_dir may not be set to a safe value. Additionaly
+ * `sys_get_temp_dir` may use a readonly directory. This attempts to
+ * find a working temp directory that is accessible under the
+ * restrictions and is writable to the web service account.
+ *
+ * Directories cheked against `open_basedir`:
+ *
+ * - `sys_get_temp_dir()`
+ * - `upload_tmp_dir`
+ * - `session.save_path`
+ * - `$cachedir`
+ *
+ * @return string
+*/
 function sm_temp_dir()
 {
 	global $cachedir;

--- a/Sources/Subs-Admin.php
+++ b/Sources/Subs-Admin.php
@@ -2198,7 +2198,7 @@ function sm_temp_dir()
 	$restriction = !empty(ini_get('open_basedir')) ? explode(':', ini_get('open_basedir')) : false;
 
 	// Prevent any errors as we search.
-	$old_error_reportig = 0;
+	$old_error_reporting = 0;
 
 	// First, check sys_get_temp_dir.
 	$possible_temp = rtrim(sys_get_temp_dir(), '/');
@@ -2260,7 +2260,7 @@ function sm_temp_dir()
 	$temp_dir = substr($temp_dir, -1) === '/' ? $temp_dir : $temp_dir . '/';
 
 	// Put things back.
-	error_reporting($old_error_reportig);
+	error_reporting($old_error_reporting);
 
 	return $temp_dir;
 }

--- a/Sources/Subs-Admin.php
+++ b/Sources/Subs-Admin.php
@@ -2281,4 +2281,5 @@ function sm_temp_dir_option($option = 'sys_get_temp_dir')
 	else
 		return sys_get_temp_dir();
 }
+
 ?>


### PR DESCRIPTION
Systems using open_basedir restrictions may receive errors with sys_get_temp_dir as it may not be properly configured to use a safe workable directory.  As well its possible that the temp directory may be readonly.  We also check if the directory is writable.

As a fall back we resort to sys_get_temp_dir again for lack of a 100% safe directory.