### PR TITLE
Fixes a javascript error due to missing semi-colon

### DIFF
--- a/Sources/Subs-Editor.php
+++ b/Sources/Subs-Editor.php
@@ -1551,7 +1551,7 @@ function create_control_richedit($editorOptions)
 			"More": "' . $editortxt['more'] . '",
 			"Close": "' . $editortxt['close'] . '",
 			dateFormat: "' . $editortxt['dateformat'] . '"
-		}';
+		};';
 
 		addInlineJavaScript($scExtraLangs, true);
 


### PR DESCRIPTION
I had a hook here:
	Display.php
```
	call_integration_hook('integrate_display_buttons', array(&$context['normal_buttons']));
```

When in the hook I called:
```
	addInlineJavaScript($javascript, true);
```

The resulting javascript was:
```
	window.setTimeout(triggerCron, 1);
		$.sceditor.locale["en"] = {
			"Width (optional):": "Width (optional):",
			"Height (optional):": "Height (optional):",
			"Insert": "Insert",
			"Description (optional):": "Description (optional)",
			"Rows:": "Rows:",
			"Cols:": "Cols:",
			"URL:": "URL:",
			"E-mail:": "E-mail:",
			"Video URL:": "Video URL:",
			"More": "More",
			"Close": "Close",
			dateFormat: "month/day/year"
		}	$("input[name=seqnum]").after(
		"<div id='docLinksContainer'></div>"
	);
	
	$("div#specialContainer").append(
```

It produced javascript that would error out because of this missing semi-colon.  Added this and the error went away.