### PR TITLE
Fix incompatibility values of "label for" and "input id"

### DIFF
--- a/Themes/default/Themes.template.php
+++ b/Themes/default/Themes.template.php
@@ -655,7 +655,7 @@ function template_set_settings()
 				echo '
 						<input type="text"';
 
-			echo ' name="', !empty($setting['default']) ? 'default_' : '', 'options[', $setting['id'], ']" id="options_', $setting['id'], '" value="', $setting['value'], '"', $setting['type'] == 'number' ? ' size="5"' : (empty($setting['size']) ? ' size="40"' : ' size="' . $setting['size'] . '"'), '>
+			echo ' name="', !empty($setting['default']) ? 'default_' : '', 'options[', $setting['id'], ']" id="', $setting['id'], '" value="', $setting['value'], '"', $setting['type'] == 'number' ? ' size="5"' : (empty($setting['size']) ? ' size="40"' : ' size="' . $setting['size'] . '"'), '>
 					</dd>';
 		}
 	}


### PR DESCRIPTION
Values of the label for attribute and input id attribute [must be equal](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/label#using_the_for_attribute).

Example:
`<label for="some_id">Text</label>
<input name="some_name" id="some_id">`

Signed-off-by: Bugo <bugo@dragomano.ru>