### PR TITLE
Update Profile show Attachments list

### DIFF
--- a/Themes/default/GenericList.template.php
+++ b/Themes/default/GenericList.template.php
@@ -108,7 +108,7 @@ function template_show_list($list_id = null)
 		foreach ($cur_list['rows'] as $id => $row)
 		{
 			echo '
-				<tr class="windowbg', empty($row['class']) ? '' : ' ' . $row['class'], '"', empty($row['style']) ? '' : ' style="' . $row['style'] . '"', ' id="list_', $list_id, '_', $id, '">';
+				<tr class="', empty($row['class']) ? 'windowbg' : $row['class'], '"', empty($row['style']) ? '' : ' style="' . $row['style'] . '"', ' id="list_', $list_id, '_', $id, '">';
 
 			if (!empty($row['data']))
 				foreach ($row['data'] as $row_id => $row_data)


### PR DESCRIPTION
* Unapproved attachments was shown to users not permitted to
show them since wrong table was used in query.
* Let moderators see unapproved attachments.
* Add Awaiting approval text after filename for unapproved
attachments.
* Remove windowbg from table rows in GenericList.template if another
class was specified, since it shadowed the specified class.

Fixes #6459
Fixes #6460

Signed-off-by: Oscar Rydhé oscar.rydhe@gmail.com