### PR TITLE
Loads all categories in Category::getTree(), not just populated ones 

### DIFF
--- a/Sources/Alert.php
+++ b/Sources/Alert.php
@@ -774,6 +774,7 @@ class Alert implements \ArrayAccess
 		$joins = $query_customizations['joins'] ?? [];
 		$where = $query_customizations['where'] ?? [];
 		$order = $query_customizations['order'] ?? ['a.id_alert DESC'];
+		$group = $query_customizations['group'] ?? [];
 		$limit = $query_customizations['limit'] ?? min(!empty(Config::$modSettings['alerts_per_page']) ? Config::$modSettings['alerts_per_page'] : 1000, 1000);
 		$params = $query_customizations['params'] ?? [];
 
@@ -1594,12 +1595,14 @@ class Alert implements \ArrayAccess
 	 *    If this is left empty, no WHERE clause will be used.
 	 * @param array $order Zero or more conditions for the ORDER BY clause.
 	 *    If this is left empty, no ORDER BY clause will be used.
+	 * @param array $group Zero or more conditions for the GROUP BY clause.
+	 *    If this is left empty, no GROUP BY clause will be used.
 	 * @param int|string $limit Maximum number of results to retrieve.
 	 *    If this is left empty, all results will be retrieved.
 	 *
 	 * @return Generator<array> Iterating over the result gives database rows.
 	 */
-	protected static function queryData(array $selects, array $params = [], array $joins = [], array $where = [], array $order = [], int|string $limit = 0)
+	protected static function queryData(array $selects, array $params = [], array $joins = [], array $where = [], array $order = [], array $group = [], int|string $limit = 0)
 	{
 		$request = Db::$db->query(
 			'',
@@ -1607,7 +1610,8 @@ class Alert implements \ArrayAccess
 				' . implode(', ', $selects) . '
 			FROM {db_prefix}user_alerts AS a' . (empty($joins) ? '' : '
 				' . implode("\n\t\t\t\t", $joins)) . (empty($where) ? '' : '
-			WHERE (' . implode(') AND (', $where) . ')') . (empty($order) ? '' : '
+			WHERE (' . implode(') AND (', $where) . ')') . (empty($group) ? '' : '
+			GROUP BY ' . implode(', ', $group)) . (empty($order) ? '' : '
 			ORDER BY ' . implode(', ', $order)) . (!empty($limit) ? '
 			LIMIT ' . $limit : ''),
 			$params,

--- a/Sources/Board.php
+++ b/Sources/Board.php
@@ -53,7 +53,6 @@ class Board implements \ArrayAccess
 			'getModeratorGroups' => 'getBoardModeratorGroups',
 			'isChildOf' => 'isChildOf',
 			'getParents' => 'getBoardParents',
-			'queryData' => 'queryData',
 		],
 		'prop_names' => [
 			'board_id' => 'board',
@@ -2189,12 +2188,14 @@ class Board implements \ArrayAccess
 	 *    If this is left empty, no WHERE clause will be used.
 	 * @param array $order Zero or more conditions for the ORDER BY clause.
 	 *    If this is left empty, no ORDER BY clause will be used.
+	 * @param array $group Zero or more conditions for the GROUP BY clause.
+	 *    If this is left empty, no GROUP BY clause will be used.
 	 * @param int $limit Maximum number of results to retrieve.
 	 *    If this is left empty, all results will be retrieved.
 	 *
 	 * @return Generator<array> Iterating over the result gives database rows.
 	 */
-	public static function queryData(array $selects, array $params = [], array $joins = [], array $where = [], array $order = [], int $limit = 0)
+	public static function queryData(array $selects, array $params = [], array $joins = [], array $where = [], array $order = [], array $group = [], int $limit = 0)
 	{
 		// If we only want some child boards, use a CTE query for improved performance.
 		if (!empty($params['id_parent']) && in_array('b.id_parent != 0', $where) && Db::$db->cte_support()) {

--- a/Sources/Group.php
+++ b/Sources/Group.php
@@ -2611,6 +2611,8 @@ class Group implements \ArrayAccess
 	 *    If this is left empty, no WHERE clause will be used.
 	 * @param array $order Zero or more conditions for the ORDER BY clause.
 	 *    If this is left empty, no ORDER BY clause will be used.
+	 * @param array $group Zero or more conditions for the GROUP BY clause.
+	 *    If this is left empty, no GROUP BY clause will be used.
 	 * @param int|string $limit Maximum number of results to retrieve.
 	 *    If this is left empty, all results will be retrieved.
 	 *

--- a/Sources/Search/SearchResult.php
+++ b/Sources/Search/SearchResult.php
@@ -462,6 +462,7 @@ class SearchResult extends \SMF\Msg
 			Db::$db->custom_order('m.id_msg', $ids),
 		];
 
+		$group = $query_customizations['group'] ?? [];
 		$limit = $query_customizations['limit'] ?? '{int:limit}';
 
 		$params = $query_customizations['params'] ?? [
@@ -475,7 +476,7 @@ class SearchResult extends \SMF\Msg
 			$params['message_list'] = self::$messages_to_get = array_filter(array_unique(array_map('intval', (array) $ids)));
 		}
 
-		foreach(self::queryData($selects, $params, $joins, $where, $order, $limit) as $row) {
+		foreach(self::queryData($selects, $params, $joins, $where, $order, $group, $limit) as $row) {
 			$id = (int) $row['id_msg'];
 
 			yield (new self($id, $row));


### PR DESCRIPTION
Fixes #7908

Also standardizes signatures for queryData() methods across various classes.