### PR TITLE
If a 3rd party mod is using this, current_board may be undefined

### DIFF
--- a/Themes/default/scripts/smf_fileUpload.js
+++ b/Themes/default/scripts/smf_fileUpload.js
@@ -7,6 +7,9 @@ function smf_fileUpload(oOptions) {
 		previewTemplate = tmp.innerHTML;
 		previewNode.parentNode.removeChild(previewNode);
 
+	if (typeof current_board == 'undefined')
+		var current_board = false;
+
 	// Default values in case oOptions isn't defined.
 	var dOptions = {
 		url: smf_prepareScriptUrl(smf_scripturl) + 'action=uploadAttach;sa=add;' + smf_session_var + '=' + smf_session_id + (current_board ? ';board=' + current_board : ''),


### PR DESCRIPTION
It is easier to fix it here than all calls and we let all calls fail naturally with a standard if/else checks.