### PR TITLE
Fix jump to select box from boards with quotes

### DIFF
--- a/Sources/Display.php
+++ b/Sources/Display.php
@@ -1122,7 +1122,7 @@ function Display()
 
 	$context['jump_to'] = array(
 		'label' => addslashes(un_htmlspecialchars($txt['jump_to'])),
-		'board_name' => $smcFunc['htmlspecialchars'](strtr(strip_tags($board_info['name']), array('&amp;' => '&'))),
+		'board_name' => strtr($smcFunc['htmlspecialchars'](strip_tags($board_info['name'])), array('&amp;' => '&')),
 		'child_level' => $board_info['child_level'],
 	);
 

--- a/Sources/MessageIndex.php
+++ b/Sources/MessageIndex.php
@@ -557,7 +557,7 @@ function MessageIndex()
 
 	$context['jump_to'] = array(
 		'label' => addslashes(un_htmlspecialchars($txt['jump_to'])),
-		'board_name' => $smcFunc['htmlspecialchars'](strtr(strip_tags($board_info['name']), array('&amp;' => '&'))),
+		'board_name' => strtr($smcFunc['htmlspecialchars'](strip_tags($board_info['name'])), array('&amp;' => '&')),
 		'child_level' => $board_info['child_level'],
 	);
 


### PR DESCRIPTION
If a board had quotes in its name, the board name
in the jump to select box had &quot; in it when
viewed from the board index or in any topic.

Signed-off-by: Oscar Rydhé <oscar.rydhe@gmail.com>