### PR TITLE
Render quotes with nested url-tag correctly

### DIFF
--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -3134,7 +3134,16 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 			else
 				$quoted = false;
 
-			$pos2 = strpos($message, $quoted == false ? ']' : '&quot;]', $pos1);
+			if ($quoted)
+			{
+				$end_of_value = strpos($message, '&quot;]', $pos1);
+				$nested_tag = strpos($message, '=&quot;', $pos1);
+				if ($nested_tag && $nested_tag < $end_of_value)
+					// Nested tag with quoted value detected, use next end tag
+					$nested_tag_pos = strpos($message, $quoted == false ? ']' : '&quot;]', $pos1) + 6;
+			}
+
+			$pos2 = strpos($message, $quoted == false ? ']' : '&quot;]', isset($nested_tag_pos) ? $nested_tag_pos : $pos1);
 			if ($pos2 === false)
 				continue;
 


### PR DESCRIPTION
If posting a quote from another website, for example:
[quote="[url=https://www.example.com/]Example.com[/url]"]The quote[/quote]
extra quotes are added to the [url]-tag value:
[quote="[url="https://www.example.com/"]Example.com[/url]"]The quote[/quote]

This would brake the display of the quote. Fixed this by checking
for nested tags during parsing of the bbc tag value.

Fixes #6336

Signed-off-by: Oscar Rydhé oscar.rydhe@gmail.com