### PR TITLE
Break long attachment dir

### DIFF
--- a/Sources/ManageAttachments.php
+++ b/Sources/ManageAttachments.php
@@ -2381,6 +2381,7 @@ function ManageAttachmentPaths()
 					'data' => array(
 						'db' => 'path',
 						'style' => 'width: 45%;',
+						'class' => 'word_break',
 					),
 				),
 				'num_dirs' => array(

--- a/Themes/default/ManageAttachments.template.php
+++ b/Themes/default/ManageAttachments.template.php
@@ -55,7 +55,7 @@ function template_maintenance()
 				<dt><strong>', $txt['attachmentdir_size'], ':</strong></dt>
 				<dd>', $context['attachment_total_size'], ' ', $txt['kilobyte'], '</dd>
 				<dt><strong>', $txt['attach_current_dir'], ':</strong></dt>
-				<dd>', $modSettings['attachmentUploadDir'][$modSettings['currentAttachmentUploadDir']], '</dd>
+				<dd class="word_break">', $modSettings['attachmentUploadDir'][$modSettings['currentAttachmentUploadDir']], '</dd>
 				<dt><strong>', $txt['attachmentdir_size_current'], ':</strong></dt>
 				<dd>', $context['attachment_current_size'], ' ', $txt['kilobyte'], '</dd>
 				<dt><strong>', $txt['attachment_space'], ':</strong></dt>

--- a/Themes/default/css/index.css
+++ b/Themes/default/css/index.css
@@ -4082,3 +4082,7 @@ tr[id^='list_news_lists_'] textarea {
 div.sceditor-container {
 	z-index: 4;
 }
+
+#attach_current_directory {
+	word-break: break-word;
+}


### PR DESCRIPTION
If the attachment directory is to long in the Attachment Settings,
a scrollbar is shown for whole block of settings.
Add a zero width space after all directory separators to allow
breaking.

Signed-off-by: Oscar Rydhé <oscar.rydhe@gmail.com>