### PR TITLE
PHP 8.1 doesn't like implicit float to int conversions

### DIFF
--- a/Sources/Subs-Charset.php
+++ b/Sources/Subs-Charset.php
@@ -440,6 +440,7 @@ function utf8_decompose($chars, $compatibility = false)
 	for ($i=0; $i < count($chars); $i++)
 	{
 		// Hangul characters.
+		// http://unicode.org/L2/L2006/06310-hangul-decompose9.pdf
 		if ($chars[$i] >= "\xEA\xB0\x80" && $chars[$i] <= "\xED\x9E\xA3")
 		{
 			if (!function_exists('mb_ord'))
@@ -447,8 +448,8 @@ function utf8_decompose($chars, $compatibility = false)
 
 			$s = mb_ord($chars[$i]);
 			$sindex = $s - 0xAC00;
-			$l = 0x1100 + $sindex / (21 * 28);
-			$v = 0x1161 + ($sindex % (21 * 28)) / 28;
+			$l = (int) (0x1100 + $sindex / (21 * 28));
+			$v = (int) (0x1161 + ($sindex % (21 * 28)) / 28);
 			$t = $sindex % 28;
 
 			$chars[$i] = implode('', array(mb_chr($l), mb_chr($v), $t ? mb_chr(0x11A7 + $t) : ''));


### PR DESCRIPTION
Fixes #7556 

Explicit int recast gets rid of the errors.  Screenshots confirm the correct letters are extracted.

**_Dump of the internal data - BEFORE:_**
![image](https://user-images.githubusercontent.com/23568484/193911275-4e0fb05e-ef64-41bb-9178-0ac00ac1d2b6.png)


**_Dump of the internal data - AFTER:_**
![image](https://user-images.githubusercontent.com/23568484/193911289-a11806dc-a7b5-432a-9119-4657b5fc96d3.png)
