### PR TITLE
Make sure the function we're trying to call is actually defined first...

### DIFF
--- a/Sources/Load.php
+++ b/Sources/Load.php
@@ -234,7 +234,7 @@ function reloadSettings()
 		{
 			return $smcFunc['convert_case']($string, 'ucwords');
 		},
-		'convert_case' => function($string, $case, $simple = false, $form = 'c') use (&$smcFunc, $utf8, $ent_check, $fix_utf8mb4)
+		'convert_case' => function($string, $case, $simple = false, $form = 'c') use (&$smcFunc, $utf8, $ent_check, $fix_utf8mb4, $sourcedir)
 		{
 			if (!$utf8)
 			{
@@ -289,7 +289,10 @@ function reloadSettings()
 				}
 				// Everything else.
 				else
+				{
+					include_once($sourcedir . '/Subs-Charset.php');
 					$string = $smcFunc['normalize'](utf8_convert_case($string, $case, $simple), $form);
+				}
 			}
 
 			return $fix_utf8mb4($string);

--- a/Sources/Load.php
+++ b/Sources/Load.php
@@ -290,7 +290,7 @@ function reloadSettings()
 				// Everything else.
 				else
 				{
-					include_once($sourcedir . '/Subs-Charset.php');
+					require_once($sourcedir . '/Subs-Charset.php');
 					$string = $smcFunc['normalize'](utf8_convert_case($string, $case, $simple), $form);
 				}
 			}


### PR DESCRIPTION
Attempting to call utf8_convert_case in Load.php fails because it's defined in Subs-Charset.php, which isn't included prior to calling this function.

**Relevant topic from the forum:**

- https://www.simplemachines.org/community/index.php?topic=582640.0

Signed-off-by: Michael Eshom <oldiesmann@gmail.com>