### PR TITLE
Save board_manager_groups upon creation

### DIFF
--- a/Sources/Load.php
+++ b/Sources/Load.php
@@ -326,7 +326,7 @@ function reloadSettings()
 		require_once($sourcedir . '/Subs-Members.php');
 		$board_managers = groupsAllowedTo('manage_boards', null);
 		$board_managers = implode(',', $board_managers['allowed']);
-		updateSettings(array('board_manager_groups' => $board_managers), true);
+		updateSettings(array('board_manager_groups' => $board_managers));
 	}
 
 	// Is post moderation alive and well? Everywhere else assumes this has been defined, so let's make sure it is.


### PR DESCRIPTION
board_manager_groups is not getting saved as expected upon creation.  

The call to updateSettings() should not issue an UPDATE, as the value doesn't exist yet.

Minor efficiency issue, as the value is created & an update is attempted with pretty much every transaction.


To reproduce, look for board_manager_groups in the settings table.

**_Before:_**
![image](https://user-images.githubusercontent.com/23568484/122113009-653b1b80-cdd6-11eb-9e4f-263f1c9bb967.png)


**_After:_**
![image](https://user-images.githubusercontent.com/23568484/122112973-52284b80-cdd6-11eb-9f89-c9f543fd0e2d.png)
