### PR TITLE
Don't check attach perms 3 times; breaks previews due to no board id

### DIFF
--- a/Sources/Subs-Attachments.php
+++ b/Sources/Subs-Attachments.php
@@ -969,10 +969,6 @@ function parseAttachBBC($attachID = 0)
 	if (empty($attachInfo) || empty($attachInfo['msg']) && empty($context['preview_message']))
 		return 'attachments_no_msg_associated';
 
-	// Hold it! got the info now check if you can see this attachment.
-	if ($view_attachment_boards !== array(0) && !in_array($attachInfo['board'], $view_attachment_boards))
-		return 'attachments_not_allowed_to_see';
-
 	if (empty($context['loaded_attachments'][$attachInfo['msg']]))
 		prepareAttachsByMsg(array($attachInfo['msg']));
 
@@ -1007,10 +1003,6 @@ function parseAttachBBC($attachID = 0)
 
 	else
 		$attachContext = $attachLoaded[$attachID];
-
-	// No point in keep going further.
-	if ($view_attachment_boards !== array(0) && !in_array($attachContext['board'], $view_attachment_boards))
-		return 'attachments_not_allowed_to_see';
 
 	// Previewing much? no msg ID has been set yet.
 	if (!empty($context['preview_message']))


### PR DESCRIPTION
Alternate approach to #6341 ...  Previews are not working for current attachments.

Board attachment permissions are checked 3x in a row here, which feels like overkill.  I see no value added by these two particular checks.  Removing them fixes the problem.  

This one, I believe, is sufficient, just a couple lines before:
https://github.com/SimpleMachines/SMF2.1/blob/8ebc081cc3c8de6519a699d82e0a090575679a7e/Sources/Subs-Attachments.php#L962

If these checks need to be kept (maybe I'm missing something...) then they must be made smarter to allow for the possible lack of a board_id.  