### PR TITLE
Calendar date processing - ensure ints

### DIFF
--- a/Sources/Subs-Calendar.php
+++ b/Sources/Subs-Calendar.php
@@ -1769,12 +1769,12 @@ function buildEventDatetimes($row)
 	$end['datetime'] = date_format($start_object, 'Y-m-d H:i:s');
 
 	// ISO formatted datetime string, relative to UTC (e.g. '2016-12-29T05:45:30+00:00')
-	$start['iso_gmdate'] = gmdate('c', $start['timestamp']);
-	$end['iso_gmdate'] = gmdate('c', $end['timestamp']);
+	$start['iso_gmdate'] = gmdate('c', (int) $start['timestamp']);
+	$end['iso_gmdate'] = gmdate('c', (int) $end['timestamp']);
 
 	// Strings showing the datetimes in the user's preferred format, relative to the user's time zone
-	list($start['date_local'], $start['time_local']) = explode(' § ', timeformat($start['timestamp'], $date_format . ' § ' . $time_format));
-	list($end['date_local'], $end['time_local']) = explode(' § ', timeformat($end['timestamp'], $date_format . ' § ' . $time_format));
+	list($start['date_local'], $start['time_local']) = explode(' § ', timeformat((int) $start['timestamp'], $date_format . ' § ' . $time_format));
+	list($end['date_local'], $end['time_local']) = explode(' § ', timeformat((int) $end['timestamp'], $date_format . ' § ' . $time_format));
 
 	// Strings showing the datetimes in the user's preferred format, relative to the event's time zone
 	list($start['date_orig'], $start['time_orig']) = explode(' § ', timeformat(strtotime(date_format($start_object, 'Y-m-d H:i:s')), $date_format . ' § ' . $time_format, 'none'));

--- a/Sources/Subs-Calendar.php
+++ b/Sources/Subs-Calendar.php
@@ -1761,20 +1761,20 @@ function buildEventDatetimes($row)
 	$end_object = date_create($row['end_date'] . (!$allday ? ' ' . $row['end_time'] : ''), $timezone_array[$row['timezone']]);
 
 	// Unix timestamps are good
-	$start['timestamp'] = date_format($start_object, 'U');
-	$end['timestamp'] = date_format($end_object, 'U');
+	$start['timestamp'] = (int) date_format($start_object, 'U');
+	$end['timestamp'] = (int) date_format($end_object, 'U');
 
 	// Datetime string without timezone  (e.g. '2016-12-28 22:45:30')
 	$start['datetime'] = date_format($start_object, 'Y-m-d H:i:s');
 	$end['datetime'] = date_format($start_object, 'Y-m-d H:i:s');
 
 	// ISO formatted datetime string, relative to UTC (e.g. '2016-12-29T05:45:30+00:00')
-	$start['iso_gmdate'] = gmdate('c', (int) $start['timestamp']);
-	$end['iso_gmdate'] = gmdate('c', (int) $end['timestamp']);
+	$start['iso_gmdate'] = gmdate('c', $start['timestamp']);
+	$end['iso_gmdate'] = gmdate('c', $end['timestamp']);
 
 	// Strings showing the datetimes in the user's preferred format, relative to the user's time zone
-	list($start['date_local'], $start['time_local']) = explode(' § ', timeformat((int) $start['timestamp'], $date_format . ' § ' . $time_format));
-	list($end['date_local'], $end['time_local']) = explode(' § ', timeformat((int) $end['timestamp'], $date_format . ' § ' . $time_format));
+	list($start['date_local'], $start['time_local']) = explode(' § ', timeformat($start['timestamp'], $date_format . ' § ' . $time_format));
+	list($end['date_local'], $end['time_local']) = explode(' § ', timeformat($end['timestamp'], $date_format . ' § ' . $time_format));
 
 	// Strings showing the datetimes in the user's preferred format, relative to the event's time zone
 	list($start['date_orig'], $start['time_orig']) = explode(' § ', timeformat(strtotime(date_format($start_object, 'Y-m-d H:i:s')), $date_format . ' § ' . $time_format, 'none'));


### PR DESCRIPTION
Fixes #7020 

The problem is that if the # is too large for an int on that platform (32-bit platforms) PHP converts it to a float.  Keeping it as an int prevents lots of errors in the log, while making behavior consistent with what is seen on 64-bit platforms.  Values beyond 1/19/2038 are not accepted on either platform; now we get a consistent error message on both.

**_BEFORE, 32-bit, entering large year values, PHP < 8:_**
<img src="https://user-images.githubusercontent.com/23568484/131008346-8194a4f7-2eb0-4b1e-a51a-8ed9cc530dd5.png" width="256">

**_BEFORE, 32-bit, entering large year values, PHP = 8:_**
![image](https://user-images.githubusercontent.com/23568484/131009399-dc5674dd-0837-4ded-aa79-a9867d12a994.png)

**_After, 32-bit (which is now in alignment with 64-bit behavior):_**
<img src="https://user-images.githubusercontent.com/23568484/131008284-b388f67b-55ff-4646-b1e6-e251085e1c0e.png" width="256">
