### PR TITLE
Fix admin members list overflows the layout

### DIFF
--- a/Themes/default/css/index.css
+++ b/Themes/default/css/index.css
@@ -4173,6 +4173,6 @@ img.theme_thumbnail {
 	max-width: 250px;
 }
 
-#lang_main_files_list .name {
+#lang_main_files_list .name, #member_list .email, #approve_list .email {
 	word-break: break-word;
 }

--- a/Themes/default/css/responsive.css
+++ b/Themes/default/css/responsive.css
@@ -39,6 +39,9 @@
 	#alerts_menu_top .main_icons {
 		display: inline-block;
 	}
+	#member_list .ip, #member_list .last_active, #member_list .user_name {
+		display: none !important;
+	}
 }
 
 @media (min-width: 720px) and (max-width: 799px) {
@@ -402,7 +405,6 @@
 	#search_form, #smflogo, #message_index_jump_to, .nextlinks, #display_jump_to,
 	#siteslogan, th.id_group, th.registered, th.posts, th.reg_group, th.reg_date, td.reg_group, td.reg_date,
 	td.id_group, td.registered, td.posts:not(.unique), td.statsbar.posts,
-	#member_list .ip, #member_list .last_active, #member_list .user_name,
 	#approve_list .ip, #approve_list .date_registered, #group_members .date_registered,
 	#main_content_section .navigate_section, .time,
 	#header_custom_profile_fields_field_type, #header_custom_profile_fields_active,


### PR DESCRIPTION
When the screen width is around 850 px the members list
in the admin center is overflowing the layout. Solved
this by hiding some columns already at 855px. Also
made the email field wrap for long email addresses.

Signed-off-by: Oscar Rydhé <oscar.rydhe@gmail.com>