### PR TITLE
Cleans up some weird whitespace

### DIFF
--- a/Sources/Class-Package.php
+++ b/Sources/Class-Package.php
@@ -630,10 +630,17 @@ class xmlArray
 		$trans_tbl = array_flip(get_html_translation_table(HTML_ENTITIES, ENT_QUOTES));
 
 		// Translate all the entities out.
-		$data = strtr(preg_replace_callback('~&#(\d{1,4});~', function($m)
-		{
-			return chr("$m[1]");
-		}, $data), $trans_tbl);
+		$data = strtr(
+			preg_replace_callback(
+				'~&#(\d{1,4});~',
+				function($m)
+				{
+					return chr("$m[1]");
+				},
+				$data
+			),
+			$trans_tbl
+		);
 
 		return $this->trim ? trim($data) : $data;
 	}

--- a/Sources/ManageLanguages.php
+++ b/Sources/ManageLanguages.php
@@ -911,10 +911,13 @@ function ModifyLanguage()
 
 		if (!empty($context['possible_files'][$theme]['files']))
 		{
-			usort($context['possible_files'][$theme]['files'], function($val1, $val2)
-			{
-				return strcmp($val1['name'], $val2['name']);
-			});
+			usort(
+				$context['possible_files'][$theme]['files'],
+				function($val1, $val2)
+				{
+					return strcmp($val1['name'], $val2['name']);
+				}
+			);
 		}
 	}
 

--- a/Sources/ManagePermissions.php
+++ b/Sources/ManagePermissions.php
@@ -1838,10 +1838,13 @@ function init_inline_permissions($permissions, $excluded_groups = array())
 	if (!empty($excluded_groups))
 	{
 		// Make sure this is an array of integers
-		$excluded_groups = array_filter((array) $excluded_groups, function ($v)
+		$excluded_groups = array_filter(
+			(array) $excluded_groups,
+			function ($v)
 			{
 				return is_int($v) || is_string($v) && (string) intval($v) === $v;
-			});
+			}
+		);
 
 		foreach ($permissions as $permission)
 			$context['permissions_excluded'][$permission] = array_unique(array_merge($context['permissions_excluded'][$permission], $excluded_groups));

--- a/Sources/Modlog.php
+++ b/Sources/Modlog.php
@@ -665,11 +665,15 @@ function list_getModLogEntries($start, $items_per_page, $sort, $query_string = '
 
 		if (empty($entries[$k]['action_text']))
 			$entries[$k]['action_text'] = isset($txt['modlog_ac_' . $entry['action']]) ? $txt['modlog_ac_' . $entry['action']] : $entry['action'];
-		$entries[$k]['action_text'] = preg_replace_callback('~\{([A-Za-z\d_]+)\}~i',
+
+		$entries[$k]['action_text'] = preg_replace_callback(
+			'~\{([A-Za-z\d_]+)\}~i',
 			function($matches) use ($entries, $k)
 			{
 				return isset($entries[$k]['extra'][$matches[1]]) ? $entries[$k]['extra'][$matches[1]] : '';
-			}, $entries[$k]['action_text']);
+			},
+			$entries[$k]['action_text']
+		);
 	}
 
 	// Back we go!

--- a/Sources/News.php
+++ b/Sources/News.php
@@ -470,10 +470,13 @@ function buildXmlFeed($xml_format, $xml_data, $feed_meta, $subaction)
 
 		foreach ($xml_data as $item)
 		{
-			$link = array_filter($item['content'], function($e)
-			{
-				return ($e['tag'] == 'link');
-			});
+			$link = array_filter(
+				$item['content'],
+				function($e)
+				{
+					return ($e['tag'] == 'link');
+				}
+			);
 			$link = array_pop($link);
 
 			$context['feed']['header'] .= '

--- a/Sources/News.php
+++ b/Sources/News.php
@@ -526,10 +526,14 @@ function fix_possible_url($val)
 	if (empty($modSettings['queryless_urls']) || ($context['server']['is_cgi'] && ini_get('cgi.fix_pathinfo') == 0 && @get_cfg_var('cgi.fix_pathinfo') == 0) || (!$context['server']['is_apache'] && !$context['server']['is_lighttpd']))
 		return $val;
 
-	$val = preg_replace_callback('~\b' . preg_quote($scripturl, '~') . '\?((?:board|topic)=[^#"]+)(#[^"]*)?$~', function($m) use ($scripturl)
-	{
-		return $scripturl . '/' . strtr("$m[1]", '&;=', '//,') . '.html' . (isset($m[2]) ? $m[2] : "");
-	}, $val);
+	$val = preg_replace_callback(
+		'~\b' . preg_quote($scripturl, '~') . '\?((?:board|topic)=[^#"]+)(#[^"]*)?$~',
+		function($m) use ($scripturl)
+		{
+			return $scripturl . '/' . strtr("$m[1]", '&;=', '//,') . '.html' . (isset($m[2]) ? $m[2] : "");
+		},
+		$val
+	);
 	return $val;
 }
 

--- a/Sources/News.php
+++ b/Sources/News.php
@@ -940,12 +940,16 @@ function getXmlNews($xml_format, $ascending = false)
 			// Sort the attachments by size to make things easier below
 			if (!empty($loaded_attachments))
 			{
-				uasort($loaded_attachments, function($a, $b)
-				{
-					if ($a['filesize'] == $b['filesize'])
-						return 0;
-					return ($a['filesize'] < $b['filesize']) ? -1 : 1;
-				});
+				uasort(
+					$loaded_attachments,
+					function($a, $b)
+					{
+						if ($a['filesize'] == $b['filesize'])
+							return 0;
+
+						return ($a['filesize'] < $b['filesize']) ? -1 : 1;
+					}
+				);
 			}
 			else
 				$loaded_attachments = null;
@@ -1395,13 +1399,16 @@ function getXmlRecent($xml_format)
 			// Sort the attachments by size to make things easier below
 			if (!empty($loaded_attachments))
 			{
-				uasort($loaded_attachments, function($a, $b)
-				{
-					if ($a['filesize'] == $b['filesize'])
-						return 0;
+				uasort(
+					$loaded_attachments,
+					function($a, $b)
+					{
+						if ($a['filesize'] == $b['filesize'])
+							return 0;
 
-					return ($a['filesize'] < $b['filesize']) ? -1 : 1;
-				});
+						return ($a['filesize'] < $b['filesize']) ? -1 : 1;
+					}
+				);
 			}
 			else
 				$loaded_attachments = null;
@@ -2190,11 +2197,16 @@ function getXmlPosts($xml_format, $ascending = false)
 			// Sort the attachments by size to make things easier below
 			if (!empty($loaded_attachments))
 			{
-				uasort($loaded_attachments, function($a, $b) {
-					if ($a['filesize'] == $b['filesize'])
+				uasort(
+					$loaded_attachments,
+					function($a, $b)
+					{
+						if ($a['filesize'] == $b['filesize'])
 					        return 0;
-					return ($a['filesize'] < $b['filesize']) ? -1 : 1;
-				});
+
+						return ($a['filesize'] < $b['filesize']) ? -1 : 1;
+					}
+				);
 			}
 			else
 				$loaded_attachments = null;

--- a/Sources/Post.php
+++ b/Sources/Post.php
@@ -854,10 +854,14 @@ function Post($post_errors = array())
 				{
 					// It goes 0 = outside, 1 = begin tag, 2 = inside, 3 = close tag, repeat.
 					if ($i % 4 == 0)
-						$parts[$i] = preg_replace_callback('~\[html\](.+?)\[/html\]~is', function($m)
-						{
-							return '[html]' . preg_replace('~<br\s?/?' . '>~i', '&lt;br /&gt;<br>', "$m[1]") . '[/html]';
-						}, $parts[$i]);
+						$parts[$i] = preg_replace_callback(
+							'~\[html\](.+?)\[/html\]~is',
+							function($m)
+							{
+								return '[html]' . preg_replace('~<br\s?/?' . '>~i', '&lt;br /&gt;<br>', "$m[1]") . '[/html]';
+							},
+							$parts[$i]
+						);
 				}
 				$form_message = implode('', $parts);
 			}
@@ -1276,10 +1280,13 @@ function Post($post_errors = array())
 	// File Upload.
 	if ($context['can_post_attachment'])
 	{
-		$acceptedFiles = empty($context['allowed_extensions']) ? '' : implode(',', array_map(function ($val) use ($smcFunc)
-		{
-			return !empty($val) ? ('.' . $smcFunc['htmltrim']($val)) : '';
-		}, explode(',', $context['allowed_extensions'])));
+		$acceptedFiles = empty($context['allowed_extensions']) ? '' : implode(',', array_map(
+			function ($val) use ($smcFunc)
+			{
+				return !empty($val) ? ('.' . $smcFunc['htmltrim']($val)) : '';
+			},
+			explode(',', $context['allowed_extensions'])
+		));
 
 		loadJavaScriptFile('dropzone.min.js', array('defer' => true), 'smf_dropzone');
 		loadJavaScriptFile('smf_fileUpload.js', array('defer' => true, 'minimize' => true), 'smf_fileUpload');

--- a/Sources/Profile-Export.php
+++ b/Sources/Profile-Export.php
@@ -468,7 +468,13 @@ function download_export_file($uid)
 
 	// Figure out the filename we'll tell the browser.
 	$datatypes = file_exists($progressfile) ? array_keys($smcFunc['json_decode'](file_get_contents($progressfile), true)) : array('profile');
-	$included_desc = array_map(function ($datatype) use ($txt) { return $txt[$datatype]; }, $datatypes);
+	$included_desc = array_map(
+		function ($datatype) use ($txt)
+		{
+			return $txt[$datatype];
+		},
+		$datatypes
+	);
 
 	$dlfilename = array_merge(array($context['forum_name'], $context['member']['username']), $included_desc);
 	$dlfilename = preg_replace('/[^\p{L}\p{M}\p{N}_]+/u', '-', str_replace('"', '', un_htmlspecialchars(strip_tags(implode('_', $dlfilename)))));

--- a/Sources/Profile-Export.php
+++ b/Sources/Profile-Export.php
@@ -1832,10 +1832,14 @@ function export_load_css_js()
 	$css_to_minify = array();
 	$normal_css_files = array();
 
-	usort($context['css_files'], function ($a, $b)
-	{
-		return $a['options']['order_pos'] < $b['options']['order_pos'] ? -1 : ($a['options']['order_pos'] > $b['options']['order_pos'] ? 1 : 0);
-	});
+	usort(
+		$context['css_files'],
+		function ($a, $b)
+		{
+			return $a['options']['order_pos'] < $b['options']['order_pos'] ? -1 : ($a['options']['order_pos'] > $b['options']['order_pos'] ? 1 : 0);
+		}
+	);
+
 	foreach ($context['css_files'] as $css_file)
 	{
 		if (!isset($css_file['options']['minimize']))

--- a/Sources/Profile-View.php
+++ b/Sources/Profile-View.php
@@ -360,12 +360,16 @@ function fetch_alerts($memID, $to_fetch = false, $limit = 0, $offset = 0, $with_
 	call_integration_hook('integrate_fetch_alerts', array(&$alerts, &$formats));
 
 	// Substitute $scripturl into the link formats. (Done here to make life easier for hooked mods.)
-	$formats = array_map(function ($format) use ($scripturl) {
-		$format['link'] = str_replace('{scripturl}', $scripturl, $format['link']);
-		$format['text'] = str_replace('{scripturl}', $scripturl, $format['text']);
+	$formats = array_map(
+		function ($format) use ($scripturl)
+		{
+			$format['link'] = str_replace('{scripturl}', $scripturl, $format['link']);
+			$format['text'] = str_replace('{scripturl}', $scripturl, $format['text']);
 
-		return $format;
-	}, $formats);
+			return $format;
+		},
+		$formats
+	);
 
 	// If we need to check board access, use the correct board access filter for the member in question.
 	if ((!isset($user_info['query_see_board']) || $user_info['id'] != $memID) && (!empty($possible_msgs) || !empty($possible_topics)))

--- a/Sources/QueryString.php
+++ b/Sources/QueryString.php
@@ -655,17 +655,27 @@ function ob_sessrewrite($buffer)
 	{
 		// Let's do something special for session ids!
 		if (defined('SID') && SID != '')
-			$buffer = preg_replace_callback('~"' . preg_quote($scripturl, '~') . '\?(?:' . SID . '(?:;|&|&amp;))((?:board|topic)=[^#"]+?)(#[^"]*?)?"~', function($m)
-			{
-				global $scripturl;
-				return '"' . $scripturl . "/" . strtr("$m[1]", '&;=', '//,') . ".html?" . SID . (isset($m[2]) ? $m[2] : "") . '"';
-			}, $buffer);
+			$buffer = preg_replace_callback(
+				'~"' . preg_quote($scripturl, '~') . '\?(?:' . SID . '(?:;|&|&amp;))((?:board|topic)=[^#"]+?)(#[^"]*?)?"~',
+				function($m)
+				{
+					global $scripturl;
+
+					return '"' . $scripturl . "/" . strtr("$m[1]", '&;=', '//,') . ".html?" . SID . (isset($m[2]) ? $m[2] : "") . '"';
+				},
+				$buffer
+			);
 		else
-			$buffer = preg_replace_callback('~"' . preg_quote($scripturl, '~') . '\?((?:board|topic)=[^#"]+?)(#[^"]*?)?"~', function($m)
-			{
-				global $scripturl;
-				return '"' . $scripturl . '/' . strtr("$m[1]", '&;=', '//,') . '.html' . (isset($m[2]) ? $m[2] : "") . '"';
-			}, $buffer);
+			$buffer = preg_replace_callback(
+				'~"' . preg_quote($scripturl, '~') . '\?((?:board|topic)=[^#"]+?)(#[^"]*?)?"~',
+				function($m)
+				{
+					global $scripturl;
+
+					return '"' . $scripturl . '/' . strtr("$m[1]", '&;=', '//,') . '.html' . (isset($m[2]) ? $m[2] : "") . '"';
+				},
+				$buffer
+			);
 	}
 
 	// Return the changed buffer.

--- a/Sources/Subs-Admin.php
+++ b/Sources/Subs-Admin.php
@@ -1928,9 +1928,17 @@ function smf_var_export($var)
 	// For the same reason, replace literal returns and newlines with "\r" and "\n"
 	elseif (is_string($var) && (strpos($var, "\n") !== false || strpos($var, "\r") !== false))
 	{
-		return strtr(preg_replace_callback('/[\r\n]+/', function($m) {
-			return '\' . "' . strtr($m[0], array("\r" => '\r', "\n" => '\n')) . '" . \'';
-		}, var_export($var, true)), array("'' . " => '', " . ''" => ''));
+		return strtr(
+			preg_replace_callback(
+				'/[\r\n]+/',
+				function($m)
+				{
+					return '\' . "' . strtr($m[0], array("\r" => '\r', "\n" => '\n')) . '" . \'';
+				},
+				var_export($var, true)
+			),
+			array("'' . " => '', " . ''" => '')
+		);
 	}
 
 	// We typically use lowercase true/false/null.

--- a/Sources/Subs-Admin.php
+++ b/Sources/Subs-Admin.php
@@ -1232,16 +1232,19 @@ function updateSettingsFile($config_vars, $keep_quotes = null, $rebuild = false)
 	}
 
 	// It's important to do the numbered ones before the named ones, or messes happen.
-	uksort($substitutions, function($a, $b) {
-		if (is_int($a) && is_int($b))
-			return $a > $b ? 1 : ($a < $b ? -1 : 0);
-		elseif (is_int($a))
-			return -1;
-		elseif (is_int($b))
-			return 1;
-		else
-			return strcasecmp($b, $a);
-	});
+	uksort(
+		$substitutions,
+		function($a, $b) {
+			if (is_int($a) && is_int($b))
+				return $a > $b ? 1 : ($a < $b ? -1 : 0);
+			elseif (is_int($a))
+				return -1;
+			elseif (is_int($b))
+				return 1;
+			else
+				return strcasecmp($b, $a);
+		}
+	);
 
 	/******************************
 	 * PART 3: Content processing *

--- a/Sources/Subs-Attachments.php
+++ b/Sources/Subs-Attachments.php
@@ -1339,13 +1339,16 @@ function loadAttachmentContext($id_msg, $attachments)
 
 	// Do we need to instigate a sort?
 	if ($have_unapproved)
-		uasort($attachmentData, function($a, $b)
-		{
-			if ($a['is_approved'] == $b['is_approved'])
-				return 0;
+		uasort(
+			$attachmentData,
+			function($a, $b)
+			{
+				if ($a['is_approved'] == $b['is_approved'])
+					return 0;
 
-			return $a['is_approved'] > $b['is_approved'] ? -1 : 1;
-		});
+				return $a['is_approved'] > $b['is_approved'] ? -1 : 1;
+			}
+		);
 
 	return $attachmentData;
 }

--- a/Sources/Subs-Db-postgresql.php
+++ b/Sources/Subs-Db-postgresql.php
@@ -78,8 +78,12 @@ function smf_db_initiate($db_server, $db_name, $db_user, $db_passwd, &$db_prefix
 	$db_passwd = str_replace(array('\\','\''), array('\\\\','\\\''), $db_passwd);
 
 	// Since pg_connect doesn't feed error info to pg_last_error, we have to catch issues with a try/catch.
-	set_error_handler(function($errno, $errstr) {
-		throw new ErrorException($errstr, $errno);});
+	set_error_handler(
+		function($errno, $errstr)
+		{
+			throw new ErrorException($errstr, $errno);
+		}
+	);
 	try
 	{
 		if (!empty($db_options['persist']))

--- a/Sources/Subs-Editor.php
+++ b/Sources/Subs-Editor.php
@@ -76,11 +76,14 @@ function bbc_to_html($text, $compat_mode = false)
 
 	// Parse unique ID's and disable javascript into the smileys - using the double space.
 	$i = 1;
-	$text = preg_replace_callback('~(?:\s|&nbsp;)?<(img\ssrc="' . preg_quote($modSettings['smileys_url'], '~') . '/[^<>]+?/([^<>]+?)"\s*)[^<>]*?class="smiley">~',
+	$text = preg_replace_callback(
+		'~(?:\s|&nbsp;)?<(img\ssrc="' . preg_quote($modSettings['smileys_url'], '~') . '/[^<>]+?/([^<>]+?)"\s*)[^<>]*?class="smiley">~',
 		function($m) use (&$i)
 		{
 			return '<' . stripslashes($m[1]) . 'alt="" title="" onresizestart="return false;" id="smiley_' . $i++ . '_' . $m[2] . '" style="padding: 0 3px 0 3px;">';
-		}, $text);
+		},
+		$text
+	);
 
 	return $text;
 }

--- a/Sources/Subs-Editor.php
+++ b/Sources/Subs-Editor.php
@@ -1090,10 +1090,13 @@ function legalise_bbc($text)
 		$lastlen = strlen($text = preg_replace($backToBackPattern, '', $text));
 
 	// Need to sort the tags by name length.
-	uksort($valid_tags, function($a, $b)
-	{
-		return strlen($a) < strlen($b) ? 1 : -1;
-	});
+	uksort(
+		$valid_tags,
+		function($a, $b)
+		{
+			return strlen($a) < strlen($b) ? 1 : -1;
+		}
+	);
 
 	// These inline tags can compete with each other regarding style.
 	$competing_tags = array(

--- a/Sources/Subs-Package.php
+++ b/Sources/Subs-Package.php
@@ -256,17 +256,18 @@ function read_zip_file($file, $destination, $single_file = false, $overwrite = f
 				$file = $file . '.zip';
 
 		// Phar doesn't handle open_basedir restrictions very well and throws a PHP Warning. Ignore that.
-		set_error_handler(function($errno, $errstr, $errfile, $errline)
-		{
-			// error was suppressed with the @-operator
-			if (0 === error_reporting())
+		set_error_handler(
+			function($errno, $errstr, $errfile, $errline)
 			{
-				return false;
+				// error was suppressed with the @-operator
+				if (0 === error_reporting())
+					return false;
+
+				if (strpos($errstr, 'PharData::__construct(): open_basedir') === false)
+					log_error($errstr, 'general', $errfile, $errline);
+
+				return true;
 			}
-			if (strpos($errstr, 'PharData::__construct(): open_basedir') === false)
-				log_error($errstr, 'general', $errfile, $errline);
-			return true;
-		}
 		);
 		$archive = new PharData($file, RecursiveIteratorIterator::SELF_FIRST, null, Phar::ZIP);
 		restore_error_handler();
@@ -3090,17 +3091,18 @@ function package_create_backup($id = 'backup')
 			@apache_reset_timeout();
 
 		// Phar doesn't handle open_basedir restrictions very well and throws a PHP Warning. Ignore that.
-		set_error_handler(function($errno, $errstr, $errfile, $errline)
-		{
-			// error was suppressed with the @-operator
-			if (0 === error_reporting())
+		set_error_handler(
+			function($errno, $errstr, $errfile, $errline)
 			{
-				return false;
+				// error was suppressed with the @-operator
+				if (0 === error_reporting())
+					return false;
+
+				if (strpos($errstr, 'PharData::__construct(): open_basedir') === false && strpos($errstr, 'PharData::compress(): open_basedir') === false)
+					log_error($errstr, 'general', $errfile, $errline);
+
+				return true;
 			}
-			if (strpos($errstr, 'PharData::__construct(): open_basedir') === false && strpos($errstr, 'PharData::compress(): open_basedir') === false)
-				log_error($errstr, 'general', $errfile, $errline);
-			return true;
-		}
 		);
 		$a = new PharData($output_file);
 		$a->buildFromIterator($iterator);

--- a/Sources/Subs-Post.php
+++ b/Sources/Subs-Post.php
@@ -50,10 +50,14 @@ function preparsecode(&$message, $previewing = false)
 		$message = preg_replace('~&amp;#(\d{4,5}|[2-9]\d{2,4}|1[2-9]\d);~', '&#$1;', $message);
 
 	// Clean up after nobbc ;).
-	$message = preg_replace_callback('~\[nobbc\](.+?)\[/nobbc\]~is', function($a)
-	{
-		return '[nobbc]' . strtr($a[1], array('[' => '&#91;', ']' => '&#93;', ':' => '&#58;', '@' => '&#64;')) . '[/nobbc]';
-	}, $message);
+	$message = preg_replace_callback(
+		'~\[nobbc\](.+?)\[/nobbc\]~is',
+		function($a)
+		{
+			return '[nobbc]' . strtr($a[1], array('[' => '&#91;', ']' => '&#93;', ':' => '&#58;', '@' => '&#64;')) . '[/nobbc]';
+		},
+		$message
+	);
 
 	// Remove \r's... they're evil!
 	$message = strtr($message, array("\r" => ''));
@@ -134,10 +138,14 @@ function preparsecode(&$message, $previewing = false)
 	if (!$previewing && strpos($message, '[html]') !== false)
 	{
 		if (allowedTo('bbc_html'))
-			$message = preg_replace_callback('~\[html\](.+?)\[/html\]~is', function($m)
-			{
-				return '[html]' . strtr(un_htmlspecialchars($m[1]), array("\n" => '&#13;', '  ' => ' &#32;', '[' => '&#91;', ']' => '&#93;')) . '[/html]';
-			}, $message);
+			$message = preg_replace_callback(
+				'~\[html\](.+?)\[/html\]~is',
+				function($m)
+				{
+					return '[html]' . strtr(un_htmlspecialchars($m[1]), array("\n" => '&#13;', '  ' => ' &#32;', '[' => '&#91;', ']' => '&#93;')) . '[/html]';
+				},
+				$message
+			);
 
 		// We should edit them out, or else if an admin edits the message they will get shown...
 		else
@@ -148,10 +156,14 @@ function preparsecode(&$message, $previewing = false)
 	}
 
 	// Let's look at the time tags...
-	$message = preg_replace_callback('~\[time(?:=(absolute))*\](.+?)\[/time\]~i', function($m) use ($modSettings, $user_info)
-	{
-		return "[time]" . (is_numeric("$m[2]") || @strtotime("$m[2]") == 0 ? "$m[2]" : strtotime("$m[2]") - ("$m[1]" == "absolute" ? 0 : (($modSettings["time_offset"] + $user_info["time_offset"]) * 3600))) . "[/time]";
-	}, $message);
+	$message = preg_replace_callback(
+		'~\[time(?:=(absolute))*\](.+?)\[/time\]~i',
+		function($m) use ($modSettings, $user_info)
+		{
+			return "[time]" . (is_numeric("$m[2]") || @strtotime("$m[2]") == 0 ? "$m[2]" : strtotime("$m[2]") - ("$m[1]" == "absolute" ? 0 : (($modSettings["time_offset"] + $user_info["time_offset"]) * 3600))) . "[/time]";
+		},
+		$message
+	);
 
 	// Change the color specific tags to [color=the color].
 	$message = preg_replace('~\[(black|blue|green|red|white)\]~', '[color=$1]', $message); // First do the opening tags.
@@ -179,10 +191,14 @@ function preparsecode(&$message, $previewing = false)
 		$message = preg_replace('~\[(?=/?' . $disallowed_tags_regex . '\b)~i', '&#91;', $message);
 
 	// Make sure all tags are lowercase.
-	$message = preg_replace_callback('~\[(/?)(list|li|table|tr|td)\b([^\]]*)\]~i', function($m)
-	{
-		return "[$m[1]" . strtolower("$m[2]") . "$m[3]]";
-	}, $message);
+	$message = preg_replace_callback(
+		'~\[(/?)(list|li|table|tr|td)\b([^\]]*)\]~i',
+		function($m)
+		{
+			return "[$m[1]" . strtolower("$m[2]") . "$m[3]]";
+		},
+		$message
+	);
 
 	$list_open = substr_count($message, '[list]') + substr_count($message, '[list ');
 	$list_close = substr_count($message, '[/list]');
@@ -304,19 +320,27 @@ function un_preparsecode($message)
 
 	$message = implode('', $parts);
 
-	$message = preg_replace_callback('~\[html\](.+?)\[/html\]~i', function($m) use ($smcFunc)
-	{
-		return "[html]" . strtr($smcFunc['htmlspecialchars']("$m[1]", ENT_QUOTES), array("\\&quot;" => "&quot;", "&amp;#13;" => "<br>", "&amp;#32;" => " ", "&amp;#91;" => "[", "&amp;#93;" => "]")) . "[/html]";
-	}, $message);
+	$message = preg_replace_callback(
+		'~\[html\](.+?)\[/html\]~i',
+		function($m) use ($smcFunc)
+		{
+			return "[html]" . strtr($smcFunc['htmlspecialchars']("$m[1]", ENT_QUOTES), array("\\&quot;" => "&quot;", "&amp;#13;" => "<br>", "&amp;#32;" => " ", "&amp;#91;" => "[", "&amp;#93;" => "]")) . "[/html]";
+		},
+		$message
+	);
 
 	if (strpos($message, '[cowsay') !== false && !allowedTo('bbc_cowsay'))
 		$message = preg_replace('~\[(/?)cowsay[^\]]*\]~iu', '[$1pre]', $message);
 
 	// Attempt to un-parse the time to something less awful.
-	$message = preg_replace_callback('~\[time\](\d{0,10})\[/time\]~i', function($m)
-	{
-		return "[time]" . timeformat("$m[1]", false) . "[/time]";
-	}, $message);
+	$message = preg_replace_callback(
+		'~\[time\](\d{0,10})\[/time\]~i',
+		function($m)
+		{
+			return "[time]" . timeformat("$m[1]", false) . "[/time]";
+		},
+		$message
+	);
 
 	if (!empty($code_tags))
 		$message = strtr($message, $code_tags);
@@ -405,10 +429,14 @@ function fixTags(&$message)
 		fixTag($message, $param['tag'], $param['protocols'], $param['embeddedUrl'], $param['hasEqualSign'], !empty($param['hasExtra']));
 
 	// Now fix possible security problems with images loading links automatically...
-	$message = preg_replace_callback('~(\[img.*?\])(.+?)\[/img\]~is', function($m)
-	{
-		return "$m[1]" . preg_replace("~action(=|%3d)(?!dlattach)~i", "action-", "$m[2]") . "[/img]";
-	}, $message);
+	$message = preg_replace_callback(
+		'~(\[img.*?\])(.+?)\[/img\]~is',
+		function($m)
+		{
+			return "$m[1]" . preg_replace("~action(=|%3d)(?!dlattach)~i", "action-", "$m[2]") . "[/img]";
+		},
+		$message
+	);
 
 }
 
@@ -690,16 +718,15 @@ function sendmail($to, $subject, $message, $from = null, $message_id = null, $se
 
 		foreach ($to_array as $to)
 		{
-			set_error_handler(function($errno, $errstr, $errfile, $errline)
-			{
-				// error was suppressed with the @-operator
-				if (0 === error_reporting())
+			set_error_handler(
+				function($errno, $errstr, $errfile, $errline)
 				{
-					return false;
-				}
+					// error was suppressed with the @-operator
+					if (0 === error_reporting())
+						return false;
 
-				throw new ErrorException($errstr, 0, $errno, $errfile, $errline);
-			}
+					throw new ErrorException($errstr, 0, $errno, $errfile, $errline);
+				}
 			);
 			try
 			{
@@ -1264,10 +1291,14 @@ function mimespecialchars($string, $with_charset = true, $hotmail_fix = false, $
 		unset($matches);
 
 		if ($simple)
-			$string = preg_replace_callback('~&#(\d{3,8});~', function($m)
-			{
-				return chr("$m[1]");
-			}, $string);
+			$string = preg_replace_callback(
+				'~&#(\d{3,8});~',
+				function($m)
+				{
+					return chr("$m[1]");
+				},
+				$string
+			);
 		else
 		{
 			// Try to convert the string to UTF-8.

--- a/Sources/Subs-Timezones.php
+++ b/Sources/Subs-Timezones.php
@@ -1714,9 +1714,13 @@ function get_tzid_fallbacks($tzids, $when = 'now')
 		// Missing, but we have a fallback.
 		else
 		{
-			usort($fallbacks[$tzid], function ($a, $b) {
-				return $a['ts'] > $b['ts'];
-			});
+			usort(
+				$fallbacks[$tzid],
+				function ($a, $b)
+				{
+					return $a['ts'] > $b['ts'];
+				}
+			);
 
 			foreach ($fallbacks[$tzid] as $alt)
 			{

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -6373,9 +6373,13 @@ function smf_list_timezones($when = 'now')
 			$desc = implode(', ', array_slice(array_unique($tzvalue['locations']), 0, 5)) . (count($tzvalue['locations']) > 5 ? ', ' . $txt['etc'] : '');
 
 		// We don't want abbreviations like '+03' or '-11'.
-		$abbrs = array_filter($tzvalue['abbrs'], function ($abbr) {
-			return !strspn($abbr, '+-');
-		});
+		$abbrs = array_filter(
+			$tzvalue['abbrs'],
+			function ($abbr)
+			{
+				return !strspn($abbr, '+-');
+			}
+		);
 		$abbrs = count($abbrs) == count($tzvalue['abbrs']) ? array_unique($abbrs) : array();
 
 		// Show the UTC offset and abbreviation(s).
@@ -6954,14 +6958,17 @@ function set_tld_regex($update = false)
 	if (!empty($tlds))
 	{
 		// Clean $tlds and convert it to an array
-		$tlds = array_filter(explode("\n", strtolower($tlds)), function($line)
-		{
-			$line = trim($line);
-			if (empty($line) || strlen($line) != strspn($line, 'abcdefghijklmnopqrstuvwxyz0123456789-'))
-				return false;
-			else
-				return true;
-		});
+		$tlds = array_filter(
+			explode("\n", strtolower($tlds)),
+			function($line)
+			{
+				$line = trim($line);
+				if (empty($line) || strlen($line) != strspn($line, 'abcdefghijklmnopqrstuvwxyz0123456789-'))
+					return false;
+				else
+					return true;
+			}
+		);
 
 		// Convert Punycode to Unicode
 		require_once($sourcedir . '/Class-Punycode.php');

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -2118,10 +2118,13 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 		// This is mainly for the bbc manager, so it's easy to add tags above.  Custom BBC should be added above this line.
 		if ($message === false)
 		{
-			usort($codes, function($a, $b)
-			{
-				return strcmp($a['tag'], $b['tag']);
-			});
+			usort(
+				$codes,
+				function($a, $b)
+				{
+					return strcmp($a['tag'], $b['tag']);
+				}
+			);
 			return $codes;
 		}
 
@@ -4441,10 +4444,14 @@ function template_css()
 	$toMinify = array();
 	$normal = array();
 
-	uasort($context['css_files'], function ($a, $b)
-	{
-		return $a['options']['order_pos'] < $b['options']['order_pos'] ? -1 : ($a['options']['order_pos'] > $b['options']['order_pos'] ? 1 : 0);
-	});
+	uasort(
+		$context['css_files'],
+		function ($a, $b)
+		{
+			return $a['options']['order_pos'] < $b['options']['order_pos'] ? -1 : ($a['options']['order_pos'] > $b['options']['order_pos'] ? 1 : 0);
+		}
+	);
+
 	foreach ($context['css_files'] as $id => $file)
 	{
 		// Last minute call! allow theme authors to disable single files.
@@ -7177,16 +7184,19 @@ function build_regex($strings, $delim = null, $returnArray = false)
 		}
 
 		// Sort by key length and then alphabetically
-		uksort($regex, function($k1, $k2) use (&$strlen)
-		{
-			$l1 = $strlen($k1);
-			$l2 = $strlen($k2);
+		uksort(
+			$regex,
+			function($k1, $k2) use (&$strlen)
+			{
+				$l1 = $strlen($k1);
+				$l2 = $strlen($k2);
 
-			if ($l1 == $l2)
-				return strcmp($k1, $k2) > 0 ? 1 : -1;
-			else
-				return $l1 > $l2 ? -1 : 1;
-		});
+				if ($l1 == $l2)
+					return strcmp($k1, $k2) > 0 ? 1 : -1;
+				else
+					return $l1 > $l2 ? -1 : 1;
+			}
+		);
 
 		$depth--;
 		return implode('|', $regex);

--- a/Sources/Themes.php
+++ b/Sources/Themes.php
@@ -1127,11 +1127,14 @@ function PickTheme()
 	// Then return it.
 	addJavaScriptVar(
 		'oThemeVariants',
-		json_encode(array_map(function($theme)
-		{
-			return $theme['variants'];
-		}, $context['available_themes']
-	)));
+		json_encode(array_map(
+			function($theme)
+			{
+				return $theme['variants'];
+			},
+			$context['available_themes']
+		))
+	);
 	loadJavaScriptFile('profile.js', array('defer' => false, 'minimize' => true), 'smf_profile');
 	$settings['images_url'] = $current_images_url;
 	$settings['theme_variants'] = $current_theme_variants;

--- a/Sources/tasks/ExportProfileData.php
+++ b/Sources/tasks/ExportProfileData.php
@@ -203,7 +203,13 @@ class ExportProfileData_Background extends SMF_BackgroundTask
 
 		$feed_meta = array(
 			'title' => sprintf($txt['profile_of_username'], $user_profile[$uid]['real_name']),
-			'desc' => sentence_list(array_map(function ($datatype) use ($txt) { return $txt[$datatype]; }, array_keys($included))),
+			'desc' => sentence_list(array_map(
+				function ($datatype) use ($txt)
+				{
+					return $txt[$datatype];
+				},
+				array_keys($included)
+			)),
 			'author' => $mbname,
 			'source' => $scripturl . '?action=profile;u=' . $uid,
 			'self' => '', // Unused, but can't be null.

--- a/Themes/default/Admin.template.php
+++ b/Themes/default/Admin.template.php
@@ -756,26 +756,29 @@ function template_show_settings()
 	}
 
 	// Filter out any redundant separators before we start the loop
-	$context['config_vars'] = array_filter($context['config_vars'], function ($v) use ($context)
-	{
-		static $config_vars, $prev;
-
-		$at_start = is_null($config_vars);
-		$config_vars = $at_start ? $context['config_vars'] : $config_vars;
-
-		$next = next($config_vars);
-		$at_end = key($config_vars) === null;
-
-		if (!$at_start && !$at_end)
+	$context['config_vars'] = array_filter(
+		$context['config_vars'],
+		function ($v) use ($context)
 		{
-			$div_types = array('title', 'desc');
-			$at_start = isset($prev['type']) && in_array($prev['type'], $div_types);
-			$at_end = isset($next['type']) && in_array($next['type'], $div_types);
-		}
+			static $config_vars, $prev;
 
-		$prev = $v;
-		return ($v === '' && ($at_start || $at_end || $v === $next)) ? false : true;
-	});
+			$at_start = is_null($config_vars);
+			$config_vars = $at_start ? $context['config_vars'] : $config_vars;
+
+			$next = next($config_vars);
+			$at_end = key($config_vars) === null;
+
+			if (!$at_start && !$at_end)
+			{
+				$div_types = array('title', 'desc');
+				$at_start = isset($prev['type']) && in_array($prev['type'], $div_types);
+				$at_end = isset($next['type']) && in_array($next['type'], $div_types);
+			}
+
+			$prev = $v;
+			return ($v === '' && ($at_start || $at_end || $v === $next)) ? false : true;
+		}
+	);
 
 	// Now actually loop through all the variables.
 	$is_open = false;

--- a/Themes/default/Admin.template.php
+++ b/Themes/default/Admin.template.php
@@ -757,25 +757,25 @@ function template_show_settings()
 
 	// Filter out any redundant separators before we start the loop
 	$context['config_vars'] = array_filter($context['config_vars'], function ($v) use ($context)
+	{
+		static $config_vars, $prev;
+
+		$at_start = is_null($config_vars);
+		$config_vars = $at_start ? $context['config_vars'] : $config_vars;
+
+		$next = next($config_vars);
+		$at_end = key($config_vars) === null;
+
+		if (!$at_start && !$at_end)
 		{
-			static $config_vars, $prev;
+			$div_types = array('title', 'desc');
+			$at_start = isset($prev['type']) && in_array($prev['type'], $div_types);
+			$at_end = isset($next['type']) && in_array($next['type'], $div_types);
+		}
 
-			$at_start = is_null($config_vars);
-			$config_vars = $at_start ? $context['config_vars'] : $config_vars;
-
-			$next = next($config_vars);
-			$at_end = key($config_vars) === null;
-
-			if (!$at_start && !$at_end)
-			{
-				$div_types = array('title', 'desc');
-				$at_start = isset($prev['type']) && in_array($prev['type'], $div_types);
-				$at_end = isset($next['type']) && in_array($next['type'], $div_types);
-			}
-
-			$prev = $v;
-			return ($v === '' && ($at_start || $at_end || $v === $next)) ? false : true;
-		});
+		$prev = $v;
+		return ($v === '' && ($at_start || $at_end || $v === $next)) ? false : true;
+	});
 
 	// Now actually loop through all the variables.
 	$is_open = false;

--- a/Themes/default/Calendar.template.php
+++ b/Themes/default/Calendar.template.php
@@ -407,12 +407,16 @@ function template_show_month_grid($grid_name, $is_mini = false)
 					if (!empty($day['events']))
 					{
 						// Sort events by start time (all day events will be listed first)
-						uasort($day['events'], function($a, $b) {
-							if ($a['start_timestamp'] == $b['start_timestamp'])
-								return 0;
+						uasort(
+							$day['events'],
+							function($a, $b)
+							{
+								if ($a['start_timestamp'] == $b['start_timestamp'])
+									return 0;
 
-							return ($a['start_timestamp'] < $b['start_timestamp']) ? -1 : 1;
-						});
+								return ($a['start_timestamp'] < $b['start_timestamp']) ? -1 : 1;
+							}
+						);
 
 						echo '
 						<div class="smalltext lefttext">
@@ -600,11 +604,16 @@ function template_show_week_grid($grid_name)
 			if (!empty($day['events']))
 			{
 				// Sort events by start time (all day events will be listed first)
-				uasort($day['events'], function($a, $b) {
-					if ($a['start_timestamp'] == $b['start_timestamp'])
-						return 0;
-					return ($a['start_timestamp'] < $b['start_timestamp']) ? -1 : 1;
-				});
+				uasort(
+					$day['events'],
+					function($a, $b)
+					{
+						if ($a['start_timestamp'] == $b['start_timestamp'])
+							return 0;
+
+						return ($a['start_timestamp'] < $b['start_timestamp']) ? -1 : 1;
+					}
+				);
 
 				foreach ($day['events'] as $event)
 				{

--- a/other/upgrade-helper.php
+++ b/other/upgrade-helper.php
@@ -450,18 +450,21 @@ if (!function_exists('array_column'))
 {
 	function array_column($input, $column_key, $index_key = null)
 	{
-		$arr = array_map(function($d) use ($column_key, $index_key)
-		{
-			if (!isset($d[$column_key]))
+		$arr = array_map(
+			function($d) use ($column_key, $index_key)
 			{
-				return null;
-			}
-			if ($index_key !== null)
-			{
-				return array($d[$index_key] => $d[$column_key]);
-			}
-			return $d[$column_key];
-		}, $input);
+				if (!isset($d[$column_key]))
+				{
+					return null;
+				}
+				if ($index_key !== null)
+				{
+					return array($d[$index_key] => $d[$column_key]);
+				}
+				return $d[$column_key];
+			},
+			$input
+		);
 
 		if ($index_key !== null)
 		{

--- a/other/upgrade.php
+++ b/other/upgrade.php
@@ -3374,7 +3374,14 @@ function fix_serialized_data($string)
 		return $string;
 
 	// This bit fixes incorrect string lengths, which can happen if the character encoding was changed (e.g. conversion to UTF-8)
-	$new_string = preg_replace_callback('~\bs:(\d+):"(.*?)";(?=$|[bidsa]:|[{}]|N;)~s', function ($matches) {return 's:' . strlen($matches[2]) . ':"' . $matches[2] . '";';}, $string);
+	$new_string = preg_replace_callback(
+		'~\bs:(\d+):"(.*?)";(?=$|[bidsa]:|[{}]|N;)~s',
+		function ($matches)
+		{
+			return 's:' . strlen($matches[2]) . ':"' . $matches[2] . '";';
+		},
+		$string
+	);
 
 	// @todo Add more possible fixes here. For example, fix incorrect array lengths, try to handle truncated strings gracefully, etc.
 


### PR DESCRIPTION
Fixes #6660 and cleans up some awkward formatting of closures inside functions like `array_map()`, `preg_replace_callback()`, `array_filter()`, `usort()`, etc. There's no functionality change, just whitespace.

The formatting changes inside `array_filter()` and `usort()` and friends are arguably less necessary than inside `array_map()`, `preg_replace_callback()`, etc., but they don't hurt and they create consistency with the other changes. If anyone really hates them, though, it's not a hill I'm willing to die on.