### PR TITLE
Fix issue when a time bbc tag is not parsed

### DIFF
--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -2078,7 +2078,7 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 					if (is_numeric($data))
 						$data = timeformat($data);
 
-					$tag['content'] = '<strong>$1</strong>';
+					$tag['content'] = '<span class="bbc_time">$1</span>';
 				},
 			),
 			array(

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -2077,8 +2077,8 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 				{
 					if (is_numeric($data))
 						$data = timeformat($data);
-					else
-						$tag['content'] = '[time]$1[/time]';
+
+					$tag['content'] = '<strong>$1</strong>';
 				},
 			),
 			array(


### PR DESCRIPTION
If we use any language (except English) we have not worked parsing for time tag:
![](https://user-images.githubusercontent.com/229402/102084406-ecfb9980-3e36-11eb-8227-05df1bd0ca4f.png)

How to see this problem:

1. Select any language, except English.
2. Post a message with a time BBC tag.
3. Edit this message and view it again.


Signed-off-by: Bugo <bugo@dragomano.ru>