### PR TITLE
Improves UI consistency

### DIFF
--- a/Sources/ManageBans.php
+++ b/Sources/ManageBans.php
@@ -2134,7 +2134,7 @@ function BanLog()
 		),
 		'additional_rows' => array(
 			array(
-				'position' => 'top_of_list',
+				'position' => 'after_title',
 				'value' => '
 					<input type="submit" name="removeSelected" value="' . $txt['ban_log_remove_selected'] . '" data-confirm="' . $txt['ban_log_remove_selected_confirm'] . '" class="button you_sure">
 					<input type="submit" name="removeAll" value="' . $txt['ban_log_remove_all'] . '" data-confirm="' . $txt['ban_log_remove_all_confirm'] . '" class="button you_sure">',

--- a/Sources/Modlog.php
+++ b/Sources/Modlog.php
@@ -283,25 +283,21 @@ function ViewModlog()
 		),
 		'additional_rows' => array(
 			array(
-				'position' => 'top_of_list',
+				'position' => 'after_title',
 				'value' => '
 					' . $txt['modlog_search'] . ' (' . $txt['modlog_by'] . ': ' . $context['search']['label'] . '):
 					<input type="text" name="search" size="18" value="' . $smcFunc['htmlspecialchars']($context['search']['string']) . '">
 					<input type="submit" name="is_search" value="' . $txt['modlog_go'] . '" class="button" style="float:none">
-					' . ($context['can_delete'] ? '&nbsp;
+					' . ($context['can_delete'] ? '
 					<input type="submit" name="remove" value="' . $txt['modlog_remove'] . '" data-confirm="' . $txt['modlog_remove_selected_confirm'] . '" class="button you_sure">
 					<input type="submit" name="removeall" value="' . $txt['modlog_removeall'] . '" data-confirm="' . $txt['modlog_remove_all_confirm'] . '" class="button you_sure">' : ''),
-				'class' => 'floatright',
+				'class' => '',
 			),
 			array(
 				'position' => 'below_table_data',
-				'value' => '
-					' . $txt['modlog_search'] . ' (' . $txt['modlog_by'] . ': ' . $context['search']['label'] . '):
-					<input type="text" name="search" size="18" value="' . $smcFunc['htmlspecialchars']($context['search']['string']) . '">
-					<input type="submit" name="is_search" value="' . $txt['modlog_go'] . '" class="button" style="float:none">
-					' . ($context['can_delete'] ? '&nbsp;
+				'value' => $context['can_delete'] ? '
 					<input type="submit" name="remove" value="' . $txt['modlog_remove'] . '" data-confirm="' . $txt['modlog_remove_selected_confirm'] . '" class="button you_sure">
-					<input type="submit" name="removeall" value="' . $txt['modlog_removeall'] . '" data-confirm="' . $txt['modlog_remove_all_confirm'] . '" class="button you_sure">' : ''),
+					<input type="submit" name="removeall" value="' . $txt['modlog_removeall'] . '" data-confirm="' . $txt['modlog_remove_all_confirm'] . '" class="button you_sure">' : '',
 				'class' => 'floatright',
 			),
 		),

--- a/Sources/ReportedContent.php
+++ b/Sources/ReportedContent.php
@@ -27,7 +27,7 @@ if (!defined('SMF'))
 function ReportedContent()
 {
 	global $txt, $context, $user_info, $smcFunc;
-	global $sourcedir, $scripturl;
+	global $sourcedir, $scripturl, $options;
 
 	// First order of business - what are these reports about?
 	// area=reported{type}
@@ -132,7 +132,7 @@ function ReportedContent()
 				'quickmod' => array(
 					'class' => 'inline_mod_check',
 					'content' => '<input type="checkbox" name="close[]" value="'.$report['id'].'">',
-					'show' => !$context['view_closed']
+					'show' => !$context['view_closed'] && !empty($options['display_quick_mod']) && $options['display_quick_mod'] == 1
 				)
 			);
 		}

--- a/Themes/default/BoardIndex.template.php
+++ b/Themes/default/BoardIndex.template.php
@@ -83,7 +83,7 @@ function template_main()
 				</h3>', !empty($category['description']) ? '
 				<div class="desc">' . $category['description'] . '</div>' : '', '
 			</div>
-			<div id="category_', $category['id'], '_boards" ', (!empty($category['css_class']) ? ('class="' . $category['css_class'] . '"') : ''), '>';
+			<div id="category_', $category['id'], '_boards" ', (!empty($category['css_class']) ? ('class="' . $category['css_class'] . '"') : ''), $category['is_collapsed'] ? ' style="display: none;"' : '', '>';
 
 		/* Each board in each category's boards has:
 		new (is it new?), id, name, description, moderators (see below), link_moderators (just a list.),

--- a/Themes/default/BoardIndex.template.php
+++ b/Themes/default/BoardIndex.template.php
@@ -359,7 +359,7 @@ function template_ic_block_recent()
 	echo '
 			<div class="sub_bar">
 				<h4 class="subbg">
-					<a href="', $scripturl, '?action=recent"><span class="xx"></span>', $txt['recent_posts'], '</a>
+					<a href="', $scripturl, '?action=recent"><span class="main_icons recent_posts"></span> ', $txt['recent_posts'], '</a>
 				</h4>
 			</div>
 			<div id="recent_posts_content">';

--- a/Themes/default/Errors.template.php
+++ b/Themes/default/Errors.template.php
@@ -70,7 +70,7 @@ function template_error_log()
 				</h3>
 			</div>
 			<div class="pagesection">
-				<div class="floatleft">
+				<div class="pagelinks">
 					', $context['page_index'], '
 				</div>';
 
@@ -179,7 +179,7 @@ function template_error_log()
 
 	echo '
 			<div class="pagesection">
-				<div class="floatleft">
+				<div class="pagelinks">
 					', $context['page_index'], '
 				</div>';
 

--- a/Themes/default/Errors.template.php
+++ b/Themes/default/Errors.template.php
@@ -69,31 +69,43 @@ function template_error_log()
 					<a href="', $scripturl, '?action=helpadmin;help=error_log" onclick="return reqOverlayDiv(this.href);" class="help"><span class="main_icons help" title="', $txt['help'], '"></span></a> ', $txt['errorlog'], '
 				</h3>
 			</div>
-			<div class="pagesection">
-				<div class="pagelinks">
-					', $context['page_index'], '
-				</div>';
+			<div class="information flow_hidden">
+				<div class="additional_row">';
 
-	if (!empty($context['errors']))
+	// No errors, so just show a message and be done with it.
+	if (empty($context['errors']))
+	{
 		echo '
+					', $txt['errorlog_no_entries'], '
+				</div>
+			</div>
+		</form>';
+		return;
+	}
+
+	echo '
 				<div class="floatright">
 					<input type="submit" name="removeSelection" value="', $txt['remove_selection'], '" data-confirm="', $txt['remove_selection_confirm'], '" class="button you_sure">
 					<input type="submit" name="delall" value="', ($context['has_filter'] ? $txt['remove_filtered_results'] : $txt['remove_all']), '" data-confirm="', ($context['has_filter'] ? $txt['remove_filtered_results_confirm'] : $txt['sure_about_errorlog_remove']), '" class="button you_sure">
-				</div>';
-
-	echo '
-			</div>
-			<div class="title_bar">
-				<div style="padding: 6px 12px 5px 12px">
-					', $txt['apply_filter_of_type'], ':';
+				</div>
+				', $txt['apply_filter_of_type'], ':';
 
 	$error_types = array();
 
 	foreach ($context['error_types'] as $type => $details)
-		$error_types[] = ($details['is_selected'] ? '<span class="main_icons right_arrow"></span> ' : '') . '<a href="' . $details['url'] . '" ' . ($details['is_selected'] ? 'style="font-weight: bold;"' : '') . ' title="' . $details['description'] . '">' . ($details['error_type'] === 'critical' ? '<span class="error">' . $details['label'] . '</span>' : $details['label']) . '</a>';
+		$error_types[] = ($details['is_selected'] ? '<span class="main_icons right_arrow"></span> ' : '') . '<a href="' . $details['url'] . '" ' . ($details['is_selected'] ? 'style="font-weight: bold;"' : 'style="font-weight: normal;"') . ' title="' . $details['description'] . '">' . ($details['error_type'] === 'critical' ? '<span class="error">' . $details['label'] . '</span>' : $details['label']) . '</a>';
 
 	echo '
-					', implode(' | ', $error_types), '
+				', implode(' | ', $error_types), '
+				</div>
+			</div>
+			<div class="pagesection">
+				<div class="pagelinks">
+					', $context['page_index'], '
+				</div>
+				<div class="floatright" style="padding: 0 12px">
+					<label for="check_all"><strong>', $txt['check_all'], '</strong></label>
+					<input type="checkbox" id="check_all" onclick="invertAll(this, this.form, \'delete[]\');">
 				</div>
 			</div>';
 
@@ -102,21 +114,6 @@ function template_error_log()
 			<div class="information">
 				<strong>', $txt['applying_filter'], ':</strong> ', $context['filter']['entity'], ' ', $context['filter']['value']['html'], ' [<a href="', $scripturl, '?action=admin;area=logs;sa=errorlog', $context['sort_direction'] == 'down' ? ';desc' : '', '">', $txt['clear_filter'], '</a>]
 			</div>';
-
-	// No errors, then show a message
-	if (empty($context['errors']))
-	{
-		echo '
-			<div class="information">', $txt['errorlog_no_entries'], '</div>';
-	}
-	else
-	{
-		echo '
-			<div class="righttext">
-				<label for="check_all"><strong>', $txt['check_all'], '</strong></label>
-				<input type="checkbox" id="check_all" onclick="invertAll(this, this.form, \'delete[]\');">
-			</div>';
-	}
 
 	// We have some errors, must be some mods installed :P
 	foreach ($context['errors'] as $error)
@@ -181,16 +178,11 @@ function template_error_log()
 			<div class="pagesection">
 				<div class="pagelinks">
 					', $context['page_index'], '
-				</div>';
-
-	if (!empty($context['errors']))
-		echo '
+				</div>
 				<div class="floatright">
 					<input type="submit" name="removeSelection" value="', $txt['remove_selection'], '" data-confirm="', $txt['remove_selection_confirm'], '" class="button you_sure">
 					<input type="submit" name="delall" value="', ($context['has_filter'] ? $txt['remove_filtered_results'] : $txt['remove_all']), '" data-confirm="', ($context['has_filter'] ? $txt['remove_filtered_results_confirm'] : $txt['sure_about_errorlog_remove']), '" class="button you_sure">
-				</div>';
-
-	echo '
+				</div>
 			</div>';
 
 	if ($context['sort_direction'] == 'down')

--- a/Themes/default/GenericList.template.php
+++ b/Themes/default/GenericList.template.php
@@ -59,8 +59,8 @@ function template_show_list($list_id = null)
 		// Show the page index (if this list doesn't intend to show all items).
 		if (!empty($cur_list['items_per_page']) && !empty($cur_list['page_index']))
 			echo '
-		<div class="floatleft">
-			<div class="pagesection">', $cur_list['page_index'], '</div>
+		<div class="pagesection">
+			<div class="pagelinks">', $cur_list['page_index'], '</div>
 		</div>';
 
 		if (isset($cur_list['additional_rows']['above_column_headers']))
@@ -134,13 +134,13 @@ function template_show_list($list_id = null)
 		// Show the page index (if this list doesn't intend to show all items).
 		if (!empty($cur_list['items_per_page']) && !empty($cur_list['page_index']))
 			echo '
-			<div class="floatleft">
-				<div class="pagesection">', $cur_list['page_index'], '</div>
+			<div class="pagesection floatleft">
+				<div class="pagelinks">', $cur_list['page_index'], '</div>
 			</div>';
+
 
 		if (isset($cur_list['additional_rows']['below_table_data']))
 			template_additional_rows('below_table_data', $cur_list);
-
 		echo '
 		</div>';
 	}

--- a/Themes/default/Help.template.php
+++ b/Themes/default/Help.template.php
@@ -123,7 +123,7 @@ function template_find_members()
 		echo '
 				</ul>
 				<div class="pagesection">
-					', $context['page_index'], '
+					<div class="pagelinks">', $context['page_index'], '</div>
 				</div>';
 	}
 

--- a/Themes/default/ManageMembergroups.template.php
+++ b/Themes/default/ManageMembergroups.template.php
@@ -593,7 +593,9 @@ function template_group_members()
 				<h3 class="catbg">', $txt['membergroups_members_group_members'], '</h3>
 			</div>
 			<br>
-			<div class="pagesection">', $context['page_index'], '</div>
+			<div class="pagesection">
+				<div class="pagelinks">', $context['page_index'], '</div>
+			</div>
 			<table class="table_grid" id="group_members">
 				<thead>
 					<tr class="title_bar">
@@ -661,8 +663,8 @@ function template_group_members()
 			</div>';
 
 	echo '
-			<div class="pagesection flow_hidden">
-				<div class="floatleft">', $context['page_index'], '</div>
+			<div class="pagesection">
+				<div class="pagelinks">', $context['page_index'], '</div>
 			</div>
 			<br>';
 

--- a/Themes/default/MessageIndex.template.php
+++ b/Themes/default/MessageIndex.template.php
@@ -100,9 +100,9 @@ function template_main()
 		', $txt['post_becomes_unapproved'], '
 	</div>';
 
-		// If this person can approve items and we have some awaiting approval tell them.
-		if (!empty($context['unapproved_posts_message']))
-			echo '
+	// If this person can approve items and we have some awaiting approval tell them.
+	if (!empty($context['unapproved_posts_message']))
+		echo '
 	<div class="noticebox">
 		', $context['unapproved_posts_message'], '
 	</div>';

--- a/Themes/default/MessageIndex.template.php
+++ b/Themes/default/MessageIndex.template.php
@@ -17,17 +17,41 @@ function template_main()
 {
 	global $context, $settings, $options, $scripturl, $modSettings, $txt;
 
-	// Let them know why their message became unapproved.
-	if ($context['becomesUnapproved'])
+	echo '<div id="display_head" class="information">
+			<h2 class="display_title">', $context['name'], '</h2>';
+
+	if (isset($context['description']) && $context['description'] != '')
 		echo '
-	<div class="noticebox">
-		', $txt['post_becomes_unapproved'], '
-	</div>';
+			<p>', $context['description'], '</p>';
+
+	if (!empty($context['moderators']))
+		echo '
+			<p>', count($context['moderators']) === 1 ? $txt['moderator'] : $txt['moderators'], ': ', implode(', ', $context['link_moderators']), '.</p>';
+
+	if (!empty($settings['display_who_viewing']))
+	{
+		echo '
+			<p>';
+
+		// Show just numbers...?
+		if ($settings['display_who_viewing'] == 1)
+			echo count($context['view_members']), ' ', count($context['view_members']) == 1 ? $txt['who_member'] : $txt['members'];
+		// Or show the actual people viewing the topic?
+		else
+			echo empty($context['view_members_list']) ? '0 ' . $txt['members'] : implode(', ', $context['view_members_list']) . ((empty($context['view_num_hidden']) || $context['can_moderate_forum']) ? '' : ' (+ ' . $context['view_num_hidden'] . ' ' . $txt['hidden'] . ')');
+
+		// Now show how many guests are here too.
+		echo $txt['who_and'], $context['view_num_guests'], ' ', $context['view_num_guests'] == 1 ? $txt['guest'] : $txt['guests'], $txt['who_viewing_board'], '
+			</p>';
+	}
+
+	echo '
+		</div>';
 
 	if (!empty($context['boards']) && (!empty($options['show_children']) || $context['start'] == 0))
 	{
 		echo '
-	<div id="board_', $context['current_board'], '_childboards" class="boardindex_table">
+	<div id="board_', $context['current_board'], '_childboards" class="boardindex_table main_container">
 		<div class="cat_bar">
 			<h3 class="catbg">', $txt['sub_boards'], '</h3>
 		</div>';
@@ -69,6 +93,20 @@ function template_main()
 	</div><!-- #board_[current_board]_childboards -->';
 	}
 
+	// Let them know why their message became unapproved.
+	if ($context['becomesUnapproved'])
+		echo '
+	<div class="noticebox">
+		', $txt['post_becomes_unapproved'], '
+	</div>';
+
+		// If this person can approve items and we have some awaiting approval tell them.
+		if (!empty($context['unapproved_posts_message']))
+			echo '
+	<div class="noticebox">
+		', $context['unapproved_posts_message'], '
+	</div>';
+
 	if (!$context['no_topic_listing'])
 	{
 		echo '
@@ -90,26 +128,6 @@ function template_main()
 		echo '
 	</div>';
 
-		if ($context['description'] != '' || !empty($context['moderators']))
-		{
-			echo '
-	<div id="description_board" class="generic_list_wrapper">
-		<h3>', $context['name'], '</h3>
-		<div>';
-
-			if ($context['description'] != '')
-				echo '
-			', $context['description'];
-
-			if (!empty($context['moderators']))
-				echo '
-			', count($context['moderators']) === 1 ? $txt['moderator'] : $txt['moderators'], ': ', implode(', ', $context['link_moderators']), '.';
-
-			echo '
-		</div>
-	</div>';
-		}
-
 		// If Quick Moderation is enabled start the form.
 		if (!empty($context['can_quick_mod']) && $options['display_quick_mod'] > 0 && !empty($context['topics']))
 			echo '
@@ -117,22 +135,6 @@ function template_main()
 
 		echo '
 		<div id="messageindex">';
-
-		if (!empty($settings['display_who_viewing']))
-		{
-			echo '
-			<div class="information">';
-
-			if ($settings['display_who_viewing'] == 1)
-				echo count($context['view_members']), ' ', count($context['view_members']) === 1 ? $txt['who_member'] : $txt['members'];
-
-			else
-				echo empty($context['view_members_list']) ? '0 ' . $txt['members'] : implode(', ', $context['view_members_list']) . (empty($context['view_num_hidden']) || $context['can_moderate_forum'] ? '' : ' (+ ' . $context['view_num_hidden'] . ' ' . $txt['hidden'] . ')');
-			echo $txt['who_and'], $context['view_num_guests'], ' ', $context['view_num_guests'] == 1 ? $txt['guest'] : $txt['guests'], $txt['who_viewing_board'];
-
-			echo '
-			</div>';
-		}
 
 		echo '
 			<div class="title_bar" id="topic_header">';
@@ -166,13 +168,6 @@ function template_main()
 
 		echo '
 			</div><!-- #topic_header -->';
-
-		// If this person can approve items and we have some awaiting approval tell them.
-		if (!empty($context['unapproved_posts_message']))
-			echo '
-			<div class="information">
-				<span class="alert">!</span> ', $context['unapproved_posts_message'], '
-			</div>';
 
 		// Contain the topic list
 		echo '

--- a/Themes/default/ModerationCenter.template.php
+++ b/Themes/default/ModerationCenter.template.php
@@ -342,7 +342,7 @@ function template_notes()
 		echo '
 					</ul>
 					<div class="pagesection notes">
-						<span class="smalltext">', $context['page_index'], '</span>
+						<div class="pagelinks">', $context['page_index'], '</div>
 					</div>';
 	}
 
@@ -384,7 +384,7 @@ function template_unapproved_posts()
 	else
 		echo '
 			<div class="pagesection floatleft">
-				', $context['page_index'], '
+				<div class="pagelinks">', $context['page_index'], '</div>
 			</div>';
 
 	foreach ($context['unapproved_items'] as $item)
@@ -443,9 +443,7 @@ function template_unapproved_posts()
 
 	if (!empty($context['unapproved_items']))
 		echo '
-				<div class="floatleft">
-					<div class="pagelinks">', $context['page_index'], '</div>
-				</div>';
+				<div class="pagelinks">', $context['page_index'], '</div>';
 
 	echo '
 			</div><!-- .pagesection -->

--- a/Themes/default/ModerationCenter.template.php
+++ b/Themes/default/ModerationCenter.template.php
@@ -410,12 +410,12 @@ function template_unapproved_posts()
 		);
 		echo '
 			<div class="windowbg clear">
-				<div class="counter">', $item['counter'], '</div>
+				<div class="page_number floatright"> #', $item['counter'], '</div>
 				<div class="topic_details">
 					<h5>
 						<strong>', $item['category']['link'], ' / ', $item['board']['link'], ' / ', $item['link'], '</strong>
 					</h5>
-					<span class="smalltext"><strong>', $txt['mc_unapproved_by'], ' ', $item['poster']['link'], ' ', $txt['on'], ':</strong> ', $item['time'], '</span>
+					<span class="smalltext">', sprintf(str_replace('<br>', ' ', $txt['last_post_topic']), $item['time'], '<strong>' . $item['poster']['link'] . '</strong>'), '</span>
 				</div>
 				<div class="list_posts">
 					<div class="post">', $item['body'], '</div>
@@ -490,7 +490,7 @@ function template_user_watch_post_callback($post)
 					<div class="smalltext">
 						&#171; ' . $txt['mc_watched_users_posted'] . ': ' . $post['poster_time'] . ' &#187;
 					</div>
-					<div class="list_posts double_height">
+					<div class="list_posts">
 						' . $post['body'] . '
 					</div>';
 

--- a/Themes/default/ModerationCenter.template.php
+++ b/Themes/default/ModerationCenter.template.php
@@ -375,17 +375,32 @@ function template_unapproved_posts()
 
 	// No posts?
 	if (empty($context['unapproved_items']))
+	{
 		echo '
 			<div class="windowbg">
 				<p class="centertext">
 					', $txt['mc_unapproved_' . $context['current_view'] . '_none_found'], '
 				</p>
 			</div>';
+	}
 	else
+	{
 		echo '
-			<div class="pagesection floatleft">
+			<div class="pagesection">';
+
+		if (!empty($options['display_quick_mod']) && $options['display_quick_mod'] == 1)
+			echo '
+				<ul class="buttonlist floatright">
+					<li class="inline_mod_check">
+						<input type="checkbox" onclick="invertAll(this, this.form, \'item[]\');" checked>
+					</li>
+				</ul>';
+
+		echo '
 				<div class="pagelinks">', $context['page_index'], '</div>
 			</div>';
+
+	}
 
 	foreach ($context['unapproved_items'] as $item)
 	{

--- a/Themes/default/ModerationCenter.template.php
+++ b/Themes/default/ModerationCenter.template.php
@@ -487,12 +487,6 @@ function template_user_watch_post_callback($post)
 						<div class="floatleft">
 							<strong><a href="' . $scripturl . '?topic=' . $post['id_topic'] . '.' . $post['id'] . '#msg' . $post['id'] . '">' . $post['subject'] . '</a></strong> ' . $txt['mc_reportedp_by'] . ' <strong>' . $post['author_link'] . '</strong>
 						</div>
-						<div class="floatright">';
-
-	$output_html .= template_quickbuttons($quickbuttons, 'user_watch_post', 'return');
-
-	$output_html .= '
-						</div>
 					</div>
 					<br>
 					<div class="smalltext">
@@ -501,6 +495,8 @@ function template_user_watch_post_callback($post)
 					<div class="list_posts double_height">
 						' . $post['body'] . '
 					</div>';
+
+	$output_html .= template_quickbuttons($quickbuttons, 'user_watch_post', 'return');
 
 	return $output_html;
 }

--- a/Themes/default/ModerationCenter.template.php
+++ b/Themes/default/ModerationCenter.template.php
@@ -369,7 +369,7 @@ function template_unapproved_posts()
 	echo '
 	<div id="modcenter">
 		<form action="', $scripturl, '?action=moderate;area=postmod;start=', $context['start'], ';sa=', $context['current_view'], '" method="post" accept-charset="', $context['character_set'], '">
-			<div class="cat_bar">
+			<div class="cat_bar', !empty($context['unapproved_items']) ? ' cat_bar_round' : '', '">
 				<h3 class="catbg">', $txt['mc_unapproved_posts'], '</h3>
 			</div>';
 

--- a/Themes/default/MoveTopic.template.php
+++ b/Themes/default/MoveTopic.template.php
@@ -232,7 +232,7 @@ function template_merge()
 	{
 		echo '
 				<div class="pagesection">
-					', $context['page_index'], '
+					<div class="pagelinks">', $context['page_index'], '</div>
 				</div>
 				<div class="windowbg">
 					<ul class="merge_topics">';
@@ -248,7 +248,7 @@ function template_merge()
 					</ul>
 				</div>
 				<div class="pagesection">
-					', $context['page_index'], '
+					<div class="pagelinks">', $context['page_index'], '</div>
 				</div>';
 	}
 	// Just a nice "There aren't any topics" message

--- a/Themes/default/PersonalMessage.template.php
+++ b/Themes/default/PersonalMessage.template.php
@@ -1941,21 +1941,23 @@ function template_showPMDrafts()
 		{
 			echo '
 		<div class="windowbg">
-			<div class="counter">', $draft['counter'], '</div>
+			<div class="page_number floatright"> #', $draft['counter'], '</div>
 			<div class="topic_details">
-				<div class="floatright smalltext righttext">
-					<div class="recipient_to">&#171;&nbsp;<strong>', $txt['to'], ':</strong> ', implode(', ', $draft['recipients']['to']), '&nbsp;&#187;</div>';
-
-			if(!empty($draft['recipients']['bcc']))
-				echo'
-					<div class="pm_bbc">&#171;&nbsp;<strong>', $txt['pm_bcc'], ':</strong> ', implode(', ', $draft['recipients']['bcc']), '&nbsp;&#187;</div>';
-
-			echo '
-				</div>
 				<h5>
 					<strong>', $draft['subject'], '</strong>
 				</h5>
-				<span class="smalltext">&#171;&nbsp;<strong>', $txt['draft_saved_on'], ':</strong> ', sprintf($txt['draft_days_ago'], $draft['age']), (!empty($draft['remaining']) ? ', ' . sprintf($txt['draft_retain'], $draft['remaining']) : ''), '&#187;</span><br>
+				<div class="smalltext">
+					<div class="recipient_to"><strong>', $txt['to'], ':</strong> ', implode(', ', $draft['recipients']['to']), '</div>';
+
+			if(!empty($draft['recipients']['bcc']))
+				echo'
+					<div class="pm_bbc"><strong>', $txt['pm_bcc'], ':</strong> ', implode(', ', $draft['recipients']['bcc']), '</div>';
+
+			echo '
+				</div>
+				<div class="smalltext">
+					<strong>', $txt['draft_saved_on'], ':</strong> ', sprintf($txt['draft_days_ago'], $draft['age']), (!empty($draft['remaining']) ? ', ' . sprintf($txt['draft_retain'], $draft['remaining']) : ''), '
+				</div>
 			</div>
 			<div class="list_posts">
 				', $draft['body'], '

--- a/Themes/default/PersonalMessage.template.php
+++ b/Themes/default/PersonalMessage.template.php
@@ -1929,9 +1929,9 @@ function template_showPMDrafts()
 				<span class="main_icons inbox"></span> ', $txt['drafts_show'], '
 			</h3>
 		</div>
-		<div class="pagesection">
-			<div class="pagelinks">', $context['page_index'], '</div>
-		</div>';
+		<p class="information">
+			', $txt['drafts_show_desc'], '
+		</p>';
 
 	// No drafts? Just show an informative message.
 	if (empty($context['drafts']))
@@ -1941,6 +1941,11 @@ function template_showPMDrafts()
 		</div>';
 	else
 	{
+		echo '
+		<div class="pagesection">
+			<div class="pagelinks">', $context['page_index'], '</div>
+		</div>';
+
 		// For every draft to be displayed, give it its own div, and show the important details of the draft.
 		foreach ($context['drafts'] as $draft)
 		{
@@ -1974,13 +1979,13 @@ function template_showPMDrafts()
 			echo '
 		</div><!-- .windowbg -->';
 		}
-	}
 
-	// Show page numbers.
-	echo '
-	<div class="pagesection">
-		<div class="pagelinks">', $context['page_index'], '</div>
-	</div>';
+		// Show page numbers.
+		echo '
+		<div class="pagesection">
+			<div class="pagelinks">', $context['page_index'], '</div>
+		</div>';
+	}
 }
 
 ?>

--- a/Themes/default/PersonalMessage.template.php
+++ b/Themes/default/PersonalMessage.template.php
@@ -611,6 +611,11 @@ function template_subject_list()
 	global $context, $settings, $txt, $scripturl;
 
 	echo '
+	<div class="cat_bar">
+		<h3 class="catbg">
+			', $context['folder'] == 'sent' ? $txt['sent_items'] : $context['current_label'], '
+		</h3>
+	</div>
 	<table class="table_grid">
 		<thead>
 			<tr class="title_bar">
@@ -965,7 +970,7 @@ function template_send()
 		<div class="cat_bar">
 			<h3 class="catbg">', $txt['pm_send_report'], '</h3>
 		</div>
-		<div class="windowbg">';
+		<div class="windowbg noup">';
 
 		if (!empty($context['send_log']['sent']))
 			foreach ($context['send_log']['sent'] as $log_entry)
@@ -990,7 +995,7 @@ function template_send()
 					<span id="preview_subject">', empty($context['preview_subject']) ? '' : $context['preview_subject'], '</span>
 				</h3>
 			</div>
-			<div class="windowbg">
+			<div class="windowbg noup">
 				<div class="post" id="preview_body">
 					', empty($context['preview_message']) ? '<br>' : $context['preview_message'], '
 				</div>
@@ -1006,7 +1011,7 @@ function template_send()
 					<span class="main_icons inbox icon" title="', $txt['new_message'], '"></span> ', $txt['new_message'], '
 				</h3>
 			</div>
-			<div class="roundframe">';
+			<div class="roundframe noup">';
 
 	// If there were errors for sending the PM, show them.
 	echo '

--- a/Themes/default/PersonalMessage.template.php
+++ b/Themes/default/PersonalMessage.template.php
@@ -233,7 +233,7 @@ function template_folder()
 		if (empty($context['display_mode']))
 			echo '
 			<div class="pagesection">
-				<div class="floatleft">', $context['page_index'], '</div>
+				<div class="pagelinks">', $context['page_index'], '</div>
 				<div class="floatright">
 					<input type="submit" name="del_selected" value="', $txt['quickmod_delete_selected'], '" onclick="if (!confirm(\'', $txt['delete_selected_confirm'], '\')) return false;" class="button">
 				</div>
@@ -689,7 +689,7 @@ function template_subject_list()
 		</tbody>
 	</table>
 	<div class="pagesection">
-		<div class="floatleft">', $context['page_index'], '</div>
+		<div class="pagelinks">', $context['page_index'], '</div>
 		<div class="floatright">&nbsp;';
 
 	if ($context['show_delete'])
@@ -897,7 +897,7 @@ function template_search_results()
 			', sprintf($txt['pm_search_results_info'], $context['num_results'], sentence_list($context['search_in'])), '
 		</div>
 		<div class="pagesection">
-			', $context['page_index'], '
+			<div class="pagelinks">', $context['page_index'], '</div>
 		</div>';
 
 	// Complete results?
@@ -946,7 +946,7 @@ function template_search_results()
 
 	echo '
 		<div class="pagesection">
-			', $context['page_index'], '
+			<div class="pagelinks">', $context['page_index'], '</div>
 		</div>';
 
 }
@@ -1925,7 +1925,7 @@ function template_showPMDrafts()
 			</h3>
 		</div>
 		<div class="pagesection">
-			<span>', $context['page_index'], '</span>
+			<div class="pagelinks">', $context['page_index'], '</div>
 		</div>';
 
 	// No drafts? Just show an informative message.
@@ -1972,7 +1972,7 @@ function template_showPMDrafts()
 	// Show page numbers.
 	echo '
 	<div class="pagesection">
-		<span>', $context['page_index'], '</span>
+		<div class="pagelinks">', $context['page_index'], '</div>
 	</div>';
 }
 

--- a/Themes/default/Post.template.php
+++ b/Themes/default/Post.template.php
@@ -631,7 +631,7 @@ function template_main()
 	{
 		echo '
 		<div id="recent" class="flow_hidden main_section">
-			<div class="cat_bar">
+			<div class="cat_bar cat_bar_round">
 				<h3 class="catbg">', $txt['topic_summary'], '</h3>
 			</div>
 			<span id="new_replies"></span>';

--- a/Themes/default/Post.template.php
+++ b/Themes/default/Post.template.php
@@ -524,7 +524,10 @@ function template_main()
 				<span>' . $txt['posted_by'] . '</span>
 				%PosterName%
 			</h5>
-			&nbsp;-&nbsp;%PostTime%&nbsp;&#187; <span class="new_posts" id="image_new_%PostID%">' . $txt['new'] . '</span>';
+			&nbsp;-&nbsp;%PostTime%&nbsp;&#187; <span class="new_posts" id="image_new_%PostID%">' . $txt['new'] . '</span>
+			<br class="clear">
+			<div id="msg_%PostID%_ignored_prompt" class="smalltext" style="display: none;">' . $txt['ignoring_user'] . '<a href="#" id="msg_%PostID%_ignored_link" style="%IgnoredStyle%">' . $txt['show_ignore_user_post'] . '</a></div>
+			<div class="list_posts smalltext" id="msg_%PostID%_body">%PostBody%</div>';
 
 	if ($context['can_quote'])
 		$newPostsHTML .= '
@@ -535,9 +538,6 @@ function template_main()
 			</ul>';
 
 	$newPostsHTML .= '
-			<br class="clear">
-			<div id="msg_%PostID%_ignored_prompt" class="smalltext" style="display: none;">' . $txt['ignoring_user'] . '<a href="#" id="msg_%PostID%_ignored_link" style="%IgnoredStyle%">' . $txt['show_ignore_user_post'] . '</a></div>
-			<div class="list_posts smalltext" id="msg_%PostID%_body">%PostBody%</div>
 		</div>';
 
 	// The functions used to preview a posts without loading a new page.
@@ -646,20 +646,12 @@ function template_main()
 			echo '
 			<div class="windowbg">
 				<div id="msg', $post['id'], '">
-					<h5 class="floatleft">
-						<span>', $txt['posted_by'], '</span> ', $post['poster'], '
-					</h5>
-					&nbsp;-&nbsp;', $post['time'];
-
-			if ($context['can_quote'])
-				echo '
-					<ul class="quickbuttons" id="msg_', $post['id'], '_quote">
-						<li style="display:none;" id="quoteSelected_', $post['id'], '" data-msgid="', $post['id'], '"><a href="javascript:void(0)"><span class="main_icons quote_selected"></span>', $txt['quote_selected_action'], '</a></li>
-						<li id="post_modify"><a href="#postmodify" onclick="return insertQuoteFast(', $post['id'], ');"><span class="main_icons quote"></span>', $txt['quote'], '</a></li>
-					</ul>';
-
-			echo '
-					<br class="clear">';
+					<div>
+						<h5 class="floatleft">
+							<span>', $txt['posted_by'], '</span> ', $post['poster'], '
+						</h5>
+						<span class="smalltext">&nbsp;-&nbsp;', $post['time'], '</span>
+					</div>';
 
 			if ($ignoring)
 				echo '
@@ -669,7 +661,16 @@ function template_main()
 					</div>';
 
 			echo '
-					<div class="list_posts smalltext" id="msg_', $post['id'], '_body" data-msgid="', $post['id'], '">', $post['message'], '</div>
+					<div class="list_posts smalltext" id="msg_', $post['id'], '_body" data-msgid="', $post['id'], '">', $post['message'], '</div>';
+
+			if ($context['can_quote'])
+				echo '
+					<ul class="quickbuttons" id="msg_', $post['id'], '_quote">
+						<li style="display:none;" id="quoteSelected_', $post['id'], '" data-msgid="', $post['id'], '"><a href="javascript:void(0)"><span class="main_icons quote_selected"></span>', $txt['quote_selected_action'], '</a></li>
+						<li id="post_modify"><a href="#postmodify" onclick="return insertQuoteFast(', $post['id'], ');"><span class="main_icons quote"></span>', $txt['quote'], '</a></li>
+					</ul>';
+
+			echo '
 				</div><!-- #msg[id] -->
 			</div><!-- .windowbg -->';
 		}

--- a/Themes/default/Profile.template.php
+++ b/Themes/default/Profile.template.php
@@ -158,7 +158,7 @@ function template_summary()
 
 	// Display the basic information about the user
 	echo '
-	<div id="profileview" class="roundframe flow_auto">
+	<div id="profileview" class="roundframe flow_auto noup">
 		<div id="basicinfo">';
 
 	// Are there any custom profile fields for above the name?
@@ -489,7 +489,7 @@ function template_showPosts()
 	global $context, $scripturl, $txt;
 
 	echo '
-		<div class="cat_bar">
+		<div class="cat_bar', !isset($context['attachments']) ? ' cat_bar_round' : '', '">
 			<h3 class="catbg">
 				', (!isset($context['attachments']) && empty($context['is_topics']) ? $txt['showMessages'] : (!empty($context['is_topics']) ? $txt['showTopics'] : $txt['showAttachments'])), ' - ', $context['member']['name'], '
 			</h3>
@@ -653,7 +653,7 @@ function template_showDrafts()
 	global $context, $scripturl, $txt;
 
 	echo '
-		<div class="cat_bar">
+		<div class="cat_bar cat_bar_round">
 			<h3 class="catbg">
 				', $txt['drafts'], ' - ', $context['member']['name'], '
 			</h3>

--- a/Themes/default/Profile.template.php
+++ b/Themes/default/Profile.template.php
@@ -506,7 +506,7 @@ function template_showPosts()
 		{
 			echo '
 		<div class="', $post['css_class'], '">
-			<div class="counter">', $post['counter'], '</div>
+			<div class="page_number floatright"> #', $post['counter'], '</div>
 			<div class="topic_details">
 				<h5>
 					<strong><a href="', $scripturl, '?board=', $post['board']['id'], '.0">', $post['board']['name'], '</a> / <a href="', $scripturl, '?topic=', $post['topic'], '.', $post['start'], '#msg', $post['id'], '">', $post['subject'], '</a></strong>
@@ -675,7 +675,7 @@ function template_showDrafts()
 		{
 			echo '
 		<div class="windowbg">
-			<div class="counter">', $draft['counter'], '</div>
+			<div class="page_number floatright"> #', $draft['counter'], '</div>
 			<div class="topic_details">
 				<h5>
 					<strong><a href="', $scripturl, '?board=', $draft['board']['id'], '.0">', $draft['board']['name'], '</a> / ', $draft['topic']['link'], '</strong> &nbsp; &nbsp;';
@@ -690,7 +690,7 @@ function template_showDrafts()
 
 			echo '
 				</h5>
-				<span class="smalltext">&#171;&nbsp;<strong>', $txt['on'], ':</strong> ', $draft['time'], '&nbsp;&#187;</span>
+				<span class="smalltext"><strong>', $txt['draft_saved_on'], ':</strong> ', $draft['time'], '</span>
 			</div><!-- .topic_details -->
 			<div class="list_posts">
 				', $draft['body'], '

--- a/Themes/default/Profile.template.php
+++ b/Themes/default/Profile.template.php
@@ -619,9 +619,7 @@ function template_showAlerts()
 		echo '
 			</table>
 			<div class="pagesection">
-				<div class="floatleft">
-					', $context['pagination'], '
-				</div>
+				<div class="pagelinks">', $context['pagination'], '</div>
 				<div class="floatright">';
 
 		if ($context['showCheckboxes'])

--- a/Themes/default/Recent.template.php
+++ b/Themes/default/Recent.template.php
@@ -19,10 +19,10 @@ function template_recent()
 
 	echo '
 	<div id="recent" class="main_section">
-		<div class="cat_bar">
-			<h3 class="catbg">
-				<span class="xx"></span>', $txt['recent_posts'], '
-			</h3>
+		<div id="display_head" class="information">
+			<h2 class="display_title">
+				<span id="top_subject">', $txt['recent_posts'], '</span>
+			</h2>
 		</div>';
 
 	if (!empty($context['page_index']))
@@ -65,7 +65,7 @@ function template_recent()
  */
 function template_unread()
 {
-	global $context, $settings, $txt, $scripturl, $modSettings;
+	global $context, $settings, $txt, $scripturl, $modSettings, $board_info;
 
 	// User action pop on mobile screen (or actually small screen), this uses responsive css does not check mobile device.
 	if (!empty($context['recent_buttons']))
@@ -81,7 +81,12 @@ function template_unread()
 	</div>';
 
 	echo '
-	<div id="recent" class="main_content">';
+	<div id="recent" class="main_content">
+		<div id="display_head" class="information">
+			<h2 class="display_title">
+				<span>', (!empty($board_info['name']) ? $board_info['name'] . ' - ' : '') . $context['page_title'], '</span>
+			</h2>
+		</div>';
 
 	if ($context['showCheckboxes'])
 		echo '
@@ -225,10 +230,10 @@ function template_unread()
 	}
 	else
 		echo '
-			<div class="cat_bar">
-				<h3 class="catbg centertext">
+			<div class="infobox">
+				<p class="centertext">
 					', $context['showing_all_topics'] ? $txt['topic_alert_none'] : sprintf($txt['unread_topics_visit_none'], $scripturl), '
-				</h3>
+				</p>
 			</div>';
 
 	if ($context['showCheckboxes'])
@@ -247,7 +252,7 @@ function template_unread()
  */
 function template_replies()
 {
-	global $context, $settings, $txt, $scripturl, $modSettings;
+	global $context, $settings, $txt, $scripturl, $modSettings, $board_info;
 
 	// User action pop on mobile screen (or actually small screen), this uses responsive css does not check mobile device.
 	if (!empty($context['recent_buttons']))
@@ -263,7 +268,12 @@ function template_replies()
 	</div>';
 
 	echo '
-	<div id="recent">';
+	<div id="recent">
+		<div id="display_head" class="information">
+			<h2 class="display_title">
+				<span>', (!empty($board_info['name']) ? $board_info['name'] . ' - ' : '') . $context['page_title'], '</span>
+			</h2>
+		</div>';
 
 	if ($context['showCheckboxes'])
 		echo '

--- a/Themes/default/Recent.template.php
+++ b/Themes/default/Recent.template.php
@@ -39,7 +39,7 @@ function template_recent()
 	{
 		echo '
 		<div class="', $post['css_class'], '">
-			<div class="counter">', $post['counter'], '</div>
+			<div class="page_number floatright"> #', $post['counter'], '</div>
 			<div class="topic_details">
 				<h5>', $post['board']['link'], ' / ', $post['link'], '</h5>
 				<span class="smalltext">', $txt['last_poster'], ' <strong>', $post['poster']['link'], ' </strong> - ', $post['time'], '</span>

--- a/Themes/default/Recent.template.php
+++ b/Themes/default/Recent.template.php
@@ -23,8 +23,13 @@ function template_recent()
 			<h3 class="catbg">
 				<span class="xx"></span>', $txt['recent_posts'], '
 			</h3>
-		</div>
-		<div class="pagesection">', $context['page_index'], '</div>';
+		</div>';
+
+	if (!empty($context['page_index']))
+		echo '
+		<div class="pagesection">
+			<div class="pagelinks">' . $context['page_index'] . '</div>
+		</div>';
 
 	if (empty($context['posts']))
 		echo '
@@ -49,7 +54,9 @@ function template_recent()
 	}
 
 	echo '
-		<div class="pagesection">', $context['page_index'], '</div>
+		<div class="pagesection">
+			<div class="pagelinks">', $context['page_index'], '</div>
+		</div>
 	</div><!-- #recent -->';
 }
 

--- a/Themes/default/ReportedContent.template.php
+++ b/Themes/default/ReportedContent.template.php
@@ -35,13 +35,13 @@ function template_reported_posts()
 
 	if (!empty($context['reports']) && !$context['view_closed'] && !empty($options['display_quick_mod']) && $options['display_quick_mod'] == 1)
 		echo '
-				<ul class="buttonlist floatright">
-					<li class="inline_mod_check">
-						<input type="checkbox" onclick="invertAll(this, this.form, \'close[]\');">
-					</li>
-				</ul>';
+			<ul class="buttonlist floatright">
+				<li class="inline_mod_check">
+					<input type="checkbox" onclick="invertAll(this, this.form, \'close[]\');">
+				</li>
+			</ul>';
 
-		echo '
+	echo '
 			<div class="pagelinks floatleft">' . $context['page_index'] . '</div>
 		</div>';
 
@@ -406,11 +406,11 @@ function template_reported_members()
 
 	if (!empty($context['reports']) && !$context['view_closed'] && !empty($options['display_quick_mod']) && $options['display_quick_mod'] == 1)
 		echo '
-				<ul class="buttonlist floatright">
-					<li class="inline_mod_check">
-						<input type="checkbox" onclick="invertAll(this, this.form, \'close[]\');">
-					</li>
-				</ul>';
+			<ul class="buttonlist floatright">
+				<li class="inline_mod_check">
+					<input type="checkbox" onclick="invertAll(this, this.form, \'close[]\');">
+				</li>
+			</ul>';
 
 		echo '
 			<div class="pagelinks">', $context['page_index'], '</div>

--- a/Themes/default/ReportedContent.template.php
+++ b/Themes/default/ReportedContent.template.php
@@ -15,7 +15,7 @@
  */
 function template_reported_posts()
 {
-	global $context, $txt, $scripturl;
+	global $context, $txt, $scripturl, $options;
 
 	// Let them know the action was a success.
 	if (!empty($context['report_post_action']))
@@ -30,6 +30,19 @@ function template_reported_posts()
 			<h3 class="catbg">
 				', $context['view_closed'] ? $txt['mc_reportedp_closed'] : $txt['mc_reportedp_active'], '
 			</h3>
+		</div>
+		<div class="pagesection">';
+
+	if (!empty($context['reports']) && !$context['view_closed'] && !empty($options['display_quick_mod']) && $options['display_quick_mod'] == 1)
+		echo '
+				<ul class="buttonlist floatright">
+					<li class="inline_mod_check">
+						<input type="checkbox" onclick="invertAll(this, this.form, \'close[]\');">
+					</li>
+				</ul>';
+
+		echo '
+			<div class="pagelinks floatleft">' . $context['page_index'] . '</div>
 		</div>';
 
 	foreach ($context['reports'] as $report)
@@ -69,17 +82,17 @@ function template_reported_posts()
 		</div>';
 
 	echo '
-		<div class="pagesection">';
-
-	if (!empty($context['total_reports']) && $context['total_reports'] >= $context['reports_how_many'])
-		echo '
+		<div class="pagesection">
 			<div class="pagelinks floatleft">' . $context['page_index'] . '</div>';
 
-	echo '
-			<div class="floatright">', !$context['view_closed'] ? '
+	if (!empty($context['reports']) && !$context['view_closed'] && !empty($options['display_quick_mod']) && $options['display_quick_mod'] == 1)
+		echo '
+			<div class="floatright">
 				<input type="hidden" name="' . $context['mod-report-close-all_token_var'] . '" value="' . $context['mod-report-close-all_token'] . '">
-				<input type="submit" name="close_selected" value="' . $txt['mc_reportedp_close_selected'] . '" class="button">' : '', '
-			</div>
+				<input type="submit" name="close_selected" value="' . $txt['mc_reportedp_close_selected'] . '" class="button">
+			</div>';
+
+	echo '
 		</div>
 		<input type="hidden" name="', $context['session_var'], '" value="', $context['session_id'], '">
 	</form>';
@@ -373,7 +386,7 @@ function template_reported_members_block()
  */
 function template_reported_members()
 {
-	global $context, $txt, $scripturl;
+	global $context, $txt, $scripturl, $options;
 
 	// Let them know the action was a success.
 	if (!empty($context['report_post_action']) && !empty($txt['report_action_' . $context['report_post_action']]))
@@ -389,7 +402,17 @@ function template_reported_members()
 				', $context['view_closed'] ? $txt['mc_reportedp_closed'] : $txt['mc_reportedp_active'], '
 			</h3>
 		</div>
-		<div class="pagesection">
+		<div class="pagesection">';
+
+	if (!empty($context['reports']) && !$context['view_closed'] && !empty($options['display_quick_mod']) && $options['display_quick_mod'] == 1)
+		echo '
+				<ul class="buttonlist floatright">
+					<li class="inline_mod_check">
+						<input type="checkbox" onclick="invertAll(this, this.form, \'close[]\');">
+					</li>
+				</ul>';
+
+		echo '
 			<div class="pagelinks">', $context['page_index'], '</div>
 		</div>';
 
@@ -427,7 +450,7 @@ function template_reported_members()
 		<div class="pagesection">
 			<div class="pagelinks floatleft">', $context['page_index'], '</div>
 			<div class="floatright">
-				', !$context['view_closed'] ? '<input type="submit" name="close_selected" value="' . $txt['mc_reportedp_close_selected'] . '" class="button">' : '', '
+				', (!$context['view_closed'] && !empty($context['reports'])) ? '<input type="submit" name="close_selected" value="' . $txt['mc_reportedp_close_selected'] . '" class="button">' : '', '
 			</div>
 		</div>
 		<input type="hidden" name="', $context['session_var'], '" value="', $context['session_id'], '">

--- a/Themes/default/ReportedContent.template.php
+++ b/Themes/default/ReportedContent.template.php
@@ -384,7 +384,7 @@ function template_reported_members()
 
 	echo '
 	<form id="reported_members" action="', $scripturl, '?action=moderate;area=reportedmembers;sa=show', $context['view_closed'] ? ';closed' : '', ';start=', $context['start'], '" method="post" accept-charset="', $context['character_set'], '">
-		<div class="cat_bar">
+		<div class="cat_bar cat_bar_round">
 			<h3 class="catbg">
 				', $context['view_closed'] ? $txt['mc_reportedp_closed'] : $txt['mc_reportedp_active'], '
 			</h3>

--- a/Themes/default/Search.template.php
+++ b/Themes/default/Search.template.php
@@ -339,18 +339,18 @@ function template_results()
 			{
 				echo '
 			<div class="block">
-				<span class="floatleft half_content">
-					<div class="counter">', $message['counter'], '</div>
-					<h5>', $topic['board']['link'], ' / <a href="', $scripturl, '?topic=', $topic['id'], '.msg', $message['id'], '#msg', $message['id'], '">', $message['subject_highlighted'], '</a></h5>
-					<span class="smalltext">&#171;&nbsp;', $txt['by'], '&nbsp;<strong>', $message['member']['link'], '</strong>&nbsp;', $txt['on'], '&nbsp;<em>', $message['time'], '</em>&nbsp;&#187;</span>
-				</span>';
-
-				echo '
+				<div class="page_number floatright"> #', $message['counter'], '</div>
+				<div class="half_content">
+					<div class="topic_details">
+						<h5>', $topic['board']['link'], ' / <a href="', $scripturl, '?topic=', $topic['id'], '.msg', $message['id'], '#msg', $message['id'], '">', $message['subject_highlighted'], '</a></h5>
+						<span class="smalltext">', sprintf(str_replace('<br>', ' ', $txt['last_post_topic']), $message['time'], '<strong>' . $message['member']['link'] . '</strong>'), '</span>
+					</div>
+				</div>
 			</div><!-- .block -->';
 
 				if ($message['body_highlighted'] != '')
 					echo '
-				<div class="list_posts double_height word_break">', $message['body_highlighted'], '</div>';
+			<div class="list_posts word_break">', $message['body_highlighted'], '</div>';
 			}
 
 			echo '
@@ -400,12 +400,12 @@ function template_results()
 			{
 				echo '
 	<div class="', $topic['css_class'], '">
-		<div class="counter">', $message['counter'], '</div>
+		<div class="page_number floatright"> #', $message['counter'], '</div>
 		<div class="topic_details">
 			<h5>
 				', $topic['board']['link'], ' / <a href="', $scripturl, '?topic=', $topic['id'], '.', $message['start'], ';topicseen#msg', $message['id'], '">', $message['subject_highlighted'], '</a>
 			</h5>
-			<span class="smalltext">&#171;&nbsp;', $txt['message'], ' ', $txt['by'], ' <strong>', $message['member']['link'], ' </strong>', $txt['on'], '&nbsp;<em>', $message['time'], '</em>&nbsp;&#187;</span>
+			<span class="smalltext">', sprintf(str_replace('<br>', ' ', $txt['last_post_topic']), $message['time'], '<strong>' . $message['member']['link'] . '</strong>'), '</span>
 		</div>
 		<div class="list_posts">', $message['body_highlighted'], '</div>';
 

--- a/Themes/default/Search.template.php
+++ b/Themes/default/Search.template.php
@@ -300,36 +300,49 @@ function template_results()
 	<form action="', $scripturl, '?action=quickmod" method="post" accept-charset="', $context['character_set'], '" name="topicForm">';
 
 		echo '
-		<div class="cat_bar">
-			<h3 class="catbg">
-				<span class="floatright">';
-
-		if (!empty($options['display_quick_mod']) && $options['display_quick_mod'] == 1)
-			echo '
-					<input type="checkbox" onclick="invertAll(this, this.form, \'topics[]\');">';
-		echo '
-				</span>
-				<span class="main_icons filter"></span> ', $txt['mlist_search_results'], ': ', $context['search_params']['search'], '
-			</h3>
-		</div>';
+		<div id="display_head" class="information">
+			<h2 class="display_title">
+				<span>', $txt['mlist_search_results'], ': ', $context['search_params']['search'], '</span>
+			</h2>
+			<div class="floatleft">
+				<a class="button" href="', $scripturl, '?action=search;params=' . $context['params'], '">', $txt['search_adjust_query'], '</a>
+			</div>';
 
 		// Was anything even found?
 		if (!empty($context['topics']))
+		{
 			echo '
-		<div class="pagesection">
-			<div class="pagelinks">', $context['page_index'], '</div>
-			<select name="sort" class="floatright" form="new_search" onchange="document.forms.new_search.submit()">
-				<option value="relevance|desc">', $txt['search_orderby_relevant_first'], '</option>
-				<option value="num_replies|desc"', $context['current_sorting'] == 'num_replies|desc' ? ' selected' : '', '>', $txt['search_orderby_large_first'], '</option>
-				<option value="num_replies|asc"', $context['current_sorting'] == 'num_replies|asc' ? ' selected' : '', '>', $txt['search_orderby_small_first'], '</option>
-				<option value="id_msg|desc"', $context['current_sorting'] == 'id_msg|desc' ? ' selected' : '', '>', $txt['search_orderby_recent_first'], '</option>
-				<option value="id_msg|asc"', $context['current_sorting'] == 'id_msg|asc' ? ' selected' : '', '>', $txt['search_orderby_old_first'], '</option>
-			</select>
-		</div>';
+			<div class="floatright">
+				<span class="padding">', $txt['search_order'], '</span>
+				<select name="sort" class="floatright" form="new_search" onchange="document.forms.new_search.submit()">
+					<option value="relevance|desc">', $txt['search_orderby_relevant_first'], '</option>
+					<option value="num_replies|desc"', $context['current_sorting'] == 'num_replies|desc' ? ' selected' : '', '>', $txt['search_orderby_large_first'], '</option>
+					<option value="num_replies|asc"', $context['current_sorting'] == 'num_replies|asc' ? ' selected' : '', '>', $txt['search_orderby_small_first'], '</option>
+					<option value="id_msg|desc"', $context['current_sorting'] == 'id_msg|desc' ? ' selected' : '', '>', $txt['search_orderby_recent_first'], '</option>
+					<option value="id_msg|asc"', $context['current_sorting'] == 'id_msg|asc' ? ' selected' : '', '>', $txt['search_orderby_old_first'], '</option>
+				</select>
+			</div>
+		</div>
+		<div class="pagesection">';
 
+			if (!empty($options['display_quick_mod']) && $options['display_quick_mod'] == 1)
+				echo '
+				<ul class="buttonlist floatright">
+					<li class="inline_mod_check">
+						<input type="checkbox" onclick="invertAll(this, this.form, \'topics[]\');">
+					</li>
+				</ul>';
+
+		echo '
+			<div class="pagelinks">', $context['page_index'], '</div>
+		</div>';
+		}
 		else
+		{
 			echo '
-		<div class="roundframe noup">', $txt['find_no_results'], '</div>';
+		</div>
+		<div class="roundframe noup">', $txt['search_no_results'], '</div>';
+		}
 
 		// While we have results to show ...
 		while ($topic = $context['get_topics']())
@@ -434,18 +447,39 @@ function template_results()
 	else
 	{
 		echo '
-	<div class="cat_bar">
-		<h3 class="catbg">
-			<span class="main_icons filter"></span> ', $txt['mlist_search_results'], ': ', $context['search_params']['search'], '
-		</h3>
+	<div id="display_head" class="information">
+		<h2 class="display_title">
+			<span>', $txt['mlist_search_results'], ': ', $context['search_params']['search'], '</span>
+		</h2>
+		<div class="floatleft">
+			<a class="button" href="', $scripturl, '?action=search;params=' . $context['params'], '">', $txt['search_adjust_query'], '</a>
+		</div>';
+
+		// Was anything even found?
+		if (!empty($context['topics']))
+		{
+			echo '
+		<div class="floatright">
+			<span class="padding">', $txt['search_order'], '</span>
+			<select name="sort" class="floatright" form="new_search" onchange="document.forms.new_search.submit()">
+				<option value="relevance|desc">', $txt['search_orderby_relevant_first'], '</option>
+				<option value="num_replies|desc"', $context['current_sorting'] == 'num_replies|desc' ? ' selected' : '', '>', $txt['search_orderby_large_first'], '</option>
+				<option value="num_replies|asc"', $context['current_sorting'] == 'num_replies|asc' ? ' selected' : '', '>', $txt['search_orderby_small_first'], '</option>
+				<option value="id_msg|desc"', $context['current_sorting'] == 'id_msg|desc' ? ' selected' : '', '>', $txt['search_orderby_recent_first'], '</option>
+				<option value="id_msg|asc"', $context['current_sorting'] == 'id_msg|asc' ? ' selected' : '', '>', $txt['search_orderby_old_first'], '</option>
+			</select>
+		</div>
 	</div>
 	<div class="pagesection">
 		<div class="pagelinks">', $context['page_index'], '</div>
 	</div>';
-
-		if (empty($context['topics']))
+		}
+		else
+		{
 			echo '
-	<div class="information">(', $txt['search_no_results'], ')</div>';
+	</div>
+	<div class="roundframe noup">', $txt['search_no_results'], '</div>';
+		}
 
 		while ($topic = $context['get_topics']())
 		{

--- a/Themes/default/Search.template.php
+++ b/Themes/default/Search.template.php
@@ -317,7 +317,7 @@ function template_results()
 		if (!empty($context['topics']))
 			echo '
 		<div class="pagesection">
-			<span>', $context['page_index'], '</span>
+			<div class="pagelinks">', $context['page_index'], '</div>
 			<select name="sort" class="floatright" form="new_search" onchange="document.forms.new_search.submit()">
 				<option value="relevance|desc">', $txt['search_orderby_relevant_first'], '</option>
 				<option value="num_replies|desc"', $context['current_sorting'] == 'num_replies|desc' ? ' selected' : '', '>', $txt['search_orderby_large_first'], '</option>
@@ -398,7 +398,7 @@ function template_results()
 		if (!empty($context['topics']))
 			echo '
 		<div class="pagesection">
-			<span>', $context['page_index'], '</span>
+			<div class="pagelinks">', $context['page_index'], '</div>
 		</div>';
 
 		if (!empty($options['display_quick_mod']) && $options['display_quick_mod'] == 1 && !empty($context['topics']))
@@ -440,7 +440,7 @@ function template_results()
 		</h3>
 	</div>
 	<div class="pagesection">
-		<span>', $context['page_index'], '</span>
+		<div class="pagelinks">', $context['page_index'], '</div>
 	</div>';
 
 		if (empty($context['topics']))
@@ -470,7 +470,7 @@ function template_results()
 
 		echo '
 	<div class="pagesection">
-		<span>', $context['page_index'], '</span>
+		<div class="pagelinks">', $context['page_index'], '</div>
 	</div>';
 	}
 

--- a/Themes/default/Search.template.php
+++ b/Themes/default/Search.template.php
@@ -294,11 +294,6 @@ function template_results()
 		echo '
 	</form>';
 
-		// Quick moderation set to checkboxes? Oh, how fun :/
-		if (!empty($options['display_quick_mod']) && $options['display_quick_mod'] == 1)
-			echo '
-	<form action="', $scripturl, '?action=quickmod" method="post" accept-charset="', $context['character_set'], '" name="topicForm">';
-
 		echo '
 		<div id="display_head" class="information">
 			<h2 class="display_title">
@@ -323,17 +318,7 @@ function template_results()
 				</select>
 			</div>
 		</div>
-		<div class="pagesection">';
-
-			if (!empty($options['display_quick_mod']) && $options['display_quick_mod'] == 1)
-				echo '
-				<ul class="buttonlist floatright">
-					<li class="inline_mod_check">
-						<input type="checkbox" onclick="invertAll(this, this.form, \'topics[]\');">
-					</li>
-				</ul>';
-
-		echo '
+		<div class="pagesection">
 			<div class="pagelinks">', $context['page_index'], '</div>
 		</div>';
 		}
@@ -360,42 +345,6 @@ function template_results()
 					<span class="smalltext">&#171;&nbsp;', $txt['by'], '&nbsp;<strong>', $message['member']['link'], '</strong>&nbsp;', $txt['on'], '&nbsp;<em>', $message['time'], '</em>&nbsp;&#187;</span>
 				</span>';
 
-				if (!empty($options['display_quick_mod']))
-				{
-					echo '
-				<span class="floatright">';
-
-					if ($options['display_quick_mod'] == 1)
-						echo '
-					<input type="checkbox" name="topics[]" value="', $topic['id'], '">';
-
-					else
-					{
-						if ($topic['quick_mod']['remove'])
-							echo '
-					<a href="', $scripturl, '?action=quickmod;board=' . $topic['board']['id'] . '.0;actions%5B', $topic['id'], '%5D=remove;', $context['session_var'], '=', $context['session_id'], '" class="you_sure"><span class="main_icons delete" title="', $txt['remove_topic'], '"></span></a>';
-
-						if ($topic['quick_mod']['lock'])
-							echo '
-					<a href="', $scripturl, '?action=quickmod;board=' . $topic['board']['id'] . '.0;actions%5B', $topic['id'], '%5D=lock;', $context['session_var'], '=', $context['session_id'], '" class="you_sure"><span class="main_icons lock" title="', $topic['is_locked'] ? $txt['set_unlock'] : $txt['set_lock'], '"></span></a>';
-
-						if ($topic['quick_mod']['lock'] || $topic['quick_mod']['remove'])
-							echo '
-					<br>';
-
-						if ($topic['quick_mod']['sticky'])
-							echo '
-					<a href="', $scripturl, '?action=quickmod;board=' . $topic['board']['id'] . '.0;actions%5B', $topic['id'], '%5D=sticky;', $context['session_var'], '=', $context['session_id'], '" class="you_sure"><span class="main_icons sticky" title="', $topic['is_sticky'] ? $txt['set_nonsticky'] : $txt['set_sticky'], '"></span></a>';
-
-						if ($topic['quick_mod']['move'])
-							echo '
-					<a href="', $scripturl, '?action=movetopic;topic=', $topic['id'], '.0"><span class="main_icons move" title="', $txt['move_topic'], '"></span></a>';
-					}
-
-					echo '
-				</span><!-- .floatright -->';
-				}
-
 				echo '
 			</div><!-- .block -->';
 
@@ -407,42 +356,6 @@ function template_results()
 			echo '
 		</div><!-- $topic[css_class] -->';
 		}
-
-		if (!empty($context['topics']))
-			echo '
-		<div class="pagesection">
-			<div class="pagelinks">', $context['page_index'], '</div>
-		</div>';
-
-		if (!empty($options['display_quick_mod']) && $options['display_quick_mod'] == 1 && !empty($context['topics']))
-		{
-			echo '
-		<div class="quick_actions righttext">
-			<select class="qaction" name="qaction"', $context['can_move'] ? ' onchange="this.form.move_to.disabled = (this.options[this.selectedIndex].value != \'move\');"' : '', '>
-				<option value="">--------</option>';
-
-			foreach ($context['qmod_actions'] as $qmod_action)
-				if ($context['can_' . $qmod_action])
-					echo '
-				<option value="' . $qmod_action . '">' . $txt['quick_mod_' . $qmod_action] . '</option>';
-
-			echo '
-			</select>';
-
-			if ($context['can_move'])
-				echo '
-			<span id="quick_mod_jump_to"></span>';
-
-			echo '
-			<input type="hidden" name="redirect_url" value="', $scripturl . '?action=search2;params=' . $context['params'], '">
-			<input type="submit" value="', $txt['quick_mod_go'], '" onclick="return this.form.qaction.value != \'\' &amp;&amp; confirm(\'', $txt['quickmod_confirm'], '\');" class="button">
-		</div><!-- .quick_actions -->';
-		}
-
-		if (!empty($options['display_quick_mod']) && $options['display_quick_mod'] == 1 && !empty($context['topics']))
-			echo '
-		<input type="hidden" name="' . $context['session_var'] . '" value="' . $context['session_id'] . '">
-	</form>';
 	}
 	else
 	{
@@ -501,37 +414,19 @@ function template_results()
 	</div><!-- $topic[css_class] -->';
 			}
 		}
-
-		echo '
-	<div class="pagesection">
-		<div class="pagelinks">', $context['page_index'], '</div>
-	</div>';
 	}
+
+	echo '
+	<div class="pagesection">';
+
+	if (!empty($context['topics']))
+		echo '
+		<div class="pagelinks">', $context['page_index'], '</div>';
 
 	// Show a jump to box for easy navigation.
 	echo '
-	<br class="clear">
-	<div class="smalltext righttext" id="search_jump_to"></div>
-	<script>';
-
-	if (!empty($options['display_quick_mod']) && $options['display_quick_mod'] == 1 && !empty($context['topics']) && $context['can_move'])
-		echo '
-		if (typeof(window.XMLHttpRequest) != "undefined")
-			aJumpTo[aJumpTo.length] = new JumpTo({
-				sContainerId: "quick_mod_jump_to",
-				sClassName: "qaction",
-				sJumpToTemplate: "%dropdown_list%",
-				sCurBoardName: "', $context['jump_to']['board_name'], '",
-				sBoardChildLevelIndicator: "==",
-				sBoardPrefix: "=> ",
-				sCatSeparator: "-----------------------------",
-				sCatPrefix: "",
-				bNoRedirect: true,
-				bDisabled: true,
-				sCustomName: "move_to"
-			});';
-
-	echo '
+		<div class="smalltext pagelinks floatright" id="search_jump_to"></div>
+		<script>
 		if (typeof(window.XMLHttpRequest) != "undefined")
 			aJumpTo[aJumpTo.length] = new JumpTo({
 				sContainerId: "search_jump_to",
@@ -545,7 +440,8 @@ function template_results()
 				sCatPrefix: "",
 				sGoButtonLabel: "', $txt['quick_mod_go'], '"
 			});
-		</script>';
+		</script>
+	</div>';
 }
 
 ?>

--- a/Themes/default/SplitTopics.template.php
+++ b/Themes/default/SplitTopics.template.php
@@ -97,7 +97,7 @@ function template_select()
 					', $txt['please_select_split'], '
 				</div>
 				<div class="pagesection">
-					<span id="pageindex_not_selected">', $context['not_selected']['page_index'], '</span>
+					<div id="pageindex_not_selected" class="pagelinks">', $context['not_selected']['page_index'], '</div>
 				</div>
 				<ul id="messages_not_selected" class="split_messages smalltext">';
 
@@ -125,7 +125,7 @@ function template_select()
 					', $txt['split_selected_posts_desc'], '
 				</div>
 				<div class="pagesection">
-					<span id="pageindex_selected">', $context['selected']['page_index'], '</span>
+					<div id="pageindex_selected" class="pagelinks">', $context['selected']['page_index'], '</div>
 				</div>
 				<ul id="messages_selected" class="split_messages smalltext">';
 

--- a/Themes/default/css/index.css
+++ b/Themes/default/css/index.css
@@ -632,7 +632,7 @@ dl.settings img {
 /* a general table class */
 table.table_grid {
 	border-collapse: collapse;
-	margin: 1px 0 5px 0;
+	margin: 0;
 	width: 100%;
 }
 table.table_grid td {
@@ -2986,7 +2986,7 @@ h3 .collapse {
 .up_contain {
 	overflow: hidden;
 	border: 1px solid #ddd;
-	margin: -1px 0 3px 0;
+	margin: 0 0 3px 0;
 	display: flex;
 	flex-wrap: wrap;
 }
@@ -3601,6 +3601,10 @@ div.cat_bar {
 	border-radius: 6px 6px 0 0;
 	box-shadow: 0 16px 20px rgba(255, 255, 255, 0.15) inset;
 	text-shadow: -1px -1px 1px rgba(0, 0, 0, 0.2);
+}
+.cat_bar.collapsed,
+.cat_bar.cat_bar_round {
+	border-radius: 6px;
 }
 .cat_bar h3 {
 	padding: 8px 12px 6px 12px;

--- a/Themes/default/css/index.css
+++ b/Themes/default/css/index.css
@@ -499,6 +499,10 @@ a img {
 	overflow: hidden;
 	clear: both;
 }
+.pagesection .pagelinks {
+	display: inline-block;
+	float: left;
+}
 .pages::after, .jump_to::after, .code::after,
 strong[id^='child_list_']::after {
 	content: ": ";

--- a/Themes/default/css/index.css
+++ b/Themes/default/css/index.css
@@ -2913,6 +2913,9 @@ div#manage_boards dl dd textarea[name=desc] {
 
 /* BoardIndex */
 /* This place covers board places (boardindex/messageindex/recent) */
+.boardindex_table:not(:last-child) {
+	margin-bottom: 15px;
+}
 h3 .collapse {
 	float: right;
 	margin: 4px 4px 0 0;
@@ -3700,7 +3703,7 @@ h3.titlebg, h4.titlebg, .titlebg, h3.subbg, h4.subbg, .subbg {
 .generic_list_wrapper .information div {
 	background: none;
 }
-.information a {
+.information a:not(.button) {
 	font-weight: bold;
 }
 p.information img {

--- a/Themes/default/css/index.css
+++ b/Themes/default/css/index.css
@@ -2343,7 +2343,9 @@ dl {
 .list_posts {
 	border-top: 1px solid #ddd;
 	box-shadow: 0 1px 0 #fff inset;
-	padding-top: 12px;
+	padding-top: 1em;
+	margin-top: 1em;
+	margin-bottom: 1em;
 	clear: both;
 	-webkit-hyphens: auto;
 	-ms-hyphens: auto;

--- a/Themes/default/css/index.css
+++ b/Themes/default/css/index.css
@@ -1004,7 +1004,6 @@ img.sort, .sort {
 .buttonlist, .buttonrow, .pagelinks {
 	z-index: 100;
 	padding: 5px 0 5px 0;
-	margin: 5px 0 5px 0;
 }
 .button, .quickbuttons > li > a, .inline_mod_check {
 	display: inline-block;
@@ -1022,11 +1021,12 @@ img.sort, .sort {
 	box-sizing: border-box;
 	vertical-align: middle;
 }
+.buttonlist .button {
+	margin-top: 2px;
+	margin-bottom: 2px;
+}
 .pagesection .button {
 	color: #346;
-}
-.button:not(:first-child) {
-	margin-left: 4px;
 }
 .button:hover, .button:focus,
 .quickbuttons > li:hover > a, .quickbuttons > li > a:focus {
@@ -1353,6 +1353,11 @@ ul li.greeting {
 }
 .quickbuttons > li:last-child > a, .inline_mod_check:last-child {
 	border-radius: 0 4px 4px 0;
+}
+.quickbuttons > li:only-child > a, .inline_mod_check:only-child {
+	border-radius: 4px;
+	margin: 2px;
+	height: 23px;
 }
 .inline_mod_check input {
 	position: relative;
@@ -2342,6 +2347,9 @@ dl {
 }
 .topic_details {
 	padding: 0 4px 4px 4px;
+}
+.counter + .topic_details {
+	margin-left: 25px;
 }
 .list_posts {
 	border-top: 1px solid #ddd;

--- a/Themes/default/css/index.css
+++ b/Themes/default/css/index.css
@@ -1975,7 +1975,8 @@ tr.windowbg td, tr.bg td, .table_grid tr td {
 	background-position: -239px -187px;
 }
 /* 9th Row */
-.main_icons.languages::before {
+.main_icons.languages::before,
+.main_icons.recent_posts::before {
 	background-position: -5px -213px;
 }
 .main_icons.members_request::before {

--- a/Themes/default/css/index.css
+++ b/Themes/default/css/index.css
@@ -2211,7 +2211,7 @@ dl {
 }
 #basicinfo h4 {
 	font-size: 1.4em;
-	font-weight: 100;
+	font-weight: normal;
 	-webkit-hyphens: auto;
 	-ms-hyphens: auto;
 	hyphens: auto;
@@ -2220,7 +2220,6 @@ dl {
 }
 #basicinfo h4 span.position {
 	font-size: 0.8em;
-	font-weight: 100;
 	display: block;
 }
 #basicinfo img.avatar, dl.settings img.avatar {

--- a/Themes/default/css/responsive.css
+++ b/Themes/default/css/responsive.css
@@ -123,13 +123,19 @@
 	dl.register_form dt span {
 		display: inline;
 	}
-	.button.qaction {
-		width: 10%;
-		margin: 0;
+	#quick_actions {
+		display: flex;
+		justify-content: flex-end;
 	}
-	.qaction {
-		width: 40%;
+	#quick_actions > * {
+		flex: 0 1 auto;
 		margin: 0 5px 0 0;
+		max-width: 40%;
+		white-space: nowrap;
+	}
+	#quick_actions > .button.qaction {
+		flex: 0 0 auto;
+		margin: 0 !important;
 	}
 
 	/* Menu */

--- a/Themes/default/languages/index.english.php
+++ b/Themes/default/languages/index.english.php
@@ -396,7 +396,7 @@ $txt['info_center_title'] = '%1$s - Info Center';
 $txt['watch'] = 'Watch';
 $txt['unwatch'] = 'Stop watching';
 
-$txt['check_all'] = 'Check all';
+$txt['check_all'] = 'Select all';
 
 // Use numeric entities in the below string.
 $txt['database_error'] = 'Database Error';


### PR DESCRIPTION
Fixes some of the issues in #7259:

- [x] Quick buttons still appear in the post header area (like in 2.0.x) in the topic summary, search results, the moderation centre, etc. These should be moved to be consistent with the layout used in the topic display.
- [x] Although the innermost part of the page index template is consistent, the wrapper divs placed around it are quite inconsistent across different templates, potentially causing theme authors all sorts of headaches.
- [x] The CSS used for the member’s name and position in the profile summary is unlike anything else in the theme. It looks nice in and of itself, sure, but it is inconsistent.
- [x] The `cat_bar` style for headings is designed to appear immediately above a table or visually similar structure, but in fact it is often appears on its own, which looks weird.
    - In some cases, rounded bottom corners should be applied to the `cat_bar` div.
    - In other cases, the following div should have the `noup` class applied to it in order to visually connect it with the preceding cat_bar
    - In yet other cases, the `cat_bar` class should be changed to some other class.
    - In a few cases, the entire `cat_bar` div is useless or redundant and can probably be removed.
- [x] When a category is collapsed on the board index and the user clicks on a category link in the linktree, the browser window may end up autoscrolling to the wrong position on the board index. This happens because the board table below a collapsed `cat_bar` is initially visible when the page loads before being immediately hidden by JavaScript, with the result that the browser initially autoscrolls the window to the original position of the target category. An easy fix is to make the collapsed content already hidden when the page first loads.
- [x] When showing a board, a topic, or even search results or recent posts, very similar information is presented to the user about what is being shown (e.g. board name and description, topic subject and author info, search query string, etc.), but we use at least three entirely different UI conventions to present this info. These should be made consistent. Since the UI used for topic display is the best of the options, the others should probably be changed to resemble that.
- [x] For no apparent reason, topic moderation UI is provided on search results when the “Show results as messages” option is not selected. This makes no sense and should be removed.
- [x] There is significant inconsistency between the presentation of posts in the topic display from the presentation of posts in search results, member profiles, the moderation centre, etc. The presentation should be made as consistent as possible.
- [x] The error log templates are (and need to be) more like post display templates that like the other log templates, but the overall UI for the error log can still be made more consistent with our UI conventions elsewhere than it is now.
