### PR TITLE
Updates timezones to reflect Enderbury -> Kanton rename in tzdb

### DIFF
--- a/Sources/Subs-Timezones.php
+++ b/Sources/Subs-Timezones.php
@@ -486,7 +486,7 @@ function get_tzid_metazones($when = 'now')
 		'Pacific/Efate' => 'Pacific_Vanuatu',
 
 		// No DST
-		'Pacific/Enderbury' => 'Pacific_Phoenix_Islands',
+		'Pacific/Kanton' => 'Pacific_Phoenix_Islands',
 
 		// No DST
 		'Pacific/Fakaofo' => 'Pacific_Tokelau',
@@ -1065,6 +1065,7 @@ function get_sorted_tzids_for_country($country_code, $when = 'now')
 		'KI' => array(
 			'Pacific/Tarawa',
 			'Pacific/Kiritimati',
+			'Pacific/Kanton',
 			'Pacific/Enderbury',
 		),
 		'KM' => array(
@@ -1615,6 +1616,12 @@ function get_tzid_fallbacks($tzids, $when = 'now')
 			array(
 				'ts' => PHP_INT_MIN,
 				'tzid' => 'Pacific/Truk',
+			),
+		),
+		'Pacific/Kanton' => array(
+			array(
+				'ts' => PHP_INT_MIN,
+				'tzid' => 'Pacific/Enderbury',
 			),
 		),
 		'Pacific/Pohnpei' => array(

--- a/Themes/default/languages/Timezones.english.php
+++ b/Themes/default/languages/Timezones.english.php
@@ -573,6 +573,7 @@ $txt['Pacific/Gambier'] = 'Gambier Islands';
 $txt['Pacific/Guadalcanal'] = 'Guadalcanal';
 $txt['Pacific/Guam'] = 'Guam';
 $txt['Pacific/Honolulu'] = 'Honolulu';
+$txt['Pacific/Kanton'] = 'Canton Island';
 $txt['Pacific/Kiritimati'] = 'Kiritimati';
 $txt['Pacific/Kosrae'] = 'Tofol';
 $txt['Pacific/Kwajalein'] = 'Kwajalein';


### PR DESCRIPTION
`Pacific/Enderbury` was renamed to `Pacific/Kanton` in version 2021b of the TZDB.