### PR TITLE
Better text for error loop

### DIFF
--- a/Sources/Errors.php
+++ b/Sources/Errors.php
@@ -48,7 +48,7 @@ function log_error($error_message, $error_type = 'general', $file = null, $line 
 	if ($error_call > 2)
 	{
 		var_dump($backtrace);
-		die('Error loop.');
+		die('Error loop. Possible reason, database tablle log_errors is broken.');
 	}
 
 	// Check if error logging is actually on.

--- a/Sources/Errors.php
+++ b/Sources/Errors.php
@@ -48,7 +48,7 @@ function log_error($error_message, $error_type = 'general', $file = null, $line 
 	if ($error_call > 2)
 	{
 		var_dump($backtrace);
-		die('Error loop. Possible reason, database tablle log_errors is broken.');
+		die('Error loop. Possible reason, database table log_errors is broken.');
 	}
 
 	// Check if error logging is actually on.


### PR DESCRIPTION
Because of 
https://www.simplemachines.org/community/index.php?topic=581859.0
and
https://www.simplemachines.org/community/index.php?topic=581859.0
i notice that the text of error loop got not enough information for support.
So i extend the error message, to provide admin/support more information about the issue.

Possible we could do more here,
but i guess this is good way to help.