### PR TITLE
Show custom fields default value in memberlist

### DIFF
--- a/Sources/Memberlist.php
+++ b/Sources/Memberlist.php
@@ -639,7 +639,7 @@ function printMemberListRows($request)
 				// Don't show anything if there isn't anything to show.
 				if (!isset($context['members'][$member]['options'][$key]))
 				{
-					$context['members'][$member]['options'][$key] = '';
+					$context['members'][$member]['options'][$key] = isset($column['default_value']) ? $column['default_value'] : '';
 					continue;
 				}
 
@@ -686,7 +686,7 @@ function getCustFieldsMList()
 	$cpf = array();
 
 	$request = $smcFunc['db_query']('', '
-		SELECT col_name, field_name, field_desc, field_type, field_options, bbc, enclose
+		SELECT col_name, field_name, field_desc, field_type, field_options, bbc, enclose, default_value
 		FROM {db_prefix}custom_fields
 		WHERE active = {int:active}
 			AND show_mlist = {int:show}
@@ -707,6 +707,7 @@ function getCustFieldsMList()
 			'options' => $row['field_options'],
 			'bbc' => !empty($row['bbc']),
 			'enclose' => $row['enclose'],
+			'default_value' => $row['default_value'],
 		);
 
 		// Get the right sort method depending on the cust field type.


### PR DESCRIPTION
In the memberlist, if a custom field is not set for a user
and there exists a default value, show the default value.
This is like the profile summary page.

Signed-off-by: Oscar Rydhé <oscar.rydhe@gmail.com>