### PR TITLE
Send dates in iso format

### DIFF
--- a/Sources/Calendar.php
+++ b/Sources/Calendar.php
@@ -113,6 +113,8 @@ function CalendarMain()
 	// Need a start date for all views
 	if (!empty($_REQUEST['start_date']))
 	{
+		if (!empty($_REQUEST['iso_start_date']))
+			$_REQUEST['start_date'] = $_REQUEST['iso_start_date'];
 		$start_parsed = date_parse($_REQUEST['start_date']);
 		if (empty($start_parsed['error_count']) && empty($start_parsed['warning_count']))
 		{
@@ -130,6 +132,8 @@ function CalendarMain()
 	// Need an end date for the list view
 	if (!empty($_REQUEST['end_date']))
 	{
+		if (!empty($_REQUEST['iso_end_date']))
+			$_REQUEST['end_date'] = $_REQUEST['iso_end_date'];
 		$end_parsed = date_parse($_REQUEST['end_date']);
 		if (empty($end_parsed['error_count']) && empty($end_parsed['warning_count']))
 		{

--- a/Sources/Subs-Calendar.php
+++ b/Sources/Subs-Calendar.php
@@ -436,6 +436,7 @@ function getCalendarGrid($selected_date, $calendarOptions, $is_previous = false,
 			'disabled' => $modSettings['cal_maxyear'] < date_format($next_object, 'Y'),
 		),
 		'start_date' => timeformat(date_format($selected_object, 'U'), get_date_or_time_format('date')),
+		'iso_start_date' => date_format($selected_object, 'Y-m-d'),
 	);
 
 	// Get today's date.
@@ -605,6 +606,7 @@ function getCalendarWeek($selected_date, $calendarOptions)
 			'disabled' => $modSettings['cal_maxyear'] < date_format($next_object, 'Y'),
 		),
 		'start_date' => timeformat(date_format($selected_object, 'U'), get_date_or_time_format('date')),
+		'iso_start_date' => date_format($selected_object, 'Y-m-d'),
 	);
 
 	// Fetch the arrays for birthdays, posted events, and holidays.
@@ -672,10 +674,12 @@ function getCalendarList($start_date, $end_date, $calendarOptions)
 
 	$calendarGrid = array(
 		'start_date' => timeformat(date_format($start_object, 'U'), get_date_or_time_format('date')),
+		'iso_start_date' => date_format($start_object, 'Y-m-d'),
 		'start_year' => date_format($start_object, 'Y'),
 		'start_month' => date_format($start_object, 'm'),
 		'start_day' => date_format($start_object, 'd'),
 		'end_date' => timeformat(date_format($end_object, 'U'), get_date_or_time_format('date')),
+		'iso_end_date' => date_format($end_object, 'Y-m-d'),
 		'end_year' => date_format($end_object, 'Y'),
 		'end_month' => date_format($end_object, 'm'),
 		'end_day' => date_format($end_object, 'd'),
@@ -869,6 +873,7 @@ function loadDatePair($container, $date_class = '', $time_class = '')
 		},
 		updateDate: function (el, v) {
 			$(el).datepicker("setDate", new Date(v.getTime() - (v.getTimezoneOffset() * 60000)));
+			smf_getISODateFromDatePicker($(el).attr("id"), "iso_" + $(el).attr("id"));
 		},';
 	}
 
@@ -1060,7 +1065,7 @@ function validateEventPost()
 		// The 2.1 way
 		if (isset($_POST['start_date']))
 		{
-			$d = date_parse($_POST['start_date']);
+			$d = date_parse(!empty($_POST['iso_start_date']) ? $_POST['iso_start_date'] : $_POST['start_date']);
 			if (!empty($d['error_count']) || !empty($d['warning_count']))
 				fatal_lang_error('invalid_date', false);
 			if (empty($d['year']))
@@ -1565,9 +1570,9 @@ function setEventStartEnd($eventOptions = array())
 	$end_string = isset($eventOptions['end_datetime']) ? $eventOptions['end_datetime'] : (isset($_POST['end_datetime']) ? $_POST['end_datetime'] : null);
 
 	// ... or as date strings and time strings.
-	$start_date_string = isset($eventOptions['start_date']) ? $eventOptions['start_date'] : (isset($_POST['start_date']) ? $_POST['start_date'] : null);
+	$start_date_string = isset($eventOptions['start_date']) ? $eventOptions['start_date'] : (isset($_POST['iso_start_date']) ? $_POST['iso_start_date'] : (isset($_POST['start_date']) ? $_POST['start_date'] : null));
 	$start_time_string = isset($eventOptions['start_time']) ? $eventOptions['start_time'] : (isset($_POST['start_time']) ? $_POST['start_time'] : null);
-	$end_date_string = isset($eventOptions['end_date']) ? $eventOptions['end_date'] : (isset($_POST['end_date']) ? $_POST['end_date'] : null);
+	$end_date_string = isset($eventOptions['end_date']) ? $eventOptions['end_date'] : (isset($_POST['iso_end_date']) ? $_POST['iso_end_date'] : (isset($_POST['end_date']) ? $_POST['end_date'] : null));
 	$end_time_string = isset($eventOptions['end_time']) ? $eventOptions['end_time'] : (isset($_POST['end_time']) ? $_POST['end_time'] : null);
 
 	// If the date and time were given in separate strings, combine them

--- a/Themes/default/Calendar.template.php
+++ b/Themes/default/Calendar.template.php
@@ -729,12 +729,14 @@ function template_calendar_top($calendar_data)
 
 	echo '
 			<form action="', $scripturl, '?action=calendar;', $context['calendar_view'], '" id="', !empty($calendar_data['end_date']) ? 'calendar_range' : 'calendar_navigation', '" method="post" accept-charset="', $context['character_set'], '">
-				<input type="text" name="start_date" id="start_date" maxlength="10" value="', $calendar_data['start_date'], '" tabindex="', $context['tabindex']++, '" class="date_input start" data-type="date">';
+				<input type="hidden" name="iso_start_date" id="iso_start_date" value="', $calendar_data['iso_start_date'], '">
+				<input type="text" name="start_date" id="start_date" maxlength="10" value="', $calendar_data['start_date'], '" tabindex="', $context['tabindex']++, '" class="date_input start" data-type="date" onchange="smf_getISODateFromDatePicker(\'start_date\', \'iso_start_date\')">';
 
 	if (!empty($calendar_data['end_date']))
 		echo '
 				<span>', strtolower($txt['to']), '</span>
-				<input type="text" name="end_date" id="end_date" maxlength="10" value="', $calendar_data['end_date'], '" tabindex="', $context['tabindex']++, '" class="date_input end" data-type="date">';
+				<input type="hidden" name="iso_end_date" id="iso_end_date" value="', $calendar_data['iso_end_date'], '">
+				<input type="text" name="end_date" id="end_date" maxlength="10" value="', $calendar_data['end_date'], '" tabindex="', $context['tabindex']++, '" class="date_input end" data-type="date" onchange="smf_getISODateFromDatePicker(\'end_date\', \'iso_end_date\')">';
 
 	echo '
 				<input type="submit" class="button" style="float:none" id="view_button" value="', $txt['view'], '">
@@ -824,12 +826,14 @@ function template_event_post()
 						<div class="event_options_left" id="event_time_input">
 							<div>
 								<span class="label">', $txt['start'], '</span>
-								<input type="text" name="start_date" id="start_date" maxlength="10" value="', $context['event']['start_date'], '" tabindex="', $context['tabindex']++, '" class="date_input start" data-type="date">
+								<input type="hidden" name="iso_start_date" id="iso_start_date" maxlength="10" value="', $context['event']['start_date'], '">
+								<input type="text" name="start_date" id="start_date" maxlength="10" value="', $context['event']['start_date'], '" tabindex="', $context['tabindex']++, '" class="date_input start" data-type="date" onchange="smf_getISODateFromDatePicker(\'start_date\', \'iso_start_date\')">
 								<input type="text" name="start_time" id="start_time" maxlength="11" value="', $context['event']['start_time_local'], '" tabindex="', $context['tabindex']++, '" class="time_input start" data-type="time"', !empty($context['event']['allday']) ? ' disabled' : '', '>
 							</div>
 							<div>
 								<span class="label">', $txt['end'], '</span>
-								<input type="text" name="end_date" id="end_date" maxlength="10" value="', $context['event']['end_date'], '" tabindex="', $context['tabindex']++, '" class="date_input end" data-type="date"', $modSettings['cal_maxspan'] == 1 ? ' disabled' : '', '>
+								<input type="hidden" name="iso_end_date" id="iso_end_date" maxlength="10" value="', $context['event']['end_date'], '">
+								<input type="text" name="end_date" id="end_date" maxlength="10" value="', $context['event']['end_date'], '" tabindex="', $context['tabindex']++, '" class="date_input end" data-type="date"', $modSettings['cal_maxspan'] == 1 ? ' disabled' : '', ' onchange="smf_getISODateFromDatePicker(\'end_date\', \'iso_end_date\')">
 								<input type="text" name="end_time" id="end_time" maxlength="11" value="', $context['event']['end_time_local'], '" tabindex="', $context['tabindex']++, '" class="time_input end" data-type="time"', !empty($context['event']['allday']) ? ' disabled' : '', '>
 							</div>
 						</div><!-- #event_time_input -->

--- a/Themes/default/Post.template.php
+++ b/Themes/default/Post.template.php
@@ -154,13 +154,15 @@ function template_main()
 								<div class="event_options_left" id="event_time_input">
 									<div>
 										<span class="label">', $txt['start'], '</span>
-										<input type="text" name="start_date" id="start_date" maxlength="10" value="', $context['event']['start_date'], '" tabindex="', $context['tabindex']++, '" class="date_input start" data-type="date">
-										<input type="text" name="start_time" id="start_time" maxlength="11" value="', $context['event']['start_time'], '" tabindex="', $context['tabindex']++, '" class="time_input start" data-type="time"', !empty($context['event']['allday']) ? ' disabled' : '', '>
+										<input type="hidden" name="iso_start_date" id="iso_start_date" maxlength="10" value="', $context['event']['start_date'], '">
+										<input type="text" name="start_date" id="start_date" maxlength="10" value="', $context['event']['start_date_orig'], '" tabindex="', $context['tabindex']++, '" class="date_input start" data-type="date" onchange="smf_getISODateFromDatePicker(\'start_date\', \'iso_start_date\')">
+										<input type="text" name="start_time" id="start_time" maxlength="11" value="', $context['event']['start_time_orig'], '" tabindex="', $context['tabindex']++, '" class="time_input start" data-type="time"', !empty($context['event']['allday']) ? ' disabled' : '', '>
 									</div>
 									<div>
 										<span class="label">', $txt['end'], '</span>
-										<input type="text" name="end_date" id="end_date" maxlength="10" value="', $context['event']['end_date'], '" tabindex="', $context['tabindex']++, '" class="date_input end" data-type="date"', $modSettings['cal_maxspan'] == 1 ? ' disabled' : '', '>
-										<input type="text" name="end_time" id="end_time" maxlength="11" value="', $context['event']['end_time'], '" tabindex="', $context['tabindex']++, '" class="time_input end" data-type="time"', !empty($context['event']['allday']) ? ' disabled' : '', '>
+										<input type="hidden" name="iso_end_date" id="iso_end_date" maxlength="10" value="', $context['event']['end_date'], '">
+										<input type="text" name="end_date" id="end_date" maxlength="10" value="', $context['event']['end_date_orig'], '" tabindex="', $context['tabindex']++, '" class="date_input end" data-type="date"', $modSettings['cal_maxspan'] == 1 ? ' disabled' : '', ' onchange="smf_getISODateFromDatePicker(\'end_date\', \'iso_end_date\')">
+										<input type="text" name="end_time" id="end_time" maxlength="11" value="', $context['event']['end_time_orig'], '" tabindex="', $context['tabindex']++, '" class="time_input end" data-type="time"', !empty($context['event']['allday']) ? ' disabled' : '', '>
 									</div>
 								</div>
 								<div class="event_options_right" id="event_time_options">

--- a/Themes/default/scripts/script.js
+++ b/Themes/default/scripts/script.js
@@ -2027,3 +2027,20 @@ smc_preview_post.prototype.onDocSent = function (XMLDoc)
 	if (typeof(smf_codeFix) != 'undefined')
 		smf_codeFix();
 }
+
+function smf_getISODateFromDatePicker(date_picker_id, iso_date_id) {
+	let date = $(`#${date_picker_id}`).datepicker("getDate");
+
+	year = date.getFullYear();
+	month = date.getMonth() + 1;
+	dt = date.getDate();
+
+	if (dt < 10) {
+		dt = '0' + dt;
+	}
+	if (month < 10) {
+		month = '0' + month;
+	}
+
+	$(`#${iso_date_id}`).val(year + '-' + month + '-' + dt);
+}


### PR DESCRIPTION
The date picker returns dates in localized format
but only english dates can be parsed.
Add a hidden field that will send the dates in
iso format.
Also format dates in Post Event screen in user
defined format.

Fixes #6631
Closes #6635

Signed-off-by: Oscar Rydhé <oscar.rydhe@gmail.com>