### PR TITLE
Check board_manager_groups when displaying permissions

### DIFF
--- a/Sources/Profile-View.php
+++ b/Sources/Profile-View.php
@@ -3109,7 +3109,8 @@ function showPermissions($memID)
 	$context['no_access_boards'] = array();
 	while ($row = $smcFunc['db_fetch_assoc']($request))
 	{
-		if ((count(array_intersect($curGroups, explode(',', $row['member_groups']))) === 0) && !$row['is_mod'] && (!empty($modSettings['board_manager_groups']) && count(array_intersect($curGroups, explode(',', $modSettings['board_manager_groups']))) === 0))
+		if ((count(array_intersect($curGroups, explode(',', $row['member_groups']))) === 0) && !$row['is_mod']
+		&& (!empty($modSettings['board_manager_groups']) && count(array_intersect($curGroups, explode(',', $modSettings['board_manager_groups']))) === 0))
 			$context['no_access_boards'][] = array(
 				'id' => $row['id_board'],
 				'name' => $row['name'],

--- a/Sources/Profile-View.php
+++ b/Sources/Profile-View.php
@@ -3064,7 +3064,7 @@ function list_getGroupRequests($start, $items_per_page, $sort, $memID)
  */
 function showPermissions($memID)
 {
-	global $txt, $board;
+	global $txt, $board, $modSettings;
 	global $user_profile, $context, $sourcedir, $smcFunc;
 
 	// Verify if the user has sufficient permissions.
@@ -3109,7 +3109,7 @@ function showPermissions($memID)
 	$context['no_access_boards'] = array();
 	while ($row = $smcFunc['db_fetch_assoc']($request))
 	{
-		if (count(array_intersect($curGroups, explode(',', $row['member_groups']))) === 0 && !$row['is_mod'])
+		if ((count(array_intersect($curGroups, explode(',', $row['member_groups']))) === 0) && !$row['is_mod'] && (!empty($modSettings['board_manager_groups']) && count(array_intersect($curGroups, explode(',', $modSettings['board_manager_groups']))) === 0))
 			$context['no_access_boards'][] = array(
 				'id' => $row['id_board'],
 				'name' => $row['name'],


### PR DESCRIPTION
Now that board managers can see all boards, this needs to be reflected on the 'Show Permissions' view.  

Otherwise, folks with 'Manage Boards and Categories' end up with boards on their restricted boards list, which doesn't make sense.


**_Before change:_**
![board_perms_conflict](https://user-images.githubusercontent.com/23568484/104349724-22d48200-54b8-11eb-80f2-28ca613e6e6b.png)


**_After change:_**
![board_perms_conflict-after](https://user-images.githubusercontent.com/23568484/104349740-27009f80-54b8-11eb-9f1d-4c8bbca2b3a0.png)

Saw this when researching #6450 .