### PR TITLE
fix: Localize code headers in editor

### DIFF
--- a/Sources/Subs-Editor.php
+++ b/Sources/Subs-Editor.php
@@ -1887,7 +1887,7 @@ function create_control_richedit($editorOptions)
 	$sce_options = array(
 		'width' => isset($editorOptions['width']) ? $editorOptions['width'] : '100%',
 		'height' => isset($editorOptions['height']) ? $editorOptions['height'] : '175px',
-		'style' => $settings[file_exists($settings['theme_dir'] . '/css/jquery.sceditor.default.css') ? 'theme_url' : 'default_theme_url'] . '/css/jquery.sceditor.default.css',
+		'style' => $settings[file_exists($settings['theme_dir'] . '/css/jquery.sceditor.default.css') ? 'theme_url' : 'default_theme_url'] . '/css/jquery.sceditor.default.css' . $context['browser_cache'],
 		'emoticonsCompat' => true,
 		'colors' => 'black,maroon,brown,green,navy,grey,red,orange,teal,blue,white,hotpink,yellow,limegreen,purple',
 		'format' => 'bbcode',
@@ -1940,6 +1940,9 @@ function create_control_richedit($editorOptions)
 	}
 
 	$sce_options['toolbar'] = '';
+	$sce_options['parserOptions']['txtVars'] = [
+		'code' => $txt['code']
+	];
 	if (!empty($modSettings['enableBBC']))
 	{
 		$count_tags = count($context['bbc_tags']);

--- a/Themes/default/scripts/jquery.sceditor.smf.js
+++ b/Themes/default/scripts/jquery.sceditor.smf.js
@@ -832,7 +832,9 @@ sceditor.formats.bbcode.set(
 				return '[php]' + content.replace('&#91;', '[') + '[/php]';
 
 			var
-				title = $(element).attr('data-title'),
+				dom = sceditor.dom,
+				attr = dom.attr,
+				title = attr(element, 'data-title'),
 				from = title ?' =' + title : '';
 
 			return '[code' + from + ']' + content.replace('&#91;', '[') + '[/code]';
@@ -840,7 +842,7 @@ sceditor.formats.bbcode.set(
 		html: function (element, attrs, content) {
 			var from = attrs.defaultattr ? ' data-title="' + attrs.defaultattr + '"'  : '';
 
-			return '<code' + from + '>' + content.replace('[', '&#91;') + '</code>'
+			return '<code data-name="' + this.opts.txtVars.code + '"' + from + '>' + content.replace('[', '&#91;') + '</code>'
 		}
 	}
 );


### PR DESCRIPTION
This is the missing half of #6528.I didn't want to set a global variable like some of the other codes do, and the global namespace is already too crowded. I cannot use the logical method of sceditor.locale because the bbcode format exposes the bbcode object, not the actual editor. So I added a new  option to `parserOptions` called `txtVars`.

Also adds the browser cache variable to the editor's `iframe` stylesheet.