### PR TITLE
fix: return $memberContext on Load::loadMemberContext()

### DIFF
--- a/Sources/Load.php
+++ b/Sources/Load.php
@@ -1706,7 +1706,8 @@ function loadMemberContext($user, $display_custom_fields = false)
 	}
 
 	call_integration_hook('integrate_member_context', array(&$memberContext[$user], $user, $display_custom_fields));
-	return true;
+
+	return $memberContext;
 }
 
 /**

--- a/Sources/Load.php
+++ b/Sources/Load.php
@@ -1487,7 +1487,8 @@ function loadMemberData($users, $is_name = false, $set = 'normal')
  *
  * @param int $user The ID of a user previously loaded by {@link loadMemberData()}
  * @param bool $display_custom_fields Whether or not to display custom profile fields
- * @return boolean Whether or not the data was loaded successfully
+ * @return boolean|array  False if the data wasn't loaded or the loaded data.
+ * @throws Exception
  */
 function loadMemberContext($user, $display_custom_fields = false)
 {


### PR DESCRIPTION
To try and minimize global usage, make Load::loadMemberContext() to return $memberContext

Core code will still rely on globalizing $memberContext  but mods and external scripts can freely use the returned array as they see fit.