### PR TITLE
fix: cors_headers implode

### DIFF
--- a/Sources/Security.php
+++ b/Sources/Security.php
@@ -1499,7 +1499,7 @@ function corsPolicyHeader($set_header = true)
 		foreach ($cors_headers as &$ch)
 			$ch = str_replace(' ', '-', trim($ch));
 
-		$context['cors_headers'] .= ',' .  implode(',', $cors_headers);
+		$context['cors_headers'] .= ',' . implode(',', $cors_headers);
 	}
 
 	// Allowing Cross-Origin Resource Sharing (CORS).

--- a/Sources/Security.php
+++ b/Sources/Security.php
@@ -1499,7 +1499,7 @@ function corsPolicyHeader($set_header = true)
 		foreach ($cors_headers as &$ch)
 			$ch = str_replace(' ', '-', trim($ch));
 
-		$context['cors_headers'] .= ',' . implode(',', $cors_headers);
+		$context['cors_headers'] .= ',' .  implode(',', $cors_headers);
 	}
 
 	// Allowing Cross-Origin Resource Sharing (CORS).

--- a/Sources/Security.php
+++ b/Sources/Security.php
@@ -1499,7 +1499,7 @@ function corsPolicyHeader($set_header = true)
 		foreach ($cors_headers as &$ch)
 			$ch = str_replace(' ', '-', trim($ch));
 
-		$context['cors_headers'] += implode(',', $cors_headers);
+		$context['cors_headers'] .= implode(',', $cors_headers);
 	}
 
 	// Allowing Cross-Origin Resource Sharing (CORS).

--- a/Sources/Security.php
+++ b/Sources/Security.php
@@ -1499,7 +1499,7 @@ function corsPolicyHeader($set_header = true)
 		foreach ($cors_headers as &$ch)
 			$ch = str_replace(' ', '-', trim($ch));
 
-		$context['cors_headers'] .= implode(',', $cors_headers);
+		$context['cors_headers'] .= ',' . implode(',', $cors_headers);
 	}
 
 	// Allowing Cross-Origin Resource Sharing (CORS).


### PR DESCRIPTION
If we enable "Allow CORS (Cross Origin Resource Sharing" setting and setup a custom header on "Additional CORS headers" SMF is appending directly the hardcoded header "X_SMF_AJAX" to the first custom header, resulting on a wrong Access-Control-Allow-Headers value being sent and thus the CORS check is never passed.

<img width="444" alt="Screen Shot 2022-09-13 at 19 47 17" src="https://user-images.githubusercontent.com/3420756/190034533-d0c7b030-3a5b-4426-a162-1234da78958f.png">
