### PR TITLE
Support persistent connections in memcached implantation

### DIFF
--- a/Sources/Cache/APIs/MemcachedImplementation.php
+++ b/Sources/Cache/APIs/MemcachedImplementation.php
@@ -80,7 +80,10 @@ class MemcachedImplementation extends CacheApi implements CacheApiInterface
 	 */
 	public function connect()
 	{
-		$this->memcached = new Memcached;
+		global $db_persist;
+
+		// If we are persisting database connections, attempt to persist the memcache connections.
+		$this->memcached = empty($db_persist) ? new Memcached : new Memcached($this->prefix);
 
 		return $this->addServers();
 	}


### PR DESCRIPTION
https://www.php.net/memcached.construct

If you pass the first parameter while creating the memcached object, this will persist the connections.  Otherwise the connection are discarded when the page is loaded.