### PR TITLE
Add specific id to responsive css selector

### DIFF
--- a/Themes/default/css/responsive.css
+++ b/Themes/default/css/responsive.css
@@ -605,7 +605,7 @@
 		width: 100%;
 		float: none;
 	}
-	#post_draft_options dl.settings dt, dl.settings dd {
+	#post_draft_options dl.settings dt, #post_draft_options dl.settings dd {
 		width: 50%;
 		float: left;
 	}


### PR DESCRIPTION
A specific id was missing from one of the responsive
css selectors. This is probably not on purpose.
Without this id many settings in the admin menu only
uses half the width when viewed on screens with widths
below 480 px.

Signed-off-by: Oscar Rydhé <oscar.rydhe@gmail.com>