### PR TITLE
Gracefully handles missing Settings.php during install

### DIFF
--- a/Sources/Subs-Admin.php
+++ b/Sources/Subs-Admin.php
@@ -1306,7 +1306,7 @@ function updateSettingsFile($config_vars, $keep_quotes = null, $rebuild = false)
 			$settingsText = '<' . "?php\n";
 			foreach ($settings_defs as $var => $setting_def)
 			{
-				if (!empty($setting_def['text']) && strpos($substitutions[$var]['replacement'], $setting_def['text']) === false)
+				if (is_string($var) && !empty($setting_def['text']) && strpos($substitutions[$var]['replacement'], $setting_def['text']) === false)
 					$substitutions[$var]['replacement'] = $setting_def['text'] . "\n" . $substitutions[$var]['replacement'];
 
 				$settingsText .= $substitutions[$var]['replacement'] . "\n";

--- a/other/install.php
+++ b/other/install.php
@@ -1098,7 +1098,7 @@ function ForumSettings()
 		}
 
 		// Set the character set here.
-		installer_updateSettingsFile(array('db_character_set' => 'utf8'));
+		installer_updateSettingsFile(array('db_character_set' => 'utf8'), true);
 
 		// Good, skip on.
 		return true;


### PR DESCRIPTION
Avoids errors about undefined path variables and tidies formatting before install is done.

Fixes #7296 