### PR TITLE
Save editor content when leaving the page

### DIFF
--- a/Themes/default/scripts/jquery.sceditor.smf.js
+++ b/Themes/default/scripts/jquery.sceditor.smf.js
@@ -177,6 +177,7 @@
 		var instance = sceditor.instance(textarea);
 		if (!isPatched && instance) {
 			sceditor.utils.extend(instance.constructor.prototype, extensionMethods);
+			window.addEventListener('beforeunload', instance.updateOriginal, false);
 
 			/*
 			 * Stop SCEditor from resizing the entire container. Long


### PR DESCRIPTION
If you use the back button in your browser then go forward, all the content is lost.  This is because the information is not sent back to the original prior to unloading the page.  This change simply attaches a event to the unload for window and triggers the base update to occur.  The browser handles the rest if it supports remembering what was entered into the textarea.

Finally fixing #1204 while waiting for samclarke/SCEditor#701  to maybe one day get merged.