### PR TITLE
Move max attachments logic to javascript

### DIFF
--- a/Sources/Post.php
+++ b/Sources/Post.php
@@ -1218,7 +1218,7 @@ function Post($post_errors = array())
 	if ($context['can_post_attachment'])
 	{
 		// If they've unchecked an attachment, they may still want to attach that many more files, but don't allow more than num_allowed_attachments.
-		$context['num_allowed_attachments'] = min(ini_get('max_file_uploads'), (empty($modSettings['attachmentNumPerPostLimit']) ? 50 : $modSettings['attachmentNumPerPostLimit'] - count($context['current_attachments'])));
+		$context['num_allowed_attachments'] = min(ini_get('max_file_uploads'), (empty($modSettings['attachmentNumPerPostLimit']) ? 50 : $modSettings['attachmentNumPerPostLimit']));
 		$context['can_post_attachment_unapproved'] = allowedTo('post_attachment');
 		$context['attachment_restrictions'] = array();
 		$context['allowed_extensions'] = !empty($modSettings['attachmentCheckExtensions']) ? (strtr(strtolower($modSettings['attachmentExtensions']), array(',' => ', '))) : '';
@@ -1228,7 +1228,7 @@ function Post($post_errors = array())
 			{
 				// Show the max number of attachments if not 0.
 				if ($type == 'attachmentNumPerPostLimit')
-					$context['attachment_restrictions'][] = sprintf($txt['attach_remaining'], $modSettings['attachmentNumPerPostLimit'] - $context['attachments']['quantity']);
+					$context['attachment_restrictions'][] = sprintf($txt['attach_remaining'], max($modSettings['attachmentNumPerPostLimit'] - $context['attachments']['quantity'], 0));
 			}
 	}
 

--- a/Themes/default/Post.template.php
+++ b/Themes/default/Post.template.php
@@ -437,7 +437,7 @@ function template_main()
 			echo '
 								', $txt['attach_restrictions'], ' ', implode(', ', $context['attachment_restrictions']), '<br>';
 
-		if ($context['num_allowed_attachments'] == 0)
+		if ($context['num_allowed_attachments'] <= count($context['current_attachments']))
 			echo '
 								', $txt['attach_limit_nag'], '<br>';
 

--- a/Themes/default/scripts/smf_fileUpload.js
+++ b/Themes/default/scripts/smf_fileUpload.js
@@ -227,7 +227,7 @@ function smf_fileUpload(oOptions) {
 								file.accepted = false;
 
 								// Show the current amount of remaining files
-								$('.attach_remaining').html(myDropzone.options.maxFileAmount - myDropzone.getAcceptedFiles().length);
+								$('.attach_remaining').html(Math.max(myDropzone.options.maxFileAmount - myDropzone.getAcceptedFiles().length, 0));
 
 								myDropzone.options.hideFileProgressAndAllButtonsIfNeeded();
 							}
@@ -247,7 +247,7 @@ function smf_fileUpload(oOptions) {
 				.appendTo(_innerElement.find('.attach-ui'));
 
 				// Show the current amount of remaining files
-				$('.attach_remaining').html(myDropzone.options.maxFileAmount - myDropzone.getAcceptedFiles().length);
+				$('.attach_remaining').html(Math.max(myDropzone.options.maxFileAmount - myDropzone.getAcceptedFiles().length, 0));
 		};
 
 		// The editor needs this to know how to handle embedded attachements
@@ -524,6 +524,10 @@ function smf_fileUpload(oOptions) {
 			mock.accepted = true;
 
 			myDropzone.emit("addedfile", mock);
+
+			// Add to the files list
+			mock.status = Dropzone.SUCCESS;
+			myDropzone.files.push(mock);
 
 			// This file is "completed".
 			myDropzone.emit("complete", mock);


### PR DESCRIPTION
The logic of how many attachments remaining that could
be uploaded was handled in PHP. This resulted in that if
the max amount of attachments was attached to a post.
If modifying it, you could not remove an attachment and
add another one, without saving it in between.
Move this logic into javascript, to solve this issue.
Also clamped the remaining attatchment counter to 0.

Fixes #6582

Signed-off-by: Oscar Rydhé oscar.rydhe@gmail.com