### PR TITLE
Add outline to jump target and some scroll padding top

### DIFF
--- a/Themes/default/Display.template.php
+++ b/Themes/default/Display.template.php
@@ -63,7 +63,7 @@ function template_main()
 	// Show the anchor for the top and for the first message. If the first message is new, say so.
 	echo '
 		</div><!-- #display_head -->
-		<a id="msg', $context['first_message'], '"></a>', $context['first_new_message'] ? '<a id="new"></a>' : '';
+		', $context['first_new_message'] ? '<a id="new"></a>' : '';
 
 	// Is this topic also a poll?
 	if ($context['is_poll'])

--- a/Themes/default/Display.template.php
+++ b/Themes/default/Display.template.php
@@ -474,9 +474,9 @@ function template_single_post($message)
 
 	// Show the message anchor and a "new" anchor if this message is new.
 	echo '
-				<div class="', $message['css_class'], '">
+				<div class="', $message['css_class'], ' targetAble" id="msg' . $message['id'] . '">
 					', $message['id'] != $context['first_message'] ? '
-					<a id="msg' . $message['id'] . '"></a>' . ($message['first_new'] ? '<a id="new"></a>' : '') : '', '
+					' . ($message['first_new'] ? '<a id="new"></a>' : '') : '', '
 					<div class="post_wrapper">';
 
 	// Show information about the poster of this message.

--- a/Themes/default/PersonalMessage.template.php
+++ b/Themes/default/PersonalMessage.template.php
@@ -277,7 +277,7 @@ function template_single_pm($message)
 	global $context, $scripturl, $txt, $settings, $options, $modSettings;
 
 	echo '
-	<div class="windowbg">
+	<div class="windowbg targetAble" id="msg', $message['id'],'">
 		<div class="post_wrapper">
 			<div class="poster">';
 
@@ -298,8 +298,7 @@ function template_single_pm($message)
 	}
 
 	echo '
-				<h4>
-					<a id="msg', $message['id'], '"></a>';
+				<h4>';
 
 	// Show online and offline buttons?
 	if (!empty($modSettings['onlineEnable']) && !$message['member']['is_guest'])

--- a/Themes/default/css/index.css
+++ b/Themes/default/css/index.css
@@ -2,6 +2,7 @@
 /* Index */
 html {
 	background: #3e5a78;
+	scroll-padding-top: 3rem;
 }
 body {
 	background: #e9eef2;
@@ -3247,6 +3248,9 @@ div#pollmoderation {
 	padding-right: 5px;
 }
 
+.targetAble:target{
+	outline:3px red dotted;
+}
 /* The visible stuff below the avatar. */
 .user_info > li {
 	margin: 3px 0 0 0;


### PR DESCRIPTION
Highlight topic when you jump by using the post id:
old:
![grafik](https://user-images.githubusercontent.com/1782906/125621925-5303a00d-9a8c-4af1-af0f-268751ee612c.png)


new:
![grafik](https://user-images.githubusercontent.com/1782906/125621903-a6053152-87c3-4d30-be40-355c4316865b.png)
some padding between the topic and the div,
and a outline around the post

would also like to do this für "new" but i see no solution to provide for both id and new jump (i had to decide)