### PR TITLE
Tweaks CSS for insert menu for small images

### DIFF
--- a/Themes/default/css/attachments.css
+++ b/Themes/default/css/attachments.css
@@ -36,7 +36,7 @@
 
 /* Stuff unique to Post.template.php */
 div#post_attachments_area.roundframe {
-	overflow: auto;
+	overflow: visible;
 	border-top: none;
 	padding: 0;
 }
@@ -102,7 +102,6 @@ div#post_attachments_area.roundframe {
 	align-items: center;
 	justify-content: center;
 	width: 200px;
-	overflow: hidden;
 	padding: 5px;
 }
 #post_attachments_area .dz-image-preview:not(.errorbox) .attachment_preview_wrapper {
@@ -155,6 +154,7 @@ div#post_attachments_area.roundframe {
 	min-height: initial;
 	margin: 0;
 	box-shadow: none;
+	z-index: 2;
 }
 #post_attachments_area .attached_BBC_width_height {
 	display: none;
@@ -185,7 +185,7 @@ div#post_attachments_area.roundframe {
 }
 #post_attachments_area #max_files_progress {
 	display: none;
-	border-radius: 0;
+	border-radius: 0 0 7px 7px;
 	border-left: none;
 	border-right: none;
 	border-bottom: none;

--- a/Themes/default/css/attachments.css
+++ b/Themes/default/css/attachments.css
@@ -30,7 +30,7 @@
 }
 .attachments_bot a,
 .attachments_bot .name,
-.attachments_info .name, {
+.attachments_info .name {
 	white-space: nowrap;
 }
 


### PR DESCRIPTION
Closes #7735

Rather than changing the min-height of the preview wrapper, this adjusts the z-index of the menu div and the overflow properties of the relevant container divs. It also adjusts the border-radius on the corners of the file size progress bar, because I was formerly relying on the overflow properties to take care of hiding those corners where they would otherwise spill outside the rounded corners of the container.