### PR TITLE
Correct typo affecting autosuggest

### DIFF
--- a/Sources/Subs-Editor.php
+++ b/Sources/Subs-Editor.php
@@ -2379,7 +2379,7 @@ function AutoSuggest_Search_MemberGroups()
 			AND id_group NOT IN ({array_int:invalid_groups})
 			AND hidden != {int:hidden}',
 		array(
-			'group_name' => $smcFunc['db_case_sensitive'] ? 'LOWER(group_name}' : 'group_name',
+			'group_name' => $smcFunc['db_case_sensitive'] ? 'LOWER(group_name)' : 'group_name',
 			'min_posts' => -1,
 			'invalid_groups' => array(1, 3),
 			'hidden' => 2,


### PR DESCRIPTION
Minor issue affecting autosuggest when modifying a board.

To reproduce error, modify a board & type a membergroup name in the Moderator Groups field:
![image](https://user-images.githubusercontent.com/23568484/122109087-d3c9aa80-cdd1-11eb-9068-3532e134cf1b.png)

The error you get is:
![image](https://user-images.githubusercontent.com/23568484/122109179-ee038880-cdd1-11eb-887e-f658cba43304.png)
