### PR TITLE
Url normalization tweaks

### DIFF
--- a/Sources/Subs-Compat.php
+++ b/Sources/Subs-Compat.php
@@ -475,15 +475,11 @@ if (!function_exists('idn_to_ascii'))
 	{
 		global $sourcedir;
 
-		if ($flags !== 0 || $variant !== 1)
-			return false;
-
 		require_once($sourcedir . '/Subs-Charset.php');
-		$domain = utf8_normalize_kc($domain);
-
 		require_once($sourcedir . '/Class-Punycode.php');
 		$Punycode = new Punycode();
-		return $Punycode->encode($domain);
+
+		return $Punycode->encode(utf8_normalize_kc(sanitize_iri($domain)));
 	}
 }
 
@@ -506,12 +502,11 @@ if (!function_exists('idn_to_utf8'))
 	{
 		global $sourcedir;
 
-		if ($flags !== 0 || $variant !== 1)
-			return false;
-
+		require_once($sourcedir . '/Subs-Charset.php');
 		require_once($sourcedir . '/Class-Punycode.php');
 		$Punycode = new Punycode();
-		return $Punycode->decode($domain);
+
+		return $Punycode->decode(utf8_normalize_kc(sanitize_iri($domain)));
 	}
 }
 

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -7582,7 +7582,10 @@ function sanitize_iri($iri)
  */
 function iri_to_url($iri)
 {
-	global $sourcedir;
+	global $smcFunc;
+
+	// Weird stuff can happen if parse_url() is given un-normalized Unicode.
+	$iri = $smcFunc['normalize'](sanitize_iri($iri), 'c');
 
 	$host = parse_url((strpos($iri, '//') === 0 ? 'http:' : '') . $iri, PHP_URL_HOST);
 


### PR DESCRIPTION
- Performs URL sanitization as part of idn_to_* polyfill functions. This is required for compatibility with the native functions, but I forgot it in 3883d02.
- Ensures Unicode is normalized in iri_to_url(). This is necessary because parse_url() can give unexpectd results if un-normalized Unicode characters are present in the IRI string.