### PR TITLE
Fix Tracking IPv6s

### DIFF
--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -5143,6 +5143,13 @@ function ip2range($fullip)
 	if ($fullip == 'unknown')
 		$fullip = '255.255.255.255';
 
+	// Cleanup the IP as needed.
+	$fullip = strtr($fullip,
+		[
+			// IPv6 ending in :: is valid for a network, but SMF doesn't handle itwell.
+			'::*' => ':*',
+		]);
+
 	$ip_parts = explode('-', $fullip);
 	$ip_array = array();
 


### PR DESCRIPTION
If you enter a IPv6 in the format:   `2001:abc:123::*`  SMF will fail to convert it to valid IPv6 range. The result is `2001:abc:123::0000` to `2001:abc:123::ffff`
However if you do a it in the format: `2001:abc:123:*` SMF will generate a valid IPv6 range of `2001:abc:123:0000:0000:0000:0000` to `2001:abc:123:ffff:ffff:ffff:ffff`