### PR TITLE
Restore showing profile areas added with `integrate_profile_areas`

### DIFF
--- a/Sources/Profile.php
+++ b/Sources/Profile.php
@@ -491,6 +491,10 @@ function ModifyProfile($post_errors = array())
 	);
 
 	// Let them modify profile areas easily.
+	call_integration_hook('integrate_profile_areas', array(&$profile_areas));
+
+	// Deprecated since 2.1.4 and will be removed in 3.0.0. Kept for compatibility with early versions of 2.1.
+	// @todo add runtime warnings.
 	call_integration_hook('integrate_pre_profile_areas', array(&$profile_areas));
 
 	// Do some cleaning ready for the menu function.
@@ -521,6 +525,7 @@ function ModifyProfile($post_errors = array())
 
 	// Set a few options for the menu.
 	$menuOptions = array(
+		'disable_hook_call' => true,
 		'disable_url_session_check' => true,
 		'current_area' => $current_area,
 		'extra_url_parameters' => array(

--- a/Sources/Subs-Menu.php
+++ b/Sources/Subs-Menu.php
@@ -69,9 +69,8 @@ function createMenu($menuData, $menuOptions = array())
 			integrate_admin_areas
 			integrate_moderate_areas
 			integrate_pm_areas
-			integrate_profile_areas
 	*/
-	if (!empty($menu_context['current_action']))
+	if (!empty($menu_context['current_action']) && empty($menuOptions['disable_hook_call']))
 		call_integration_hook('integrate_' . $menu_context['current_action'] . '_areas', array(&$menuData));
 
 	// What is the current area selected?


### PR DESCRIPTION
`integrate_profile_areas ` should  work (retain functionality from  2.0). The problem is that the changed array is lost when `createMenu()` exits, so that the calling code in `Profile.php` thinks that nothing happened.


#### What this PR does
- Move the hook point from `createMenu()` to `Profile()` (like it was in 2.0 which I think is proper).
- Deprecate `integrate_pre_profile_areas` because it is unused now.
- Add a new menu option `disable_hook_call` to make this work right.

#### Alternative fix
Pass `$menuData` as a reference

#### Related issues
- https://github.com/SimpleMachines/SMF/issues/3118
- https://github.com/SimpleMachines/SMF/issues/3145
- https://github.com/SimpleMachines/SMF/issues/3945