### PR TITLE
Remove size restriction of resized images on mobile

### DIFF
--- a/Themes/default/css/responsive.css
+++ b/Themes/default/css/responsive.css
@@ -242,10 +242,6 @@
 	.keyinfo h5 .modified {
 		float: none;
 	}
-	.bbc_img.resized {
-		max-width: 250px;
-		max-height: 300px;
-	}
 	img.icon, #forumposts .catbg img {
 		display: none;
 	}


### PR DESCRIPTION
Resized images are only allowed to be 250 by 300 pixels
on mobile phones. There is no reason to do so, since not
resized images can be bigger and it can mess up the aspect
ratio of the image.

Signed-off-by: Oscar Rydhé <oscar.rydhe@gmail.com>