### PR TITLE
Make ipv6 address wrappable

### DIFF
--- a/Themes/default/Who.template.php
+++ b/Themes/default/Who.template.php
@@ -71,7 +71,7 @@ function template_main()
 
 		if (!empty($member['ip']))
 			echo '
-								(<a href="' . $scripturl . '?action=', ($member['is_guest'] ? 'trackip' : 'profile;area=tracking;sa=ip;u=' . $member['id']), ';searchip=' . $member['ip'] . '">' . $member['ip'] . '</a>)';
+								(<a href="' . $scripturl . '?action=', ($member['is_guest'] ? 'trackip' : 'profile;area=tracking;sa=ip;u=' . $member['id']), ';searchip=' . $member['ip'] . '">' . str_replace(':', ':&ZeroWidthSpace;', $member['ip']) . '</a>)';
 
 		echo '
 							</td>


### PR DESCRIPTION
Add a non width space after every colon in ipv6 addresses.
This will make it possible for the browser to wrap the
ipv6 address if it is to long, and make place for other
information.

Fixes #5587

Signed-off-by: Oscar Rydhé oscar.rydhe@gmail.com