### PR TITLE
Use template_css in popups/new windows

### DIFF
--- a/Themes/default/Errors.template.php
+++ b/Themes/default/Errors.template.php
@@ -208,7 +208,7 @@ function template_show_file()
 	<head>
 		<meta charset="', $context['character_set'], '">
 		<title>', $context['file_data']['file'], '</title>
-		<link rel="stylesheet" href="', $settings['theme_url'], '/css/index', $context['theme_variant'], '.css', $context['browser_cache'], '">
+		', template_css(), '
 	</head>
 	<body>
 		<table class="errorfile_table">';

--- a/Themes/default/Help.template.php
+++ b/Themes/default/Help.template.php
@@ -24,7 +24,7 @@ function template_popup()
 		<meta charset="', $context['character_set'], '">
 		<meta name="robots" content="noindex">
 		<title>', $context['page_title'], '</title>
-		<link rel="stylesheet" href="', $settings['theme_url'], '/css/index', $context['theme_variant'], '.css', $context['browser_cache'], '">
+		', template_css(), '
 		<script src="', $settings['default_theme_url'], '/scripts/script.js', $context['browser_cache'], '"></script>
 	</head>
 	<body id="help_popup">
@@ -50,7 +50,7 @@ function template_find_members()
 		<title>', $txt['find_members'], '</title>
 		<meta charset="', $context['character_set'], '">
 		<meta name="robots" content="noindex">
-		<link rel="stylesheet" href="', $settings['theme_url'], '/css/index', $context['theme_variant'], '.css', $context['browser_cache'], '">
+		', template_css(), '
 		<script src="', $settings['default_theme_url'], '/scripts/script.js', $context['browser_cache'], '"></script>
 		<script>
 			var membersAdded = [];

--- a/Themes/default/Likes.template.php
+++ b/Themes/default/Likes.template.php
@@ -24,7 +24,7 @@ function template_popup()
 		<meta charset="', $context['character_set'], '">
 		<meta name="robots" content="noindex">
 		<title>', $context['page_title'], '</title>
-		<link rel="stylesheet" href="', $settings['theme_url'], '/css/index', $context['theme_variant'], '.css', $context['browser_cache'], '">
+		', template_css(), '
 		<script src="', $settings['default_theme_url'], '/scripts/script.js', $context['browser_cache'], '"></script>
 	</head>
 	<body id="likes_popup">

--- a/Themes/default/ModerationCenter.template.php
+++ b/Themes/default/ModerationCenter.template.php
@@ -546,7 +546,7 @@ function template_show_notice()
 	<head>
 		<meta charset="', $context['character_set'], '">
 		<title>', $context['page_title'], '</title>
-		<link rel="stylesheet" href="', $settings['theme_url'], '/css/index', $context['theme_variant'], '.css', $context['browser_cache'], '">
+		', template_css(), '
 	</head>
 	<body>
 		<div class="cat_bar">

--- a/Themes/default/Packages.template.php
+++ b/Themes/default/Packages.template.php
@@ -1316,8 +1316,7 @@ function template_view_operations()
 	<head>
 		<meta charset="', $context['character_set'], '">
 		<title>', $txt['operation_title'], '</title>
-		<link rel="stylesheet" href="', $settings['theme_url'], '/css/index', $context['theme_variant'], '.css', $context['browser_cache'], '">
-		<link rel="stylesheet" href="', $settings['theme_url'], '/css/admin.css', $context['browser_cache'], '">';
+		', template_css();
 
 	template_javascript();
 

--- a/Themes/default/Register.template.php
+++ b/Themes/default/Register.template.php
@@ -448,7 +448,7 @@ function template_verification_sound()
 		<meta charset="', $context['character_set'], '">
 		<title>', $txt['visual_verification_sound'], '</title>
 		<meta name="robots" content="noindex">
-		<link rel="stylesheet" href="', $settings['theme_url'], '/css/index', $context['theme_variant'], '.css', $context['browser_cache'], '">
+		', template_css(), '
 		<style>';
 
 	// Just show the help text and a "close window" link.


### PR DESCRIPTION
As discussed previously, this will prevent unexpected situations where a custom theme will load these subtemplates with empty styles.