### PR TITLE
Fix various issue with the upgrader running PHP 8.1

### DIFF
--- a/other/upgrade.php
+++ b/other/upgrade.php
@@ -1118,6 +1118,13 @@ function checkFolders()
 	{
 		// OK...
 	}
+	// An array already?
+	elseif (is_array($modSettings['attachmentUploadDir']))
+	{
+		foreach($modSettings['attachmentUploadDir'] AS $dir)
+			if (!empty($dir) && !is_dir($dir))
+				$attdr_problem_found = true;
+	}
 	// Serialized?
 	elseif ($ser_test !== false)
 	{


### PR DESCRIPTION
While testing for 2.1.3, I ran into the following issues on my git env.  This fixes them up. I did borrow code from a PHP RFC, but due to the simplicity of the code, I don't know if it can really be 'copyrighted'.  Included a url at least to the RFC for now.  This should go away in the future once we have moved to a PHP version that can handle unserialize properly.

( ! ) Fatal error: Uncaught TypeError: unserialize(): Argument #1 ($data) must be of type string, array given in /smf21git/upgrade.php on line 1091 ( ! ) TypeError: unserialize(): Argument #1 ($data) must be of type string, array given in /smf21git/upgrade.php on line 1091

( ! ) Fatal error: Uncaught TypeError: json_decode(): Argument #1 ($json) must be of type string, array given in /smf21git/upgrade.php on line 1104 ( ! ) TypeError: json_decode(): Argument #1 ($json) must be of type string, array given in /smf21git/upgrade.php on line 1104

( ! ) Deprecated: Implicit conversion from float 0.03333333333333333 to int loses precision in /smf21git/upgrade.php on line 5080

FYI, I am on PHP 8.1