### PR TITLE
Set forum default timezone at registration

### DIFF
--- a/Sources/Register.php
+++ b/Sources/Register.php
@@ -436,7 +436,6 @@ function Register2()
 		'require' => !empty($modSettings['coppaAge']) && empty($_SESSION['skip_coppa']) ? 'coppa' : (empty($modSettings['registration_method']) ? 'nothing' : ($modSettings['registration_method'] == 1 ? 'activation' : 'approval')),
 		'extra_register_vars' => array(),
 		'theme_vars' => array(),
-		'timezone' => !empty($modSettings['default_timezone']) ? $modSettings['default_timezone'] : '',
 	);
 
 	// Include the additional options that might have been filled in.

--- a/Sources/Subs-Members.php
+++ b/Sources/Subs-Members.php
@@ -663,6 +663,11 @@ function registerMember(&$regOptions, $return_errors = false)
 			$regOptions['register_vars']['id_group'] = 0;
 	}
 
+	// Verify that timezone is correct, if provided.
+	if (!empty($regOptions['extra_register_vars']) && !empty($regOptions['extra_register_vars']['timezone']) &&
+		!array_key_exists($regOptions['extra_register_vars']['timezone'], smf_list_timezones()))
+		unset($regOptions['extra_register_vars']['timezone']);
+
 	// Integrate optional member settings to be set.
 	if (!empty($regOptions['extra_register_vars']))
 		foreach ($regOptions['extra_register_vars'] as $var => $value)

--- a/Sources/Subs-Members.php
+++ b/Sources/Subs-Members.php
@@ -618,7 +618,7 @@ function registerMember(&$regOptions, $return_errors = false)
 		'additional_groups' => '',
 		'ignore_boards' => '',
 		'smiley_set' => '',
-		'timezone' => empty($regOptions['timezone']) || !in_array($regOptions['timezone'], smf_list_timezones()) ? 'UTC' : $regOptions['timezone'],
+		'timezone' => empty($modSettings['default_timezone']) || !array_key_exists($modSettings['default_timezone'], smf_list_timezones()) ? 'UTC' : $modSettings['default_timezone'],
 	);
 
 	// Setup the activation status on this new account so it is correct - firstly is it an under age account?

--- a/Themes/default/Register.template.php
+++ b/Themes/default/Register.template.php
@@ -253,7 +253,7 @@ function template_registration_form()
 						if (is_array($field['options']))
 							foreach ($field['options'] as $value => $name)
 								echo '
-								<option', (!empty($field['disabled_options']) && is_array($field['disabled_options']) && in_array($value, $field['disabled_options'], true) ? ' disabled' : ''), ' value="' . $value . '"', $value == $field['value'] ? ' selected' : '', '>', $name, '</option>';
+								<option', (!empty($field['disabled_options']) && is_array($field['disabled_options']) && in_array($value, $field['disabled_options'], true) ? ' disabled' : ''), ' value="' . $value . '"', $value === $field['value'] ? ' selected' : '', '>', $name, '</option>';
 					}
 
 					echo '


### PR DESCRIPTION
* If the timezone field was not shown on registration
new users would get the UTC timezone set by default,
instead of the forum default timezone.
* And if the default timezone was not provided by the
caller of RegisterMember() UTC was also used. Move the
fetching of the default timezone from the caller to
the function.
* Also fixed a small error where timezone selection
would not stay if the registration form was reloaded,
e.g. if an error occured, if the forum default timezone
was selected.

Fixes #6747

Signed-off-by: Oscar Rydhé <oscar.rydhe@gmail.com>