### PR TITLE
Export dir tweaks

### DIFF
--- a/Sources/ManageServer.php
+++ b/Sources/ManageServer.php
@@ -795,12 +795,16 @@ function ModifyExportSettings($return_config = false)
 	if (empty($modSettings['export_dir']))
 		$modSettings['export_dir'] = $boarddir . DIRECTORY_SEPARATOR . 'exports';
 
-	/* Some paranoid hosts worry that the disk space functions pose a security risk. Usually these
-	 * hosts just disable the functions and move on, which is fine. A rare few, however, are not
-	 * only paranoid, but also think it'd be a "clever" security move to overload the disk space
-	 * functions with custom code that intentionally delivers false information, which is idiotic
-	 * and evil. At any rate, if the functions are unavailable or if they report obviously insane
-	 * values, it's not possible to track disk usage correctly. */
+	/*
+		Some paranoid hosts worry that the disk space functions pose a security
+		risk. Usually these hosts just disable the functions and move on, which
+		is fine. A rare few, however, are not only paranoid, but also think it'd
+		be a "clever" security move to overload the disk space functions with
+		custom code that intentionally delivers false information, which is
+		idiotic and evil. At any rate, if the functions are unavailable or if
+		they report obviously insane values, it's not possible to track disk
+		usage correctly.
+	 */
 	$diskspace_disabled = (!function_exists('disk_free_space') || !function_exists('disk_total_space') || intval(@disk_total_space(file_exists($modSettings['export_dir']) ? $modSettings['export_dir'] : $boarddir)) < 1440);
 
 	$context['settings_message'] = $txt['export_settings_description'];
@@ -819,7 +823,7 @@ function ModifyExportSettings($return_config = false)
 
 	if (isset($_REQUEST['save']))
 	{
-		$prev_export_dir = file_exists($modSettings['export_dir']) ? rtrim($modSettings['export_dir'], '/\\') : '';
+		$prev_export_dir = is_dir($modSettings['export_dir']) ? rtrim($modSettings['export_dir'], '/\\') : '';
 
 		if (!empty($_POST['export_dir']))
 			$_POST['export_dir'] = rtrim($_POST['export_dir'], '/\\');

--- a/Sources/Profile-Export.php
+++ b/Sources/Profile-Export.php
@@ -181,7 +181,7 @@ function export_profile_data($uid)
 		),
 	);
 
-	if (empty($modSettings['export_dir']) || !file_exists($modSettings['export_dir']))
+	if (empty($modSettings['export_dir']) || !is_dir($modSettings['export_dir']) || !smf_chmod($modSettings['export_dir']))
 		create_export_dir();
 
 	$export_dir_slash = $modSettings['export_dir'] . DIRECTORY_SEPARATOR;

--- a/Sources/Profile-Export.php
+++ b/Sources/Profile-Export.php
@@ -747,7 +747,7 @@ function create_export_dir($fallback = '')
 		// Try again at the fallback location.
 		if ($modSettings['export_dir'] != $fallback)
 		{
-			log_error($txt['export_dir_forced_change'], $modSettings['export_dir'], $fallback);
+			log_error(sprintf($txt['export_dir_forced_change'], $modSettings['export_dir'], $fallback));
 			updateSettings(array('export_dir' => $fallback));
 
 			// Secondary fallback will be the default location, so no parameter this time.

--- a/Sources/tasks/ExportProfileData.php
+++ b/Sources/tasks/ExportProfileData.php
@@ -180,7 +180,7 @@ class ExportProfileData_Background extends SMF_BackgroundTask
 		$query_this_board = '{query_see_message_board}' . (!empty($modSettings['recycle_enable']) && $modSettings['recycle_board'] > 0 ? ' AND m.id_board != ' . $modSettings['recycle_board'] : '');
 
 		// We need a valid export directory.
-		if (empty($modSettings['export_dir']) || !file_exists($modSettings['export_dir']))
+		if (empty($modSettings['export_dir']) || !is_dir($modSettings['export_dir']) || !smf_chmod($modSettings['export_dir']))
 		{
 			require_once($sourcedir . DIRECTORY_SEPARATOR . 'Profile-Export.php');
 			if (create_export_dir() === false)


### PR DESCRIPTION
- Fixes the error message that is generated when the export directory could not be created.
- In a few places, checks whether $modSettings['export_dir'] is a writable directory, not just whether it exists.