### PR TITLE
Stops us from trying to hash validate a directory.

### DIFF
--- a/Sources/Subs-Package.php
+++ b/Sources/Subs-Package.php
@@ -3180,7 +3180,9 @@ function package_validate_installtest($package)
 {
 	global $context;
 
-	$context['package_sha256_hash'] = hash_file('sha256', $package['file_name']);
+	// Don't validate directories.
+	$context['package_sha256_hash'] = is_dir($package['file_name']) ? null : hash_file('sha256', $package['file_name']);
+
 	$sendData = array(array(
 		'sha256_hash' => $context['package_sha256_hash'],
 		'file_name' => basename($package['file_name']),


### PR DESCRIPTION
I don't see it as worth it to try to generate a hash for a directory to validate, just check the id