### PR TITLE
Avoids an esoteric bug in recent versions of the PCRE2 library

### DIFF
--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -2535,16 +2535,7 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 							}
 
 							// Time to build this monster!
-							// First, define the PCRE subroutines.
-							$url_regex = '(?(DEFINE)';
-
-							foreach ($pcre_subroutines as $name => $subroutine)
-								$url_regex .= '(?<' . $name . '>' . $subroutine . ')';
-
-							$url_regex .= ')';
-
-							// Now build the rest of the regex
-							$url_regex .=
+							$url_regex =
 							// 1. IRI scheme and domain components
 							'(?:' .
 								// 1a. IRIs with a scheme, or at least an opening "//"
@@ -2702,6 +2693,14 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 									'(?P>fragment_segment)*+' .
 								')?' .
 							')?+';
+
+							// Finally, define the PCRE subroutines in the regex.
+							$url_regex .= '(?(DEFINE)';
+
+							foreach ($pcre_subroutines as $name => $subroutine)
+								$url_regex .= '(?<' . $name . '>' . $subroutine . ')';
+
+							$url_regex .= ')';
 						}
 
 						$tmp_data = preg_replace_callback('~' . $url_regex . '~i' . ($context['utf8'] ? 'u' : ''), function($matches) use ($schemes)


### PR DESCRIPTION
Fixes #6836

After hours of testing, fiddling, and muttering in bewilderment, I strongly suspect that in #6836 we've stumbled onto a rather esoteric bug in recent versions of the PCRE2 library itself. Specifically, it appears that in PCRE2 10.34+, lookbehinds do not work for the `/` character if the lookbehind occurs after a `(?(DEFINE))` pattern block that contains at least one subroutine pattern.

To see what I mean, try this bit of PHP code:
```
<?php

$regexes = array(
	// Bad
	'(?(DEFINE)(?<foo>\w))edu(?<!/)/00/Weather',
	'edu/00(?(DEFINE)(?<foo>\w))(?<!/)/Weather',
	'edu/00(?(DEFINE)(?<foo>\w))/(?<=/)Weather',

	// Good
	'(?(DEFINE)(?<foo>\w))edu(?<!_)/00(?<!_)/Weather',
	'(?(DEFINE)(?<foo>\w))edu(?<!//)/00(?<!//)/Weather',
	'edu(?<!/)/00(?(DEFINE)(?<foo>\w))/Weather',
	'edu(?<!/)/00(?<!/)/Weather(?(DEFINE)(?<foo>\w))',
	'edu/(?<=/)00(?<!/)/Weather(?(DEFINE)(?<foo>\w))',
);

$string = 'gopher://spinaltap.micro.umn.edu/00/Weather/California/Los%20Angeles';

$results = array();
foreach ($regexes as $regex) {
	preg_match('~' . $regex . '~', $string, $matches);
	$results[$regex] = isset($matches[0]) ? $matches[0] : null;
}

var_export($results);
```

It only fails if the lookbehind is checking for a _single_ `/` character (as in `(?<=/)` and `(?<!/)`) and only if `(?(DEFINE)(?<foo>\w))` occurs _before_ the lookbehind (where the `(?<foo>\w)` bit is any non-zero number of named subpatterns).

At any rate, this affects us in the autolinker because the autolinker uses `(?<!/)` while searching for the path segment of a URL.

Fortunately, we can work around this PCRE bug simply by moving the `(?(DEFINE))` block to the end of the regex.