### PR TITLE
Post-PSR 12 cleanup

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -115,11 +115,6 @@ return (new PhpCsFixer\Config())
 		'no_empty_statement' => true,
 		'multiline_whitespace_before_semicolons' => true,
 		'no_singleline_whitespace_before_semicolons' => true,
-		'escape_implicit_backslashes' => [
-			'double_quoted' => true,
-			'heredoc_syntax' => true,
-			'single_quoted' => true,
-		],
 		'explicit_string_variable' => true,
 		'simple_to_complex_string_variable' => true,
 		'single_quote' => true,

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -113,6 +113,7 @@ return (new PhpCsFixer\Config())
 		'no_useless_return' => true,
 		'simplified_null_return' => true,
 		'no_empty_statement' => true,
+		'multiline_whitespace_before_semicolons' => true,
 		'no_singleline_whitespace_before_semicolons' => true,
 		'escape_implicit_backslashes' => [
 			'double_quoted' => true,

--- a/Sources/Actions/Activate.php
+++ b/Sources/Actions/Activate.php
@@ -44,7 +44,6 @@ class Activate implements ActionInterface
 		],
 	];
 
-
 	/*******************
 	 * Public properties
 	 *******************/

--- a/Sources/Actions/Admin/ACP.php
+++ b/Sources/Actions/Admin/ACP.php
@@ -726,7 +726,6 @@ class ACP implements ActionInterface
 		],
 	];
 
-
 	/****************************
 	 * Internal static properties
 	 ****************************/
@@ -1981,7 +1980,6 @@ class ACP implements ActionInterface
 			return "\n" . '<input type="hidden" name="' . Utils::htmlspecialchars($k) . '" value="' . strtr($v, ['"' => '&quot;', '<' => '&lt;', '>' => '&gt;']) . '">';
 		}
 
-
 		$ret = '';
 
 		foreach ($v as $k2 => $v2) {
@@ -1989,7 +1987,6 @@ class ACP implements ActionInterface
 		}
 
 		return $ret;
-
 	}
 
 	/**
@@ -2029,7 +2026,6 @@ class ACP implements ActionInterface
 
 		return $query_string;
 	}
-
 }
 
 // Export public static functions and properties to global namespace for backward compatibility.

--- a/Sources/Actions/Admin/ACP.php
+++ b/Sources/Actions/Admin/ACP.php
@@ -1094,7 +1094,7 @@ class ACP implements ActionInterface
 
 		// Fix the darn stupid cookiename! (more may not be allowed, but these for sure!)
 		if (isset($_POST['cookiename'])) {
-			$_POST['cookiename'] = preg_replace('~[,;\\s\\.$]+~' . (Utils::$context['utf8'] ? 'u' : ''), '', $_POST['cookiename']);
+			$_POST['cookiename'] = preg_replace('~[,;\s\.$]+~' . (Utils::$context['utf8'] ? 'u' : ''), '', $_POST['cookiename']);
 		}
 
 		// Fix the forum's URL if necessary.
@@ -1545,7 +1545,7 @@ class ACP implements ActionInterface
 			fclose($fp);
 
 			// The comment looks rougly like... that.
-			if (preg_match('~\\*\\s@version\\s+(.+)[\\s]{2}~i', $header, $match) == 1) {
+			if (preg_match('~\*\s@version\s+(.+)[\s]{2}~i', $header, $match) == 1) {
 				$version_info['file_versions']['SSI.php'] = $match[1];
 			}
 			// Not found!  This is bad.
@@ -1561,7 +1561,7 @@ class ACP implements ActionInterface
 			fclose($fp);
 
 			// Found it?
-			if (preg_match('~\\*\\s@version\\s+(.+)[\\s]{2}~i', $header, $match) == 1) {
+			if (preg_match('~\*\s@version\s+(.+)[\s]{2}~i', $header, $match) == 1) {
 				$version_info['file_versions']['subscriptions.php'] = $match[1];
 			}
 			// If we haven't how do we all get paid?
@@ -1581,7 +1581,7 @@ class ACP implements ActionInterface
 				fclose($fp);
 
 				// Look for the version comment in the file header.
-				if (preg_match('~\\*\\s@version\\s+(.+)[\\s]{2}~i', $header, $match) == 1) {
+				if (preg_match('~\*\s@version\s+(.+)[\s]{2}~i', $header, $match) == 1) {
 					$version_info['file_versions'][$entry] = $match[1];
 				}
 				// It wasn't found, but the file was... show a '??'.
@@ -1604,7 +1604,7 @@ class ACP implements ActionInterface
 					fclose($fp);
 
 					// Look for the version comment in the file header.
-					if (preg_match('~\\*\\s@version\\s+(.+)[\\s]{2}~i', $header, $match) == 1) {
+					if (preg_match('~\*\s@version\s+(.+)[\s]{2}~i', $header, $match) == 1) {
 						$version_info['tasks_versions'][$entry] = $match[1];
 					}
 					// It wasn't found, but the file was... show a '??'.
@@ -1634,7 +1634,7 @@ class ACP implements ActionInterface
 					fclose($fp);
 
 					// Look for the version comment in the file header.
-					if (preg_match('~\\*\\s@version\\s+(.+)[\\s]{2}~i', $header, $match) == 1) {
+					if (preg_match('~\*\s@version\s+(.+)[\s]{2}~i', $header, $match) == 1) {
 						$version_info[$type][$entry] = $match[1];
 					}
 					// It wasn't found, but the file was... show a '??'.
@@ -1660,7 +1660,7 @@ class ACP implements ActionInterface
 				list($name, $language) = explode('.', $entry);
 
 				// Look for the version comment in the file header.
-				if (preg_match('~(?://|/\\*)\\s*Version:\\s+(.+?);\\s*' . preg_quote($name, '~') . '(?:[\\s]{2}|\\*/)~i', $header, $match) == 1) {
+				if (preg_match('~(?://|/\*)\s*Version:\s+(.+?);\s*' . preg_quote($name, '~') . '(?:[\s]{2}|\*/)~i', $header, $match) == 1) {
 					$version_info['default_language_versions'][$language][$name] = $match[1];
 				}
 				// It wasn't found, but the file was... show a '??'.
@@ -2003,7 +2003,7 @@ class ACP implements ActionInterface
 		$q = strpos(Config::$scripturl, '?');
 
 		if ($q !== false) {
-			parse_str(preg_replace('/&(\\w+)(?=&|$)/', '&$1=', strtr(substr(Config::$scripturl, $q + 1), ';', '&')), $temp);
+			parse_str(preg_replace('/&(\w+)(?=&|$)/', '&$1=', strtr(substr(Config::$scripturl, $q + 1), ';', '&')), $temp);
 
 			foreach ($get as $k => $v) {
 				// Only if it's not already in the Config::$scripturl!

--- a/Sources/Actions/Admin/AntiSpam.php
+++ b/Sources/Actions/Admin/AntiSpam.php
@@ -486,7 +486,6 @@ class AntiSpam implements ActionInterface
 	 */
 	protected function __construct()
 	{
-
 	}
 }
 

--- a/Sources/Actions/Admin/Attachments.php
+++ b/Sources/Actions/Admin/Attachments.php
@@ -1323,7 +1323,6 @@ class Attachments implements ActionInterface
 		// What stage are we at?
 		Utils::$context['completed'] = $fix_errors ? true : false;
 		Utils::$context['errors_found'] = !empty($to_fix) ? true : false;
-
 	}
 
 	/**
@@ -2036,13 +2035,11 @@ class Attachments implements ActionInterface
 								break;
 							}
 
-
 							// Hmm, not in auto. Time to bail out then...
 							$results[] = Lang::$txt['attachment_transfer_no_room'];
 							$break = true;
 
 							break;
-
 						}
 					}
 

--- a/Sources/Actions/Admin/Bans.php
+++ b/Sources/Actions/Admin/Bans.php
@@ -1984,7 +1984,7 @@ class Bans implements ActionInterface
 						];
 					}
 				} elseif ($key == 'hostname') {
-					if (preg_match('/[^\\w.\\-*]/', $value) == 1) {
+					if (preg_match('/[^\w.\-*]/', $value) == 1) {
 						Utils::$context['ban_errors'][] = 'invalid_hostname';
 					} else {
 						// Replace the * wildcard by a MySQL wildcard %.
@@ -1993,7 +1993,7 @@ class Bans implements ActionInterface
 						$ban_triggers['hostname']['hostname'] = $value;
 					}
 				} elseif ($key == 'email') {
-					if (preg_match('/[^\\w.\\-\\+*@]/', $value) == 1) {
+					if (preg_match('/[^\w.\-\+*@]/', $value) == 1) {
 						Utils::$context['ban_errors'][] = 'invalid_email';
 					}
 
@@ -2020,7 +2020,7 @@ class Bans implements ActionInterface
 
 					$ban_triggers['email']['email_address'] = $value;
 				} elseif ($key == 'user') {
-					$user = preg_replace('~&amp;#(\\d{4,5}|[2-9]\\d{2,4}|1[2-9]\\d);~', '&#$1;', Utils::htmlspecialchars($value, ENT_QUOTES));
+					$user = preg_replace('~&amp;#(\d{4,5}|[2-9]\d{2,4}|1[2-9]\d);~', '&#$1;', Utils::htmlspecialchars($value, ENT_QUOTES));
 
 					$request = Db::$db->query(
 						'',

--- a/Sources/Actions/Admin/Boards.php
+++ b/Sources/Actions/Admin/Boards.php
@@ -1024,7 +1024,6 @@ class Boards implements ActionInterface
 	 *************************/
 
 	// code...
-
 }
 
 // Export public static functions and properties to global namespace for backward compatibility.

--- a/Sources/Actions/Admin/Features.php
+++ b/Sources/Actions/Admin/Features.php
@@ -389,7 +389,7 @@ class Features implements ActionInterface
 						}
 					}
 
-					if (!empty($sig_limits[7]) && preg_match_all('~\\[size=([\\d\\.]+)?(px|pt|em|x-large|larger)~i', $sig, $matches) !== false && isset($matches[2])) {
+					if (!empty($sig_limits[7]) && preg_match_all('~\[size=([\d\.]+)?(px|pt|em|x-large|larger)~i', $sig, $matches) !== false && isset($matches[2])) {
 						foreach ($matches[1] as $ind => $size) {
 							$limit_broke = 0;
 
@@ -416,10 +416,10 @@ class Features implements ActionInterface
 						$img_count = 0;
 
 						// Get all BBC tags...
-						preg_match_all('~\\[img(\\s+width=([\\d]+))?(\\s+height=([\\d]+))?(\\s+width=([\\d]+))?\\s*\\](?:<br>)*([^<">]+?)(?:<br>)*\\[/img\\]~i', $sig, $matches);
+						preg_match_all('~\[img(\s+width=([\d]+))?(\s+height=([\d]+))?(\s+width=([\d]+))?\s*\](?:<br>)*([^<">]+?)(?:<br>)*\[/img\]~i', $sig, $matches);
 
 						// ... and all HTML ones.
-						preg_match_all('~&lt;img\\s+src=(?:&quot;)?((?:http://|ftp://|https://|ftps://).+?)(?:&quot;)?(?:\\s+alt=(?:&quot;)?(.*?)(?:&quot;)?)?(?:\\s?/)?&gt;~i', $sig, $matches2, PREG_PATTERN_ORDER);
+						preg_match_all('~&lt;img\s+src=(?:&quot;)?((?:http://|ftp://|https://|ftps://).+?)(?:&quot;)?(?:\s+alt=(?:&quot;)?(.*?)(?:&quot;)?)?(?:\s?/)?&gt;~i', $sig, $matches2, PREG_PATTERN_ORDER);
 
 						// And stick the HTML in the BBC.
 						if (!empty($matches2)) {
@@ -536,9 +536,9 @@ class Features implements ActionInterface
 
 					// Try to fix disabled tags.
 					if (!empty($disabledTags)) {
-						$sig = preg_replace('~\\[(?:' . implode('|', $disabledTags) . ').+?\\]~i', '', $sig);
+						$sig = preg_replace('~\[(?:' . implode('|', $disabledTags) . ').+?\]~i', '', $sig);
 
-						$sig = preg_replace('~\\[/(?:' . implode('|', $disabledTags) . ')\\]~i', '', $sig);
+						$sig = preg_replace('~\[/(?:' . implode('|', $disabledTags) . ')\]~i', '', $sig);
 					}
 
 					$sig = strtr($sig, ["\n" => '<br>']);
@@ -1172,7 +1172,7 @@ class Features implements ActionInterface
 			if (empty(Utils::$context['fid'])) {
 				$col_name = Utils::normalize($_POST['field_name'], 'kc_casefold');
 				$col_name = Utils::sanitizeChars($col_name, 2, '-');
-				$col_name = preg_replace('~[^\\w-]~u', '', $col_name);
+				$col_name = preg_replace('~[^\w-]~u', '', $col_name);
 				$col_name = trim($col_name, '-_');
 				$col_name = Utils::truncate($col_name, 6);
 

--- a/Sources/Actions/Admin/Find.php
+++ b/Sources/Actions/Admin/Find.php
@@ -199,7 +199,6 @@ class Find implements ActionInterface
 		}
 	}
 
-
 	/**
 	 * A complicated but relatively quick internal search.
 	 */

--- a/Sources/Actions/Admin/Find.php
+++ b/Sources/Actions/Admin/Find.php
@@ -292,7 +292,7 @@ class Find implements ActionInterface
 					// Format the name - and remove any descriptions the entry may have.
 					$name = Lang::$txt[$found] ?? (Lang::$txt['setting_' . $found] ?? (!empty($item['alttxt']) ? $item['alttxt'] : $found));
 
-					$name = preg_replace('~<(?:div|span)\\sclass="smalltext">.+?</(?:div|span)>~', '', $name);
+					$name = preg_replace('~<(?:div|span)\sclass="smalltext">.+?</(?:div|span)>~', '', $name);
 
 					Utils::$context['search_results'][] = [
 						'url' => (substr($item[1], 0, 4) == 'area' ? Config::$scripturl . '?action=admin;' . $item[1] : $item[1]) . ';' . Utils::$context['session_var'] . '=' . Utils::$context['session_id'] . ((substr($item[1], 0, 4) == 'area' && $section == 'settings' ? '#' . $item[0][0] : '')),
@@ -344,7 +344,7 @@ class Find implements ActionInterface
 		$search_results = WebFetchApi::fetch(Utils::$context['doc_apiurl'] . '?action=query&list=search&srprop=timestamp|snippet&format=xml&srwhat=text&srsearch=' . $postVars);
 
 		// If we didn't get any xml back we are in trouble - perhaps the doc site is overloaded?
-		if (!$search_results || preg_match('~<' . '\\?xml\\sversion="\\d+\\.\\d+"\\?' . '>\\s*(<api\\b[^>]*>.+?</api>)~is', $search_results, $matches) != true) {
+		if (!$search_results || preg_match('~<' . '\?xml\sversion="\d+\.\d+"\?' . '>\s*(<api\b[^>]*>.+?</api>)~is', $search_results, $matches) != true) {
 			ErrorHandler::fatalLang('cannot_connect_doc_site');
 		}
 

--- a/Sources/Actions/Admin/Languages.php
+++ b/Sources/Actions/Admin/Languages.php
@@ -981,7 +981,6 @@ class Languages implements ActionInterface
 									'string' => $this->cleanLangString($_POST['entry'][$k][$subk], false),
 								];
 							}
-
 						}
 					}
 				}

--- a/Sources/Actions/Admin/Languages.php
+++ b/Sources/Actions/Admin/Languages.php
@@ -219,7 +219,7 @@ class Languages implements ActionInterface
 			// Check writable status.
 			foreach ($_POST['copy_file'] as $file) {
 				// Check it's not very bad.
-				if (strpos($file, '..') !== false || (strpos($file, 'Themes') !== 0 && !preg_match('~agreement\\.[A-Za-z-_0-9]+\\.txt$~', $file))) {
+				if (strpos($file, '..') !== false || (strpos($file, 'Themes') !== 0 && !preg_match('~agreement\.[A-Za-z-_0-9]+\.txt$~', $file))) {
 					ErrorHandler::fatal(Lang::$txt['languages_download_illegal_paths']);
 				}
 
@@ -318,7 +318,7 @@ class Languages implements ActionInterface
 			}
 
 			// I love PHP files, that's why I'm a developer and not an artistic type spending my time drinking absinth and living a life of sin...
-			if ($extension == 'php' && preg_match('~\\w+\\.\\w+(?:-utf8)?\\.php~', $basename)) {
+			if ($extension == 'php' && preg_match('~\w+\.\w+(?:-utf8)?\.php~', $basename)) {
 				$context_data += [
 					'version' => '??',
 					'cur_version' => false,
@@ -328,7 +328,7 @@ class Languages implements ActionInterface
 				list($name, $language) = explode('.', $basename);
 
 				// Let's get the new version, I like versions, they tell me that I'm up to date.
-				if (preg_match('~\\s*Version:\\s+(.+?);\\s*' . preg_quote($name, '~') . '~i', $file['preview'], $match) == 1) {
+				if (preg_match('~\s*Version:\s+(.+?);\s*' . preg_quote($name, '~') . '~i', $file['preview'], $match) == 1) {
 					$context_data['version'] = $match[1];
 				}
 
@@ -340,7 +340,7 @@ class Languages implements ActionInterface
 					fclose($fp);
 
 					// Find the version.
-					if (preg_match('~(?://|/\\*)\\s*Version:\\s+(.+?);\\s*' . preg_quote($name, '~') . '(?:[\\s]{2}|\\*/)~i', $header, $match) == 1) {
+					if (preg_match('~(?://|/\*)\s*Version:\s+(.+?);\s*' . preg_quote($name, '~') . '(?:[\s]{2}|\*/)~i', $header, $match) == 1) {
 						$context_data['cur_version'] = $match[1];
 
 						// How does this compare?
@@ -778,7 +778,7 @@ class Languages implements ActionInterface
 
 			while ($entry = $dir->read()) {
 				// We're only after the files for this language.
-				if (!preg_match('~^([A-Za-z]+)\\.' . $lang_id . '\\.php$~', $entry, $matches)) {
+				if (!preg_match('~^([A-Za-z]+)\.' . $lang_id . '\.php$~', $entry, $matches)) {
 					continue;
 				}
 
@@ -902,7 +902,7 @@ class Languages implements ActionInterface
 			$replace_array = [];
 
 			foreach ($primary_settings as $setting => $type) {
-				$replace_array['~\\$txt\\[\'' . $setting . '\'\\]\\s*=\\s*[^\\r\\n]+~'] = '$txt[\'' . $setting . '\'] = ' . ($type === 'bool' ? (!empty($_POST[$setting]) ? 'true' : 'false') : '\'' . ($setting = 'native_name' ? htmlentities(Utils::htmlspecialcharsDecode($_POST[$setting]), ENT_QUOTES, Utils::$context['character_set']) : preg_replace('~[^\\w-]~i', '', $_POST[$setting])) . '\'') . ';';
+				$replace_array['~\$txt\[\'' . $setting . '\'\]\s*=\s*[^\r\n]+~'] = '$txt[\'' . $setting . '\'] = ' . ($type === 'bool' ? (!empty($_POST[$setting]) ? 'true' : 'false') : '\'' . ($setting = 'native_name' ? htmlentities(Utils::htmlspecialcharsDecode($_POST[$setting]), ENT_QUOTES, Utils::$context['character_set']) : preg_replace('~[^\w-]~i', '', $_POST[$setting])) . '\'') . ';';
 			}
 
 			$current_data = preg_replace(array_keys($replace_array), array_values($replace_array), $current_data);
@@ -1020,12 +1020,12 @@ class Languages implements ActionInterface
 			// Also, remove any lines for uneditable variables like $forum_copyright from the working data.
 			$entries = [];
 
-			foreach (preg_split('~^(?=\\$(?:' . implode('|', $string_types) . ')\\[\'([^\\n]+?)\'\\])~m' . (Utils::$context['utf8'] ? 'u' : ''), preg_replace('~\\s*\\n(\\$(?!(?:' . implode('|', $string_types) . '))[^\\n]*)~', '', file_get_contents($current_file))) as $blob) {
+			foreach (preg_split('~^(?=\$(?:' . implode('|', $string_types) . ')\[\'([^\n]+?)\'\])~m' . (Utils::$context['utf8'] ? 'u' : ''), preg_replace('~\s*\n(\$(?!(?:' . implode('|', $string_types) . '))[^\n]*)~', '', file_get_contents($current_file))) as $blob) {
 				// Comment lines at the end of the blob can make terrible messes
-				$blob = preg_replace('~(\\n[ \\t]*//[^\\n]*)*$~' . (Utils::$context['utf8'] ? 'u' : ''), '', $blob);
+				$blob = preg_replace('~(\n[ \t]*//[^\n]*)*$~' . (Utils::$context['utf8'] ? 'u' : ''), '', $blob);
 
 				// Extract the variable
-				if (preg_match('~^\\$(' . implode('|', $string_types) . ')\\[\'([^\\n]+?)\'\\](?:\\[\'?([^\\n]+?)\'?\\])?\\s?=\\s?(.+);([ \\t]*(?://[^\\n]*)?)$~ms' . (Utils::$context['utf8'] ? 'u' : ''), strtr($blob, ["\r" => '']), $matches)) {
+				if (preg_match('~^\$(' . implode('|', $string_types) . ')\[\'([^\n]+?)\'\](?:\[\'?([^\n]+?)\'?\])?\s?=\s?(.+);([ \t]*(?://[^\n]*)?)$~ms' . (Utils::$context['utf8'] ? 'u' : ''), strtr($blob, ["\r" => '']), $matches)) {
 					// If no valid subkey was found, we need it to be explicitly null
 					$matches[3] = isset($matches[3]) && $matches[3] !== '' ? $matches[3] : null;
 
@@ -1070,29 +1070,29 @@ class Languages implements ActionInterface
 						# Optional explicit key assignment
 						(?:
 							(?:
-								\\d+
+								\d+
 								|
 								(?:
 									(?:
-										\'(?:[^\']|(?<=\\\\)\')*\'
+										\'(?:[^\']|(?<=\\\)\')*\'
 									)
 									|
 									(?:
-										"(?:[^"]|(?<=\\\\)")*"
+										"(?:[^"]|(?<=\\\)")*"
 									)
 								)
 							)
-							\\s*=>\\s*
+							\s*=>\s*
 						)?
 
 						# String value in single or double quotes
 						(?:
 							(?:
-								\'(?:[^\']|(?<=\\\\)\')*\'
+								\'(?:[^\']|(?<=\\\)\')*\'
 							)
 							|
 							(?:
-								"(?:[^"]|(?<=\\\\)")*"
+								"(?:[^"]|(?<=\\\)")*"
 							)
 						)
 
@@ -1116,7 +1116,7 @@ class Languages implements ActionInterface
 
 					foreach ($entryValue['entry'] as $id => $subValue) {
 						// Is this a new index?
-						if (preg_match('/^(\\d+|(?:(?:\'(?:[^\']|(?<=\\\\)\')*\')|(?:"(?:[^"]|(?<=\\\\)")*")))\\s*=>/', $subValue, $matches)) {
+						if (preg_match('/^(\d+|(?:(?:\'(?:[^\']|(?<=\\\)\')*\')|(?:"(?:[^"]|(?<=\\\)")*")))\s*=>/', $subValue, $matches)) {
 							$subKey = trim($matches[1], '\'"');
 
 							if (ctype_digit($subKey)) {
@@ -1295,7 +1295,7 @@ class Languages implements ActionInterface
 						}
 
 						$final_saves[$string_key] = [
-							'find' => '\\s*\\?' . '>$',
+							'find' => '\s*\?' . '>$',
 							'replace' => "\n\$" . $type . '[\'' . $string_key . '\'] = ' . $string_val['string'] . ';' . "\n\n?" . '>',
 							'is_regex' => true,
 						];
@@ -1312,7 +1312,7 @@ class Languages implements ActionInterface
 							$subKey = ctype_digit(trim($substring_key, '\'')) ? trim($substring_key, '\'') : '\'' . $substring_key . '\'';
 
 							$final_saves[$string_key . '[' . $substring_key . ']'] = [
-								'find' => '\\s*\\?' . '>$',
+								'find' => '\s*\?' . '>$',
 								'replace' => "\n\$" . $type . '[\'' . $string_key . '\'][' . $subKey . '] = ' . $substring_val['string'] . ';' . "\n\n?" . '>',
 								'is_regex' => true,
 							];
@@ -1362,7 +1362,7 @@ class Languages implements ActionInterface
 						if (key !== null) {
 							++entry_num;
 
-							var array_regex = /^(.*)(\\[[^\\[\\]]*\\])$/
+							var array_regex = /^(.*)(\[[^\[\]]*\])$/
 							var result = array_regex.exec(key);
 							if (result != null) {
 								key = result[1];
@@ -1371,7 +1371,7 @@ class Languages implements ActionInterface
 								var subkey = "";
 							}
 
-							var bracket_regex = /[\\[\\]]/
+							var bracket_regex = /[\[\]]/
 							if (bracket_regex.test(key)) {
 								alert("' . Lang::$txt['languages_invalid_key'] . '" + key + subkey);
 								return;
@@ -1799,7 +1799,7 @@ class Languages implements ActionInterface
 				// Start of a variable?
 				elseif ($in_string == 0 && $string[$i] == '$') {
 					// Find the whole of it!
-					preg_match('~([\\$A-Za-z0-9\'\\[\\]_-]+)~', substr($string, $i), $matches);
+					preg_match('~([\$A-Za-z0-9\'\[\]_-]+)~', substr($string, $i), $matches);
 
 					if (!empty($matches[1])) {
 						// Come up with some pseudo thing to indicate this is a var.
@@ -1850,7 +1850,7 @@ class Languages implements ActionInterface
 				// Is this a variable?
 				if ($string[$i] == '{' && $string[$i + 1] == '%' && $string[$i + 2] == '$') {
 					// Grab the variable.
-					preg_match('~\\{%([\\$A-Za-z0-9\'\\[\\]_-]+)%\\}~', substr($string, $i), $matches);
+					preg_match('~\{%([\$A-Za-z0-9\'\[\]_-]+)%\}~', substr($string, $i), $matches);
 
 					if (!empty($matches[1])) {
 						if ($in_string == 1) {

--- a/Sources/Actions/Admin/Maintenance.php
+++ b/Sources/Actions/Admin/Maintenance.php
@@ -996,7 +996,7 @@ class Maintenance implements ActionInterface
 		Utils::$context['continue_countdown'] = 3;
 
 		// Only optimize the tables related to this smf install, not all the tables in the db
-		$real_prefix = preg_match('~^(`?)(.+?)\\1\\.(.*?)$~', Db::$db->prefix, $match) === 1 ? $match[3] : Db::$db->prefix;
+		$real_prefix = preg_match('~^(`?)(.+?)\1\.(.*?)$~', Db::$db->prefix, $match) === 1 ? $match[3] : Db::$db->prefix;
 
 		// Get a list of tables, as well as how many there are.
 		$temp_tables = Db::$db->list_tables(false, $real_prefix . '%');
@@ -2732,7 +2732,7 @@ class Maintenance implements ActionInterface
 	{
 		$source = file_get_contents($file);
 		// token_get_all() is too slow so use a nice little regex instead.
-		preg_match_all('/\\bnamespace\\s++((?P>label)(?:\\\\(?P>label))*+)\\s*+;|\\bclass\\s++((?P>label))[\\w\\s]*+{|\\bfunction\\s++((?P>label))\\s*+\\(.*\\)[:\\|\\w\\s]*+{(?(DEFINE)(?<label>[a-zA-Z_\\x80-\\xff][a-zA-Z0-9_\\x80-\\xff]*+))/i', $source, $matches, PREG_SET_ORDER);
+		preg_match_all('/\bnamespace\s++((?P>label)(?:\\\(?P>label))*+)\s*+;|\bclass\s++((?P>label))[\w\s]*+{|\bfunction\s++((?P>label))\s*+\(.*\)[:\|\w\s]*+{(?(DEFINE)(?<label>[a-zA-Z_\x80-\xff][a-zA-Z0-9_\x80-\xff]*+))/i', $source, $matches, PREG_SET_ORDER);
 
 		$functions = [];
 		$namespace = '';

--- a/Sources/Actions/Admin/Maintenance.php
+++ b/Sources/Actions/Admin/Maintenance.php
@@ -2025,7 +2025,6 @@ class Maintenance implements ActionInterface
 								return $instance . Lang::$txt['hooks_field_function'] . ': ' . $data['real_function'] . '<br>' . Lang::$txt['hooks_field_included_file'] . ': ' . $data['included_file'];
 							}
 
-
 							return $instance . $data['real_function'];
 						},
 						'class' => 'word_break',
@@ -2060,7 +2059,6 @@ class Maintenance implements ActionInterface
 								return '<span class="main_icons ' . ($data['hook_exists'] ? 'posts' : 'error') . '" title="' . $data['img_text'] . '"></span>';
 							}
 
-
 							$change_status = ['before' => '', 'after' => ''];
 
 							// Can only enable/disable if it exists...
@@ -2070,7 +2068,6 @@ class Maintenance implements ActionInterface
 							}
 
 							return $change_status['before'] . '<span class="main_icons post_moderation_' . $data['status'] . '" title="' . $data['img_text'] . '"></span>' . $change_status['after'];
-
 						},
 						'class' => 'centertext',
 					],

--- a/Sources/Actions/Admin/Membergroups.php
+++ b/Sources/Actions/Admin/Membergroups.php
@@ -543,7 +543,6 @@ class Membergroups implements ActionInterface
 						['id_group', 'id_board', 'deny'],
 					);
 				}
-
 			}
 
 			// If this is joinable then set it to show group membership in people's profiles.

--- a/Sources/Actions/Admin/Membergroups.php
+++ b/Sources/Actions/Admin/Membergroups.php
@@ -730,7 +730,7 @@ class Membergroups implements ActionInterface
 				'hidden' => empty($_POST['group_hidden']) || $_POST['min_posts'] != -1 || $group->id == Group::MOD ? Group::VISIBLE : (int) $_POST['group_hidden'],
 				'parent' => $group->id > Group::ADMIN && $group->id != Group::MOD && (empty($inherit_type) || $inherit_type != Group::TYPE_PROTECTED) ? (int) $_POST['group_inherit'] : Group::NONE,
 				'tfa_required' => (empty(Config::$modSettings['tfa_mode']) || Config::$modSettings['tfa_mode'] != 2 || empty($_POST['group_tfa_force'])) ? false : true,
-				'online_color' => (int) $group->id != Group::MOD && preg_match('/^#?\\w+$/', Utils::htmlTrim($_POST['online_color'])) ? Utils::htmlTrim($_POST['online_color']) : '',
+				'online_color' => (int) $group->id != Group::MOD && preg_match('/^#?\w+$/', Utils::htmlTrim($_POST['online_color'])) ? Utils::htmlTrim($_POST['online_color']) : '',
 			]);
 
 			// Does the group have any moderators?

--- a/Sources/Actions/Admin/Members.php
+++ b/Sources/Actions/Admin/Members.php
@@ -398,7 +398,6 @@ class Members implements ActionInterface
 						$where_params[$param_name . '_low'] = $search_params[$param_name]['low'];
 						$where_params[$param_name . '_high'] = $search_params[$param_name]['high'];
 					}
-
 				} elseif ($param_info['type'] != 'groups') {
 					// Replace the wildcard characters ('*' and '?') into MySQL ones.
 					$parameter = strtolower(strtr(Utils::htmlspecialchars($search_params[$param_name], ENT_QUOTES), ['%' => '\\%', '_' => '\\_', '*' => '%', '?' => '_']));
@@ -1426,7 +1425,6 @@ class Members implements ActionInterface
 		self::$obj->subaction = 'search';
 		self::$obj->execute();
 	}
-
 
 	/******************
 	 * Internal methods

--- a/Sources/Actions/Admin/Registration.php
+++ b/Sources/Actions/Admin/Registration.php
@@ -598,7 +598,6 @@ class Registration implements ActionInterface
 		self::$obj->execute();
 	}
 
-
 	/******************
 	 * Internal methods
 	 ******************/

--- a/Sources/Actions/Admin/RepairBoards.php
+++ b/Sources/Actions/Admin/RepairBoards.php
@@ -1393,7 +1393,6 @@ class RepairBoards implements ActionInterface
 		);
 	}
 
-
 	/**
 	 * Callback to remove all topics that have zero messages in the messages table.
 	 */

--- a/Sources/Actions/Admin/Search.php
+++ b/Sources/Actions/Admin/Search.php
@@ -355,7 +355,7 @@ class Search implements ActionInterface
 
 		// Get some info about the messages table, to show its size and index size.
 		if (Config::$db_type == 'mysql') {
-			if (preg_match('~^`(.+?)`\\.(.+?)$~', Db::$db->prefix, $match) !== 0) {
+			if (preg_match('~^`(.+?)`\.(.+?)$~', Db::$db->prefix, $match) !== 0) {
 				$request = Db::$db->query(
 					'',
 					'SHOW TABLE STATUS
@@ -387,7 +387,7 @@ class Search implements ActionInterface
 			}
 
 			// Now check the custom index table, if it exists at all.
-			if (preg_match('~^`(.+?)`\\.(.+?)$~', Db::$db->prefix, $match) !== 0) {
+			if (preg_match('~^`(.+?)`\.(.+?)$~', Db::$db->prefix, $match) !== 0) {
 				$request = Db::$db->query(
 					'',
 					'SHOW TABLE STATUS
@@ -811,7 +811,7 @@ class Search implements ActionInterface
 				}
 			}
 
-			if (preg_match('~^`(.+?)`\\.(.+?)$~', Db::$db->prefix, $match) !== 0) {
+			if (preg_match('~^`(.+?)`\.(.+?)$~', Db::$db->prefix, $match) !== 0) {
 				$request = Db::$db->query(
 					'',
 					'SHOW TABLE STATUS

--- a/Sources/Actions/Admin/Search.php
+++ b/Sources/Actions/Admin/Search.php
@@ -675,9 +675,7 @@ class Search implements ActionInterface
 						break;
 					}
 
-
 					Config::updateModSettings(['search_custom_index_resume' => Utils::jsonEncode(array_merge(Utils::$context['index_settings'], ['resume_at' => Utils::$context['start']]))]);
-
 				}
 
 				// Since there are still two steps to go, 80% is the maximum here.

--- a/Sources/Actions/Admin/Server.php
+++ b/Sources/Actions/Admin/Server.php
@@ -389,7 +389,7 @@ class Server implements ActionInterface
 			if (!empty($_POST['globalCookiesDomain'])) {
 				$_POST['globalCookiesDomain'] = Url::create((strpos($_POST['globalCookiesDomain'], '//') === false ? 'http://' : '') . ltrim($_POST['globalCookiesDomain'], '.'), true)->host;
 
-				if (!preg_match('/(?:^|\\.)' . preg_quote($_POST['globalCookiesDomain'], '/') . '$/u', Url::create(Config::$boardurl))->host) {
+				if (!preg_match('/(?:^|\.)' . preg_quote($_POST['globalCookiesDomain'], '/') . '$/u', Url::create(Config::$boardurl))->host) {
 					ErrorHandler::fatalLang('invalid_cookie_domain', false);
 				}
 			}
@@ -1089,7 +1089,7 @@ class Server implements ActionInterface
 			Config::$modSettings['load_average'] = (float) $matches[1];
 		}
 		// On both Linux and Unix (e.g. macOS), we can we can check shell_exec('uptime').
-		elseif ((Config::$modSettings['load_average'] = @shell_exec('uptime')) !== null && preg_match('~load averages?: (\\d+\\.\\d+)~i', Config::$modSettings['load_average'], $matches) !== 0) {
+		elseif ((Config::$modSettings['load_average'] = @shell_exec('uptime')) !== null && preg_match('~load averages?: (\d+\.\d+)~i', Config::$modSettings['load_average'], $matches) !== 0) {
 			Config::$modSettings['load_average'] = (float) $matches[1];
 		}
 		// No shell_exec('uptime') and no /proc/loadavg, so we can't check.
@@ -1578,7 +1578,7 @@ class Server implements ActionInterface
 			fclose($fp);
 
 			// Get the unique site ID.
-			preg_match('~SITE-ID:\\s(\\w{10})~', $return_data, $ID);
+			preg_match('~SITE-ID:\s(\w{10})~', $return_data, $ID);
 
 			if (!empty($ID[1])) {
 				Db::$db->insert(

--- a/Sources/Actions/Admin/Smileys.php
+++ b/Sources/Actions/Admin/Smileys.php
@@ -1531,7 +1531,7 @@ class Smileys implements ActionInterface
 
 			// Check that the smiley is from simplemachines.org, for now... maybe add mirroring later.
 			if (
-				!preg_match('~^https://[\\w_\\-]+\\.simplemachines\\.org/~', $_REQUEST['set_gz'])
+				!preg_match('~^https://[\w_\-]+\.simplemachines\.org/~', $_REQUEST['set_gz'])
 				|| strpos($_REQUEST['set_gz'], 'dlattach') !== false
 			) {
 				ErrorHandler::fatalLang('not_on_simplemachines', false);
@@ -2861,11 +2861,11 @@ class Smileys implements ActionInterface
 		$pathinfo = pathinfo($string);
 
 		// Get rid of all whitespace and dots in the filename component.
-		$pathinfo['filename'] = preg_replace('/[\\s._]+/', '_', Utils::htmlTrim($pathinfo['filename']));
+		$pathinfo['filename'] = preg_replace('/[\s._]+/', '_', Utils::htmlTrim($pathinfo['filename']));
 
 		// Just in case there's something unexpected in the extension...
 		if (!empty($pathinfo['extension'])) {
-			$pathinfo['extension'] = preg_replace('/[\\s_]+/', '_', Utils::htmlTrim($pathinfo['extension']));
+			$pathinfo['extension'] = preg_replace('/[\s_]+/', '_', Utils::htmlTrim($pathinfo['extension']));
 		}
 
 		return $pathinfo['filename'] . (!empty($pathinfo['extension']) ? '.' . $pathinfo['extension'] : '');

--- a/Sources/Actions/Admin/Smileys.php
+++ b/Sources/Actions/Admin/Smileys.php
@@ -2369,14 +2369,10 @@ class Smileys implements ActionInterface
 		// If customized smileys is disabled don't show the setting page
 		if (empty(Config::$modSettings['smiley_enable'])) {
 			unset(self::$subactions['addsmiley'], self::$subactions['editsmileys'], self::$subactions['setorder'], self::$subactions['modifysmiley']);
-
-
-
 		}
 
 		if (empty(Config::$modSettings['messageIcons_enable'])) {
 			unset(self::$subactions['editicon'], self::$subactions['editicons']);
-
 		}
 
 		// Load up all the tabs...

--- a/Sources/Actions/Admin/Subscriptions.php
+++ b/Sources/Actions/Admin/Subscriptions.php
@@ -787,7 +787,7 @@ class Subscriptions implements ActionInterface
 
 			while ($row = Db::$db->fetch_assoc($request)) {
 				// Sort the date.
-				preg_match('~(\\d*)(\\w)~', $row['length'], $match);
+				preg_match('~(\d*)(\w)~', $row['length'], $match);
 
 				if (isset($match[2])) {
 					$_POST['span_value'] = $match[1];
@@ -1492,7 +1492,7 @@ class Subscriptions implements ActionInterface
 			}
 
 			// Do the span.
-			preg_match('~(\\d*)(\\w)~', $row['length'], $match);
+			preg_match('~(\d*)(\w)~', $row['length'], $match);
 
 			if (isset($match[2])) {
 				$num_length = $match[1];
@@ -2109,7 +2109,7 @@ class Subscriptions implements ActionInterface
 
 		if ($dh = opendir(Config::$sourcedir)) {
 			while (($file = readdir($dh)) !== false) {
-				if (is_file(Config::$sourcedir . '/' . $file) && preg_match('~^Subscriptions-([A-Za-z\\d]+)\\.php$~', $file, $matches)) {
+				if (is_file(Config::$sourcedir . '/' . $file) && preg_match('~^Subscriptions-([A-Za-z\d]+)\.php$~', $file, $matches)) {
 					// Check this is definitely a valid gateway!
 					$fp = fopen(Config::$sourcedir . '/' . $file, 'rb');
 					$header = fread($fp, 4096);

--- a/Sources/Actions/Admin/Subscriptions.php
+++ b/Sources/Actions/Admin/Subscriptions.php
@@ -976,7 +976,6 @@ class Subscriptions implements ActionInterface
 						],
 						['id_sublog'],
 					);
-
 				}
 			}
 			// Updating.

--- a/Sources/Actions/Admin/Tasks.php
+++ b/Sources/Actions/Admin/Tasks.php
@@ -315,7 +315,7 @@ class Tasks implements ActionInterface
 			SecurityToken::validate('admin-st');
 
 			// Sanitize the offset. Prepend a '0' so that ':05' works as expected.
-			list($h, $m) = array_pad(preg_split('/:/', preg_replace('/[^\\d:]/', '', '0' . $_POST['offset']), -1, PREG_SPLIT_NO_EMPTY), 2, '00');
+			list($h, $m) = array_pad(preg_split('/:/', preg_replace('/[^\d:]/', '', '0' . $_POST['offset']), -1, PREG_SPLIT_NO_EMPTY), 2, '00');
 
 			// Now the offset is easy; easy peasy - except we need to offset by a few hours,
 			// take account of DST at this time of year, and... okay, not so easy.

--- a/Sources/Actions/Admin/Tasks.php
+++ b/Sources/Actions/Admin/Tasks.php
@@ -728,7 +728,6 @@ class Tasks implements ActionInterface
 		self::$obj->execute();
 	}
 
-
 	/******************
 	 * Internal methods
 	 ******************/

--- a/Sources/Actions/Admin/Themes.php
+++ b/Sources/Actions/Admin/Themes.php
@@ -1089,7 +1089,6 @@ class Themes implements ActionInterface
 			return;
 		}
 
-
 		if (substr($_REQUEST['filename'], 0, 1) == '.') {
 			$_REQUEST['filename'] = '';
 		} else {
@@ -1105,7 +1104,6 @@ class Themes implements ActionInterface
 		if (empty($_REQUEST['filename'])) {
 			ErrorHandler::fatalLang('theme_edit_missing', false);
 		}
-
 
 		if (isset($_POST['save'])) {
 			if (User::$me->checkSession('post', '', false) == '' && SecurityToken::validate('admin-te-' . md5($_GET['th'] . '-' . $_REQUEST['filename']), 'post', false) == true) {
@@ -1578,9 +1576,7 @@ class Themes implements ActionInterface
 			return Utils::$context['to_install'];
 		}
 
-
 		ErrorHandler::fatalLang('theme_install_error_title', false);
-
 	}
 
 	/**

--- a/Sources/Actions/Admin/Themes.php
+++ b/Sources/Actions/Admin/Themes.php
@@ -742,7 +742,7 @@ class Themes implements ActionInterface
 		if (file_exists(Theme::$current->settings['theme_dir'] . '/index.template.php')) {
 			$file_contents = implode('', file(Theme::$current->settings['theme_dir'] . '/index.template.php'));
 
-			if (preg_match('~((?:SMF\\\\)?Theme::\\$current(?:->|_)|\\$)settings\\[\'theme_variants\'\\]\\s*=(.+?);~', $file_contents, $matches)) {
+			if (preg_match('~((?:SMF\\\\)?Theme::\$current(?:->|_)|\$)settings\[\'theme_variants\'\]\s*=(.+?);~', $file_contents, $matches)) {
 				eval('use SMF\\Theme; global $settings; ' . $matches[0]);
 			}
 		}
@@ -1048,7 +1048,7 @@ class Themes implements ActionInterface
 				if (substr($_GET['directory'], 0, 1) == '.') {
 					$_GET['directory'] = '';
 				} else {
-					$_GET['directory'] = preg_replace(['~^[\\./\\:\\0\\n\\r]+~', '~[\\\\]~', '~/[\\./]+~'], ['', '/', '/'], $_GET['directory']);
+					$_GET['directory'] = preg_replace(['~^[\./\\:\0\n\r]+~', '~[\\\\]~', '~/[\./]+~'], ['', '/', '/'], $_GET['directory']);
 
 					$temp = realpath($currentTheme['theme_dir'] . '/' . $_GET['directory']);
 
@@ -1092,7 +1092,7 @@ class Themes implements ActionInterface
 		if (substr($_REQUEST['filename'], 0, 1) == '.') {
 			$_REQUEST['filename'] = '';
 		} else {
-			$_REQUEST['filename'] = preg_replace(['~^[\\./\\:\\0\\n\\r]+~', '~[\\\\]~', '~/[\\./]+~'], ['', '/', '/'], $_REQUEST['filename']);
+			$_REQUEST['filename'] = preg_replace(['~^[\./\\:\0\n\r]+~', '~[\\\\]~', '~/[\./]+~'], ['', '/', '/'], $_REQUEST['filename']);
 
 			$temp = realpath($currentTheme['theme_dir'] . '/' . $_REQUEST['filename']);
 
@@ -1119,7 +1119,7 @@ class Themes implements ActionInterface
 
 					$error = @file_get_contents($currentTheme['theme_url'] . '/tmp_' . session_id() . '.php');
 
-					if (preg_match('~ <b>(\\d+)</b><br( /)?' . '>$~i', $error) != 0) {
+					if (preg_match('~ <b>(\d+)</b><br( /)?' . '>$~i', $error) != 0) {
 						$error_file = $currentTheme['theme_dir'] . '/tmp_' . session_id() . '.php';
 					} else {
 						unlink($currentTheme['theme_dir'] . '/tmp_' . session_id() . '.php');
@@ -1177,7 +1177,7 @@ class Themes implements ActionInterface
 			if (!isset($error_file)) {
 				$file_data = file($currentTheme['theme_dir'] . '/' . $_REQUEST['filename']);
 			} else {
-				if (preg_match('~(<b>.+?</b>:.+?<b>).+?(</b>.+?<b>\\d+</b>)<br( /)?' . '>$~i', $error, $match) != 0) {
+				if (preg_match('~(<b>.+?</b>:.+?<b>).+?(</b>.+?<b>\d+</b>)<br( /)?' . '>$~i', $error, $match) != 0) {
 					Utils::$context['parse_error'] = $match[1] . $_REQUEST['filename'] . $match[2];
 				}
 
@@ -1236,7 +1236,7 @@ class Themes implements ActionInterface
 		$theme = $this->getSingleTheme($_GET['th']);
 		Utils::$context['theme_id'] = $theme['id'];
 
-		if (isset($_REQUEST['template']) && preg_match('~[\\./\\\\:\\0]~', $_REQUEST['template']) == 0) {
+		if (isset($_REQUEST['template']) && preg_match('~[\./\\\\:\0]~', $_REQUEST['template']) == 0) {
 			if (file_exists(Theme::$current->settings['default_theme_dir'] . '/' . $_REQUEST['template'] . '.template.php')) {
 				$filename = Theme::$current->settings['default_theme_dir'] . '/' . $_REQUEST['template'] . '.template.php';
 			} else {
@@ -1248,7 +1248,7 @@ class Themes implements ActionInterface
 			fclose($fp);
 
 			Utils::redirectexit('action=admin;area=theme;th=' . Utils::$context['theme_id'] . ';' . Utils::$context['session_var'] . '=' . Utils::$context['session_id'] . ';sa=copy');
-		} elseif (isset($_REQUEST['lang_file']) && preg_match('~^[^\\./\\\\:\\0]\\.[^\\./\\\\:\\0]$~', $_REQUEST['lang_file']) != 0) {
+		} elseif (isset($_REQUEST['lang_file']) && preg_match('~^[^\./\\\\:\0]\.[^\./\\\\:\0]$~', $_REQUEST['lang_file']) != 0) {
 			if (file_exists(Theme::$current->settings['default_theme_dir'] . '/languages/' . $_REQUEST['template'] . '.php')) {
 				$filename = Theme::$current->settings['default_theme_dir'] . '/languages/' . $_REQUEST['template'] . '.php';
 			} else {
@@ -1278,7 +1278,7 @@ class Themes implements ActionInterface
 		$dir = dir(Theme::$current->settings['default_theme_dir'] . '/languages');
 
 		while ($entry = $dir->read()) {
-			if (preg_match('~^([^\\.]+\\.[^\\.]+)\\.php$~', $entry, $matches)) {
+			if (preg_match('~^([^\.]+\.[^\.]+)\.php$~', $entry, $matches)) {
 				$lang_files[] = $matches[1];
 			}
 		}
@@ -1326,7 +1326,7 @@ class Themes implements ActionInterface
 			$dir = dir($theme['theme_dir'] . '/languages');
 
 			while ($entry = $dir->read()) {
-				if (preg_match('~^([^\\.]+\\.[^\\.]+)\\.php$~', $entry, $matches) && isset(Utils::$context['available_language_files'][$matches[1]])) {
+				if (preg_match('~^([^\.]+\.[^\.]+)\.php$~', $entry, $matches) && isset(Utils::$context['available_language_files'][$matches[1]])) {
 					Utils::$context['available_language_files'][$matches[1]]['already_exists'] = true;
 
 					Utils::$context['available_language_files'][$matches[1]]['can_copy'] = is_writable($theme['theme_dir'] . '/languages/' . $entry);
@@ -1548,7 +1548,7 @@ class Themes implements ActionInterface
 
 		// Get the theme's name.
 		$name = pathinfo($_FILES['theme_gz']['name'], PATHINFO_FILENAME);
-		$name = preg_replace(['/\\s/', '/\\.[\\.]+/', '/[^\\w_\\.\\-]/', '/\\.tar$/'], ['_', '.', '', ''], $name);
+		$name = preg_replace(['/\s/', '/\.[\.]+/', '/[^\w_\.\-]/', '/\.tar$/'], ['_', '.', '', ''], $name);
 
 		// Start setting some vars.
 		Utils::$context['to_install'] = [
@@ -1594,7 +1594,7 @@ class Themes implements ActionInterface
 		}
 
 		// Get a cleaner version.
-		$name = preg_replace('~[^A-Za-z0-9_\\- ]~', '', $_REQUEST['copy']);
+		$name = preg_replace('~[^A-Za-z0-9_\- ]~', '', $_REQUEST['copy']);
 
 		// Is there a theme already named like this?
 		if (file_exists(Utils::$context['themedir'] . '/' . $name)) {
@@ -1723,7 +1723,7 @@ class Themes implements ActionInterface
 		}
 
 		$name = basename($_REQUEST['theme_dir']);
-		$name = preg_replace(['/\\s/', '/\\.[\\.]+/', '/[^\\w_\\.\\-]/'], ['_', '.', ''], $name);
+		$name = preg_replace(['/\s/', '/\.[\.]+/', '/[^\w_\.\-]/'], ['_', '.', ''], $name);
 
 		// All good! set some needed vars.
 		Utils::$context['to_install'] = [
@@ -2103,7 +2103,7 @@ class Themes implements ActionInterface
 			}
 			// Custom theme based on another custom theme, lets get some info.
 			elseif (Utils::$context['to_install']['based_on'] != '') {
-				Utils::$context['to_install']['based_on'] = preg_replace('~[^A-Za-z0-9\\-_ ]~', '', Utils::$context['to_install']['based_on']);
+				Utils::$context['to_install']['based_on'] = preg_replace('~[^A-Za-z0-9\-_ ]~', '', Utils::$context['to_install']['based_on']);
 
 				// Get the theme info first.
 				$request = Db::$db->query(
@@ -2344,9 +2344,9 @@ class Themes implements ActionInterface
 					'filename' => $entry,
 					'is_writable' => is_writable($path . '/' . $entry),
 					'is_directory' => false,
-					'is_template' => preg_match('~\\.template\\.php$~', $entry) != 0,
-					'is_image' => preg_match('~\\.(jpg|jpeg|gif|bmp|png)$~', $entry) != 0,
-					'is_editable' => is_writable($path . '/' . $entry) && preg_match('~\\.(php|pl|css|js|vbs|xml|xslt|txt|xsl|html|htm|shtm|shtml|asp|aspx|cgi|py)$~', $entry) != 0,
+					'is_template' => preg_match('~\.template\.php$~', $entry) != 0,
+					'is_image' => preg_match('~\.(jpg|jpeg|gif|bmp|png)$~', $entry) != 0,
+					'is_editable' => is_writable($path . '/' . $entry) && preg_match('~\.(php|pl|css|js|vbs|xml|xslt|txt|xsl|html|htm|shtm|shtml|asp|aspx|cgi|py)$~', $entry) != 0,
 					'href' => Config::$scripturl . '?action=admin;area=theme;th=' . $_GET['th'] . ';' . Utils::$context['session_var'] . '=' . Utils::$context['session_id'] . ';sa=edit;filename=' . $relative . $entry,
 					'size' => $size,
 					'last_modified' => Time::create('@' . filemtime($path . '/' . $entry))->format(),

--- a/Sources/Actions/Admin/Warnings.php
+++ b/Sources/Actions/Admin/Warnings.php
@@ -244,7 +244,6 @@ class Warnings implements ActionInterface
 	 */
 	protected function __construct()
 	{
-
 	}
 }
 

--- a/Sources/Actions/Announce.php
+++ b/Sources/Actions/Announce.php
@@ -277,7 +277,6 @@ class Announce implements ActionInterface
 
 				Mail::send($member_email, $mail['subject'], $body, null, null, false, 5);
 			}
-
 		}
 
 		Utils::$context['percentage_done'] = round(100 * Utils::$context['start'] / Config::$modSettings['latestMember'], 1);

--- a/Sources/Actions/AttachmentUpload.php
+++ b/Sources/Actions/AttachmentUpload.php
@@ -490,7 +490,6 @@ class AttachmentUpload implements ActionInterface
 			// You don't need to know.
 			unset($attachmentOptions['tmp_name'], $attachmentOptions['destination']);
 
-
 			// Regardless of errors, pass the results.
 			$this->_attachResults[] = $attachmentOptions;
 		}

--- a/Sources/Actions/Calendar.php
+++ b/Sources/Actions/Calendar.php
@@ -1283,7 +1283,7 @@ class Calendar implements ActionInterface
 		foreach (['birthdays', 'holidays'] as $type) {
 			foreach ($calendarGrid[$type] as $date => $date_content) {
 				// Make sure to apply no offsets
-				$date_local = preg_replace('~(?<=\\s)0+(\\d)~', '$1', trim(Time::create($date)->format($date_format), " \t\n\r\0\x0B,./;:<>()[]{}\\|-_=+"));
+				$date_local = preg_replace('~(?<=\s)0+(\d)~', '$1', trim(Time::create($date)->format($date_format), " \t\n\r\0\x0B,./;:<>()[]{}\\|-_=+"));
 
 				$calendarGrid[$type][$date]['date_local'] = $date_local;
 			}

--- a/Sources/Actions/Calendar.php
+++ b/Sources/Actions/Calendar.php
@@ -1457,7 +1457,6 @@ class Calendar implements ActionInterface
 
 		Theme::addInlineJavaScript('
 		$("' . $container . '").datepair({' . $datepair_options . "\n\t});", true);
-
 	}
 
 	/**

--- a/Sources/Actions/Display.php
+++ b/Sources/Actions/Display.php
@@ -904,7 +904,6 @@ class Display implements ActionInterface
 				Utils::$context['page_index'] .= sprintf(strtr(Theme::$current->settings['page_index']['page'], ['{URL}' => Config::$scripturl . '?topic=' . Topic::$info->id . '.0;all']), '', Lang::$txt['all']);
 			}
 		}
-
 	}
 
 	/**

--- a/Sources/Actions/Feed.php
+++ b/Sources/Actions/Feed.php
@@ -544,7 +544,7 @@ class Feed implements ActionInterface
 
 		$filename[] = $this->format;
 
-		$filename = preg_replace(Utils::$context['utf8'] ? '/[^\\p{L}\\p{M}\\p{N}\\-]+/u' : '/[\\s_,.\\/\\;:\'<>?|\\[\\]{}~!@#$%^&*()=+`]+/', '_', str_replace('"', '', Utils::htmlspecialcharsDecode(strip_tags(implode('-', $filename)))));
+		$filename = preg_replace(Utils::$context['utf8'] ? '/[^\p{L}\p{M}\p{N}\-]+/u' : '/[\s_,.\/\\;:\'<>?|\[\]{}~!@#$%^&*()=+`]+/', '_', str_replace('"', '', Utils::htmlspecialcharsDecode(strip_tags(implode('-', $filename)))));
 
 		$file = [
 			'filename' => $filename . '.xml',
@@ -1007,7 +1007,7 @@ class Feed implements ActionInterface
 								[
 									'tag' => 'name',
 									'attributes' => ['label' => Lang::$txt['name']],
-									'content' => preg_replace('~&amp;#(\\d{1,7}|x[0-9a-fA-F]{1,6});~', '&#\\1;', $attachment->name),
+									'content' => preg_replace('~&amp;#(\d{1,7}|x[0-9a-fA-F]{1,6});~', '&#\1;', $attachment->name),
 								],
 								[
 									'tag' => 'downloads',
@@ -1439,7 +1439,7 @@ class Feed implements ActionInterface
 								[
 									'tag' => 'name',
 									'attributes' => ['label' => Lang::$txt['name']],
-									'content' => preg_replace('~&amp;#(\\d{1,7}|x[0-9a-fA-F]{1,6});~', '&#\\1;', $attachment->name),
+									'content' => preg_replace('~&amp;#(\d{1,7}|x[0-9a-fA-F]{1,6});~', '&#\1;', $attachment->name),
 								],
 								[
 									'tag' => 'downloads',
@@ -2188,7 +2188,7 @@ class Feed implements ActionInterface
 								[
 									'tag' => 'name',
 									'attributes' => ['label' => Lang::$txt['name']],
-									'content' => preg_replace('~&amp;#(\\d{1,7}|x[0-9a-fA-F]{1,6});~', '&#\\1;', $attachment->name),
+									'content' => preg_replace('~&amp;#(\d{1,7}|x[0-9a-fA-F]{1,6});~', '&#\1;', $attachment->name),
 								],
 								[
 									'tag' => 'downloads',
@@ -3147,7 +3147,7 @@ class Feed implements ActionInterface
 		}
 
 		$val = preg_replace_callback(
-			'~\\b' . preg_quote(Config::$scripturl, '~') . '\\?((?:board|topic)=[^#"]+)(#[^"]*)?$~',
+			'~\b' . preg_quote(Config::$scripturl, '~') . '\?((?:board|topic)=[^#"]+)(#[^"]*)?$~',
 			function ($m) {
 				return Config::$scripturl . '/' . strtr("{$m[1]}", '&;=', '//,') . '.html' . ($m[2] ?? '');
 			},

--- a/Sources/Actions/FindMember.php
+++ b/Sources/Actions/FindMember.php
@@ -80,7 +80,7 @@ class FindMember implements ActionInterface
 		}
 
 		// Allow the user to pass the input to be added to to the box.
-		Utils::$context['input_box_name'] = isset($_REQUEST['input']) && preg_match('~^[\\w-]+$~', $_REQUEST['input']) === 1 ? $_REQUEST['input'] : 'to';
+		Utils::$context['input_box_name'] = isset($_REQUEST['input']) && preg_match('~^[\w-]+$~', $_REQUEST['input']) === 1 ? $_REQUEST['input'] : 'to';
 
 		// Take the delimiter over GET in case it's \n or something.
 		Utils::$context['delimiter'] = isset($_REQUEST['delim']) ? ($_REQUEST['delim'] == 'LB' ? "\n" : $_REQUEST['delim']) : ', ';

--- a/Sources/Actions/FindMember.php
+++ b/Sources/Actions/FindMember.php
@@ -158,7 +158,6 @@ class FindMember implements ActionInterface
 	protected function __construct()
 	{
 	}
-
 }
 
 // Export public static functions and properties to global namespace for backward compatibility.

--- a/Sources/Actions/Groups.php
+++ b/Sources/Actions/Groups.php
@@ -850,9 +850,7 @@ class Groups implements ActionInterface
 			return true;
 		}
 
-
 		return false;
-
 	}
 
 	/**

--- a/Sources/Actions/HelpAdmin.php
+++ b/Sources/Actions/HelpAdmin.php
@@ -114,7 +114,7 @@ class HelpAdmin implements ActionInterface
 		}
 
 		// Does this text contain a link that we should fill in?
-		if (preg_match('~%([0-9]+\\$)?s\\?~', Utils::$context['help_text'], $match)) {
+		if (preg_match('~%([0-9]+\$)?s\?~', Utils::$context['help_text'], $match)) {
 			Utils::$context['help_text'] = sprintf(Utils::$context['help_text'], Config::$scripturl, Utils::$context['session_id'], Utils::$context['session_var']);
 		}
 

--- a/Sources/Actions/JavaScriptModify.php
+++ b/Sources/Actions/JavaScriptModify.php
@@ -194,7 +194,7 @@ class JavaScriptModify implements ActionInterface
 				'id' => $row['id_msg'],
 				'subject' => $_POST['subject'] ?? null,
 				'body' => $_POST['message'] ?? null,
-				'icon' => isset($_REQUEST['icon']) ? preg_replace('~[\\./\\\\*\':"<>]~', '', $_REQUEST['icon']) : null,
+				'icon' => isset($_REQUEST['icon']) ? preg_replace('~[\./\\\\*\':"<>]~', '', $_REQUEST['icon']) : null,
 				'modify_reason' => ($_POST['modify_reason'] ?? ''),
 				'approved' => ($row['approved'] ?? null),
 			];

--- a/Sources/Actions/Like.php
+++ b/Sources/Actions/Like.php
@@ -766,8 +766,8 @@ class Like implements ActionInterface
 
 			return;
 		}
-		// A like operation.
 
+		// A like operation.
 
 		// Not an AJAX request so send the user back to the previous
 		// location or the main page.
@@ -788,7 +788,6 @@ class Like implements ActionInterface
 			Utils::$context['sub_template'] = $this->subaction;
 			Utils::$context['data'] = $this->data;
 		}
-
 	}
 
 	/**

--- a/Sources/Actions/Like.php
+++ b/Sources/Actions/Like.php
@@ -322,7 +322,7 @@ class Like implements ActionInterface
 		}
 
 		// Zerothly, they did indicate some kind of content to like, right?
-		preg_match('~^([a-z0-9\\-\\_]{1,6})~i', $this->type, $matches);
+		preg_match('~^([a-z0-9\-\_]{1,6})~i', $this->type, $matches);
 
 		$this->type = $matches[1] ?? '';
 

--- a/Sources/Actions/Login2.php
+++ b/Sources/Actions/Login2.php
@@ -463,7 +463,6 @@ class Login2 implements ActionInterface
 
 		// Otherwise set the members data. If they correct on their first attempt then we actually clear it, otherwise we set it!
 		User::updateMemberData($id_member, ['passwd_flood' => $was_correct && $number_tries == 1 ? '' : $time_stamp . '|' . $number_tries]);
-
 	}
 
 	/******************
@@ -836,7 +835,6 @@ class Login2 implements ActionInterface
 			Utils::redirectexit('action=logout;' . Utils::$context['session_var'] . '=' . Utils::$context['session_id'], Utils::$context['server']['needs_login_fix']);
 		}
 	}
-
 }
 
 // Export public static functions and properties to global namespace for backward compatibility.

--- a/Sources/Actions/Login2.php
+++ b/Sources/Actions/Login2.php
@@ -128,19 +128,19 @@ class Login2 implements ActionInterface
 		}
 
 		// First check for 2.1 json-format cookie in $_COOKIE
-		if (isset($_COOKIE[Config::$cookiename]) && preg_match('~^{"0":\\d+,"1":"[0-9a-f]*","2":\\d+~', $_COOKIE[Config::$cookiename]) === 1) {
+		if (isset($_COOKIE[Config::$cookiename]) && preg_match('~^{"0":\d+,"1":"[0-9a-f]*","2":\d+~', $_COOKIE[Config::$cookiename]) === 1) {
 			list(, , $timeout) = Utils::jsonDecode($_COOKIE[Config::$cookiename], true);
 		}
 		// Try checking for 2.1 json-format cookie in $_SESSION
-		elseif (isset($_SESSION['login_' . Config::$cookiename]) && preg_match('~^{"0":\\d+,"1":"[0-9a-f]*","2":\\d+~', $_SESSION['login_' . Config::$cookiename]) === 1) {
+		elseif (isset($_SESSION['login_' . Config::$cookiename]) && preg_match('~^{"0":\d+,"1":"[0-9a-f]*","2":\d+~', $_SESSION['login_' . Config::$cookiename]) === 1) {
 			list(, , $timeout) = Utils::jsonDecode($_SESSION['login_' . Config::$cookiename]);
 		}
 		// Next, try checking for 2.0 serialized string cookie in $_COOKIE
-		elseif (isset($_COOKIE[Config::$cookiename]) && preg_match('~^a:[34]:\\{i:0;i:\\d+;i:1;s:(0|40):"([a-fA-F0-9]{40})?";i:2;[id]:\\d+;~', $_COOKIE[Config::$cookiename]) === 1) {
+		elseif (isset($_COOKIE[Config::$cookiename]) && preg_match('~^a:[34]:\{i:0;i:\d+;i:1;s:(0|40):"([a-fA-F0-9]{40})?";i:2;[id]:\d+;~', $_COOKIE[Config::$cookiename]) === 1) {
 			list(, , $timeout) = Utils::safeUnserialize($_COOKIE[Config::$cookiename]);
 		}
 		// Last, see if you need to fall back on checking for 2.0 serialized string cookie in $_SESSION
-		elseif (isset($_SESSION['login_' . Config::$cookiename]) && preg_match('~^a:[34]:\\{i:0;i:\\d+;i:1;s:(0|40):"([a-fA-F0-9]{40})?";i:2;[id]:\\d+;~', $_SESSION['login_' . Config::$cookiename]) === 1) {
+		elseif (isset($_SESSION['login_' . Config::$cookiename]) && preg_match('~^a:[34]:\{i:0;i:\d+;i:1;s:(0|40):"([a-fA-F0-9]{40})?";i:2;[id]:\d+;~', $_SESSION['login_' . Config::$cookiename]) === 1) {
 			list(, , $timeout) = Utils::safeUnserialize($_SESSION['login_' . Config::$cookiename]);
 		} else {
 			Lang::load('Errors');
@@ -259,7 +259,7 @@ class Login2 implements ActionInterface
 		SecurityToken::create('login');
 
 		// Set up the default/fallback stuff.
-		Utils::$context['default_username'] = isset($_POST['user']) ? preg_replace('~&amp;#(\\d{1,7}|x[0-9a-fA-F]{1,6});~', '&#\\1;', Utils::htmlspecialchars($_POST['user'])) : '';
+		Utils::$context['default_username'] = isset($_POST['user']) ? preg_replace('~&amp;#(\d{1,7}|x[0-9a-fA-F]{1,6});~', '&#$1;', Utils::htmlspecialchars($_POST['user'])) : '';
 		Utils::$context['default_password'] = '';
 		Utils::$context['never_expire'] = Config::$modSettings['cookieTime'] <= 525600;
 		Utils::$context['login_errors'] = [Lang::$txt['error_occured']];
@@ -501,7 +501,7 @@ class Login2 implements ActionInterface
 		}
 
 		// No funky symbols either.
-		if (preg_match('~[<>&"\'=\\\\]~', preg_replace('~(&#(\\d{1,7}|x[0-9a-fA-F]{1,6});)~', '', $_POST['user'])) != 0) {
+		if (preg_match('~[<>&"\'=\\\]~', preg_replace('~(&#(\d{1,7}|x[0-9a-fA-F]{1,6});)~', '', $_POST['user'])) != 0) {
 			Utils::$context['login_errors'] = [Lang::$txt['error_invalid_characters_username']];
 
 			return false;
@@ -510,7 +510,7 @@ class Login2 implements ActionInterface
 		// And if it's too long, trim it back.
 		if (Utils::entityStrlen($_POST['user']) > 80) {
 			$_POST['user'] = Utils::entitySubstr($_POST['user'], 0, 79);
-			Utils::$context['default_username'] = preg_replace('~&amp;#(\\d{1,7}|x[0-9a-fA-F]{1,6});~', '&#\\1;', Utils::htmlspecialchars($_POST['user']));
+			Utils::$context['default_username'] = preg_replace('~&amp;#(\d{1,7}|x[0-9a-fA-F]{1,6});~', '&#$1;', Utils::htmlspecialchars($_POST['user']));
 		}
 
 		return true;

--- a/Sources/Actions/MessageIndex.php
+++ b/Sources/Actions/MessageIndex.php
@@ -1109,7 +1109,6 @@ class MessageIndex implements ActionInterface
 		// Note: Utils::$context['normal_buttons'] is added for backward compatibility with 2.0, but is deprecated and should not be used
 		IntegrationHook::call('integrate_messageindex_buttons', [&Utils::$context['normal_buttons']]);
 	}
-
 }
 
 // Export public static functions to global namespace for backward compatibility.

--- a/Sources/Actions/Moderation/Logs.php
+++ b/Sources/Actions/Moderation/Logs.php
@@ -663,7 +663,7 @@ class Logs implements ActionInterface
 			}
 
 			$entries[$k]['action_text'] = preg_replace_callback(
-				'~\\{([A-Za-z\\d_]+)\\}~i',
+				'~\{([A-Za-z\d_]+)\}~i',
 				function ($matches) use ($entries, $k) {
 					return $entries[$k]['extra'][$matches[1]] ?? '';
 				},

--- a/Sources/Actions/Moderation/Logs.php
+++ b/Sources/Actions/Moderation/Logs.php
@@ -999,7 +999,6 @@ class Logs implements ActionInterface
 	 *************************/
 
 	// code...
-
 }
 
 // Export public static functions and properties to global namespace for backward compatibility.

--- a/Sources/Actions/Moderation/Warnings.php
+++ b/Sources/Actions/Moderation/Warnings.php
@@ -818,7 +818,6 @@ class Warnings implements ActionInterface
 	 *************************/
 
 	// code...
-
 }
 
 // Export public static functions and properties to global namespace for backward compatibility.

--- a/Sources/Actions/NotifyBoard.php
+++ b/Sources/Actions/NotifyBoard.php
@@ -155,7 +155,6 @@ class NotifyBoard extends Notify implements ActionInterface
 	 *************************/
 
 	// code...
-
 }
 
 // Export public static functions and properties to global namespace for backward compatibility.

--- a/Sources/Actions/NotifyTopic.php
+++ b/Sources/Actions/NotifyTopic.php
@@ -186,7 +186,6 @@ class NotifyTopic extends Notify implements ActionInterface
 	{
 		return sprintf(Lang::$txt['notify_topic' . (!empty($this->alert_pref & parent::PREF_EMAIL) ? '_subscribed' : '_unsubscribed')], $this->member_info['email']);
 	}
-
 }
 
 // Export public static functions and properties to global namespace for backward compatibility.

--- a/Sources/Actions/Post.php
+++ b/Sources/Actions/Post.php
@@ -1512,7 +1512,6 @@ class Post implements ActionInterface
 					} elseif ($type == 'attachmentPostLimit' && Utils::$context['attachments']['total_size'] > 0) {
 						Utils::$context['attachment_restrictions'][$type] .= '<span class="attach_available"> (' . sprintf(Lang::$txt['attach_available'], round(max(Config::$modSettings['attachmentPostLimit'] - (Utils::$context['attachments']['total_size'] / 1024), 0), 2)) . ')</span>';
 					}
-
 				}
 			}
 		}

--- a/Sources/Actions/Post.php
+++ b/Sources/Actions/Post.php
@@ -1002,7 +1002,7 @@ class Post implements ActionInterface
 		Utils::$context['notify'] = !empty($_REQUEST['notify']);
 		Utils::$context['use_smileys'] = !isset($_REQUEST['ns']);
 
-		Utils::$context['icon'] = isset($_REQUEST['icon']) ? preg_replace('~[\\./\\\\*\':"<>]~', '', $_REQUEST['icon']) : 'xx';
+		Utils::$context['icon'] = isset($_REQUEST['icon']) ? preg_replace('~[./\\\\*\':"<>]~', '', $_REQUEST['icon']) : 'xx';
 
 		// Set the destination action for submission.
 		Utils::$context['destination'] = 'post2;start=' . $_REQUEST['start'] . (isset($_REQUEST['msg']) ? ';msg=' . $_REQUEST['msg'] . ';' . Utils::$context['session_var'] . '=' . Utils::$context['session_id'] : '') . (isset($_REQUEST['poll']) ? ';poll' : '');
@@ -1240,15 +1240,15 @@ class Post implements ActionInterface
 
 			// But if it's in HTML world, turn them into htmlspecialchar's so they can be edited!
 			if (strpos($this->form_message, '[html]') !== false) {
-				$parts = preg_split('~(\\[/code\\]|\\[code(?:=[^\\]]+)?\\])~i', $this->form_message, -1, PREG_SPLIT_DELIM_CAPTURE);
+				$parts = preg_split('~(\[/code\]|\[code(?:=[^\]]+)?\])~i', $this->form_message, -1, PREG_SPLIT_DELIM_CAPTURE);
 
 				for ($i = 0, $n = count($parts); $i < $n; $i++) {
 					// It goes 0 = outside, 1 = begin tag, 2 = inside, 3 = close tag, repeat.
 					if ($i % 4 == 0) {
 						$parts[$i] = preg_replace_callback(
-							'~\\[html\\](.+?)\\[/html\\]~is',
+							'~\[html\](.+?)\[/html\]~is',
 							function ($m) {
-								return '[html]' . preg_replace('~<br\\s?/?' . '>~i', '&lt;br /&gt;<br>', "{$m[1]}") . '[/html]';
+								return '[html]' . preg_replace('~<br\s?/?' . '>~i', '&lt;br /&gt;<br>', "{$m[1]}") . '[/html]';
 							},
 							$parts[$i],
 						);
@@ -1262,7 +1262,7 @@ class Post implements ActionInterface
 
 			// Remove any nested quotes, if necessary.
 			if (!empty(Config::$modSettings['removeNestedQuotes'])) {
-				$this->form_message = preg_replace(['~\\n?\\[quote.*?\\].+?\\[/quote\\]\\n?~is', '~^\\n~', '~\\[/quote\\]~'], '', $this->form_message);
+				$this->form_message = preg_replace(['~\n?\[quote.*?\].+?\[/quote\]\n?~is', '~^\n~', '~\[/quote\]~'], '', $this->form_message);
 			}
 
 			// Add a quote string on the front and end.

--- a/Sources/Actions/Post2.php
+++ b/Sources/Actions/Post2.php
@@ -285,7 +285,6 @@ class Post2 extends Post
 			if (Utils::htmlTrim(strip_tags(BBCodeParser::load()->parse($_POST['message'], false), implode('', Utils::$context['allowed_html_tags']))) === '' && (!User::$me->allowedTo('bbc_html') || strpos($_POST['message'], '[html]') === false)) {
 				$this->errors[] = 'no_message';
 			}
-
 		}
 
 		if (isset($_POST['calendar']) && !isset($_REQUEST['deleteevent']) && Utils::htmlTrim($_POST['evtitle']) === '') {
@@ -1050,7 +1049,6 @@ class Post2 extends Post
 			$searchAPI->postRemoved($_REQUEST['msg']);
 		}
 	}
-
 }
 
 // Export public static functions and properties to global namespace for backward compatibility.

--- a/Sources/Actions/Post2.php
+++ b/Sources/Actions/Post2.php
@@ -465,7 +465,7 @@ class Post2 extends Post
 			'id' => empty($_REQUEST['msg']) ? 0 : (int) $_REQUEST['msg'],
 			'subject' => $_POST['subject'],
 			'body' => $_POST['message'],
-			'icon' => preg_replace('~[\\./\\\\*:"\'<>]~', '', $_POST['icon']),
+			'icon' => preg_replace('~[./\\\\*:"\'<>]~', '', $_POST['icon']),
 			'smileys_enabled' => !isset($_POST['ns']),
 			'attachments' => empty($attachIDs) ? [] : $attachIDs,
 			'approved' => $this->becomes_approved,

--- a/Sources/Actions/Profile/Delete.php
+++ b/Sources/Actions/Profile/Delete.php
@@ -96,7 +96,6 @@ class Delete implements ActionInterface
 		Utils::$context['page_title'] = Lang::$txt['deleteAccount'] . ': ' . Profile::$member->name;
 	}
 
-
 	/**
 	 * Actually deletes the account.
 	 */

--- a/Sources/Actions/Profile/Export.php
+++ b/Sources/Actions/Profile/Export.php
@@ -208,7 +208,7 @@ class Export implements ActionInterface
 
 			$dlfilename = array_merge([Utils::$context['forum_name'], Utils::$context['member']['username']], $included_desc);
 
-			$dlfilename = preg_replace('/[^\\p{L}\\p{M}\\p{N}_]+/u', '-', str_replace('"', '', Utils::htmlspecialcharsDecode(strip_tags(implode('_', $dlfilename)))));
+			$dlfilename = preg_replace('/[^\p{L}\p{M}\p{N}_]+/u', '-', str_replace('"', '', Utils::htmlspecialcharsDecode(strip_tags(implode('_', $dlfilename)))));
 
 			if (file_exists($tempfile) && file_exists($progressfile)) {
 				$done = false;
@@ -308,7 +308,7 @@ class Export implements ActionInterface
 
 			$dlfilename = array_merge([Utils::$context['forum_name'], Utils::$context['member']['username']], $included_desc);
 
-			$dlfilename = preg_replace('/[^\\p{L}\\p{M}\\p{N}_]+/u', '-', str_replace('"', '', Utils::htmlspecialcharsDecode(strip_tags(implode('_', $dlfilename)))));
+			$dlfilename = preg_replace('/[^\p{L}\p{M}\p{N}_]+/u', '-', str_replace('"', '', Utils::htmlspecialcharsDecode(strip_tags(implode('_', $dlfilename)))));
 
 			$last_page = ceil(array_sum($total) / self::$formats[$format]['per_page']);
 

--- a/Sources/Actions/Profile/ExportDownload.php
+++ b/Sources/Actions/Profile/ExportDownload.php
@@ -246,7 +246,7 @@ class ExportDownload implements ActionInterface
 		);
 
 		$dlfilename = array_merge([Utils::$context['forum_name'], Utils::$context['member']['username']], $included_desc);
-		$dlfilename = preg_replace('/[^\\p{L}\\p{M}\\p{N}_]+/u', '-', str_replace('"', '', Utils::htmlspecialcharsDecode(strip_tags(implode('_', $dlfilename)))));
+		$dlfilename = preg_replace('/[^\p{L}\p{M}\p{N}_]+/u', '-', str_replace('"', '', Utils::htmlspecialcharsDecode(strip_tags(implode('_', $dlfilename)))));
 
 		$suffix = ($this->part > 1 || file_exists($this->export_dir_slash . '2_' . $this->idhash . '.' . $this->extension)) ? '_' . $this->part : '';
 

--- a/Sources/Actions/Profile/Main.php
+++ b/Sources/Actions/Profile/Main.php
@@ -826,7 +826,6 @@ class Main implements ActionInterface
 
 		$this->profile_areas['info']['areas']['viewwarning']['enabled'] = Config::$modSettings['warning_settings'][0] == 1 && Profile::$member->warning;
 
-
 		$this->profile_areas['edit_profile']['areas']['account']['enabled'] = User::$me->is_admin || (Profile::$member->group_id != 1 && !in_array(1, Profile::$member->additional_groups));
 
 		$this->profile_areas['edit_profile']['areas']['tfasetup']['enabled'] = !empty(Config::$modSettings['tfa_mode']);
@@ -838,7 +837,6 @@ class Main implements ActionInterface
 		$this->profile_areas['edit_profile']['areas']['lists']['enabled'] = !empty(Config::$modSettings['enable_buddylist']) && User::$me->is_owner;
 
 		$this->profile_areas['edit_profile']['areas']['groupmembership']['enabled'] = !empty(Config::$modSettings['show_group_membership']) && User::$me->is_owner;
-
 
 		$this->profile_areas['profile_action']['areas']['sendpm']['enabled'] = User::$me->allowedTo('profile_view');
 

--- a/Sources/Actions/Profile/PaidSubs.php
+++ b/Sources/Actions/Profile/PaidSubs.php
@@ -339,9 +339,7 @@ class PaidSubs implements ActionInterface
 			return;
 		}
 
-
 		Utils::$context['sub_template'] = 'user_subscription';
-
 	}
 
 	/***********************

--- a/Sources/Actions/Profile/PaidSubs.php
+++ b/Sources/Actions/Profile/PaidSubs.php
@@ -235,7 +235,7 @@ class PaidSubs implements ActionInterface
 				Utils::$context['cost'] = sprintf(Config::$modSettings['paid_currency_symbol'], Utils::$context['value']);
 
 				// Recurring?
-				preg_match('~(\\d*)(\\w)~', Utils::$context['sub']['real_length'], $match);
+				preg_match('~(\d*)(\w)~', Utils::$context['sub']['real_length'], $match);
 				Utils::$context['paypal_unit'] = $match[1];
 				Utils::$context['paypal_period'] = $match[2];
 			}

--- a/Sources/Actions/Profile/Popup.php
+++ b/Sources/Actions/Profile/Popup.php
@@ -109,7 +109,6 @@ class Popup implements ActionInterface
 		],
 	];
 
-
 	/****************************
 	 * Internal static properties
 	 ****************************/

--- a/Sources/Actions/QuoteFast.php
+++ b/Sources/Actions/QuoteFast.php
@@ -125,7 +125,7 @@ class QuoteFast implements ActionInterface
 
 			// Remove any nested quotes.
 			if (!empty(Config::$modSettings['removeNestedQuotes'])) {
-				$row['body'] = preg_replace(['~\\n?\\[quote.*?\\].+?\\[/quote\\]\\n?~is', '~^\\n~', '~\\[/quote\\]~'], '', $row['body']);
+				$row['body'] = preg_replace(['~\n?\[quote.*?\].+?\[/quote\]\n?~is', '~^\n~', '~\[/quote\]~'], '', $row['body']);
 			}
 
 			$lb = "\n";

--- a/Sources/Actions/Recent.php
+++ b/Sources/Actions/Recent.php
@@ -111,7 +111,6 @@ class Recent implements ActionInterface
 		'any' => [],
 	];
 
-
 	/****************************
 	 * Internal static properties
 	 ****************************/

--- a/Sources/Actions/Register2.php
+++ b/Sources/Actions/Register2.php
@@ -923,7 +923,6 @@ class Register2 extends Register
 	 */
 	protected function __construct()
 	{
-
 	}
 }
 

--- a/Sources/Actions/Register2.php
+++ b/Sources/Actions/Register2.php
@@ -363,7 +363,7 @@ class Register2 extends Register
 				if ($row['field_type'] == 'text' && !empty($row['mask']) && $row['mask'] != 'none') {
 					if ($row['mask'] == 'email' && (!filter_var($value, FILTER_VALIDATE_EMAIL) || strlen($value) > 255)) {
 						$custom_field_errors[] = ['custom_field_invalid_email', [$row['field_name']]];
-					} elseif ($row['mask'] == 'number' && preg_match('~[^\\d]~', $value)) {
+					} elseif ($row['mask'] == 'number' && preg_match('~[^\d]~', $value)) {
 						$custom_field_errors[] = ['custom_field_not_number', [$row['field_name']]];
 					} elseif (substr($row['mask'], 0, 5) == 'regex' && trim($value) != '' && preg_match(substr($row['mask'], 5), $value) === 0) {
 						$custom_field_errors[] = ['custom_field_inproper_format', [$row['field_name']]];

--- a/Sources/Actions/Search2.php
+++ b/Sources/Actions/Search2.php
@@ -456,7 +456,7 @@ class Search2 implements ActionInterface
 				}
 
 				// Don't check phrases.
-				if (preg_match('~^\\w+$~', $word) === 0) {
+				if (preg_match('~^\w+$~', $word) === 0) {
 					$did_you_mean['search'][] = '"' . $word . '"';
 					$did_you_mean['display'][] = '&quot;' . Utils::htmlspecialchars($word) . '&quot;';
 
@@ -464,7 +464,7 @@ class Search2 implements ActionInterface
 				}
 
 				// For some strange reason spell check can crash PHP on decimals.
-				if (preg_match('~\\d~', $word) === 1) {
+				if (preg_match('~\d~', $word) === 1) {
 					$did_you_mean['search'][] = $word;
 					$did_you_mean['display'][] = Utils::htmlspecialchars($word);
 
@@ -509,7 +509,7 @@ class Search2 implements ActionInterface
 				$temp_excluded = ['search' => [], 'display' => []];
 
 				foreach (SearchApi::$loadedApi->excludedWords as $word) {
-					if (preg_match('~^\\w+$~', $word) == 0) {
+					if (preg_match('~^\w+$~', $word) == 0) {
 						$temp_excluded['search'][] = '-"' . $word . '"';
 						$temp_excluded['display'][] = '-&quot;' . Utils::htmlspecialchars($word) . '&quot;';
 					} else {

--- a/Sources/Actions/SendActivation.php
+++ b/Sources/Actions/SendActivation.php
@@ -108,7 +108,6 @@ class SendActivation implements ActionInterface
 	 */
 	protected function __construct()
 	{
-
 	}
 }
 

--- a/Sources/Actions/TopicMove.php
+++ b/Sources/Actions/TopicMove.php
@@ -161,7 +161,6 @@ class TopicMove implements ActionInterface
 
 		// Register this form and get a sequence number in Utils::$context.
 		Security::checkSubmitOnce('register');
-
 	}
 
 	/***********************

--- a/Sources/Actions/TopicMove2.php
+++ b/Sources/Actions/TopicMove2.php
@@ -368,7 +368,6 @@ class TopicMove2 implements ActionInterface
 			return true;
 		}
 
-
 		$request = Db::$db->query(
 			'',
 			'SELECT m.subject, b.name
@@ -389,7 +388,6 @@ class TopicMove2 implements ActionInterface
 		$topic_link = '<a href="' . Config::$scripturl . '?topic=' . Topic::$topic_id . '.0">' . $topic_subject . '</a>';
 
 		ErrorHandler::fatalLang('topic_already_moved', false, [$topic_link, $board_link]);
-
 	}
 
 	/******************

--- a/Sources/Actions/TopicRemove.php
+++ b/Sources/Actions/TopicRemove.php
@@ -279,7 +279,6 @@ class TopicRemove implements ActionInterface
 	/*************************
 	 * Internal static methods
 	 *************************/
-
 }
 
 // Export public static functions and properties to global namespace for backward compatibility.

--- a/Sources/Actions/TopicRestore.php
+++ b/Sources/Actions/TopicRestore.php
@@ -593,7 +593,6 @@ class TopicRestore implements ActionInterface
 
 		Msg::updateLastMessages([$from_board, $target_board]);
 	}
-
 }
 
 // Export public static functions and properties to global namespace for backward compatibility.

--- a/Sources/Actions/UnreadReplies.php
+++ b/Sources/Actions/UnreadReplies.php
@@ -395,7 +395,6 @@ class UnreadReplies extends Unread
 			],
 		);
 	}
-
 }
 
 ?>

--- a/Sources/Actions/VerificationCode.php
+++ b/Sources/Actions/VerificationCode.php
@@ -167,7 +167,6 @@ class VerificationCode implements ActionInterface
 		$this->verification_id = $_GET['vid'] ?? '';
 
 		$this->code = $this->verification_id && isset($_SESSION[$this->verification_id . '_vv']) ? $_SESSION[$this->verification_id . '_vv']['code'] : ($_SESSION['visual_verification_code'] ?? '');
-
 	}
 
 	/**

--- a/Sources/Actions/VerificationCode.php
+++ b/Sources/Actions/VerificationCode.php
@@ -269,11 +269,11 @@ class VerificationCode implements ActionInterface
 		$font_dir = dir(Theme::$current->settings['default_theme_dir'] . '/fonts');
 
 		while ($entry = $font_dir->read()) {
-			if (preg_match('~^(.+)\\.gdf$~', $entry, $matches) === 1) {
+			if (preg_match('~^(.+)\.gdf$~', $entry, $matches) === 1) {
 				if ($endian ^ (strpos($entry, '_end.gdf') === false)) {
 					$font_list[] = $entry;
 				}
-			} elseif (preg_match('~^(.+)\\.ttf$~', $entry, $matches) === 1) {
+			} elseif (preg_match('~^(.+)\.ttf$~', $entry, $matches) === 1) {
 				$ttfont_list[] = $entry;
 			}
 		}

--- a/Sources/Actions/ViewQuery.php
+++ b/Sources/Actions/ViewQuery.php
@@ -120,7 +120,7 @@ class ViewQuery implements ActionInterface
 			$min_indent = 0;
 
 			foreach ($query as $line) {
-				preg_match('/^(\\t*)/', $line, $temp);
+				preg_match('/^(\t*)/', $line, $temp);
 
 				if (strlen($temp[0]) < $min_indent || $min_indent == 0) {
 					$min_indent = strlen($temp[0]);
@@ -142,7 +142,7 @@ class ViewQuery implements ActionInterface
 
 			if ($is_select_query) {
 				$select = $query_data['q'];
-			} elseif (preg_match('~^INSERT(?: IGNORE)? INTO \\w+(?:\\s+\\([^)]+\\))?\\s+(SELECT .+)$~s', trim($query_data['q']), $matches) != 0) {
+			} elseif (preg_match('~^INSERT(?: IGNORE)? INTO \w+(?:\s+\([^)]+\))?\s+(SELECT .+)$~s', trim($query_data['q']), $matches) != 0) {
 				$is_select_query = true;
 				$select = $matches[1];
 			} elseif (preg_match('~^CREATE TEMPORARY TABLE .+?(SELECT .+)$~s', trim($query_data['q']), $matches) != 0) {

--- a/Sources/Actions/Who.php
+++ b/Sources/Actions/Who.php
@@ -674,9 +674,7 @@ class Who implements ActionInterface
 			return $data[0] ?? false;
 		}
 
-
 		return $data;
-
 	}
 
 	/******************

--- a/Sources/Alert.php
+++ b/Sources/Alert.php
@@ -333,7 +333,7 @@ class Alert implements \ArrayAccess
 					$separator = $item == 'msg' ? '=?' : '=';
 
 					if (isset($this->extra['content_link']) && strpos($this->extra['content_link'], $item . $separator) !== false && strpos($this->extra['content_link'], $item . $separator . $data['id_' . $item]) === false) {
-						$patterns[] = '/\\b' . $item . $separator . '\\d+/';
+						$patterns[] = '/\b' . $item . $separator . '\d+/';
 						$replacements[] = $item . $separator . $data['id_' . $item];
 					}
 

--- a/Sources/Attachment.php
+++ b/Sources/Attachment.php
@@ -1679,7 +1679,7 @@ class Attachment implements \ArrayAccess
 				'approve_attach',
 				[
 					'message' => $row['id_msg'],
-					'filename' => preg_replace('~&amp;#(\\d{1,7}|x[0-9a-fA-F]{1,6});~', '&#\\1;', Utils::htmlspecialchars($row['filename'])),
+					'filename' => preg_replace('~&amp;#(\d{1,7}|x[0-9a-fA-F]{1,6});~', '&#$1;', Utils::htmlspecialchars($row['filename'])),
 				],
 			);
 		}
@@ -1842,7 +1842,7 @@ class Attachment implements \ArrayAccess
 					'remove_attach',
 					[
 						'message' => $row['id_msg'],
-						'filename' => preg_replace('~&amp;#(\\d{1,7}|x[0-9a-fA-F]{1,6});~', '&#\\1;', Utils::htmlspecialchars($row['filename'])),
+						'filename' => preg_replace('~&amp;#(\d{1,7}|x[0-9a-fA-F]{1,6});~', '&#$1;', Utils::htmlspecialchars($row['filename'])),
 					],
 				);
 			}
@@ -2450,7 +2450,7 @@ class Attachment implements \ArrayAccess
 				* while in linux should be safe to explode only for / (aka DIRECTORY_SEPARATOR)
 		*/
 		if (DIRECTORY_SEPARATOR === '\\') {
-			$tree = preg_split('#[\\\\/]#', $directory);
+			$tree = preg_split('#[\\\/]#', $directory);
 		} else {
 			if (substr($directory, 0, 1) != DIRECTORY_SEPARATOR) {
 				return false;

--- a/Sources/Attachment.php
+++ b/Sources/Attachment.php
@@ -929,9 +929,7 @@ class Attachment implements \ArrayAccess
 			return true;
 		}
 
-
 		return false;
-
 	}
 
 	/**
@@ -1978,9 +1976,7 @@ class Attachment implements \ArrayAccess
 			return 'attachments_no_data_loaded';
 		}
 
-
 		$attachContext = $attachLoaded[$attachID];
-
 
 		// It's theoretically possible that prepareByMsg() changed the board id, so check again.
 		if ($check_board_perms && !in_array($attachContext['board'], $view_attachment_boards)) {
@@ -2531,7 +2527,6 @@ class Attachment implements \ArrayAccess
 		}
 		Db::$db->free_result($request);
 	}
-
 }
 
 // Export public static functions and properties to global namespace for backward compatibility.

--- a/Sources/BBCodeParser.php
+++ b/Sources/BBCodeParser.php
@@ -300,7 +300,7 @@ class BBCodeParser
 		[
 			'tag' => 'anchor',
 			'type' => 'unparsed_equals',
-			'test' => '[#]?([A-Za-z][A-Za-z0-9_\\-]*)\\]',
+			'test' => '[#]?([A-Za-z][A-Za-z0-9_\-]*)\]',
 			'before' => '<span id="post_$1">',
 			'after' => '</span>',
 		],
@@ -308,10 +308,10 @@ class BBCodeParser
 			'tag' => 'attach',
 			'type' => 'unparsed_content',
 			'parameters' => [
-				'id' => ['match' => '(\\d+)'],
+				'id' => ['match' => '(\d+)'],
 				'alt' => ['optional' => true],
-				'width' => ['optional' => true, 'match' => '(\\d+)'],
-				'height' => ['optional' => true, 'match' => '(\\d+)'],
+				'width' => ['optional' => true, 'match' => '(\d+)'],
+				'height' => ['optional' => true, 'match' => '(\d+)'],
 				'display' => ['optional' => true, 'match' => '(link|embed)'],
 			],
 			'content' => '$1',
@@ -328,7 +328,7 @@ class BBCodeParser
 			'type' => 'unparsed_equals',
 			'before' => '<bdo dir="$1">',
 			'after' => '</bdo>',
-			'test' => '(rtl|ltr)\\]',
+			'test' => '(rtl|ltr)\]',
 			'block_level' => true,
 		],
 		// Legacy (alias of [color=black])
@@ -371,7 +371,7 @@ class BBCodeParser
 		[
 			'tag' => 'color',
 			'type' => 'unparsed_equals',
-			'test' => '(#[\\da-fA-F]{3}|#[\\da-fA-F]{6}|[A-Za-z]{1,20}|rgb\\((?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\s?,\\s?){2}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\))\\]',
+			'test' => '(#[\da-fA-F]{3}|#[\da-fA-F]{6}|[A-Za-z]{1,20}|rgb\((?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\s?,\s?){2}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\))\]',
 			'before' => '<span style="color: $1;" class="bbc_color">',
 			'after' => '</span>',
 		],
@@ -393,14 +393,14 @@ class BBCodeParser
 		[
 			'tag' => 'flash',
 			'type' => 'unparsed_commas_content',
-			'test' => '\\d+,\\d+\\]',
+			'test' => '\d+,\d+\]',
 			'content' => '<a href="$1" target="_blank" rel="noopener">$1</a>',
 			'validate' => __CLASS__ . '::flashValidate',
 		],
 		[
 			'tag' => 'float',
 			'type' => 'unparsed_equals',
-			'test' => '(left|right)(\\s+max=\\d+(?:%|px|em|rem|ex|pt|pc|ch|vw|vh|vmin|vmax|cm|mm|in)?)?\\]',
+			'test' => '(left|right)(\s+max=\d+(?:%|px|em|rem|ex|pt|pc|ch|vw|vh|vmin|vmax|cm|mm|in)?)?\]',
 			'before' => '<div $1>',
 			'after' => '</div>',
 			'validate' => __CLASS__ . '::floatValidate',
@@ -427,7 +427,7 @@ class BBCodeParser
 		[
 			'tag' => 'font',
 			'type' => 'unparsed_equals',
-			'test' => '[A-Za-z0-9_,\\-\\s]+?\\]',
+			'test' => '[A-Za-z0-9_,\-\s]+?\]',
 			'before' => '<span style="font-family: $1;" class="bbc_font">',
 			'after' => '</span>',
 		],
@@ -435,7 +435,7 @@ class BBCodeParser
 		[
 			'tag' => 'glow',
 			'type' => 'unparsed_commas',
-			'test' => '[#0-9a-zA-Z\\-]{3,12},([012]\\d{1,2}|\\d{1,2})(,[^]]+)?\\]',
+			'test' => '[#0-9a-zA-Z\-]{3,12},([012]\d{1,2}|\d{1,2})(,[^]]+)?\]',
 			'before' => '<span style="text-shadow: $1 1px 1px 1px">',
 			'after' => '</span>',
 		],
@@ -469,8 +469,8 @@ class BBCodeParser
 			'parameters' => [
 				'alt' => ['optional' => true],
 				'title' => ['optional' => true],
-				'width' => ['optional' => true, 'value' => ' width="$1"', 'match' => '(\\d+)'],
-				'height' => ['optional' => true, 'value' => ' height="$1"', 'match' => '(\\d+)'],
+				'width' => ['optional' => true, 'value' => ' width="$1"', 'match' => '(\d+)'],
+				'height' => ['optional' => true, 'value' => ' height="$1"', 'match' => '(\d+)'],
 			],
 			'content' => '$1',
 			'validate' => __CLASS__ . '::imgValidate',
@@ -613,8 +613,8 @@ class BBCodeParser
 			'tag' => 'quote',
 			'parameters' => [
 				'author' => ['match' => '([^<>]{1,192}?)'],
-				'link' => ['match' => '(?:board=\\d+;)?((?:topic|threadid)=[\\dmsg#\\./]{1,40}(?:;start=[\\dmsg#\\./]{1,40})?|msg=\\d+?|action=profile;u=\\d+)'],
-				'date' => ['match' => '(\\d+)', 'validate' => 'timeformat'],
+				'link' => ['match' => '(?:board=\d+;)?((?:topic|threadid)=[\dmsg#\./]{1,40}(?:;start=[\dmsg#\./]{1,40})?|msg=\d+?|action=profile;u=\d+)'],
+				'date' => ['match' => '(\d+)', 'validate' => 'timeformat'],
 			],
 			'before' => '<blockquote><cite><a href="{scripturl}?{link}">{txt_quote_from}: {author} {txt_search_on} {date}</a></cite>',
 			'after' => '</blockquote>',
@@ -658,7 +658,7 @@ class BBCodeParser
 		[
 			'tag' => 'shadow',
 			'type' => 'unparsed_commas',
-			'test' => '[#0-9a-zA-Z\\-]{3,12},(left|right|top|bottom|[0123]\\d{0,2})\\]',
+			'test' => '[#0-9a-zA-Z\-]{3,12},(left|right|top|bottom|[0123]\d{0,2})\]',
 			'before' => '<span style="text-shadow: $1 $2">',
 			'after' => '</span>',
 			'validate' => __CLASS__ . '::shadowValidate',
@@ -666,14 +666,14 @@ class BBCodeParser
 		[
 			'tag' => 'size',
 			'type' => 'unparsed_equals',
-			'test' => '([1-9][\\d]?p[xt]|small(?:er)?|large[r]?|x[x]?-(?:small|large)|medium|(0\\.[1-9]|[1-9](\\.[\\d][\\d]?)?)?em)\\]',
+			'test' => '([1-9][\d]?p[xt]|small(?:er)?|large[r]?|x[x]?-(?:small|large)|medium|(0\.[1-9]|[1-9](\.[\d][\d]?)?)?em)\]',
 			'before' => '<span style="font-size: $1;" class="bbc_size">',
 			'after' => '</span>',
 		],
 		[
 			'tag' => 'size',
 			'type' => 'unparsed_equals',
-			'test' => '[1-7]\\]',
+			'test' => '[1-7]\]',
 			'before' => '<span style="font-size: $1;" class="bbc_size">',
 			'after' => '</span>',
 			'validate' => __CLASS__ . '::sizeValidate',
@@ -814,13 +814,13 @@ class BBCodeParser
 	 * Regular expression character class to match all characters allowed to
 	 * appear in a domain name.
 	 */
-	public static $domain_label_chars = '0-9A-Za-z\\-' . '\\x{A0}-\\x{D7FF}' .
-		'\\x{F900}-\\x{FDCF}' . '\\x{FDF0}-\\x{FFEF}' . '\\x{10000}-\\x{1FFFD}' .
-		'\\x{20000}-\\x{2FFFD}' . '\\x{30000}-\\x{3FFFD}' . '\\x{40000}-\\x{4FFFD}' .
-		'\\x{50000}-\\x{5FFFD}' . '\\x{60000}-\\x{6FFFD}' . '\\x{70000}-\\x{7FFFD}' .
-		'\\x{80000}-\\x{8FFFD}' . '\\x{90000}-\\x{9FFFD}' . '\\x{A0000}-\\x{AFFFD}' .
-		'\\x{B0000}-\\x{BFFFD}' . '\\x{C0000}-\\x{CFFFD}' . '\\x{D0000}-\\x{DFFFD}' .
-		'\\x{E1000}-\\x{EFFFD}';
+	public static $domain_label_chars = '0-9A-Za-z\-' . '\x{A0}-\x{D7FF}' .
+		'\x{F900}-\x{FDCF}' . '\x{FDF0}-\x{FFEF}' . '\x{10000}-\x{1FFFD}' .
+		'\x{20000}-\x{2FFFD}' . '\x{30000}-\x{3FFFD}' . '\x{40000}-\x{4FFFD}' .
+		'\x{50000}-\x{5FFFD}' . '\x{60000}-\x{6FFFD}' . '\x{70000}-\x{7FFFD}' .
+		'\x{80000}-\x{8FFFD}' . '\x{90000}-\x{9FFFD}' . '\x{A0000}-\x{AFFFD}' .
+		'\x{B0000}-\x{BFFFD}' . '\x{C0000}-\x{CFFFD}' . '\x{D0000}-\x{DFFFD}' .
+		'\x{E1000}-\x{EFFFD}';
 
 	/**
 	 * @var array
@@ -1113,7 +1113,7 @@ class BBCodeParser
 		$this->autolink_enabled = !empty(Config::$modSettings['autoLinkUrls']);
 
 		if (!$this->utf8) {
-			self::$domain_label_chars = '0-9A-Za-z\\-';
+			self::$domain_label_chars = '0-9A-Za-z\-';
 		}
 
 		// In case a mod wants to control behaviour for a special URI scheme.
@@ -1302,7 +1302,7 @@ class BBCodeParser
 			}
 
 			// The non-breaking-space is a complex thing...
-			$non_breaking_space = $this->utf8 ? '\\x{A0}' : '\\xA0';
+			$non_breaking_space = $this->utf8 ? '\x{A0}' : '\xA0';
 
 			// This smiley regex makes sure it doesn't parse smileys within code tags (so [url=mailto:David@bla.com] doesn't parse the :D smiley)
 			$this->smiley_preg_replacements = [];
@@ -1323,7 +1323,7 @@ class BBCodeParser
 					$search_parts[] = $special_chars;
 
 					// Some 2.0 hex htmlchars are in there as 3 digits; allow for finding leading 0 or not
-					$special_chars2 = preg_replace('/&#(\\d{2});/', '&#0$1;', $special_chars);
+					$special_chars2 = preg_replace('/&#(\d{2});/', '&#0$1;', $special_chars);
 
 					if ($special_chars2 != $special_chars) {
 						$this->smiley_preg_replacements[$special_chars2] = $smiley_code;
@@ -1332,7 +1332,7 @@ class BBCodeParser
 				}
 			}
 
-			$this->smiley_preg_search = '~(?<=[>:\\?\\.\\s' . $non_breaking_space . '[\\]()*\\\\;]|(?<![a-zA-Z0-9])\\(|^)(' . Utils::buildRegex($search_parts, '~') . ')(?=[^[:alpha:]0-9]|$)~' . ($this->utf8 ? 'u' : '');
+			$this->smiley_preg_search = '~(?<=[>:\?\.\s' . $non_breaking_space . '[\]()*\\\;]|(?<![a-zA-Z0-9])\(|^)(' . Utils::buildRegex($search_parts, '~') . ')(?=[^[:alpha:]0-9]|$)~' . ($this->utf8 ? 'u' : '');
 		}
 
 		// If there are no smileys defined, no need to replace anything
@@ -1361,24 +1361,24 @@ class BBCodeParser
 	public function unparse(string $string): string
 	{
 		// Replace newlines with spaces, as that's how browsers usually interpret them.
-		$string = preg_replace("~\\s*[\r\n]+\\s*~", ' ', $string);
+		$string = preg_replace('~\s*[\r\n]+\s*~', ' ', $string);
 
 		// Though some of us love paragraphs, the parser will do better with breaks.
-		$string = preg_replace('~</p>\\s*?<p~i', '</p><br><p', $string);
-		$string = preg_replace('~</p>\\s*(?!<)~i', '</p><br>', $string);
+		$string = preg_replace('~</p>\s*?<p~i', '</p><br><p', $string);
+		$string = preg_replace('~</p>\s*(?!<)~i', '</p><br>', $string);
 
 		// Safari/webkit wraps lines in Wysiwyg in <div>'s.
 		if (BrowserDetector::isBrowser('webkit')) {
-			$string = preg_replace(['~<div(?:\\s(?:[^<>]*?))?' . '>~i', '</div>'], ['<br>', ''], $string);
+			$string = preg_replace(['~<div(?:\s(?:[^<>]*?))?' . '>~i', '</div>'], ['<br>', ''], $string);
 		}
 
 		// If there's a trailing break get rid of it - Firefox tends to add one.
-		$string = preg_replace('~<br\\s?/?' . '>$~i', '', $string);
+		$string = preg_replace('~<br\s?/?' . '>$~i', '', $string);
 
 		// Remove any formatting within code tags.
 		if (strpos($string, '[code') !== false) {
-			$string = preg_replace('~<br\\s?/?' . '>~i', '#smf_br_spec_grudge_cool!#', $string);
-			$parts = preg_split('~(\\[/code\\]|\\[code(?:=[^\\]]+)?\\])~i', $string, -1, PREG_SPLIT_DELIM_CAPTURE);
+			$string = preg_replace('~<br\s?/?' . '>~i', '#smf_br_spec_grudge_cool!#', $string);
+			$parts = preg_split('~(\[/code\]|\[code(?:=[^\]]+)?\])~i', $string, -1, PREG_SPLIT_DELIM_CAPTURE);
 
 			// Only mess with stuff outside [code] tags.
 			for ($i = 0, $n = count($parts); $i < $n; $i++) {
@@ -1398,7 +1398,7 @@ class BBCodeParser
 		$string = preg_replace('~\\<\\!\\[CDATA\\[.*?\\]\\]\\>~i', '', $string);
 
 		// Do the smileys ultra first!
-		preg_match_all('~<img\\b[^>]+alt="([^"]+)"[^>]+class="smiley"[^>]*>(?:\\s)?~i', $string, $matches);
+		preg_match_all('~<img\b[^>]+alt="([^"]+)"[^>]+class="smiley"[^>]*>(?:\s)?~i', $string, $matches);
 
 		if (!empty($matches[0])) {
 			// Get all our smiley codes
@@ -1434,13 +1434,13 @@ class BBCodeParser
 			@apache_reset_timeout();
 		}
 
-		$parts = preg_split('~(<[A-Za-z]+\\s*[^<>]*?style="?[^<>"]+"?[^<>]*?(?:/?)>|</[A-Za-z]+>)~', $string, -1, PREG_SPLIT_DELIM_CAPTURE);
+		$parts = preg_split('~(<[A-Za-z]+\s*[^<>]*?style="?[^<>"]+"?[^<>]*?(?:/?)>|</[A-Za-z]+>)~', $string, -1, PREG_SPLIT_DELIM_CAPTURE);
 		$replacement = '';
 		$stack = [];
 
 		foreach ($parts as $part) {
 			// Opening tag.
-			if (preg_match('~(<([A-Za-z]+)\\s*[^<>]*?)style="?([^<>"]+)"?([^<>]*?(/?)>)~', $part, $matches) === 1) {
+			if (preg_match('~(<([A-Za-z]+)\s*[^<>]*?)style="?([^<>"]+)"?([^<>]*?(/?)>)~', $part, $matches) === 1) {
 				// If it's being closed instantly, we can't deal with it...yet.
 				if ($matches[5] === '/') {
 					continue;
@@ -1513,7 +1513,7 @@ class BBCodeParser
 
 						case 'font-size':
 							// Sometimes people put decimals where decimals should not be.
-							if (preg_match('~(\\d)+\\.\\d+(p[xt])~i', $style_value, $dec_matches) === 1) {
+							if (preg_match('~(\d)+\.\d+(p[xt])~i', $style_value, $dec_matches) === 1) {
 								$style_value = $dec_matches[1] . $dec_matches[2];
 							}
 
@@ -1534,7 +1534,7 @@ class BBCodeParser
 							// This is a hack for images with dimensions embedded.
 						case 'width':
 						case 'height':
-							if (preg_match('~[1-9]\\d*~i', $style_value, $dimension) === 1) {
+							if (preg_match('~[1-9]\d*~i', $style_value, $dimension) === 1) {
 								$extra_attr .= ' ' . $style_type . '="' . $dimension[0] . '"';
 							}
 							break;
@@ -1593,7 +1593,7 @@ class BBCodeParser
 		}
 
 		// Let's pull out any legacy alignments.
-		while (preg_match('~<([A-Za-z]+)\\s+[^<>]*?(align="*(left|center|right)"*)[^<>]*?(/?)>~i', $string, $matches) === 1) {
+		while (preg_match('~<([A-Za-z]+)\s+[^<>]*?(align="*(left|center|right)"*)[^<>]*?(/?)>~i', $string, $matches) === 1) {
 			// Find the position in the text of this tag over again.
 			$start_pos = strpos($string, $matches[0]);
 
@@ -1619,7 +1619,7 @@ class BBCodeParser
 		}
 
 		// Let's do some special stuff for fonts - cause we all love fonts.
-		while (preg_match('~<font\\s+([^<>]*)>~i', $string, $matches) === 1) {
+		while (preg_match('~<font\s+([^<>]*)>~i', $string, $matches) === 1) {
 			// Find the position of this again.
 			$start_pos = strpos($string, $matches[0]);
 			$end_pos = false;
@@ -1842,7 +1842,7 @@ class BBCodeParser
 								$parts[$i + 3] = '';
 							} else {
 								// Remove the trailing breaks from the list item.
-								$parts[$i] = preg_replace('~\\s*<br\\s*' . '/?' . '>\\s*$~', '', $parts[$i]);
+								$parts[$i] = preg_replace('~\s*<br\s*' . '/?' . '>\s*$~', '', $parts[$i]);
 								$parts[$i + 1] = '';
 								$parts[$i + 2] = '[/li]' . "\n";
 								$parts[$i + 3] = '';
@@ -1855,7 +1855,7 @@ class BBCodeParser
 				}
 
 				// If we're in the [list] space, no content is allowed.
-				if ($inList && trim(preg_replace('~\\s*<br\\s*' . '/?' . '>\\s*~', '', $parts[$i + 4])) !== '') {
+				if ($inList && trim(preg_replace('~\s*<br\s*' . '/?' . '>\s*~', '', $parts[$i + 4])) !== '') {
 					// Fix it by injecting an extra list item.
 					array_splice($parts, $i + 4, 0, [
 						'', // No content.
@@ -1881,7 +1881,7 @@ class BBCodeParser
 		}
 
 		// I love my own image...
-		while (preg_match('~<img\\s+([^<>]*)/*>~i', $string, $matches) === 1) {
+		while (preg_match('~<img\s+([^<>]*)/*>~i', $string, $matches) === 1) {
 			// Find the position of the image.
 			$start_pos = strpos($string, $matches[0]);
 
@@ -1918,7 +1918,7 @@ class BBCodeParser
 					if (substr($src, 0, 1) === '/') {
 						$src = $base_url . $src;
 					} else {
-						$src = $base_url . (empty($src->path) ? '/' : preg_replace('~/(?:index\\.php)?$~', '', $src->path)) . '/' . $src;
+						$src = $base_url . (empty($src->path) ? '/' : preg_replace('~/(?:index\.php)?$~', '', $src->path)) . '/' . $src;
 					}
 				}
 
@@ -1931,124 +1931,124 @@ class BBCodeParser
 
 		// The final bits are the easy ones - tags which map to tags which map to tags - etc etc.
 		$tags = [
-			'~<b(\\s(.)*?)*?' . '>~i' => function () {
+			'~<b(\s(.)*?)*?' . '>~i' => function () {
 				return '[b]';
 			},
 			'~</b>~i' => function () {
 				return '[/b]';
 			},
-			'~<i(\\s(.)*?)*?' . '>~i' => function () {
+			'~<i(\s(.)*?)*?' . '>~i' => function () {
 				return '[i]';
 			},
 			'~</i>~i' => function () {
 				return '[/i]';
 			},
-			'~<u(\\s(.)*?)*?' . '>~i' => function () {
+			'~<u(\s(.)*?)*?' . '>~i' => function () {
 				return '[u]';
 			},
 			'~</u>~i' => function () {
 				return '[/u]';
 			},
-			'~<strong(\\s(.)*?)*?' . '>~i' => function () {
+			'~<strong(\s(.)*?)*?' . '>~i' => function () {
 				return '[b]';
 			},
 			'~</strong>~i' => function () {
 				return '[/b]';
 			},
-			'~<em(\\s(.)*?)*?' . '>~i' => function () {
+			'~<em(\s(.)*?)*?' . '>~i' => function () {
 				return '[i]';
 			},
 			'~</em>~i' => function () {
 				return '[i]';
 			},
-			'~<s(\\s(.)*?)*?' . '>~i' => function () {
+			'~<s(\s(.)*?)*?' . '>~i' => function () {
 				return '[s]';
 			},
 			'~</s>~i' => function () {
 				return '[/s]';
 			},
-			'~<strike(\\s(.)*?)*?' . '>~i' => function () {
+			'~<strike(\s(.)*?)*?' . '>~i' => function () {
 				return '[s]';
 			},
 			'~</strike>~i' => function () {
 				return '[/s]';
 			},
-			'~<del(\\s(.)*?)*?' . '>~i' => function () {
+			'~<del(\s(.)*?)*?' . '>~i' => function () {
 				return '[s]';
 			},
 			'~</del>~i' => function () {
 				return '[/s]';
 			},
-			'~<center(\\s(.)*?)*?' . '>~i' => function () {
+			'~<center(\s(.)*?)*?' . '>~i' => function () {
 				return '[center]';
 			},
 			'~</center>~i' => function () {
 				return '[/center]';
 			},
-			'~<pre(\\s(.)*?)*?' . '>~i' => function () {
+			'~<pre(\s(.)*?)*?' . '>~i' => function () {
 				return '[pre]';
 			},
 			'~</pre>~i' => function () {
 				return '[/pre]';
 			},
-			'~<sub(\\s(.)*?)*?' . '>~i' => function () {
+			'~<sub(\s(.)*?)*?' . '>~i' => function () {
 				return '[sub]';
 			},
 			'~</sub>~i' => function () {
 				return '[/sub]';
 			},
-			'~<sup(\\s(.)*?)*?' . '>~i' => function () {
+			'~<sup(\s(.)*?)*?' . '>~i' => function () {
 				return '[sup]';
 			},
 			'~</sup>~i' => function () {
 				return '[/sup]';
 			},
-			'~<tt(\\s(.)*?)*?' . '>~i' => function () {
+			'~<tt(\s(.)*?)*?' . '>~i' => function () {
 				return '[tt]';
 			},
 			'~</tt>~i' => function () {
 				return '[/tt]';
 			},
-			'~<table(\\s(.)*?)*?' . '>~i' => function () {
+			'~<table(\s(.)*?)*?' . '>~i' => function () {
 				return '[table]';
 			},
 			'~</table>~i' => function () {
 				return '[/table]';
 			},
-			'~<tr(\\s(.)*?)*?' . '>~i' => function () {
+			'~<tr(\s(.)*?)*?' . '>~i' => function () {
 				return '[tr]';
 			},
 			'~</tr>~i' => function () {
 				return '[/tr]';
 			},
-			'~<(td|th)\\s[^<>]*?colspan="?(\\d{1,2})"?.*?' . '>~i' => function ($matches) {
+			'~<(td|th)\s[^<>]*?colspan="?(\d{1,2})"?.*?' . '>~i' => function ($matches) {
 				return str_repeat('[td][/td]', $matches[2] - 1) . '[td]';
 			},
-			'~<(td|th)(\\s(.)*?)*?' . '>~i' => function () {
+			'~<(td|th)(\s(.)*?)*?' . '>~i' => function () {
 				return '[td]';
 			},
 			'~</(td|th)>~i' => function () {
 				return '[/td]';
 			},
-			'~<br(?:\\s[^<>]*?)?' . '>~i' => function () {
+			'~<br(?:\s[^<>]*?)?' . '>~i' => function () {
 				return "\n";
 			},
-			'~<hr[^<>]*>(\\n)?~i' => function ($matches) {
+			'~<hr[^<>]*>(\n)?~i' => function ($matches) {
 				return "[hr]\n" . $matches[0];
 			},
-			'~(\\n)?\\[hr\\]~i' => function () {
+			'~(\n)?\[hr\]~i' => function () {
 				return "\n[hr]";
 			},
-			'~^\\n\\[hr\\]~i' => function () {
+			'~^\n\[hr\]~i' => function () {
 				return '[hr]';
 			},
-			'~<blockquote(\\s(.)*?)*?' . '>~i' => function () {
+			'~<blockquote(\s(.)*?)*?' . '>~i' => function () {
 				return '&lt;blockquote&gt;';
 			},
 			'~</blockquote>~i' => function () {
 				return '&lt;/blockquote&gt;';
 			},
-			'~<ins(\\s(.)*?)*?' . '>~i' => function () {
+			'~<ins(\s(.)*?)*?' . '>~i' => function () {
 				return '&lt;ins&gt;';
 			},
 			'~</ins>~i' => function () {
@@ -2066,7 +2066,7 @@ class BBCodeParser
 		}
 
 		// What about URL's - the pain in the ass of the tag world.
-		while (preg_match('~<a\\s+([^<>]*)>([^<>]*)</a>~i', $string, $matches) === 1) {
+		while (preg_match('~<a\s+([^<>]*)>([^<>]*)</a>~i', $string, $matches) === 1) {
 			// Find the position of the URL.
 			$start_pos = strpos($string, $matches[0]);
 
@@ -2132,7 +2132,7 @@ class BBCodeParser
 		$string = strip_tags($string);
 
 		// Some tags often end up as just dummy tags - remove those.
-		$string = preg_replace('~\\[[bisu]\\]\\s*\\[/[bisu]\\]~', '', $string);
+		$string = preg_replace('~\[[bisu]\]\s*\[/[bisu]\]~', '', $string);
 
 		// Fix up entities.
 		$string = preg_replace('~&#0*38;~i', '&#38;#38;', $string);
@@ -2233,7 +2233,7 @@ class BBCodeParser
 		error_reporting($oldlevel);
 
 		// Yes, I know this is kludging it, but this is the best way to preserve tabs from PHP :P.
-		$buffer = preg_replace('~SMF_TAB(?:</(?:font|span)><(?:font color|span style)="[^"]*?">)?\\(\\);~', '<pre style="display: inline;">' . "\t" . '</pre>', $buffer);
+		$buffer = preg_replace('~SMF_TAB(?:</(?:font|span)><(?:font color|span style)="[^"]*?">)?\(\);~', '<pre style="display: inline;">' . "\t" . '</pre>', $buffer);
 
 		return strtr($buffer, ['\'' => '&#039;', '<code>' => '', '</code>' => '']);
 	}
@@ -2460,7 +2460,7 @@ class BBCodeParser
 		if (!isset($disabled['code'])) {
 			$code = is_array($data) ? $data[0] : $data;
 
-			$php_parts = preg_split('~(&lt;\\?php|\\?&gt;)~', $code, -1, PREG_SPLIT_DELIM_CAPTURE);
+			$php_parts = preg_split('~(&lt;\?php|\?&gt;)~', $code, -1, PREG_SPLIT_DELIM_CAPTURE);
 
 			for ($php_i = 0, $php_n = count($php_parts); $php_i < $php_n; $php_i++) {
 				// Do PHP code coloring?
@@ -2540,7 +2540,7 @@ class BBCodeParser
 	{
 		$class = 'class="bbc_float float' . (strpos($data, 'left') === 0 ? 'left' : 'right') . '"';
 
-		if (preg_match('~\\bmax=(\\d+(?:%|px|em|rem|ex|pt|pc|ch|vw|vh|vmin|vmax|cm|mm|in)?)~', $data, $matches)) {
+		if (preg_match('~\bmax=(\d+(?:%|px|em|rem|ex|pt|pc|ch|vw|vh|vmin|vmax|cm|mm|in)?)~', $data, $matches)) {
 			$css = ' style="max-width:' . $matches[1] . (is_numeric($matches[1]) ? 'px' : '') . '"';
 		} else {
 			$css = '';
@@ -2653,7 +2653,7 @@ class BBCodeParser
 			$data = self::highlightPhpCode($add_begin ? '&lt;?php ' . $data . '?&gt;' : $data);
 
 			if ($add_begin) {
-				$data = preg_replace(['~^(.+?)&lt;\\?.{0,40}?php(?:&nbsp;|\\s)~', '~\\?&gt;((?:</(font|span)>)*)$~'], '$1', $data, 2);
+				$data = preg_replace(['~^(.+?)&lt;\?.{0,40}?php(?:&nbsp;|\s)~', '~\?&gt;((?:</(font|span)>)*)$~'], '$1', $data, 2);
 			}
 		}
 	}
@@ -2729,7 +2729,7 @@ class BBCodeParser
 		while ($this->pos !== false) {
 			$this->last_pos = isset($this->last_pos) ? max($this->pos, $this->last_pos) : $this->pos;
 
-			preg_match('~\\[/?(?=' . $this->alltags_regex . ')~i', $this->message, $matches, PREG_OFFSET_CAPTURE, $this->pos + 1);
+			preg_match('~\[/?(?=' . $this->alltags_regex . ')~i', $this->message, $matches, PREG_OFFSET_CAPTURE, $this->pos + 1);
 
 			$this->pos = $matches[0][1] ?? false;
 
@@ -3180,21 +3180,21 @@ class BBCodeParser
 		$pcre_subroutines = [
 			'tlds' => $this->tld_regex,
 			'pct' => '%[0-9A-Fa-f]{2}',
-			'space_lookahead' => '(?=$|\\s|<br>)',
-			'space_lookbehind' => '(?<=^|\\s|<br>)',
+			'space_lookahead' => '(?=$|\s|<br>)',
+			'space_lookbehind' => '(?<=^|\s|<br>)',
 			'domain_label_char' => '[' . self::$domain_label_chars . ']',
 			'not_domain_label_char' => '[^' . self::$domain_label_chars . ']',
-			'domain' => '(?:(?P>domain_label_char)+\\.)+(?P>tlds)(?!\\.(?P>domain_label_char))',
+			'domain' => '(?:(?P>domain_label_char)+\.)+(?P>tlds)(?!\.(?P>domain_label_char))',
 			'no_domain' => '(?:(?P>domain_label_char)|[._\\~!$&\'()*+,;=:@]|(?P>pct))+',
 			'scheme_need_domain' => Utils::buildRegex(self::$schemes['need_domain'], '~'),
 			'scheme_empty_authority' => Utils::buildRegex(self::$schemes['empty_authority'], '~'),
 			'scheme_no_authority' => Utils::buildRegex(self::$schemes['no_authority'], '~'),
-			'scheme_any' => '[A-Za-z][0-9A-Za-z+\\-.]*',
+			'scheme_any' => '[A-Za-z][0-9A-Za-z+\-.]*',
 			'user_info' => '(?:(?P>domain_label_char)|[._\\~!$&\'()*+,;=:]|(?P>pct))+',
-			'dec_octet' => '(?:25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]\\d|\\d)',
+			'dec_octet' => '(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)',
 			'h16' => '[0-9A-Fa-f]{1,4}',
-			'ipv4' => '(?:\\b(?:(?P>dec_octet)\\.){3}(?P>dec_octet)\\b)',
-			'ipv6' => '\\[(?:' . implode('|', [
+			'ipv4' => '(?:\b(?:(?P>dec_octet)\.){3}(?P>dec_octet)\b)',
+			'ipv6' => '\[(?:' . implode('|', [
 				'(?:(?P>h16):){7}(?P>h16)',
 				'(?:(?P>h16):){1,7}:',
 				'(?:(?P>h16):){1,6}(?::(?P>h16))',
@@ -3207,14 +3207,14 @@ class BBCodeParser
 				'fe80:(?::(?P>h16)){0,4}%[0-9A-Za-z]+',
 				'::(ffff(:0{1,4})?:)?(?P>ipv4)',
 				'(?:(?P>h16):){1,4}:(?P>ipv4)',
-			]) . ')\\]',
+			]) . ')\]',
 			'host' => '(?:' . implode('|', [
 				'localhost',
 				'(?P>domain)',
 				'(?P>ipv4)',
 				'(?P>ipv6)',
 			]) . ')',
-			'authority' => '(?:(?P>user_info)@)?(?P>host)(?::\\d+)?',
+			'authority' => '(?:(?P>user_info)@)?(?P>host)(?::\d+)?',
 		];
 
 		// Brackets and quotation marks are problematic at the end of an IRI.
@@ -3263,7 +3263,7 @@ class BBCodeParser
 				}
 			}
 		}
-		$bracket_quote_chars = str_replace(['[', ']'], ['\\[', '\\]'], $bracket_quote_chars);
+		$bracket_quote_chars = str_replace(['[', ']'], ['\[', '\]'], $bracket_quote_chars);
 
 		$pcre_subroutines['bracket_quote'] = '[' . $bracket_quote_chars . ']|&' . Utils::buildRegex($bracket_quote_entities, '~');
 		$pcre_subroutines['allowed_entities'] = '&(?!' . Utils::buildRegex(array_merge($bracket_quote_entities, ['lt;', 'gt;']), '~') . ')';
@@ -3272,17 +3272,17 @@ class BBCodeParser
 		foreach (['path', 'query', 'fragment'] as $part) {
 			switch ($part) {
 				case 'path':
-					$part_disallowed_chars = '\\s<>' . $bracket_quote_chars . self::$excluded_trailing_chars . '/#&';
+					$part_disallowed_chars = '\s<>' . $bracket_quote_chars . self::$excluded_trailing_chars . '/#&';
 					$part_excluded_trailing_chars = str_replace('?', '', self::$excluded_trailing_chars);
 					break;
 
 				case 'query':
-					$part_disallowed_chars = '\\s<>' . $bracket_quote_chars . self::$excluded_trailing_chars . '#&';
+					$part_disallowed_chars = '\s<>' . $bracket_quote_chars . self::$excluded_trailing_chars . '#&';
 					$part_excluded_trailing_chars = self::$excluded_trailing_chars;
 					break;
 
 				default:
-					$part_disallowed_chars = '\\s<>' . $bracket_quote_chars . self::$excluded_trailing_chars . '&';
+					$part_disallowed_chars = '\s<>' . $bracket_quote_chars . self::$excluded_trailing_chars . '&';
 					$part_excluded_trailing_chars = self::$excluded_trailing_chars;
 					break;
 			}
@@ -3321,7 +3321,7 @@ class BBCodeParser
 				// URI scheme (or lack thereof for schemeless URLs)
 				'(?' . '>' .
 					// URI scheme and colon
-					'\\b' .
+					'\b' .
 					'(?:' .
 						// Either a scheme that need a domain in the authority
 						// (Remember for later that we need a domain)
@@ -3394,7 +3394,7 @@ class BBCodeParser
 					// A run of IRI characters
 					'(?P>no_domain)' .
 					// If scheme needs a domain, require a dot and a TLD
-					'(?(<need_domain>)\\.(?P>tlds))' .
+					'(?(<need_domain>)\.(?P>tlds))' .
 					// Followed by a non-domain character or end of line
 					'(?=(?P>not_domain_label_char)|$)' .
 				')' .
@@ -3457,7 +3457,7 @@ class BBCodeParser
 			// 2.b. Query component, if any.
 			'(?:' .
 				// Initial "?" that is not last character.
-				'\\?' . '(?=(?P>bracket_quote)*(?P>query_allowed))' .
+				'\?' . '(?=(?P>bracket_quote)*(?P>query_allowed))' .
 				// Then a run of allowed query characters
 				'(?P>query_segment)*+' .
 			')?' .
@@ -3493,13 +3493,13 @@ class BBCodeParser
 		$this->setTldRegex();
 
 		// Preceded by a space or start of line
-		$this->email_regex = '(?<=^|\\s|<br>)' .
+		$this->email_regex = '(?<=^|\s|<br>)' .
 
 		// An email address
 		'[' . self::$domain_label_chars . '_.]{1,80}' .
 		'@' .
 		'[' . self::$domain_label_chars . '.]+' .
-		'\\.' . $this->tld_regex .
+		'\.' . $this->tld_regex .
 
 		// Followed by a non-domain character or end of line
 		'(?=[^' . self::$domain_label_chars . ']|$)';
@@ -3518,7 +3518,7 @@ class BBCodeParser
 			}
 		}
 
-		$this->alltags_regex = '(?' . '>\\b' . Utils::buildRegex(array_unique($alltags)) . '\\b|' . Utils::buildRegex(array_keys(self::$itemcodes)) . ')';
+		$this->alltags_regex = '(?' . '>\b' . Utils::buildRegex(array_unique($alltags)) . '\b|' . Utils::buildRegex(array_keys(self::$itemcodes)) . ')';
 	}
 
 	/**
@@ -3578,7 +3578,7 @@ class BBCodeParser
 			return $data;
 		}
 
-		$data = preg_replace('~&lt;a\\s+href=((?:&quot;)?)((?:https?://|ftps?://|mailto:|tel:)\\S+?)\\1&gt;(.*?)&lt;/a&gt;~i', '[url=&quot;$2&quot;]$3[/url]', $data);
+		$data = preg_replace('~&lt;a\s+href=((?:&quot;)?)((?:https?://|ftps?://|mailto:|tel:)\S+?)\1&gt;(.*?)&lt;/a&gt;~i', '[url=&quot;$2&quot;]$3[/url]', $data);
 
 		// <br> should be empty.
 		$empty_tags = ['br', 'hr'];
@@ -3601,7 +3601,7 @@ class BBCodeParser
 		}
 
 		// Do <img ...> - with security... action= -> action-.
-		preg_match_all('~&lt;img\\s+src=((?:&quot;)?)((?:https?://|ftps?://)\\S+?)\\1(?:\\s+alt=(&quot;.*?&quot;|\\S*?))?(?:\\s?/)?&gt;~i', $data, $matches, PREG_PATTERN_ORDER);
+		preg_match_all('~&lt;img\s+src=((?:&quot;)?)((?:https?://|ftps?://)\S+?)\1(?:\s+alt=(&quot;.*?&quot;|\S*?))?(?:\s?/)?&gt;~i', $data, $matches, PREG_PATTERN_ORDER);
 
 		if (!empty($matches[0])) {
 			$replaces = [];
@@ -3717,12 +3717,12 @@ class BBCodeParser
 			$whitespace_regex = '';
 
 			if (!empty($tag['block_level'])) {
-				$whitespace_regex .= '(&nbsp;|\\s)*(<br\\s*/?' . '>)?';
+				$whitespace_regex .= '(&nbsp;|\s)*(<br\s*/?' . '>)?';
 			}
 
 			// Trim one line of whitespace after unnested tags, but all of it after nested ones
 			if (!empty($tag['trim']) && $tag['trim'] != 'inside') {
-				$whitespace_regex .= empty($tag['require_parents']) ? '(&nbsp;|\\s)*' : '(<br>|&nbsp;|\\s)*';
+				$whitespace_regex .= empty($tag['require_parents']) ? '(&nbsp;|\s)*' : '(<br>|&nbsp;|\s)*';
 			}
 
 			if (!empty($whitespace_regex) && preg_match('~' . $whitespace_regex . '~', substr($this->message, $this->pos), $matches) != 0) {
@@ -3846,13 +3846,13 @@ class BBCodeParser
 					$params_regexes[$regex_key] = '';
 
 					foreach ($possible['parameters'] as $p => $info) {
-						$params_regexes[$regex_key] .= '(\\s+' . $p . '=' . (empty($info['quoted']) ? '' : '&quot;') . ($info['match'] ?? '(.+?)') . (empty($info['quoted']) ? '' : '&quot;') . '\\s*)' . (empty($info['optional']) ? '' : '?');
+						$params_regexes[$regex_key] .= '(\s+' . $p . '=' . (empty($info['quoted']) ? '' : '&quot;') . ($info['match'] ?? '(.+?)') . (empty($info['quoted']) ? '' : '&quot;') . '\s*)' . (empty($info['optional']) ? '' : '?');
 					}
 				}
 
 				// Extract the string that potentially holds our parameters.
-				$blob = preg_split('~\\[/?(?:' . $this->alltags_regex . ')~i', substr($this->message, $this->pos));
-				$blobs = preg_split('~\\]~i', $blob[1]);
+				$blob = preg_split('~\[/?(?:' . $this->alltags_regex . ')~i', substr($this->message, $this->pos));
+				$blobs = preg_split('~\]~i', $blob[1]);
 
 				$splitters = implode('=|', array_keys($possible['parameters'])) . '=';
 
@@ -3862,7 +3862,7 @@ class BBCodeParser
 				while ($blob_counter <= count($blobs)) {
 					$given_param_string = implode(']', array_slice($blobs, 0, $blob_counter++));
 
-					$given_params = preg_split('~\\s(?=(' . $splitters . '))~i', $given_param_string);
+					$given_params = preg_split('~\s(?=(' . $splitters . '))~i', $given_param_string);
 					sort($given_params, SORT_STRING);
 
 					$match = preg_match('~^' . $params_regexes[$regex_key] . '$~i', implode(' ', $given_params), $matches) !== 0;
@@ -3991,7 +3991,7 @@ class BBCodeParser
 		$pos3 = strpos($this->message, '[/', $this->pos);
 
 		if ($pos2 !== false && ($pos2 <= $pos3 || $pos3 === false)) {
-			preg_match('~^(<br>|&nbsp;|\\s|\\[)+~', substr($this->message, $pos2 + 4), $matches);
+			preg_match('~^(<br>|&nbsp;|\s|\[)+~', substr($this->message, $pos2 + 4), $matches);
 
 			$this->message = substr($this->message, 0, $pos2) . (!empty($matches[0]) && substr($matches[0], -1) == '[' ? '[/li]' : '[/li][/list]') . substr($this->message, $pos2);
 
@@ -4051,11 +4051,11 @@ class BBCodeParser
 			$whitespace_regex = '';
 
 			if (!empty($tag['block_level'])) {
-				$whitespace_regex .= '(&nbsp;|\\s)*(<br>)?';
+				$whitespace_regex .= '(&nbsp;|\s)*(<br>)?';
 			}
 
 			if (!empty($tag['trim']) && $tag['trim'] != 'inside') {
-				$whitespace_regex .= empty($tag['require_parents']) ? '(&nbsp;|\\s)*' : '(<br>|&nbsp;|\\s)*';
+				$whitespace_regex .= empty($tag['require_parents']) ? '(&nbsp;|\s)*' : '(<br>|&nbsp;|\s)*';
 			}
 
 			if (!empty($whitespace_regex) && preg_match('~' . $whitespace_regex . '~', substr($this->message, $this->pos), $matches) != 0) {
@@ -4338,7 +4338,7 @@ class BBCodeParser
 		}
 
 		// Are we trimming outside this tag?
-		if (!empty($tag['trim']) && $tag['trim'] != 'outside' && preg_match('~(<br>|&nbsp;|\\s)*~', substr($this->message, $this->pos + 1), $matches) != 0) {
+		if (!empty($tag['trim']) && $tag['trim'] != 'outside' && preg_match('~(<br>|&nbsp;|\s)*~', substr($this->message, $this->pos + 1), $matches) != 0) {
 			$this->message = substr($this->message, 0, $this->pos + 1) . substr($this->message, $this->pos + 1 + strlen($matches[0]));
 		}
 	}
@@ -4444,7 +4444,7 @@ class BBCodeParser
 		$align_tags = array_intersect($align_tags, array_keys($valid_tags));
 
 		// These keep track of where we are!
-		if (!empty($align_tags) && count($matches = preg_split('~(\\[/?(?:' . implode('|', $align_tags) . ')\\])~', $string, -1, PREG_SPLIT_DELIM_CAPTURE)) > 1) {
+		if (!empty($align_tags) && count($matches = preg_split('~(\[/?(?:' . implode('|', $align_tags) . ')\])~', $string, -1, PREG_SPLIT_DELIM_CAPTURE)) > 1) {
 			// The first one is never a tag.
 			$is_tag = false;
 
@@ -4485,7 +4485,7 @@ class BBCodeParser
 		}
 
 		// Quickly remove any tags which are back to back.
-		$back_to_back_pattern = '~\\[(' . implode('|', array_diff(array_keys($valid_tags), ['td', 'anchor'])) . ')[^<>\\[\\]]*\\]\\s*\\[/\\1\\]~';
+		$back_to_back_pattern = '~\[(' . implode('|', array_diff(array_keys($valid_tags), ['td', 'anchor'])) . ')[^<>\[\]]*\]\s*\[/\1\]~';
 
 		$lastlen = 0;
 
@@ -4508,7 +4508,7 @@ class BBCodeParser
 		];
 
 		// These keep track of where we are!
-		if (count($parts = preg_split(sprintf('~(\\[)(/?)(%1$s)((?:[\\s=][^\\]\\[]*)?\\])~', implode('|', array_keys($valid_tags))), $string, -1, PREG_SPLIT_DELIM_CAPTURE)) > 1) {
+		if (count($parts = preg_split(sprintf('~(\[)(/?)(%1$s)((?:[\s=][^\]\[]*)?\])~', implode('|', array_keys($valid_tags))), $string, -1, PREG_SPLIT_DELIM_CAPTURE)) > 1) {
 			// Start outside [nobbc] or [code] blocks.
 			$in_code = false;
 			$in_nobbc = false;

--- a/Sources/BBCodeParser.php
+++ b/Sources/BBCodeParser.php
@@ -2919,9 +2919,7 @@ class BBCodeParser
 								return '[email=' . $url->path . ']' . $url . '[/email]';
 							}
 
-
 							return $url;
-
 						}
 
 						// Are we linking a schemeless URL or naked domain name (e.g. "example.com")?
@@ -3562,9 +3560,7 @@ class BBCodeParser
 					return Lang::$txt[substr($matches[1], 4)];
 				}
 
-
 				return $matches[0];
-
 			},
 			$string,
 		);

--- a/Sources/Board.php
+++ b/Sources/Board.php
@@ -2199,7 +2199,7 @@ class Board implements \ArrayAccess
 		// If we only want some child boards, use a CTE query for improved performance.
 		if (!empty($params['id_parent']) && in_array('b.id_parent != 0', $where) && Db::$db->cte_support()) {
 			// Ensure we include all the necessary fields for the CTE query.
-			preg_match_all('/\\bb\\.(\\w+)/', implode(', ', $selects), $matches);
+			preg_match_all('/\bb\.(\w+)/', implode(', ', $selects), $matches);
 
 			$cte_fields = array_unique(array_merge(
 				$matches[1],

--- a/Sources/Board.php
+++ b/Sources/Board.php
@@ -2278,7 +2278,6 @@ class Board implements \ArrayAccess
 				LIMIT ' . $limit : ''),
 				$params,
 			);
-
 		}
 
 		while ($row = Db::$db->fetch_assoc($request)) {

--- a/Sources/BrowserDetector.php
+++ b/Sources/BrowserDetector.php
@@ -188,7 +188,7 @@ class BrowserDetector
 	{
 		// I'm IE, Yes I'm the real IE; All you other IEs are just imitating.
 		if (!isset($this->_browsers['is_ie'])) {
-			$this->_browsers['is_ie'] = !$this->isOpera() && !$this->isGecko() && !$this->isWebTv() && preg_match('~MSIE \\d+~', $_SERVER['HTTP_USER_AGENT']) === 1;
+			$this->_browsers['is_ie'] = !$this->isOpera() && !$this->isGecko() && !$this->isWebTv() && preg_match('~MSIE \d+~', $_SERVER['HTTP_USER_AGENT']) === 1;
 		}
 
 		return $this->_browsers['is_ie'];
@@ -385,7 +385,7 @@ class BrowserDetector
 		$this->_browsers['is_ie_compat_view'] = false;
 
 		// get the version of the browser from the msie tag
-		if (preg_match('~MSIE\\s?([0-9][0-9]?.[0-9])~i', $_SERVER['HTTP_USER_AGENT'], $msie_match) === 1) {
+		if (preg_match('~MSIE\s?([0-9][0-9]?.[0-9])~i', $_SERVER['HTTP_USER_AGENT'], $msie_match) === 1) {
 			$msie_match[1] = trim($msie_match[1]);
 			$msie_match[1] = (($msie_match[1] - (int) $msie_match[1]) == 0) ? (int) $msie_match[1] : $msie_match[1];
 			$this->_browsers['is_ie' . $msie_match[1]] = true;
@@ -431,7 +431,7 @@ class BrowserDetector
 	 */
 	private function setupFirefox()
 	{
-		if (preg_match('~(?:Firefox|Ice[wW]easel|IceCat|Shiretoko|Minefield)[\\/ \\(]([^ ;\\)]+)~', $_SERVER['HTTP_USER_AGENT'], $match) === 1) {
+		if (preg_match('~(?:Firefox|Ice[wW]easel|IceCat|Shiretoko|Minefield)[\/ \(]([^ ;\)]+)~', $_SERVER['HTTP_USER_AGENT'], $match) === 1) {
 			$this->_browsers['is_firefox' . (int) $match[1]] = true;
 		}
 	}
@@ -444,11 +444,11 @@ class BrowserDetector
 	private function setupOpera()
 	{
 		// Opera 10+ uses the version tag at the end of the string
-		if (preg_match('~\\sVersion/([0-9]+)\\.[0-9]+(?:\\s*|$)~', $_SERVER['HTTP_USER_AGENT'], $match)) {
+		if (preg_match('~\sVersion/([0-9]+)\.[0-9]+(?:\s*|$)~', $_SERVER['HTTP_USER_AGENT'], $match)) {
 			$this->_browsers['is_opera' . (int) $match[1]] = true;
 		}
 		// Opera pre 10 is supposed to uses the Opera tag alone, as do some spoofers
-		elseif (preg_match('~Opera[ /]([0-9]+)(?!\\.[89])~', $_SERVER['HTTP_USER_AGENT'], $match)) {
+		elseif (preg_match('~Opera[ /]([0-9]+)(?!\.[89])~', $_SERVER['HTTP_USER_AGENT'], $match)) {
 			$this->_browsers['is_opera' . (int) $match[1]] = true;
 		}
 
@@ -461,7 +461,7 @@ class BrowserDetector
 	 */
 	private function setupEdge()
 	{
-		if (preg_match('~Edge[\\/]([0-9][0-9]?[\\.][0-9][0-9])~i', $_SERVER['HTTP_USER_AGENT'], $match) === 1) {
+		if (preg_match('~Edge[\/]([0-9][0-9]?[\.][0-9][0-9])~i', $_SERVER['HTTP_USER_AGENT'], $match) === 1) {
 			$this->_browsers['is_edge' . (int) $match[1]] = true;
 		}
 	}

--- a/Sources/Cache/APIs/Apcu.php
+++ b/Sources/Cache/APIs/Apcu.php
@@ -73,7 +73,6 @@ class Apcu extends CacheApi implements CacheApiInterface
 			return apcu_delete($key . 'smf');
 		}
 
-
 		return apcu_store($key . 'smf', $value, $ttl !== null ? $ttl : $this->ttl);
 	}
 

--- a/Sources/Cache/APIs/FileBased.php
+++ b/Sources/Cache/APIs/FileBased.php
@@ -141,8 +141,6 @@ class FileBased extends CacheApi implements CacheApiInterface
 
 			@unlink($file);
 		}
-
-
 	}
 
 	/**

--- a/Sources/Cache/APIs/MemcacheImplementation.php
+++ b/Sources/Cache/APIs/MemcacheImplementation.php
@@ -59,12 +59,9 @@ class MemcacheImplementation extends CacheApi implements CacheApiInterface
 					return [$server, 0];
 				}
 
-
-
 				$server = explode(':', $server);
 
 				return [$server[0], isset($server[1]) ? (int) $server[1] : 11211];
-
 			},
 			array_map('trim', explode(',', Config::$cache_memcached)),
 		);

--- a/Sources/Cache/APIs/MemcachedImplementation.php
+++ b/Sources/Cache/APIs/MemcachedImplementation.php
@@ -59,12 +59,9 @@ class MemcachedImplementation extends CacheApi implements CacheApiInterface
 					return [$server, 0];
 				}
 
-
-
 				$server = explode(':', $server);
 
 				return [$server[0], isset($server[1]) ? (int) $server[1] : 11211];
-
 			},
 			explode(',', Config::$cache_memcached),
 		);

--- a/Sources/Cache/CacheApi.php
+++ b/Sources/Cache/CacheApi.php
@@ -326,7 +326,6 @@ abstract class CacheApi
 			return substr($class_name, $position + 1);
 		}
 
-
 		return get_class($this);
 	}
 

--- a/Sources/Cache/CacheApiInterface.php
+++ b/Sources/Cache/CacheApiInterface.php
@@ -17,7 +17,6 @@ if (!defined('SMF')) {
 	die('No direct access...');
 }
 
-
 interface CacheApiInterface
 {
 	/**

--- a/Sources/Config.php
+++ b/Sources/Config.php
@@ -1796,9 +1796,7 @@ class Config
 					return 1;
 				}
 
-
 				return strcasecmp($b, $a);
-
 			},
 		);
 
@@ -2967,7 +2965,6 @@ class Config
 			}
 		}
 	}
-
 }
 
 ?>

--- a/Sources/Config.php
+++ b/Sources/Config.php
@@ -361,7 +361,7 @@ class Config
 				' * @version ' . SMF_VERSION . "\n" .
 				' */' . "\n" .
 				'',
-			'search_pattern' => '~/\\*\\*.*?@package\\h+SMF\\b.*?\\*/\\n{0,2}~s',
+			'search_pattern' => '~/\*\*.*?@package\h+SMF\b.*?\*/\n{0,2}~s',
 		],
 		'maintenance' => [
 			'text' => <<<'END'
@@ -784,7 +784,7 @@ class Config
 				if (!is_dir(realpath($cachedir)) && is_dir($boarddir . '/cache'))
 					$cachedir = $boarddir . '/cache';
 				END,
-			'search_pattern' => '~\\n?(#[^\\n]+)?(?:\\n\\h*if\\s*\\((?:\\!file_exists\\(\\$(?' . '>boarddir|sourcedir|tasksdir|packagesdir|cachedir)\\)|\\!is_dir\\(realpath\\(\\$(?' . '>boarddir|sourcedir|tasksdir|packagesdir|cachedir)\\)\\))[^;]+\\n\\h*\\$(?' . '>boarddir|sourcedir|tasksdir|packagesdir|cachedir)[^\\n]+;)+~sm',
+			'search_pattern' => '~\n?(#[^\n]+)?(?:\n\h*if\s*\((?:\!file_exists\(\$(?' . '>boarddir|sourcedir|tasksdir|packagesdir|cachedir)\)|\!is_dir\(realpath\(\$(?' . '>boarddir|sourcedir|tasksdir|packagesdir|cachedir)\)\))[^;]+\n\h*\$(?' . '>boarddir|sourcedir|tasksdir|packagesdir|cachedir)[^\n]+;)+~sm',
 		],
 		'db_character_set' => [
 			'text' => <<<'END'
@@ -829,7 +829,7 @@ class Config
 				}
 				END,
 			// Designed to match both 2.0 and 2.1 versions of this code.
-			'search_pattern' => '~\\n?#+ Error.Catching #+\\n[^\\n]*?settings\\.\\n(?:\\$db_last_error = \\d{1,11};|if \\(file_exists.*?\\$db_last_error = 0;(?' . '>\\s*}))(?=\\n|\\?' . '>|$)~s',
+			'search_pattern' => '~\n?#+ Error.Catching #+\n[^\n]*?settings\.\n(?:\$db_last_error = \d{1,11};|if \(file_exists.*?\$db_last_error = 0;(?' . '>\s*}))(?=\n|\?' . '>|$)~s',
 		],
 		// Temporary variable used during the upgrade process.
 		'upgradeData' => [
@@ -1118,7 +1118,7 @@ class Config
 
 				if (!empty(self::$modSettings['load_average']) && preg_match('~^([^ ]+?) ([^ ]+?) ([^ ]+)~', self::$modSettings['load_average'], $matches) != 0) {
 					self::$modSettings['load_average'] = (float) $matches[1];
-				} elseif ((self::$modSettings['load_average'] = @shell_exec('uptime')) != null && preg_match('~load averages?: (\\d+\\.\\d+)~i', self::$modSettings['load_average'], $matches) != 0) {
+				} elseif ((self::$modSettings['load_average'] = @shell_exec('uptime')) != null && preg_match('~load averages?: (\d+\.\d+)~i', self::$modSettings['load_average'], $matches) != 0) {
 					self::$modSettings['load_average'] = (float) $matches[1];
 				} else {
 					unset(self::$modSettings['load_average']);
@@ -1504,21 +1504,21 @@ class Config
 					// match the opening quotation mark...
 					'(["\'])' .
 					// then any number of other characters or escaped quotation marks...
-					'(?:.(?!\\1)|\\\\(?=\\1))*.?' .
+					'(?:.(?!\\1)|\\\(?=\\1))*.?' .
 					// then the closing quotation mark.
 					'\\1' .
 					// Maybe there's a second string concatenated to this one.
-					'(?:\\s*\\.\\s*)*' .
+					'(?:\s*\.\s*)*' .
 				')+',
 			// Some numeric values might have been stored as strings.
-			'integer' =>  '["\']?[+-]?\\d+["\']?',
-			'double' =>  '["\']?[+-]?\\d+\\.\\d+([Ee][+-]\\d+)?["\']?',
+			'integer' =>  '["\']?[+-]?\d+["\']?',
+			'double' =>  '["\']?[+-]?\d+\.\d+([Ee][+-]\d+)?["\']?',
 			// Some boolean values might have been stored as integers.
-			'boolean' =>  '(?i:TRUE|FALSE|(["\']?)[01]\\b\\1)',
+			'boolean' =>  '(?i:TRUE|FALSE|(["\']?)[01]\b\\1)',
 			'NULL' =>  '(?i:NULL)',
 			// These use a PCRE subroutine to match nested arrays.
-			'array' =>  'array\\s*(\\((?' . '>[^()]|(?1))*\\))',
-			'object' =>  '\\w+::__set_state\\(array\\s*(\\((?' . '>[^()]|(?1))*\\))\\)',
+			'array' =>  'array\s*(\((?' . '>[^()]|(?1))*\))',
+			'object' =>  '\w+::__set_state\(array\s*(\((?' . '>[^()]|(?1))*\))\)',
 		];
 
 		/*
@@ -1539,26 +1539,26 @@ class Config
 		$neg_index = -1;
 		$substitutions = [
 			$neg_index-- => [
-				'search_pattern' => '~^\\s*<\\?(php\\b)?\\n?~',
+				'search_pattern' => '~^\s*<\?(php\b)?\n?~',
 				'placeholder' => '',
 				'replace_pattern' => '~^~',
 				'replacement' => '<' . "?php\n",
 			],
 			$neg_index-- => [
-				'search_pattern' => '~\\S\\K\\s*(\\?' . '>)?\\s*$~',
+				'search_pattern' => '~\S\K\s*(\?' . '>)?\s*$~',
 				'placeholder' => "\n" . md5($prefix . '?' . '>'),
 				'replacement' => "\n\n?" . '>',
 			],
 			// Remove the code that redirects to the installer.
 			$neg_index-- => [
-				'search_pattern' => '~^if\\s*\\(file_exists\\(dirname\\(__FILE__\\)\\s*\\.\\s*\'/install\\.php\'\\)\\)\\s*(?:({(?' . '>[^{}]|(?1))*})\\h*|header(\\((?' . '>[^()]|(?2))*\\));\\n)~m',
+				'search_pattern' => '~^if\s*\(file_exists\(dirname\(__FILE__\)\s*\.\s*\'/install\.php\'\)\)\s*(?:({(?' . '>[^{}]|(?1))*})\h*|header(\((?' . '>[^()]|(?2))*\));\n)~m',
 				'placeholder' => '',
 			],
 		];
 
 		if (defined('SMF_INSTALLING')) {
 			$substitutions[$neg_index--] = [
-				'search_pattern' => '~/\\*.*?SMF\\s+1\\.\\d.*?\\*/~s',
+				'search_pattern' => '~/\*.*?SMF\s+1\.\d.*?\*/~s',
 				'placeholder' => '',
 			];
 		}
@@ -1673,7 +1673,7 @@ class Config
 						$var_pattern[] = @$type_regex[gettype($config_vars[$var])];
 
 						if (is_string($config_vars[$var]) && strpos($config_vars[$var], dirname($settingsFile)) === 0) {
-							$var_pattern[] = '(?:__DIR__|dirname\\(__FILE__\\)) . \'' . (preg_quote(str_replace(dirname($settingsFile), '', $config_vars[$var]), '~')) . '\'';
+							$var_pattern[] = '(?:__DIR__|dirname\(__FILE__\)) . \'' . (preg_quote(str_replace(dirname($settingsFile), '', $config_vars[$var]), '~')) . '\'';
 						}
 					}
 
@@ -1681,19 +1681,19 @@ class Config
 						$var_pattern[] = @$type_regex[gettype($settings_vars[$var])];
 
 						if (is_string($settings_vars[$var]) && strpos($settings_vars[$var], dirname($settingsFile)) === 0) {
-							$var_pattern[] = '(?:__DIR__|dirname\\(__FILE__\\)) . \'' . (preg_quote(str_replace(dirname($settingsFile), '', $settings_vars[$var]), '~')) . '\'';
+							$var_pattern[] = '(?:__DIR__|dirname\(__FILE__\)) . \'' . (preg_quote(str_replace(dirname($settingsFile), '', $settings_vars[$var]), '~')) . '\'';
 						}
 					}
 
 					if (!empty($setting_def['raw_default']) && $setting_def['default'] !== '') {
-						$var_pattern[] = preg_replace('/\\s+/', '\\s+', preg_quote($setting_def['default'], '~'));
+						$var_pattern[] = preg_replace('/\s+/', '\s+', preg_quote($setting_def['default'], '~'));
 
 						if (strpos($setting_def['default'], 'dirname(__FILE__)') !== false) {
-							$var_pattern[] = preg_replace('/\\s+/', '\\s+', preg_quote(str_replace('dirname(__FILE__)', '__DIR__', $setting_def['default']), '~'));
+							$var_pattern[] = preg_replace('/\s+/', '\s+', preg_quote(str_replace('dirname(__FILE__)', '__DIR__', $setting_def['default']), '~'));
 						}
 
 						if (strpos($setting_def['default'], '__DIR__') !== false) {
-							$var_pattern[] = preg_replace('/\\s+/', '\\s+', preg_quote(str_replace('__DIR__', 'dirname(__FILE__)', $setting_def['default']), '~'));
+							$var_pattern[] = preg_replace('/\s+/', '\s+', preg_quote(str_replace('__DIR__', 'dirname(__FILE__)', $setting_def['default']), '~'));
 						}
 					}
 
@@ -1701,7 +1701,7 @@ class Config
 
 					$var_pattern = count($var_pattern) > 1 ? '(?:' . (implode('|', $var_pattern)) . ')' : $var_pattern[0];
 
-					$substitutions[$var]['search_pattern'] = '~(?<=^|\\s)\\h*\\$' . preg_quote($var, '~') . '\\s*=\\s*' . $var_pattern . ';~' . (!empty($utf8) ? 'u' : '');
+					$substitutions[$var]['search_pattern'] = '~(?<=^|\s)\h*\$' . preg_quote($var, '~') . '\s*=\s*' . $var_pattern . ';~' . (!empty($utf8) ? 'u' : '');
 				}
 
 				// Next create the placeholder or replace_pattern.
@@ -1721,7 +1721,7 @@ class Config
 						$substitutions[$var]['placeholder'] = '';
 
 						// This is just for cosmetic purposes. Removes the blank line.
-						$substitutions[$var]['search_pattern'] = str_replace('(?<=^|\\s)', '\\n?', $substitutions[$var]['search_pattern']);
+						$substitutions[$var]['search_pattern'] = str_replace('(?<=^|\s)', '\n?', $substitutions[$var]['search_pattern']);
 					}
 				}
 				// Add this setting's value.
@@ -1762,20 +1762,20 @@ class Config
 
 			$placeholder = md5($prefix . $var);
 
-			$substitutions[$var]['search_pattern'] = '~(?<=^|\\s)\\h*\\$' . preg_quote($var, '~') . '\\s*=\\s*' . $var_pattern . ';~' . (!empty($utf8) ? 'u' : '');
+			$substitutions[$var]['search_pattern'] = '~(?<=^|\s)\h*\$' . preg_quote($var, '~') . '\s*=\s*' . $var_pattern . ';~' . (!empty($utf8) ? 'u' : '');
 			$substitutions[$var]['placeholder'] = $placeholder;
 			$substitutions[$var]['replacement'] = '$' . $var . ' = ' . self::varExport($val, true) . ';';
 		}
 
 		// During an upgrade, some of the path variables may not have been declared yet.
 		if (defined('SMF_INSTALLING') && empty($rebuild)) {
-			preg_match_all('~^\\h*\\$(\\w+)\\s*=\\s*~m', $substitutions[$pathcode_var]['replacement'], $matches);
+			preg_match_all('~^\h*\$(\w+)\s*=\s*~m', $substitutions[$pathcode_var]['replacement'], $matches);
 
 			$missing_pathvars = array_diff($matches[1], array_keys($substitutions));
 
 			if (!empty($missing_pathvars)) {
 				foreach ($missing_pathvars as $var) {
-					$substitutions[$pathcode_var]['replacement'] = preg_replace('~\\nif[^\\n]+\\$' . $var . '[^\\n]+\\n\\h*\\$' . $var . ' = [^\\n]+~', '', $substitutions[$pathcode_var]['replacement']);
+					$substitutions[$pathcode_var]['replacement'] = preg_replace('~\nif[^\n]+\$' . $var . '[^\n]+\n\h*\$' . $var . ' = [^\n]+~', '', $substitutions[$pathcode_var]['replacement']);
 				}
 			}
 		}
@@ -1834,7 +1834,7 @@ class Config
 		}
 
 		// Settings.php is unlikely to contain any heredocs, but just in case...
-		if (preg_match_all('/<<<([\'"]?)(\\w+)\\1\\R(.*?)\\R\\h*\\2;$/ms', $settingsText, $matches)) {
+		if (preg_match_all('/<<<([\'"]?)(\w+)\1\R(.*?)\R\h*\2;$/ms', $settingsText, $matches)) {
 			foreach ($matches[0] as $mkey => $heredoc) {
 				if (!empty($matches[1][$mkey]) && $matches[1][$mkey] === '\'') {
 					$heredoc_replacements[$heredoc] = var_export($matches[3][$mkey], true) . ';';
@@ -1876,7 +1876,7 @@ class Config
 						// Maybe we can try something more interesting?
 						$sp = substr($substitution['search_pattern'], 1);
 
-						if (strpos($sp, '(?<=^|\\s)') === 0) {
+						if (strpos($sp, '(?<=^|\s)') === 0) {
 							$sp = substr($sp, 9);
 						}
 
@@ -1886,7 +1886,7 @@ class Config
 
 						// See if we can exclude `if` blocks, etc., to narrow down the matches.
 						// @todo Multiple layers of nested brackets might confuse this.
-						$sp = '~(?:^|//[^\\n]+c\\n|\\*/|[;}]|' . implode('|', array_filter($placeholders)) . ')\\s*' . (strpos($sp, '\\K') === false ? '\\K' : '') . $sp;
+						$sp = '~(?:^|//[^\n]+c\n|\*/|[;}]|' . implode('|', array_filter($placeholders)) . ')\s*' . (strpos($sp, '\K') === false ? '\K' : '') . $sp;
 
 						preg_match_all($sp, $settingsText, $matches);
 					} else {
@@ -1919,7 +1919,7 @@ class Config
 					$in_s = in_array($var, array_keys($settings_vars));
 
 					// Is it in there at all?
-					if (!preg_match('~(^|\\s)\\$' . preg_quote($var, '~') . '\\s*=\\s*~', $bare_settingsText)) {
+					if (!preg_match('~(^|\s)\$' . preg_quote($var, '~') . '\s*=\s*~', $bare_settingsText)) {
 						// It's defined by Settings.php, but not by code in the file.
 						// Probably done via an include or something. Skip it.
 						if ($in_s) {
@@ -1953,8 +1953,8 @@ class Config
 							$sp = $type_regex['array'];
 						}
 
-						if (preg_match('~(^|\\s)\\$' . preg_quote($var, '~') . '\\s*=\\s*' . $sp . '~', $bare_settingsText, $derp)) {
-							$settingsText = preg_replace('~(^|\\s)\\$' . preg_quote($var, '~') . '\\s*=\\s*' . $sp . '~', $substitution['placeholder'], $settingsText);
+						if (preg_match('~(^|\s)\$' . preg_quote($var, '~') . '\s*=\s*' . $sp . '~', $bare_settingsText, $derp)) {
+							$settingsText = preg_replace('~(^|\s)\$' . preg_quote($var, '~') . '\s*=\s*' . $sp . '~', $substitution['placeholder'], $settingsText);
 
 							$found = true;
 
@@ -2004,7 +2004,7 @@ class Config
 				$bare_settingsText = str_replace([$placeholder . "\n\n", $placeholder], $placeholder . "\n", $bare_settingsText);
 			}
 
-			$bare_settingsText = preg_replace('/\\h+$/m', '', rtrim($bare_settingsText));
+			$bare_settingsText = preg_replace('/\h+$/m', '', rtrim($bare_settingsText));
 
 			/*
 			 * Divide the existing content into sections.
@@ -2172,7 +2172,7 @@ class Config
 
 		// Make absolutely sure that the path correction code is included.
 		if (strpos($settingsText, $substitutions[$pathcode_var]['replacement']) === false) {
-			$settingsText = preg_replace('~(?=\\n#+ Error.Catching #+)~', "\n" . $substitutions[$pathcode_var]['replacement'] . "\n", $settingsText);
+			$settingsText = preg_replace('~(?=\n#+ Error.Catching #+)~', "\n" . $substitutions[$pathcode_var]['replacement'] . "\n", $settingsText);
 		}
 
 		// If we did not rebuild, do just enough to make sure the thing is viable.
@@ -2229,11 +2229,11 @@ class Config
 					continue;
 				}
 
-				$before = is_int($prev_var) ? preg_quote($settings_defs[$prev_var]['text'], '~') . '\\s*\\K' : '';
+				$before = is_int($prev_var) ? preg_quote($settings_defs[$prev_var]['text'], '~') . '\s*\K' : '';
 
 				// If this setting's comment is immediately preceded by another
 				// DocBlock comment, remove the preceding one.
-				$settingsText = preg_replace('~' . $before . '(#[^\\n]*\\s*)?/[*]{2}([^*]|[*](?!/))*[*]/\\s*' . preg_quote($setting_def['text'], '~') . '~', $setting_def['text'], $settingsText);
+				$settingsText = preg_replace('~' . $before . '(#[^\n]*\s*)?/[*]{2}([^*]|[*](?!/))*[*]/\s*' . preg_quote($setting_def['text'], '~') . '~', $setting_def['text'], $settingsText);
 
 				$prev_var = $var;
 			}
@@ -2243,15 +2243,15 @@ class Config
 		foreach ($new_settings_vars as $var => $val) {
 			if (isset($substitutions[$var]) && !preg_match($substitutions[$var]['search_pattern'], $settingsText)) {
 				if (!isset($settings_defs[$var]) && strpos($settingsText, '# Custom Settings #') === false) {
-					$settingsText = preg_replace('~(?=\\n#+ Error.Catching #+)~', "\n\n######### Custom Settings #########\n", $settingsText);
+					$settingsText = preg_replace('~(?=\n#+ Error.Catching #+)~', "\n\n######### Custom Settings #########\n", $settingsText);
 				}
 
-				$settingsText = preg_replace('~(?=\\n#+ Error.Catching #+)~', $substitutions[$var]['replacement'] . "\n", $settingsText);
+				$settingsText = preg_replace('~(?=\n#+ Error.Catching #+)~', $substitutions[$var]['replacement'] . "\n", $settingsText);
 			}
 		}
 
 		// This is just cosmetic. Get rid of extra lines of whitespace.
-		$settingsText = preg_replace('~\\n\\s*\\n~', "\n\n", $settingsText);
+		$settingsText = preg_replace('~\n\s*\n~', "\n\n", $settingsText);
 
 		/**************************************
 		 * PART 4: Check syntax before saving *
@@ -2341,7 +2341,7 @@ class Config
 
 		// Prevents warnings about constants that are already defined.
 		$settingsText = preg_replace_callback(
-			'~\\bdefine\\s*\\(\\s*(["\'])(\\w+)\\1~',
+			'~\bdefine\s*\(\s*(["\'])(\w+)\1~',
 			function ($matches) {
 				return 'define(\'' . md5(mt_rand()) . '\'';
 			},
@@ -2535,9 +2535,9 @@ class Config
 		if (is_string($var) && (strpos($var, "\n") !== false || strpos($var, "\r") !== false)) {
 			return strtr(
 				preg_replace_callback(
-					'/[\\r\\n]+/',
+					'/[\r\n]+/',
 					function ($m) {
-						return '\' . "' . strtr($m[0], ["\r" => '\\r', "\n" => '\\n']) . '" . \'';
+						return '\' . "' . strtr($m[0], ["\r" => '\r', "\n" => '\n']) . '" . \'';
 					},
 					var_export($var, true),
 				),
@@ -2611,7 +2611,7 @@ class Config
 		// If the tokenizer extension has been disabled, do the job manually.
 
 		// Leave any heredocs alone.
-		if (preg_match_all('/<<<([\'"]?)(\\w+)\\1?\\R(.*?)\\R\\h*\\2;$/ms', $code_str, $matches)) {
+		if (preg_match_all('/<<<([\'"]?)(\w+)\1?\R(.*?)\R\h*\2;$/ms', $code_str, $matches)) {
 			$heredoc_replacements = [];
 
 			foreach ($matches[0] as $mkey => $heredoc) {
@@ -2622,7 +2622,7 @@ class Config
 		}
 
 		// Split before everything that could possibly delimit a comment or a string.
-		$parts = preg_split('~(?=#+|/(?=/|\\*)|\\*/|\\R|(?<!\\\\)[\'"])~m', $code_str);
+		$parts = preg_split('~(?=#+|/(?=/|\*)|\*/|\R|(?<!\\\)[\'"])~m', $code_str);
 
 		$in_string = 0;
 		$in_comment = 0;

--- a/Sources/Cookie.php
+++ b/Sources/Cookie.php
@@ -268,11 +268,11 @@ class Cookie
 		// Special case for the login cookie.
 		if ($name === Config::$cookiename) {
 			// First check for JSON-format cookie
-			if (preg_match('~^{"0":\\d+,"1":"[0-9a-f]*","2":\\d+,"3":"[^"]+","4":"[^"]+"~', $_COOKIE[$name])) {
+			if (preg_match('~^{"0":\d+,"1":"[0-9a-f]*","2":\d+,"3":"[^"]+","4":"[^"]+"~', $_COOKIE[$name])) {
 				$data = Utils::jsonDecode($_COOKIE[$name], true);
 			}
 			// Legacy format (for recent upgrades from SMF 2.0.x)
-			elseif (preg_match('~^a:[34]:\\{i:0;i:\\d+;i:1;s:(0|40):"([a-fA-F0-9]{40})?";i:2;[id]:\\d+;(i:3;i:\\d;)?~', $_COOKIE[$name])) {
+			elseif (preg_match('~^a:[34]:\{i:0;i:\d+;i:1;s:(0|40):"([a-fA-F0-9]{40})?";i:2;[id]:\d+;(i:3;i:\d;)?~', $_COOKIE[$name])) {
 				$data = Utils::safeUnserialize($_COOKIE[$name]);
 
 				list(, , , $state) = $data;
@@ -495,7 +495,7 @@ class Cookie
 			$host = Config::$modSettings['globalCookiesDomain'];
 		}
 		// Globalize cookies across domains? (filter out IP-addresses)
-		elseif ($global && preg_match('~^\\d{1,3}(\\.\\d{1,3}){3}$~', $host) == 0 && preg_match('~(?:[^\\.]+\\.)?([^\\.]{2,}\\..+)\\z~i', $host, $parts) == 1) {
+		elseif ($global && preg_match('~^\d{1,3}(\.\d{1,3}){3}$~', $host) == 0 && preg_match('~(?:[^\.]+\.)?([^\.]{2,}\..+)\z~i', $host, $parts) == 1) {
 			$host = '.' . $parts[1];
 		}
 		// We shouldn't use a host at all if both options are off.

--- a/Sources/Cookie.php
+++ b/Sources/Cookie.php
@@ -316,9 +316,8 @@ class Cookie
 
 			return new self($name, [$member, $hash], $expires, $domain, $path);
 		}
+
 		// Other cookies.
-
-
 		$data = Utils::jsonDecode($_COOKIE[$name], true, false);
 
 		if (json_last_error() !== JSON_ERROR_NONE) {
@@ -326,7 +325,6 @@ class Cookie
 		}
 
 		return new self($name, $data);
-
 	}
 
 	/**

--- a/Sources/Db/APIs/MySQL.php
+++ b/Sources/Db/APIs/MySQL.php
@@ -1162,10 +1162,7 @@ class MySQL extends DatabaseApi implements DatabaseApiInterface
 	{
 		$value = ini_get('mysqli.allow_persistent');
 
-		return (bool) (strtolower($value) == 'on' || strtolower($value) == 'true' || $value == '1')
-
-
-		;
+		return (bool) (strtolower($value) == 'on' || strtolower($value) == 'true' || $value == '1');
 	}
 
 	/*****************************************
@@ -1223,7 +1220,6 @@ class MySQL extends DatabaseApi implements DatabaseApiInterface
 	 */
 	public function search_language()
 	{
-
 	}
 
 	/*******************************************
@@ -2280,7 +2276,6 @@ class MySQL extends DatabaseApi implements DatabaseApiInterface
 
 					return implode(', ', $replacement);
 				}
-
 
 				$this->error_backtrace('Wrong value type sent to the database. Array of IPv4 or IPv6 expected. (' . $matches[2] . ')', '', E_USER_ERROR, __FILE__, __LINE__);
 

--- a/Sources/Db/APIs/MySQL.php
+++ b/Sources/Db/APIs/MySQL.php
@@ -122,10 +122,10 @@ class MySQL extends DatabaseApi implements DatabaseApiInterface
 	{
 		// Comments that are allowed in a query are preg_removed.
 		$allowed_comments_from = [
-			'~\\s+~s',
-			'~/\\*!40001 SQL_NO_CACHE \\*/~',
-			'~/\\*!40000 USE INDEX \\([A-Za-z\\_]+?\\) \\*/~',
-			'~/\\*!40100 ON DUPLICATE KEY UPDATE id_msg = \\d+ \\*/~',
+			'~\s+~s',
+			'~/\*!40001 SQL_NO_CACHE \*/~',
+			'~/\*!40000 USE INDEX \([A-Za-z\_]+?\) \*/~',
+			'~/\*!40100 ON DUPLICATE KEY UPDATE id_msg = \d+ \*/~',
 		];
 		$allowed_comments_to = [
 			' ',
@@ -145,7 +145,7 @@ class MySQL extends DatabaseApi implements DatabaseApiInterface
 		}
 
 		// Use "ORDER BY null" to prevent Mysql doing filesorts for Group By clauses without an Order By
-		if (strpos($db_string, 'GROUP BY') !== false && strpos($db_string, 'ORDER BY') === false && preg_match('~^\\s+SELECT~i', $db_string)) {
+		if (strpos($db_string, 'GROUP BY') !== false && strpos($db_string, 'ORDER BY') === false && preg_match('~^\s+SELECT~i', $db_string)) {
 			// Add before LIMIT
 			if ($pos = strpos($db_string, 'LIMIT ')) {
 				$db_string = substr($db_string, 0, $pos) . "\t\t\tORDER BY null\n" . substr($db_string, $pos, strlen($db_string));
@@ -620,8 +620,8 @@ class MySQL extends DatabaseApi implements DatabaseApiInterface
 	public function escape_wildcard_string($string, $translate_human_wildcards = false)
 	{
 		$replacements = [
-			'%' => '\\%',
-			'_' => '\\_',
+			'%' => '\%',
+			'_' => '\_',
 			'\\' => '\\\\',
 		];
 
@@ -822,7 +822,7 @@ class MySQL extends DatabaseApi implements DatabaseApiInterface
 		list(, $create) = $this->fetch_row($result);
 		$this->free_result($result);
 
-		$create = preg_split('/[\\n\\r]/', $create);
+		$create = preg_split('/[\n\r]/', $create);
 
 		$auto_inc = '';
 		// Default engine type.
@@ -839,7 +839,7 @@ class MySQL extends DatabaseApi implements DatabaseApiInterface
 			// For the engine type, see if we can work out what it is.
 			if (strpos($l, 'ENGINE') !== false || strpos($l, 'TYPE') !== false) {
 				// Extract the engine type.
-				preg_match('~(ENGINE|TYPE)=(\\w+)(\\sDEFAULT)?(\\sCHARSET=(\\w+))?(\\sCOLLATE=(\\w+))?~', $l, $match);
+				preg_match('~(ENGINE|TYPE)=(\w+)(\sDEFAULT)?(\sCHARSET=(\w+))?(\sCOLLATE=(\w+))?~', $l, $match);
 
 				if (!empty($match[1])) {
 					$engine = $match[1];
@@ -890,7 +890,7 @@ class MySQL extends DatabaseApi implements DatabaseApiInterface
 		);
 
 		if ($auto_inc != '') {
-			if (preg_match('~\\`(.+?)\\`\\s~', $auto_inc, $match) != 0 && substr($auto_inc, -1, 1) == ',') {
+			if (preg_match('~\`(.+?)\`\s~', $auto_inc, $match) != 0 && substr($auto_inc, -1, 1) == ',') {
 				$auto_inc = substr($auto_inc, 0, -1);
 			}
 
@@ -1311,7 +1311,7 @@ class MySQL extends DatabaseApi implements DatabaseApiInterface
 			if (isset($index_info['type']) && $index_info['type'] == 'primary') {
 				$index_info['name'] = '';
 			} else {
-				$index_info['name'] = trim(implode('_', preg_replace('~(\\(\\d+\\))~', '', $index_info['columns'])));
+				$index_info['name'] = trim(implode('_', preg_replace('~(\(\d+\))~', '', $index_info['columns'])));
 			}
 		}
 
@@ -1605,7 +1605,7 @@ class MySQL extends DatabaseApi implements DatabaseApiInterface
 				$table_query .= "\n\t" . 'PRIMARY KEY (' . implode(',', $index['columns']) . '),';
 			} else {
 				if (empty($index['name'])) {
-					$index['name'] = trim(implode('_', preg_replace('~(\\(\\d+\\))~', '', $index['columns'])));
+					$index['name'] = trim(implode('_', preg_replace('~(\(\d+\))~', '', $index['columns'])));
 				}
 
 				$table_query .= "\n\t" . (isset($index['type']) && $index['type'] == 'unique' ? 'UNIQUE' : 'KEY') . ' ' . $index['name'] . ' (' . $idx_columns . '),';
@@ -1798,7 +1798,7 @@ class MySQL extends DatabaseApi implements DatabaseApiInterface
 				$auto = strpos($row['Extra'], 'auto_increment') !== false ? true : false;
 
 				// Can we split out the size?
-				if (preg_match('~(.+?)\\s*\\((\\d+)\\)(?:(?:\\s*)?(unsigned))?~i', $row['Type'], $matches) === 1) {
+				if (preg_match('~(.+?)\s*\((\d+)\)(?:(?:\s*)?(unsigned))?~i', $row['Type'], $matches) === 1) {
 					$type = $matches[1];
 					$size = $matches[2];
 
@@ -2198,7 +2198,7 @@ class MySQL extends DatabaseApi implements DatabaseApiInterface
 				break;
 
 			case 'date':
-				if (preg_match('~^(\\d{4})-([0-1]?\\d)-([0-3]?\\d)$~', $replacement, $date_matches) === 1) {
+				if (preg_match('~^(\d{4})-([0-1]?\d)-([0-3]?\d)$~', $replacement, $date_matches) === 1) {
 					return sprintf('\'%04d-%02d-%02d\'', $date_matches[1], $date_matches[2], $date_matches[3]);
 				}
 
@@ -2207,7 +2207,7 @@ class MySQL extends DatabaseApi implements DatabaseApiInterface
 				break;
 
 			case 'time':
-				if (preg_match('~^([0-1]?\\d|2[0-3]):([0-5]\\d):([0-5]\\d)$~', $replacement, $time_matches) === 1) {
+				if (preg_match('~^([0-1]?\d|2[0-3]):([0-5]\d):([0-5]\d)$~', $replacement, $time_matches) === 1) {
 					return sprintf('\'%02d:%02d:%02d\'', $time_matches[1], $time_matches[2], $time_matches[3]);
 				}
 
@@ -2216,7 +2216,7 @@ class MySQL extends DatabaseApi implements DatabaseApiInterface
 				break;
 
 			case 'datetime':
-				if (preg_match('~^(\\d{4})-([0-1]?\\d)-([0-3]?\\d) ([0-1]?\\d|2[0-3]):([0-5]\\d):([0-5]\\d)$~', $replacement, $datetime_matches) === 1) {
+				if (preg_match('~^(\d{4})-([0-1]?\d)-([0-3]?\d) ([0-1]?\d|2[0-3]):([0-5]\d):([0-5]\d)$~', $replacement, $datetime_matches) === 1) {
 					return 'str_to_date(' .
 						sprintf('\'%04d-%02d-%02d %02d:%02d:%02d\'', $datetime_matches[1], $datetime_matches[2], $datetime_matches[3], $datetime_matches[4], $datetime_matches[5], $datetime_matches[6]) .
 						',\'%Y-%m-%d %h:%i:%s\')';

--- a/Sources/Db/APIs/PostgreSQL.php
+++ b/Sources/Db/APIs/PostgreSQL.php
@@ -1095,10 +1095,7 @@ class PostgreSQL extends DatabaseApi implements DatabaseApiInterface
 	{
 		$value = ini_get('pgsql.allow_persistent');
 
-		return (bool) (strtolower($value) == 'on' || strtolower($value) == 'true' || $value == '1')
-
-
-		;
+		return (bool) (strtolower($value) == 'on' || strtolower($value) == 'true' || $value == '1');
 	}
 
 	/*****************************************
@@ -1294,7 +1291,6 @@ class PostgreSQL extends DatabaseApi implements DatabaseApiInterface
 				'security_override' => true,
 			],
 		);
-
 
 		// If there's more attributes they need to be done via a change on PostgreSQL.
 		unset($column_info['type'], $column_info['size']);
@@ -1801,7 +1797,6 @@ class PostgreSQL extends DatabaseApi implements DatabaseApiInterface
 				[],
 			);
 		}
-
 
 		// And the indexes...
 		foreach ($index_queries as $query) {

--- a/Sources/Db/APIs/PostgreSQL.php
+++ b/Sources/Db/APIs/PostgreSQL.php
@@ -146,7 +146,7 @@ class PostgreSQL extends DatabaseApi implements DatabaseApiInterface
 		// Special queries that need processing.
 		$replacements = [
 			'profile_board_stats' => [
-				'~COUNT\\(\\*\\) \\/ MAX\\(b.num_posts\\)~' => 'CAST(COUNT(*) AS DECIMAL) / CAST(b.num_posts AS DECIMAL)',
+				'~COUNT\(\*\) \/ MAX\(b.num_posts\)~' => 'CAST(COUNT(*) AS DECIMAL) / CAST(b.num_posts AS DECIMAL)',
 			],
 		];
 
@@ -165,7 +165,7 @@ class PostgreSQL extends DatabaseApi implements DatabaseApiInterface
 		}
 
 		// Limits need to be a little different.
-		$db_string = preg_replace('~\\sLIMIT\\s(\\d+|{int:.+}),\\s*(\\d+|{int:.+})\\s*$~i', 'LIMIT $2 OFFSET $1', $db_string);
+		$db_string = preg_replace('~\sLIMIT\s(\d+|{int:.+}),\s*(\d+|{int:.+})\s*$~i', 'LIMIT $2 OFFSET $1', $db_string);
 
 		if (trim($db_string) == '') {
 			return false;
@@ -173,10 +173,10 @@ class PostgreSQL extends DatabaseApi implements DatabaseApiInterface
 
 		// Comments that are allowed in a query are preg_removed.
 		$allowed_comments_from = [
-			'~\\s+~s',
-			'~/\\*!40001 SQL_NO_CACHE \\*/~',
-			'~/\\*!40000 USE INDEX \\([A-Za-z\\_]+?\\) \\*/~',
-			'~/\\*!40100 ON DUPLICATE KEY UPDATE id_msg = \\d+ \\*/~',
+			'~\s+~s',
+			'~/\*!40001 SQL_NO_CACHE \*/~',
+			'~/\*!40000 USE INDEX \([A-Za-z\_]+?\) \*/~',
+			'~/\*!40100 ON DUPLICATE KEY UPDATE id_msg = \d+ \*/~',
 		];
 		$allowed_comments_to = [
 			' ',
@@ -195,7 +195,7 @@ class PostgreSQL extends DatabaseApi implements DatabaseApiInterface
 		}
 
 		// Use "ORDER BY null" to prevent Mysql doing filesorts for Group By clauses without an Order By
-		if (strpos($db_string, 'GROUP BY') !== false && strpos($db_string, 'ORDER BY') === false && preg_match('~^\\s+SELECT~i', $db_string)) {
+		if (strpos($db_string, 'GROUP BY') !== false && strpos($db_string, 'ORDER BY') === false && preg_match('~^\s+SELECT~i', $db_string)) {
 			// Add before LIMIT
 			if ($pos = strpos($db_string, 'LIMIT ')) {
 				$db_string = substr($db_string, 0, $pos) . "\t\t\tORDER BY null\n" . substr($db_string, $pos, strlen($db_string));
@@ -663,8 +663,8 @@ class PostgreSQL extends DatabaseApi implements DatabaseApiInterface
 	public function escape_wildcard_string($string, $translate_human_wildcards = false)
 	{
 		$replacements = [
-			'%' => '\\%',
-			'_' => '\\_',
+			'%' => '\%',
+			'_' => '\_',
 			'\\' => '\\\\',
 		];
 
@@ -972,7 +972,7 @@ class PostgreSQL extends DatabaseApi implements DatabaseApiInterface
 				$schema_create .= ' default ' . $row['column_default'] . '';
 
 				// Auto increment?
-				if (preg_match('~nextval\\(\'(.+?)\'(.+?)*\\)~i', $row['column_default'], $matches) != 0) {
+				if (preg_match('~nextval\(\'(.+?)\'(.+?)*\)~i', $row['column_default'], $matches) != 0) {
 					// Get to find the next variable first!
 					$count_req = $this->query(
 						'',
@@ -1115,26 +1115,26 @@ class PostgreSQL extends DatabaseApi implements DatabaseApiInterface
 				'~ENGINE=MEMORY~i' => '',
 			],
 			'insert_into_log_messages_fulltext' => [
-				'/NOT\\sLIKE/' => 'NOT ILIKE',
-				'/\\bLIKE\\b/' => 'ILIKE',
+				'/NOT\sLIKE/' => 'NOT ILIKE',
+				'/\bLIKE\b/' => 'ILIKE',
 				'/NOT RLIKE/' => '!~*',
 				'/RLIKE/' => '~*',
 			],
 			'insert_log_search_results_subject' => [
-				'/NOT\\sLIKE/' => 'NOT ILIKE',
-				'/\\bLIKE\\b/' => 'ILIKE',
+				'/NOT\sLIKE/' => 'NOT ILIKE',
+				'/\bLIKE\b/' => 'ILIKE',
 				'/NOT RLIKE/' => '!~*',
 				'/RLIKE/' => '~*',
 			],
 			'insert_log_search_topics' => [
-				'/NOT\\sLIKE/' => 'NOT ILIKE',
-				'/\\bLIKE\\b/' => 'ILIKE',
+				'/NOT\sLIKE/' => 'NOT ILIKE',
+				'/\bLIKE\b/' => 'ILIKE',
 				'/NOT RLIKE/' => '!~*',
 				'/RLIKE/' => '~*',
 			],
 			'insert_log_search_results_no_index' => [
-				'/NOT\\sLIKE/' => 'NOT ILIKE',
-				'/\\bLIKE\\b/' => 'ILIKE',
+				'/NOT\sLIKE/' => 'NOT ILIKE',
+				'/\bLIKE\b/' => 'ILIKE',
 				'/NOT RLIKE/' => '!~*',
 				'/RLIKE/' => '~*',
 			],
@@ -1144,8 +1144,8 @@ class PostgreSQL extends DatabaseApi implements DatabaseApiInterface
 			$db_string = preg_replace(array_keys($replacements[$identifier]), array_values($replacements[$identifier]), $db_string);
 		}
 
-		if (preg_match('~^\\s*INSERT\\s+IGNORE\\b~i', $db_string) != 0) {
-			$db_string = preg_replace('~^\\s*INSERT\\s+IGNORE\\b~i', 'INSERT', $db_string);
+		if (preg_match('~^\s*INSERT\s+IGNORE\b~i', $db_string) != 0) {
+			$db_string = preg_replace('~^\s*INSERT\s+IGNORE\b~i', 'INSERT', $db_string);
 
 			if ($this->support_ignore) {
 				// pg style "INSERT INTO.... ON CONFLICT DO NOTHING"
@@ -1319,7 +1319,7 @@ class PostgreSQL extends DatabaseApi implements DatabaseApiInterface
 		$cols = $this->list_columns($table_name, true);
 
 		foreach ($index_info['columns'] as &$c) {
-			$c = preg_replace('~\\s+(\\(\\d+\\))~', '', $c);
+			$c = preg_replace('~\s+(\(\d+\))~', '', $c);
 		}
 
 		$columns = implode(',', $index_info['columns']);
@@ -1330,7 +1330,7 @@ class PostgreSQL extends DatabaseApi implements DatabaseApiInterface
 			if (isset($index_info['type']) && $index_info['type'] == 'primary') {
 				$index_info['name'] = '';
 			} else {
-				$index_info['name'] = trim(implode('_', preg_replace('~(\\(\\d+\\))~', '', $index_info['columns'])));
+				$index_info['name'] = trim(implode('_', preg_replace('~(\(\d+\))~', '', $index_info['columns'])));
 			}
 		}
 
@@ -1730,7 +1730,7 @@ class PostgreSQL extends DatabaseApi implements DatabaseApiInterface
 		foreach ($indexes as $index) {
 			// MySQL you can do a "column_name (length)", postgresql does not allow this.  Strip it.
 			foreach ($index['columns'] as &$c) {
-				$c = preg_replace('~\\s+(\\(\\d+\\))~', '', $c);
+				$c = preg_replace('~\s+(\(\d+\))~', '', $c);
 			}
 
 			$idx_columns = implode(',', $index['columns']);
@@ -1740,7 +1740,7 @@ class PostgreSQL extends DatabaseApi implements DatabaseApiInterface
 				$table_query .= "\n\t" . 'PRIMARY KEY (' . implode(',', $index['columns']) . '),';
 			} else {
 				if (empty($index['name'])) {
-					$index['name'] = trim(implode('_', preg_replace('~(\\(\\d+\\))~', '', $index['columns'])));
+					$index['name'] = trim(implode('_', preg_replace('~(\(\d+\))~', '', $index['columns'])));
 				}
 
 				$index_queries[] = 'CREATE ' . (isset($index['type']) && $index['type'] == 'unique' ? 'UNIQUE' : '') . ' INDEX ' . $short_table_name . '_' . $index['name'] . ' ON ' . $short_table_name . ' (' . $idx_columns . ')';
@@ -1923,7 +1923,7 @@ class PostgreSQL extends DatabaseApi implements DatabaseApiInterface
 
 				// What is the default?
 				if ($row['column_default'] !== null) {
-					if (preg_match('~nextval\\(\'(.+?)\'(.+?)*\\)~i', $row['column_default'], $matches) != 0) {
+					if (preg_match('~nextval\(\'(.+?)\'(.+?)*\)~i', $row['column_default'], $matches) != 0) {
 						$auto = true;
 					} elseif (substr($row['column_default'], 0, 4) != 'NULL' && trim($row['column_default']) != '') {
 						$pos = strpos($row['column_default'], '::');
@@ -1978,7 +1978,7 @@ class PostgreSQL extends DatabaseApi implements DatabaseApiInterface
 
 		while ($row = $this->fetch_assoc($result)) {
 			// Try get the columns that make it up.
-			if (preg_match('~\\(([^\\)]+?)\\)~i', $row['inddef'], $matches) == 0) {
+			if (preg_match('~\(([^\)]+?)\)~i', $row['inddef'], $matches) == 0) {
 				continue;
 			}
 
@@ -2308,7 +2308,7 @@ class PostgreSQL extends DatabaseApi implements DatabaseApiInterface
 				break;
 
 			case 'date':
-				if (preg_match('~^(\\d{4})-([0-1]?\\d)-([0-3]?\\d)$~', $replacement, $date_matches) === 1) {
+				if (preg_match('~^(\d{4})-([0-1]?\d)-([0-3]?\d)$~', $replacement, $date_matches) === 1) {
 					return sprintf('\'%04d-%02d-%02d\'', $date_matches[1], $date_matches[2], $date_matches[3]) . '::date';
 				}
 
@@ -2317,7 +2317,7 @@ class PostgreSQL extends DatabaseApi implements DatabaseApiInterface
 				break;
 
 			case 'time':
-				if (preg_match('~^([0-1]?\\d|2[0-3]):([0-5]\\d):([0-5]\\d)$~', $replacement, $time_matches) === 1) {
+				if (preg_match('~^([0-1]?\d|2[0-3]):([0-5]\d):([0-5]\d)$~', $replacement, $time_matches) === 1) {
 					return sprintf('\'%02d:%02d:%02d\'', $time_matches[1], $time_matches[2], $time_matches[3]) . '::time';
 				}
 
@@ -2326,7 +2326,7 @@ class PostgreSQL extends DatabaseApi implements DatabaseApiInterface
 				break;
 
 			case 'datetime':
-				if (preg_match('~^(\\d{4})-([0-1]?\\d)-([0-3]?\\d) ([0-1]?\\d|2[0-3]):([0-5]\\d):([0-5]\\d)$~', $replacement, $datetime_matches) === 1) {
+				if (preg_match('~^(\d{4})-([0-1]?\d)-([0-3]?\d) ([0-1]?\d|2[0-3]):([0-5]\d):([0-5]\d)$~', $replacement, $datetime_matches) === 1) {
 					return 'to_timestamp(' .
 						sprintf('\'%04d-%02d-%02d %02d:%02d:%02d\'', $datetime_matches[1], $datetime_matches[2], $datetime_matches[3], $datetime_matches[4], $datetime_matches[5], $datetime_matches[6]) .
 						',\'YYYY-MM-DD HH24:MI:SS\')';

--- a/Sources/Draft.php
+++ b/Sources/Draft.php
@@ -644,7 +644,7 @@ class Draft
 		}
 
 		if (isset($_POST['subject'])) {
-			$this->subject = Utils::entitySubstr(trim(preg_replace('/(\\pZ|&nbsp;)+/u', ' ', Utils::htmlspecialchars($_POST['subject']))), 0, 100);
+			$this->subject = Utils::entitySubstr(trim(preg_replace('/(\pZ|&nbsp;)+/u', ' ', Utils::htmlspecialchars($_POST['subject']))), 0, 100);
 		}
 
 		if (empty($this->member)) {
@@ -663,7 +663,7 @@ class Draft
 			$this->locked = !empty($_POST['lock']);
 		}
 
-		if (!empty($_POST['icon']) && preg_match('/^\\w+$/', $_POST['icon'])) {
+		if (!empty($_POST['icon']) && preg_match('/^\w+$/', $_POST['icon'])) {
 			$this->icon = $_POST['icon'];
 		}
 

--- a/Sources/DynamicPropertyHelper.php
+++ b/Sources/DynamicPropertyHelper.php
@@ -234,9 +234,7 @@ trait DynamicPropertyHelper
 			return $this->{$prop} ?? null;
 		}
 
-
 		return $this->custom[$prop] ?? null;
-
 	}
 
 	/**
@@ -261,23 +259,17 @@ trait DynamicPropertyHelper
 					return isset($this->{$real_prop[0]}->{$real_prop[1]});
 				}
 
-
 				return isset($this->{$real_prop[0]}[$real_prop[1]]);
-
 			}
 
-
 			return isset($this->{$real_prop});
-
 		}
 
 		if (property_exists($this, $prop)) {
 			return isset($this->{$prop});
 		}
 
-
 		return isset($this->custom[$prop]);
-
 	}
 
 	/**

--- a/Sources/Event.php
+++ b/Sources/Event.php
@@ -629,7 +629,6 @@ class Event implements \ArrayAccess
 			return $not ? !$value : $value;
 		}
 
-
 		if (in_array($prop, ['year', 'month', 'day', 'hour', 'minute', 'second'])) {
 			$prop = 'start_' . $prop;
 		}
@@ -767,7 +766,6 @@ class Event implements \ArrayAccess
 		}
 
 		return $value;
-
 	}
 
 	/**
@@ -790,11 +788,8 @@ class Event implements \ArrayAccess
 				return isset($this->{$real_prop[0]}[$real_prop[1]]);
 			}
 
-
 			return isset($this->{$real_prop});
-
 		}
-
 
 		if (in_array($prop, ['year', 'month', 'day', 'hour', 'minute', 'second'])) {
 			$prop = 'start_' . $prop;
@@ -856,7 +851,6 @@ class Event implements \ArrayAccess
 			default:
 				return isset($this->custom[$prop]);
 		}
-
 	}
 
 	/***********************

--- a/Sources/Event.php
+++ b/Sources/Event.php
@@ -710,7 +710,7 @@ class Event implements \ArrayAccess
 
 			case 'start_iso_gmdate':
 			case 'end_iso_gmdate':
-				$value = $this->allday ? preg_replace('/T\\d\\d:\\d\\d:\\d\\d/', 'T00:00:00', $this->{$start_end}->iso_gmdate) : $this->{$start_end}->iso_gmdate;
+				$value = $this->allday ? preg_replace('/T\d\d:\d\d:\d\d/', 'T00:00:00', $this->{$start_end}->iso_gmdate) : $this->{$start_end}->iso_gmdate;
 				break;
 
 			case 'tz':

--- a/Sources/Forum.php
+++ b/Sources/Forum.php
@@ -359,11 +359,9 @@ class Forum
 			if (isset($_REQUEST['action']) && (in_array($_REQUEST['action'], ['login2', 'logintfa', 'logout']))) {
 				return self::$actions[$_REQUEST['action']][1];
 			}
+
 			// Don't even try it, sonny.
-
-
 			return __CLASS__ . '::inMaintenance';
-
 		}
 
 		// If guest access is off, a guest can only do one of the very few following actions.

--- a/Sources/Graphics/Gif/FileHeader.php
+++ b/Sources/Graphics/Gif/FileHeader.php
@@ -37,7 +37,6 @@ class FileHeader
 	public function __construct()
 	{
 		unset($this->m_lpVer, $this->m_nWidth, $this->m_nHeight, $this->m_bGlobalClr, $this->m_nColorRes, $this->m_bSorted, $this->m_nTableSize, $this->m_nBgColor, $this->m_nPixelRatio, $this->m_colorTable);
-
 	}
 
 	public function load($lpData, &$hdrLen)

--- a/Sources/Graphics/Gif/ImageHeader.php
+++ b/Sources/Graphics/Gif/ImageHeader.php
@@ -36,7 +36,6 @@ class ImageHeader
 	public function __construct()
 	{
 		unset($this->m_nLeft, $this->m_nTop, $this->m_nWidth, $this->m_nHeight, $this->m_bLocalClr, $this->m_bInterlace, $this->m_bSorted, $this->m_nTableSize, $this->m_colorTable);
-
 	}
 
 	public function load($lpData, &$hdrLen)

--- a/Sources/Graphics/Image.php
+++ b/Sources/Graphics/Image.php
@@ -897,7 +897,7 @@ class Image
 	 */
 	protected function getSvgDimensions(): void
 	{
-		preg_match('/<svg\\b[^>]*>/', file_get_contents($this->source, false, null, 0, 480), $matches);
+		preg_match('/<svg\b[^>]*>/', file_get_contents($this->source, false, null, 0, 480), $matches);
 
 		if (!isset($matches[0])) {
 			return;
@@ -909,7 +909,7 @@ class Image
 		// If attribute is missing, SVG spec says the default is '100%'.
 		// If no unit is supplied, spec says unit defaults to px.
 		foreach (['width', 'height'] as $dimension) {
-			if (preg_match("/\\b{$dimension}\\s*=\\s*([\"'])\\s*([\\d.]+)([\\D\\S]*)\\s*\\1/", $svg, $matches)) {
+			if (preg_match("/\b{$dimension}\s*=\s*([\"'])\s*([\d.]+)([\D\S]*)\s*\1/", $svg, $matches)) {
 				$$dimension = $matches[2];
 				$unit = !empty($matches[3]) ? $matches[3] : 'px';
 			} else {
@@ -975,7 +975,7 @@ class Image
 		}
 
 		// Width and/or height is missing or a percentage, so try the viewBox attribute.
-		if ((!isset($width) || !isset($height)) && preg_match('/\\bviewBox\\s*=\\s*(["\'])\\s*[\\d.]+[,\\s]+[\\d.]+[,\\s]+([\\d.]+)[,\\s]+([\\d.]+)\\s*\\1/', $svg, $matches)) {
+		if ((!isset($width) || !isset($height)) && preg_match('/\bviewBox\s*=\s*(["\'])\s*[\d.]+[,\s]+[\d.]+[,\s]+([\d.]+)[,\s]+([\d.]+)\s*\1/', $svg, $matches)) {
 			$vb_width = $matches[2];
 			$vb_height = $matches[3];
 
@@ -1028,7 +1028,7 @@ class Image
 			if (!empty($extensive)) {
 				// Paranoid check.
 				// Will result in MANY false positives, and is not suitable for photography sites.
-				if (preg_match('~(iframe|\\<\\?|\\<%|html|eval|body|script\\W|(?-i)[CFZ]WS[\\x01-\\x0E])~i', $prev_chunk . $cur_chunk) === 1) {
+				if (preg_match('~(iframe|\\<\\?|\\<%|html|eval|body|script\W|(?-i)[CFZ]WS[\x01-\x0E])~i', $prev_chunk . $cur_chunk) === 1) {
 					fclose($fp);
 
 					return false;
@@ -1036,7 +1036,7 @@ class Image
 			} else {
 				// Check for potential infection - focus on clues for inline PHP & flash.
 				// Will result in significantly fewer false positives than the paranoid check.
-				if (preg_match('~(\\<\\?php\\s|(?-i)[CFZ]WS[\\x01-\\x0E])~i', $prev_chunk . $cur_chunk) === 1) {
+				if (preg_match('~(\\<\\?php\s|(?-i)[CFZ]WS[\x01-\x0E])~i', $prev_chunk . $cur_chunk) === 1) {
 					fclose($fp);
 
 					return false;
@@ -1067,28 +1067,28 @@ class Image
 
 		$patterns = [
 			// No external or embedded scripts allowed.
-			'/<(\\S*:)?script\\b/i',
-			'/\\b(\\S:)?href\\s*=\\s*["\']\\s*javascript:/i',
+			'/<(\S*:)?script\b/i',
+			'/\b(\S:)?href\s*=\s*["\']\s*javascript:/i',
 
 			// No SVG event attributes allowed, since they execute scripts.
-			'/\\bon\\w+\\s*=\\s*["\']/',
-			'/<(\\S*:)?set\\b[^>]*\\battributeName\\s*=\\s*(["\'])\\s*on\\w+\\1/i',
+			'/\bon\w+\s*=\s*["\']/',
+			'/<(\S*:)?set\b[^>]*\battributeName\s*=\s*(["\'])\s*on\w+\1/i',
 
 			// No XML Events allowed, since they execute scripts.
-			'~\\bhttp://www\\.w3\\.org/2001/xml-events\\b~i',
+			'~\bhttp://www\.w3\.org/2001/xml-events\b~i',
 
 			// No data URIs allowed, since they contain arbitrary data.
-			'/\\b(\\S*:)?href\\s*=\\s*["\']\\s*data:/i',
+			'/\b(\S*:)?href\s*=\s*["\']\s*data:/i',
 
 			// No foreignObjects allowed, since they allow embedded HTML.
-			'/<(\\S*:)?foreignObject\\b/i',
+			'/<(\S*:)?foreignObject\b/i',
 
 			// No custom entities allowed, since they can be used for entity
 			// recursion attacks.
-			'/<!ENTITY\\b/',
+			'/<!ENTITY\b/',
 
 			// Embedded external images can't have custom cross-origin rules.
-			'/<\\b(\\S*:)?image\\b[^>]*\\bcrossorigin\\s*=/',
+			'/<\b(\S*:)?image\b[^>]*\bcrossorigin\s*=/',
 
 			// No embedded PHP tags allowed.
 			// Harmless if the SVG is just the src of an img element, but very

--- a/Sources/Graphics/Image.php
+++ b/Sources/Graphics/Image.php
@@ -537,10 +537,7 @@ class Image
 						return false;
 					}
 
-					return !($constant_name === 'IMAGETYPE_UNKNOWN' || $constant_name === 'IMAGETYPE_COUNT')
-
-
-					;
+					return !($constant_name === 'IMAGETYPE_UNKNOWN' || $constant_name === 'IMAGETYPE_COUNT');
 				},
 				ARRAY_FILTER_USE_KEY,
 			);
@@ -1219,9 +1216,7 @@ class Image
 			return imagejpeg($dst_img, $destination, !empty(Config::$modSettings['avatar_jpeg_quality']) ? Config::$modSettings['avatar_jpeg_quality'] : 82);
 		}
 
-
 		return $imagesave($dst_img, $destination);
-
 	}
 
 	/**

--- a/Sources/Group.php
+++ b/Sources/Group.php
@@ -418,7 +418,7 @@ class Group implements \ArrayAccess
 		if ($prop === 'icons' && is_string($value)) {
 			$prop = 'raw_icons';
 
-			if (preg_match('/^\\d+#/', $value)) {
+			if (preg_match('/^\d+#/', $value)) {
 				list($this->icon_count, $this->icon_image) = explode('#', $value);
 			} else {
 				$this->icon_count = 0;

--- a/Sources/IP.php
+++ b/Sources/IP.php
@@ -389,7 +389,7 @@ class IP implements \Stringable
 			// If they're still too short, pad them out.
 			while (filter_var(implode($mode, $range[$key]), FILTER_VALIDATE_IP) === false && count($range[$key]) < $max_parts) {
 				if (in_array('*', $range[$key])) {
-					$range[$key] = explode($mode, preg_replace('/\\*(?!' . preg_quote($mode . '*') . ')/', '*' . $mode . '*', implode($mode, $range[$key])));
+					$range[$key] = explode($mode, preg_replace('/\*(?!' . preg_quote($mode . '*') . ')/', '*' . $mode . '*', implode($mode, $range[$key])));
 				} else {
 					$range[$key][] = '*';
 				}
@@ -545,7 +545,7 @@ class IP implements \Stringable
 		if (Utils::$context['server']['is_mac']) {
 			$test = (string) @shell_exec('dscacheutil -q host -a ' . ($this->isValid(FILTER_FLAG_IPV6) ? 'ipv6_address' : 'ip_address') . ' ' . @escapeshellarg($this->ip));
 
-			if (preg_match('~name:\\s+([^\\s]+)~i', $test, $match)) {
+			if (preg_match('~name:\s+([^\s]+)~i', $test, $match)) {
 				$host = $match[1];
 			}
 		}
@@ -567,7 +567,7 @@ class IP implements \Stringable
 				Config::updateModSettings(['host_to_dis' => 1]);
 			}
 			// Maybe it found something, after all?
-			elseif (preg_match('~\\s([^\\s]+?)\\.\\s~', $test, $match)) {
+			elseif (preg_match('~\s([^\s]+?)\.\s~', $test, $match)) {
 				$host = $match[1];
 			}
 		}
@@ -578,7 +578,7 @@ class IP implements \Stringable
 
 			if (strpos($test, 'Non-existent domain') !== false) {
 				$host = '';
-			} elseif (preg_match('~Name\\s*(?:=|:)\\s+([^\\s]+)~i', $test, $match)) {
+			} elseif (preg_match('~Name\s*(?:=|:)\s+([^\s]+)~i', $test, $match)) {
 				$host = $match[1];
 			}
 		}

--- a/Sources/ItemList.php
+++ b/Sources/ItemList.php
@@ -423,7 +423,7 @@ class ItemList implements \ArrayAccess
 				}
 				// A modified value (inject the database values).
 				elseif (isset($column['data']['eval'])) {
-					$cur_data['value'] = eval(preg_replace('~%([a-zA-Z0-9\\-_]+)%~', '$list_item[\'$1\']', $column['data']['eval']));
+					$cur_data['value'] = eval(preg_replace('~%([a-zA-Z0-9\-_]+)%~', '$list_item[\'$1\']', $column['data']['eval']));
 				}
 				// A literal value.
 				elseif (isset($column['data']['value'])) {

--- a/Sources/Lang.php
+++ b/Sources/Lang.php
@@ -377,7 +377,7 @@ class Lang
 
 				while ($entry = $dir->read()) {
 					// Look for the index language file... For good measure skip any "index.language-utf8.php" files
-					if (!preg_match('~^index\\.((?:.(?!-utf8))+)\\.php$~', $entry, $matches)) {
+					if (!preg_match('~^index\.((?:.(?!-utf8))+)\.php$~', $entry, $matches)) {
 						continue;
 					}
 
@@ -397,7 +397,7 @@ class Lang
 								continue;
 							}
 
-							preg_match('~\\$txt\\[\'native_name\'\\]\\s*=\\s*\'([^\']+)\';~', $line, $matchNative);
+							preg_match('~\$txt\[\'native_name\'\]\s*=\s*\'([^\']+)\';~', $line, $matchNative);
 
 							// Set the language's name.
 							if (!empty($matchNative) && !empty($matchNative[1])) {
@@ -476,8 +476,8 @@ class Lang
 					$censor_vulgar[$i] = str_replace(['\\\\\\*', '\\*', '&', '\''], ['[*]', '[^\\s]*?', '&amp;', '&#039;'], preg_quote($censor_vulgar[$i], '/'));
 
 					// Use the faster \b if we can, or something more complex if we can't
-					$boundary_before = preg_match('/^\\w/', $censor_vulgar[$i]) ? '\\b' : ($charset === 'UTF-8' ? '(?<![\\p{L}\\p{M}\\p{N}_])' : '(?<!\\w)');
-					$boundary_after = preg_match('/\\w$/', $censor_vulgar[$i]) ? '\\b' : ($charset === 'UTF-8' ? '(?![\\p{L}\\p{M}\\p{N}_])' : '(?!\\w)');
+					$boundary_before = preg_match('/^\w/', $censor_vulgar[$i]) ? '\b' : ($charset === 'UTF-8' ? '(?<![\p{L}\p{M}\p{N}_])' : '(?<!\w)');
+					$boundary_after = preg_match('/\w$/', $censor_vulgar[$i]) ? '\b' : ($charset === 'UTF-8' ? '(?![\p{L}\p{M}\p{N}_])' : '(?!\w)');
 
 					$censor_vulgar[$i] = '/' . $boundary_before . $censor_vulgar[$i] . $boundary_after . '/' . (empty(Config::$modSettings['censorIgnoreCase']) ? '' : 'i') . ($charset === 'UTF-8' ? 'u' : '');
 				}
@@ -600,7 +600,7 @@ class Lang
 		// Cache these values...
 		if (!isset(self::$decimal_separator)) {
 			// Not set for whatever reason?
-			if (empty(Lang::$txt['number_format']) || preg_match('~^1(\\D*)234(\\D*)(0*)$~', Lang::$txt['number_format'], $matches) != 1) {
+			if (empty(Lang::$txt['number_format']) || preg_match('~^1(\D*)234(\D*)(0*)$~', Lang::$txt['number_format'], $matches) != 1) {
 				return (string) $number;
 			}
 

--- a/Sources/Lang.php
+++ b/Sources/Lang.php
@@ -618,7 +618,6 @@ class Lang
 			self::$thousands_separator,
 		);
 	}
-
 }
 
 // Export public static functions and properties to global namespace for backward compatibility.

--- a/Sources/Logging.php
+++ b/Sources/Logging.php
@@ -841,7 +841,7 @@ class Logging
 		$temp = ob_get_contents();
 		ob_clean();
 
-		echo preg_replace('~</body>\\s*</html>~', '', $temp), '
+		echo preg_replace('~</body>\s*</html>~', '', $temp), '
 	<div class="smalltext" style="text-align: left; margin: 1ex;">
 		', Lang::$txt['debug_browser'], Utils::$context['browser_body_id'], ' <em>(', implode('</em>, <em>', array_reverse(array_keys(Utils::$context['browser'], true))), ')</em><br>
 		', Lang::$txt['debug_templates'], count(Utils::$context['debug']['templates']), ': <em>', implode('</em>, <em>', Utils::$context['debug']['templates']), '</em>.<br>
@@ -892,7 +892,7 @@ class Logging
 
 		if ($_SESSION['view_queries'] == 1 && !empty(Db::$cache)) {
 			foreach (Db::$cache as $q => $query_data) {
-				$is_select = strpos(trim($query_data['q']), 'SELECT') === 0 || preg_match('~^INSERT(?: IGNORE)? INTO \\w+(?:\\s+\\([^)]+\\))?\\s+SELECT .+$~s', trim($query_data['q'])) != 0 || strpos(trim($query_data['q']), 'WITH') === 0;
+				$is_select = strpos(trim($query_data['q']), 'SELECT') === 0 || preg_match('~^INSERT(?: IGNORE)? INTO \w+(?:\s+\([^)]+\))?\s+SELECT .+$~s', trim($query_data['q'])) != 0 || strpos(trim($query_data['q']), 'WITH') === 0;
 
 				// Temporary tables created in earlier queries are not explainable.
 				if ($is_select) {

--- a/Sources/Mail.php
+++ b/Sources/Mail.php
@@ -555,7 +555,6 @@ class Mail
 			}
 		}
 
-
 		// Any emails that didn't send?
 		if (!empty($failed_emails)) {
 			// Update the failed attempts check.
@@ -728,7 +727,6 @@ class Mail
 
 			return [$charset, $string, 'base64'];
 		}
-
 
 		return [$charset, $string, '7bit'];
 	}

--- a/Sources/Mail.php
+++ b/Sources/Mail.php
@@ -94,7 +94,7 @@ class Mail
 			$hotmail_to = [];
 
 			foreach ($to_array as $i => $to_address) {
-				if (preg_match('~@(att|comcast|bellsouth)\\.[a-zA-Z\\.]{2,6}$~i', $to_address) === 1) {
+				if (preg_match('~@(att|comcast|bellsouth)\.[a-zA-Z\.]{2,6}$~i', $to_address) === 1) {
 					$hotmail_to[] = $to_address;
 					$to_array = array_diff($to_array, [$to_address]);
 				}
@@ -123,7 +123,7 @@ class Mail
 		if ($hotmail_fix && !$send_html) {
 			$send_html = true;
 			$message = strtr($message, [$line_break => '<br>' . $line_break]);
-			$message = preg_replace('~(' . preg_quote(Config::$scripturl, '~') . '(?:[?/][\\w\\-_%\\.,\\?&;=#]+)?)~', '<a href="$1">$1</a>', $message);
+			$message = preg_replace('~(' . preg_quote(Config::$scripturl, '~') . '(?:[?/][\w\-_%\.,\?&;=#]+)?)~', '<a href="$1">$1</a>', $message);
 		}
 
 		list(, $from_name) = self::mimespecialchars(addcslashes($from !== null ? $from : Utils::$context['forum_name'], '<>()\'\\"'), true, $hotmail_fix, $line_break);
@@ -638,7 +638,7 @@ class Mail
 		$charset = $custom_charset !== null ? $custom_charset : Utils::$context['character_set'];
 
 		// This is the fun part....
-		if (preg_match_all('~&#(\\d{3,8});~', $string, $matches) !== 0 && !$hotmail_fix) {
+		if (preg_match_all('~&#(\d{3,8});~', $string, $matches) !== 0 && !$hotmail_fix) {
 			// Let's, for now, assume there are only &#021;'ish characters.
 			$simple = true;
 
@@ -651,7 +651,7 @@ class Mail
 
 			if ($simple) {
 				$string = preg_replace_callback(
-					'~&#(\\d{3,8});~',
+					'~&#(\d{3,8});~',
 					function ($m) {
 						return chr("{$m[1]}");
 					},
@@ -707,11 +707,11 @@ class Mail
 			};
 
 			// Convert all 'special' characters to HTML entities.
-			return [$charset, preg_replace_callback('~([\\x80-\\x{10FFFF}])~u', $entityConvert, $string), '7bit'];
+			return [$charset, preg_replace_callback('~([\x80-\x{10FFFF}])~u', $entityConvert, $string), '7bit'];
 		}
 
 		// We don't need to mess with the subject line if no special characters were in it..
-		if (!$hotmail_fix && preg_match('~([^\\x09\\x0A\\x0D\\x20-\\x7F])~', $string) === 1) {
+		if (!$hotmail_fix && preg_match('~([^\x09\x0A\x0D\x20-\x7F])~', $string) === 1) {
 			// Base64 encode.
 			$string = base64_encode($string);
 
@@ -814,7 +814,7 @@ class Mail
 				|| substr_compare($helo, '.local', -6) === 0
 				|| (
 					!empty(Config::$modSettings['tld_regex'])
-					&& !preg_match('/\\.' . Config::$modSettings['tld_regex'] . '$/u', $helo)
+					&& !preg_match('/\.' . Config::$modSettings['tld_regex'] . '$/u', $helo)
 				)
 			) {
 				$url = new Url(Config::$boardurl);

--- a/Sources/Mentions.php
+++ b/Sources/Mentions.php
@@ -262,18 +262,18 @@ class Mentions
 		}
 
 		// preparse code does a few things which might mess with our parsing
-		$body = htmlspecialchars_decode(preg_replace('~<br\\s*/?' . '>~', "\n", str_replace('&nbsp;', ' ', $body)), ENT_QUOTES);
+		$body = htmlspecialchars_decode(preg_replace('~<br\s*/?' . '>~', "\n", str_replace('&nbsp;', ' ', $body)), ENT_QUOTES);
 
 		if (empty(self::$excluded_bbc_regex)) {
 			self::setExcludedBbcRegex();
 		}
 
 		// Exclude the content of various BBCodes.
-		$body = preg_replace('~\\[(' . self::$excluded_bbc_regex . ')[^\\]]*\\](?' . '>(?' . '>[^\\[]|\\[(?!/?\\1[^\\]]*\\]))|(?0))*\\[/\\1\\]~', '', $body);
+		$body = preg_replace('~\[(' . self::$excluded_bbc_regex . ')[^\]]*\](?' . '>(?' . '>[^\[]|\[(?!/?\1[^\]]*\]))|(?0))*\[/\1\]~', '', $body);
 
 		$matches = [];
 		// Split before every Unicode character.
-		$string = preg_split('/(?=\\X)/u', $body, -1, PREG_SPLIT_NO_EMPTY);
+		$string = preg_split('/(?=\X)/u', $body, -1, PREG_SPLIT_NO_EMPTY);
 		$depth = 0;
 
 		foreach ($string as $k => $char) {
@@ -304,7 +304,7 @@ class Mentions
 
 		foreach ($matches as $match) {
 			// '[^\p{L}\p{M}\p{N}_]' is the Unicode equivalent of '[^\w]'
-			$match = preg_split('/([^\\p{L}\\p{M}\\p{N}_])/u', $match, -1, PREG_SPLIT_DELIM_CAPTURE);
+			$match = preg_split('/([^\p{L}\p{M}\p{N}_])/u', $match, -1, PREG_SPLIT_DELIM_CAPTURE);
 			$count = count($match);
 
 			for ($i = 1; $i <= $count; $i++) {
@@ -332,11 +332,11 @@ class Mentions
 		}
 
 		// Don't include mentions inside quotations, etc.
-		$body = preg_replace('~\\[(' . self::$excluded_bbc_regex . ')[^\\]]*\\](?' . '>(?' . '>[^\\[]|\\[(?!/?\\1[^\\]]*\\]))|(?0))*\\[/\\1\\]~', '', $body);
+		$body = preg_replace('~\[(' . self::$excluded_bbc_regex . ')[^\]]*\](?' . '>(?' . '>[^\[]|\[(?!/?\1[^\]]*\]))|(?0))*\[/\1\]~', '', $body);
 
 		$existing_mentions = [];
 
-		preg_match_all('~\\[member=([0-9]+)\\]([^\\[]*)\\[/member\\]~', $body, $matches, PREG_SET_ORDER);
+		preg_match_all('~\[member=([0-9]+)\]([^\[]*)\[/member\]~', $body, $matches, PREG_SET_ORDER);
 
 		foreach ($matches as $match_set) {
 			$existing_mentions[$match_set[1]] = trim($match_set[2]);
@@ -367,7 +367,7 @@ class Mentions
 		}
 
 		// Don't include mentions inside quotations, etc.
-		$body = preg_replace('~\\[(' . self::$excluded_bbc_regex . ')[^\\]]*\\](?' . '>(?' . '>[^\\[]|\\[(?!/?\\1[^\\]]*\\]))|(?0))*\\[/\\1\\]~', '', $body);
+		$body = preg_replace('~\[(' . self::$excluded_bbc_regex . ')[^\]]*\](?' . '>(?' . '>[^\[]|\[(?!/?\1[^\]]*\]))|(?0))*\[/\1\]~', '', $body);
 
 		foreach ($members as $member) {
 			if (strpos($body, '[member=' . $member['id'] . ']' . $member['real_name'] . '[/member]') === false) {
@@ -392,18 +392,18 @@ class Mentions
 			return [];
 		}
 
-		$blocks = preg_split('/(\\[quote.*?\\]|\\[\\/quote\\])/i', $body, -1, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE);
+		$blocks = preg_split('/(\[quote.*?\]|\[\/quote\])/i', $body, -1, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE);
 
 		$quote_level = 0;
 		$message = '';
 
 		foreach ($blocks as $block) {
-			if (preg_match('/\\[quote(.*)?\\]/i', $block, $matches)) {
+			if (preg_match('/\[quote(.*)?\]/i', $block, $matches)) {
 				if ($quote_level == 0) {
 					$message .= '[quote' . $matches[1] . ']';
 				}
 				$quote_level++;
-			} elseif (preg_match('/\\[\\/quote\\]/i', $block)) {
+			} elseif (preg_match('/\[\/quote\]/i', $block)) {
 				if ($quote_level <= 1) {
 					$message .= '[/quote]';
 				}
@@ -417,7 +417,7 @@ class Mentions
 			}
 		}
 
-		preg_match_all('/\\[quote.*?link=msg=([0-9]+).*?\\]/i', $message, $matches);
+		preg_match_all('/\[quote.*?link=msg=([0-9]+).*?\]/i', $message, $matches);
 
 		$id_msgs = $matches[1];
 

--- a/Sources/Menu.php
+++ b/Sources/Menu.php
@@ -338,7 +338,6 @@ class Menu implements \ArrayAccess
 				unset(Utils::$context['max_menu_id'], $this->data, $this->options);
 			}
 
-
 			$this->include_data = [];
 
 			return;
@@ -461,10 +460,7 @@ class Menu implements \ArrayAccess
 			return false;
 		}
 
-		return !(isset($menu_item['permission']) && !User::$me->allowedTo($menu_item['permission']))
-
-
-		;
+		return !(isset($menu_item['permission']) && !User::$me->allowedTo($menu_item['permission']));
 	}
 
 	/**
@@ -558,9 +554,8 @@ class Menu implements \ArrayAccess
 
 				return;
 			}
+
 			// Set which one is first, last, and selected in the group.
-
-
 			$first_sa = array_key_first($this_area['subsections']);
 			$last_sa = array_key_last($this_area['subsections']);
 
@@ -571,7 +566,6 @@ class Menu implements \ArrayAccess
 			if ($this->current_area == $this->area_id && empty($this->current_subsection)) {
 				$this->current_subsection = $first_sa;
 			}
-
 		}
 
 		$this->setCurrentSectionAndArea();
@@ -750,7 +744,6 @@ class Menu implements \ArrayAccess
 			$this->sections[$section_id]['url'] = $first_area['url'] ?? $this->base_url . ';area=' . array_key_first($section['areas']);
 		}
 	}
-
 }
 
 // Export public static functions and properties to global namespace for backward compatibility.

--- a/Sources/Msg.php
+++ b/Sources/Msg.php
@@ -1044,7 +1044,6 @@ class Msg implements \ArrayAccess
 			},
 			$message,
 		);
-
 	}
 
 	/**
@@ -2247,7 +2246,6 @@ class Msg implements \ArrayAccess
 			],
 			true,
 		);
-
 	}
 
 	/**
@@ -2896,10 +2894,8 @@ class Msg implements \ArrayAccess
 				return $enchant_link;
 			}
 
-
 			// Free up any resources used...
 			@enchant_broker_free(Utils::$context['enchant_broker']);
-
 		}
 
 		// Fall through to pspell if enchant didn't work
@@ -2988,9 +2984,7 @@ class Msg implements \ArrayAccess
 				return $suggestions;
 			}
 
-
 			return enchant_dict_suggest($dict, $word);
-
 		}
 
 		if (Utils::$context['provider'] == 'pspell') {

--- a/Sources/PackageManager/FtpConnection.php
+++ b/Sources/PackageManager/FtpConnection.php
@@ -183,8 +183,6 @@ class FtpConnection
 				break;
 			}
 
-
-
 			// Convert the chmod value from octal (0777) to text ("777").
 			fwrite($this->connection, 'SITE CHMOD ' . decoct($val) . ' ' . $ftp_file . "\r\n");
 
@@ -192,7 +190,6 @@ class FtpConnection
 				$this->error = 'bad_file';
 				break;
 			}
-
 		}
 
 		return $is_writable;

--- a/Sources/PackageManager/FtpConnection.php
+++ b/Sources/PackageManager/FtpConnection.php
@@ -274,7 +274,7 @@ class FtpConnection
 		}
 
 		// Snatch the IP and port information, or die horribly trying...
-		if (preg_match('~\\((\\d+),\\s*(\\d+),\\s*(\\d+),\\s*(\\d+),\\s*(\\d+)(?:,\\s*(\\d+))\\)~', $response, $match) == 0) {
+		if (preg_match('~\((\d+),\s*(\d+),\s*(\d+),\s*(\d+),\s*(\d+)(?:,\s*(\d+))\)~', $response, $match) == 0) {
 			$this->error = 'bad_response';
 
 			return false;

--- a/Sources/PackageManager/PackageManager.php
+++ b/Sources/PackageManager/PackageManager.php
@@ -193,7 +193,7 @@ class PackageManager
 		if (!isset($_REQUEST['package']) || $_REQUEST['package'] == '') {
 			Utils::redirectexit('action=admin;area=packages');
 		}
-		Utils::$context['filename'] = preg_replace('~[\\.]+~', '.', $_REQUEST['package']);
+		Utils::$context['filename'] = preg_replace('~[\.]+~', '.', $_REQUEST['package']);
 
 		// Do we have an existing id, for uninstalls and the like.
 		Utils::$context['install_id'] = isset($_REQUEST['pid']) ? (int) $_REQUEST['pid'] : 0;
@@ -431,7 +431,7 @@ class PackageManager
 				}
 
 				if (!empty($action['parse_bbc'])) {
-					Utils::$context[$type] = preg_replace('~\\[[/]?html\\]~i', '', Utils::$context[$type]);
+					Utils::$context[$type] = preg_replace('~\[[/]?html\]~i', '', Utils::$context[$type]);
 					Msg::preparsecode(Utils::$context[$type]);
 					Utils::$context[$type] = BBCodeParser::load()->parse(Utils::$context[$type]);
 				} else {
@@ -479,7 +479,7 @@ class PackageManager
 						// Lets get the last section of the file name.
 						if (isset($mod_action['filename']) && substr($mod_action['filename'], -13) != '.template.php') {
 							$actual_filename = strtolower(substr(strrchr($mod_action['filename'], '/'), 1) . '||' . $action['filename']);
-						} elseif (isset($mod_action['filename']) && preg_match('~([\\w]*)/([\\w]*)\\.template\\.php$~', $mod_action['filename'], $matches)) {
+						} elseif (isset($mod_action['filename']) && preg_match('~([\w]*)/([\w]*)\.template\.php$~', $mod_action['filename'], $matches)) {
 							$actual_filename = strtolower($matches[1] . '/' . $matches[2] . '.template.php' . '||' . $action['filename']);
 						} else {
 							$actual_filename = $key;
@@ -552,7 +552,7 @@ class PackageManager
 						// Lets get the last section of the file name.
 						if (isset($mod_action['filename']) && substr($mod_action['filename'], -13) != '.template.php') {
 							$actual_filename = strtolower(substr(strrchr($mod_action['filename'], '/'), 1) . '||' . $action['filename']);
-						} elseif (isset($mod_action['filename']) && preg_match('~([\\w]*)/([\\w]*)\\.template\\.php$~', $mod_action['filename'], $matches)) {
+						} elseif (isset($mod_action['filename']) && preg_match('~([\w]*)/([\w]*)\.template\.php$~', $mod_action['filename'], $matches)) {
 							$actual_filename = strtolower($matches[1] . '/' . $matches[2] . '.template.php' . '||' . $action['filename']);
 						} else {
 							$actual_filename = $key;
@@ -671,7 +671,7 @@ class PackageManager
 				];
 
 				// Could this be theme related?
-				if (!empty($action['unparsed_destination']) && preg_match('~^\\$(languagedir|languages_dir|imagesdir|themedir|themes_dir)~i', $action['unparsed_destination'], $matches)) {
+				if (!empty($action['unparsed_destination']) && preg_match('~^\$(languagedir|languages_dir|imagesdir|themedir|themes_dir)~i', $action['unparsed_destination'], $matches)) {
 					// Is the action already stated?
 					$theme_action = !empty($action['theme_action']) && in_array($action['theme_action'], ['no', 'yes', 'auto']) ? $action['theme_action'] : 'auto';
 
@@ -705,7 +705,7 @@ class PackageManager
 				];
 
 				// Could this be theme related?
-				if (!empty($action['unparsed_filename']) && preg_match('~^\\$(languagedir|languages_dir|imagesdir|themedir|themes_dir)~i', $action['unparsed_filename'], $matches)) {
+				if (!empty($action['unparsed_filename']) && preg_match('~^\$(languagedir|languages_dir|imagesdir|themedir|themes_dir)~i', $action['unparsed_filename'], $matches)) {
 					// Is the action already stated?
 					$theme_action = !empty($action['theme_action']) && in_array($action['theme_action'], ['no', 'yes', 'auto']) ? $action['theme_action'] : 'auto';
 					$action['unparsed_destination'] = $action['unparsed_filename'];
@@ -764,7 +764,7 @@ class PackageManager
 		if (!empty($themeFinds['candidates'])) {
 			foreach ($themeFinds['candidates'] as $action_data) {
 				// Get the part of the file we'll be dealing with.
-				preg_match('~^\\$(languagedir|languages_dir|imagesdir|themedir)(\\|/)*(.+)*~i', $action_data['unparsed_destination'], $matches);
+				preg_match('~^\$(languagedir|languages_dir|imagesdir|themedir)(\\|/)*(.+)*~i', $action_data['unparsed_destination'], $matches);
 
 				if ($matches[1] == 'imagesdir') {
 					$path = '/' . basename(Theme::$current->settings['default_images_url']);
@@ -1185,7 +1185,7 @@ class PackageManager
 					Utils::$context['redirect_timeout'] = empty($action['redirect_timeout']) ? 5 : (int) ceil($action['redirect_timeout'] / 1000);
 
 					if (!empty($action['parse_bbc'])) {
-						Utils::$context['redirect_text'] = preg_replace('~\\[[/]?html\\]~i', '', Utils::$context['redirect_text']);
+						Utils::$context['redirect_text'] = preg_replace('~\[[/]?html\]~i', '', Utils::$context['redirect_text']);
 						Msg::preparsecode(Utils::$context['redirect_text']);
 						Utils::$context['redirect_text'] = BBCodeParser::load()->parse(Utils::$context['redirect_text']);
 					}
@@ -1425,8 +1425,8 @@ class PackageManager
 			Utils::redirectexit('action=admin;area=packages');
 		}
 
-		$_REQUEST['package'] = preg_replace('~[\\.]+~', '.', strtr($_REQUEST['package'], ['/' => '_', '\\' => '_']));
-		$_REQUEST['file'] = preg_replace('~[\\.]+~', '.', $_REQUEST['file']);
+		$_REQUEST['package'] = preg_replace('~\.+~', '.', strtr($_REQUEST['package'], ['/' => '_', '\\' => '_']));
+		$_REQUEST['file'] = preg_replace('~\.+~', '.', $_REQUEST['file']);
 
 		if (isset($_REQUEST['raw'])) {
 			if (is_file(Config::$packagesdir . '/' . $_REQUEST['package'])) {
@@ -1477,7 +1477,7 @@ class PackageManager
 		if (!isset($_GET['package']) || $_GET['package'] == 'index.php' || $_GET['package'] == 'backups') {
 			Utils::redirectexit('action=admin;area=packages;sa=browse');
 		}
-		$_GET['package'] = preg_replace('~[\\.]+~', '.', strtr($_GET['package'], ['/' => '_', '\\' => '_']));
+		$_GET['package'] = preg_replace('~\.+~', '.', strtr($_GET['package'], ['/' => '_', '\\' => '_']));
 
 		// Can't delete what's not there.
 		if (file_exists(Config::$packagesdir . '/' . $_GET['package']) && (substr($_GET['package'], -4) == '.zip' || substr($_GET['package'], -4) == '.tgz' || substr($_GET['package'], -7) == '.tar.gz' || is_dir(Config::$packagesdir . '/' . $_GET['package'])) && $_GET['package'] != 'backups' && substr($_GET['package'], 0, 1) != '.') {
@@ -1664,7 +1664,7 @@ class PackageManager
 			Utils::redirectexit('action=admin;area=packages;sa=options');
 		}
 
-		if (preg_match('~^/home\\d*/([^/]+?)/public_html~', $_SERVER['DOCUMENT_ROOT'], $match)) {
+		if (preg_match('~^/home\d*/([^/]+?)/public_html~', $_SERVER['DOCUMENT_ROOT'], $match)) {
 			$default_username = $match[1];
 		} else {
 			$default_username = '';
@@ -1702,7 +1702,7 @@ class PackageManager
 		$reverse = isset($_REQUEST['reverse']) ? true : false;
 
 		// Get the base name.
-		Utils::$context['filename'] = preg_replace('~[\\.]+~', '.', $_REQUEST['package']);
+		Utils::$context['filename'] = preg_replace('~\.+~', '.', $_REQUEST['package']);
 
 		// We need to extract this again.
 		if (is_file(Config::$packagesdir . '/' . Utils::$context['filename'])) {
@@ -2092,7 +2092,7 @@ class PackageManager
 				'identifier' => 'root',
 				'children' => [
 					[
-						'value' => preg_replace('~[^A-Za-z0-9_\\-=:]~', ':-:', Utils::$context['only_find']),
+						'value' => preg_replace('~[^A-Za-z0-9_\-=:]~', ':-:', Utils::$context['only_find']),
 					],
 				],
 			],
@@ -2699,7 +2699,7 @@ class PackageManager
 					if ($package['description'] == '') {
 						$package['description'] = Lang::$txt['package_no_description'];
 					} else {
-						$package['description'] = BBCodeParser::load()->parse(preg_replace('~\\[[/]?html\\]~i', '', Utils::htmlspecialchars($package['description'])));
+						$package['description'] = BBCodeParser::load()->parse(preg_replace('~\[[/]?html\]~i', '', Utils::htmlspecialchars($package['description'])));
 					}
 
 					$package['is_installed'] = isset($installed_mods[$package['id']]);
@@ -2915,7 +2915,7 @@ class PackageManager
 
 		// Done!  Did we get this package automatically?
 		// @ TODO: These are usually update packages.  Allowing both for now until more testing has been done.
-		if (preg_match('~^https?://[\\w_\\-]+\\.simplemachines\\.org/~', $_REQUEST['package']) == 1 && strpos($_REQUEST['package'], 'dlattach') === false && isset($_REQUEST['auto'])) {
+		if (preg_match('~^https?://[\w_\-]+\.simplemachines\.org/~', $_REQUEST['package']) == 1 && strpos($_REQUEST['package'], 'dlattach') === false && isset($_REQUEST['auto'])) {
 			Utils::redirectexit('action=admin;area=packages;sa=install;package=' . $package_name);
 		}
 
@@ -2963,9 +2963,9 @@ class PackageManager
 		}
 
 		// Make sure it has a sane filename.
-		$_FILES['package']['name'] = preg_replace(['/\\s/', '/\\.[\\.]+/', '/[^\\w_\\.\\-]/'], ['_', '.', ''], $_FILES['package']['name']);
+		$_FILES['package']['name'] = preg_replace(['/\s/', '/\.+/', '/[^\w.-]/'], ['_', '.', ''], $_FILES['package']['name']);
 
-		$found_ext = preg_match('/\\.(zip|tgz|tar\\.gz)$/i', $_FILES['package']['name'], $match);
+		$found_ext = preg_match('/\.(zip|tgz|tar\.gz)$/i', $_FILES['package']['name'], $match);
 
 		if ($found_ext === 0) {
 			ErrorHandler::fatalLang('package_upload_error_supports', false, ['zip, tgz, tar.gz']);
@@ -3474,8 +3474,8 @@ class PackageManager
 						'level' => $level,
 						'more' => 0,
 						'offset' => Utils::$context['file_offset'],
-						'my_ident' => preg_replace('~[^A-Za-z0-9_\\-=:]~', ':-:', Utils::$context['only_find'] . '/' . $folder),
-						'ident' => preg_replace('~[^A-Za-z0-9_\\-=:]~', ':-:', Utils::$context['only_find']),
+						'my_ident' => preg_replace('~[^A-Za-z0-9_\-=:]~', ':-:', Utils::$context['only_find'] . '/' . $folder),
+						'ident' => preg_replace('~[^A-Za-z0-9_\-=:]~', ':-:', Utils::$context['only_find']),
 					],
 					'value' => $folder,
 				];
@@ -3523,8 +3523,8 @@ class PackageManager
 						'level' => $level,
 						'more' => $counter == (Utils::$context['file_offset'] + Utils::$context['file_limit']) ? 1 : 0,
 						'offset' => Utils::$context['file_offset'],
-						'my_ident' => preg_replace('~[^A-Za-z0-9_\\-=:]~', ':-:', Utils::$context['only_find'] . '/' . $file),
-						'ident' => preg_replace('~[^A-Za-z0-9_\\-=:]~', ':-:', Utils::$context['only_find']),
+						'my_ident' => preg_replace('~[^A-Za-z0-9_\-=:]~', ':-:', Utils::$context['only_find'] . '/' . $file),
+						'ident' => preg_replace('~[^A-Za-z0-9_\-=:]~', ':-:', Utils::$context['only_find']),
 					],
 					'value' => $file,
 				];

--- a/Sources/PackageManager/SubsPackage.php
+++ b/Sources/PackageManager/SubsPackage.php
@@ -516,7 +516,7 @@ class SubsPackage
 		$head = fread($fid, 1024);
 		fclose($fid);
 
-		return preg_match('~^HTTP/.+\\s+(20[01]|30[127])~i', $head) == 1;
+		return preg_match('~^HTTP/.+\s+(20[01]|30[127])~i', $head) == 1;
 	}
 
 	/**
@@ -1668,7 +1668,7 @@ class SubsPackage
 		foreach ([1 => $version1, $version2] as $id => $version) {
 			// Clean the version and extract the version parts.
 			$clean = str_replace([' ', '2.0rc1-1'], ['', '2.0rc1.1'], strtolower($version));
-			preg_match('~(\\d+)(?:\\.(\\d+|))?(?:\\.)?(\\d+|)(?:(alpha|beta|rc)(\\d+|)(?:\\.)?(\\d+|))?(?:(dev))?(\\d+|)~', $clean, $parts);
+			preg_match('~(\d+)(?:\.(\d+|))?(?:\.)?(\d+|)(?:(alpha|beta|rc)(\d+|)(?:\.)?(\d+|))?(?:(dev))?(\d+|)~', $clean, $parts);
 
 			// Build an array of parts.
 			$versions[$id] = [
@@ -2217,7 +2217,7 @@ class SubsPackage
 
 							// Using 'loose', a random amount of tabs and spaces may be used.
 							if ($search['loose_whitespace']) {
-								$actual_operation['searches'][$i]['preg_search'] = preg_replace('~[ \\t]+~', '[ \\t]+', $actual_operation['searches'][$i]['preg_search']);
+								$actual_operation['searches'][$i]['preg_search'] = preg_replace('~[ \t]+~', '[ \t]+', $actual_operation['searches'][$i]['preg_search']);
 							}
 						}
 
@@ -2384,7 +2384,7 @@ class SubsPackage
 		$step_counter = 0;
 
 		// Before we do *anything*, let's build a list of what we're editing, as it's going to be used for other theme edits.
-		while (preg_match('~<(edit file|file|search|search for|add|add after|replace|add before|add above|above|before)>\\n(.*?)\\n</\\1>~is', $temp_file, $code_match) != 0) {
+		while (preg_match('~<(edit file|file|search|search for|add|add after|replace|add before|add above|above|before)>\n(.*?)\n</\\1>~is', $temp_file, $code_match) != 0) {
 			$counter++;
 
 			// Get rid of the old stuff.
@@ -2451,7 +2451,7 @@ class SubsPackage
 		$counter = 0;
 		$is_custom = 0;
 
-		while (preg_match('~<(edit file|file|search|search for|add|add after|replace|add before|add above|above|before)>\\n(.*?)\\n</\\1>~is', $file, $code_match) != 0) {
+		while (preg_match('~<(edit file|file|search|search for|add|add after|replace|add before|add above|above|before)>\n(.*?)\n</\\1>~is', $file, $code_match) != 0) {
 			// This is for working out what we should be editing.
 			$counter++;
 
@@ -3021,7 +3021,7 @@ class SubsPackage
 						continue;
 					}
 
-					if (preg_match('~^(\\.{1,2}|CVS|backup.*|help|images|.*\\~|.*minified_[a-z0-9]{32}\\.(js|css))$~', $entry) != 0) {
+					if (preg_match('~^(\.{1,2}|CVS|backup.*|help|images|.*\~|.*minified_[a-z0-9]{32}\.(js|css))$~', $entry) != 0) {
 						continue;
 					}
 
@@ -3336,8 +3336,8 @@ class SubsPackage
 						'level' => $level,
 						'more' => 0,
 						'offset' => Utils::$context['file_offset'],
-						'my_ident' => preg_replace('~[^A-Za-z0-9_\\-=:]~', ':-:', Utils::$context['only_find'] . '/' . $folder),
-						'ident' => preg_replace('~[^A-Za-z0-9_\\-=:]~', ':-:', Utils::$context['only_find']),
+						'my_ident' => preg_replace('~[^A-Za-z0-9_\-=:]~', ':-:', Utils::$context['only_find'] . '/' . $folder),
+						'ident' => preg_replace('~[^A-Za-z0-9_\-=:]~', ':-:', Utils::$context['only_find']),
 					],
 					'value' => $folder,
 				];
@@ -3385,8 +3385,8 @@ class SubsPackage
 						'level' => $level,
 						'more' => $counter == (Utils::$context['file_offset'] + Utils::$context['file_limit']) ? 1 : 0,
 						'offset' => Utils::$context['file_offset'],
-						'my_ident' => preg_replace('~[^A-Za-z0-9_\\-=:]~', ':-:', Utils::$context['only_find'] . '/' . $file),
-						'ident' => preg_replace('~[^A-Za-z0-9_\\-=:]~', ':-:', Utils::$context['only_find']),
+						'my_ident' => preg_replace('~[^A-Za-z0-9_\-=:]~', ':-:', Utils::$context['only_find'] . '/' . $file),
+						'ident' => preg_replace('~[^A-Za-z0-9_\-=:]~', ':-:', Utils::$context['only_find']),
 					],
 					'value' => $file,
 				];

--- a/Sources/PackageManager/SubsPackage.php
+++ b/Sources/PackageManager/SubsPackage.php
@@ -1705,8 +1705,8 @@ class SubsPackage
 				if ($category == 'dev') {
 					return $versions[1]['dev'] ? ($versions[2]['type'] == 'stable' ? -1 : 0) : ($versions[1]['type'] == 'stable' ? 1 : 0);
 				}
-				// Otherwise a simple comparison.
 
+				// Otherwise a simple comparison.
 				return $versions[1][$category] > $versions[2][$category] ? 1 : -1;
 			}
 		}
@@ -1879,7 +1879,6 @@ class SubsPackage
 			return false;
 		}
 
-
 		@mkdir($strPath, $mode);
 		$test = @opendir($strPath);
 
@@ -1890,7 +1889,6 @@ class SubsPackage
 		}
 
 		return false;
-
 	}
 
 	/**

--- a/Sources/PackageManager/XmlArray.php
+++ b/Sources/PackageManager/XmlArray.php
@@ -73,7 +73,7 @@ class XmlArray
 		}
 
 		// Remove any xml declaration or doctype, and parse out comments and CDATA.
-		$data = preg_replace('/<!--.*?-->/s', '', $this->_to_cdata(preg_replace(['/^<\\?xml.+?\\?' . '>/is', '/<!DOCTYPE[^>]+?' . '>/s'], '', $data)));
+		$data = preg_replace('/<!--.*?-->/s', '', $this->_to_cdata(preg_replace(['/^<\?xml.+?\?' . '>/is', '/<!DOCTYPE[^>]+?' . '>/s'], '', $data)));
 
 		// Now parse the xml!
 		$this->array = $this->_parse($data);
@@ -367,7 +367,7 @@ class XmlArray
 		// Loop until we're out of data.
 		while ($data != '') {
 			// Find and remove the next tag.
-			preg_match('/\\A<([\\w\\-:]+)((?:\\s+.+?)?)([\\s]?\\/)?' . '>/', $data, $match);
+			preg_match('/\A<([\w\-:]+)((?:\s+.+?)?)([\s]?\/)?' . '>/', $data, $match);
 
 			if (isset($match[0])) {
 				$data = preg_replace('/' . preg_quote($match[0], '/') . '/s', '', $data, 1);
@@ -488,7 +488,7 @@ class XmlArray
 			// If we're dealing with attributes as well, parse them out.
 			if (isset($match[2]) && $match[2] != '') {
 				// Find all the attribute pairs in the string.
-				preg_match_all('/([\\w:]+)="(.+?)"/', $match[2], $attr, PREG_SET_ORDER);
+				preg_match_all('/([\w:]+)="(.+?)"/', $match[2], $attr, PREG_SET_ORDER);
 
 				// Set them as @attribute-name.
 				foreach ($attr as $match_attr) {
@@ -600,7 +600,7 @@ class XmlArray
 		$inCdata = $inComment = false;
 		$output = '';
 
-		$parts = preg_split('~(<!\\[CDATA\\[|\\]\\]>|<!--|-->)~', $data, -1, PREG_SPLIT_DELIM_CAPTURE);
+		$parts = preg_split('~(<!\[CDATA\[|\]\]>|<!--|-->)~', $data, -1, PREG_SPLIT_DELIM_CAPTURE);
 
 		foreach ($parts as $part) {
 			// Handle XML comments.
@@ -646,7 +646,7 @@ class XmlArray
 		// Translate all the entities out.
 		$data = strtr(
 			preg_replace_callback(
-				'~&#(\\d{1,4});~',
+				'~&#(\d{1,4});~',
 				function ($m) {
 					return chr("{$m[1]}");
 				},

--- a/Sources/PackageManager/XmlArray.php
+++ b/Sources/PackageManager/XmlArray.php
@@ -164,7 +164,6 @@ class XmlArray
 					return $array[$el];
 				}
 
-
 				$trace = debug_backtrace();
 				$i = 0;
 
@@ -180,7 +179,6 @@ class XmlArray
 				}
 
 				return false;
-
 			} else {
 				$lvl = null;
 			}
@@ -462,10 +460,8 @@ class XmlArray
 						break;
 					}
 
-
 					$last_tag_end = $next_tag_end;
 					$offset = $next_tag_start + 1;
-
 				}
 				// Parse the insides.
 				$inner_match = substr($data, 0, $last_tag_end);
@@ -763,8 +759,8 @@ class XmlArray
 		if (count($results) == 1 || $level !== null) {
 			return $results[0];
 		}
-		// Return the result set.
 
+		// Return the result set.
 		return $results + ['name' => $path . '[]'];
 	}
 }

--- a/Sources/PersonalMessage/Folder.php
+++ b/Sources/PersonalMessage/Folder.php
@@ -270,7 +270,7 @@ class Folder
 
 		// Remove 'view' from the query string so that refreshing the browser
 		// doesn't cause the view to change again.
-		Utils::redirectexit(preg_replace('/\\bview;\\b/', '', $_SERVER['QUERY_STRING']));
+		Utils::redirectexit(preg_replace('/\bview;\b/', '', $_SERVER['QUERY_STRING']));
 	}
 
 	/**

--- a/Sources/PersonalMessage/PM.php
+++ b/Sources/PersonalMessage/PM.php
@@ -1368,7 +1368,6 @@ class PM implements \ArrayAccess
 					unset($all_to[array_search($row['id_member'], $all_to)]);
 
 					continue;
-
 				}
 
 				// Do they have any of the allowed groups?
@@ -1378,7 +1377,6 @@ class PM implements \ArrayAccess
 					unset($all_to[array_search($row['id_member'], $all_to)]);
 
 					continue;
-
 				}
 			}
 
@@ -1554,7 +1552,6 @@ class PM implements \ArrayAccess
 				} else {
 					$notification_texts[$lang]['body'] = '';
 				}
-
 
 				if ($lang != User::$me->language) {
 					Lang::load('index+Modifications', User::$me->language, false);

--- a/Sources/PersonalMessage/PM.php
+++ b/Sources/PersonalMessage/PM.php
@@ -672,7 +672,7 @@ class PM implements \ArrayAccess
 				$form_message = preg_replace('~<br ?/?' . '>~i', "\n", $pm->body);
 
 				if (!empty(Config::$modSettings['removeNestedQuotes'])) {
-					$form_message = preg_replace(['~\\n?\\[quote.*?\\].+?\\[/quote\\]\\n?~is', '~^\\n~', '~\\[/quote\\]~'], '', $form_message);
+					$form_message = preg_replace(['~\n?\[quote.*?\].+?\[/quote\]\n?~is', '~^\n~', '~\[/quote\]~'], '', $form_message);
 				}
 
 				if (empty($pm->member_from)) {
@@ -1184,7 +1184,7 @@ class PM implements \ArrayAccess
 		foreach ($recipients as $rec_type => $rec) {
 			foreach ($rec as $id => $member) {
 				if (!is_numeric($recipients[$rec_type][$id])) {
-					$recipients[$rec_type][$id] = Utils::strtolower(trim(preg_replace('~[<>&"\'=\\\\]~', '', $recipients[$rec_type][$id])));
+					$recipients[$rec_type][$id] = Utils::strtolower(trim(preg_replace('~[<>&"\'=\\\]~', '', $recipients[$rec_type][$id])));
 
 					$usernames[$recipients[$rec_type][$id]] = 0;
 				}

--- a/Sources/PersonalMessage/Received.php
+++ b/Sources/PersonalMessage/Received.php
@@ -287,7 +287,6 @@ class Received implements \ArrayAccess
 				$inserts,
 				[],
 			);
-
 		}
 	}
 

--- a/Sources/PersonalMessage/Rule.php
+++ b/Sources/PersonalMessage/Rule.php
@@ -665,7 +665,6 @@ class Rule implements \ArrayAccess
 			Utils::redirectexit('action=pm;sa=manrules');
 		}
 	}
-
 }
 
 // Export public static functions and properties to global namespace for backward compatibility.

--- a/Sources/PersonalMessage/Search.php
+++ b/Sources/PersonalMessage/Search.php
@@ -607,12 +607,12 @@ class Search
 	protected function setSearchQuery(): void
 	{
 		// Extract phrase parts first (e.g. some words "this is a phrase" some more words.)
-		preg_match_all('~(?:^|\\s)([-]?)"([^"]+)"(?:$|\\s)~' . (Utils::$context['utf8'] ? 'u' : ''), $this->params['search'], $matches, PREG_PATTERN_ORDER);
+		preg_match_all('~(?:^|\s)([-]?)"([^"]+)"(?:$|\s)~' . (Utils::$context['utf8'] ? 'u' : ''), $this->params['search'], $matches, PREG_PATTERN_ORDER);
 
 		$searchArray = $matches[2];
 
 		// Remove the phrase parts and extract the words.
-		$tempSearch = explode(' ', preg_replace('~(?:^|\\s)(?:[-]?)"(?:[^"]+)"(?:$|\\s)~' . (Utils::$context['utf8'] ? 'u' : ''), ' ', $this->params['search']));
+		$tempSearch = explode(' ', preg_replace('~(?:^|\s)(?:[-]?)"(?:[^"]+)"(?:$|\s)~' . (Utils::$context['utf8'] ? 'u' : ''), ' ', $this->params['search']));
 
 		// A minus sign in front of a word excludes the word.... so...
 		$excludedWords = [];

--- a/Sources/PersonalMessage/Search.php
+++ b/Sources/PersonalMessage/Search.php
@@ -187,7 +187,6 @@ class Search
 			'url' => Config::$scripturl . '?action=pm;sa=search',
 			'name' => Lang::$txt['pm_search_bar_title'],
 		];
-
 	}
 
 	/**
@@ -694,7 +693,6 @@ class Search
 			$this->search_query = implode(!empty($this->params['searchtype']) && $this->params['searchtype'] == 2 ? ' OR ' : ' AND ', $andQueryParts);
 		}
 	}
-
 }
 
 // Export public static functions and properties to global namespace for backward compatibility.

--- a/Sources/Poll.php
+++ b/Sources/Poll.php
@@ -1903,7 +1903,7 @@ class Poll implements \ArrayAccess
 		// Clean up the question and answers.
 		$_POST['question'] = Utils::htmlspecialchars($_POST['question']);
 		$_POST['question'] = Utils::truncate($_POST['question'], 255);
-		$_POST['question'] = preg_replace('~&amp;#(\\d{4,5}|[2-9]\\d{2,4}|1[2-9]\\d);~', '&#$1;', $_POST['question']);
+		$_POST['question'] = preg_replace('~&amp;#(\d{4,5}|[2-9]\d{2,4}|1[2-9]\d);~', '&#$1;', $_POST['question']);
 		$_POST['options'] = Utils::htmlspecialcharsRecursive($_POST['options']);
 	}
 }

--- a/Sources/Profile.php
+++ b/Sources/Profile.php
@@ -408,7 +408,7 @@ class Profile extends User implements \ArrayAccess
 				'permission' => 'profile_extra',
 				'input_validate' => function (&$value) {
 					// @todo Should we check for this year and tell them they made a mistake :P? (based on coppa at least?)
-					if (preg_match('/(\\d{4})[\\-\\., ](\\d{2})[\\-\\., ](\\d{2})/', $value, $dates) === 1) {
+					if (preg_match('/(\d{4})[\-., ](\d{2})[\-., ](\d{2})/', $value, $dates) === 1) {
 						$value = checkdate($dates[2], $dates[3], $dates[1] < 4 ? 4 : $dates[1]) ? sprintf('%04d-%02d-%02d', $dates[1] < 4 ? 4 : $dates[1], $dates[2], $dates[3]) : '1004-01-01';
 
 						return true;
@@ -1929,7 +1929,7 @@ class Profile extends User implements \ArrayAccess
 			}
 
 			// Maybe we are abusing font sizes?
-			if (!empty($sig_limits[7]) && preg_match_all('~\\[size=([\\d\\.]+)?(px|pt|em|x-large|larger)~i', $unparsed_signature, $matches) !== false && isset($matches[2])) {
+			if (!empty($sig_limits[7]) && preg_match_all('~\[size=([\d.]+)?(px|pt|em|x-large|larger)~i', $unparsed_signature, $matches) !== false && isset($matches[2])) {
 				foreach ($matches[1] as $ind => $size) {
 					$limit_broke = 0;
 
@@ -1955,10 +1955,10 @@ class Profile extends User implements \ArrayAccess
 			// The difficult one - image sizes! Don't error on this - just fix it.
 			if ((!empty($sig_limits[5]) || !empty($sig_limits[6]))) {
 				// Get all BBC tags...
-				preg_match_all('~\\[img(\\s+width=([\\d]+))?(\\s+height=([\\d]+))?(\\s+width=([\\d]+))?\\s*\\](?:<br>)*([^<">]+?)(?:<br>)*\\[/img\\]~i', $unparsed_signature, $matches);
+				preg_match_all('~\[img(\s+width=(\d+))?(\s+height=(\d+))?(\s+width=(\d+))?\s*\](?:<br>)*([^<">]+?)(?:<br>)*\[/img\]~i', $unparsed_signature, $matches);
 
 				// ... and all HTML ones.
-				preg_match_all('~<img\\s+src=(?:")?((?:http://|ftp://|https://|ftps://).+?)(?:")?(?:\\s+alt=(?:")?(.*?)(?:")?)?(?:\\s?/)?' . '>~i', $unparsed_signature, $matches2, PREG_PATTERN_ORDER);
+				preg_match_all('~<img\s+src=(?:")?((?:http://|ftp://|https://|ftps://).+?)(?:")?(?:\s+alt=(?:")?(.*?)(?:")?)?(?:\s?/)?' . '>~i', $unparsed_signature, $matches2, PREG_PATTERN_ORDER);
 
 				// And stick the HTML in the BBC.
 				if (!empty($matches2)) {
@@ -2047,7 +2047,7 @@ class Profile extends User implements \ArrayAccess
 			$disabledSigBBC = implode('|', $disabledTags);
 
 			if (!empty($disabledSigBBC)) {
-				if (preg_match('~\\[(' . $disabledSigBBC . '[ =\\]/])~i', $unparsed_signature, $matches) !== false && isset($matches[1])) {
+				if (preg_match('~\[(' . $disabledSigBBC . '[ =\]/])~i', $unparsed_signature, $matches) !== false && isset($matches[1])) {
 					$disabledTags = array_unique($disabledTags);
 
 					Lang::$txt['profile_error_signature_disabled_bbc'] = sprintf(Lang::$txt['profile_error_signature_disabled_bbc'], implode(', ', $disabledTags));
@@ -2464,7 +2464,7 @@ class Profile extends User implements \ArrayAccess
 						$value = '';
 					}
 
-					if ($cf_def['mask'] == 'nohtml' && ($valueReference != strip_tags($valueReference) || $value != Utils::htmlspecialchars($value, ENT_NOQUOTES) || preg_match('/<(.+?)[\\s]*\\/?[\\s]*>/si', $valueReference))) {
+					if ($cf_def['mask'] == 'nohtml' && ($valueReference != strip_tags($valueReference) || $value != Utils::htmlspecialchars($value, ENT_NOQUOTES) || preg_match('/<(.+?)\s*\\/?\s*>/si', $valueReference))) {
 						$mask_error = 'custom_field_nohtml_fail';
 						$value = '';
 					} elseif ($cf_def['mask'] == 'email' && !empty($value) && (!filter_var($value, FILTER_VALIDATE_EMAIL) || strlen($value) > 255)) {
@@ -3061,7 +3061,7 @@ class Profile extends User implements \ArrayAccess
 		}
 
 		// Generate a random password.
-		$new_password = implode('-', str_split(substr(preg_replace('/\\W/', '', base64_encode(Utils::randomBytes(18))), 0, 18), 6));
+		$new_password = implode('-', str_split(substr(preg_replace('/\W/', '', base64_encode(Utils::randomBytes(18))), 0, 18), 6));
 		$new_password_sha1 = Security::hashPassword($username ?? $this->username, $new_password);
 
 		// Do some checks on the username if needed.

--- a/Sources/Profile.php
+++ b/Sources/Profile.php
@@ -414,11 +414,9 @@ class Profile extends User implements \ArrayAccess
 						return true;
 					}
 
-
 					$value = empty($this->birthdate) ? '1004-01-01' : $this->birthdate;
 
 					return false;
-
 				},
 			],
 			'date_registered' => [
@@ -549,11 +547,9 @@ class Profile extends User implements \ArrayAccess
 						return true;
 					}
 
-
 					$value = $this->language;
 
 					return false;
-
 				},
 			],
 			// The username is not always editable - so adjust it as such.
@@ -1795,7 +1791,6 @@ class Profile extends User implements \ArrayAccess
 			default:
 				$result = $this->setAvatarNone();
 				break;
-
 		}
 
 		if (is_string($result)) {

--- a/Sources/Punycode.php
+++ b/Sources/Punycode.php
@@ -478,9 +478,7 @@ class Punycode
 			return (($code - 224) * 4096) + ((ord($char[1]) - 128) * 64) + (ord($char[2]) - 128);
 		}
 
-
 		return (($code - 240) * 262144) + ((ord($char[1]) - 128) * 4096) + ((ord($char[2]) - 128) * 64) + (ord($char[3]) - 128);
-
 	}
 
 	/**
@@ -503,9 +501,7 @@ class Punycode
 			return chr(($code >> 12) + 224) . chr((($code >> 6) & 63) + 128) . chr(($code & 63) + 128);
 		}
 
-
 		return chr(($code >> 18) + 240) . chr((($code >> 12) & 63) + 128) . chr((($code >> 6) & 63) + 128) . chr(($code & 63) + 128);
-
 	}
 
 	/**

--- a/Sources/Punycode.php
+++ b/Sources/Punycode.php
@@ -574,7 +574,7 @@ class Punycode
 			return self::IDNA_ERROR_HYPHEN_3_4;
 		}
 
-		if (preg_match('/^\\p{M}/u', $label)) {
+		if (preg_match('/^\p{M}/u', $label)) {
 			return self::IDNA_ERROR_LEADING_COMBINING_MARK;
 		}
 

--- a/Sources/QueryString.php
+++ b/Sources/QueryString.php
@@ -102,7 +102,7 @@ class QueryString
 
 			// Replace ';' with '&' and '&something&' with '&something=&'.  (this is done for compatibility...)
 			// @todo smflib
-			parse_str(preg_replace('/&(\\w+)(?=&|$)/', '&$1=', strtr($_SERVER['QUERY_STRING'], [';?' => '&', ';' => '&', '%00' => '', "\0" => ''])), $_GET);
+			parse_str(preg_replace('/&(\w+)(?=&|$)/', '&$1=', strtr($_SERVER['QUERY_STRING'], [';?' => '&', ';' => '&', '%00' => '', "\0" => ''])), $_GET);
 
 			// Magic quotes still applies with parse_str - so clean it up.
 			if ($magicQuotesEnabled) {
@@ -148,7 +148,7 @@ class QueryString
 			// @todo smflib.
 			// Replace 'index.php/a,b,c/d/e,f' with 'a=b,c&d=&e=f' and parse it into $_GET.
 			if (strpos($request, basename(Config::$scripturl) . '/') !== false) {
-				parse_str(substr(preg_replace('/&(\\w+)(?=&|$)/', '&$1=', strtr(preg_replace('~/([^,/]+),~', '/$1=', substr($request, strpos($request, basename(Config::$scripturl)) + strlen(basename(Config::$scripturl)))), '/', '&')), 1), $temp);
+				parse_str(substr(preg_replace('/&(\w+)(?=&|$)/', '&$1=', strtr(preg_replace('~/([^,/]+),~', '/$1=', substr($request, strpos($request, basename(Config::$scripturl)) + strlen(basename(Config::$scripturl)))), '/', '&')), 1), $temp);
 
 				if (function_exists('get_magic_quotes_gpc') && @get_magic_quotes_gpc() != 0 && empty(Config::$modSettings['integrate_magic_quotes'])) {
 					$temp = $removeMagicQuoteFunction($temp);
@@ -287,7 +287,7 @@ class QueryString
 		}
 		// Perhaps we have a IPv6 address.
 		elseif (IP::create($_SERVER['REMOTE_ADDR'])->isValid()) {
-			$_SERVER['REMOTE_ADDR'] = preg_replace('~^::ffff:(\\d+\\.\\d+\\.\\d+\\.\\d+)~', '\\1', $_SERVER['REMOTE_ADDR']);
+			$_SERVER['REMOTE_ADDR'] = preg_replace('~^::ffff:(\d+\.\d+\.\d+\.\d+)~', '$1', $_SERVER['REMOTE_ADDR']);
 		}
 
 		// Try to calculate their most likely IP for those people behind proxies (And the like).
@@ -336,13 +336,13 @@ class QueryString
 				// Go through each IP...
 				foreach ($ips as $i => $ip) {
 					// Make sure it's in a valid range...
-					if (preg_match('~^((0|10|172\\.(1[6-9]|2[0-9]|3[01])|192\\.168|255|127)\\.|unknown|::1|fe80::|fc00::)~', $ip) != 0 && preg_match('~^((0|10|172\\.(1[6-9]|2[0-9]|3[01])|192\\.168|255|127)\\.|unknown|::1|fe80::|fc00::)~', $_SERVER['REMOTE_ADDR']) == 0) {
-						if (!IP::create($_SERVER[$proxyIPheader])->isValid(FILTER_FLAG_IPV6) || preg_match('~::ffff:\\d+\\.\\d+\\.\\d+\\.\\d+~', $_SERVER[$proxyIPheader]) !== 0) {
-							$_SERVER[$proxyIPheader] = preg_replace('~^::ffff:(\\d+\\.\\d+\\.\\d+\\.\\d+)~', '\\1', $_SERVER[$proxyIPheader]);
+					if (preg_match('~^((0|10|172\.(1[6-9]|2[0-9]|3[01])|192\.168|255|127)\.|unknown|::1|fe80::|fc00::)~', $ip) != 0 && preg_match('~^((0|10|172\.(1[6-9]|2[0-9]|3[01])|192\.168|255|127)\.|unknown|::1|fe80::|fc00::)~', $_SERVER['REMOTE_ADDR']) == 0) {
+						if (!IP::create($_SERVER[$proxyIPheader])->isValid(FILTER_FLAG_IPV6) || preg_match('~::ffff:\d+\.\d+\.\d+\.\d+~', $_SERVER[$proxyIPheader]) !== 0) {
+							$_SERVER[$proxyIPheader] = preg_replace('~^::ffff:(\d+\.\d+\.\d+\.\d+)~', '$1', $_SERVER[$proxyIPheader]);
 
 							// Just incase we have a legacy IPv4 address.
 							// @ TODO: Convert to IPv6.
-							if (preg_match('~^((([1]?\\d)?\\d|2[0-4]\\d|25[0-5])\\.){3}(([1]?\\d)?\\d|2[0-4]\\d|25[0-5])$~', $_SERVER[$proxyIPheader]) === 0) {
+							if (preg_match('~^((([1]?\d)?\d|2[0-4]\d|25[0-5])\.){3}(([1]?\d)?\d|2[0-4]\d|25[0-5])$~', $_SERVER[$proxyIPheader]) === 0) {
 								continue;
 							}
 						}
@@ -357,14 +357,14 @@ class QueryString
 				}
 			}
 			// Otherwise just use the only one.
-			elseif (preg_match('~^((0|10|172\\.(1[6-9]|2[0-9]|3[01])|192\\.168|255|127)\\.|unknown|::1|fe80::|fc00::)~', $_SERVER[$proxyIPheader]) == 0 || preg_match('~^((0|10|172\\.(1[6-9]|2[0-9]|3[01])|192\\.168|255|127)\\.|unknown|::1|fe80::|fc00::)~', $_SERVER['REMOTE_ADDR']) != 0) {
+			elseif (preg_match('~^((0|10|172\.(1[6-9]|2[0-9]|3[01])|192\.168|255|127)\.|unknown|::1|fe80::|fc00::)~', $_SERVER[$proxyIPheader]) == 0 || preg_match('~^((0|10|172\.(1[6-9]|2[0-9]|3[01])|192\.168|255|127)\.|unknown|::1|fe80::|fc00::)~', $_SERVER['REMOTE_ADDR']) != 0) {
 				$_SERVER['BAN_CHECK_IP'] = $_SERVER[$proxyIPheader];
-			} elseif (!IP::create($_SERVER[$proxyIPheader])->isValid(FILTER_FLAG_IPV6) || preg_match('~::ffff:\\d+\\.\\d+\\.\\d+\\.\\d+~', $_SERVER[$proxyIPheader]) !== 0) {
-				$_SERVER[$proxyIPheader] = preg_replace('~^::ffff:(\\d+\\.\\d+\\.\\d+\\.\\d+)~', '\\1', $_SERVER[$proxyIPheader]);
+			} elseif (!IP::create($_SERVER[$proxyIPheader])->isValid(FILTER_FLAG_IPV6) || preg_match('~::ffff:\d+\.\d+\.\d+\.\d+~', $_SERVER[$proxyIPheader]) !== 0) {
+				$_SERVER[$proxyIPheader] = preg_replace('~^::ffff:(\d+\.\d+\.\d+\.\d+)~', '$1', $_SERVER[$proxyIPheader]);
 
 				// Just incase we have a legacy IPv4 address.
 				// @ TODO: Convert to IPv6.
-				if (preg_match('~^((([1]?\\d)?\\d|2[0-4]\\d|25[0-5])\\.){3}(([1]?\\d)?\\d|2[0-4]\\d|25[0-5])$~', $_SERVER[$proxyIPheader]) === 0) {
+				if (preg_match('~^(((1?\d)?\d|2[0-4]\d|25[0-5])\.){3}(([1]?\d)?\d|2[0-4]\d|25[0-5])$~', $_SERVER[$proxyIPheader]) === 0) {
 					continue;
 				}
 			}
@@ -464,11 +464,11 @@ class QueryString
 
 		// Do nothing if the session is cookied, or they are a crawler - guests are caught by redirectexit().
 		if (empty($_COOKIE) && SID != '' && !BrowserDetector::isBrowser('possibly_robot')) {
-			$buffer = preg_replace('/(?<!<link rel="canonical" href=)"' . preg_quote(Config::$scripturl, '/') . '(?!\\?' . preg_quote(SID, '/') . ')\\??/', '"' . Config::$scripturl . '?' . SID . '&amp;', $buffer);
+			$buffer = preg_replace('/(?<!<link rel="canonical" href=)"' . preg_quote(Config::$scripturl, '/') . '(?!\?' . preg_quote(SID, '/') . ')\??/', '"' . Config::$scripturl . '?' . SID . '&amp;', $buffer);
 		}
 		// Debugging templates, are we?
 		elseif (isset($_GET['debug'])) {
-			$buffer = preg_replace('/(?<!<link rel="canonical" href=)"' . preg_quote(Config::$scripturl, '/') . '\\??/', '"' . Config::$scripturl . '?debug;', $buffer);
+			$buffer = preg_replace('/(?<!<link rel="canonical" href=)"' . preg_quote(Config::$scripturl, '/') . '\??/', '"' . Config::$scripturl . '?debug;', $buffer);
 		}
 
 		// More work needed if using "queryless" URLS.
@@ -488,7 +488,7 @@ class QueryString
 			// Let's do something special for session ids!
 			if (defined('SID') && SID != '') {
 				$buffer = preg_replace_callback(
-					'~"' . preg_quote(Config::$scripturl, '~') . '\\?(?:' . SID . '(?:;|&|&amp;))((?:board|topic)=[^#"]+?)(#[^"]*?)?"~',
+					'~"' . preg_quote(Config::$scripturl, '~') . '\?(?:' . SID . '(?:;|&|&amp;))((?:board|topic)=[^#"]+?)(#[^"]*?)?"~',
 					function ($m) {
 						return '"' . Config::$scripturl . '/' . strtr("{$m[1]}", '&;=', '//,') . '.html?' . SID . ($m[2] ?? '') . '"';
 					},
@@ -496,7 +496,7 @@ class QueryString
 				);
 			} else {
 				$buffer = preg_replace_callback(
-					'~"' . preg_quote(Config::$scripturl, '~') . '\\?((?:board|topic)=[^#"]+?)(#[^"]*?)?"~',
+					'~"' . preg_quote(Config::$scripturl, '~') . '\?((?:board|topic)=[^#"]+?)(#[^"]*?)?"~',
 					function ($m) {
 						return '"' . Config::$scripturl . '/' . strtr("{$m[1]}", '&;=', '//,') . '.html' . ($m[2] ?? '') . '"';
 					},

--- a/Sources/QueryString.php
+++ b/Sources/QueryString.php
@@ -60,7 +60,6 @@ class QueryString
 		// Save some memory.. (since we don't use these anyway.)
 		unset($GLOBALS['HTTP_POST_VARS'], $GLOBALS['HTTP_POST_VARS'], $GLOBALS['HTTP_POST_FILES'], $GLOBALS['HTTP_POST_FILES']);
 
-
 		// These keys shouldn't be set...ever.
 		if (isset($_REQUEST['GLOBALS']) || isset($_COOKIE['GLOBALS'])) {
 			die('Invalid request variable.');
@@ -555,7 +554,6 @@ class QueryString
 
 		return (ip2long($ip_address) & (~((1 << (32 - $cidr_subnetmask)) - 1))) == ip2long($cidr_network);
 	}
-
 }
 
 // Export public static functions and properties to global namespace for backward compatibility.

--- a/Sources/Search/APIs/Custom.php
+++ b/Sources/Search/APIs/Custom.php
@@ -135,7 +135,6 @@ class Custom extends SearchApi
 			return;
 		}
 
-
 		foreach ($subwords as $subword) {
 			if (Utils::entityStrlen($subword) >= $this->min_word_length && !in_array($subword, $this->bannedWords)) {
 				$wordsSearch['indexed_words'][] = $subword;
@@ -145,7 +144,6 @@ class Custom extends SearchApi
 				}
 			}
 		}
-
 	}
 
 	/**

--- a/Sources/Search/APIs/Standard.php
+++ b/Sources/Search/APIs/Standard.php
@@ -42,7 +42,6 @@ class Standard extends SearchApi
 	{
 		parent::__construct();
 	}
-
 }
 
 ?>

--- a/Sources/Search/SearchApi.php
+++ b/Sources/Search/SearchApi.php
@@ -838,7 +838,7 @@ abstract class SearchApi implements SearchApiInterface
 			}
 
 			// Skip if file name doesn't match.
-			if (!preg_match('~^SearchAPI-([A-Za-z\\d_]+)\\.php$~', $file_info->getFilename(), $matches)) {
+			if (!preg_match('~^SearchAPI-([A-Za-z\d_]+)\.php$~', $file_info->getFilename(), $matches)) {
 				continue;
 			}
 
@@ -1042,7 +1042,7 @@ abstract class SearchApi implements SearchApiInterface
 	protected function setSearchTerms(): void
 	{
 		// Change non-word characters into spaces.
-		$stripped_query = preg_replace('~(?:[\\x0B\\0' . (Utils::$context['utf8'] ? '\\x{A0}' : '\\xA0') . '\\t\\r\\s\\n(){}\\[\\]<>!@$%^*.,:+=`\\~\\?/\\\\]+|&(?:amp|lt|gt|quot);)+~' . (Utils::$context['utf8'] ? 'u' : ''), ' ', $this->params['search']);
+		$stripped_query = preg_replace('~(?:[\x0B\0' . (Utils::$context['utf8'] ? '\x{A0}' : '\xA0') . '\t\r\s\n(){}\\[\\]<>!@$%^*.,:+=`\~\?/\\\\]+|&(?:amp|lt|gt|quot);)+~' . (Utils::$context['utf8'] ? 'u' : ''), ' ', $this->params['search']);
 
 		// Make the query lower case. It's gonna be case insensitive anyway.
 		$stripped_query = Utils::htmlspecialcharsDecode(Utils::strtolower($stripped_query));
@@ -1053,15 +1053,15 @@ abstract class SearchApi implements SearchApiInterface
 		}
 
 		// Specify the function to search with. Regex is for word boundaries.
-		$this->query_match_type = !empty(Config::$modSettings['search_match_words']) && !preg_match('~&#(?:\\d{1,7}|x[0-9a-fA-F]{1,6});~', $stripped_query) ? 'RLIKE' : 'LIKE';
+		$this->query_match_type = !empty(Config::$modSettings['search_match_words']) && !preg_match('~&#(?:\d{1,7}|x[0-9a-fA-F]{1,6});~', $stripped_query) ? 'RLIKE' : 'LIKE';
 
 		// Extract phrase parts first (e.g. some words "this is a phrase" some more words.)
-		preg_match_all('/(?:^|\\s)([-]?)"([^"]+)"(?:$|\\s)/', $stripped_query, $matches, PREG_PATTERN_ORDER);
+		preg_match_all('/(?:^|\s)([-]?)"([^"]+)"(?:$|\s)/', $stripped_query, $matches, PREG_PATTERN_ORDER);
 
 		$phraseArray = $matches[2];
 
 		// Remove the phrase parts and extract the words.
-		$wordArray = preg_replace('~(?:^|\\s)[-]?"[^"]+"(?:$|\\s)~' . (Utils::$context['utf8'] ? 'u' : ''), ' ', $this->params['search']);
+		$wordArray = preg_replace('~(?:^|\s)[-]?"[^"]+"(?:$|\s)~' . (Utils::$context['utf8'] ? 'u' : ''), ' ', $this->params['search']);
 
 		$wordArray = explode(' ', Utils::htmlspecialchars(Utils::htmlspecialcharsDecode($wordArray), ENT_QUOTES));
 
@@ -1214,7 +1214,7 @@ abstract class SearchApi implements SearchApiInterface
 	 */
 	protected function escapeSqlRegex(string $str): string
 	{
-		return addcslashes(preg_replace('/[\\[\\]$.+*?&^|{}()]/', '[$0]', $str), '\\\'');
+		return addcslashes(preg_replace('/[\[\]$.+*?&^|{}()]/', '[$0]', $str), '\\\'');
 	}
 
 	/**

--- a/Sources/Search/SearchApi.php
+++ b/Sources/Search/SearchApi.php
@@ -1198,7 +1198,6 @@ abstract class SearchApi implements SearchApiInterface
 			$this->searchWords[$orIndex]['indexed_words'] = array_slice($this->searchWords[$orIndex]['indexed_words'], 0, 7);
 			$this->searchWords[$orIndex]['subject_words'] = array_slice($this->searchWords[$orIndex]['subject_words'], 0, 7);
 			$this->searchWords[$orIndex]['words'] = array_slice($this->searchWords[$orIndex]['words'], 0, 4);
-
 		}
 	}
 

--- a/Sources/Search/SearchResult.php
+++ b/Sources/Search/SearchResult.php
@@ -229,7 +229,7 @@ class SearchResult extends \SMF\Msg
 						$keyword = Utils::htmlspecialcharsDecode($keyword);
 						$keyword = Utils::sanitizeEntities(Utils::entityFix(strtr($keyword, ['\\\'' => '\'', '&' => '&amp;'])));
 
-						if (preg_match('~[\'\\.,/@%&;:(){}\\[\\]_\\-+\\\\]$~', $keyword) != 0 || preg_match('~^[\'\\.,/@%&;:(){}\\[\\]_\\-+\\\\]~', $keyword) != 0) {
+						if (preg_match('~[\'\.,/@%&;:(){}\[\]_\-+\\\\]$~', $keyword) || preg_match('~^[\'\.,/@%&;:(){}\[\]_\-+\\\\]~', $keyword)) {
 							$force_partial_word = true;
 						}
 						$matchString .= strtr(preg_quote($keyword, '/'), ['\\*' => '.+?']) . '|';
@@ -239,9 +239,9 @@ class SearchResult extends \SMF\Msg
 					$this->body = Utils::htmlspecialcharsDecode(strtr($this->body, ['&nbsp;' => ' ', '<br>' => "\n", '&#91;' => '[', '&#93;' => ']', '&#58;' => ':', '&#64;' => '@']));
 
 					if (empty(Config::$modSettings['search_method']) || $force_partial_word) {
-						preg_match_all('/([^\\s\\W]{' . $charLimit . '}[\\s\\W]|[\\s\\W].{0,' . $charLimit . '}?|^)(' . $matchString . ')(.{0,' . $charLimit . '}[\\s\\W]|[^\\s\\W]{0,' . $charLimit . '})/is' . (Utils::$context['utf8'] ? 'u' : ''), $this->body, $matches);
+						preg_match_all('/([^\s\W]{' . $charLimit . '}[\s\W]|[\s\W].{0,' . $charLimit . '}?|^)(' . $matchString . ')(.{0,' . $charLimit . '}[\s\W]|[^\s\W]{0,' . $charLimit . '})/is' . (Utils::$context['utf8'] ? 'u' : ''), $this->body, $matches);
 					} else {
-						preg_match_all('/([^\\s\\W]{' . $charLimit . '}[\\s\\W]|[\\s\\W].{0,' . $charLimit . '}?[\\s\\W]|^)(' . $matchString . ')([\\s\\W].{0,' . $charLimit . '}[\\s\\W]|[\\s\\W][^\\s\\W]{0,' . $charLimit . '})/is' . (Utils::$context['utf8'] ? 'u' : ''), $this->body, $matches);
+						preg_match_all('/([^\s\W]{' . $charLimit . '}[\s\W]|[\s\W].{0,' . $charLimit . '}?[\s\W]|^)(' . $matchString . ')([\s\W].{0,' . $charLimit . '}[\s\W]|[\s\W][^\s\W]{0,' . $charLimit . '})/is' . (Utils::$context['utf8'] ? 'u' : ''), $this->body, $matches);
 					}
 
 					$this->body = '';

--- a/Sources/Security.php
+++ b/Sources/Security.php
@@ -108,13 +108,11 @@ class Security
 			return true;
 		}
 
-
 		$token = bin2hex(Utils::randomBytes(16));
 
 		$_SESSION['confirm_' . $action] = hash_hmac('md5', $_SERVER['HTTP_USER_AGENT'], $token);
 
 		return $token;
-
 	}
 
 	/**
@@ -316,7 +314,6 @@ class Security
 				continue;
 			}
 
-
 			$fh = @fopen($path . '/.htaccess', 'w');
 
 			if ($fh) {
@@ -326,14 +323,12 @@ class Security
 				$errors[] = 'htaccess_cannot_create_file';
 			}
 
-
 			// Next, the index.php file
 			if (file_exists($path . '/index.php')) {
 				$errors[] = 'index-php_exists';
 
 				continue;
 			}
-
 
 			$contents = <<<END
 				<?php
@@ -355,7 +350,6 @@ class Security
 			} else {
 				$errors[] = 'index-php_cannot_create_file';
 			}
-
 		}
 
 		return !empty($errors) ? $errors : true;

--- a/Sources/ServerSideIncludes.php
+++ b/Sources/ServerSideIncludes.php
@@ -2521,7 +2521,7 @@ class ServerSideIncludes
 		$attachments = [];
 
 		while ($row = Db::$db->fetch_assoc($request)) {
-			$filename = preg_replace('~&amp;#(\\d{1,7}|x[0-9a-fA-F]{1,6});~', '&#\\1;', htmlspecialchars($row['filename']));
+			$filename = preg_replace('~&amp;#(\d{1,7}|x[0-9a-fA-F]{1,6});~', '&#$1;', htmlspecialchars($row['filename']));
 
 			// Is it an image?
 			$attachments[$row['id_attach']] = [

--- a/Sources/ServerSideIncludes.php
+++ b/Sources/ServerSideIncludes.php
@@ -98,7 +98,6 @@ class ServerSideIncludes
 	 */
 	protected static $setup_done = false;
 
-
 	/******************************************************************
 	 * Properties that allow external scripts to control SSI behaviour.
 	 ******************************************************************/
@@ -194,7 +193,6 @@ class ServerSideIncludes
 	 * Whether to compress output using the GZip algorithm.
 	 */
 	public $gzip;
-
 
 	/****************************************************************
 	 * Static methods that allow external scripts to access SMF data.
@@ -1506,7 +1504,6 @@ class ServerSideIncludes
 					</tr>
 				</table>
 			</form>';
-
 	}
 
 	/**
@@ -2596,7 +2593,6 @@ class ServerSideIncludes
 		echo '
 			</table>';
 	}
-
 
 	/******************
 	 * Primary methods.

--- a/Sources/Session.php
+++ b/Sources/Session.php
@@ -211,7 +211,7 @@ class Session implements \SessionHandlerInterface
 		if (!empty(Config::$modSettings['globalCookies'])) {
 			$url = new Url(Config::$boardurl);
 
-			if (preg_match('~^\\d{1,3}(\\.\\d{1,3}){3}$~', $url->host) == 0 && preg_match('~(?:[^\\.]+\\.)?([^\\.]{2,}\\..+)\\z~i', $url->host, $parts) == 1) {
+			if (preg_match('~^\d{1,3}(\.\d{1,3}){3}$~', $url->host) == 0 && preg_match('~(?:[^.]+\.)?([^.]{2,}\..+)\z~i', $url->host, $parts) == 1) {
 				@ini_set('session.cookie_domain', '.' . $parts[1]);
 			}
 		}
@@ -264,7 +264,7 @@ class Session implements \SessionHandlerInterface
 		if (!isset($_SESSION['session_var'])) {
 			$_SESSION['session_value'] = md5(session_id() . Utils::randomInt());
 
-			$_SESSION['session_var'] = substr(preg_replace('~^\\d+~', '', sha1(Utils::randomInt() . session_id() . Utils::randomInt())), 0, Utils::randomInt(7, 12));
+			$_SESSION['session_var'] = substr(preg_replace('~^\d+~', '', sha1(Utils::randomInt() . session_id() . Utils::randomInt())), 0, Utils::randomInt(7, 12));
 		}
 
 		User::$sc = $_SESSION['session_value'];

--- a/Sources/Subscriptions/PayPal/Display.php
+++ b/Sources/Subscriptions/PayPal/Display.php
@@ -111,7 +111,7 @@ class Display
 			$return_data['hidden']['p3'] = 1;
 			$return_data['hidden']['t3'] = strtoupper(substr($period, 0, 1));
 		} else {
-			preg_match('~(\\d*)(\\w)~', $sub_data['real_length'], $match);
+			preg_match('~(\d*)(\w)~', $sub_data['real_length'], $match);
 			$unit = $match[1];
 			$period = $match[2];
 

--- a/Sources/Subscriptions/PayPal/Payment.php
+++ b/Sources/Subscriptions/PayPal/Payment.php
@@ -53,9 +53,7 @@ class Payment
 			return false;
 		}
 
-		return !(strtolower(Config::$modSettings['paypal_email']) != strtolower($_POST['business']) && (empty(Config::$modSettings['paypal_additional_emails']) || !in_array(strtolower($_POST['business']), explode(',', Config::$modSettings['paypal_additional_emails']))))
-
-		;
+		return !(strtolower(Config::$modSettings['paypal_email']) != strtolower($_POST['business']) && (empty(Config::$modSettings['paypal_additional_emails']) || !in_array(strtolower($_POST['business']), explode(',', Config::$modSettings['paypal_additional_emails']))));
 	}
 
 	/**
@@ -187,10 +185,7 @@ class Payment
 	 */
 	public function isRefund()
 	{
-		return (bool) ($_POST['payment_status'] === 'Refunded' || $_POST['payment_status'] === 'Reversed' || $_POST['txn_type'] === 'Refunded' || ($_POST['txn_type'] === 'reversal' && $_POST['payment_status'] === 'Completed'))
-
-
-		;
+		return (bool) ($_POST['payment_status'] === 'Refunded' || $_POST['payment_status'] === 'Reversed' || $_POST['txn_type'] === 'Refunded' || ($_POST['txn_type'] === 'reversal' && $_POST['payment_status'] === 'Completed'));
 	}
 
 	/**
@@ -200,10 +195,7 @@ class Payment
 	 */
 	public function isSubscription()
 	{
-		return (bool) (substr($_POST['txn_type'], 0, 14) === 'subscr_payment' && $_POST['payment_status'] === 'Completed')
-
-
-		;
+		return (bool) (substr($_POST['txn_type'], 0, 14) === 'subscr_payment' && $_POST['payment_status'] === 'Completed');
 	}
 
 	/**
@@ -213,10 +205,7 @@ class Payment
 	 */
 	public function isPayment()
 	{
-		return (bool) ($_POST['payment_status'] === 'Completed' && $_POST['txn_type'] === 'web_accept')
-
-
-		;
+		return (bool) ($_POST['payment_status'] === 'Completed' && $_POST['txn_type'] === 'web_accept');
 	}
 
 	/**
@@ -229,10 +218,7 @@ class Payment
 		// subscr_cancel is sent when the user cancels, subscr_eot is sent when the subscription reaches final payment
 		// Neither require us to *do* anything as per performCancel().
 		// subscr_eot, if sent, indicates an end of payments term.
-		return (bool) (substr($_POST['txn_type'], 0, 13) === 'subscr_cancel' || substr($_POST['txn_type'], 0, 10) === 'subscr_eot')
-
-
-		;
+		return (bool) (substr($_POST['txn_type'], 0, 13) === 'subscr_cancel' || substr($_POST['txn_type'], 0, 10) === 'subscr_eot');
 	}
 
 	/**

--- a/Sources/TaskRunner.php
+++ b/Sources/TaskRunner.php
@@ -525,19 +525,15 @@ class TaskRunner
 				return $row;
 			}
 
-
 			// Uh oh, we just missed it. Try to claim another one, and let
 			// it fall through if there aren't any.
 			return $this->fetchTask();
-
 		}
-
 
 		// No dice. Clean up and go home.
 		Db::$db->free_result($request);
 
 		return false;
-
 	}
 
 	/**
@@ -743,7 +739,6 @@ class TaskRunner
 		];
 	}
 
-
 	/* Helper functions that resemble their big brother counterparts. */
 
 	/**
@@ -780,11 +775,9 @@ class TaskRunner
 			die(0);
 		}
 
-
 		header('content-type: image/gif');
 
 		die("\x47\x49\x46\x38\x39\x61\x01\x00\x01\x00\x80\x00\x00\x00\x00\x00\x00\x00\x00\x21\xF9\x04\x01\x00\x00\x00\x00\x2C\x00\x00\x00\x00\x01\x00\x01\x00\x00\x02\x02\x44\x01\x00\x3B");
-
 	}
 
 	/*************************

--- a/Sources/Theme.php
+++ b/Sources/Theme.php
@@ -3118,7 +3118,6 @@ class Theme
 			die;
 		}
 	}
-
 }
 
 // Export public static functions and properties to global namespace for backward compatibility.

--- a/Sources/Theme.php
+++ b/Sources/Theme.php
@@ -2182,7 +2182,7 @@ class Theme
 			if (file_exists($theme_data['theme_dir'] . '/index.template.php') && (empty($theme_data['disable_user_variant']) || User::$me->allowedTo('admin_forum'))) {
 				$file_contents = implode('', file($theme_data['theme_dir'] . '/index.template.php'));
 
-				if (preg_match('~((?:SMF\\\\)?Theme::\\$current(?:->|_)|\\$)settings\\[\'theme_variants\'\\]\\s*=(.+?);~', $file_contents, $matches)) {
+				if (preg_match('~((?:SMF\\\\)?Theme::\$current(?:->|_)|\$)settings\[\'theme_variants\'\]\s*=(.+?);~', $file_contents, $matches)) {
 					self::$current->settings['theme_variants'] = [];
 
 					// Fill settings up.
@@ -2602,7 +2602,7 @@ class Theme
 			}
 
 			// Okay, #4 - perhaps it's an IP address?  We're gonna want to use that one, then. (assuming it's the IP or something...)
-			if (!empty($do_fix) || preg_match('~^http[s]?://(?:[\\d\\.:]+|\\[[\\d:]+\\](?::\\d+)?)(?:$|/)~', $detected_url) == 1) {
+			if (!empty($do_fix) || preg_match('~^http[s]?://(?:[\d\.:]+|\[[\d:]+\](?::\d+)?)(?:$|/)~', $detected_url) == 1) {
 				// Caching is good ;).
 				$oldurl = Config::$boardurl;
 
@@ -3033,7 +3033,7 @@ class Theme
 				}
 
 				// I know, I know... this is VERY COMPLICATED.  Still, it's good.
-				if (preg_match('~ <strong>(\\d+)</strong><br( /)?' . '>$~i', $error, $match) != 0) {
+				if (preg_match('~ <strong>(\d+)</strong><br( /)?' . '>$~i', $error, $match) != 0) {
 					$data = file($filename);
 					$data2 = BBCodeParser::highlightPhpCode(implode('', $data));
 					$data2 = preg_split('~\\<br( /)?\\>~', $data2);

--- a/Sources/Time.php
+++ b/Sources/Time.php
@@ -574,9 +574,7 @@ class Time extends \DateTime implements \ArrayAccess
 						break;
 					}
 
-
 					$placeholders[str_replace($f, $num, $placeholder)] = Lang::$txt[$key][$num];
-
 				}
 
 				$parts[$i] = $txt_strings_exist ? $placeholder : self::FORMAT_EQUIVALENTS[$parts[$i]];

--- a/Sources/Time.php
+++ b/Sources/Time.php
@@ -646,7 +646,7 @@ class Time extends \DateTime implements \ArrayAccess
 		// Deal with the complicated ones.
 		if ($complex) {
 			$result = preg_replace_callback(
-				'/\\xEE\\x84\\xA0([\\d_]+)(\\xEE\\x84(?:[\\xA1-\\xAF]))/',
+				'/\xEE\x84\xA0([\d_]+)(\xEE\x84(?:[\xA1-\xAF]))/',
 				function ($matches) {
 					switch ($matches[2]) {
 						// %j
@@ -832,13 +832,13 @@ class Time extends \DateTime implements \ArrayAccess
 
 			$date_format = Utils::normalizeSpaces($date_format, true, true, ['replace_tabs' => true, 'collapse_hspace' => true, 'no_breaks' => true]);
 
-			$date_format = preg_replace('/^([\\p{Z}\\p{C}]|[^%\\P{P}])*|[\\p{Z}\\p{C}\\p{P}]*$/u', '', $date_format);
+			$date_format = preg_replace('/^([\p{Z}\p{C}]|[^%\P{P}])*|[\p{Z}\p{C}\p{P}]*$/u', '', $date_format);
 		} else {
 			$date_format = preg_replace('/(?<!\\\\)[LoXxYy]/', '', $date_format);
 
 			$date_format = Utils::normalizeSpaces($date_format, true, true, ['replace_tabs' => true, 'collapse_hspace' => true, 'no_breaks' => true]);
 
-			$date_format = preg_replace('/^[\\p{Z}\\p{C}\\p{P}]*|[\\p{Z}\\p{C}\\p{P}]*$/u', '', $date_format);
+			$date_format = preg_replace('/^[\p{Z}\p{C}\p{P}]*|[\p{Z}\p{C}\p{P}]*$/u', '', $date_format);
 		}
 
 		if ($format === '') {
@@ -884,9 +884,9 @@ class Time extends \DateTime implements \ArrayAccess
 
 			$time_format = Utils::normalizeSpaces($time_format, true, true, ['replace_tabs' => true, 'collapse_hspace' => true, 'no_breaks' => true]);
 
-			$time_format = preg_replace('/:(?=\\p{Z}|$|%[pPzZ])/u', '', $time_format);
+			$time_format = preg_replace('/:(?=\p{Z}|$|%[pPzZ])/u', '', $time_format);
 
-			$time_format = preg_replace('/^([\\p{Z}\\p{C}]|[^%\\P{P}])*|[\\p{Z}\\p{C}\\p{P}]*$/u', '', $time_format);
+			$time_format = preg_replace('/^([\p{Z}\p{C}]|[^%\P{P}])*|[\p{Z}\p{C}\p{P}]*$/u', '', $time_format);
 		} else {
 			$substitutions = [
 				'H' => 'G',
@@ -904,9 +904,9 @@ class Time extends \DateTime implements \ArrayAccess
 
 			$time_format = Utils::normalizeSpaces($time_format, true, true, ['replace_tabs' => true, 'collapse_hspace' => true, 'no_breaks' => true]);
 
-			$time_format = preg_replace('/:(?=\\p{Z}|$|[aAeOPpTZ])/u', '', $time_format);
+			$time_format = preg_replace('/:(?=\p{Z}|$|[aAeOPpTZ])/u', '', $time_format);
 
-			$time_format = preg_replace('/^[\\p{Z}\\p{C}\\p{P}]*|[\\p{Z}\\p{C}\\p{P}]*$/u', '', $time_format);
+			$time_format = preg_replace('/^[\p{Z}\p{C}\p{P}]*|[\p{Z}\p{C}\p{P}]*$/u', '', $time_format);
 		}
 
 		if ($format === '') {
@@ -1082,16 +1082,16 @@ class Time extends \DateTime implements \ArrayAccess
 		$format = preg_replace(
 			[
 				// Anything that isn't a specification, punctuation mark, or whitespace.
-				'~(?<!%)\\p{L}|[^\\p{L}\\p{P}\\p{Z}]~u',
+				'~(?<!%)\p{L}|[^\p{L}\p{P}\p{Z}]~u',
 				// Repeated punctuation marks (except %), possibly separated by whitespace.
-				'~(?' . '>([^%\\P{P}])\\p{Z}*(?=\\1))*~u',
-				'~([^%\\P{P}])(?' . '>\\1(?!$))*~u',
+				'~(?' . '>([^%\P{P}])\p{Z}*(?=\1))*~u',
+				'~([^%\P{P}])(?' . '>\1(?!$))*~u',
 				// Unwanted trailing punctuation and whitespace.
-				'~(?' . '>([\\p{Pd}\\p{Ps}\\p{Pi}\\p{Pc}]|[^%\\P{Po}])\\p{Z}*)*$~u',
+				'~(?' . '>([\p{Pd}\p{Ps}\p{Pi}\p{Pc}]|[^%\P{Po}])\p{Z}*)*$~u',
 				// Unwanted opening punctuation and whitespace.
-				'~^\\p{Z}*(?' . '>([\\p{Pd}\\p{Pe}\\p{Pf}\\p{Pc}]|[^%\\P{Po}])\\p{Z}*)*~u',
+				'~^\p{Z}*(?' . '>([\p{Pd}\p{Pe}\p{Pf}\p{Pc}]|[^%\P{Po}])\p{Z}*)*~u',
 				// Runs of horizontal whitespace.
-				'~\\p{Z}+~',
+				'~\p{Z}+~',
 			],
 			[
 				'',
@@ -1202,16 +1202,16 @@ class Time extends \DateTime implements \ArrayAccess
 		$format = preg_replace(
 			[
 				// Anything that isn't a specification, punctuation mark, or whitespace.
-				'~\\\\\\p{L}|[^\\p{L}\\p{P}\\p{Z}]~u',
+				'~\\\\\p{L}|[^\p{L}\p{P}\p{Z}]~u',
 				// Repeated punctuation marks, possibly separated by whitespace.
-				'~(?' . '>(\\p{P})\\p{Z}*(?=\\1))*~u',
-				'~(\\p{P})(?' . '>\\1(?!$))*~u',
+				'~(?' . '>(\p{P})\p{Z}*(?=\1))*~u',
+				'~(\p{P})(?' . '>\1(?!$))*~u',
 				// Unwanted trailing punctuation and whitespace.
-				'~(?' . '>(\\p{P})\\p{Z}*)*$~u',
+				'~(?' . '>(\p{P})\p{Z}*)*$~u',
 				// Unwanted opening punctuation and whitespace.
-				'~^\\p{Z}*(?' . '>(\\p{P})\\p{Z}*)*~u',
+				'~^\p{Z}*(?' . '>(\p{P})\p{Z}*)*~u',
 				// Runs of horizontal whitespace.
-				'~\\p{Z}+~',
+				'~\p{Z}+~',
 			],
 			[
 				'',

--- a/Sources/Unicode/Utf8String.php
+++ b/Sources/Unicode/Utf8String.php
@@ -224,15 +224,15 @@ class Utf8String implements \Stringable
 			switch ($case) {
 				case 'title':
 					$this->convertCase($this->string, 'lower', $simple);
-					$regex = '/(?:^|[^\\w' . $prop_classes['Case_Ignorable'] . '])\\K(\\p{L})/u';
+					$regex = '/(?:^|[^\w' . $prop_classes['Case_Ignorable'] . '])\K(\p{L})/u';
 					break;
 
 				case 'ucwords':
-					$regex = '/(?:^|[^\\w' . $prop_classes['Case_Ignorable'] . '])\\K(\\p{L})(?=[' . $prop_classes['Case_Ignorable'] . ']*(?:(?<upper>\\p{Lu})|\\w?))/u';
+					$regex = '/(?:^|[^\w' . $prop_classes['Case_Ignorable'] . '])\K(\p{L})(?=[' . $prop_classes['Case_Ignorable'] . ']*(?:(?<upper>\p{Lu})|\w?))/u';
 					break;
 
 				case 'ucfirst':
-					$regex = '/^[^\\w' . $prop_classes['Case_Ignorable'] . ']*\\K(\\p{L})(?=[' . $prop_classes['Case_Ignorable'] . ']*(?:(?<upper>\\p{Lu})|\\w?))/u';
+					$regex = '/^[^\w' . $prop_classes['Case_Ignorable'] . ']*\K(\p{L})(?=[' . $prop_classes['Case_Ignorable'] . ']*(?:(?<upper>\p{Lu})|\w?))/u';
 					break;
 			}
 
@@ -271,7 +271,7 @@ class Utf8String implements \Stringable
 			$substitutions['ς'] = 'σ';
 
 			// Then convert any at the end of words to final form.
-			$replacements['/\\Bσ([' . $prop_classes['Case_Ignorable'] . ']*)(?!\\p{L})/u'] = 'ς$1';
+			$replacements['/\Bσ([' . $prop_classes['Case_Ignorable'] . ']*)(?!\p{L})/u'] = 'ς$1';
 		}
 
 		// Greek conditional casing, part 2: No accents on uppercase strings.
@@ -333,18 +333,18 @@ class Utf8String implements \Stringable
 			// Note: some fonts handle this incorrectly and show two dots,
 			// but that's a bug in those fonts and cannot be fixed here.
 			if ($case !== 'upper') {
-				$replacements['/(i\\x{328}?|\\x{12F}|j)([\\x{300}\\x{301}\\x{303}])/u'] = '$1' . "\xCC\x87" . '$2';
+				$replacements['/(i\x{328}?|\x{12F}|j)([\x{300}\x{301}\x{303}])/u'] = '$1' . "\xCC\x87" . '$2';
 			}
 
 			// Remove "COMBINING DOT ABOVE" after uppercase I and J.
 			if ($case !== 'lower') {
-				$replacements['/(I\\x{328}?|\\x{12E}|J)\\x{307}/u'] = '$1';
+				$replacements['/(I\x{328}?|\x{12E}|J)\x{307}/u'] = '$1';
 			}
 		}
 
 		// Dutch has a special titlecase rule.
 		if ($this->language === 'nl' && $case === 'title') {
-			$replacements['/\\bIj/u'] = 'IJ';
+			$replacements['/\bIj/u'] = 'IJ';
 		}
 
 		// Now perform whatever conditional casing fixes we need.
@@ -470,7 +470,7 @@ class Utf8String implements \Stringable
 		// That means the more thorough checks will occasionally be performed on
 		// strings that don't need them, but building and running a perfect regex
 		// would be more expensive in the vast majority of cases, so meh.
-		if (preg_match_all('/([\\p{M}\\p{Cn}])/u', $this->string, $matches, PREG_OFFSET_CAPTURE)) {
+		if (preg_match_all('/([\p{M}\p{Cn}])/u', $this->string, $matches, PREG_OFFSET_CAPTURE)) {
 			require_once __DIR__ . '/CombiningClasses.php';
 
 			$combining_classes = utf8_combining_classes();
@@ -526,46 +526,46 @@ class Utf8String implements \Stringable
 		$prop_classes = utf8_regex_properties();
 
 		// We never want non-whitespace control characters
-		$disallowed[] = '[^\\P{Cc}\\t\\r\\n]';
+		$disallowed[] = '[^\P{Cc}\t\r\n]';
 
 		// We never want private use characters or non-characters.
 		// Use our own version of \p{Cn} in order to avoid possible inconsistencies
 		// between our data and whichever version of PCRE happens to be installed
 		// on this server. Unlike \p{Cc} and \p{Co}, which never change, the value
 		// of \p{Cn} changes with every new version of Unicode.
-		$disallowed[] = '[\\p{Co}' . $prop_classes['Cn'] . ']';
+		$disallowed[] = '[\p{Co}' . $prop_classes['Cn'] . ']';
 
 		// Several more things we never want:
 		$disallowed[] = '[' . implode('', [
 			// Soft Hyphen.
-			'\\x{AD}',
+			'\x{AD}',
 			// Khmer Vowel Inherent AQ and Khmer Vowel Inherent AA.
 			// Unicode Standard ch. 16 says: "they are insufficient for [their]
 			// purpose and should be considered errors in the encoding."
-			'\\x{17B4}-\\x{17B5}',
+			'\x{17B4}-\x{17B5}',
 			// Invisible math characters.
-			'\\x{2061}-\\x{2064}',
+			'\x{2061}-\x{2064}',
 			// Deprecated formatting characters.
-			'\\x{206A}-\\x{206F}',
+			'\x{206A}-\x{206F}',
 			// Zero Width No-Break Space, a.k.a. Byte Order Mark.
-			'\\x{FEFF}',
+			'\x{FEFF}',
 			// Annotation characters and Object Replacement Character.
-			'\\x{FFF9}-\\x{FFFC}',
+			'\x{FFF9}-\x{FFFC}',
 		]) . ']';
 
 		switch ($level) {
 			case 2:
 				$disallowed[] = '[' . implode('', [
 					// Combining Grapheme Character.
-					'\\x{34F}',
+					'\x{34F}',
 					// Zero Width Non-Joiner.
-					'\\x{200C}',
+					'\x{200C}',
 					// Zero Width Joiner.
-					'\\x{200D}',
+					'\x{200D}',
 					// All variation selectors.
 					$prop_classes['Variation_Selector'],
 					// Tag characters.
-					'\\x{E0000}-\\x{E007F}',
+					'\x{E0000}-\x{E007F}',
 				]) . ']';
 
 				// no break
@@ -573,48 +573,48 @@ class Utf8String implements \Stringable
 			case 1:
 				$disallowed[] = '[' . implode('', [
 					// Zero Width Space.
-					'\\x{200B}',
+					'\x{200B}',
 					// Word Joiner.
-					'\\x{2060}',
+					'\x{2060}',
 					// "Bidi_Control" characters.
 					// Disallowing means that all characters will behave according
 					// to their default bidirectional text properties.
 					$prop_classes['Bidi_Control'],
 					// Hangul filler characters.
 					// Used as placeholders in incomplete ideographs.
-					'\\x{115F}\\x{1160}\\x{3164}\\x{FFA0}',
+					'\x{115F}\x{1160}\x{3164}\x{FFA0}',
 					// Shorthand formatting characters.
-					'\\x{1BCA0}-\\x{1BCA3}',
+					'\x{1BCA0}-\x{1BCA3}',
 					// Musical formatting characters.
-					'\\x{1D173}-\\x{1D17A}',
+					'\x{1D173}-\x{1D17A}',
 				]) . ']';
 
 				break;
 
 			default:
 				// Zero Width Space only allowed in certain scripts.
-				$disallowed[] = '(?<![\\p{Thai}\\p{Myanmar}\\p{Khmer}\\p{Hiragana}\\p{Katakana}])\\x{200B}';
+				$disallowed[] = '(?<![\p{Thai}\p{Myanmar}\p{Khmer}\p{Hiragana}\p{Katakana}])\x{200B}';
 
 				// Word Joiner disallowed inside words. (Yes, \w is Unicode safe.)
-				$disallowed[] = '(?<=\\w)\\x{2060}(?=\\w)';
+				$disallowed[] = '(?<=\w)\x{2060}(?=\w)';
 
 				// Hangul Choseong Filler and Hangul Jungseong Filler must followed
 				// by more Hangul Jamo characters.
-				$disallowed[] = '[\\x{115F}\\x{1160}](?![\\x{1100}-\\x{11FF}\\x{A960}-\\x{A97F}\\x{D7B0}-\\x{D7FF}])';
+				$disallowed[] = '[\x{115F}\x{1160}](?![\x{1100}-\x{11FF}\x{A960}-\x{A97F}\x{D7B0}-\x{D7FF}])';
 
 				// Hangul Filler for Hangul compatibility chars.
-				$disallowed[] = '\\x{3164}(?![\\x{3130}-\\x{318F}])';
+				$disallowed[] = '\x{3164}(?![\x{3130}-\x{318F}])';
 
 				// Halfwidth Hangul Filler for halfwidth Hangul compatibility chars.
-				$disallowed[] = '\\x{FFA0}(?![\\x{FFA1}-\\x{FFDC}])';
+				$disallowed[] = '\x{FFA0}(?![\x{FFA1}-\x{FFDC}])';
 
 				// Shorthand formatting characters only with other shorthand chars.
-				$disallowed[] = '[\\x{1BCA0}-\\x{1BCA3}](?![\\x{1BC00}-\\x{1BC9F}])';
-				$disallowed[] = '(?<![\\x{1BC00}-\\x{1BC9F}])[\\x{1BCA0}-\\x{1BCA3}]';
+				$disallowed[] = '[\x{1BCA0}-\x{1BCA3}](?![\x{1BC00}-\x{1BC9F}])';
+				$disallowed[] = '(?<![\x{1BC00}-\x{1BC9F}])[\x{1BCA0}-\x{1BCA3}]';
 
 				// Musical formatting characters only with other musical chars.
-				$disallowed[] = '[\\x{1D173}\\x{1D175}\\x{1D177}\\x{1D179}](?![\\x{1D100}-\\x{1D1FF}])';
-				$disallowed[] = '(?<![\\x{1D100}-\\x{1D1FF}])[\\x{1D174}\\x{1D176}\\x{1D178}\\x{1D17A}]';
+				$disallowed[] = '[\x{1D173}\x{1D175}\x{1D177}\x{1D179}](?![\x{1D100}-\x{1D1FF}])';
+				$disallowed[] = '(?<![\x{1D100}-\x{1D1FF}])[\x{1D174}\x{1D176}\x{1D178}\x{1D17A}]';
 
 				break;
 		}
@@ -628,10 +628,10 @@ class Utf8String implements \Stringable
 				simply test whether it is followed by a combining mark in order to
 				determine whether to allow it.
 			*/
-			$disallowed[] = '\\x{34F}(?!\\p{M})';
+			$disallowed[] = '\x{34F}(?!\p{M})';
 
 			// Tag characters not allowed inside words.
-			$disallowed[] = '(?<=\\w)[\\x{E0000}-\\x{E007F}](?=\\w)';
+			$disallowed[] = '(?<=\w)[\x{E0000}-\x{E007F}](?=\w)';
 		}
 
 		$this->string = preg_replace('/' . implode('|', $disallowed) . '/u', $substitute, $this->string);
@@ -733,13 +733,13 @@ class Utf8String implements \Stringable
 			 * the Unicode word break algorithm.
 			 * See https://www.unicode.org/reports/tr29/#Word_Boundaries
 			 */
-			$words = preg_split('/(?<![\\p{L}\\p{M}\\p{N}_])(?=[\\p{L}\\p{M}\\p{N}_])|(?<=[\\p{L}\\p{M}\\p{N}_])(?![\\p{L}\\p{M}\\p{N}_])/su', $this->string);
+			$words = preg_split('/(?<![\p{L}\p{M}\p{N}_])(?=[\p{L}\p{M}\p{N}_])|(?<=[\p{L}\p{M}\p{N}_])(?![\p{L}\p{M}\p{N}_])/su', $this->string);
 		}
 
 		foreach ($words as $key => $word) {
 			$word = trim($word);
 
-			if (preg_replace('/\\W/u', '', $word) === '') {
+			if (preg_replace('/\W/u', '', $word) === '') {
 				unset($words[$key]);
 
 				continue;
@@ -1282,20 +1282,20 @@ class Utf8String implements \Stringable
 			'(' .
 				'[' . $prop_classes['Emoji_Modifier'] . ']' .
 				'|' .
-				'\\x{FE0F}\\x{20E3}?' .
+				'\x{FE0F}\x{20E3}?' .
 				'|' .
-				'[\\x{E0020}-\\x{E007E}]+\\x{E007F}' .
+				'[\x{E0020}-\x{E007E}]+\x{E007F}' .
 			')?' .
 			// Possibly concatenated with Zero Width Joiner and more emojis
 			// (e.g. the "family" emoji sequences)
 			'(' .
-				'\\x{200D}[' . $prop_classes['Emoji'] . ']' .
+				'\x{200D}[' . $prop_classes['Emoji'] . ']' .
 				'(' .
 					'[' . $prop_classes['Emoji_Modifier'] . ']' .
 					'|' .
-					'\\x{FE0F}\\x{20E3}?' .
+					'\x{FE0F}\x{20E3}?' .
 					'|' .
-					'[\\x{E0020}-\\x{E007E}]+\\x{E007F}' .
+					'[\x{E0020}-\x{E007E}]+\x{E007F}' .
 				')?' .
 			')*' .
 			'/u',
@@ -1335,7 +1335,7 @@ class Utf8String implements \Stringable
 		require_once __DIR__ . '/RegularExpressions.php';
 		$prop_classes = utf8_regex_properties();
 
-		$patterns = ['/[' . $prop_classes['Ideographic'] . '][\\x{E0100}-\\x{E01EF}]/u'];
+		$patterns = ['/[' . $prop_classes['Ideographic'] . '][\x{E0100}-\x{E01EF}]/u'];
 
 		foreach (utf8_regex_variation_selectors() as $variation_selector => $allowed_base_chars) {
 			$patterns[] = '/[' . $allowed_base_chars . '][' . $variation_selector . ']/u';
@@ -1384,7 +1384,7 @@ class Utf8String implements \Stringable
 
 		// When not in strict mode, allow ZWJ at word boundaries.
 		if ($level === 0) {
-			$this->string = preg_replace('/\\b\\x{200D}|\\x{200D}\\b/u', $placeholders[$zwj], $this->string);
+			$this->string = preg_replace('/\b\x{200D}|\x{200D}\b/u', $placeholders[$zwj], $this->string);
 		}
 
 		// Tests for Zero Width Joiner and Zero Width Non-Joiner.
@@ -1426,14 +1426,14 @@ class Utf8String implements \Stringable
 				$nonspacing_combining_marks = '[' . $classes['Nonspacing_Combining_Mark'] . ']*';
 
 				// ZWNJ must be followed by another letter in the same script.
-				$zwnj_pattern = '\\x{200C}(?=' . $nonspacing_combining_marks . $letter . ')';
+				$zwnj_pattern = '\x{200C}(?=' . $nonspacing_combining_marks . $letter . ')';
 
 				// ZWJ must NOT be followed by a vowel dependent character in
 				// this script or by any character from a different script.
-				$zwj_pattern = '\\x{200D}(?!' . (!empty($classes['Vowel_Dependent']) ? '[' . $classes['Vowel_Dependent'] . ']|' : '') . '[^' . $classes['All'] . '])';
+				$zwj_pattern = '\x{200D}(?!' . (!empty($classes['Vowel_Dependent']) ? '[' . $classes['Vowel_Dependent'] . ']|' : '') . '[^' . $classes['All'] . '])';
 
 				// Now build the pattern for this script.
-				$pattern = $letter . $nonspacing_marks . '[' . $classes['Virama'] . ']' . $nonspacing_combining_marks . '\\K' . (!empty($zwj_pattern) ? '(?:' . $zwj_pattern . '|' . $zwnj_pattern . ')' : $zwnj_pattern);
+				$pattern = $letter . $nonspacing_marks . '[' . $classes['Virama'] . ']' . $nonspacing_combining_marks . '\K' . (!empty($zwj_pattern) ? '(?:' . $zwj_pattern . '|' . $zwnj_pattern . ')' : $zwnj_pattern);
 			}
 
 			// Do the thing.

--- a/Sources/Url.php
+++ b/Sources/Url.php
@@ -617,10 +617,7 @@ class Url implements \Stringable
 				function ($line) {
 					$line = trim($line);
 
-					return !(empty($line) || strlen($line) != strspn($line, 'abcdefghijklmnopqrstuvwxyz0123456789-'))
-
-
-					;
+					return !(empty($line) || strlen($line) != strspn($line, 'abcdefghijklmnopqrstuvwxyz0123456789-'));
 				},
 			);
 
@@ -819,7 +816,6 @@ class Url implements \Stringable
 	{
 		$this->is_ascii = mb_check_encoding($this->url, 'ASCII');
 	}
-
 }
 
 // Export public static functions and properties to global namespace for backward compatibility.

--- a/Sources/Url.php
+++ b/Sources/Url.php
@@ -309,7 +309,7 @@ class Url implements \Stringable
 		// Encode any non-ASCII characters (but not space or control characters of any sort)
 		// Also encode '%' in order to preserve anything that is already percent-encoded.
 		$url = preg_replace_callback(
-			'~[^\\x00-\\x7F\\pZ\\pC]|%~u',
+			'~[^\x00-\x7F\pZ\pC]|%~u',
 			function ($matches) {
 				return rawurlencode($matches[0]);
 			},
@@ -375,7 +375,7 @@ class Url implements \Stringable
 	public function parse(int $component = -1): mixed
 	{
 		$url = preg_replace_callback(
-			'~[^\\x00-\\x7F\\pZ\\pC]|%~u',
+			'~[^\x00-\x7F\pZ\pC]|%~u',
 			function ($matches) {
 				return rawurlencode($matches[0]);
 			},

--- a/Sources/User.php
+++ b/Sources/User.php
@@ -2269,9 +2269,7 @@ class User implements \ArrayAccess
 			die;
 		}
 
-
 		ErrorHandler::fatalLang($error, isset($log_error) ? 'user' : false);
-
 
 		// We really should never fall through here, for very important reasons.  Let's make sure.
 		trigger_error('No direct access...', E_USER_ERROR);
@@ -2490,13 +2488,11 @@ class User implements \ArrayAccess
 				return [0];
 			}
 
-
 			foreach ($permissions as $permission) {
 				$boards[$permission] = [0];
 			}
 
 			return $boards;
-
 		}
 
 		// All groups the user is in except 'moderator'.
@@ -2891,16 +2887,14 @@ class User implements \ArrayAccess
 				'url' => $image,
 			];
 		}
+
 		// Fallback to make life easier for everyone...
-
-
 		return [
 			'name' => '',
 			'image' => '',
 			'href' => '',
 			'url' => '',
 		];
-
 	}
 
 	/**

--- a/Sources/User.php
+++ b/Sources/User.php
@@ -2209,15 +2209,15 @@ class User implements \ArrayAccess
 
 			// Are global cookies on?  If so, let's check them ;).
 			if (!empty(Config::$modSettings['globalCookies'])) {
-				if (preg_match('~(?:[^\\.]+\\.)?([^\\.]{3,}\\..+)\\z~i', $board_host, $parts)) {
+				if (preg_match('~(?:[^.]+\.)?([^.]{3,}\..+)\z~i', $board_host, $parts)) {
 					$board_host = $parts[1];
 				}
 
-				if (preg_match('~(?:[^\\.]+\\.)?([^\\.]{3,}\\..+)\\z~i', $referrer['host'], $parts)) {
+				if (preg_match('~(?:[^.]+\.)?([^.]{3,}\.+)\z~i', $referrer['host'], $parts)) {
 					$referrer['host'] = $parts[1];
 				}
 
-				if (preg_match('~(?:[^\\.]+\\.)?([^\\.]{3,}\\..+)\\z~i', $real_host, $parts)) {
+				if (preg_match('~(?:[^.]+\.)?([^.]{3,}\.+)\z~i', $real_host, $parts)) {
 					$real_host = $parts[1];
 				}
 			}
@@ -3040,7 +3040,7 @@ class User implements \ArrayAccess
 
 			// Ensure posts, instant_messages, and unread_messages don't overflow or underflow.
 			if (in_array($var, ['posts', 'instant_messages', 'unread_messages'])) {
-				if (preg_match('~^' . $var . ' (\\+ |- |\\+ -)(\\d+)~', $val, $match)) {
+				if (preg_match('~^' . $var . ' (\+ |- |\+ -)(\d+)~', $val, $match)) {
 					if ($match[1] != '+ ') {
 						$val = 'CASE WHEN ' . $var . ' <= ' . abs($match[2]) . ' THEN 0 ELSE ' . $val . ' END';
 					}
@@ -3617,7 +3617,7 @@ class User implements \ArrayAccess
 		}
 
 		// Otherwise, perform the medium strength test - checking if password appears in the restricted string.
-		if (!preg_match('~\\b' . preg_quote($password, '~') . '\\b~', implode(' ', $restrict_in))) {
+		if (!preg_match('~\b' . preg_quote($password, '~') . '\b~', implode(' ', $restrict_in))) {
 			return 'restricted_words';
 		}
 
@@ -3631,7 +3631,7 @@ class User implements \ArrayAccess
 		}
 
 		// Check for both numbers and letters.
-		$good = preg_match('~\\p{N}~u', $password) && preg_match('~\\p{L}~u', $password);
+		$good = preg_match('~\p{N}~u', $password) && preg_match('~\p{L}~u', $password);
 
 		// If there are any letters from bicameral scripts (Latin, Greek, etc.),
 		// check that there are both lowercase and uppercase letters present.
@@ -3673,7 +3673,7 @@ class User implements \ArrayAccess
 			in_array($username, ['_', '|'])
 			|| strpos($username, '[code') !== false
 			|| strpos($username, '[/code') !== false
-			|| preg_match('~[<>&"\'=\\\\]~', preg_replace('~&#(?:\\d{1,7}|x[0-9a-fA-F]{1,6});~', '', $username))
+			|| preg_match('~[<>&"\'=\\\\]~', preg_replace('~&#(?:\d{1,7}|x[0-9a-fA-F]{1,6});~', '', $username))
 		) {
 			$errors[] = ['lang', 'error_invalid_characters_username'];
 		}

--- a/Sources/Utils.php
+++ b/Sources/Utils.php
@@ -317,9 +317,7 @@ class Utils
 					return $substitute;
 				}
 
-
 				return '&#' . $num . ';';
-
 			},
 			(string) $string,
 		);
@@ -591,7 +589,6 @@ class Utils
 			return is_int($result) ? $result + $offset : false;
 		}
 
-
 		$needle_arr = preg_split('~(' . self::ENT_LIST . '|\\X)~u', self::sanitizeEntities($needle), -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY);
 
 		$needle_size = count($needle_arr);
@@ -609,7 +606,6 @@ class Utils
 		}
 
 		return false;
-
 	}
 
 	/**

--- a/Sources/Utils.php
+++ b/Sources/Utils.php
@@ -73,7 +73,7 @@ class Utils
 	 * Regular expression to match named entities for HTML special characters
 	 * and any numeric entities.
 	 */
-	public const ENT_LIST = '&(?' . '>nbsp|quot|gt|lt|a(?' . '>pos|mp)|#(?' . '>\\d+|x[0-9a-fA-F]+));';
+	public const ENT_LIST = '&(?' . '>nbsp|quot|gt|lt|a(?' . '>pos|mp)|#(?' . '>\d+|x[0-9a-fA-F]+));';
 
 	/**
 	 * Regular expression to match all forms of the non-breaking space entity.
@@ -184,7 +184,7 @@ class Utils
 	{
 		// Used to force browsers to download fresh CSS and JavaScript when necessary
 		if (isset(Config::$modSettings['browser_cache'])) {
-			self::$context['browser_cache'] = '?' . preg_replace('~\\W~', '', strtolower(SMF_FULL_VERSION)) . '_' . Config::$modSettings['browser_cache'];
+			self::$context['browser_cache'] = '?' . preg_replace('~\W~', '', strtolower(SMF_FULL_VERSION)) . '_' . Config::$modSettings['browser_cache'];
 		}
 
 		// UTF-8?
@@ -295,7 +295,7 @@ class Utils
 
 		// Disallow entities for control characters, non-characters, etc.
 		return preg_replace_callback(
-			'~(&#(0*\\d{1,7}|x0*[0-9a-fA-F]{1,6});)~',
+			'~(&#(0*\d{1,7}|x0*[0-9a-fA-F]{1,6});)~',
 			function ($matches) use ($substitute) {
 				$num = $matches[2][0] === 'x' ? hexdec(substr($matches[2], 1)) : (int) $matches[2];
 
@@ -394,7 +394,7 @@ class Utils
 		if (!empty(Utils::$context['utf8'])) {
 			$string = (string) Unicode\Utf8String::create($string)->sanitizeInvisibles($level, $substitute);
 		} else {
-			$string = preg_replace('/[^\\P{Cc}\\t\\r\\n]/', $substitute, $string);
+			$string = preg_replace('/[^\P{Cc}\t\r\n]/', $substitute, $string);
 		}
 
 		return $string;
@@ -434,13 +434,13 @@ class Utils
 
 		if ($vspace) {
 			// \R is like \v, except it handles "\r\n" as a single unit.
-			$patterns[] = '/\\R/' . (Utils::$context['utf8'] ? 'u' : '');
+			$patterns[] = '/\R/' . (Utils::$context['utf8'] ? 'u' : '');
 			$replacements[] = $options['no_breaks'] ? ' ' : "\n";
 		}
 
 		if ($hspace) {
 			// Interesting fact: Unicode properties like \p{Zs} work even when not in UTF-8 mode.
-			$patterns[] = '/' . ($options['replace_tabs'] ? '\\h' : '\\p{Zs}') . ($options['collapse_hspace'] ? '+' : '') . '/' . (Utils::$context['utf8'] ? 'u' : '');
+			$patterns[] = '/' . ($options['replace_tabs'] ? '\h' : '\p{Zs}') . ($options['collapse_hspace'] ? '+' : '') . '/' . (Utils::$context['utf8'] ? 'u' : '');
 			$replacements[] = ' ';
 		}
 
@@ -523,7 +523,7 @@ class Utils
 	 */
 	public static function htmlTrim(string $string): string
 	{
-		return preg_replace('~^(?' . '>[\\p{Z}\\p{C}]|' . self::ENT_NBSP . ')+|(?' . '>[\\p{Z}\\p{C}]|' . self::ENT_NBSP . ')+$~u', '', self::sanitizeEntities($string));
+		return preg_replace('~^(?' . '>[\p{Z}\p{C}]|' . self::ENT_NBSP . ')+|(?' . '>[\p{Z}\p{C}]|' . self::ENT_NBSP . ')+$~u', '', self::sanitizeEntities($string));
 	}
 
 	/**
@@ -567,7 +567,7 @@ class Utils
 	 */
 	public static function entityStrlen(string $string): int
 	{
-		return strlen(preg_replace('~' . self::ENT_LIST . '|\\X~u', '_', self::sanitizeEntities($string)));
+		return strlen(preg_replace('~' . self::ENT_LIST . '|\X~u', '_', self::sanitizeEntities($string)));
 	}
 
 	/**
@@ -581,7 +581,7 @@ class Utils
 	 */
 	public static function entityStrpos(string $haystack, string $needle, int $offset = 0): int|false
 	{
-		$haystack_arr = preg_split('~(' . self::ENT_LIST . '|\\X)~u', self::sanitizeEntities($haystack), -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY);
+		$haystack_arr = preg_split('~(' . self::ENT_LIST . '|\X)~u', self::sanitizeEntities($haystack), -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY);
 
 		if (strlen($needle) === 1) {
 			$result = array_search($needle, array_slice($haystack_arr, $offset));
@@ -589,7 +589,7 @@ class Utils
 			return is_int($result) ? $result + $offset : false;
 		}
 
-		$needle_arr = preg_split('~(' . self::ENT_LIST . '|\\X)~u', self::sanitizeEntities($needle), -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY);
+		$needle_arr = preg_split('~(' . self::ENT_LIST . '|\X)~u', self::sanitizeEntities($needle), -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY);
 
 		$needle_size = count($needle_arr);
 
@@ -619,7 +619,7 @@ class Utils
 	 */
 	public static function entitySubstr(string $string, int $offset, ?int $length = null): string
 	{
-		$ent_arr = preg_split('~(' . self::ENT_LIST . '|\\X)~u', self::sanitizeEntities($string), -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY);
+		$ent_arr = preg_split('~(' . self::ENT_LIST . '|\X)~u', self::sanitizeEntities($string), -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY);
 
 		return $length === null ? implode('', array_slice($ent_arr, $offset)) : implode('', array_slice($ent_arr, $offset, $length));
 	}
@@ -642,7 +642,7 @@ class Utils
 		$string = self::sanitizeEntities($string);
 
 		while (strlen($string) > $length) {
-			$string = preg_replace('~(?:' . self::ENT_LIST . '|\\X)$~u', '', $string);
+			$string = preg_replace('~(?:' . self::ENT_LIST . '|\X)$~u', '', $string);
 		}
 
 		return $string;
@@ -1053,7 +1053,7 @@ class Utils
 		// The Unicode surrogate pair code points should never be present in our
 		// strings to begin with, but if any snuck in, they need to be removed.
 		if (!empty(Utils::$context['utf8']) && strpos($string, "\xED") !== false) {
-			$string = preg_replace('/\\xED[\\xA0-\\xBF][\\x80-\\xBF]/', '', $string);
+			$string = preg_replace('/\xED[\xA0-\xBF][\x80-\xBF]/', '', $string);
 		}
 
 		return $string;
@@ -1473,7 +1473,7 @@ class Utils
 				} elseif ($type == 'i' && preg_match('/^i:(-?[0-9]+);(.*)/s', $str, $matches)) {
 					$value = (int) $matches[1];
 					$str = $matches[2];
-				} elseif ($type == 'd' && preg_match('/^d:(-?[0-9]+\\.?[0-9]*(E[+-][0-9]+)?);(.*)/s', $str, $matches)) {
+				} elseif ($type == 'd' && preg_match('/^d:(-?[0-9]+\.?[0-9]*(E[+-][0-9]+)?);(.*)/s', $str, $matches)) {
 					$value = (float) $matches[1];
 					$str = $matches[3];
 				} elseif ($type == 's' && preg_match('/^s:([0-9]+):"(.*)/s', $str, $matches) && substr($matches[2], (int) $matches[1], 2) == '";') {
@@ -1665,7 +1665,7 @@ class Utils
 					// SVG sometimes needs a little extra help.
 					if ($mime_type === 'text/html' && strtolower(pathinfo($path, PATHINFO_EXTENSION)) === 'svg') {
 						// Detection sometimes fails if the <svg> element isn't first.
-						$data = preg_replace('/^([^<]|<(?!svg\\b))*/i', '', $data);
+						$data = preg_replace('/^([^<]|<(?!svg\b))*/i', '', $data);
 
 						if (finfo_buffer(finfo_open(FILEINFO_MIME_TYPE), $data) == 'image/svg+xml') {
 							$mime_type = 'image/svg+xml';
@@ -1821,7 +1821,7 @@ class Utils
 		$file['filename'] = !self::$context['utf8'] ? mb_convert_encoding($file['filename'], 'UTF-8', self::$context['character_set']) : $file['filename'];
 
 		// Also provide a plain ASCII name for the sake of old browsers.
-		$file['asciiname'] = preg_replace('/[\\x{80}-\\x{10FFFF}]+/u', '?', Utils::entityDecode($file['filename'], true));
+		$file['asciiname'] = preg_replace('/[\x{80}-\x{10FFFF}]+/u', '?', Utils::entityDecode($file['filename'], true));
 
 		// Replace ASCII names like ??????.jpg with something more unique.
 		if (strspn($file['asciiname'], '?') === strpos($file['asciiname'], '.')) {
@@ -1960,7 +1960,7 @@ class Utils
 			503 => 'Service Unavailable',
 		];
 
-		$protocol = !empty($_SERVER['SERVER_PROTOCOL']) && preg_match('~^\\s*(HTTP/[12]\\.\\d)\\s*$~i', $_SERVER['SERVER_PROTOCOL'], $matches) ? $matches[1] : 'HTTP/1.0';
+		$protocol = !empty($_SERVER['SERVER_PROTOCOL']) && preg_match('~^\s*(HTTP/[12]\.\d)\s*$~i', $_SERVER['SERVER_PROTOCOL'], $matches) ? $matches[1] : 'HTTP/1.0';
 
 		// Typically during these requests, we have cleaned the response (ob_*clean), ensure these headers exist.
 		Security::frameOptionsHeader();
@@ -2033,11 +2033,11 @@ class Utils
 
 		// Put the session ID in.
 		if (defined('SID') && SID != '') {
-			$setLocation = preg_replace('/^' . preg_quote(Config::$scripturl, '/') . '(?!\\?' . preg_quote(SID, '/') . ')\\??/', Config::$scripturl . '?' . SID . ';', $setLocation);
+			$setLocation = preg_replace('/^' . preg_quote(Config::$scripturl, '/') . '(?!\?' . preg_quote(SID, '/') . ')\??/', Config::$scripturl . '?' . SID . ';', $setLocation);
 		}
 		// Keep that debug in their for template debugging!
 		elseif (isset($_GET['debug'])) {
-			$setLocation = preg_replace('/^' . preg_quote(Config::$scripturl, '/') . '\\??/', Config::$scripturl . '?debug;', $setLocation);
+			$setLocation = preg_replace('/^' . preg_quote(Config::$scripturl, '/') . '\??/', Config::$scripturl . '?debug;', $setLocation);
 		}
 
 		if (
@@ -2055,7 +2055,7 @@ class Utils
 		) {
 			if (defined('SID') && SID != '') {
 				$setLocation = preg_replace_callback(
-					'~^' . preg_quote(Config::$scripturl, '~') . '\\?(?:' . SID . '(?:;|&|&amp;))((?:board|topic)=[^#]+?)(#[^"]*?)?$~',
+					'~^' . preg_quote(Config::$scripturl, '~') . '\?(?:' . SID . '(?:;|&|&amp;))((?:board|topic)=[^#]+?)(#[^"]*?)?$~',
 					function ($m) {
 						return Config::$scripturl . '/' . strtr("{$m[1]}", '&;=', '//,') . '.html?' . SID . (isset($m[2]) ? "{$m[2]}" : '');
 					},
@@ -2063,7 +2063,7 @@ class Utils
 				);
 			} else {
 				$setLocation = preg_replace_callback(
-					'~^' . preg_quote(Config::$scripturl, '~') . '\\?((?:board|topic)=[^#"]+?)(#[^"]*?)?$~',
+					'~^' . preg_quote(Config::$scripturl, '~') . '\?((?:board|topic)=[^#"]+?)(#[^"]*?)?$~',
 					function ($m) {
 						return Config::$scripturl . '/' . strtr("{$m[1]}", '&;=', '//,') . '.html' . (isset($m[2]) ? "{$m[2]}" : '');
 					},

--- a/Sources/Verifier.php
+++ b/Sources/Verifier.php
@@ -380,7 +380,6 @@ class Verifier implements \ArrayAccess
 		<script>
 			var verification' . $this->id . 'Handle = new smfCaptcha("' . $this->image_href . '", "' . $this->id . '", ' . (Utils::$context['use_graphic_library'] ? 1 : 0) . ');
 		</script>';
-
 	}
 
 	/**

--- a/Sources/Verifier.php
+++ b/Sources/Verifier.php
@@ -361,7 +361,7 @@ class Verifier implements \ArrayAccess
 		}
 
 		// Only allow 40 alphanumeric, underscore, and dash characters.
-		$this->recaptcha_site_key = substr(preg_replace('/\\W/', '', Config::$modSettings['recaptcha_site_key']), 0, 40);
+		$this->recaptcha_site_key = substr(preg_replace('/\W/', '', Config::$modSettings['recaptcha_site_key']), 0, 40);
 
 		// Light or dark theme...
 		$this->recaptcha_theme = Config::$modSettings['recaptcha_theme'] == 'dark' ? 'dark' : 'light';

--- a/Sources/WebFetch/APIs/CurlFetcher.php
+++ b/Sources/WebFetch/APIs/CurlFetcher.php
@@ -273,11 +273,9 @@ class CurlFetcher extends WebFetchApi
 			return $this->response;
 		}
 
-
 		$response_number = min($response_number, count($this->response) - 1);
 
 		return $this->response[$response_number];
-
 	}
 
 	/******************

--- a/Sources/WebFetch/APIs/FtpFetcher.php
+++ b/Sources/WebFetch/APIs/FtpFetcher.php
@@ -208,9 +208,7 @@ class FtpFetcher extends WebFetchApi
 			return $this->response;
 		}
 
-
 		return $this->response[0];
-
 	}
 }
 

--- a/Sources/WebFetch/APIs/SocketFetcher.php
+++ b/Sources/WebFetch/APIs/SocketFetcher.php
@@ -207,7 +207,7 @@ class SocketFetcher extends WebFetchApi
 		$response = fgets($this->fp, 768);
 
 		// What response code was sent?
-		if (preg_match('~^HTTP/\\S+\\s+(\\d+)~i', $response, $matches)) {
+		if (preg_match('~^HTTP/\S+\s+(\d+)~i', $response, $matches)) {
 			$http_code = (int) $matches[1];
 			$this->response[$this->current_redirect]['code'] = $http_code;
 		}
@@ -255,9 +255,9 @@ class SocketFetcher extends WebFetchApi
 		while (!feof($this->fp) && trim($header = fgets($this->fp, 4096)) != '') {
 			$this->response[$this->current_redirect]['headers'][] = $header;
 
-			if (preg_match('~Content-Length:\\s*(\\d+)~i', $header, $match)) {
+			if (preg_match('~Content-Length:\s*(\d+)~i', $header, $match)) {
 				$content_length = $match[1];
-			} elseif (preg_match('~Connection:\\s*Close~i', $header)) {
+			} elseif (preg_match('~Connection:\s*Close~i', $header)) {
 				$this->keep_alive = false;
 			}
 

--- a/Sources/WebFetch/APIs/SocketFetcher.php
+++ b/Sources/WebFetch/APIs/SocketFetcher.php
@@ -323,11 +323,9 @@ class SocketFetcher extends WebFetchApi
 			return $this->response;
 		}
 
-
 		$response_number = min($response_number, count($this->response) - 1);
 
 		return $this->response[$response_number];
-
 	}
 
 	/**

--- a/Sources/WebFetch/WebFetchApi.php
+++ b/Sources/WebFetch/WebFetchApi.php
@@ -173,9 +173,7 @@ abstract class WebFetchApi implements WebFetchApiInterface
 			return http_build_query($post_data, '', '&');
 		}
 
-
 		return trim($post_data);
-
 	}
 }
 

--- a/Sources/tasks/CreatePost_Notify.php
+++ b/Sources/tasks/CreatePost_Notify.php
@@ -161,10 +161,8 @@ class CreatePost_Notify extends BackgroundTask
 				continue;
 			}
 
-
 			$row['groups'] = $groups;
 			unset($row['id_group'], $row['id_post_group'], $row['additional_groups']);
-
 
 			$this->members['watching'][$row['id_member']] = $row;
 		}
@@ -200,7 +198,6 @@ class CreatePost_Notify extends BackgroundTask
 		$unnotified = array_filter($this->members['watching'], function ($member) {
 			return empty($member['sent']);
 		});
-
 
 		// Modified post, or dealing with delayed mention and quote notifications.
 		if ($type == 'edit' || !empty($this->_details['respawns'])) {
@@ -726,7 +723,6 @@ class CreatePost_Notify extends BackgroundTask
 					]),
 				];
 			}
-
 
 			// Bitwise check: Receiving a email notification?
 			if (!($pref & self::RECEIVE_NOTIFY_EMAIL)) {

--- a/Sources/tasks/ExportProfileData.php
+++ b/Sources/tasks/ExportProfileData.php
@@ -1164,9 +1164,8 @@ class ExportProfileData extends BackgroundTask
 						$delay = Taskrunner::MAX_CLAIM_THRESHOLD;
 						break;
 					}
+
 					// All went well.
-
-
 					// Track progress by ID where appropriate, and by time otherwise.
 					$progress[$datatype] = !isset($last_id) ? time() : $last_id;
 					file_put_contents($progressfile, Utils::jsonEncode($progress));
@@ -1187,7 +1186,6 @@ class ExportProfileData extends BackgroundTask
 						// Should we append more items to this file next time?
 						$new_item_count = isset($last_id) ? $prev_item_count + count($items) : 0;
 					}
-
 				}
 			}
 		}

--- a/Sources/tasks/ExportProfileData.php
+++ b/Sources/tasks/ExportProfileData.php
@@ -1637,14 +1637,14 @@ class ExportProfileData extends BackgroundTask
 		if ($this->_details['format'] == 'XML_XSLT') {
 			$placeholders = [];
 
-			if (preg_match_all('/<!\\[CDATA\\[\\X*?\\]\\]>/u', $this->stylesheet, $matches)) {
+			if (preg_match_all('/<!\[CDATA\[\X*?\]\]>/u', $this->stylesheet, $matches)) {
 				foreach ($matches[0] as $cdata) {
 					$placeholders[$cdata] = md5($cdata);
 				}
 			}
 
 			$this->stylesheet = strtr($this->stylesheet, $placeholders);
-			$this->stylesheet = preg_replace('/^(?!\\n)/mu', "\t", $this->stylesheet);
+			$this->stylesheet = preg_replace('/^(?!\n)/mu', "\t", $this->stylesheet);
 			$this->stylesheet = strtr($this->stylesheet, array_flip($placeholders));
 		}
 
@@ -1813,7 +1813,7 @@ class ExportProfileData extends BackgroundTask
 
 		Utils::$context['javascript_inline']['defer'][] = implode("\n", [
 			'$("img.smiley").each(function() {',
-			'	var data_uri_var = $(this).attr("src").replace(/.*\\/(\\w+)\\.(\\w+)$/, "smf_smiley_$1_$2");',
+			'	var data_uri_var = $(this).attr("src").replace(/.*\/(\w+)\.(\w+)$/, "smf_smiley_$1_$2");',
 			'	$(this).attr("src", window[data_uri_var]);',
 			'});',
 		]);
@@ -1925,7 +1925,7 @@ class ExportProfileData extends BackgroundTask
 		foreach ($codes as &$code) {
 			// To make the "Select" link work we'd need to embed a bunch more JS. Not worth it.
 			if ($code['tag'] === 'code') {
-				$code['content'] = preg_replace('~<a class="codeoperation\\b.*?</a>~', '', $code['content']);
+				$code['content'] = preg_replace('~<a class="codeoperation\b.*?</a>~', '', $code['content']);
 			}
 		}
 	}
@@ -1962,7 +1962,7 @@ class ExportProfileData extends BackgroundTask
 		} elseif (!empty($currentAttachment['is_image'])) {
 			$returnContext = '<span style="display: inline-flex; justify-content: center; align-items: center; position: relative;">' . preg_replace(
 				[
-					'thumbnail_toggle' => '~</?a\\b[^>]*>~',
+					'thumbnail_toggle' => '~</?a\b[^>]*>~',
 					'src' => '~src="' . preg_quote($currentAttachment['href'], '~') . ';image"~',
 				],
 				[
@@ -1988,7 +1988,7 @@ class ExportProfileData extends BackgroundTask
 		} elseif (strpos($currentAttachment['mime_type'], 'audio/') === 0) {
 			$returnContext = '<span style="display: inline-flex; justify-content: center; align-items: center; position: relative;">' . preg_replace(
 				[
-					'opening_tag' => '~^<audio\\b~',
+					'opening_tag' => '~^<audio\b~',
 				],
 				[
 					'opening_tag' => '<audio onerror="$(this).fadeTo(0, 0); $(\'.dlattach_' . $currentAttachment['id'] . '\').show(); $(\'.dlattach_' . $currentAttachment['id'] . '\').css({\'position\': \'absolute\'});"',
@@ -1998,7 +1998,7 @@ class ExportProfileData extends BackgroundTask
 		} else {
 			$returnContext = '<span style="display: inline-flex; justify-content: center; align-items: center; position: relative;">' . preg_replace(
 				[
-					'obj_opening' => '~^<object\\b~',
+					'obj_opening' => '~^<object\b~',
 					'link' => '~<a href="' . preg_quote($currentAttachment['href'], '~') . '" class="bbc_link">([^<]*)</a>~',
 				],
 				[

--- a/Sources/tasks/RemoveTopicRedirects.php
+++ b/Sources/tasks/RemoveTopicRedirects.php
@@ -13,9 +13,9 @@
 
 namespace SMF\Tasks;
 
+use SMF\Db\DatabaseApi as Db;
 use SMF\Theme;
 use SMF\Topic;
-use SMF\Db\DatabaseApi as Db;
 
 /**
  * Deletes moved topic notices that have passed their best-by date.

--- a/Sources/tasks/UpdateUnicode.php
+++ b/Sources/tasks/UpdateUnicode.php
@@ -83,7 +83,7 @@ class UpdateUnicode extends BackgroundTask
 	private $funcs = [
 		[
 			'file' => 'Metadata.php',
-			'regex' => '/if \\(!defined\\(\'SMF_UNICODE_VERSION\'\\)\\)(?:\s*{)?\\n\\tdefine\\(\'SMF_UNICODE_VERSION\', \'\\d+(\\.\\d+)*\'\\);(?:\n})?/',
+			'regex' => '/if \(!defined\(\'SMF_UNICODE_VERSION\'\)\)(?:\s*{)?\n\tdefine\(\'SMF_UNICODE_VERSION\', \'\d+(\.\d+)*\'\);(?:\n})?/',
 			'data' => [
 				// 0.0.0.0 will be replaced with correct value at runtime.
 				"if (!defined('SMF_UNICODE_VERSION')) {\n\tdefine('SMF_UNICODE_VERSION', '0.0.0.0');\n}",
@@ -571,7 +571,7 @@ class UpdateUnicode extends BackgroundTask
 				// Only move if the file has changed, discounting the license block.
 				foreach (['temp', 'real'] as $f) {
 					if (file_exists($file_paths[$f])) {
-						$file_contents[$f] = preg_replace('~/\\*\\*.*?@package\\h+SMF\\b.*?\\*/~s', '', file_get_contents($file_paths[$f]));
+						$file_contents[$f] = preg_replace('~/\*\*.*?@package\h+SMF\b.*?\*/~s', '', file_get_contents($file_paths[$f]));
 					} else {
 						$file_contents[$f] = '';
 					}
@@ -787,7 +787,7 @@ class UpdateUnicode extends BackgroundTask
 			$func_regex = $this->funcs[$func_name]['regex'] ?? '/' . preg_quote($func_code, '/') . '/';
 		} else {
 			// The regex to look for this function in the existing file content.
-			$func_regex = "/(\\/\\*([^*]|\\*(?!\\/))*\\*\\/\n)?function {$func_name}\\(\\)\n{.+?\n}/s";
+			$func_regex = '~(/\*([^*]|\*(?!/))*\*/\n)?function ' . $func_name . '\(\)\n{.+?\n}~s';
 
 			// The PHPDoc comment for this function.
 			$func_code = '/**' . implode("\n * ", array_merge(
@@ -827,7 +827,7 @@ class UpdateUnicode extends BackgroundTask
 
 		// Some final tidying.
 		$func_code = str_replace('""', "''", $func_code);
-		$func_code = preg_replace('/\\h+$/m', '', $func_code);
+		$func_code = preg_replace('/\h+$/m', '', $func_code);
 
 		return [$func_code, $func_regex];
 	}
@@ -939,7 +939,7 @@ class UpdateUnicode extends BackgroundTask
 			return false;
 		}
 
-		preg_match('/Version\\s+(\\d+(?:\\.\\d+)*)/', file_get_contents($local_file), $matches);
+		preg_match('/Version\s+(\d+(?:\.\d+)*)/', file_get_contents($local_file), $matches);
 
 		if (empty($matches[1])) {
 			return false;
@@ -1425,7 +1425,7 @@ class UpdateUnicode extends BackgroundTask
 		}
 
 		foreach ($this->funcs['utf8_regex_variation_selectors']['data'] as $variation_selector => $class_string) {
-			$this->funcs['utf8_regex_variation_selectors']['data'][$variation_selector] = array_unique(preg_split('/(?<=})(?=\\\\x{)/', $class_string));
+			$this->funcs['utf8_regex_variation_selectors']['data'][$variation_selector] = array_unique(preg_split('/(?<=})(?=\\\x{)/', $class_string));
 		}
 
 		krsort($this->funcs['utf8_regex_variation_selectors']['data']);
@@ -1858,7 +1858,7 @@ class UpdateUnicode extends BackgroundTask
 					}
 				}
 
-				$this->funcs['utf8_regex_indic']['data'][$char_script][$insc] = array_unique(preg_split('/(?<=})(?=\\\\x{)/', $class_string));
+				$this->funcs['utf8_regex_indic']['data'][$char_script][$insc] = array_unique(preg_split('/(?<=})(?=\\\x{)/', $class_string));
 			}
 
 			ksort($this->funcs['utf8_regex_indic']['data'][$char_script]);
@@ -1888,7 +1888,7 @@ class UpdateUnicode extends BackgroundTask
 			$fields = explode(';', $line);
 
 			foreach ($fields as $key => $value) {
-				$fields[$key] = preg_replace('/\\b(0(?!\\b))+/', '', trim($value));
+				$fields[$key] = preg_replace('/\b(0(?!\b))+/', '', trim($value));
 			}
 
 			if (strpos($fields[0], '..') === false) {

--- a/Sources/tasks/UpdateUnicode.php
+++ b/Sources/tasks/UpdateUnicode.php
@@ -1391,7 +1391,6 @@ class UpdateUnicode extends BackgroundTask
 					continue;
 				}
 
-
 				$class_string .= '\\x{' . strtoupper(sprintf('%04s', dechex($current_range['start']))) . '}';
 
 				if ($current_range['start'] != $current_range['end']) {
@@ -1399,7 +1398,6 @@ class UpdateUnicode extends BackgroundTask
 				}
 
 				$current_range = ['start' => $ord, 'end' => $ord];
-
 			}
 
 			if (isset($current_range['start'])) {
@@ -1699,9 +1697,7 @@ class UpdateUnicode extends BackgroundTask
 				return $b['stats']['count'] - $a['stats']['count'];
 			}
 
-
 			return $a['stats']['age'] - $b['stats']['age'];
-
 		});
 
 		foreach ($this->funcs['utf8_regex_joining_type']['data'] as $char_script => &$joining_types) {
@@ -1777,9 +1773,7 @@ class UpdateUnicode extends BackgroundTask
 				return $b['stats']['count'] - $a['stats']['count'];
 			}
 
-
 			return $a['stats']['age'] - $b['stats']['age'];
-
 		});
 
 		// We only want scripts with viramas.
@@ -1847,7 +1841,6 @@ class UpdateUnicode extends BackgroundTask
 						continue;
 					}
 
-
 					$class_string .= '\\x{' . strtoupper(sprintf('%04s', dechex($current_range['start']))) . '}';
 
 					if ($current_range['start'] != $current_range['end']) {
@@ -1855,7 +1848,6 @@ class UpdateUnicode extends BackgroundTask
 					}
 
 					$current_range = ['start' => $ord, 'end' => $ord];
-
 				}
 
 				if (isset($current_range['start'])) {

--- a/subscriptions.php
+++ b/subscriptions.php
@@ -291,7 +291,6 @@ elseif ($gatewayClass->isCancellation()) {
 	}
 }
 
-
 // Some other "valid" transaction such as:
 //
 // subscr_signup: This IPN response (txn_type) is sent only the first time the user signs up for a subscription.
@@ -299,7 +298,6 @@ elseif ($gatewayClass->isCancellation()) {
 // subscription is received (txn_type=subscr_payment) which is what we do process
 //
 // Should we log any of these ...
-
 
 // In case we have anything specific to do.
 $gatewayClass->close();


### PR DESCRIPTION
- Fixes some whitespace weirdness introduced in #7886.
- Reverts the double-escaping of backslashes in regular expression strings introduced in #7886. The double backslashes didn't hurt anything, but they made it harder to read the regular expressions.
- Tweaks PHP-CS-Fixer rules to avoid reintroducing those unwanted changes in the future.