### PR TITLE
Uses inherent width and height of image attachments with no thumbnail

### DIFF
--- a/Themes/default/Display.template.php
+++ b/Themes/default/Display.template.php
@@ -783,7 +783,7 @@ function template_single_post($message)
 											<a href="', $attachment['href'], ';image" id="link_', $attachment['id'], '" onclick="', $attachment['thumbnail']['javascript'], '"><img src="', $attachment['thumbnail']['href'], '" alt="" id="thumb_', $attachment['id'], '" class="atc_img"></a>';
 				else
 					echo '
-											<img src="' . $attachment['href'] . ';image" alt="" width="' . $attachment['width'] . '" height="' . $attachment['height'] . '" loading="lazy" class="atc_img">';
+											<img src="' . $attachment['href'] . ';image" alt="" loading="lazy" class="atc_img">';
 
 				echo '
 										</div><!-- .attachments_top -->';


### PR DESCRIPTION
Fixes #7338 