### PR TITLE
fix: url tags should not change to iurl

### DIFF
--- a/Themes/default/scripts/jquery.sceditor.smf.js
+++ b/Themes/default/scripts/jquery.sceditor.smf.js
@@ -327,11 +327,11 @@ sceditor.command.set(
 							'</a>'
 						);
 					else
-						// Can't just use `editor.execCommand('createlink', url)`
+						// Can't just use `editor.execCommand('createlink', email)`
 						// because we need to set a custom attribute.
 						editor.wysiwygEditorInsertHtml(
-							'<a data-type="email" href="' +
-							sceditor.escapeEntities(url) + '">', '</a>'
+							'<a data-type="email" href="mailto:' +
+							sceditor.escapeEntities(email) + '">', '</a>'
 						);
 				}
 			);
@@ -743,11 +743,11 @@ sceditor.formats.bbcode.set(
 		},
 		format: function (element, content)
 		{
-			return '[email=' + element.href + ']' + content + '[/email]';
+			return '[email=' + element.href.substr(7) + ']' + content + '[/email]';
 		},
 		html: function (token, attrs, content)
 		{
-			return '<a data-type="email" href="' + sceditor.escapeEntities(attrs.defaultattr || content, true) + '">' + content + '</a>';
+			return '<a data-type="email" href="mailto:' + sceditor.escapeEntities(attrs.defaultattr || content, true) + '">' + content + '</a>';
 		}
 	}
 );

--- a/Themes/default/scripts/jquery.sceditor.smf.js
+++ b/Themes/default/scripts/jquery.sceditor.smf.js
@@ -630,7 +630,7 @@ sceditor.formats.bbcode.set(
 		tags: {
 			img: {
 				'data-attachment': null
-			}
+			},
 			a: {
 				'data-attachment': null
 			}
@@ -743,11 +743,11 @@ sceditor.formats.bbcode.set(
 		},
 		format: function (element, content)
 		{
-			return '[email=' + decodeURI(element.href) + ']' + content + '[/email]';
+			return '[email=' + element.href + ']' + content + '[/email]';
 		},
 		html: function (token, attrs, content)
 		{
-			return '<a data-type="email" href="' + encodeURI(attrs.defaultattr || content) + '">' + content + '</a>';
+			return '<a data-type="email" href="' + sceditor.escapeEntities(attrs.defaultattr || content, true) + '">' + content + '</a>';
 		}
 	}
 );
@@ -755,7 +755,7 @@ sceditor.formats.bbcode.set(
 sceditor.formats.bbcode.set(
 	'url', {
 		allowsEmpty: true,
-		quoteType: sceditor.BBCodeParser.QuoteType.never,
+		quoteType: sceditor.BBCodeParser.QuoteType.always,
 		tags: {
 			a: {
 				'data-type': ['url']
@@ -775,7 +775,7 @@ sceditor.formats.bbcode.set(
 sceditor.formats.bbcode.set(
 	'iurl', {
 		allowsEmpty: true,
-		quoteType: sceditor.BBCodeParser.QuoteType.never,
+		quoteType: sceditor.BBCodeParser.QuoteType.always,
 		tags: {
 			a: {
 				'data-type': ['iurl']

--- a/Themes/default/scripts/jquery.sceditor.smf.js
+++ b/Themes/default/scripts/jquery.sceditor.smf.js
@@ -209,25 +209,19 @@ sceditor.command.set(
 			var editor = this;
 
 			editor.commands.link._dropDown(editor, caller, function (url, text) {
-				// needed for IE to restore the last range
-				editor.focus();
-
-				// If there is no selected text then must set the URL as
-				// the text. Most browsers do this automatically, sadly
-				// IE doesn't.
 				if (!editor.getRangeHelper().selectedHtml() || text) {
 					text = text || url;
 
 					editor.wysiwygEditorInsertHtml(
-						'<a target="_blank" rel="noopener" href="' +
+						'<a data-type="url" href="' +
 						sceditor.escapeEntities(url) + '">' +
 						sceditor.escapeEntities(text, true) + '</a>'
 					);
 				} else {
 					// Can't just use `editor.execCommand('createlink', url)`
-					// because we need to set the target attribute.
+					// because we need to set a custom attribute.
 					editor.wysiwygEditorInsertHtml(
-						'<a target="_blank" rel="noopener" href="' +
+						'<a data-type="url" href="' +
 						sceditor.escapeEntities(url) + '">', '</a>'
 					);
 				}
@@ -325,18 +319,20 @@ sceditor.command.set(
 				caller,
 				function (email, text)
 				{
-					// needed for IE to reset the last range
-					editor.focus();
-
 					if (!editor.getRangeHelper().selectedHtml() || text)
 						editor.wysiwygEditorInsertHtml(
-							'<a href="' +
+							'<a data-type="email" href="' +
 							'mailto:' + sceditor.escapeEntities(email) + '">' +
 								sceditor.escapeEntities(text || email) +
 							'</a>'
 						);
 					else
-						editor.execCommand('createlink', 'mailto:' + email);
+						// Can't just use `editor.execCommand('createlink', url)`
+						// because we need to set a custom attribute.
+						editor.wysiwygEditorInsertHtml(
+							'<a data-type="email" href="' +
+							sceditor.escapeEntities(url) + '">', '</a>'
+						);
 				}
 			);
 		},
@@ -632,8 +628,11 @@ sceditor.formats.bbcode.set(
 sceditor.formats.bbcode.set(
 	'attach', {
 		tags: {
-			attach: {
-				src: null
+			img: {
+				'data-attachment': null
+			}
+			a: {
+				'data-attachment': null
 			}
 		},
 		allowsEmpty: true,
@@ -734,49 +733,41 @@ sceditor.formats.bbcode.set(
 );
 
 sceditor.formats.bbcode.set(
-	'url', {
+	'email', {
 		allowsEmpty: true,
-		quoteType: $.sceditor.BBCodeParser.QuoteType.never,
+		quoteType: sceditor.BBCodeParser.QuoteType.never,
 		tags: {
 			a: {
-				href: null
+				'data-type': ['email']
 			}
 		},
-		format: function (element, content) {
-			var element = $(element),
-				url = element.attr('href');
-
-			// make sure this link is not an e-mail, if it is return e-mail BBCode
-			if (url.substr(0, 7) === 'mailto:')
-				return '[email=' + url.substr(7) + ']' + content + '[/email]';
-
-			if (typeof element.attr('target') !== "undefined")
-				return '[url=\"' + decodeURI(url) + '\"]' + content + '[/url]';
-
-			// A mention?
-			else if (typeof element.attr('data-mention') !== "undefined")
-				return '[member='+ element.attr('data-mention') +']'+ content.replace('@','') +'[/member]';
-
-			// Is this an attachment?
-			else if (typeof element.attr('data-attachment') !== "undefined")
-			{
-				var attribs = ' id=' + element.attr('data-attachment');
-				if (typeof element.attr('alt') !== "undefined")
-					attribs += ' alt=' + element.attr('alt');
-				if (typeof element.attr('data-type') !== "undefined")
-					attribs += ' type=' + element.attr("data-type");
-
-				return '[attach' + attribs + ']' + content + '[/attach]';
-			}
-
-			else
-				return '[iurl=\"' + decodeURI(url) + '\"]' + content + '[/iurl]';
+		format: function (element, content)
+		{
+			return '[email=' + decodeURI(element.href) + ']' + content + '[/email]';
 		},
-		html: function (token, attrs, content) {
-			if (typeof attrs.defaultattr === "undefined" || attrs.defaultattr.length === 0)
-				attrs.defaultattr = content;
+		html: function (token, attrs, content)
+		{
+			return '<a data-type="email" href="' + encodeURI(attrs.defaultattr || content) + '">' + content + '</a>';
+		}
+	}
+);
 
-			return '<a target="_blank" rel="noopener" href="' + encodeURI(attrs.defaultattr) + '">' + content + '</a>';
+sceditor.formats.bbcode.set(
+	'url', {
+		allowsEmpty: true,
+		quoteType: sceditor.BBCodeParser.QuoteType.never,
+		tags: {
+			a: {
+				'data-type': ['url']
+			}
+		},
+		format: function (element, content)
+		{
+			return '[url=' + decodeURI(element.href) + ']' + content + '[/url]';
+		},
+		html: function (token, attrs, content)
+		{
+			return '<a data-type="url" href="' + encodeURI(attrs.defaultattr || content) + '">' + content + '</a>';
 		}
 	}
 );
@@ -784,13 +775,19 @@ sceditor.formats.bbcode.set(
 sceditor.formats.bbcode.set(
 	'iurl', {
 		allowsEmpty: true,
-		quoteType: $.sceditor.BBCodeParser.QuoteType.never,
-		html: function (token, attrs, content) {
-
-			if (typeof attrs.defaultattr === "undefined" || attrs.defaultattr.length === 0)
-				attrs.defaultattr = content;
-
-			return '<a href="' + encodeURI(attrs.defaultattr) + '">' + content + '</a>';
+		quoteType: sceditor.BBCodeParser.QuoteType.never,
+		tags: {
+			a: {
+				'data-type': ['iurl']
+			}
+		},
+		format: function (element, content)
+		{
+			return '[iurl=' + decodeURI(element.href) + ']' + content + '[/iurl]';
+		},
+		html: function (token, attrs, content)
+		{
+			return '<a data-type="iurl" href="' + encodeURI(attrs.defaultattr || content) + '">' + content + '</a>';
 		}
 	}
 );
@@ -919,12 +916,17 @@ sceditor.formats.bbcode.set(
 
 			return '[font=' + font + ']' + content + '[/font]';
 		}
-}
+	}
 );
 
 sceditor.formats.bbcode.set(
 	'member', {
 		isInline: true,
+		tags: {
+			a: {
+				'data-mention': null
+			}
+		},
 		format: function (element, content) {
 			return '[member='+ $(element).attr('data-mention') +']'+ content.replace('@','') +'[/member]';
 		},


### PR DESCRIPTION
Fixes #6886 by adding a unique data attribute to the different link types. While at it I unraveled some o the code so that each link type/bbcode uses its own formatting function.

Signed-off-by: John Rayes <live627@gmail.com>