### PR TITLE
Comparing arrays and ints doesn't work

### DIFF
--- a/Sources/Tasks/EventNew_Notify.php
+++ b/Sources/Tasks/EventNew_Notify.php
@@ -37,7 +37,7 @@ class EventNew_Notify extends BackgroundTask
 
 		// Don't alert the event creator
 		if (!empty($this->_details['sender_id'])) {
-			$members = array_diff($members, $this->_details['sender_id']);
+			$members = array_diff($members, [$this->_details['sender_id']]);
 		}
 
 		// Having successfully figured this out, now let's get the preferences of everyone.


### PR DESCRIPTION
This fixes one minor bug I found, possibly caused by the conversion from array() to [] syntax.