### PR TITLE
Explicitly define a default value for credits column in log_packages

### DIFF
--- a/other/install_2-1_mysql.sql
+++ b/other/install_2-1_mysql.sql
@@ -463,7 +463,7 @@ CREATE TABLE {$db_prefix}log_packages (
 	failed_steps TEXT NOT NULL,
 	themes_installed VARCHAR(255) NOT NULL DEFAULT '',
 	db_changes TEXT NOT NULL,
-	credits TEXT NOT NULL,
+	credits TEXT NOT NULL DEFAULT '',
 	sha256_hash TEXT,
 	PRIMARY KEY (id_install),
 	INDEX idx_filename (filename(15))

--- a/other/install_2-1_postgresql.sql
+++ b/other/install_2-1_postgresql.sql
@@ -733,7 +733,7 @@ CREATE TABLE {$db_prefix}log_packages (
 	failed_steps text NOT NULL,
 	themes_installed varchar(255) NOT NULL DEFAULT '',
 	db_changes text NOT NULL,
-	credits text NOT NULL,
+	credits text NOT NULL DEFAULT '',
 	sha256_hash TEXT,
 	PRIMARY KEY (id_install)
 );

--- a/other/upgrade_2-1_mysql.sql
+++ b/other/upgrade_2-1_mysql.sql
@@ -666,7 +666,7 @@ ADD INDEX `idx_id_member` (`id_member`, `id_group`);
 /******************************************************************************/
 ---# Adding support for <credits> tag in package manager
 ALTER TABLE {$db_prefix}log_packages
-ADD COLUMN credits TEXT NOT NULL;
+ADD COLUMN credits TEXT NOT NULL DEFAULT '';
 ---#
 
 ---# Adding support for package hashes

--- a/other/upgrade_2-1_postgresql.sql
+++ b/other/upgrade_2-1_postgresql.sql
@@ -824,7 +824,7 @@ CREATE INDEX {$db_prefix}log_group_requests_id_member ON {$db_prefix}log_group_r
 /******************************************************************************/
 ---# Adding support for <credits> tag in package manager
 ALTER TABLE {$db_prefix}log_packages
-ADD COLUMN IF NOT EXISTS credits TEXT NOT NULL;
+ADD COLUMN IF NOT EXISTS credits TEXT NOT NULL DEFAULT '';
 ---#
 
 ---# Adding support for package hashes


### PR DESCRIPTION
Mysql got an implicit default value on credits col,
to make this point clear for both databases i convert this implicit definition to an explicit defintion.

Test case:
https://dbfiddle.uk/?rdbms=postgres_14&fiddle=664b05272751062e3981ddb055ea7744


fixes: #7345