### PR TITLE
Fix ability to set null on a column

### DIFF
--- a/Sources/DbPackages-mysql.php
+++ b/Sources/DbPackages-mysql.php
@@ -420,13 +420,20 @@ function smf_db_change_column($table_name, $old_column, $column_info)
 	// Allow for unsigned integers (mysql only)
 	$unsigned = in_array($type, array('int', 'tinyint', 'smallint', 'mediumint', 'bigint')) && !empty($column_info['unsigned']) ? 'unsigned ' : '';
 
+	// Fix the default.
+	$default = '';
+	if (isset($column_info['default']) && $column_info['default'] == 'NULL' && empty($column_info['not_null']))
+		$default = 'NULL';
+	else
+		$default = '\'' . $smcFunc['db_escape_string']($column_info['default']) . '\'';
+
 	if ($size !== null)
 		$type = $type . '(' . $size . ')';
 
 	$smcFunc['db_query']('', '
 		ALTER TABLE ' . $table_name . '
 		CHANGE COLUMN `' . $old_column . '` `' . $column_info['name'] . '` ' . $type . ' ' . (!empty($unsigned) ? $unsigned : '') . (!empty($column_info['not_null']) ? 'NOT NULL' : '') . ' ' .
-			(!isset($column_info['default']) ? '' : 'default \'' . $smcFunc['db_escape_string']($column_info['default']) . '\'') . ' ' .
+				(empty($default) ? '' : 'default ' . $default) . ' ' .
 			(empty($column_info['auto']) ? '' : 'auto_increment') . ' ',
 		array(
 			'security_override' => true,

--- a/Sources/DbPackages-mysql.php
+++ b/Sources/DbPackages-mysql.php
@@ -422,7 +422,7 @@ function smf_db_change_column($table_name, $old_column, $column_info)
 
 	// Fix the default.
 	$default = '';
-	if (isset($column_info['default']) && $column_info['default'] == 'NULL' && empty($column_info['not_null']))
+	if (isset($column_info['default']) && is_null($column_info['default']) && empty($column_info['not_null']))
 		$default = 'NULL';
 	else
 		$default = '\'' . $smcFunc['db_escape_string']($column_info['default']) . '\'';
@@ -795,14 +795,15 @@ function smf_db_create_query_column($column)
 	global $smcFunc;
 
 	// Auto increment is easy here!
+	$default = '';
 	if (!empty($column['auto']))
 	{
 		$default = 'auto_increment';
 	}
 	elseif (isset($column['default']) && $column['default'] !== null)
 		$default = 'default \'' . $smcFunc['db_escape_string']($column['default']) . '\'';
-	else
-		$default = '';
+	elseif (isset($column['default']) && is_null($column['default']))
+		$default = 'NULL';
 
 	// Sort out the size... and stuff...
 	$column['size'] = isset($column['size']) && is_numeric($column['size']) ? $column['size'] : null;

--- a/Sources/DbPackages-mysql.php
+++ b/Sources/DbPackages-mysql.php
@@ -433,7 +433,7 @@ function smf_db_change_column($table_name, $old_column, $column_info)
 	$smcFunc['db_query']('', '
 		ALTER TABLE ' . $table_name . '
 		CHANGE COLUMN `' . $old_column . '` `' . $column_info['name'] . '` ' . $type . ' ' . (!empty($unsigned) ? $unsigned : '') . (!empty($column_info['not_null']) ? 'NOT NULL' : '') . ' ' .
-				(empty($default) ? '' : 'default ' . $default) . ' ' .
+				($default === '' ? '' : 'default ' . $default) . ' ' .
 			(empty($column_info['auto']) ? '' : 'auto_increment') . ' ',
 		array(
 			'security_override' => true,

--- a/Sources/DbPackages-postgresql.php
+++ b/Sources/DbPackages-postgresql.php
@@ -480,7 +480,7 @@ function smf_db_change_column($table_name, $old_column, $column_info)
 		else
 			$default = '\'' . $smcFunc['db_escape_string']($column_info['default']) . '\'';
 
-		$action = $column_info['default'] !== null ? 'SET DEFAULT ' . $default : 'DROP DEFAULT';
+		$action = $default !== '' ? 'SET DEFAULT ' . $default : 'DROP DEFAULT';
 		$smcFunc['db_query']('', '
 			ALTER TABLE ' . $table_name . '
 			ALTER COLUMN ' . $column_info['name'] . ' ' . $action,

--- a/Sources/DbPackages-postgresql.php
+++ b/Sources/DbPackages-postgresql.php
@@ -473,7 +473,14 @@ function smf_db_change_column($table_name, $old_column, $column_info)
 	// Different default?
 	if (isset($column_info['default']) && $column_info['default'] != $old_info['default'])
 	{
-		$action = $column_info['default'] !== null ? 'SET DEFAULT \'' . $smcFunc['db_escape_string']($column_info['default']) . '\'' : 'DROP DEFAULT';
+		// Fix the default.
+		$default = '';
+		if (isset($column_info['default']) && $column_info['default'] == 'NULL' && empty($column_info['not_null']))
+			$default = 'NULL';
+		else
+			$default = '\'' . $smcFunc['db_escape_string']($column_info['default']) . '\'';
+
+		$action = $column_info['default'] !== null ? 'SET DEFAULT ' . $default : 'DROP DEFAULT';
 		$smcFunc['db_query']('', '
 			ALTER TABLE ' . $table_name . '
 			ALTER COLUMN ' . $column_info['name'] . ' ' . $action,

--- a/Sources/DbPackages-postgresql.php
+++ b/Sources/DbPackages-postgresql.php
@@ -480,7 +480,7 @@ function smf_db_change_column($table_name, $old_column, $column_info)
 		else
 			$default = '\'' . $smcFunc['db_escape_string']($column_info['default']) . '\'';
 
-		$action = $default !== '' ? 'SET DEFAULT ' . $default : 'DROP DEFAULT';
+		$action = $default === '' ? 'DROP DEFAULT' : 'SET DEFAULT ' . $default;
 		$smcFunc['db_query']('', '
 			ALTER TABLE ' . $table_name . '
 			ALTER COLUMN ' . $column_info['name'] . ' ' . $action,

--- a/Sources/DbPackages-postgresql.php
+++ b/Sources/DbPackages-postgresql.php
@@ -475,7 +475,7 @@ function smf_db_change_column($table_name, $old_column, $column_info)
 	{
 		// Fix the default.
 		$default = '';
-		if (isset($column_info['default']) && $column_info['default'] == 'NULL' && empty($column_info['not_null']))
+		if (isset($column_info['default']) && is_null($column_info['default']) && empty($column_info['not_null']))
 			$default = 'NULL';
 		else
 			$default = '\'' . $smcFunc['db_escape_string']($column_info['default']) . '\'';


### PR DESCRIPTION
Something minor I noticed.  I wasn't able to use $smcFunc['db_change_column'] to set the default to null for a nullable column.  This is because we force it to a string.  So we check if the default is set to 'NULL' and the column allows nulls, then we set it to the literal NULL.

I thought about the default being set to the literal NULL as well.  But wasn't sure if this would cause confusion or other issues with coding to call this.

@albertlast I didn't have PG setup to test, but I followed the same syntax and it seems it should be fine.  Can you confirm?