### PR TITLE
Fix encoding issues that can occur from missing utf8 declaration.

### DIFF
--- a/SSI.php
+++ b/SSI.php
@@ -30,7 +30,7 @@ foreach (array('db_character_set', 'cachedir') as $variable)
 
 // We're going to want a few globals... these are all set later.
 global $maintenance, $msubject, $mmessage, $mbname, $language;
-global $boardurl, $boarddir, $sourcedir, $webmaster_email, $cookiename;
+global $boardurl, $boarddir, $sourcedir, $webmaster_email, $cookiename, $db_character_set;
 global $db_type, $db_server, $db_name, $db_user, $db_prefix, $db_persist, $db_error_send, $db_last_error, $db_show_debug;
 global $db_connection, $db_port, $modSettings, $context, $sc, $user_info, $topic, $board, $txt;
 global $smcFunc, $ssi_db_user, $scripturl, $ssi_db_passwd, $db_passwd, $cache_enable, $cachedir;

--- a/Sources/Load.php
+++ b/Sources/Load.php
@@ -29,13 +29,14 @@ function reloadSettings()
 	global $image_proxy_enabled;
 
 	// Most database systems have not set UTF-8 as their default input charset.
-	if (!empty($db_character_set))
-		$smcFunc['db_query']('', '
-			SET NAMES {string:db_character_set}',
-			array(
-				'db_character_set' => $db_character_set,
-			)
-		);
+	if (empty($db_character_set))
+		$db_character_set = 'utf8';
+	$smcFunc['db_query']('', '
+		SET NAMES {string:db_character_set}',
+		array(
+			'db_character_set' => $db_character_set,
+		)
+	);
 
 	// We need some caching support, maybe.
 	loadCacheAccelerator();


### PR DESCRIPTION
This is another issue with using SSI.php inside a function.   Because we don't global some variables in SSI.php, their usage later on and global calls does not work. 

If you want to test this more.  call SSI.php from inside a function.  Although I could not reproduce it on all environments.  So something else may be there.

The reason it also fails in this case is because we specifically do a unset to the global when starting up SSI.php.  Which prevents the function calling SSI, from globalizing it.

SSI has had this issue in the past.  See previously related issues:
#4409
#6276
#3511


As a final bonus.  I decided we should also fix Load.php to always call a set names.  We expect 2.1 to be UTF-8.  If $db_character_set is empty, we never set it and will get character encoding issues.  This should also take care of the issue above in a secondary way.
