### PR TITLE
Load fallback avatar from the set avatars directory

### DIFF
--- a/Sources/Load.php
+++ b/Sources/Load.php
@@ -2455,6 +2455,7 @@ function loadTheme($id_theme = 0, $initialize = true)
 		'smf_smileys_url' => '"' . $modSettings['smileys_url'] . '"',
 		'smf_smiley_sets' => '"' . $modSettings['smiley_sets_known'] . '"',
 		'smf_smiley_sets_default' => '"' . $modSettings['smiley_sets_default'] . '"',
+		'smf_avatars_url' => '"' . $modSettings['avatar_url'] . '"',
 		'smf_scripturl' => '"' . $scripturl . '"',
 		'smf_iso_case_folding' => $context['server']['iso_case_folding'] ? 'true' : 'false',
 		'smf_charset' => '"' . $context['character_set'] . '"',

--- a/Themes/default/scripts/script.js
+++ b/Themes/default/scripts/script.js
@@ -1814,8 +1814,7 @@ function expand_quote_parent(oElement)
 
 function avatar_fallback(e) {
     var e = window.e || e;
-	var default_avatar = '/avatars/default.png';
-	var default_url = document.URL.substr(0,smf_scripturl.lastIndexOf('/')) + default_avatar;
+	var default_url = smf_avatars_url + '/default.png';
 
     if (e.target.tagName !== 'IMG' || !e.target.classList.contains('avatar') || e.target.src === default_url )
         return;


### PR DESCRIPTION
If an avatar could not be loaded a fallback to the default
avatar exists. However it was always loaded from /avatars/
directory, and not from the set avatars directory.

Fixes #6976

Signed-off-by: Oscar Rydhé <oscar.rydhe@gmail.com>