### PR TITLE
Limit the value of number of posts to match database

### DIFF
--- a/Sources/Profile-Modify.php
+++ b/Sources/Profile-Modify.php
@@ -385,11 +385,15 @@ function loadProfileFields($force_reload = false)
 			'label' => $txt['profile_posts'],
 			'log_change' => true,
 			'size' => 7,
+			'min' => 0,
+			'max' => 2 ** 24 - 1,
 			'permission' => 'moderate_forum',
 			'input_validate' => function(&$value)
 			{
 				if (!is_numeric($value))
 					return 'digits_only';
+				elseif ($value < 0 || $value > 2 ** 24 - 1)
+					return 'posts_out_of_range';
 				else
 					$value = $value != '' ? strtr($value, array(',' => '', '.' => '', ' ' => '')) : 0;
 				return true;

--- a/Themes/default/Profile.template.php
+++ b/Themes/default/Profile.template.php
@@ -1527,7 +1527,7 @@ function template_edit_options()
 				$step = $field['type'] == 'float' ? ' step="0.1"' : '';
 
 				echo '
-						<input type="', $type, '" name="', $key, '" id="', $key, '" size="', empty($field['size']) ? 30 : $field['size'], '" value="', $field['value'], '" ', $field['input_attr'], ' ', $step, '>';
+						<input type="', $type, '" name="', $key, '" id="', $key, '" size="', empty($field['size']) ? 30 : $field['size'], '"', isset($field['min']) ? ' min="' . $field['min'] . '"' : '', isset($field['max']) ? ' max="' . $field['max'] . '"' : '', ' value="', $field['value'], '" ', $field['input_attr'], ' ', $step, '>';
 			}
 			// You "checking" me out? ;)
 			elseif ($field['type'] == 'check')

--- a/Themes/default/languages/Errors.english.php
+++ b/Themes/default/languages/Errors.english.php
@@ -353,6 +353,7 @@ $txt['profile_error_user_title_too_long'] = 'The custom title is too long.';
 $txt['profile_error_custom_field_mail_fail'] = 'The mail validation check returned an error, you need to enter an email in a valid format (user@domain).';
 $txt['profile_error_custom_field_regex_fail'] = 'The regex verification returned an error. If you are unsure about what to type here, please contact the forum administrator.';
 $txt['profile_error_custom_field_nohtml_fail'] = 'HTML tags are not allowed.';
+$txt['profile_error_posts_out_of_range'] = 'The number of posts is out of range';
 
 // Registration form.
 $txt['under_age_registration_prohibited'] = 'Sorry, but users under the age of %1$d are not allowed to register on this forum.';


### PR DESCRIPTION
The database column for a users post count is
mediumint(8) unsigned.
However the form did not limit the value resulting in
database errors if a value outside of the exepted range
was entered. Add input_validate and also set min max
value on the input field.

Fixes #6771

Signed-off-by: Oscar Rydhé <oscar.rydhe@gmail.com>