### PR TITLE
Miscellaneous fixes to small bugs

### DIFF
--- a/Sources/Display.php
+++ b/Sources/Display.php
@@ -1342,6 +1342,16 @@ function Display()
 	// Note: integrate_mod_buttons is no more necessary and deprecated, but is kept for backward compatibility with 2.0
 	call_integration_hook('integrate_mod_buttons', array(&$context['mod_buttons']));
 
+	// If any buttons have a 'test' check, run those tests now to keep things clean.
+	foreach (array('normal_buttons', 'mod_buttons') as $button_strip)
+	{
+		foreach ($context[$button_strip] as $key => $value)
+		{
+			if (isset($value['test']) && empty($context[$value['test']]))
+				unset($context[$button_strip][$key]);
+		}
+	}
+
 	// Load the drafts js file
 	if ($context['drafts_autosave'])
 		loadJavaScriptFile('drafts.js', array('defer' => false, 'minimize' => true), 'smf_drafts');

--- a/Sources/Display.php
+++ b/Sources/Display.php
@@ -1348,7 +1348,17 @@ function Display()
 		foreach ($context[$button_strip] as $key => $value)
 		{
 			if (isset($value['test']) && empty($context[$value['test']]))
+			{
 				unset($context[$button_strip][$key]);
+			}
+			elseif (isset($value['sub_buttons']))
+			{
+				foreach ($value['sub_buttons'] as $subkey => $subvalue)
+				{
+					if (isset($subvalue['test']) && empty($context[$subvalue['test']]))
+						unset($context[$button_strip][$key]['sub_buttons'][$subkey]);
+				}
+			}
 		}
 	}
 

--- a/Sources/Display.php
+++ b/Sources/Display.php
@@ -1039,7 +1039,7 @@ function Display()
 					'now' => time(),
 				)
 			);
-			$user_info['alerts'] = $user_info['alerts'] - max(0, $smcFunc['db_affected_rows']());
+			$user_info['alerts'] = max(0, $user_info['alerts'] - max(0, $smcFunc['db_affected_rows']()));
 			updateMemberData($user_info['id'], array('alerts' => $user_info['alerts']));
 		}
 	}

--- a/Sources/Register.php
+++ b/Sources/Register.php
@@ -313,20 +313,14 @@ function Register2()
 		}
 	}
 
-	foreach ($_POST as $key => $value)
-	{
-		if (!is_array($_POST[$key]))
+	array_walk_recursive(
+		$_POST,
+		function (&$value, $key) use ($context, $smcFunc)
 		{
-			// For UTF-8, replace any kind of space with a normal space, and remove any kind of control character, then trim.
-			if ($context['utf8'])
-				$_POST[$key] = $smcFunc['htmltrim'](preg_replace(array('~[\h\v]+~u', '~\p{C}+~u'), array(' ', ''), $_POST[$key]));
-			// Otherwise, just remove "\n" and "\r", then trim.
-			else
-				$_POST[$key] = $smcFunc['htmltrim'](str_replace(array("\n", "\r"), '', $_POST[$key]));
+			// Replace any kind of space with a normal space, and remove any kind of control character, then trim.
+			$value = $smcFunc['htmltrim'](preg_replace(array('~[\h\v]+~' . ($context['utf8'] ? 'u' : ''), '~\p{Cc}+~'), array(' ', ''), $value));
 		}
-		else
-			$_POST[$key] = htmltrim__recursive($_POST[$key]);
-	}
+	);
 
 	// Collect all extra registration fields someone might have filled in.
 	$possible_strings = array(

--- a/Sources/Register.php
+++ b/Sources/Register.php
@@ -317,9 +317,9 @@ function Register2()
 	{
 		if (!is_array($_POST[$key]))
 		{
-			// For UTF-8, replace any kind of space with a normal space, and remove any kind of control character (incl. "\n" and "\r"), then trim.
+			// For UTF-8, replace any kind of space with a normal space, and remove any kind of control character, then trim.
 			if ($context['utf8'])
-				$_POST[$key] = $smcFunc['htmltrim'](preg_replace(array('~\p{Z}+~u', '~\p{C}+~u'), array(' ', ''), $_POST[$key]));
+				$_POST[$key] = $smcFunc['htmltrim'](preg_replace(array('~[\h\v]+~u', '~\p{C}+~u'), array(' ', ''), $_POST[$key]));
 			// Otherwise, just remove "\n" and "\r", then trim.
 			else
 				$_POST[$key] = $smcFunc['htmltrim'](str_replace(array("\n", "\r"), '', $_POST[$key]));

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -2356,8 +2356,8 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 					// An &nbsp; right after a URL can break the autolinker
 					if (strpos($data, '&nbsp;') !== false)
 					{
-						$placeholders[html_entity_decode('&nbsp;')] = '&nbsp;';
-						$data = strtr($data, array('&nbsp;' => html_entity_decode('&nbsp;')));
+						$placeholders[html_entity_decode('&nbsp;', null, $context['character_set'])] = '&nbsp;';
+						$data = strtr($data, array('&nbsp;' => html_entity_decode('&nbsp;', null, $context['character_set'])));
 					}
 
 					// Some reusable character classes
@@ -2463,16 +2463,16 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 								'(' => ')', '[' => ']', '{' => '}',
 								// Double quotation marks
 								'"' => '"',
-								html_entity_decode('&#x201C;') => html_entity_decode('&#x201D;'),
-								html_entity_decode('&#x201E;') => html_entity_decode('&#x201D;'),
-								html_entity_decode('&#x201F;') => html_entity_decode('&#x201D;'),
-								html_entity_decode('&#x00AB;') => html_entity_decode('&#x00BB;'),
+								html_entity_decode('&#x201C;', null, $context['character_set']) => html_entity_decode('&#x201D;', null, $context['character_set']),
+								html_entity_decode('&#x201E;', null, $context['character_set']) => html_entity_decode('&#x201D;', null, $context['character_set']),
+								html_entity_decode('&#x201F;', null, $context['character_set']) => html_entity_decode('&#x201D;', null, $context['character_set']),
+								html_entity_decode('&#x00AB;', null, $context['character_set']) => html_entity_decode('&#x00BB;', null, $context['character_set']),
 								// Single quotation marks
 								'\'' => '\'',
-								html_entity_decode('&#x2018;') => html_entity_decode('&#x2019;'),
-								html_entity_decode('&#x201A;') => html_entity_decode('&#x2019;'),
-								html_entity_decode('&#x201B;') => html_entity_decode('&#x2019;'),
-								html_entity_decode('&#x2039;') => html_entity_decode('&#x203A;'),
+								html_entity_decode('&#x2018;', null, $context['character_set']) => html_entity_decode('&#x2019;', null, $context['character_set']),
+								html_entity_decode('&#x201A;', null, $context['character_set']) => html_entity_decode('&#x2019;', null, $context['character_set']),
+								html_entity_decode('&#x201B;', null, $context['character_set']) => html_entity_decode('&#x2019;', null, $context['character_set']),
+								html_entity_decode('&#x2039;', null, $context['character_set']) => html_entity_decode('&#x203A;', null, $context['character_set']),
 							);
 							foreach ($balanced_pairs as $pair_opener => $pair_closer)
 								$balanced_pairs[$smcFunc['htmlspecialchars']($pair_opener)] = $smcFunc['htmlspecialchars']($pair_closer);

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -2356,8 +2356,8 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 					// An &nbsp; right after a URL can break the autolinker
 					if (strpos($data, '&nbsp;') !== false)
 					{
-						$placeholders[sprintf($placeholder_template, 'nbsp')] = '&nbsp;';
-						$data = strtr($data, array('&nbsp;' => sprintf($placeholder_template, 'nbsp')));
+						$placeholders[html_entity_decode('&nbsp;')] = '&nbsp;';
+						$data = strtr($data, array('&nbsp;' => html_entity_decode('&nbsp;')));
 					}
 
 					// Some reusable character classes

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -2360,21 +2360,21 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 						$data = strtr($data, array('&nbsp;' => sprintf($placeholder_template, 'nbsp')));
 					}
 
+					// Some reusable character classes
+					$space_chars = ($context['utf8'] ? '\p{Z}' : '\s');
+					$excluded_trailing_chars = '!;:.,?';
+					$domain_label_chars = '0-9A-Za-z\-' . ($context['utf8'] ? implode('', array(
+						'\x{A0}-\x{D7FF}', '\x{F900}-\x{FDCF}', '\x{FDF0}-\x{FFEF}',
+						'\x{10000}-\x{1FFFD}', '\x{20000}-\x{2FFFD}', '\x{30000}-\x{3FFFD}',
+						'\x{40000}-\x{4FFFD}', '\x{50000}-\x{5FFFD}', '\x{60000}-\x{6FFFD}',
+						'\x{70000}-\x{7FFFD}', '\x{80000}-\x{8FFFD}', '\x{90000}-\x{9FFFD}',
+						'\x{A0000}-\x{AFFFD}', '\x{B0000}-\x{BFFFD}', '\x{C0000}-\x{CFFFD}',
+						'\x{D0000}-\x{DFFFD}', '\x{E1000}-\x{EFFFD}',
+					)) : '');
+
 					// Parse any URLs
 					if (!isset($disabled['url']) && strpos($data, '[url') === false)
 					{
-						// Some reusable character classes
-						$space_chars = ($context['utf8'] ? '\p{Z}' : '\s');
-						$excluded_trailing_chars = '!;:.,?';
-						$domain_label_chars = '0-9A-Za-z\-' . ($context['utf8'] ? implode('', array(
-							'\x{A0}-\x{D7FF}', '\x{F900}-\x{FDCF}', '\x{FDF0}-\x{FFEF}',
-							'\x{10000}-\x{1FFFD}', '\x{20000}-\x{2FFFD}', '\x{30000}-\x{3FFFD}',
-							'\x{40000}-\x{4FFFD}', '\x{50000}-\x{5FFFD}', '\x{60000}-\x{6FFFD}',
-							'\x{70000}-\x{7FFFD}', '\x{80000}-\x{8FFFD}', '\x{90000}-\x{9FFFD}',
-							'\x{A0000}-\x{AFFFD}', '\x{B0000}-\x{BFFFD}', '\x{C0000}-\x{CFFFD}',
-							'\x{D0000}-\x{DFFFD}', '\x{E1000}-\x{EFFFD}',
-						)) : '');
-
 						// URI schemes that require some sort of special handling.
 						$schemes = array(
 							// Schemes whose URI definitions require a domain name in the

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -5160,10 +5160,6 @@ function setupMenuContext()
 			{
 				$button['active_button'] = false;
 
-				// This button needs some action.
-				if (isset($button['action_hook']))
-					$needs_action_hook = true;
-
 				// Make sure the last button truly is the last button.
 				if (!empty($button['is_last']))
 				{
@@ -5299,8 +5295,7 @@ function setupMenuContext()
 	}
 
 	// Not all actions are simple.
-	if (!empty($needs_action_hook))
-		call_integration_hook('integrate_current_action', array(&$current_action));
+	call_integration_hook('integrate_current_action', array(&$current_action));
 
 	if (isset($context['menu_buttons'][$current_action]))
 		$context['menu_buttons'][$current_action]['active_button'] = true;

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -2361,7 +2361,6 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 					}
 
 					// Some reusable character classes
-					$space_chars = ($context['utf8'] ? '\p{Z}' : '\s');
 					$excluded_trailing_chars = '!;:.,?';
 					$domain_label_chars = '0-9A-Za-z\-' . ($context['utf8'] ? implode('', array(
 						'\x{A0}-\x{D7FF}', '\x{F900}-\x{FDCF}', '\x{FDF0}-\x{FFEF}',
@@ -2497,23 +2496,23 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 
 							$pcre_subroutines['bracket_quote'] = '[' . $bracket_quote_chars . ']|&' . build_regex($bracket_quote_entities, '~');
 							$pcre_subroutines['allowed_entities'] = '&(?!' . build_regex(array_merge($bracket_quote_entities, array('lt;', 'gt;')), '~') . ')';
-							$pcre_subroutines['excluded_lookahead'] = '(?![' . $excluded_trailing_chars . ']*(?>' . $space_chars . '|<br>|$))';
+							$pcre_subroutines['excluded_lookahead'] = '(?![' . $excluded_trailing_chars . ']*(?>[\h\v]|<br>|$))';
 
 							foreach (array('path', 'query', 'fragment') as $part)
 							{
 								switch ($part) {
 									case 'path':
-										$part_disallowed_chars = '<>' . $bracket_quote_chars . $space_chars . $excluded_trailing_chars . '/#&';
+										$part_disallowed_chars = '\h\v<>' . $bracket_quote_chars . $excluded_trailing_chars . '/#&';
 										$part_excluded_trailing_chars = str_replace('?', '', $excluded_trailing_chars);
 										break;
 
 									case 'query':
-										$part_disallowed_chars = '<>' . $bracket_quote_chars . $space_chars . $excluded_trailing_chars . '#&';
+										$part_disallowed_chars = '\h\v<>' . $bracket_quote_chars . $excluded_trailing_chars . '#&';
 										$part_excluded_trailing_chars = $excluded_trailing_chars;
 										break;
 
 									default:
-										$part_disallowed_chars = '<>' . $bracket_quote_chars . $space_chars . $excluded_trailing_chars . '&';
+										$part_disallowed_chars = '\h\v<>' . $bracket_quote_chars . $excluded_trailing_chars . '&';
 										$part_excluded_trailing_chars = $excluded_trailing_chars;
 										break;
 								}
@@ -2637,7 +2636,7 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 								// (e.g. "example.com" in "Go to example.com for an example.")
 								'(?P<naked_domain>' .
 									// Preceded by start of line or a space
-									'(?<=^|<br>|[' . $space_chars . '])' .
+									'(?<=^|<br>|[\h\v])' .
 									// A domain name
 									'(?P>domain)' .
 									// Followed by a non-domain character or end of line
@@ -2764,7 +2763,7 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 					if (!isset($disabled['email']) && strpos($data, '@') !== false && strpos($data, '[email') === false && stripos($data, 'mailto:') === false)
 					{
 						// Preceded by a space or start of line
-						$email_regex = '(?<=^|<br>|[' . $space_chars . '])' .
+						$email_regex = '(?<=^|<br>|[\h\v])' .
 
 						// An email address
 						'[' . $domain_label_chars . '_.]{1,80}' .


### PR DESCRIPTION
Fixes #6975: Runs 'test' checks on normal_buttons & mod_buttons earlier in process
Fixes #6984: Temporarily decodes `&nbsp;` to non-breaking space in autolinker
Fixes #6985: Ensures autolinker character classes are defined for email autolinker
Fixes #6950: Ensures $user_info['alerts'] is not set to a negative value
Fixes #6978: Removes useless $needs_action_hook test