### PR TITLE
Hide charset column for mobiles in edit langs table

### DIFF
--- a/Themes/default/css/responsive.css
+++ b/Themes/default/css/responsive.css
@@ -369,6 +369,10 @@
 	#private, #enclose {
 		width: 95%;
 	}
+	/* Edit Language */
+	#language_list .character_set {
+		display: none;
+	}
 	/* Generic Classes for Customizations */
 	.hide_720 {
 		display: none;


### PR DESCRIPTION
The table extends beyond the page when viewing
the edit langs table on a mobile. Fixed that by
hiding the charset column.

Fixes the remaining of #5594

Signed-off-by: Oscar Rydhé oscar.rydhe@gmail.com