### PR TITLE
Fix the inability to disable the email field for guests

### DIFF
--- a/Themes/default/Display.template.php
+++ b/Themes/default/Display.template.php
@@ -963,21 +963,30 @@ function template_quickreply()
 
 	// Guests just need more.
 	if ($context['user']['is_guest'])
+	{
 		echo '
 						<dl id="post_header">
 							<dt>
 								', $txt['name'], ':
 							</dt>
 							<dd>
-								<input type="text" name="guestname" size="25" value="', $context['name'], '" tabindex="', $context['tabindex']++, '">
-							</dd>
+								<input type="text" name="guestname" size="25" value="', $context['name'], '" tabindex="', $context['tabindex']++, '" required>
+							</dd>';
+
+		if (empty($modSettings['guest_post_no_email']))
+		{
+			echo '
 							<dt>
 								', $txt['email'], ':
 							</dt>
 							<dd>
 								<input type="email" name="email" size="25" value="', $context['email'], '" tabindex="', $context['tabindex']++, '" required>
-							</dd>
+							</dd>';
+		}
+
+		echo '
 						</dl>';
+	}
 
 	echo '
 						', template_control_richedit($context['post_box_name'], 'smileyBox_message', 'bbcBox_message'), '


### PR DESCRIPTION
Fixes an issue when the setting "Do not show the email field for guests' posts" does not affect on guests.

Signed-off-by: Bugo <bugo@dragomano.ru>