### PR TITLE
Remove unnecessary br

### DIFF
--- a/Themes/default/MessageIndex.template.php
+++ b/Themes/default/MessageIndex.template.php
@@ -551,7 +551,6 @@ function template_topic_legend()
 			</script>';
 
 	echo '
-			<br class="clear">
 		</div><!-- .information -->
 	</div><!-- #topic_icons -->';
 }


### PR DESCRIPTION
The br will cause a bottom margin for the legend on the
Message Index on small screens. I have not found any need
for it on bigger screens either.

Signed-off-by: Oscar Rydhé <oscar.rydhe@gmail.com>