### PR TITLE
Lists smileys even when smiley_files table is empty

### DIFF
--- a/Sources/ManageSmileys.php
+++ b/Sources/ManageSmileys.php
@@ -1392,7 +1392,7 @@ function EditSmileys()
 		$request = $smcFunc['db_query']('', '
 			SELECT s.id_smiley AS id, s.code, f.filename, f.smiley_set, s.description, s.hidden AS location
 			FROM {db_prefix}smileys AS s
-				JOIN {db_prefix}smiley_files AS f ON (s.id_smiley = f.id_smiley)
+				LEFT JOIN {db_prefix}smiley_files AS f ON (s.id_smiley = f.id_smiley)
 			WHERE s.id_smiley = {int:current_smiley}',
 			array(
 				'current_smiley' => (int) $_REQUEST['smiley'],
@@ -1465,7 +1465,7 @@ function list_getSmileys($start, $items_per_page, $sort)
 	$request = $smcFunc['db_query']('', '
 		SELECT s.id_smiley, s.code, f.filename, f.smiley_set, s.description, s.smiley_row, s.smiley_order, s.hidden
 		FROM {db_prefix}smileys AS s
-			JOIN {db_prefix}smiley_files AS f ON (s.id_smiley = f.id_smiley)
+			LEFT JOIN {db_prefix}smiley_files AS f ON (s.id_smiley = f.id_smiley)
 		ORDER BY {raw:sort}',
 		array(
 			'sort' => $sort,
@@ -1598,9 +1598,8 @@ function EditSmileyOrder()
 	$request = $smcFunc['db_query']('', '
 		SELECT s.id_smiley, s.code, f.filename, s.description, s.smiley_row, s.smiley_order, s.hidden
 		FROM {db_prefix}smileys AS s
-			JOIN {db_prefix}smiley_files AS f ON (s.id_smiley = f.id_smiley)
+			LEFT JOIN {db_prefix}smiley_files AS f ON (s.id_smiley = f.id_smiley AND f.smiley_set = {string:smiley_set})
 		WHERE s.hidden != {int:popup}
-			AND f.smiley_set = {string:smiley_set}
 		ORDER BY s.smiley_order, s.smiley_row',
 		array(
 			'popup' => 1,

--- a/Themes/default/ManageSmileys.template.php
+++ b/Themes/default/ManageSmileys.template.php
@@ -144,7 +144,7 @@ function template_modifysmiley()
 					', $smiley_set['name'], '
 				</dt>
 				<dd', in_array($set, $context['missing_sets']) ? ' class="errorbox"' : '', '>
-					<select name="smiley_filename[', $set, ']" id="smiley_filename_', $set, '" onchange="$(\'#set\').val(\'', $set, '\');updatePreview($(\'#smiley_filename_\' + $(\'#set\').val()).val(), $(\'#set\').val());" required>';
+					<select name="smiley_filename[', $set, ']" id="smiley_filename_', $set, '" onchange="$(\'#set\').val(\'', $set, '\');updatePreview($(\'#smiley_filename_\' + $(\'#set\').val()).val(), $(\'#set\').val());">';
 
 			foreach ($context['filenames'][$set] as $filename)
 				echo '


### PR DESCRIPTION
Fixes #6918

With this, smileys will still be listed in the various "Smileys and Message Icons" lists even if the smiley_files table is empty.

Note: this PR does not try to correct bad smiley settings during upgrade, but it does allow the admin to fix missing smiley_file data in the UI afterward.