### PR TITLE
Improve temporary hook handling

### DIFF
--- a/Sources/ManageMaintenance.php
+++ b/Sources/ManageMaintenance.php
@@ -1977,12 +1977,24 @@ function list_integration_hooks()
 				'data' => array(
 					'function' => function($data) use ($txt, $scripturl, $context, $filter_url)
 					{
-						$change_status = array('before' => '', 'after' => '');
+						// Cannot update temp hooks in any way, really.  Just show the appropriate icon.
+						if ($data['status'] == 'temp')
+						{
+							return '<span class="main_icons ' . ($data['hook_exists'] ? 'posts' : 'error') . '" title="' . $data['img_text'] . '"></span>';
+						}
+						else
+						{
+							$change_status = array('before' => '', 'after' => '');
 
-						$change_status['before'] = '<a href="' . $scripturl . '?action=admin;area=maintain;sa=hooks;do=' . ($data['enabled'] ? 'disable' : 'enable') . ';hook=' . $data['hook_name'] . ';function=' . urlencode($data['function_name']) . $filter_url . ';' . $context['admin-hook_token_var'] . '=' . $context['admin-hook_token'] . ';' . $context['session_var'] . '=' . $context['session_id'] . '" data-confirm="' . $txt['quickmod_confirm'] . '" class="you_sure">';
-						$change_status['after'] = '</a>';
+							// Can only enable/disable if it exists...
+							if ($data['hook_exists'])
+							{
+								$change_status['before'] = '<a href="' . $scripturl . '?action=admin;area=maintain;sa=hooks;do=' . ($data['enabled'] ? 'disable' : 'enable') . ';hook=' . $data['hook_name'] . ';function=' . urlencode($data['function_name']) . $filter_url . ';' . $context['admin-hook_token_var'] . '=' . $context['admin-hook_token'] . ';' . $context['session_var'] . '=' . $context['session_id'] . '" data-confirm="' . $txt['quickmod_confirm'] . '" class="you_sure">';
+								$change_status['after'] = '</a>';
+							}
 
-						return $change_status['before'] . '<span class="main_icons post_moderation_' . $data['status'] . '" title="' . $data['img_text'] . '"></span>' . $change_status['after'];
+							return $change_status['before'] . '<span class="main_icons post_moderation_' . $data['status'] . '" title="' . $data['img_text'] . '"></span>' . $change_status['after'];
+						}
 					},
 					'class' => 'centertext',
 				),
@@ -2001,6 +2013,8 @@ function list_integration_hooks()
 					<li><span class="main_icons post_moderation_allow"></span> ' . $txt['hooks_disable_legend_exists'] . '</li>
 					<li><span class="main_icons post_moderation_moderate"></span> ' . $txt['hooks_disable_legend_disabled'] . '</li>
 					<li><span class="main_icons post_moderation_deny"></span> ' . $txt['hooks_disable_legend_missing'] . '</li>
+					<li><span class="main_icons posts"></span> ' . $txt['hooks_disable_legend_temp'] . '</li>
+					<li><span class="main_icons error"></span> ' . $txt['hooks_disable_legend_temp_missing'] . '</li>
 				</ul>'
 			),
 		),
@@ -2014,7 +2028,8 @@ function list_integration_hooks()
 		'data' => array(
 			'function' => function($data) use ($txt, $scripturl, $context, $filter_url)
 			{
-				if (!$data['hook_exists'])
+				// Note: Cannot remove temp hooks via the UI...
+				if (!$data['hook_exists'] && $data['status'] != 'temp')
 					return '
 					<a href="' . $scripturl . '?action=admin;area=maintain;sa=hooks;do=remove;hook=' . $data['hook_name'] . ';function=' . urlencode($data['function_name']) . $filter_url . ';' . $context['admin-hook_token_var'] . '=' . $context['admin-hook_token'] . ';' . $context['session_var'] . '=' . $context['session_id'] . '" data-confirm="' . $txt['quickmod_confirm'] . '" class="you_sure">
 						<span class="main_icons delete" title="' . $txt['hooks_button_remove'] . '"></span>
@@ -2100,6 +2115,7 @@ function get_integration_hooks_data($start, $per_page, $sort, $filtered_hooks, $
 				$function_list += get_defined_functions_in_file($absPath_clean);
 
 			$hook_exists = isset($function_list[$hookParsedData['call']]) || (substr($hook, -8) === '_include' && isset($files[$absPath_clean]));
+			$hook_temp = !empty($context['integration_hooks_temporary'][$hook][$hookParsedData['rawData']]);
 			$temp = array(
 				'hook_name' => $hook,
 				'function_name' => $hookParsedData['rawData'],
@@ -2108,8 +2124,8 @@ function get_integration_hooks_data($start, $per_page, $sort, $filtered_hooks, $
 				'file_name' => strtr($hookParsedData['absPath'] ?: ($function_list[$hookParsedData['call']] ?? ''), [$normalized_boarddir => '.']),
 				'instance' => $hookParsedData['object'],
 				'hook_exists' => $hook_exists,
-				'status' => $hook_exists ? ($hookParsedData['enabled'] ? 'allow' : 'moderate') : 'deny',
-				'img_text' => $txt['hooks_' . ($hook_exists ? ($hookParsedData['enabled'] ? 'active' : 'disabled') : 'missing')],
+				'status' => ($hook_temp ? 'temp' : ($hook_exists ? ($hookParsedData['enabled'] ? 'allow' : 'moderate') : 'deny')),
+				'img_text' => $txt['hooks_' . ($hook_exists ? ($hook_temp ? 'temp' : ($hookParsedData['enabled'] ? 'active' : 'disabled')) : 'missing')],
 				'enabled' => $hookParsedData['enabled'],
 			);
 			$sort_array[] = $temp[$sort_types[$sort][0]];

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -5801,7 +5801,7 @@ function call_integration_hook($hook, $parameters = array())
  */
 function add_integration_function($hook, $function, $permanent = true, $file = '', $object = false)
 {
-	global $smcFunc, $modSettings;
+	global $smcFunc, $modSettings, $context;
 
 	// Any objects?
 	if ($object)
@@ -5853,6 +5853,14 @@ function add_integration_function($hook, $function, $permanent = true, $file = '
 
 	$functions = array_unique(array_merge($functions, array($integration_call)));
 	$modSettings[$hook] = implode(',', $functions);
+
+	// It is handy to be able to know which hooks are temporary...
+	if ($permanent !== true)
+	{
+		if (!isset($context['integration_hooks_temporary']))
+			$context['integration_hooks_temporary'] = array();
+		$context['integration_hooks_temporary'][$hook][$function] = true;
+	}
 }
 
 /**

--- a/Themes/default/languages/Admin.english.php
+++ b/Themes/default/languages/Admin.english.php
@@ -727,6 +727,7 @@ $txt['hooks_field_hook_exists'] = 'Status';
 $txt['hooks_active'] = 'Exists';
 $txt['hooks_disabled'] = 'Disabled';
 $txt['hooks_missing'] = 'Not found';
+$txt['hooks_temp'] = 'Temporary';
 $txt['hooks_no_hooks'] = 'There are currently no hooks in the system.';
 $txt['hooks_button_remove'] = 'Remove';
 $txt['hooks_disable_instructions'] = 'Click on the status icon to enable or disable the hook';
@@ -734,6 +735,8 @@ $txt['hooks_disable_legend'] = 'Legend';
 $txt['hooks_disable_legend_exists'] = 'the hook exists and is active';
 $txt['hooks_disable_legend_disabled'] = 'the hook exists but has been disabled';
 $txt['hooks_disable_legend_missing'] = 'the hook has not been found';
+$txt['hooks_disable_legend_temp'] = 'the hook is temporary';
+$txt['hooks_disable_legend_temp_missing'] = 'temporary hook not found';
 $txt['hooks_reset_filter'] = 'No filter';
 
 $txt['board_perms_allow'] = 'Allow';


### PR DESCRIPTION
Followup on & enhance #7666

The UI was still confusing, in particular when dealing with temporary hooks.  Tightened up on allowed actions based on status.  E.g., it _looked_ like it was updating temporary hooks, but the updates were ignored.

Specific changes:
 - Added ability to discern which hooks are temporary.
 - Added two new statuses to the legend, for temporary hooks & for temporary hooks that are missing.
 - No actions are allowed on temporary hooks.  The only way to remove or disable a temporary hook is to deinstall the mod or theme.
 - The only appropriate action for permanent hooks that are not found is removal.

**_With Changes - all is good, one temp hook:_**
![Hooks-1](https://user-images.githubusercontent.com/23568484/227410192-a389c0ca-d1de-45ca-aa8a-4c749a3d63b1.png)

**_With Changes - some hooks disabled:_**
![Hooks-2](https://user-images.githubusercontent.com/23568484/227410205-41b10389-997b-469b-b29d-d0a3e21b3131.png)

**_With Changes - source code is missing for some hooks:_**
![Hooks-3](https://user-images.githubusercontent.com/23568484/227410218-2c485a71-52ae-4a14-b2b8-b97278ed4763.png)
