### PR TITLE
Replace some lang variables to improve view for some cyrillic languages

### DIFF
--- a/Sources/Calendar.php
+++ b/Sources/Calendar.php
@@ -228,7 +228,7 @@ function CalendarMain()
 
 	// Set the page title to mention the month or week, too
 	if ($context['calendar_view'] != 'viewlist')
-		$context['page_title'] .= ' - ' . ($context['calendar_view'] == 'viewweek' ? $context['calendar_grid_main']['week_title'] : $txt['months'][$context['current_month']] . ' ' . $context['current_year']);
+		$context['page_title'] .= ' - ' . ($context['calendar_view'] == 'viewweek' ? $context['calendar_grid_main']['week_title'] : $txt['months_titles'][$context['current_month']] . ' ' . $context['current_year']);
 
 	// Load up the linktree!
 	$context['linktree'][] = array(
@@ -238,7 +238,7 @@ function CalendarMain()
 	// Add the current month to the linktree.
 	$context['linktree'][] = array(
 		'url' => $scripturl . '?action=calendar;year=' . $context['current_year'] . ';month=' . $context['current_month'],
-		'name' => $txt['months'][$context['current_month']] . ' ' . $context['current_year']
+		'name' => $txt['months_titles'][$context['current_month']] . ' ' . $context['current_year']
 	);
 	// If applicable, add the current week to the linktree.
 	if ($context['calendar_view'] == 'viewweek')

--- a/Sources/Subs-Calendar.php
+++ b/Sources/Subs-Calendar.php
@@ -610,7 +610,7 @@ function getCalendarWeek($selected_date, $calendarOptions)
 	$events = $calendarOptions['show_events'] ? getEventRange(date_format($first_day_object, 'Y-m-d'), date_format($last_day_object, 'Y-m-d')) : array();
 	$holidays = $calendarOptions['show_holidays'] ? getHolidayRange(date_format($first_day_object, 'Y-m-d'), date_format($last_day_object, 'Y-m-d')) : array();
 
-	$calendarGrid['week_title'] = sprintf($txt['calendar_week_beginning'], $txt['months_titles'][date_format($first_day_object, 'n')], date_format($first_day_object, 'j'), date_format($first_day_object, 'Y'));
+	$calendarGrid['week_title'] = sprintf($txt['calendar_week_beginning'], $txt['months'][date_format($first_day_object, 'n')], date_format($first_day_object, 'j'), date_format($first_day_object, 'Y'));
 
 	// This holds all the main data - there is at least one month!
 	$calendarGrid['months'] = array();


### PR DESCRIPTION
English-speakers will not see a difference, but it is.

For example, currently, in the calendar linktree we have a genitive:
![2020-11-20 11_49_28-Календарь - ноября 2020 — Firefox Developer Edition](https://user-images.githubusercontent.com/229402/99768574-cf346080-2b26-11eb-862f-acacd011e60a.png)
After this fix we will have a nominative:
![2020-11-20 11_49_11-Календарь - Ноябрь 2020 — Firefox Developer Edition](https://user-images.githubusercontent.com/229402/99768572-ce9bca00-2b26-11eb-9671-00f342368289.png)

Signed-off-by: Bugo <bugo@dragomano.ru>