### PR TITLE
Support Unsubscribing from all emails

### DIFF
--- a/Sources/Notify.php
+++ b/Sources/Notify.php
@@ -334,7 +334,7 @@ function AnnouncementsNotify()
 
 	require_once($sourcedir . '/Subs-Notify.php');
 
-	if (isset($_REQUEST['u']) && isset($_REQUEST['token']))
+	if (isset($_REQUEST['u']) && $_REQUEST['u'] > 0 && isset($_REQUEST['token']))
 	{
 		$member_info = getMemberWithToken('announcements');
 		$skipCheckSession = true;
@@ -381,6 +381,118 @@ function AnnouncementsNotify()
 	// Show a confirmation message.
 	$context['sub_template'] = 'notify_pref_changed';
 	$context['notify_success_msg'] = sprintf($txt['notify_announcements' . (!empty($mode) ? '_subscribed' : '_unsubscribed')], $member_info['email']);
+}
+
+/**
+ * Disable an account if they unsubscribe/delete account.
+ * Accessed via ?action=unsubscribe.
+ */
+function Unsubscribe()
+{
+	global $scripturl, $txt, $user_info, $context, $smcFunc, $sourcedir, $modSettings;
+
+	require_once($sourcedir . '/Subs-Notify.php');
+
+	// Logged in? Just delete your account.
+	if (!$user_info['is_guest'])
+		redirectexit('action=profile;area=deleteaccount');
+
+	loadTemplate('Notify');
+	$context['page_title'] = $txt['unsubscribe'];
+
+	if (isset($_REQUEST['u']) && $_REQUEST['u'] > 0 && isset($_REQUEST['token']))
+	{
+		$member_info = getMemberWithToken('unsubscribe');
+
+		if (isset($_POST['delete']) || isset($_POST['notify']))
+			validateToken('unsubscribe');
+
+		// Approval is required to delete, but this will also stop notifications.
+		if (isset($_POST['delete']) && !empty($modSettings['approveAccountDeletion']) && !allowedTo('moderate_forum'))
+		{
+			updateMemberData($member_info['id'], array('is_activated' => 4));
+			updateSettings(array('unapprovedMembers' => true), true);
+		}
+		// Also check if you typed your password correctly.
+		elseif (isset($_POST['delete']))
+		{
+			require_once($sourcedir . '/Subs-Members.php');		
+			deleteMembers($member_info['id']);
+		}
+		elseif (isset($_POST['notify']))
+		{
+			// Get all notifications preferences.
+			$notifyPrefs = getNotifyPrefs($member_info['id'], '', true);
+
+			if (!empty($notifyPrefs[$member_info['id']]))
+			{
+				foreach ($notifyPrefs[$member_info['id']] as $pref_key => &$pref_value)
+					if ($pref_key != 'alert_timeout')
+						$pref_value = $pref_value == 2 ? 0 : 1;
+
+				setNotifyPrefs($member_info['id'], $notifyPrefs[$member_info['id']]); 
+			}
+		}
+
+		if (isset($_POST['delete']) || isset($_POST['notify']))
+		{
+			$context['sub_template'] = 'unsubscribe_success';
+			$context['success_msg'] = $txt['unsubscribe_success_done'];
+		}
+		else
+		{
+			createToken('unsubscribe');
+			$context['sub_template'] = 'unsubscribe_type';
+			$context['token'] = $smcFunc['htmlspecialchars']($_REQUEST['token']);
+			$context['user_id'] = $member_info['id'];
+		}
+
+		return;
+	}
+
+	// A request has been received, lookup the member and send a request.
+	if (isset($_POST['email']))
+	{
+		checkSession('post');
+		validateToken('unsubscribe');
+
+		// Lookup the member.
+		$request = $smcFunc['db_query']('', '
+			SELECT id_member, email_address
+			FROM {db_prefix}members
+			WHERE email_address = {string:email}',
+			array(
+				'email' => $_POST['email']
+		));
+
+		// Regardless, we pretend it was succesful, so we don't leak member data.
+		if ($smcFunc['db_num_rows']($request) > 0)
+		{
+			$user_settings = $smcFunc['db_fetch_assoc']($request);
+			$smcFunc['db_free_result']($request);
+
+			$token = createUnsubscribeToken($user_settings['id_member'], $user_settings['email_address'], 'unsubscribe');
+
+			require_once($sourcedir . '/Subs-Post.php');
+
+			// Send them a email (yes) with a token to unsubscribe.
+			sendmail(
+				$user_settings['email_address'],
+				$txt['unsubscribe_email_subject'],
+				sprintf($txt['unsubscribe_email_body'], $scripturl . '?action=unsubscribe;u=' . $user_settings['id_member'] . ';token=' . $token) . "\n\n" . sprintf($txt['regards_team'], $context['forum_name'])
+			);
+
+			$context['sub_template'] = 'unsubscribe_success';
+			$context['success_msg'] = $txt['unsubscribe_success_request'];
+		}
+	}
+	else
+	{
+		// Default email address if provided with one.
+		$context['email_address'] = isset($_GET['email']) ? $smcFunc['htmlspecialchars'](urldecode($_GET['email'])) : '';
+		$context['sub_template'] = 'unsubscribe';
+		createToken('unsubscribe');
+	}
 }
 
 ?>

--- a/Sources/Subs-Post.php
+++ b/Sources/Subs-Post.php
@@ -626,7 +626,7 @@ function sendmail($to, $subject, $message, $from = null, $message_id = null, $se
 	$subject = un_htmlspecialchars($subject);
 
 	// Add in a unsubscribe link.
-	$message .= "\n\n" . $txt['unsubscribe'] . ': ' . $scripturl . '?action=unsubscribe';
+	$message .= "\n\n" . sprintf($txt['unsubscribe_email_message'], $scripturl . '?action=unsubscribe');
 
 	// Make the message use the proper line breaks.
 	$message = str_replace(array("\r", "\n"), array('', $line_break), $message);

--- a/Sources/Subs-Post.php
+++ b/Sources/Subs-Post.php
@@ -624,6 +624,10 @@ function sendmail($to, $subject, $message, $from = null, $message_id = null, $se
 
 	// Get rid of entities.
 	$subject = un_htmlspecialchars($subject);
+
+	// Add in a unsubscribe link.
+	$message .= "\n\n" . $txt['unsubscribe'] . ': ' . $scripturl . '?action=unsubscribe';
+
 	// Make the message use the proper line breaks.
 	$message = str_replace(array("\r", "\n"), array('', $line_break), $message);
 
@@ -647,6 +651,7 @@ function sendmail($to, $subject, $message, $from = null, $message_id = null, $se
 	if ($message_id !== null && empty($modSettings['mail_no_message_id']))
 		$headers .= 'Message-ID: <' . md5($scripturl . microtime()) . '-' . $message_id . strstr(empty($modSettings['mail_from']) ? $webmaster_email : $modSettings['mail_from'], '@') . '>' . $line_break;
 	$headers .= 'X-Mailer: SMF' . $line_break;
+    $headers .= 'List-Unsubscribe: <' . $scripturl . '?action=unsubscribe>' . $line_break;
 
 	// Pass this to the integration before we start modifying the output -- it'll make it easier later.
 	if (in_array(false, call_integration_hook('integrate_outgoing_email', array(&$subject, &$message, &$headers, &$to_array)), true))

--- a/Themes/default/Notify.template.php
+++ b/Themes/default/Notify.template.php
@@ -95,4 +95,83 @@ function template_notify_pref_changed()
 		</div>';
 }
 
+/**
+ *
+ */
+function template_unsubscribe()
+{
+	global $context, $txt, $scripturl;
+
+	echo '
+		<div class="cat_bar">
+			<h3 class="catbg">
+				<span class="main_icons mail icon"></span>
+				', $txt['unsubscribe'], '
+			</h3>
+		</div>
+		<div class="roundframe centertext">
+			<p>', $txt['unsubscribe_process'], '</p>
+		</div>
+		<form method="post" accept-charset="', $context['character_set'], '" action="', $scripturl, '?action=unsubscribe">
+			<div class="roundframe centertext">
+				<dl>
+					<dt>', $txt['user_email_address'], ':</dt>
+					<dd><input type="text" name="email" value="', $context['email_address'], '" size="60"></dd>
+				</dl>
+				<p class="centertext">
+					<input type="submit" value="', $txt['request_unsubscribe'], '" class="button">
+				</p>
+			</div>
+			<input type="hidden" name="', $context['session_var'], '" value="', $context['session_id'], '">
+			<input type="hidden" name="', $context['unsubscribe_token_var'], '" value="', $context['unsubscribe_token'], '">
+		</form>';
+}
+
+/**
+ *
+ */
+function template_unsubscribe_success()
+{
+	global $txt, $context;
+
+	echo '
+		<div class="cat_bar">
+			<h3 class="catbg">
+				<span class="main_icons mail icon"></span>
+				', $txt['unsubscribe'], '
+			</h3>
+		</div>
+		<div class="roundframe centertext">
+			<p>', $context['success_msg'], '</p>
+		</div>';
+}
+
+/**
+ *
+ */
+function template_unsubscribe_type()
+{
+	global $txt, $scripturl, $context;
+
+	echo '
+		<div class="cat_bar">
+			<h3 class="catbg">
+				<span class="main_icons mail icon"></span>
+				', $txt['unsubscribe'], '
+			</h3>
+		</div>
+		<form method="post" accept-charset="', $context['character_set'], '" action="', $scripturl, '?action=unsubscribe">
+			<div class="roundframe centertext">
+				<p class="centertext">
+					<button name="delete" class="button">', $txt['unsubscribe_delete_account'], '</button>
+					<button name="notify" class="button">', $txt['unsubscribe_remove_notifications'], '</button>
+				</p>
+			</div>
+			<input type="hidden" name="u" value="', $context['user_id'], '">
+			<input type="hidden" name="token" value="', $context['token'], '">
+			<input type="hidden" name="', $context['session_var'], '" value="', $context['session_id'], '">
+			<input type="hidden" name="', $context['unsubscribe_token_var'], '" value="', $context['unsubscribe_token'], '">
+		</form>';
+}
+
 ?>

--- a/Themes/default/Notify.template.php
+++ b/Themes/default/Notify.template.php
@@ -98,7 +98,7 @@ function template_notify_pref_changed()
 /**
  *
  */
-function template_unsubscribe()
+function template_unsubscribe_request()
 {
 	global $context, $txt, $scripturl;
 
@@ -149,7 +149,7 @@ function template_unsubscribe_success()
 /**
  *
  */
-function template_unsubscribe_type()
+function template_unsubscribe_confirm()
 {
 	global $txt, $scripturl, $context;
 
@@ -163,7 +163,6 @@ function template_unsubscribe_type()
 		<form method="post" accept-charset="', $context['character_set'], '" action="', $scripturl, '?action=unsubscribe">
 			<div class="roundframe centertext">
 				<p class="centertext">
-					<button name="delete" class="button">', $txt['unsubscribe_delete_account'], '</button>
 					<button name="notify" class="button">', $txt['unsubscribe_remove_notifications'], '</button>
 				</p>
 			</div>

--- a/Themes/default/languages/index.english.php
+++ b/Themes/default/languages/index.english.php
@@ -953,4 +953,14 @@ $txt['sentence_list_format']['n'] = '{series}, and {-1}';
 $txt['sentence_list_separator'] = ', ';
 $txt['sentence_list_separator_alt'] = '; ';
 
+$txt['unsubscribe'] = 'Unsubscribe';
+$txt['unsubscribe_process'] = 'To unsubscribe, enter your email address and a verification link will be sent.';
+$txt['request_unsubscribe'] = 'Send Email Verification';
+$txt['unsubscribe_email_subject'] = 'Unsubscribe Requested';
+$txt['unsubscribe_email_body'] = 'A request to unsubscribe was received.  To approve this request, follow this link: %1$s.';
+$txt['unsubscribe_success_request'] = 'An email has been sent with a approval link to the member if one exists.';
+$txt['unsubscribe_success_done'] = 'Your rqeuest has been received and is being processed.';
+$txt['unsubscribe_delete_account'] = 'Delete Account';
+$txt['unsubscribe_remove_notifications'] = 'Remove all email notifications';
+
 ?>

--- a/Themes/default/languages/index.english.php
+++ b/Themes/default/languages/index.english.php
@@ -960,7 +960,7 @@ $txt['unsubscribe_email_subject'] = 'Unsubscribe Requested';
 $txt['unsubscribe_email_body'] = 'A request to unsubscribe was received.  To approve this request, follow this link: %1$s.';
 $txt['unsubscribe_success_request'] = 'An email has been sent with a approval link to the member if one exists.';
 $txt['unsubscribe_success_done'] = 'Your rqeuest has been received and is being processed.';
-$txt['unsubscribe_delete_account'] = 'Delete Account';
 $txt['unsubscribe_remove_notifications'] = 'Remove all email notifications';
+$txt['unsubscribe_email_message'] = 'To unsubscribe, visit %1$s';
 
 ?>

--- a/index.php
+++ b/index.php
@@ -400,6 +400,7 @@ function smf_main()
 		'unread' => array('Recent.php', 'UnreadTopics'),
 		'unreadreplies' => array('Recent.php', 'UnreadTopics'),
 		'uploadAttach' => array('Attachments.php', 'Attachments::call#'),
+		'unsubscribe' => array('Notify.php', 'Unsubscribe'),
 		'verificationcode' => array('Register.php', 'VerificationCode'),
 		'viewprofile' => array('Profile.php', 'ModifyProfile'),
 		'vote' => array('Poll.php', 'Vote'),


### PR DESCRIPTION
Fixes #7841

Firstly this adds List-Unsubscribe as described in the issue.  This helps email clients provide links/information for the user to stop getting emails. As well larger email providers, like Google, requires this for domains sending large volumes of email.

I choose to not use the notifyAnnouncements here as that is tuned to just remove notifications from email announcements.  This adds ability to remove notifications and alternatively delete their account.  This would also help comply with GDPR that a operator must delete the account.