### PR TITLE
Fix handling of external avatars with parse_iri (fixes #7139)

### DIFF
--- a/Sources/Load.php
+++ b/Sources/Load.php
@@ -3883,7 +3883,10 @@ function set_avatar_data($data = array())
 
 			// External url.
 			else
-				$image = parse_iri($data['avatar'], PHP_URL_SCHEME) !== null ? get_proxied_url($data['avatar']) : $modSettings['avatar_url'] . '/' . $data['avatar'];
+			{
+				$parsed_image = parse_iri($data['avatar']. PHP_URL_SCHEME);
+				$image = is_array($parsed_image) ? get_proxied_url($data['avatar']) : $modSettings['avatar_url'] . '/' . $data['avatar'];
+			}
 		}
 
 		// Perhaps this user has an attachment as avatar...


### PR DESCRIPTION
The code expected a return of "null" from parse_iri (which the old parse_url call would do if there was no scheme in the given string), but parse_iri will return a string if there's no scheme rather than null Since we know it will be an array when there's a scheme, we can just check whether the function returned an array. Fixes #7139 

Signed-off-by: Michael Eshom <oldiesmann@gmail.com>