### PR TITLE
Ensures cookieTime setting options match $context['login_cookie_times']

### DIFF
--- a/Sources/ManageServer.php
+++ b/Sources/ManageServer.php
@@ -476,13 +476,13 @@ function ModifyCookieSettings($return_config = false)
 	$config_vars = array(
 		// Cookies...
 		array('cookiename', $txt['cookie_name'], 'file', 'text', 20),
-		array('cookieTime', $txt['cookieTime'], 'db', 'select', array(
-			3153600 => $txt['always_logged_in'],
-			60 => $txt['one_hour'],
-			1440 => $txt['one_day'],
-			10080 => $txt['one_week'],
-			43200 => $txt['one_month'],
-		)),
+		array('cookieTime', $txt['cookieTime'], 'db', 'select', array_filter(array_map(
+			function ($str) use ($txt)
+			{
+				return isset($txt[$str]) ? $txt[$str] : '';
+			},
+			$context['login_cookie_times']
+		))),
 		array('localCookies', $txt['localCookies'], 'db', 'check', false, 'localCookies'),
 		array('globalCookies', $txt['globalCookies'], 'db', 'check', false, 'globalCookies'),
 		array('globalCookiesDomain', $txt['globalCookiesDomain'], 'db', 'text', false, 'globalCookiesDomain'),


### PR DESCRIPTION
If a mod or something changes the values of $context['login_cookie_times'], this will make sure that the options presented to the admin for $modSettings['cookieTime'] match with the current values. Previously, the options were hard-coded to assume the standard set of values in $context['login_cookie_times'].