### PR TITLE
Increase margin-bottom value for "Back" button on error pages

### DIFF
--- a/Themes/default/css/index.css
+++ b/Themes/default/css/index.css
@@ -2075,7 +2075,7 @@ tr.windowbg td, tr.bg td, .table_grid tr td {
 
 #fatal_error {
 	width: 80%;
-	margin: auto;
+	margin: 0 auto 10px auto;
 }
 .errorbox::before, .noticebox::before, .infobox::before {
 	width: 16px;


### PR DESCRIPTION
Currently:
![2020-11-20 12_02_34-Ошибка! — Firefox Developer Edition](https://user-images.githubusercontent.com/229402/99769678-7c5ba880-2b28-11eb-8316-3dd57cb94c9f.png)
After this fix:
![2020-11-20 12_02_48-Ошибка! — Firefox Developer Edition](https://user-images.githubusercontent.com/229402/99769672-7bc31200-2b28-11eb-9705-65ff834f849a.png)

Signed-off-by: Bugo <bugo@dragomano.ru>