### PR TITLE
Set alerts to have a page limit

### DIFF
--- a/Sources/ManageSettings.php
+++ b/Sources/ManageSettings.php
@@ -233,6 +233,7 @@ function ModifyBasicSettings($return_config = false)
 				'90' => $txt['alerts_auto_purge_90'],
 			),
 		),
+		array('int', 'alerts_per_page', 'step' => 1, 'min' => 0, 'max' => 999),
 	);
 
 	call_integration_hook('integrate_modify_basic_settings', array(&$config_vars));

--- a/Sources/Profile-View.php
+++ b/Sources/Profile-View.php
@@ -663,7 +663,7 @@ function fetch_alerts($memID, $to_fetch = false, $limit = 0, $offset = 0, $with_
  */
 function showAlerts($memID)
 {
-	global $context, $smcFunc, $txt, $sourcedir, $scripturl, $options;
+	global $context, $smcFunc, $txt, $sourcedir, $scripturl, $options, $modSettings;
 
 	require_once($sourcedir . '/Profile-Modify.php');
 

--- a/Sources/Profile-View.php
+++ b/Sources/Profile-View.php
@@ -236,7 +236,10 @@ function fetch_alerts($memID, $to_fetch = false, $limit = 0, $offset = 0, $with_
 	// Basic sanitation.
 	$memID = (int) $memID;
 	$unread = $to_fetch === false;
-	$limit = max(0, (int) $limit);
+	
+	if (empty($limit) || $limit > 1000)
+		$limit = min(!empty($modSettings['alerts_per_page']) && (int) $modSettings['alerts_per_page'] < 1000 ? (int) $modSettings['alerts_per_page'] : 1000, 1000);
+
 	$offset = !empty($alertIDs) ? 0 : max(0, (int) $offset);
 	$with_avatar = !empty($with_avatar);
 	$show_links = !empty($show_links);
@@ -690,7 +693,7 @@ function showAlerts($memID)
 	}
 
 	// Prepare the pagination vars.
-	$maxIndex = 10;
+	$maxIndex = !empty($modSettings['alerts_per_page']) && (int) $modSettings['alerts_per_page'] < 1000 ? min((int) $modSettings['alerts_per_page'], 1000) : 25;
 	$context['start'] = (int) isset($_REQUEST['start']) ? $_REQUEST['start'] : 0;
 	$count = alert_count($memID);
 

--- a/Sources/Profile.php
+++ b/Sources/Profile.php
@@ -922,13 +922,14 @@ function alerts_popup($memID)
 
 	// No funny business allowed
 	$counter = isset($_REQUEST['counter']) ? max(0, (int) $_REQUEST['counter']) : 0;
+	$limit = !empty($modSettings['alerts_per_page']) && (int) $modSettings['alerts_per_page'] < 1000 ? min((int) $modSettings['alerts_per_page'], 1000) : 25;
 
 	$context['unread_alerts'] = array();
 	if ($counter < $cur_profile['alerts'])
 	{
 		// Now fetch me my unread alerts, pronto!
 		require_once($sourcedir . '/Profile-View.php');
-		$context['unread_alerts'] = fetch_alerts($memID, false, !empty($counter) ? $cur_profile['alerts'] - $counter : 0, 0, !isset($_REQUEST['counter']));
+		$context['unread_alerts'] = fetch_alerts($memID, false, !empty($counter) ? $cur_profile['alerts'] - $counter : $limit, 0, !isset($_REQUEST['counter']));
 
 		// This shouldn't happen, but just in case...
 		if (empty($counter) && $cur_profile['alerts'] != count($context['unread_alerts']))

--- a/Sources/Profile.php
+++ b/Sources/Profile.php
@@ -909,7 +909,7 @@ function profile_popup($memID)
  */
 function alerts_popup($memID)
 {
-	global $context, $sourcedir, $db_show_debug, $cur_profile;
+	global $context, $sourcedir, $db_show_debug, $cur_profile, $modSettings;
 
 	// Load the Alerts language file.
 	loadLanguage('Alerts');

--- a/Themes/default/languages/ManageSettings.english.php
+++ b/Themes/default/languages/ManageSettings.english.php
@@ -68,6 +68,7 @@ $txt['alerts_auto_purge_7'] = 'After 1 week';
 $txt['alerts_auto_purge_30'] = 'After 1 month';
 $txt['alerts_auto_purge_90'] = 'After 3 months';
 $txt['alerts_auto_purge_0'] = 'Never';
+$txt['alerts_per_page'] = 'Alerts Per Page';
 $txt['jquery_source'] = 'Source for the jQuery Library';
 $txt['jquery_custom_label'] = 'Custom';
 $txt['jquery_custom'] = 'Custom URL to the jQuery Library';


### PR DESCRIPTION
Default to 25 per page, but allow anything from 1 to 1000.  Anything outside of this defaults again to 25
Fixes #7169

Attaching to 2.1.0 since it could be used to perform a DOS.  I crashed my test forum a few times while testing this alone.