### PR TITLE
Passes correct parameters to TaskRunner::getScheduledTaskDetails()

### DIFF
--- a/Sources/TaskRunner.php
+++ b/Sources/TaskRunner.php
@@ -316,12 +316,12 @@ class TaskRunner
 
 		while ($row = Db::$db->fetch_assoc($request)) {
 			// What kind of task are we handling?
-			// Note: keep the next_time value unchanged, because running the
-			// task manually shouldn't interfere with the normal schedule.
 			if (!empty($row['callable'])) {
-				$task_details = $this->getScheduledTaskDetails($row['id_task'], $row['next_time'], $row['callable'], true);
+				$task_details = $this->getScheduledTaskDetails($row['id_task'], $row['callable'], true);
 			} elseif (!empty($row['task'])) {
-				$task_details = $this->getScheduledTaskDetails($row['id_task'], $row['next_time'], $row['task']);
+				$task_details = $this->getScheduledTaskDetails($row['id_task'], $row['task']);
+			} else {
+				continue;
 			}
 
 			// Does the class exist?


### PR DESCRIPTION
Fixes #7925

@Oldiesmann, please test to confirm.