### PR TITLE
Use correct class for debug blocks

### DIFF
--- a/Sources/Load.php
+++ b/Sources/Load.php
@@ -2688,7 +2688,7 @@ function loadSubTemplate($sub_template_name, $fatal = false)
 	if (allowedTo('admin_forum') && isset($_REQUEST['debug']) && !in_array($sub_template_name, array('init', 'main_below')) && ob_get_length() > 0 && !isset($_REQUEST['xml']))
 	{
 		echo '
-<div class="warningbox">---- ', $sub_template_name, ' ends ----</div>';
+<div class="noticebox">---- ', $sub_template_name, ' ends ----</div>';
 	}
 }
 


### PR DESCRIPTION
The "warningbox" class does not use in SMF 2.1

Signed-off-by: Bugo <bugo@dragomano.ru>