### PR TITLE
Fix text selection in package manager

### DIFF
--- a/Sources/Packages.php
+++ b/Sources/Packages.php
@@ -1931,8 +1931,8 @@ function ViewOperations()
 	$context['javascript_files'] = array_intersect_key(
 		$context['javascript_files'],
 		[
-			'smf_script' => true,
-			'smf_jquery' => true
+			'smf_script_js' => true,
+			'smf_jquery_js' => true
 		]
 	);
 


### PR DESCRIPTION
When viewing the search and replace popup the text
selection link does not work. This is because the
js files are not loaded properly.

Signed-off-by: Oscar Rydhé <oscar.rydhe@gmail.com>