### PR TITLE
Forum Maintenance Related fixes

### DIFF
--- a/Sources/ManageMaintenance.php
+++ b/Sources/ManageMaintenance.php
@@ -815,11 +815,10 @@ function AdminBoardRecount()
 	checkSession('request');
 
 	// validate the request or the loop
-	if (!isset($_REQUEST['step']))
-		validateToken('admin-maint');
-	else
-		validateToken('admin-boardrecount');
-
+	validateToken(!isset($_REQUEST['step']) ? 'admin-maint' : 'admin-boardrecount');
+	$context['not_done_token'] = 'admin-boardrecount';
+	createToken($context['not_done_token']);
+	
 	$context['page_title'] = $txt['not_done_title'];
 	$context['continue_post_data'] = '';
 	$context['continue_countdown'] = 3;
@@ -911,9 +910,6 @@ function AdminBoardRecount()
 
 			if (microtime(true) - TIME_START > 3)
 			{
-				createToken('admin-boardrecount');
-				$context['continue_post_data'] = '<input type="hidden" name="' . $context['admin-boardrecount_token_var'] . '" value="' . $context['admin-boardrecount_token'] . '">';
-
 				$context['continue_get_data'] = '?action=admin;area=maintain;sa=routine;activity=recount;step=0;start=' . $_REQUEST['start'] . ';' . $context['session_var'] . '=' . $context['session_id'];
 				$context['continue_percent'] = round((100 * $_REQUEST['start'] / $max_topics) / $total_steps);
 
@@ -969,9 +965,6 @@ function AdminBoardRecount()
 
 			if (microtime(true) - TIME_START > 3)
 			{
-				createToken('admin-boardrecount');
-				$context['continue_post_data'] = '<input type="hidden" name="' . $context['admin-boardrecount_token_var'] . '" value="' . $context['admin-boardrecount_token'] . '">';
-
 				$context['continue_get_data'] = '?action=admin;area=maintain;sa=routine;activity=recount;step=1;start=' . $_REQUEST['start'] . ';' . $context['session_var'] . '=' . $context['session_id'];
 				$context['continue_percent'] = round((200 + 100 * $_REQUEST['start'] / $max_topics) / $total_steps);
 
@@ -1025,9 +1018,6 @@ function AdminBoardRecount()
 
 			if (microtime(true) - TIME_START > 3)
 			{
-				createToken('admin-boardrecount');
-				$context['continue_post_data'] = '<input type="hidden" name="' . $context['admin-boardrecount_token_var'] . '" value="' . $context['admin-boardrecount_token'] . '">';
-
 				$context['continue_get_data'] = '?action=admin;area=maintain;sa=routine;activity=recount;step=2;start=' . $_REQUEST['start'] . ';' . $context['session_var'] . '=' . $context['session_id'];
 				$context['continue_percent'] = round((300 + 100 * $_REQUEST['start'] / $max_topics) / $total_steps);
 
@@ -1081,9 +1071,6 @@ function AdminBoardRecount()
 
 			if (microtime(true) - TIME_START > 3)
 			{
-				createToken('admin-boardrecount');
-				$context['continue_post_data'] = '<input type="hidden" name="' . $context['admin-boardrecount_token_var'] . '" value="' . $context['admin-boardrecount_token'] . '">';
-
 				$context['continue_get_data'] = '?action=admin;area=maintain;sa=routine;activity=recount;step=3;start=' . $_REQUEST['start'] . ';' . $context['session_var'] . '=' . $context['session_id'];
 				$context['continue_percent'] = round((400 + 100 * $_REQUEST['start'] / $max_topics) / $total_steps);
 
@@ -1137,9 +1124,6 @@ function AdminBoardRecount()
 
 			if (microtime(true) - TIME_START > 3)
 			{
-				createToken('admin-boardrecount');
-				$context['continue_post_data'] = '<input type="hidden" name="' . $context['admin-boardrecount_token_var'] . '" value="' . $context['admin-boardrecount_token'] . '">';
-
 				$context['continue_get_data'] = '?action=admin;area=maintain;sa=routine;activity=recount;step=4;start=' . $_REQUEST['start'] . ';' . $context['session_var'] . '=' . $context['session_id'];
 				$context['continue_percent'] = round((500 + 100 * $_REQUEST['start'] / $max_topics) / $total_steps);
 
@@ -1186,9 +1170,6 @@ function AdminBoardRecount()
 
 		if (microtime(true) - TIME_START > 3)
 		{
-			createToken('admin-boardrecount');
-			$context['continue_post_data'] = '<input type="hidden" name="' . $context['admin-boardrecount_token_var'] . '" value="' . $context['admin-boardrecount_token'] . '">';
-
 			$context['continue_get_data'] = '?action=admin;area=maintain;sa=routine;activity=recount;step=6;start=0;' . $context['session_var'] . '=' . $context['session_id'];
 			$context['continue_percent'] = round(700 / $total_steps);
 
@@ -1233,9 +1214,6 @@ function AdminBoardRecount()
 
 			if (microtime(true) - TIME_START > 3)
 			{
-				createToken('admin-boardrecount');
-				$context['continue_post_data'] = '<input type="hidden" name="' . $context['admin-boardrecount_token_var'] . '" value="' . $context['admin-boardrecount_token'] . '">';
-
 				$context['continue_get_data'] = '?action=admin;area=maintain;sa=routine;activity=recount;step=6;start=' . $_REQUEST['start'] . ';' . $context['session_var'] . '=' . $context['session_id'];
 				$context['continue_percent'] = round((700 + 100 * $_REQUEST['start'] / $modSettings['maxMsgID']) / $total_steps);
 

--- a/Sources/Session.php
+++ b/Sources/Session.php
@@ -180,14 +180,14 @@ function sessionWrite($session_id, $data)
 	}
 
 	// If an insert fails due to a dupe, replace the existing session...
-	$smcFunc['db_insert']('replace',
+	$session_update = $smcFunc['db_insert']('replace',
 		'{db_prefix}sessions',
 		array('session_id' => 'string', 'data' => 'string', 'last_update' => 'int'),
 		array($session_id, $data, time()),
 		array('session_id')
 	);
 
-	return ($smcFunc['db_affected_rows']() == 0 ? false : true);
+	return ($smcFunc['db_affected_rows']($session_update) == 0 ? false : true);
 }
 
 /**
@@ -231,7 +231,7 @@ function sessionGC($max_lifetime)
 		$max_lifetime = max($modSettings['databaseSession_lifetime'], 60);
 
 	// Clean up after yerself ;).
-	$smcFunc['db_query']('', '
+	$session_update = $smcFunc['db_query']('', '
 		DELETE FROM {db_prefix}sessions
 		WHERE last_update < {int:last_update}',
 		array(
@@ -239,7 +239,7 @@ function sessionGC($max_lifetime)
 		)
 	);
 
-	return ($smcFunc['db_affected_rows']() == 0 ? false : true);
+	return ($smcFunc['db_affected_rows']($session_update) == 0 ? false : true);
 }
 
 ?>


### PR DESCRIPTION
Fix token issues related to session updates issues (Fixes #7150)
On sessions, keep a $session_update variable, to ensure we get the correct db_affected_rows result.
Repair boards we add some logic for:
1. If we determine we are low on memory (currently less than 64 mb), we will pause.
2. If we have a lot of errors (100k or more), we decrease the step sizes, as session and other variables will start to take more memory to work with.  So try to do stuff in smaller batches so we are more efficient on memory.
3. Add some code to allow us in the future to call the repair boar process from a 3rd party script.  This is currently error prone and needs more logic work possibly.  But if we get it working, it will let big boards call a script via a dedicated job/cron script.