### PR TITLE
During upgrade do not set force_ssl if already set

### DIFF
--- a/other/upgrade.php
+++ b/other/upgrade.php
@@ -1362,7 +1362,7 @@ function UpgradeOptions()
 	// If $boardurl reflects https, set force_ssl
 	if (!function_exists('cache_put_data'))
 		require_once($sourcedir . '/Load.php');
-	if (stripos($boardurl, 'https://') !== false)
+	if (stripos($boardurl, 'https://') !== false && !isset($modSettings['force_ssl']))
 		updateSettings(array('force_ssl' => '1'));
 
 	// If we're overriding the language follow it through.


### PR DESCRIPTION
Changing the force_ssl flag could break forums. So
if the force_ssl flag is already set, do not change it
during an upgrade.

Fixes #6564

Signed-off-by: Oscar Rydhé oscar.rydhe@gmail.com