### PR TITLE
Add SQLite Cache file to the gitgnore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ Settings_bak.php
 Settings_org.php
 db_last_error.php
 cache/data*.php
+cache/*.db3
 Packages/backups/*
 Packages/temp
 *.*~


### PR DESCRIPTION
for reason i don't know,
the sqlite cache got enabled on my side.

so it showed up in my git changes...
Full name would be: SQLite3Cache.db3
https://github.com/SimpleMachines/SMF2.1/blob/b9674508df9874c6d356e1b99fc95b553c2e1e6d/Sources/CacheAPI-sqlite.php#L47
