### PR TITLE
Fix "copy" theme missing language file

### DIFF
--- a/Sources/Themes.php
+++ b/Sources/Themes.php
@@ -1343,8 +1343,19 @@ function InstallCopy()
 	mkdir($context['to_install']['theme_dir'] . '/css', 0777);
 	mkdir($context['to_install']['theme_dir'] . '/scripts', 0777);
 
+	// Create subdirectory for language files
+	mkdir($context['to_install']['theme_dir'] . '/languages', 0777);
+
 	// Copy over the default non-theme files.
-	$to_copy = array('/index.php', '/index.template.php', '/css/index.css', '/css/responsive.css', '/css/slider.min.css', '/css/rtl.css', '/css/calendar.css', '/css/calendar.rtl.css', '/css/admin.css', '/scripts/theme.js');
+	$to_copy = array(
+		'/index.php',
+		'/index.template.php',
+		'/css/index.css',
+		'/css/responsive.css',
+		'/css/rtl.css',
+		'/scripts/theme.js',
+		'/languages/Settings.english.php',
+	);
 
 	foreach ($to_copy as $file)
 	{

--- a/Sources/Themes.php
+++ b/Sources/Themes.php
@@ -1350,6 +1350,7 @@ function InstallCopy()
 	$to_copy = array(
 		'/index.php',
 		'/index.template.php',
+		'/css/admin.css',
 		'/css/index.css',
 		'/css/responsive.css',
 		'/css/rtl.css',

--- a/Sources/Themes.php
+++ b/Sources/Themes.php
@@ -1355,6 +1355,7 @@ function InstallCopy()
 		'/css/responsive.css',
 		'/css/rtl.css',
 		'/scripts/theme.js',
+		'/languages/index.php',
 		'/languages/Settings.english.php',
 	);
 

--- a/Sources/Themes.php
+++ b/Sources/Themes.php
@@ -1351,6 +1351,8 @@ function InstallCopy()
 		'/index.php',
 		'/index.template.php',
 		'/css/admin.css',
+		'/css/calendar.css',
+		'/css/calendar.rtl.css',
 		'/css/index.css',
 		'/css/responsive.css',
 		'/css/rtl.css',


### PR DESCRIPTION
- Create languages dir with the Settings.english.php file
- Remove unnecessary files that might confuse a new theme author:
  - _calendar.css_
  - _calendar.rtl.css_
  - _slider.min.css_
These files are not usually modified and can just override their elements from index.css or similar. Can also manually include them in their themes and directly modify it if they require it.