### PR TITLE
Delete quote & mention alerts if removed during edit

### DIFF
--- a/Sources/Post.php
+++ b/Sources/Post.php
@@ -2340,10 +2340,6 @@ function Post2()
 			$msgOptions['poster_time'] = $row['poster_time'];
 		}
 
-		// This will save some time...
-		if (empty($approve_has_changed))
-			unset($msgOptions['approved']);
-
 		modifyPost($msgOptions, $topicOptions, $posterOptions);
 	}
 	// This is a new topic or an already existing one. Save it.
@@ -3105,6 +3101,7 @@ function JavaScriptModify()
 			'body' => isset($_POST['message']) ? $_POST['message'] : null,
 			'icon' => isset($_REQUEST['icon']) ? preg_replace('~[\./\\\\*\':"<>]~', '', $_REQUEST['icon']) : null,
 			'modify_reason' => (isset($_POST['modify_reason']) ? $_POST['modify_reason'] : ''),
+			'approved' => (isset($row['approved']) ? $row['approved'] : null),
 		);
 		$topicOptions = array(
 			'id' => $topic,

--- a/Sources/Subs-Post.php
+++ b/Sources/Subs-Post.php
@@ -2357,7 +2357,7 @@ function modifyPost(&$msgOptions, &$topicOptions, &$posterOptions)
 		$searchAPI->postModified($msgOptions, $topicOptions, $posterOptions);
 
 	// Send notifications about any new quotes or mentions.
-	if ($msgOptions['send_notifications'] && !empty($msgOptions['approved']) && (!empty($msgOptions['quoted_members']) || !empty($msgOptions['mentioned_members'])))
+	if ($msgOptions['send_notifications'] && !empty($msgOptions['approved']) && (!empty($msgOptions['quoted_members']) || !empty($msgOptions['mentioned_members']) || !empty($mention_modifications['removed']) || !empty($quoted_modifications['removed'])))
 	{
 		$smcFunc['db_insert']('',
 			'{db_prefix}background_tasks',


### PR DESCRIPTION
Partial for #7423 

If a post is edited, & mentions or quotes are removed, delete any alerts for them.  The logic to do this cleanup has been around, but it wasn't being invoked correctly.  It works fine once it's invoked.

It needed to know approval status, because you don't want to generate alerts for unapproved posts.  But for some reason, the approval status wasn't passed.  

Also, it needed to explicitly check for removals.  Previously it was just checking for the presence of quotes or mentions in the edited post...  So...  If they were deleted...  It didn't know it had cleanup to do...  🙄