### PR TITLE
3.0: Fix missing use

### DIFF
--- a/Sources/tasks/RemoveTopicRedirects.php
+++ b/Sources/tasks/RemoveTopicRedirects.php
@@ -15,6 +15,7 @@ namespace SMF\Tasks;
 
 use SMF\Theme;
 use SMF\Topic;
+use SMF\Db\DatabaseApi as Db;
 
 /**
  * Deletes moved topic notices that have passed their best-by date.


### PR DESCRIPTION
Fixes this issue reported in the php error log (not the SMF log) when navigating server settings:

> [22-Nov-2023 03:57:41 UTC] PHP Fatal error:  Uncaught Error: Class "SMF\Tasks\Db" not found in blah\blah\80van30\Sources\tasks\RemoveTopicRedirects.php:37
> Stack trace:
> 0 blah\blah\80van30\Sources\TaskRunner.php(577): SMF\Tasks\RemoveTopicRedirects->execute()
> 1 blah\blah\80van30\Sources\TaskRunner.php(209): SMF\TaskRunner->performTask(Array)
> 2 blah\blah\80van30\cron.php(30): SMF\TaskRunner->execute()
> 3 {main}
>   thrown in blah\blah\80van30\Sources\tasks\RemoveTopicRedirects.php on line 37