### PR TITLE
Follow the Enable selection of drafts from posting screen setting

### DIFF
--- a/Themes/default/Post.template.php
+++ b/Themes/default/Post.template.php
@@ -454,7 +454,7 @@ function template_main()
 					</div><!-- #post_additional_options -->';
 
 	// If the admin enabled the drafts feature, show a draft selection box
-	if (!empty($modSettings['drafts_post_enabled']) && !empty($context['drafts']) && !empty($options['drafts_show_saved_enabled']))
+	if (!empty($modSettings['drafts_post_enabled']) && !empty($context['drafts']) && !empty($modSettings['drafts_show_saved_enabled']) && !empty($options['drafts_show_saved_enabled']))
 	{
 		echo '
 					<div id="post_draft_options_header" class="title_bar">


### PR DESCRIPTION
If the setting "Enable the selection of drafts from the posting
screen" was disabled, the selection ui was still visible if
the user had enabled the same setting in his profile.

Fixes #4697

Signed-off-by: Oscar Rydhé oscar.rydhe@gmail.com