### PR TITLE
Fix 403 error due disabled Gravatar

### DIFF
--- a/Sources/Load.php
+++ b/Sources/Load.php
@@ -1725,7 +1725,7 @@ function loadMemberContext($user, $display_custom_fields = false)
 		else
 		{
 			// So it's stored in the member table?
-			if (!empty($profile['avatar']))
+			if (!empty($profile['avatar']) && !stristr($profile['avatar'], 'gravatar://'))
 				$image = (stristr($profile['avatar'], 'http://') || stristr($profile['avatar'], 'https://')) ? $profile['avatar'] : $modSettings['avatar_url'] . '/' . $profile['avatar'];
 
 			elseif (!empty($profile['filename']))


### PR DESCRIPTION
This PR fixes such a problem:
* Enable Gravatars
* Select "Use my Gravatar" via Profile => Forum Profile
* Then disable Gravatars via Avatar Settings in Admin
* Open any topics with own posts, open Console and see an error:
`GET http://yourdomain.com/avatars/gravatar://any@gmail.com
[HTTP/1.1 403 Forbidden 13ms]`


Signed-off-by: Bugo <bugo@dragomano.ru>