### PR TITLE
Stop counting spiders twice

### DIFF
--- a/Sources/BoardIndex.php
+++ b/Sources/BoardIndex.php
@@ -119,7 +119,7 @@ function BoardIndex()
 
 	// Track most online statistics? (Subs-MembersOnline.php)
 	if (!empty($modSettings['trackStats']))
-		trackStatsUsersOnline($context['num_guests'] + $context['num_spiders'] + $context['num_users_online']);
+		trackStatsUsersOnline($context['num_guests'] + $context['num_users_online']);
 
 	// Are we showing all membergroups on the board index?
 	if (!empty($settings['show_group_key']))


### PR DESCRIPTION
If spiders are visible they are counted twice towards the
total users online since they are included both in num_guests
and in num_spiders.

Signed-off-by: Oscar Rydhé <oscar.rydhe@gmail.com>