### PR TITLE
Fix upgrader freezes

### DIFF
--- a/other/upgrade.php
+++ b/other/upgrade.php
@@ -1445,6 +1445,9 @@ function BackupDatabase()
 	if (!empty($_POST['backup_done']))
 		return true;
 
+	// We cannot execute this step in strict mode - strict mode data fixes are not applied yet
+	setSqlMode(false);
+
 	// Some useful stuff here.
 	db_extend();
 

--- a/other/upgrade_2-1_mysql.sql
+++ b/other/upgrade_2-1_mysql.sql
@@ -1,6 +1,41 @@
 /* ATTENTION: You don't need to run or use this file!  The upgrade.php script does everything for you! */
 
 /******************************************************************************/
+--- Fixing dates...
+/******************************************************************************/
+
+---# Updating old values
+UPDATE {$db_prefix}calendar
+SET start_date = DATE(CONCAT(1004, '-', MONTH(start_date), '-', DAY(start_date)))
+WHERE YEAR(start_date) < 1004;
+
+UPDATE {$db_prefix}calendar
+SET end_date = DATE(CONCAT(1004, '-', MONTH(end_date), '-', DAY(end_date)))
+WHERE YEAR(end_date) < 1004;
+
+UPDATE {$db_prefix}calendar_holidays
+SET event_date = DATE(CONCAT(1004, '-', MONTH(event_date), '-', DAY(event_date)))
+WHERE YEAR(event_date) < 1004;
+
+UPDATE {$db_prefix}log_spider_stats
+SET stat_date = DATE(CONCAT(1004, '-', MONTH(stat_date), '-', DAY(stat_date)))
+WHERE YEAR(stat_date) < 1004;
+
+UPDATE {$db_prefix}members
+SET birthdate = DATE(CONCAT(IF(YEAR(birthdate) < 1004, 1004, YEAR(birthdate)), '-', IF(MONTH(birthdate) < 1, 1, MONTH(birthdate)), '-', IF(DAY(birthdate) < 1, 1, DAY(birthdate))))
+WHERE YEAR(birthdate) < 1004 OR MONTH(birthdate) < 1 OR DAY(birthdate) < 1;
+---#
+
+---# Changing default values
+ALTER TABLE {$db_prefix}calendar CHANGE start_date start_date date NOT NULL DEFAULT '1004-01-01';
+ALTER TABLE {$db_prefix}calendar CHANGE end_date end_date date NOT NULL DEFAULT '1004-01-01';
+ALTER TABLE {$db_prefix}calendar_holidays CHANGE event_date event_date date NOT NULL DEFAULT '1004-01-01';
+ALTER TABLE {$db_prefix}log_spider_stats CHANGE stat_date stat_date date NOT NULL DEFAULT '1004-01-01';
+ALTER TABLE {$db_prefix}members CHANGE birthdate birthdate date NOT NULL DEFAULT '1004-01-01';
+ALTER TABLE {$db_prefix}log_activity CHANGE DATE DATE date NOT NULL;
+---#
+
+/******************************************************************************/
 --- Removing karma
 /******************************************************************************/
 
@@ -68,41 +103,6 @@ if (!empty($upcontext['empty_error']))
 	);
 }
 ---}
----#
-
-/******************************************************************************/
---- Fixing dates...
-/******************************************************************************/
-
----# Updating old values
-UPDATE {$db_prefix}calendar
-SET start_date = DATE(CONCAT(1004, '-', MONTH(start_date), '-', DAY(start_date)))
-WHERE YEAR(start_date) < 1004;
-
-UPDATE {$db_prefix}calendar
-SET end_date = DATE(CONCAT(1004, '-', MONTH(end_date), '-', DAY(end_date)))
-WHERE YEAR(end_date) < 1004;
-
-UPDATE {$db_prefix}calendar_holidays
-SET event_date = DATE(CONCAT(1004, '-', MONTH(event_date), '-', DAY(event_date)))
-WHERE YEAR(event_date) < 1004;
-
-UPDATE {$db_prefix}log_spider_stats
-SET stat_date = DATE(CONCAT(1004, '-', MONTH(stat_date), '-', DAY(stat_date)))
-WHERE YEAR(stat_date) < 1004;
-
-UPDATE {$db_prefix}members
-SET birthdate = DATE(CONCAT(IF(YEAR(birthdate) < 1004, 1004, YEAR(birthdate)), '-', IF(MONTH(birthdate) < 1, 1, MONTH(birthdate)), '-', IF(DAY(birthdate) < 1, 1, DAY(birthdate))))
-WHERE YEAR(birthdate) < 1004 OR MONTH(birthdate) < 1 OR DAY(birthdate) < 1;
----#
-
----# Changing default values
-ALTER TABLE {$db_prefix}calendar CHANGE start_date start_date date NOT NULL DEFAULT '1004-01-01';
-ALTER TABLE {$db_prefix}calendar CHANGE end_date end_date date NOT NULL DEFAULT '1004-01-01';
-ALTER TABLE {$db_prefix}calendar_holidays CHANGE event_date event_date date NOT NULL DEFAULT '1004-01-01';
-ALTER TABLE {$db_prefix}log_spider_stats CHANGE stat_date stat_date date NOT NULL DEFAULT '1004-01-01';
-ALTER TABLE {$db_prefix}members CHANGE birthdate birthdate date NOT NULL DEFAULT '1004-01-01';
-ALTER TABLE {$db_prefix}log_activity CHANGE DATE DATE date NOT NULL;
 ---#
 
 /******************************************************************************/


### PR DESCRIPTION
Fixes #6800 
Fixes #6518 
Fixes #6788 

The backup errors are addressed by ensuring the backup step is NOT run in strict mode.

The karma errors are addressed by making sure the member data fixes are executed before any ALTER TABLE for members.