### PR TITLE
Hide loading bar when quoting from quick reply

### DIFF
--- a/Themes/default/scripts/jquery.sceditor.smf.js
+++ b/Themes/default/scripts/jquery.sceditor.smf.js
@@ -23,6 +23,8 @@
 					for (var i = 0, n = XMLDoc.getElementsByTagName('quote')[0].childNodes.length; i < n; i++)
 						text += XMLDoc.getElementsByTagName('quote')[0].childNodes[i].nodeValue;
 					self.insert(text);
+
+					ajax_indicator(false);
 				}
 			);
 		},


### PR DESCRIPTION
If using the quote button in the quick reply box the
loading banner was not removed.

Signed-off-by: Oscar Rydhé <oscar.rydhe@gmail.com>