### PR TITLE
Fixes various password/activate related issues. Fixes #6219

### DIFF
--- a/Sources/Profile-Modify.php
+++ b/Sources/Profile-Modify.php
@@ -284,7 +284,7 @@ function loadProfileFields($force_reload = false)
 
 					// Maybe they are trying to change their password as well?
 					$resetPassword = true;
-					if (isset($_POST['passwrd1']) && $_POST['passwrd1'] != '' && isset($_POST['passwrd2']) && $_POST['passwrd1'] == $_POST['passwrd2'] && validatePassword($_POST['passwrd1'], $value, array($cur_profile['real_name'], $user_info['username'], $user_info['name'], $user_info['email'])) == null)
+					if (isset($_POST['passwrd1']) && $_POST['passwrd1'] != '' && isset($_POST['passwrd2']) && $_POST['passwrd1'] == $_POST['passwrd2'] && validatePassword(un_htmlspecialchars($_POST['passwrd1']), $value, array($cur_profile['real_name'], $user_info['username'], $user_info['name'], $user_info['email'])) == null)
 						$resetPassword = false;
 
 					// Do the reset... this will send them an email too.
@@ -323,7 +323,7 @@ function loadProfileFields($force_reload = false)
 
 				// Let's get the validation function into play...
 				require_once($sourcedir . '/Subs-Auth.php');
-				$passwordErrors = validatePassword($value, $cur_profile['member_name'], array($cur_profile['real_name'], $user_info['username'], $user_info['name'], $user_info['email']));
+				$passwordErrors = validatePassword(un_htmlspecialchars($value), $cur_profile['member_name'], array($cur_profile['real_name'], $user_info['username'], $user_info['name'], $user_info['email']));
 
 				// Were there errors?
 				if ($passwordErrors != null)

--- a/Sources/Profile.php
+++ b/Sources/Profile.php
@@ -680,7 +680,7 @@ function ModifyProfile($post_errors = array())
 			$good_password = in_array(true, call_integration_hook('integrate_verify_password', array($cur_profile['member_name'], $password, false)), true);
 
 			// Bad password!!!
-			if (!$good_password && !hash_verify_password($user_profile[$memID]['member_name'], un_htmlspecialchars(stripslashes($password)), $user_info['passwd']))
+			if (!$good_password && !hash_verify_password($user_profile[$memID]['member_name'], $password, $user_info['passwd']))
 				$post_errors[] = 'bad_password';
 
 			// Warn other elements not to jump the gun and do custom changes!

--- a/Sources/Register.php
+++ b/Sources/Register.php
@@ -645,7 +645,7 @@ function Activate()
 	$smcFunc['db_free_result']($request);
 
 	// Change their email address? (they probably tried a fake one first :P.)
-	if (isset($_POST['new_email'], $_REQUEST['passwd']) && hash_password($row['member_name'], $_REQUEST['passwd']) == $row['passwd'] && ($row['is_activated'] == 0 || $row['is_activated'] == 2))
+	if (!empty($_POST['new_email']) &&!empty($_REQUEST['passwd']) && hash_verify_password($row['member_name'], $_REQUEST['passwd'], $row['passwd']) && ($row['is_activated'] == 0 || $row['is_activated'] == 2))
 	{
 		if (empty($modSettings['registration_method']) || $modSettings['registration_method'] == 3)
 			fatal_lang_error('no_access', false);
@@ -698,9 +698,9 @@ function Activate()
 		$context['page_title'] = $txt['invalid_activation_resend'];
 
 		// This will ensure we don't actually get an error message if it works!
-		$context['error_title'] = '';
+		$context['error_title'] = $txt['invalid_activation_resend'];
 
-		fatal_lang_error(!empty($email_change) ? 'change_email_success' : 'resend_email_success', false);
+		fatal_lang_error(!empty($email_change) ? 'change_email_success' : 'resend_email_success', false, array(), false);
 	}
 
 	// Quit if this code is not right.

--- a/Sources/Register.php
+++ b/Sources/Register.php
@@ -645,7 +645,7 @@ function Activate()
 	$smcFunc['db_free_result']($request);
 
 	// Change their email address? (they probably tried a fake one first :P.)
-	if (!empty($_POST['new_email']) &&!empty($_REQUEST['passwd']) && hash_verify_password($row['member_name'], $_REQUEST['passwd'], $row['passwd']) && ($row['is_activated'] == 0 || $row['is_activated'] == 2))
+	if (!empty($_POST['new_email']) && !empty($_REQUEST['passwd']) && hash_verify_password($row['member_name'], $_REQUEST['passwd'], $row['passwd']) && ($row['is_activated'] == 0 || $row['is_activated'] == 2))
 	{
 		if (empty($modSettings['registration_method']) || $modSettings['registration_method'] == 3)
 			fatal_lang_error('no_access', false);

--- a/other/upgrade.php
+++ b/other/upgrade.php
@@ -1062,7 +1062,7 @@ function checkLogin()
 				foreach ($groups as $k => $v)
 					$groups[$k] = (int) $v;
 
-				$sha_passwd = sha1(strtolower($name) . un_htmlspecialchars($_REQUEST['passwrd']));
+				$sha_passwd = sha1(strtolower($name) . $_REQUEST['passwrd']);
 
 				// We don't use "-utf8" anymore...
 				$user_language = str_ireplace('-utf8', '', $user_language);


### PR DESCRIPTION
Fixes #6219.

Bugfix 1: Fixes a problem which prevented the user from changing e-mail address on the activate action if they entered a non-valid e-mail on sign up and your board requires activation.
Bugfix 2: Added proper titles to some of the message pages the user sees when requesting a new verification code.
Bugfix 3: No longer gives 404 html header when user requests a new verification code.
Bugfix 4: Added un_htmlspecialchars to missing password post from verifyPassword calls where needed.
Bugfix 5: Removed strip_slashes on password which will prevent any user from having a backslash in their password from saving their profile. Also removed the extra un_htmlspecialchars which was already handled when setting $password.
Bugfix 6: Removed unneeded un_htmlspecialchars from upgrade hash password which will prevent an error if your password contains html special chars by random chance.