### PR TITLE
Simplifies and tidies up the markup & CSS for admin search

### DIFF
--- a/Themes/default/Admin.template.php
+++ b/Themes/default/Admin.template.php
@@ -1327,7 +1327,7 @@ function template_edit_profile_field()
  */
 function template_admin_search_results()
 {
-	global $context, $txt, $scripturl;
+	global $context, $txt;
 
 	echo '
 						<div id="section_header" class="cat_bar">

--- a/Themes/default/Admin.template.php
+++ b/Themes/default/Admin.template.php
@@ -1331,19 +1331,12 @@ function template_admin_search_results()
 
 	echo '
 						<div id="section_header" class="cat_bar">
-							<form action="', $scripturl, '?action=admin;area=search" method="post" accept-charset="', $context['character_set'], '">
-								<h3 class="catbg">
-									<span id="quick_search" class="floatright">
-										<input type="search" name="search_term" value="', $context['search_term'], '">
-										<input type="hidden" name="search_type" value="', $context['search_type'], '">
-										<input type="submit" name="search_go" value="', $txt['admin_search_results_again'], '" class="button">
-									</span>
-									<span class="main_icons filter"></span>
-									<span id="quick_search_results">
-										', sprintf($txt['admin_search_results_desc'], $context['search_term']), '
-									</span>
-								</h3>
-							</form>
+							<h3 class="catbg">
+								', template_admin_quick_search(), '
+								<span id="quick_search_results">
+									', sprintf($txt['admin_search_results_desc'], $context['search_term']), '
+								</span>
+							</h3>
 						</div><!-- #section_header -->
 						<div class="windowbg generic_list_wrapper">';
 
@@ -1660,20 +1653,20 @@ function template_clean_cache_button_below()
  */
 function template_admin_quick_search()
 {
-	global $context, $txt;
+	global $context, $txt, $scripturl;
 
 	if ($context['user']['is_admin'])
 		echo '
-								<span class="floatright admin_search">
+								<form action="' . $scripturl . '?action=admin;area=search" method="post" accept-charset="' . $context['character_set'] . '" class="admin_search">
 									<span class="main_icons filter centericon"></span>
-									<input type="search" name="search_term" placeholder="', $txt['admin_search'], '">
+									<input type="search" name="search_term" placeholder="', $txt['admin_search'], '"', isset($context['search_term']) ? ' value="' . $context['search_term'] . '"' : '','>
 									<select name="search_type">
 										<option value="internal"', (empty($context['admin_preferences']['sb']) || $context['admin_preferences']['sb'] == 'internal' ? ' selected' : ''), '>', $txt['admin_search_type_internal'], '</option>
 										<option value="member"', (!empty($context['admin_preferences']['sb']) && $context['admin_preferences']['sb'] == 'member' ? ' selected' : ''), '>', $txt['admin_search_type_member'], '</option>
 										<option value="online"', (!empty($context['admin_preferences']['sb']) && $context['admin_preferences']['sb'] == 'online' ? ' selected' : ''), '>', $txt['admin_search_type_online'], '</option>
 									</select>
 									<input type="submit" name="search_go" id="search_go" value="', $txt['admin_search_go'], '" class="button">
-								</span>';
+								</form>';
 }
 
 ?>

--- a/Themes/default/GenericMenu.template.php
+++ b/Themes/default/GenericMenu.template.php
@@ -150,9 +150,8 @@ function template_generic_menu_tabs(&$menu_context)
 	if (!empty($tab_context['title']))
 	{
 		echo '
-					<div class="cat_bar">', (function_exists('template_admin_quick_search') ? '
-						<form action="' . $scripturl . '?action=admin;area=search" method="post" accept-charset="' . $context['character_set'] . '">' : ''), '
-							<h3 class="catbg">';
+					<div class="cat_bar">
+						<h3 class="catbg">';
 
 		// The function is in Admin.template.php, but since this template is used elsewhere too better check if the function is available
 		if (function_exists('template_admin_quick_search'))
@@ -229,8 +228,7 @@ function template_generic_menu_tabs(&$menu_context)
 								', $tab_context['title'];
 
 		echo '
-							</h3>', (function_exists('template_admin_quick_search') ? '
-						</form>' : ''), '
+						</h3>
 					</div><!-- .cat_bar -->';
 	}
 

--- a/Themes/default/css/admin.css
+++ b/Themes/default/css/admin.css
@@ -49,41 +49,21 @@ legend {
 /* Styles for the admin home screen.
 ------------------------------------------------------- */
 /* Admin quick search bar, and results page. */
-h3.catbg #quick_search form {
-	padding-top: 2px;
+.admin_search {
+	margin: -3px 0;
 	font-size: 0.9em;
+	float: right;
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
 }
-h3.catbg #quick_search form input, h3.catbg #quick_search form select, h3.catbg #quick_search form .button {
-	margin: 0 3px !important;
-	padding: 4px 3px 3px 3px;
+.admin_search input, .admin_search select, .admin_search .button {
 	border-radius: 4px;
-	border: 1px solid #777;
-	vertical-align: top;
+	margin: 0 0 0 2px;
 }
-h3.catbg #quick_search form select {
-	font-size: 0.9em;
-	margin: -1px 0 0 0;
-	padding: 2px;
-}
-h3.catbg #quick_search form select option {
-	padding: 2px 4px;
-}
-h3.catbg #quick_search form .button {
-	font-weight: bold;
-	padding: 3px 6px 2px 6px;
-}
-h3.catbg #quick_search form .button:hover {
-	background: #fff;
-}
-span#quick_search {
-	display: block;
-}
-/* Browser tweaks. */
-body#chrome #quick_search form input[type="search"] {
-	padding: 2px;
-}
-body#chrome #quick_search form input {
-	float: none;
+.admin_search input[type="search"] {
+	min-width: 0;
+	flex: 1 1 auto;
 }
 
 /* The welcome thingy. */

--- a/Themes/default/css/responsive.css
+++ b/Themes/default/css/responsive.css
@@ -417,6 +417,11 @@
 	}
 
 	/* Admin */
+	.admin_search {
+		float: none;
+		width: 100%;
+		margin-bottom: 10px;
+	}
 	.table_grid.half_content {
 		width: 100%;
 		margin: 0;
@@ -751,23 +756,10 @@
 		padding: 0;
 		margin: 0 0 5px 0;
 	}
-	.admin_search {
-		float: none;
-		display: block;
-		width: 100%;
-		margin-bottom: 10px;
-	}
 	fieldset.admin_group a {
 		width: 50%;
 		float: left;
 		margin: 0 0 5px 0;
-	}
-	.action_admin .navigate_section {
-		display: none;
-	}
-	#quick_search input[type="search"],
-	#quick_search select {
-		width: 90%;
 	}
 
 	.error_info, #fatal_error {


### PR DESCRIPTION
Before:
<img width="310" alt="Screen Shot 2022-01-26 at 9 28 57 PM" src="https://user-images.githubusercontent.com/191731/151292083-7608533d-75a9-4aa1-8a55-c8c95e16b0b3.png">


After:
<img width="307" alt="Screen Shot 2022-01-26 at 9 30 02 PM" src="https://user-images.githubusercontent.com/191731/151292176-46b42d92-f71c-43b7-8e18-d52ddb192e6b.png">

