### PR TITLE
Misc notification fixes

### DIFF
--- a/Sources/Actions/Notify.php
+++ b/Sources/Actions/Notify.php
@@ -174,7 +174,7 @@ abstract class Notify
 	public static function getNotifyPrefs($members, $prefs = '', $process_default = false)
 	{
 		// We want this as an array whether it is or not.
-		$members = is_array($members) ? $members : (array) $members;
+		$members = array_map('intval', (array) $members);
 
 		if (!empty($prefs))
 			$prefs = is_array($prefs) ? $prefs : (array) $prefs;

--- a/Sources/Actions/Profile/ShowAlerts.php
+++ b/Sources/Actions/Profile/ShowAlerts.php
@@ -64,8 +64,6 @@ class ShowAlerts implements ActionInterface
 	 */
 	public function execute(): void
 	{
-		require_once(Config::$sourcedir . '/Actions/Profile/Modify.php');
-
 		// Are we opening a specific alert? (i.e.: ?action=profile;area=showalerts;alert=12345)
 		if (!empty($_REQUEST['alert']))
 		{

--- a/Sources/Alert.php
+++ b/Sources/Alert.php
@@ -649,7 +649,7 @@ class Alert implements \ArrayAccess
 		$possible_topics = array();
 
 		// First, weed out any alerts that wouldn't be visible.
-		foreach ($props_batch as $props)
+		foreach ($props_batch as &$props)
 		{
 			$members[] = $props['id_member'];
 

--- a/Sources/tasks/EventNew_Notify.php
+++ b/Sources/tasks/EventNew_Notify.php
@@ -39,7 +39,7 @@ class EventNew_Notify extends BackgroundTask
 
 		// Don't alert the event creator
 		if (!empty($this->_details['sender_id']))
-			$members = array_diff($members, array($this->_details['sender_id']));
+			$members = array_diff($members, $this->_details['sender_id']);
 
 		// Having successfully figured this out, now let's get the preferences of everyone.
 		$prefs = Notify::getNotifyPrefs($members, 'event_new', true);
@@ -85,7 +85,7 @@ class EventNew_Notify extends BackgroundTask
 					'content_id' => $this->_details['event_id'],
 					'content_action' => empty($this->_details['sender_id']) ? 'new_guest' : 'new',
 					'is_read' => 0,
-					'extra' => Db::$db->smcFunc['json_encode'](
+					'extra' => Utils::jsonEncode(
 						array(
 							"event_id" => $this->_details['event_id'],
 							"event_title" => $this->_details['event_title']


### PR DESCRIPTION
Fixes a few bugs related to alerts and notifications:

- fd0632f removes an obsolete require_once call that would cause a fatal error when viewing alerts.
- 107cea9 fixes a bug where $props['visible'] would not be set correctly in SMF\Alert::createBatch().
- 09e2ac1 fixes two bugs that would prevent notifications about new events from being sent.