### PR TITLE
Don't use the cache if it fails

### DIFF
--- a/Sources/Load.php
+++ b/Sources/Load.php
@@ -3773,7 +3773,7 @@ function loadCacheAccelerator($overrideCache = '', $fallbackSMF = true)
 		}
 
 		// Connect up to the accelerator.
-		$cache_api->connect();
+		if ($cache_api->connect() === false) return false;
 
 		// Don't set this if we are overriding the cache.
 		if (empty($overrideCache))


### PR DESCRIPTION
When the cache fail,
smf is still using the cache,
lead into a lock out from smf.

Change to:
Cache connection failed, cache is not used.

Signed-off-by: albertlast albertlast@hotmail.de