### PR TITLE
Type field sometimes alpha

### DIFF
--- a/Sources/Subs-Package.php
+++ b/Sources/Subs-Package.php
@@ -111,7 +111,7 @@ function read_tgz_data($gzfilename, $destination, $single_file = false, $overwri
 	$flags = $flags['f'];
 
 	$offset = 10;
-	$octdec = array('mode', 'uid', 'gid', 'size', 'mtime', 'checksum', 'type');
+	$octdec = array('mode', 'uid', 'gid', 'size', 'mtime', 'checksum');
 
 	// "Read" the filename and comment.
 	// @todo Might be mussed.
@@ -155,7 +155,7 @@ function read_tgz_data($gzfilename, $destination, $single_file = false, $overwri
 				$current[$k] = trim($v);
 		}
 
-		if ($current['type'] == 5 && substr($current['filename'], -1) != '/')
+		if ($current['type'] == '5' && substr($current['filename'], -1) != '/')
 			$current['filename'] .= '/';
 
 		$checksum = 256;


### PR DESCRIPTION
Porting over from 2.0.

Turns out the type field in the tar header that is usually numeric, but sometimes alpha... The package manager uses the field to determine if it's working on a directory or not. In this instance, there was a value of 'g' in there.  Prior to 7.4, errors were "silent", but not in 7.4+.

The error occurs when trying to do an octdec('g') in Subs-Package.php ~line 152.

Spec may be found here:
https://www.gnu.org/software/tar/manual/html_node/Standard.html

Applicable part is this, note that 'x' and 'g' are sometimes used:
>     /* Values used in typeflag field. /
>     #define REGTYPE '0' / regular file /
>     #define AREGTYPE '\0' / regular file /
>     #define LNKTYPE '1' / link /
>     #define SYMTYPE '2' / reserved /
>     #define CHRTYPE '3' / character special /
>     #define BLKTYPE '4' / block special /
>     #define DIRTYPE '5' / directory /
>     #define FIFOTYPE '6' / FIFO special /
>     #define CONTTYPE '7' / reserved */
> 
>     #define XHDTYPE 'x' /* Extended header referring to the
>     next file in the archive /
>     #define XGLTYPE 'g' / Global extended header */