### PR TITLE
Make images responsive if max width is set

### DIFF
--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -3731,7 +3731,7 @@ function setupThemeContext($forceload = false)
 	// Add max image limits
 	if (!empty($modSettings['max_image_width']))
 		addInlineCss('
-	.postarea .bbc_img, .list_posts .bbc_img, .post .inner .bbc_img, form#reported_posts .bbc_img, #preview_body .bbc_img { max-width: ' . $modSettings['max_image_width'] . 'px; }');
+	.postarea .bbc_img, .list_posts .bbc_img, .post .inner .bbc_img, form#reported_posts .bbc_img, #preview_body .bbc_img { max-width: min(100%,' . $modSettings['max_image_width'] . 'px); }');
 
 	if (!empty($modSettings['max_image_height']))
 		addInlineCss('


### PR DESCRIPTION
If the attachments max width is set the max-width
was set to a px value. This would override the responsive
default value of 100% and would make the images non responsive.
Instead calculate a minimum value of 100% and the selected
max width. This will make the image responsive up to the
selected max value.

Fixes #6772

Signed-off-by: Oscar Rydhé <oscar.rydhe@gmail.com>