### PR TITLE
Allow ignoring file errors if requested

### DIFF
--- a/Sources/Packages.php
+++ b/Sources/Packages.php
@@ -663,7 +663,7 @@ function PackageInstallTest()
 		}
 
 		// Don't fail if a file/directory we're trying to create doesn't exist...
-		if (isset($action['filename']) && !file_exists($file) && !in_array($action['type'], array('create-dir', 'create-file')))
+		if (isset($action['filename']) && !file_exists($file) && !in_array($action['type'], array('create-dir', 'create-file')) && $action['error'] != 'ignore')
 		{
 			$context['has_failure'] = true;
 

--- a/Sources/Subs-Package.php
+++ b/Sources/Subs-Package.php
@@ -1224,7 +1224,8 @@ function parsePackageInfo(&$packageXML, $testing_only = true, $method = 'install
 			$this_action = array(
 				'type' => $actionType,
 				'filename' => $action->fetch('@name'),
-				'description' => $action->fetch('.')
+				'description' => $action->fetch('.'),
+				'error' => $action->exists('@error') ? $action->fetch('@error') : 'fail'
 			);
 
 			// If there is a destination, make sure it makes sense.
@@ -1458,7 +1459,7 @@ function parsePackageInfo(&$packageXML, $testing_only = true, $method = 'install
 			}
 			// The file that was supposed to be deleted couldn't be found.
 			else
-				$failure = true;
+				$failure = $action['error'] != 'ignore';
 
 			// Any other theme folders?
 			if (!empty($context['theme_copies']) && !empty($context['theme_copies'][$action['type']][$action['filename']]))


### PR DESCRIPTION
This is simple.
The following will have SMF say an error will exist during package install

```
		<remove-file name="$sourcedir/Test.php" error="ignore" />
```

With this change, SMF ignores this as we requested in the xml.