### PR TITLE
Remove erroneous verification check

### DIFF
--- a/Sources/Subs-Editor.php
+++ b/Sources/Subs-Editor.php
@@ -2111,9 +2111,6 @@ function create_control_verification(&$verificationOptions, $do_test = false)
 		// This cannot happen!
 		if (!isset($_SESSION[$verificationOptions['id'] . '_vv']['count']))
 			fatal_lang_error('no_access', false);
-		// Verification question does not exist for this language.
-		if ($thisVerification['number_questions'] && (!isset($_SESSION[$verificationOptions['id'] . '_vv']['q']) || !isset($_REQUEST[$verificationOptions['id'] . '_vv']['q'])))
-			fatal_lang_error('registration_no_verification_questions');
 		// Hmm, it's requested but not actually declared. This shouldn't happen.
 		if ($thisVerification['empty_field'] && empty($_SESSION[$verificationOptions['id'] . '_vv']['empty_field']))
 			fatal_lang_error('no_access', false);

--- a/Themes/default/languages/Errors.english.php
+++ b/Themes/default/languages/Errors.english.php
@@ -139,7 +139,6 @@ $txt['no_theme'] = 'That theme does not exist.';
 $txt['theme_dir_wrong'] = 'The default theme\'s directory is wrong, please correct it by clicking this text.';
 $txt['registration_disabled'] = 'Sorry, registration is currently disabled.';
 $txt['registration_no_secret_question'] = 'Sorry, there is no secret question set for this member.';
-$txt['registration_no_verification_questions'] = 'Verification questions not configured properly. Please report this error to an administrator.';
 $txt['poll_range_error'] = 'Sorry, the poll must run for more than 0 days.';
 $txt['delFirstPost'] = 'You are not allowed to delete the first post in a topic.<p>If you want to delete this topic, click on the Remove Topic link, or ask a moderator/administrator to do it for you.</p>';
 $txt['parent_error'] = 'Unable to create board!';


### PR DESCRIPTION
Fixes #7597 

This error appeared whenever a user changed languages while a incorrect answer to a verification question error was displayed.  

Note that this error said the verification questions were incorrectly configured, however, the verification questions were in fact configured properly.  So, completely erroneous errors were logged and presented to the user, and the user was left in a weird state having lost their input.

This could happen anywhere there were verification questions: e.g., guest search, registration, new user first posts.  

The old edit was looking at $_REQUEST, which might get clobbered upon a submit - and changing languages issues another form submit on the same page.

With this PR, the erroneous error is no longer logged or presented.  The users may still lose their input (due to changing the language in the middle of a form submit), but at least they now get a meaningful error message.  