### PR TITLE
Correctly handle spider actions

### DIFF
--- a/Sources/ManageSearchEngines.php
+++ b/Sources/ManageSearchEngines.php
@@ -803,7 +803,12 @@ function SpiderLogs()
 		$urls = determineActions($urls, 'whospider_');
 		foreach ($urls as $k => $new_url)
 		{
-			$context['spider_logs']['rows'][$k]['data']['viewing']['value'] = $new_url;
+			if (is_array($new_url))
+			{
+				$context['spider_logs']['rows'][$k]['data']['viewing']['value'] = $txt[$new_url['label']];
+				$context['spider_logs']['rows'][$k]['data']['viewing']['class'] = $new_url['class'];
+			} else
+				$context['spider_logs']['rows'][$k]['data']['viewing']['value'] = $new_url;
 		}
 	}
 


### PR DESCRIPTION
The function determineActions can return an array.
That was not handled in the spider log list, resulting
in Array to string conversion errors.
Handle returned arrays as well as strings.

Signed-off-by: Oscar Rydhé <oscar.rydhe@gmail.com>