### PR TITLE
Remove DESC from likes index

### DIFF
--- a/other/install_2-1_postgresql.sql
+++ b/other/install_2-1_postgresql.sql
@@ -1227,7 +1227,7 @@ CREATE INDEX {$db_prefix}messages_show_posts ON {$db_prefix}messages (id_member,
 CREATE INDEX {$db_prefix}messages_id_member_msg ON {$db_prefix}messages (id_member, approved, id_msg);
 CREATE INDEX {$db_prefix}messages_current_topic ON {$db_prefix}messages (id_topic, id_msg, id_member, approved);
 CREATE INDEX {$db_prefix}messages_related_ip ON {$db_prefix}messages (id_member, poster_ip, id_msg);
-CREATE INDEX {$db_prefix}messages_likes ON {$db_prefix}messages (likes DESC);
+CREATE INDEX {$db_prefix}messages_likes ON {$db_prefix}messages (likes);
 #
 # Table structure for table `moderators`
 #

--- a/other/upgrade_2-1_mysql.sql
+++ b/other/upgrade_2-1_mysql.sql
@@ -2499,7 +2499,8 @@ SET lngfile = REPLACE(lngfile, '-utf8', '');
 --- Create index for messages likes
 /******************************************************************************/
 ---# Add Index for messages likes
-CREATE INDEX idx_likes ON {$db_prefix}messages (likes DESC);
+DROP INDEX idx_likes ON {$db_prefix}messages;
+CREATE INDEX idx_likes ON {$db_prefix}messages (likes);
 ---#
 
 /******************************************************************************/

--- a/other/upgrade_2-1_postgresql.sql
+++ b/other/upgrade_2-1_postgresql.sql
@@ -2785,7 +2785,7 @@ CREATE INDEX {$db_prefix}members_birthdate2 ON {$db_prefix}members (indexable_mo
 /******************************************************************************/
 ---# Add Index for messages likes
 DROP INDEX IF EXISTS {$db_prefix}messages_likes;
-CREATE INDEX {$db_prefix}messages_likes ON {$db_prefix}messages (likes DESC);
+CREATE INDEX {$db_prefix}messages_likes ON {$db_prefix}messages (likes);
 ---#
 
 /******************************************************************************/


### PR DESCRIPTION
Fixes #6066 

This brings the definition of the likes index on the messages table consistent across installs & upgrades, mysql & pg.  Turns out that the 2.1 mysql installer never created the index DESC to begin with, only the upgrader, so it has been inconsistent.

I could not find any other DESC indexes.  

I don't have a MySQL 8.0 environment to test in, hopefully this is the only issue.

Tested pg install, & various permutations of upgrades for pg & mysql.  