### PR TITLE
Check backup database by default in upgrader

### DIFF
--- a/other/upgrade.php
+++ b/other/upgrade.php
@@ -4229,7 +4229,7 @@ function template_upgrade_options()
 	echo '
 				<ul class="upgrade_settings">
 					<li>
-						<input type="checkbox" name="backup" id="backup" value="1">
+						<input type="checkbox" name="backup" id="backup" value="1" checked>
 						<label for="backup">', $txt['upgrade_backup_table'], ' &quot;backup_' . $db_prefix . '&quot;.</label>
 						(', $txt['upgrade_recommended'], ')
 					</li>


### PR DESCRIPTION
The backup option is not checked by default
in the upgrader even though it is clearly recommended
to do it. Change so that the checkbox is checked
by default.

Signed-off-by: Oscar Rydhé <oscar.rydhe@gmail.com>