### PR TITLE
Installing SMF in php 8.0 failed

### DIFF
--- a/Sources/Subs-Admin.php
+++ b/Sources/Subs-Admin.php
@@ -1221,16 +1221,13 @@ function updateSettingsFile($config_vars, $keep_quotes = null, $rebuild = false)
 	// It's important to do the numbered ones before the named ones, or messes happen.
 	uksort($substitutions, function($a, $b) {
 		if (is_int($a) && is_int($b))
-			return $a > $b ? 1 : 0;
+			return $a > $b ? 1 : ($a < $b ? -1 : 0);
 		elseif (is_int($a))
 			return -1;
 		elseif (is_int($b))
 			return 1;
 		else
-		{
-			$res = strcasecmp($b, $a);
-			return $res > 0 ? 1 : ($res < 0 ? -1 : 0);
-		}
+			return strcasecmp($b, $a);
 	});
 
 	/******************************

--- a/Sources/Subs-Admin.php
+++ b/Sources/Subs-Admin.php
@@ -1221,13 +1221,16 @@ function updateSettingsFile($config_vars, $keep_quotes = null, $rebuild = false)
 	// It's important to do the numbered ones before the named ones, or messes happen.
 	uksort($substitutions, function($a, $b) {
 		if (is_int($a) && is_int($b))
-			return $a > $b;
+			return $a > $b ? 1 : 0;
 		elseif (is_int($a))
 			return -1;
 		elseif (is_int($b))
 			return 1;
 		else
-			return strcasecmp($b, $a);
+		{
+			$res = strcasecmp($b, $a);
+			return $res > 0 ? 1 : ($res < 0 ? -1 : 0);
+		}
 	});
 
 	/******************************


### PR DESCRIPTION
PHP Deprecated:  uksort(): Returning bool from comparison function is deprecated, return an integer less than, equal to, or greater than zero in /smf/Sources/Subs-Admin.php on line 1231

Hopefully I didn't foobar the logic.  It still looks right and doesn't appear to have broken anything.