### PR TITLE
Only parse allowed bbc tags in signatures

### DIFF
--- a/Sources/Load.php
+++ b/Sources/Load.php
@@ -1650,7 +1650,7 @@ function loadMemberContext($user, $display_custom_fields = false)
 
 		// Set things up to be used before hand.
 		$profile['signature'] = str_replace(array("\n", "\r"), array('<br>', ''), $profile['signature']);
-		$profile['signature'] = parse_bbc($profile['signature'], true, 'sig' . $profile['id_member']);
+		$profile['signature'] = parse_bbc($profile['signature'], true, 'sig' . $profile['id_member'], get_signature_allowed_bbc_tags());
 
 		$profile['is_online'] = (!empty($profile['show_online']) || allowedTo('moderate_forum')) && $profile['is_online'] > 0;
 		$profile['icons'] = empty($profile['icons']) ? array('', '') : explode('#', $profile['icons']);

--- a/Sources/Profile-Modify.php
+++ b/Sources/Profile-Modify.php
@@ -3187,7 +3187,7 @@ function profileLoadSignatureData()
 		censorText($context['member']['signature']);
 		$context['member']['current_signature'] = $context['member']['signature'];
 		censorText($signature);
-		$context['member']['signature_preview'] = parse_bbc($signature, true, 'sig' . $memberContext[$context['id_member']]);
+		$context['member']['signature_preview'] = parse_bbc($signature, true, 'sig' . $memberContext[$context['id_member']], get_signature_allowed_bbc_tags());
 		$context['member']['signature'] = $_POST['signature'];
 	}
 

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -1182,6 +1182,35 @@ function permute($array)
 }
 
 /**
+ * Return an array with allowed bbc tags for signatures, that can be passed to parse_bbc().
+ *
+ * @return array An array containing allowed tags for signatures, or an empty array if all tags are allowed.
+ */
+function get_signature_allowed_bbc_tags()
+{
+	global $modSettings;
+
+	list ($sig_limits, $sig_bbc) = explode(':', $modSettings['signature_settings']);
+	if (empty($sig_bbc))
+		return array();
+	$disabledTags = explode(',', $sig_bbc);
+
+	// Get all available bbc tags
+	$temp = parse_bbc(false);
+	$allowedTags = array();
+	foreach ($temp as $tag)
+		if (!in_array($tag['tag'], $disabledTags))
+			$allowedTags[] = $tag['tag'];
+
+	$allowedTags = array_unique($allowedTags);
+	if (empty($allowedTags))
+		// An empty array means that all bbc tags are allowed. So if all tags are disabled we need to add a dummy tag.
+		$allowedTags[] = 'nonexisting';
+
+	return $allowedTags;
+}
+
+/**
  * Parse bulletin board code in a string, as well as smileys optionally.
  *
  * - only parses bbc tags which are not disabled in disabledBBC.

--- a/Sources/Xml.php
+++ b/Sources/Xml.php
@@ -192,7 +192,8 @@ function sig_preview()
 		list($current_signature) = $smcFunc['db_fetch_row']($request);
 		$smcFunc['db_free_result']($request);
 		censorText($current_signature);
-		$current_signature = !empty($current_signature) ? parse_bbc($current_signature, true, 'sig' . $user) : $txt['no_signature_set'];
+		$allowedTags = get_signature_allowed_bbc_tags();
+		$current_signature = !empty($current_signature) ? parse_bbc($current_signature, true, 'sig' . $user, $allowedTags) : $txt['no_signature_set'];
 
 		$preview_signature = !empty($_POST['signature']) ? $smcFunc['htmlspecialchars']($_POST['signature']) : $txt['no_signature_preview'];
 		$validation = profileValidateSignature($preview_signature);
@@ -201,7 +202,7 @@ function sig_preview()
 			$errors[] = array('value' => $txt['profile_error_' . $validation], 'attributes' => array('type' => 'error'));
 
 		censorText($preview_signature);
-		$preview_signature = parse_bbc($preview_signature, true, 'sig' . $user);
+		$preview_signature = parse_bbc($preview_signature, true, 'sig' . $user, $allowedTags);
 	}
 	elseif (!$can_change)
 	{


### PR DESCRIPTION
Allowed bbc tags for signatrues can be set separate
from the allowed bbc tags in messages. However it was never
passed to parse_bbc() so all bbc tags was parsed.
Create a helper function to get the allowed tags for signatures
and use it when parsing signatures.

Fixes #7050

Signed-off-by: Oscar Rydhé <oscar.rydhe@gmail.com>