### PR TITLE
Avoid double javascripts for date picker

### DIFF
--- a/Sources/Calendar.php
+++ b/Sources/Calendar.php
@@ -199,15 +199,15 @@ function CalendarMain()
 		$context['calendar_grid_main'] = getCalendarGrid($curPage['start_date'], $calendarOptions);
 
 	// Load up the previous and next months.
-	$context['calendar_grid_current'] = getCalendarGrid($curPage['start_date'], $calendarOptions);
+	$context['calendar_grid_current'] = getCalendarGrid($curPage['start_date'], $calendarOptions, false, false);
 
 	// Only show previous month if it isn't pre-January of the min-year
 	if ($context['calendar_grid_current']['previous_calendar']['year'] > $modSettings['cal_minyear'] || $curPage['month'] != 1)
-		$context['calendar_grid_prev'] = getCalendarGrid($context['calendar_grid_current']['previous_calendar']['start_date'], $calendarOptions, true);
+		$context['calendar_grid_prev'] = getCalendarGrid($context['calendar_grid_current']['previous_calendar']['start_date'], $calendarOptions, true, false);
 
 	// Only show next month if it isn't post-December of the max-year
 	if ($context['calendar_grid_current']['next_calendar']['year'] < $modSettings['cal_maxyear'] || $curPage['month'] != 12)
-		$context['calendar_grid_next'] = getCalendarGrid($context['calendar_grid_current']['next_calendar']['start_date'], $calendarOptions);
+		$context['calendar_grid_next'] = getCalendarGrid($context['calendar_grid_current']['next_calendar']['start_date'], $calendarOptions, false, false);
 
 	// Basic template stuff.
 	$context['allow_calendar_event'] = allowedTo('calendar_post');

--- a/Sources/Subs-Calendar.php
+++ b/Sources/Subs-Calendar.php
@@ -397,9 +397,10 @@ function getTodayInfo()
  * @param string $selected_date A date in YYYY-MM-DD format
  * @param array $calendarOptions An array of calendar options
  * @param bool $is_previous Whether this is the previous month
+ * @param bool $has_picker Wheter to add javascript to handle a date picker
  * @return array A large array containing all the information needed to show a calendar grid for the given month
  */
-function getCalendarGrid($selected_date, $calendarOptions, $is_previous = false)
+function getCalendarGrid($selected_date, $calendarOptions, $is_previous = false, $has_picker = true)
 {
 	global $scripturl, $modSettings;
 
@@ -536,8 +537,11 @@ function getCalendarGrid($selected_date, $calendarOptions, $is_previous = false)
 	$calendarGrid['previous_calendar']['href'] = $scripturl . '?action=calendar;viewmonth;year=' . $calendarGrid['previous_calendar']['year'] . ';month=' . $calendarGrid['previous_calendar']['month'] . ';day=' . $calendarGrid['previous_calendar']['day'];
 	$calendarGrid['next_calendar']['href'] = $scripturl . '?action=calendar;viewmonth;year=' . $calendarGrid['next_calendar']['year'] . ';month=' . $calendarGrid['next_calendar']['month'] . ';day=' . $calendarGrid['previous_calendar']['day'];
 
-	loadDatePicker('#calendar_navigation .date_input');
-	loadDatePair('#calendar_navigation', 'date_input');
+	if ($has_picker)
+	{
+		loadDatePicker('#calendar_navigation .date_input');
+		loadDatePair('#calendar_navigation', 'date_input');
+	}
 
 	return $calendarGrid;
 }


### PR DESCRIPTION
To handle the date picker some javascript needs to be added.
This is done by the functions that creates the calendar views.
This function also creates the views for the mini calendars,
resulting in adding the same javascript four times.
Only add javascript when it is needed.

Signed-off-by: Oscar Rydhé oscar.rydhe@gmail.com