### PR TITLE
MariaDB needs all selections in GROUP BY

### DIFF
--- a/Sources/RemoveTopic.php
+++ b/Sources/RemoveTopic.php
@@ -1393,7 +1393,7 @@ function mergePosts($msgs, $from_topic, $target_topic)
 			SELECT MIN(id_msg) AS id_first_msg, MAX(id_msg) AS id_last_msg, COUNT(*) AS message_count, approved, subject
 			FROM {db_prefix}messages
 			WHERE id_topic = {int:from_topic}
-			GROUP BY id_topic, approved
+			GROUP BY id_topic, approved, subject
 			ORDER BY approved ASC
 			LIMIT 2',
 			array(


### PR DESCRIPTION
Fixes #7656

Works fine in MySQL.  I don't have a MariaDB to do a test, however, the user who originally reported the issue says this solved his issue:
https://www.simplemachines.org/community/index.php?msg=4141787
