### PR TITLE
Honor user setting drafts_autosave_enabled

### DIFF
--- a/Sources/Display.php
+++ b/Sources/Display.php
@@ -1206,7 +1206,7 @@ function Display()
 
 	// Check if the draft functions are enabled and that they have permission to use them (for quick reply.)
 	$context['drafts_save'] = !empty($modSettings['drafts_post_enabled']) && allowedTo('post_draft') && $context['can_reply'];
-	$context['drafts_autosave'] = !empty($context['drafts_save']) && !empty($modSettings['drafts_autosave_enabled']);
+	$context['drafts_autosave'] = !empty($context['drafts_save']) && !empty($modSettings['drafts_autosave_enabled']) && !empty($options['drafts_autosave_enabled']);
 	if (!empty($context['drafts_save']))
 		loadLanguage('Drafts');
 

--- a/Sources/PersonalMessage.php
+++ b/Sources/PersonalMessage.php
@@ -25,7 +25,7 @@ if (!defined('SMF'))
  */
 function MessageMain()
 {
-	global $txt, $scripturl, $sourcedir, $context, $user_info, $user_settings, $smcFunc, $modSettings;
+	global $txt, $scripturl, $sourcedir, $context, $user_info, $user_settings, $smcFunc, $modSettings, $options;
 
 	// No guests!
 	is_not_guest();
@@ -180,7 +180,7 @@ function MessageMain()
 
 	// Are PM drafts enabled?
 	$context['drafts_pm_save'] = !empty($modSettings['drafts_pm_enabled']) && allowedTo('pm_draft');
-	$context['drafts_autosave'] = !empty($context['drafts_pm_save']) && !empty($modSettings['drafts_autosave_enabled']);
+	$context['drafts_autosave'] = !empty($context['drafts_pm_save']) && !empty($modSettings['drafts_autosave_enabled']) && !empty($options['drafts_autosave_enabled']);
 
 	// Build the linktree for all the actions...
 	$context['linktree'][] = array(

--- a/Sources/Post.php
+++ b/Sources/Post.php
@@ -32,7 +32,7 @@ function Post($post_errors = array())
 {
 	global $txt, $scripturl, $topic, $modSettings, $board;
 	global $user_info, $context, $settings;
-	global $sourcedir, $smcFunc, $language;
+	global $sourcedir, $smcFunc, $language, $options;
 
 	loadLanguage('Post');
 	if (!empty($modSettings['drafts_post_enabled']))
@@ -1138,7 +1138,7 @@ function Post($post_errors = array())
 
 	// Are post drafts enabled?
 	$context['drafts_save'] = !empty($modSettings['drafts_post_enabled']) && allowedTo('post_draft');
-	$context['drafts_autosave'] = !empty($context['drafts_save']) && !empty($modSettings['drafts_autosave_enabled']) && allowedTo('post_autosave_draft');
+	$context['drafts_autosave'] = !empty($context['drafts_save']) && !empty($modSettings['drafts_autosave_enabled']) && allowedTo('post_autosave_draft') && !empty($options['drafts_autosave_enabled']);
 
 	// Build a list of drafts that they can load in to the editor
 	if (!empty($context['drafts_save']))


### PR DESCRIPTION
The per user setting drafts_autosave_enabled was not
used when determine if a draft should be auto saved.
Fixed that.

Signed-off-by: Oscar Rydhé <oscar.rydhe@gmail.com>