### PR TITLE
Used Count(*) where possible

### DIFF
--- a/Sources/Drafts.php
+++ b/Sources/Drafts.php
@@ -549,7 +549,7 @@ function showProfileDrafts($memID, $draft_type = 0)
 	// Get the count of applicable drafts on the boards they can (still) see ...
 	// @todo .. should we just let them see their drafts even if they have lost board access ?
 	$request = $smcFunc['db_query']('', '
-		SELECT COUNT(id_draft)
+		SELECT COUNT(*)
 		FROM {db_prefix}user_drafts AS ud
 			INNER JOIN {db_prefix}boards AS b ON (b.id_board = ud.id_board AND {query_see_board})
 		WHERE id_member = {int:id_member}
@@ -723,7 +723,7 @@ function showPMDrafts($memID = -1)
 
 	// Get the count of applicable drafts
 	$request = $smcFunc['db_query']('', '
-		SELECT COUNT(id_draft)
+		SELECT COUNT(*)
 		FROM {db_prefix}user_drafts
 		WHERE id_member = {int:id_member}
 			AND type={int:draft_type}' . (!empty($modSettings['drafts_keep_days']) ? '

--- a/Sources/Errors.php
+++ b/Sources/Errors.php
@@ -133,7 +133,7 @@ function log_error($error_message, $error_type = 'general', $file = null, $line 
 		if (!isset($context['num_errors']))
 		{
 			$query = $smcFunc['db_query']('', '
-				SELECT COUNT(id_error)
+				SELECT COUNT(*)
 				FROM {db_prefix}log_errors',
 				array()
 			);

--- a/Sources/Likes.php
+++ b/Sources/Likes.php
@@ -344,7 +344,7 @@ class Likes
 		global $smcFunc;
 
 		$request = $smcFunc['db_query']('', '
-			SELECT COUNT(id_member)
+			SELECT COUNT(*)
 			FROM {db_prefix}user_likes
 			WHERE content_id = {int:like_content}
 				AND content_type = {string:like_type}',

--- a/Sources/ManageErrors.php
+++ b/Sources/ManageErrors.php
@@ -137,7 +137,7 @@ function ViewErrorLog()
 	{
 		// We want all errors, not just the number of filtered messages...
 		$query = $smcFunc['db_query']('', '
-			SELECT COUNT(id_error)
+			SELECT COUNT(*)
 			FROM {db_prefix}log_errors',
 			array()
 		);

--- a/Sources/ManageMaintenance.php
+++ b/Sources/ManageMaintenance.php
@@ -1739,7 +1739,7 @@ function MaintainRecountPosts()
 
 	// Lets get a group of members and determine their post count (from the boards that have post count enabled of course).
 	$request = $smcFunc['db_query']('', '
-		SELECT m.id_member, COUNT(m.id_member) AS posts
+		SELECT m.id_member, COUNT(*) AS posts
 		FROM {db_prefix}messages AS m
 			INNER JOIN {db_prefix}boards AS b ON m.id_board = b.id_board
 		WHERE m.id_member != {int:zero}

--- a/Sources/ManageMembergroups.php
+++ b/Sources/ManageMembergroups.php
@@ -684,7 +684,7 @@ function EditMembergroup()
 
 	// Can this group moderate any boards?
 	$request = $smcFunc['db_query']('', '
-		SELECT COUNT(id_board)
+		SELECT COUNT(*)
 		FROM {db_prefix}moderator_groups
 		WHERE id_group = {int:current_group}',
 		array(

--- a/Sources/ManagePaid.php
+++ b/Sources/ManagePaid.php
@@ -1957,7 +1957,7 @@ function loadSubscriptions()
 
 	// Do the counts.
 	$request = $smcFunc['db_query']('', '
-		SELECT COUNT(id_sublog) AS member_count, id_subscribe, status
+		SELECT COUNT(*) AS member_count, id_subscribe, status
 		FROM {db_prefix}log_subscribed
 		GROUP BY id_subscribe, status',
 		array(

--- a/Sources/ManagePermissions.php
+++ b/Sources/ManagePermissions.php
@@ -2111,7 +2111,7 @@ function EditPermissionProfiles()
 
 	// Work out what ones are in use.
 	$request = $smcFunc['db_query']('', '
-		SELECT id_profile, COUNT(id_board) AS board_count
+		SELECT id_profile, COUNT(*) AS board_count
 		FROM {db_prefix}boards
 		GROUP BY id_profile',
 		array(

--- a/Sources/PersonalMessage.php
+++ b/Sources/PersonalMessage.php
@@ -2749,7 +2749,7 @@ function MessageActionsApply()
 				// If we're removing from the inbox, see if we have at least one other label.
 				// This query is faster than the one above
 				$request2 = $smcFunc['db_query']('', '
-					SELECT COUNT(l.id_label)
+					SELECT COUNT(*)
 					FROM {db_prefix}pm_labels AS l
 						INNER JOIN {db_prefix}pm_labeled_messages AS pml ON (pml.id_label = l.id_label)
 					WHERE l.id_member = {int:current_member}

--- a/Sources/PostModeration.php
+++ b/Sources/PostModeration.php
@@ -203,7 +203,7 @@ function UnapprovedPosts()
 
 	// What about topics?  Normally we'd use the table alias t for topics but lets use m so we don't have to redo our approve query.
 	$request = $smcFunc['db_query']('', '
-		SELECT COUNT(m.id_topic)
+		SELECT COUNT(*)
 		FROM {db_prefix}topics AS m
 		WHERE m.approved = {int:not_approved}
 			AND {query_see_message_board}

--- a/Sources/Profile-Modify.php
+++ b/Sources/Profile-Modify.php
@@ -4137,7 +4137,7 @@ function groupMembership2($profile_vars, $post_errors, $memID)
 	if ($context['can_manage_membergroups'] && !allowedTo('admin_forum'))
 	{
 		$request = $smcFunc['db_query']('', '
-			SELECT COUNT(permission)
+			SELECT COUNT(*)
 			FROM {db_prefix}permissions
 			WHERE id_group = {int:selected_group}
 				AND permission = {string:admin_forum}

--- a/Sources/Profile-View.php
+++ b/Sources/Profile-View.php
@@ -912,7 +912,7 @@ function showPosts($memID)
 		);
 	else
 		$request = $smcFunc['db_query']('', '
-			SELECT COUNT(id_msg)
+			SELECT COUNT(*)
 			FROM {db_prefix}messages AS m
 			WHERE {query_see_message_board} AND m.id_member = {int:current_member}' . (!empty($board) ? '
 				AND m.id_board = {int:board}' : '') . (!$modSettings['postmod_active'] || $context['user']['is_owner'] ? '' : '
@@ -2123,7 +2123,7 @@ function list_getUserErrorCount($where, $where_vars = array())
 	global $smcFunc;
 
 	$request = $smcFunc['db_query']('', '
-		SELECT COUNT(id_error)
+		SELECT COUNT(*)
 		FROM {db_prefix}log_errors
 		WHERE ' . $where,
 		$where_vars
@@ -2192,7 +2192,7 @@ function list_getIPMessageCount($where, $where_vars = array())
 	global $smcFunc, $user_info;
 
 	$request = $smcFunc['db_query']('', '
-		SELECT COUNT(id_msg)
+		SELECT COUNT(*)
 		FROM {db_prefix}messages AS m
 		WHERE {query_see_message_board} AND ' . $where,
 		$where_vars

--- a/Sources/RemoveTopic.php
+++ b/Sources/RemoveTopic.php
@@ -1207,7 +1207,7 @@ function RestoreTopic()
 			{
 				// Lets get the members that need their post count restored.
 				$request2 = $smcFunc['db_query']('', '
-					SELECT id_member, COUNT(id_msg) AS post_count
+					SELECT id_member, COUNT(*) AS post_count
 					FROM {db_prefix}messages
 					WHERE id_topic = {int:topic}
 						AND approved = {int:is_approved}

--- a/Sources/Stats.php
+++ b/Sources/Stats.php
@@ -161,7 +161,7 @@ function DisplayStats()
 		if (($context['gender'] = cache_get_data('stats_gender', 240)) == null)
 		{
 			$result = $smcFunc['db_query']('', '
-				SELECT COUNT(id_member) AS total_members, value AS gender
+				SELECT COUNT(*) AS total_members, value AS gender
 				FROM {db_prefix}themes
 				WHERE variable = {string:gender_var} AND id_theme = {int:default_theme}
 				GROUP BY value',


### PR DESCRIPTION
When a count(*) is used the db had to check if the row is visible
When a count(col) is used the db had to check if the row is visible and is not null

Less checks = faster

Changed only count where no join or normal join is used.

On a plain 11 mio rows table was the different 600 ms vs 400 ms