### PR TITLE
Drop defaults for TEXT NOT NULL columns

### DIFF
--- a/other/install_2-1_mysql.sql
+++ b/other/install_2-1_mysql.sql
@@ -463,7 +463,7 @@ CREATE TABLE {$db_prefix}log_packages (
 	failed_steps TEXT NOT NULL,
 	themes_installed VARCHAR(255) NOT NULL DEFAULT '',
 	db_changes TEXT NOT NULL,
-	credits TEXT NOT NULL DEFAULT '',
+	credits TEXT NOT NULL,
 	sha256_hash TEXT,
 	PRIMARY KEY (id_install),
 	INDEX idx_filename (filename(15))

--- a/other/install_2-1_postgresql.sql
+++ b/other/install_2-1_postgresql.sql
@@ -733,7 +733,7 @@ CREATE TABLE {$db_prefix}log_packages (
 	failed_steps text NOT NULL,
 	themes_installed varchar(255) NOT NULL DEFAULT '',
 	db_changes text NOT NULL,
-	credits text NOT NULL DEFAULT '',
+	credits text NOT NULL,
 	sha256_hash TEXT,
 	PRIMARY KEY (id_install)
 );

--- a/other/upgrade_2-1_mysql.sql
+++ b/other/upgrade_2-1_mysql.sql
@@ -666,7 +666,7 @@ ADD INDEX `idx_id_member` (`id_member`, `id_group`);
 /******************************************************************************/
 ---# Adding support for <credits> tag in package manager
 ALTER TABLE {$db_prefix}log_packages
-ADD COLUMN credits TEXT NOT NULL DEFAULT '';
+ADD COLUMN credits TEXT NOT NULL;
 ---#
 
 ---# Adding support for package hashes

--- a/other/upgrade_2-1_postgresql.sql
+++ b/other/upgrade_2-1_postgresql.sql
@@ -811,7 +811,12 @@ ADD COLUMN IF NOT EXISTS status smallint NOT NULL default '0',
 ADD COLUMN IF NOT EXISTS id_member_acted int NOT NULL default '0',
 ADD COLUMN IF NOT EXISTS member_name_acted varchar(255) NOT NULL default '',
 ADD COLUMN IF NOT EXISTS time_acted int NOT NULL default '0',
-ADD COLUMN IF NOT EXISTS act_reason text NOT NULL;
+ADD COLUMN IF NOT EXISTS act_reason text NOT NULL default '';
+---#
+
+---# Adding new columns to log_group_requests - drop defaults now that existing rows have been set
+ALTER TABLE {$db_prefix}log_group_requests
+ALTER COLUMN act_reason DROP DEFAULT;
 ---#
 
 ---# Adjusting the indexes for log_group_requests
@@ -824,7 +829,12 @@ CREATE INDEX {$db_prefix}log_group_requests_id_member ON {$db_prefix}log_group_r
 /******************************************************************************/
 ---# Adding support for <credits> tag in package manager
 ALTER TABLE {$db_prefix}log_packages
-ADD COLUMN IF NOT EXISTS credits TEXT NOT NULL DEFAULT '';
+ADD COLUMN IF NOT EXISTS credits TEXT NOT NULL default '';
+---#
+
+---# Adding support for <credits> - drop default now that existing rows have been set
+ALTER TABLE {$db_prefix}log_packages
+ALTER COLUMN credits DROP DEFAULT;
 ---#
 
 ---# Adding support for package hashes


### PR DESCRIPTION
Fixes #7366 
Fixes #7345 

Alternate solution to #7346 

Most versions of MySQL will not allow you to put a default on a TEXT column.  I've read that there are some differences between versions < 8.0.13 and otherwise, strict mode or not, etc., etc...  But it's clear that the default has got to go.  MySQL appears to use an implicit default of '' when adding new NOT NULL columns to existing tables with rows and no default is specified.  

Then again, pg will squawk if a table has existing rows, and you attempt to add a NOT NULL column without a default.  Because you haven't specified a default for the existing rows, and they cannot be null.  🙄

So...  Consistent with the rest of SMF, this PR will leave the text fields with a NOT NULL and no default.  The recommended solution for pg is to add the column with a default (so existing rows get set) and then immediately drop the default.  So that's what is done here.

This will provide us with the most consistent DB definition across MySQL and pg, and the most consistent app behavior across them as well.

Note that act_reason appeared to be the only other column with the same situation.  Corrected that as well.  I left the backtrace column alone, it's inconsistent, but has been working fine.

Feedback welcome.  

_Testing completed, checked mysql & pg, installs & upgrades..._