### PR TITLE
Fix error when editing language file with arrays

### DIFF
--- a/Sources/ManageLanguages.php
+++ b/Sources/ManageLanguages.php
@@ -1148,7 +1148,7 @@ function ModifyLanguage()
 				continue;
 
 			// These are arrays that need breaking out.
-			if (strpos($entryValue['entry'], 'array(') === 0 && strpos($entryValue['entry'], ')', -1) === strlen($entryValue['entry']) - 1)
+			if (strpos($entryValue['entry'], 'array(') === 0 && substr($entryValue['entry'], -1) === ')')
 			{
 				// No, you may not use multidimensional arrays of $txt strings. Madness stalks that path.
 				if (isset($entryValue['subkey']))


### PR DESCRIPTION
If using PHP 5.6 and editing a language file containing
arrays, an error was reported to the error log. Fixed that.

Signed-off-by: Oscar Rydhé oscar.rydhe@gmail.com