### PR TITLE
Avoid multiple quotes for every selection

### DIFF
--- a/Themes/default/scripts/quotedText.js
+++ b/Themes/default/scripts/quotedText.js
@@ -129,6 +129,9 @@ $(function() {
 		// Show the "quote this" button.
 		$('#quoteSelected_' + oSelected.msgID).show();
 
+		// Remove any previous selection
+		$(document).off('click', '#quoteSelected_' + oSelected.msgID + ' a');
+
 		$(document).one('click', '#quoteSelected_' + oSelected.msgID + ' a', function(e) {
 			e.preventDefault();
 			quotedTextClick(oSelected);


### PR DESCRIPTION
If you do multiple text selections in the same message,
and then click the "Quote selected text" button, you
would get multiple quotes with every text you selected.
Remove the old click listener before adding a new on.
This will only quote the latest selected text.

Fixes #6960

Signed-off-by: Oscar Rydhé <oscar.rydhe@gmail.com>