### PR TITLE
Makes fixTag() more strict

### DIFF
--- a/Sources/Subs-Post.php
+++ b/Sources/Subs-Post.php
@@ -467,7 +467,7 @@ function fixTag(&$message, $myTag, $protocols, $embeddedUrl = false, $hasEqualSi
 
 		if (in_array($current_protocol, $forbidden_protocols))
 		{
-			$replace = preg_replace('~' . preg_quote($current_protocol, '~') . ':~i', 'invalid:', $replace);
+			$replace = 'about:invalid';
 		}
 		elseif (!$found && $protocols[0] == 'http')
 		{

--- a/Sources/Subs-Post.php
+++ b/Sources/Subs-Post.php
@@ -463,11 +463,11 @@ function fixTag(&$message, $myTag, $protocols, $embeddedUrl = false, $hasEqualSi
 				break;
 		}
 
-		$current_protocol = parse_url($replace, PHP_URL_SCHEME);
+		$current_protocol = strtolower(parse_url($replace, PHP_URL_SCHEME));
 
 		if (in_array($current_protocol, $forbidden_protocols))
 		{
-			$replace = str_replace($current_protocol . ':', 'invalid:', $replace);
+			$replace = preg_replace('~' . preg_quote($current_protocol, '~') . ':~i', 'invalid:', $replace);
 		}
 		elseif (!$found && $protocols[0] == 'http')
 		{

--- a/Sources/Subs-Post.php
+++ b/Sources/Subs-Post.php
@@ -428,7 +428,10 @@ function fixTag(&$message, $myTag, $protocols, $embeddedUrl = false, $hasEqualSi
 	global $boardurl, $scripturl;
 
 	$forbidden_protocols = array(
+		// Poses security risks.
 		'javascript',
+		// Allows file data to be embedded, bypassing our attachment system.
+		'data',
 	);
 
 	if (preg_match('~^([^:]+://[^/]+)~', $boardurl, $match) != 0)


### PR DESCRIPTION
Improves efficiency when filtering out URIs with invalid schemes, and explicitly changes invalid schemes to "invalid" just for good measure.