### PR TITLE
Only delete board_permissions if new exists

### DIFF
--- a/Sources/Subs-Boards.php
+++ b/Sources/Subs-Boards.php
@@ -664,14 +664,16 @@ function modifyBoard($board_id, &$boardOptions)
 			))
 		);
 
-	// Before we add new access_groups or deny_groups, remove all of the old entries
-	$smcFunc['db_query']('', '
-		DELETE FROM {db_prefix}board_permissions_view
-		WHERE id_board = {int:selected_board}',
-		array(
-			'selected_board' => $board_id,
-		)
-	);
+	if (!empty($boardOptions['deny_groups']) || !empty($boardOptions['access_groups'])) {
+		// Before we add new access_groups or deny_groups, remove all of the old entries
+		$smcFunc['db_query']('', '
+			DELETE FROM {db_prefix}board_permissions_view
+			WHERE id_board = {int:selected_board}',
+			array(
+				'selected_board' => $board_id,
+			)
+		);
+	}
 
 	// Do permission sync
 	if (!empty($boardOptions['deny_groups']))


### PR DESCRIPTION
When moving a board all board_permissions was
removed, leading to the board not being visible
for regular users. Fix this by only removing the
board_permission_view if new access or deny groups
are provided.

Fixes: #7539
Signed-off-by: Oscar Rydhé <oscar.rydhe@gmail.com>