### PR TITLE
Fixes pagination issue in exports; removes redundant tempfile creation

### DIFF
--- a/Sources/tasks/ExportProfileData.php
+++ b/Sources/tasks/ExportProfileData.php
@@ -373,9 +373,6 @@ class ExportProfileData_Background extends SMF_BackgroundTask
 						{
 							rename($tempfile, $realfile);
 							$realfile = $export_dir_slash . ++$filenum . '_' . $idhash_ext;
-
-							file_put_contents($tempfile, implode('', array($context['feed']['header'], $profile_basic_items, $context['feed']['footer'])), LOCK_EX);
-
 							$prev_item_count = $new_item_count = 0;
 						}
 						// This was the last chunk.

--- a/Themes/default/scripts/profile.js
+++ b/Themes/default/scripts/profile.js
@@ -317,8 +317,13 @@ $(document).ready(function() {
 
 function export_download_all(format)
 {
-	var export_file_links = $('#' + format + '_export_files a');
+	$('#' + format + '_export_files a').each(function(index, element) {
+		// Add an invisible iframe pointing to the file.
+		var iframe = $('<iframe style="visibility: collapse;"></iframe>');
+		iframe[0].src = $(element).attr('href');
+		$('body').append(iframe);
 
-	for (var i = 0; i < export_file_links.length; i++)
-		export_file_links[i].click();
+		// Give plenty of time for the download to complete, then clean up.
+		setTimeout(function() { iframe.remove(); }, 30000);
+	});
 }


### PR DESCRIPTION
This file_put_contents() call was redundant and caused page numbers for all page numbers after the first to be off by one.
Fixes #6281

Also implements a more reliable method to download all the export files when the user clicks the "Download All" button. The old way used the jQuery `.click()` method to simulate user interaction, which is always an inherently fragile approach and much subject to browser restrictions and quirks.