### PR TITLE
Combine img bbc definition

### DIFF
--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -1731,37 +1731,23 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 				'parameters' => array(
 					'alt' => array('optional' => true),
 					'title' => array('optional' => true),
-				),
-				'content' => '<img src="$1" alt="{alt}" title="{title}" class="bbc_img" loading="lazy">',
-				'validate' => function(&$tag, &$data, $disabled)
-				{
-					$data = strtr($data, array('<br>' => ''));
-
-					if (parse_url($data, PHP_URL_SCHEME) === null)
-						$data = '//' . ltrim($data, ':/');
-					else
-						$data = get_proxied_url($data);
-				},
-				'disabled_content' => '($1)',
-			),
-			array(
-				'tag' => 'img',
-				'type' => 'unparsed_content',
-				'parameters' => array(
-					'alt' => array('optional' => true),
-					'title' => array('optional' => true),
 					'width' => array('optional' => true, 'value' => ' width="$1"', 'match' => '(\d+)'),
 					'height' => array('optional' => true, 'value' => ' height="$1"', 'match' => '(\d+)'),
 				),
-				'content' => '<img src="$1" alt="{alt}" title="{title}"{width}{height} class="bbc_img resized" loading="lazy">',
-				'validate' => function(&$tag, &$data, $disabled)
+				'content' => '$1',
+				'validate' => function(&$tag, &$data, $disabled, $params)
 				{
-					$data = strtr($data, array('<br>' => ''));
+					$url = strtr($data, array('<br>' => ''));
 
-					if (parse_url($data, PHP_URL_SCHEME) === null)
-						$data = '//' . ltrim($data, ':/');
+					if (parse_url($url, PHP_URL_SCHEME) === null)
+						$url = '//' . ltrim($url, ':/');
 					else
-						$data = get_proxied_url($data);
+						$url = get_proxied_url($url);
+
+					$alt = !empty($params['{alt}']) ? ' alt="' . $params['{alt}']. '"' : '';
+					$title = !empty($params['{title}']) ? ' title="' . $params['{title}']. '"' : '';
+
+					$data = isset($disabled[$tag['tag']]) ? $url : '<img src="' . $url . '"' . $alt . $title . $params['{width}'] . $params['{height}'] . 'class="bbc_img' . (!empty($params['{width}']) || !empty($params['{height}']) ? ' resized' : '') . '" loading="lazy">';
 				},
 				'disabled_content' => '($1)',
 			),


### PR DESCRIPTION
Two img bbc definitions exists for unparsed_content.
One with width or hight and one without.
Combine these into one definition.

Fixes #6654

Signed-off-by: Oscar Rydhé <oscar.rydhe@gmail.com>