### PR TITLE
Modsettings cache fix

### DIFF
--- a/Sources/CacheAPI-smf.php
+++ b/Sources/CacheAPI-smf.php
@@ -69,7 +69,13 @@ class smf_cache extends cache_api
 				@apc_delete_file($cachedir . '/data_' . $key . '.php');
 
 			// php will cache file_exists et all, we can't 100% depend on its results so proceed with caution
-			@include($cachedir . '/data_' . $key . '.php');
+			$cached = file_get_contents($cachedir . '/data_' . $key . '.php');
+			if (!empty($cached) && (substr($cached, 0, 6) === '<' . '?' . 'php ') && (substr($cached, -2, 2) === '?' . '>'))
+			{
+				$cached = substr($cached, 6, strlen($cached) - 8);
+				eval($cached);
+			}
+
 			if (!empty($expired) && isset($value))
 			{
 				@unlink($cachedir . '/data_' . $key . '.php');


### PR DESCRIPTION
Fixes #5826 

This addresses the T_CONSTANT_ENCAPSED_STRING problem we see in 2.1 as well as 2.0 production.  For some forums, all users are locked out until someone clears the cache...

To reproduce the error & test a fix, I wrote two bonehead scripts - one that writes cache 1000x and one that reads cache 1000x.  Running both does not in itself reproduce the issue, however, running TWO of the PUT scripts causes all kinds of issues with the GET scripts (confirming Suki's idea that it's related to conflicting writes).

_What we want to see in these tests is 1000 successful reads, with few, if any, NULLs returned..._  

WAMP & Linux fail differently here.

(This is an alternate approach to #5900 )

**_BEFORE THIS PR - WIN:_**
Although this always successfully completes on WIN, there are a LOT of NULLS returned...  LOTS...  
![smf21-current-code-WIN](https://user-images.githubusercontent.com/23568484/89081587-75721580-d340-11ea-825e-fe33ddee4027.png)

**_BEFORE THIS PR - linux:_**
This NEVER returns the 1000 reads - ever - on linux.  These failures kill the script, as it is a PARSE error.  There are usually (not always) accompanied with the T_CONSTANT_ENCAPSED_STRING errors in the apache log.
![smf21-current-code-linux](https://user-images.githubusercontent.com/23568484/89081600-7dca5080-d340-11ea-9384-7c736f58a863.png)
![image](https://user-images.githubusercontent.com/23568484/89081674-b5d19380-d340-11ea-9b0a-2204529f8b0a.png)

**_TESTING THIS PR - WIN:_**
Now it completes all 1000 reads successfully, with rare NULLs returned (~1 per 1000).  
![smf21-sbfix-WIN](https://user-images.githubusercontent.com/23568484/89081700-c7b33680-d340-11ea-9336-00cd8b072d87.png)
![smf21-sbfix-WIN-err](https://user-images.githubusercontent.com/23568484/89081701-c84bcd00-d340-11ea-8616-ba4e7f7fba97.png)

**_TESTING THIS PR - linux:_**
Now it completes all 1000 reads successfully, with rare NULLs returned (~1 per 1000).  
![smf21-sbfix-linux](https://user-images.githubusercontent.com/23568484/89081712-ce41ae00-d340-11ea-8e01-170de4bf14c3.png)

