### PR TITLE
Show original attachment during preview

### DIFF
--- a/Sources/ShowAttachments.php
+++ b/Sources/ShowAttachments.php
@@ -65,7 +65,7 @@ function showAttachment()
 
 	// A thumbnail has been requested? madness! madness I say!
 	$preview = isset($_REQUEST['preview']) ? $_REQUEST['preview'] : (isset($_REQUEST['type']) && $_REQUEST['type'] == 'preview' ? $_REQUEST['type'] : 0);
-	$showThumb = isset($_REQUEST['thumb']) || !empty($preview);
+	$showThumb = isset($_REQUEST['thumb']);
 	$attachTopic = isset($_REQUEST['topic']) ? (int) $_REQUEST['topic'] : 0;
 
 	// No access in strict maintenance mode or you don't have permission to see attachments.


### PR DESCRIPTION
When previewing a post with an inline attachment,
only the thumbnail of the attachment was shown.
Show the original attachment, like how it will be
shown in the posted message.

Signed-off-by: Oscar Rydhé <oscar.rydhe@gmail.com>