### PR TITLE
Include user_id when notifying about a reported member

### DIFF
--- a/Sources/tasks/MemberReport-Notify.php
+++ b/Sources/tasks/MemberReport-Notify.php
@@ -74,6 +74,7 @@ class MemberReport_Notify_Background extends SMF_BackgroundTask
 						array(
 							'report_link' => '?action=moderate;area=reportedmembers;sa=details;rid=' . $this->_details['report_id'], // We don't put $scripturl in these!
 							'user_name' => $this->_details['user_name'],
+							'user_id' => $this->_details['user_id'],
 						)
 					),
 				);


### PR DESCRIPTION
Notifications about reported members is required to
include the user_id of the reported member.
If it was missing the member name was not replaced
causing it to be (N/A).

Fixes #6250

Signed-off-by: Oscar Rydhé oscar.rydhe@gmail.com