### PR TITLE
add missing language string

### DIFF
--- a/Themes/default/languages/Admin.english.php
+++ b/Themes/default/languages/Admin.english.php
@@ -363,6 +363,7 @@ $txt['attachment_image_paranoid'] = 'Perform extensive security checks on upload
 $txt['attachmentThumbnails'] = 'Resize images when showing under posts';
 $txt['attachment_thumb_png'] = 'Save thumbnails as PNG';
 $txt['attachment_thumb_memory'] = 'Adaptive thumbnail memory';
+$txt['attachment_thumb_memory_note'] = 'If disabled, memory is limited to 128M';
 $txt['attachmentThumbWidth'] = 'Maximum width of thumbnails';
 $txt['attachmentThumbHeight'] = 'Maximum height of thumbnails';
 $txt['attachment_thumbnail_settings'] = 'Thumbnail Settings';


### PR DESCRIPTION
Fixes #7163 

I don't know the context for this, besides the conditional from `attachment_thumb_memory`
We could just remove the warning.