### PR TITLE
Set user id after registration

### DIFF
--- a/Sources/Register.php
+++ b/Sources/Register.php
@@ -251,7 +251,7 @@ function Register($reg_errors = array())
 function Register2()
 {
 	global $txt, $modSettings, $context, $sourcedir;
-	global $smcFunc, $maintenance;
+	global $smcFunc, $maintenance, $user_info;
 
 	checkSession();
 	validateToken('register');
@@ -560,6 +560,8 @@ function Register2()
 	{
 		require_once($sourcedir . '/Profile.php');
 		require_once($sourcedir . '/Profile-Modify.php');
+		// Set user_info id, it is used by log actions
+		$user_info['id'] = $memberID;
 		makeCustomFieldChanges($memberID, 'register');
 	}
 


### PR DESCRIPTION
During the registration of a new user, custom profile fields
could be configured to be set during the registration.
When changed these custom profile field edits are added to the
profile edits log. But since the user id is not set at this time,
the changed by user ended up as 0.
Solve this by setting the user id after it has been created.

Fixes #6237

Signed-off-by: Oscar Rydhé oscar.rydhe@gmail.com