### PR TITLE
Uses built-in 'matcher' callback of At.js

### DIFF
--- a/Themes/default/scripts/mentions.js
+++ b/Themes/default/scripts/mentions.js
@@ -4,6 +4,7 @@ var atwhoConfig = {
 	at: '@',
 	data: [],
 	show_the_at: true,
+	startWithSpace: true,
 	limit: 10,
 	callbacks: {
 		remoteFilter: function (query, callback) {

--- a/Themes/default/scripts/mentions.js
+++ b/Themes/default/scripts/mentions.js
@@ -6,25 +6,6 @@ var atwhoConfig = {
 	show_the_at: true,
 	limit: 10,
 	callbacks: {
-		matcher: function(flag, subtext, should_start_with_space) {
-			var match = '', started = false;
-			var string = subtext.split('');
-			for (var i = 0; i < string.length; i++)
-			{
-				if (string[i] == flag && (!should_start_with_space || i == 0 || /[\s\n]/gi.test(string[i - 1])))
-				{
-					started = true;
-					match = '';
-				}
-				else if (started)
-					match = match + string[i];
-			}
-
-			if (match.length > 0)
-				return match;
-
-			return null;
-		},
 		remoteFilter: function (query, callback) {
 			if (typeof query == 'undefined' || query.length < 2 || query.length > 60)
 				return;


### PR DESCRIPTION
Fixes #7687

For those who are curious, the issue was that the custom 'matcher' callback we were using would capture everything from the `@` to the end of the line, rather than just the actual matching string. Reverting to the default behaviour fixes this, and I can find no negative side effects in my tests.