### PR TITLE
Fix error when using slash in searches

### DIFF
--- a/Sources/Search.php
+++ b/Sources/Search.php
@@ -2315,7 +2315,7 @@ function searchSort($a, $b)
 function highlight($text, array $words)
 {
 	$words = implode('|', array_map('preg_quote', $words));
-	$highlighted = preg_filter('/' . $words . '/i', '<span class="highlight">$0</span>', $text);
+	$highlighted = preg_filter('<' . $words . '>i', '<span class="highlight">$0</span>', $text);
 
 	if (!empty($highlighted))
 		$text = $highlighted;


### PR DESCRIPTION
If using a slash (/) when searching an error was
reported in the error log.
Changed delimiters to fix it.

Fixes #6413

Signed-off-by: Oscar Rydhé oscar.rydhe@gmail.com