### PR TITLE
Move user actions button to same row as pagelinks for mobiles

### DIFF
--- a/Themes/default/Display.template.php
+++ b/Themes/default/Display.template.php
@@ -231,8 +231,7 @@ function template_main()
 			<div class="pagelinks floatleft">
 				<a href="#bot" class="button">', $txt['go_down'], '</a>
 				', $context['page_index'], '
-			</div>
-		</div>';
+			</div>';
 
 	// Mobile action - moderation buttons (top)
 	if (!empty($context['normal_buttons']))
@@ -240,6 +239,9 @@ function template_main()
 		<div class="mobile_buttons floatright">
 			<a class="button mobile_act">', $txt['mobile_action'], '</a>
 			', !empty($context['mod_buttons']) ? '<a class="button mobile_mod">' . $txt['mobile_moderation'] . '</a>' : '', '
+		</div>';
+
+	echo '
 		</div>';
 
 	// Show the topic information - icon, subject, etc.
@@ -258,14 +260,6 @@ function template_main()
 			</form>
 		</div><!-- #forumposts -->';
 
-	// Mobile action - moderation buttons (bottom)
-	if (!empty($context['normal_buttons']))
-		echo '
-		<div class="mobile_buttons floatright">
-			<a class="button mobile_act">', $txt['mobile_action'], '</a>
-			', !empty($context['mod_buttons']) ? '<a class="button mobile_mod">' . $txt['mobile_moderation'] . '</a>' : '', '
-		</div>';
-
 	// Show the page index... "Pages: [1]".
 	echo '
 		<div class="pagesection">
@@ -274,7 +268,17 @@ function template_main()
 			<div class="pagelinks floatleft">
 				<a href="#main_content_section" class="button" id="bot">', $txt['go_up'], '</a>
 				', $context['page_index'], '
-			</div>
+			</div>';
+
+	// Mobile action - moderation buttons (bottom)
+	if (!empty($context['normal_buttons']))
+		echo '
+		<div class="mobile_buttons floatright">
+			<a class="button mobile_act">', $txt['mobile_action'], '</a>
+			', !empty($context['mod_buttons']) ? '<a class="button mobile_mod">' . $txt['mobile_moderation'] . '</a>' : '', '
+		</div>';
+
+	echo '
 		</div>';
 
 	// Show the lower breadcrumbs.

--- a/Themes/default/MessageIndex.template.php
+++ b/Themes/default/MessageIndex.template.php
@@ -71,13 +71,6 @@ function template_main()
 
 	if (!$context['no_topic_listing'])
 	{
-		// Mobile action buttons (top)
-		if (!empty($context['normal_buttons']))
-			echo '
-	<div class="mobile_buttons floatright">
-		<a class="button mobile_act">', $txt['mobile_action'], '</a>
-	</div>';
-
 		echo '
 	<div class="pagesection">
 		', $context['menu_separator'], '
@@ -85,7 +78,16 @@ function template_main()
 			<a href="#bot" class="button">', $txt['go_down'], '</a>
 			', $context['page_index'], '
 		</div>
-		', template_button_strip($context['normal_buttons'], 'right'), '
+		', template_button_strip($context['normal_buttons'], 'right');
+
+		// Mobile action buttons (top)
+		if (!empty($context['normal_buttons']))
+			echo '
+		<div class="mobile_buttons floatright">
+			<a class="button mobile_act">', $txt['mobile_action'], '</a>
+		</div>';
+
+		echo '
 	</div>';
 
 		if ($context['description'] != '' || !empty($context['moderators']))
@@ -305,13 +307,6 @@ function template_main()
 		<input type="hidden" name="' . $context['session_var'] . '" value="' . $context['session_id'] . '">
 	</form>';
 
-		// Mobile action buttons (bottom)
-		if (!empty($context['normal_buttons']))
-			echo '
-	<div class="mobile_buttons floatright">
-		<a class="button mobile_act">', $txt['mobile_action'], '</a>
-	</div>';
-
 		echo '
 	<div class="pagesection">
 		', template_button_strip($context['normal_buttons'], 'right'), '
@@ -319,7 +314,16 @@ function template_main()
 		<div class="pagelinks floatleft">
 			<a href="#main_content_section" class="button" id="bot">', $txt['go_up'], '</a>
 			', $context['page_index'], '
-		</div>
+		</div>';
+
+		// Mobile action buttons (bottom)
+		if (!empty($context['normal_buttons']))
+			echo '
+			<div class="mobile_buttons floatright">
+				<a class="button mobile_act">', $txt['mobile_action'], '</a>
+			</div>';
+
+		echo '
 	</div>';
 	}
 

--- a/Themes/default/css/responsive.css
+++ b/Themes/default/css/responsive.css
@@ -257,6 +257,9 @@
 	.button.mobile {
 		margin: 0 0 5px 0;
 	}
+	.pagelinks {
+		margin: 0;
+	}
 
 	/* Profile */
 	#admin_content .content {


### PR DESCRIPTION
On mobile screens the pagelinks and the user actions button
was on different lines. Move the user actions button to the
same line as pagelinks if they fit, to avoid some unused space.

Signed-off-by: Oscar Rydhé <oscar.rydhe@gmail.com>