### PR TITLE
Hide Quote selected text button on deselect text

### DIFF
--- a/Themes/default/scripts/quotedText.js
+++ b/Themes/default/scripts/quotedText.js
@@ -143,7 +143,7 @@ $(function() {
 				if (typeof selectedText != 'undefined' && selectedText != false)
 					return;
 
-				// Revome any 'click' event to the button.
+				// Remove any 'click' event to the button.
 				$(document).off('click', '#quoteSelected_' + oSelected.msgID + ' a');
 
 				// Hide the button.

--- a/Themes/default/scripts/quotedText.js
+++ b/Themes/default/scripts/quotedText.js
@@ -119,27 +119,41 @@ $(function() {
 			msgID : $(this).data('msgid'),
 		};
 
-		// Revome any 'click' event to the button.
-		$(document).off('click', '#quoteSelected_' + oSelected.msgID + ' a');
-
-		// If the button is already visible, hide it!
-		$('#quoteSelected_' + oSelected.msgID).hide();
-
 		// Get any selected text.
 		oSelected.text = getSelectedText(oSelected.divID);
 
 		// Do we have some selected text?
 		if (typeof oSelected.text == 'undefined' || oSelected.text == false)
-			return false;
+			return true;
 
 		// Show the "quote this" button.
 		$('#quoteSelected_' + oSelected.msgID).show();
 
-			$(document).one('click', '#quoteSelected_' + oSelected.msgID + ' a', function(e){
-				e.preventDefault();
-				quotedTextClick(oSelected);
-			});
+		$(document).one('click', '#quoteSelected_' + oSelected.msgID + ' a', function(e) {
+			e.preventDefault();
+			quotedTextClick(oSelected);
+		});
 
-		return false;
+		// Register global on click listener to catch deselect clicks outside of the div.
+		$(document).on('click.ondeselecttext' + oSelected.msgID, function() {
+			// Delay the check a bit to allow the deselection to happen.
+			setTimeout(function() {
+				selectedText = getSelectedText(oSelected.divID);
+
+				if (typeof selectedText != 'undefined' && selectedText != false)
+					return;
+
+				// Revome any 'click' event to the button.
+				$(document).off('click', '#quoteSelected_' + oSelected.msgID + ' a');
+
+				// Hide the button.
+				$('#quoteSelected_' + oSelected.msgID).hide();
+
+				// Remove this on click listener
+				$(document).off('click.ondeselecttext' + oSelected.msgID);
+			}, 1);
+		});
+
+		return true;
 	});
 });


### PR DESCRIPTION
If clicking outside the post div to deselect text, did not
hide the "Quote selected text" button. Fixed that by
adding a global click listener.

Fixes #6716

Signed-off-by: Oscar Rydhé <oscar.rydhe@gmail.com>