### PR TITLE
Prioritize avatar max width and height if set

### DIFF
--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -3726,7 +3726,7 @@ function setupThemeContext($forceload = false)
 	// Now add the capping code for avatars.
 	if (!empty($modSettings['avatar_max_width_external']) && !empty($modSettings['avatar_max_height_external']) && !empty($modSettings['avatar_action_too_large']) && $modSettings['avatar_action_too_large'] == 'option_css_resize')
 		addInlineCss('
-	img.avatar { max-width: ' . $modSettings['avatar_max_width_external'] . 'px; max-height: ' . $modSettings['avatar_max_height_external'] . 'px; }');
+	img.avatar { max-width: ' . $modSettings['avatar_max_width_external'] . 'px !important; max-height: ' . $modSettings['avatar_max_height_external'] . 'px !important; }');
 
 	// Add max image limits
 	if (!empty($modSettings['max_image_width']))

--- a/Themes/default/css/index.css
+++ b/Themes/default/css/index.css
@@ -214,7 +214,7 @@ body#help_popup {
 #likes .avatar {
 	max-height: 45px;
 	max-width: 45px;
-	padding: 0 10px 0 0;
+	margin: 0 10px 0 0;
 }
 #likes .avatar, #likes li .like_profile {
 	vertical-align: middle;
@@ -1100,8 +1100,8 @@ img.sort, .sort {
 	width: auto;
 }
 #profile_menu_top > img.avatar {
-	max-height: 18px;
-	max-width: 18px;
+	height: 18px;
+	width: 18px;
 	margin: 2px 5px 0 0;
 	float: left;
 }
@@ -3267,6 +3267,9 @@ div#pollmoderation {
 }
 .poster img {
 	vertical-align: middle;
+}
+img.avatar {
+	object-fit: scale-down;
 }
 .poster img.avatar {
 	max-width: 100%;


### PR DESCRIPTION
If the setting to resize external avatars in css is set,
the avatars could be shown with incorrect aspect ratio,
Prioritize the max-width and max-height setting in code
over other css rules.

Signed-off-by: Oscar Rydhé <oscar.rydhe@gmail.com>