### PR TITLE
fix: coerce user permissions to array before checking it

### DIFF
--- a/Sources/Security.php
+++ b/Sources/Security.php
@@ -916,16 +916,12 @@ function allowedTo($permission, $boards = null, $any = false)
 	// Are we checking the _current_ board, or some other boards?
 	if ($boards === null)
 	{
-		$user_permissions = $user_info['permissions'];
+		$user_permissions = (array) $user_info['permissions'];
 
 		// Allow temporary overrides for general permissions?
 		call_integration_hook('integrate_allowed_to_general', array(&$user_permissions, $permission));
 
-		if (count(array_intersect($permission, $user_permissions)) != 0)
-			return true;
-		// You aren't allowed, by default.
-		else
-			return false;
+		return array_intersect($permission, $user_permissions) != [];
 	}
 	elseif (!is_array($boards))
 		$boards = array($boards);


### PR DESCRIPTION
this is a longstanding issue that sometimes rears its ugly head. I tried to parch it once ago (I think it was 2.0.14) which was adequate at the time when PHP was less strict about type mismatches.

**Forum topics of interest**

- https://www.simplemachines.org/community/index.php?topic=580558.0
- https://www.simplemachines.org/community/index.php?topic=582622.0

Signed-off-by: John Rayes <live627@gmail.com>