### PR TITLE
[2.1] Hide PHP errors from failing to remove files/directories while removing a theme

### DIFF
--- a/Sources/Subs-Themes.php
+++ b/Sources/Subs-Themes.php
@@ -487,12 +487,12 @@ function remove_dir($path)
 					remove_dir($path . '/' . $object);
 
 				else
-					unlink($path . '/' . $object);
+					@unlink($path . '/' . $object);
 			}
 	}
 
 	reset($objects);
-	rmdir($path);
+	@rmdir($path);
 }
 
 /**


### PR DESCRIPTION
Also.  If you choose to install a theme by a path on the server and it fails, the logic tries to remove the directory.  I'm not certain of the proper fix.  The logic is done in the wrong place.  The get_theme_info does the deleting, instead of the higher up functions.