### PR TITLE
Improve the hooks list

### DIFF
--- a/Sources/ManageMaintenance.php
+++ b/Sources/ManageMaintenance.php
@@ -2225,7 +2225,7 @@ function get_defined_functions_in_file(string $file): array
 {
 	$source = file_get_contents($file);
 	// token_get_all() is too slow so use a nice little regex instead.
-	preg_match_all('/^namespace\s([a-z\\\]++)\s*;|class\s+(\w++)[\w\s]*{|function\s+(\w++)\s*\(.*\)[:\|\w\s]*{/im', $source, $matches, PREG_SET_ORDER);
+	preg_match_all('/\bnamespace\s++((?P>label)(?:\\\(?P>label))*+)\s*+;|\bclass\s++((?P>label))[\w\s]*+{|\bfunction\s++((?P>label))\s*+\(.*\)[:\|\w\s]*+{(?(DEFINE)(?<label>[a-zA-Z_\x80-\xff][a-zA-Z0-9_\x80-\xff]*+))/i', $source, $matches, PREG_SET_ORDER);
 
 	$functions = array();
 	$namespace = '';

--- a/Sources/Subs-List.php
+++ b/Sources/Subs-List.php
@@ -79,7 +79,7 @@ function createList($listOptions)
 	else
 	{
 		// First get an impression of how many items to expect.
-		if (!empty($listOptions['get_count']['value']) && ctype_digit($listOptions['get_count']['value']))
+		if (!empty($listOptions['get_count']['value']) && (is_int($listOptions['get_count']['value']) || ctype_digit($listOptions['get_count']['value'])))
 			$list_context['total_num_items'] = $listOptions['get_count']['value'];
 
 		else

--- a/Sources/Subs-List.php
+++ b/Sources/Subs-List.php
@@ -79,7 +79,7 @@ function createList($listOptions)
 	else
 	{
 		// First get an impression of how many items to expect.
-		if (!empty($listOptions['get_count']['value']) && (is_int($listOptions['get_count']['value']) || ctype_digit($listOptions['get_count']['value'])))
+		if (isset($listOptions['get_count']['value']) && (is_int($listOptions['get_count']['value']) || ctype_digit($listOptions['get_count']['value'])))
 			$list_context['total_num_items'] = $listOptions['get_count']['value'];
 
 		else


### PR DESCRIPTION
- Greatly reduces the number of calls to `file_exists()` because it's kinda slow on Windows
- Fix sorting
- Functions with the same name but have different namespaces, classes, are now resolved correctly

The previous name resolution algorithm saws tightly wound in several loops (`num_files * nun_hooks *, num_functions`) and therefore could note scale at all. This is now changed so that all filesystem operations are outside of the main loops.

Filesystem operations on Windows can be a bit slow,    (NTFS) even with a SSD. So build a list of files from `$sourcedir` and use that to check for file existence before resorting to reading the disk.

Signed-off-by: John Rayes <live627@gmail.com>