### PR TITLE
Fixes some faulty logic in loadMemberContext()

### DIFF
--- a/Sources/Load.php
+++ b/Sources/Load.php
@@ -1583,12 +1583,12 @@ function loadMemberContext($user, $display_custom_fields = false)
 {
 	global $memberContext, $user_profile, $txt, $scripturl, $user_info;
 	global $context, $modSettings, $settings, $smcFunc;
-	static $dataLoaded = array();
+	static $dcf = array();
 	static $loadedLanguages = array();
 
 	// If this person's data is already loaded, skip it.
-	if (isset($dataLoaded[$user]))
-		return $dataLoaded[$user];
+	if (!empty($memberContext[$user]) && !empty($dcf[$user]) >= $display_custom_fields)
+		return $memberContext[$user];
 
 	// We can't load guests or members not loaded by loadMemberData()!
 	if ($user == 0)
@@ -1600,7 +1600,6 @@ function loadMemberContext($user, $display_custom_fields = false)
 	}
 
 	// Well, it's loaded now anyhow.
-	$dataLoaded[$user] = true;
 	$profile = $user_profile[$user];
 
 	// Censor everything.
@@ -1799,6 +1798,8 @@ function loadMemberContext($user, $display_custom_fields = false)
 	}
 
 	call_integration_hook('integrate_member_context', array(&$memberContext[$user], $user, $display_custom_fields));
+
+	$dcf[$user] = !empty($dcf[$user]) | $display_custom_fields;
 
 	return $memberContext[$user];
 }


### PR DESCRIPTION
Previously we used a static variable named `$dataLoaded` to remember which members we had already loaded data for. This was both useless and buggy in multiple ways. First, it was useless because we can just check `$memberContext[$user]` directly and skip the middleman. Second, the value recorded in `$dataLoaded[$user]` could fall out of date if `$memberContext[$user]` were unset elsewhere, such as in News.php's `getXmlProfile()` function. Third, this static variable did nothing to remember whether the `$display_custom_fields` had been passed a true or false.

This PR fixes all of that.

See #6111, #6112, #6113, and https://github.com/SimpleMachines/SMF2.1/pull/6101#issuecomment-628375442 for more info.
