### PR TITLE
Confirm methods exist before calling

### DIFF
--- a/Sources/Subs-Compat.php
+++ b/Sources/Subs-Compat.php
@@ -485,8 +485,10 @@ if (!function_exists('idn_to_ascii'))
 		if (!is_object($Punycode))
 			$Punycode = new Punycode();
 
-		$Punycode->useStd3($flags === ($flags | IDNA_USE_STD3_RULES));
-		$Punycode->useNonTransitional($flags === ($flags | IDNA_NONTRANSITIONAL_TO_ASCII));
+		if (method_exists($Punycode, 'useStd3'))
+			$Punycode->useStd3($flags === ($flags | IDNA_USE_STD3_RULES));
+		if (method_exists($Punycode, 'useNonTransitional'))
+			$Punycode->useNonTransitional($flags === ($flags | IDNA_NONTRANSITIONAL_TO_ASCII));
 
 		return $Punycode->encode($domain);
 	}


### PR DESCRIPTION
Fixes #7572 

Tested, works!

As noted in the discussion in the issue, this is needed because pacman behavior under PHP 8.1 seems to have changed a bit.  The class-Punycode.php appears to be getting reloaded & used immediately after pacman applies its updates.  BUT...  It's out of sync with the calling program, Subs-Compat.php.  This caused issues upon deinstall, as Subs-Compat was calling methods that no longer existed.  