### PR TITLE
Upgrader attachment & avatar fixes

### DIFF
--- a/other/upgrade_2-1_mysql.sql
+++ b/other/upgrade_2-1_mysql.sql
@@ -390,7 +390,7 @@ if (!is_writable($custom_av_dir))
 }
 
 // If we already are using a custom dir, delete the predefined one.
-if ($custom_av_dir != $GLOBALS['boarddir'] .'/custom_avatar')
+if (realpath($custom_av_dir) != realpath($GLOBALS['boarddir'] .'/custom_avatar'))
 {
 	// Borrow custom_avatars index.php file.
 	if (!file_exists($custom_av_dir . '/index.php'))

--- a/other/upgrade_2-1_mysql.sql
+++ b/other/upgrade_2-1_mysql.sql
@@ -424,7 +424,7 @@ if (!empty($modSettings['currentAttachmentUploadDir']) && !is_array($modSettings
 	$modSettings['attachmentUploadDir'] = @unserialize($modSettings['attachmentUploadDir']);
 
 // No need to do this if we already did it previously...
-if (empty($modSettings['json_done']))
+if (empty($modSettings['attachments_21_done']))
   $is_done = false;
 else
   $is_done = true;
@@ -549,6 +549,10 @@ while (!$is_done)
 
 unset($_GET['a']);
 ---}
+---#
+
+---# Note attachment conversion complete
+INSERT INTO {$db_prefix}settings (variable, value) VALUES ('attachments_21_done', '1');
 ---#
 
 ---# Fixing invalid sizes on attachments


### PR DESCRIPTION
Fixes #7082 
Fixes #6942 

The attachment issues were only seen on restarts or reruns for forums with multiple attachment directories.  Just needed to keep better track of when it really completes successfully.  (json_done != attachments_done...)

We used to see 'failed to unserialize' for the attachment dir setting via CLI before, this PR cleans that up as well.  We only need to serialize it once...

The custom av issue only appeared if you had directory separators misaligned (e.g., \custom_avatar vs /custom_avatar...) - pretty rare, but I did in fact have it delete my custom_avatar directory multiple times during test...