### PR TITLE
Properly call timeformat(); get all birthdays

### DIFF
--- a/Sources/Subs-Calendar.php
+++ b/Sources/Subs-Calendar.php
@@ -39,8 +39,7 @@ function getBirthdayRange($low_date, $high_date)
 		$result = $smcFunc['db_query']('birthday_array', '
 			SELECT id_member, real_name, YEAR(birthdate) AS birth_year, birthdate
 			FROM {db_prefix}members
-			WHERE YEAR(birthdate) != {string:year_one}
-				AND MONTH(birthdate) != {int:no_month}
+			WHERE MONTH(birthdate) != {int:no_month}
 				AND DAYOFMONTH(birthdate) != {int:no_day}
 				AND YEAR(birthdate) <= {int:max_year}
 				AND (
@@ -52,7 +51,6 @@ function getBirthdayRange($low_date, $high_date)
 				'is_activated' => 1,
 				'no_month' => 0,
 				'no_day' => 0,
-				'year_one' => '1004',
 				'year_low' => $year_low . '-%m-%d',
 				'year_high' => $year_high . '-%m-%d',
 				'low_date' => $low_date,
@@ -699,15 +697,25 @@ function getCalendarList($start_date, $end_date, $calendarOptions)
 	// Give birthdays and holidays a friendly format, without the year
 	$date_format = str_replace(array('%Y', '%y', '%G', '%g', '%C', '%c', '%D'), array('', '', '', '', '', '%b %d', '%m/%d'), get_date_or_time_format('date'));
 
+	// timeformat() uses $user_info to get the format
+	if (isset($user_info['time_format']))
+		$saved_dt_format = $user_info['time_format'];
+	$user_info['time_format'] = $date_format;
 	foreach (array('birthdays', 'holidays') as $type)
 	{
 		foreach ($calendarGrid[$type] as $date => $date_content)
 		{
-			$date_local = preg_replace('~(?<=\s)0+(\d)~', '$1', trim(timeformat(strtotime($date), $date_format), " \t\n\r\0\x0B,./;:<>()[]{}\\|-_=+"));
+			// Make sure to apply no offsets
+			$date_local = preg_replace('~(?<=\s)0+(\d)~', '$1', trim(timeformat(strtotime($date), true, true), " \t\n\r\0\x0B,./;:<>()[]{}\\|-_=+"));
 
 			$calendarGrid[$type][$date]['date_local'] = $date_local;
 		}
 	}
+	// Restore it exactly as you found it
+	if (isset($saved_dt_format))
+		$user_info['time_format'] = $saved_dt_format;
+	else
+		unset($user_info['time_format']);
 
 	loadDatePicker('#calendar_range .date_input');
 	loadDatePair('#calendar_range', 'date_input', '');

--- a/Sources/Subs-Calendar.php
+++ b/Sources/Subs-Calendar.php
@@ -697,25 +697,16 @@ function getCalendarList($start_date, $end_date, $calendarOptions)
 	// Give birthdays and holidays a friendly format, without the year
 	$date_format = str_replace(array('%Y', '%y', '%G', '%g', '%C', '%c', '%D'), array('', '', '', '', '', '%b %d', '%m/%d'), get_date_or_time_format('date'));
 
-	// timeformat() uses $user_info to get the format
-	if (isset($user_info['time_format']))
-		$saved_dt_format = $user_info['time_format'];
-	$user_info['time_format'] = $date_format;
 	foreach (array('birthdays', 'holidays') as $type)
 	{
 		foreach ($calendarGrid[$type] as $date => $date_content)
 		{
 			// Make sure to apply no offsets
-			$date_local = preg_replace('~(?<=\s)0+(\d)~', '$1', trim(timeformat(strtotime($date), true, true), " \t\n\r\0\x0B,./;:<>()[]{}\\|-_=+"));
+			$date_local = preg_replace('~(?<=\s)0+(\d)~', '$1', trim(timeformat(strtotime($date), $date_format, true), " \t\n\r\0\x0B,./;:<>()[]{}\\|-_=+"));
 
 			$calendarGrid[$type][$date]['date_local'] = $date_local;
 		}
 	}
-	// Restore it exactly as you found it
-	if (isset($saved_dt_format))
-		$user_info['time_format'] = $saved_dt_format;
-	else
-		unset($user_info['time_format']);
 
 	loadDatePicker('#calendar_range .date_input');
 	loadDatePair('#calendar_range', 'date_input', '');

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -721,7 +721,7 @@ function comma_format($number, $override_decimal_count = false)
  * - performs localization (more than just strftime would do alone.)
  *
  * @param int $log_time A timestamp
- * @param bool $show_today Whether to show "Today"/"Yesterday" or just a date
+ * @param bool|string $show_today Whether to show "Today"/"Yesterday" or just a date. If a string is specified, that is used to temporarily override the date format.
  * @param bool|string $offset_type If false, uses both user time offset and forum offset. If 'forum', uses only the forum offset. Otherwise no offset is applied.
  * @param bool $process_safe Activate setlocale check for changes at runtime. Slower, but safer.
  * @return string A formatted timestamp
@@ -772,6 +772,7 @@ function timeformat($log_time, $show_today = true, $offset_type = false, $proces
 		}
 	}
 
+	// If $show_today is not a bool, use it as the date format & don't use $user_info. Allows for temp override of the format.
 	$str = !is_bool($show_today) ? $show_today : $user_info['time_format'];
 
 	// Use the cached formats if available


### PR DESCRIPTION
Fixes #5863 

The basic problem was that the call to timeformat() was applying timezone offsets, which wasn't appropriate for things like birthdays & holidays.  

While in there discovered it wasn't getting all birthdays, in particular, birthdays without years specified were dropped.

Feedback welcome,

**_BEFORE:  Note dates in list are incorrect & don't match the grid (3/17 & 3/20), birthday missing (3/18):_**
![Cal_fix_before-1](https://user-images.githubusercontent.com/23568484/111058959-f2bd4700-8446-11eb-9d97-5b0a2698530e.png)
![Cal_fix_before-2](https://user-images.githubusercontent.com/23568484/111058960-f355dd80-8446-11eb-8529-43d5277eb13d.png)


**_AFTER:  Dates are in alignment; birthday properly displayed:_**
![Cal_fix_after-2](https://user-images.githubusercontent.com/23568484/111058973-09639e00-8447-11eb-9ac2-ef8c488c5a0f.png)
![Cal_fix_after-1](https://user-images.githubusercontent.com/23568484/111058974-09fc3480-8447-11eb-9646-8f966b25e32a.png)
