### PR TITLE
Fix alert counts

### DIFF
--- a/Sources/Display.php
+++ b/Sources/Display.php
@@ -1039,8 +1039,13 @@ function Display()
 					'now' => time(),
 				)
 			);
-			$user_info['alerts'] = max(0, $user_info['alerts'] - max(0, $smcFunc['db_affected_rows']()));
-			updateMemberData($user_info['id'], array('alerts' => $user_info['alerts']));
+			// If changes made, update the member record as well
+			if ($smcFunc['db_affected_rows']() > 0)
+			{
+				require_once($sourcedir . '/Profile-Modify.php');
+				$user_info['alerts'] = alert_count($user_info['id'], true);
+				updateMemberData($user_info['id'], array('alerts' => $user_info['alerts']));
+			}
 		}
 	}
 

--- a/Sources/Profile.php
+++ b/Sources/Profile.php
@@ -930,10 +930,6 @@ function alerts_popup($memID)
 		// Now fetch me my unread alerts, pronto!
 		require_once($sourcedir . '/Profile-View.php');
 		$context['unread_alerts'] = fetch_alerts($memID, false, !empty($counter) ? $cur_profile['alerts'] - $counter : $limit, 0, !isset($_REQUEST['counter']));
-
-		// This shouldn't happen, but just in case...
-		if (empty($counter) && $cur_profile['alerts'] != count($context['unread_alerts']))
-			updateMemberData($memID, array('alerts' => count($context['unread_alerts'])));
 	}
 }
 

--- a/Sources/tasks/CreatePost-Notify.php
+++ b/Sources/tasks/CreatePost-Notify.php
@@ -437,15 +437,8 @@ class CreatePost_Notify_Background extends SMF_BackgroundTask
 				array()
 			);
 
-			$new_alerts = array();
-			foreach ($this->alert_rows as $row)
-			{
-				$group = implode(' ', array($row['content_type'], $row['content_id'], $row['content_action']));
-				$new_alerts[$group] = $row['id_member'];
-			}
-
-			foreach ($new_alerts as $member_ids)
-				updateMemberData($member_ids, array('alerts' => '+'));
+			foreach ($this->alert_rows as $alert_row)
+				updateMemberData($alert_row['id_member'], array('alerts' => '+'));
 		}
 	}
 

--- a/Sources/tasks/CreatePost-Notify.php
+++ b/Sources/tasks/CreatePost-Notify.php
@@ -437,8 +437,7 @@ class CreatePost_Notify_Background extends SMF_BackgroundTask
 				array()
 			);
 
-			foreach ($this->alert_rows as $alert_row)
-				updateMemberData($alert_row['id_member'], array('alerts' => '+'));
+			updateMemberData(array_column($alert_rows, 'id_member'), array('alerts' => '+'));
 		}
 	}
 

--- a/Sources/tasks/CreatePost-Notify.php
+++ b/Sources/tasks/CreatePost-Notify.php
@@ -437,7 +437,7 @@ class CreatePost_Notify_Background extends SMF_BackgroundTask
 				array()
 			);
 
-			updateMemberData(array_column($alert_rows, 'id_member'), array('alerts' => '+'));
+			updateMemberData(array_column($this->alert_rows, 'id_member'), array('alerts' => '+'));
 		}
 	}
 


### PR DESCRIPTION
Three changes:
 - Addressed an issue where alert counter was not getting updated for all subscribers on replies.  This is a bug that definitely impacts the alert counter and popup.
 - Used the standard calculation in one instance where the logic looked a little sketchy.
 - Removed an erroneous calc, where it was updating the alert counter with _new_ unread, instead of _all_ unread.  Not sure it was necessary there anyway.