### PR TITLE
Don't register twice with rapid clicks

### DIFF
--- a/Themes/default/Register.template.php
+++ b/Themes/default/Register.template.php
@@ -313,7 +313,7 @@ function template_registration_form()
 				<input type="submit" name="accept_agreement_coppa" value="', $context['coppa_agree_below'], '" class="button">';
 	else
 		echo '
-				<input type="submit" name="regSubmit" value="', $txt['register'], '" tabindex="', $context['tabindex']++, '" class="button">';
+				<input type="submit" name="regSubmit" value="', $txt['register'], '" tabindex="', $context['tabindex']++, '" class="button" onclick="this.disabled = true;form.submit();">';
 
 	echo '
 			</div>


### PR DESCRIPTION
Fixes #6207 

I have been able to reproduce the issue.  It takes disabling anything that might slow down registration, e.g., captcha, custom field registration requirements, & even browser debugger helpers.  And using a fast DB engine, e.g., pg or MySQL 8, also helps to reproduce.  

Once you do all that, I have seen doubled up registrations more than 50% of the time.  So it's a real thing.

I have performed dozens of tests before & after.  This fix works 100% of the time.


What is even more interesting, though...   Is that _before_ this change, while testing, I saw many token & session errors - familar to everyone...  After this change, I saw literally _zero_...  This really did clean things up.  **_A lot..._**

**_This approach may be helpful in other areas where we see unexplained token & session errors reported..._**

The basic idea is to disable the control (button) immediately, but to allow the rest of the submit logic to continue.