### PR TITLE
Avoid undefined index error when issue warning

### DIFF
--- a/Themes/default/Profile.template.php
+++ b/Themes/default/Profile.template.php
@@ -2701,7 +2701,7 @@ function template_error_message()
 		{
 			$text_key_error = $error == 'password_short' ?
 				sprintf($txt['profile_error_' . $error], (empty($modSettings['password_strength']) ? 4 : 8)) :
-				$txt['profile_error_' . $error];
+				(isset($txt['profile_error_' . $error]) ? $txt['profile_error_' . $error] : '');
 
 			echo '
 				<li>', isset($txt['profile_error_' . $error]) ? $text_key_error : $error, '</li>';


### PR DESCRIPTION
If a warning was issued without a reason,
an undefined index error was added to the error log.
Fix that by checking if the text string is defined
before accessing it.

Signed-off-by: Oscar Rydhé oscar.rydhe@gmail.com