### PR TITLE
No need to specify in php; it is assumed when CURLOPT_POSTFIELDS is s…

### DIFF
--- a/Sources/Subscriptions-PayPal.php
+++ b/Sources/Subscriptions-PayPal.php
@@ -210,7 +210,6 @@ class paypal_payment
 		{
 			// Set the post data.
 			curl_setopt($curl, CURLOPT_POST, true);
-			curl_setopt($curl, CURLOPT_POSTFIELDSIZE, 0);
 			curl_setopt($curl, CURLOPT_POSTFIELDS, $requestString);
 
 			// Set up the headers so paypal will accept the post


### PR DESCRIPTION
Fixes #7521 

CURLOPT_POSTFIELDSIZE is not supported in php.  It is assumed when CURLOPT_POSTFIELDS is specified...

I actually don't have a way to test this, but it seems straightforward enough...