### PR TITLE
Revamps autolinker to fix bugs and improve efficiency

### DIFF
--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -7401,7 +7401,7 @@ function validate_iri($iri, $flags = null)
 	{
 		$host = parse_url((strpos($url, '//') === 0 ? 'http:' : '') . $url, PHP_URL_HOST);
 
-		if (strpos($host, '[') === 0 && strpos($host, ']') === strlen($host) && strpos($host, ':') !== false)
+		if (strpos($host, '[') === 0 && strpos($host, ']') === strlen($host) - 1 && strpos($host, ':') !== false)
 			$url = str_replace($host, '127.0.0.1', $url);
 	}
 

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -2726,9 +2726,16 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 
 							if (!empty($parsedurl['scheme']) && $parsedurl['scheme'] == 'mailto')
 							{
-								$email_address = str_replace('mailto:', '', $url);
-								if (!isset($disabled['email']) && filter_var($parsedurl['path'], FILTER_VALIDATE_EMAIL, FILTER_FLAG_EMAIL_UNICODE) !== false)
-									return '[email=' . $email_address . ']' . $url . '[/email]';
+								if (isset($disabled['email']))
+									return $url;
+
+								// Is this version of PHP capable of validating this email address?
+								$can_validate = defined('FILTER_FLAG_EMAIL_UNICODE') || strlen($parsedurl['path']) == strspn(strtolower($parsedurl['path']), 'abcdefghijklmnopqrstuvwxyz0123456789!#$%&\'*+-/=?^_`{|}~.@');
+
+								$flags = defined('FILTER_FLAG_EMAIL_UNICODE') ? FILTER_FLAG_EMAIL_UNICODE : null;
+
+								if (!$can_validate || filter_var($parsedurl['path'], FILTER_VALIDATE_EMAIL, $flags) !== false)
+									return '[email=' . str_replace('mailto:', '', $url) . ']' . $url . '[/email]';
 								else
 									return $url;
 							}

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -2410,6 +2410,10 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 								'mailto', 'maps', 'news', 'ni', 'nih', 'service', 'skype',
 								'sms', 'tel', 'tv',
 							),
+							// Schemes that we should never link.
+							'forbidden' => array(
+								'javascript', 'data',
+							),
 						);
 
 						// In case a mod wants to control behaviour for a special URI scheme.
@@ -2750,7 +2754,7 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 								$fullUrl = $url;
 
 							// Make sure that $fullUrl really is valid
-							if (!in_array($parsedurl['scheme'], $schemes['no_authority']) && validate_iri((strpos($fullUrl, '//') === 0 ? 'http:' : '') . $fullUrl) === false)
+							if (in_array($parsedurl['scheme'], $schemes['forbidden']) || (!in_array($parsedurl['scheme'], $schemes['no_authority']) && validate_iri((strpos($fullUrl, '//') === 0 ? 'http:' : '') . $fullUrl) === false))
 								return $url;
 
 							return '[url=&quot;' . str_replace(array('[', ']'), array('&#91;', '&#93;'), $fullUrl) . '&quot;]' . $url . '[/url]';

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -7393,6 +7393,15 @@ function validate_iri($iri, $flags = null)
 {
 	$url = iri_to_url($iri);
 
+	// PHP 5 doesn't recognize IPv6 addresses in the URL host.
+	if (version_compare(phpversion(), '7.0.0', '<'))
+	{
+		$host = parse_url((strpos($url, '//') === 0 ? 'http:' : '') . $url, PHP_URL_HOST);
+
+		if (strpos($host, '[') === 0 && strpos($host, ']') === strlen($host) && strpos($host, ':') !== false)
+			$url = str_replace($host, '127.0.0.1', $url);
+	}
+
 	if (filter_var($url, FILTER_VALIDATE_URL, $flags) !== false)
 		return $iri;
 	else

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -7160,7 +7160,8 @@ function validate_iri($iri, $flags = null)
 function sanitize_iri($iri)
 {
 	// Encode any non-ASCII characters (but not space or control characters of any sort)
-	$iri = preg_replace_callback('~[^\x00-\x7F\pZ\pC]~u', function($matches)
+	// Also encode '%' in order to preserve anything that is already percent-encoded.
+	$iri = preg_replace_callback('~[^\x00-\x7F\pZ\pC]|%~u', function($matches)
 	{
 		return rawurlencode($matches[0]);
 	}, $iri);

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -2480,19 +2480,19 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 							if ($url != sanitize_iri($url))
 								return $url;
 
-							$scheme = parse_url($url, PHP_URL_SCHEME);
+							$parsedurl = parse_url($url);
 
-							if ($scheme == 'mailto')
+							if (!empty($parsedurl['scheme']) && $parsedurl['scheme'] == 'mailto')
 							{
 								$email_address = str_replace('mailto:', '', $url);
-								if (!isset($disabled['email']) && filter_var($email_address, FILTER_VALIDATE_EMAIL) !== false)
+								if (!isset($disabled['email']) && filter_var($parsedurl['path'], FILTER_VALIDATE_EMAIL, FILTER_FLAG_EMAIL_UNICODE) !== false)
 									return '[email=' . $email_address . ']' . $url . '[/email]';
 								else
 									return $url;
 							}
 
 							// Are we linking a schemeless URL or naked domain name (e.g. "example.com")?
-							if (empty($scheme))
+							if (empty($parsedurl['scheme']))
 								$fullUrl = '//' . ltrim($url, ':/');
 							else
 								$fullUrl = $url;

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -2500,7 +2500,7 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 
 							$pcre_subroutines['bracket_quote'] = '[' . $bracket_quote_chars . ']|&' . build_regex($bracket_quote_entities, '~');
 							$pcre_subroutines['allowed_entities'] = '&(?!' . build_regex(array_merge($bracket_quote_entities, array('lt;', 'gt;')), '~') . ')';
-							$pcre_subroutines['excluded_lookahead'] = '(?![' . $excluded_trailing_chars . ']*(?>' . $space_chars . '|$))';
+							$pcre_subroutines['excluded_lookahead'] = '(?![' . $excluded_trailing_chars . ']*(?>' . $space_chars . '|<br>|$))';
 
 							foreach (array('path', 'query', 'fragment') as $part)
 							{

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -2292,6 +2292,8 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 
 			$placeholders = array();
 			$placeholders_counter = 0;
+			// Wrap in "private use" Unicode characters to ensure there will be no conflicts.
+			$placeholder_template = html_entity_decode('&#xE03C;') . '%1$s' . html_entity_decode('&#xE03E;');
 
 			// Take care of some HTML!
 			if (!empty($modSettings['enablePostHTML']) && strpos($data, '&lt;') !== false)
@@ -2328,7 +2330,7 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 						if (preg_match('~action(=|%3d)(?!dlattach)~i', $imgtag) != 0)
 							$imgtag = preg_replace('~action(?:=|%3d)(?!dlattach)~i', 'action-', $imgtag);
 
-						$placeholder = '<placeholder ' . ++$placeholders_counter . '>';
+						$placeholder = sprintf($placeholder_template, ++$placeholders_counter);
 						$placeholders[$placeholder] = '[img' . $alt . ']' . $imgtag . '[/img]';
 
 						$replaces[$matches[0][$match]] = $placeholder;
@@ -2361,8 +2363,8 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 					// An &nbsp; right after a URL can break the autolinker
 					if (strpos($data, '&nbsp;') !== false)
 					{
-						$placeholders['<placeholder non-breaking-space>'] = '&nbsp;';
-						$data = strtr($data, array('&nbsp;' => '<placeholder non-breaking-space>'));
+						$placeholders[sprintf($placeholder_template, 'nbsp')] = '&nbsp;';
+						$data = strtr($data, array('&nbsp;' => sprintf($placeholder_template, 'nbsp')));
 					}
 
 					// Parse any URLs


### PR DESCRIPTION
Fixes #6685
Closes #6691
Closes #6692
Fixes #6497

This uses some more advanced PCRE techniques that I have learned since the last time I revamped the autolinker. Not only does this solve bugs (particularly the aforementioned showstopper bug involving parentheses in an URI), but it also improves efficiency by making more extensive use of PCRE subroutines. Additionally, this takes advantage of PCRE conditional logic to test for specific conditions based on the URI scheme, allowing us to do better at avoiding false positives. Along the way, I also found and fixed a couple of edge case bugs in my `validate_iri()`, `sanitize_iri()`, `iri_to_url()`, and `url_to_iri()` functions.