### PR TITLE
Fix other currency for paid subscriptions

### DIFF
--- a/Sources/ManagePaid.php
+++ b/Sources/ManagePaid.php
@@ -202,7 +202,8 @@ function ModifySubscriptionSettings($return_config = false)
 					document.getElementById("custom_currency_code_div_dd").style.display = "none";
 				}
 			}
-		}
+		}');
+		addInlineJavaScript('
 		toggleOther();', true);
 	}
 	else


### PR DESCRIPTION
When selecing other current the text boxes for defining the
currency was not shown. Move the definition of the js function
to the header. Only defer the call to the function until DOM
is loaded.

Signed-off-by: Oscar Rydhé <oscar.rydhe@gmail.com>