### PR TITLE
Prevent CrowdIn interface execution on forks

### DIFF
--- a/.github/workflows/crowdin_wf.yml
+++ b/.github/workflows/crowdin_wf.yml
@@ -22,9 +22,13 @@ jobs:
     steps:
 
     - name: Checkout
+      # This prevents all the forks from attempting to run the interface...
+      if: env.CROWDIN_API_TOKEN != null
       uses: actions/checkout@v2
 
     - name: crowdin-action
+      # This prevents all the forks from attempting to run the interface...
+      if: env.CROWDIN_API_TOKEN != null
       # You need to pin to a specific version for some reason...
       uses: crowdin/github-action@1.0.19
       with:

--- a/.github/workflows/crowdin_wf_next.yml
+++ b/.github/workflows/crowdin_wf_next.yml
@@ -26,9 +26,13 @@ jobs:
     steps:
 
     - name: Checkout
+      # This prevents all the forks from attempting to run the interface...
+      if: env.CROWDIN_API_TOKEN != null
       uses: actions/checkout@v2
 
     - name: crowdin-action
+      # This prevents all the forks from attempting to run the interface...
+      if: env.CROWDIN_API_TOKEN != null
       # You need to pin to a specific version for some reason...
       uses: crowdin/github-action@1.0.19
       with:


### PR DESCRIPTION
Partially addresses #6570 

This works quite nicely & will prevent the interface steps from executing if the environment is incomplete - e.g., the SECRETs aren't setup.

This will effectively prevent these interfaces from attempting to run on the 200+ SMF forks out there.

Tested fine on my test CrowdIn repo.

Note that the execution is fully GREEN - looks successful - when completed on the forks.