### PR TITLE
Changed newicon to use :target css

### DIFF
--- a/Sources/Load.php
+++ b/Sources/Load.php
@@ -1031,15 +1031,16 @@ function loadBoard()
 			SELECT
 				m.id_msg
 			FROM
-				smf_messages AS m
+			{db_prefix}messages AS m
 				JOIN (
 					SELECT
 						COALESCE(lt.id_msg, lmr.id_msg, - 1) AS new_from
-					FROM smf_log_topics AS lt
-					LEFT JOIN smf_log_mark_read AS lmr ON (lmr.id_board = {int:id_topic} AND
+					FROM {db_prefix}topics t
+					left join {db_prefix}log_topics AS lt on (t.id_topic = lt.id_topic)
+					LEFT JOIN {db_prefix}log_mark_read AS lmr ON (lmr.id_board = t.id_board AND
 							lmr.id_member = {int:current_member})
 					WHERE
-						lt.id_topic = {int:id_topic} AND
+						t.id_topic = {int:id_topic} AND
 						lt.id_member = {int:current_member}
 					LIMIT 1) AS nf ON (m.id_msg > nf.new_from)
 					WHERE m.id_topic = {int:id_topic} 

--- a/Sources/MessageIndex.php
+++ b/Sources/MessageIndex.php
@@ -524,7 +524,7 @@ function MessageIndex()
 			'new' => $row['new_from'] <= $row['id_msg_modified'],
 			'new_from' => $row['new_from'],
 			'newtime' => $row['new_from'],
-			'new_href' => $scripturl . '?topic=' . $row['id_topic'] . '.msg' . $row['new_from'] . '#new',
+			'new_href' => $scripturl . '?topic=' . $row['id_topic'] . '.nm',
 			'pages' => $pages,
 			'replies' => comma_format($row['num_replies']),
 			'views' => comma_format($row['num_views']),

--- a/Sources/QueryString.php
+++ b/Sources/QueryString.php
@@ -225,6 +225,11 @@ function cleanRequest()
 			$timestamp = (int) substr($_REQUEST['start'], 4);
 			$_REQUEST['start'] = $timestamp === 0 ? 0 : 'from' . $timestamp;
 		}
+		// ... or whatever is nm ...
+		elseif (strpos($_REQUEST['start'], 'nm') === 0)
+		{
+			$_REQUEST['start'] = 'nm';
+		}
 		// ... or something invalid, in which case we reset it to 0.
 		else
 			$_REQUEST['start'] = 0;


### PR DESCRIPTION
With this pr a user see now where new is starting,
by using the new :target css

![grafik](https://user-images.githubusercontent.com/1782906/128065937-bb443e63-4bc9-42bb-bd90-be52a0a83210.png)
the newicon use now a static url topic.123456.nm instead of topic.123456.msg1234#new get than redirected to the newest msg when existing.
![grafik](https://user-images.githubusercontent.com/1782906/128066265-9e6f57cb-3a9e-43c8-a89b-d9204930497e.png)

in essential the id= #new is not used any more from this jump 