### PR TITLE
Fixes adding invisible level 2 membergroups to a members primary group

### DIFF
--- a/Sources/Subs-Membergroups.php
+++ b/Sources/Subs-Membergroups.php
@@ -544,27 +544,6 @@ function addMembersToGroup($members, $group, $type = 'auto', $permissionCheckDon
 		if ($is_protected == 1)
 			return false;
 	}
-
-	// Safety check for invisible level 2 membergroups to prevent adding it as the members primary group
-	if ($type != 'only_additional')
-	{
-	$request = $smcFunc['db_query']('', '
-			SELECT hidden
-			FROM {db_prefix}membergroups
-			WHERE id_group = {int:current_group}
-			LIMIT {int:limit}',
-			array(
-				'current_group' => $group,
-				'limit' => 1,
-			)
-		);
-		list ($is_hidden) = $smcFunc['db_fetch_row']($request);
-		$smcFunc['db_free_result']($request);
-
-		// Is it hidden?
-		if ($is_hidden == 2)
-			$type='only_additional';
-	}
 	
 	// Do the actual updates.
 	if ($type == 'only_additional')

--- a/Sources/Subs-Membergroups.php
+++ b/Sources/Subs-Membergroups.php
@@ -545,6 +545,27 @@ function addMembersToGroup($members, $group, $type = 'auto', $permissionCheckDon
 			return false;
 	}
 
+	// Safety check for invisible level 2 membergroups to prevent adding it as the members primary group
+	if ($type != 'only_additional')
+	{
+	$request = $smcFunc['db_query']('', '
+			SELECT hidden
+			FROM {db_prefix}membergroups
+			WHERE id_group = {int:current_group}
+			LIMIT {int:limit}',
+			array(
+				'current_group' => $group,
+				'limit' => 1,
+			)
+		);
+		list ($is_hidden) = $smcFunc['db_fetch_row']($request);
+		$smcFunc['db_free_result']($request);
+
+		// Is it hidden?
+		if ($is_hidden == 2)
+			$type='only_additional';
+	}
+	
 	// Do the actual updates.
 	if ($type == 'only_additional')
 		$smcFunc['db_query']('', '

--- a/Sources/tasks/GroupAct-Notify.php
+++ b/Sources/tasks/GroupAct-Notify.php
@@ -32,7 +32,7 @@ class GroupAct_Notify_Background extends SMF_BackgroundTask
 		// Get the details of all the members concerned...
 		$request = $smcFunc['db_query']('', '
 			SELECT lgr.id_request, lgr.id_member, lgr.id_group, mem.email_address,
-				mem.lngfile, mem.member_name,  mg.group_name
+				mem.lngfile, mem.member_name,  mg.group_name, mg.hidden
 			FROM {db_prefix}log_group_requests AS lgr
 				INNER JOIN {db_prefix}members AS mem ON (mem.id_member = lgr.id_member)
 				INNER JOIN {db_prefix}membergroups AS mg ON (mg.id_group = lgr.id_group)
@@ -62,7 +62,7 @@ class GroupAct_Notify_Background extends SMF_BackgroundTask
 				$user_info['ip'] = $this->_details['member_ip'];
 
 				require_once($sourcedir . '/Subs-Membergroups.php');
-				addMembersToGroup($row['id_member'], $row['id_group'], 'auto', true);
+				addMembersToGroup($row['id_member'], $row['id_group'], $row['hidden'] == 2 ? 'only_additional' : 'auto', true);
 			}
 
 			// Build the required information array


### PR DESCRIPTION
Fixes #7089

This is a quick and dirty fix to prevent adding an invisible level 2 group as a members primary group. The culprit of #7089 is the call to addMembersToGroup() in GroupAct-Notify.php where the group type is set to 'auto' without checking if the group type should be set to anything else. I wasn't able to fix the lack of checking in GroupAct-Notify.php effectively so hence this quick and dirty fix.

If someone else can do something more elegant, do it!
