### PR TITLE
Fix error with allow_xhjr_credentials not being defined in 3rd party scripting.

### DIFF
--- a/Sources/ManageNews.php
+++ b/Sources/ManageNews.php
@@ -236,7 +236,7 @@ function EditNews()
 									"X-SMF-AJAX": 1
 								},
 								xhrFields: {
-									withCredentials: allow_xhjr_credentials
+									withCredentials: typeof allow_xhjr_credentials !== "undefined" ? allow_xhjr_credentials : false
 								},
 								url: "' . $scripturl . '?action=xmlhttp;sa=previews;xml",
 								data: {item: "newspreview", news: $("#data_" + preview_id).val()},

--- a/Themes/default/Login.template.php
+++ b/Themes/default/Login.template.php
@@ -105,7 +105,7 @@ function template_login()
 									"X-SMF-AJAX": 1
 								},
 								xhrFields: {
-									withCredentials: allow_xhjr_credentials
+									withCredentials: typeof allow_xhjr_credentials !== "undefined" ? allow_xhjr_credentials : false
 								},
 								data: form.serialize(),
 								success: function(data) {';

--- a/Themes/default/ModerationCenter.template.php
+++ b/Themes/default/ModerationCenter.template.php
@@ -646,7 +646,7 @@ function template_warn_template()
 					"X-SMF-AJAX": 1
 				},
 				xhrFields: {
-					withCredentials: allow_xhjr_credentials
+					withCredentials: typeof allow_xhjr_credentials !== "undefined" ? allow_xhjr_credentials : false
 				},
 				url: "' . $scripturl . '?action=xmlhttp;sa=previews;xml",
 				data: {item: "warning_preview", title: $("#template_title").val(), body: $("#template_body").val(), user: $(\'input[name="u"]\').attr("value")},

--- a/Themes/default/Profile.template.php
+++ b/Themes/default/Profile.template.php
@@ -2515,7 +2515,7 @@ function template_issueWarning()
 					"X-SMF-AJAX": 1
 				},
 				xhrFields: {
-					withCredentials: allow_xhjr_credentials
+					withCredentials: typeof allow_xhjr_credentials !== "undefined" ? allow_xhjr_credentials : false
 				},
 				url: "' . $scripturl . '?action=xmlhttp;sa=previews;xml",
 				data: {item: "warning_preview", title: $("#warn_sub").val(), body: $("#warn_body").val(), issuing: true},

--- a/Themes/default/scripts/mentions.js
+++ b/Themes/default/scripts/mentions.js
@@ -40,7 +40,7 @@ var atwhoConfig = {
 					"X-SMF-AJAX": 1
 				},
 				xhrFields: {
-					withCredentials: allow_xhjr_credentials
+					withCredentials: typeof allow_xhjr_credentials !== "undefined" ? allow_xhjr_credentials : false
 				},
 				data: {
 					search: query,

--- a/Themes/default/scripts/profile.js
+++ b/Themes/default/scripts/profile.js
@@ -98,7 +98,7 @@ function ajax_getSignaturePreview (showPreview)
 			"X-SMF-AJAX": 1
 		},
 		xhrFields: {
-			withCredentials: allow_xhjr_credentials
+			withCredentials: typeof allow_xhjr_credentials !== "undefined" ? allow_xhjr_credentials : false
 		},
 		data: {item: "sig_preview", signature: $("#signature").val(), user: $('input[name="u"]').attr("value")},
 		context: document.body,

--- a/Themes/default/scripts/quotedText.js
+++ b/Themes/default/scripts/quotedText.js
@@ -74,7 +74,7 @@ function quotedTextClick(oOptions)
 				"X-SMF-AJAX": 1
 			},
 			xhrFields: {
-				withCredentials: allow_xhjr_credentials
+				withCredentials: typeof allow_xhjr_credentials !== "undefined" ? allow_xhjr_credentials : false
 			},
 			dataType: 'xml',
 			beforeSend: function () {

--- a/Themes/default/scripts/script.js
+++ b/Themes/default/scripts/script.js
@@ -46,7 +46,7 @@ function getServerResponse(sUrl, funcCallback, sType, sDataType)
 			"X-SMF-AJAX": 1
 		},
 		xhrFields: {
-			withCredentials: allow_xhjr_credentials
+			withCredentials: typeof allow_xhjr_credentials !== "undefined" ? allow_xhjr_credentials : false
 		},
 		cache: false,
 		dataType: sDataType,
@@ -71,7 +71,7 @@ function getXMLDocument(sUrl, funcCallback)
 			"X-SMF-AJAX": 1
 		},
 		xhrFields: {
-			withCredentials: allow_xhjr_credentials
+			withCredentials: typeof allow_xhjr_credentials !== "undefined" ? allow_xhjr_credentials : false
 		},
 		cache: false,
 		dataType: 'xml',
@@ -95,7 +95,7 @@ function sendXMLDocument(sUrl, sContent, funcCallback)
 			"X-SMF-AJAX": 1
 		},
 		xhrFields: {
-			withCredentials: allow_xhjr_credentials
+			withCredentials: typeof allow_xhjr_credentials !== "undefined" ? allow_xhjr_credentials : false
 		},
 		data: sContent,
 		beforeSend: function(xhr) {
@@ -352,7 +352,7 @@ function reqOverlayDiv(desktopURL, sHeader, sIcon)
 			'X-SMF-AJAX': 1
 		},
 		xhrFields: {
-			withCredentials: allow_xhjr_credentials
+			withCredentials: typeof allow_xhjr_credentials !== "undefined" ? allow_xhjr_credentials : false
 		},
 		type: "GET",
 		dataType: "html",
@@ -421,7 +421,7 @@ smc_PopupMenu.prototype.open = function (sItem)
 				'X-SMF-AJAX': 1
 			},
 			xhrFields: {
-				withCredentials: allow_xhjr_credentials
+				withCredentials: typeof allow_xhjr_credentials !== "undefined" ? allow_xhjr_credentials : false
 			},
 			type: "GET",
 			dataType: "html",

--- a/Themes/default/scripts/smf_fileUpload.js
+++ b/Themes/default/scripts/smf_fileUpload.js
@@ -200,7 +200,7 @@ function smf_fileUpload(oOptions) {
 							"X-SMF-AJAX": 1
 						},
 						xhrFields: {
-							withCredentials: allow_xhjr_credentials
+							withCredentials: typeof allow_xhjr_credentials !== "undefined" ? allow_xhjr_credentials : false
 						},
 						dataType: 'json',
 						beforeSend: function () {

--- a/Themes/default/scripts/topic.js
+++ b/Themes/default/scripts/topic.js
@@ -730,7 +730,7 @@ $(function() {
 				"X-SMF-AJAX": 1
 			},
 			xhrFields: {
-				withCredentials: allow_xhjr_credentials
+				withCredentials: typeof allow_xhjr_credentials !== "undefined" ? allow_xhjr_credentials : false
 			},
 			cache: false,
 			dataType: 'html',


### PR DESCRIPTION
Ensure if allow_xhjr_credentials is not defined we default too false, which should prevent scripting errors on 3rd party APIs that are using SMF components.

We don't need to merge this until after 2.1.0, but it would be ideal.