### PR TITLE
Retain aspect ratio for images in posts

### DIFF
--- a/Themes/default/css/index.css
+++ b/Themes/default/css/index.css
@@ -428,6 +428,9 @@ blockquote cite::before {
 	margin-left: 1em;
 	clear: right;
 }
+.bbc_img {
+	object-fit: contain;
+}
 .postarea .bbc_img.resized:hover {
 	cursor: pointer;
 }


### PR DESCRIPTION
This will scale the image to fit in the box to keep the
aspect ratio, if height is specified.

Fixes #6541
Closes #6575

Signed-off-by: Oscar Rydhé <oscar.rydhe@gmail.com>