### PR TITLE
Pacman tries to read a directory as a compressed file

### DIFF
--- a/Sources/Subs-Package.php
+++ b/Sources/Subs-Package.php
@@ -31,6 +31,10 @@ if (!defined('SMF'))
  */
 function read_tgz_file($gzfilename, $destination, $single_file = false, $overwrite = false, $files_to_extract = null)
 {
+	// Directories are not compressed files.
+	if (is_dir($gzfilename))
+		return false;
+
 	$data = substr($gzfilename, 0, 7) == 'http://' || substr($gzfilename, 0, 8) == 'https://'
 		? fetch_web_data($gzfilename)
 		: file_get_contents($gzfilename);


### PR DESCRIPTION
Fixes error caused by package manager trying to read a directory as a compressed file

```
Notice
: file_get_contents(): Read of 8192 bytes failed with errno=21 Is a directory in
/Sources/Subs-Package.php
on line
36
```