### PR TITLE
code tag changes

### DIFF
--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -1860,75 +1860,55 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 			),
 			array(
 				'tag' => 'code',
-				'type' => 'unparsed_content',
-				'content' => '<div class="codeheader"><span class="code floatleft">' . $txt['code'] . '</span> <a class="codeoperation smf_select_text">' . $txt['code_select'] . '</a> <a class="codeoperation smf_expand_code hidden" data-shrink-txt="' . $txt['code_shrink'] . '" data-expand-txt="' . $txt['code_expand'] . '">' . $txt['code_expand'] . '</a></div><code class="bbc_code">$1</code>',
-				// @todo Maybe this can be simplified?
-				'validate' => isset($disabled['code']) ? null : function(&$tag, &$data, $disabled) use ($context)
+				'type' => 'unparsed_content',,
+				'content' => '<div class="codeheader">' . $txt['code'] . '</div><pre data-select-txt="' . $txt['code_select'] . '" data-shrink-txt="' . $txt['code_shrink'] . '" data-expand-txt="' . $txt['code_expand'] . '" class="bbc_code"><code>$1</code></pre>',
+				'validate' => isset($disabled['code']) ? null : function(&$tag, &$data)
 				{
-					if (!isset($disabled['code']))
+					$parts = preg_split('~(&lt;\?php|\?&gt;)~', $data, -1, PREG_SPLIT_DELIM_CAPTURE);
+
+					for ($i = 0, $n = count($parts); $i < $n; $i++)
 					{
-						$php_parts = preg_split('~(&lt;\?php|\?&gt;)~', $data, -1, PREG_SPLIT_DELIM_CAPTURE);
+						// Do PHP code coloring?
+						if ($parts[$i] != '&lt;?php')
+							continue;
 
-						for ($php_i = 0, $php_n = count($php_parts); $php_i < $php_n; $php_i++)
+						$string = '';
+						while ($i + 1 < $n && $parts[$i] != '?&gt;')
 						{
-							// Do PHP code coloring?
-							if ($php_parts[$php_i] != '&lt;?php')
-								continue;
-
-							$php_string = '';
-							while ($php_i + 1 < count($php_parts) && $php_parts[$php_i] != '?&gt;')
-							{
-								$php_string .= $php_parts[$php_i];
-								$php_parts[$php_i++] = '';
-							}
-							$php_parts[$php_i] = highlight_php_code($php_string . $php_parts[$php_i]);
+							$string .= $parts[$i];
+							$parts[$i++] = '';
 						}
-
-						// Fix the PHP code stuff...
-						$data = str_replace("<pre style=\"display: inline;\">\t</pre>", "\t", implode('', $php_parts));
-						$data = str_replace("\t", "<span style=\"white-space: pre;\">\t</span>", $data);
-
-						// Recent Opera bug requiring temporary fix. &nsbp; is needed before </code> to avoid broken selection.
-						if (!empty($context['browser']['is_opera']))
-							$data .= '&nbsp;';
+						$parts[$i] = highlight_php_code($string . $parts[$i]);
 					}
+
+					$data = implode('', $parts);
 				},
 				'block_level' => true,
 			),
 			array(
 				'tag' => 'code',
 				'type' => 'unparsed_equals_content',
-				'content' => '<div class="codeheader"><span class="code floatleft">' . $txt['code'] . '</span> ($2) <a class="codeoperation smf_select_text">' . $txt['code_select'] . '</a> <a class="codeoperation smf_expand_code hidden" data-shrink-txt="' . $txt['code_shrink'] . '" data-expand-txt="' . $txt['code_expand'] . '">' . $txt['code_expand'] . '</a></div><code class="bbc_code">$1</code>',
-				// @todo Maybe this can be simplified?
-				'validate' => isset($disabled['code']) ? null : function(&$tag, &$data, $disabled) use ($context)
+				'content' => '<div class="codeheader">' . $txt['code'] . ' ($2)</div><pre data-select-txt="' . $txt['code_select'] . '" data-shrink-txt="' . $txt['code_shrink'] . '" data-expand-txt="' . $txt['code_expand'] . '" class="bbc_code"><code>$1</code></pre>',
+				'validate' => isset($disabled['code']) ? null : function(&$tag, &$data)
 				{
-					if (!isset($disabled['code']))
+					$parts = preg_split('~(&lt;\?php|\?&gt;)~', $data[0], -1, PREG_SPLIT_DELIM_CAPTURE);
+
+					for ($i = 0, $n = count($parts); $i < $n; $i++)
 					{
-						$php_parts = preg_split('~(&lt;\?php|\?&gt;)~', $data[0], -1, PREG_SPLIT_DELIM_CAPTURE);
+						// Do PHP code coloring?
+						if ($parts[$i] != '&lt;?php')
+							continue;
 
-						for ($php_i = 0, $php_n = count($php_parts); $php_i < $php_n; $php_i++)
+						$string = '';
+						while ($i + 1 < $n && $parts[$i] != '?&gt;')
 						{
-							// Do PHP code coloring?
-							if ($php_parts[$php_i] != '&lt;?php')
-								continue;
-
-							$php_string = '';
-							while ($php_i + 1 < count($php_parts) && $php_parts[$php_i] != '?&gt;')
-							{
-								$php_string .= $php_parts[$php_i];
-								$php_parts[$php_i++] = '';
-							}
-							$php_parts[$php_i] = highlight_php_code($php_string . $php_parts[$php_i]);
+							$string .= $parts[$i];
+							$parts[$i++] = '';
 						}
-
-						// Fix the PHP code stuff...
-						$data[0] = str_replace("<pre style=\"display: inline;\">\t</pre>", "\t", implode('', $php_parts));
-						$data[0] = str_replace("\t", "<span style=\"white-space: pre;\">\t</span>", $data[0]);
-
-						// Recent Opera bug requiring temporary fix. &nsbp; is needed before </code> to avoid broken selection.
-						if (!empty($context['browser']['is_opera']))
-							$data[0] .= '&nbsp;';
+						$parts[$i] = highlight_php_code($string . $parts[$i]);
 					}
+
+					$data[0] = implode('', $parts);
 				},
 				'block_level' => true,
 			),
@@ -2223,7 +2203,7 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 						$add_begin = substr(trim($data), 0, 5) != '&lt;?';
 						$data = highlight_php_code($add_begin ? '&lt;?php ' . $data . '?&gt;' : $data);
 						if ($add_begin)
-							$data = preg_replace(array('~^(.+?)&lt;\?.{0,40}?php(?:&nbsp;|\s)~', '~\?&gt;((?:</(font|span)>)*)$~'), '$1', $data, 2);
+							$data = preg_replace(array('/&lt;\?php(?:&nbsp;|\s)/', '/<span class="highlight-default"><\/span>/'), '', $data, 2);
 					}
 				},
 				'block_level' => false,

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -1860,7 +1860,7 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 			),
 			array(
 				'tag' => 'code',
-				'type' => 'unparsed_content',,
+				'type' => 'unparsed_content',
 				'content' => '<div class="codeheader">' . $txt['code'] . '</div><pre data-select-txt="' . $txt['code_select'] . '" data-shrink-txt="' . $txt['code_shrink'] . '" data-expand-txt="' . $txt['code_expand'] . '" class="bbc_code"><code>$1</code></pre>',
 				'validate' => isset($disabled['code']) ? null : function(&$tag, &$data)
 				{

--- a/Themes/default/css/index.css
+++ b/Themes/default/css/index.css
@@ -47,17 +47,8 @@ input, button, select, textarea {
 	box-shadow: 1px 2px 1px rgba(160, 187, 221, 0.2) inset;
 	padding: 0.3em 0.4em;
 }
-input:hover, textarea:hover, button:hover, select:hover {
-	outline: none;
-	border-color: #82a2bc;
-}
 textarea:hover {
 	background: #fbfbfb;
-}
-input:focus, textarea:focus, button:focus, select:focus {
-	outline: none;
-	border-color: #7fb0d8;
-	background: #fff;
 }
 input, button, select {
 	padding: 0 0.4em;
@@ -192,15 +183,6 @@ hr {
 	background: #fff;
 	box-shadow: 0 1px 0 #bbb inset;
 }
-/* This is about links */
-a, a:visited {
-	color: #346;
-	text-decoration: none;
-}
-a:hover {
-	text-decoration: underline;
-	cursor: pointer;
-}
 
 /* Help popups require a different styling of the body element. */
 /* Deprecated? */
@@ -277,6 +259,19 @@ a.new_posts:visited {
 }
 .clear_right {
 	clear: right;
+}
+.reset {
+	all: unset;
+	outline: revert;
+}
+/* This is about links */
+a, a:visited, .reset.link {
+	color: #346;
+	text-decoration: none;
+}
+a:hover, .reset.link:hover {
+	text-decoration: underline;
+	cursor: pointer;
 }
 
 /* Default font sizes: small (8pt), normal (10pt), and large (14pt). */
@@ -365,7 +360,6 @@ blockquote cite::before {
 
 /* A code block - maybe PHP ;). */
 .bbc_code {
-	display: block;
 	font-size: 0.78rem;
 	background: #f3f3f3;
 	border: 1px solid #dfdfdf;
@@ -375,7 +369,6 @@ blockquote cite::before {
 	margin: 1px 0 6px 0;
 	padding: 3px 12px;
 	overflow: auto;
-	white-space: nowrap;
 	max-height: 25em;
 }
 /* The "Quote:" and "Code:" header parts... */

--- a/Themes/default/css/jquery.sceditor.default.css
+++ b/Themes/default/css/jquery.sceditor.default.css
@@ -1,5 +1,5 @@
 /*! SCEditor | (C) 2011-2013, Sam Clarke | sceditor.com/license */
-html, p, code::before, table {
+html, p, .bbc_code code::before, table {
 	margin: 0;
 	padding: 0;
 	font-family: Verdana, Arial, Helvetica, sans-serif;
@@ -43,30 +43,21 @@ table, td {
 	min-width: 0.5ch;
 }
 
-code::before {
+.bbc_code code::before {
 	position: absolute;
 	content: 'Code:';
 	top: -1.35em;
 	left: 0;
 }
-code[data-title]::before {
+.bbc_code code[data-title]::before {
 	content: 'Code: (' attr(data-title) ')';
 }
-code {
+.bbc_code {
 	margin-top: 1.5em;
 	position: relative;
 	background: #eee;
 	border: 1px solid #aaa;
-	white-space: pre;
 	padding: .25em;
-	display: block;
-}
-.ie6 code, .ie7 code {
-	margin-top: 0;
-}
-code::before, code {
-	display: block;
-	text-align: left;
 }
 
 blockquote {

--- a/Themes/default/scripts/jquery.sceditor.smf.js
+++ b/Themes/default/scripts/jquery.sceditor.smf.js
@@ -814,6 +814,14 @@ sceditor.formats.bbcode.set(
 
 sceditor.formats.bbcode.set(
 	'php', {
+		tags: {
+			code: {
+				class: 'php'
+			},
+			span: {
+				class: 'phpcode'
+			}
+		},
 		isInline: false,
 		format: "[php]{0}[/php]",
 		html: '<code class="php">{0}</code>'
@@ -823,26 +831,41 @@ sceditor.formats.bbcode.set(
 sceditor.formats.bbcode.set(
 	'code', {
 		tags: {
-			code: null
+			code: null,
+			div: {
+				class: 'codeheader'
+			},
+			pre: {
+				class: 'bbc_code'
+			}
 		},
 		isInline: false,
 		allowedChildren: ['#', '#newline'],
 		format: function (element, content) {
-			if ($(element).hasClass('php'))
-				return '[php]' + content.replace('&#91;', '[') + '[/php]';
+			let title = element.getAttribute('data-title');
 
-			var
-				dom = sceditor.dom,
-				attr = dom.attr,
-				title = attr(element, 'data-title'),
-				from = title ?' =' + title : '';
+			if (element.className = 'php')
+				return '[php]' + content.replace('&#91;', '[') + '[/php]';
+			else if (element.tagName === 'DIV')
+				return '';
+			else if (element.tagName === 'PRE')
+				return content;
+			else if (element.parentNode.tagName === 'PRE' && !title)
+			{
+				const t = element.parentNode.previousSibling.textContent;
+
+				if (t.indexOf('(') != -1)
+					title = t.replace(/^[^(]+\(/, '').replace(/\)? \[.+/, '');
+			}
+
+			const from = title ? ' =' + title : '';
 
 			return '[code' + from + ']' + content.replace('&#91;', '[') + '[/code]';
 		},
 		html: function (element, attrs, content) {
 			var from = attrs.defaultattr ? ' data-title="' + attrs.defaultattr + '"'  : '';
 
-			return '<code data-name="' + this.opts.txtVars.code + '"' + from + '>' + content.replace('[', '&#91;') + '</code>'
+			return '<pre class="bbc_code"><code data-name="' + this.opts.txtVars.code + '"' + from + '>' + content.replace('[', '&#91;') + '</code></pre>'
 		}
 	}
 );


### PR DESCRIPTION
- wrap code in preformatted html tags
- do the same in the sceditor
- bonus: fix php tag processing in the sceditor
- php 8.3 changes highlight_string(), so update our integrations
- do not add php start and end php tags to the final output of the php bbcode
- add buttons for selecting and expanding code blocks with js; don't output them from php
- remove smfSelectText( ) as it is unused now

(cherry picked from commit f9d90a8f7f299f10be8160ca0b6a3a062390c3e6)