### PR TITLE
Improve handling of SVG image attachments and WYSIWYG attachment previews

### DIFF
--- a/Sources/ShowAttachments.php
+++ b/Sources/ShowAttachments.php
@@ -289,7 +289,7 @@ function showAttachment()
 	}
 
 	// Update the download counter (unless it's a thumbnail or resuming an incomplete download).
-	if ($file['attachment_type'] != 3 && empty($showThumb) && $range === 0 && empty($context['skip_downloads_increment']))
+	if ($file['attachment_type'] != 3 && empty($showThumb) && empty($_REQUEST['preview']) && $range === 0 && empty($context['skip_downloads_increment']))
 		$smcFunc['db_query']('', '
 			UPDATE {db_prefix}attachments
 			SET downloads = downloads + 1

--- a/Sources/Subs-Attachments.php
+++ b/Sources/Subs-Attachments.php
@@ -687,6 +687,12 @@ function createAttachment(&$attachmentOptions)
 	$size = @getimagesize($attachmentOptions['tmp_name']);
 	list ($attachmentOptions['width'], $attachmentOptions['height']) = $size;
 
+	if (!empty($attachmentOptions['mime_type']) && $attachmentOptions['mime_type'] === 'image/svg+xml')
+	{
+		foreach (getSvgSize($attachmentOptions['tmp_name']) as $key => $value)
+			$attachmentOptions[$key] = $value === INF ? 0 : $value;
+	}
+
 	if (function_exists('exif_read_data') && ($exif_data = @exif_read_data($attachmentOptions['tmp_name'])) !== false && !empty($exif_data['Orientation']))
 		if (in_array($exif_data['Orientation'], [5, 6, 7, 8]))
 		{
@@ -1305,7 +1311,7 @@ function loadAttachmentContext($id_msg, $attachments)
 			if (!empty($attachment['id_thumb']))
 				$attachmentData[$i]['thumbnail'] = array(
 					'id' => $attachment['id_thumb'],
-					'href' => $scripturl . '?action=dlattach;attach=' . $attachment['id_thumb'] . ';image',
+					'href' => $scripturl . '?action=dlattach;attach=' . $attachment['id_thumb'] . ';image;thumb',
 				);
 			$attachmentData[$i]['thumbnail']['has_thumb'] = !empty($attachment['id_thumb']);
 
@@ -1334,6 +1340,17 @@ function loadAttachmentContext($id_msg, $attachments)
 
 			if (!$attachmentData[$i]['thumbnail']['has_thumb'])
 				$attachmentData[$i]['downloads']++;
+
+			// Describe undefined dimensions as "unknown".
+			// This can happen if an uploaded SVG is missing some key data.
+			foreach (array('real_width', 'real_height') as $key)
+			{
+				if (!isset($attachmentData[$i][$key]) || $attachmentData[$i][$key] === INF)
+				{
+					loadLanguage('Admin');
+					$attachmentData[$i][$key] = ' (' . $txt['unknown'] . ') ';
+				}
+			}
 		}
 	}
 
@@ -1362,7 +1379,7 @@ function loadAttachmentContext($id_msg, $attachments)
  */
 function prepareAttachsByMsg($msgIDs)
 {
-	global $context, $modSettings, $smcFunc;
+	global $context, $modSettings, $smcFunc, $sourcedir;
 
 	if (empty($context['loaded_attachments']))
 		$context['loaded_attachments'] = array();
@@ -1409,6 +1426,30 @@ function prepareAttachsByMsg($msgIDs)
 
 		foreach ($rows as $row)
 		{
+			// SVGs are special.
+			if ($row['mime_type'] === 'image/svg+xml')
+			{
+				if (empty($row['width']) || empty($row['height']))
+				{
+					require_once($sourcedir . '/Subs-Graphics.php');
+
+					$row = array_merge($row, getSvgSize(getAttachmentFilename($row['filename'], $row['id_attach'], $row['id_folder'])));
+				}
+
+				// SVG is its own thumbnail.
+				if (isset($row['id_thumb']))
+				{
+					$row['id_thumb'] = $row['id_attach'];
+
+					// For SVGs, we don't need to calculate thumbnail size precisely.
+					$row['thumb_width'] = min($row['width'], !empty($modSettings['attachmentThumbWidth']) ? $modSettings['attachmentThumbWidth'] : 1000);
+					$row['thumb_height'] = min($row['height'], !empty($modSettings['attachmentThumbHeight']) ? $modSettings['attachmentThumbHeight'] : 1000);
+
+					// Must set the thumbnail's CSS dimensions manually.
+					addInlineCss('img#thumb_' . $row['id_thumb'] . ':not(.original_size) {width: ' . $row['thumb_width'] . 'px; height: ' . $row['thumb_height'] . 'px;}');
+				}
+			}
+
 			if (empty($context['loaded_attachments'][$row['id_msg']]))
 				$context['loaded_attachments'][$row['id_msg']] = array();
 

--- a/Sources/Subs-Attachments.php
+++ b/Sources/Subs-Attachments.php
@@ -559,6 +559,16 @@ function attachmentChecks($attachID)
 				$_SESSION['temp_attachments'][$attachID]['type'] = 'image/' . $context['valid_image_types'][$size[2]];
 		}
 	}
+	// SVGs have their own set of security checks.
+	elseif ($_SESSION['temp_attachments'][$attachID]['type'] === 'image/svg+xml')
+	{
+		require_once($sourcedir . '/Subs-Graphics.php');
+		if (!checkSVGContents($_SESSION['temp_attachments'][$attachID]['tmp_name']))
+		{
+			$_SESSION['temp_attachments'][$attachID]['errors'][] = 'bad_attachment';
+			return false;
+		}
+	}
 
 	// Is there room for this sucker?
 	if (!empty($modSettings['attachmentDirSizeLimit']) || !empty($modSettings['attachmentDirFileLimit']))

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -1769,6 +1769,9 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 						// Image.
 						if (!empty($currentAttachment['is_image']))
 						{
+							// Just viewing the page shouldn't increase the download count for embedded images.
+							$currentAttachment['href'] .= ';preview';
+
 							if (empty($params['{width}']) && empty($params['{height}']))
 								$returnContext .= '<img src="' . $currentAttachment['href'] . '"' . $alt . $title . ' class="bbc_img">';
 							else

--- a/Themes/default/scripts/jquery.sceditor.smf.js
+++ b/Themes/default/scripts/jquery.sceditor.smf.js
@@ -728,14 +728,14 @@ sceditor.formats.bbcode.set(
 				if (typeof attrs.height !== "undefined")
 					attribs += ' height="' + attrs.height + '"';
 
-				var contentUrl = smf_scripturl +'?action=dlattach;attach='+ id + ';type=preview;thumb';
+				var contentUrl = smf_scripturl +'?action=dlattach;attach='+ id + ';preview;image';
 				contentIMG = new Image();
 					contentIMG.src = contentUrl;
 			}
 
 			// If not an image, show a boring ol' link
 			if (typeof contentUrl === "undefined" || contentIMG.getAttribute('width') == 0)
-				return '<a href="' + smf_scripturl + '?action=dlattach;attach=' + id + ';type=preview;file"' + attribs + '>' + content + '</a>';
+				return '<a href="' + smf_scripturl + '?action=dlattach;attach=' + id + ';file"' + attribs + '>' + content + '</a>';
 			// Show our purdy li'l picture
 			else
 				return '<img' + attribs + ' src="' + contentUrl + '">';

--- a/Themes/default/scripts/script.js
+++ b/Themes/default/scripts/script.js
@@ -1537,6 +1537,7 @@ function expandThumb(thumbID)
 	img.src = link.href;
 	img.style.width = link.style.width;
 	img.style.height = link.style.height;
+	img.classList.toggle('original_size');
 
 	// place the image attributes back
 	link.href = tmp_src;

--- a/Themes/default/scripts/smf_fileUpload.js
+++ b/Themes/default/scripts/smf_fileUpload.js
@@ -173,7 +173,7 @@ function smf_fileUpload(oOptions) {
 
 		// If the file is too small, it won't have a thumbnail, show the regular file.
 		else if (typeof file.isMock !== "undefined" && typeof file.attachID !== "undefined") {
-			myDropzone.emit('thumbnail', file, smf_prepareScriptUrl(smf_scripturl) + 'action=dlattach;attach=' + (file.thumbID > 0 ? file.thumbID : file.attachID) + ';type=preview');
+			myDropzone.emit('thumbnail', file, smf_prepareScriptUrl(smf_scripturl) + 'action=dlattach;attach=' + (file.thumbID > 0 ? file.thumbID : file.attachID) + ';preview');
 		}
 
 		file.name = file.name.php_to8bit().php_urlencode();


### PR DESCRIPTION
Fixes #7719 by showing SVG attachments as images.

The fiddliest part was handling thumbnails. SVG images don't need thumbnails for obvious reasons, but SMF assumes that images do need them. So I had to add some special handling for SVGs to tell SMF that the SVG image is its own thumbnail, and then slightly tweak the JavaScript used to expand thumbnails when the user clicks on them.

---

Fixes #7720 by showing original images for embedded attachments in WYSIWYG editor. 

The basic task of switching from thumbnails to original images merely required changing `thumb` to `image` on the relevant line in jquery.sceditor.smf.js. However, to prevent the download counter from incrementing unexpectedly, I also had to resurrect the `preview` URL parameter in ShowAttachment.php as a way to tell SMF that this shouldn't count as a download. 