### PR TITLE
Handle bogus notification requests

### DIFF
--- a/Sources/tasks/CreatePost-Notify.php
+++ b/Sources/tasks/CreatePost-Notify.php
@@ -182,10 +182,6 @@ class CreatePost_Notify_Background extends SMF_BackgroundTask
 		// Modified post, or dealing with delayed mention and quote notifications.
 		if ($type == 'edit' || !empty($this->_details['respawns']))
 		{
-			// Filter out members who have already been notified about this post's topic
-			$this->members['quoted'] = array_intersect_key($this->members['quoted'], $unnotified);
-			$this->members['mentioned'] = array_intersect_key($this->members['mentioned'], $unnotified);
-
 			// Notifications about modified posts only go to members who were mentioned or quoted
 			$this->members['watching'] = $type == 'edit' ? array(): $unnotified;
 

--- a/Sources/tasks/CreatePost-Notify.php
+++ b/Sources/tasks/CreatePost-Notify.php
@@ -84,7 +84,7 @@ class CreatePost_Notify_Background extends SMF_BackgroundTask
 	 */
 	public function execute()
 	{
-		global $smcFunc, $sourcedir, $scripturl, $language, $modSettings, $user_info;
+		global $smcFunc, $sourcedir, $scripturl, $language, $modSettings, $user_info, $txt;
 
 		require_once($sourcedir . '/Subs-Post.php');
 		require_once($sourcedir . '/Mentions.php');
@@ -97,6 +97,15 @@ class CreatePost_Notify_Background extends SMF_BackgroundTask
 		$topicOptions = &$this->_details['topicOptions'];
 		$posterOptions = &$this->_details['posterOptions'];
 		$type = &$this->_details['type'];
+
+		// Board id is required; if missing, log an error and return
+		if (!isset($topicOptions['board']))
+		{
+			require_once($sourcedir . '/Errors.php');
+			loadLanguage('Errors');
+			log_error($txt['missing_board_id'], 'general', __FILE__, __LINE__);
+			return true;
+		}
 
 		$this->mention_mail_time = (isset($msgOptions['poster_time']) ? $msgOptions['poster_time'] : 0) + self::MENTION_DELAY * 60;
 

--- a/Sources/tasks/CreatePost-Notify.php
+++ b/Sources/tasks/CreatePost-Notify.php
@@ -107,7 +107,11 @@ class CreatePost_Notify_Background extends SMF_BackgroundTask
 			return true;
 		}
 
-		$this->mention_mail_time = (isset($msgOptions['poster_time']) ? $msgOptions['poster_time'] : 0) + self::MENTION_DELAY * 60;
+		// poster_time not always supplied, but used throughout
+		if (empty($msgOptions['poster_time']))
+			$msgOptions['poster_time'] = 0;
+
+		$this->mention_mail_time = $msgOptions['poster_time'] + self::MENTION_DELAY * 60;
 
 		// We need some more info about the quoted and mentioned members.
 		if (!empty($msgOptions['quoted_members']))


### PR DESCRIPTION
Fixes #7238 

Now, if the board_id isn't specified, a single error is logged & the task returns true so the background task gets deleted.  It no longer causes thousands of errors to be logged due to the background task with the broken request laying around...

While testing, noticed that notifications for quotes & mentions did not go out unless the quoted/mentioned person was watching the topic.  This is incorrect, so it was fixed.

While testing _that_, was occasionally getting undefined errors on poster_time.  Some of the logic handled it not being present, some of the logic did not.  Ensured poster_time is set.  

@Sesquipedalian - I'd appreciate it if you could take a peek since you're more familiar with that notification logic.