### PR TITLE
Move these to the user error log

### DIFF
--- a/Sources/LogInOut.php
+++ b/Sources/LogInOut.php
@@ -622,7 +622,7 @@ function checkActivation()
 	// Standard activation?
 	elseif ($activation_status != 1)
 	{
-		log_error($txt['activate_not_completed1'] . ' - <span class="remove">' . $user_settings['member_name'] . '</span>', false);
+		log_error($txt['activate_not_completed1'] . ' - <span class="remove">' . $user_settings['member_name'] . '</span>', 'user');
 
 		$context['login_errors'][] = $txt['activate_not_completed1'] . ' <a href="' . $scripturl . '?action=activate;sa=resend;u=' . $user_settings['id_member'] . '">' . $txt['activate_not_completed2'] . '</a>';
 		return false;


### PR DESCRIPTION
Just want to fix this annoyance.  Non activated user errors go to the general log rather than the user log.