### PR TITLE
Specify login class in css

### DIFF
--- a/Themes/default/css/responsive.css
+++ b/Themes/default/css/responsive.css
@@ -565,7 +565,7 @@
 		width: 100%;
 		text-align: left;
 	}
-	.login #ajax_loginuser, .login #ajax_loginpass, .login #loginuser, .login #loginpass, select {
+	.login #ajax_loginuser, .login #ajax_loginpass, .login #loginuser, .login #loginpass, .login select {
 		width: 100%;
 	}
 


### PR DESCRIPTION
This will prevent all select tags to be changed for
low resolution devices, when it is only meant for
the login box.