### PR TITLE
SMTP Mail Queueing improvements

### DIFF
--- a/Sources/ManageMail.php
+++ b/Sources/ManageMail.php
@@ -249,6 +249,8 @@ function list_getMailQueue($start, $items_per_page, $sort)
 		// Private PM/email subjects and similar shouldn't be shown in the mailbox area.
 		if (!empty($row['private']))
 			$row['subject'] = $txt['personal_message'];
+		else
+			$row['subject'] = mb_decode_mimeheader($row['subject']);
 
 		$mails[] = $row;
 	}

--- a/Sources/ScheduledTasks.php
+++ b/Sources/ScheduledTasks.php
@@ -774,7 +774,7 @@ function ReduceMailQueue($number = false, $override_limit = false, $force_send =
 	// Send each email, yea!
 	$failed_emails = array();
 	$max_priority = 127;
-	$smtp_expire = ($modSettings['smtp_day_expiry'] ?? 3) * 60 * 60 * 24;
+	$smtp_expire = 259200;
 	$priority_offset = 4;
 	foreach ($emails as $email)
 	{

--- a/Sources/Subs-Post.php
+++ b/Sources/Subs-Post.php
@@ -1592,7 +1592,7 @@ function server_parse($message, $socket, $code, &$response = null)
 	if ($code === null)
 		return substr($server_response, 0, 3);
 
-	$resonse_code = (int) substr($server_response, 0, 3);
+	$response_code = (int) substr($server_response, 0, 3);
 	if ($resonse_code != $code)
 	{
 		// Ignoreable errors that we can't fix should not be logged.

--- a/Sources/Subs-Post.php
+++ b/Sources/Subs-Post.php
@@ -1600,7 +1600,7 @@ function server_parse($message, $socket, $code, &$response = null)
 		 * 550 - cPanel rejected sending due to DNS issues
 		 * 450 - DNS Routing issues
 		 */
-		if ($response_code < 500 && $response_code != 450))
+		if ($response_code < 500 && $response_code != 450)
 			log_error($txt['smtp_error'] . $server_response);
 
 		return false;

--- a/Sources/Subs-Post.php
+++ b/Sources/Subs-Post.php
@@ -1600,7 +1600,7 @@ function server_parse($message, $socket, $code, &$response = null)
 		 * 550 - cPanel rejected sending due to DNS issues
 		 * 450 - DNS Routing issues
 		 */
-		if ($resonse_code < 500 && !in_array($resonse_code, [450]))
+		if ($response_code < 500 && $response_code != 450))
 			log_error($txt['smtp_error'] . $server_response);
 
 		return false;

--- a/Sources/Subs-Post.php
+++ b/Sources/Subs-Post.php
@@ -1592,10 +1592,17 @@ function server_parse($message, $socket, $code, &$response = null)
 	if ($code === null)
 		return substr($server_response, 0, 3);
 
-	if (($server_code = substr($server_response, 0, 3)) != $code)
+	$resonse_code = (int) substr($server_response, 0, 3);
+	if ($resonse_code != $code)
 	{
-		if ($server_code < 500 && !in_array($server_code, [450, 451, 421]))
+		// Ignoreable errors that we can't fix should not be logged.
+		/*
+		 * 550 - cPanel rejected sending due to DNS issues
+		 * 450 - DNS Routing issues
+		 */
+		if ($resonse_code < 500 && !in_array($resonse_code, [450]))
 			log_error($txt['smtp_error'] . $server_response);
+
 		return false;
 	}
 

--- a/Sources/Subs-Post.php
+++ b/Sources/Subs-Post.php
@@ -1593,7 +1593,7 @@ function server_parse($message, $socket, $code, &$response = null)
 		return substr($server_response, 0, 3);
 
 	$response_code = (int) substr($server_response, 0, 3);
-	if ($resonse_code != $code)
+	if ($response_code != $code)
 	{
 		// Ignoreable errors that we can't fix should not be logged.
 		/*

--- a/Sources/Subs-Post.php
+++ b/Sources/Subs-Post.php
@@ -1592,9 +1592,10 @@ function server_parse($message, $socket, $code, &$response = null)
 	if ($code === null)
 		return substr($server_response, 0, 3);
 
-	if (substr($server_response, 0, 3) != $code)
+	if (($server_code = substr($server_response, 0, 3)) != $code)
 	{
-		log_error($txt['smtp_error'] . $server_response);
+		if ($server_code < 500 && !in_array($server_code, [450, 451, 421]))
+			log_error($txt['smtp_error'] . $server_response);
 		return false;
 	}
 


### PR DESCRIPTION
Fixes #7787

Trying to keep inside the database schema, i'm abusing the priority level to slowly raise it to the max (127 due to signed tinyint).  It does this over a period of 3 days (which can be changed) by calculating the difference between the current time and the time the email was sent.