### PR TITLE
Unwatched fix

### DIFF
--- a/Sources/Recent.php
+++ b/Sources/Recent.php
@@ -824,13 +824,13 @@ function UnreadTopics()
 			CREATE TEMPORARY TABLE {db_prefix}log_topics_unread (
 				PRIMARY KEY (id_topic)
 			)
-			SELECT lt.id_topic, lt.id_msg
+			SELECT lt.id_topic, lt.id_msg, lt.unwatched
 			FROM {db_prefix}topics AS t
 				INNER JOIN {db_prefix}log_topics AS lt ON (lt.id_topic = t.id_topic)
 			WHERE lt.id_member = {int:current_member}
 				AND t.' . $query_this_board . (empty($earliest_msg) ? '' : '
 				AND t.id_last_msg > {int:earliest_msg}') . ($modSettings['postmod_active'] ? '
-				AND t.approved = {int:is_approved}' : '') . ' AND lt.unwatched != 1',
+				AND t.approved = {int:is_approved}' : ''),
 			array_merge($query_parameters, array(
 				'current_member' => $user_info['id'],
 				'earliest_msg' => !empty($earliest_msg) ? $earliest_msg : 0,
@@ -852,7 +852,8 @@ function UnreadTopics()
 			WHERE t.' . $query_this_board . (!empty($earliest_msg) ? '
 				AND t.id_last_msg > {int:earliest_msg}' : '') . '
 				AND COALESCE(lt.id_msg, lmr.id_msg, 0) < t.id_last_msg' . ($modSettings['postmod_active'] ? '
-				AND t.approved = {int:is_approved}' : ''),
+				AND t.approved = {int:is_approved}' : '') . '
+				AND COALESCE(lt.unwatched, 0) != 1',
 			array_merge($query_parameters, array(
 				'current_member' => $user_info['id'],
 				'earliest_msg' => !empty($earliest_msg) ? $earliest_msg : 0,
@@ -911,6 +912,7 @@ function UnreadTopics()
 				AND t.id_last_msg >= {int:min_message}
 				AND COALESCE(lt.id_msg, lmr.id_msg, 0) < t.id_last_msg' . ($modSettings['postmod_active'] ? '
 				AND ms.approved = {int:is_approved}' : '') . '
+				AND COALESCE(lt.unwatched, 0) != 1
 			ORDER BY {raw:sort}
 			LIMIT {int:offset}, {int:limit}',
 			array_merge($query_parameters, array(
@@ -1055,6 +1057,7 @@ function UnreadTopics()
 				WHERE m.id_member = {int:current_member}' . (!empty($board) ? '
 					AND t.id_board = {int:current_board}' : '') . ($modSettings['postmod_active'] ? '
 					AND t.approved = {int:is_approved}' : '') . '
+					AND COALESCE(lt.unwatched, 0) != 1
 				GROUP BY m.id_topic',
 				array(
 					'current_board' => $board,


### PR DESCRIPTION
This extends pr #6908 logic to the temp table (log_topics_unread) used during "ALL UNREAD TOPICS" processing as well.  #6908 fixed "Recent Unread Topics", but not "All Unread Topics".  

This addresses the issue from the forum:  https://www.simplemachines.org/community/index.php?topic=582135.0

The bottom line is that when determining if something is unwatched, you have to have the unwatched field accessible to the query...  It's a little counterintuitive here, though, since the table is normally telling you what you are watching.  BUT...  That same table also tells you when you are explicitly not watching something also...

Note that the temp table log_topics_unread is only used when doing an "ALL UNREAD TOPICS", not when doing an "RECENT UNREAD TOPICS"...  For the issue to be visible, you need to click on "Unread Posts" then subsequently click on the "ALL UNREAD TOPICS" button.  

Initial testing looks good.

@live627 , I'd appreciate your input.

Also...  Fixes #7402 