### PR TITLE
More word_break in admin tables

### DIFF
--- a/Sources/ManageMaintenance.php
+++ b/Sources/ManageMaintenance.php
@@ -1951,6 +1951,7 @@ function list_integration_hooks()
 						else
 							return $instance . $data['real_function'];
 					},
+					'class' => 'word_break',
 				),
 				'sort' => array(
 					'default' => 'function_name',
@@ -1963,6 +1964,7 @@ function list_integration_hooks()
 				),
 				'data' => array(
 					'db' => 'file_name',
+					'class' => 'word_break',
 				),
 				'sort' => array(
 					'default' => 'file_name',

--- a/Themes/default/Admin.template.php
+++ b/Themes/default/Admin.template.php
@@ -1606,7 +1606,7 @@ function template_php_info()
 				echo '
 								<tr class="windowbg">
 									<td class="equal_table">', $key, '</td>
-									<td colspan="2">', str_replace(',', ', ', $setting), '</td>
+									<td colspan="2" class="word_break">', str_replace(',', ', ', $setting), '</td>
 								</tr>';
 			}
 		}


### PR DESCRIPTION
Slightly increasing the font size will cause tables to overflow in certain browsers like Chrome.
This fixes that issue for:

- Hooks list
- phpinfo