### PR TITLE
Raise PG min version to 9.6

### DIFF
--- a/Sources/DbSearch-postgresql.php
+++ b/Sources/DbSearch-postgresql.php
@@ -34,17 +34,7 @@ function db_search_init()
 
 	db_extend();
 
-	//pg 9.5 got ignore support
-	$version = $smcFunc['db_get_version']();
-	// if we got a Beta Version
-	if (stripos($version, 'beta') !== false)
-		$version = substr($version, 0, stripos($version, 'beta')) . '.0';
-	// or RC
-	if (stripos($version, 'rc') !== false)
-		$version = substr($version, 0, stripos($version, 'rc')) . '.0';
-
-	if (version_compare($version, '9.5.0', '>='))
-		$smcFunc['db_support_ignore'] = true;
+	$smcFunc['db_support_ignore'] = true;
 }
 
 /**

--- a/Sources/Subs-Db-postgresql.php
+++ b/Sources/Subs-Db-postgresql.php
@@ -978,26 +978,7 @@ function smf_db_custom_order($field, $array_values, $desc = false)
  */
 function smf_db_native_replace()
 {
-	global $smcFunc;
-	static $pg_version;
-	static $replace_support;
-
-	if (empty($pg_version))
-	{
-		db_extend();
-		//pg 9.5 got replace support
-		$pg_version = $smcFunc['db_get_version']();
-		// if we got a Beta Version
-		if (stripos($pg_version, 'beta') !== false)
-			$pg_version = substr($pg_version, 0, stripos($pg_version, 'beta')) . '.0';
-		// or RC
-		if (stripos($pg_version, 'rc') !== false)
-			$pg_version = substr($pg_version, 0, stripos($pg_version, 'rc')) . '.0';
-
-		$replace_support = (version_compare($pg_version, '9.5.0', '>=') ? true : false);
-	}
-
-	return $replace_support;
+	return true;
 }
 
 /**

--- a/other/install.php
+++ b/other/install.php
@@ -63,7 +63,7 @@ $databases = array(
 	),
 	'postgresql' => array(
 		'name' => 'PostgreSQL',
-		'version' => '9.4',
+		'version' => '9.6',
 		'function_check' => 'pg_connect',
 		'version_check' => '$request = pg_query(\'SELECT version()\'); list ($version) = pg_fetch_row($request); list($pgl, $version) = explode(" ", $version); return $version;',
 		'supported' => function_exists('pg_connect'),

--- a/other/readme.html
+++ b/other/readme.html
@@ -122,7 +122,7 @@
 								<ul>
 									<li><a href="https://www.mysql.com/" target="_blank" rel="noopener">MySQL</a> 5.0.22/5.1.10 or higher.</li>
 									<li><a href="https://mariadb.com/" target="_blank" rel="noopener">MariaDB</a> 5.1.10 or higher.</li>
-									<li><a href="https://www.postgresql.org/" target="_blank" rel="noopener">PostgreSQL</a> 9.4 or higher.</li>
+									<li><a href="https://www.postgresql.org/" target="_blank" rel="noopener">PostgreSQL</a> 9.6 or higher.</li>
 								</ul>
 							</li>
 							<li>at least 2 megabytes of storage space in the database, although more is highly recommended.</li>
@@ -150,7 +150,7 @@
 								<ul>
 									<li><a href="https://www.mysql.com/" target="_blank" rel="noopener">MySQL</a> 8.0 or higher.</li>
 									<li><a href="https://mariadb.com/" target="_blank" rel="noopener">MariaDB</a> 10.2 or higher.</li>
-									<li><a href="https://www.postgresql.org/" target="_blank" rel="noopener">PostgreSQL</a> 9.5 or higher.</li>
+									<li><a href="https://www.postgresql.org/" target="_blank" rel="noopener">PostgreSQL</a> 9.6 or higher.</li>
 								</ul>
 							</li>
 							<li><a href="https://libgd.github.io/" target="_blank" rel="noopener">GD Graphics Library</a> 2.0 or higher.</li>
@@ -279,7 +279,7 @@
 								<ul>
 									<li><a href="https://www.mysql.com/" target="_blank" rel="noopener">MySQL</a> 5.0.22/5.1.10 or higher.</li>
 									<li><a href="https://mariadb.com/" target="_blank" rel="noopener">MariaDB</a> 5.1.10 or higher.</li>
-									<li><a href="https://www.postgresql.org/" target="_blank" rel="noopener">PostgreSQL</a> 9.4 or higher.</li>
+									<li><a href="https://www.postgresql.org/" target="_blank" rel="noopener">PostgreSQL</a> 9.6 or higher.</li>
 								</ul>
 							</li>
 							<li>at least 2 megabytes of storage space in the database, although more is highly recommended.</li>
@@ -309,7 +309,7 @@
 								<ul>
 									<li><a href="https://www.mysql.com/" target="_blank" rel="noopener">MySQL</a> 8.0 or higher.</li>
 									<li><a href="https://mariadb.com/" target="_blank" rel="noopener">MariaDB</a> 10.2 or higher.</li>
-									<li><a href="https://www.postgresql.org/" target="_blank" rel="noopener">PostgreSQL</a> 9.5 or higher.</li>
+									<li><a href="https://www.postgresql.org/" target="_blank" rel="noopener">PostgreSQL</a> 9.6 or higher.</li>
 								</ul>
 							</li>
 							<li><a href="https://libgd.github.io/" target="_blank" rel="noopener">GD Graphics Library</a> 2.0 or higher.</li>

--- a/other/upgrade.php
+++ b/other/upgrade.php
@@ -49,7 +49,7 @@ $databases = array(
 	),
 	'postgresql' => array(
 		'name' => 'PostgreSQL',
-		'version' => '9.4',
+		'version' => '9.6',
 		'version_check' => '$version = pg_version(); return $version[\'client\'];',
 		'always_has_db' => true,
 	),


### PR DESCRIPTION
Same reason like the pr 2 years before: https://github.com/SimpleMachines/SMF2.1/pull/4788
good thing on this,
we got now always ignore support on pg side and didn't had to check any more.