### PR TITLE
Use proper error message for missing verification questions

### DIFF
--- a/Sources/Subs-Editor.php
+++ b/Sources/Subs-Editor.php
@@ -2111,9 +2111,9 @@ function create_control_verification(&$verificationOptions, $do_test = false)
 		// This cannot happen!
 		if (!isset($_SESSION[$verificationOptions['id'] . '_vv']['count']))
 			fatal_lang_error('no_access', false);
-		// ... nor this!
+		// Verification question does not exist for this language.
 		if ($thisVerification['number_questions'] && (!isset($_SESSION[$verificationOptions['id'] . '_vv']['q']) || !isset($_REQUEST[$verificationOptions['id'] . '_vv']['q'])))
-			fatal_lang_error('no_access', false);
+			fatal_lang_error('registration_no_verification_questions');
 		// Hmm, it's requested but not actually declared. This shouldn't happen.
 		if ($thisVerification['empty_field'] && empty($_SESSION[$verificationOptions['id'] . '_vv']['empty_field']))
 			fatal_lang_error('no_access', false);

--- a/Themes/default/languages/Errors.english.php
+++ b/Themes/default/languages/Errors.english.php
@@ -139,6 +139,7 @@ $txt['no_theme'] = 'That theme does not exist.';
 $txt['theme_dir_wrong'] = 'The default theme\'s directory is wrong, please correct it by clicking this text.';
 $txt['registration_disabled'] = 'Sorry, registration is currently disabled.';
 $txt['registration_no_secret_question'] = 'Sorry, there is no secret question set for this member.';
+$txt['registration_no_verification_questions'] = 'Verification questions not configured properly. Please report this error to an administrator.';
 $txt['poll_range_error'] = 'Sorry, the poll must run for more than 0 days.';
 $txt['delFirstPost'] = 'You are not allowed to delete the first post in a topic.<p>If you want to delete this topic, click on the Remove Topic link, or ask a moderator/administrator to do it for you.</p>';
 $txt['parent_error'] = 'Unable to create board!';


### PR DESCRIPTION
If verification questions are configured to be used at
registration, but no questions exists for the current
language, the user is presented with the error message:
"You are not allowed to access this section". This is very
confusing, both for the user and the admin. Display a proper
error message and also log it to the error log.

Signed-off-by: Oscar Rydhé <oscar.rydhe@gmail.com>