### PR TITLE
Hide last post on unread topics for mobiles

### DIFF
--- a/Themes/default/css/responsive.css
+++ b/Themes/default/css/responsive.css
@@ -227,8 +227,11 @@
 		display: none;
 	}
 	/* Unread */
-	#unread .board_icon, #unread .lastpost {
+	#unread .board_icon, #unread .lastpost, #unreadreplies .board_icon, #unreadreplies .lastpost {
 		display: none;
+	}
+	#unread .info, #unreadreplies .info {
+		padding-left: 5px;
 	}
 
 	/* Display (Topics) */


### PR DESCRIPTION
Hide last post and board icon on the unread topics page
for low resolution devices.
This will align with the unread posts page.

Fixes #6483

Signed-off-by: Oscar Rydhé oscar.rydhe@gmail.com