### PR TITLE
Fixes bug in SMF\Graphics\Image::move()

### DIFF
--- a/Sources/Graphics/Image.php
+++ b/Sources/Graphics/Image.php
@@ -505,7 +505,7 @@ class Image
 		$this->pathinfo = pathinfo($this->source);
 
 		// Attempt to chmod it.
-		@Utils::makeWritable($image->source);
+		@Utils::makeWritable($this->source);
 
 		return true;
 	}


### PR DESCRIPTION
SMF\Graphics\Image::move() would always fail with an error about trying to pass a null value to SMF\Utils::makeWritable(). Problem was due to a silly copy-and-paste error on my part.