### PR TITLE
Fix comment in emails about reported messages

### DIFF
--- a/Sources/ReportToMod.php
+++ b/Sources/ReportToMod.php
@@ -307,7 +307,7 @@ function reportPost($msg, $reason)
 	// Now just add our report...
 	if ($id_report)
 	{
-		$smcFunc['db_insert']('',
+		$id_comment = $smcFunc['db_insert']('',
 			'{db_prefix}log_reported_comments',
 			array(
 				'id_report' => 'int', 'id_member' => 'int', 'membername' => 'string',
@@ -317,7 +317,8 @@ function reportPost($msg, $reason)
 				$id_report, $user_info['id'], $user_info['name'],
 				$user_info['ip'], $reason, time(),
 			),
-			array('id_comment')
+			array('id_comment'),
+			1
 		);
 
 		// And get ready to notify people.
@@ -332,6 +333,7 @@ function reportPost($msg, $reason)
 				'sender_id' => $context['user']['id'],
 				'sender_name' => $context['user']['name'],
 				'time' => time(),
+				'comment_id' => $id_comment,
 			)), 0),
 			array('id_task')
 		);

--- a/Sources/tasks/MsgReport-Notify.php
+++ b/Sources/tasks/MsgReport-Notify.php
@@ -155,11 +155,14 @@ class MsgReport_Notify_Background extends SMF_BackgroundTask
 			// Second, get some details that might be nice for the report email.
 			// We don't bother cluttering up the tasks data for this, when it's really no bother to fetch it.
 			$request = $smcFunc['db_query']('', '
-				SELECT lr.subject, lr.membername, lr.body
+				SELECT lr.subject, lr.membername, lrc.comment
 				FROM {db_prefix}log_reported AS lr
-				WHERE id_report = {int:report}',
+					INNER JOIN {db_prefix}log_reported_comments AS lrc ON (lr.id_report = lrc.id_report)
+				WHERE lr.id_report = {int:report}
+					AND lrc.id_comment = {int:comment}',
 				array(
 					'report' => $this->_details['report_id'],
+					'comment' => $this->_details['comment_id'],
 				)
 			);
 			list ($subject, $poster_name, $comment) = $smcFunc['db_fetch_row']($request);


### PR DESCRIPTION
The comment in the email was not the comment left
by the reporter, but the actual message.

Fixes #7149

Signed-off-by: Oscar Rydhé <oscar.rydhe@gmail.com>