### PR TITLE
Remove menu item if all submenu items are disabled

### DIFF
--- a/Sources/Subs-Menu.php
+++ b/Sources/Subs-Menu.php
@@ -229,6 +229,13 @@ function createMenu($menuData, $menuOptions = array())
 									$menu_context['sections'][$section_id]['areas'][$area_id]['subsections'][$sa]['disabled'] = true;
 							}
 
+							// If permissions removed/disabled for all submenu items, remove the menu item
+							if (empty($first_sa) && empty($last_sa))
+							{
+								unset($menu_context['sections'][$section_id]['areas'][$area_id]);
+								continue;
+							}
+
 							// Set which one is first, last and selected in the group.
 							if (!empty($menu_context['sections'][$section_id]['areas'][$area_id]['subsections']))
 							{


### PR DESCRIPTION
Fixes #7559 

This occurs if all submenu items are disabled.  You get a weird submenu list, and an error in the error log.

_**BEFORE...**  You can see that all submenu items were disabled via permissions._
![label_issue_1](https://user-images.githubusercontent.com/23568484/233806246-52ce2ee3-58d5-46ef-ae11-4b9fcb053b78.png)
![label_issue_3](https://user-images.githubusercontent.com/23568484/233806249-f61b75b5-8c28-4a4b-93b1-103af466ca9a.png)

**_AFTER..._**
![label_issue_4](https://user-images.githubusercontent.com/23568484/233806243-4e2ca6d4-9f6c-4367-a9a1-110e2bd136ef.png)

