### PR TITLE
Mark orphaned alerts as read

### DIFF
--- a/Sources/Profile-Modify.php
+++ b/Sources/Profile-Modify.php
@@ -2525,16 +2525,19 @@ function alert_count($memID, $unread = false)
 
 	// One last thing - tweak counter on member record.
 	// Do it directly, as updateMemberData() calls this function, and may create a loop.
+	// Note that $user_info is not populated when this is invoked via cron, hence the CASE statement.
 	if ($num_unread_deletes > 0)
 	{
-		$user_info['alerts'] = max(0, $user_info['alerts'] - $num_unread_deletes);
-			
 		$smcFunc['db_query']('', '
 			UPDATE {db_prefix}members
-			SET alerts = {int:num_alerts}
+			SET alerts =
+				CASE
+					WHEN alerts < {int:unread_deletes} THEN 0
+					ELSE alerts - {int:unread_deletes}
+				END
 			WHERE id_member = {int:member}',
 			array(
-				'num_alerts' => $user_info['alerts'],
+				'unread_deletes' => $num_unread_deletes,
 				'member' => $memID,
 			)
 		);


### PR DESCRIPTION
Partial for #7423

Unread alerts are not purged.  Alerts that point to messages that have been deleted or moved to boards that the user does not have visibility to, are not displayed.  

So...  These unread alerts will stay around forever as invisible orphans...   (Although a nit, this really bugs me...)

This can be easily detected during the count function, which is frequently invoked, so this PR cleans them up by marking them as read.

_An alternate approach would be to change the purge function to purge alerts whether or not they have been read..._