### PR TITLE
Workaround for Content-Encoding header bug in PHP 8.0.17 & 8.1.4

### DIFF
--- a/Sources/Profile-Export.php
+++ b/Sources/Profile-Export.php
@@ -493,6 +493,7 @@ function download_export_file($uid)
 		if (strtotime($modified_since) >= $mtime)
 		{
 			ob_end_clean();
+			header_remove('content-encoding');
 
 			// Answer the question - no, it hasn't been modified ;).
 			send_http_status(304);
@@ -505,6 +506,7 @@ function download_export_file($uid)
 	if (!empty($_SERVER['HTTP_IF_NONE_MATCH']) && strpos($_SERVER['HTTP_IF_NONE_MATCH'], $eTag) !== false)
 	{
 		ob_end_clean();
+		header_remove('content-encoding');
 
 		send_http_status(304);
 		exit;
@@ -571,6 +573,8 @@ function download_export_file($uid)
 		while (@ob_get_level() > 0)
 			@ob_end_clean();
 
+		header_remove('content-encoding');
+
 		// 40 kilobytes is a good-ish amount
 		$chunksize = 40 * 1024;
 		$bytes_sent = 0;
@@ -595,6 +599,8 @@ function download_export_file($uid)
 		// Forcibly end any output buffering going on.
 		while (@ob_get_level() > 0)
 			@ob_end_clean();
+
+		header_remove('content-encoding');
 
 		$fp = fopen($filepath, 'rb');
 		while (!feof($fp))

--- a/Sources/ShowAttachments.php
+++ b/Sources/ShowAttachments.php
@@ -37,6 +37,7 @@ function showAttachment()
 
 	// This is done to clear any output that was made before now.
 	ob_end_clean();
+	header_remove('content-encoding');
 
 	if (!empty($modSettings['enableCompressedOutput']) && !headers_sent() && ob_get_length() == 0)
 	{
@@ -241,6 +242,7 @@ function showAttachment()
 		if (!empty($file['mtime']) && strtotime($modified_since) >= $file['mtime'])
 		{
 			ob_end_clean();
+			header_remove('content-encoding');
 
 			// Answer the question - no, it hasn't been modified ;).
 			send_http_status(304);
@@ -252,6 +254,7 @@ function showAttachment()
 	if (!empty($file['etag']) && !empty($_SERVER['HTTP_IF_NONE_MATCH']) && strpos($_SERVER['HTTP_IF_NONE_MATCH'], $file['etag']) !== false)
 	{
 		ob_end_clean();
+		header_remove('content-encoding');
 
 		send_http_status(304);
 		exit;
@@ -361,6 +364,8 @@ function showAttachment()
 		while (@ob_get_level() > 0)
 			@ob_end_clean();
 
+		header_remove('content-encoding');
+
 		// 40 kilobytes is a good-ish amount
 		$chunksize = 40 * 1024;
 		$bytes_sent = 0;
@@ -385,6 +390,8 @@ function showAttachment()
 		// Forcibly end any output buffering going on.
 		while (@ob_get_level() > 0)
 			@ob_end_clean();
+
+		header_remove('content-encoding');
 
 		$fp = fopen($file['filePath'], 'rb');
 		while (!feof($fp))

--- a/Sources/Subs-Sound.php
+++ b/Sources/Subs-Sound.php
@@ -101,6 +101,7 @@ function createWaveFile($word)
 
 	// Disable compression.
 	ob_end_clean();
+	header_remove('content-encoding');
 	header('content-encoding: none');
 	header('accept-ranges: bytes');
 	header('connection: close');


### PR DESCRIPTION
Fixes #7395 

Make sure to test on PHP 7.4.x, 8.0.x, and 8.1.x, with the "Enable compressed output" setting enabled and again with it disabled.