### PR TITLE
Avoid error if no smileys are defined

### DIFF
--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -3283,6 +3283,10 @@ function parsesmileys(&$message)
 		$smileyPregSearch = '~(?<=[>:\?\.\s' . $non_breaking_space . '[\]()*\\\;]|(?<![a-zA-Z0-9])\(|^)(' . build_regex($searchParts, '~') . ')(?=[^[:alpha:]0-9]|$)~' . ($context['utf8'] ? 'u' : '');
 	}
 
+	// If there are no smileys defined, no need to replace anything
+	if (empty($smileyPregReplacements))
+		return;
+
 	// Replace away!
 	$message = preg_replace_callback($smileyPregSearch, function($matches) use ($smileyPregReplacements)
 		{


### PR DESCRIPTION
If no smileys are defined, return before doing the
replacement, to avoid any errors.

Signed-off-by: Oscar Rydhé <oscar.rydhe@gmail.com>