### PR TITLE
Added "as b" to the news query fixes #6186

### DIFF
--- a/Sources/News.php
+++ b/Sources/News.php
@@ -189,7 +189,7 @@ function ShowXmlFeed()
 	{
 		$request = $smcFunc['db_query']('', '
 			SELECT num_posts
-			FROM {db_prefix}boards
+			FROM {db_prefix}boards AS b
 			WHERE id_board = {int:current_board}
 				AND {query_see_board}
 			LIMIT 1',


### PR DESCRIPTION
When {query_see_board} is used a table need to had a alias b
should fix #6186