### PR TITLE
Hide label of disabled notification setting

### DIFF
--- a/Themes/default/Profile.template.php
+++ b/Themes/default/Profile.template.php
@@ -1914,6 +1914,9 @@ function template_alert_configuration()
 		{
 			foreach ($context['alert_group_options'][$alert_group] as $opts)
 			{
+				if ($opts[0] == 'hide')
+					continue;
+
 				echo '
 				<tr class="windowbg">
 					<td colspan="3">';


### PR DESCRIPTION
In PR #6559 the checkbox for the notification setting
"Receive message body in e-mails" was removed if the master
setting was disabled. However the label was still shown.
Completely remove the setting row if it is disabled.

Signed-off-by: Oscar Rydhé <oscar.rydhe@sony.com>