### PR TITLE
Fix wrong position name for some buttons in tables

### DIFF
--- a/Sources/ManageAttachments.php
+++ b/Sources/ManageAttachments.php
@@ -9,10 +9,10 @@
  *
  * @package SMF
  * @author Simple Machines https://www.simplemachines.org
- * @copyright 2022 Simple Machines and individual contributors
+ * @copyright 2023 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 2.1.3
+ * @version 2.1.4
  */
 
 if (!defined('SMF'))
@@ -579,7 +579,7 @@ function BrowseFiles()
 		),
 		'additional_rows' => array(
 			array(
-				'position' => 'above_table_headers',
+				'position' => 'above_column_headers',
 				'value' => '<input type="submit" name="remove_submit" class="button you_sure" value="' . $txt['quickmod_delete_selected'] . '" data-confirm="' . $txt['confirm_delete_attachments'] . '">',
 			),
 			array(

--- a/Sources/ManageAttachments.php
+++ b/Sources/ManageAttachments.php
@@ -9,7 +9,7 @@
  *
  * @package SMF
  * @author Simple Machines https://www.simplemachines.org
- * @copyright 2023 Simple Machines and individual contributors
+ * @copyright 2022 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
  * @version 2.1.3

--- a/Sources/ManageAttachments.php
+++ b/Sources/ManageAttachments.php
@@ -12,7 +12,7 @@
  * @copyright 2023 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 2.1.4
+ * @version 2.1.3
  */
 
 if (!defined('SMF'))

--- a/Sources/ManageBans.php
+++ b/Sources/ManageBans.php
@@ -471,13 +471,13 @@ function BanEdit()
 				),
 				'additional_rows' => array(
 					array(
-						'position' => 'above_table_headers',
+						'position' => 'above_column_headers',
 						'value' => '
 						<input type="submit" name="remove_selection" value="' . $txt['ban_remove_selected_triggers'] . '" class="button"> <a class="button" href="' . $scripturl . '?action=admin;area=ban;sa=edittrigger;bg=' . $ban_group_id . '">' . $txt['ban_add_trigger'] . '</a>',
 						'style' => 'text-align: right;',
 					),
 					array(
-						'position' => 'above_table_headers',
+						'position' => 'above_column_headers',
 						'value' => '
 						<input type="hidden" name="bg" value="' . $ban_group_id . '">
 						<input type="hidden" name="' . $context['session_var'] . '" value="' . $context['session_id'] . '">

--- a/Sources/ManageMembergroups.php
+++ b/Sources/ManageMembergroups.php
@@ -173,7 +173,7 @@ function MembergroupIndex()
 		),
 		'additional_rows' => array(
 			array(
-				'position' => 'above_table_headers',
+				'position' => 'above_column_headers',
 				'value' => '<a class="button" href="' . $scripturl . '?action=admin;area=membergroups;sa=add;generalgroup">' . $txt['membergroups_add_group'] . '</a>',
 			),
 			array(

--- a/Sources/ManagePaid.php
+++ b/Sources/ManagePaid.php
@@ -428,7 +428,7 @@ function ViewSubscriptions()
 		),
 		'additional_rows' => array(
 			array(
-				'position' => 'above_table_headers',
+				'position' => 'above_column_headers',
 				'value' => '<input type="submit" name="add" value="' . $txt['paid_add_subscription'] . '" class="button">',
 			),
 			array(

--- a/Sources/ManageSmileys.php
+++ b/Sources/ManageSmileys.php
@@ -507,7 +507,7 @@ function EditSmileySets()
 		),
 		'additional_rows' => array(
 			array(
-				'position' => 'above_table_headers',
+				'position' => 'above_column_headers',
 				'value' => '<input type="hidden" name="smiley_save"><input type="submit" name="delete" value="' . $txt['smiley_sets_delete'] . '" data-confirm="' . $txt['smiley_sets_confirm'] . '" class="button you_sure"> <a class="button" href="' . $scripturl . '?action=admin;area=smileys;sa=modifyset' . '">' . $txt['smiley_sets_add'] . '</a> ',
 			),
 			array(

--- a/Themes/default/GenericList.template.php
+++ b/Themes/default/GenericList.template.php
@@ -59,7 +59,7 @@ function template_show_list($list_id = null)
 		// Show the page index (if this list doesn't intend to show all items).
 		if (!empty($cur_list['items_per_page']) && !empty($cur_list['page_index']))
 			echo '
-		<div class="pagesection">
+		<div class="pagesection floatleft">
 			<div class="pagelinks">', $cur_list['page_index'], '</div>
 		</div>';
 


### PR DESCRIPTION
It fixes the wrong position for the top button in the Attachments and Avatars/ Browse Files area. Now (in the current version of SMF) this button is not visible.

![2023-03-18 00_47_24-Attachments and Avatars — Firefox Developer Edition](https://user-images.githubusercontent.com/229402/226017609-32f18dea-b739-4391-a432-582f6ecf3792.png)
