### PR TITLE
Update Subs-Themes.php

### DIFF
--- a/Sources/Subs-Themes.php
+++ b/Sources/Subs-Themes.php
@@ -271,6 +271,7 @@ function get_theme_info($path)
 	$install_versions = $theme_info_xml->fetch('theme-info/install/@for');
 
 	// The theme isn't compatible with the current SMF version.
+	require_once($sourcedir . '/Subs-Package.php');
 	if (!$install_versions || !matchPackageVersion($the_version, $install_versions))
 	{
 		remove_dir($path);


### PR DESCRIPTION
Manual calls to get_theme_info() would error out because it calls matchPackageVersion() without ensuring that Subs-Package.php is loaded first.

Fix #7112

Signed-off-by: John Rayes <live627@gmail.com>