### PR TITLE
[2.1] Only delete board_permissions_view if we have modified the access

### DIFF
--- a/Sources/Subs-Boards.php
+++ b/Sources/Subs-Boards.php
@@ -672,13 +672,14 @@ function modifyBoard($board_id, &$boardOptions)
 		);
 
 	// Before we add new access_groups or deny_groups, remove all of the old entries
-	$smcFunc['db_query']('', '
-		DELETE FROM {db_prefix}board_permissions_view
-		WHERE id_board = {int:selected_board}',
-		array(
-			'selected_board' => $board_id,
-		)
-	);
+	if (isset($boardOptions['access_groups']) || isset($boardOptions['deny_groups']))
+		$smcFunc['db_query']('', '
+			DELETE FROM {db_prefix}board_permissions_view
+			WHERE id_board = {int:selected_board}',
+			array(
+				'selected_board' => $board_id,
+			)
+		);
 
 	if ($board_permissions_inserts != array())
 		$smcFunc['db_insert']('insert',


### PR DESCRIPTION
This bug keeps reappearing in various ways.

To reproduce this one, simply move a board.  When you do, only the new position for the board is passed.  Resulting in modifyBoard deleting the board_permissions_view data, but has no data to rebuild with.  Simply modifying the board and saving again rebuilds the access.

@sbulen, @live627, @BrickOzp, @albertlast can you all test this

Related #7689
Related #7692
Related #7539
Related #7540
Related #5514
Related #5515
Related #5265
Related #5152
Related #5153
Related #4727