### PR TITLE
Don't break the menu items in the user menu

### DIFF
--- a/Themes/default/css/index.css
+++ b/Themes/default/css/index.css
@@ -805,6 +805,7 @@ img.sort, .sort {
 	text-indent: -24px;
 	-webkit-hyphens: auto;
 	hyphens: auto;
+	white-space: nowrap;
 }
 /* Fixes bug with border-box on scrollable js */
 .scrollable, .scrollable * {


### PR DESCRIPTION
Some languages have problems that some menu items
are too long and gets broken into two lines.
Avoid this.

Reported in
https://www.simplemachines.org/community/index.php?topic=578572.0
https://www.simplemachines.org/community/index.php?topic=578575.0

Signed-off-by: Oscar Rydhé <oscar.rydhe@gmail.com>