### PR TITLE
Fixes various issues with DbPackages functions

### DIFF
--- a/Sources/DbPackages-mysql.php
+++ b/Sources/DbPackages-mysql.php
@@ -325,6 +325,7 @@ function smf_db_add_column($table_name, $column_info, $parameters = array(), $if
 	global $smcFunc, $db_package_log, $db_prefix;
 
 	$short_table_name = str_replace('{db_prefix}', $db_prefix, $table_name);
+	$column_info = array_change_key_case($column_info);
 
 	// Log that we will want to uninstall this!
 	$db_package_log[] = array('remove_column', $short_table_name, $column_info['name']);
@@ -407,6 +408,7 @@ function smf_db_change_column($table_name, $old_column, $column_info)
 	global $smcFunc, $db_prefix;
 
 	$short_table_name = str_replace('{db_prefix}', $db_prefix, $table_name);
+	$column_info = array_change_key_case($column_info);
 
 	// Check it does exist!
 	$columns = $smcFunc['db_list_columns']($table_name, true);
@@ -850,6 +852,8 @@ function smf_db_list_indexes($table_name, $detail = false, $parameters = array()
 function smf_db_create_query_column($column)
 {
 	global $smcFunc;
+
+	$column = array_change_key_case($column);
 
 	// Auto increment is easy here!
 	$default = '';

--- a/Sources/DbPackages-mysql.php
+++ b/Sources/DbPackages-mysql.php
@@ -158,9 +158,26 @@ function smf_db_create_table($table_name, $columns, $indexes = array(), $paramet
 		$table_query .= "\n\t" . smf_db_create_query_column($column) . ',';
 
 	// Loop through the indexes next...
+	$version = $smcFunc['db_get_version']();
 	foreach ($indexes as $index)
 	{
-		$columns = implode(',', $index['columns']);
+		// MySQL If its a text column, we need to add a size.
+		foreach ($index['columns'] as &$c)
+		{
+			$c = trim($c);
+
+			// If a size was already specified, we won't be able to match it anyways.
+			if (!isset($columns[$c]) || !in_array($columns[$c]['type'], array('text', 'mediumntext', 'largetext')))
+				continue;
+
+			// This is a column we need a size on and we are below 5.7 we have to stick to a smaller size.
+			if (version_compare($version, '5.7', '<'))
+				$c .= '(64)';
+			else
+				$c .= '(255)';
+		}
+
+		$idx_columns = implode(',', $index['columns']);
 
 		// Is it the primary?
 		if (isset($index['type']) && $index['type'] == 'primary')
@@ -168,8 +185,9 @@ function smf_db_create_table($table_name, $columns, $indexes = array(), $paramet
 		else
 		{
 			if (empty($index['name']))
-				$index['name'] = implode('_', $index['columns']);
-			$table_query .= "\n\t" . (isset($index['type']) && $index['type'] == 'unique' ? 'UNIQUE' : 'KEY') . ' ' . $index['name'] . ' (' . $columns . '),';
+				$index['name'] = trim(implode('_', preg_replace('~(\(\d+\))~', '', $index['columns'])));
+
+			$table_query .= "\n\t" . (isset($index['type']) && $index['type'] == 'unique' ? 'UNIQUE' : 'KEY') . ' ' . $index['name'] . ' (' . $idx_columns . '),';
 		}
 	}
 

--- a/Sources/DbPackages-mysql.php
+++ b/Sources/DbPackages-mysql.php
@@ -853,7 +853,6 @@ function smf_db_create_query_column($column)
 	// Auto increment is easy here!
 	if (!empty($column['auto']))
 		$default = 'auto_increment';
-
 	// Make it null.
 	elseif (array_key_exists('default', $column) && is_null($column['default']))
 		$default = 'DEFAULT NULL';
@@ -863,6 +862,8 @@ function smf_db_create_query_column($column)
 	// Non empty string.
 	elseif (isset($column['default']))
 		$default = 'DEFAULT \'' . $smcFunc['db_escape_string']($column['default']) . '\'';
+	else
+		$default = '';
 
 	// Backwards compatible with the nullable column.
 	if (isset($column['null']) && !isset($column['not_null']))

--- a/Sources/DbPackages-mysql.php
+++ b/Sources/DbPackages-mysql.php
@@ -490,23 +490,18 @@ function smf_db_add_index($table_name, $index_info, $parameters = array(), $if_e
 	// No columns = no index.
 	if (empty($index_info['columns']))
 		return false;
-		
+
 	// MySQL If its a text column, we need to add a size.
 	$cols = $smcFunc['db_list_columns']($table_name, true);
-	$version = $smcFunc['db_get_version']();
 	foreach ($index_info['columns'] as &$c)
 	{
 		$c = trim($c);
 
 		// If a size was already specified, we won't be able to match it anyways.
-		if (!isset($cols[$c]) || !in_array($cols[$c]['type'], array('text', 'mediumntext', 'largetext')))
+		if (!isset($cols[$c]) || !in_array($cols[$c]['type'], array('text', 'mediumntext', 'largetext', 'varchar', 'char')))
 			continue;
 
-		// This is a column we need a size on and we are below 5.7 we have to stick to a smaller size.
-		if (version_compare($version, '5.7', '<'))
-			$c .= '(64)';
-		else
-			$c .= '(255)';
+		$c .= '(191)';
 	}
 
 	$columns = implode(',', $index_info['columns']);

--- a/Sources/DbPackages-mysql.php
+++ b/Sources/DbPackages-mysql.php
@@ -167,7 +167,7 @@ function smf_db_create_table($table_name, $columns, $indexes = array(), $paramet
 
 			// If a size was already specified, we won't be able to match it anyways.
 			$key = array_search($c, array_column($columns, 'name'));
-			if ($key !== false && !isset($columns[$key]) || !in_array($columns[$key]['type'], array('text', 'mediumntext', 'largetext', 'varchar', 'char')))
+			if ($key === false || !isset($columns[$key]) || !in_array($columns[$key]['type'], array('text', 'mediumntext', 'largetext', 'varchar', 'char')))
 				continue;
 
 			$c .= '(191)';

--- a/Sources/DbPackages-mysql.php
+++ b/Sources/DbPackages-mysql.php
@@ -158,7 +158,6 @@ function smf_db_create_table($table_name, $columns, $indexes = array(), $paramet
 		$table_query .= "\n\t" . smf_db_create_query_column($column) . ',';
 
 	// Loop through the indexes next...
-	$version = $smcFunc['db_get_version']();
 	foreach ($indexes as $index)
 	{
 		// MySQL If its a text column, we need to add a size.
@@ -167,14 +166,11 @@ function smf_db_create_table($table_name, $columns, $indexes = array(), $paramet
 			$c = trim($c);
 
 			// If a size was already specified, we won't be able to match it anyways.
-			if (!isset($columns[$c]) || !in_array($columns[$c]['type'], array('text', 'mediumntext', 'largetext')))
+			$key = array_search($c, array_column($columns, 'name'));
+			if ($key !== false && !isset($columns[$key]) || !in_array($columns[$key]['type'], array('text', 'mediumntext', 'largetext', 'varchar', 'char')))
 				continue;
 
-			// This is a column we need a size on and we are below 5.7 we have to stick to a smaller size.
-			if (version_compare($version, '5.7', '<'))
-				$c .= '(64)';
-			else
-				$c .= '(255)';
+			$c .= '(191)';
 		}
 
 		$idx_columns = implode(',', $index['columns']);

--- a/Sources/DbPackages-mysql.php
+++ b/Sources/DbPackages-mysql.php
@@ -453,7 +453,7 @@ function smf_db_change_column($table_name, $old_column, $column_info)
 	if (array_key_exists('default', $column_info) && is_null($column_info['default']))
 		$default = 'NULL';
 	elseif (isset($column_info['default']) && is_numeric($column_info['default']))
-		$default = 'DEFAULT ' . (strpos($column_info['default'], '.') ? floatval($column_info['default']) : intval($column_info['default']));
+		$default = strpos($column_info['default'], '.') ? floatval($column_info['default']) : intval($column_info['default']);
 	else
 		$default = '\'' . $smcFunc['db_escape_string']($column_info['default']) . '\'';
 
@@ -463,7 +463,7 @@ function smf_db_change_column($table_name, $old_column, $column_info)
 	$smcFunc['db_query']('', '
 		ALTER TABLE ' . $short_table_name . '
 		CHANGE COLUMN `' . $old_column . '` `' . $column_info['name'] . '` ' . $type . ' ' . (!empty($unsigned) ? $unsigned : '') . (!empty($column_info['not_null']) ? 'NOT NULL' : '') . ' ' .
-				($default === '' ? '' : 'default ' . $default) . ' ' .
+				($default === '' ? '' : 'DEFAULT ' . $default) . ' ' .
 			(empty($column_info['auto']) ? '' : 'auto_increment') . ' ',
 		array(
 			'security_override' => true,
@@ -861,7 +861,7 @@ function smf_db_create_query_column($column)
 		$default = 'auto_increment';
 	// Make it null.
 	elseif (array_key_exists('default', $column) && is_null($column['default']))
-		$default = 'default NULL';
+		$default = 'DEFAULT NULL';
 	// Numbers don't need quotes.
 	elseif (isset($column['default']) && is_numeric($column['default']))
 		$default = 'DEFAULT ' . (strpos($column['default'], '.') ? floatval($column['default']) : intval($column['default']));

--- a/Sources/DbPackages-mysql.php
+++ b/Sources/DbPackages-mysql.php
@@ -458,8 +458,9 @@ function smf_db_change_column($table_name, $old_column, $column_info)
 
 	$smcFunc['db_query']('', '
 		ALTER TABLE ' . $short_table_name . '
-		CHANGE COLUMN `' . $old_column . '` `' . $column_info['name'] . '` ' . $type . ' ' . (!empty($unsigned) ? $unsigned : '') . (!empty($column_info['not_null']) ? 'NOT NULL' : '') . ' ' .
-				($default === '' ? '' : 'DEFAULT ' . $default) . ' ' .
+		CHANGE COLUMN `' . $old_column . '` `' . $column_info['name'] . '` ' . $type . ' ' .
+			(!empty($unsigned) ? $unsigned : '') . (!empty($column_info['not_null']) ? 'NOT NULL' : '') . ' ' .
+			($default === '' ? '' : 'DEFAULT ' . $default) . ' ' .
 			(empty($column_info['auto']) ? '' : 'auto_increment') . ' ',
 		array(
 			'security_override' => true,

--- a/Sources/DbPackages-postgresql.php
+++ b/Sources/DbPackages-postgresql.php
@@ -197,6 +197,10 @@ function smf_db_create_table($table_name, $columns, $indexes = array(), $paramet
 	$index_queries = array();
 	foreach ($indexes as $index)
 	{
+		// MySQL you can do a "column_name (length)", postgresql does not allow this.  Strip it.
+		foreach ($index['columns'] as &$c)
+			$c = preg_replace('~\s+(\(\d+\))~', '', $c);
+
 		$columns = implode(',', $index['columns']);
 
 		// Primary goes in the table...
@@ -205,8 +209,9 @@ function smf_db_create_table($table_name, $columns, $indexes = array(), $paramet
 		else
 		{
 			if (empty($index['name']))
-				$index['name'] = implode('_', $index['columns']);
-			$index_queries[] = 'CREATE ' . (isset($index['type']) && $index['type'] == 'unique' ? 'UNIQUE' : '') . ' INDEX ' . $table_name . '_' . $index['name'] . ' ON ' . $table_name . ' (' . $columns . ')';
+				$index['name'] = trim(implode('_', preg_replace('~(\(\d+\))~', '', $index['columns'])));
+
+			$index_queries[] = 'CREATE ' . (isset($index['type']) && $index['type'] == 'unique' ? 'UNIQUE' : '') . ' INDEX ' . $short_table_name . '_' . $index['name'] . ' ON ' . $short_table_name . ' (' . $columns . ')';
 		}
 	}
 

--- a/Sources/DbPackages-postgresql.php
+++ b/Sources/DbPackages-postgresql.php
@@ -104,27 +104,28 @@ function db_packages_init()
  */
 function smf_db_create_table($table_name, $columns, $indexes = array(), $parameters = array(), $if_exists = 'ignore', $error = 'fatal')
 {
-	global $reservedTables, $smcFunc, $db_package_log, $db_prefix;
+	global $reservedTables, $smcFunc, $db_package_log, $db_prefix, $db_name;
 
 	$db_trans = false;
 	$old_table_exists = false;
 
 	// Strip out the table name, we might not need it in some cases
 	$real_prefix = preg_match('~^("?)(.+?)\\1\\.(.*?)$~', $db_prefix, $match) === 1 ? $match[3] : $db_prefix;
+	$database = !empty($match[2]) ? $match[2] : $db_name;
 
 	// With or without the database name, the fullname looks like this.
 	$full_table_name = str_replace('{db_prefix}', $real_prefix, $table_name);
-	$table_name = str_replace('{db_prefix}', $db_prefix, $table_name);
+	$short_table_name = str_replace('{db_prefix}', $db_prefix, $table_name);
 
 	// First - no way do we touch SMF tables.
-	if (in_array(strtolower($table_name), $reservedTables))
+	if (in_array(strtolower($short_table_name), $reservedTables))
 		return false;
 
 	// Log that we'll want to remove this on uninstall.
-	$db_package_log[] = array('remove_table', $table_name);
+	$db_package_log[] = array('remove_table', $short_table_name);
 
 	// This... my friends... is a function in a half - let's start by checking if the table exists!
-	$tables = $smcFunc['db_list_tables']();
+	$tables = $smcFunc['db_list_tables']($database);
 	if (in_array($full_table_name, $tables))
 	{
 		// This is a sad day... drop the table? If not, return false (error) by default.
@@ -136,7 +137,7 @@ function smf_db_create_table($table_name, $columns, $indexes = array(), $paramet
 			$smcFunc['db_transaction']('begin');
 			$db_trans = true;
 			$smcFunc['db_query']('', '
-				ALTER TABLE ' . $table_name . ' RENAME TO ' . $table_name . '_old',
+				ALTER TABLE ' . $short_table_name . ' RENAME TO ' . $short_table_name . '_old',
 				array(
 					'security_override' => true,
 				)
@@ -150,7 +151,7 @@ function smf_db_create_table($table_name, $columns, $indexes = array(), $paramet
 	// If we've got this far - good news - no table exists. We can build our own!
 	if (!$db_trans)
 		$smcFunc['db_transaction']('begin');
-	$table_query = 'CREATE TABLE ' . $table_name . "\n" . '(';
+	$table_query = 'CREATE TABLE ' . $short_table_name . "\n" . '(';
 	foreach ($columns as $column)
 	{
 		// If we have an auto increment do it!
@@ -158,7 +159,7 @@ function smf_db_create_table($table_name, $columns, $indexes = array(), $paramet
 		{
 			if (!$old_table_exists)
 				$smcFunc['db_query']('', '
-					DROP SEQUENCE IF EXISTS ' . $table_name . '_seq',
+					DROP SEQUENCE IF EXISTS ' . $short_table_name . '_seq',
 					array(
 						'security_override' => true,
 					)
@@ -166,12 +167,12 @@ function smf_db_create_table($table_name, $columns, $indexes = array(), $paramet
 
 			if (!$old_table_exists)
 				$smcFunc['db_query']('', '
-					CREATE SEQUENCE ' . $table_name . '_seq',
+					CREATE SEQUENCE ' . $short_table_name . '_seq',
 					array(
 						'security_override' => true,
 					)
 				);
-			$default = 'default nextval(\'' . $table_name . '_seq\')';
+			$default = 'default nextval(\'' . $short_table_name . '_seq\')';
 		}
 		elseif (isset($column['default']) && $column['default'] !== null)
 			$default = 'default \'' . $smcFunc['db_escape_string']($column['default']) . '\'';
@@ -185,8 +186,8 @@ function smf_db_create_table($table_name, $columns, $indexes = array(), $paramet
 			$type = $type . '(' . $size . ')';
 
 		// backward compatibility
-		if (isset($column['null']))
-			$column['not_null'] != $column['null'];
+		if (isset($column['null']) && !isset($column['not_null']))
+			$column['not_null'] = !$column['null'];
 
 		// Now just put it together!
 		$table_query .= "\n\t\"" . $column['name'] . '" ' . $type . ' ' . (!empty($column['not_null']) ? 'NOT NULL' : '') . ' ' . $default . ',';
@@ -234,8 +235,8 @@ function smf_db_create_table($table_name, $columns, $indexes = array(), $paramet
 			GROUP BY column_name
 			HAVING count(*) > 1',
 			array(
-				'table1' => $table_name,
-				'table2' => $table_name . '_old',
+				'table1' => $short_table_name,
+				'table2' => $short_table_name . '_old',
 				'schema' => 'public',
 			)
 		);
@@ -246,11 +247,11 @@ function smf_db_create_table($table_name, $columns, $indexes = array(), $paramet
 		}
 
 		$smcFunc['db_query']('', '
-			INSERT INTO ' . $table_name . '('
+			INSERT INTO ' . $short_table_name . '('
 			. implode(',', $same_col) .
 			')
 			SELECT ' . implode(',', $same_col) . '
-			FROM ' . $table_name . '_old',
+			FROM ' . $short_table_name . '_old',
 			array()
 		);
 	}
@@ -282,30 +283,32 @@ function smf_db_create_table($table_name, $columns, $indexes = array(), $paramet
  */
 function smf_db_drop_table($table_name, $parameters = array(), $error = 'fatal')
 {
-	global $reservedTables, $smcFunc, $db_prefix;
+	global $reservedTables, $smcFunc, $db_prefix, $db_name;
 
 	// After stripping away the database name, this is what's left.
 	$real_prefix = preg_match('~^("?)(.+?)\\1\\.(.*?)$~', $db_prefix, $match) === 1 ? $match[3] : $db_prefix;
+	$database = !empty($match[2]) ? $match[2] : $db_name;
 
 	// Get some aliases.
 	$full_table_name = str_replace('{db_prefix}', $real_prefix, $table_name);
-	$table_name = str_replace('{db_prefix}', $db_prefix, $table_name);
+	$short_table_name = str_replace('{db_prefix}', $db_prefix, $table_name);
 
 	// God no - dropping one of these = bad.
 	if (in_array(strtolower($table_name), $reservedTables))
 		return false;
 
 	// Does it exist?
-	if (in_array($full_table_name, $smcFunc['db_list_tables']()))
+	$tables = $smcFunc['db_list_tables']($database);
+	if (in_array($full_table_name, $tables))
 	{
 		// We can then drop the table.
 		$smcFunc['db_transaction']('begin');
 
 		// the table
-		$table_query = 'DROP TABLE ' . $table_name;
+		$table_query = 'DROP TABLE ' . $short_table_name;
 
 		// and the assosciated sequence, if any
-		$sequence_query = 'DROP SEQUENCE IF EXISTS ' . $table_name . '_seq';
+		$sequence_query = 'DROP SEQUENCE IF EXISTS ' . $short_table_name . '_seq';
 
 		// drop them
 		$smcFunc['db_query']('',
@@ -344,10 +347,10 @@ function smf_db_add_column($table_name, $column_info, $parameters = array(), $if
 {
 	global $smcFunc, $db_package_log, $db_prefix;
 
-	$table_name = str_replace('{db_prefix}', $db_prefix, $table_name);
+	$short_table_name = str_replace('{db_prefix}', $db_prefix, $table_name);
 
 	// Log that we will want to uninstall this!
-	$db_package_log[] = array('remove_column', $table_name, $column_info['name']);
+	$db_package_log[] = array('remove_column', $short_table_name, $column_info['name']);
 
 	// Does it exist - if so don't add it again!
 	$columns = $smcFunc['db_list_columns']($table_name, false);
@@ -369,7 +372,7 @@ function smf_db_add_column($table_name, $column_info, $parameters = array(), $if
 
 	// Now add the thing!
 	$query = '
-		ALTER TABLE ' . $table_name . '
+		ALTER TABLE ' . $short_table_name . '
 		ADD COLUMN ' . $column_info['name'] . ' ' . $type;
 	$smcFunc['db_query']('', $query,
 		array(
@@ -399,24 +402,25 @@ function smf_db_remove_column($table_name, $column_name, $parameters = array(), 
 {
 	global $smcFunc, $db_prefix;
 
-	$table_name = str_replace('{db_prefix}', $db_prefix, $table_name);
+	$short_table_name = str_replace('{db_prefix}', $db_prefix, $table_name);
 
 	// Does it exist?
 	$columns = $smcFunc['db_list_columns']($table_name, true);
+
 	foreach ($columns as $column)
-		if ($column['name'] == $column_name)
+		if (strtolower($column['name']) == strtolower($column_name))
 		{
 			// If there is an auto we need remove it!
 			if ($column['auto'])
 				$smcFunc['db_query']('', '
-					DROP SEQUENCE IF EXISTS ' . $table_name . '_seq',
+					DROP SEQUENCE IF EXISTS ' . $short_table_name . '_seq',
 					array(
 						'security_override' => true,
 					)
 				);
 
 			$smcFunc['db_query']('', '
-				ALTER TABLE ' . $table_name . '
+				ALTER TABLE ' . $short_table_name . '
 				DROP COLUMN ' . $column_name,
 				array(
 					'security_override' => true,
@@ -442,10 +446,10 @@ function smf_db_change_column($table_name, $old_column, $column_info)
 {
 	global $smcFunc, $db_prefix;
 
-	$table_name = str_replace('{db_prefix}', $db_prefix, $table_name);
+	$short_table_name = str_replace('{db_prefix}', $db_prefix, $table_name);
 
 	// backward compatibility
-	if (isset($column_info['null']))
+	if (isset($column_info['null']) && !isset($column_info['not_null']))
 		$column_info['not_null'] = !$column_info['null'];
 
 	// Check it does exist!
@@ -463,7 +467,7 @@ function smf_db_change_column($table_name, $old_column, $column_info)
 	if (isset($column_info['name']) && $column_info['name'] != $old_column)
 	{
 		$smcFunc['db_query']('', '
-			ALTER TABLE ' . $table_name . '
+			ALTER TABLE ' . $short_table_name . '
 			RENAME COLUMN ' . $old_column . ' TO ' . $column_info['name'],
 			array(
 				'security_override' => true,
@@ -471,24 +475,27 @@ function smf_db_change_column($table_name, $old_column, $column_info)
 		);
 	}
 	// Different default?
-	if (isset($column_info['default']) && $column_info['default'] != $old_info['default'])
+	if (array_key_exists('default', $column_info) && $column_info['default'] != $old_info['default'])
 	{
 		// Fix the default.
 		$default = '';
-		if (isset($column_info['default']) && is_null($column_info['default']) && empty($column_info['not_null']))
+		if (array_key_exists('default', $column_info) && is_null($column_info['default']))
 			$default = 'NULL';
+		elseif (isset($column_info['default']) && is_numeric($column_info['default']))
+			$default = strpos($column_info['default'], '.') ? floatval($column_info['default']) : intval($column_info['default']);
 		else
 			$default = '\'' . $smcFunc['db_escape_string']($column_info['default']) . '\'';
 
 		$action = $default === '' ? 'DROP DEFAULT' : 'SET DEFAULT ' . $default;
 		$smcFunc['db_query']('', '
-			ALTER TABLE ' . $table_name . '
+			ALTER TABLE ' . $short_table_name . '
 			ALTER COLUMN ' . $column_info['name'] . ' ' . $action,
 			array(
 				'security_override' => true,
 			)
 		);
 	}
+
 	// Is it null - or otherwise?
 	if (isset($column_info['not_null']) && $column_info['not_null'] != $old_info['not_null'])
 	{
@@ -499,7 +506,7 @@ function smf_db_change_column($table_name, $old_column, $column_info)
 			// We have to set it to something if we are making it NOT NULL. And we must comply with the current column format.
 			$setTo = isset($column_info['default']) ? $column_info['default'] : (strpos($old_info['type'], 'int') !== false ? 0 : '');
 			$smcFunc['db_query']('', '
-				UPDATE ' . $table_name . '
+				UPDATE ' . $short_table_name . '
 				SET ' . $column_info['name'] . ' = \'' . $setTo . '\'
 				WHERE ' . $column_info['name'] . ' IS NULL',
 				array(
@@ -508,7 +515,7 @@ function smf_db_change_column($table_name, $old_column, $column_info)
 			);
 		}
 		$smcFunc['db_query']('', '
-			ALTER TABLE ' . $table_name . '
+			ALTER TABLE ' . $short_table_name . '
 			ALTER COLUMN ' . $column_info['name'] . ' ' . $action . ' NOT NULL',
 			array(
 				'security_override' => true,
@@ -527,28 +534,28 @@ function smf_db_change_column($table_name, $old_column, $column_info)
 		// The alter is a pain.
 		$smcFunc['db_transaction']('begin');
 		$smcFunc['db_query']('', '
-			ALTER TABLE ' . $table_name . '
+			ALTER TABLE ' . $short_table_name . '
 			ADD COLUMN ' . $column_info['name'] . '_tempxx ' . $type,
 			array(
 				'security_override' => true,
 			)
 		);
 		$smcFunc['db_query']('', '
-			UPDATE ' . $table_name . '
+			UPDATE ' . $short_table_name . '
 			SET ' . $column_info['name'] . '_tempxx = CAST(' . $column_info['name'] . ' AS ' . $type . ')',
 			array(
 				'security_override' => true,
 			)
 		);
 		$smcFunc['db_query']('', '
-			ALTER TABLE ' . $table_name . '
+			ALTER TABLE ' . $short_table_name . '
 			DROP COLUMN ' . $column_info['name'],
 			array(
 				'security_override' => true,
 			)
 		);
 		$smcFunc['db_query']('', '
-			ALTER TABLE ' . $table_name . '
+			ALTER TABLE ' . $short_table_name . '
 			RENAME COLUMN ' . $column_info['name'] . '_tempxx TO ' . $column_info['name'],
 			array(
 				'security_override' => true,
@@ -564,14 +571,14 @@ function smf_db_change_column($table_name, $old_column, $column_info)
 		{
 			// Alter the table first - then drop the sequence.
 			$smcFunc['db_query']('', '
-				ALTER TABLE ' . $table_name . '
+				ALTER TABLE ' . $short_table_name . '
 				ALTER COLUMN ' . $column_info['name'] . ' SET DEFAULT \'0\'',
 				array(
 					'security_override' => true,
 				)
 			);
 			$smcFunc['db_query']('', '
-				DROP SEQUENCE IF EXISTS ' . $table_name . '_seq',
+				DROP SEQUENCE IF EXISTS ' . $short_table_name . '_seq',
 				array(
 					'security_override' => true,
 				)
@@ -581,21 +588,21 @@ function smf_db_change_column($table_name, $old_column, $column_info)
 		else
 		{
 			$smcFunc['db_query']('', '
-				DROP SEQUENCE IF EXISTS ' . $table_name . '_seq',
+				DROP SEQUENCE IF EXISTS ' . $short_table_name . '_seq',
 				array(
 					'security_override' => true,
 				)
 			);
 
 			$smcFunc['db_query']('', '
-				CREATE SEQUENCE ' . $table_name . '_seq',
+				CREATE SEQUENCE ' . $short_table_name . '_seq',
 				array(
 					'security_override' => true,
 				)
 			);
 			$smcFunc['db_query']('', '
-				ALTER TABLE ' . $table_name . '
-				ALTER COLUMN ' . $column_info['name'] . ' SET DEFAULT nextval(\'' . $table_name . '_seq\')',
+				ALTER TABLE ' . $short_table_name . '
+				ALTER COLUMN ' . $column_info['name'] . ' SET DEFAULT nextval(\'' . $short_table_name . '_seq\')',
 				array(
 					'security_override' => true,
 				)
@@ -620,11 +627,17 @@ function smf_db_add_index($table_name, $index_info, $parameters = array(), $if_e
 {
 	global $smcFunc, $db_package_log, $db_prefix;
 
-	$table_name = str_replace('{db_prefix}', $db_prefix, $table_name);
+	$parsed_table_name = str_replace('{db_prefix}', $db_prefix, $table_name);
+	$real_table_name = preg_match('~^(`?)(.+?)\\1\\.(.*?)$~', $parsed_table_name, $match) === 1 ? $match[3] : $parsed_table_name;
 
 	// No columns = no index.
 	if (empty($index_info['columns']))
 		return false;
+
+	// MySQL you can do a "column_name (length)", postgresql does not allow this.  Strip it.
+	foreach ($index_info['columns'] as &$c)
+		$c = preg_replace('~\s+(\(\d+\))~', '', $c);
+
 	$columns = implode(',', $index_info['columns']);
 
 	// No name - make it up!
@@ -634,16 +647,17 @@ function smf_db_add_index($table_name, $index_info, $parameters = array(), $if_e
 		if (isset($index_info['type']) && $index_info['type'] == 'primary')
 			$index_info['name'] = '';
 		else
-			$index_info['name'] = $table_name . implode('_', $index_info['columns']);
+			$index_info['name'] = trim(implode('_', preg_replace('~(\(\d+\))~', '', $index_info['columns'])));
 	}
 	else
-		$index_info['name'] = $table_name . $index_info['name'];
+		$index_info['name'] = $index_info['name'];
 
 	// Log that we are going to want to remove this!
-	$db_package_log[] = array('remove_index', $table_name, $index_info['name']);
+	$db_package_log[] = array('remove_index', $parsed_table_name, $index_info['name']);
 
 	// Let's get all our indexes.
 	$indexes = $smcFunc['db_list_indexes']($table_name, true);
+
 	// Do we already have it?
 	foreach ($indexes as $index)
 	{
@@ -661,7 +675,7 @@ function smf_db_add_index($table_name, $index_info, $parameters = array(), $if_e
 	if (!empty($index_info['type']) && $index_info['type'] == 'primary')
 	{
 		$smcFunc['db_query']('', '
-			ALTER TABLE ' . $table_name . '
+			ALTER TABLE ' . $real_table_name . '
 			ADD PRIMARY KEY (' . $columns . ')',
 			array(
 				'security_override' => true,
@@ -671,7 +685,7 @@ function smf_db_add_index($table_name, $index_info, $parameters = array(), $if_e
 	else
 	{
 		$smcFunc['db_query']('', '
-			CREATE ' . (isset($index_info['type']) && $index_info['type'] == 'unique' ? 'UNIQUE' : '') . ' INDEX ' . $index_info['name'] . ' ON ' . $table_name . ' (' . $columns . ')',
+			CREATE ' . (isset($index_info['type']) && $index_info['type'] == 'unique' ? 'UNIQUE' : '') . ' INDEX ' . $real_table_name . '_' . $index_info['name'] . ' ON ' . $real_table_name . ' (' . $columns . ')',
 			array(
 				'security_override' => true,
 			)
@@ -692,12 +706,15 @@ function smf_db_remove_index($table_name, $index_name, $parameters = array(), $e
 {
 	global $smcFunc, $db_prefix;
 
-	$table_name = str_replace('{db_prefix}', $db_prefix, $table_name);
+	$parsed_table_name = str_replace('{db_prefix}', $db_prefix, $table_name);
+	$real_table_name = preg_match('~^(`?)(.+?)\\1\\.(.*?)$~', $parsed_table_name, $match) === 1 ? $match[3] : $parsed_table_name;
 
 	// Better exist!
 	$indexes = $smcFunc['db_list_indexes']($table_name, true);
-	if ($index_name != 'primary')
-		$index_name = $table_name . '_' . $index_name;
+
+	// Do not add the table name to the index if it is arleady there.
+	if ($index_name != 'primary' && strpos($index_name, $real_table_name) !== false)
+		$index_name = str_replace($real_table_name . '_', '', $index_name);
 
 	foreach ($indexes as $index)
 	{
@@ -706,7 +723,7 @@ function smf_db_remove_index($table_name, $index_name, $parameters = array(), $e
 		{
 			// Dropping primary key is odd...
 			$smcFunc['db_query']('', '
-				ALTER TABLE ' . $table_name . '
+				ALTER TABLE ' . $real_table_name . '
 				DROP CONSTRAINT ' . $index['name'],
 				array(
 					'security_override' => true,
@@ -715,11 +732,12 @@ function smf_db_remove_index($table_name, $index_name, $parameters = array(), $e
 
 			return true;
 		}
+
 		if ($index['name'] == $index_name)
 		{
 			// Drop the bugger...
 			$smcFunc['db_query']('', '
-				DROP INDEX ' . $index_name,
+				DROP INDEX ' . $real_table_name . '_' . $index_name,
 				array(
 					'security_override' => true,
 				)
@@ -800,10 +818,11 @@ function smf_db_table_structure($table_name)
 {
 	global $smcFunc, $db_prefix;
 
-	$table_name = str_replace('{db_prefix}', $db_prefix, $table_name);
+	$parsed_table_name = str_replace('{db_prefix}', $db_prefix, $table_name);
+	$real_table_name = preg_match('~^(`?)(.+?)\\1\\.(.*?)$~', $parsed_table_name, $match) === 1 ? $match[3] : $parsed_table_name;
 
 	return array(
-		'name' => $table_name,
+		'name' => $real_table_name,
 		'columns' => $smcFunc['db_list_columns']($table_name, true),
 		'indexes' => $smcFunc['db_list_indexes']($table_name, true),
 	);
@@ -819,9 +838,11 @@ function smf_db_table_structure($table_name)
  */
 function smf_db_list_columns($table_name, $detail = false, $parameters = array())
 {
-	global $smcFunc, $db_prefix;
+	global $smcFunc, $db_prefix, $db_name;
 
-	$table_name = str_replace('{db_prefix}', $db_prefix, $table_name);
+	$parsed_table_name = str_replace('{db_prefix}', $db_prefix, $table_name);
+	$real_table_name = preg_match('~^(`?)(.+?)\\1\\.(.*?)$~', $parsed_table_name, $match) === 1 ? $match[3] : $parsed_table_name;
+	$database = !empty($match[2]) ? $match[2] : $db_name;
 
 	$result = $smcFunc['db_query']('', '
 		SELECT column_name, column_default, is_nullable, data_type, character_maximum_length
@@ -831,7 +852,7 @@ function smf_db_list_columns($table_name, $detail = false, $parameters = array()
 		ORDER BY ordinal_position',
 		array(
 			'schema_public' => 'public',
-			'table_name' => $table_name,
+			'table_name' => $real_table_name,
 		)
 	);
 	$columns = array();
@@ -851,7 +872,7 @@ function smf_db_list_columns($table_name, $detail = false, $parameters = array()
 				$auto = true;
 			}
 			elseif (trim($row['column_default']) != '')
-				$default = strpos($row['column_default'], '::') === false ? $row['column_default'] : substr($row['column_default'], 0, strpos($row['column_default'], '::'));
+				$default = trim(strpos($row['column_default'], '::') === false ? $row['column_default'] : substr($row['column_default'], 0, strpos($row['column_default'], '::')), '\'');
 			else
 				$default = null;
 
@@ -860,8 +881,8 @@ function smf_db_list_columns($table_name, $detail = false, $parameters = array()
 
 			$columns[$row['column_name']] = array(
 				'name' => $row['column_name'],
-				'not_null' => !($row['is_nullable'] ? true : false),
-				'null' => $row['is_nullable'] ? true : false,
+				'not_null' => $row['is_nullable'] == 'YES' ? false : true,
+				'null' => $row['is_nullable'] == 'YES' ? true : false,
 				'default' => $default,
 				'type' => $type,
 				'size' => $size,
@@ -884,9 +905,11 @@ function smf_db_list_columns($table_name, $detail = false, $parameters = array()
  */
 function smf_db_list_indexes($table_name, $detail = false, $parameters = array())
 {
-	global $smcFunc, $db_prefix;
+	global $smcFunc, $db_prefix, $db_name;
 
-	$table_name = str_replace('{db_prefix}', $db_prefix, $table_name);
+	$parsed_table_name = str_replace('{db_prefix}', $db_prefix, $table_name);
+	$real_table_name = preg_match('~^(`?)(.+?)\\1\\.(.*?)$~', $parsed_table_name, $match) === 1 ? $match[3] : $parsed_table_name;
+	$database = !empty($match[2]) ? $match[2] : $db_name;
 
 	$result = $smcFunc['db_query']('', '
 		SELECT CASE WHEN i.indisprimary THEN 1 ELSE 0 END AS is_primary,
@@ -898,7 +921,7 @@ function smf_db_list_indexes($table_name, $detail = false, $parameters = array()
 			AND c.oid = i.indrelid
 			AND i.indexrelid = c2.oid',
 		array(
-			'table_name' => $table_name,
+			'table_name' => $real_table_name,
 		)
 	);
 	$indexes = array();
@@ -920,7 +943,7 @@ function smf_db_list_indexes($table_name, $detail = false, $parameters = array()
 		if (substr($row['name'], -5) == '_pkey' && $row['is_primary'] == 1)
 			$row['name'] = 'PRIMARY';
 		else
-			$row['name'] = str_replace($table_name . '_', '', $row['name']);
+			$row['name'] = str_replace($real_table_name . '_', '', $row['name']);
 
 		if (!$detail)
 			$indexes[] = $row['name'];

--- a/Sources/DbPackages-postgresql.php
+++ b/Sources/DbPackages-postgresql.php
@@ -154,6 +154,8 @@ function smf_db_create_table($table_name, $columns, $indexes = array(), $paramet
 	$table_query = 'CREATE TABLE ' . $short_table_name . "\n" . '(';
 	foreach ($columns as $column)
 	{
+		$column = array_change_key_case($column);
+
 		// If we have an auto increment do it!
 		if (!empty($column['auto']))
 		{
@@ -201,7 +203,7 @@ function smf_db_create_table($table_name, $columns, $indexes = array(), $paramet
 		foreach ($index['columns'] as &$c)
 			$c = preg_replace('~\s+(\(\d+\))~', '', $c);
 
-		$columns = implode(',', $index['columns']);
+		$idx_columns = implode(',', $index['columns']);
 
 		// Primary goes in the table...
 		if (isset($index['type']) && $index['type'] == 'primary')
@@ -211,7 +213,7 @@ function smf_db_create_table($table_name, $columns, $indexes = array(), $paramet
 			if (empty($index['name']))
 				$index['name'] = trim(implode('_', preg_replace('~(\(\d+\))~', '', $index['columns'])));
 
-			$index_queries[] = 'CREATE ' . (isset($index['type']) && $index['type'] == 'unique' ? 'UNIQUE' : '') . ' INDEX ' . $short_table_name . '_' . $index['name'] . ' ON ' . $short_table_name . ' (' . $columns . ')';
+			$index_queries[] = 'CREATE ' . (isset($index['type']) && $index['type'] == 'unique' ? 'UNIQUE' : '') . ' INDEX ' . $short_table_name . '_' . $index['name'] . ' ON ' . $short_table_name . ' (' . $idx_columns . ')';
 		}
 	}
 
@@ -353,6 +355,7 @@ function smf_db_add_column($table_name, $column_info, $parameters = array(), $if
 	global $smcFunc, $db_package_log, $db_prefix;
 
 	$short_table_name = str_replace('{db_prefix}', $db_prefix, $table_name);
+	$column_info = array_change_key_case($column_info);
 
 	// Log that we will want to uninstall this!
 	$db_package_log[] = array('remove_column', $short_table_name, $column_info['name']);
@@ -452,6 +455,7 @@ function smf_db_change_column($table_name, $old_column, $column_info)
 	global $smcFunc, $db_prefix;
 
 	$short_table_name = str_replace('{db_prefix}', $db_prefix, $table_name);
+	$column_info = array_change_key_case($column_info);
 
 	// backward compatibility
 	if (isset($column_info['null']) && !isset($column_info['not_null']))

--- a/Sources/Subs-Db-postgresql.php
+++ b/Sources/Subs-Db-postgresql.php
@@ -924,7 +924,7 @@ function smf_db_error_insert($error_array)
 
 	// If we are in a transaction, abort.
 	if (!empty($inTransaction))
-		$smcFunc['db_transaction']('rollback');
+		smf_db_transaction('rollback');
 
 	if(empty($db_persist))
 	{ // without pooling

--- a/Sources/Subs-Db-postgresql.php
+++ b/Sources/Subs-Db-postgresql.php
@@ -923,7 +923,7 @@ function smf_db_error_insert($error_array)
 		$error_array[2] = null;
 
 	// If we are in a transaction, abort.
-	if ($inTransaction)
+	if (!empty($inTransaction))
 		$smcFunc['db_transaction']('rollback');
 
 	if(empty($db_persist))

--- a/Sources/Subs-Db-postgresql.php
+++ b/Sources/Subs-Db-postgresql.php
@@ -574,17 +574,26 @@ function smf_db_insert_id($table, $field = null, $connection = null)
  */
 function smf_db_transaction($type = 'commit', $connection = null)
 {
-	global $db_connection;
+	global $db_connection, $inTransaction;
 
 	// Decide which connection to use
 	$connection = $connection === null ? $db_connection : $connection;
 
 	if ($type == 'begin')
+	{
+		$inTransaction = true;
 		return @pg_query($connection, 'BEGIN');
+	}
 	elseif ($type == 'rollback')
+	{
+		$inTransaction = false;
 		return @pg_query($connection, 'ROLLBACK');
+	}
 	elseif ($type == 'commit')
+	{
+		$inTransaction = false;
 		return @pg_query($connection, 'COMMIT');
+	}
 
 	return false;
 }
@@ -903,7 +912,7 @@ function smf_db_fetch_all($request)
  */
 function smf_db_error_insert($error_array)
 {
-	global $db_prefix, $db_connection, $db_persist;
+	global $db_prefix, $db_connection, $db_persist, $smcFunc, $inTransaction;
 	static $pg_error_data_prep;
 
 	// without database we can't do anything
@@ -912,6 +921,10 @@ function smf_db_error_insert($error_array)
 
 	if (filter_var($error_array[2], FILTER_VALIDATE_IP) === false)
 		$error_array[2] = null;
+
+	// If we are in a transaction, abort.
+	if ($inTransaction)
+		$smcFunc['db_transaction']('rollback');
 
 	if(empty($db_persist))
 	{ // without pooling


### PR DESCRIPTION
1. We sometimes will pass in `databasename`.`table_name` and have not uses a select database.  So we try to parse our the database info when running select commands that need this such as list tables, list keys, list columns.
2. When working with default, we need to handle nulls properly as a default using the literal NULL.  We should also try to handle numericals better
3. MySQL doesn't allow you to do an index on a text column without a length.  Force one if found.
4. Postgresql doesn't support a length on an index, so strip it out if specified.
5. Postgresql didn't handle indexes well in all scenarios because they are prefixed with the table name and we may not pass the index name prefixed with the table name.
6. Postgresql didn't do NULLs properly because we didn't check the right value returned from the list of columns.
7. Avoid overwriting $table_name, as this can cause unexpected results when the parsed name is sent to other functions.
8. MySQL with text index needs a limit, so we try to add one.

Attached are simple scripts I used to test these.  Please modify the scripts and send them back if you are finding cases where we are still not doing something right.

[test-7417.php.txt](https://github.com/SimpleMachines/SMF2.1/files/8456163/test-7417.php.txt)
[test-7420.php.txt](https://github.com/SimpleMachines/SMF2.1/files/8456164/test-7420.php.txt)
[test-7419.php.txt](https://github.com/SimpleMachines/SMF2.1/files/8456165/test-7419.php.txt)
[test-7418.php.txt](https://github.com/SimpleMachines/SMF2.1/files/8456166/test-7418.php.txt)

Fixes #7417 
Fixes #7418 
Fixes #7419 
Fixes #7420 

I'm doing this as a WIP right now and asking @albertlast and @sbulen to provide feedback.  But once we are happy there, this will want more dev eyes on it.  Its a lot of changes to make.