### PR TITLE
Your DBMS is not a good random number generator

### DIFF
--- a/Sources/Subs-Db-postgresql.php
+++ b/Sources/Subs-Db-postgresql.php
@@ -330,9 +330,6 @@ function smf_db_query($identifier, $db_string, $db_values = array(), $connection
 
 	// Special queries that need processing.
 	$replacements = array(
-		'get_random_number' => array(
-			'~RAND~' => 'RANDOM',
-		),
 		'insert_log_search_topics' => array(
 			'~NOT RLIKE~' => '!~',
 		),

--- a/Sources/Subs-Members.php
+++ b/Sources/Subs-Members.php
@@ -1518,24 +1518,11 @@ function populateDuplicateMembers(&$members)
 /**
  * Generate a random validation code.
  *
- * @todo Err. Whatcha doin' here.
- *
  * @return string A random validation code
  */
 function generateValidationCode()
 {
-	global $smcFunc, $modSettings;
-
-	$request = $smcFunc['db_query']('get_random_number', '
-		SELECT RAND()',
-		array(
-		)
-	);
-
-	list ($dbRand) = $smcFunc['db_fetch_row']($request);
-	$smcFunc['db_free_result']($request);
-
-	return substr(preg_replace('/\W/', '', sha1(microtime() . $smcFunc['random_int']() . $dbRand . $modSettings['rand_seed'])), 0, 10);
+	return bin2hex(random_bytes(5));
 }
 
 ?>

--- a/Sources/Subs-Members.php
+++ b/Sources/Subs-Members.php
@@ -1522,7 +1522,9 @@ function populateDuplicateMembers(&$members)
  */
 function generateValidationCode()
 {
-	return bin2hex(random_bytes(5));
+	global $smcFunc;
+
+	return bin2hex($smcFunc['random_bytes'](5));
 }
 
 ?>


### PR DESCRIPTION
This commit refactors `generateValidationCode()` to rely solely on PHP's preferred source of entropy.

The current approach is not only inefficient, but comes with virtually no guarantee of producing an unpredictable code. Database management systems are good at, well, managing databases. They're not really intended as part of your pseudo-random number generator.

Signed-off by: Miłosz Gaczkowski <milosz@omgomg.eu>