### PR TITLE
Cache api error

### DIFF
--- a/SSI.php
+++ b/SSI.php
@@ -34,7 +34,7 @@ global $boardurl, $boarddir, $sourcedir, $webmaster_email, $cookiename, $db_char
 global $db_type, $db_server, $db_name, $db_user, $db_prefix, $db_persist, $db_error_send, $db_last_error, $db_show_debug;
 global $db_connection, $db_port, $modSettings, $context, $sc, $user_info, $topic, $board, $txt;
 global $smcFunc, $ssi_db_user, $scripturl, $ssi_db_passwd, $db_passwd, $cache_enable, $cachedir;
-global $auth_secret;
+global $auth_secret, $cache_accelerator, $cache_memcached;
 
 if (!defined('TIME_START'))
 	define('TIME_START', microtime(true));

--- a/Sources/Cache/APIs/FileBased.php
+++ b/Sources/Cache/APIs/FileBased.php
@@ -59,7 +59,7 @@ class FileBased extends CacheApi implements CacheApiInterface
 
 	private function readFile($file)
 	{
-		if (($fp = fopen($file, 'rb')) !== false)
+		if (file_exists($file) && ($fp = fopen($file, 'rb')) !== false)
 		{
 			if (!flock($fp, LOCK_SH))
 			{
@@ -129,7 +129,7 @@ class FileBased extends CacheApi implements CacheApiInterface
 		// SMF Data returns $value and $expired.  $expired has a unix timestamp of when this expires.
 		if (file_exists($file) && ($raw = $this->readFile($file)) !== false)
 		{
-			if (($value = smf_json_decode($raw, true, false)) !== array() && $value['expiration'] >= time())
+			if (($value = smf_json_decode($raw, true, false)) !== array() && isset($value['expiration']) && $value['expiration'] >= time())
 				return $value['value'];
 			else
 				@unlink($file);


### PR DESCRIPTION
SMF file caching errors
If the file doesn't exist, do not try to open it.
Even when we decode the data, ensure the expiration exists
Ensure that SSI.php has $cache_memcached and $cache_accelerator declared as loading SSI in a function may not allow these globals to persist properly.

I noticed these while testing PHP 8.0