### PR TITLE
sceditor css only in default theme

### DIFF
--- a/Sources/Subs-Editor.php
+++ b/Sources/Subs-Editor.php
@@ -1516,7 +1516,7 @@ function create_control_richedit($editorOptions)
 			$context['drafts_autosave_frequency'] = empty($modSettings['drafts_autosave_frequency']) ? 60000 : $modSettings['drafts_autosave_frequency'] * 1000;
 
 		// This really has some WYSIWYG stuff.
-		loadCSSFile('jquery.sceditor.css', array('force_current' => true, 'validate' => true), 'smf_jquery_sceditor');
+		loadCSSFile('jquery.sceditor.css', array('default_theme' => true, 'validate' => true), 'smf_jquery_sceditor');
 		loadTemplate('GenericControls');
 
 		// JS makes the editor go round

--- a/Sources/Subs-Editor.php
+++ b/Sources/Subs-Editor.php
@@ -1516,7 +1516,7 @@ function create_control_richedit($editorOptions)
 			$context['drafts_autosave_frequency'] = empty($modSettings['drafts_autosave_frequency']) ? 60000 : $modSettings['drafts_autosave_frequency'] * 1000;
 
 		// This really has some WYSIWYG stuff.
-		loadCSSFile('jquery.sceditor.css', array('force_current' => false, 'validate' => true), 'smf_jquery_sceditor');
+		loadCSSFile('jquery.sceditor.css', array('force_current' => true, 'validate' => true), 'smf_jquery_sceditor');
 		loadTemplate('GenericControls');
 
 		// JS makes the editor go round

--- a/Sources/Subs-Editor.php
+++ b/Sources/Subs-Editor.php
@@ -1519,6 +1519,13 @@ function create_control_richedit($editorOptions)
 		loadCSSFile('jquery.sceditor.css', array('default_theme' => true, 'validate' => true), 'smf_jquery_sceditor');
 		loadTemplate('GenericControls');
 
+		/*
+		 *		THEME AUTHORS:
+		 			If you want to change or tweak the CSS for the editor,
+					include a file named 'jquery.sceditor.theme.css' in your theme.
+		*/
+		loadCSSFile('jquery.sceditor.theme.css', array('force_current' => true, 'validate' => true,), 'smf_jquery_sceditor_theme');
+
 		// JS makes the editor go round
 		loadJavaScriptFile('editor.js', array('minimize' => true), 'smf_editor');
 		loadJavaScriptFile('jquery.sceditor.bbcode.min.js', array(), 'smf_sceditor_bbcode');

--- a/Themes/default/index.template.php
+++ b/Themes/default/index.template.php
@@ -106,6 +106,8 @@ function template_html_above()
 			index.css plus variant.css files. If you've set them up properly
 			(through $settings['theme_variants']), the variant files will be loaded
 			for you automatically.
+			Additionally, tweaking the CSS for the editor requires you to include
+			a custom 'jquery.sceditor.theme.css' file in the css folder if you need it.
 
 	*	MODs:
 			If you want to load CSS or JS files in here, the best way is to use the


### PR DESCRIPTION
For instance, the force_current is false by default so it wasn't needed in first place (unless I'm wrong of course)
And just load it from the default theme so themers don't have to update/maintain this file if it's ever updated.

For reference: https://www.simplemachines.org/community/index.php?topic=577856.0

In the topic I mentioned that this file wasn't copied when creating a new theme anyways, I didn't test if it's an expected behavior.