### PR TITLE
Implements smf_strftime

### DIFF
--- a/SSI.php
+++ b/SSI.php
@@ -2293,7 +2293,7 @@ function ssi_recentEvents($max_events = 7, $output_method = 'echo')
 		ORDER BY cal.start_date DESC
 		LIMIT ' . $max_events,
 		array(
-			'current_date' => strftime('%Y-%m-%d', forum_time(false)),
+			'current_date' => smf_strftime('%Y-%m-%d', forum_time(false)),
 			'no_board' => 0,
 		)
 	);
@@ -2308,8 +2308,8 @@ function ssi_recentEvents($max_events = 7, $output_method = 'echo')
 		// Censor the title.
 		censorText($row['title']);
 
-		if ($row['start_date'] < strftime('%Y-%m-%d', forum_time(false)))
-			$date = strftime('%Y-%m-%d', forum_time(false));
+		if ($row['start_date'] < smf_strftime('%Y-%m-%d', forum_time(false)))
+			$date = smf_strftime('%Y-%m-%d', forum_time(false));
 		else
 			$date = $row['start_date'];
 

--- a/Sources/Calendar.php
+++ b/Sources/Calendar.php
@@ -394,7 +394,7 @@ function CalendarPost()
 		$eventDatetimes = getNewEventDatetimes();
 		$context['event'] = array_merge($context['event'], $eventDatetimes);
 
-		$context['event']['last_day'] = (int) strftime('%d', mktime(0, 0, 0, $context['event']['month'] == 12 ? 1 : $context['event']['month'] + 1, 0, $context['event']['month'] == 12 ? $context['event']['year'] + 1 : $context['event']['year']));
+		$context['event']['last_day'] = (int) smf_strftime('%d', mktime(0, 0, 0, $context['event']['month'] == 12 ? 1 : $context['event']['month'] + 1, 0, $context['event']['month'] == 12 ? $context['event']['year'] + 1 : $context['event']['year']));
 	}
 	else
 	{

--- a/Sources/Logging.php
+++ b/Sources/Logging.php
@@ -349,7 +349,7 @@ function trackStats($stats = array())
 
 	$setStringUpdate = '';
 	$insert_keys = array();
-	$date = strftime('%Y-%m-%d', forum_time(false));
+	$date = smf_strftime('%Y-%m-%d', forum_time(false));
 	$update_parameters = array(
 		'current_date' => $date,
 	);

--- a/Sources/ManageCalendar.php
+++ b/Sources/ManageCalendar.php
@@ -229,7 +229,7 @@ function EditHoliday()
 			);
 		else
 		{
-			$date = strftime($_REQUEST['year'] <= 1004 ? '1004-%m-%d' : '%Y-%m-%d', mktime(0, 0, 0, $_REQUEST['month'], $_REQUEST['day'], $_REQUEST['year']));
+			$date = smf_strftime($_REQUEST['year'] <= 1004 ? '1004-%m-%d' : '%Y-%m-%d', mktime(0, 0, 0, $_REQUEST['month'], $_REQUEST['day'], $_REQUEST['year']));
 			if (isset($_REQUEST['edit']))
 				$smcFunc['db_query']('', '
 					UPDATE {db_prefix}calendar_holidays
@@ -297,7 +297,7 @@ function EditHoliday()
 	}
 
 	// Last day for the drop down?
-	$context['holiday']['last_day'] = (int) strftime('%d', mktime(0, 0, 0, $context['holiday']['month'] == 12 ? 1 : $context['holiday']['month'] + 1, 0, $context['holiday']['month'] == 12 ? $context['holiday']['year'] + 1 : $context['holiday']['year']));
+	$context['holiday']['last_day'] = (int) smf_strftime('%d', mktime(0, 0, 0, $context['holiday']['month'] == 12 ? 1 : $context['holiday']['month'] + 1, 0, $context['holiday']['month'] == 12 ? $context['holiday']['year'] + 1 : $context['holiday']['year']));
 }
 
 /**

--- a/Sources/ManagePaid.php
+++ b/Sources/ManagePaid.php
@@ -1270,25 +1270,25 @@ function ModifyUserSubscription()
 		$context['sub'] = array(
 			'id' => 0,
 			'start' => array(
-				'year' => (int) strftime('%Y', time()),
-				'month' => (int) strftime('%m', time()),
-				'day' => (int) strftime('%d', time()),
-				'hour' => (int) strftime('%H', time()),
-				'min' => (int) strftime('%M', time()) < 10 ? '0' . (int) strftime('%M', time()) : (int) strftime('%M', time()),
+				'year' => (int) smf_strftime('%Y', time()),
+				'month' => (int) smf_strftime('%m', time()),
+				'day' => (int) smf_strftime('%d', time()),
+				'hour' => (int) smf_strftime('%H', time()),
+				'min' => (int) smf_strftime('%M', time()) < 10 ? '0' . (int) smf_strftime('%M', time()) : (int) smf_strftime('%M', time()),
 				'last_day' => 0,
 			),
 			'end' => array(
-				'year' => (int) strftime('%Y', time()),
-				'month' => (int) strftime('%m', time()),
-				'day' => (int) strftime('%d', time()),
-				'hour' => (int) strftime('%H', time()),
-				'min' => (int) strftime('%M', time()) < 10 ? '0' . (int) strftime('%M', time()) : (int) strftime('%M', time()),
+				'year' => (int) smf_strftime('%Y', time()),
+				'month' => (int) smf_strftime('%m', time()),
+				'day' => (int) smf_strftime('%d', time()),
+				'hour' => (int) smf_strftime('%H', time()),
+				'min' => (int) smf_strftime('%M', time()) < 10 ? '0' . (int) smf_strftime('%M', time()) : (int) smf_strftime('%M', time()),
 				'last_day' => 0,
 			),
 			'status' => 1,
 		);
-		$context['sub']['start']['last_day'] = (int) strftime('%d', mktime(0, 0, 0, $context['sub']['start']['month'] == 12 ? 1 : $context['sub']['start']['month'] + 1, 0, $context['sub']['start']['month'] == 12 ? $context['sub']['start']['year'] + 1 : $context['sub']['start']['year']));
-		$context['sub']['end']['last_day'] = (int) strftime('%d', mktime(0, 0, 0, $context['sub']['end']['month'] == 12 ? 1 : $context['sub']['end']['month'] + 1, 0, $context['sub']['end']['month'] == 12 ? $context['sub']['end']['year'] + 1 : $context['sub']['end']['year']));
+		$context['sub']['start']['last_day'] = (int) smf_strftime('%d', mktime(0, 0, 0, $context['sub']['start']['month'] == 12 ? 1 : $context['sub']['start']['month'] + 1, 0, $context['sub']['start']['month'] == 12 ? $context['sub']['start']['year'] + 1 : $context['sub']['start']['year']));
+		$context['sub']['end']['last_day'] = (int) smf_strftime('%d', mktime(0, 0, 0, $context['sub']['end']['month'] == 12 ? 1 : $context['sub']['end']['month'] + 1, 0, $context['sub']['end']['month'] == 12 ? $context['sub']['end']['year'] + 1 : $context['sub']['end']['year']));
 
 		if (isset($_GET['uid']))
 		{
@@ -1395,26 +1395,26 @@ function ModifyUserSubscription()
 		$context['sub'] = array(
 			'id' => 0,
 			'start' => array(
-				'year' => (int) strftime('%Y', $row['start_time']),
-				'month' => (int) strftime('%m', $row['start_time']),
-				'day' => (int) strftime('%d', $row['start_time']),
-				'hour' => (int) strftime('%H', $row['start_time']),
-				'min' => (int) strftime('%M', $row['start_time']) < 10 ? '0' . (int) strftime('%M', $row['start_time']) : (int) strftime('%M', $row['start_time']),
+				'year' => (int) smf_strftime('%Y', $row['start_time']),
+				'month' => (int) smf_strftime('%m', $row['start_time']),
+				'day' => (int) smf_strftime('%d', $row['start_time']),
+				'hour' => (int) smf_strftime('%H', $row['start_time']),
+				'min' => (int) smf_strftime('%M', $row['start_time']) < 10 ? '0' . (int) smf_strftime('%M', $row['start_time']) : (int) smf_strftime('%M', $row['start_time']),
 				'last_day' => 0,
 			),
 			'end' => array(
-				'year' => (int) strftime('%Y', $row['end_time']),
-				'month' => (int) strftime('%m', $row['end_time']),
-				'day' => (int) strftime('%d', $row['end_time']),
-				'hour' => (int) strftime('%H', $row['end_time']),
-				'min' => (int) strftime('%M', $row['end_time']) < 10 ? '0' . (int) strftime('%M', $row['end_time']) : (int) strftime('%M', $row['end_time']),
+				'year' => (int) smf_strftime('%Y', $row['end_time']),
+				'month' => (int) smf_strftime('%m', $row['end_time']),
+				'day' => (int) smf_strftime('%d', $row['end_time']),
+				'hour' => (int) smf_strftime('%H', $row['end_time']),
+				'min' => (int) smf_strftime('%M', $row['end_time']) < 10 ? '0' . (int) smf_strftime('%M', $row['end_time']) : (int) smf_strftime('%M', $row['end_time']),
 				'last_day' => 0,
 			),
 			'status' => $row['status'],
 			'username' => $row['username'],
 		);
-		$context['sub']['start']['last_day'] = (int) strftime('%d', mktime(0, 0, 0, $context['sub']['start']['month'] == 12 ? 1 : $context['sub']['start']['month'] + 1, 0, $context['sub']['start']['month'] == 12 ? $context['sub']['start']['year'] + 1 : $context['sub']['start']['year']));
-		$context['sub']['end']['last_day'] = (int) strftime('%d', mktime(0, 0, 0, $context['sub']['end']['month'] == 12 ? 1 : $context['sub']['end']['month'] + 1, 0, $context['sub']['end']['month'] == 12 ? $context['sub']['end']['year'] + 1 : $context['sub']['end']['year']));
+		$context['sub']['start']['last_day'] = (int) smf_strftime('%d', mktime(0, 0, 0, $context['sub']['start']['month'] == 12 ? 1 : $context['sub']['start']['month'] + 1, 0, $context['sub']['start']['month'] == 12 ? $context['sub']['start']['year'] + 1 : $context['sub']['start']['year']));
+		$context['sub']['end']['last_day'] = (int) smf_strftime('%d', mktime(0, 0, 0, $context['sub']['end']['month'] == 12 ? 1 : $context['sub']['end']['month'] + 1, 0, $context['sub']['end']['month'] == 12 ? $context['sub']['end']['year'] + 1 : $context['sub']['end']['year']));
 	}
 
 	loadJavaScriptFile('suggest.js', array('defer' => false, 'minimize' => true), 'smf_suggest');

--- a/Sources/ManageSearchEngines.php
+++ b/Sources/ManageSearchEngines.php
@@ -558,7 +558,7 @@ function logSpider()
 	// Attempt to update today's entry.
 	if ($modSettings['spider_mode'] == 1)
 	{
-		$date = strftime('%Y-%m-%d', forum_time(false));
+		$date = smf_strftime('%Y-%m-%d', forum_time(false));
 		$smcFunc['db_query']('', '
 			UPDATE {db_prefix}log_spider_stats
 			SET last_seen = {int:current_time}, page_hits = page_hits + 1
@@ -636,7 +636,7 @@ function consolidateSpiderStats()
 	foreach ($spider_hits as $stat)
 	{
 		// We assume the max date is within the right day.
-		$date = strftime('%Y-%m-%d', $stat['last_seen']);
+		$date = smf_strftime('%Y-%m-%d', $stat['last_seen']);
 		$smcFunc['db_query']('', '
 			UPDATE {db_prefix}log_spider_stats
 			SET page_hits = page_hits + {int:hits},

--- a/Sources/Memberlist.php
+++ b/Sources/Memberlist.php
@@ -635,7 +635,7 @@ function printMemberListRows($request)
 
 		$context['members'][$member] = $memberContext[$member];
 		$context['members'][$member]['post_percent'] = round(($context['members'][$member]['real_posts'] * 100) / $most_posts);
-		$context['members'][$member]['registered_date'] = strftime('%Y-%m-%d', $context['members'][$member]['registered_timestamp']);
+		$context['members'][$member]['registered_date'] = smf_strftime('%Y-%m-%d', $context['members'][$member]['registered_timestamp']);
 
 		if (!empty($context['custom_profile_fields']['columns']))
 		{

--- a/Sources/News.php
+++ b/Sources/News.php
@@ -427,7 +427,7 @@ function buildXmlFeed($xml_format, $xml_data, $feed_meta, $subaction)
 	<title>' . $feed_meta['title'] . '</title>
 	<link rel="alternate" type="text/html" href="' . $feed_meta['source'] . '" />
 	<link rel="self" type="application/atom+xml" href="' . $feed_meta['self'] . '" />
-	<updated>' . gmstrftime('%Y-%m-%dT%H:%M:%SZ') . '</updated>
+	<updated>' . smf_gmstrftime('%Y-%m-%dT%H:%M:%SZ') . '</updated>
 	<id>' . $feed_meta['source'] . '</id>
 	<subtitle>' . $feed_meta['desc'] . '</subtitle>
 	<generator uri="https://www.simplemachines.org" version="' . SMF_VERSION . '">SMF</generator>';
@@ -497,7 +497,7 @@ function buildXmlFeed($xml_format, $xml_data, $feed_meta, $subaction)
 	else
 	{
 		$context['feed']['header'] .= '
-<smf:xml-feed xml:lang="' . strtr($txt['lang_locale'], '_', '-') . '"' . $ns_string . ' version="' . SMF_VERSION . '" forum-name="' . $context['forum_name'] . '" forum-url="' . $scripturl . '"' . (!empty($feed_meta['title']) && $feed_meta['title'] != $context['forum_name'] ? ' title="' . $feed_meta['title'] . '"' : '') . (!empty($feed_meta['desc']) ? ' description="' . $feed_meta['desc'] . '"' : '') . ' source="' . $feed_meta['source'] . '" generated-date-localized="' . strip_tags(timeformat(time(), false, 'forum')) . '" generated-date-UTC="' . gmstrftime('%F %T') . '"' . (!empty($feed_meta['page']) ? ' page="' . $feed_meta['page'] . '"' : '') . '>';
+<smf:xml-feed xml:lang="' . strtr($txt['lang_locale'], '_', '-') . '"' . $ns_string . ' version="' . SMF_VERSION . '" forum-name="' . $context['forum_name'] . '" forum-url="' . $scripturl . '"' . (!empty($feed_meta['title']) && $feed_meta['title'] != $context['forum_name'] ? ' title="' . $feed_meta['title'] . '"' : '') . (!empty($feed_meta['desc']) ? ' description="' . $feed_meta['desc'] . '"' : '') . ' source="' . $feed_meta['source'] . '" generated-date-localized="' . strip_tags(timeformat(time(), false, 'forum')) . '" generated-date-UTC="' . smf_gmstrftime('%F %T') . '"' . (!empty($feed_meta['page']) ? ' page="' . $feed_meta['page'] . '"' : '') . '>';
 
 		// Hard to imagine anyone wanting to add these for the proprietary format, but just in case...
 		$context['feed']['header'] .= $extraFeedTags_string;
@@ -787,11 +787,11 @@ function getXmlMembers($xml_format, $ascending = false)
 					),
 					array(
 						'tag' => 'published',
-						'content' => gmstrftime('%Y-%m-%dT%H:%M:%SZ', $row['date_registered']),
+						'content' => smf_gmstrftime('%Y-%m-%dT%H:%M:%SZ', $row['date_registered']),
 					),
 					array(
 						'tag' => 'updated',
-						'content' => gmstrftime('%Y-%m-%dT%H:%M:%SZ', $row['last_login']),
+						'content' => smf_gmstrftime('%Y-%m-%dT%H:%M:%SZ', $row['last_login']),
 					),
 					array(
 						'tag' => 'id',
@@ -813,7 +813,7 @@ function getXmlMembers($xml_format, $ascending = false)
 					),
 					array(
 						'tag' => 'time',
-						'attributes' => array('label' => $txt['date_registered'], 'UTC' => gmstrftime('%F %T', $row['date_registered'])),
+						'attributes' => array('label' => $txt['date_registered'], 'UTC' => smf_gmstrftime('%F %T', $row['date_registered'])),
 						'content' => $smcFunc['htmlspecialchars'](strip_tags(timeformat($row['date_registered'], false, 'forum'))),
 					),
 					array(
@@ -1116,11 +1116,11 @@ function getXmlNews($xml_format, $ascending = false)
 					),
 					array(
 						'tag' => 'published',
-						'content' => gmstrftime('%Y-%m-%dT%H:%M:%SZ', $row['poster_time']),
+						'content' => smf_gmstrftime('%Y-%m-%dT%H:%M:%SZ', $row['poster_time']),
 					),
 					array(
 						'tag' => 'updated',
-						'content' => gmstrftime('%Y-%m-%dT%H:%M:%SZ', empty($row['modified_time']) ? $row['poster_time'] : $row['modified_time']),
+						'content' => smf_gmstrftime('%Y-%m-%dT%H:%M:%SZ', empty($row['modified_time']) ? $row['poster_time'] : $row['modified_time']),
 					),
 					array(
 						'tag' => 'id',
@@ -1189,7 +1189,7 @@ function getXmlNews($xml_format, $ascending = false)
 				'content' => array(
 					array(
 						'tag' => 'time',
-						'attributes' => array('label' => $txt['date'], 'UTC' => gmstrftime('%F %T', $row['poster_time'])),
+						'attributes' => array('label' => $txt['date'], 'UTC' => smf_gmstrftime('%F %T', $row['poster_time'])),
 						'content' => $smcFunc['htmlspecialchars'](strip_tags(timeformat($row['poster_time'], false, 'forum'))),
 					),
 					array(
@@ -1576,11 +1576,11 @@ function getXmlRecent($xml_format)
 					),
 					array(
 						'tag' => 'published',
-						'content' => gmstrftime('%Y-%m-%dT%H:%M:%SZ', $row['poster_time']),
+						'content' => smf_gmstrftime('%Y-%m-%dT%H:%M:%SZ', $row['poster_time']),
 					),
 					array(
 						'tag' => 'updated',
-						'content' => gmstrftime('%Y-%m-%dT%H:%M:%SZ', empty($row['modified_time']) ? $row['poster_time'] : $row['modified_time']),
+						'content' => smf_gmstrftime('%Y-%m-%dT%H:%M:%SZ', empty($row['modified_time']) ? $row['poster_time'] : $row['modified_time']),
 					),
 					array(
 						'tag' => 'id',
@@ -1649,7 +1649,7 @@ function getXmlRecent($xml_format)
 				'content' => array(
 					array(
 						'tag' => 'time',
-						'attributes' => array('label' => $txt['date'], 'UTC' => gmstrftime('%F %T', $row['poster_time'])),
+						'attributes' => array('label' => $txt['date'], 'UTC' => smf_gmstrftime('%F %T', $row['poster_time'])),
 						'content' => $smcFunc['htmlspecialchars'](strip_tags(timeformat($row['poster_time'], false, 'forum'))),
 					),
 					array(
@@ -1908,11 +1908,11 @@ function getXmlProfile($xml_format)
 				),
 				array(
 					'tag' => 'published',
-					'content' => gmstrftime('%Y-%m-%dT%H:%M:%SZ', $profile['registered_timestamp']),
+					'content' => smf_gmstrftime('%Y-%m-%dT%H:%M:%SZ', $profile['registered_timestamp']),
 				),
 				array(
 					'tag' => 'updated',
-					'content' => gmstrftime('%Y-%m-%dT%H:%M:%SZ', $profile['last_login_timestamp']),
+					'content' => smf_gmstrftime('%Y-%m-%dT%H:%M:%SZ', $profile['last_login_timestamp']),
 				),
 				array(
 					'tag' => 'id',
@@ -1962,12 +1962,12 @@ function getXmlProfile($xml_format)
 			),
 			array(
 				'tag' => 'last-login',
-				'attributes' => array('label' => $txt['lastLoggedIn'], 'UTC' => gmstrftime('%F %T', $profile['last_login_timestamp'])),
+				'attributes' => array('label' => $txt['lastLoggedIn'], 'UTC' => smf_gmstrftime('%F %T', $profile['last_login_timestamp'])),
 				'content' => timeformat($profile['last_login_timestamp'], false, 'forum'),
 			),
 			array(
 				'tag' => 'registered',
-				'attributes' => array('label' => $txt['date_registered'], 'UTC' => gmstrftime('%F %T', $profile['registered_timestamp'])),
+				'attributes' => array('label' => $txt['date_registered'], 'UTC' => smf_gmstrftime('%F %T', $profile['registered_timestamp'])),
 				'content' => timeformat($profile['registered_timestamp'], false, 'forum'),
 			),
 			array(
@@ -2370,11 +2370,11 @@ function getXmlPosts($xml_format, $ascending = false)
 					),
 					array(
 						'tag' => 'published',
-						'content' => gmstrftime('%Y-%m-%dT%H:%M:%SZ', $row['poster_time']),
+						'content' => smf_gmstrftime('%Y-%m-%dT%H:%M:%SZ', $row['poster_time']),
 					),
 					array(
 						'tag' => 'updated',
-						'content' => gmstrftime('%Y-%m-%dT%H:%M:%SZ', empty($row['modified_time']) ? $row['poster_time'] : $row['modified_time']),
+						'content' => smf_gmstrftime('%Y-%m-%dT%H:%M:%SZ', empty($row['modified_time']) ? $row['poster_time'] : $row['modified_time']),
 					),
 					array(
 						'tag' => 'id',
@@ -2542,12 +2542,12 @@ function getXmlPosts($xml_format, $ascending = false)
 					),
 					array(
 						'tag' => 'time',
-						'attributes' => array('label' => $txt['date'], 'UTC' => gmstrftime('%F %T', $row['poster_time'])),
+						'attributes' => array('label' => $txt['date'], 'UTC' => smf_gmstrftime('%F %T', $row['poster_time'])),
 						'content' => $smcFunc['htmlspecialchars'](strip_tags(timeformat($row['poster_time'], false, 'forum'))),
 					),
 					array(
 						'tag' => 'modified_time',
-						'attributes' => !empty($row['modified_time']) ? array('label' => $txt['modified_time'], 'UTC' => gmstrftime('%F %T', $row['modified_time'])) : null,
+						'attributes' => !empty($row['modified_time']) ? array('label' => $txt['modified_time'], 'UTC' => smf_gmstrftime('%F %T', $row['modified_time'])) : null,
 						'content' => !empty($row['modified_time']) ? $smcFunc['htmlspecialchars'](strip_tags(timeformat($row['modified_time'], false, 'forum'))) : null,
 					),
 					array(
@@ -2733,7 +2733,7 @@ function getXmlPMs($xml_format, $ascending = false)
 					),
 					array(
 						'tag' => 'updated',
-						'content' => gmstrftime('%Y-%m-%dT%H:%M:%SZ', $row['msgtime']),
+						'content' => smf_gmstrftime('%Y-%m-%dT%H:%M:%SZ', $row['msgtime']),
 					),
 					array(
 						'tag' => 'title',
@@ -2791,7 +2791,7 @@ function getXmlPMs($xml_format, $ascending = false)
 					),
 					array(
 						'tag' => 'sent_date',
-						'attributes' => array('label' => $txt['date'], 'UTC' => gmstrftime('%F %T', $row['msgtime'])),
+						'attributes' => array('label' => $txt['date'], 'UTC' => smf_gmstrftime('%F %T', $row['msgtime'])),
 						'content' => $smcFunc['htmlspecialchars'](strip_tags(timeformat($row['msgtime'], false, 'forum'))),
 					),
 					array(

--- a/Sources/Post.php
+++ b/Sources/Post.php
@@ -328,7 +328,7 @@ function Post($post_errors = array())
 		}
 
 		// Find the last day of the month.
-		$context['event']['last_day'] = (int) strftime('%d', mktime(0, 0, 0, $context['event']['month'] == 12 ? 1 : $context['event']['month'] + 1, 0, $context['event']['month'] == 12 ? $context['event']['year'] + 1 : $context['event']['year']));
+		$context['event']['last_day'] = (int) smf_strftime('%d', mktime(0, 0, 0, $context['event']['month'] == 12 ? 1 : $context['event']['month'] + 1, 0, $context['event']['month'] == 12 ? $context['event']['year'] + 1 : $context['event']['year']));
 
 		// An all day event? Set up some nice defaults in case the user wants to change that
 		if ($context['event']['allday'] == true)

--- a/Sources/Profile-Modify.php
+++ b/Sources/Profile-Modify.php
@@ -137,7 +137,7 @@ function loadProfileFields($force_reload = false)
 		),
 		'date_registered' => array(
 			'type' => 'date',
-			'value' => empty($cur_profile['date_registered']) ? $txt['not_applicable'] : strftime('%Y-%m-%d', $cur_profile['date_registered'] + ($user_info['time_offset'] + $modSettings['time_offset']) * 3600),
+			'value' => empty($cur_profile['date_registered']) ? $txt['not_applicable'] : smf_strftime('%Y-%m-%d', $cur_profile['date_registered'] + ($user_info['time_offset'] + $modSettings['time_offset']) * 3600),
 			'label' => $txt['date_registered'],
 			'log_change' => true,
 			'permission' => 'moderate_forum',
@@ -147,11 +147,11 @@ function loadProfileFields($force_reload = false)
 				if (($value = strtotime($value)) === false)
 				{
 					$value = $cur_profile['date_registered'];
-					return $txt['invalid_registration'] . ' ' . strftime('%d %b %Y ' . (strpos($user_info['time_format'], '%H') !== false ? '%I:%M:%S %p' : '%H:%M:%S'), forum_time(false));
+					return $txt['invalid_registration'] . ' ' . smf_strftime('%d %b %Y ' . (strpos($user_info['time_format'], '%H') !== false ? '%I:%M:%S %p' : '%H:%M:%S'), forum_time(false));
 				}
 
 				// As long as it doesn't equal "N/A"...
-				elseif ($value != $txt['not_applicable'] && $value != strtotime(strftime('%Y-%m-%d', $cur_profile['date_registered'] + ($user_info['time_offset'] + $modSettings['time_offset']) * 3600)))
+				elseif ($value != $txt['not_applicable'] && $value != strtotime(smf_strftime('%Y-%m-%d', $cur_profile['date_registered'] + ($user_info['time_offset'] + $modSettings['time_offset']) * 3600)))
 					$value = $value - ($user_info['time_offset'] + $modSettings['time_offset']) * 3600;
 
 				else
@@ -595,8 +595,8 @@ function loadProfileFields($force_reload = false)
 
 				$context['member']['time_format'] = $cur_profile['time_format'];
 				$context['current_forum_time'] = timeformat(time() - $user_info['time_offset'] * 3600, false);
-				$context['current_forum_time_js'] = strftime('%Y,' . ((int) strftime('%m', time() + $modSettings['time_offset'] * 3600) - 1) . ',%d,%H,%M,%S', time() + $modSettings['time_offset'] * 3600);
-				$context['current_forum_time_hour'] = (int) strftime('%H', forum_time(false));
+				$context['current_forum_time_js'] = smf_strftime('%Y,' . ((int) smf_strftime('%m', time() + $modSettings['time_offset'] * 3600) - 1) . ',%d,%H,%M,%S', time() + $modSettings['time_offset'] * 3600);
+				$context['current_forum_time_hour'] = (int) smf_strftime('%H', forum_time(false));
 				return true;
 			},
 		),

--- a/Sources/Register.php
+++ b/Sources/Register.php
@@ -398,7 +398,7 @@ function Register2()
 
 	// Handle a string as a birthdate...
 	if (isset($_POST['birthdate']) && $_POST['birthdate'] != '')
-		$_POST['birthdate'] = strftime('%Y-%m-%d', strtotime($_POST['birthdate']));
+		$_POST['birthdate'] = smf_strftime('%Y-%m-%d', strtotime($_POST['birthdate']));
 	// Or birthdate parts...
 	elseif (!empty($_POST['bday1']) && !empty($_POST['bday2']))
 		$_POST['birthdate'] = sprintf('%04d-%02d-%02d', empty($_POST['bday3']) ? 0 : (int) $_POST['bday3'], (int) $_POST['bday1'], (int) $_POST['bday2']);

--- a/Sources/Stats.php
+++ b/Sources/Stats.php
@@ -202,7 +202,7 @@ function DisplayStats()
 		}
 	}
 
-	$date = strftime('%Y-%m-%d', forum_time(false));
+	$date = smf_strftime('%Y-%m-%d', forum_time(false));
 
 	// Members online so far today.
 	$result = $smcFunc['db_query']('', '

--- a/Sources/Subs-Calendar.php
+++ b/Sources/Subs-Calendar.php
@@ -382,10 +382,10 @@ function canLinkEvent()
 function getTodayInfo()
 {
 	return array(
-		'day' => (int) strftime('%d', forum_time()),
-		'month' => (int) strftime('%m', forum_time()),
-		'year' => (int) strftime('%Y', forum_time()),
-		'date' => strftime('%Y-%m-%d', forum_time()),
+		'day' => (int) smf_strftime('%d', forum_time()),
+		'month' => (int) smf_strftime('%m', forum_time()),
+		'year' => (int) smf_strftime('%Y', forum_time()),
+		'date' => smf_strftime('%Y-%m-%d', forum_time()),
 	);
 }
 
@@ -904,8 +904,8 @@ function cache_getOffsetIndependentEvents($eventOptions)
 {
 	$days_to_index = $eventOptions['num_days_shown'];
 
-	$low_date = strftime('%Y-%m-%d', forum_time(false) - 24 * 3600);
-	$high_date = strftime('%Y-%m-%d', forum_time(false) + $days_to_index * 24 * 3600);
+	$low_date = smf_strftime('%Y-%m-%d', forum_time(false) - 24 * 3600);
+	$high_date = smf_strftime('%Y-%m-%d', forum_time(false) + $days_to_index * 24 * 3600);
 
 	return array(
 		'data' => array(
@@ -913,7 +913,7 @@ function cache_getOffsetIndependentEvents($eventOptions)
 			'birthdays' => (!empty($eventOptions['include_birthdays']) ? getBirthdayRange($low_date, $high_date) : array()),
 			'events' => (!empty($eventOptions['include_events']) ? getEventRange($low_date, $high_date, false) : array()),
 		),
-		'refresh_eval' => 'return \'' . strftime('%Y%m%d', forum_time(false)) . '\' != strftime(\'%Y%m%d\', forum_time(false)) || (!empty($modSettings[\'calendar_updated\']) && ' . time() . ' < $modSettings[\'calendar_updated\']);',
+		'refresh_eval' => 'return \'' . smf_strftime('%Y%m%d', forum_time(false)) . '\' != smf_strftime(\'%Y%m%d\', forum_time(false)) || (!empty($modSettings[\'calendar_updated\']) && ' . time() . ' < $modSettings[\'calendar_updated\']);',
 		'expires' => time() + 3600,
 	);
 }
@@ -951,8 +951,8 @@ function cache_getRecentEvents($eventOptions)
 		// Holidays between now and now + days.
 		for ($i = $now; $i < $now + $days_for_index; $i += 86400)
 		{
-			if (isset($cached_data['holidays'][strftime('%Y-%m-%d', $i)]))
-				$return_data['calendar_holidays'] = array_merge($return_data['calendar_holidays'], $cached_data['holidays'][strftime('%Y-%m-%d', $i)]);
+			if (isset($cached_data['holidays'][smf_strftime('%Y-%m-%d', $i)]))
+				$return_data['calendar_holidays'] = array_merge($return_data['calendar_holidays'], $cached_data['holidays'][smf_strftime('%Y-%m-%d', $i)]);
 		}
 	}
 
@@ -961,11 +961,11 @@ function cache_getRecentEvents($eventOptions)
 		// Happy Birthday, guys and gals!
 		for ($i = $now; $i < $now + $days_for_index; $i += 86400)
 		{
-			$loop_date = strftime('%Y-%m-%d', $i);
+			$loop_date = smf_strftime('%Y-%m-%d', $i);
 			if (isset($cached_data['birthdays'][$loop_date]))
 			{
 				foreach ($cached_data['birthdays'][$loop_date] as $index => $dummy)
-					$cached_data['birthdays'][strftime('%Y-%m-%d', $i)][$index]['is_today'] = $loop_date === $today['date'];
+					$cached_data['birthdays'][smf_strftime('%Y-%m-%d', $i)][$index]['is_today'] = $loop_date === $today['date'];
 				$return_data['calendar_birthdays'] = array_merge($return_data['calendar_birthdays'], $cached_data['birthdays'][$loop_date]);
 			}
 		}
@@ -977,7 +977,7 @@ function cache_getRecentEvents($eventOptions)
 		for ($i = $now; $i < $now + $days_for_index; $i += 86400)
 		{
 			// Determine the date of the current loop step.
-			$loop_date = strftime('%Y-%m-%d', $i);
+			$loop_date = smf_strftime('%Y-%m-%d', $i);
 
 			// No events today? Check the next day.
 			if (empty($cached_data['events'][$loop_date]))
@@ -1018,7 +1018,7 @@ function cache_getRecentEvents($eventOptions)
 	return array(
 		'data' => $return_data,
 		'expires' => time() + 3600,
-		'refresh_eval' => 'return \'' . strftime('%Y%m%d', forum_time(false)) . '\' != strftime(\'%Y%m%d\', forum_time(false)) || (!empty($modSettings[\'calendar_updated\']) && ' . time() . ' < $modSettings[\'calendar_updated\']);',
+		'refresh_eval' => 'return \'' . smf_strftime('%Y%m%d', forum_time(false)) . '\' != smf_strftime(\'%Y%m%d\', forum_time(false)) || (!empty($modSettings[\'calendar_updated\']) && ' . time() . ' < $modSettings[\'calendar_updated\']);',
 		'post_retri_eval' => '
 			global $context, $scripturl, $user_info;
 
@@ -1440,7 +1440,7 @@ function getEventProperties($event_id)
 		),
 	);
 
-	$return_value['last_day'] = (int) strftime('%d', mktime(0, 0, 0, $return_value['month'] == 12 ? 1 : $return_value['month'] + 1, 0, $return_value['month'] == 12 ? $return_value['year'] + 1 : $return_value['year']));
+	$return_value['last_day'] = (int) smf_strftime('%d', mktime(0, 0, 0, $return_value['month'] == 12 ? 1 : $return_value['month'] + 1, 0, $return_value['month'] == 12 ? $return_value['year'] + 1 : $return_value['year']));
 
 	return $return_value;
 }
@@ -1896,15 +1896,15 @@ function convertDateToEnglish($date)
 	// Find all possible variants of AM and PM for this language.
 	$replacements[strtolower($txt['time_am'])] = 'AM';
 	$replacements[strtolower($txt['time_pm'])] = 'PM';
-	if (($am = strftime('%p', strtotime('01:00:00'))) !== 'p' && $am !== false)
+	if (($am = smf_strftime('%p', strtotime('01:00:00'))) !== 'p' && $am !== false)
 	{
 		$replacements[strtolower($am)] = 'AM';
-		$replacements[strtolower(strftime('%p', strtotime('23:00:00')))] = 'PM';
+		$replacements[strtolower(smf_strftime('%p', strtotime('23:00:00')))] = 'PM';
 	}
-	if (($am = strftime('%P', strtotime('01:00:00'))) !== 'P' && $am !== false)
+	if (($am = smf_strftime('%P', strtotime('01:00:00'))) !== 'P' && $am !== false)
 	{
 		$replacements[strtolower($am)] = 'AM';
-		$replacements[strtolower(strftime('%P', strtotime('23:00:00')))] = 'PM';
+		$replacements[strtolower(smf_strftime('%P', strtotime('23:00:00')))] = 'PM';
 	}
 
 	return strtr(strtolower($date), $replacements);

--- a/Sources/Subs-MembersOnline.php
+++ b/Sources/Subs-MembersOnline.php
@@ -212,7 +212,7 @@ function trackStatsUsersOnline($total_users_online)
 			'mostDate' => time()
 		);
 
-	$date = strftime('%Y-%m-%d', forum_time(false));
+	$date = smf_strftime('%Y-%m-%d', forum_time(false));
 
 	// No entry exists for today yet?
 	if (!isset($modSettings['mostOnlineUpdated']) || $modSettings['mostOnlineUpdated'] != $date)

--- a/Sources/Subs-Package.php
+++ b/Sources/Subs-Package.php
@@ -3091,7 +3091,7 @@ function package_create_backup($id = 'backup')
 			mktree($packagesdir . '/backups', 0777);
 		if (!is_writable($packagesdir . '/backups'))
 			package_chmod($packagesdir . '/backups');
-		$output_file = $packagesdir . '/backups/' . strftime('%Y-%m-%d_') . preg_replace('~[$\\\\/:<>|?*"\']~', '', $id);
+		$output_file = $packagesdir . '/backups/' . smf_strftime('%Y-%m-%d_') . preg_replace('~[$\\\\/:<>|?*"\']~', '', $id);
 		$output_ext = '.tar';
 		$output_ext_target = '.tar.gz';
 

--- a/other/install.php
+++ b/other/install.php
@@ -1733,7 +1733,7 @@ function DeleteInstall()
 	$smcFunc['db_insert']('ignore',
 		'{db_prefix}log_activity',
 		array('date' => 'date', 'topics' => 'int', 'posts' => 'int', 'registers' => 'int'),
-		array(strftime('%Y-%m-%d', time()), 1, 1, (!empty($incontext['member_id']) ? 1 : 0)),
+		array(smf_strftime('%Y-%m-%d', time()), 1, 1, (!empty($incontext['member_id']) ? 1 : 0)),
 		array('date')
 	);
 


### PR DESCRIPTION
Fixes #7167

This avoids calling strftime() and uses PHP's built-in DateTime functions instead.

Obviously, this means smf_strftime() does not use the system's strftime library or locale setting, so results may vary in a few cases from the results of strftime():

 - %a, %A, %b, %B, %p, %P: Output will use SMF's language strings to localize these values. If SMF's language strings have not been loaded, PHP's default English strings will be used.

 - %c, %x, %X: Output will always use ISO format.
