### PR TITLE
Revert "Responsive Tables"

### DIFF
--- a/Themes/default/css/responsive.css
+++ b/Themes/default/css/responsive.css
@@ -341,6 +341,17 @@
 	input#searchfor, input#userspec {
 		width: 75%;
 	}
+	/* Hide me */
+	#inner_wrap, #search_form, #smflogo, #message_index_jump_to, .nextlinks, #display_jump_to,
+	#siteslogan, th.id_group, th.registered, th.posts, th.reg_group, th.reg_date, td.reg_group, td.reg_date,
+	td.id_group, td.registered, td.posts:not(.unique), td.statsbar.posts,
+	#member_list .ip, #member_list .last_active, #member_list .user_name,
+	#approve_list .ip, #approve_list .date_registered, #group_members .date_registered,
+	#main_content_section .navigate_section, .pagesection.top, .time,
+	#header_custom_profile_fields_field_type, #header_custom_profile_fields_active,
+	#header_custom_profile_fields_placement, #custom_profile_fields .active, #custom_profile_fields .field_type, #custom_profile_fields .placement {
+		display: none !important;
+	}
 	/* Generic Lists */
 	#topic_notification_list .last_post, #topic_notification_list .started_by,
 	#request_list .time_applied, #file_list .date, #ban_list .notes, #ban_list .reason, #ban_log .email,
@@ -356,19 +367,6 @@
 	}
 	#private, #enclose {
 		width: 95%;
-	}
-	/* Search & Language */
-	#search_form {
-		width: 100%;
-		padding: 5px;
-		text-align: center;
-	}
-	/* (BETA) Table */
-	.table_grid th, .table_grid td {
-		display: block;
-		text-align: center; /* Make sure everything centered */
-		width: 100% !important; /* Note: Dunno if we can eliminate !imporant here due to inline width's */
-		word-break: break-all;
 	}
 }
 
@@ -563,7 +561,7 @@
 		text-align: left;
 	}
 	.login #ajax_loginuser, .login #ajax_loginpass, .login #loginuser, .login #loginpass, select {
-		max-width: 100%;
+		width: 100%;
 	}
 
 	/* Display (Topic View) */
@@ -739,6 +737,15 @@
 	#adm_submenus .dropmenu li {
 		float: left;
 		margin: 0;
+	}
+	#header_news_lists_preview, tr[id^="list_news_lists_"] td:nth-child(even),
+	#header_smiley_set_list_default, #header_smiley_set_list_url, #header_smiley_set_list_check,
+	tr[id^="list_smiley_set_list_"] td:nth-child(odd),
+	#header_mail_queue_priority,
+	tr[id^="list_mail_queue_"] td:nth-child(odd),
+	#header_member_list_user_name, #header_member_list_ip,
+	#header_member_list_last_active, #header_member_list_posts {
+		display: none;
 	}
 	tr[id^="list_mail_queue_"] td:first-of-type,
 	tr[id^="list_mail_queue_"] td:last-of-type {


### PR DESCRIPTION
Reverts #5763 
Opens #5594 
Opens #5587 

Sorry but I am strongly opposed to this change. Not only does it unintentionally break the mobile view (as you can see in the following screenshots)

**Before that PR** | **After that PR**
-- | --
<img src="https://user-images.githubusercontent.com/20267363/96853637-7f447a00-1452-11eb-985c-1a16dbabb089.png" width=200> | <img src="https://user-images.githubusercontent.com/20267363/96853617-794e9900-1452-11eb-84b9-681542964ad1.png" width=200>

But it is a big change of how tables are handled on smaller screens, the type of change that would be better made around a time like RC1 or before it so that the community and devs can properly test and tweak in time, but just not now, it's not a bugfix but an attempted improvement (subjective because to me it isn't so) and we really should keep changes to bugfixes right now.