### PR TITLE
PHP 8 email line break change

### DIFF
--- a/Sources/Subs-Post.php
+++ b/Sources/Subs-Post.php
@@ -572,8 +572,8 @@ function sendmail($to, $subject, $message, $from = null, $message_id = null, $se
 	// Use sendmail if it's set or if no SMTP server is set.
 	$use_sendmail = empty($modSettings['mail_type']) || $modSettings['smtp_host'] == '';
 
-	// Line breaks need to be \r\n only in windows or for SMTP.
-	$line_break = $context['server']['is_windows'] || !$use_sendmail ? "\r\n" : "\n";
+	// Starting with php 8x, line breaks need to be \r\n for windows & linux.
+	$line_break = "\r\n";
 
 	// So far so good.
 	$mail_result = true;

--- a/Sources/Subs-Post.php
+++ b/Sources/Subs-Post.php
@@ -572,8 +572,9 @@ function sendmail($to, $subject, $message, $from = null, $message_id = null, $se
 	// Use sendmail if it's set or if no SMTP server is set.
 	$use_sendmail = empty($modSettings['mail_type']) || $modSettings['smtp_host'] == '';
 
-	// Starting with php 8x, line breaks need to be \r\n for windows & linux.
-	$line_break = "\r\n";
+	// Line breaks need to be \r\n only in windows or for SMTP.
+	// Starting with php 8x, line breaks need to be \r\n even for linux.
+	$line_break = ($context['server']['is_windows'] || !$use_sendmail || version_compare(PHP_VERSION, '8.0.0', '>=')) ? "\r\n" : "\n";
 
 	// So far so good.
 	$mail_result = true;


### PR DESCRIPTION
Emails were not getting sent properly due to malformed headers under the following circumstances:
 - PHP 8+
 - Unix only (Windows worked OK)
 - Mail type PHP only (SMTP worked OK)

Due to a change in PHP 8, the PHP mail() function now expects line endings to be "\r\n", even on linux systems.  The old SMF logic that changed the line endings per the OS was actually breaking things when using the mail type of PHP on linux.

This fix has been tested on all variants of PHP7.4 vs PHP8.1, windows vs linux, PHP vs SMTP.  

See forum discussion:
https://www.simplemachines.org/community/index.php?topic=583842.0

See PHP 8 bug report & discussion.  Note the bug report was closed w/o action, saying the new behavior is in line with the RFC:
https://github.com/php/php-src/issues/8086
