### PR TITLE
Convert text into string in upgrade.php

### DIFF
--- a/Themes/default/languages/Install.english.php
+++ b/Themes/default/languages/Install.english.php
@@ -302,6 +302,7 @@ $txt['upgrade_json_completed'] = 'Convert to JSON Complete! Click Continue to Pr
 $txt['upgrade_executing'] = 'Executing:';
 $txt['upgrade_of'] = 'of';
 $txt['upgrade_admin_login'] = 'Admin Login:';
+$txt['upgrade_admin_disabled'] = '(DISABLED)';
 /* Same sentence, 3 different strings */
 $txt['upgrade_done'] = 'Upgrade complete. Now you are ready to use';
 $txt['upgrade_done2'] = 'your installation of SMF';

--- a/other/upgrade.php
+++ b/other/upgrade.php
@@ -4030,13 +4030,13 @@ function template_xml_below()
 
 function template_error_message()
 {
-	global $upcontext;
+	global $upcontext, $txt;
 
 	echo '
 	<div class="error">
 		', $upcontext['error_msg'], '
 		<br>
-		<a href="', $_SERVER['PHP_SELF'], '">Click here to try again.</a>
+		<a href="', $_SERVER['PHP_SELF'], '">', $txt['upgrade_respondtime_clickhere'], '</a>
 	</div>';
 }
 
@@ -4123,7 +4123,7 @@ function template_welcome_message()
 	}
 
 	echo '
-					<strong>', $txt['upgrade_admin_login'], ' ', $disable_security ? '(DISABLED)' : '', '</strong>
+					<strong>', $txt['upgrade_admin_login'], ' ', $disable_security ? $txt['upgrade_admin_disabled'] : '', '</strong>
 					<h3>', $txt['upgrade_sec_login'], '</h3>
 					<dl class="settings adminlogin">
 						<dt>


### PR DESCRIPTION
Some strings where hard coded. Convert to strings.

Fixes #6422

Signed-off-by: Oscar Rydhé oscar.rydhe@gmail.com