### PR TITLE
Ensure password_salt is the proper length

### DIFF
--- a/other/upgrade_2-1_mysql.sql
+++ b/other/upgrade_2-1_mysql.sql
@@ -2552,6 +2552,11 @@ ALTER TABLE {$db_prefix}members
 MODIFY COLUMN pm_ignore_list TEXT NULL;
 ---#
 
+---# Updating password_salt
+ALTER TABLE {$db_prefix}members
+MODIFY COLUMN password_salt VARCHAR(255) NOT NULL DEFAULT '';
+---#
+
 ---# Updating member_logins id_member
 ALTER TABLE {$db_prefix}member_logins
 MODIFY COLUMN id_member MEDIUMINT NOT NULL DEFAULT '0';

--- a/other/upgrade_2-1_postgresql.sql
+++ b/other/upgrade_2-1_postgresql.sql
@@ -3074,6 +3074,9 @@ ALTER secret_question SET DEFAULT '';
 
 ALTER TABLE {$db_prefix}members
 ALTER additional_groups SET DEFAULT '';
+
+ALTER TABLE {$db_prefix}members
+ALTER COLUMN password_salt TYPE varchar(255);
 ---#
 
 ---# messages


### PR DESCRIPTION
Some converted forums may have the wrong length of password_salt.

Sample issue in forum:
https://www.simplemachines.org/community/index.php?topic=575241.msg4071364#msg4071364
Converters have been fixed:
https://github.com/SimpleMachines/converters/pull/5