### PR TITLE
Make a setting column more responsive and readable (PHPInfo area)

### DIFF
--- a/Themes/default/Admin.template.php
+++ b/Themes/default/Admin.template.php
@@ -1603,7 +1603,7 @@ function template_php_info()
 				echo '
 								<tr class="windowbg">
 									<td class="equal_table">', $key, '</td>
-									<td colspan="2">', $setting, '</td>
+									<td colspan="2">', str_replace(',', ', ', $setting), '</td>
 								</tr>';
 			}
 		}


### PR DESCRIPTION
Currently,  we have a horizontal scrollbar (on small screen devices) on the PHPInfo area. This PR fixes it.

Signed-off-by: Bugo <bugo@dragomano.ru>