### PR TITLE
Utf8 hiccups

### DIFF
--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -3735,7 +3735,7 @@ function obExit($header = null, $do_footer = null, $from_index = false, $from_fa
 	{
 		// Was the page title set last minute? Also update the HTML safe one.
 		if (!empty($context['page_title']) && empty($context['page_title_html_safe']))
-			$context['page_title_html_safe'] = $smcFunc['htmlspecialchars'](un_htmlspecialchars($context['page_title'])) . (!empty($context['current_page']) ? ' - ' . $txt['page'] . ' ' . ($context['current_page'] + 1) : '');
+			$context['page_title_html_safe'] = $smcFunc['htmlspecialchars'](html_entity_decode($context['page_title'])) . (!empty($context['current_page']) ? ' - ' . $txt['page'] . ' ' . ($context['current_page'] + 1) : '');
 
 		// Start up the session URL fixer.
 		ob_start('ob_sessrewrite');
@@ -4040,7 +4040,7 @@ function setupThemeContext($forceload = false)
 		$context['page_title'] = '';
 
 	// Set some specific vars.
-	$context['page_title_html_safe'] = $smcFunc['htmlspecialchars'](un_htmlspecialchars($context['page_title'])) . (!empty($context['current_page']) ? ' - ' . $txt['page'] . ' ' . ($context['current_page'] + 1) : '');
+	$context['page_title_html_safe'] = $smcFunc['htmlspecialchars'](html_entity_decode($context['page_title'])) . (!empty($context['current_page']) ? ' - ' . $txt['page'] . ' ' . ($context['current_page'] + 1) : '');
 	$context['meta_keywords'] = !empty($modSettings['meta_keywords']) ? $smcFunc['htmlspecialchars']($modSettings['meta_keywords']) : '';
 
 	// Content related meta tags, including Open Graph

--- a/Sources/Xml.php
+++ b/Sources/Xml.php
@@ -194,7 +194,7 @@ function sig_preview()
 		censorText($current_signature);
 		$current_signature = !empty($current_signature) ? parse_bbc($current_signature, true, 'sig' . $user) : $txt['no_signature_set'];
 
-		$preview_signature = !empty($_POST['signature']) ? $_POST['signature'] : $txt['no_signature_preview'];
+		$preview_signature = !empty($_POST['signature']) ? $smcFunc['htmlspecialchars']($_POST['signature']) : $txt['no_signature_preview'];
 		$validation = profileValidateSignature($preview_signature);
 
 		if ($validation !== true && $validation !== false)


### PR DESCRIPTION
Fixes #6875 

Fixes two nuisance UTF8 character issues...

**_Browser tab issue, before - note that the page title on the browser tab does not match the board name as expected:_**
![tab_before](https://user-images.githubusercontent.com/23568484/126883191-2f6447b3-46f6-4fad-95ec-3df3d56cf274.png)


**_Browser tab issue, after - note that the page title now matches, and also, that any various html entities are properly depicted:_**
![tab_after](https://user-images.githubusercontent.com/23568484/126883192-b9938c79-7a2d-4d17-bed3-c4c3585bea55.png)



**_Signature preview, before - the signature should be as-entered, but it is instead interpreting entities.  Note this only affects the preview, the signature itself is OK:_**
![sig_preview_before](https://user-images.githubusercontent.com/23568484/126883196-20ed0102-1ed5-4ce2-aa91-091748ba7d95.png)
![sig_before](https://user-images.githubusercontent.com/23568484/126883198-d91d79bc-254f-4c2a-8435-16ba7f55ac63.png)


**_Signature preview, after - now matches the value as-entered:_**
![sig_preview_after](https://user-images.githubusercontent.com/23568484/126883200-92fb9553-47b9-4b49-8b08-9fb16988d328.png)


