### PR TITLE
Remove trailing colon from event time

### DIFF
--- a/Sources/Calendar.php
+++ b/Sources/Calendar.php
@@ -293,6 +293,8 @@ function CalendarPost()
 		'%T' => '%l:%M',
 	));
 
+	$time_string = preg_replace('~:(?=\s|$|%[pPzZ])~', '', $time_string);
+
 	// Submitting?
 	if (isset($_POST[$context['session_var']], $_REQUEST['eventid']))
 	{

--- a/Sources/Post.php
+++ b/Sources/Post.php
@@ -296,6 +296,8 @@ function Post($post_errors = array())
 			'%T' => '%l:%M',
 		));
 
+		$time_string = preg_replace('~:(?=\s|$|%[pPzZ])~', '', $time_string);
+
 		// Editing an event?  (but NOT previewing!?)
 		if (empty($context['event']['new']) && !isset($_REQUEST['subject']))
 		{

--- a/Sources/Subs-Calendar.php
+++ b/Sources/Subs-Calendar.php
@@ -1737,6 +1737,8 @@ function buildEventDatetimes($row)
 			'%T' => '%l:%M',
 		));
 
+	$time_format = preg_replace('~:(?=\s|$|%[pPzZ])~', '', $time_format);
+
 	// Should this be an all day event?
 	$allday = (empty($row['start_time']) || empty($row['end_time']) || empty($row['timezone']) || !in_array($row['timezone'], timezone_identifiers_list(DateTimeZone::ALL_WITH_BC))) ? true : false;
 


### PR DESCRIPTION
When creating a new event, the time box had a trailing colon, like
9:10: or 9:10: am. Removed that.

Signed-off-by: Oscar Rydhé oscar.rydhe@gmail.com