### PR TITLE
Protect from overlong USER_AGENTs

### DIFF
--- a/Sources/Logging.php
+++ b/Sources/Logging.php
@@ -52,7 +52,7 @@ function writeLog($force = false)
 
 	if (!empty($modSettings['who_enabled']))
 	{
-		$encoded_get = truncate_array($_GET) + array('USER_AGENT' => $_SERVER['HTTP_USER_AGENT']);
+		$encoded_get = truncate_array($_GET) + array('USER_AGENT' => mb_substr($_SERVER['HTTP_USER_AGENT'], 0, 128));
 
 		// In the case of a dlattach action, session_var may not be set.
 		if (!isset($context['session_var']))
@@ -60,6 +60,10 @@ function writeLog($force = false)
 
 		unset($encoded_get['sesc'], $encoded_get[$context['session_var']]);
 		$encoded_get = $smcFunc['json_encode']($encoded_get);
+
+		// Sometimes folks mess with USER_AGENT & $_GET data, so one last check to avoid 'data too long' errors
+		if (mb_strlen($encoded_get) > 2048)
+			$encoded_get = '';
 	}
 	else
 		$encoded_get = '';


### PR DESCRIPTION
Fixes #7596 

Avoid storing/truncating strings that are too long in the url column in log_online.

Note that the truncate_array() function used already attempts to make sure the $_GET part is < 1900,  So in theory we have 2048 - 1900 = 148 bytes to work with.  But that's all before encoding, escaping, control characters, etc.  