### PR TITLE
Doesn't (un)approve all posts in topic when (un)approving first post

### DIFF
--- a/Sources/ModerationCenter.php
+++ b/Sources/ModerationCenter.php
@@ -1238,10 +1238,12 @@ function list_getWatchedUsers($start, $items_per_page, $sort, $approve_query, $d
 		// First get the latest messages from these users.
 		$request = $smcFunc['db_query']('', '
 			SELECT m.id_member, MAX(m.id_msg) AS last_post_id
-			FROM {db_prefix}messages AS m
+			FROM {db_prefix}messages AS m' . (!$modSettings['postmod_active'] || allowedTo('approve_posts') ? '' : '
+				INNER JOIN {db_prefix}topics AS t ON (t.id_topic = m.id_topic)') . '
 			WHERE {query_see_message_board}
 				AND m.id_member IN ({array_int:member_list})' . (!$modSettings['postmod_active'] || allowedTo('approve_posts') ? '' : '
-				AND m.approved = {int:is_approved}') . '
+				AND m.approved = {int:is_approved}
+				AND t.approved = {int:is_approved}') . '
 			GROUP BY m.id_member',
 			array(
 				'member_list' => $members,

--- a/Sources/News.php
+++ b/Sources/News.php
@@ -1290,7 +1290,8 @@ function getXmlRecent($xml_format)
 			WHERE ' . $query_this_board . (empty($optimize_msg) ? '' : '
 				AND {raw:optimize_msg}') . (empty($board) ? '' : '
 				AND m.id_board = {int:current_board}') . ($modSettings['postmod_active'] ? '
-				AND m.approved = {int:is_approved}' : '') . '
+				AND m.approved = {int:is_approved}
+				AND t.approved = {int:is_approved}' : '') . '
 			ORDER BY m.id_msg DESC
 			LIMIT {int:limit}',
 			array(
@@ -2126,11 +2127,13 @@ function getXmlPosts($xml_format, $ascending = false)
 			m.id_msg, m.id_topic, m.id_board, m.id_member, m.poster_email, m.poster_ip,
 			m.poster_time, m.subject, m.modified_time, m.modified_name, m.modified_reason, m.body,
 			m.likes, m.approved, m.smileys_enabled
-		FROM {db_prefix}messages AS m
+		FROM {db_prefix}messages AS m' . ($modSettings['postmod_active'] && !$show_all ?'
+			INNER JOIN {db_prefix}topics AS t ON (t.id_topic = m.id_topic)' : '') . '
 		WHERE m.id_member = {int:uid}
 			AND m.id_msg > {int:start_after}
 			AND ' . $query_this_message_board . ($modSettings['postmod_active'] && !$show_all ? '
-			AND m.approved = {int:is_approved}' : '') . '
+			AND m.approved = {int:is_approved}
+			AND t.approved = {int:is_approved}' : '') . '
 		ORDER BY m.id_msg {raw:ascdesc}
 		LIMIT {int:limit}',
 		array(

--- a/Sources/Post.php
+++ b/Sources/Post.php
@@ -821,10 +821,12 @@ function Post($post_errors = array())
 			$request = $smcFunc['db_query']('', '
 				SELECT m.subject, COALESCE(mem.real_name, m.poster_name) AS poster_name, m.poster_time, m.body
 				FROM {db_prefix}messages AS m
-					LEFT JOIN {db_prefix}members AS mem ON (mem.id_member = m.id_member)
+					LEFT JOIN {db_prefix}members AS mem ON (mem.id_member = m.id_member)' . (!$modSettings['postmod_active'] || allowedTo('approve_posts') ? '' : '
+					INNER JOIN {db_prefix}topics AS t ON (t.id_topic = m.id_topic)') . '
 				WHERE {query_see_message_board}
 					AND m.id_msg = {int:id_msg}' . (!$modSettings['postmod_active'] || allowedTo('approve_posts') ? '' : '
-					AND m.approved = {int:is_approved}') . '
+					AND m.approved = {int:is_approved}
+					AND t.approved = {int:is_approved}') . '
 				LIMIT 1',
 				array(
 					'id_msg' => (int) $_REQUEST['quote'],

--- a/Sources/Profile-View.php
+++ b/Sources/Profile-View.php
@@ -921,10 +921,12 @@ function showPosts($memID)
 	else
 		$request = $smcFunc['db_query']('', '
 			SELECT COUNT(*)
-			FROM {db_prefix}messages AS m
+			FROM {db_prefix}messages AS m' . (!$modSettings['postmod_active'] || $context['user']['is_owner'] ? '' : '
+				INNER JOIN {db_prefix}topics AS t ON (t.id_topic = m.id_topic)') . '
 			WHERE {query_see_message_board} AND m.id_member = {int:current_member}' . (!empty($board) ? '
 				AND m.id_board = {int:board}' : '') . (!$modSettings['postmod_active'] || $context['user']['is_owner'] ? '' : '
-				AND m.approved = {int:is_approved}'),
+				AND m.approved = {int:is_approved}
+				AND t.approved = {int:is_approved}'),
 			array(
 				'current_member' => $memID,
 				'is_approved' => 1,
@@ -936,10 +938,12 @@ function showPosts($memID)
 
 	$request = $smcFunc['db_query']('', '
 		SELECT MIN(id_msg), MAX(id_msg)
-		FROM {db_prefix}messages AS m
+		FROM {db_prefix}messages AS m' . (!$modSettings['postmod_active'] || $context['user']['is_owner'] ? '' : '
+			INNER JOIN {db_prefix}topics AS t ON (t.id_topic = m.id_topic)') . '
 		WHERE m.id_member = {int:current_member}' . (!empty($board) ? '
 			AND m.id_board = {int:board}' : '') . (!$modSettings['postmod_active'] || $context['user']['is_owner'] ? '' : '
-			AND m.approved = {int:is_approved}'),
+			AND m.approved = {int:is_approved}
+			AND t.approved = {int:is_approved}'),
 		array(
 			'current_member' => $memID,
 			'is_approved' => 1,
@@ -1393,13 +1397,15 @@ function list_getNumAttachments($boardsAllowed, $memID)
 		SELECT COUNT(*)
 		FROM {db_prefix}attachments AS a
 			INNER JOIN {db_prefix}messages AS m ON (m.id_msg = a.id_msg)
-			INNER JOIN {db_prefix}boards AS b ON (b.id_board = m.id_board AND {query_see_board})
+			INNER JOIN {db_prefix}boards AS b ON (b.id_board = m.id_board AND {query_see_board})' . (!$modSettings['postmod_active'] || $context['user']['is_owner'] || allowedTo('approve_posts') ? '' : '
+			INNER JOIN {db_prefix}topics AS t ON (t.id_topic = m.id_topic)') . '
 		WHERE a.attachment_type = {int:attachment_type}
 			AND a.id_msg != {int:no_message}
 			AND m.id_member = {int:current_member}' . (!empty($board) ? '
 			AND b.id_board = {int:board}' : '') . (!in_array(0, $boardsAllowed) ? '
-			AND b.id_board IN ({array_int:boards_list})' : '') . (!$modSettings['postmod_active'] || $context['user']['is_owner'] ? '' : '
-			AND m.approved = {int:is_approved}'),
+			AND b.id_board IN ({array_int:boards_list})' : '') . (!$modSettings['postmod_active'] || $context['user']['is_owner'] || allowedTo('approve_posts') ? '' : '
+			AND m.approved = {int:is_approved}
+			AND t.approved = {int:is_approved}'),
 		array(
 			'boards_list' => $boardsAllowed,
 			'attachment_type' => 0,

--- a/Sources/Subs-Post.php
+++ b/Sources/Subs-Post.php
@@ -2620,8 +2620,8 @@ function approveTopics($topics, $approve = true)
 
 	// Just get the messages to be approved and pass through...
 	$request = $smcFunc['db_query']('', '
-		SELECT id_msg
-		FROM {db_prefix}messages
+		SELECT id_first_msg
+		FROM {db_prefix}topics
 		WHERE id_topic IN ({array_int:topic_list})
 			AND approved = {int:approve_type}',
 		array(
@@ -2631,7 +2631,7 @@ function approveTopics($topics, $approve = true)
 	);
 	$msgs = array();
 	while ($row = $smcFunc['db_fetch_assoc']($request))
-		$msgs[] = $row['id_msg'];
+		$msgs[] = $row['id_first_msg'];
 	$smcFunc['db_free_result']($request);
 
 	return approvePosts($msgs, $approve);


### PR DESCRIPTION
Fixes #379 (a really old issue that no one ever seems to have bothered dealing with)

Previously, approving or unapproving the first post in the topic would (1) mark the topic as a whole as approved or unapproved, and (2) mark *every other post* in the topic as approved or unapproved, too! With this change, the second of those actions no longer occurs. 

To prevent approved posts in unapproved topics from appearing in, e.g., the list of recent posts, I had to add a checks for the topic approval status to a few queries.

Finally, I also added some checks about topic approval status when viewing a member's posts in the profile view.