### PR TITLE
Fix registration emails

### DIFF
--- a/Sources/Actions/Register2.php
+++ b/Sources/Actions/Register2.php
@@ -22,6 +22,7 @@ use SMF\Group;
 use SMF\IntegrationHook;
 use SMF\Lang;
 use SMF\Logging;
+use SMF\Mail;
 use SMF\Profile;
 use SMF\Security;
 use SMF\SecurityToken;


### PR DESCRIPTION
Registration emails fail (at least when registering a new member from the admin center) due to a missing use statement.