### PR TITLE
Undesirable results when a file doesn't exist when loading css or js.

### DIFF
--- a/Sources/Load.php
+++ b/Sources/Load.php
@@ -2387,7 +2387,7 @@ function loadTheme($id_theme = 0, $initialize = true)
 			$_SESSION['id_variant'] = $_REQUEST['variant'];
 		// User selection?
 		if (empty($settings['disable_user_variant']) || allowedTo('admin_forum'))
-			$context['theme_variant'] = !empty($_SESSION['id_variant']) ? $_SESSION['id_variant'] : (!empty($options['theme_variant']) ? $options['theme_variant'] : '');
+			$context['theme_variant'] = !empty($_SESSION['id_variant']) && in_array($_SESSION['id_variant'], $settings['theme_variants']) ? $_SESSION['id_variant'] : (!empty($options['theme_variant']) && in_array($options['theme_variant'], $settings['theme_variants']) ? $options['theme_variant'] : '');
 		// If not a user variant, select the default.
 		if ($context['theme_variant'] == '' || !in_array($context['theme_variant'], $settings['theme_variants']))
 			$context['theme_variant'] = !empty($settings['default_variant']) && in_array($settings['default_variant'], $settings['theme_variants']) ? $settings['default_variant'] : $settings['theme_variants'][0];

--- a/Sources/Load.php
+++ b/Sources/Load.php
@@ -2703,14 +2703,12 @@ function loadCSSFile($fileName, $params = array(), $id = '')
 				$fileUrl = $settings['default_theme_url'] . '/css/' . $fileName;
 				$filePath = $settings['default_theme_dir'] . '/css/' . $fileName;
 			}
-
 			else
 			{
 				$fileUrl = false;
 				$filePath = false;
 			}
 		}
-
 		else
 		{
 			$fileUrl = $settings[$themeRef . '_url'] . '/css/' . $fileName;
@@ -2718,7 +2716,6 @@ function loadCSSFile($fileName, $params = array(), $id = '')
 			$mtime = @filemtime($filePath);
 		}
 	}
-
 	// An external file doesn't have a filepath. Mock one for simplicity.
 	else
 	{
@@ -2729,7 +2726,7 @@ function loadCSSFile($fileName, $params = array(), $id = '')
 	$mtime = empty($mtime) ? 0 : $mtime;
 
 	// Add it to the array for use in the template
-	if (!empty($fileName))
+	if (!empty($fileName) && !empty($fileUrl))
 	{
 		// find a free number/position
 		while (isset($context['css_files_order'][$params['order_pos']]))
@@ -2818,14 +2815,12 @@ function loadJavaScriptFile($fileName, $params = array(), $id = '')
 				$fileUrl = $settings['default_theme_url'] . '/scripts/' . $fileName;
 				$filePath = $settings['default_theme_dir'] . '/scripts/' . $fileName;
 			}
-
 			else
 			{
 				$fileUrl = false;
 				$filePath = false;
 			}
 		}
-
 		else
 		{
 			$fileUrl = $settings[$themeRef . '_url'] . '/scripts/' . $fileName;
@@ -2833,7 +2828,6 @@ function loadJavaScriptFile($fileName, $params = array(), $id = '')
 			$mtime = @filemtime($filePath);
 		}
 	}
-
 	// An external file doesn't have a filepath. Mock one for simplicity.
 	else
 	{
@@ -2844,7 +2838,7 @@ function loadJavaScriptFile($fileName, $params = array(), $id = '')
 	$mtime = empty($mtime) ? 0 : $mtime;
 
 	// Add it to the array for use in the template
-	if (!empty($fileName))
+	if (!empty($fileName) && !empty($fileUrl))
 		$context['javascript_files'][$id] = array('fileUrl' => $fileUrl, 'filePath' => $filePath, 'fileName' => $fileName, 'options' => $params, 'mtime' => $mtime);
 
 	if ($mtime > $modSettings['browser_cache'])


### PR DESCRIPTION
If you call loadCSS('foo.bar'), the HTML output will be:
`	<link rel="stylesheet" href="?smf21rc2_#TIMESTAMP#">`

This is wrong.  This is produced because we only check that $fileName is not empty, not $fileUrl.  I'm not 100% sure if the intention to be able to call these without a valid file is intended, such as in the case of wanting to trigger the updateSettings call.  So instead of return, I just modified the check.