### PR TITLE
Improve handling of funky IP data

### DIFF
--- a/other/upgrade_2-1_mysql.sql
+++ b/other/upgrade_2-1_mysql.sql
@@ -2632,8 +2632,13 @@ if ($doChange)
 
 ---# Add the new ip columns to members
 ALTER TABLE {$db_prefix}members
-ADD COLUMN member_ip VARBINARY(16) DEFAULT '',
-ADD COLUMN member_ip2 VARBINARY(16) DEFAULT '';
+ADD COLUMN member_ip VARBINARY(16),
+ADD COLUMN member_ip2 VARBINARY(16);
+---#
+
+---# Set them all to empty strings for the ConvertIp function
+UPDATE {$db_prefix}members
+	SET member_ip = '', member_ip2 = '';
 ---#
 
 ---# Create an ip index for old ips
@@ -2685,7 +2690,11 @@ if ($doChange)
 ---#
 
 ---# Add the new ip column to messages
-ALTER TABLE {$db_prefix}messages ADD COLUMN poster_ip VARBINARY(16) DEFAULT '';
+ALTER TABLE {$db_prefix}messages ADD COLUMN poster_ip VARBINARY(16);
+---#
+
+---# Set them all to empty strings for the ConvertIp function
+UPDATE {$db_prefix}messages SET poster_ip = '';
 ---#
 
 ---# Create an ip index for old ips

--- a/other/upgrade_2-1_mysql.sql
+++ b/other/upgrade_2-1_mysql.sql
@@ -2632,8 +2632,8 @@ if ($doChange)
 
 ---# Add the new ip columns to members
 ALTER TABLE {$db_prefix}members
-ADD COLUMN member_ip VARBINARY(16),
-ADD COLUMN member_ip2 VARBINARY(16);
+ADD COLUMN member_ip VARBINARY(16) DEFAULT '',
+ADD COLUMN member_ip2 VARBINARY(16) DEFAULT '';
 ---#
 
 ---# Create an ip index for old ips
@@ -2685,7 +2685,7 @@ if ($doChange)
 ---#
 
 ---# Add the new ip column to messages
-ALTER TABLE {$db_prefix}messages ADD COLUMN poster_ip VARBINARY(16);
+ALTER TABLE {$db_prefix}messages ADD COLUMN poster_ip VARBINARY(16) DEFAULT '';
 ---#
 
 ---# Create an ip index for old ips


### PR DESCRIPTION
Fixes #6945

Everything gets updated to either a valid IPv4, a valid IPv6, or NULL.  No more funky strings allowed - it's fixed or NULL.

I simplified the loop logic - it seemed to hang or skip data when different values were set for LIMIT and setSize.  Simplification helped.

Note that new columns to be processed by MySQLConvertOldIPs() must have ~~a default~~ _an initial_ value of ''.  That's how we know there is work remaining.  Can't use NULL, because that's a valid outcome; we need another state.

Note I think our inet conversion logic returns some very odd values sometimes, e.g., "EVe2" and "F>I:".  Always 4 bytes.  Will research more & log a bug.