### PR TITLE
Do not replace selected text when inserting attachment

### DIFF
--- a/Themes/default/scripts/smf_fileUpload.js
+++ b/Themes/default/scripts/smf_fileUpload.js
@@ -171,7 +171,7 @@ function smf_fileUpload(oOptions) {
 					var e = $('#' + oEditorID).get(0);
 					var oEditor = sceditor.instance(e);
 
-					oEditor.insert(myDropzone.options.smf_insertBBC(response, w, h));
+					oEditor.insert(myDropzone.options.smf_insertBBC(response, w, h), ' ');
 				})
 				.appendTo(_innerElement.find('.attach-ui'));
 		};


### PR DESCRIPTION
When an attachment was inserted into a post, and the
user had selected some text in the message, the selected
text was replaced with the attachment.
Now the attachment will be placed before the selection instead.

Fixes #6958

Signed-off-by: Oscar Rydhé <oscar.rydhe@gmail.com>