### PR TITLE
Remove child bbc tags from enable settings

### DIFF
--- a/Sources/ManageServer.php
+++ b/Sources/ManageServer.php
@@ -1267,7 +1267,8 @@ function prepareDBSettingContext(&$config_vars)
 		$temp = parse_bbc(false);
 		$bbcTags = array();
 		foreach ($temp as $tag)
-			$bbcTags[] = $tag['tag'];
+			if (!isset($tag['require_parents']))
+				$bbcTags[] = $tag['tag'];
 
 		$bbcTags = array_unique($bbcTags);
 

--- a/Sources/ManageSettings.php
+++ b/Sources/ManageSettings.php
@@ -355,8 +355,29 @@ function ModifyBBCSettings($return_config = false)
 
 		// Clean up the tags.
 		$bbcTags = array();
+		$bbcTagsChildren = array();
 		foreach (parse_bbc(false) as $tag)
 			$bbcTags[] = $tag['tag'];
+			if (isset($tag['require_children']))
+				$bbcTagsChildren[$tag['tag']] = !isset($bbcTagsChildren[$tag['tag']]) ? $tag['require_children'] : array_unique(array_merge($bbcTagsChildren[$tag['tag']], $tag['require_children']));
+
+		// Clean up tags with children
+		foreach($bbcTagsChildren as $parent_tag => $children)
+			foreach($children as $index => $child_tag)
+			{
+				// Remove entries where parent and child tag is the same
+				if ($child_tag == $parent_tag)
+				{
+					unset($bbcTagsChildren[$parent_tag][$index]);
+					continue;
+				}
+				// Combine chains of tags
+				if (isset($bbcTagsChildren[$child_tag]))
+				{
+					$bbcTagsChildren[$parent_tag] = array_merge($bbcTagsChildren[$parent_tag], $bbcTagsChildren[$child_tag]);
+					unset($bbcTagsChildren[$child_tag]);
+				}
+			}
 
 		if (!isset($_POST['disabledBBC_enabledTags']))
 			$_POST['disabledBBC_enabledTags'] = array();
@@ -369,6 +390,11 @@ function ModifyBBCSettings($return_config = false)
 			$_POST['legacyBBC_enabledTags'] = array($_POST['legacyBBC_enabledTags']);
 
 		$_POST['disabledBBC_enabledTags'] = array_unique(array_merge($_POST['disabledBBC_enabledTags'], $_POST['legacyBBC_enabledTags']));
+
+		// Enable all children if parent is enabled
+		foreach ($bbcTagsChildren as $tag => $children)
+			if (in_array($tag, $_POST['disabledBBC_enabledTags']))
+				$_POST['disabledBBC_enabledTags'] = array_merge($_POST['disabledBBC_enabledTags'], $children);
 
 		// Work out what is actually disabled!
 		$_POST['disabledBBC'] = implode(',', array_diff($bbcTags, $_POST['disabledBBC_enabledTags']));

--- a/Sources/ManageSettings.php
+++ b/Sources/ManageSettings.php
@@ -357,9 +357,11 @@ function ModifyBBCSettings($return_config = false)
 		$bbcTags = array();
 		$bbcTagsChildren = array();
 		foreach (parse_bbc(false) as $tag)
+		{
 			$bbcTags[] = $tag['tag'];
 			if (isset($tag['require_children']))
 				$bbcTagsChildren[$tag['tag']] = !isset($bbcTagsChildren[$tag['tag']]) ? $tag['require_children'] : array_unique(array_merge($bbcTagsChildren[$tag['tag']], $tag['require_children']));
+		}
 
 		// Clean up tags with children
 		foreach($bbcTagsChildren as $parent_tag => $children)


### PR DESCRIPTION
It makes no sense of handling bbc codes that requires other tags
to work. For example li that is a sub tag of list.
Remove all bbc child codes from the enable/disable settings page
and let the parent settings control also the children.

Fixes #6023