### PR TITLE
Consolidates and simplifies entity handling

### DIFF
--- a/SSI.php
+++ b/SSI.php
@@ -2450,7 +2450,7 @@ function ssi_recentAttachments($num_attachments = 10, $attachment_ext = array(),
 	$attachments = array();
 	while ($row = $smcFunc['db_fetch_assoc']($request))
 	{
-		$filename = preg_replace('~&amp;#(\\d{1,7}|x[0-9a-fA-F]{1,6});~', '&#\\1;', htmlspecialchars($row['filename']));
+		$filename = $smcFunc['entity_fix'](htmlspecialchars($row['filename']));
 
 		// Is it an image?
 		$attachments[$row['id_attach']] = array(

--- a/Sources/Load.php
+++ b/Sources/Load.php
@@ -114,45 +114,6 @@ function reloadSettings()
 		{
 			return $string;
 		};
-	$fix_utf8mb4 = function($string) use ($utf8, $smcFunc)
-	{
-		if (!$utf8 || $smcFunc['db_mb4'])
-			return $string;
-
-		$i = 0;
-		$len = strlen($string);
-		$new_string = '';
-		while ($i < $len)
-		{
-			$ord = ord($string[$i]);
-			if ($ord < 128)
-			{
-				$new_string .= $string[$i];
-				$i++;
-			}
-			elseif ($ord < 224)
-			{
-				$new_string .= $string[$i] . $string[$i + 1];
-				$i += 2;
-			}
-			elseif ($ord < 240)
-			{
-				$new_string .= $string[$i] . $string[$i + 1] . $string[$i + 2];
-				$i += 3;
-			}
-			elseif ($ord < 248)
-			{
-				// Magic happens.
-				$val = (ord($string[$i]) & 0x07) << 18;
-				$val += (ord($string[$i + 1]) & 0x3F) << 12;
-				$val += (ord($string[$i + 2]) & 0x3F) << 6;
-				$val += (ord($string[$i + 3]) & 0x3F);
-				$new_string .= '&#' . $val . ';';
-				$i += 4;
-			}
-		}
-		return $new_string;
-	};
 
 	// global array of anonymous helper functions, used mostly to properly handle multi byte strings
 	$smcFunc += array(
@@ -161,9 +122,9 @@ function reloadSettings()
 			$num = $string[0] === 'x' ? hexdec(substr($string, 1)) : (int) $string;
 			return $num < 0x20 || $num > 0x10FFFF || ($num >= 0xD800 && $num <= 0xDFFF) || $num === 0x202E || $num === 0x202D ? '' : '&#' . $num . ';';
 		},
-		'htmlspecialchars' => function($string, $quote_style = ENT_COMPAT, $charset = 'ISO-8859-1') use ($ent_check, $utf8, $fix_utf8mb4)
+		'htmlspecialchars' => function($string, $quote_style = ENT_COMPAT, $charset = 'ISO-8859-1') use ($ent_check, $utf8)
 		{
-			return $fix_utf8mb4($ent_check(htmlspecialchars($string, $quote_style, $utf8 ? 'UTF-8' : $charset)));
+			return fix_utf8mb4($ent_check(htmlspecialchars($string, $quote_style, $utf8 ? 'UTF-8' : $charset)));
 		},
 		'htmltrim' => function($string) use ($utf8, $ent_check)
 		{

--- a/Sources/Load.php
+++ b/Sources/Load.php
@@ -119,10 +119,11 @@ function reloadSettings()
 		},
 		'htmltrim' => function($string) use ($utf8)
 		{
-			// Preg_replace space characters depend on the character set in use
-			$space_chars = $utf8 ? '\p{Z}\p{C}' : '\x00-\x20\x80-\xA0';
+			// Find all possible versions of &nbsp;
+			$nbsp = '&(?'.'>nbsp|#(?'.'>x0*A0|0*160));';
 
-			return preg_replace('~^(?:[' . $space_chars . ']|&nbsp;)+|(?:[' . $space_chars . ']|&nbsp;)+$~' . ($utf8 ? 'u' : ''), '', sanitize_entities($string));
+			// Interesting fact: Unicode properties work even when not in UTF-8 mode.
+			return preg_replace('~^(?'.'>[\p{Z}\p{C}]|' . $nbsp . ')+|(?'.'>[\p{Z}\p{C}]|' . $nbsp . ')+$~' . ($utf8 ? 'u' : ''), '', sanitize_entities($string));
 		},
 		'strlen' => function($string) use ($ent_list, $utf8)
 		{

--- a/Sources/Load.php
+++ b/Sources/Load.php
@@ -109,10 +109,9 @@ function reloadSettings()
 
 	// global array of anonymous helper functions, used mostly to properly handle multi byte strings
 	$smcFunc += array(
-		'entity_fix' => function($string)
+		'entity_fix' => function($string) use ($ent_list)
 		{
-			$num = $string[0] === 'x' ? hexdec(substr($string, 1)) : (int) $string;
-			return $num < 0x20 || $num > 0x10FFFF || ($num >= 0xD800 && $num <= 0xDFFF) || $num === 0x202E || $num === 0x202D ? '' : '&#' . $num . ';';
+			return preg_replace('~&amp;(' . substr($ent_list, 1, -1) . ');~', '&$1;', $string);
 		},
 		'htmlspecialchars' => function($string, $quote_style = ENT_COMPAT, $charset = 'ISO-8859-1') use ($utf8)
 		{

--- a/Sources/Load.php
+++ b/Sources/Load.php
@@ -105,7 +105,7 @@ function reloadSettings()
 	$context['utf8'] = $utf8;
 
 	// Set a list of common functions.
-	$ent_list = '&(?:#' . (empty($modSettings['disableEntityCheck']) ? '\d{1,7}' : '021') . '|quot|amp|lt|gt|nbsp);';
+	$ent_list = '&(?'.'>nbsp|quot|gt|lt|a(?'.'>pos|mp)|#(?'.'>\d+|x[0-9a-fA-F]+));';
 
 	// global array of anonymous helper functions, used mostly to properly handle multi byte strings
 	$smcFunc += array(

--- a/Sources/LogInOut.php
+++ b/Sources/LogInOut.php
@@ -206,7 +206,7 @@ function Login2()
 	createToken('login');
 
 	// Set up the default/fallback stuff.
-	$context['default_username'] = isset($_POST['user']) ? preg_replace('~&amp;#(\\d{1,7}|x[0-9a-fA-F]{1,6});~', '&#\\1;', $smcFunc['htmlspecialchars']($_POST['user'])) : '';
+	$context['default_username'] = isset($_POST['user']) ? $smcFunc['entity_fix']($smcFunc['htmlspecialchars']($_POST['user'])) : '';
 	$context['default_password'] = '';
 	$context['never_expire'] = $modSettings['cookieTime'] <= 525600;
 	$context['login_errors'] = array($txt['error_occured']);
@@ -243,7 +243,7 @@ function Login2()
 	if ($smcFunc['strlen']($_POST['user']) > 80)
 	{
 		$_POST['user'] = $smcFunc['substr']($_POST['user'], 0, 79);
-		$context['default_username'] = preg_replace('~&amp;#(\\d{1,7}|x[0-9a-fA-F]{1,6});~', '&#\\1;', $smcFunc['htmlspecialchars']($_POST['user']));
+		$context['default_username'] = $smcFunc['entity_fix']($smcFunc['htmlspecialchars']($_POST['user']));
 	}
 
 	// Are we using any sort of integration to validate the login?

--- a/Sources/ManageAttachments.php
+++ b/Sources/ManageAttachments.php
@@ -466,7 +466,7 @@ function BrowseFiles()
 						if (!empty($rowData['width']) && !empty($rowData['height']))
 							$link .= sprintf(' onclick="return reqWin(this.href' . ($rowData['attachment_type'] == 1 ? '' : ' + \';image\'') . ', %1$d, %2$d, true);"', $rowData['width'] + 20, $rowData['height'] + 20);
 
-						$link .= sprintf('>%1$s</a>', preg_replace('~&amp;#(\\\\d{1,7}|x[0-9a-fA-F]{1,6});~', '&#\\\\1;', $smcFunc['htmlspecialchars']($rowData['filename'])));
+						$link .= sprintf('>%1$s</a>', $smcFunc['entity_fix']($smcFunc['htmlspecialchars']($rowData['filename'])));
 
 						// Show the dimensions.
 						if (!empty($rowData['width']) && !empty($rowData['height']))
@@ -1098,7 +1098,7 @@ function removeAttachments($condition, $query_type = '', $return_affected_messag
 				'remove_attach',
 				array(
 					'message' => $row['id_msg'],
-					'filename' => preg_replace('~&amp;#(\\d{1,7}|x[0-9a-fA-F]{1,6});~', '&#\\1;', $smcFunc['htmlspecialchars']($row['filename'])),
+					'filename' => $smcFunc['entity_fix']($smcFunc['htmlspecialchars']($row['filename'])),
 				)
 			);
 		$smcFunc['db_free_result']($request);
@@ -1887,7 +1887,7 @@ function ApproveAttachments($attachments)
 			'approve_attach',
 			array(
 				'message' => $row['id_msg'],
-				'filename' => preg_replace('~&amp;#(\\d{1,7}|x[0-9a-fA-F]{1,6});~', '&#\\1;', $smcFunc['htmlspecialchars']($row['filename'])),
+				'filename' => $smcFunc['entity_fix']($smcFunc['htmlspecialchars']($row['filename'])),
 			)
 		);
 	$smcFunc['db_free_result']($request);

--- a/Sources/ManageBans.php
+++ b/Sources/ManageBans.php
@@ -1245,7 +1245,7 @@ function validateTriggers(&$triggers)
 			}
 			elseif ($key == 'user')
 			{
-				$user = preg_replace('~&amp;#(\d{4,5}|[2-9]\d{2,4}|1[2-9]\d);~', '&#$1;', $smcFunc['htmlspecialchars']($value, ENT_QUOTES));
+				$user = $smcFunc['entity_fix']($smcFunc['htmlspecialchars']($value, ENT_QUOTES));
 
 				$request = $smcFunc['db_query']('', '
 					SELECT id_member, (id_group = {int:admin_group} OR FIND_IN_SET({int:admin_group}, additional_groups) != 0) AS isAdmin

--- a/Sources/ManageMaintenance.php
+++ b/Sources/ManageMaintenance.php
@@ -657,7 +657,7 @@ function ConvertEntities()
 					if ($column_name !== $primary_key && strpos($column_value, '&#') !== false)
 					{
 						$changes[] = $column_name . ' = {string:changes_' . $column_name . '}';
-						$insertion_variables['changes_' . $column_name] = preg_replace_callback('~&#(\d{1,5}|x[0-9a-fA-F]{1,4});~', 'fixchardb__callback', $column_value);
+						$insertion_variables['changes_' . $column_name] = smf_entity_decode($column_value);
 					}
 
 				$where = array();
@@ -2297,32 +2297,6 @@ function get_hook_info_from_raw($rawData)
 		$hookData['pureFunc'] = $modFunc;
 
 	return $hookData;
-}
-
-/**
- * Converts html entities to utf8 equivalents
- * special db wrapper for mysql based on the limitation of mysql/mb3
- *
- * Callback function for preg_replace_callback
- * Uses capture group 1 in the supplied array
- * Does basic checks to keep characters inside a viewable range.
- *
- * @param array $matches An array of matches (relevant info should be the 2nd item in the array)
- * @return string The fixed string or return the old when limitation of mysql is hit
- */
-function fixchardb__callback($matches)
-{
-	global $smcFunc;
-	if (!isset($matches[1]))
-		return '';
-
-	$num = $matches[1][0] === 'x' ? hexdec(substr($matches[1], 1)) : (int) $matches[1];
-
-	// it's to big for mb3?
-	if ($num > 0xFFFF && !$smcFunc['db_mb4'])
-		return $matches[0];
-	else
-		return fixchar__callback($matches);
 }
 
 ?>

--- a/Sources/ManageMembergroups.php
+++ b/Sources/ManageMembergroups.php
@@ -973,7 +973,7 @@ function EditMembergroup()
 			// Get all the usernames from the string
 			if (!empty($moderator_string))
 			{
-				$moderator_string = strtr(preg_replace('~&amp;#(\d{4,5}|[2-9]\d{2,4}|1[2-9]\d);~', '&#$1;', $smcFunc['htmlspecialchars']($moderator_string, ENT_QUOTES)), array('&quot;' => '"'));
+				$moderator_string = strtr($smcFunc['entity_fix']($smcFunc['htmlspecialchars']($moderator_string, ENT_QUOTES)), array('&quot;' => '"'));
 				preg_match_all('~"([^"]+)"~', $moderator_string, $matches);
 				$moderators = array_merge($matches[1], explode(',', preg_replace('~"[^"]+"~', '', $moderator_string)));
 				for ($k = 0, $n = count($moderators); $k < $n; $k++)

--- a/Sources/News.php
+++ b/Sources/News.php
@@ -1143,7 +1143,7 @@ function getXmlNews($xml_format, $ascending = false)
 							array(
 								'tag' => 'name',
 								'attributes' => array('label' => $txt['name']),
-								'content' => preg_replace('~&amp;#(\\d{1,7}|x[0-9a-fA-F]{1,6});~', '&#\\1;', $smcFunc['htmlspecialchars']($attachment['filename'])),
+								'content' => $smcFunc['entity_fix']($smcFunc['htmlspecialchars']($attachment['filename'])),
 							),
 							array(
 								'tag' => 'downloads',
@@ -1599,7 +1599,7 @@ function getXmlRecent($xml_format)
 							array(
 								'tag' => 'name',
 								'attributes' => array('label' => $txt['name']),
-								'content' => preg_replace('~&amp;#(\\d{1,7}|x[0-9a-fA-F]{1,6});~', '&#\\1;', $smcFunc['htmlspecialchars']($attachment['filename'])),
+								'content' => $smcFunc['entity_fix']($smcFunc['htmlspecialchars']($attachment['filename'])),
 							),
 							array(
 								'tag' => 'downloads',
@@ -2386,7 +2386,7 @@ function getXmlPosts($xml_format, $ascending = false)
 							array(
 								'tag' => 'name',
 								'attributes' => array('label' => $txt['name']),
-								'content' => preg_replace('~&amp;#(\\d{1,7}|x[0-9a-fA-F]{1,6});~', '&#\\1;', $smcFunc['htmlspecialchars']($attachment['filename'])),
+								'content' => $smcFunc['entity_fix']($smcFunc['htmlspecialchars']($attachment['filename'])),
 							),
 							array(
 								'tag' => 'downloads',

--- a/Sources/Post.php
+++ b/Sources/Post.php
@@ -2146,7 +2146,7 @@ function Post2()
 		// Clean up the question and answers.
 		$_POST['question'] = $smcFunc['htmlspecialchars']($_POST['question']);
 		$_POST['question'] = $smcFunc['truncate']($_POST['question'], 255);
-		$_POST['question'] = preg_replace('~&amp;#(\d{4,5}|[2-9]\d{2,4}|1[2-9]\d);~', '&#$1;', $_POST['question']);
+		$_POST['question'] = $smcFunc['entity_fix']($_POST['question']);
 		$_POST['options'] = htmlspecialchars__recursive($_POST['options']);
 	}
 

--- a/Sources/Post.php
+++ b/Sources/Post.php
@@ -2146,7 +2146,6 @@ function Post2()
 		// Clean up the question and answers.
 		$_POST['question'] = $smcFunc['htmlspecialchars']($_POST['question']);
 		$_POST['question'] = $smcFunc['truncate']($_POST['question'], 255);
-		$_POST['question'] = $smcFunc['entity_fix']($_POST['question']);
 		$_POST['options'] = htmlspecialchars__recursive($_POST['options']);
 	}
 

--- a/Sources/Profile-Export.php
+++ b/Sources/Profile-Export.php
@@ -533,13 +533,13 @@ function download_export_file($uid)
 
 	// Different browsers like different standards...
 	if (isBrowser('firefox'))
-		header('content-disposition: attachment; filename*=UTF-8\'\'' . rawurlencode(preg_replace_callback('~&#(\d{3,8});~', 'fixchar__callback', $utf8name)));
+		header('content-disposition: attachment; filename*=UTF-8\'\'' . rawurlencode(smf_entity_decode($utf8name)));
 
 	elseif (isBrowser('opera'))
-		header('content-disposition: attachment; filename="' . preg_replace_callback('~&#(\d{3,8});~', 'fixchar__callback', $utf8name) . '"');
+		header('content-disposition: attachment; filename="' . smf_entity_decode($utf8name) . '"');
 
 	elseif (isBrowser('ie'))
-		header('content-disposition: attachment; filename="' . urlencode(preg_replace_callback('~&#(\d{3,8});~', 'fixchar__callback', $utf8name)) . '"');
+		header('content-disposition: attachment; filename="' . urlencode(smf_entity_decode($utf8name)) . '"');
 
 	else
 		header('content-disposition: attachment; filename="' . $utf8name . '"');

--- a/Sources/Profile-Modify.php
+++ b/Sources/Profile-Modify.php
@@ -292,7 +292,7 @@ function loadProfileFields($force_reload = false)
 						resetPassword($context['id_member'], $value);
 					elseif ($value !== null)
 					{
-						validateUsername($context['id_member'], trim(preg_replace('~[\t\n\r \x0B\0' . ($context['utf8'] ? '\x{A0}\x{AD}\x{2000}-\x{200F}\x{201F}\x{202F}\x{3000}\x{FEFF}' : '\x00-\x08\x0B\x0C\x0E-\x19\xA0') . ']+~' . ($context['utf8'] ? 'u' : ''), ' ', $value)));
+						validateUsername($context['id_member'], trim(normalize_spaces(sanitize_chars($value, ' '), true, true, array('no_breaks' => true, 'replace_tabs' => true, 'collapse_hspace' => true))));
 						updateMemberData($context['id_member'], array('member_name' => $value));
 
 						// Call this here so any integrated systems will know about the name change (resetPassword() takes care of this if we're letting SMF generate the password)
@@ -405,7 +405,7 @@ function loadProfileFields($force_reload = false)
 			'enabled' => allowedTo('profile_displayed_name_own') || allowedTo('profile_displayed_name_any') || allowedTo('moderate_forum'),
 			'input_validate' => function(&$value) use ($context, $smcFunc, $sourcedir, $cur_profile)
 			{
-				$value = trim(preg_replace('~[\t\n\r \x0B\0' . ($context['utf8'] ? '\x{A0}\x{AD}\x{2000}-\x{200F}\x{201F}\x{202F}\x{3000}\x{FEFF}' : '\x00-\x08\x0B\x0C\x0E-\x19\xA0') . ']+~' . ($context['utf8'] ? 'u' : ''), ' ', $value));
+				$value = trim(normalize_spaces(sanitize_chars($value, ' '), true, true, array('no_breaks' => true, 'replace_tabs' => true, 'collapse_hspace' => true)));
 
 				if (trim($value) == '')
 					return 'no_name';

--- a/Sources/Register.php
+++ b/Sources/Register.php
@@ -912,7 +912,7 @@ function RegisterCheckUsername()
 	$context['valid_username'] = true;
 
 	// Clean it up like mother would.
-	$context['checked_username'] = preg_replace('~[\t\n\r \x0B\0' . ($context['utf8'] ? '\x{A0}\x{AD}\x{2000}-\x{200F}\x{201F}\x{202F}\x{3000}\x{FEFF}' : '\x00-\x08\x0B\x0C\x0E-\x19\xA0') . ']+~' . ($context['utf8'] ? 'u' : ''), ' ', $context['checked_username']);
+	$context['checked_username'] = trim(normalize_spaces(sanitize_chars($context['checked_username'], ' '), true, true, array('no_breaks' => true, 'replace_tabs' => true, 'collapse_hspace' => true)));
 
 	require_once($sourcedir . '/Subs-Auth.php');
 	$errors = validateUsername(0, $context['checked_username'], true);

--- a/Sources/Search.php
+++ b/Sources/Search.php
@@ -2058,7 +2058,7 @@ function prepareSearchContext($reset = false)
 				foreach ($context['key_words'] as $keyword)
 				{
 					$keyword = un_htmlspecialchars($keyword);
-					$keyword = preg_replace_callback('~(&amp;#(\d{1,7}|x[0-9a-fA-F]{1,6});)~', 'entity_fix__callback', strtr($keyword, array('\\\'' => '\'', '&' => '&amp;')));
+					$keyword = $smcFunc['entity_fix'](strtr($keyword, array('\\\'' => '\'')));
 
 					if (preg_match('~[\'\.,/@%&;:(){}\[\]_\-+\\\\]$~', $keyword) != 0 || preg_match('~^[\'\.,/@%&;:(){}\[\]_\-+\\\\]~', $keyword) != 0)
 						$force_partial_word = true;
@@ -2082,7 +2082,7 @@ function prepareSearchContext($reset = false)
 			}
 
 			// Re-fix the international characters.
-			$message['body'] = preg_replace_callback('~(&amp;#(\d{1,7}|x[0-9a-fA-F]{1,6});)~', 'entity_fix__callback', $message['body']);
+			$message['body'] = $smcFunc['entity_fix']($message['body']);
 		}
 		$message['subject_highlighted'] = highlight($message['subject'], $context['key_words']);
 		$message['body_highlighted'] = highlight($message['body'], $context['key_words']);

--- a/Sources/ShowAttachments.php
+++ b/Sources/ShowAttachments.php
@@ -313,13 +313,13 @@ function showAttachment()
 
 	// Different browsers like different standards...
 	if (isBrowser('firefox'))
-		header('content-disposition: ' . $disposition . '; filename*=UTF-8\'\'' . rawurlencode(preg_replace_callback('~&#(\d{3,8});~', 'fixchar__callback', $utf8name)));
+		header('content-disposition: ' . $disposition . '; filename*=UTF-8\'\'' . rawurlencode(smf_entity_decode($utf8name)));
 
 	elseif (isBrowser('opera'))
-		header('content-disposition: ' . $disposition . '; filename="' . preg_replace_callback('~&#(\d{3,8});~', 'fixchar__callback', $utf8name) . '"');
+		header('content-disposition: ' . $disposition . '; filename="' . smf_entity_decode($utf8name) . '"');
 
 	elseif (isBrowser('ie'))
-		header('content-disposition: ' . $disposition . '; filename="' . urlencode(preg_replace_callback('~&#(\d{3,8});~', 'fixchar__callback', $utf8name)) . '"');
+		header('content-disposition: ' . $disposition . '; filename="' . urlencode(smf_entity_decode($utf8name)) . '"');
 
 	else
 		header('content-disposition: ' . $disposition . '; filename="' . $utf8name . '"');

--- a/Sources/Subs-Attachments.php
+++ b/Sources/Subs-Attachments.php
@@ -1168,7 +1168,7 @@ function loadAttachmentContext($id_msg, $attachments)
 		{
 			$attachmentData[$i] = array(
 				'id' => $attachment['id_attach'],
-				'name' => preg_replace('~&amp;#(\\d{1,7}|x[0-9a-fA-F]{1,6});~', '&#\\1;', $smcFunc['htmlspecialchars']($attachment['filename'])),
+				'name' => $smcFunc['entity_fix']($smcFunc['htmlspecialchars']($attachment['filename'])),
 				'downloads' => $attachment['downloads'],
 				'size' => ($attachment['filesize'] < 1024000) ? round($attachment['filesize'] / 1024, 2) . ' ' . $txt['kilobyte'] : round($attachment['filesize'] / 1024 / 1024, 2) . ' ' . $txt['megabyte'],
 				'byte_size' => $attachment['filesize'],

--- a/Sources/Subs-Auth.php
+++ b/Sources/Subs-Auth.php
@@ -568,10 +568,7 @@ function RequestMembers()
 				$row['real_name'] = $utf8;
 		}
 
-		$row['real_name'] = strtr($row['real_name'], array('&amp;' => '&#038;', '&lt;' => '&#060;', '&gt;' => '&#062;', '&quot;' => '&#034;'));
-
-		if (preg_match('~&#\d+;~', $row['real_name']) != 0)
-			$row['real_name'] = preg_replace_callback('~&#(\d+);~', 'fixchar__callback', $row['real_name']);
+		$row['real_name'] = smf_entity_decode($row['real_name']);
 
 		echo $row['real_name'], "\n";
 	}

--- a/Sources/Subs-Members.php
+++ b/Sources/Subs-Members.php
@@ -464,7 +464,7 @@ function registerMember(&$regOptions, $return_errors = false)
 	}
 
 	// Spaces and other odd characters are evil...
-	$regOptions['username'] = trim(preg_replace('~[\t\n\r \x0B\0' . ($context['utf8'] ? '\x{A0}\x{AD}\x{2000}-\x{200F}\x{201F}\x{202F}\x{3000}\x{FEFF}' : '\x00-\x08\x0B\x0C\x0E-\x19\xA0') . ']+~' . ($context['utf8'] ? 'u' : ''), ' ', $regOptions['username']));
+	$regOptions['username'] = trim(normalize_spaces(sanitize_chars($regOptions['username'], ' '), true, true, array('no_breaks' => true, 'replace_tabs' => true, 'collapse_hspace' => true)));
 
 	// Convert character encoding for non-utf8mb4 database
 	$regOptions['username'] = $smcFunc['htmlspecialchars']($regOptions['username']);

--- a/Sources/Subs-Members.php
+++ b/Sources/Subs-Members.php
@@ -866,7 +866,7 @@ function isReservedName($name, $current_id_member = 0, $is_name = true, $fatal =
 {
 	global $modSettings, $smcFunc;
 
-	$name = preg_replace_callback('~(&#(\d{1,7}|x[0-9a-fA-F]{1,6});)~', 'replaceEntities__callback', $name);
+	$name = $smcFunc['htmlspecialchars'](smf_entity_decode($name));
 	$checkName = $smcFunc['strtolower']($name);
 
 	// Administrators are never restricted ;).
@@ -883,7 +883,7 @@ function isReservedName($name, $current_id_member = 0, $is_name = true, $fatal =
 				continue;
 
 			// The admin might've used entities too, level the playing field.
-			$reservedCheck = preg_replace('~(&#(\d{1,7}|x[0-9a-fA-F]{1,6});)~', 'replaceEntities__callback', $reserved);
+			$reservedCheck = $smcFunc['htmlspecialchars'](smf_entity_decode($reserved));
 
 			// Case sensitive name?
 			if (empty($modSettings['reserveCase']))

--- a/Sources/Subs-Post.php
+++ b/Sources/Subs-Post.php
@@ -28,7 +28,7 @@ if (!defined('SMF'))
  */
 function preparsecode(&$message, $previewing = false)
 {
-	global $user_info, $modSettings, $context, $sourcedir;
+	global $user_info, $modSettings, $context, $sourcedir, $smcFunc;
 
 	static $tags_regex, $disallowed_tags_regex;
 
@@ -47,7 +47,7 @@ function preparsecode(&$message, $previewing = false)
 
 	// This line makes all languages *theoretically* work even with the wrong charset ;).
 	if (empty($context['utf8']))
-		$message = preg_replace('~&amp;#(\d{4,5}|[2-9]\d{2,4}|1[2-9]\d);~', '&#$1;', $message);
+		$message = $smcFunc['entity_fix']($message);
 
 	// Clean up after nobbc ;).
 	$message = preg_replace_callback('~\[nobbc\](.+?)\[/nobbc\]~is', function($a)

--- a/Sources/Subs-Post.php
+++ b/Sources/Subs-Post.php
@@ -1267,7 +1267,7 @@ function mimespecialchars($string, $with_charset = true, $hotmail_fix = false, $
 					$string = $newstring;
 			}
 
-			$string = preg_replace_callback('~&#(\d{3,8});~', 'fixchar__callback', $string);
+			$string = smf_entity_decode($string);
 
 			// Unicode, baby.
 			$charset = 'UTF-8';

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -1283,6 +1283,112 @@ function sanitize_entities($string, $substitute = '&#65533;')
 }
 
 /**
+ * Replaces invalid characters with a substitute.
+ *
+ * !!! Warning !!! Setting $substitute to '' in order to delete invalid
+ * characters from the string can create unexpected security problems. See
+ * https://www.unicode.org/reports/tr36/#Deletion_of_Noncharacters for an
+ * explanation.
+ *
+ * @param string $string The string to sanitize.
+ * @param string|null $substitute Replacement string for the invalid characters.
+ *      If not set, the Unicode replacement character "�" (U+FFFD) will be used
+ *      (or a fallback like "?" if necessary).
+ * @return string The sanitized string.
+ */
+function sanitize_chars($string, $substitute = null)
+{
+	global $context;
+
+	$string = (string) $string;
+
+	// What substitute character should we use?
+	if (isset($substitute))
+	{
+		$substitute = strval($substitute);
+	}
+	elseif (!empty($context['utf8']))
+	{
+		// Raw UTF-8 bytes for the replacement character.
+		$substitute = chr(239) . chr(191) . chr(189);
+	}
+	elseif (!empty($context['character_set']) && is_callable('mb_decode_numericentity'))
+	{
+		$substitute = mb_decode_numericentity('&#xFFFD;', array(0xFFFD,0xFFFD,0,0xFFFF), $context['character_set']);
+	}
+	else
+		$substitute = '?';
+
+	// Fix any invalid byte sequences.
+	if (!empty($context['character_set']) && is_callable('mb_scrub'))
+	{
+		// For UTF-8, this preg_match test is much faster than mb_check_encoding.
+		$malformed = !empty($context['utf8']) ? @preg_match('//u', $string) === false && preg_last_error() === PREG_BAD_UTF8_ERROR : is_callable('mb_check_encoding') && !mb_check_encoding($string, $context['character_set']);
+
+		if ($malformed)
+			$string = mb_scrub($string, $context['character_set']);
+	}
+
+	// Fix any weird vertical space characters.
+	$string = normalize_spaces($string, true);
+
+	// Fix any unwanted control characters and other creepy-crawlies.
+	$string = preg_replace('/[^\P{C}\t\r\n]/' . (!empty($context['utf8']) ? 'u' : ''), $substitute, $string);
+
+	return $string;
+}
+
+/**
+ * Normalizes space characters and line breaks.
+ *
+ * @param string $string The string to sanitize.
+ * @param bool $vspace If true, replaces all line breaks and vertical space
+ *      characters with "\n". Default: true.
+ * @param bool $hspace If true, replaces horizontal space characters with a
+ *      plain " " character. (Note: tabs are not replaced unless the
+ *      'replace_tabs' option is supplied.) Default: false.
+ * @param array $options An array of boolean options. Possible values are:
+ *      - no_breaks: Vertical spaces are replaced by " " instead of "\n".
+ *      - replace_tabs: If true, tabs are are replaced by " " chars.
+ *      - collapse_hspace: If true, removes extra horizontal spaces.
+ * @return string The sanitized string.
+ */
+function normalize_spaces($string, $vspace = true, $hspace = false, $options = array())
+{
+	global $context;
+
+	$string = (string) $string;
+	$vspace = !empty($vspace);
+	$hspace = !empty($hspace);
+
+	if (!$vspace && !$hspace)
+		return $string;
+
+	$options['no_breaks'] = !empty($options['no_breaks']);
+	$options['collapse_hspace'] = !empty($options['collapse_hspace']);
+	$options['replace_tabs'] = !empty($options['replace_tabs']);
+
+	$patterns = array();
+	$replacements = array();
+
+	if ($vspace)
+	{
+		// \R is like \v, except it handles "\r\n" as a single unit.
+		$patterns[] = '/\R/' . ($context['utf8'] ? 'u' : '');
+		$replacements[] = $options['no_breaks'] ? ' ' : "\n";
+	}
+
+	if ($hspace)
+	{
+		// Interesting fact: Unicode properties like \p{Zs} work even when not in UTF-8 mode.
+		$patterns[] = '/' . ($options['replace_tabs'] ? '\h' : '\p{Zs}') . ($options['collapse_hspace'] ? '+' : '') . '/' . ($context['utf8'] ? 'u' : '');
+		$replacements[] = ' ';
+	}
+
+	return preg_replace($patterns, $replacements, $string);
+}
+
+/**
  * Shorten a subject + internationalization concerns.
  *
  * - shortens a subject so that it is either shorter than length, or that length plus an ellipsis.

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -1152,6 +1152,137 @@ function fix_utf8mb4($string)
 }
 
 /**
+ * Decodes and sanitizes HTML entities.
+ *
+ * If database does not support 4-byte UTF-8 characters, entities for 4-byte
+ * characters are left in place.
+ *
+ * @param string $string The string in which to decode entities.
+ * @param bool $nbsp_to_space If true, decode '&nbsp;' to space character.
+ * 		Default: false.
+ * @param integer $flags Flags to pass to html_entity_decode.
+ * 		Default: ENT_QUOTES | ENT_HTML5.
+ * @return string The string with the entities decoded.
+ */
+function smf_entity_decode($string, $nbsp_to_space = false, $flags = ENT_QUOTES | ENT_HTML5)
+{
+	global $context, $smcFunc;
+
+	// Basic parameter sanitization.
+	$string = (string) $string;
+	$nbsp_to_space = (bool) $nbsp_to_space;
+	$flags = !is_int($flags) ? ENT_QUOTES | ENT_HTML5 : $flags;
+
+	// Don't waste time on empty strings.
+	if (trim($string) === '')
+		return $string;
+
+	// In theory this is always UTF-8, but...
+	if (empty($context['character_set']))
+		$charset = is_callable('mb_detect_encoding') ? mb_detect_encoding($string) : 'UTF-8';
+	elseif (strpos($context['character_set'], 'ISO-8859-') !== false && !in_array($context['character_set'], array('ISO-8859-5', 'ISO-8859-15')))
+		$charset = 'ISO-8859-1';
+	else
+		$charset = $context['character_set'];
+
+	// Enables consistency with the behaviour of un_htmlspecialchars.
+	if ($nbsp_to_space)
+		$string = strtr($string, array('&nbsp;' => ' ', '&#xA0;' => ' ', '&#160;' => ' '));
+
+	// Do the deed.
+	$string = html_entity_decode($string, $flags, $charset);
+
+	// Remove any illegal character entities.
+	$string = sanitize_entities($string);
+
+	// Finally, make sure we don't break the database.
+	$string = fix_utf8mb4($string);
+
+	return $string;
+}
+
+/**
+ * Replaces HTML entities for invalid characters with a substitute.
+ *
+ * The default substitute is the entity for the replacement character U+FFFD
+ * (a.k.a. the question-mark-in-a-box).
+ *
+ * !!! Warning !!! Setting $substitute to '' in order to delete invalid
+ * entities from the string can create unexpected security problems. See
+ * https://www.unicode.org/reports/tr36/#Deletion_of_Noncharacters for an
+ * explanation.
+ *
+ * @param string $string The string to sanitize.
+ * @param string $substitute Replacement for the invalid entities.
+ *      Default: '&#65533;'
+ * @return string The sanitized string.
+ */
+function sanitize_entities($string, $substitute = '&#65533;')
+{
+	static $disallowed;
+
+	$string = (string) $string;
+	$substitute = (string) $substitute;
+
+	if (strpos($string, '&#') === false)
+		return $string;
+
+	if (empty($disallowed))
+	{
+		$disallowed['dec'] = array();
+
+		// Control characters.
+		for ($i = 0x0; $i < 0x20; $i++)
+		{
+			// Allow \t, \n, and \r
+			if ($i === 0x9 || $i === 0xA || $i === 0xD)
+				continue;
+
+			$disallowed['dec'][] = $i;
+		}
+		for ($i = 0x7F; $i < 0xA0; $i++)
+			$disallowed['dec'][] = $i;
+
+		// UTF-16 surrogate pairs.
+		for ($i = 0xD800; $i < 0xE000; $i++)
+			$disallowed['dec'][] = $i;
+
+		// Non-character code points.
+		for ($i = 0xFDD0; $i <= 0xFDEF; $i++)
+			$disallowed['dec'][] = $i;
+
+		$disallowed['dec'] = array_merge($disallowed['dec'], array(
+			0xFFFE, 0xFFFF,
+			0x1FFFE, 0x1FFFF,
+			0x2FFFE, 0x2FFFF,
+			0x3FFFE, 0x3FFFF,
+			0x4FFFE, 0x4FFFF,
+			0x5FFFE, 0x5FFFF,
+			0x6FFFE, 0x6FFFF,
+			0x7FFFE, 0x7FFFF,
+			0x8FFFE, 0x8FFFF,
+			0x9FFFE, 0x9FFFF,
+			0xAFFFE, 0xAFFFF,
+			0xBFFFE, 0xBFFFF,
+			0xCFFFE, 0xCFFFF,
+			0xDFFFE, 0xDFFFF,
+			0xEFFFE, 0xEFFFF,
+			0xFFFFE, 0xFFFFF,
+			0x10FFFE, 0x10FFFF,
+		));
+
+		// Now build the regexes to match these illegal entities.
+		$disallowed['hex'] = build_regex(array_map('dechex', $disallowed['dec']));
+		$disallowed['dec'] = build_regex($disallowed['dec']);
+	}
+
+	// Replace all illegal entities with the entity for the replacement character.
+	$string = preg_replace('/&#(?'.'>x0*' . $disallowed['hex'] . '|0*' . $disallowed['dec'] . ');/i', $substitute, $string);
+
+	return $string;
+}
+
+/**
  * Shorten a subject + internationalization concerns.
  *
  * - shortens a subject so that it is either shorter than length, or that length plus an ellipsis.
@@ -5828,124 +5959,6 @@ function sanitizeMSCutPaste($string)
 		$string = str_replace($findchars_iso, $replacechars, $string);
 
 	return $string;
-}
-
-/**
- * Decode numeric html entities to their ascii or UTF8 equivalent character.
- *
- * Callback function for preg_replace_callback in subs-members
- * Uses capture group 2 in the supplied array
- * Does basic scan to ensure characters are inside a valid range
- *
- * @param array $matches An array of matches (relevant info should be the 3rd item)
- * @return string A fixed string
- */
-function replaceEntities__callback($matches)
-{
-	global $context;
-
-	if (!isset($matches[2]))
-		return '';
-
-	$num = $matches[2][0] === 'x' ? hexdec(substr($matches[2], 1)) : (int) $matches[2];
-
-	// remove left to right / right to left overrides
-	if ($num === 0x202D || $num === 0x202E)
-		return '';
-
-	// Quote, Ampersand, Apostrophe, Less/Greater Than get html replaced
-	if (in_array($num, array(0x22, 0x26, 0x27, 0x3C, 0x3E)))
-		return '&#' . $num . ';';
-
-	if (empty($context['utf8']))
-	{
-		// no control characters
-		if ($num < 0x20)
-			return '';
-		// text is text
-		elseif ($num < 0x80)
-			return chr($num);
-		// all others get html-ised
-		else
-			return '&#' . $matches[2] . ';';
-	}
-	else
-	{
-		// <0x20 are control characters, 0x20 is a space, > 0x10FFFF is past the end of the utf8 character set
-		// 0xD800 >= $num <= 0xDFFF are surrogate markers (not valid for utf8 text)
-		if ($num < 0x20 || $num > 0x10FFFF || ($num >= 0xD800 && $num <= 0xDFFF))
-			return '';
-		// <0x80 (or less than 128) are standard ascii characters a-z A-Z 0-9 and punctuation
-		elseif ($num < 0x80)
-			return chr($num);
-		// <0x800 (2048)
-		elseif ($num < 0x800)
-			return chr(($num >> 6) + 192) . chr(($num & 63) + 128);
-		// < 0x10000 (65536)
-		elseif ($num < 0x10000)
-			return chr(($num >> 12) + 224) . chr((($num >> 6) & 63) + 128) . chr(($num & 63) + 128);
-		// <= 0x10FFFF (1114111)
-		else
-			return chr(($num >> 18) + 240) . chr((($num >> 12) & 63) + 128) . chr((($num >> 6) & 63) + 128) . chr(($num & 63) + 128);
-	}
-}
-
-/**
- * Converts html entities to utf8 equivalents
- *
- * Callback function for preg_replace_callback
- * Uses capture group 1 in the supplied array
- * Does basic checks to keep characters inside a viewable range.
- *
- * @param array $matches An array of matches (relevant info should be the 2nd item in the array)
- * @return string The fixed string
- */
-function fixchar__callback($matches)
-{
-	if (!isset($matches[1]))
-		return '';
-
-	$num = $matches[1][0] === 'x' ? hexdec(substr($matches[1], 1)) : (int) $matches[1];
-
-	// <0x20 are control characters, > 0x10FFFF is past the end of the utf8 character set
-	// 0xD800 >= $num <= 0xDFFF are surrogate markers (not valid for utf8 text), 0x202D-E are left to right overrides
-	if ($num < 0x20 || $num > 0x10FFFF || ($num >= 0xD800 && $num <= 0xDFFF) || $num === 0x202D || $num === 0x202E)
-		return '';
-	// <0x80 (or less than 128) are standard ascii characters a-z A-Z 0-9 and punctuation
-	elseif ($num < 0x80)
-		return chr($num);
-	// <0x800 (2048)
-	elseif ($num < 0x800)
-		return chr(($num >> 6) + 192) . chr(($num & 63) + 128);
-	// < 0x10000 (65536)
-	elseif ($num < 0x10000)
-		return chr(($num >> 12) + 224) . chr((($num >> 6) & 63) + 128) . chr(($num & 63) + 128);
-	// <= 0x10FFFF (1114111)
-	else
-		return chr(($num >> 18) + 240) . chr((($num >> 12) & 63) + 128) . chr((($num >> 6) & 63) + 128) . chr(($num & 63) + 128);
-}
-
-/**
- * Strips out invalid html entities, replaces others with html style &#123; codes
- *
- * Callback function used of preg_replace_callback in smcFunc $ent_checks, for example
- * strpos, strlen, substr etc
- *
- * @param array $matches An array of matches (relevant info should be the 3rd item in the array)
- * @return string The fixed string
- */
-function entity_fix__callback($matches)
-{
-	if (!isset($matches[2]))
-		return '';
-
-	$num = $matches[2][0] === 'x' ? hexdec(substr($matches[2], 1)) : (int) $matches[2];
-
-	// we don't allow control characters, characters out of range, byte markers, etc
-	if ($num < 0x20 || $num > 0x10FFFF || ($num >= 0xD800 && $num <= 0xDFFF) || $num == 0x202D || $num == 0x202E)
-		return '';
-	else
-		return '&#' . $num . ';';
 }
 
 /**

--- a/other/install.php
+++ b/other/install.php
@@ -1655,7 +1655,7 @@ function AdminAccount()
 			$incontext['member_salt'] = bin2hex(random_bytes(16));
 
 			// Format the username properly.
-			$_POST['username'] = preg_replace('~[\t\n\r\x0B\0\xA0]+~', ' ', $_POST['username']);
+			$_POST['username'] = trim(normalize_spaces(sanitize_chars($_POST['username'], ' '), true, true, array('no_breaks' => true, 'replace_tabs' => true, 'collapse_hspace' => true)));
 			$ip = isset($_SERVER['REMOTE_ADDR']) ? substr($_SERVER['REMOTE_ADDR'], 0, 255) : '';
 
 			$_POST['password1'] = hash_password($_POST['username'], $_POST['password1']);


### PR DESCRIPTION
Inspired by discussion in SimpleMachines/SMF2.0#212, this PR consolidates and simplifies a bunch of redundant code that was used for handling HTML entities.

The changes can be summarized as follow:

1. Gets rid of `fixchar__callback()`, `fixchardb__callback()`, `replaceEntities__callback()`, and `entity_fix__callback()`, in favour of the simpler, faster, and more reliable `smf_entity_decode()`, `sanitize_entities()`, and `$smcFunc['entity_fix']()`.
	- Also makes `fix_utf8mb4()` a named function in order to faciliate the above changes.

2. Adds `sanitize_chars()` and `normalize_spaces()` to deal with invalid characters and weird or undesired whitespace.

3. Makes the `$ent_list` regular expression (which is used in many `$smcFunc` functions) much more robust.

As a bonus, this also improves `$smcFunc['html_trim']()` so that it correctly trims `&#160;` and `&#xA0;` as well as `&nbsp;`.

---------

This PR seems a lot bigger than it really is, because there are a lot of files that have a line here or there that can benefit from these improvements. In reality, it is actually not very hard to test all possible routes that are affected by these changes. The following tests will cover literally everything:

- Log in and log out. This tests the changes in `Login2()`.

- Run a search for a string containing entities and characters that should be entities, e.g. `long &amp; short & wide`. This tests the changes in `prepareSearchContext()`.

- Create a poll with an ampersand in the question. This tests the changes in `Post2()`.

- Change the name of the forum to something with a `<`, `>`, or `&` character in it, and then do something that will trigger an email notification to be created. This tests the changes in `mimespecialchars()`.

- Create a new topic, attach an image with an ampersand in its file name to the post, embed that attachment into the post via the `[attach]` BBCode, then view the topic. This tests the changes in `preparsecode()`, `showAttachment()`, and `loadAttachmentContext()`.

- In Administration Center ► Attachments and Avatars ► Browse Files, check that the file name of the attachment from the previous test is displayed correctly. This tests the changes in `BrowseFiles()`.

- In your browser, go to `index.php?action=.xml;type=smf;sa=recent` and `index.php?action=.xml;type=smf;sa=news` to get XML files that contain references to the attachment from the previous test. This tests the changes in `getXmlRecent()` and `getXmlNews()`.

- Perform a profile export that includes your posts in order to get an XML file that contains a reference to the attachment. This tests the changes in `getXmlPosts()` and `download_export_file()`.

- In your browser, go to ssi_examples.php and view the Recent Attachments function to verify that the ampersand is handled correctly there, too. This tests the changes in `ssi_recentAttachments()`.

- In Administration Center ► Ban list, add a username ban trigger to a ban. This tests the changes in `validateTriggers()`. (Note: I encountered some pre-existing bugs when trying to modify ban triggers during my tests, but those were not affected by this PR in any way.)

- In Administration Center ► Forum Maintenance ► Database, run the Convert HTML-entities to UTF-8 characters task. For the most rigourous testing, do this with a MySQL database that uses plain `utf8` encoding rather than `utf8mb4`, and make sure that at least one post contains an emoji or similar 4-byte character. This tests the changes in `ConvertEntities()`.

- In Administration Center ► Membergroups ► Edit membergroups, edit the group moderators of a membergroup. This tests the changes in `EditMembergroup()`.

- In Administration Center ► Registration ► Set reserved names, add a reserved name that contains an ampersand (e.g. `long&short`) to the list of reserved names, and make sure the option to check displayed names is enabled. Then log in as a non-admin user and try to change your displayed name to `long&short` or whatever the reserved name was. This tests the changes in `isReservedName()`.

- Still logged in as that non-admin user, try to change your displayed name to something that contains a few tab characters, (e.g. `My			Name` [← three tabs between the words]). The tabs should be replaced with a single space when saved. This tests the changes in `loadProfileFields()`.

- Log out and then try to register new member accounts using the two names you tested above. This tests the changes in `registerMember()` and `RegisterCheckUsername()`.

- Run the installer and try to create an admin account with the name `My			Name`. Again, the tabs should be replaced with a single space when saved. This tests the changes in `AdminAccount()`.

By the time you have completed these tests, you will also have tested every change to the affected `$smcFunc` functions and, of course, the new functions in Subs.php.

----------

@sbulen: some of the changes in this PR will require changes to #6409 before that could be merged.