### PR TITLE
Add periods to upgrader strings

### DIFF
--- a/Themes/default/languages/Install.english.php
+++ b/Themes/default/languages/Install.english.php
@@ -270,8 +270,8 @@ $txt['upgrade_maintenance'] = 'Put the forum into maintenance mode during upgrad
 $txt['upgrade_maintenance_title'] = 'Maintenance Title:';
 $txt['upgrade_maintenance_message'] = 'Maintenance Message:';
 $txt['upgrade_customize'] = 'Customize';
-$txt['upgrade_debug_info'] = 'Output extra debugging information';
-$txt['upgrade_empty_errorlog'] = 'Empty error log before upgrading';
+$txt['upgrade_debug_info'] = 'Output extra debugging information.';
+$txt['upgrade_empty_errorlog'] = 'Empty error log before upgrading.';
 $txt['upgrade_delete_karma'] = 'Delete all karma settings and info from the DB';
 $txt['upgrade_stats_collection'] = 'Allow Simple Machines to collect basic stats monthly.';
 $txt['upgrade_stats_info'] = 'If enabled, this will allow Simple Machines to visit your site once a month to collect basic statistics. This will help us make decisions as to which configurations to optimise the software for. For more information please visit our <a href="%1$s" target="_blank" rel="noopener">info page</a>.';


### PR DESCRIPTION
All other options in the upgrader ends with a period
but these two.

Signed-off-by: Oscar Rydhé <oscar.rydhe@sony.com>