### PR TITLE
Remove the use of INTL_IDNA_VARIANT_UTS46 constant

### DIFF
--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -2785,13 +2785,13 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 
 								if (!empty($host))
 								{
-									$ascii_host = idn_to_ascii($host, IDNA_DEFAULT, INTL_IDNA_VARIANT_UTS46);
+									$ascii_host = idn_to_ascii($host, IDNA_DEFAULT);
 
 									if ($ascii_host !== $host)
 									{
 										$fullUrl = substr($fullUrl, 0, strpos($fullUrl, $host)) . $ascii_host . substr($fullUrl, strpos($fullUrl, $host) + strlen($host));
 
-										$utf8_host = idn_to_utf8($ascii_host, IDNA_DEFAULT, INTL_IDNA_VARIANT_UTS46);
+										$utf8_host = idn_to_utf8($ascii_host, IDNA_DEFAULT);
 
 										if ($utf8_host !== $host)
 										{
@@ -7055,7 +7055,7 @@ function set_tld_regex($update = false)
 			require_once($sourcedir . '/Subs-Compat.php');
 
 		foreach ($tlds as &$tld)
-			$tld = idn_to_utf8($tld, IDNA_DEFAULT, INTL_IDNA_VARIANT_UTS46);
+			$tld = idn_to_utf8($tld, IDNA_DEFAULT);
 	}
 	// Otherwise, use the 2012 list of gTLDs and ccTLDs for now and schedule a background update
 	else
@@ -7563,7 +7563,7 @@ function iri_to_url($iri)
 			require_once($sourcedir . '/Subs-Compat.php');
 
 		// Convert the host using the Punycode algorithm
-		$encoded_host = idn_to_ascii($host, IDNA_DEFAULT, INTL_IDNA_VARIANT_UTS46);
+		$encoded_host = idn_to_ascii($host, IDNA_DEFAULT);
 
 		$pos = strpos($iri, $host);
 	}
@@ -7612,7 +7612,7 @@ function url_to_iri($url)
 			require_once($sourcedir . '/Subs-Compat.php');
 
 		// Decode the domain from Punycode
-		$decoded_host = idn_to_utf8($host, IDNA_DEFAULT, INTL_IDNA_VARIANT_UTS46);
+		$decoded_host = idn_to_utf8($host, IDNA_DEFAULT);
 
 		$pos = strpos($url, $host);
 	}


### PR DESCRIPTION
This constant is causing problem for php 5.6
Since it is the default parameter there is no need
to send it.

Fixes #7063

Signed-off-by: Oscar Rydhé <oscar.rydhe@gmail.com>