### PR TITLE
Fix log_action loop encountered when data can't be corrected...

### DIFF
--- a/other/upgrade.php
+++ b/other/upgrade.php
@@ -4986,21 +4986,26 @@ function MySQLConvertOldIp($targetTable, $oldCol, $newCol, $limit = 50000, $setS
 	$smcFunc['db_free_result']($request);
 
 	// Setup progress bar
-	$request = $smcFunc['db_query']('', '
-		SELECT COUNT(DISTINCT {raw:old_col})
-		FROM {db_prefix}{raw:table_name}',
-		array(
-			'old_col' => $oldCol,
-			'table_name' => $targetTable,
-		)
-	);
-	list ($step_progress['total']) = $smcFunc['db_fetch_row']($request);
-	$smcFunc['db_free_result']($request);
+	if (!isset($_GET['total_fixes']) || !isset($_GET['a']))
+	{
+		$request = $smcFunc['db_query']('', '
+			SELECT COUNT(DISTINCT {raw:old_col})
+			FROM {db_prefix}{raw:table_name}',
+			array(
+				'old_col' => $oldCol,
+				'table_name' => $targetTable,
+			)
+		);
+		list ($step_progress['total']) = $smcFunc['db_fetch_row']($request);
+		$_GET['total_fixes'] = $step_progress['total'];
+		$smcFunc['db_free_result']($request);
 
-	if (empty($_GET['a']))
 		$_GET['a'] = 0;
+	}
+
 	$step_progress['name'] = 'Converting ips';
 	$step_progress['current'] = $_GET['a'];
+	$step_progress['total'] = $_GET['total_fixes'];
 
 	// Main process loop
 	$is_done = false;
@@ -5076,6 +5081,7 @@ function MySQLConvertOldIp($targetTable, $oldCol, $newCol, $limit = 50000, $setS
 
 	$step_progress = array();
 	unset($_GET['a']);
+	unset($_GET['total_fixes']);
 }
 
 /**

--- a/other/upgrade_2-1_mysql.sql
+++ b/other/upgrade_2-1_mysql.sql
@@ -3765,11 +3765,7 @@ foreach($files AS $filename)
 
 		foreach ($extras AS $id => $extra_ser)
 		{
-			if (empty($modSettings['json_done']))
-				$extra = @unserialize($extra_ser);
-			else
-				$extra = @json_decode($extra_ser);
-
+			$extra = upgrade_unserialize($extra_ser);
 			if ($extra === false)
 				continue;
 

--- a/other/upgrade_2-1_postgresql.sql
+++ b/other/upgrade_2-1_postgresql.sql
@@ -4090,6 +4090,8 @@ foreach($files AS $filename)
 
 	if (empty($_GET['a']))
 		$_GET['a'] = 0;
+	if (empty($_GET['last_action_id']))
+		$_GET['last_action_id'] = 0;
 	$step_progress['name'] = 'Fixing missing IDs in log_actions';
 	$step_progress['current'] = $_GET['a'];
 
@@ -4107,10 +4109,13 @@ foreach($files AS $filename)
 				FROM {db_prefix}log_actions
 				WHERE id_member = {int:blank_id}
 				AND action IN ({array_string:target_actions})
+				AND id_action >  {int:last}
+				ORDER BY id_action
 				LIMIT {int:limit}',
 			array(
 				'blank_id' => 0,
 				'target_actions' => array('policy_accepted', 'agreement_accepted'),
+				'last' => $_GET['last_action_id'],
 				'limit' => $limit,
 			)
 		);
@@ -4120,12 +4125,19 @@ foreach($files AS $filename)
 
 		if (empty($extras))
 			$is_done = true;
+		else
+			$_GET['last_action_id'] = max(array_keys($extras));
 
 		foreach ($extras AS $id => $extra_ser)
 		{
-			$extra = @unserialize($extra_ser);
+			if (empty($modSettings['json_done']))
+				$extra = @unserialize($extra_ser);
+			else
+				$extra = @json_decode($extra_ser);
+
 			if ($extra === false)
 				continue;
+
 			if (!empty($extra['applicator']))
 			{
 				$request = $smcFunc['db_query']('', '
@@ -4141,10 +4153,14 @@ foreach($files AS $filename)
 		}
 		$_GET['a'] += $limit;
 		$step_progress['current'] = $_GET['a'];
+
+		if ($step_progress['current'] >= $step_progress['total'])
+			$is_done = true;
 	}
 
 	$step_progress = array();
 	unset($_GET['a']);
+	unset($_GET['last_action_id']);
 
 ---}
 ---#

--- a/other/upgrade_2-1_postgresql.sql
+++ b/other/upgrade_2-1_postgresql.sql
@@ -4075,25 +4075,29 @@ foreach($files AS $filename)
 	$current_substep = !isset($_GET['substep']) ? 0 : (int) $_GET['substep'];
 
 	// Setup progress bar
-	$request = $smcFunc['db_query']('', '
-		SELECT COUNT(*)
-			FROM {db_prefix}log_actions
-			WHERE id_member = {int:blank_id}
-			AND action IN ({array_string:target_actions})',
-		array(
-			'blank_id' => 0,
-			'target_actions' => array('policy_accepted', 'agreement_accepted'),
-		)
-	);
-	list ($step_progress['total']) = $smcFunc['db_fetch_row']($request);
-	$smcFunc['db_free_result']($request);
+	if (!isset($_GET['total_fixes']) || !isset($_GET['a']) || !isset($_GET['last_action_id']))
+	{
+		$request = $smcFunc['db_query']('', '
+			SELECT COUNT(*)
+				FROM {db_prefix}log_actions
+				WHERE id_member = {int:blank_id}
+				AND action IN ({array_string:target_actions})',
+			array(
+				'blank_id' => 0,
+				'target_actions' => array('policy_accepted', 'agreement_accepted'),
+			)
+		);
+		list ($step_progress['total']) = $smcFunc['db_fetch_row']($request);
+		$_GET['total_fixes'] = $step_progress['total'];
+		$smcFunc['db_free_result']($request);
 
-	if (empty($_GET['a']))
 		$_GET['a'] = 0;
-	if (empty($_GET['last_action_id']))
 		$_GET['last_action_id'] = 0;
+	}
+
 	$step_progress['name'] = 'Fixing missing IDs in log_actions';
 	$step_progress['current'] = $_GET['a'];
+	$step_progress['total'] = $_GET['total_fixes'];
 
 	// Main process loop
 	$limit = 10000;
@@ -4149,14 +4153,11 @@ foreach($files AS $filename)
 		}
 		$_GET['a'] += $limit;
 		$step_progress['current'] = $_GET['a'];
-
-		if ($step_progress['current'] >= $step_progress['total'])
-			$is_done = true;
 	}
 
 	$step_progress = array();
 	unset($_GET['a']);
 	unset($_GET['last_action_id']);
-
+	unset($_GET['total_fixes']);
 ---}
 ---#

--- a/other/upgrade_2-1_postgresql.sql
+++ b/other/upgrade_2-1_postgresql.sql
@@ -4130,11 +4130,7 @@ foreach($files AS $filename)
 
 		foreach ($extras AS $id => $extra_ser)
 		{
-			if (empty($modSettings['json_done']))
-				$extra = @unserialize($extra_ser);
-			else
-				$extra = @json_decode($extra_ser);
-
+			$extra = upgrade_unserialize($extra_ser);
 			if ($extra === false)
 				continue;
 


### PR DESCRIPTION
Fixes #7223 
Which was fallout from #7215 ...

Two issues:
(1) What if the bad data is in JSON, not in a serialized string?  This caught me by surprise, I thought the bug that left id_member 0 after policy acceptance was only in 2.0, but apparently, it happened _(or happens?)_ in 2.1 also.  This was a problem, because it could never get fixed, and yet it would loop until it was fixed...  So it needs to look at json, too.  
(2) A broader case of (1) above, what if the data is so bad it can't get fixed at all - whether json or serialized?  Now it keeps track of last ID processed, so it can continue from there.  

The problem with any "loop until it's all fixed" loop is that sometimes things aren't fixable...  🙄