### PR TITLE
Add right padding to language selector for mobile

### DIFF
--- a/Themes/default/css/responsive.css
+++ b/Themes/default/css/responsive.css
@@ -174,6 +174,9 @@
 		padding: 5px 0 5px 0;
 		margin-right: 3px;
 	}
+	#languages_form {
+		padding-right: 10px;
+	}
 
 	/* BoardIndex */
 	.board_stats {


### PR DESCRIPTION
If viewing the forum in a mobile or other small screen
device, the language selector form is right at the edge
of the screen. Add a padding to match the other boxes.

Signed-off-by: Oscar Rydhé oscar.rydhe@gmail.com