### PR TITLE
Fix attachment images when printing topics

### DIFF
--- a/Sources/Printpage.php
+++ b/Sources/Printpage.php
@@ -304,6 +304,9 @@ function PrintTopic()
 		// load them into $context so the template can use them
 		foreach ($temp as $row)
 		{
+			if (!empty($modSettings['dont_show_attach_under_post']) && !empty($context['show_attach_under_post'][$row['id_attach']]))
+				continue;
+
 			if (!empty($row['width']) && !empty($row['height']))
 			{
 				if (!empty($modSettings['max_image_width']) && (empty($modSettings['max_image_height']) || $row['height'] * ($modSettings['max_image_width'] / $row['width']) <= $modSettings['max_image_height']))

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -2241,7 +2241,10 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 
 		// @todo Change maybe?
 		if (!isset($_GET['images']))
+		{
 			$disabled['img'] = true;
+			$disabled['attach'] = true;
+		}
 
 		// Maybe some custom BBC need to be disabled for printing.
 		call_integration_hook('integrate_bbc_print', array(&$disabled));


### PR DESCRIPTION
* When printing without images, attachments where shown
as images. Disabled attachments when printing without
images.
* Hide attachments below posts if they are included
in the post, if the setting "dont_show_attach_under_post"
is enabled.

Signed-off-by: Oscar Rydhé <oscar.rydhe@gmail.com>