### PR TITLE
Use reverse proxy IP for users

### DIFF
--- a/Sources/QueryString.php
+++ b/Sources/QueryString.php
@@ -327,12 +327,16 @@ function cleanRequest()
 
 				// Otherwise, we've got an IP!
 				$_SERVER['BAN_CHECK_IP'] = trim($ip);
+				$_SERVER['REMOTE_ADDR'] = trim($ip);
 				break;
 			}
 		}
 		// Otherwise just use the only one.
 		elseif (preg_match('~^((0|10|172\.(1[6-9]|2[0-9]|3[01])|192\.168|255|127)\.|unknown|::1|fe80::|fc00::)~', $_SERVER[$proxyIPheader]) == 0 || preg_match('~^((0|10|172\.(1[6-9]|2[0-9]|3[01])|192\.168|255|127)\.|unknown|::1|fe80::|fc00::)~', $_SERVER['REMOTE_ADDR']) != 0)
+		{
 			$_SERVER['BAN_CHECK_IP'] = $_SERVER[$proxyIPheader];
+			$_SERVER['REMOTE_ADDR'] = $_SERVER[$proxyIPheader];
+		}
 		elseif (!isValidIPv6($_SERVER[$proxyIPheader]) || preg_match('~::ffff:\d+\.\d+\.\d+\.\d+~', $_SERVER[$proxyIPheader]) !== 0)
 		{
 			$_SERVER[$proxyIPheader] = preg_replace('~^::ffff:(\d+\.\d+\.\d+\.\d+)~', '\1', $_SERVER[$proxyIPheader]);


### PR DESCRIPTION
The real client IP is not used in $user_info. This causes incorrect behavior when used behind a reverse proxy.
For example only one guest will be visible (as only the IP of the reverse proxy is used) and all logging is linked to that IP.

Again a small hotfix. A better aproach would be to use a proper getClientIP() function which processes the headers and checks for the reverse proxy IP.

Example: [Symphony getClientIP()](https://github.com/symfony/http-foundation/blob/5ef86ac7927d2de08dc1e26eb91325f9ccbe6309/Request.php#L832)