### PR TITLE
Do not log error when attachmentUploadDir decoding fails

### DIFF
--- a/Sources/Load.php
+++ b/Sources/Load.php
@@ -69,7 +69,7 @@ function reloadSettings()
 		// We explicitly do not use $smcFunc['json_decode'] here yet, as $smcFunc is not fully loaded.
 		if (!is_array($modSettings['attachmentUploadDir']))
 		{
-			$attachmentUploadDir = smf_json_decode($modSettings['attachmentUploadDir'], true);
+			$attachmentUploadDir = smf_json_decode($modSettings['attachmentUploadDir'], true, false);
 			$modSettings['attachmentUploadDir'] = !empty($attachmentUploadDir) ? $attachmentUploadDir : $modSettings['attachmentUploadDir'];
 		}
 


### PR DESCRIPTION
Since not all data is loaded at this time it is not
possible to write to the log.

Fixes #6663

Signed-off-by: Oscar Rydhé oscar.rydhe@gmail.com