### PR TITLE
Let buttons be multiple lines

### DIFF
--- a/Themes/default/css/index.css
+++ b/Themes/default/css/index.css
@@ -1015,7 +1015,7 @@ img.sort, .sort {
 	line-height: 2em;
 	text-transform: uppercase;
 	cursor: pointer;
-	height: calc(2em + 2em * (0.9 - 0.85)); /* "input" font size minus ".button" font size */
+	min-height: calc(2em + 2em * (0.9 - 0.85)); /* "input" font size minus ".button" font size */
 	border: 1px solid;
 	border-color: #ddd #bbb #aaa #ddd;
 	border-radius: 3px;


### PR DESCRIPTION
If the layout width is limited and a button with a
long text exists, the text could be rendered outside
the button. Fixed this by allowing the button frame
to extend over multiple lines.

Fixes #7265

Signed-off-by: Oscar Rydhé <oscar.rydhe@gmail.com>