### PR TITLE
Do not show deleted pms in the pm popup

### DIFF
--- a/Sources/PersonalMessage.php
+++ b/Sources/PersonalMessage.php
@@ -397,10 +397,12 @@ function MessagePopup()
 		FROM {db_prefix}pm_recipients AS pmr
 		WHERE pmr.id_member = {int:current_member}
 			AND is_read = {int:not_read}
+			AND deleted = {int:not_deleted}
 		ORDER BY id_pm',
 		array(
 			'current_member' => $context['user']['id'],
 			'not_read' => 0,
+			'not_deleted' => 0,
 		)
 	);
 	$pms = array();


### PR DESCRIPTION
The pm popup listed all unread pms, even if they where
deleted. Changed so that deleted pms don't show up.

Fixes #6994

Signed-off-by: Oscar Rydhé <oscar.rydhe@gmail.com>