### PR TITLE
Attachments fixes

### DIFF
--- a/Themes/default/css/attachments.css
+++ b/Themes/default/css/attachments.css
@@ -129,7 +129,7 @@ div#post_attachments_area.roundframe {
 	display: flex;
 	justify-content: center;
 	margin: 0.5em 0;
-	min-height: 175px;
+	min-height: 75px;
 	max-height: 200px;
 	width: auto;
 }

--- a/Themes/default/css/attachments.css
+++ b/Themes/default/css/attachments.css
@@ -30,7 +30,7 @@
 }
 .attachments_bot a,
 .attachments_bot .name,
-.attachments_info .name, {
+.attachments_info .name {
 	white-space: nowrap;
 }
 
@@ -129,6 +129,7 @@ div#post_attachments_area.roundframe {
 	display: flex;
 	justify-content: center;
 	margin: 0.5em 0;
+	min-height: 175px;
 	max-height: 200px;
 	width: auto;
 }


### PR DESCRIPTION
- The insert popup has a higher height than what a small image could have:
These are examples uploading images with low height:
<img width="208" alt="Screenshot_88" src="https://user-images.githubusercontent.com/3318127/234144202-3caeb000-4f51-41ea-b67b-b11492b5944f.png">
<img width="199" alt="Screenshot_86" src="https://user-images.githubusercontent.com/3318127/234144206-7ae57f4f-7878-4e8a-8994-2a7bf3ac6076.png">

- Fixes a typo in the file.