### PR TITLE
Fixes a few phpdoc-related issues

### DIFF
--- a/Sources/Class-Package.php
+++ b/Sources/Class-Package.php
@@ -137,7 +137,7 @@ class xmlArray
 	 *
 	 * @param $path string The path to the element to get
 	 * @param $return_full bool Whether to return the full result set
-	 * @return xmlArray, a new xmlArray.
+	 * @return xmlArray a new xmlArray.
 	 */
 	public function path($path, $return_full = false)
 	{

--- a/Sources/ManageSearch.php
+++ b/Sources/ManageSearch.php
@@ -483,7 +483,9 @@ function EditSearchMethod()
  * Requires the admin_forum permission.
  * Depending on the size of the message table, the process is divided in steps.
  *
- * @uses template_create_index(), template_create_index_progress(), template_create_index_done()
+ * @uses template_create_index()
+ * @uses template_create_index_progress()
+ * @uses template_create_index_done()
  */
 function CreateMessageIndex()
 {

--- a/Sources/ManageServer.php
+++ b/Sources/ManageServer.php
@@ -1718,7 +1718,7 @@ function loadCacheAPIs()
  * purposely does not use updateSettings.php as it will be called shortly after
  * this process completes by the saveSettings() function.
  *
- * @see Stats.php SMStats() for more information.
+ * @see SMStats() for more information.
  * @link https://www.simplemachines.org/about/stats.php for more info.
  *
  */

--- a/Sources/RepairBoards.php
+++ b/Sources/RepairBoards.php
@@ -1549,7 +1549,7 @@ function loadForumTests()
  * won't have to recheck everything.
  *
  * @param bool $do_fix Whether to actually fix the errors or just return the info
- * @return array, the errors found.
+ * @return array the errors found.
  */
 function findForumErrors($do_fix = false)
 {

--- a/Sources/Subs-Attachments.php
+++ b/Sources/Subs-Attachments.php
@@ -1085,7 +1085,7 @@ function parseAttachBBC($attachID = 0)
  *
  * @param array $attachIDs An array of attachments IDs.
  *
- * @return array.
+ * @return array
  */
 function getRawAttachInfo($attachIDs)
 {
@@ -1131,7 +1131,7 @@ function getRawAttachInfo($attachIDs)
  *
  * @param int $attachID the attachment ID to load info from.
  *
- * @return array.
+ * @return array
  */
 function getAttachMsgInfo($attachID)
 {
@@ -1367,7 +1367,7 @@ function loadAttachmentContext($id_msg, $attachments)
  *
  * @param int array $msgIDs the message ID to load info from.
  *
- * @return void.
+ * @return void
  */
 function prepareAttachsByMsg($msgIDs)
 {

--- a/Sources/Subs-Package.php
+++ b/Sources/Subs-Package.php
@@ -228,14 +228,13 @@ function read_tgz_data($gzfilename, $destination, $single_file = false, $overwri
 }
 
 /**
- * Extract zip data. A functional copy of {@list read_zip_data()}.
+ * Extract zip data. A functional copy of {@list read_zip_data()} using PHP's {@link https://www.php.net/class.phardata PharData} class.
  *
  * @param string $file Input filename
  * @param string $destination Null to display a listing of files in the archive, the destination for the files in the archive or the name of a single file to display (if $single_file is true)
  * @param boolean $single_file If true, returns the contents of the file specified by destination or false if the file can't be found (default value is false).
  * @param boolean $overwrite If true, will overwrite files with newer modication times. Default is false.
  * @param array $files_to_extract Specific files to extract
- * @uses {@link PharData}
  * @return mixed If destination is null, return a short array of a few file details optionally delimited by $files_to_extract. If $single_file is true, return contents of a file as a string; false otherwise
  */
 

--- a/Sources/Who.php
+++ b/Sources/Who.php
@@ -260,7 +260,7 @@ function Who()
  *
  * @param mixed $urls a single url (string) or an array of arrays, each inner array being (JSON-encoded request data, id_member)
  * @param string|bool $preferred_prefix = false
- * @return array, an array of descriptions if you passed an array, otherwise the string describing their current location.
+ * @return array an array of descriptions if you passed an array, otherwise the string describing their current location.
  */
 function determineActions($urls, $preferred_prefix = false)
 {


### PR DESCRIPTION
This fixes a few issues reported by phpdoc (run phpdoc then look at the errors.html file in the reports folder of the output directory), mainly related to commas after param types. Still need to decide what to do about the `@see` tag at smf_db_initiate() in Subs-Db-Postgresql.php as well.

Signed-off-by: Michael Eshom <oldiesmann@gmail.com>