### PR TITLE
Show all users post count in members list

### DIFF
--- a/Themes/default/Memberlist.template.php
+++ b/Themes/default/Memberlist.template.php
@@ -91,7 +91,7 @@ function template_main()
 				echo '
 						<td class="post_count centertext">';
 
-				if (!empty($member['post_percent']))
+				if (!empty($member['posts']))
 					echo '
 							<div class="generic_bar">
 								<div class="bar" style="width: ', $member['post_percent'], '%;"></div>


### PR DESCRIPTION
In the members list the post counts are shown as a bar
relative to the member with most posts. If a user
had a lot less posts than the most poster, where the
percentage was rounded to 0, no post count was shown.
Changed so that post count are shown for all users that
has at lest one post.

Fixes #6830

Signed-off-by: Oscar Rydhé <oscar.rydhe@gmail.com>