### PR TITLE
Fixes two minor bugs with BBC settings templates

### DIFF
--- a/Sources/ManageServer.php
+++ b/Sources/ManageServer.php
@@ -1346,8 +1346,7 @@ function prepareDBSettingContext(&$config_vars)
 
 				$context['bbc_sections'][$bbcSection]['columns'][$col][] = array(
 					'tag' => $tag,
-					// @todo  'tag_' . ?
-					'show_help' => isset($helptxt[$tag]),
+					'show_help' => isset($helptxt['tag_' . $tag]),
 				);
 
 				$i++;

--- a/Themes/default/Admin.template.php
+++ b/Themes/default/Admin.template.php
@@ -941,7 +941,7 @@ function template_show_settings()
 				{
 					echo '
 										<fieldset id="', $config_var['name'], '">
-											<legend>', $txt['enabled_bbc_select'], '</legend>
+											<legend>', $context['bbc_sections'][$config_var['name']]['title'], '</legend>
 											<ul>';
 
 					foreach ($context['bbc_sections'][$config_var['name']]['columns'] as $bbcColumn)


### PR DESCRIPTION
1. Uses correct legend for BBCode selection settings
2. Uses correct logic for showing helptxt link for individual BBCodes in the BBCode selection box.