### PR TITLE
Send our error message to our xhr handlers

### DIFF
--- a/Sources/Errors.php
+++ b/Sources/Errors.php
@@ -210,6 +210,17 @@ function fatal_lang_error($error, $log = 'general', $sprintf = array(), $status 
 		loadTheme();
 	}
 
+	// Attempt to load the text string.
+	loadLanguage('Errors');
+	if (empty($txt[$error]))
+		$error_message = $error;
+	else
+		$error_message = empty($sprintf) ? $txt[$error] : vsprintf($txt[$error], $sprintf);
+
+	// Send a custom header if we have a custom message.
+	if (isset($_REQUEST['js']) || isset($_REQUEST['xml']) || isset($_RQEUEST['ajax']))
+		header('X-SMF-errormsg: ' .  $error_message);
+
 	// If we have no theme stuff we can't have the language file...
 	if (empty($context['theme_loaded']))
 		die($error);
@@ -228,7 +239,7 @@ function fatal_lang_error($error, $log = 'general', $sprintf = array(), $status 
 	}
 
 	// Load the language file, only if it needs to be reloaded
-	if ($reload_lang_file)
+	if ($reload_lang_file && !empty($txt[$error]))
 	{
 		loadLanguage('Errors');
 		$error_message = empty($sprintf) ? $txt[$error] : vsprintf($txt[$error], $sprintf);

--- a/Sources/Likes.php
+++ b/Sources/Likes.php
@@ -27,6 +27,11 @@ class Likes
 	protected $_js = false;
 
 	/**
+	 * @var string The sub action sent in $_GET['sa'].
+	 */
+	protected $_sa = null;
+
+	/**
 	 * @var string If filled, its value will contain a string matching a key on a language var $txt[$this->_error]
 	 */
 	protected $_error = false;

--- a/Themes/default/scripts/script.js
+++ b/Themes/default/scripts/script.js
@@ -371,8 +371,9 @@ function reqOverlayDiv(desktopURL, sHeader, sIcon)
 			oPopup_body.html(textStatus);
 		},
 		statusCode: {
-			403: function() {
-				oPopup_body.html(banned_text);
+			403: function(res, status, xhr) {
+				let errorMsg = res.getResponseHeader('x-smf-errormsg');
+				oPopup_body.html(errorMsg ?? banned_text);
 			},
 			500: function() {
 				oPopup_body.html('500 Internal Server Error');


### PR DESCRIPTION
Fixes #7761
A new header x-SMF-errormsg is now sent.  This can be received by xhr on the client side to be displayed.

Additionally fixes a PHP 8.2 error with $_sa being undefined in the Likes class Ensures that $txt[$error] exists before we try to use it during a non fatal error