### PR TITLE
Properly handle disabled hooks & includes

### DIFF
--- a/Sources/ManageMaintenance.php
+++ b/Sources/ManageMaintenance.php
@@ -1884,8 +1884,9 @@ function list_integration_hooks()
 
 		else
 		{
-			$function_remove = urldecode($_REQUEST['function']) . (($_REQUEST['do'] == 'disable') ? '' : '!');
-			$function_add = urldecode($_REQUEST['function']) . (($_REQUEST['do'] == 'disable') ? '!' : '');
+			// Disable/enable logic; always remove exactly what was passed
+			$function_remove = urldecode($_REQUEST['function']);
+			$function_add = urldecode(rtrim($_REQUEST['function'], '!')) . (($_REQUEST['do'] == 'disable') ? '!' : '');
 
 			remove_integration_function($_REQUEST['hook'], $function_remove);
 			add_integration_function($_REQUEST['hook'], $function_add);

--- a/Sources/ManageMaintenance.php
+++ b/Sources/ManageMaintenance.php
@@ -1979,11 +1979,8 @@ function list_integration_hooks()
 					{
 						$change_status = array('before' => '', 'after' => '');
 
-						if ($data['can_disable'])
-						{
-							$change_status['before'] = '<a href="' . $scripturl . '?action=admin;area=maintain;sa=hooks;do=' . ($data['enabled'] ? 'disable' : 'enable') . ';hook=' . $data['hook_name'] . ';function=' . urlencode($data['function_name']) . $filter_url . ';' . $context['admin-hook_token_var'] . '=' . $context['admin-hook_token'] . ';' . $context['session_var'] . '=' . $context['session_id'] . '" data-confirm="' . $txt['quickmod_confirm'] . '" class="you_sure">';
-							$change_status['after'] = '</a>';
-						}
+						$change_status['before'] = '<a href="' . $scripturl . '?action=admin;area=maintain;sa=hooks;do=' . ($data['enabled'] ? 'disable' : 'enable') . ';hook=' . $data['hook_name'] . ';function=' . urlencode($data['function_name']) . $filter_url . ';' . $context['admin-hook_token_var'] . '=' . $context['admin-hook_token'] . ';' . $context['session_var'] . '=' . $context['session_id'] . '" data-confirm="' . $txt['quickmod_confirm'] . '" class="you_sure">';
+						$change_status['after'] = '</a>';
 
 						return $change_status['before'] . '<span class="main_icons post_moderation_' . $data['status'] . '" title="' . $data['img_text'] . '"></span>' . $change_status['after'];
 					},
@@ -2098,10 +2095,11 @@ function get_integration_hooks_data($start, $per_page, $sort, $filtered_hooks, $
 			$hookParsedData = parse_integration_hook($hook, $rawFunc);
 
 			// Handle hooks pointing outside the sources directory.
-			if ($hookParsedData['absPath'] != '' && !isset($files[$hookParsedData['absPath']]) && file_exists($hookParsedData['absPath']))
-				$function_list += get_defined_functions_in_file($hookParsedData['absPath']);
+			$absPath_clean =  rtrim($hookParsedData['absPath'], '!');
+			if ($absPath_clean != '' && !isset($files[$absPath_clean]) && file_exists($absPath_clean))
+				$function_list += get_defined_functions_in_file($absPath_clean);
 
-			$hook_exists = isset($function_list[$hookParsedData['call']]) || (substr($hook, -8) === '_include' && isset($files[$hookParsedData['absPath']]));
+			$hook_exists = isset($function_list[$hookParsedData['call']]) || (substr($hook, -8) === '_include' && isset($absPath_clean));
 			$temp = array(
 				'hook_name' => $hook,
 				'function_name' => $hookParsedData['rawData'],
@@ -2113,7 +2111,6 @@ function get_integration_hooks_data($start, $per_page, $sort, $filtered_hooks, $
 				'status' => $hook_exists ? ($hookParsedData['enabled'] ? 'allow' : 'moderate') : 'deny',
 				'img_text' => $txt['hooks_' . ($hook_exists ? ($hookParsedData['enabled'] ? 'active' : 'disabled') : 'missing')],
 				'enabled' => $hookParsedData['enabled'],
-				'can_disable' => $hookParsedData['call'] != '',
 			);
 			$sort_array[] = $temp[$sort_types[$sort][0]];
 			$temp_data[] = $temp;
@@ -2194,7 +2191,8 @@ function parse_integration_hook(string $hook, string $rawData)
 	}
 
 	// Hook is "disabled"
-	if (strpos($modFunc, '!') !== false)
+	// May need to inspect $rawData here for includes...
+	if ((strpos($modFunc, '!') !== false) || (empty($modFunc) && (strpos($rawData, '!') !== false)))
 	{
 		$modFunc = str_replace('!', '', $modFunc);
 		$hookData['enabled'] = false;

--- a/Sources/ManageMaintenance.php
+++ b/Sources/ManageMaintenance.php
@@ -1981,7 +1981,7 @@ function list_integration_hooks()
 
 						if ($data['can_disable'])
 						{
-							$change_status['before'] = '<a href="' . $scripturl . '?action=admin;area=maintain;sa=hooks;do=' . ($data['enabled'] ? 'disable' : 'enable') . ';hook=' . $data['hook_name'] . ';function=' . urlencode($data['real_function']) . $filter_url . ';' . $context['admin-hook_token_var'] . '=' . $context['admin-hook_token'] . ';' . $context['session_var'] . '=' . $context['session_id'] . '" data-confirm="' . $txt['quickmod_confirm'] . '" class="you_sure">';
+							$change_status['before'] = '<a href="' . $scripturl . '?action=admin;area=maintain;sa=hooks;do=' . ($data['enabled'] ? 'disable' : 'enable') . ';hook=' . $data['hook_name'] . ';function=' . urlencode($data['function_name']) . $filter_url . ';' . $context['admin-hook_token_var'] . '=' . $context['admin-hook_token'] . ';' . $context['session_var'] . '=' . $context['session_id'] . '" data-confirm="' . $txt['quickmod_confirm'] . '" class="you_sure">';
 							$change_status['after'] = '</a>';
 						}
 

--- a/Sources/ManageMaintenance.php
+++ b/Sources/ManageMaintenance.php
@@ -2099,7 +2099,7 @@ function get_integration_hooks_data($start, $per_page, $sort, $filtered_hooks, $
 			if ($absPath_clean != '' && !isset($files[$absPath_clean]) && file_exists($absPath_clean))
 				$function_list += get_defined_functions_in_file($absPath_clean);
 
-			$hook_exists = isset($function_list[$hookParsedData['call']]) || (substr($hook, -8) === '_include' && isset($absPath_clean));
+			$hook_exists = isset($function_list[$hookParsedData['call']]) || (substr($hook, -8) === '_include' && isset($files[$absPath_clean]));
 			$temp = array(
 				'hook_name' => $hook,
 				'function_name' => $hookParsedData['rawData'],


### PR DESCRIPTION
Fixes #7634

This addresses a number of problems where adding/removing mods did not properly deal with disabled hooks.  It also addresses numerous issues with the Integration Hooks admin function when dealing with disabled hooks & also when dealing with includes. 

Changes:
 - When adding a hook, if a disabled entry previously exists, it should get rid of the old disabled entry, & avoid creating a dupe.
 - When removing a hook, it should look for disabled entries as well, otherwise they will be left in place, e.g., even after a mod de-install.
 - Some file operations (file exists, etc.) were including the disabled indicator (!) in the file/function name, which would make it look like the file/function did not exist when it did.  This prevented some operations in the Integration Hooks maintenance function from working.
 - Use the path when it's available.  Some add/remove hook operations did not check for the path.  In particular, enable/disable operations use a remove/add approach, so removing an entry resulted in no change (due to no hit, since the path wasn't specified), but the add resulted in adding a partial entry (no path).  The result was an erroneous partial entry that could not be fixed.
 - Eat dupes, to help when cleaning things up.  There should never be duplicates.
 - Allow for enabling/disabling of includes.  Needed for when they are disabled elsewhere, e.g., in repair_settings.php.

At this point, adding mods no longer creates dupes, and results in one clean set of integration hooks, even when cleaning up after a broken install/uninstall.  Removing mods removes all the hooks, no matter what the status.  

Also, as intended, you can now use the Integration Hooks function to do most hook cleanup activity.  Even if you were to accidentally disable all hooks in repair_settings.php.
