### PR TITLE
Change error message for embedded unapproved attachments

### DIFF
--- a/Themes/default/languages/index.english.php
+++ b/Themes/default/languages/index.english.php
@@ -864,6 +864,7 @@ $txt['attachments_not_enable'] = 'Attachments are disabled';
 $txt['attachments_no_data_loaded'] = 'Not a valid attachment ID.';
 $txt['attachments_not_allowed_to_see'] = 'You cannot see attachments on this board.';
 $txt['attachments_no_msg_associated'] = 'No message is associated with this attachment.';
+$txt['attachments_unapproved'] = 'Attachment is awating approval.';
 
 // Accessibility
 $txt['hide_category'] = 'Hide Category';


### PR DESCRIPTION
Show "Attachment awaiting approval." instead of
"Not a valid attachment ID." when viewing a message
with an embedded unapproved attachment, without permission
to view the attachment.

Fixes #6457

Signed-off-by: Oscar Rydhé oscar.rydhe@gmail.com