### PR TITLE
Avoid error if banning invalid user

### DIFF
--- a/Sources/ManageBans.php
+++ b/Sources/ManageBans.php
@@ -894,8 +894,11 @@ function banEdit2()
 	if (!empty($context['ban_errors']))
 	{
 		$context['ban_suggestions'] = !empty($saved_triggers) ? $saved_triggers : array();
-		$context['ban']['from_user'] = true;
-		$context['ban_suggestions'] = array_merge($context['ban_suggestions'], getMemberData((int) $_REQUEST['u']));
+		if (isset($_REQUEST['u']))
+		{
+			$context['ban']['from_user'] = true;
+			$context['ban_suggestions'] = array_merge($context['ban_suggestions'], getMemberData((int) $_REQUEST['u']));
+		}
 
 		// Not strictly necessary, but it's nice
 		if (!empty($context['ban_suggestions']['member']['id']))


### PR DESCRIPTION
If an error occured when adding a username trigger to a ban,
some undefined indexes errors would occur.
Fix this by checking if some request data is available before
using it.

Signed-off-by: Oscar Rydhé <oscar.rydhe@gmail.com>