### PR TITLE
Fix display of topics in reverse order

### DIFF
--- a/Sources/Display.php
+++ b/Sources/Display.php
@@ -864,7 +864,7 @@ function Display()
 	$ascending = empty($options['view_newest_first']);
 
 	// Check if we can use the seek method to speed things up
-	if (isset($_SESSION['page_topic']) && $_SESSION['page_topic'] == $topic && $_SESSION['page_ascending'] == $ascending)
+	if (isset($_SESSION['page_topic']) && $_SESSION['page_topic'] == $topic && $_SESSION['page_ascending'] == $ascending && ($ascending || $_SESSION['page_topic_last_id'] == $context['topicinfo']['id_last_msg']))
 	{
 		// User moved to the next page
 		if (isset($_SESSION['page_next_start']) && $_SESSION['page_next_start'] == $start)
@@ -1022,6 +1022,7 @@ function Display()
 	$_SESSION['page_next_start'] = $_REQUEST['start'] + $limit;
 	$_SESSION['page_current_start'] = $_REQUEST['start'];
 	$_SESSION['page_topic'] = $topic;
+	$_SESSION['page_topic_last_id'] = $context['topicinfo']['id_last_msg'];
 	$_SESSION['page_ascending'] = $ascending;
 
 	$smcFunc['db_free_result']($request);

--- a/Sources/Display.php
+++ b/Sources/Display.php
@@ -968,9 +968,7 @@ function Display()
 			}
 		}
 
-		// Before Page bring in the right order
-		if (!empty($start_char) && $start_char === 'L')
-			krsort($messages);
+		sort($messages);
 	}
 
 	// Jump to page


### PR DESCRIPTION
When the setting "Show most recent posts at the top in topic view"
is enabled the topic is not displayed correctly.
Fix that by sorting the message list, since other code expect
the message list to always be sorted in ascending order.

Fixes #6349 #5764