### PR TITLE
Fix wrong day names in calendar list view

### DIFF
--- a/Sources/Subs-Calendar.php
+++ b/Sources/Subs-Calendar.php
@@ -630,7 +630,7 @@ function getCalendarWeek($selected_date, $calendarOptions)
 
 		$calendarGrid['months'][$current_month]['days'][$current_day] = array(
 			'day' => $current_day,
-			'day_of_week' => (date_format($current_day_object, 'w') + 7 - $calendarOptions['start_day']) % 7,
+			'day_of_week' => (date_format($current_day_object, 'w') + 7) % 7,
 			'date' => $current_date,
 			'is_today' => $current_date == $today['date'],
 			'holidays' => !empty($holidays[$current_date]) ? $holidays[$current_date] : array(),


### PR DESCRIPTION
If the week starts at settings was set to monday or saturday, the
names of the days was wrong in the calendar list view.
The dates was correct but the first day was always displayed
as sunday and so on.

Signed-off-by: Oscar Rydhé oscar.rydhe@gmail.com