### PR TITLE
Handle basedir restrictions in php8

### DIFF
--- a/Sources/Packages.php
+++ b/Sources/Packages.php
@@ -2304,6 +2304,10 @@ function fetchPerms__recursive($path, &$data, $level)
 	$dh = opendir($path);
 	while ($entry = readdir($dh))
 	{
+		// Bypass directory abbreviations altogether...
+		if ($entry == '.' || $entry == '..')
+			continue;
+
 		// Some kind of file?
 		if (is_file($path . '/' . $entry))
 		{
@@ -2315,7 +2319,7 @@ function fetchPerms__recursive($path, &$data, $level)
 				$foundData['files'][$entry] = true;
 		}
 		// It's a directory - we're interested one way or another, probably...
-		elseif ($entry != '.' && $entry != '..')
+		else
 		{
 			// Going further?
 			if ((!empty($data['type']) && $data['type'] == 'dir_recursive') || (isset($data['contents'][$entry]) && (!empty($data['contents'][$entry]['list_contents']) || (!empty($data['contents'][$entry]['type']) && $data['contents'][$entry]['type'] == 'dir_recursive'))))

--- a/Sources/Subs-Package.php
+++ b/Sources/Subs-Package.php
@@ -158,8 +158,11 @@ function read_tgz_data($data, $destination, $single_file = false, $overwrite = f
 		$current['data'] = substr($data, ++$offset << 9, $current['size']);
 		$offset += $size;
 
+		// If hunting for a file in subdirectories, pass to subsequent write test...
+		if ($single_file && $destination !== null && (substr($destination, 0, 2) == '*/'))
+			$write_this = true;
 		// Not a directory and doesn't exist already...
-		if (substr($current['filename'], -1, 1) != '/' && $destination !== null && !file_exists($destination . '/' . $current['filename']))
+		elseif (substr($current['filename'], -1, 1) != '/' && $destination !== null && !file_exists($destination . '/' . $current['filename']))
 			$write_this = true;
 		// File exists... check if it is newer.
 		elseif (substr($current['filename'], -1, 1) != '/')
@@ -230,7 +233,7 @@ function read_tgz_data($data, $destination, $single_file = false, $overwrite = f
 function read_zip_data($data, $destination, $single_file = false, $overwrite = false, $files_to_extract = null)
 {
 	umask(0);
-	if ($destination !== null && !file_exists($destination) && !$single_file)
+	if ($destination !== null && (substr($destination, 0, 2) != '*/') && !file_exists($destination) && !$single_file)
 		mktree($destination, 0777);
 
 	// Search for the end of directory signature 0x06054b50.
@@ -291,8 +294,11 @@ function read_zip_data($data, $destination, $single_file = false, $overwrite = f
 		$write_this = false;
 		if ($destination !== null)
 		{
+			// If hunting for a file in subdirectories, pass to subsequent write test...
+			if ($single_file && $destination !== null && (substr($destination, 0, 2) == '*/'))
+				$write_this = true;
 			// If this is a file, and it doesn't exist.... happy days!
-			if ($is_file)
+			elseif ($is_file)
 				$write_this = !file_exists($destination . '/' . $file_info['filename']) || $overwrite;
 			// This is a directory, so we're gonna want to create it. (probably...)
 			elseif (!$single_file)


### PR DESCRIPTION
Fixes #7738 

In php 8+, open_basedir generates warnings & errors when you perform file read or write operations outside the constraints defined in open_basedir, in php or apache.  Some hosts use open_basedir to make sure you're not reading & writing where you shouldn't...

This PR addresses open_basedir issues associated with installing & unstalling mods, and using the package manager file permissions functions.

