### PR TITLE
Base pagination on all results

### DIFF
--- a/Sources/Search.php
+++ b/Sources/Search.php
@@ -1919,7 +1919,10 @@ function PlushSearch2()
 		);
 
 		// How many results will the user be able to see?
-		$num_results = $smcFunc['db_num_rows']($messages_request);
+		if (!empty($_SESSION['search_cache']['num_results']))
+			$num_results = $_SESSION['search_cache']['num_results'];
+		else
+			$num_results = $smcFunc['db_num_rows']($messages_request);
 
 		// If there are no results that means the things in the cache got deleted, so pretend we have no topics anymore.
 		if ($num_results == 0)


### PR DESCRIPTION
Fixes #6884 

Falls back to the existing query number if the search cache isn't populated.

**_BEFORE:_**
Test search from my guitar fx forum.  Note we have LOTS of references to Fender...
![image](https://user-images.githubusercontent.com/23568484/127049545-e8ac5839-f2d5-464d-adb3-8e0ee89a10d3.png)

**_AFTER:_**
That's more like it...
![image](https://user-images.githubusercontent.com/23568484/127049322-24194b6e-895d-427c-8281-b66bc96a0bbb.png)
