### PR TITLE
Issues with bypassing steps on forks

### DIFF
--- a/.github/workflows/crowdin_wf.yml
+++ b/.github/workflows/crowdin_wf.yml
@@ -22,13 +22,9 @@ jobs:
     steps:
 
     - name: Checkout
-      # This prevents all the forks from attempting to run the interface...
-      if: env.CROWDIN_API_TOKEN != null
       uses: actions/checkout@v2
 
     - name: crowdin-action
-      # This prevents all the forks from attempting to run the interface...
-      if: env.CROWDIN_API_TOKEN != null
       # You need to pin to a specific version for some reason...
       uses: crowdin/github-action@1.0.19
       with:

--- a/.github/workflows/crowdin_wf_next.yml
+++ b/.github/workflows/crowdin_wf_next.yml
@@ -26,13 +26,9 @@ jobs:
     steps:
 
     - name: Checkout
-      # This prevents all the forks from attempting to run the interface...
-      if: env.CROWDIN_API_TOKEN != null
       uses: actions/checkout@v2
 
     - name: crowdin-action
-      # This prevents all the forks from attempting to run the interface...
-      if: env.CROWDIN_API_TOKEN != null
       # You need to pin to a specific version for some reason...
       uses: crowdin/github-action@1.0.19
       with:


### PR DESCRIPTION
Reverting #6580 until a better long-term solution is found.

Note this worked perfectly bypassing the steps on the forks, however, it interfered with actual push execution from SMF.  Last week's execution failed.

For more info see: https://github.com/crowdin/github-action/issues/62