### PR TITLE
Fixes #5843 plus some other layout issues with embedded video & images

### DIFF
--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -1432,8 +1432,16 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 						$alt = ' alt="' . (!empty($params['{alt}']) ? $params['{alt}'] : $currentAttachment['name']) . '"';
 						$title = !empty($data) ? ' title="' . $smcFunc['htmlspecialchars']($data) . '"' : '';
 
-						$width = !empty($params['{width}']) ? $params['{width}'] : (!empty($currentAttachment['width']) ? $currentAttachment['width'] : '');
-						$height = !empty($params['{height}']) ? $params['{height}'] : (!empty($currentAttachment['height']) ? $currentAttachment['height'] : '');
+						if (empty($params['{width}']) && empty($params['{height}']))
+						{
+							$width = !empty($currentAttachment['width']) ? $currentAttachment['width'] : '';
+							$height = !empty($currentAttachment['height']) ? $currentAttachment['height'] : '';
+						}
+						else
+						{
+							$width = !empty($params['{width}']) ? $params['{width}'] : '';
+							$height = !empty($params['{height}']) ? $params['{height}'] : '';
+						}
 
 						// Image.
 						if (!empty($currentAttachment['is_image']))
@@ -1452,7 +1460,7 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 							$width = !empty($width) ? ' width="' . $width . '"' : '';
 							$height = !empty($height) ? ' height="' . $height . '"' : '';
 
-							$returnContext .= '<div class="videocontainer"><div><video controls preload="none" src="'. $currentAttachment['href'] . '" playsinline' . $width . $height . ' style="object-fit:contain;"><a href="' . $currentAttachment['href'] . '" class="bbc_link">' . $smcFunc['htmlspecialchars'](!empty($data) ? $data : $currentAttachment['name']) . '</a></video></div></div>' . (!empty($data) && $data != $currentAttachment['name'] ? '<div class="smalltext">' . $data . '</div>' : '');
+							$returnContext .= '<div class="videocontainer"><video controls preload="metadata" src="'. $currentAttachment['href'] . '" playsinline' . $width . $height . '><a href="' . $currentAttachment['href'] . '" class="bbc_link">' . $smcFunc['htmlspecialchars'](!empty($data) ? $data : $currentAttachment['name']) . '</a></video></div>' . (!empty($data) && $data != $currentAttachment['name'] ? '<div class="smalltext">' . $data . '</div>' : '');
 						}
 						// Audio.
 						elseif (strpos($currentAttachment['mime_type'], 'audio/') === 0)
@@ -1787,13 +1795,13 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 			),
 			array(
 				'tag' => 'justify',
-				'before' => '<div style="text-align: justify;">',
+				'before' => '<div class="justifytext">',
 				'after' => '</div>',
 				'block_level' => true,
 			),
 			array(
 				'tag' => 'left',
-				'before' => '<div style="text-align: left;">',
+				'before' => '<div class="lefttext">',
 				'after' => '</div>',
 				'block_level' => true,
 			),
@@ -1941,7 +1949,7 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 			),
 			array(
 				'tag' => 'right',
-				'before' => '<div style="text-align: right;">',
+				'before' => '<div class="righttext">',
 				'after' => '</div>',
 				'block_level' => true,
 			),

--- a/Themes/default/css/index.css
+++ b/Themes/default/css/index.css
@@ -303,6 +303,9 @@ h3.largetext {
 	margin-right: auto;
 	text-align: left;
 }
+.justifytext {
+	text-align: justify;
+}
 .double_height {
 	line-height: 2em;
 }
@@ -4045,7 +4048,17 @@ tr[id^='list_news_lists_'] textarea {
 .videocontainer {
 	max-width: 560px;
 }
-.videocontainer div {
+.centertext .videocontainer,
+.justifytext .videocontainer {
+	margin: 0 auto;
+}
+.righttext .videocontainer {
+	margin: 0 0 0 auto;
+}
+.lefttext .videocontainer {
+	margin: 0 auto 0 0;
+}
+.videocontainer > div {
 	position: relative;
 	padding-bottom: 56.25%;
 }
@@ -4055,6 +4068,10 @@ tr[id^='list_news_lists_'] textarea {
 	left: 0;
 	width: 100% !important;
 	height: 100% !important;
+}
+.videocontainer video {
+	object-fit: contain;
+	background: black;
 }
 
 .backtrace:not(:last-child) {


### PR DESCRIPTION
- Allows an embedded video's position to be controlled using the editor's text alignment controls (fixes #5843).
- Adds a .justifytext class and tweaks the [left], [center], [right], and [justify] BBCodes to set the appropriate class on the <div> element rather than setting its style directly.
- Fixes a layout issue when embedding a video attachment into a post.
- Fixes a problem where setting width or height, but not both, on the [attach] BBC could result in a distorted aspect ratio of the displayed image.