### PR TITLE
Honor admin setting Don't allow post text in notifications

### DIFF
--- a/Sources/Profile-Modify.php
+++ b/Sources/Profile-Modify.php
@@ -2037,7 +2037,7 @@ function alert_configuration($memID, $defaultSettings = false)
 	$group_options = array(
 		'board' => array(
 			array('check', 'msg_auto_notify', 'label' => 'after'),
-			array('check', 'msg_receive_body', 'label' => 'after'),
+			array(empty($modSettings['disallow_sendBody']) ? 'check' : 'hide', 'msg_receive_body', 'label' => 'after'),
 			array('select', 'msg_notify_pref', 'label' => 'before', 'opts' => array(
 				0 => $txt['alert_opt_msg_notify_pref_never'],
 				1 => $txt['alert_opt_msg_notify_pref_instant'],

--- a/Sources/tasks/CreatePost-Notify.php
+++ b/Sources/tasks/CreatePost-Notify.php
@@ -216,7 +216,7 @@ class CreatePost_Notify_Background extends SMF_BackgroundTask
 
 				if ($type == 'reply')
 				{
-					if (!empty($prefs[$member_id]['msg_receive_body']))
+					if (empty($modSettings['disallow_sendBody']) && !empty($prefs[$member_id]['msg_receive_body']))
 						$message_type .= '_body';
 
 					if (!empty($frequency))
@@ -236,7 +236,7 @@ class CreatePost_Notify_Background extends SMF_BackgroundTask
 
 				$message_type = !empty($frequency) ? 'notify_boards_once' : 'notify_boards';
 
-				if (!empty($prefs[$member_id]['msg_receive_body']))
+				if (empty($modSettings['disallow_sendBody']) && !empty($prefs[$member_id]['msg_receive_body']))
 					$message_type .= '_body';
 			}
 


### PR DESCRIPTION
If the admin setting "Don't allow post text in
notifications" is enabled; hide the profile notification
setting "Receive message body in e-mails" and do not send
message texts in notifications.

Fixes #5821

Signed-off-by: Oscar Rydhé oscar.rydhe@gmail.com