### PR TITLE
Fixing theme install that is based on another theme

### DIFF
--- a/Sources/Subs-Themes.php
+++ b/Sources/Subs-Themes.php
@@ -277,8 +277,7 @@ function get_theme_info($path)
 		fatal_lang_error('package_get_error_theme_not_compatible', false, SMF_FULL_VERSION);
 	}
 
-	$theme_info_xml = $theme_info_xml->path('theme-info[0]');
-	$theme_info_xml = $theme_info_xml->to_array();
+	$theme_info_xml = $theme_info_xml->to_array('theme-info[0]');
 
 	$xml_elements = array(
 		'theme_layers' => 'layers',

--- a/Sources/Subs-Themes.php
+++ b/Sources/Subs-Themes.php
@@ -20,9 +20,10 @@ if (!defined('SMF'))
  * Gets a single theme's info.
  *
  * @param int $id The theme ID to get the info from.
+ * @param string[] $variables
  * @return array The theme info as an array.
  */
-function get_single_theme($id)
+function get_single_theme($id, array $variables = array())
 {
 	global $smcFunc, $modSettings;
 
@@ -33,21 +34,8 @@ function get_single_theme($id)
 	// Make sure $id is an int.
 	$id = (int) $id;
 
-	// List of all possible  values.
-	$themeValues = array(
-		'theme_dir',
-		'images_url',
-		'theme_url',
-		'name',
-		'theme_layers',
-		'theme_templates',
-		'version',
-		'install_for',
-		'based_on',
-	);
-
 	// Make changes if you really want it.
-	call_integration_hook('integrate_get_single_theme', array(&$themeValues, $id));
+	call_integration_hook('integrate_get_single_theme', array(&$variables, $id));
 
 	$single = array(
 		'id' => $id,
@@ -60,11 +48,11 @@ function get_single_theme($id)
 	$request = $smcFunc['db_query']('', '
 		SELECT id_theme, variable, value
 		FROM {db_prefix}themes
-		WHERE variable IN ({array_string:theme_values})
-			AND id_theme = ({int:id_theme})
-			AND id_member = {int:no_member}',
+		WHERE id_theme = ({int:id_theme})
+			AND id_member = {int:no_member}' . (!empty($variables) ? '
+			AND variable IN ({array_string:variables})' : ''),
 		array(
-			'theme_values' => $themeValues,
+			'variables' => $variables,
 			'id_theme' => $id,
 			'no_member' => 0,
 		)

--- a/Sources/Subs-Themes.php
+++ b/Sources/Subs-Themes.php
@@ -268,7 +268,7 @@ function get_theme_info($path)
 
 	// So, we have an install tag which is cool and stuff but we also need to check it and match your current SMF version...
 	$the_version = SMF_VERSION;
-	$install_versions = $theme_info_xml->path('theme-info/install/@for');
+	$install_versions = $theme_info_xml->fetch('theme-info/install/@for');
 
 	// The theme isn't compatible with the current SMF version.
 	if (!$install_versions || !matchPackageVersion($the_version, $install_versions))

--- a/Sources/Subs-Themes.php
+++ b/Sources/Subs-Themes.php
@@ -132,17 +132,19 @@ function get_all_themes($enable_only = false)
 
 	while ($row = $smcFunc['db_fetch_assoc']($request))
 	{
-		$context['themes'][$row['id_theme']]['id'] = (int) $row['id_theme'];
+		if (!isset($context['themes'][$row['id_theme']]))
+			$context['themes'][$row['id_theme']] = array(
+				'id' => (int) $row['id_theme'],
+				'known' => in_array($row['id_theme'], $knownThemes),
+				'enable' => in_array($row['id_theme'], $enableThemes)
+			);
 
 		// Fix the path and tell if its a valid one.
 		if ($row['variable'] == 'theme_dir')
 		{
-			$context['themes'][$row['id_theme']][$row['variable']] = realpath($row['value']);
-			$context['themes'][$row['id_theme']]['valid_path'] = file_exists(realpath($row['value'])) && is_dir(realpath($row['value']));
+			$row['value'] = realpath($row['value']);
+			$context['themes'][$row['id_theme']]['valid_path'] = file_exists($row['value']) && is_dir($row['value']);
 		}
-
-		$context['themes'][$row['id_theme']]['known'] = in_array($row['id_theme'], $knownThemes);
-		$context['themes'][$row['id_theme']]['enable'] = in_array($row['id_theme'], $enableThemes);
 		$context['themes'][$row['id_theme']][$row['variable']] = $row['value'];
 	}
 
@@ -196,17 +198,19 @@ function get_installed_themes()
 
 	while ($row = $smcFunc['db_fetch_assoc']($request))
 	{
-		$context['themes'][$row['id_theme']]['id'] = (int) $row['id_theme'];
+		if (!isset($context['themes'][$row['id_theme']]))
+			$context['themes'][$row['id_theme']] = array(
+				'id' => (int) $row['id_theme'],
+				'known' => in_array($row['id_theme'], $knownThemes),
+				'enable' => in_array($row['id_theme'], $enableThemes)
+			);
 
 		// Fix the path and tell if its a valid one.
 		if ($row['variable'] == 'theme_dir')
 		{
-			$context['themes'][$row['id_theme']][$row['variable']] = realpath($row['value']);
-			$context['themes'][$row['id_theme']]['valid_path'] = file_exists(realpath($row['value'])) && is_dir(realpath($row['value']));
+			$row['value'] = realpath($row['value']);
+			$context['themes'][$row['id_theme']]['valid_path'] = file_exists($row['value']) && is_dir($row['value']);
 		}
-
-		$context['themes'][$row['id_theme']]['known'] = in_array($row['id_theme'], $knownThemes);
-		$context['themes'][$row['id_theme']]['enable'] = in_array($row['id_theme'], $enableThemes);
 		$context['themes'][$row['id_theme']][$row['variable']] = $row['value'];
 	}
 

--- a/Sources/Themes.php
+++ b/Sources/Themes.php
@@ -832,7 +832,7 @@ function RemoveTheme()
 	if ($themeID == 1)
 		fatal_lang_error('no_access', false);
 
-	$theme_info = get_single_theme($themeID);
+	$theme_info = get_single_theme($themeID, array('theme_dir'));
 
 	// Remove it from the DB.
 	remove_theme($themeID);
@@ -1089,7 +1089,7 @@ function PickTheme()
 			$txt['theme_description'] = '';
 		}
 
-		$context['available_themes'][$id_theme]['thumbnail_href'] = sprintf($txt['theme_thumbnail_href'], $settings['images_url']);
+		$context['available_themes'][$id_theme]['thumbnail_href'] = $txt['theme_thumbnail_href'];
 		$context['available_themes'][$id_theme]['description'] = $txt['theme_description'];
 
 		// Are there any variants?
@@ -1324,6 +1324,8 @@ function InstallCopy()
 		'install_for' => '2.1 - 2.1.99, ' . SMF_VERSION,
 		'based_on' => '',
 		'based_on_dir' => $themedir . '/default',
+		'theme_layers' => 'html,body',
+		'theme_templates' => 'index',
 	);
 
 	// Create the specific dir.
@@ -1352,37 +1354,10 @@ function InstallCopy()
 	copytree($settings['default_theme_dir'] . '/images', $context['to_install']['theme_dir'] . '/images');
 	package_flush_cache();
 
-	// Lets get some data for the new theme.
-	$request = $smcFunc['db_query']('', '
-		SELECT variable, value
-		FROM {db_prefix}themes
-		WHERE variable IN ({string:theme_templates}, {string:theme_layers})
-			AND id_member = {int:no_member}
-			AND id_theme = {int:default_theme}',
-		array(
-			'no_member' => 0,
-			'default_theme' => 1,
-			'theme_templates' => 'theme_templates',
-			'theme_layers' => 'theme_layers',
-		)
-	);
-
-	while ($row = $smcFunc['db_fetch_assoc']($request))
-	{
-		if ($row['variable'] == 'theme_templates')
-			$theme_templates = $row['value'];
-		elseif ($row['variable'] == 'theme_layers')
-			$theme_layers = $row['value'];
-		else
-			continue;
-	}
-
-	$smcFunc['db_free_result']($request);
-
-	$context['to_install'] += array(
-		'theme_layers' => empty($theme_layers) ? 'html,body' : $theme_layers,
-		'theme_templates' => empty($theme_templates) ? 'index' : $theme_templates,
-	);
+	// Any data from the default theme that we want?
+	foreach (get_single_theme(1, array('theme_layers', 'theme_templates')) as $variable => $value)
+		if ($variable == 'theme_templates' || $variable == 'theme_layers')
+			$context['to_install'][$variable] = $value;
 
 	// Lets add a theme_info.xml to this theme.
 	$xml_info = '<' . '?xml version="1.0"?' . '>


### PR DESCRIPTION
I don't really have a theme to test it with (manually doing it would eat up too much time!) so instead I wrote a unit test that i could quickly run every time I made a change:.
```
> php  vendor/phpunit/phpunit/phpunit --debug

PHPUnit 8.5.2 by Sebastian Bergmann and contributors.

Runtime:       PHP 7.2.10
Configuration: C:\Users\John\repos\SMF2.1\phpunit.xml
Error:         No code coverage driver is available

Test 'PHPTDD\ThemeTest::testThemeInfo' started
Test 'PHPTDD\ThemeTest::testThemeInfo' ended
Test 'PHPTDD\ThemeTest::testGetSingleTheme' started
Test 'PHPTDD\ThemeTest::testGetSingleTheme' ended
Test 'PHPTDD\ThemeTest::testGetSingleThemeNotExists' started
Test 'PHPTDD\ThemeTest::testGetSingleThemeNotExists' ended
Test 'PHPTDD\ThemeTest::testInstallCopy' started
Test 'PHPTDD\ThemeTest::testInstallCopy' ended
Test 'PHPTDD\ThemeTest::testInstallDuplicateCopy' started
Test 'PHPTDD\ThemeTest::testInstallDuplicateCopy' ended
Test 'PHPTDD\ThemeTest::testInstallCopyWithNoName' started
Test 'PHPTDD\ThemeTest::testInstallCopyWithNoName' ended
Test 'PHPTDD\ThemeTest::testInstallDependentTheme' started
Test 'PHPTDD\ThemeTest::testInstallDependentTheme' ended
Test 'PHPTDD\ThemeTest::testUpdateDependentTheme' started
Test 'PHPTDD\ThemeTest::testUpdateDependentTheme' ended
Test 'PHPTDD\ThemeTest::testRemoveDependentTheme' started
Test 'PHPTDD\ThemeTest::testRemoveDependentTheme' ended
Test 'PHPTDD\ThemeTest::testRemoveTheme' started
Test 'PHPTDD\ThemeTest::testRemoveTheme' ended
Test 'PHPTDD\ThemeTest::testGetAllThemes' started
Test 'PHPTDD\ThemeTest::testGetAllThemes' ended
Test 'PHPTDD\ThemeTest::testGetInstalledThemes' started
Test 'PHPTDD\ThemeTest::testGetInstalledThemes' ended


Time: 535 ms, Memory: 8.00 MB

OK (12 tests, 65 assertions)
``` 