### PR TITLE
Correct previous and next month in calendar

### DIFF
--- a/Sources/Subs-Calendar.php
+++ b/Sources/Subs-Calendar.php
@@ -406,10 +406,10 @@ function getCalendarGrid($selected_date, $calendarOptions, $is_previous = false)
 	$selected_object = date_create($selected_date);
 
 	$next_object = date_create($selected_date);
-	date_add($next_object, date_interval_create_from_date_string('1 month'));
+	$next_object->modify('first day of next month');
 
 	$prev_object = date_create($selected_date);
-	date_sub($prev_object, date_interval_create_from_date_string('1 month'));
+	$prev_object->modify('first day of previous month');
 
 	// Eventually this is what we'll be returning.
 	$calendarGrid = array(


### PR DESCRIPTION
Sometimes if selecting a date in the beginning or end of
the month, the previous and next month was incorrectly
calculated.
This was because we added or subtracted "1 month" to the
current date. PHP treats 1 month as 31 days. So if the current
month has less than 31 days the calculation is wrong.
Insted use "first day of next month" and
"first day of previous month".

Signed-off-by: Oscar Rydhé oscar.rydhe@gmail.com