### PR TITLE
Fix error logging board edits

### DIFF
--- a/Sources/Board.php
+++ b/Sources/Board.php
@@ -1627,7 +1627,7 @@ class Board implements \ArrayAccess
 
 		// Log the changes unless told otherwise.
 		if (empty($boardOptions['dont_log'])) {
-			Logging::logAction('edit_board', ['board' => $this->id], 'admin');
+			Logging::logAction('edit_board', ['board' => $board->id], 'admin');
 		}
 	}
 


### PR DESCRIPTION
The code uses $board for the board object but when we call the function to log the edits, the code references $this->id instead, which causes an error (the edits still go through, they just don't get logged in the admin log)