### PR TITLE
Avoid errors for unknown time zones

### DIFF
--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -5987,7 +5987,10 @@ function smf_list_timezones($when = 'now')
 		if ($tzid == 'UTC')
 			continue;
 
-		$tz = timezone_open($tzid);
+		$tz = @timezone_open($tzid);
+
+		if ($tz == null)
+			continue;
 
 		// First, get the set of transition rules for this tzid
 		$tzinfo = timezone_transitions_get($tz, $when, $later);


### PR DESCRIPTION
If a time zone is not defined in the tz database installed on
the server, several errors was written to the error log.
Check that tz can be created before using it.

Signed-off-by: Oscar Rydhé oscar.rydhe@gmail.com