### PR TITLE
Show all unapproved attachments in approve box

### DIFF
--- a/Themes/default/Display.template.php
+++ b/Themes/default/Display.template.php
@@ -743,7 +743,7 @@ function template_single_post($message)
 		foreach ($message['attachment'] as $attachment)
 		{
 			// Do we want this attachment to not be showed here?
-			if (!empty($modSettings['dont_show_attach_under_post']) && !empty($context['show_attach_under_post'][$attachment['id']]))
+			if ($attachment['is_approved'] && !empty($modSettings['dont_show_attach_under_post']) && !empty($context['show_attach_under_post'][$attachment['id']]))
 				continue;
 			elseif (!$div_output)
 			{


### PR DESCRIPTION
If setting "Do not show attachments under the post if they
are already embedded in it" was enabled, only non embedded
and unapproved attachments was shown in the approve box.

Fixes #6458

Signed-off-by: Oscar Rydhé oscar.rydhe@gmail.com