### PR TITLE
Fix PHP error from a failed database connection

### DIFF
--- a/Sources/Subs-Db-mysql.php
+++ b/Sources/Subs-Db-mysql.php
@@ -50,7 +50,7 @@ function smf_db_initiate($db_server, $db_name, $db_user, $db_passwd, $db_prefix,
 			'db_server_info'            => 'smf_db_get_server_info',
 			'db_affected_rows'          => 'smf_db_affected_rows',
 			'db_transaction'            => 'smf_db_transaction',
-			'db_error'                  => 'mysqli_error',
+			'db_error'                  => 'smf_db_errormsg',
 			'db_select_db'              => 'smf_db_select',
 			'db_title'                  => MYSQL_TITLE,
 			'db_sybase'                 => false,
@@ -1097,6 +1097,22 @@ function smf_db_escape_string($string, $connection = null)
 	global $db_connection;
 
 	return mysqli_real_escape_string($connection === null ? $db_connection : $connection, $string);
+}
+
+/**
+ * Wrapper to handle null errors
+ *
+ * @param null|mysqli $connection = null The connection to use (null to use $db_connection)
+ * @return string escaped string
+ */
+function smf_db_errormsg($connection = null)
+{
+	global $db_connection;
+
+	if (is_null($connection) && is_null($db_connection))
+		return '';
+
+	return mysqli_error($connection === null ? $db_connection : $connection);
 }
 
 ?>

--- a/Sources/Subs-Db-mysql.php
+++ b/Sources/Subs-Db-mysql.php
@@ -1109,7 +1109,7 @@ function smf_db_errormsg($connection = null)
 {
 	global $db_connection;
 
-	if ($connection !== null && $db_connection !== null)
+	if ($connection === null && $db_connection === null)
 		return '';
 
 	return mysqli_error($connection === null ? $db_connection : $connection);

--- a/Sources/Subs-Db-mysql.php
+++ b/Sources/Subs-Db-mysql.php
@@ -1109,7 +1109,7 @@ function smf_db_errormsg($connection = null)
 {
 	global $db_connection;
 
-	if (is_null($connection) && is_null($db_connection))
+	if ($connection !== null && $db_connection !== null)
 		return '';
 
 	return mysqli_error($connection === null ? $db_connection : $connection);

--- a/Sources/Subs-Db-postgresql.php
+++ b/Sources/Subs-Db-postgresql.php
@@ -1043,7 +1043,7 @@ function smf_db_errormsg($connection = null)
 {
 	global $db_connection;
 
-	if ($connection !== null && $db_connection !== null)
+	if ($connection === null && $db_connection === null)
 		return '';
 
 	return pg_last_error($connection === null ? $db_connection : $connection);

--- a/Sources/Subs-Db-postgresql.php
+++ b/Sources/Subs-Db-postgresql.php
@@ -1043,7 +1043,7 @@ function smf_db_errormsg($connection = null)
 {
 	global $db_connection;
 
-	if (is_null($connection) && is_null($db_connection))
+	if ($connection !== null && $db_connection !== null)
 		return '';
 
 	return pg_last_error($connection === null ? $db_connection : $connection);

--- a/Sources/Subs-Db-postgresql.php
+++ b/Sources/Subs-Db-postgresql.php
@@ -52,7 +52,7 @@ function smf_db_initiate($db_server, $db_name, $db_user, $db_passwd, &$db_prefix
 			'db_server_info'            => 'smf_db_version',
 			'db_affected_rows'          => 'smf_db_affected_rows',
 			'db_transaction'            => 'smf_db_transaction',
-			'db_error'                  => 'pg_last_error',
+			'db_error'                  => 'smf_db_errormsg',
 			'db_select_db'              => 'smf_db_select_db',
 			'db_title'                  => POSTGRE_TITLE,
 			'db_sybase'                 => true,
@@ -1031,6 +1031,22 @@ function smf_db_connect_errno()
 		$pg_connect_errno = '';
 
 	return $pg_connect_errno;
+}
+
+/**
+ * Wrapper to handle null errors
+ *
+ * @param null|PgSql\Connection $connection = null The connection to use (null to use $db_connection)
+ * @return string escaped string
+ */
+function smf_db_errormsg($connection = null)
+{
+	global $db_connection;
+
+	if (is_null($connection) && is_null($db_connection))
+		return '';
+
+	return pg_last_error($connection === null ? $db_connection : $connection);
 }
 
 ?>


### PR DESCRIPTION
PHP 8.1+ will generate the following error upon a failed database connection:
```
PHP Fatal error:  Uncaught TypeError: mysqli_error(): Argument #1 ($mysql) must be of type mysqli, null given in /Sources/Errors.php:464
```

To fix this, I built a wrapper to check to ensure that the we don't have a null argument going into the related function.  Instead if its null and the primary connection is null, it returns a empty string, which is what the code seems to expect.

@albertlast I don't have PG setup anymore to test.  But I believe it will suffer the same problem according to the PHP docs.  Have you seen that?