### PR TITLE
Hide IP addresses

### DIFF
--- a/Themes/default/Display.template.php
+++ b/Themes/default/Display.template.php
@@ -634,14 +634,14 @@ function template_single_post($message)
 	if (!empty($context['can_moderate_forum']) && !empty($message['member']['ip']))
 		echo '
 								<li class="poster_ip">
-									<a href="', $scripturl, '?action=', !empty($message['member']['is_guest']) ? 'trackip' : 'profile;area=tracking;sa=ip;u=' . $message['member']['id'], ';searchip=', $message['member']['ip'], '">', $message['member']['ip'], '</a> <a href="', $scripturl, '?action=helpadmin;help=see_admin_ip" onclick="return reqOverlayDiv(this.href);" class="help">(?)</a>
+									<a href="', $scripturl, '?action=', !empty($message['member']['is_guest']) ? 'trackip' : 'profile;area=tracking;sa=ip;u=' . $message['member']['id'], ';searchip=', $message['member']['ip'], '" data-hover="', $message['member']['ip'], '" class="show_on_hover"><span>', $txt['show_ip'], '</span></a> <a href="', $scripturl, '?action=helpadmin;help=see_admin_ip" onclick="return reqOverlayDiv(this.href);" class="help">(?)</a>
 								</li>';
 
 	// Or, should we show it because this is you?
 	elseif ($message['can_see_ip'])
 		echo '
 								<li class="poster_ip">
-									<a href="', $scripturl, '?action=helpadmin;help=see_member_ip" onclick="return reqOverlayDiv(this.href);" class="help">', $message['member']['ip'], '</a>
+									<a href="', $scripturl, '?action=helpadmin;help=see_member_ip" onclick="return reqOverlayDiv(this.href);" class="help show_on_hover" data-hover="', $message['member']['ip'], '"><span>', $txt['show_ip'], '</span></a>
 								</li>';
 
 	// Okay, are you at least logged in? Then we can show something about why IPs are logged...

--- a/Themes/default/css/index.css
+++ b/Themes/default/css/index.css
@@ -3412,6 +3412,12 @@ img.smiley {
 	clear: both;
 	margin: 12px 0;
 }
+.show_on_hover:hover span {
+	display:none;
+}
+.show_on_hover:hover:before {
+	content:attr(data-hover);
+}
 /* Separator of posts. More useful in the print stylesheet. */
 #forumposts .post_separator {
 	display: none;

--- a/Themes/default/languages/index.english.php
+++ b/Themes/default/languages/index.english.php
@@ -336,6 +336,7 @@ $txt['preview'] = 'Preview';
 $txt['always_logged_in'] = 'Forever';
 
 $txt['logged'] = 'Logged';
+$txt['show_ip'] = 'Show IP address';
 // Use numeric entities in the below string.
 $txt['ip'] = 'IP';
 $txt['url'] = 'URL';


### PR DESCRIPTION
To not accidentally share users ip addresses when fore example
taking a screenshot of the forum, hide the ip addresses and only
show when hovering.

Fixes #6265

Signed-off-by: Oscar Rydhé oscar.rydhe@gmail.com