### PR TITLE
Adds a integration option to modify download headers

### DIFF
--- a/Sources/ShowAttachments.php
+++ b/Sources/ShowAttachments.php
@@ -342,37 +342,8 @@ function showAttachment()
 	else
 		header("content-length: " . $size);
 
-	/* X-Send-File support.
-	 * This is a advanced server configuration option and requires configuration of your web server to support it.  Shared hosting will most likely not support this.
-	 * xsendfile_header is the header to send.  For Nginx use "X-Accel-Redirect", LightPD use "X-LIGHTTPD-send-file" and Apache HTTPD use "X-Sendfile".
-	 * xsendfile_base is the base path of the xsendfile directory.  This is a special directory used internally by the web server to process the header.
-	 * If multiple attachment directories is setup you, this will send the folder name of the attachment directory and the file name.  You will need to ensure the foldername is unquie.
-	 * If you have attachment directories in multiple locations, you will need to configure your server to handle each one from the single base.
-	 * When we can't figure out the proper header, this falls through and the rest of the attachment handling is processed.
-	*/
-	$use_sendfile = null;
-	if (!empty($modSettings['xsendfile_header']) && !empty($modSettings['xsendfile_base']))
-	{
-		// Multiple attachment directories, or we have support for it.
-		if (is_array($modSettings['attachmentUploadDir']))
-		{
-			// Try to find the right attachment folder.
-			$prevFolder = dirname(isset($modSettings['attachmentUploadDir'][$file['id_folder']]) ? $modSettings['attachmentUploadDir'][$file['id_folder']] : $modSettings['attachmentUploadDir'][$modSettings['currentAttachmentUploadDir']]);
-
-			// Just a santiy check to ensure we didn't get this wrong.
-			if ($prevFolder == dirname(dirname($file['filePath'])))
-				$use_sendfile = substr($file['filePath'], strlen($prevFolder) + 1);
-		}
-		elseif ($modSettings['attachmentUploadDir'] == dirname($file['filePath']))
-				$use_sendfile = substr($file['filePath'], strlen(dirname($file['filePath'])) + 1);
-
-		// Send it using X-SendFile.
-		if (!empty($use_sendfile))
-		{
-			header($modSettings['xsendfile_header'] . ': ' . $modSettings['xsendfile_base'] . $use_sendfile);
-			die;
-		}
-	}
+	// Allow customizations to hook in here before we send anything to modify any headers needed.  Or to change the process of how we output.
+	call_integration_hook('integrate_download_headers');
 
 	// Try to buy some time...
 	@set_time_limit(600);

--- a/Sources/ShowAttachments.php
+++ b/Sources/ShowAttachments.php
@@ -342,6 +342,38 @@ function showAttachment()
 	else
 		header("content-length: " . $size);
 
+	/* X-Send-File support.
+	 * This is a advanced server configuration option and requires configuration of your web server to support it.  Shared hosting will most likely not support this.
+	 * xsendfile_header is the header to send.  For Nginx use "X-Accel-Redirect", LightPD use "X-LIGHTTPD-send-file" and Apache HTTPD use "X-Sendfile".
+	 * xsendfile_base is the base path of the xsendfile directory.  This is a special directory used internally by the web server to process the header.
+	 * If multiple attachment directories is setup you, this will send the folder name of the attachment directory and the file name.  You will need to ensure the foldername is unquie.
+	 * If you have attachment directories in multiple locations, you will need to configure your server to handle each one from the single base.
+	 * When we can't figure out the proper header, this falls through and the rest of the attachment handling is processed.
+	*/
+	$use_sendfile = null;
+	if (!empty($modSettings['xsendfile_header']) && !empty($modSettings['xsendfile_base']))
+	{
+		// Multiple attachment directories, or we have support for it.
+		if (is_array($modSettings['attachmentUploadDir']))
+		{
+			// Try to find the right attachment folder.
+			$prevFolder = dirname(isset($modSettings['attachmentUploadDir'][$file['id_folder']]) ? $modSettings['attachmentUploadDir'][$file['id_folder']] : $modSettings['attachmentUploadDir'][$modSettings['currentAttachmentUploadDir']]);
+
+			// Just a santiy check to ensure we didn't get this wrong.
+			if ($prevFolder == dirname(dirname($file['filePath'])))
+				$use_sendfile = substr($file['filePath'], strlen($prevFolder) + 1);
+		}
+		elseif ($modSettings['attachmentUploadDir'] == dirname($file['filePath']))
+				$use_sendfile = substr($file['filePath'], strlen(dirname($file['filePath'])) + 1);
+
+		// Send it using X-SendFile.
+		if (!empty($use_sendfile))
+		{
+			header($modSettings['xsendfile_header'] . ': ' . $modSettings['xsendfile_base'] . $use_sendfile);
+			die;
+		}
+	}
+
 	// Try to buy some time...
 	@set_time_limit(600);
 


### PR DESCRIPTION
I've changed this to just add a hook.

~~This is not a configuration that standard SMF installs will use.  As such, I didn't want to implant a UI interface to configure this.  If we feel differently, we can.~~

~~To help understand this your web servers config files will need to be setup manually and this will relate directly to your environment setup completely.~~
~~For example, lets say your SMF install is at "/var/www/smf/" and your attachments are "/var/secret/attachments1" and "/var/secret/attachments2".~~
~~With nginx you may have this configured~~

```
       location /protected/ {
                internal;
                alias /var/secret/;
        }
```

~~Then in SMF you would configure~~
```
	$modSettings['xsendfile_header'] = 'X-Accel-Redirect';
	$modSettings['xsendfile_base'] = '/protected/';
```

~~When you download an attachment in attachments2 folder, the header would send:~~
```
X-Accel-Redirect: /protected/attachments2/32_abc123.dat
```

~~Nginx would then interrupt that, send the client through the protected location, which is a internal protected directory and then serve you the file from `/var/secret/attachments2/32_abc123.dat`~~

~~If you have a single attachments directory you could specify the "xsendfile_base" directly to the attachments folder.  As mentioned in the comments, if you have two attachment directories scattered around (such as `/var/secret/attachments/` and `/var/www/smf/attachments/`, this would not work.  Of course, I could have worked around this by sending the folder id instead, but then for each new folder, the admin would have to add a new configuration to the web server config to make it work.~~
~~If you have attachments like `/var/secret/attachments/1/`, `/var/secret/attachments/2/` and `/var/secret/attachments/3/`, then setting the base works well and continues to make it automatic with no need to update the config for each new attachment directory.~~