### PR TITLE
Prevent null value from $user_info in logActions

### DIFF
--- a/Sources/Logging.php
+++ b/Sources/Logging.php
@@ -543,7 +543,7 @@ function logActions(array $logs)
 		if (isset($log['extra']['member_affected']))
 			$memID = $log['extra']['member_affected'];
 		else
-			$memID = $user_info['id'];
+			$memID = (isset($user_info['id']) && !empty($user_info['id']) ? $user_info['id'] : (!empty($log['extra']['member']) ? $log['extra']['member'] : 0));
 
 		if (isset($user_info['ip']))
 			$memIP = $user_info['ip'];

--- a/Sources/Logging.php
+++ b/Sources/Logging.php
@@ -543,7 +543,7 @@ function logActions(array $logs)
 		if (isset($log['extra']['member_affected']))
 			$memID = $log['extra']['member_affected'];
 		else
-			$memID = (isset($user_info['id']) && !empty($user_info['id']) ? $user_info['id'] : (!empty($log['extra']['member']) ? $log['extra']['member'] : 0));
+			$memID = $user_info['id'] ?? $log['extra']['member'] ?? 0;
 
 		if (isset($user_info['ip']))
 			$memIP = $user_info['ip'];


### PR DESCRIPTION
Fixes #7546 