### PR TITLE
Fixed issues with SSI cachedir because we unset the global

### DIFF
--- a/SSI.php
+++ b/SSI.php
@@ -24,6 +24,9 @@ define('POSTGRE_TITLE', 'PostgreSQL');
 define('MYSQL_TITLE', 'MySQL');
 define('SMF_USER_AGENT', 'Mozilla/5.0 (' . php_uname('s') . ' ' . php_uname('m') . ') AppleWebKit/605.1.15 (KHTML, like Gecko)  SMF/' . strtr(SMF_VERSION, ' ', '.'));
 
+// Just being safe...  Do this before defining globals as otherwise it unsets the global.
+foreach (array('db_character_set', 'cachedir') as $variable)
+	unset($GLOBALS[$variable]);
 
 // We're going to want a few globals... these are all set later.
 global $maintenance, $msubject, $mmessage, $mbname, $language;
@@ -35,10 +38,6 @@ global $auth_secret;
 
 if (!defined('TIME_START'))
 	define('TIME_START', microtime(true));
-
-// Just being safe...
-foreach (array('db_character_set', 'cachedir') as $variable)
-	unset($GLOBALS[$variable]);
 
 // Get the forum's settings for database and file paths.
 require_once(dirname(__FILE__) . '/Settings.php');


### PR DESCRIPTION
This is needed because we global $cachedir just a few lines up, then we unset it here.  Which causes the global to become undefined and thus caching fails with errors.