### PR TITLE
Speed up order upgrade

### DIFF
--- a/other/upgrade_2-1_mysql.sql
+++ b/other/upgrade_2-1_mysql.sql
@@ -341,6 +341,7 @@ while (!$is_done)
 		SELECT id_attach, id_member, id_folder, filename, file_hash, mime_type
 		FROM {$db_prefix}attachments
 		WHERE attachment_type != 1
+		ORDER BY id_attach
 		LIMIT $_GET[a], 100");
 
 	// Finished?
@@ -882,6 +883,7 @@ if (in_array('notify_regularity', $results))
 		$request = $smcFunc['db_query']('', '
 			SELECT id_member, notify_regularity, notify_send_body, notify_types
 			FROM {db_prefix}members
+			ORDER BY id_member
 			LIMIT {int:start}, {int:limit}',
 			array(
 				'db_error_skip' => true,
@@ -1214,6 +1216,7 @@ if (!empty($select_columns))
 		$request = $smcFunc['db_query']('', '
 			SELECT id_member, '. implode(',', $select_columns) .'
 			FROM {db_prefix}members
+			ORDER BY id_member
 			LIMIT {int:start}, {int:limit}',
 			array(
 				'start' => $_GET['a'],

--- a/other/upgrade_2-1_postgresql.sql
+++ b/other/upgrade_2-1_postgresql.sql
@@ -511,6 +511,7 @@ while (!$is_done)
 		SELECT id_attach, id_member, id_folder, filename, file_hash, mime_type
 		FROM {$db_prefix}attachments
 		WHERE attachment_type != 1
+		ORDER BY id_attach
 		LIMIT $_GET[a], 100");
 
 	// Finished?
@@ -1088,6 +1089,7 @@ if (in_array('notify_regularity', $results))
 		$request = $smcFunc['db_query']('', '
 			SELECT id_member, notify_regularity, notify_send_body, notify_types
 			FROM {db_prefix}members
+			ORDER BY id_member
 			LIMIT {int:start}, {int:limit}',
 			array(
 				'db_error_skip' => true,


### PR DESCRIPTION
This would be an advanced version of #6184 ,
with the result that the upgrade process get faster instead of slower actual state.

This pr is mostly a show case...

170ba15 include the changes which we could do on all places where the upgrade process do paging.
In general is the idea to make advantage about the existing of the pk index to jump faster to next point,
also since it should safe it only use the methode so long no page refresh is happening,
when a page refresh happen than the next loop is done in "normal" mode with the result that the next loops again go fast.

The choosen example i had to admit make less sense since it got a high limit amount..
so maybe places like 
https://github.com/SimpleMachines/SMF2.1/blob/8104e4328223106289fcb7719f85cb5ce88b1b1a/other/upgrade_2-1_mysql.sql#L340-L344
where the limit is 100 and the possible rows can got up to 80k entries than the optimization make more sense.

So the question is,
Want we this?
Do we want this every where?