### PR TITLE
Fixes logic when deciding to run scheduled tasks

### DIFF
--- a/cron.php
+++ b/cron.php
@@ -142,7 +142,7 @@ while ($task_details = fetch_task())
 }
 
 // If we have time, check the scheduled tasks.
-if (time() - TIME_START > ceil(MAX_CRON_TIME / 2))
+if (time() - TIME_START < ceil(MAX_CRON_TIME / 2))
 {
 	require_once($sourcedir . '/ScheduledTasks.php');
 


### PR DESCRIPTION
I just noticed that I put an inequality sign backwards in #7698. This fixes it.