### PR TITLE
Normalizes and sanitizes UTF-8 input

### DIFF
--- a/Sources/Load.php
+++ b/Sources/Load.php
@@ -161,8 +161,10 @@ function reloadSettings()
 			$num = $string[0] === 'x' ? hexdec(substr($string, 1)) : (int) $string;
 			return $num < 0x20 || $num > 0x10FFFF || ($num >= 0xD800 && $num <= 0xDFFF) || $num === 0x202E || $num === 0x202D ? '' : '&#' . $num . ';';
 		},
-		'htmlspecialchars' => function($string, $quote_style = ENT_COMPAT, $charset = 'ISO-8859-1') use ($ent_check, $utf8, $fix_utf8mb4)
+		'htmlspecialchars' => function($string, $quote_style = ENT_COMPAT, $charset = 'ISO-8859-1') use ($ent_check, $utf8, $fix_utf8mb4, &$smcFunc)
 		{
+			$string = $smcFunc['normalize']($string);
+
 			return $fix_utf8mb4($ent_check(htmlspecialchars($string, $quote_style, $utf8 ? 'UTF-8' : $charset)));
 		},
 		'htmltrim' => function($string) use ($utf8, $ent_check)
@@ -206,8 +208,10 @@ function reloadSettings()
 			$ent_arr = preg_split('~(' . $ent_list . '|.)~' . ($utf8 ? 'u' : '') . '', $ent_check($string), -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY);
 			return $length === null ? implode('', array_slice($ent_arr, $start)) : implode('', array_slice($ent_arr, $start, $length));
 		},
-		'strtolower' => $utf8 ? function($string) use ($sourcedir)
+		'strtolower' => $utf8 ? function($string) use ($sourcedir, &$smcFunc)
 		{
+			$string = $smcFunc['normalize']($string);
+
 			if (!function_exists('mb_strtolower'))
 			{
 				require_once($sourcedir . '/Subs-Charset.php');
@@ -216,9 +220,9 @@ function reloadSettings()
 
 			return mb_strtolower($string, 'UTF-8');
 		} : 'strtolower',
-		'strtoupper' => $utf8 ? function($string)
+		'strtoupper' => $utf8 ? function($string) use ($sourcedir, &$smcFunc)
 		{
-			global $sourcedir;
+			$string = $smcFunc['normalize']($string);
 
 			if (!function_exists('mb_strtolower'))
 			{

--- a/Sources/ManageCalendar.php
+++ b/Sources/ManageCalendar.php
@@ -216,7 +216,7 @@ function EditHoliday()
 		validateToken('admin-eh');
 
 		// Not too long good sir?
-		$_REQUEST['title'] = $smcFunc['substr']($_REQUEST['title'], 0, 60);
+		$_REQUEST['title'] = $smcFunc['substr']($smcFunc['normalize']($_REQUEST['title']), 0, 60);
 		$_REQUEST['holiday'] = isset($_REQUEST['holiday']) ? (int) $_REQUEST['holiday'] : 0;
 
 		if (isset($_REQUEST['delete']))

--- a/Sources/ManageLanguages.php
+++ b/Sources/ManageLanguages.php
@@ -1659,6 +1659,8 @@ function cleanLangString($string, $to_display = true)
 	}
 	else
 	{
+		$string = $smcFunc['normalize']($string);
+
 		// Keep track of what we're doing...
 		$in_string = 0;
 		// This is for deciding whether to HTML a quote.

--- a/Sources/ManageMembergroups.php
+++ b/Sources/ManageMembergroups.php
@@ -765,7 +765,7 @@ function EditMembergroup()
 				'group_name' => $smcFunc['htmlspecialchars']($_POST['group_name']),
 				'online_color' => $_POST['online_color'],
 				'icons' => $_POST['icons'],
-				'group_desc' => $_POST['group_desc'],
+				'group_desc' => $smcFunc['normalize']($_POST['group_desc']),
 				'tfa_required' => $_POST['group_tfa_force'],
 			)
 		);

--- a/Sources/ManagePosts.php
+++ b/Sources/ManagePosts.php
@@ -123,8 +123,8 @@ function SetCensor()
 
 		// Set the new arrays and settings in the database.
 		$updates = array(
-			'censor_vulgar' => implode("\n", $censored_vulgar),
-			'censor_proper' => implode("\n", $censored_proper),
+			'censor_vulgar' => $smcFunc['normalize'](implode("\n", $censored_vulgar)),
+			'censor_proper' => $smcFunc['normalize'](implode("\n", $censored_proper)),
 			'allow_no_censored' => empty($_POST['allow_no_censored']) ? '0' : '1',
 			'censorWholeWord' => empty($_POST['censorWholeWord']) ? '0' : '1',
 			'censorIgnoreCase' => empty($_POST['censorIgnoreCase']) ? '0' : '1',

--- a/Sources/ManageRegistration.php
+++ b/Sources/ManageRegistration.php
@@ -272,7 +272,7 @@ function EditAgreement()
  */
 function SetReserved()
 {
-	global $txt, $context, $modSettings;
+	global $txt, $context, $modSettings, $smcFunc;
 
 	// Submitting new reserved words.
 	if (!empty($_POST['save_reserved_names']))
@@ -319,7 +319,7 @@ function SetReserved()
  */
 function ModifyRegistrationSettings($return_config = false)
 {
-	global $txt, $context, $scripturl, $modSettings, $sourcedir;
+	global $txt, $context, $scripturl, $modSettings, $sourcedir, $smcFunc;
 	global $language, $boarddir;
 
 	// This is really quite wanting.

--- a/Sources/ManageRegistration.php
+++ b/Sources/ManageRegistration.php
@@ -105,7 +105,7 @@ function AdminRegister()
 
 		foreach ($_POST as $key => $value)
 			if (!is_array($_POST[$key]))
-				$_POST[$key] = htmltrim__recursive(str_replace(array("\n", "\r"), '', $_POST[$key]));
+				$_POST[$key] = htmltrim__recursive(str_replace(array("\n", "\r"), '', $smcFunc['normalize']($_POST[$key])));
 
 		$regOptions = array(
 			'interface' => 'admin',
@@ -224,6 +224,8 @@ function EditAgreement()
 		checkSession();
 		validateToken('admin-rega');
 
+		$_POST['agreement'] = $smcFunc['normalize']($_POST['agreement']);
+
 		// Off it goes to the agreement file.
 		$to_write = str_replace("\r", '', $_POST['agreement']);
 		$bytes = file_put_contents($boarddir . '/agreement' . $context['current_agreement'] . '.txt', $to_write, LOCK_EX);
@@ -277,6 +279,8 @@ function SetReserved()
 	{
 		checkSession();
 		validateToken('admin-regr');
+
+		$_POST['reserved'] = $smcFunc['normalize']($_POST['reserved']);
 
 		// Set all the options....
 		updateSettings(array(
@@ -359,7 +363,7 @@ function ModifyRegistrationSettings($return_config = false)
 			fatal_lang_error('admin_setting_coppa_require_contact');
 
 		// Post needs to take into account line breaks.
-		$_POST['coppaPost'] = str_replace("\n", '<br>', empty($_POST['coppaPost']) ? '' : $_POST['coppaPost']);
+		$_POST['coppaPost'] = str_replace("\n", '<br>', empty($_POST['coppaPost']) ? '' : $smcFunc['normalize']($_POST['coppaPost']));
 
 		call_integration_hook('integrate_save_registration_settings');
 

--- a/Sources/ManageSearchEngines.php
+++ b/Sources/ManageSearchEngines.php
@@ -393,6 +393,9 @@ function EditSpider()
 		checkSession();
 		validateToken('admin-ses');
 
+		foreach (array('spider_name', 'spider_agent') as $key)
+			$_POST[$key] = trim($smcFunc['normalize']($_POST[$key]));
+
 		$ips = array();
 		// Check the IP range is valid.
 		$ip_sets = explode(',', $_POST['spider_ip']);

--- a/Sources/ManageServer.php
+++ b/Sources/ManageServer.php
@@ -198,6 +198,12 @@ function ModifyGeneralSettings($return_config = false)
 	{
 		call_integration_hook('integrate_save_general_settings');
 
+		foreach ($config_vars as $config_var)
+		{
+			if ($config_var[3] == 'text' && !empty($_POST[$config_var[0]]))
+				$_POST[$config_var[0]] = $smcFunc['normalize']($_POST[$config_var[0]]);
+		}
+
 		// Are we saving the stat collection?
 		if (!empty($_POST['enable_sm_stats']) && empty($modSettings['sm_stats_key']))
 		{
@@ -531,6 +537,8 @@ function ModifyCookieSettings($return_config = false)
 	if (isset($_REQUEST['save']))
 	{
 		call_integration_hook('integrate_save_cookie_settings');
+
+		$_POST['cookiename'] = $smcFunc['normalize']($_POST['cookiename']);
 
 		// Local and global do not play nicely together.
 		if (!empty($_POST['localCookies']) && empty($_POST['globalCookies']))

--- a/Sources/ManageServer.php
+++ b/Sources/ManageServer.php
@@ -150,7 +150,7 @@ function ModifySettings()
  */
 function ModifyGeneralSettings($return_config = false)
 {
-	global $scripturl, $context, $txt, $modSettings, $boardurl, $sourcedir;
+	global $scripturl, $context, $txt, $modSettings, $boardurl, $sourcedir, $smcFunc;
 
 	// If no cert, force_ssl must remain 0
 	require_once($sourcedir . '/Subs.php');

--- a/Sources/ManageSettings.php
+++ b/Sources/ManageSettings.php
@@ -1963,9 +1963,10 @@ function EditCustomProfiles()
 		$mask = isset($_POST['mask']) ? $_POST['mask'] : '';
 		if ($mask == 'regex' && isset($_POST['regex']))
 			$mask .= $_POST['regex'];
+		$mask = $smcFunc['normalize']($mask);
 
 		$field_length = isset($_POST['max_length']) ? (int) $_POST['max_length'] : 255;
-		$enclose = isset($_POST['enclose']) ? $_POST['enclose'] : '';
+		$enclose = isset($_POST['enclose']) ? $smcFunc['normalize']($_POST['enclose']) : '';
 		$placement = isset($_POST['placement']) ? (int) $_POST['placement'] : 0;
 
 		// Select options?

--- a/Sources/ManageSmileys.php
+++ b/Sources/ManageSmileys.php
@@ -250,6 +250,9 @@ function EditSmileySets()
 			$set_paths = explode(',', $modSettings['smiley_sets_known']);
 			$set_names = explode("\n", $modSettings['smiley_sets_names']);
 
+			foreach (array('smiley_sets_path', 'smiley_sets_name') as $key)
+				$_POST[$key] = $smcFunc['normalize']($_POST[$key]);
+
 			// Create a new smiley set.
 			if ($_POST['set'] == -1 && isset($_POST['smiley_sets_path']))
 			{
@@ -612,6 +615,9 @@ function AddSmiley()
 	if (isset($_POST[$context['session_var']], $_POST['smiley_code']))
 	{
 		checkSession();
+
+		foreach (array('smiley_code', 'smiley_filename', 'smiley_description') as $key)
+			$_POST[$key] = $smcFunc['normalize']($_POST[$key]);
 
 		$_POST['smiley_code'] = htmltrim__recursive($_POST['smiley_code']);
 		$_POST['smiley_location'] = empty($_POST['smiley_location']) || $_POST['smiley_location'] > 2 || $_POST['smiley_location'] < 0 ? 0 : (int) $_POST['smiley_location'];
@@ -1005,6 +1011,9 @@ function EditSmileys()
 			// Otherwise an edit.
 			else
 			{
+				foreach (array('smiley_code', 'smiley_description') as $key)
+					$_POST[$key] = $smcFunc['normalize']($_POST[$key]);
+
 				$_POST['smiley'] = (int) $_POST['smiley'];
 				$_POST['smiley_code'] = htmltrim__recursive($_POST['smiley_code']);
 				$_POST['smiley_location'] = empty($_POST['smiley_location']) || $_POST['smiley_location'] > 2 || $_POST['smiley_location'] < 0 ? 0 : (int) $_POST['smiley_location'];
@@ -1068,8 +1077,8 @@ function EditSmileys()
 				$filenames = array();
 				foreach ($_POST['smiley_filename'] as $posted_set => $posted_filename)
 				{
-					$posted_set = htmltrim__recursive($posted_set);
-					$posted_filename = htmltrim__recursive($posted_filename);
+					$posted_set = $smcFunc['htmltrim']($smcFunc['normalize']($posted_set));
+					$posted_filename = $smcFunc['htmltrim']($smcFunc['normalize']($posted_filename));
 
 					// Make sure the set already exists.
 					if (!in_array($posted_set, $known_sets))
@@ -2223,6 +2232,9 @@ function EditMessageIcons()
 		elseif ($context['sub_action'] == 'editicon' && isset($_GET['icon']))
 		{
 			$_GET['icon'] = (int) $_GET['icon'];
+
+			foreach (array('icon_filename', 'icon_description') as $key)
+				$_POST[$key] = $smcFunc['normalize']($_POST[$key]);
 
 			// Do some preperation with the data... like check the icon exists *somewhere*
 			if (strpos($_POST['icon_filename'], '.png') !== false)

--- a/Sources/Post.php
+++ b/Sources/Post.php
@@ -1966,7 +1966,7 @@ function Post2()
 	// If the poster is a guest evaluate the legality of name and email.
 	if ($posterIsGuest)
 	{
-		$_POST['guestname'] = !isset($_POST['guestname']) ? '' : trim(normalize_spaces(sanitize_chars($_POST['guestname'], true, ' '), true, true, array('no_breaks' => true, 'replace_tabs' => true, 'collapse_hspace' => true)));
+		$_POST['guestname'] = !isset($_POST['guestname']) ? '' : trim(normalize_spaces(sanitize_chars($_POST['guestname'], 1, ' '), true, true, array('no_breaks' => true, 'replace_tabs' => true, 'collapse_hspace' => true)));
 		$_POST['email'] = !isset($_POST['email']) ? '' : trim($_POST['email']);
 
 		if ($_POST['guestname'] == '' || $_POST['guestname'] == '_')

--- a/Sources/Post.php
+++ b/Sources/Post.php
@@ -1966,7 +1966,7 @@ function Post2()
 	// If the poster is a guest evaluate the legality of name and email.
 	if ($posterIsGuest)
 	{
-		$_POST['guestname'] = !isset($_POST['guestname']) ? '' : trim($_POST['guestname']);
+		$_POST['guestname'] = !isset($_POST['guestname']) ? '' : trim(normalize_spaces(sanitize_chars($_POST['guestname'], true, ' '), true, true, array('no_breaks' => true, 'replace_tabs' => true, 'collapse_hspace' => true)));
 		$_POST['email'] = !isset($_POST['email']) ? '' : trim($_POST['email']);
 
 		if ($_POST['guestname'] == '' || $_POST['guestname'] == '_')

--- a/Sources/Profile-Modify.php
+++ b/Sources/Profile-Modify.php
@@ -795,7 +795,7 @@ function setupProfileContext($fields)
  */
 function saveProfileFields()
 {
-	global $profile_fields, $profile_vars, $context, $old_profile, $post_errors, $cur_profile;
+	global $profile_fields, $profile_vars, $context, $old_profile, $post_errors, $cur_profile, $smcFunc;
 
 	// Load them up.
 	loadProfileFields();
@@ -816,6 +816,8 @@ function saveProfileFields()
 	{
 		if (!isset($_POST[$key]) || !empty($field['is_dummy']) || (isset($_POST['preview_signature']) && $key == 'signature'))
 			continue;
+
+		$_POST[$key] = $smcFunc['normalize']($_POST[$key]);
 
 		// What gets updated?
 		$db_key = isset($field['save_key']) ? $field['save_key'] : $key;
@@ -3143,7 +3145,7 @@ function profileLoadGroups()
  */
 function profileLoadSignatureData()
 {
-	global $modSettings, $context, $txt, $cur_profile, $memberContext;
+	global $modSettings, $context, $txt, $cur_profile, $memberContext, $smcFunc;
 
 	// Signature limits.
 	list ($sig_limits, $sig_bbc) = explode(':', $modSettings['signature_settings']);
@@ -3173,7 +3175,7 @@ function profileLoadSignatureData()
 		$context['member']['signature'] = empty($cur_profile['signature']) ? '' : str_replace(array('<br>', '<', '>', '"', '\''), array("\n", '&lt;', '&gt;', '&quot;', '&#039;'), $cur_profile['signature']);
 	else
 	{
-		$signature = !empty($_POST['signature']) ? $_POST['signature'] : '';
+		$signature = $_POST['signature'] = !empty($_POST['signature']) ? $smcFunc['normalize']($_POST['signature']) : '';
 		$validation = profileValidateSignature($signature);
 		if (empty($context['post_errors']))
 		{

--- a/Sources/Profile-Modify.php
+++ b/Sources/Profile-Modify.php
@@ -817,7 +817,7 @@ function saveProfileFields()
 		if (!isset($_POST[$key]) || !empty($field['is_dummy']) || (isset($_POST['preview_signature']) && $key == 'signature'))
 			continue;
 
-		$_POST[$key] = $smcFunc['normalize']($_POST[$key]);
+		$_POST[$key] = sanitize_chars($smcFunc['normalize']($_POST[$key]), in_array($key, array('member_name', 'real_name')) ? 1 : 0);
 
 		// What gets updated?
 		$db_key = isset($field['save_key']) ? $field['save_key'] : $key;

--- a/Sources/Profile-Modify.php
+++ b/Sources/Profile-Modify.php
@@ -292,7 +292,7 @@ function loadProfileFields($force_reload = false)
 						resetPassword($context['id_member'], $value);
 					elseif ($value !== null)
 					{
-						validateUsername($context['id_member'], trim(preg_replace('~[\t\n\r \x0B\0' . ($context['utf8'] ? '\x{A0}\x{AD}\x{2000}-\x{200F}\x{201F}\x{202F}\x{3000}\x{FEFF}' : '\x00-\x08\x0B\x0C\x0E-\x19\xA0') . ']+~' . ($context['utf8'] ? 'u' : ''), ' ', $value)));
+						validateUsername($context['id_member'], trim(normalize_spaces(sanitize_chars($value, true, ' '), true, true, array('no_breaks' => true, 'replace_tabs' => true, 'collapse_hspace' => true))));
 						updateMemberData($context['id_member'], array('member_name' => $value));
 
 						// Call this here so any integrated systems will know about the name change (resetPassword() takes care of this if we're letting SMF generate the password)
@@ -409,7 +409,7 @@ function loadProfileFields($force_reload = false)
 			'enabled' => allowedTo('profile_displayed_name_own') || allowedTo('profile_displayed_name_any') || allowedTo('moderate_forum'),
 			'input_validate' => function(&$value) use ($context, $smcFunc, $sourcedir, $cur_profile)
 			{
-				$value = trim(preg_replace('~[\t\n\r \x0B\0' . ($context['utf8'] ? '\x{A0}\x{AD}\x{2000}-\x{200F}\x{201F}\x{202F}\x{3000}\x{FEFF}' : '\x00-\x08\x0B\x0C\x0E-\x19\xA0') . ']+~' . ($context['utf8'] ? 'u' : ''), ' ', $value));
+				$value = trim(normalize_spaces(sanitize_chars($value, true, ' '), true, true, array('no_breaks' => true, 'replace_tabs' => true, 'collapse_hspace' => true)));
 
 				if (trim($value) == '')
 					return 'no_name';

--- a/Sources/Profile-Modify.php
+++ b/Sources/Profile-Modify.php
@@ -292,7 +292,7 @@ function loadProfileFields($force_reload = false)
 						resetPassword($context['id_member'], $value);
 					elseif ($value !== null)
 					{
-						validateUsername($context['id_member'], trim(normalize_spaces(sanitize_chars($value, true, ' '), true, true, array('no_breaks' => true, 'replace_tabs' => true, 'collapse_hspace' => true))));
+						validateUsername($context['id_member'], trim(normalize_spaces(sanitize_chars($value, 1, ' '), true, true, array('no_breaks' => true, 'replace_tabs' => true, 'collapse_hspace' => true))));
 						updateMemberData($context['id_member'], array('member_name' => $value));
 
 						// Call this here so any integrated systems will know about the name change (resetPassword() takes care of this if we're letting SMF generate the password)
@@ -409,7 +409,7 @@ function loadProfileFields($force_reload = false)
 			'enabled' => allowedTo('profile_displayed_name_own') || allowedTo('profile_displayed_name_any') || allowedTo('moderate_forum'),
 			'input_validate' => function(&$value) use ($context, $smcFunc, $sourcedir, $cur_profile)
 			{
-				$value = trim(normalize_spaces(sanitize_chars($value, true, ' '), true, true, array('no_breaks' => true, 'replace_tabs' => true, 'collapse_hspace' => true)));
+				$value = trim(normalize_spaces(sanitize_chars($value, 1, ' '), true, true, array('no_breaks' => true, 'replace_tabs' => true, 'collapse_hspace' => true)));
 
 				if (trim($value) == '')
 					return 'no_name';

--- a/Sources/Register.php
+++ b/Sources/Register.php
@@ -908,7 +908,7 @@ function RegisterCheckUsername()
 	$context['valid_username'] = true;
 
 	// Clean it up like mother would.
-	$context['checked_username'] = trim(normalize_spaces(sanitize_chars($context['checked_username'], true, ' '), true, true, array('no_breaks' => true, 'replace_tabs' => true, 'collapse_hspace' => true)));
+	$context['checked_username'] = trim(normalize_spaces(sanitize_chars($context['checked_username'], 1, ' '), true, true, array('no_breaks' => true, 'replace_tabs' => true, 'collapse_hspace' => true)));
 
 	require_once($sourcedir . '/Subs-Auth.php');
 	$errors = validateUsername(0, $context['checked_username'], true);

--- a/Sources/Register.php
+++ b/Sources/Register.php
@@ -317,6 +317,9 @@ function Register2()
 		$_POST,
 		function (&$value, $key) use ($context, $smcFunc)
 		{
+			// Normalize Unicode characters. (Does nothing if not in UTF-8 mode.)
+			$value = $smcFunc['normalize']($value);
+
 			// Replace any kind of space with a normal space, and remove any kind of control character, then trim.
 			$value = $smcFunc['htmltrim'](preg_replace(array('~[\h\v]+~' . ($context['utf8'] ? 'u' : ''), '~\p{Cc}+~'), array(' ', ''), $value));
 		}

--- a/Sources/Register.php
+++ b/Sources/Register.php
@@ -320,8 +320,8 @@ function Register2()
 			// Normalize Unicode characters. (Does nothing if not in UTF-8 mode.)
 			$value = $smcFunc['normalize']($value);
 
-			// Replace any kind of space with a normal space, and remove any kind of control character, then trim.
-			$value = $smcFunc['htmltrim'](preg_replace(array('~[\h\v]+~' . ($context['utf8'] ? 'u' : ''), '~\p{Cc}+~'), array(' ', ''), $value));
+			// Replace any kind of space or illegal character with a normal space, and then trim.
+			$value = $smcFunc['htmltrim'](normalize_spaces(sanitize_chars($value, 1, ' '), true, true, array('no_breaks' => true, 'replace_tabs' => true, 'collapse_hspace' => true)));
 		}
 	);
 
@@ -908,7 +908,7 @@ function RegisterCheckUsername()
 	$context['valid_username'] = true;
 
 	// Clean it up like mother would.
-	$context['checked_username'] = preg_replace('~[\t\n\r \x0B\0' . ($context['utf8'] ? '\x{A0}\x{AD}\x{2000}-\x{200F}\x{201F}\x{202F}\x{3000}\x{FEFF}' : '\x00-\x08\x0B\x0C\x0E-\x19\xA0') . ']+~' . ($context['utf8'] ? 'u' : ''), ' ', $context['checked_username']);
+	$context['checked_username'] = trim(normalize_spaces(sanitize_chars($context['checked_username'], true, ' '), true, true, array('no_breaks' => true, 'replace_tabs' => true, 'collapse_hspace' => true)));
 
 	require_once($sourcedir . '/Subs-Auth.php');
 	$errors = validateUsername(0, $context['checked_username'], true);

--- a/Sources/Subs-Charset.php
+++ b/Sources/Subs-Charset.php
@@ -3101,6 +3101,590 @@ function utf8_compose($string)
 	return $string;
 }
 
+/**
+ * Helper function for sanitize_chars() that deals with invisible characters.
+ *
+ * This function deals with control characters, private use characters,
+ * non-characters, and characters that are invisible by definition in the
+ * Unicode standard. It does not deal with characters that are supposed to be
+ * visible according to the Unicode standard, and makes no attempt to compensate
+ * for possibly incomplete Unicode support in text rendering engines on client
+ * devices.
+ *
+ * @param string $string The string to sanitize.
+ * @param int $level Controls how invisible formatting characters are handled.
+ *      0: Allow valid formatting characters. Use for sanitizing text in posts.
+ *      1: Allow necessary formatting characters. Use for sanitizing usernames.
+ *      2: Disallow all formatting characters. Use for internal comparisions
+ *         only, such as in the word censor, search contexts, etc.
+ * @param string $substitute Replacement string for the invalid characters.
+ * @return string The sanitized string.
+ */
+function utf8_sanitize_invisibles($string, $level, $substitute)
+{
+	$string = (string) $string;
+	$level = min(max((int) $level, 0), 2);
+	$substitute = (string) $substitute;
+
+	// We never want non-whitespace control characters
+	$disallowed[] = '[^\P{Cc}\t\r\n]';
+
+	// We never want private use characters or non-characters.
+	$disallowed[] = '[\p{Co}\p{Cn}]';
+
+	// Several more things we never want:
+	$disallowed[] = '[' . implode('', array(
+		// Soft Hyphen.
+		'\x{AD}',
+		// Khmer Vowel Inherent AQ and Khmer Vowel Inherent AA.
+		// Unicode Standard ch. 16 says: "they are insufficient for [their]
+		// purpose and should be considered errors in the encoding."
+		'\x{17B4}-\x{17B5}',
+		// Invisible math characters.
+		'\x{2061}-\x{2064}',
+		// Deprecated formatting characters.
+		'\x{206A}-\x{206F}',
+		// Zero Width No-Break Space, a.k.a. Byte Order Mark.
+		'\x{FEFF}',
+		// Annotation characters and Object Replacement Character.
+		'\x{FFF9}-\x{FFFC}',
+	)) . ']';
+
+	switch ($level)
+	{
+		case 2:
+			$disallowed[] = '[' . implode('', array(
+				// Combining Grapheme Character.
+				'\x{34F}',
+				// Zero Width Non-Joiner.
+				'\x{200C}',
+				// Zero Width Non-Joiner.
+				'\x{200D}',
+				// All variation selectors.
+				'\x{180B}-\x{180D}\x{180F}\x{FE00}-\x{FE0F}\x{E0100}-\x{E01EF}',
+				// Tag characters.
+				'\x{E0000}-\x{E007F}',
+			)) . ']';
+
+			// no break
+
+		case 1:
+			$disallowed[] = '[' . implode('', array(
+				// Zero Width Space.
+				'\x{200B}',
+				// Word Joiner.
+				'\x{2060}',
+				// "Bidi_Control" characters.
+				// Disallowing means that all characters will behave according
+				// to their default bidirectional text properties.
+				'\x{61C}\x{200E}\x{200F}\x{202A}-\x{202E}\x{2066}-\x{2069}',
+				// Hangul filler characters.
+				// Used as placeholders in incomplete ideographs.
+				'\x{115F}\x{1160}\x{3164}\x{FFA0}',
+				// Shorthand formatting characters.
+				'\x{1BCA0}-\x{1BCA3}',
+				// Musical formatting characters.
+				'\x{1D173}-\x{1D17A}',
+			)) . ']';
+
+			break;
+
+		default:
+			// Zero Width Space only allowed in certain scripts.
+			$disallowed[] = '(?<![\p{Thai}\p{Myanmar}\p{Khmer}\p{Hiragana}\p{Katakana}])\x{200B}';
+
+			// Word Joiner disallowed inside words. (Yes, \w is Unicode safe.)
+			$disallowed[] = '(?<=\w)\x{2060}(?=\w)';
+
+			// Hangul Choseong Filler and Hangul Jungseong Filler must followed
+			// by more Hangul Jamo characters.
+			$disallowed[] = '[\x{115F}\x{1160}](?![\x{1100}-\x{11FF}\x{A960}-\x{A97F}\x{D7B0}-\x{D7FF}])';
+
+			// Hangul Filler for Hangul compatibility chars.
+			$disallowed[] = '\x{3164}(?![\x{3130}-\x{318F}])';
+
+			// Halfwidth Hangul Filler for halfwidth Hangul compatibility chars.
+			$disallowed[] = '\x{FFA0}(?![\x{FFA1}-\x{FFDC}])';
+
+			// Shorthand formatting characters only with other shorthand chars.
+			$disallowed[] = '[\x{1BCA0}-\x{1BCA3}](?![\x{1BC00}-\x{1BC9F}])';
+			$disallowed[] = '(?<![\x{1BC00}-\x{1BC9F}])[\x{1BCA0}-\x{1BCA3}]';
+
+			// Musical formatting characters only with other musical chars.
+			$disallowed[] = '[\x{1D173}\x{1D175}\x{1D177}\x{1D179}](?![\x{1D100}-\x{1D1FF}])';
+			$disallowed[] = '(?<![\x{1D100}-\x{1D1FF}])[\x{1D174}\x{1D176}\x{1D178}\x{1D17A}]';
+
+			break;
+	}
+
+	if ($level < 2)
+	{
+		/*
+			Combining Grapheme Character has two uses: to override standard
+			search and collation behaviours, which we never want to allow, and
+			to ensure correct behaviour of combining marks in a few exceptional
+			cases, which is legitimate and should be allowed. This means we can
+			simply test whether it is followed by a combining mark in order to
+			determine whether to allow it.
+		*/
+		$disallowed[] = '\x{34F}(?!\p{M})';
+
+		// Tag characters not allowed inside words.
+		$disallowed[] = '(?<=\w)[\x{E0000}-\x{E007F}](?=\w)';
+
+		// Mongolian Free Variation Selectors.
+		$disallowed[] = '(?<!\p{Mongolian})[\x{180B}-\x{180D}\x{180F}]';
+	}
+
+	$string = preg_replace('/' . implode('|', $disallowed) . '/u', $substitute, $string);
+
+	/*
+		Past this point, we need to use mb_ereg* functions because they support
+		character class intersection and more Unicode properties than the preg*
+		functions do.
+	*/
+	if (!function_exists('mb_ereg_replace_callback') || !preg_match('/[\x{200C}\x{200D}\x{202A}-\x{202E}\x{2066}-\x{2069}\x{FE00}-\x{FE0F}\x{E0100}-\x{E01EF}]/u', $string))
+		return $string;
+
+	mb_regex_encoding('UTF-8');
+
+	// String must be in Normalization Form C for the following checks to work.
+	$string = utf8_normalize_c($string);
+
+	$placeholders = array();
+
+	/*
+		Use placeholders to preserve known emoji from further processing.
+
+		This only matches emoji known to the installed version of mbstring,
+		so we still need to account for new possible emoji further down, but
+		this will cover the majority.
+
+		Regex source is https://unicode.org/reports/tr51/#EBNF_and_Regex
+	*/
+	$string  = mb_ereg_replace_callback(
+		'\p{Regional_Indicator}\p{Regional_Indicator}' .
+		'|' .
+		'\p{Emoji}' .
+		'(' .
+			'\p{Emoji_Modifier}' .
+			'|' .
+			'\x{FE0F}\x{20E3}?' .
+			'|' .
+			'[\x{E0020}-\x{E007E}]+\x{E007F}' .
+		')?' .
+		'(' .
+			'\x{200D}\p{Emoji}' .
+			'(' .
+				'\p{Emoji_Modifier}' .
+				'|' .
+				'\x{FE0F}\x{20E3}?' .
+				'|' .
+				'[\x{E0020}-\x{E007E}]+\x{E007F}' .
+			')?' .
+		')*',
+		function ($matches) use (&$placeholders)
+		{
+			// Skip lone ASCII characters that are not actully part of an emoji sequence.
+			// This can happen because the digits 0-9 and the '*' and '#' characters are
+			// the base characters for the "Emoji_Keycap_Sequence" emojis.
+			if (strlen($matches[0]) === 1)
+				return $matches[0];
+
+			$placeholders[$matches[0]] = "\xEE\xB3\x9B" . md5($matches[0]) . "\xEE\xB3\x9C";
+			return $placeholders[$matches[0]];
+		},
+		$string
+	);
+
+	// Get rid of any unsanctioned variation selectors.
+	if (mb_ereg('[\x{FE00}-\x{FE0F}\x{E0100}-\x{E01EF}]', $string))
+	{
+		/*
+			Unicode gives pre-defined lists of sanctioned variation sequences
+			and says any use of variation selectors outside those sequences is
+			unsanctioned. However, those lists will continue to grow over time.
+			Therefore, the regex patterns below are more permissive than
+			Unicode itself, making reasonable guesses about the types of
+			characters that are likely to be used as base characters for new
+			variation sequences in the future.
+		*/
+
+		// Base characters that take variation selectors 1 - 16
+		$variation_base_chars_low = implode('', array(
+			// Symbols.
+			'\p{S}',
+			// CJK Symbols and Punctuation.
+			'\x{3000}-\x{303F}',
+			// CJK Unified Ideographs.
+			'\x{3400}-\x{4DBF}',
+			'\x{4E00}-\x{9FFF}',
+			'\x{20000}-\x{2A6DF}',
+			// Halfwidth and Fullwidth Forms.
+			'\x{FF01}-\x{FFEE}',
+			// Multiple characters in these scripts can have variations.
+			'\p{Myanmar}',
+			'\p{Phags_Pa}',
+			'\p{Manichaean}',
+		));
+		$string = mb_ereg_replace('[^' . $variation_base_chars_low . ']\K[\x{FE00}-\x{FE0F}]', $substitute, $string);
+
+		// For variation selectors 17 - 256, things are simpler.
+		$string = mb_ereg_replace('\P{Ideographic}\K[\x{E0100}-\x{E01EF}]', $substitute, $string);
+	}
+
+	// Join controls are only allowed inside words in special circumstances.
+	// See https://unicode.org/reports/tr31/#Layout_and_Format_Control_Characters
+	if (mb_ereg('[\x{200C}\x{200D}]', $string))
+	{
+		// Zero Width Non-Joiner (U+200C)
+		$zwnj = "\xE2\x80\x8C";
+		// Zero Width Joiner (U+200D)
+		$zwj = "\xE2\x80\x8D";
+
+		$placeholders[$zwnj] = "\xEE\x80\x8C";
+		$placeholders[$zwj] = "\xEE\x80\x8C";
+
+		// When not in strict mode, allow ZWJ at word boundaries.
+		if ($level === 0)
+			$temp = mb_ereg_replace('\b\x{200D}|\x{200D}\b', $placeholders[$zwj], $string);
+
+		// Tests for Zero Width Joiner and Zero Width Non-Joiner.
+		$script_tests = array(
+			// For these scripts, use test A1 for allowing ZWNJ
+			// https://unicode.org/reports/tr31/#A1
+			// Character class lists compiled from:
+			// https://unicode.org/Public/UNIDATA/extracted/DerivedJoiningType.txt
+			'Arabic' => array(
+				'dual_joining' => '\x{0620}\x{0626}\x{0628}\x{062A}-\x{062E}\x{0633}-\x{063F}\x{0641}-\x{0647}\x{0649}-\x{064A}\x{066E}-\x{066F}\x{0678}-\x{0687}\x{069A}-\x{06BF}\x{06C1}-\x{06C2}\x{06CC}\x{06CE}\x{06D0}-\x{06D1}\x{06FA}-\x{06FC}\x{06FF}\x{074E}-\x{0758}\x{075C}-\x{076A}\x{076D}-\x{0770}\x{0772}\x{0775}-\x{0777}\x{077A}-\x{077F}\x{08A0}-\x{08A9}\x{08AF}-\x{08B0}\x{08B3}-\x{08B8}\x{08BA}-\x{08C8}',
+				'right_joining' => '\x{0622}-\x{0625}\x{0627}\x{0629}\x{062F}-\x{0632}\x{0648}\x{0671}-\x{0673}\x{0675}-\x{0677}\x{0688}-\x{0699}\x{06C0}\x{06C3}-\x{06CB}\x{06CD}\x{06CF}\x{06D2}-\x{06D3}\x{06D5}\x{06EE}-\x{06EF}\x{0759}-\x{075B}\x{076B}-\x{076C}\x{0771}\x{0773}-\x{0774}\x{0778}-\x{0779}\x{08AA}-\x{08AC}\x{08AE}\x{08B1}-\x{08B2}\x{08B9}',
+				'transparent_joining' => '\x{0610}-\x{061A}\x{061C}\x{064B}-\x{065F}\x{06D6}-\x{06DC}\x{06DF}-\x{06E4}\x{06E7}-\x{06E8}\x{06EA}-\x{06ED}\x{08CA}-\x{08E1}\x{08E3}-\x{0902}',
+			),
+			'Syriac' => array(
+				'dual_joining' => '\x{0712}-\x{0714}\x{071A}-\x{071D}\x{071F}-\x{0727}\x{0729}\x{072B}\x{072D}-\x{072E}\x{0860}\x{0862}-\x{0865}\x{0868}',
+				'right_joining' => '\x{0710}\x{0715}-\x{0719}\x{071E}\x{0728}\x{072A}\x{072C}\x{072F}\x{074D}\x{0867}\x{0869}-\x{086A}',
+				'transparent_joining' => '\x{070F}\x{0711}\x{0730}-\x{074A}',
+			),
+			'Mongolian' => array(
+				'dual_joining' => '\x{1807}\x{1820}-\x{1878}\x{1887}-\x{18A8}\x{18AA}',
+				'transparent_joining' => '\x{180B}-\x{180D}\x{1885}-\x{1886}\x{18A9}',
+			),
+			'Nko' => array(
+				'dual_joining' => '\x{07CA}-\x{07EA}',
+				'transparent_joining' => '\x{07EB}-\x{07F3}\x{07FD}',
+			),
+			'Mandaic' => array(
+				'dual_joining' => '\x{0841}-\x{0845}\x{0848}\x{084A}-\x{0853}\x{0855}',
+				'right_joining' => '\x{0840}\x{0846}-\x{0847}\x{0849}\x{0854}\x{0856}-\x{0858}',
+				'transparent_joining' => '\x{0859}-\x{085B}',
+			),
+			'Manichaean' => array(
+				'dual_joining' => '\x{10AC0}-\x{10AC4}\x{10AD3}-\x{10AD6}\x{10AD8}-\x{10ADC}\x{10ADE}-\x{10AE0}\x{10AEB}-\x{10AEE}',
+				'right_joining' => '\x{10AC5}\x{10AC7}\x{10AC9}-\x{10ACA}\x{10ACE}-\x{10AD2}\x{10ADD}\x{10AE1}\x{10AE4}\x{10AEF}',
+				'left_joining' => '\x{10ACD}\x{10AD7}',
+				'transparent_joining' => '\x{10AE5}-\x{10AE6}',
+			),
+			'Psalter_Pahlavi' => array(
+				'dual_joining' => '\x{10B80}\x{10B82}\x{10B86}-\x{10B88}\x{10B8A}-\x{10B8B}\x{10B8D}\x{10B90}\x{10BAD}-\x{10BAE}',
+				'right_joining' => '\x{10B81}\x{10B83}-\x{10B85}\x{10B89}\x{10B8C}\x{10B8E}-\x{10B8F}\x{10B91}\x{10BA9}-\x{10BAC}',
+			),
+			'Hanifi_Rohingya' => array(
+				'dual_joining' => '\x{10D01}-\x{10D21}\x{10D23}',
+				'right_joining' => '\x{10D22}',
+				'left_joining' => '\x{10D00}',
+				'transparent_joining' => '\x{10D24}-\x{10D27}',
+			),
+			'Sogdian' => array(
+				'dual_joining' => '\x{10F30}-\x{10F32}\x{10F34}-\x{10F44}\x{10F51}-\x{10F53}',
+				'right_joining' => '\x{10F33}\x{10F54}',
+				'transparent_joining' => '\x{10F46}-\x{10F50}',
+			),
+			'Chorasmian' => array(
+				'dual_joining' => '\x{0FB0}\x{0FB2)-\x{10FB3}\x{0FB8}\x{0FBB)-\x{10FBC}\x{0FBE)-\x{10FBF}\x{0FC1}\x{0FC4}\x{0FCA}',
+				'right_joining' => '\x{0FB4)-\x{10FB6}\x{0FB9)-\x{10FBA}\x{0FBD}\x{0FC2)-\x{10FC3}\x{0FC9}',
+				'left_joining' => '\x{0FCB}',
+			),
+			'Adlam' => array(
+				'dual_joining' => '\x{1E900}-\x{1E943}',
+				'transparent_joining' => '\x{1E944}-\x{1E94B}',
+			),
+
+			// For these scripts, use tests A2 and B for allowing ZWNJ and ZWJ
+			// https://unicode.org/reports/tr31/#A2
+			// https://unicode.org/reports/tr31/#B
+			// Character class lists compiled from:
+			// https://unicode.org/Public/UNIDATA/extracted/DerivedCombiningClass.txt
+			// https://unicode.org/Public/UNIDATA/IndicSyllabicCategory.txt
+			'Devanagari' => array(
+				'viramas' => '\x{094D}',
+				'vowel_dependents' => '\x{093A}-\x{093B}\x{093E}-\x{094C}\x{094E}-\x{094F}\x{0955}-\x{0957}\x{0962}-\x{0963}\x{A8FF}',
+			),
+			'Bengali' => array(
+				'viramas' => '\x{09CD}',
+				'vowel_dependents' => '\x{09BE}-\x{09C4}\x{09C7}-\x{09C8}\x{09CB}-\x{09CC}\x{09D7}\x{09E2}-\x{09E3}',
+			),
+			'Gurmukhi' => array(
+				'viramas' => '\x{0A4D}',
+				'vowel_dependents' => '\x{0A3E}-\x{0A42}\x{0A47}-\x{0A48}\x{0A4B}-\x{0A4C}',
+			),
+			'Gujarati' => array(
+				'viramas' => '\x{0ACD}',
+				'vowel_dependents' => '\x{0ABE}-\x{0AC5}\x{0AC7}-\x{0AC9}\x{0ACB}-\x{0ACC}\x{0AE2}-\x{0AE3}',
+			),
+			'Oriya' => array(
+				'viramas' => '\x{0B4D}',
+				'vowel_dependents' => '\x{0B3E}-\x{0B44}\x{0B47}-\x{0B48}\x{0B4B}-\x{0B4C}\x{0B55}-\x{0B57}\x{0B62}-\x{0B63}',
+			),
+			'Tamil' => array(
+				'viramas' => '\x{0BCD}',
+				'vowel_dependents' => '\x{0BBE}-\x{0BC2}\x{0BC6}-\x{0BC8}\x{0BCA}-\x{0BCC}\x{0BD7}',
+			),
+			'Telugu' => array(
+				'viramas' => '\x{0C4D}',
+				'vowel_dependents' => '\x{0C3E}-\x{0C44}\x{0C46}-\x{0C48}\x{0C4A}-\x{0C4C}\x{0C55}-\x{0C56}\x{0C62}-\x{0C63}',
+			),
+			'Kannada' => array(
+				'viramas' => '\x{0CCD}',
+				'vowel_dependents' => '\x{0CBE}-\x{0CC4}\x{0CC6}-\x{0CC8}\x{0CCA}-\x{0CCC}\x{0CD5}-\x{0CD6}\x{0CE2}-\x{0CE3}',
+			),
+			'Malayalam' => array(
+				'viramas' => '\x{0D4D}',
+				'vowel_dependents' => '\x{0D3E}-\x{0D44}\x{0D46}-\x{0D48}\x{0D4A}-\x{0D4C}\x{0D57}\x{0D62}-\x{0D63}',
+			),
+			'Sinhala' => array(
+				'viramas' => '\x{0DCA}',
+				'vowel_dependents' => '\x{0DCF}-\x{0DD4}\x{0DD6}\x{0DD8}-\x{0DDF}\x{0DF2}-\x{0DF3}',
+			),
+			'Thai' => array(
+				'viramas' => '\x{0E3A}',
+				'vowel_dependents' => '\x{0E30}\x{0E40}\x{0E47}',
+			),
+			'Lao' => array(
+				'viramas' => '\x{0EBA}',
+				'vowel_dependents' => '\x{0EB0}-\x{0EB9}\x{0EBB}\x{0EC0}-\x{0EC4}',
+			),
+			'Tibetan' => array(
+				'viramas' => '\x{0F84}',
+				'vowel_dependents' => '\x{0F71}-\x{0F7D}\x{0F80}-\x{0F81}',
+			),
+			'Myanmar' => array(
+				'viramas' => '\x{1039}-\x{103A}',
+				'vowel_dependents' => '\x{102B}-\x{1035}\x{1056}-\x{1059}\x{1062}\x{1067}-\x{1068}\x{1071}-\x{1074}\x{1083}-\x{1086}\x{109C}-\x{109D}\x{A9E5}',
+			),
+			'Tagalog' => array(
+				'viramas' => '\x{1714}-\x{1715}',
+				'vowel_dependents' => '\x{1712}-\x{1713}',
+			),
+			'Hanunoo' => array(
+				'viramas' => '\x{1734}',
+				'vowel_dependents' => '\x{1732}-\x{1733}',
+			),
+			'Khmer' => array(
+				'viramas' => '\x{17D2}',
+				'vowel_dependents' => '\x{17B6}-\x{17C5}\x{17C8}',
+			),
+			'Tai_Tham' => array(
+				'viramas' => '\x{1A60}',
+				'vowel_dependents' => '\x{1A61}-\x{1A73}',
+			),
+			'Balinese' => array(
+				'viramas' => '\x{1B44}',
+				'vowel_dependents' => '\x{1B35}-\x{1B43}',
+			),
+			'Sundanese' => array(
+				'viramas' => '\x{1BAA}-\x{1BAB}',
+				'vowel_dependents' => '\x{1BA4}-\x{1BA9}',
+			),
+			'Batak' => array(
+				'viramas' => '\x{1BF2}-\x{1BF3}',
+				'vowel_dependents' => '\x{1BE7}-\x{1BEF}',
+			),
+			'Tifinagh' => array(
+				'viramas' => '\x{2D7F}',
+				'vowel_dependents' => '',
+			),
+			'Syloti_Nagri' => array(
+				'viramas' => '\x{A806}-\x{A82C}',
+				'vowel_dependents' => '\x{A802}\x{A823}-\x{A827}',
+			),
+			'Saurashtra' => array(
+				'viramas' => '\x{A8C4}',
+				'vowel_dependents' => '\x{A8B5}-\x{A8C3}',
+			),
+			'Rejang' => array(
+				'viramas' => '\x{A953}',
+				'vowel_dependents' => '\x{A947}-\x{A94E}',
+			),
+			'Javanese' => array(
+				'viramas' => '\x{A9C0}',
+				'vowel_dependents' => '\x{A9B4}-\x{A9BC}',
+			),
+			'Meetei_Mayek' => array(
+				'viramas' => '\x{AAF6}-\x{ABED}',
+				'vowel_dependents' => '\x{AAEB}-\x{AAEF}\x{ABE3}-\x{ABEA}',
+			),
+			'Kharoshthi' => array(
+				'viramas' => '\x{10A3F}',
+				'vowel_dependents' => '\x{10A01}-\x{10A03}\x{10A05}-\x{10A06}\x{10A0C}-\x{10A0D}',
+			),
+			'Brahmi' => array(
+				'viramas' => '\x{11046}\x{11070}\x{1107F}',
+				'vowel_dependents' => '\x{11038}-\x{11045}',
+			),
+			'Kaithi' => array(
+				'viramas' => '\x{110B9}',
+				'vowel_dependents' => '\x{110B0}-\x{110B8}',
+			),
+			'Chakma' => array(
+				'viramas' => '\x{11133}-\x{11134}',
+				'vowel_dependents' => '\x{11127}-\x{11132}\x{11145}-\x{11146}',
+			),
+			'Sharada' => array(
+				'viramas' => '\x{111C0}',
+				'vowel_dependents' => '\x{111B3}-\x{111BF}\x{111CB}-\x{111CC}',
+			),
+			'Khojki' => array(
+				'viramas' => '\x{11235}',
+				'vowel_dependents' => '\x{1122C}-\x{11233}',
+			),
+			'Khudawadi' => array(
+				'viramas' => '\x{112EA}',
+				'vowel_dependents' => '\x{112E0}-\x{112E8}',
+			),
+			'Grantha' => array(
+				'viramas' => '\x{1134D}',
+				'vowel_dependents' => '\x{1133E}-\x{11344}\x{11347}-\x{11348}\x{1134B}-\x{1134C}\x{11357}\x{11362}-\x{11363}',
+			),
+			'Newa' => array(
+				'viramas' => '\x{11442}',
+				'vowel_dependents' => '\x{11435}-\x{11441}',
+			),
+			'Tirhuta' => array(
+				'viramas' => '\x{114C2}',
+				'vowel_dependents' => '\x{114B0}-\x{114BE}',
+			),
+			'Siddham' => array(
+				'viramas' => '\x{115BF}',
+				'vowel_dependents' => '\x{115AF}-\x{115B5}\x{115B8}-\x{115BB}\x{115DC}-\x{115DD}',
+			),
+			'Modi' => array(
+				'viramas' => '\x{1163F}',
+				'vowel_dependents' => '\x{11630}-\x{1163C}\x{11640}',
+			),
+			'Takri' => array(
+				'viramas' => '\x{116B6}',
+				'vowel_dependents' => '\x{116AD}-\x{116B5}',
+			),
+			'Ahom' => array(
+				'viramas' => '\x{1172B}',
+				'vowel_dependents' => '\x{11720}-\x{1172A}',
+			),
+			'Dogra' => array(
+				'viramas' => '\x{11839}',
+				'vowel_dependents' => '\x{1182C}-\x{11836}',
+			),
+			'Nandinagari' => array(
+				'viramas' => '\x{119E0}',
+				'vowel_dependents' => '\x{119D1}-\x{119D7}\x{119DA}-\x{119DD}\x{119E4}',
+			),
+			'Zanabazar_Square' => array(
+				'viramas' => '\x{11A34}\x{11A47}',
+				'vowel_dependents' => '\x{11A01}-\x{11A0A}',
+			),
+			'Soyombo' => array(
+				'viramas' => '\x{11A99}',
+				'vowel_dependents' => '\x{11A51}-\x{11A5B}',
+			),
+			'Bhaiksuki' => array(
+				'viramas' => '\x{11C3F}',
+				'vowel_dependents' => '\x{11C2F}-\x{11C36}\x{11C38}-\x{11C3B}',
+			),
+			'Masaram_Gondi' => array(
+				'viramas' => '\x{11D44}-\x{11D45}',
+				'vowel_dependents' => '\x{11D31}-\x{11D36}\x{11D3A}\x{11D3C}-\x{11D3D}\x{11D3F}\x{11D43}',
+			),
+			'Gunjala_Gondi' => array(
+				'viramas' => '\x{11D97}',
+				'vowel_dependents' => '\x{11D8A}-\x{11D8E}\x{11D90}-\x{11D91}\x{11D93}-\x{11D94}',
+			),
+		);
+
+		$all_combining_marks = '[' . implode('', array_keys(utf8_combining_classes())) . ']';
+
+		foreach ($script_tests as $script => $chars)
+		{
+			// https://unicode.org/reports/tr31/#A1
+			if (empty($chars['viramas']))
+			{
+				$lj = !empty($chars['left_joining']) ? $chars['left_joining'] : '';
+				$rj = !empty($chars['right_joining']) ? $chars['right_joining'] : '';
+				$t = !empty($chars['transparent_joining']) ? '[' . $chars['transparent_joining'] . ']*' : '';
+
+				if (!empty($chars['dual_joining']))
+				{
+					$lj .= $chars['dual_joining'];
+					$rj .= $chars['dual_joining'];
+				}
+
+				$pattern = '[' . $lj . ']' . $t . $zwnj . $t . '[' . $rj . ']';
+			}
+			// https://unicode.org/reports/tr31/#A2
+			// https://unicode.org/reports/tr31/#B
+			else
+			{
+				// Characters used in this script.
+				$used_in_script = '[\p{' . $script . '}\p{Common}\p{Inherited}]';
+
+				// A letter that is part of this particular script.
+				$letter = '[\p{L}&&\p{' . $script . '}]';
+
+				// Zero or more non-spacing marks used in this script.
+				$nonspacing_marks = '[\p{Mn}&&' . $used_in_script . ']*';
+
+				// Zero or more non-spacing combining marks used in this script.
+				$nonspacing_combining_marks = '[\p{Mn}&&' . $used_in_script . '&&' . $all_combining_marks . ']*';
+
+				// ZWNJ must be followed by another letter in the same script.
+				$zwnj_pattern = '\x{200C}(?=' . $nonspacing_combining_marks . $letter . ')';
+
+				// ZWJ must NOT be followed by a vowel dependent character in this
+				// script or by any character from a different script.
+				$zwj_pattern = !empty($chars['vowel_dependents']) ? '\x{200D}(?![' . $chars['vowel_dependents'] . ']|\P{' . $script . '}})' : '';
+
+				// Now build the pattern for this script.
+				$pattern = $letter . $nonspacing_marks . '[' . $chars['viramas'] . ']' . $nonspacing_combining_marks . '\K' . (!empty($zwj_pattern) ? '(?:' . $zwj_pattern . '|' . $zwnj_pattern . ')' : $zwnj_pattern);
+			}
+
+			// Do the thing.
+			$temp = @mb_ereg_replace_callback(
+				$pattern,
+				function ($matches) use ($placeholders)
+				{
+					return strtr($matches[0], $placeholders);
+				},
+				$string
+			);
+
+			// False means the installed version of mbstring lacks support for this script.
+			if ($temp !== false)
+				$string = $temp;
+
+			// Did we catch 'em all?
+			if (strpos($string, $zwnj) === false && strpos($string, $zwj) === false)
+				break;
+		}
+
+		// Apart from the exceptions above, ZWNJ and ZWJ are not allowed.
+		$string = str_replace(array($zwj, $zwnj), $substitute, $string);
+	}
+
+	// Revert placeholders back to original characters.
+	$string = strtr($string, array_flip($placeholders));
+
+
+	return $string;
+}
+
 function utf8_normalize_d_maps()
 {
 	return array(

--- a/Sources/Subs-Charset.php
+++ b/Sources/Subs-Charset.php
@@ -3158,7 +3158,7 @@ function utf8_sanitize_invisibles($string, $level, $substitute)
 				'\x{34F}',
 				// Zero Width Non-Joiner.
 				'\x{200C}',
-				// Zero Width Non-Joiner.
+				// Zero Width Joiner.
 				'\x{200D}',
 				// All variation selectors.
 				'\x{180B}-\x{180D}\x{180F}\x{FE00}-\x{FE0F}\x{E0100}-\x{E01EF}',
@@ -3347,7 +3347,7 @@ function utf8_sanitize_invisibles($string, $level, $substitute)
 
 		// When not in strict mode, allow ZWJ at word boundaries.
 		if ($level === 0)
-			$temp = mb_ereg_replace('\b\x{200D}|\x{200D}\b', $placeholders[$zwj], $string);
+			$string = mb_ereg_replace('\b\x{200D}|\x{200D}\b', $placeholders[$zwj], $string);
 
 		// Tests for Zero Width Joiner and Zero Width Non-Joiner.
 		$script_tests = array(
@@ -3649,7 +3649,7 @@ function utf8_sanitize_invisibles($string, $level, $substitute)
 
 				// ZWJ must NOT be followed by a vowel dependent character in this
 				// script or by any character from a different script.
-				$zwj_pattern = !empty($chars['vowel_dependents']) ? '\x{200D}(?![' . $chars['vowel_dependents'] . ']|\P{' . $script . '}})' : '';
+				$zwj_pattern = '\x{200D}(?!' . (!empty($chars['vowel_dependents']) ? '[' . $chars['vowel_dependents'] . ']|' : '') . '\P{' . $script . '}})';
 
 				// Now build the pattern for this script.
 				$pattern = $letter . $nonspacing_marks . '[' . $chars['viramas'] . ']' . $nonspacing_combining_marks . '\K' . (!empty($zwj_pattern) ? '(?:' . $zwj_pattern . '|' . $zwnj_pattern . ')' : $zwnj_pattern);

--- a/Sources/Subs-Members.php
+++ b/Sources/Subs-Members.php
@@ -464,7 +464,7 @@ function registerMember(&$regOptions, $return_errors = false)
 	}
 
 	// Spaces and other odd characters are evil...
-	$regOptions['username'] = trim(preg_replace('~[\t\n\r \x0B\0' . ($context['utf8'] ? '\x{A0}\x{AD}\x{2000}-\x{200F}\x{201F}\x{202F}\x{3000}\x{FEFF}' : '\x00-\x08\x0B\x0C\x0E-\x19\xA0') . ']+~' . ($context['utf8'] ? 'u' : ''), ' ', $regOptions['username']));
+	$regOptions['username'] = trim(normalize_spaces(sanitize_chars($regOptions['username'], true, ' '), true, true, array('no_breaks' => true, 'replace_tabs' => true, 'collapse_hspace' => true)));
 
 	// Convert character encoding for non-utf8mb4 database
 	$regOptions['username'] = $smcFunc['htmlspecialchars']($regOptions['username']);

--- a/Sources/Subs-Members.php
+++ b/Sources/Subs-Members.php
@@ -464,7 +464,7 @@ function registerMember(&$regOptions, $return_errors = false)
 	}
 
 	// Spaces and other odd characters are evil...
-	$regOptions['username'] = trim(normalize_spaces(sanitize_chars($regOptions['username'], true, ' '), true, true, array('no_breaks' => true, 'replace_tabs' => true, 'collapse_hspace' => true)));
+	$regOptions['username'] = trim(normalize_spaces(sanitize_chars($regOptions['username'], 1, ' '), true, true, array('no_breaks' => true, 'replace_tabs' => true, 'collapse_hspace' => true)));
 
 	// Convert character encoding for non-utf8mb4 database
 	$regOptions['username'] = $smcFunc['htmlspecialchars']($regOptions['username']);

--- a/Sources/Subs-Post.php
+++ b/Sources/Subs-Post.php
@@ -53,6 +53,9 @@ function preparsecode(&$message, $previewing = false)
 	else
 		$message = $smcFunc['normalize']($message);
 
+	// Clean out any other funky stuff.
+	$message = sanitize_chars($message, 0);
+
 	// Clean up after nobbc ;).
 	$message = preg_replace_callback(
 		'~\[nobbc\](.+?)\[/nobbc\]~is',

--- a/Sources/Subs-Post.php
+++ b/Sources/Subs-Post.php
@@ -28,7 +28,7 @@ if (!defined('SMF'))
  */
 function preparsecode(&$message, $previewing = false)
 {
-	global $user_info, $modSettings, $context, $sourcedir;
+	global $user_info, $modSettings, $context, $sourcedir, $smcFunc;
 
 	static $tags_regex, $disallowed_tags_regex;
 
@@ -48,6 +48,10 @@ function preparsecode(&$message, $previewing = false)
 	// This line makes all languages *theoretically* work even with the wrong charset ;).
 	if (empty($context['utf8']))
 		$message = preg_replace('~&amp;#(\d{4,5}|[2-9]\d{2,4}|1[2-9]\d);~', '&#$1;', $message);
+
+	// Normalize Unicode characters for storage efficiency, better searching, etc.
+	else
+		$message = $smcFunc['normalize']($message);
 
 	// Clean up after nobbc ;).
 	$message = preg_replace_callback(

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -1100,6 +1100,134 @@ function un_htmlspecialchars($string)
 }
 
 /**
+ * Replaces invalid characters with a substitute.
+ *
+ * !!! Warning !!! Setting $substitute to '' in order to delete invalid
+ * characters from the string can create unexpected security problems. See
+ * https://www.unicode.org/reports/tr36/#Deletion_of_Noncharacters for an
+ * explanation.
+ *
+ * @param string $string The string to sanitize.
+ * @param bool $strict Whether to treat most formatting characters as invalid.
+ *      Default: true.
+ * @param string|null $substitute Replacement string for the invalid characters.
+ *      If not set, the Unicode replacement character (U+FFFD) will be used
+ *      (or a fallback like "?" if necessary).
+ * @return string The sanitized string.
+ */
+function sanitize_chars($string, $strict = true, $substitute = null)
+{
+	global $context, $sourcedir;
+
+	$string = (string) $string;
+	$strict = !empty($strict);
+
+	// What substitute character should we use?
+	if (isset($substitute))
+	{
+		$substitute = strval($substitute);
+	}
+	elseif (!empty($context['utf8']))
+	{
+		// Raw UTF-8 bytes for U+FFFD.
+		$substitute = "\xEF\xBF\xBD";
+	}
+	elseif (!empty($context['character_set']) && is_callable('mb_decode_numericentity'))
+	{
+		// Get whatever the default replacement character is for this encoding.
+		$substitute = mb_decode_numericentity('&#xFFFD;', array(0xFFFD,0xFFFD,0,0xFFFF), $context['character_set']);
+	}
+	else
+		$substitute = '?';
+
+	// Fix any invalid byte sequences.
+	if (!empty($context['character_set']))
+	{
+		// For UTF-8, this preg_match test is much faster than mb_check_encoding.
+		$malformed = !empty($context['utf8']) ? @preg_match('//u', $string) === false && preg_last_error() === PREG_BAD_UTF8_ERROR : (!is_callable('mb_check_encoding') || !mb_check_encoding($string, $context['character_set']));
+
+		if ($malformed)
+		{
+			// mb_convert_encoding will replace invalid byte sequences with our substitute.
+			if (is_callable('mb_convert_encoding'))
+			{
+				if (!is_callable('mb_ord'))
+					require_once($sourcedir . '/Subs-Compat.php');
+
+				$substitute_ord = $substitute === '' ? 'none' : mb_ord($substitute, $context['character_set']);
+
+				$mb_substitute_character = mb_substitute_character();
+				mb_substitute_character($substitute_ord);
+
+				$string = mb_convert_encoding($string, $context['character_set'], $context['character_set']);
+
+				mb_substitute_character($mb_substitute_character);
+			}
+			else
+				return false;
+		}
+	}
+
+	// Fix any weird vertical space characters.
+	$string = normalize_spaces($string, true);
+
+	// Fix any unwanted control characters and other creepy-crawlies.
+	$string = preg_replace('/[^\P{Cc}\t\r\n]|[\p{Co}\p{Cn}\p{Cs}' . ($strict ? '\p{Cf}' : '') . ']/' . (!empty($context['utf8']) ? 'u' : ''), $substitute, $string);
+
+	return $string;
+}
+
+/**
+ * Normalizes space characters and line breaks.
+ *
+ * @param string $string The string to sanitize.
+ * @param bool $vspace If true, replaces all line breaks and vertical space
+ *      characters with "\n". Default: true.
+ * @param bool $hspace If true, replaces horizontal space characters with a
+ *      plain " " character. (Note: tabs are not replaced unless the
+ *      'replace_tabs' option is supplied.) Default: false.
+ * @param array $options An array of boolean options. Possible values are:
+ *      - no_breaks: Vertical spaces are replaced by " " instead of "\n".
+ *      - replace_tabs: If true, tabs are are replaced by " " chars.
+ *      - collapse_hspace: If true, removes extra horizontal spaces.
+ * @return string The sanitized string.
+ */
+function normalize_spaces($string, $vspace = true, $hspace = false, $options = array())
+{
+	global $context;
+
+	$string = (string) $string;
+	$vspace = !empty($vspace);
+	$hspace = !empty($hspace);
+
+	if (!$vspace && !$hspace)
+		return $string;
+
+	$options['no_breaks'] = !empty($options['no_breaks']);
+	$options['collapse_hspace'] = !empty($options['collapse_hspace']);
+	$options['replace_tabs'] = !empty($options['replace_tabs']);
+
+	$patterns = array();
+	$replacements = array();
+
+	if ($vspace)
+	{
+		// \R is like \v, except it handles "\r\n" as a single unit.
+		$patterns[] = '/\R/' . ($context['utf8'] ? 'u' : '');
+		$replacements[] = $options['no_breaks'] ? ' ' : "\n";
+	}
+
+	if ($hspace)
+	{
+		// Interesting fact: Unicode properties like \p{Zs} work even when not in UTF-8 mode.
+		$patterns[] = '/' . ($options['replace_tabs'] ? '\h' : '\p{Zs}') . ($options['collapse_hspace'] ? '+' : '') . '/' . ($context['utf8'] ? 'u' : '');
+		$replacements[] = ' ';
+	}
+
+	return preg_replace($patterns, $replacements, $string);
+}
+
+/**
  * Shorten a subject + internationalization concerns.
  *
  * - shortens a subject so that it is either shorter than length, or that length plus an ellipsis.


### PR DESCRIPTION
Fixes #7085 
Fixes #7100 
Fixes #7101 

This took a long time to finish, not because the code was particularly difficult, but because I had to spend a lot more time in the depths of the Unicode Standard's documentation, annexes, and technical reports than I ever expected. But enough of my whining and moaning....

The first thing this PR does is apply Unicode normalization to strings supplied via user input. A big chunk of that work is done by adding calls to `$smcFunc['normalize]()` in `preparsecode()`, `$smcFunc['htmlspecialchars']()`, `$smcFunc['strtoupper']()`, and `$smcFunc['strtolower']()`. Applying normalization to user inputs for the profile fields makes up the bulk of the remaining changes in this regard, as well as in a few odds and ends like `censorText()` and some admin input fields.

Testing the normalization aspect of this PR is pretty simple. Put some non-ASCII characters into a post, into a profile field (e.g. your displayed name or your signature), and into the description text of a membergroup or a calendar holiday title or whatever. If all goes well, you should see no visible difference whatsoever.

The second thing this PR does is improve input sanitization, particularly in user names and posts. To test this aspect, first try inserting a soft hyphen (U+00A0) or some other invisible formatting character into your displayed name in your user profile, or into the text of a post. If all goes well, the soft hyphen character will be replaced with a `�` (U+FFFD). Next, try inserting this string of text: `نامه‌ای`. If all goes well, the sanitization will leave the string unchanged. If it comes out looking like `⁧نامهای⁩` or `نامه�ای`, that's bad. Third, try inserting this string: `one ‮two‬ three`. In a post, it should appear unchanged, but in the displayed name, it should be changed to `one �two� three`.