### PR TITLE
Improve error logging while in SSI

### DIFF
--- a/Sources/Errors.php
+++ b/Sources/Errors.php
@@ -79,14 +79,17 @@ function log_error($error_message, $error_type = 'general', $file = null, $line 
 		$user_info['ip'] = '';
 
 	// Find the best query string we can...
-	$query_string = empty($_SERVER['QUERY_STRING']) ? (empty($_SERVER['REQUEST_URL']) ? '' : str_replace($scripturl, '', $_SERVER['REQUEST_URL'])) : $_SERVER['QUERY_STRING'];
+	if (SMF == 'SSI')
+		$query_string = $_SERVER['REQUEST_URL'] ?? (($_SERVER['REQUEST_SCHEME'] ?? 'http') . '://' . ($_SERVER['SERVER_NAME'] ?? 'unknown') . '/' . ($_SERVER['REQUEST_URI'] ?? (($_SERVER['DOCUMENT_URI'] ?? $_SERVER['SCRIPT_NAME']	?? 'unknown.php') . !empty($_SERVER['QUERY_STRING']) ? '?' . $_SERVER['QUERY_STRING'] : '')));
+	else
+		$query_string = empty($_SERVER['QUERY_STRING']) ? (empty($_SERVER['REQUEST_URL']) ? '' : str_replace($scripturl, '', $_SERVER['REQUEST_URL'])) : $_SERVER['QUERY_STRING'];
 
 	// Don't log the session hash in the url twice, it's a waste.
 	if (!empty($smcFunc['htmlspecialchars']))
 		$query_string = $smcFunc['htmlspecialchars']((SMF == 'SSI' || SMF == 'BACKGROUND' ? '' : '?') . preg_replace(array('~;sesc=[^&;]+~', '~' . session_name() . '=' . session_id() . '[&;]~'), array(';sesc', ''), $query_string));
 
 	// Just so we know what board error messages are from.
-	if (isset($_POST['board']) && !isset($_GET['board']))
+	if (isset($_POST['board']) && !isset($_GET['board']) && SMF != 'SSI')
 		$query_string .= ($query_string == '' ? 'board=' : ';board=') . $_POST['board'];
 
 	// What types of categories do we have?

--- a/Sources/Errors.php
+++ b/Sources/Errors.php
@@ -79,7 +79,7 @@ function log_error($error_message, $error_type = 'general', $file = null, $line 
 		$user_info['ip'] = '';
 
 	// Find the best query string we can...
-	if (SMF == 'SSI')
+	if (SMF === 'SSI')
 		$query_string = $_SERVER['REQUEST_URL'] ?? (($_SERVER['REQUEST_SCHEME'] ?? 'http') . '://' . ($_SERVER['SERVER_NAME'] ?? 'unknown') . '/' . ($_SERVER['REQUEST_URI'] ?? (($_SERVER['DOCUMENT_URI'] ?? $_SERVER['SCRIPT_NAME']	?? 'unknown.php') . !empty($_SERVER['QUERY_STRING']) ? '?' . $_SERVER['QUERY_STRING'] : '')));
 	else
 		$query_string = empty($_SERVER['QUERY_STRING']) ? (empty($_SERVER['REQUEST_URL']) ? '' : str_replace($scripturl, '', $_SERVER['REQUEST_URL'])) : $_SERVER['QUERY_STRING'];
@@ -89,7 +89,7 @@ function log_error($error_message, $error_type = 'general', $file = null, $line 
 		$query_string = $smcFunc['htmlspecialchars']((SMF == 'SSI' || SMF == 'BACKGROUND' ? '' : '?') . preg_replace(array('~;sesc=[^&;]+~', '~' . session_name() . '=' . session_id() . '[&;]~'), array(';sesc', ''), $query_string));
 
 	// Just so we know what board error messages are from.
-	if (isset($_POST['board']) && !isset($_GET['board']) && SMF != 'SSI')
+	if (isset($_POST['board']) && !isset($_GET['board']) && SMF !== 'SSI')
 		$query_string .= ($query_string == '' ? 'board=' : ';board=') . $_POST['board'];
 
 	// What types of categories do we have?

--- a/Sources/Errors.php
+++ b/Sources/Errors.php
@@ -80,7 +80,7 @@ function log_error($error_message, $error_type = 'general', $file = null, $line 
 
 	// Find the best query string we can...
 	if (SMF === 'SSI')
-		$query_string = $_SERVER['REQUEST_URL'] ?? (($_SERVER['REQUEST_SCHEME'] ?? 'http') . '://' . ($_SERVER['SERVER_NAME'] ?? 'unknown') . '/' . ($_SERVER['REQUEST_URI'] ?? (($_SERVER['DOCUMENT_URI'] ?? $_SERVER['SCRIPT_NAME']	?? 'unknown.php') . !empty($_SERVER['QUERY_STRING']) ? '?' . $_SERVER['QUERY_STRING'] : '')));
+		$query_string = (($_SERVER['REQUEST_SCHEME'] ?? 'http') . '://' . ($_SERVER['SERVER_NAME'] ?? 'unknown') . '/' . ($_SERVER['REQUEST_URI'] ?? (($_SERVER['DOCUMENT_URI'] ?? $_SERVER['SCRIPT_NAME']	?? 'unknown.php') . !empty($_SERVER['QUERY_STRING']) ? '?' . $_SERVER['QUERY_STRING'] : '')));
 	else
 		$query_string = empty($_SERVER['QUERY_STRING']) ? (empty($_SERVER['REQUEST_URL']) ? '' : str_replace($scripturl, '', $_SERVER['REQUEST_URL'])) : $_SERVER['QUERY_STRING'];
 

--- a/Sources/ManageErrors.php
+++ b/Sources/ManageErrors.php
@@ -180,7 +180,7 @@ function ViewErrorLog()
 			'time' => timeformat($row['log_time']),
 			'timestamp' => $row['log_time'],
 			'url' => array(
-				'html' => $smcFunc['htmlspecialchars'](strpos($row['url'], 'cron.php') === false ? (substr($row['url'], 0, 1) == '?' ? $scripturl : '') . $row['url'] : $row['url']),
+				'html' => $smcFunc['htmlspecialchars'](strpos($row['url'], 'cron.php') === false && !strpos($row['url'], 'https://') && !strpos($row['url'], 'http://')  ? (substr($row['url'], 0, 1) == '?' ? $scripturl : '') . $row['url'] : $row['url']),
 				'href' => base64_encode($smcFunc['db_escape_wildcard_string']($row['url']))
 			),
 			'message' => array(

--- a/Sources/ManageErrors.php
+++ b/Sources/ManageErrors.php
@@ -180,7 +180,7 @@ function ViewErrorLog()
 			'time' => timeformat($row['log_time']),
 			'timestamp' => $row['log_time'],
 			'url' => array(
-				'html' => $smcFunc['htmlspecialchars'](strpos($row['url'], 'cron.php') === false && !strpos($row['url'], 'https://') && !strpos($row['url'], 'http://')  ? (substr($row['url'], 0, 1) == '?' ? $scripturl : '') . $row['url'] : $row['url']),
+				'html' => $smcFunc['htmlspecialchars'](strpos($row['url'], 'cron.php') === false && !(strpos($row['url'], 'https://') === 0) && !(strpos($row['url'], 'http://') === 0) ? ($row['url'][0] == '?' ? $scripturl : '') . $row['url'] : $row['url']),
 				'href' => base64_encode($smcFunc['db_escape_wildcard_string']($row['url']))
 			),
 			'message' => array(


### PR DESCRIPTION
When a error occurs on a remote script, the full url is not logged. For example.  Given a forum at:  https://example.com/forum/ and site content at https://example.com/about/

Some examples here:
A error at /about/ will log just the /about/ if no query string is provided. A error at /about/?foo=bar will log just ?foo=bar
A error at https://sub.example.com/ will log no url

SMF will then when displaying the error log, give false urls due to its handling of urls in the viewer.

This will for SSI, attempt to use the correct URLs, falling back to various methods and default responses.

This is draft for now, I am performing testing with this.