### PR TITLE
Do not check post_attachment permission at upload

### DIFF
--- a/Sources/Attachments.php
+++ b/Sources/Attachments.php
@@ -128,8 +128,6 @@ class Attachments
 	{
 		global $smcFunc, $sourcedir;
 
-		isAllowedTo('post_attachment');
-
 		require_once($sourcedir . '/Subs-Attachments.php');
 
 		// Need this. For reasons...


### PR DESCRIPTION
If the user requires approval for attachments, the
post_attachments permission is not active. So this
permission check will fail. The correct permission
checks are made later so this check is redundant.
Also the response is expected to be json, and this
check will result in a html error page.

Fixes #6381

Signed-off-by: Oscar Rydhé oscar.rydhe@gmail.com