### PR TITLE
Define PHP_INT_MIN if not defined

### DIFF
--- a/Sources/Subs-Timezones.php
+++ b/Sources/Subs-Timezones.php
@@ -16,6 +16,9 @@
 if (!defined('SMF'))
 	die('No direct access...');
 
+if (!defined('PHP_INT_MIN'))
+	define('PHP_INT_MIN', ~PHP_INT_MAX);
+
 /**
  * Returns an array that instructs SMF how to map specific time zones
  * (e.g. "America/Denver") onto the user-friendly "meta-zone" labels that


### PR DESCRIPTION
Prior to PHP 7.0.0 PHP_INT_MIN is not defined.
It is used for some timezones.
Define it if not defined.

Signed-off-by: Oscar Rydhé oscar.rydhe@gmail.com