### PR TITLE
Handle error case better when $txt is not loaded

### DIFF
--- a/Sources/Errors.php
+++ b/Sources/Errors.php
@@ -217,7 +217,10 @@ function fatal_lang_error($error, $log = 'general', $sprintf = array(), $status 
 	{
 		loadLanguage('Errors', $language);
 		$reload_lang_file = $language != $user_info['language'];
-		$error_message = empty($sprintf) ? $txt[$error] : vsprintf($txt[$error], $sprintf);
+		if (empty($txt[$error]))
+			$error_message = $error;
+		else
+			$error_message = empty($sprintf) ? $txt[$error] : vsprintf($txt[$error], $sprintf);
 		log_error($error_message, $log);
 	}
 


### PR DESCRIPTION
Tryed to upload an avatar which was to big,
so i run in attach_timeout and the $txt['attach_timeout'] exists but was not loaded at the point of time,
since i can image this could be happen we should handle the case in the error.php that this not create a second issue.