### PR TITLE
Fix attachment counter for images

### DIFF
--- a/Sources/ShowAttachments.php
+++ b/Sources/ShowAttachments.php
@@ -175,10 +175,8 @@ function showAttachment()
 			// Got something! replace the $file var with the thumbnail info.
 			if ($thumbFile)
 			{
-				$attachId = $thumbFile['id_attach'];
-
 				// set filePath and ETag time
-				$thumbFile['filePath'] = getAttachmentFilename($thumbFile['filename'], $attachId, $thumbFile['id_folder'], false, $thumbFile['file_hash']);
+				$thumbFile['filePath'] = getAttachmentFilename($thumbFile['filename'], $thumbFile['id_attach'], $thumbFile['id_folder'], false, $thumbFile['file_hash']);
 				$thumbFile['etag'] = '"' . md5_file($thumbFile['filePath']) . '"';
 			}
 		}


### PR DESCRIPTION
When downloading or showing an image attachment the attachId
is overwritten with the id of the thumbnail. Later this is used
to increase the attachment counter. Removing this reassigment
should be safe since this is the only use after.

Fixes #6399

Signed-off-by: Oscar Rydhé oscar.rydhe@gmail.com