### PR TITLE
Fix database error on using search in Modlog area

### DIFF
--- a/Sources/Modlog.php
+++ b/Sources/Modlog.php
@@ -164,7 +164,7 @@ function ViewModlog()
 		'get_items' => array(
 			'function' => 'list_getModLogEntries',
 			'params' => array(
-				(!empty($search_params['string']) ? ' INSTR({raw:sql_type}, {string:search_string})' : ''),
+				(!empty($search_params['string']) ? ' INSTR({raw:sql_type}, {string:search_string}) > 0' : ''),
 				array('sql_type' => $search_params_column, 'search_string' => $search_params['string']),
 				$context['log_type'],
 			),
@@ -172,7 +172,7 @@ function ViewModlog()
 		'get_count' => array(
 			'function' => 'list_getModLogEntryCount',
 			'params' => array(
-				(!empty($search_params['string']) ? ' INSTR({raw:sql_type}, {string:search_string})' : ''),
+				(!empty($search_params['string']) ? ' INSTR({raw:sql_type}, {string:search_string}) > 0' : ''),
 				array('sql_type' => $search_params_column, 'search_string' => $search_params['string']),
 				$context['log_type'],
 			),


### PR DESCRIPTION
#### Description
When we use the quick search on the Modlog area, it causes an error:
![1](https://user-images.githubusercontent.com/229402/83602431-f785ce00-a58b-11ea-8ae1-1e8acfa0f7d5.png)

### Steps to reproduce
1. Go to Admin => Maintenance => Logs => Moderation logs
2.  Use Quick Search (by Member, etc) to find something on this area

### Environment (complete as necessary)
- Version/Git revision: https://github.com/SimpleMachines/SMF2.1/commit/fdc9c476450851c9173f76821a8dc1aac2c8f1e2
- Database Type: PostgreSQL
- Database Version: 9.6
- PHP Version: 7.3.18

Signed-off-by: Bugo <bugo@dragomano.ru>