### PR TITLE
Adds translatable placeholder for attachment insert menu fields

### DIFF
--- a/Themes/default/Post.template.php
+++ b/Themes/default/Post.template.php
@@ -367,11 +367,11 @@ function template_main()
 											<div class="attached_BBC_width_height">
 												<div class="attached_BBC_width">
 													<label for="attached_BBC_width">', $txt['attached_insert_width'], '</label>
-													<input type="number" name="attached_BBC_width" min="0" value="">
+													<input type="number" name="attached_BBC_width" min="0" value="" placeholder="', $txt['attached_insert_placeholder'], '">
 												</div>
 												<div class="attached_BBC_height">
 													<label for="attached_BBC_height">', $txt['attached_insert_height'], '</label>
-													<input type="number" name="attached_BBC_height" min="0" value="">
+													<input type="number" name="attached_BBC_height" min="0" value="" placeholder="', $txt['attached_insert_placeholder'], '">
 												</div>
 											</div>
 										</div>

--- a/Themes/default/languages/Post.english.php
+++ b/Themes/default/languages/Post.english.php
@@ -190,6 +190,7 @@ $txt['attached_upload_all'] = 'Upload all';
 $txt['attachments_left'] = 'There are a few attachments left, please upload them or cancel them before posting.';
 $txt['attached_insert_width'] = 'Insert width (px):';
 $txt['attached_insert_height'] = 'Insert height (px):';
+$txt['attached_insert_placeholder'] = 'auto';
 
 $txt['attach_php_error'] = 'Due to an error, your attachment could not be uploaded. Please contact the forum administrator if this problem continues.';
 $txt['php_upload_error_1'] = 'The uploaded file exceeds the upload_max_filesize directive in php.ini. Please contact your host if you are unable to correct this issue.';


### PR DESCRIPTION
The old attachment UI had a hard-coded "auto" placeholder for these fields. I removed the hard-coded value while working on #7676, and intended to replace it with a translatable placeholder, but apparently I forgot to go back and do that. At any rate, here it is.