### PR TITLE
Check attachment and avatar folders before upgrade

### DIFF
--- a/Themes/default/languages/Install.english.php
+++ b/Themes/default/languages/Install.english.php
@@ -271,6 +271,7 @@ $txt['upgrade_customize'] = 'Customize';
 $txt['upgrade_debug_info'] = 'Output extra debugging information.';
 $txt['upgrade_empty_errorlog'] = 'Empty error log before upgrading.';
 $txt['upgrade_delete_karma'] = 'Delete all karma settings and info from the DB';
+$txt['upgrade_reprocess_attachments'] = 'Rerun attachment conversion';
 $txt['upgrade_stats_collection'] = 'Allow Simple Machines to collect basic stats monthly.';
 $txt['upgrade_stats_info'] = 'If enabled, this will allow Simple Machines to visit your site once a month to collect basic statistics. This will help us make decisions as to which configurations to optimise the software for. For more information please visit our <a href="%1$s" target="_blank" rel="noopener">info page</a>.';
 $txt['upgrade_migrate_settings_file'] = 'Migrate to a new Settings file.';

--- a/Themes/default/languages/Install.english.php
+++ b/Themes/default/languages/Install.english.php
@@ -372,9 +372,9 @@ $txt['warning_lang_old'] = 'The language files for your selected language, %1$s,
 $txt['warning_lang_missing'] = 'The upgrader could not find the &quot;Install&quot; language file for your selected language, %1$s. Upgrade will continue with the forum default, %2$s.';
 
 // Attachment & Avatar folder checks
-$txt['warning_av_missing'] = 'Warning!  Avatar directory not found.  Continuing may be unsafe.  Please confirm folder settings before proceeding.';
-$txt['warning_custom_av_missing'] = 'Warning!  Custom avatar directory not found.  Continuing may be unsafe.  Please confirm folder settings before proceeding.';
-$txt['warning_att_dir_missing'] = 'Warning!  One or more attachment directories not found.  Continuing may be unsafe.  Please confirm folder settings before proceeding.';
+$txt['warning_av_missing'] = 'Warning! Avatar directory not found. Continuing may be unsafe. Please confirm folder settings before proceeding.';
+$txt['warning_custom_av_missing'] = 'Warning! Custom avatar directory not found. Continuing may be unsafe. Please confirm folder settings before proceeding.';
+$txt['warning_att_dir_missing'] = 'Warning! One or more attachment directories not found. Continuing may be unsafe. Please confirm folder settings before proceeding.';
 
 // Page titles
 $txt['updating_smf_installation'] = 'Updating Your SMF Installation!';

--- a/Themes/default/languages/Install.english.php
+++ b/Themes/default/languages/Install.english.php
@@ -371,6 +371,11 @@ $txt['error_not_admin'] = 'You need to be an admin to perform an upgrade!';
 $txt['warning_lang_old'] = 'The language files for your selected language, %1$s, have not been updated to the latest version. Upgrade will continue with the forum default, %2$s.';
 $txt['warning_lang_missing'] = 'The upgrader could not find the &quot;Install&quot; language file for your selected language, %1$s. Upgrade will continue with the forum default, %2$s.';
 
+// Attachment & Avatar folder checks
+$txt['warning_av_missing'] = 'Warning!  Avatar directory not found.  Continuing may be unsafe.  Please confirm folder settings before proceeding.';
+$txt['warning_custom_av_missing'] = 'Warning!  Custom avatar directory not found.  Continuing may be unsafe.  Please confirm folder settings before proceeding.';
+$txt['warning_att_dir_missing'] = 'Warning!  One or more attachment directories not found.  Continuing may be unsafe.  Please confirm folder settings before proceeding.';
+
 // Page titles
 $txt['updating_smf_installation'] = 'Updating Your SMF Installation!';
 $txt['upgrade_options'] = 'Upgrade Options';

--- a/other/upgrade.php
+++ b/other/upgrade.php
@@ -1073,7 +1073,8 @@ function checkFolders()
 	$warnings = '';
 
 	// First, check the avatar directory...
-	if (!is_dir($modSettings['avatar_directory']))
+	// Note it wasn't specified in yabbse, but there was no smfVersion either.
+	if (!empty($modSettings['smfVersion']) && !is_dir($modSettings['avatar_directory']))
 		$warnings .= $txt['warning_av_missing'];
 
 	// Next, check the custom avatar directory...  Note this is optional in 2.0.
@@ -1089,10 +1090,16 @@ function checkFolders()
 	// A bit more complex, since it may be json or serialized, and it may be an array or just a string...
 	$ser_test = @unserialize($modSettings['attachmentUploadDir']);
 	$json_test = @json_decode($modSettings['attachmentUploadDir'], true);
+	$string_test = !empty($modSettings['attachmentUploadDir']) && is_string($modSettings['attachmentUploadDir']) && is_dir($modSettings['attachmentUploadDir']);
 
-	// Serialized?
+	// String?
 	$attdr_problem_found = false;
-	if ($ser_test !== false)
+	if ($string_test === true)
+	{
+		// OK...
+	}
+	// Serialized?
+	elseif ($ser_test !== false)
 	{
 		if (is_array($ser_test))
 		{
@@ -1108,8 +1115,8 @@ function checkFolders()
 				$attdr_problem_found = true;
 		}
 	}
-	// Json???
-	elseif ($json_test !== false)
+	// Json?  Note the test returns null if encoding was unsuccessful
+	elseif ($json_test !== null)
 	{
 		if (is_array($json_test))
 		{
@@ -1125,11 +1132,10 @@ function checkFolders()
 				$attdr_problem_found = true;
 		}
 	}
-	// Must be a plain string...
+	// Unclear, needs a look...
 	else
 	{
-		if (!is_dir($modSettings['attachmentUploadDir']))
-			$attdr_problem_found = true;
+		$attdr_problem_found = true;
 	}
 
 	if ($attdr_problem_found)

--- a/other/upgrade.php
+++ b/other/upgrade.php
@@ -1068,7 +1068,7 @@ function WelcomeLogin()
 // Display a warning if issues found.  Does not force a hard stop.
 function checkFolders()
 {
-	global $modSettings, $upcontext, $txt;
+	global $modSettings, $upcontext, $txt, $command_line;
 
 	$warnings = '';
 

--- a/other/upgrade.php
+++ b/other/upgrade.php
@@ -1146,13 +1146,26 @@ function checkFolders()
 			$warnings .= '<br><br>' . $txt['warning_att_dir_missing'];
 	}
 
-	// Might be adding to an existing warning...
-	if (!empty($warnings))
+	// Might be using CLI
+	if ($command_line)
 	{
-		if (empty($upcontext['custom_warning']))
-			$upcontext['custom_warning'] = $warnings;
-		else
-			$upcontext['custom_warning'] .= '<br><br>' . $warnings;
+		// Change brs to new lines & display
+		if (!empty($warnings))
+		{
+			$warnings = str_replace('<br>', "\n", $warnings);
+			echo "\n\n" . $warnings . "\n\n";
+		}
+	}
+	else
+	{
+		// Might be adding to an existing warning...
+		if (!empty($warnings))
+		{
+			if (empty($upcontext['custom_warning']))
+				$upcontext['custom_warning'] = $warnings;
+			else
+				$upcontext['custom_warning'] .= '<br><br>' . $warnings;
+		}
 	}
 }
 
@@ -2883,6 +2896,9 @@ Usage: /path/to/php -f ' . basename(__FILE__) . ' -- [OPTION]...
 		updateSettings(array('custom_avatar_dir' => $custom_av_dir));
 		updateSettings(array('custom_avatar_url' => $custom_av_url));
 	}
+
+	// Make sure attachment & avatar folders exist.  Big problem if folks move or restructure sites upon upgrade.
+	checkFolders();
 
 	// Make sure we skip the HTML for login.
 	$_POST['upcont'] = true;

--- a/other/upgrade.php
+++ b/other/upgrade.php
@@ -1446,6 +1446,9 @@ function UpgradeOptions()
 	// Emptying the error log?
 	$_SESSION['empty_error'] = !empty($_POST['empty_error']);
 
+	// Reprocessing attachments?
+	$_SESSION['reprocess_attachments'] = !empty($_POST['reprocess_attachments']);
+
 	$changes = array();
 
 	// Add proxy settings.
@@ -1690,6 +1693,7 @@ function DatabaseChanges()
 
 	$upcontext['delete_karma'] = !empty($_SESSION['delete_karma']);
 	$upcontext['empty_error'] = !empty($_SESSION['empty_error']);
+	$upcontext['reprocess_attachments'] = !empty($_SESSION['reprocess_attachments']);
 
 	// All possible files.
 	// Name, < version, insert_on_complete
@@ -4305,6 +4309,15 @@ function template_upgrade_options()
 					<li>
 						<input type="checkbox" name="delete_karma" id="delete_karma" value="1">
 						<label for="delete_karma">', $txt['upgrade_delete_karma'], '</label>
+					</li>';
+
+	// If attachment step has been run previously, offer an option to do it again.
+	// Helpful if folks had improper attachment folders specified previously.
+	if (!empty($modSettings['attachments_21_done']))
+		echo '
+					<li>
+						<input type="checkbox" name="reprocess_attachments" id="reprocess_attachments" value="1">
+						<label for="reprocess_attachments">', $txt['upgrade_reprocess_attachments'], '</label>
 					</li>';
 
 	echo '

--- a/other/upgrade_2-1_mysql.sql
+++ b/other/upgrade_2-1_mysql.sql
@@ -432,10 +432,15 @@ $step_progress['name'] = 'Converting legacy attachments';
 $step_progress['current'] = $_GET['a'];
 
 // We may be using multiple attachment directories.
-if (!empty($modSettings['currentAttachmentUploadDir']) && !is_array($modSettings['attachmentUploadDir']) && empty($modSettings['json_done']))
-	$modSettings['attachmentUploadDir'] = @unserialize($modSettings['attachmentUploadDir']);
+// Allow for reruns - it's possible it's json...
+if (!empty($modSettings['currentAttachmentUploadDir']) && !is_array($modSettings['attachmentUploadDir']))
+	if (empty($modSettings['json_done']))
+		$modSettings['attachmentUploadDir'] = @unserialize($modSettings['attachmentUploadDir']);
+	else
+		$modSettings['attachmentUploadDir'] = @json_decode($modSettings['attachmentUploadDir'], true);
 
 // No need to do this if we already did it previously...
+// If we want the upgrader to re-process attachments upon a rerun, attachments_21_done must be deleted.
 if (empty($modSettings['attachments_21_done']))
   $is_done = false;
 else

--- a/other/upgrade_2-1_mysql.sql
+++ b/other/upgrade_2-1_mysql.sql
@@ -439,8 +439,8 @@ if (!empty($modSettings['currentAttachmentUploadDir']) && !is_array($modSettings
 	else
 		$modSettings['attachmentUploadDir'] = @json_decode($modSettings['attachmentUploadDir'], true);
 
-// No need to do this if we already did it previously...
-if (empty($modSettings['attachments_21_done']))
+// No need to do this if we already did it previously...  Unless requested...
+if (empty($modSettings['attachments_21_done']) || !empty($upcontext['reprocess_attachments'])) 
   $is_done = false;
 else
   $is_done = true;

--- a/other/upgrade_2-1_mysql.sql
+++ b/other/upgrade_2-1_mysql.sql
@@ -440,7 +440,6 @@ if (!empty($modSettings['currentAttachmentUploadDir']) && !is_array($modSettings
 		$modSettings['attachmentUploadDir'] = @json_decode($modSettings['attachmentUploadDir'], true);
 
 // No need to do this if we already did it previously...
-// If we want the upgrader to re-process attachments upon a rerun, attachments_21_done must be deleted.
 if (empty($modSettings['attachments_21_done']))
   $is_done = false;
 else


### PR DESCRIPTION
Fixes #7555 

If folders are not found, warnings are produced:
![image](https://user-images.githubusercontent.com/23568484/197134029-0755c544-b469-46ee-97cd-daed40dd91db.png)

Also, if we are rerunning the upgrader, a new option has been added to allow for rerunning the attachment conversion:
![att_dir_option](https://user-images.githubusercontent.com/23568484/198751809-1a1ac197-e3a1-486a-bb3c-76bbcb9364ce.png)
