### PR TITLE
Fixes problem getting the number of search results

### DIFF
--- a/Sources/Actions/Search2.php
+++ b/Sources/Actions/Search2.php
@@ -251,9 +251,7 @@ class Search2 implements ActionInterface
 		// Number of pages hard maximum - normally not set at all.
 		Config::$modSettings['search_max_results'] = empty(Config::$modSettings['search_max_results']) ? 200 * Config::$modSettings['search_results_per_page'] : (int) Config::$modSettings['search_max_results'];
 
-		if (isset($_REQUEST['start'])) {
-			$_REQUEST['start'] = (int) $_REQUEST['start'];
-		}
+		$_REQUEST['start'] = isset($_REQUEST['start']) ? (int) $_REQUEST['start'] - ((int) $_REQUEST['start'] % Config::$modSettings['search_results_per_page']) : 0;
 
 		Lang::load('Search');
 

--- a/Sources/Search/SearchResult.php
+++ b/Sources/Search/SearchResult.php
@@ -317,7 +317,7 @@ class SearchResult extends \SMF\Msg
 			$colorClass .= ' locked';
 		}
 
-		$output = array_merge(SearchApi::$loadedApi->results[$this->id_msg], [
+		$output = array_merge(SearchApi::$loadedApi->results[$this->id], [
 			'id' => $this->id_topic,
 			'is_sticky' => !empty($this->is_sticky),
 			'is_locked' => !empty($this->locked),
@@ -521,12 +521,10 @@ class SearchResult extends \SMF\Msg
 	 */
 	public static function getNumResults(): int
 	{
-		// @todo Should this trigger an error instead?
-		if (!isset(self::$messages_request)) {
-			return 0;
-		}
+		// Initialize the generator in order to set self::$messages_request.
+		self::$getter->current();
 
-		return Db::$db->num_rows(self::$messages_request);
+		return Db::$db->num_rows(self::$messages_request) + (int) $_REQUEST['start'];
 	}
 
 	/**


### PR DESCRIPTION
Fixes #7877

Since a generator doesn't start executing its code until the first time it is asked to do so, we had to call it at least once in order to cause SearchResult::$messages_request to be set. The easiest way to do that was just to call `self::$getter->current();` in order to kick off the query.