### PR TITLE
Honor the gravatar enabled setting

### DIFF
--- a/Sources/Load.php
+++ b/Sources/Load.php
@@ -1731,7 +1731,7 @@ function loadMemberContext($user, $display_custom_fields = false)
 	// If the set isn't minimal then load their avatar as well.
 	if ($context['loadMemberContext_set'] != 'minimal')
 	{
-		if (!empty($modSettings['gravatarOverride']) || (!empty($modSettings['gravatarEnabled']) && stristr($profile['avatar'], 'gravatar://')))
+		if (!empty($modSettings['gravatarEnabled']) && (!empty($modSettings['gravatarOverride']) || stristr($profile['avatar'], 'gravatar://')))
 		{
 			if (!empty($modSettings['gravatarAllowExtraEmail']) && stristr($profile['avatar'], 'gravatar://') && strlen($profile['avatar']) > 11)
 				$image = get_gravatar_url($smcFunc['substr']($profile['avatar'], 11));
@@ -3799,7 +3799,7 @@ function set_avatar_data($data = array())
 	$image = '';
 
 	// Gravatar has been set as mandatory!
-	if (!empty($modSettings['gravatarOverride']))
+	if (!empty($modSettings['gravatarEnabled']) && !empty($modSettings['gravatarOverride']))
 	{
 		if (!empty($modSettings['gravatarAllowExtraEmail']) && !empty($data['avatar']) && stristr($data['avatar'], 'gravatar://'))
 			$image = get_gravatar_url($smcFunc['substr']($data['avatar'], 11));

--- a/Sources/Profile-Modify.php
+++ b/Sources/Profile-Modify.php
@@ -3212,7 +3212,7 @@ function profileLoadAvatarData()
 		'allow_server_stored' => (empty($modSettings['gravatarEnabled']) || empty($modSettings['gravatarOverride'])) && (allowedTo('profile_server_avatar') || (!$context['user']['is_owner'] && allowedTo('profile_extra_any'))),
 		'allow_upload' => (empty($modSettings['gravatarEnabled']) || empty($modSettings['gravatarOverride'])) && (allowedTo('profile_upload_avatar') || (!$context['user']['is_owner'] && allowedTo('profile_extra_any'))),
 		'allow_external' => (empty($modSettings['gravatarEnabled']) || empty($modSettings['gravatarOverride'])) && (allowedTo('profile_remote_avatar') || (!$context['user']['is_owner'] && allowedTo('profile_extra_any'))),
-		'allow_gravatar' => !empty($modSettings['gravatarEnabled']) || !empty($modSettings['gravatarOverride']),
+		'allow_gravatar' => !empty($modSettings['gravatarEnabled']),
 	);
 
 	if ($context['member']['avatar']['allow_gravatar'] && (stristr($cur_profile['avatar'], 'gravatar://') || !empty($modSettings['gravatarOverride'])))

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -3651,7 +3651,7 @@ function setupThemeContext($forceload = false)
 		$context['user']['avatar'] = array();
 
 		// Check for gravatar first since we might be forcing them...
-		if (($modSettings['gravatarEnabled'] && substr($user_info['avatar']['url'], 0, 11) == 'gravatar://') || !empty($modSettings['gravatarOverride']))
+		if (!empty($modSettings['gravatarEnabled']) && (substr($user_info['avatar']['url'], 0, 11) == 'gravatar://' || !empty($modSettings['gravatarOverride'])))
 		{
 			if (!empty($modSettings['gravatarAllowExtraEmail']) && stristr($user_info['avatar']['url'], 'gravatar://') && strlen($user_info['avatar']['url']) > 11)
 				$context['user']['avatar']['href'] = get_gravatar_url($smcFunc['substr']($user_info['avatar']['url'], 11));

--- a/Themes/default/Profile.template.php
+++ b/Themes/default/Profile.template.php
@@ -2863,7 +2863,7 @@ function template_profile_avatar_select()
 									<label for="avatar_upload_box">', $txt['personal_picture'], '</label>
 								</strong>';
 
-	if (empty($modSettings['gravatarOverride']))
+	if (empty($modSettings['gravatarEnabled']) || empty($modSettings['gravatarOverride']))
 		echo '
 								<input type="radio" onclick="swap_avatar(this); return true;" name="avatar_choice" id="avatar_choice_none" value="none"' . ($context['member']['avatar']['choice'] == 'none' ? ' checked="checked"' : '') . '>
 								<label for="avatar_choice_none"' . (isset($context['modify_error']['bad_avatar']) ? ' class="error"' : '') . '>


### PR DESCRIPTION
If the "Enable gravatars" setting was disabled but the "Force
gravatars" settings was enabled, gravatars was used, but
the profile editor was messed up.
Change to honor the "Enable gravatars" setting to enable/disable
all gravatars usage.

Fixes #6522

Signed-off-by: Oscar Rydhé oscar.rydhe@gmail.com