### PR TITLE
Ensure SERVER_PROTOCOL exists

### DIFF
--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -8170,7 +8170,7 @@ function send_http_status($code, $status = '')
 		503 => 'Service Unavailable',
 	);
 
-	$protocol = preg_match('~^\s*(HTTP/[12]\.\d)\s*$~i', $_SERVER['SERVER_PROTOCOL'], $matches) ? $matches[1] : 'HTTP/1.0';
+	$protocol = !empty($_SERVER['SERVER_PROTOCOL']) && preg_match('~^\s*(HTTP/[12]\.\d)\s*$~i', $_SERVER['SERVER_PROTOCOL'], $matches) ? $matches[1] : 'HTTP/1.0';
 
 	// Typically during these requests, we have cleaned the response (ob_*clean), ensure these headers exist.
 	require_once($sourcedir . '/Security.php');


### PR DESCRIPTION
Some calls such as cron or SSI (called via a cron) don't generate $_SERVER['SERVER_PROTOCOL'].  We should ensure we check it exists prior to using it.