### PR TITLE
More CrowdIn-friendly line feeds

### DIFF
--- a/Themes/default/languages/Admin.english.php
+++ b/Themes/default/languages/Admin.english.php
@@ -130,8 +130,12 @@ $txt['ip_address'] = 'IP address';
 $txt['member_id'] = 'ID';
 
 $txt['unknown'] = 'unknown';
+
 // argument(s): HTTP_REFERER (if applicable), HTTP_USER_AGENT, ip address
-$txt['security_wrong'] = "Administration login attempt!\nReferrer: %1\$s\nUser agent: %2\$s\nIP: %3\$s";
+$txt['security_wrong'] = 'Administration login attempt!
+Referrer: %1$s
+User agent: %2$s
+IP: %3$s';
 
 $txt['email_as_html'] = 'Send in HTML format. (with this you can put normal HTML in the email.)';
 $txt['email_parsed_html'] = 'Add &lt;br&gt;s and &amp;nbsp;s to this message.';

--- a/Themes/default/languages/Profile.english.php
+++ b/Themes/default/languages/Profile.english.php
@@ -463,11 +463,29 @@ $txt['profile_warning_notify_template'] = 'Select template:';
 $txt['profile_warning_notify_subject'] = 'Notification Subject';
 $txt['profile_warning_notify_body'] = 'Notification Message';
 $txt['profile_warning_notify_template_subject'] = 'You have received a warning';
+
 // Use numeric entities in below string.
 // argument(s): one of the reasons defined in $txt['profile_warning_notify_for_*']
-$txt['profile_warning_notify_template_outline'] = "{MEMBER},\n\nYou have received a warning for %1\$s. Please cease these activities and abide by the forum rules otherwise we will take further action.\n\nIf you wish to discuss this, please get in touch with an administrator.\n\n{REGARDS}";
+$txt['profile_warning_notify_template_outline'] = '{MEMBER},
+
+You have received a warning for %1$s. Please cease these activities and abide by the forum rules otherwise we will take further action.
+
+If you wish to discuss this, please get in touch with an administrator.
+
+{REGARDS}';
+
 // argument(s): one of the reasons defined in $txt['profile_warning_notify_for_*']
-$txt['profile_warning_notify_template_outline_post'] = "{MEMBER},\n\nYou have received a warning for %1\$s in regards to the message:\n{MESSAGE}.\n\nPlease cease these activities and abide by the forum rules otherwise we will take further action.\n\nIf you wish to discuss this, please get in touch with an administrator.\n\n{REGARDS}";
+$txt['profile_warning_notify_template_outline_post'] = '{MEMBER},
+
+You have received a warning for %1$s in regards to the message:
+{MESSAGE}.
+
+Please cease these activities and abide by the forum rules otherwise we will take further action.
+
+If you wish to discuss this, please get in touch with an administrator.
+
+{REGARDS}';
+
 $txt['profile_warning_notify_for_spamming'] = 'spamming';
 $txt['profile_warning_notify_title_spamming'] = 'Spamming';
 $txt['profile_warning_notify_for_offence'] = 'posting offensive material';

--- a/Themes/default/languages/index.english.php
+++ b/Themes/default/languages/index.english.php
@@ -145,9 +145,12 @@ $txt['unwatch_topic'] = 'Stop watching Topic';
 $txt['watching_this_topic'] = 'You are watching this topic, and will receive notifications about it.';
 $txt['notify'] = 'Notify';
 $txt['unnotify'] = 'Unnotify';
+
 // Use numeric entities in the below string.
 // argument(s): forum name
-$txt['regards_team'] = "Regards,\nThe %1\$s Team.";
+$txt['regards_team'] = 'Regards,
+The %1$s Team.';
+
 $txt['notify_replies'] = 'Notify of replies';
 $txt['move_topic'] = 'Move Topic';
 $txt['move_to'] = 'Move to';
@@ -537,8 +540,12 @@ $txt['movetopic_change_all_subjects'] = 'Change every message\'s subject';
 $txt['move_topic_unapproved_js'] = 'Warning! This topic has not yet been approved.\\n\\nIt is not recommended that you create a redirection topic unless you intend to approve the post immediately following the move.';
 $txt['movetopic_auto_board'] = '[BOARD]';
 $txt['movetopic_auto_topic'] = '[TOPIC LINK]';
+
 // argument(s): $txt['movetopic_auto_board'], $txt['movetopic_auto_topic']
-$txt['movetopic_default'] = "This topic has been moved to %1\$s.\n\n%2\$s";
+$txt['movetopic_default'] = 'This topic has been moved to %1$s.
+
+%2$s';
+
 $txt['movetopic_redirect'] = 'Redirect to the moved topic';
 
 $txt['post_redirection'] = 'Post a redirection topic';


### PR DESCRIPTION
Fixes #6597 

When passing arguments to language strings that also had line feeds in them, we sometimes used double quotes around the strings & \n to represent the line feed.  The problem is that the arguments then needed escaping, e.g., %1$s became %1\\$s, and CrowdIn would not export the string properly.  

The fix is to stop using double-quotes around arguments, so we do not have to escape the $.  Fortunately, there are very few strings that need changing.  

**_I had considered 3 options, and <ins>all worked</ins>, but using real line feeds was the cleanest for the translators. The string remained one string, and appeared as expected in the CrowdIn UI:_**
![real-lfs-s](https://user-images.githubusercontent.com/23568484/112403433-a3d7a300-8ccb-11eb-9b33-dfe5cd398bd3.png)
In CrowdIn:
![real-lfs-t](https://user-images.githubusercontent.com/23568484/112403434-a4703980-8ccb-11eb-9d66-1a9e5f0320ce.png)


**_Segregating the line feeds & using double-quotes solely for them worked, but split the string into multiple strings & noted there was whitespace between them:_**
![dq-seg-s](https://user-images.githubusercontent.com/23568484/112403475-b651dc80-8ccb-11eb-8f02-52aace2fdd61.png)
In CrowdIn:
![dq-seg-t](https://user-images.githubusercontent.com/23568484/112403476-b6ea7300-8ccb-11eb-8680-280dd0354aa6.png)


**_Using PHP_EOL constant was a little cleaner, but still split the string into multiple strings:_**
![const-s](https://user-images.githubusercontent.com/23568484/112403452-ab974780-8ccb-11eb-968b-af5c95c2d709.png)
In CrowdIn:
![const-t](https://user-images.githubusercontent.com/23568484/112403454-ac2fde00-8ccb-11eb-9f5f-09bad23ac9a4.png)
