### PR TITLE
Change the reg email input type from text to email

### DIFF
--- a/Themes/default/ManageBans.template.php
+++ b/Themes/default/ManageBans.template.php
@@ -133,7 +133,7 @@ function template_ban_edit()
 							<label for="email_check">', $txt['ban_on_email'], '</label>
 						</dt>
 						<dd>
-							<input type="text" name="email" value="', $context['ban_suggestions']['email'], '" size="44" onfocus="document.getElementById(\'email_check\').checked = true;">
+							<input type="email" name="email" value="', $context['ban_suggestions']['email'], '" size="44" onfocus="document.getElementById(\'email_check\').checked = true;">
 						</dd>
 						<dt>
 							<input type="checkbox" name="ban_suggestions[]" id="user_check" value="user"', !empty($context['ban_suggestions']['user']) || isset($context['ban']['from_user']) ? ' checked' : '', '>
@@ -287,7 +287,7 @@ function template_ban_edit_trigger()
 							<label for="email_check">', $txt['ban_on_email'], '</label>
 						</dt>
 						<dd>
-							<input type="text" name="email" value="', $context['ban_trigger']['email']['value'], '" size="44" onfocus="document.getElementById(\'email_check\').checked = true;">
+							<input type="email" name="email" value="', $context['ban_trigger']['email']['value'], '" size="44" onfocus="document.getElementById(\'email_check\').checked = true;">
 						</dd>
 						<dt>
 							<input type="checkbox" name="ban_suggestions[]" id="user_check" value="user"', $context['ban_trigger']['banneduser']['selected'] ? ' checked' : '', '>

--- a/Themes/default/Register.template.php
+++ b/Themes/default/Register.template.php
@@ -517,7 +517,7 @@ function template_admin_register()
 							<span class="smalltext">', $txt['admin_register_email_desc'], '</span>
 						</dt>
 						<dd>
-							<input type="text" name="email" id="email_input" tabindex="', $context['tabindex']++, '" size="50">
+							<input type="email" name="email" id="email_input" tabindex="', $context['tabindex']++, '" size="50">
 						</dd>
 						<dt>
 							<strong><label for="password_input">', $txt['admin_register_password'], ':</label></strong>

--- a/Themes/default/Register.template.php
+++ b/Themes/default/Register.template.php
@@ -124,7 +124,7 @@ function template_registration_form()
 						</dd>
 						<dt><strong><label for="smf_autov_reserve1">', $txt['user_email_address'], ':</label></strong></dt>
 						<dd>
-							<input type="text" name="email" id="smf_autov_reserve1" size="50" tabindex="', $context['tabindex']++, '" value="', isset($context['email']) ? $context['email'] : '', '">
+							<input type="email" name="email" id="smf_autov_reserve1" size="50" tabindex="', $context['tabindex']++, '" value="', isset($context['email']) ? $context['email'] : '', '">
 						</dd>
 					</dl>
 					<dl class="register_form" id="password1_group">

--- a/other/install.php
+++ b/other/install.php
@@ -2482,7 +2482,7 @@ function template_admin_account()
 				<label for="email">', $txt['user_settings_admin_email'], ':</label>
 			</dt>
 			<dd>
-				<input type="text" name="email" id="email" value="', $incontext['email'], '" size="40">
+				<input type="email" name="email" id="email" value="', $incontext['email'], '" size="40">
 				<div class="smalltext">', $txt['user_settings_admin_email_info'], '</div>
 			</dd>
 			<dt>


### PR DESCRIPTION
In the profile modify the input type is alread email,
also the browser validation could be here used:
```
input[type=email]:invalid {
color:red;
}
```
since i had no idea how it should look like,
i keep this out.