### PR TITLE
Specify memory for upgrader

### DIFF
--- a/other/upgrade.php
+++ b/other/upgrade.php
@@ -113,12 +113,13 @@ $upcontext['steps'] = array(
 );
 // Just to remember which one has files in it.
 $upcontext['database_step'] = 3;
+
+// Secure some resources
 @set_time_limit(600);
-if (!ini_get('safe_mode'))
-{
-	ini_set('mysql.connect_timeout', -1);
-	ini_set('default_socket_timeout', 900);
-}
+@ini_set('mysql.connect_timeout', -1);
+@ini_set('default_socket_timeout', 900);
+@ini_set('memory_limit', '512M');
+
 // Clean the upgrade path if this is from the client.
 if (!empty($_SERVER['argv']) && php_sapi_name() == 'cli' && empty($_SERVER['REMOTE_ADDR']))
 	for ($i = 1; $i < $_SERVER['argc']; $i++)


### PR DESCRIPTION
Fixes #6941 

Sets aside some memory for the upgrader.

While at it, got rid of the safe_mode check, since safe_mode was removed in php 5.4...
