### PR TITLE
Respects $modSettings['securityDisable_moderate'] when issuing warning

### DIFF
--- a/Sources/Profile.php
+++ b/Sources/Profile.php
@@ -582,7 +582,7 @@ function ModifyProfile($post_errors = array())
 				}
 
 				// Does this require session validating?
-				if (!empty($area['validate']) || (isset($_REQUEST['save']) && !$context['user']['is_owner'] && ($area_id != 'issuewarning' || !empty($modSettings['securityDisable_moderate']))))
+				if (!empty($area['validate']) || (isset($_REQUEST['save']) && !$context['user']['is_owner'] && ($area_id != 'issuewarning' || empty($modSettings['securityDisable_moderate']))))
 					$security_checks['validate'] = true;
 
 				// Permissions for good measure.


### PR DESCRIPTION
Previous attempt to fix this in #7125 had an incorrect `!` in the logic, which made it do the opposite of what was intended.