### PR TITLE
Ensure board managers can access all boards

### DIFF
--- a/Sources/Load.php
+++ b/Sources/Load.php
@@ -326,7 +326,7 @@ function reloadSettings()
 		require_once($sourcedir . '/Subs-Members.php');
 		$board_managers = groupsAllowedTo('manage_boards', null);
 		$board_managers = implode(',', $board_managers['allowed']);
-		updateSettings(array('board_manager_groups' => $board_managers), true);
+		updateSettings(array('board_manager_groups' => $board_managers));
 	}
 
 	// Is post moderation alive and well? Everywhere else assumes this has been defined, so let's make sure it is.


### PR DESCRIPTION
Fixes #5830 

If a group is given the ability to manage boards & categories, this change will follow thru & add board access for all boards to that group.  This is fixing a situation where they could actually be locked out under some circumstances (see the original issue).

Existing help text already says they will be given access to all boards.  This makes that statement true...

Also fixed a bug in which board_manager_groups was still not getting saved as a setting...  

Tested in both pg & mysql.

Note this is a one-way deal - if you remove access, we do not want board access removed for that group across all boards.  You cannot 'undo' this by just flipping the permission for that group.
