### PR TITLE
SMF sometimes wants to send headers, when they are sent already.

### DIFF
--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -8132,6 +8132,10 @@ function check_cron()
 function send_http_status($code, $status = '')
 {
 	global $sourcedir;
+	
+	// This will fail anyways if headers have been sent.
+	if (!headers_sent())
+		return;
 
 	$statuses = array(
 		204 => 'No Content',

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -8134,7 +8134,7 @@ function send_http_status($code, $status = '')
 	global $sourcedir;
 	
 	// This will fail anyways if headers have been sent.
-	if (!headers_sent())
+	if (headers_sent())
 		return;
 
 	$statuses = array(


### PR DESCRIPTION
I was able to trigger this while using $ssi_on_error_method with a callable from a CLI script with ob_end_clean() having been called.  Thus when a database error occurred, it would output additional errors

```
Warning: Cannot modify header information - headers already sent by (output started at /custom-script.php:103) in /Sources/Security.php on line 1356
Warning: Cannot modify header information - headers already sent by (output started at /custom-script.php:103) in /Sources/Security.php on line 1359
Warning: Cannot modify header information - headers already sent by (output started at /custom-script.php:103) in /Sources/Security.php on line 1360
Warning: Cannot modify header information - headers already sent by (output started at /custom-script.php:103) in /Sources/Subs.php on line 8150
```

```
#0 /Sources/Subs.php(8144): frameOptionsHeader()
#1 /Sources/Errors.php(169): send_http_status(500)
#2 /Sources/Subs-Db-mysql.php(719): fatal_error('...', false)
#3 /Sources/Subs-Db-mysql.php(494): smf_db_error('...', Object(mysqli))
#4 /custom-script.php(569): smf_db_query('', '...', Array, Object(mysqli))
```