### PR TITLE
Fixes smf_var_export() for strings containing line breaks.

### DIFF
--- a/Sources/Subs-Admin.php
+++ b/Sources/Subs-Admin.php
@@ -1930,7 +1930,7 @@ function smf_var_export($var)
 	{
 		return strtr(preg_replace_callback('/[\r\n]+/', function($m) {
 			return '\' . "' . strtr($m[0], array("\r" => '\r', "\n" => '\n')) . '" . \'';
-		}, $var), array("'' . " => '', " . ''" => ''));
+		}, var_export($var, true)), array("'' . " => '', " . ''" => ''));
 	}
 
 	// We typically use lowercase true/false/null.


### PR DESCRIPTION
Fixes #6812