### PR TITLE
Fix integrate_attachments_browse hook to properly used

### DIFF
--- a/Sources/ManageAttachments.php
+++ b/Sources/ManageAttachments.php
@@ -9,7 +9,7 @@
  *
  * @package SMF
  * @author Simple Machines https://www.simplemachines.org
- * @copyright 2023 Simple Machines and individual contributors
+ * @copyright 2022 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
  * @version 2.1.3

--- a/Sources/ManageAttachments.php
+++ b/Sources/ManageAttachments.php
@@ -12,7 +12,7 @@
  * @copyright 2023 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 2.1.4
+ * @version 2.1.3
  */
 
 if (!defined('SMF'))

--- a/Sources/ManageAttachments.php
+++ b/Sources/ManageAttachments.php
@@ -9,10 +9,10 @@
  *
  * @package SMF
  * @author Simple Machines https://www.simplemachines.org
- * @copyright 2022 Simple Machines and individual contributors
+ * @copyright 2023 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 2.1.3
+ * @version 2.1.4
  */
 
 if (!defined('SMF'))
@@ -402,28 +402,9 @@ function BrowseFiles()
 	// Attachments or avatars?
 	$context['browse_type'] = isset($_REQUEST['avatars']) ? 'avatars' : (isset($_REQUEST['thumbs']) ? 'thumbs' : 'attachments');
 
-	$titles = array(
-		'attachments' => array('?action=admin;area=manageattachments;sa=browse', $txt['attachment_manager_attachments']),
-		'avatars' => array('?action=admin;area=manageattachments;sa=browse;avatars', $txt['attachment_manager_avatars']),
-		'thumbs' => array('?action=admin;area=manageattachments;sa=browse;thumbs', $txt['attachment_manager_thumbs']),
-	);
-
-	$list_title = $txt['attachment_manager_browse_files'] . ': ';
-	foreach ($titles as $browse_type => $details)
-	{
-		if ($browse_type != 'attachments')
-			$list_title .= ' | ';
-
-		if ($context['browse_type'] == $browse_type)
-			$list_title .= '<img src="' . $settings['images_url'] . '/selected.png" alt="&gt;"> ';
-
-		$list_title .= '<a href="' . $scripturl . $details[0] . '">' . $details[1] . '</a>';
-	}
-
 	// Set the options for the list component.
 	$listOptions = array(
 		'id' => 'file_list',
-		'title' => $list_title,
 		'items_per_page' => $modSettings['defaultMaxListItems'],
 		'base_href' => $scripturl . '?action=admin;area=manageattachments;sa=browse' . ($context['browse_type'] === 'avatars' ? ';avatars' : ($context['browse_type'] === 'thumbs' ? ';thumbs' : '')),
 		'default_sort_col' => 'name',
@@ -589,8 +570,29 @@ function BrowseFiles()
 		),
 	);
 
+	$titles = array(
+		'attachments' => array('?action=admin;area=manageattachments;sa=browse', $txt['attachment_manager_attachments']),
+		'avatars' => array('?action=admin;area=manageattachments;sa=browse;avatars', $txt['attachment_manager_avatars']),
+		'thumbs' => array('?action=admin;area=manageattachments;sa=browse;thumbs', $txt['attachment_manager_thumbs']),
+	);
+
+	$list_title = $txt['attachment_manager_browse_files'] . ': ';
+
 	// Does a hook want to display their attachments better?
-	call_integration_hook('integrate_attachments_browse', array(&$listOptions, &$titles, &$list_title));
+	call_integration_hook('integrate_attachments_browse', array(&$listOptions, &$titles));
+
+	foreach ($titles as $browse_type => $details)
+	{
+		if ($browse_type != 'attachments')
+			$list_title .= ' | ';
+
+		if ($context['browse_type'] == $browse_type)
+			$list_title .= '<img src="' . $settings['images_url'] . '/selected.png" alt="&gt;"> ';
+
+		$list_title .= '<a href="' . $scripturl . $details[0] . '">' . $details[1] . '</a>';
+	}
+
+	$listOptions['title'] = $list_title;
 
 	// Create the list.
 	require_once($sourcedir . '/Subs-List.php');


### PR DESCRIPTION
These changes will allow new heading sections to be added to and switched between the current sections.

![2023-03-18 00_45_59-Attachments and Avatars — Firefox Developer Edition](https://user-images.githubusercontent.com/229402/226014616-151e2c0c-86d8-44c3-bd82-a151335cdacf.png)

Example:
```php
public function attachmentsBrowse(array &$listOptions, array &$titles): void
{
  global $context, $txt;
  
  if (isset($_REQUEST['my_attach']))
	  $context['browse_type'] = 'my_attach';
  
  $titles['my_attach'] = ['?action=admin;area=manageattachments;sa=browse;my_attach', $txt['attachment_manager_attachments'] . ' ' . $txt['my_list_title']];
  
  if (isset($_REQUEST['my_attach']))
	  $listOptions = $this->getListOptions();
}
```