### PR TITLE
Sometimes find 0s in mm or dd

### DIFF
--- a/other/upgrade.php
+++ b/other/upgrade.php
@@ -1234,6 +1234,9 @@ function UpgradeOptions()
 	if (empty($_POST['upcont']))
 		return false;
 
+	// We cannot execute this step in strict mode - strict mode data fixes are not applied yet
+	setSqlMode(false);
+
 	// Firstly, if they're enabling SM stat collection just do it.
 	if (!empty($_POST['stats']) && substr($boardurl, 0, 16) != 'http://localhost' && empty($modSettings['allow_sm_stats']) && empty($modSettings['enable_sm_stats']))
 	{

--- a/other/upgrade_2-1_mysql.sql
+++ b/other/upgrade_2-1_mysql.sql
@@ -23,7 +23,7 @@ WHERE YEAR(stat_date) < 1004;
 
 UPDATE {$db_prefix}members
 SET birthdate = DATE(CONCAT(IF(YEAR(birthdate) < 1004, 1004, YEAR(birthdate)), '-', IF(MONTH(birthdate) < 1, 1, MONTH(birthdate)), '-', IF(DAY(birthdate) < 1, 1, DAY(birthdate))))
-WHERE YEAR(birthdate) < 1004;
+WHERE YEAR(birthdate) < 1004 OR MONTH(birthdate) < 1 OR DAY(birthdate) < 1;
 ---#
 
 ---# Changing default values

--- a/other/upgrade_2-1_postgresql.sql
+++ b/other/upgrade_2-1_postgresql.sql
@@ -205,7 +205,7 @@ ALTER stat_date SET DEFAULT '1004-01-01';
 
 UPDATE {$db_prefix}members
 SET birthdate = concat_ws('-', CASE WHEN EXTRACT(YEAR FROM birthdate) < 1004 THEN 1004 END, CASE WHEN EXTRACT(MONTH FROM birthdate) < 1 THEN 1 ELSE EXTRACT(MONTH FROM birthdate) END, CASE WHEN EXTRACT(DAY FROM birthdate) < 1 THEN 1 ELSE EXTRACT(DAY FROM birthdate) END)::date
-WHERE EXTRACT(YEAR FROM birthdate) < 1004;
+WHERE EXTRACT(YEAR FROM birthdate) < 1004 OR EXTRACT(MONTH FROM birthdate) < 1 OR EXTRACT(DAY FROM birthdate) < 1;
 ---#
 
 ---# Changing default values


### PR DESCRIPTION
Fixes #6316 

Need to account for some old/migrated DBs with year-only birthdates.

Tests fine - it will now set mm & dd to 1.  

I could not replicate the erroneous data in pg in 2.0, but replicated the fix here anyway & confirmed upgrader still runs fine.