### PR TITLE
Fix PM rule apply label

### DIFF
--- a/Sources/PersonalMessage.php
+++ b/Sources/PersonalMessage.php
@@ -4072,30 +4072,21 @@ function ApplyRules($all_messages = false)
 			// Quickly check each label is valid!
 			$realLabels = array();
 			foreach ($context['labels'] as $label)
-			{
-				if (in_array($label['id'], $labels) && $label['id'] != -1 || empty($options['pm_remove_inbox_label']))
-				{
-					// Make sure this stays in the inbox
-					if ($label['id'] == '-1')
-					{
-						$smcFunc['db_query']('', '
-							UPDATE {db_prefix}pm_recipients
-							SET in_inbox = {int:in_inbox}
-							WHERE id_pm = {int:id_pm}
-								AND id_member = {int:current_member}',
-							array(
-								'in_inbox' => 1,
-								'id_pm' => $pm,
-								'current_member' => $user_info['id'],
-							)
-						);
-					}
-					else
-					{
-						$realLabels[] = $label['id'];
-					}
-				}
-			}
+				if (in_array($label['id'], $labels))
+					$realLabels[] = $label['id'];
+
+			if (!empty($options['pm_remove_inbox_label']))
+				$smcFunc['db_query']('', '
+					UPDATE {db_prefix}pm_recipients
+					SET in_inbox = {int:in_inbox}
+					WHERE id_pm = {int:id_pm}
+						AND id_member = {int:current_member}',
+					array(
+						'in_inbox' => 0,
+						'id_pm' => $pm,
+						'current_member' => $user_info['id'],
+					)
+				);
 
 			$inserts = array();
 			// Now we insert the label info


### PR DESCRIPTION
If a PM rule existed with a label action, all the users
label would be applied regardless of what labels where
selected in the rule. The inbox label would not be removed
even if the user has selected that option.
Fixed this.

Signed-off-by: Oscar Rydhé <oscar.rydhe@gmail.com>