### PR TITLE
Use HTTPS for stats reporting

### DIFF
--- a/Sources/ManageServer.php
+++ b/Sources/ManageServer.php
@@ -1685,7 +1685,9 @@ function registerSMStats()
 	if (!empty($modSettings['sm_stats_key']))
 		return true;
 
-	$fp = @fsockopen('www.simplemachines.org', 80, $errno, $errstr);
+	$fp = @fsockopen('www.simplemachines.org', 443, $errno, $errstr);
+	if (!$fp)
+		$fp = @fsockopen('www.simplemachines.org', 80, $errno, $errstr);
 	if ($fp)
 	{
 		$out = 'GET /smf/stats/register_stats.php?site=' . base64_encode($boardurl) . ' HTTP/1.1' . "\r\n";

--- a/Sources/Stats.php
+++ b/Sources/Stats.php
@@ -831,7 +831,9 @@ function SMStats()
 	else
 	{
 		// Connect to the collection script.
-		$fp = @fsockopen('www.simplemachines.org', 80, $errno, $errstr);
+		$fp = @fsockopen('www.simplemachines.org', 443, $errno, $errstr);
+		if (!$fp)
+			$fp = @fsockopen('www.simplemachines.org', 80, $errno, $errstr);
 		if ($fp)
 		{
 			$length = strlen($stats_to_send);

--- a/other/install.php
+++ b/other/install.php
@@ -1335,7 +1335,9 @@ function DatabasePopulation()
 		$incontext['allow_sm_stats'] = true;
 
 		// Attempt to register the site etc.
-		$fp = @fsockopen('www.simplemachines.org', 80, $errno, $errstr);
+		$fp = @fsockopen('www.simplemachines.org', 443, $errno, $errstr);
+		if (!$fp)
+			$fp = @fsockopen('www.simplemachines.org', 80, $errno, $errstr);
 		if ($fp)
 		{
 			$out = 'GET /smf/stats/register_stats.php?site=' . base64_encode($boardurl) . ' HTTP/1.1' . "\r\n";

--- a/other/upgrade.php
+++ b/other/upgrade.php
@@ -1243,7 +1243,9 @@ function UpgradeOptions()
 		if (empty($modSettings['sm_stats_key']))
 		{
 			// Attempt to register the site etc.
-			$fp = @fsockopen('www.simplemachines.org', 80, $errno, $errstr);
+			$fp = @fsockopen('www.simplemachines.org', 443, $errno, $errstr);
+			if (!$fp)
+				$fp = @fsockopen('www.simplemachines.org', 80, $errno, $errstr);
 			if ($fp)
 			{
 				$out = 'GET /smf/stats/register_stats.php?site=' . base64_encode($boardurl) . ' HTTP/1.1' . "\r\n";


### PR DESCRIPTION
Use https when reporting stats to simplemachines.org.
Fallback to http if https fails.

Fixes #5670

Signed-off-by: Oscar Rydhé oscar.rydhe@gmail.com