### PR TITLE
Backup karma data

### DIFF
--- a/other/upgrade.php
+++ b/other/upgrade.php
@@ -1299,55 +1299,10 @@ function UpgradeOptions()
 		);
 
 	// Deleting old karma stuff?
-	if (!empty($_POST['delete_karma']))
-	{
-		// Delete old settings vars.
-		$smcFunc['db_query']('', '
-			DELETE FROM {db_prefix}settings
-			WHERE variable IN ({array_string:karma_vars})',
-			array(
-				'karma_vars' => array('karmaMode', 'karmaTimeRestrictAdmins', 'karmaWaitTime', 'karmaMinPosts', 'karmaLabel', 'karmaSmiteLabel', 'karmaApplaudLabel'),
-			)
-		);
-
-		// Cleaning up old karma member settings.
-		if ($upcontext['karma_installed']['good'])
-			$smcFunc['db_query']('', '
-				ALTER TABLE {db_prefix}members
-				DROP karma_good',
-				array()
-			);
-
-		// Does karma bad was enable?
-		if ($upcontext['karma_installed']['bad'])
-			$smcFunc['db_query']('', '
-				ALTER TABLE {db_prefix}members
-				DROP karma_bad',
-				array()
-			);
-
-		// Cleaning up old karma permissions.
-		$smcFunc['db_query']('', '
-			DELETE FROM {db_prefix}permissions
-			WHERE permission = {string:karma_vars}',
-			array(
-				'karma_vars' => 'karma_edit',
-			)
-		);
-		// Cleaning up old log_karma table
-		$smcFunc['db_query']('', '
-			DROP TABLE IF EXISTS {db_prefix}log_karma',
-			array()
-		);
-	}
+	$_SESSION['delete_karma'] = !empty($_POST['delete_karma']);
 
 	// Emptying the error log?
-	if (!empty($_POST['empty_error']))
-		$smcFunc['db_query']('truncate_table', '
-			TRUNCATE {db_prefix}log_errors',
-			array(
-			)
-		);
+	$_SESSION['empty_error'] = !empty($_POST['empty_error']);
 
 	$changes = array();
 
@@ -1587,6 +1542,9 @@ function DatabaseChanges()
 
 	$upcontext['sub_template'] = isset($_GET['xml']) ? 'database_xml' : 'database_changes';
 	$upcontext['page_title'] = $txt['database_changes'];
+
+	$upcontext['delete_karma'] = !empty($_SESSION['delete_karma']);
+	$upcontext['empty_error'] = !empty($_SESSION['empty_error']);
 
 	// All possible files.
 	// Name, < version, insert_on_complete

--- a/other/upgrade_2-1_mysql.sql
+++ b/other/upgrade_2-1_mysql.sql
@@ -1,6 +1,76 @@
 /* ATTENTION: You don't need to run or use this file!  The upgrade.php script does everything for you! */
 
 /******************************************************************************/
+--- Removing karma
+/******************************************************************************/
+
+---# Removing all karma data, if selected
+---{
+if (!empty($upcontext['delete_karma']))
+{
+	// Delete old settings vars.
+	$smcFunc['db_query']('', '
+		DELETE FROM {db_prefix}settings
+		WHERE variable IN ({array_string:karma_vars})',
+		array(
+			'karma_vars' => array('karmaMode', 'karmaTimeRestrictAdmins', 'karmaWaitTime', 'karmaMinPosts', 'karmaLabel', 'karmaSmiteLabel', 'karmaApplaudLabel'),
+		)
+	);
+
+    $member_columns = $smcFunc['db_list_columns']('{db_prefix}members');
+
+	// Cleaning up old karma member settings.
+	if (in_array('karma_good', $member_columns))
+		$smcFunc['db_query']('', '
+			ALTER TABLE {db_prefix}members
+			DROP karma_good',
+			array()
+		);
+
+	// Does karma bad was enable?
+	if (in_array('karma_bad', $member_columns))
+		$smcFunc['db_query']('', '
+			ALTER TABLE {db_prefix}members
+			DROP karma_bad',
+			array()
+		);
+
+	// Cleaning up old karma permissions.
+	$smcFunc['db_query']('', '
+		DELETE FROM {db_prefix}permissions
+		WHERE permission = {string:karma_vars}',
+		array(
+			'karma_vars' => 'karma_edit',
+		)
+	);
+
+	// Cleaning up old log_karma table
+	$smcFunc['db_query']('', '
+		DROP TABLE IF EXISTS {db_prefix}log_karma',
+		array()
+	);
+}
+---}
+---#
+
+/******************************************************************************/
+--- Emptying error log
+/******************************************************************************/
+
+---# Emptying error log, if selected
+---{
+if (!empty($upcontext['empty_error']))
+{
+	$smcFunc['db_query']('truncate_table', '
+		TRUNCATE {db_prefix}log_errors',
+		array(
+		)
+	);
+}
+---}
+---#
+
+/******************************************************************************/
 --- Fixing dates...
 /******************************************************************************/
 

--- a/other/upgrade_2-1_postgresql.sql
+++ b/other/upgrade_2-1_postgresql.sql
@@ -1,6 +1,76 @@
 /* ATTENTION: You don't need to run or use this file! The upgrade.php script does everything for you! */
 
 /******************************************************************************/
+--- Removing karma
+/******************************************************************************/
+
+---# Removing all karma data, if selected
+---{
+if (!empty($upcontext['delete_karma']))
+{
+	// Delete old settings vars.
+	$smcFunc['db_query']('', '
+		DELETE FROM {db_prefix}settings
+		WHERE variable IN ({array_string:karma_vars})',
+		array(
+			'karma_vars' => array('karmaMode', 'karmaTimeRestrictAdmins', 'karmaWaitTime', 'karmaMinPosts', 'karmaLabel', 'karmaSmiteLabel', 'karmaApplaudLabel'),
+		)
+	);
+
+    $member_columns = $smcFunc['db_list_columns']('{db_prefix}members');
+
+	// Cleaning up old karma member settings.
+	if (in_array('karma_good', $member_columns))
+		$smcFunc['db_query']('', '
+			ALTER TABLE {db_prefix}members
+			DROP karma_good',
+			array()
+		);
+
+	// Does karma bad was enable?
+	if (in_array('karma_bad', $member_columns))
+		$smcFunc['db_query']('', '
+			ALTER TABLE {db_prefix}members
+			DROP karma_bad',
+			array()
+		);
+
+	// Cleaning up old karma permissions.
+	$smcFunc['db_query']('', '
+		DELETE FROM {db_prefix}permissions
+		WHERE permission = {string:karma_vars}',
+		array(
+			'karma_vars' => 'karma_edit',
+		)
+	);
+
+	// Cleaning up old log_karma table
+	$smcFunc['db_query']('', '
+		DROP TABLE IF EXISTS {db_prefix}log_karma',
+		array()
+	);
+}
+---}
+---#
+
+/******************************************************************************/
+--- Emptying error log
+/******************************************************************************/
+
+---# Emptying error log, if selected
+---{
+if (!empty($upcontext['empty_error']))
+{
+	$smcFunc['db_query']('truncate_table', '
+		TRUNCATE {db_prefix}log_errors',
+		array(
+		)
+	);
+}
+---}
+---#
+
+/******************************************************************************/
 --- Fixing sequences
 /******************************************************************************/
 


### PR DESCRIPTION
If selected to delete karma data during upgrade, the karma
data is removed before the database backup is made.
Move deletion of karma data and error log until after backup
is made.

Signed-off-by: Oscar Rydhé <oscar.rydhe@gmail.com>