### PR TITLE
Enable file_hash for people requires to do thing with attachment

### DIFF
--- a/Sources/Subs-Attachments.php
+++ b/Sources/Subs-Attachments.php
@@ -1159,6 +1159,7 @@ function loadAttachmentContext($id_msg, $attachments)
 			$attachmentData[$i] = array(
 				'id' => $attachment['id_attach'],
 				'name' => preg_replace('~&amp;#(\\d{1,7}|x[0-9a-fA-F]{1,6});~', '&#\\1;', $smcFunc['htmlspecialchars']($attachment['filename'])),
+				'file_hash' => $attachment['file_hash'],
 				'downloads' => $attachment['downloads'],
 				'size' => ($attachment['filesize'] < 1024000) ? round($attachment['filesize'] / 1024, 2) . ' ' . $txt['kilobyte'] : round($attachment['filesize'] / 1024 / 1024, 2) . ' ' . $txt['megabyte'],
 				'byte_size' => $attachment['filesize'],

--- a/Sources/Subs-Attachments.php
+++ b/Sources/Subs-Attachments.php
@@ -1160,6 +1160,7 @@ function loadAttachmentContext($id_msg, $attachments)
 				'id' => $attachment['id_attach'],
 				'name' => preg_replace('~&amp;#(\\d{1,7}|x[0-9a-fA-F]{1,6});~', '&#\\1;', $smcFunc['htmlspecialchars']($attachment['filename'])),
 				'file_hash' => $attachment['file_hash'],
+				'file_ext' => $attachment['fileext'],
 				'downloads' => $attachment['downloads'],
 				'size' => ($attachment['filesize'] < 1024000) ? round($attachment['filesize'] / 1024, 2) . ' ' . $txt['kilobyte'] : round($attachment['filesize'] / 1024 / 1024, 2) . ' ' . $txt['megabyte'],
 				'byte_size' => $attachment['filesize'],
@@ -1339,7 +1340,7 @@ function prepareAttachsByMsg($msgIDs)
 	{
 		$request = $smcFunc['db_query']('', '
 			SELECT
-				a.id_attach, a.id_folder, a.id_msg, a.filename, a.file_hash, COALESCE(a.size, 0) AS filesize, a.downloads, a.approved, m.id_topic AS topic, m.id_board AS board, m.id_member, a.mime_type,
+				a.id_attach, a.id_folder, a.id_msg, a.filename, a.file_hash, a.fileext, COALESCE(a.size, 0) AS filesize, a.downloads, a.approved, m.id_topic AS topic, m.id_board AS board, m.id_member, a.mime_type,
 				a.width, a.height' . (empty($modSettings['attachmentShowImages']) || empty($modSettings['attachmentThumbnails']) ? '' : ',
 				COALESCE(thumb.id_attach, 0) AS id_thumb, thumb.width AS thumb_width, thumb.height AS thumb_height') . '
 			FROM {db_prefix}attachments AS a' . (empty($modSettings['attachmentShowImages']) || empty($modSettings['attachmentThumbnails']) ? '' : '


### PR DESCRIPTION
Dunno if this posses any security risk directly but, this will enable people to do some modules (like MarkDown parsing via Attachments etc...)