### PR TITLE
Remove the option to set height

### DIFF
--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -1438,38 +1438,35 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 						// Image.
 						if (!empty($currentAttachment['is_image']))
 						{
-							if (empty($params['{width}']) && empty($params['{height}']))
+							if (empty($params['{width}']))
 								$returnContext .= '<img src="' . $currentAttachment['href'] . '"' . $alt . $title . ' class="bbc_img"></a>';
 							else
 							{
 								$width = !empty($params['{width}']) ? ' width="' . $params['{width}'] . '"': '';
-								$height = !empty($params['{height}']) ? 'height="' . $params['{height}'] . '"' : '';
-								$returnContext .= '<img src="' . $currentAttachment['href'] . ';image"' . $alt . $title . $width . $height . ' class="bbc_img resized"/>';
+								$returnContext .= '<img src="' . $currentAttachment['href'] . ';image"' . $alt . $title . $width . ' class="bbc_img resized"/>';
 							}
 						}
 						// Video.
 						elseif (strpos($currentAttachment['mime_type'], 'video/') === 0)
 						{
 							$width = !empty($width) ? ' width="' . $width . '"' : '';
-							$height = !empty($height) ? ' height="' . $height . '"' : '';
 
-							$returnContext .= '<div class="videocontainer"><video controls preload="metadata" src="'. $currentAttachment['href'] . '" playsinline' . $width . $height . '><a href="' . $currentAttachment['href'] . '" class="bbc_link">' . $smcFunc['htmlspecialchars'](!empty($data) ? $data : $currentAttachment['name']) . '</a></video></div>' . (!empty($data) && $data != $currentAttachment['name'] ? '<div class="smalltext">' . $data . '</div>' : '');
+							$returnContext .= '<div class="videocontainer"><video controls preload="metadata" src="'. $currentAttachment['href'] . '" playsinline' . $width . '><a href="' . $currentAttachment['href'] . '" class="bbc_link">' . $smcFunc['htmlspecialchars'](!empty($data) ? $data : $currentAttachment['name']) . '</a></video></div>' . (!empty($data) && $data != $currentAttachment['name'] ? '<div class="smalltext">' . $data . '</div>' : '');
 						}
 						// Audio.
 						elseif (strpos($currentAttachment['mime_type'], 'audio/') === 0)
 						{
 							$width = 'max-width:100%; width: ' . (!empty($width) ? $width : '400') . 'px;';
-							$height = !empty($height) ? 'height: ' . $height . 'px;' : '';
 
-							$returnContext .= (!empty($data) && $data != $currentAttachment['name'] ? $data . ' ' : '') . '<audio controls preload="none" src="'. $currentAttachment['href'] . '" class="bbc_audio" style="vertical-align:middle;' . $width . $height . '"><a href="' . $currentAttachment['href'] . '" class="bbc_link">' . $smcFunc['htmlspecialchars'](!empty($data) ? $data : $currentAttachment['name']) . '</a></audio>';
+
+							$returnContext .= (!empty($data) && $data != $currentAttachment['name'] ? $data . ' ' : '') . '<audio controls preload="none" src="'. $currentAttachment['href'] . '" class="bbc_audio" style="vertical-align:middle;' . $width . '"><a href="' . $currentAttachment['href'] . '" class="bbc_link">' . $smcFunc['htmlspecialchars'](!empty($data) ? $data : $currentAttachment['name']) . '</a></audio>';
 						}
 						// Anything else.
 						else
 						{
 							$width = !empty($width) ? ' width="' . $width . '"' : '';
-							$height = !empty($height) ? ' height="' . $height . '"' : '';
 
-							$returnContext .= '<object type="' . $currentAttachment['mime_type'] . '" data="' . $currentAttachment['href'] . '"' . $width . $height . ' typemustmatch><a href="' . $currentAttachment['href'] . '" class="bbc_link">' . $smcFunc['htmlspecialchars'](!empty($data) ? $data : $currentAttachment['name']) . '</a></object>';
+							$returnContext .= '<object type="' . $currentAttachment['mime_type'] . '" data="' . $currentAttachment['href'] . '"' . $width . ' typemustmatch><a href="' . $currentAttachment['href'] . '" class="bbc_link">' . $smcFunc['htmlspecialchars'](!empty($data) ? $data : $currentAttachment['name']) . '</a></object>';
 						}
 					}
 
@@ -1750,9 +1747,9 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 					'alt' => array('optional' => true),
 					'title' => array('optional' => true),
 					'width' => array('optional' => true, 'value' => ' width="$1"', 'match' => '(\d+)'),
-					'height' => array('optional' => true, 'value' => ' height="$1"', 'match' => '(\d+)'),
+					'height' => array('optional' => true, 'value' => '', 'match' => '(\d+)'),
 				),
-				'content' => '<img src="$1" alt="{alt}" title="{title}"{width}{height} class="bbc_img resized" loading="lazy">',
+				'content' => '<img src="$1" alt="{alt}" title="{title}"{width} class="bbc_img resized">',
 				'validate' => function(&$tag, &$data, $disabled)
 				{
 					$data = strtr($data, array('<br>' => ''));

--- a/Themes/default/Post.template.php
+++ b/Themes/default/Post.template.php
@@ -367,11 +367,7 @@ function template_main()
 										<div class="attached_BBC_width_height">
 											<div class="attached_BBC_width">
 												<label for="attached_BBC_width">', $txt['attached_insert_width'], '</label>
-												<input type="number" name="attached_BBC_width" min="0" value="" placeholder="auto">
-											</div>
-											<div class="attached_BBC_height">
-												<label for="attached_BBC_height">', $txt['attached_insert_height'], '</label>
-												<input type="number" name="attached_BBC_height" min="0" value="" placeholder="auto">
+												<input type="number" id="attached_BBC_width" name="attached_BBC_width" min="0" value="" placeholder="auto">
 											</div>
 										</div>
 									</div><!-- .attached_BBC -->

--- a/Themes/default/css/jquery.sceditor.css
+++ b/Themes/default/css/jquery.sceditor.css
@@ -612,3 +612,9 @@ div.sceditor-dropdown img,
 .sceditor-smileyPopup img {
 	cursor: pointer;
 }
+.sceditor-insertimage #height {
+	display: none;
+}
+.sceditor-insertimage label[for="height"] {
+    display: none;
+}

--- a/Themes/default/scripts/jquery.sceditor.smf.js
+++ b/Themes/default/scripts/jquery.sceditor.smf.js
@@ -359,9 +359,6 @@ sceditor.command.set(
 
 					if (width)
 						attrs.push('width="' + sceditor.escapeEntities(width, true) + '"');
-
-					if (height)
-						attrs.push('height="' + sceditor.escapeEntities(height, true) + '"');
  
 					editor.wysiwygEditorInsertHtml(
 						'<img ' + attrs.join(' ') + '>'
@@ -591,8 +588,6 @@ sceditor.formats.bbcode.set(
 			// only add width and height if one is specified
 			if (element.attr('width') || style('width'))
 				attribs += " width=" + element.attr('width');
-			if (element.attr('height') || style('height'))
-				attribs += " height=" + element.attr('height');
 			if (element.attr('alt'))
 				attribs += " alt=" + element.attr('alt');
 
@@ -617,8 +612,6 @@ sceditor.formats.bbcode.set(
 			// handle [img width=340 height=240]url[/img]
 			if (typeof attrs.width !== "undefined")
 				attribs += ' width="' + attrs.width + '"';
-			if (typeof attrs.height !== "undefined")
-				attribs += ' height="' + attrs.height + '"';
 			if (typeof attrs.alt !== "undefined")
 				attribs += ' alt="' + attrs.alt + '"';
 			if (typeof attrs.title !== "undefined")
@@ -650,8 +643,6 @@ sceditor.formats.bbcode.set(
 			attribs += " id=" + element.attr('data-attachment');
 			if (element.attr('width') || style('width'))
 				attribs += " width=" + element.attr('width');
-			if (element.attr('height') || style('height'))
-				attribs += " height=" + element.attr('height');
 			if (element.attr('alt'))
 				attribs += " alt=" + element.attr('alt');
 
@@ -698,8 +689,6 @@ sceditor.formats.bbcode.set(
 				attribs += ' id=' + id;
 				if (typeof attrs.width !== "undefined")
 					attribs += ' width=' + attrs.width;
-				if (typeof attrs.height !== "undefined")
-					attribs += ' height=' + attrs.height;
 				if (typeof attrs.alt !== "undefined")
 					attribs += ' alt=' + attrs.alt;
 
@@ -715,8 +704,6 @@ sceditor.formats.bbcode.set(
 				attribs += ' title="' + content + '"';
 				if (typeof attrs.width !== "undefined")
 					attribs += ' width="' + attrs.width + '"';
-				if (typeof attrs.height !== "undefined")
-					attribs += ' height="' + attrs.height + '"';
 
 				var contentUrl = smf_scripturl +'?action=dlattach;attach='+ id + ';type=preview;thumb';
 				contentIMG = new Image();

--- a/Themes/default/scripts/smf_fileUpload.js
+++ b/Themes/default/scripts/smf_fileUpload.js
@@ -26,15 +26,14 @@ function smf_fileUpload(oOptions) {
 		clickable: '.fileinput-button',
 		currentUsedSize: 0,
 		timeout: null,
-		smf_insertBBC: function (file, w, h) {
+		smf_insertBBC: function (file, w) {
 
 			var mime_type = typeof file.type !== "undefined" ? file.type : (typeof file.mime_type !== "undefined" ? file.mime_type : ''),
 				bbcOptionalParams = {
 					width: mime_type.indexOf('image') == 0 && + w > 0 ? (' width=' + w) : '',
-					height: mime_type.indexOf('image') == 0 && + h > 0 ? (' height=' + h) : '',
 				};
 
-			return '[attach id=' + file.attachID + bbcOptionalParams.width + bbcOptionalParams.height + ']' + (typeof file.name !== "undefined" ? decodeURIComponent(file.name.replace(/\+/g,' ')) : '') + '[/attach]';
+			return '[attach id=' + file.attachID + bbcOptionalParams.width + ']' + (typeof file.name !== "undefined" ? decodeURIComponent(file.name.replace(/\+/g,' ')) : '') + '[/attach]';
 		},
 		createMaxSizeBar: function () {
 
@@ -165,13 +164,12 @@ function smf_fileUpload(oOptions) {
 					e.preventDefault();
 
 					w = _innerElement.find('input[name="attached_BBC_width"]').val();
-					h = _innerElement.find('input[name="attached_BBC_height"]').val();
 
 					// Get the editor stuff.
 					var e = $('#' + oEditorID).get(0);
 					var oEditor = sceditor.instance(e);
 
-					oEditor.insert(myDropzone.options.smf_insertBBC(response, w, h));
+					oEditor.insert(myDropzone.options.smf_insertBBC(response, w));
 				})
 				.appendTo(_innerElement.find('.attach-ui'));
 		};
@@ -379,8 +377,7 @@ function smf_fileUpload(oOptions) {
 
 		// Append the BBC.
 		w = _thisElement.find('input[name="attached_BBC_width"]').val();
-		h = _thisElement.find('input[name="attached_BBC_height"]').val();
-		_thisElement.find('input[name="attachBBC"]').val(myDropzone.options.smf_insertBBC(response, w, h));
+		_thisElement.find('input[name="attachBBC"]').val(myDropzone.options.smf_insertBBC(response, w));
 
 		file.insertAttachment(_thisElement, response);
 
@@ -429,8 +426,7 @@ function smf_fileUpload(oOptions) {
 
 			// Append the BBC.
 			w = _thisElement.find('input[name="attached_BBC_width"]').val();
-			h = _thisElement.find('input[name="attached_BBC_height"]').val();
-			_thisElement.find('input[name="attachBBC"]').val(myDropzone.options.smf_insertBBC(file, w, h));
+			_thisElement.find('input[name="attachBBC"]').val(myDropzone.options.smf_insertBBC(file, w));
 
 			file.insertAttachment(_thisElement, file);
 


### PR DESCRIPTION
Remove the option to set height for images and embedded
attachments. Having a set height when the width is
responsive, causes aspect ratio to be wrong in some cituations.

Fixes #6541

Signed-off-by: Oscar Rydhé <oscar.rydhe@gmail.com>