### PR TITLE
Remove double periods on credits page

### DIFF
--- a/Themes/default/languages/Who.english.php
+++ b/Themes/default/languages/Who.english.php
@@ -201,11 +201,11 @@ $txt['credits_version'] = 'Version';
 // Replace "English" with the name of this language pack in the string below.
 $txt['credits_groups_translation'] = 'English Translation';
 $txt['credits_groups_translators'] = 'Language Translators';
-$txt['credits_translators_message'] = 'Thank you for your efforts which make it possible for people all around the world to use SMF.';
+$txt['credits_translators_message'] = 'Thank you for your efforts which make it possible for people all around the world to use SMF';
 $txt['credits_groups_consultants'] = 'Consulting Developers';
 $txt['credits_code_contributors'] = 'everyone who <a href="https://github.com/SimpleMachines/SMF2.1/graphs/contributors">contributed on GitHub</a>';
 $txt['credits_groups_beta'] = 'Beta Testers';
-$txt['credits_beta_message'] = 'The invaluable few who tirelessly find bugs, provide feedback, and drive the developers crazier.';
+$txt['credits_beta_message'] = 'The invaluable few who tirelessly find bugs, provide feedback, and drive the developers crazier';
 $txt['credits_groups_founder'] = 'Founding Father of SMF';
 $txt['credits_groups_orignal_pm'] = 'Original Project Managers';
 $txt['credits_in_memoriam'] = 'In loving memory of';


### PR DESCRIPTION
All names in the credits page are sent through the sentence_list
to format it according to a list. This will add a period to the end.
Remove periods from two strings to avoid double periods.

Signed-off-by: Oscar Rydhé oscar.rydhe@gmail.com