### PR TITLE
Separate strings with different number of arguments

### DIFF
--- a/Themes/default/index.template.php
+++ b/Themes/default/index.template.php
@@ -242,10 +242,17 @@ function template_body_above()
 	}
 	// Otherwise they're a guest. Ask them to either register or login.
 	elseif (empty($maintenance))
-		echo '
-			<ul class="floatleft welcome">
-				<li>', sprintf($txt[$context['can_register'] ? 'welcome_guest_register' : 'welcome_guest'], $context['forum_name_html_safe'], $scripturl . '?action=login', 'return reqOverlayDiv(this.href, ' . JavaScriptEscape($txt['login']) . ');', $scripturl . '?action=signup'), '</li>
-			</ul>';
+		if ($context['can_register']) 
+			echo '
+				<ul class="floatleft welcome">
+					<li>', sprintf($txt['welcome_guest_register'], $context['forum_name_html_safe'], $scripturl . '?action=login', 'return reqOverlayDiv(this.href, ' . JavaScriptEscape($txt['login']) . ');', $scripturl . '?action=signup'), '</li>
+				</ul>';
+
+		else
+			echo '
+				<ul class="floatleft welcome">
+					<li>', sprintf($txt['welcome_guest'], $context['forum_name_html_safe'], $scripturl . '?action=login', 'return reqOverlayDiv(this.href, ' . JavaScriptEscape($txt['login']) . ');'), '</li>
+				</ul>';
 	else
 		// In maintenance mode, only login is allowed and don't show OverlayDiv
 		echo '


### PR DESCRIPTION
This fixes #6487 but while testing I noticed that some languages (I tested German and French) were using the wrong numbers in the index.language.php files. For example, in French:

```
$txt['welcome_guest'] = 'Bienvenue, <strong>%1$s</strong>. Merci de <a href="%3$s" onclick="%4$s">vous connecter</a>.';

// argument(s): forum name, login URL, login JavaScript snippet, signup URL
$txt['welcome_guest_register'] = 'Bienvenue sur <strong>%2$s</strong>. Veuillez vous <a href="%3$s" onclick="%4$s">connecter</a> ou vous <a href="%5$s">enregistrer</a>.';
```

I'll track this internally with the localization team.