### PR TITLE
fix: Move login_cookie_times earlier in the process

### DIFF
--- a/Sources/Load.php
+++ b/Sources/Load.php
@@ -428,6 +428,15 @@ function reloadSettings()
 		'html',
 	);
 
+	// Login Cookie times. Format: time => txt
+	$context['login_cookie_times'] = array(
+		3153600 => 'always_logged_in',
+		60 => 'one_hour',
+		1440 => 'one_day',
+		10080 => 'one_week',
+		43200 => 'one_month',
+	);
+
 	// Call pre load integration functions.
 	call_integration_hook('integrate_pre_load');
 }
@@ -769,15 +778,6 @@ function loadUserSettings()
 		// We don't know the offset...
 		$user_info['time_offset'] = 0;
 	}
-
-	// Login Cookie times. Format: time => txt
-	$context['login_cookie_times'] = array(
-		3153600 => 'always_logged_in',
-		60 => 'one_hour',
-		1440 => 'one_day',
-		10080 => 'one_week',
-		43200 => 'one_month',
-	);
 
 	// Set up the $user_info array.
 	$user_info += array(


### PR DESCRIPTION
Makes $context['login_cookie_times'] always available. As an extra it can be modified by integrate_pre_load hook

Fixes #6179