### PR TITLE
Avoid errors if the currentAttachmentUploadDir is invalid

### DIFF
--- a/Sources/Attachments.php
+++ b/Sources/Attachments.php
@@ -116,7 +116,7 @@ class Attachments
 
 		$this->_attachmentUploadDir = $modSettings['attachmentUploadDir'];
 
-		$this->_attchDir = $context['attach_dir'] = $this->_attachmentUploadDir[$modSettings['currentAttachmentUploadDir']];
+		$this->_attchDir = $context['attach_dir'] = isset($this->_attachmentUploadDir[$modSettings['currentAttachmentUploadDir']]) ? $this->_attachmentUploadDir[$modSettings['currentAttachmentUploadDir']] : NULL;
 
 		$this->_canPostAttachment = $context['can_post_attachment'] = !empty($modSettings['attachmentEnable']) && $modSettings['attachmentEnable'] == 1 && (allowedTo('post_attachment', $this->_board) || ($modSettings['postmod_active'] && allowedTo('post_unapproved_attachments', $this->_board)));
 	}

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -4574,12 +4574,13 @@ function template_header()
 
 			// We are already checking so many files...just few more doesn't make any difference! :P
 			if (!empty($modSettings['currentAttachmentUploadDir']))
-				$path = $modSettings['attachmentUploadDir'][$modSettings['currentAttachmentUploadDir']];
-
+				if (isset($modSettings['attachmentUploadDir'][$modSettings['currentAttachmentUploadDir']]))
+					$path = $modSettings['attachmentUploadDir'][$modSettings['currentAttachmentUploadDir']];
 			else
 				$path = $modSettings['attachmentUploadDir'];
 
-			secureDirectory($path, true);
+			if (isset($path))
+				secureDirectory($path, true);
 			secureDirectory($cachedir);
 
 			// If agreement is enabled, at least the english version shall exist


### PR DESCRIPTION
If the currentAttachmentUploadDir points to an invalid
attachment index, an error would be added to the error log.
Avoid this by checking if the index exists before using it.

Signed-off-by: Oscar Rydhé <oscar.rydhe@gmail.com>