### PR TITLE
This is my implementation of a JSON cache

### DIFF
--- a/Sources/Cache/APIs/FileBased.php
+++ b/Sources/Cache/APIs/FileBased.php
@@ -59,7 +59,7 @@ class FileBased extends CacheApi implements CacheApiInterface
 	{
 		if (($fp = fopen($file, 'rb')) !== false)
 		{
-			if (!flock($fp, LOCK_SH | LOCK_NB))
+			if (!flock($fp, LOCK_SH))
 			{
 				fclose($fp);
 				return false;
@@ -81,7 +81,7 @@ class FileBased extends CacheApi implements CacheApiInterface
 	{
 		if (($fp = fopen($file, 'cb')) !== false)
 		{
-			if (!flock($fp, LOCK_EX | LOCK_NB))
+			if (!flock($fp, LOCK_EX))
 			{
 				fclose($fp);
 				return false;
@@ -184,7 +184,7 @@ class FileBased extends CacheApi implements CacheApiInterface
 		$files = new GlobIterator($this->cachedir . '/' . $type . '*.cache', FilesystemIterator::NEW_CURRENT_AND_KEY);
 
 		foreach ($files as $file => $info)
-			@unlink($this->cachedir . '/' . $file);
+			unlink($this->cachedir . '/' . $file);
 
 		// Make this invalid.
 		$this->invalidateCache();


### PR DESCRIPTION
Fixes #5826

- encodes the data with the JSON lib 
- removes the risky code evaluation that sometimes threw fatal errors
- use a reader lock to avoid reading exclusively locked files
- don't block the script if any lock could not be obtained

[A user comment on php.net about how file locks work](https://www.php.net/manual/en/function.flock.php#78318)