### PR TITLE
Create label-cleanup.yml

### DIFF
--- a/.github/workflows/label-cleanup.yml
+++ b/.github/workflows/label-cleanup.yml
@@ -1,0 +1,38 @@
+name: Label cleanup
+
+on:
+  pull_request_target:
+    types:
+      - closed
+
+jobs:
+  remove-label:
+    name: Cleanup after PR Triage
+    if: github.event.pull_request.merged
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v4
+        with:
+          script: |
+            const labels = [
+                'Work in progress',
+                'PR: draft',
+                'PR: unreviewed',
+                'PR: reviewed-changes-requested',
+                'PR: partially-approved',
+                'PR: review-approved'
+            ];
+            for (const label of labels)
+                try
+                {
+                    github.issues.removeLabel({
+                        name: label,
+                        issue_number: context.issue.number,
+                        owner: context.repo.owner,
+                        repo: context.repo.repo
+                    });
+                }
+                catch (e)
+                {
+                    core.warning(`failed to remove label: ${label}: ${e.message}`);
+                }


### PR DESCRIPTION
A simple workflow that removes tags left by the PR Triage bot. It will execute on a PR once it is merged, but not if closed unmerged.

Signed-off-by: John Rayes <live627@gmail.com>