### PR TITLE
Pass int to setNotifyPrefs

### DIFF
--- a/Sources/Notify.php
+++ b/Sources/Notify.php
@@ -105,7 +105,7 @@ function BoardNotify()
 
 		$alertPref = $mode <= 1 ? 0 : ($mode == 2 ? 1 : 3);
 
-		setNotifyPrefs($member_info['id'], array('board_notify_' . $board => $alertPref));
+		setNotifyPrefs((int) $member_info['id'], array('board_notify_' . $board => $alertPref));
 
 		if ($mode > 1)
 			// Turn notification on.  (note this just blows smoke if it's already on.)
@@ -273,7 +273,7 @@ function TopicNotify()
 			array('id_member', 'id_topic')
 		);
 
-		setNotifyPrefs($member_info['id'], array('topic_notify_' . $log['id_topic'] => $alertPref));
+		setNotifyPrefs((int) $member_info['id'], array('topic_notify_' . $log['id_topic'] => $alertPref));
 
 		if ($mode > 1)
 		{
@@ -376,7 +376,7 @@ function AnnouncementsNotify()
 	$mode = (int) !empty($_GET['mode']);
 
 	// Update their announcement notification preference.
-	setNotifyPrefs($member_info['id'], array('announcements' => $mode));
+	setNotifyPrefs((int) $member_info['id'], array('announcements' => $mode));
 
 	// Show a confirmation message.
 	$context['sub_template'] = 'notify_pref_changed';

--- a/Sources/Profile-Modify.php
+++ b/Sources/Profile-Modify.php
@@ -1173,7 +1173,7 @@ function makeNotificationChanges($memID)
 			)
 		);
 		foreach ($_POST['notify_topics'] as $topic)
-			setNotifyPrefs($memID, array('topic_notify_' . $topic => 0));
+			setNotifyPrefs((int) $memID, array('topic_notify_' . $topic => 0));
 	}
 
 	// We are removing topic preferences


### PR DESCRIPTION
setNotifyPrefs expects the memID to be an int.
Otherwise it will be a no-op.

Fixes #6753

Signed-off-by: Oscar Rydhé <oscar.rydhe@gmail.com>