### PR TITLE
Fix an issue when regular members (not admins) do not see attachments…

### DIFF
--- a/Sources/ShowAttachments.php
+++ b/Sources/ShowAttachments.php
@@ -69,7 +69,7 @@ function showAttachment()
 	$attachTopic = isset($_REQUEST['topic']) ? (int) $_REQUEST['topic'] : 0;
 
 	// No access in strict maintenance mode or you don't have permission to see attachments.
-	if ((!empty($maintenance) && $maintenance == 2) || !allowedTo('view_attachments'))
+	if ((!empty($maintenance) && $maintenance == 2))
 	{
 		send_http_status(404, 'File Not Found');
 		die('404 File Not Found');

--- a/Sources/ShowAttachments.php
+++ b/Sources/ShowAttachments.php
@@ -69,7 +69,7 @@ function showAttachment()
 	$attachTopic = isset($_REQUEST['topic']) ? (int) $_REQUEST['topic'] : 0;
 
 	// No access in strict maintenance mode or you don't have permission to see attachments.
-	if ((!empty($maintenance) && $maintenance == 2))
+	if (!empty($maintenance) && $maintenance == 2)
 	{
 		send_http_status(404, 'File Not Found');
 		die('404 File Not Found');

--- a/Sources/Subs-Attachments.php
+++ b/Sources/Subs-Attachments.php
@@ -969,6 +969,9 @@ function parseAttachBBC($attachID = 0)
 	if (empty($attachInfo) || empty($attachInfo['msg']) && empty($context['preview_message']))
 		return 'attachments_no_msg_associated';
 
+	if (!empty($board) && empty($attachInfo['board']))
+		$attachInfo['board'] = $board;
+
 	// Hold it! got the info now check if you can see this attachment.
 	if ($view_attachment_boards !== array(0) && !in_array($attachInfo['board'], $view_attachment_boards))
 		return 'attachments_not_allowed_to_see';
@@ -1007,6 +1010,9 @@ function parseAttachBBC($attachID = 0)
 
 	else
 		$attachContext = $attachLoaded[$attachID];
+
+	if (!empty($board) && empty($attachContext['board']))
+		$attachContext['board'] = $board;
 
 	// No point in keep going further.
 	if ($view_attachment_boards !== array(0) && !in_array($attachContext['board'], $view_attachment_boards))

--- a/Themes/default/Post.template.php
+++ b/Themes/default/Post.template.php
@@ -376,10 +376,15 @@ function template_main()
 							<div>
 								<strong>', $txt['attached'], ':</strong>
 							</div>
-							<div id="au-template">
+							<div id="au-template">';
+
+		if (allowedTo('view_attachments'))
+			echo '
 								<div class="attach-preview">
 									<img data-dz-thumbnail />
-								</div>
+								</div>';
+
+		echo '
 								<div class="attachment_info">
 									<div>
 										<span class="name" data-dz-name></span>


### PR DESCRIPTION
… on attaching

#### Description
![2020-11-13 20_27_29-Window](https://user-images.githubusercontent.com/229402/99089424-1da9a280-25ef-11eb-838b-2f09cbd2a0c8.png)
![2020-11-13 20_27_43-Window](https://user-images.githubusercontent.com/229402/99089434-21d5c000-25ef-11eb-8f06-30361be43e32.png)

### Steps to reproduce
0. be sure regular members have permissions to view and upload attachments
1. log in as a simple member (not admin)
2. try to upload any image

Signed-off-by: Bugo <bugo@dragomano.ru>