### PR TITLE
Fix the activating link in profile

### DIFF
--- a/Sources/Profile-View.php
+++ b/Sources/Profile-View.php
@@ -124,7 +124,8 @@ function summary($memID)
 		createToken($context['token_check'], 'get');
 
 		// Puerile comment
-		$context['activate_link'] = $scripturl . '?action=admin;area=viewmembers;sa=browse;type=approve;' . $context['session_var'] . '=' . $context['session_id'] . ';' . $context[$context['token_check'] . '_token_var'] . '=' . $context[$context['token_check'] . '_token'];
+		$type = in_array($context['member']['is_activated'], array(3, 4, 5, 13, 14, 15)) ? 'approve' : 'activate';
+		$context['activate_link'] = $scripturl . '?action=admin;area=viewmembers;sa=browse;type=' . $type . ';' . $context['session_var'] . '=' . $context['session_id'] . ';' . $context[$context['token_check'] . '_token_var'] . '=' . $context[$context['token_check'] . '_token'];
 	}
 
 	// Is the signature even enabled on this forum?

--- a/Themes/default/Profile.template.php
+++ b/Themes/default/Profile.template.php
@@ -376,7 +376,7 @@ function template_summary()
 		if (!empty($context['activate_message']))
 			echo '
 				<dt class="clear">
-					<span class="alert">', $context['activate_message'], '</span> (<a href="', $context['activate_link'], '"', ($context['activate_type'] == 4 ? ' class="you_sure" data-confirm="' . $txt['profileConfirm'] . '"' : ''), '>', $context['activate_link_text'], '</a>)
+					<span class="alert">', $context['activate_message'], '</span> (<a href="', $context['activate_link'], '">', $context['activate_link_text'], '</a>)
 				</dt>';
 
 		// If the current member is banned, show a message and possibly a link to the ban.


### PR DESCRIPTION
If a user was not yet activated a warning and a link will
be shown in the users profile. However the link would go
to the ACP approval tab, and not the activation tab. This
is confusing a lot of people since the link used to activate
the users directly in 2.0. Fixed so that the link would go
to the activating tab when the users need to be activated and
to the approval tab when approvals are needed.
Also removed the warning when users want to be deleted, as
the action will not happen on clicking the link.

Signed-off-by: Oscar Rydhé <oscar.rydhe@gmail.com>