### PR TITLE
Add SMF_2-1_NEXT branch for next release

### DIFF
--- a/.github/workflows/crowdin_wf_next.yml
+++ b/.github/workflows/crowdin_wf_next.yml
@@ -1,9 +1,13 @@
 # CrowdIn workflow for SMF
 
-name: CrowdIn - Update SMF_2-1 branch once per release
+name: CrowdIn NEXT - Update SMF_2-1_NEXT branch periodically
 
 # Controls when the action will run. 
 on:
+  # Sundays, 7th minute, 7th hour
+  schedule:
+  - cron: "7 7 * * 0"
+
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
@@ -34,7 +38,7 @@ jobs:
         download_translations: false
         # The crowdin_branch_name is the name of the highest level folder in your "Files" tab in CrowdIn
         # At the moment, it really does not like embedded spaces (2/2021)
-        crowdin_branch_name: 'SMF_2-1'
+        crowdin_branch_name: 'SMF_2-1_NEXT'
         # Path to crowdin.yml, no leading /
         config: .github/crowdin.yml
 


### PR DESCRIPTION
Allow for periodic updates of GH code over on CrowdIn.

This goes for weekly udpates.  It will update a new, separate branch, SMF_2-1_NEXT.

@jdarwood007 - My only question here is whether you need to specify the branch on your download.  If unspecified, it will probably download both branches, SMF_2-1 & SMF_2-1_NEXT, which might interfere with your process.

So please take a look!   THX....

