### PR TITLE
Ignore the default option when comparing timezones (fixes #6139)

### DIFF
--- a/Sources/Calendar.php
+++ b/Sources/Calendar.php
@@ -442,6 +442,10 @@ function CalendarPost()
 		$found = false;
 		foreach ($context['all_timezones'] as $possible_tzid => $dummy)
 		{
+			// Ignore the "-----" option
+			if (empty($possible_tzid))
+				continue;
+
 			$possible_tzinfo = timezone_transitions_get(timezone_open($possible_tzid), $context['event']['start_timestamp'], $later);
 
 			if ($tzinfo === $possible_tzinfo)


### PR DESCRIPTION
Signed-off-by: Michael Eshom <oldiesmann@gmail.com>