### PR TITLE
Set default board profile when profile set to inherit

### DIFF
--- a/Sources/ManageBoards.php
+++ b/Sources/ManageBoards.php
@@ -697,7 +697,7 @@ function EditBoard2()
 		$boardOptions['redirect'] = !empty($_POST['redirect_enable']) && isset($_POST['redirect_address']) && trim($_POST['redirect_address']) != '' ? trim($_POST['redirect_address']) : '';
 
 		// Profiles...
-		$boardOptions['profile'] = $_POST['profile'];
+		$boardOptions['profile'] = $_POST['profile'] == -1 ? 1 : $_POST['profile'];
 		$boardOptions['inherit_permissions'] = $_POST['profile'] == -1;
 
 		// We need to know what used to be case in terms of redirection.


### PR DESCRIPTION
If creating a new board with the profile set as
"Inherit from parent board" an error will occur.
The board will be created, but without most of the
set options. Fixed this by setting the default profile
if inherit is selected. After the board is created
a check is done to find the parent board profile
setting and copy it.

Fixes #6798

Signed-off-by: Oscar Rydhé <oscar.rydhe@gmail.com>