### PR TITLE
Fixing upgrade

### DIFF
--- a/other/upgrade_2-1_mysql.sql
+++ b/other/upgrade_2-1_mysql.sql
@@ -188,7 +188,7 @@ INSERT INTO {$db_prefix}settings (variable, value) VALUES ('defaultMaxListItems'
 			'{db_prefix}settings',
 			array('variable' => 'string', 'value' => 'string'),
 			array('loginHistoryDays', '30'),
-			array()
+			array('variable')
 		);
 ---}
 ---#
@@ -251,16 +251,26 @@ INSERT INTO {$db_prefix}settings (variable, value) VALUES ('defaultMaxListItems'
 			'{db_prefix}settings',
 			array('variable' => 'string', 'value' => 'string'),
 			array('securityDisable_moderate', '1'),
-			array()
+			array('variable')
 		);
 ---}
 ---#
 
 ---# Adding new profile data export settings
-INSERT INTO {$db_prefix}settings (variable, value) VALUES ('export_dir', '{$boarddir}/exports');
-INSERT INTO {$db_prefix}settings (variable, value) VALUES ('export_expiry', '7');
-INSERT INTO {$db_prefix}settings (variable, value) VALUES ('export_min_diskspace_pct', '5');
-INSERT INTO {$db_prefix}settings (variable, value) VALUES ('export_rate', '250');
+---{
+	$inserts = array(
+		'export_dir' => '{$boarddir}/exports',
+		'export_expiry' => '7',
+		'export_min_diskspace_pct' => '5',
+		'export_rate' => '250'
+		);
+	$smcFunc['db_insert']('ignore',
+		'{db_prefix}settings',
+		array('variable' => 'string', 'value' => 'string'),
+		$inserts,
+		array('variable')
+	);
+---}
 ---#
 
 /******************************************************************************/

--- a/other/upgrade_2-1_postgresql.sql
+++ b/other/upgrade_2-1_postgresql.sql
@@ -222,7 +222,7 @@ ALTER TABLE {$db_prefix}log_activity ALTER COLUMN date DROP DEFAULT;
 /******************************************************************************/
 
 ---# Creating login history sequence.
-CREATE SEQUENCE {$db_prefix}member_logins_seq;
+CREATE SEQUENCE IF NOT EXISTS {$db_prefix}member_logins_seq;
 ---#
 
 ---# Creating login history table.
@@ -379,7 +379,7 @@ INSERT INTO {$db_prefix}settings (variable, value) VALUES ('defaultMaxListItems'
 			'{db_prefix}settings',
 			array('variable' => 'string', 'value' => 'string'),
 			array('loginHistoryDays', '30'),
-			array()
+			array('variable')
 		);
 ---}
 ---#
@@ -420,16 +420,26 @@ INSERT INTO {$db_prefix}settings (variable, value) VALUES ('defaultMaxListItems'
 			'{db_prefix}settings',
 			array('variable' => 'string', 'value' => 'string'),
 			array('securityDisable_moderate', '1'),
-			array()
+			array('variable')
 		);
 ---}
 ---#
 
 ---# Adding new profile data export settings
-INSERT INTO {$db_prefix}settings (variable, value) VALUES ('export_dir', '{$boarddir}/exports');
-INSERT INTO {$db_prefix}settings (variable, value) VALUES ('export_expiry', '7');
-INSERT INTO {$db_prefix}settings (variable, value) VALUES ('export_min_diskspace_pct', '5');
-INSERT INTO {$db_prefix}settings (variable, value) VALUES ('export_rate', '250');
+---{
+	$inserts = array(
+		'export_dir' => '{$boarddir}/exports',
+		'export_expiry' => '7',
+		'export_min_diskspace_pct' => '5',
+		'export_rate' => '250'
+		);
+	$smcFunc['db_insert']('ignore',
+		'{db_prefix}settings',
+		array('variable' => 'string', 'value' => 'string'),
+		$inserts,
+		array('variable')
+	);
+---}
 ---#
 
 /******************************************************************************/


### PR DESCRIPTION
- Missing IF NOT EXISTS for create sequence (work with pg 9.6+)
- added missing pk fields in insert
- convert insert to insert with ignore

For a full upgrade test, the pr #6170 is needed.