### PR TITLE
Always unset $_SESSION['temp_attachments'] after post is made.

### DIFF
--- a/Sources/Post.php
+++ b/Sources/Post.php
@@ -2233,8 +2233,8 @@ function Post2()
 					unlink($attachment['tmp_name']);
 			}
 		}
-		unset($_SESSION['temp_attachments']);
 	}
+	unset($_SESSION['temp_attachments']);
 
 	// Make the poll...
 	if (isset($_REQUEST['poll']))


### PR DESCRIPTION
Should fix some weird glitches with attachments ending up attached to the wrong post.