### PR TITLE
Allow mod added tables to be mb4 when smf is running in mb4

### DIFF
--- a/Sources/DbPackages-mysql.php
+++ b/Sources/DbPackages-mysql.php
@@ -197,8 +197,11 @@ function smf_db_create_table($table_name, $columns, $indexes = array(), $paramet
 	}
 
 	$table_query .= ') ENGINE=' . $parameters['engine'];
-	if (!empty($db_character_set) && $db_character_set == 'utf8')
+	if (!empty($db_character_set) && $db_character_set == 'utf8' && !$smcFunc['db_mb4'])
 		$table_query .= ' DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci';
+
+	if (!empty($db_character_set) && $db_character_set == 'utf8' && $smcFunc['db_mb4'])
+		$table_query .= ' DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci';
 
 	// Create the table!
 	$smcFunc['db_query']('', $table_query,


### PR DESCRIPTION
Based on the discussion #6405
i checked the existing mb4 logic of smf and
found a spot which got not covered atm.

In general when someone plan to convert his smf 2.1 to mb4,
the programm logic expect that not only the existing column get changed,
also the default setting of the tables needs to be changed to mb4.