### PR TITLE
General fixes

### DIFF
--- a/Sources/Actions/Admin/Permissions.php
+++ b/Sources/Actions/Admin/Permissions.php
@@ -1775,19 +1775,19 @@ class Permissions implements ActionInterface
 		foreach (self::getPermissions() as $permission => $perm_info) {
 			if (isset($perm_info['group_level'])) {
 				switch ($perm_info['group_level']) {
-					case GROUP_LEVEL_RESTRICT:
+					case self::GROUP_LEVEL_RESTRICT:
 						$group_levels[$perm_info['scope']]['restrict'][] = $permission;
 						// no break
 
-					case GROUP_LEVEL_STANDARD:
+					case self::GROUP_LEVEL_STANDARD:
 						$group_levels[$perm_info['scope']]['standard'][] = $permission;
 						// no break
 
-					case GROUP_LEVEL_MODERATOR:
+					case self::GROUP_LEVEL_MODERATOR:
 						$group_levels[$perm_info['scope']]['moderator'][] = $permission;
 						// no break
 
-					case GROUP_LEVEL_MAINTENANCE:
+					case self::GROUP_LEVEL_MAINTENANCE:
 						$group_levels[$perm_info['scope']]['maintenance'][] = $permission;
 						break;
 				}
@@ -1795,19 +1795,19 @@ class Permissions implements ActionInterface
 
 			if (isset($perm_info['board_level'])) {
 				switch ($perm_info['board_level']) {
-					case BOARD_LEVEL_STANDARD:
+					case self::BOARD_LEVEL_STANDARD:
 						$group_levels[$perm_info['scope']]['standard'][] = $permission;
 						// no break
 
-					case BOARD_LEVEL_LOCKED:
+					case self::BOARD_LEVEL_LOCKED:
 						$group_levels[$perm_info['scope']]['locked'][] = $permission;
 						// no break
 
-					case BOARD_LEVEL_PUBLISH:
+					case self::BOARD_LEVEL_PUBLISH:
 						$group_levels[$perm_info['scope']]['publish'][] = $permission;
 						// no break
 
-					case BOARD_LEVEL_FREE:
+					case self::BOARD_LEVEL_FREE:
 						$group_levels[$perm_info['scope']]['free'][] = $permission;
 						break;
 				}

--- a/Sources/Theme.php
+++ b/Sources/Theme.php
@@ -1995,12 +1995,12 @@ class Theme
 			// -1 means we are setting the forum's default theme.
 			if ($_REQUEST['u'] === -1) {
 				Config::updateModSettings(['theme_guests' => $id_theme]);
-				Utils::redirectexit('action=admin;area=theme;sa=admin;' . $context['session_var'] . '=' . $context['session_id']);
+				Utils::redirectexit('action=admin;area=theme;sa=admin;' . Utils::$context['session_var'] . '=' . Utils::$context['session_id']);
 			}
 			// 0 means we are resetting everyone's theme.
 			elseif ($_REQUEST['u'] === 0) {
 				User::updateMemberData(null, ['id_theme' => $id_theme]);
-				Utils::redirectexit('action=admin;area=theme;sa=admin;' . $context['session_var'] . '=' . $context['session_id']);
+				Utils::redirectexit('action=admin;area=theme;sa=admin;' . Utils::$context['session_var'] . '=' . Utils::$context['session_id']);
 			}
 			// Setting a particular user's theme.
 			elseif (self::canPickTheme($_REQUEST['u'], $id_theme)) {


### PR DESCRIPTION
/Sources/Theme Utils::$context usage ('session_var', 'session_id')
/Sources/Actions/Admin/Permissions class const usage that did not use self::