### PR TITLE
Avoid "install language table" to overflow the layout

### DIFF
--- a/Themes/default/css/index.css
+++ b/Themes/default/css/index.css
@@ -4129,3 +4129,7 @@ div.sceditor-container:not(.sceditor-maximize) {
 img.theme_thumbnail {
 	max-width: 250px;
 }
+
+#lang_main_files_list .name {
+	word-break: break-word;
+}


### PR DESCRIPTION
In mobiles or other low resolution devices the install
language table overflows outside the screen. Avoid
this by breaking words.

Signed-off-by: Oscar Rydhé <oscar.rydhe@gmail.com>