### PR TITLE
Remove some deprecated code from createList

### DIFF
--- a/Sources/Subs-List.php
+++ b/Sources/Subs-List.php
@@ -266,10 +266,6 @@ function createList($listOptions)
 	if (isset($listOptions['javascript']))
 		$list_context['javascript'] = $listOptions['javascript'];
 
-	// We want a menu.
-	if (isset($listOptions['list_menu']))
-		$list_context['list_menu'] = $listOptions['list_menu'];
-
 	// Make sure the template is loaded.
 	loadTemplate('GenericList');
 }

--- a/Themes/default/GenericList.template.php
+++ b/Themes/default/GenericList.template.php
@@ -27,10 +27,6 @@ function template_show_list($list_id = null)
 
 	$cur_list = &$context[$list_id];
 
-	// These are the main tabs that is used all around the template.
-	if (isset($cur_list['list_menu'], $cur_list['list_menu']['show_on']) && ($cur_list['list_menu']['show_on'] == 'both' || $cur_list['list_menu']['show_on'] == 'top'))
-		template_create_list_menu($cur_list['list_menu'], 'top');
-
 	if (isset($cur_list['form']))
 		echo '
 	<form action="', $cur_list['form']['href'], '" method="post"', empty($cur_list['form']['name']) ? '' : ' name="' . $cur_list['form']['name'] . '" id="' . $cur_list['form']['name'] . '"', ' accept-charset="', $context['character_set'], '">';
@@ -166,10 +162,6 @@ function template_show_list($list_id = null)
 	</form>';
 	}
 
-	// Tabs at the bottom.  Usually bottom aligned.
-	if (isset($cur_list['list_menu'], $cur_list['list_menu']['show_on']) && ($cur_list['list_menu']['show_on'] == 'both' || $cur_list['list_menu']['show_on'] == 'bottom'))
-		template_create_list_menu($cur_list['list_menu'], 'bottom');
-
 	if (isset($cur_list['javascript']))
 		echo '
 	<script>
@@ -190,111 +182,6 @@ function template_additional_rows($row_position, $cur_list)
 			<div class="additional_row', empty($row['class']) ? '' : ' ' . $row['class'], '"', empty($row['style']) ? '' : ' style="' . $row['style'] . '"', '>
 				', $row['value'], '
 			</div>';
-}
-
-/**
- * This function creates a menu
- *
- * @param array $list_menu An array of menu data
- * @param string $direction Which direction the items should go
- */
-function template_create_list_menu($list_menu, $direction = 'top')
-{
-	global $context;
-
-	/**
-		// This is used if you want your generic lists to have tabs.
-		$cur_list['list_menu'] = array(
-			// This is the style to use.  Tabs or Buttons (Text 1 | Text 2).
-			// By default tabs are selected if not set.
-			// The main difference between tabs and buttons is that tabs get highlighted if selected.
-			// If style is set to buttons and use tabs is disabled then we change the style to old styled tabs.
-			'style' => 'tabs',
-			// The position of the tabs/buttons.  Left or Right.  By default is set to left.
-			'position' => 'left',
-			// This is used by the old styled menu.  We *need* to know the total number of columns to span.
-			'columns' => 0,
-			// This gives you the option to show tabs only at the top, bottom or both.
-			// By default they are just shown at the top.
-			'show_on' => 'top',
-			// Links.  This is the core of the array.  It has all the info that we need.
-			'links' => array(
-				'name' => array(
-					// This will tell use were to go when they click it.
-					'href' => $scripturl . '?action=theaction',
-					// The name that you want to appear for the link.
-					'label' => $txt['name'],
-					// If we use tabs instead of buttons we highlight the current tab.
-					// Must use conditions to determine if its selected or not.
-					'is_selected' => isset($_REQUEST['name']),
-				),
-			),
-		);
-	*/
-
-	// Are we using right-to-left orientation?
-	$first = $context['right_to_left'] ? 'last' : 'first';
-	$last = $context['right_to_left'] ? 'first' : 'last';
-
-	if (!isset($list_menu['style']) || isset($list_menu['style']) && $list_menu['style'] == 'tabs')
-	{
-		echo '
-		<table style="margin-', $list_menu['position'], ': 10px; width: 100%;">
-			<tr>', $list_menu['position'] == 'right' ? '
-				<td></td>' : '', '
-				<td class="', $list_menu['position'], 'text">
-					<table>
-						<tr>
-							<td class="', $direction == 'top' ? 'mirror' : 'main', 'tab_', $first, '"></td>';
-
-		foreach ($list_menu['links'] as $link)
-		{
-			if ($link['is_selected'])
-				echo '
-							<td class="', $direction == 'top' ? 'mirror' : 'main', 'tab_active_', $first, '"></td>
-							<td class="', $direction == 'top' ? 'mirrortab' : 'maintab', '_active_back">
-								<a href="', $link['href'], '">', $link['label'], '</a>
-							</td>
-							<td class="', $direction == 'top' ? 'mirror' : 'main', 'tab_active_', $last, '"></td>';
-			else
-				echo '
-							<td class="', $direction == 'top' ? 'mirror' : 'main', 'tab_back">
-								<a href="', $link['href'], '">', $link['label'], '</a>
-							</td>';
-		}
-
-		echo '
-							<td class="', $direction == 'top' ? 'mirror' : 'main', 'tab_', $last, '"></td>
-						</tr>
-					</table>
-				</td>', $list_menu['position'] == 'left' ? '
-				<td></td>' : '', '
-			</tr>
-		</table>';
-	}
-	elseif (isset($list_menu['style']) && $list_menu['style'] == 'buttons')
-	{
-		$links = array();
-		foreach ($list_menu['links'] as $link)
-			$links[] = '<a href="' . $link['href'] . '">' . $link['label'] . '</a>';
-
-		echo '
-		<table style="margin-', $list_menu['position'], ': 10px; width: 100%;">
-			<tr>', $list_menu['position'] == 'right' ? '
-				<td></td>' : '', '
-				<td class="', $list_menu['position'], 'text">
-					<table>
-						<tr>
-							<td class="', $direction == 'top' ? 'mirror' : 'main', 'tab_', $first, '"></td>
-							<td class="', $direction == 'top' ? 'mirror' : 'main', 'tab_back">', implode(' &nbsp;|&nbsp; ', $links), '</td>
-							<td class="', $direction == 'top' ? 'mirror' : 'main', 'tab_', $last, '"></td>
-						</tr>
-					</table>
-				</td>', $list_menu['position'] == 'left' ? '
-				<td></td>' : '', '
-			</tr>
-		</table>';
-	}
 }
 
 ?>


### PR DESCRIPTION
I found a code that is currently not used anywhere. The styles used (.mirrortab_back, .maintab_back, etc.) are missing not only in SMF 2.1 but in 2.0 too (I only found them in the CSS file SMF 1.1.x).

Signed-off-by: Bugo <bugo@dragomano.ru>