### PR TITLE
Adds "Rebuild Settings.php" maintenance task

### DIFF
--- a/Sources/ManageMaintenance.php
+++ b/Sources/ManageMaintenance.php
@@ -52,6 +52,7 @@ function ManageMaintenance()
 				'version' => 'VersionDetail',
 				'repair' => 'MaintainFindFixErrors',
 				'recount' => 'AdminBoardRecount',
+				'rebuild_settings' => 'RebuildSettingsFile',
 				'logs' => 'MaintainEmptyUnimportantLogs',
 				'cleancache' => 'MaintainCleanCache',
 			),
@@ -154,8 +155,8 @@ function MaintainRoutine()
 {
 	global $context, $txt;
 
-	if (isset($_GET['done']) && $_GET['done'] == 'recount')
-		$context['maintenance_finished'] = $txt['maintain_recount'];
+	if (isset($_GET['done']) && in_array($_GET['done'], array('recount', 'rebuild_settings')))
+		$context['maintenance_finished'] = $txt['maintain_' . $_GET['done']];
 }
 
 /**
@@ -1821,6 +1822,18 @@ function MaintainRecountPosts()
 	unset($_SESSION['total_members']);
 	$context['maintenance_finished'] = $txt['maintain_recountposts'];
 	redirectexit('action=admin;area=maintain;sa=members;done=recountposts');
+}
+
+function RebuildSettingsFile()
+{
+	global $sourcedir;
+
+	isAllowedTo('admin_forum');
+
+	require_once($sourcedir . '/Subs-Admin.php');
+	updateSettingsFile(array(), false, true);
+
+	redirectexit('action=admin;area=maintain;sa=routine;done=rebuild_settings');
 }
 
 /**

--- a/Sources/Subs-Admin.php
+++ b/Sources/Subs-Admin.php
@@ -1168,6 +1168,7 @@ function updateSettingsFile($config_vars, $keep_quotes = null, $rebuild = false)
 				else
 				{
 					$replacement = '';
+					$substitutions[$var]['placeholder'] = '';
 
 					// This is just for cosmetic purposes. Removes the blank line.
 					$substitutions[$var]['search_pattern'] = str_replace('(?<=^|\s)', '\n?', $substitutions[$var]['search_pattern']);

--- a/Themes/default/ManageMaintenance.template.php
+++ b/Themes/default/ManageMaintenance.template.php
@@ -131,6 +131,18 @@ function template_maintain_routine()
 			</form>
 		</div>
 		<div class="cat_bar">
+			<h3 class="catbg">', $txt['maintain_rebuild_settings'], '</h3>
+		</div>
+		<div class="windowbg">
+			<form action="', $scripturl, '?action=admin;area=maintain;sa=routine;activity=rebuild_settings" method="post" accept-charset="', $context['character_set'], '">
+				<p>
+					', $txt['maintain_rebuild_settings_info'], '
+					<input type="submit" value="', $txt['maintain_run_now'], '" class="button">
+					<input type="hidden" name="', $context['session_var'], '" value="', $context['session_id'], '">
+				</p>
+			</form>
+		</div>
+		<div class="cat_bar">
 			<h3 class="catbg">', $txt['maintain_logs'], '</h3>
 		</div>
 		<div class="windowbg">

--- a/Themes/default/languages/ManageMaintenance.english.php
+++ b/Themes/default/languages/ManageMaintenance.english.php
@@ -154,6 +154,8 @@ $txt['maintain_optimize'] = 'Optimize all tables';
 $txt['maintain_optimize_info'] = 'This task allows you to optimize all tables. This will get rid of overhead, effectively making the tables smaller in size and your forum faster.';
 $txt['maintain_version'] = 'Check all files against current versions';
 $txt['maintain_version_info'] = 'This maintenance task allows you to do a detailed version check of all forum files against the official list of latest versions.';
+$txt['maintain_rebuild_settings'] = 'Rebuild Settings.php';
+$txt['maintain_rebuild_settings_info'] = 'This task reconstructs your Settings.php file. It does not change the values stored in the file. Instead, it cleans up and reformats your Settings.php file to a pristine version.';
 $txt['maintain_run_now'] = 'Run task now';
 $txt['maintain_return'] = 'Back to Forum Maintenance';
 


### PR DESCRIPTION
This adds a "Rebuild Settings.php" maintenance task to Administration Center ► Forum Maintenance ► Routine. The task exposes the rebuild functionality of `updateSettingsFile()` so that the admin can use it to tidy up a messy Settings.php file safely and automatically. It is functionally identical to the "Migrate to a new Settings file" option that we provide in the upgrader, except that now the admin can run it at any time.