### PR TITLE
Strip -utf8 string from privacy policy settings

### DIFF
--- a/other/upgrade_2-1_mysql.sql
+++ b/other/upgrade_2-1_mysql.sql
@@ -3151,11 +3151,12 @@ ALTER TABLE {$db_prefix}log_spider_stats CHANGE page_hits page_hits INT NOT NULL
 /******************************************************************************/
 ---# Strip -utf8 from policy settings
 ---{
-$utf8_policy_settings = array_filter($modSettings, function($v, $k)
-		{
-			return (substr($k, 0, 7) === 'policy_') && (substr($k, -5) === '-utf8');
-		}, ARRAY_FILTER_USE_BOTH
-	);
+$utf8_policy_settings = array();
+foreach($modSettings AS $k => $v)
+{
+	if ((substr($k, 0, 7) === 'policy_') && (substr($k, -5) === '-utf8'))
+		$utf8_policy_settings[$k] = $v;
+}
 $adds = array();
 $deletes = array();
 foreach($utf8_policy_settings AS $var => $val)

--- a/other/upgrade_2-1_mysql.sql
+++ b/other/upgrade_2-1_mysql.sql
@@ -3147,7 +3147,7 @@ ALTER TABLE {$db_prefix}log_spider_stats CHANGE page_hits page_hits INT NOT NULL
 ---#
 
 /******************************************************************************/
---- Update policy settings
+--- Update policy & agreement settings
 /******************************************************************************/
 ---# Strip -utf8 from policy settings
 ---{
@@ -3165,7 +3165,7 @@ foreach($utf8_policy_settings AS $var => $val)
 	if (!array_key_exists('policy_' . $language, $modSettings))
 	{
 		$adds[] =  '(\'policy_' . $language . '\', \'' . $val . '\')';
-		$deletes[] = '\'policy_' . $language . '-utf8\'';
+		$deletes[] = '\'' . $var . '\'';
 	}
 }
 if (!empty($adds))
@@ -3186,11 +3186,21 @@ if (!empty($deletes))
 ---}
 ---#
 
-/******************************************************************************/
---- Fixing old policy acceptance records...
-/******************************************************************************/
+---# Strip -utf8 from agreement file names
+---{
+$files = glob($boarddir . '/agreement.*-utf8.txt');
+foreach($files AS $filename)
+{
+	$newfile = substr($filename, 0, strlen($filename) - 9) . '.txt';
+	// Do not overwrite existing files
+	if (!file_exists($newfile))
+		@rename($filename, $newfile);
+}
 
----# Fixing missing values in log_actions
+---}
+---#
+
+---# Fix missing values in log_actions
 ---{
 // Find the missing id_members
 $request = upgrade_query("

--- a/other/upgrade_2-1_mysql.sql
+++ b/other/upgrade_2-1_mysql.sql
@@ -3185,3 +3185,34 @@ if (!empty($deletes))
 
 ---}
 ---#
+
+/******************************************************************************/
+--- Fixing old policy acceptance records...
+/******************************************************************************/
+
+---# Fixing missing values in log_actions
+---{
+// Find the missing id_members
+$request = upgrade_query("
+	SELECT id_action, extra
+		FROM {$db_prefix}log_actions
+		WHERE id_member = 0
+		AND action IN ('policy_accepted', 'agreement_accepted')");
+
+// Fortunately they're in the extra field
+while ($row = mysqli_fetch_assoc($request))
+{
+	$extra = @unserialize($row['extra']);
+	if ($extra === false)
+		continue;
+	if (!empty($extra['applicator']))
+	{
+		upgrade_query("
+			UPDATE {$db_prefix}log_actions
+				SET id_member = " . $extra['applicator'] . "
+				WHERE id_action = " . $row['id_action']);
+	}
+}
+
+---}
+---#

--- a/other/upgrade_2-1_postgresql.sql
+++ b/other/upgrade_2-1_postgresql.sql
@@ -3551,7 +3551,7 @@ ALTER TABLE {$db_prefix}log_spider_stats ALTER COLUMN page_hits TYPE INT;
 ---#
 
 /******************************************************************************/
---- Update policy settings
+--- Update policy & agreement settings
 /******************************************************************************/
 ---# Strip -utf8 from policy settings
 ---{
@@ -3569,7 +3569,7 @@ foreach($utf8_policy_settings AS $var => $val)
 	if (!array_key_exists('policy_' . $language, $modSettings))
 	{
 		$adds[] =  '(\'policy_' . $language . '\', \'' . $val . '\')';
-		$deletes[] = '\'policy_' . $language . '-utf8\'';
+		$deletes[] = '\'' . $var . '\'';
 	}
 }
 if (!empty($adds))
@@ -3590,11 +3590,21 @@ if (!empty($deletes))
 ---}
 ---#
 
-/******************************************************************************/
---- Fixing old policy acceptance records...
-/******************************************************************************/
+---# Strip -utf8 from agreement file names
+---{
+$files = glob($boarddir . '/agreement.*-utf8.txt');
+foreach($files AS $filename)
+{
+	$newfile = substr($filename, 0, strlen($filename) - 9) . '.txt';
+	// Do not overwrite existing files
+	if (!file_exists($newfile))
+		@rename($filename, $newfile);
+}
 
----# Fixing missing values in log_actions
+---}
+---#
+
+---# Fix missing values in log_actions
 ---{
 // Find the missing id_members
 $request = upgrade_query("

--- a/other/upgrade_2-1_postgresql.sql
+++ b/other/upgrade_2-1_postgresql.sql
@@ -3589,3 +3589,34 @@ if (!empty($deletes))
 
 ---}
 ---#
+
+/******************************************************************************/
+--- Fixing old policy acceptance records...
+/******************************************************************************/
+
+---# Fixing missing values in log_actions
+---{
+// Find the missing id_members
+$request = upgrade_query("
+	SELECT id_action, extra
+		FROM {$db_prefix}log_actions
+		WHERE id_member = 0
+		AND action IN ('policy_accepted', 'agreement_accepted')");
+
+// Fortunately they're in the extra field
+while ($row = mysqli_fetch_assoc($request))
+{
+	$extra = @unserialize($row['extra']);
+	if ($extra === false)
+		continue;
+	if (!empty($extra['applicator']))
+	{
+		upgrade_query("
+			UPDATE {$db_prefix}log_actions
+				SET id_member = " . $extra['applicator'] . "
+				WHERE id_action = " . $row['id_action']);
+	}
+}
+
+---}
+---#

--- a/other/upgrade_2-1_postgresql.sql
+++ b/other/upgrade_2-1_postgresql.sql
@@ -3555,11 +3555,12 @@ ALTER TABLE {$db_prefix}log_spider_stats ALTER COLUMN page_hits TYPE INT;
 /******************************************************************************/
 ---# Strip -utf8 from policy settings
 ---{
-$utf8_policy_settings = array_filter($modSettings, function($v, $k)
-		{
-			return (substr($k, 0, 7) === 'policy_') && (substr($k, -5) === '-utf8');
-		}, ARRAY_FILTER_USE_BOTH
-	);
+$utf8_policy_settings = array();
+foreach($modSettings AS $k => $v)
+{
+	if ((substr($k, 0, 7) === 'policy_') && (substr($k, -5) === '-utf8'))
+		$utf8_policy_settings[$k] = $v;
+}
 $adds = array();
 $deletes = array();
 foreach($utf8_policy_settings AS $var => $val)


### PR DESCRIPTION
This is a companion PR to #6100 

Fixes #6238 

The privacy policies are language-specific, and include the languages in the setting names in the settings table.  If the language was utf8, it had a -utf8 suffix on the language name in 2.0.  Since -utf8 is stripped from language names & settings during the upgrade from 2.0 to 2.1, it now has to be stripped from the privacy settings as well, otherwise there are disconnects between the settings & the app for privacy policies entered in 2.0, & you lose privacy policies entered in 2.0.  

This issue was discovered during testing of #6100.  

Feedback welcome.  

Tested in mysql 5.7 & pg 10.