### PR TITLE
Very bad to do this twice

### DIFF
--- a/other/upgrade_2-0_mysql.sql
+++ b/other/upgrade_2-0_mysql.sql
@@ -3018,29 +3018,6 @@ ADD COLUMN email_address varchar(255) NOT NULL default '' AFTER membername;
 --- Adjusting group types.
 /******************************************************************************/
 
----# Fixing the group types.
----{
-// Get the admin group type.
-$request = upgrade_query("
-	SELECT group_type
-	FROM {$db_prefix}membergroups
-	WHERE id_group = 1
-	LIMIT 1");
-list ($admin_group_type) = smf_mysql_fetch_row($request);
-smf_mysql_free_result($request);
-
-// Not protected means we haven't updated yet!
-if ($admin_group_type != 1)
-{
-	// Increase by one.
-	upgrade_query("
-		UPDATE {$db_prefix}membergroups
-		SET group_type = group_type + 1
-		WHERE group_type > 0");
-}
----}
----#
-
 ---# Changing the group type for Administrator group.
 UPDATE {$db_prefix}membergroups
 SET group_type = 1

--- a/other/upgrade_2-0_postgresql.sql
+++ b/other/upgrade_2-0_postgresql.sql
@@ -1232,29 +1232,6 @@ else
 --- Adjusting group types.
 /******************************************************************************/
 
----# Fixing the group types.
----{
-// Get the admin group type.
-$request = upgrade_query("
-	SELECT group_type
-	FROM {$db_prefix}membergroups
-	WHERE id_group = 1
-	LIMIT 1");
-list ($admin_group_type) = pg_fetch_row($request);
-pg_free_result($request);
-
-// Not protected means we haven't updated yet!
-if ($admin_group_type != 1)
-{
-	// Increase by one.
-	upgrade_query("
-		UPDATE {$db_prefix}membergroups
-		SET group_type = group_type + 1
-		WHERE group_type > 0");
-}
----}
----#
-
 ---# Changing the group type for Administrator group.
 UPDATE {$db_prefix}membergroups
 SET group_type = 1


### PR DESCRIPTION
Fixes #6318 

2.0 RC4 needed to fix the membergroup group_type for folks who had upgraded from 1.x to 2.0 prior to RC4.  This fix has long outlived its usefulness.

For you to still have the _original_ bug addressed by this logic, you must have upgraded to 2.0 prior to RC4, and somehow not noticed the issue in 10 years.  You certainly fixed it by now.

OTOH, leaving this old logic in place can cause significant issues & corrupt your membegroups if you run the upgrader, as in the reported issue.  
