### PR TITLE
Convert dates to english

### DIFF
--- a/Sources/Calendar.php
+++ b/Sources/Calendar.php
@@ -113,7 +113,7 @@ function CalendarMain()
 	// Need a start date for all views
 	if (!empty($_REQUEST['start_date']))
 	{
-		$start_parsed = date_parse($_REQUEST['start_date']);
+		$start_parsed = date_parse(convertDateToEnglish($_REQUEST['start_date']));
 		if (empty($start_parsed['error_count']) && empty($start_parsed['warning_count']))
 		{
 			$_REQUEST['year'] = $start_parsed['year'];
@@ -130,7 +130,7 @@ function CalendarMain()
 	// Need an end date for the list view
 	if (!empty($_REQUEST['end_date']))
 	{
-		$end_parsed = date_parse($_REQUEST['end_date']);
+		$end_parsed = date_parse(convertDateToEnglish($_REQUEST['end_date']));
 		if (empty($end_parsed['error_count']) && empty($end_parsed['warning_count']))
 		{
 			$_REQUEST['end_year'] = $end_parsed['year'];

--- a/Sources/Subs-Calendar.php
+++ b/Sources/Subs-Calendar.php
@@ -1060,7 +1060,7 @@ function validateEventPost()
 		// The 2.1 way
 		if (isset($_POST['start_date']))
 		{
-			$d = date_parse($_POST['start_date']);
+			$d = date_parse(convertDateToEnglish($_POST['start_date']));
 			if (!empty($d['error_count']) || !empty($d['warning_count']))
 				fatal_lang_error('invalid_date', false);
 			if (empty($d['year']))
@@ -1070,7 +1070,7 @@ function validateEventPost()
 		}
 		elseif (isset($_POST['start_datetime']))
 		{
-			$d = date_parse($_POST['start_datetime']);
+			$d = date_parse(convertDateToEnglish($_POST['start_datetime']));
 			if (!empty($d['error_count']) || !empty($d['warning_count']))
 				fatal_lang_error('invalid_date', false);
 			if (empty($d['year']))
@@ -1579,7 +1579,7 @@ function setEventStartEnd($eventOptions = array())
 	// If some form of string input was given, override individually defined options with it
 	if (isset($start_string))
 	{
-		$start_string_parsed = date_parse($start_string);
+		$start_string_parsed = date_parse(convertDateToEnglish($start_string));
 		if (empty($start_string_parsed['error_count']) && empty($start_string_parsed['warning_count']))
 		{
 			if ($start_string_parsed['year'] != false)
@@ -1598,7 +1598,7 @@ function setEventStartEnd($eventOptions = array())
 	}
 	if (isset($end_string))
 	{
-		$end_string_parsed = date_parse($end_string);
+		$end_string_parsed = date_parse(convertDateToEnglish($end_string));
 		if (empty($end_string_parsed['error_count']) && empty($end_string_parsed['warning_count']))
 		{
 			if ($end_string_parsed['year'] != false)
@@ -1861,6 +1861,51 @@ function removeHolidays($holiday_ids)
 	updateSettings(array(
 		'calendar_updated' => time(),
 	));
+}
+
+/**
+ * Helper function to convert date string to english
+ * so that date_parse can parse the date
+ *
+ * @param string $date A localized date string
+ * @return string English date string
+ */
+function convertDateToEnglish($date)
+{
+	global $txt, $context;
+
+	if ($context['user']['language'] == 'english')
+		return $date;
+
+	$replacements = array_combine(array_map('strtolower', $txt['months_titles']), array(
+		'January', 'February', 'March', 'April', 'May', 'June',
+		'July', 'August', 'September', 'October', 'November', 'December'
+	));
+	$replacements += array_combine(array_map('strtolower', $txt['months_short']), array(
+		'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+		'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'
+	));
+	$replacements += array_combine(array_map('strtolower', $txt['days']), array(
+		'Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'
+	));
+	$replacements += array_combine(array_map('strtolower', $txt['days_short']), array(
+		'Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'
+	));
+	// Find all possible variants of AM and PM for this language.
+	$replacements[strtolower($txt['time_am'])] = 'AM';
+	$replacements[strtolower($txt['time_pm'])] = 'PM';
+	if (($am = strftime('%p', strtotime('01:00:00'))) !== 'p' && $am !== false)
+	{
+		$replacements[strtolower($am)] = 'AM';
+		$replacements[strtolower(strftime('%p', strtotime('23:00:00')))] = 'PM';
+	}
+	if (($am = strftime('%P', strtotime('01:00:00'))) !== 'P' && $am !== false)
+	{
+		$replacements[strtolower($am)] = 'AM';
+		$replacements[strtolower(strftime('%P', strtotime('23:00:00')))] = 'PM';
+	}
+
+	return strtr(strtolower($date), $replacements);
 }
 
 ?>

--- a/Themes/default/Calendar.template.php
+++ b/Themes/default/Calendar.template.php
@@ -729,12 +729,12 @@ function template_calendar_top($calendar_data)
 
 	echo '
 			<form action="', $scripturl, '?action=calendar;', $context['calendar_view'], '" id="', !empty($calendar_data['end_date']) ? 'calendar_range' : 'calendar_navigation', '" method="post" accept-charset="', $context['character_set'], '">
-				<input type="text" name="start_date" id="start_date" maxlength="10" value="', $calendar_data['start_date'], '" tabindex="', $context['tabindex']++, '" class="date_input start" data-type="date">';
+				<input type="text" name="start_date" id="start_date" maxlength="10" value="', trim($calendar_data['start_date']), '" tabindex="', $context['tabindex']++, '" class="date_input start" data-type="date">';
 
 	if (!empty($calendar_data['end_date']))
 		echo '
 				<span>', strtolower($txt['to']), '</span>
-				<input type="text" name="end_date" id="end_date" maxlength="10" value="', $calendar_data['end_date'], '" tabindex="', $context['tabindex']++, '" class="date_input end" data-type="date">';
+				<input type="text" name="end_date" id="end_date" maxlength="10" value="', trim($calendar_data['end_date']), '" tabindex="', $context['tabindex']++, '" class="date_input end" data-type="date">';
 
 	echo '
 				<input type="submit" class="button" style="float:none" id="view_button" value="', $txt['view'], '">
@@ -824,13 +824,13 @@ function template_event_post()
 						<div class="event_options_left" id="event_time_input">
 							<div>
 								<span class="label">', $txt['start'], '</span>
-								<input type="text" name="start_date" id="start_date" maxlength="10" value="', $context['event']['start_date'], '" tabindex="', $context['tabindex']++, '" class="date_input start" data-type="date">
-								<input type="text" name="start_time" id="start_time" maxlength="11" value="', $context['event']['start_time_local'], '" tabindex="', $context['tabindex']++, '" class="time_input start" data-type="time"', !empty($context['event']['allday']) ? ' disabled' : '', '>
+								<input type="text" name="start_date" id="start_date" maxlength="10" value="', trim($context['event']['start_date_orig']), '" tabindex="', $context['tabindex']++, '" class="date_input start" data-type="date">
+								<input type="text" name="start_time" id="start_time" maxlength="11" value="', $context['event']['start_time_orig'], '" tabindex="', $context['tabindex']++, '" class="time_input start" data-type="time"', !empty($context['event']['allday']) ? ' disabled' : '', '>
 							</div>
 							<div>
 								<span class="label">', $txt['end'], '</span>
-								<input type="text" name="end_date" id="end_date" maxlength="10" value="', $context['event']['end_date'], '" tabindex="', $context['tabindex']++, '" class="date_input end" data-type="date"', $modSettings['cal_maxspan'] == 1 ? ' disabled' : '', '>
-								<input type="text" name="end_time" id="end_time" maxlength="11" value="', $context['event']['end_time_local'], '" tabindex="', $context['tabindex']++, '" class="time_input end" data-type="time"', !empty($context['event']['allday']) ? ' disabled' : '', '>
+								<input type="text" name="end_date" id="end_date" maxlength="10" value="', trim($context['event']['end_date_orig']), '" tabindex="', $context['tabindex']++, '" class="date_input end" data-type="date"', $modSettings['cal_maxspan'] == 1 ? ' disabled' : '', '>
+								<input type="text" name="end_time" id="end_time" maxlength="11" value="', $context['event']['end_time_orig'], '" tabindex="', $context['tabindex']++, '" class="time_input end" data-type="time"', !empty($context['event']['allday']) ? ' disabled' : '', '>
 							</div>
 						</div><!-- #event_time_input -->
 						<div class="event_options_right" id="event_time_options">

--- a/Themes/default/Post.template.php
+++ b/Themes/default/Post.template.php
@@ -154,13 +154,13 @@ function template_main()
 								<div class="event_options_left" id="event_time_input">
 									<div>
 										<span class="label">', $txt['start'], '</span>
-										<input type="text" name="start_date" id="start_date" maxlength="10" value="', $context['event']['start_date'], '" tabindex="', $context['tabindex']++, '" class="date_input start" data-type="date">
-										<input type="text" name="start_time" id="start_time" maxlength="11" value="', $context['event']['start_time'], '" tabindex="', $context['tabindex']++, '" class="time_input start" data-type="time"', !empty($context['event']['allday']) ? ' disabled' : '', '>
+										<input type="text" name="start_date" id="start_date" maxlength="10" value="', trim($context['event']['start_date_orig']), '" tabindex="', $context['tabindex']++, '" class="date_input start" data-type="date">
+										<input type="text" name="start_time" id="start_time" maxlength="11" value="', $context['event']['start_time_orig'], '" tabindex="', $context['tabindex']++, '" class="time_input start" data-type="time"', !empty($context['event']['allday']) ? ' disabled' : '', '>
 									</div>
 									<div>
 										<span class="label">', $txt['end'], '</span>
-										<input type="text" name="end_date" id="end_date" maxlength="10" value="', $context['event']['end_date'], '" tabindex="', $context['tabindex']++, '" class="date_input end" data-type="date"', $modSettings['cal_maxspan'] == 1 ? ' disabled' : '', '>
-										<input type="text" name="end_time" id="end_time" maxlength="11" value="', $context['event']['end_time'], '" tabindex="', $context['tabindex']++, '" class="time_input end" data-type="time"', !empty($context['event']['allday']) ? ' disabled' : '', '>
+										<input type="text" name="end_date" id="end_date" maxlength="10" value="', trim($context['event']['end_date_orig']), '" tabindex="', $context['tabindex']++, '" class="date_input end" data-type="date"', $modSettings['cal_maxspan'] == 1 ? ' disabled' : '', '>
+										<input type="text" name="end_time" id="end_time" maxlength="11" value="', $context['event']['end_time_orig'], '" tabindex="', $context['tabindex']++, '" class="time_input end" data-type="time"', !empty($context['event']['allday']) ? ' disabled' : '', '>
 									</div>
 								</div>
 								<div class="event_options_right" id="event_time_options">


### PR DESCRIPTION
date_parse can only parse english dates.
If the forum is in another language, convert
month names to english before convertion.
Also format dates in Post Event screen in user
defined format.

Fixes #6631

Signed-off-by: Oscar Rydhé oscar.rydhe@gmail.com