### PR TITLE
Correct calculation if user can see warning

### DIFF
--- a/Sources/Profile-View.php
+++ b/Sources/Profile-View.php
@@ -33,8 +33,9 @@ function summary($memID)
 		'can_send_pm' => allowedTo('pm_send'),
 		'can_have_buddy' => allowedTo('profile_extra_own') && !empty($modSettings['enable_buddylist']),
 		'can_issue_warning' => allowedTo('issue_warning') && $modSettings['warning_settings'][0] == 1,
-		'can_view_warning' => (allowedTo('moderate_forum') || allowedTo('issue_warning') || allowedTo('view_warning_any') || ($context['user']['is_owner'] && allowedTo('view_warning_own')) && $modSettings['warning_settings'][0] === 1)
+		'can_view_warning' => (allowedTo('moderate_forum') || allowedTo('issue_warning') || allowedTo('view_warning_any') || ($context['user']['is_owner'] && allowedTo('view_warning_own'))) && $modSettings['warning_settings'][0] === '1'
 	);
+
 	$context['member'] = &$memberContext[$memID];
 
 	// Set a canonical URL for this page.


### PR DESCRIPTION
The calculation if the user can see a user warning on the
profile summary was wrong. Leading to that users with
permission to see only their own warning status, could not
do so.
The check for if the warning system is turned on, used int
to string comparison, leading to it never evaluation to true.
This was however only checked if the user viewed their own
profile.
Corrected both these issues.

Signed-off-by: Oscar Rydhé oscar.rydhe@gmail.com