### PR TITLE
Notifications shouldn't come through for denied boards

### DIFF
--- a/Sources/tasks/CreatePost-Notify.php
+++ b/Sources/tasks/CreatePost-Notify.php
@@ -119,6 +119,22 @@ class CreatePost_Notify_Background extends SMF_BackgroundTask
 		if (!empty($msgOptions['mentioned_members']))
 			$this->members['mentioned'] = Mentions::getMentionsByContent('msg', $msgOptions['id'], array_keys($msgOptions['mentioned_members']));
 
+		$group_permissions = array(
+			'allowed' => array(),
+			'denied' => array(),
+		);
+		$request = $smcFunc['db_query']('', '
+			SELECT id_group, deny
+			FROM {db_prefix}board_permissions_view
+			WHERE id_board = {int:current_board}',
+			array(
+				'current_board' => $topicOptions['board'],
+			)
+		);
+		while (list ($id_group, $deny) = $smcFunc['db_fetch_row']($request))
+			$group_permissions[$deny === '0' ? 'allowed' : 'denied'][] = $id_group;
+		$smcFunc['db_free_result']($request);
+
 		// Find the people interested in receiving notifications for this topic
 		$request = $smcFunc['db_query']('', '
 			SELECT
@@ -130,9 +146,8 @@ class CreatePost_Notify_Background extends SMF_BackgroundTask
 			FROM {db_prefix}log_notify AS ln
 				INNER JOIN {db_prefix}members AS mem ON (ln.id_member = mem.id_member)
 				LEFT JOIN {db_prefix}topics AS t ON (t.id_topic = ln.id_topic)
-				LEFT JOIN {db_prefix}boards AS b ON (b.id_board = ln.id_board OR b.id_board = t.id_board)
-			WHERE ln.id_member != {int:member}
-				AND (ln.id_topic = {int:topic} OR ln.id_board = {int:board})',
+			WHERE ' . ($type == 'topic' ? 'ln.id_board = {int:board}' : 'ln.id_topic = {int:topic}') . '
+				AND ln.id_member != {int:member}',
 			array(
 				'member' => $posterOptions['id'],
 				'topic' => $topicOptions['id'],
@@ -144,9 +159,8 @@ class CreatePost_Notify_Background extends SMF_BackgroundTask
 			// Skip members who aren't allowed to see this board
 			$groups = array_merge(array($row['id_group'], $row['id_post_group']), (empty($row['additional_groups']) ? array() : explode(',', $row['additional_groups'])));
 
-			$allowed_groups = explode(',', $row['member_groups']);
-
-			if (!in_array(1, $groups) && count(array_intersect($groups, $allowed_groups)) == 0)
+			$is_denied = array_intersect($group_permissions['denied'], $groups) != array();
+			if (!in_array(1, $groups) && ($is_denied || array_intersect($groups, $group_permissions['allowed']) == array()))
 				continue;
 			else
 			{
@@ -161,27 +175,12 @@ class CreatePost_Notify_Background extends SMF_BackgroundTask
 		// Filter out mentioned and quoted members who can't see this board.
 		if (!empty($this->members['mentioned']) || !empty($this->members['quoted']))
 		{
-			// This won't be set yet if no one is watching this board or topic.
-			if (!isset($allowed_groups))
-			{
-				$request = $smcFunc['db_query']('', '
-					SELECT member_groups
-					FROM {db_prefix}boards
-					WHERE id_board = {int:board}',
-					array(
-						'board' => $topicOptions['board'],
-					)
-				);
-				list($allowed_groups) = $smcFunc['db_fetch_row']($request);
-				$smcFunc['db_free_result']($request);
-				$allowed_groups = explode(',', $allowed_groups);
-			}
-
 			foreach (array('mentioned', 'quoted') as $member_type)
 			{
 				foreach ($this->members[$member_type] as $member_id => $member_data)
 				{
-					if (!in_array(1, $member_data['groups']) && count(array_intersect($member_data['groups'], $allowed_groups)) == 0)
+					$is_denied = array_intersect($group_permissions['denied'], $member_data['groups']) != array();
+					if (!in_array(1, $member_data['groups']) && ($is_denied || array_intersect($member_data['groups'], $group_permissions['allowed']) == array()))
 						unset($this->members[$member_type][$member_id], $msgOptions[$member_type . '_members'][$member_id]);
 				}
 			}
@@ -534,10 +533,6 @@ class CreatePost_Notify_Background extends SMF_BackgroundTask
 				if (empty($modSettings['disallow_sendBody']) && !empty($this->prefs[$member_id]['msg_receive_body']))
 					$message_type .= '_body';
 			}
-
-			// If neither of the above, this might be a redundant row due to the OR clause in our SQL query, skip
-			else
-				continue;
 
 			// We need to fake some of $user_info to make BBC parsing work correctly.
 			if (isset($user_info))


### PR DESCRIPTION
### Setup
1. Two users: admin and global moderator
2. The preinstalled board with default permissions
### Recreate
1. Create a  membergroup
4. Set that membergroup to deny as  board
5. Add that group to a member
6. That member should receive alerts from a topic in that board
7. Admin replies to that topic

And then the alert comes even though the    user is in a group that denies access. If I understand denied access, it should override any group that granted access.