### PR TITLE
Fix quoting smileys when quoting selected text

### DIFF
--- a/Themes/default/scripts/quotedText.js
+++ b/Themes/default/scripts/quotedText.js
@@ -84,6 +84,9 @@ function quotedTextClick(oOptions)
 				ajax_indicator(false);
 			},
 			success: function (data, textStatus, xhr) {
+				// Convert all smileys from images back to smiley code
+				oOptions.text = oOptions.text.replaceAll(/<img src=".*?" alt="(.*?)" title=".*?" class="smiley">/, '$1');
+
 				// Search the xml data to get the quote tag.
 				text = $(data).find('quote').text();
 


### PR DESCRIPTION
Convert smiley images back to the smiley code when
quoting selected text.

Fixes #7117

Signed-off-by: Oscar Rydhé <oscar.rydhe@gmail.com>