### PR TITLE
Fix slowdown with nested images

### DIFF
--- a/Themes/default/scripts/theme.js
+++ b/Themes/default/scripts/theme.js
@@ -5,7 +5,7 @@ $(function() {
 	$('.preview').SMFtooltip();
 
 	// find all nested linked images and turn off the border
-	$('a.bbc_link img.bbc_img').parent().css('border', '0');
+	$('a.bbc_link img').parent().css('border', '0');
 });
 
 // The purpose of this code is to fix the height of overflow: auto blocks, because some browsers can't figure it out for themselves.


### PR DESCRIPTION
Source: https://www.simplemachines.org/community/index.php?msg=4125120

> any image inside a .bbc_link tag will automatically be .bbc_img, and searching by class in javascript is a lot slower than searching by tag (the opposite of CSS) so all the .bbc_img class is doing here is slowing things down.