### PR TITLE
Fixes bug where non-admins could not preview attachments

### DIFF
--- a/Sources/Attachments.php
+++ b/Sources/Attachments.php
@@ -461,6 +461,12 @@ class Attachments
 			$this->_attachSuccess = $_SESSION['already_attached'];
 
 		unset($_SESSION['temp_attachments']);
+
+		// Allow user to see previews for all of this post's attachments, even if the post hasn't been submitted yet.
+		if (!isset($_SESSION['attachments_can_preview']))
+			$_SESSION['attachments_can_preview'] = array();
+		if (!empty($_SESSION['already_attached']))
+			$_SESSION['attachments_can_preview'] += array_fill_keys(array_keys($_SESSION['already_attached']), true);
 	}
 
 	/**

--- a/Sources/Post.php
+++ b/Sources/Post.php
@@ -1040,6 +1040,21 @@ function Post($post_errors = array())
 		}
 	}
 
+	// Allow user to see previews for all of this post's attachments, even if the post hasn't been submitted yet.
+	if (!isset($_SESSION['attachments_can_preview']))
+		$_SESSION['attachments_can_preview'] = array();
+
+	if (!empty($_SESSION['already_attached']))
+		$_SESSION['attachments_can_preview'] += array_fill_keys(array_keys($_SESSION['already_attached']), true);
+
+	foreach ($context['current_attachments'] as $attachID => $attachment)
+	{
+		$_SESSION['attachments_can_preview'][$attachID] = true;
+
+		if (!empty($attachment['thumb']))
+			$_SESSION['attachments_can_preview'][$attachment['thumb']] = true;
+	}
+
 	// Do we need to show the visual verification image?
 	$context['require_verification'] = !$user_info['is_mod'] && !$user_info['is_admin'] && !empty($modSettings['posts_require_captcha']) && ($user_info['posts'] < $modSettings['posts_require_captcha'] || ($user_info['is_guest'] && $modSettings['posts_require_captcha'] == -1));
 	if ($context['require_verification'])

--- a/Sources/ShowAttachments.php
+++ b/Sources/ShowAttachments.php
@@ -69,7 +69,7 @@ function showAttachment()
 	$attachTopic = isset($_REQUEST['topic']) ? (int) $_REQUEST['topic'] : 0;
 
 	// No access in strict maintenance mode or you don't have permission to see attachments.
-	if ((!empty($maintenance) && $maintenance == 2) || !allowedTo('view_attachments'))
+	if ((!empty($maintenance) && $maintenance == 2) || (!allowedTo('view_attachments') && !isset($_SESSION['already_attached'][$attachId])))
 	{
 		send_http_status(404, 'File Not Found');
 		die('404 File Not Found');

--- a/Sources/ShowAttachments.php
+++ b/Sources/ShowAttachments.php
@@ -69,7 +69,7 @@ function showAttachment()
 	$attachTopic = isset($_REQUEST['topic']) ? (int) $_REQUEST['topic'] : 0;
 
 	// No access in strict maintenance mode or you don't have permission to see attachments.
-	if ((!empty($maintenance) && $maintenance == 2) || (!allowedTo('view_attachments') && !isset($_SESSION['already_attached'][$attachId])))
+	if ((!empty($maintenance) && $maintenance == 2) || (!allowedTo('view_attachments') && !isset($_SESSION['attachments_can_preview'][$attachId])))
 	{
 		send_http_status(404, 'File Not Found');
 		die('404 File Not Found');

--- a/Sources/Subs-Attachments.php
+++ b/Sources/Subs-Attachments.php
@@ -953,7 +953,7 @@ function parseAttachBBC($attachID = 0)
 	if (empty($modSettings['attachmentEnable']))
 		return 'attachments_not_enable';
 
-	$check_board_perms = !isset($_SESSION['already_attached'][$attachID]) && $view_attachment_boards !== array(0);
+	$check_board_perms = !isset($_SESSION['attachments_can_preview'][$attachID]) && $view_attachment_boards !== array(0);
 
 	// There is always the chance someone else has already done our dirty work...
 	// If so, all pertinent checks were already done. Hopefully...

--- a/Sources/Subs-Attachments.php
+++ b/Sources/Subs-Attachments.php
@@ -959,7 +959,7 @@ function parseAttachBBC($attachID = 0)
 		return $context['current_attachments'][$attachID];
 
 	// If we are lucky enough to be in $board's scope then check it!
-	if (!empty($board) && $view_attachment_boards !== array(0) && !in_array($board, $view_attachment_boards))
+	if (!empty($board) && $view_attachment_boards !== array(0) && !in_array($board, $view_attachment_boards) && !isset($_SESSION['already_attached'][$attachID]))
 		return 'attachments_not_allowed_to_see';
 
 	// Get the message info associated with this particular attach ID.
@@ -970,7 +970,7 @@ function parseAttachBBC($attachID = 0)
 		return 'attachments_no_msg_associated';
 
 	// Hold it! got the info now check if you can see this attachment.
-	if ($view_attachment_boards !== array(0) && !in_array($attachInfo['board'], $view_attachment_boards))
+	if ($view_attachment_boards !== array(0) && !in_array($attachInfo['board'], $view_attachment_boards) && !isset($_SESSION['already_attached'][$attachID]))
 		return 'attachments_not_allowed_to_see';
 
 	if (empty($context['loaded_attachments'][$attachInfo['msg']]))
@@ -1009,7 +1009,7 @@ function parseAttachBBC($attachID = 0)
 		$attachContext = $attachLoaded[$attachID];
 
 	// No point in keep going further.
-	if ($view_attachment_boards !== array(0) && !in_array($attachContext['board'], $view_attachment_boards))
+	if ($view_attachment_boards !== array(0) && !in_array($attachContext['board'], $view_attachment_boards) && !isset($_SESSION['already_attached'][$attachID]))
 		return 'attachments_not_allowed_to_see';
 
 	// Previewing much? no msg ID has been set yet.

--- a/Sources/Subs-Attachments.php
+++ b/Sources/Subs-Attachments.php
@@ -960,7 +960,7 @@ function parseAttachBBC($attachID = 0)
 	if (!empty($context['current_attachments']) && !empty($context['current_attachments'][$attachID]))
 		return $context['current_attachments'][$attachID];
 
-	// If we are lucky enough to be in $board's scope then check it!
+	// Can the user view attachments on this board?
 	if ($check_board_perms && !empty($board) && !in_array($board, $view_attachment_boards))
 		return 'attachments_not_allowed_to_see';
 
@@ -971,7 +971,8 @@ function parseAttachBBC($attachID = 0)
 	if (empty($attachInfo) || empty($attachInfo['msg']) && empty($context['preview_message']))
 		return 'attachments_no_msg_associated';
 
-	// Hold it! got the info now check if you can see this attachment.
+	// Can the user view attachments on the board that holds the attachment's original post?
+	// (This matters when one post quotes another on a different board.)
 	if ($check_board_perms && !in_array($attachInfo['board'], $view_attachment_boards))
 		return 'attachments_not_allowed_to_see';
 
@@ -998,23 +999,20 @@ function parseAttachBBC($attachID = 0)
 	// Load this particular attach's context.
 	if (!empty($attachContext))
 		$attachLoaded = loadAttachmentContext($attachContext['id_msg'], $context['loaded_attachments']);
-
-	// One last check, you know, gotta be paranoid...
 	else
 		return 'attachments_no_data_loaded';
 
-	// This is the last "if" I promise!
 	if (empty($attachLoaded))
 		return 'attachments_no_data_loaded';
 
 	else
 		$attachContext = $attachLoaded[$attachID];
 
-	// No point in keep going further.
+	// It's theoretically possible that prepareAttachsByMsg() changed the board id, so check again.
 	if ($check_board_perms && !in_array($attachContext['board'], $view_attachment_boards))
 		return 'attachments_not_allowed_to_see';
 
-	// Previewing much? no msg ID has been set yet.
+	// Previewing much? No msg ID has been set yet.
 	if (!empty($context['preview_message']))
 	{
 		$attachContext['href'] = $scripturl . '?action=dlattach;attach=' . $attachID . ';type=preview';

--- a/Sources/Subs-Attachments.php
+++ b/Sources/Subs-Attachments.php
@@ -953,13 +953,15 @@ function parseAttachBBC($attachID = 0)
 	if (empty($modSettings['attachmentEnable']))
 		return 'attachments_not_enable';
 
+	$check_board_perms = !isset($_SESSION['already_attached'][$attachID]) && $view_attachment_boards !== array(0);
+
 	// There is always the chance someone else has already done our dirty work...
 	// If so, all pertinent checks were already done. Hopefully...
 	if (!empty($context['current_attachments']) && !empty($context['current_attachments'][$attachID]))
 		return $context['current_attachments'][$attachID];
 
 	// If we are lucky enough to be in $board's scope then check it!
-	if (!empty($board) && $view_attachment_boards !== array(0) && !in_array($board, $view_attachment_boards) && !isset($_SESSION['already_attached'][$attachID]))
+	if ($check_board_perms && !empty($board) && !in_array($board, $view_attachment_boards))
 		return 'attachments_not_allowed_to_see';
 
 	// Get the message info associated with this particular attach ID.
@@ -970,7 +972,7 @@ function parseAttachBBC($attachID = 0)
 		return 'attachments_no_msg_associated';
 
 	// Hold it! got the info now check if you can see this attachment.
-	if ($view_attachment_boards !== array(0) && !in_array($attachInfo['board'], $view_attachment_boards) && !isset($_SESSION['already_attached'][$attachID]))
+	if ($check_board_perms && !in_array($attachInfo['board'], $view_attachment_boards))
 		return 'attachments_not_allowed_to_see';
 
 	if (empty($context['loaded_attachments'][$attachInfo['msg']]))
@@ -1009,7 +1011,7 @@ function parseAttachBBC($attachID = 0)
 		$attachContext = $attachLoaded[$attachID];
 
 	// No point in keep going further.
-	if ($view_attachment_boards !== array(0) && !in_array($attachContext['board'], $view_attachment_boards) && !isset($_SESSION['already_attached'][$attachID]))
+	if ($check_board_perms && !in_array($attachContext['board'], $view_attachment_boards))
 		return 'attachments_not_allowed_to_see';
 
 	// Previewing much? no msg ID has been set yet.


### PR DESCRIPTION
Checks ~`$_SESSION['already_attached']`~ `$_SESSION['attachments_can_preview']` to see if the user is currently editing the post that holds this attachment. If so, then we allow the user to preview the attachment. This approach allows us to bypass the problem that no board id has been set yet when previewing messages that have not yet been posted.

Closes #6341
Closes #6343