### PR TITLE
Responsive menus

### DIFF
--- a/Themes/default/GenericMenu.template.php
+++ b/Themes/default/GenericMenu.template.php
@@ -20,20 +20,24 @@ function template_generic_menu_dropdown_above()
 	// Which menu are we rendering?
 	$context['cur_menu_id'] = isset($context['cur_menu_id']) ? $context['cur_menu_id'] + 1 : 1;
 	$menu_context = &$context['menu_data_' . $context['cur_menu_id']];
+	$menu_label = isset($context['admin_menu_name']) ? $txt['admin_center'] : (isset($context['moderation_menu_name']) ? $txt['moderation_center'] : '');
 
 	// Load the menu
 	// Add mobile menu as well
 	echo '
-	<a class="menu_icon mobile_generic_menu_', $context['cur_menu_id'], '"></a>
+	<a class="mobile_generic_menu_', $context['cur_menu_id'], '">
+		<span class="menu_icon"></span>
+		<span class="text_menu">', sprintf($txt['mobile_generic_menu'], $menu_label), '</span>
+	</a>
 	<div id="genericmenu">
 		<div id="mobile_generic_menu_', $context['cur_menu_id'], '" class="popup_container">
 			<div class="popup_window description">
 				<div class="popup_heading">
-					', $txt['mobile_user_menu'], '
+					', sprintf($txt['mobile_generic_menu'], $menu_label), '
 					<a href="javascript:void(0);" class="main_icons hide_popup"></a>
 				</div>
 				', template_generic_menu($menu_context), '
-				</div>
+			</div>
 		</div>
 	</div>
 	<script>
@@ -246,8 +250,21 @@ function template_generic_menu_tabs(&$menu_context)
 	{
 		// The admin tabs.
 		echo '
+					<a class="mobile_generic_menu_', $context['cur_menu_id'], '_tabs">
+						<span class="menu_icon"></span>
+						<span class="text_menu">', sprintf($txt['mobile_generic_menu'], $tab_context['title']), '</span>
+					</a>
 					<div id="adm_submenus">
-						<ul class="dropmenu">';
+						<div id="mobile_generic_menu_', $context['cur_menu_id'], '_tabs" class="popup_container">
+							<div class="popup_window description">
+								<div class="popup_heading">
+									', sprintf($txt['mobile_generic_menu'], $tab_context['title']), '
+									<a href="javascript:void(0);" class="main_icons hide_popup"></a>
+								</div>';
+
+		echo '
+								<div class="generic_menu">
+									<ul class="dropmenu dropdown_menu_', $context['cur_menu_id'], '_tabs">';
 
 		foreach ($tab_context['tabs'] as $sa => $tab)
 		{
@@ -256,20 +273,31 @@ function template_generic_menu_tabs(&$menu_context)
 
 			if (!empty($tab['is_selected']))
 				echo '
-							<li>
-								<a class="active" href="', isset($tab['url']) ? $tab['url'] : $menu_context['base_url'] . ';area=' . $menu_context['current_area'] . ';sa=' . $sa, $menu_context['extra_parameters'], isset($tab['add_params']) ? $tab['add_params'] : '', '">', $tab['label'], '</a>
-							</li>';
+										<li>
+											<a class="active" href="', isset($tab['url']) ? $tab['url'] : $menu_context['base_url'] . ';area=' . $menu_context['current_area'] . ';sa=' . $sa, $menu_context['extra_parameters'], isset($tab['add_params']) ? $tab['add_params'] : '', '">', $tab['label'], '</a>
+										</li>';
 			else
 				echo '
-							<li>
-								<a href="', isset($tab['url']) ? $tab['url'] : $menu_context['base_url'] . ';area=' . $menu_context['current_area'] . ';sa=' . $sa, $menu_context['extra_parameters'], isset($tab['add_params']) ? $tab['add_params'] : '', '">', $tab['label'], '</a>
-							</li>';
+										<li>
+											<a href="', isset($tab['url']) ? $tab['url'] : $menu_context['base_url'] . ';area=' . $menu_context['current_area'] . ';sa=' . $sa, $menu_context['extra_parameters'], isset($tab['add_params']) ? $tab['add_params'] : '', '">', $tab['label'], '</a>
+										</li>';
 		}
 
 		// The end of tabs
 		echo '
-						</ul>
-					</div><!-- #adm_submenus -->';
+									</ul>
+								</div>
+							</div>
+						</div>
+					</div><!-- #adm_submenus -->
+					<script>
+						$( ".mobile_generic_menu_', $context['cur_menu_id'], '_tabs" ).click(function() {
+							$( "#mobile_generic_menu_', $context['cur_menu_id'], '_tabs" ).show();
+							});
+						$( ".hide_popup" ).click(function() {
+							$( "#mobile_generic_menu_', $context['cur_menu_id'], '_tabs" ).hide();
+						});
+					</script>';
 	}
 }
 

--- a/Themes/default/css/index.css
+++ b/Themes/default/css/index.css
@@ -2792,6 +2792,12 @@ dl.addrules dt.floatleft {
 	background: rgba(40, 64, 80, 0.5);
 	z-index: 6;
 }
+#genericmenu > .popup_container {
+	z-index: 5;
+}
+#adm_submenus > .popup_container {
+	z-index: 4;
+}
 .popup_window,
 #main_menu .popup_window,
 #genericmenu .popup_window,
@@ -2829,10 +2835,6 @@ dl.addrules dt.floatleft {
 #genericmenu .popup_heading,
 #adm_submenus .popup_heading {
 	display: none;
-}
-#genericmenu > .popup_container,
-#adm_submenus > .popup_container {
-	z-index: 5;
 }
 #main_menu .popup_container,
 #genericmenu > .popup_container,

--- a/Themes/default/css/index.css
+++ b/Themes/default/css/index.css
@@ -778,6 +778,11 @@ img.sort, .sort {
 	text-shadow: none;
 }
 
+a.mobile_user_menu,
+a[class^="mobile_generic_menu_"] {
+	display: none;
+}
+
 #main_menu {
 	margin: 0 0 4px 0;
 }
@@ -2789,7 +2794,8 @@ dl.addrules dt.floatleft {
 }
 .popup_window,
 #main_menu .popup_window,
-#genericmenu .popup_window {
+#genericmenu .popup_window,
+#adm_submenus .popup_window {
 	position: relative;
 	width: auto;
 	z-index: 99;
@@ -2819,13 +2825,18 @@ dl.addrules dt.floatleft {
 	border-radius: 6px 6px 2px 2px;
 	box-shadow: 0 -2px 3px rgba(0, 0, 0, 0.15), 0 1px 1px rgba(255, 255, 255, 0.2);
 }
-#main_menu .popup_heading, #genericmenu .popup_heading {
+#main_menu .popup_heading,
+#genericmenu .popup_heading,
+#adm_submenus .popup_heading {
 	display: none;
 }
-#genericmenu > .popup_container {
+#genericmenu > .popup_container,
+#adm_submenus > .popup_container {
 	z-index: 5;
 }
-#main_menu .popup_container, #genericmenu > .popup_container {
+#main_menu .popup_container,
+#genericmenu > .popup_container,
+#adm_submenus > .popup_container {
 	display: block;
 	position: relative;
 	background: none;

--- a/Themes/default/css/responsive.css
+++ b/Themes/default/css/responsive.css
@@ -559,12 +559,14 @@
 		border-left: 0;
 		border-right: 0;
 	}
-	.dropmenu li a, .dropmenu li:hover a {
-		padding: 5px 0;
-	}
 	.dropmenu li a, .dropmenu li a:hover {
 		text-indent: 10px;
 		border-radius: 0;
+		padding: 5px 0 !important;
+	}
+	.dropmenu li li li a,
+	.dropmenu li li li a:hover {
+		padding: 5px 24px !important;
 	}
 	.dropmenu li a, .dropmenu li:hover a,
 	.dropmenu li a.active, .dropmenu li a.active:hover,
@@ -577,11 +579,19 @@
 	.dropmenu ul li a {
 		width: auto !important;
 	}
+	.dropmenu li.subsections > a::after {
+		position: absolute;
+		padding: 5px 0;
+		right: 10px;
+		font: 83.33%/150% Arial, sans-serif;
+		content: "\25bc" !important;
+	}
 	.dropmenu li ul,
 	.dropmenu li li:hover ul, .dropmenu li li ul {
 		position: relative;
 		border-radius: 0;
 		left: 0;
+		box-shadow: none;
 	}
 	#footer {
 		text-align: center;

--- a/Themes/default/css/responsive.css
+++ b/Themes/default/css/responsive.css
@@ -457,7 +457,8 @@
 		page-break-inside: avoid;
 	}
 	#main_menu .popup_window,
-	#genericmenu .popup_window {
+	#genericmenu .popup_window,
+	#adm_submenus .popup_window {
 		box-shadow: none;
 		border-width: 0;
 		background: none;
@@ -480,7 +481,9 @@
 /* Entry level phones */
 @media (max-width: 480px) {
 	/* This is general */
-	#main_menu .popup_container, #genericmenu .popup_container {
+	#main_menu .popup_container,
+	#genericmenu .popup_container,
+	#adm_submenus .popup_container {
 		display: none;
 		position: fixed;
 		top: 0;
@@ -489,7 +492,9 @@
 		height: 100%;
 		z-index: 5;
 	}
-	#main_menu .popup_heading, #genericmenu .popup_heading {
+	#main_menu .popup_heading,
+	#genericmenu .popup_heading,
+	#adm_submenus .popup_heading {
 		display: block;
 	}
 	#main_menu {
@@ -497,7 +502,8 @@
 	}
 	.popup_window,
 	#main_menu .popup_window,
-	#genericmenu .popup_window {
+	#genericmenu .popup_window,
+	#adm_submenus .popup_window {
 		top: 15%;
 		width: 95vw;
 		min-height: auto;
@@ -528,11 +534,20 @@
 	div[id^="mobile_generic_menu_"] .generic_menu {
 		display: block;
 	}
+	a.mobile_user_menu,
+	a[class^="mobile_generic_menu_"] {
+		display: flex;
+		align-items: center;
+		margin: 0 0 4px 0;
+	}
+	a[class^="mobile_generic_menu_"] {
+		margin: 8px 0;
+	}
 	.menu_icon {
 		display: inline-block;
 		background: url(../images/icons/menu.svg) no-repeat;
-		height: 20px;
-		width: 20px;
+		height: 24px;
+		width: 24px;
 	}
 	.dropmenu li, .dropmenu li:hover,
 	.dropmenu li a, .dropmenu li a:hover,
@@ -761,9 +776,6 @@
 		width: 50%;
 		float: left;
 		margin: 0 0 5px 0;
-	}
-	.action_admin .navigate_section {
-		display: none;
 	}
 	#quick_search input[type="search"],
 	#quick_search select {

--- a/Themes/default/css/responsive.css
+++ b/Themes/default/css/responsive.css
@@ -442,7 +442,7 @@
 }
 
 /* Tricky menu */
-@media (min-width: 481px) {
+@media (min-width: 561px) {
 	#mobile_user_menu.popup_container {
 		display: block !important;
 	}
@@ -464,22 +464,7 @@
 		background: none;
 	}
 }
-
-@media (min-width: 480px) and (max-width: 560px) {
-	/* Calendar */
-	#event_time_options {
-		width: 40%;
-	}
-	#event_title, #event_board {
-		width: 100%;
-	}
-	#evtitle {
-		width: 98%;
-	}
-}
-
-/* Entry level phones */
-@media (max-width: 480px) {
+@media (max-width: 560px) {
 	/* This is general */
 	#main_menu .popup_container,
 	#genericmenu .popup_container,
@@ -511,21 +496,12 @@
 		overflow-x: hidden;
 		overflow-y: scroll;
 	}
-	h1.forumtitle a, h1.forumtitle {
-		padding: 5px 0 0 4px;
-		max-width: 300px;
-		margin: 10px 0;
+	#adm_submenus {
+		padding: 0;
 	}
-	.board_moderators {
-		display: none;
-	}
-	#top_info .welcome {
-		display: none;
-	}
-	#pm_menu, #alerts_menu, #profile_menu {
-		min-width: initial;
-		width: 25em;
-		max-width: calc(100vw - 17px);
+	#adm_submenus .dropmenu li {
+		float: left;
+		margin: 0;
 	}
 	.generic_menu {
 		display: none;
@@ -592,6 +568,43 @@
 		border-radius: 0;
 		left: 0;
 		box-shadow: none;
+	}
+	/* 3rd level menu tests */
+	.dropmenu li ul ul {
+		margin: 0 !important;
+	}
+}
+
+@media (min-width: 480px) and (max-width: 560px) {
+	/* Calendar */
+	#event_time_options {
+		width: 40%;
+	}
+	#event_title, #event_board {
+		width: 100%;
+	}
+	#evtitle {
+		width: 98%;
+	}
+}
+
+/* Entry level phones */
+@media (max-width: 480px) {
+	h1.forumtitle a, h1.forumtitle {
+		padding: 5px 0 0 4px;
+		max-width: 300px;
+		margin: 10px 0;
+	}
+	.board_moderators {
+		display: none;
+	}
+	#top_info .welcome {
+		display: none;
+	}
+	#pm_menu, #alerts_menu, #profile_menu {
+		min-width: initial;
+		width: 25em;
+		max-width: calc(100vw - 17px);
 	}
 	#footer {
 		text-align: center;
@@ -810,13 +823,6 @@
 	}
 
 	/* Menu tests */
-	#adm_submenus {
-		padding: 0;
-	}
-	#adm_submenus .dropmenu li {
-		float: left;
-		margin: 0;
-	}
 	#header_news_lists_preview, tr[id^="list_news_lists_"] td:nth-child(even),
 	#header_smiley_set_list_default, #header_smiley_set_list_url, #header_smiley_set_list_check,
 	tr[id^="list_smiley_set_list_"] td:nth-child(odd),
@@ -852,10 +858,6 @@
 	/* Likes */
 	#likes li .like_time {
 		display: none;
-	}
-	/* 3rd level menu tests */
-	.dropmenu li ul ul {
-		margin: 0 !important;
 	}
 	/* Generic Classes for Customizations */
 	.hide_480 {

--- a/Themes/default/css/responsive.css
+++ b/Themes/default/css/responsive.css
@@ -575,7 +575,7 @@
 	}
 }
 
-@media (min-width: 480px) and (max-width: 560px) {
+@media (min-width: 481px) and (max-width: 560px) {
 	/* Calendar */
 	#event_time_options {
 		width: 40%;

--- a/Themes/default/index.template.php
+++ b/Themes/default/index.template.php
@@ -409,7 +409,10 @@ function template_body_above()
 	// Show the menu here, according to the menu sub template, followed by the navigation tree.
 	// Load mobile menu here
 	echo '
-				<a class="menu_icon mobile_user_menu"></a>
+				<a class="mobile_user_menu">
+					<span class="menu_icon"></span>
+					<span class="text_menu">', $txt['mobile_user_menu'], '</span>
+				</a>
 				<div id="main_menu">
 					<div id="mobile_user_menu" class="popup_container">
 						<div class="popup_window description">

--- a/Themes/default/languages/index.english.php
+++ b/Themes/default/languages/index.english.php
@@ -931,7 +931,8 @@ $txt['unsubscribe_announcements_manual'] = 'To unsubscribe from forum newsletter
 // Mobile Actions
 $txt['mobile_action'] = 'User actions';
 $txt['mobile_moderation'] = 'Moderation';
-$txt['mobile_user_menu'] = 'Mobile Main Menu';
+$txt['mobile_user_menu'] = 'Main Menu';
+$txt['mobile_generic_menu'] = '%1$s Menu';
 
 // Formats for lists in a sentence (e.g. "Alice, Bob, and Charlie")
 // Examples:


### PR DESCRIPTION
Shows descriptive labels for the mobile menu links and tidies up the presentation of the mobile menus themselves.
<img width="396" alt="Screen Shot 2022-01-26 at 9 25 35 PM" src="https://user-images.githubusercontent.com/191731/151291807-a5178990-e699-4c93-aaca-a33d334a0953.png">
<img width="388" alt="Screen Shot 2022-01-26 at 9 26 58 PM" src="https://user-images.githubusercontent.com/191731/151291905-f35e0f64-c37c-431e-80c7-c9ac8ae7aceb.png">

