### PR TITLE
Check timestamp when calculating last post from sub boards

### DIFF
--- a/Sources/Subs-BoardIndex.php
+++ b/Sources/Subs-BoardIndex.php
@@ -426,7 +426,9 @@ function getBoardIndex($board_index_options)
 
 		// Set the last post in the parent board.
 		if ($isChild && !empty($row_board['poster_time'])
-			&& $row_boards[$row_board['id_parent']]['poster_time'] < $row_board['poster_time'])
+			&& $row_boards[$row_board['id_parent']]['poster_time'] < $row_board['poster_time']
+			&& (empty($this_category[$row_board['id_parent']]['last_post'])
+				|| $this_category[$row_board['id_parent']]['last_post']['timestamp'] < $this_last_post['timestamp']))
 			$this_category[$row_board['id_parent']]['last_post'] = $this_last_post;
 
 		// Set the last post in the root board


### PR DESCRIPTION
When calculating the last post from sub boards the timestamp
was not checked. Resulting in that the last post from the
last checked sub board was selected.
Add a timestamp check to only use the latest post from any of
the sub boards.

Fixes #7052

Signed-off-by: Oscar Rydhé <oscar.rydhe@gmail.com>