### PR TITLE
Improves validation and escaping for JavaScript variables in template_javascript() and addJavaScriptVar()

### DIFF
--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -4308,16 +4308,13 @@ function template_javascript($do_deferred = false)
 
 		foreach ($context['javascript_vars'] as $key => $value)
 		{
-			if (empty($value) && !is_numeric($value))
-			{
-				echo '
-		var ', $key, ';';
-			}
-			else
-			{
-				echo '
-		var ', $key, ' = ', $value, ';';
-			}
+			if (!is_string($key) || is_numeric($key))
+				continue;
+
+			if (!is_string($value) && !is_numeric($value))
+				$value = null;
+
+			echo "\n\t\t", 'var ', $key, isset($value) ? ' = ' . $value : '', ';';
 		}
 
 		echo '

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -4308,7 +4308,7 @@ function template_javascript($do_deferred = false)
 
 		foreach ($context['javascript_vars'] as $key => $value)
 		{
-			if (empty($value))
+			if (empty($value) && !is_numeric($value))
 			{
 				echo '
 		var ', $key, ';';


### PR DESCRIPTION
Fixes #6859 and generally improves our support for exporting different variable types from PHP to JavaScript.