### PR TITLE
Fixes Issue #7655: Correct notification mail template for "Immediate"

### DIFF
--- a/Sources/tasks/CreatePost-Notify.php
+++ b/Sources/tasks/CreatePost-Notify.php
@@ -529,7 +529,7 @@ class CreatePost_Notify_Background extends SMF_BackgroundTask
 
 				$content_type = 'board';
 
-				$message_type = !empty($frequency) ? 'notify_boards_once' : 'notify_boards';
+				$message_type = (!empty($frequency) && $frequency==2) ? 'notify_boards_once' : 'notify_boards';
 
 				if (empty($modSettings['disallow_sendBody']) && !empty($this->prefs[$member_id]['msg_receive_body']))
 					$message_type .= '_body';

--- a/Sources/tasks/CreatePost-Notify.php
+++ b/Sources/tasks/CreatePost-Notify.php
@@ -529,7 +529,7 @@ class CreatePost_Notify_Background extends SMF_BackgroundTask
 
 				$content_type = 'board';
 
-				$message_type = (!empty($frequency) && $frequency==2) ? 'notify_boards_once' : 'notify_boards';
+				$message_type = !empty($frequency) && $frequency == 2 ? 'notify_boards_once' : 'notify_boards';
 
 				if (empty($modSettings['disallow_sendBody']) && !empty($this->prefs[$member_id]['msg_receive_body']))
 					$message_type .= '_body';


### PR DESCRIPTION
The value of $frequency must be checked in order to select the correct message based on user notification frequency setting
