### PR TITLE
Remove hover action for disabled continue button in upgrader

### DIFF
--- a/Themes/default/css/install.css
+++ b/Themes/default/css/install.css
@@ -102,7 +102,7 @@ ul.steps_list .stepcurrent ~ li {
 .panel .button {
 	font-weight: bold;
 }
-.panel .button:hover {
+.panel .button:enabled:hover {
 	color: #af6700;
 	text-decoration: none;
 }


### PR DESCRIPTION
Hovering the continue button in the upgrader when the
button was disabled, turned the text orange. Use this style
only when the button is enabled, to not confuse the user.

Signed-off-by: Oscar Rydhé <oscar.rydhe@gmail.com>