### PR TITLE
Avoid double current version in the emulated version drop down

### DIFF
--- a/Sources/Packages.php
+++ b/Sources/Packages.php
@@ -1536,7 +1536,10 @@ function PackageBrowse()
 	// Current SMF version, which is selected by default
 	$context['default_version'] = SMF_VERSION;
 
-	$context['emulation_versions'][] = $context['default_version'];
+	if (!in_array($context['default_version'], $context['emulation_versions']))
+	{
+		$context['emulation_versions'][] = $context['default_version'];
+	}
 
 	// Version we're currently emulating, if any
 	$context['selected_version'] = preg_replace('~^SMF ~', '', $context['forum_version']);


### PR DESCRIPTION
Avoid double items of the current version in the emulated version
drop down, in the package manager.

Fixes #6883

Signed-off-by: Oscar Rydhé <oscar.rydhe@gmail.com>