### PR TITLE
Better connect errors

### DIFF
--- a/Sources/Errors.php
+++ b/Sources/Errors.php
@@ -425,11 +425,19 @@ function display_maintenance_message()
  */
 function display_db_error()
 {
-	global $mbname, $modSettings, $maintenance;
+	global $mbname, $modSettings, $maintenance, $smcFunc;
 	global $db_connection, $webmaster_email, $db_last_error, $db_error_send, $smcFunc, $sourcedir, $cache_enable;
 
 	require_once($sourcedir . '/Logging.php');
 	set_fatal_error_headers();
+
+	// Get error info...  Recast just in case we get false or 0...
+	$error_message = $smcFunc['db_connect_error']();
+	if (empty($error_message))
+		$error_message = '';
+	$error_number = $smcFunc['db_connect_errno']();
+	if (empty($error_number))
+		$error_number = '';
 
 	// For our purposes, we're gonna want this on if at all possible.
 	$cache_enable = '1';
@@ -458,8 +466,9 @@ function display_db_error()
 	</head>
 	<body>
 		<h3>Connection Problems</h3>
-		Sorry, SMF was unable to connect to the database.  This may be caused by the server being busy.  Please try again later.
-	</body>
+		Sorry, SMF was unable to connect to the database.  This may be caused by the server being busy.  Please try again later.<br><br>' .
+		(!empty($error_number) ? $error_number . ': ' : '') . $error_message . '<br>' .
+	'</body>
 </html>';
 
 	die();

--- a/Sources/Errors.php
+++ b/Sources/Errors.php
@@ -425,19 +425,11 @@ function display_maintenance_message()
  */
 function display_db_error()
 {
-	global $mbname, $modSettings, $maintenance, $smcFunc;
+	global $mbname, $modSettings, $maintenance;
 	global $db_connection, $webmaster_email, $db_last_error, $db_error_send, $smcFunc, $sourcedir, $cache_enable;
 
 	require_once($sourcedir . '/Logging.php');
 	set_fatal_error_headers();
-
-	// Get error info...  Recast just in case we get false or 0...
-	$error_message = $smcFunc['db_connect_error']();
-	if (empty($error_message))
-		$error_message = '';
-	$error_number = $smcFunc['db_connect_errno']();
-	if (empty($error_number))
-		$error_number = '';
 
 	// For our purposes, we're gonna want this on if at all possible.
 	$cache_enable = '1';
@@ -466,9 +458,8 @@ function display_db_error()
 	</head>
 	<body>
 		<h3>Connection Problems</h3>
-		Sorry, SMF was unable to connect to the database.  This may be caused by the server being busy.  Please try again later.<br><br>' .
-		(!empty($error_number) ? $error_number . ': ' : '') . $error_message . '<br>' .
-	'</body>
+		Sorry, SMF was unable to connect to the database.  This may be caused by the server being busy.  Please try again later.
+	</body>
 </html>';
 
 	die();

--- a/Sources/Subs-Db-mysql.php
+++ b/Sources/Subs-Db-mysql.php
@@ -64,6 +64,8 @@ function smf_db_initiate($db_server, $db_name, $db_user, $db_passwd, $db_prefix,
 			'db_custom_order'			=> 'smf_db_custom_order',
 			'db_native_replace'			=> 'smf_db_native_replace',
 			'db_cte_support'			=> 'smf_db_cte_support',
+			'db_connect_error'			=> 'mysqli_connect_error',
+			'db_connect_errno'			=> 'mysqli_connect_errno',
 		);
 
 	if (!empty($db_options['persist']))

--- a/Sources/Subs-Db-postgresql.php
+++ b/Sources/Subs-Db-postgresql.php
@@ -32,7 +32,7 @@ if (!defined('SMF'))
  */
 function smf_db_initiate($db_server, $db_name, $db_user, $db_passwd, &$db_prefix, $db_options = array())
 {
-	global $smcFunc;
+	global $smcFunc, $pg_connect_error, $pg_connect_errno;
 
 	// Map some database specific functions, only do this once.
 	if (!isset($smcFunc['db_fetch_assoc']))
@@ -66,6 +66,8 @@ function smf_db_initiate($db_server, $db_name, $db_user, $db_passwd, &$db_prefix
 			'db_custom_order'           => 'smf_db_custom_order',
 			'db_native_replace'         => 'smf_db_native_replace',
 			'db_cte_support'            => 'smf_db_cte_support',
+			'db_connect_error'          => 'smf_db_connect_error',
+			'db_connect_errno'          => 'smf_db_connect_errno',
 		);
 
 	// We are not going to make it very far without these.
@@ -75,10 +77,24 @@ function smf_db_initiate($db_server, $db_name, $db_user, $db_passwd, &$db_prefix
 	// We need to escape ' and \
 	$db_passwd = str_replace(array('\\','\''), array('\\\\','\\\''), $db_passwd);
 
-	if (!empty($db_options['persist']))
-		$connection = @pg_pconnect((empty($db_server) ? '' : 'host=' . $db_server . ' ') . 'dbname=' . $db_name . ' user=\'' . $db_user . '\' password=\'' . $db_passwd . '\'' . (empty($db_options['port']) ? '' : ' port=\'' . $db_options['port'] . '\''));
-	else
-		$connection = @pg_connect((empty($db_server) ? '' : 'host=' . $db_server . ' ') . 'dbname=' . $db_name . ' user=\'' . $db_user . '\' password=\'' . $db_passwd . '\'' . (empty($db_options['port']) ? '' : ' port=\'' . $db_options['port'] . '\''));
+	// Since pg_connect doesn't feed error info to pg_last_error, we have to catch issues with a try/catch.
+	set_error_handler(function($errno, $errstr) {
+		throw new ErrorException($errstr, $errno);});
+	try
+	{
+		if (!empty($db_options['persist']))
+			$connection = @pg_pconnect((empty($db_server) ? '' : 'host=' . $db_server . ' ') . 'dbname=' . $db_name . ' user=\'' . $db_user . '\' password=\'' . $db_passwd . '\'' . (empty($db_options['port']) ? '' : ' port=\'' . $db_options['port'] . '\''));
+		else
+			$connection = @pg_connect((empty($db_server) ? '' : 'host=' . $db_server . ' ') . 'dbname=' . $db_name . ' user=\'' . $db_user . '\' password=\'' . $db_passwd . '\'' . (empty($db_options['port']) ? '' : ' port=\'' . $db_options['port'] . '\''));
+	}
+	catch (Exception $e)
+	{
+		// Make error info available to calling processes
+		$pg_connect_error = $e->getMessage();
+		$pg_connect_errno = $e->getCode();
+		$connection = false;
+	}
+	restore_error_handler();
 
 	// Something's wrong, show an error if its fatal (which we assume it is)
 	if (!$connection)
@@ -1019,6 +1035,42 @@ function smf_db_escape_string($string, $connection = null)
 	global $db_connection;
 
 	return pg_escape_string($connection === null ? $db_connection : $connection, $string);
+}
+
+/**
+ * Function to return the pg connection error message.
+ * Emulating mysqli_connect_error.
+ * Since pg_connect() doesn't feed info to pg_last_error, we need to
+ * use a try/catch & preserve error info.
+ *
+ * @return string connection error message
+ */
+function smf_db_connect_error()
+{
+	global $pg_connect_error;
+
+	if (empty($pg_connect_error))
+		$pg_connect_error = '';
+
+	return $pg_connect_error;
+}
+
+/**
+ * Function to return the pg connection error number.
+ * Emulating mysqli_connect_errno.
+ * Since pg_connect() doesn't feed info to pg_last_error, we need to
+ * use a try/catch & preserve error info.
+ *
+ * @return string connection error number
+ */
+function smf_db_connect_errno()
+{
+	global $pg_connect_errno;
+
+	if (empty($pg_connect_errno))
+		$pg_connect_errno = '';
+
+	return $pg_connect_errno;
 }
 
 ?>

--- a/other/install.php
+++ b/other/install.php
@@ -862,19 +862,6 @@ function DatabaseSettings()
 
 		$db_connection = smf_db_initiate($db_server, $db_name, $db_user, $db_passwd, $db_prefix, $options);
 
-		// No dice?  Let's try adding the prefix they specified, just in case they misread the instructions ;)
-		if ($db_connection == null)
-		{
-			$db_error = @$smcFunc['db_error']();
-
-			$db_connection = smf_db_initiate($db_server, $db_name, $_POST['db_prefix'] . $db_user, $db_passwd, $db_prefix, $options);
-			if ($db_connection != null)
-			{
-				$db_user = $_POST['db_prefix'] . $db_user;
-				installer_updateSettingsFile(array('db_user' => $db_user));
-			}
-		}
-
 		// Still no connection?  Big fat error message :P.
 		if (!$db_connection)
 		{

--- a/other/install.php
+++ b/other/install.php
@@ -878,6 +878,15 @@ function DatabaseSettings()
 		// Still no connection?  Big fat error message :P.
 		if (!$db_connection)
 		{
+			// Get error info...  Recast just in case we get false or 0...
+			$error_message = $smcFunc['db_connect_error']();
+			if (empty($error_message))
+				$error_message = '';
+			$error_number = $smcFunc['db_connect_errno']();
+			if (empty($error_number))
+				$error_number = '';
+			$db_error = (!empty($error_number) ? $error_number . ': ' : '') . $error_message;
+
 			$incontext['error'] = $txt['error_db_connect'] . '<div class="error_content"><strong>' . $db_error . '</strong></div>';
 			return false;
 		}

--- a/other/upgrade.php
+++ b/other/upgrade.php
@@ -717,7 +717,18 @@ function loadEssentialData()
 
 		// Oh dear god!!
 		if ($db_connection === null)
-			die($txt['error_db_connect_settings']);
+		{
+			// Get error info...  Recast just in case we get false or 0...
+			$error_message = $smcFunc['db_connect_error']();
+			if (empty($error_message))
+				$error_message = '';
+			$error_number = $smcFunc['db_connect_errno']();
+			if (empty($error_number))
+				$error_number = '';
+			$db_error = (!empty($error_number) ? $error_number . ': ' : '') . $error_message;
+
+			die($txt['error_db_connect_settings'] . '<br><br>' . $db_error);
+		}
 
 		if ($db_type == 'mysql' && isset($db_character_set) && preg_match('~^\w+$~', $db_character_set) === 1)
 			$smcFunc['db_query']('', '


### PR DESCRIPTION
Fixes #6242 

This PR:
 - Gets & displays error #s and error message texts in the event of a db connection issue
 - Displays #s and errors in the installer & upgrader - admin functions only
 - Removes one of the 'second guessing' steps in the installer, where it would try variants to login; the problem was the error messages would reflect the behind-the-scenes guesswork, not what the user entered...

There actually was an attempt to report connection errors in there, but it was returning empty strings...

PG was difficult, since connection error info is not available via calls such as pg_last_error.  Had to insert a try/catch around the pg connect, & save off the error details.

Feedback welcome.

**_EDIT: Based on input below, left public-facing application error messaging alone._**

### **_Connection error messages, BEFORE..._**
**_Installer:_**
![21-before-installer](https://user-images.githubusercontent.com/23568484/92179504-a0e19780-edf9-11ea-86e7-67d2dd994694.png)

**_Upgrader:_**
![21-before-upgrader](https://user-images.githubusercontent.com/23568484/92179515-a6d77880-edf9-11ea-8a8e-0462f6721667.png)

### **_Connection error messages, AFTER, MySql..._**
**_Installer:_**
![21-after-installer](https://user-images.githubusercontent.com/23568484/92179527-b1920d80-edf9-11ea-8ef1-116672c1cd59.png)

**_Upgrader:_**
![21-after-upgrader](https://user-images.githubusercontent.com/23568484/92179552-bc4ca280-edf9-11ea-9a03-2cbaafbe3faa.png)

### _**Connection error messages, AFTER, PG...**_
**_Installer:_**
![21-pg-after-installer](https://user-images.githubusercontent.com/23568484/92179571-c9699180-edf9-11ea-9603-43b07f62c04d.png)

**_Upgrader:_**
![21-pg-after-upgrader](https://user-images.githubusercontent.com/23568484/92179586-cec6dc00-edf9-11ea-86a6-afe09e82f4f4.png)

