### PR TITLE
Match old error catching block

### DIFF
--- a/Sources/Subs-Admin.php
+++ b/Sources/Subs-Admin.php
@@ -877,7 +877,7 @@ function updateSettingsFile($config_vars, $keep_quotes = null, $rebuild = false)
 				'}',
 			)),
 			// Designed to match both 2.0 and 2.1 versions of this code.
-			'search_pattern' => '~\n?#+ Error.Catching #+.*?\$db_last_error = 0;(?' . '>\s*})?(?=\n|\?' . '>|$)~s',
+			'search_pattern' => '~\n?#+ Error.Catching #+\n[^\n]*?settings\.\n(?:\$db_last_error = \d{1,11};|if \(file_exists.*?\$db_last_error = 0;(?' . '>\s*}))(?=\n|\?' . '>|$)~s',
 		),
 		// Temporary variable used during the upgrade process.
 		'upgradeData' => array(


### PR DESCRIPTION
FIxes #6047 .

When modifying Settings.php, the upgrader wasn't detecting the old-style error-catching block.  Instead, thinking it was missing, it inserted a new-style one.  Problem was on any subsequent updates, it replaced all content from the start of the first block to the end of the second with a new block...  Which meant it ate all the settings inbetween the two - cachedir in the original error report.  Difficult to detect, because on even further updates (settings are modified a few times throughout the upgrader), it detected the missing settings & replaced them with default values...  

It will now get a proper hit on both the old style:
![image](https://user-images.githubusercontent.com/23568484/77977179-d5ce4900-72b3-11ea-80e9-98fc17307fd0.png)

And the new style:
![image](https://user-images.githubusercontent.com/23568484/77977198-e1217480-72b3-11ea-957a-d7295e17cd05.png)

All settings are now properly kept.  Input welcome.