### PR TITLE
Fix ignore boards save function

### DIFF
--- a/Sources/Profile-Modify.php
+++ b/Sources/Profile-Modify.php
@@ -966,25 +966,25 @@ function saveProfileChanges(&$profile_vars, &$post_errors, $memID)
 		'ignore_boards',
 	);
 
-	if (isset($_POST['sa']) && $_POST['sa'] == 'ignoreboards' && empty($_POST['ignore_brd']))
-		$_POST['ignore_brd'] = array();
+	if (isset($_POST['sa']) && $_POST['sa'] == 'ignoreboards' && empty($_POST['brd']))
+		$_POST['brd'] = array();
 
 	unset($_POST['ignore_boards']); // Whatever it is set to is a dirty filthy thing.  Kinda like our minds.
-	if (isset($_POST['ignore_brd']))
+	if (isset($_POST['brd']))
 	{
-		if (!is_array($_POST['ignore_brd']))
-			$_POST['ignore_brd'] = array($_POST['ignore_brd']);
+		if (!is_array($_POST['brd']))
+			$_POST['brd'] = array($_POST['brd']);
 
-		foreach ($_POST['ignore_brd'] as $k => $d)
+		foreach ($_POST['brd'] as $k => $d)
 		{
 			$d = (int) $d;
 			if ($d != 0)
-				$_POST['ignore_brd'][$k] = $d;
+				$_POST['brd'][$k] = $d;
 			else
-				unset($_POST['ignore_brd'][$k]);
+				unset($_POST['brd'][$k]);
 		}
-		$_POST['ignore_boards'] = implode(',', $_POST['ignore_brd']);
-		unset($_POST['ignore_brd']);
+		$_POST['ignore_boards'] = implode(',', $_POST['brd']);
+		unset($_POST['brd']);
 	}
 
 	// Here's where we sort out all the 'other' values...


### PR DESCRIPTION
Due to a name mixup it was not possible to save
ignored boards settings. In fact when saved all
ignored boards where wiped.

Fixes #7343

Signed-off-by: Oscar Rydhé <oscar.rydhe@gmail.com>