### PR TITLE
Fix Detailed Versions

### DIFF
--- a/Sources/Actions/Admin/ACP.php
+++ b/Sources/Actions/Admin/ACP.php
@@ -1578,8 +1578,9 @@ class ACP implements ActionInterface
 		];
 
 		foreach ($sources_dir as $filename => $file) {
-			if (!$file->isFile() || $file->getFilename() === 'index.php' || $file->getExtension() !== 'php')
+			if (!$file->isFile() || $file->getFilename() === 'index.php' || $file->getExtension() !== 'php') {
 				continue;
+			}
 			foreach ($ignore_sources as $if)
 				if (preg_match('~' . $if . '~i', $filename)){
 					continue 2;

--- a/Sources/Actions/Admin/ACP.php
+++ b/Sources/Actions/Admin/ACP.php
@@ -1517,7 +1517,7 @@ class ACP implements ActionInterface
 	 * - returns an array containing information on source files, templates, and
 	 *   language files found in the default theme directory (grouped by language).
 	 *
-	 * @param array &$versionOptions An array of options. Can contain one or more of 'include_ssi', 'include_subscriptions', 'include_tasks' and 'sort_results'
+	 * @param array &$versionOptions An array of options. Can contain one or more of 'include_root', 'include_tasks' and 'sort_results'
 	 * @return array An array of file version info.
 	 */
 	public static function getFileVersions(&$versionOptions)
@@ -1526,6 +1526,7 @@ class ACP implements ActionInterface
 		$lang_dir = Theme::$current->settings['default_theme_dir'] . '/languages';
 
 		$version_info = [
+			'root_versions' => [],
 			'file_versions' => [],
 			'default_template_versions' => [],
 			'template_versions' => [],
@@ -1533,59 +1534,74 @@ class ACP implements ActionInterface
 			'tasks_versions' => [],
 		];
 
-		// Find the version in SSI.php's file header.
-		if (!empty($versionOptions['include_ssi']) && file_exists(Config::$boarddir . '/SSI.php')) {
-			$fp = fopen(Config::$boarddir . '/SSI.php', 'rb');
-			$header = fread($fp, 4096);
-			fclose($fp);
+		$root_files = [
+			'cron.php',
+			'proxy.php',
+			'SSI.php',
+			'subscriptions.php'
+		];
 
-			// The comment looks rougly like... that.
-			if (preg_match('~\*\s@version\s+(.+)[\s]{2}~i', $header, $match) == 1) {
-				$version_info['file_versions']['SSI.php'] = $match[1];
-			}
-			// Not found!  This is bad.
-			else {
-				$version_info['file_versions']['SSI.php'] = '??';
-			}
-		}
+		// Find the version in root files header.
+		if (!empty($versionOptions['include_root'])) {
+			foreach ($root_files as $file) {
+				if (!file_exists(Config::$boarddir . '/' . $file)){
+					continue;
+				}
 
-		// Do the paid subscriptions handler?
-		if (!empty($versionOptions['include_subscriptions']) && file_exists(Config::$boarddir . '/subscriptions.php')) {
-			$fp = fopen(Config::$boarddir . '/subscriptions.php', 'rb');
-			$header = fread($fp, 4096);
-			fclose($fp);
-
-			// Found it?
-			if (preg_match('~\*\s@version\s+(.+)[\s]{2}~i', $header, $match) == 1) {
-				$version_info['file_versions']['subscriptions.php'] = $match[1];
-			}
-			// If we haven't how do we all get paid?
-			else {
-				$version_info['file_versions']['subscriptions.php'] = '??';
+				$fp = fopen(Config::$boarddir . '/' . $file, 'rb');
+				$header = fread($fp, 4096);
+				fclose($fp);
+	
+				// The comment looks rougly like... that.
+				if (preg_match('~\*\s@version\s+(.+)[\s]{2}~i', $header, $match) == 1) {
+					$version_info['root_versions'][$file] = $match[1];
+				}
+				// Not found!  This is bad.
+				else {
+					$version_info['file_versions'][$file] = '??';
+				}
 			}
 		}
 
 		// Load all the files in the Sources directory, except this file and the redirect.
-		$sources_dir = dir(Config::$sourcedir);
+		$sources_dir = new \RecursiveIteratorIterator(
+			new \RecursiveDirectoryIterator(
+				Config::$sourcedir,
+				\RecursiveDirectoryIterator::SKIP_DOTS
+			)
+		);
 
-		while ($entry = $sources_dir->read()) {
-			if (substr($entry, -4) === '.php' && !is_dir(Config::$sourcedir . '/' . $entry) && $entry !== 'index.php') {
-				// Read the first 4k from the file.... enough for the header.
-				$fp = fopen(Config::$sourcedir . '/' . $entry, 'rb');
-				$header = fread($fp, 4096);
-				fclose($fp);
+		$ignore_sources = [
+			Config::$sourcedir . '/minify/*',
+			Config::$sourcedir . '/ReCaptcha/*',
+			Config::$sourcedir . '/Tasks/*'
+		];
+		
+		foreach ($sources_dir as $filename => $file) {
+			if (!$file->isFile() || $file->getFilename() === 'index.php' || $file->getExtension() !== 'php')
+				continue;
+			foreach ($ignore_sources as $if)
+				if (preg_match('~' . $if . '~i', $filename)){
+					continue 2;
+				}
 
-				// Look for the version comment in the file header.
-				if (preg_match('~\*\s@version\s+(.+)[\s]{2}~i', $header, $match) == 1) {
-					$version_info['file_versions'][$entry] = $match[1];
-				}
-				// It wasn't found, but the file was... show a '??'.
-				else {
-					$version_info['file_versions'][$entry] = '??';
-				}
+			$shortname = str_replace(Config::$sourcedir . '/', '', $filename);
+
+			// Read the first 4k from the file.... enough for the header.
+			$fp = $file->openFile('rb');
+			$header = $fp->fread(4096);
+			$fp = null;
+
+			// Look for the version comment in the file header.
+			if (preg_match('~\*\s@version\s+(.+)[\s]{2}~i', $header, $match) == 1) {
+				$version_info['file_versions'][$shortname] = $match[1];
+			}
+			// It wasn't found, but the file was... show a '??'.
+			else {
+				$version_info['file_versions'][$shortname] = '??';
 			}
 		}
-		$sources_dir->close();
+		$sources_dir = null;
 
 		// Load all the files in the tasks directory.
 		if (!empty($versionOptions['include_tasks'])) {

--- a/Sources/Actions/Admin/ACP.php
+++ b/Sources/Actions/Admin/ACP.php
@@ -1551,7 +1551,7 @@ class ACP implements ActionInterface
 				$fp = fopen(Config::$boarddir . '/' . $file, 'rb');
 				$header = fread($fp, 4096);
 				fclose($fp);
-	
+
 				// The comment looks rougly like... that.
 				if (preg_match('~\*\s@version\s+(.+)[\s]{2}~i', $header, $match) == 1) {
 					$version_info['root_versions'][$file] = $match[1];
@@ -1576,7 +1576,7 @@ class ACP implements ActionInterface
 			Config::$sourcedir . '/ReCaptcha/*',
 			Config::$sourcedir . '/Tasks/*'
 		];
-		
+
 		foreach ($sources_dir as $filename => $file) {
 			if (!$file->isFile() || $file->getFilename() === 'index.php' || $file->getExtension() !== 'php')
 				continue;

--- a/Sources/Actions/Admin/ACP.php
+++ b/Sources/Actions/Admin/ACP.php
@@ -1558,12 +1558,12 @@ class ACP implements ActionInterface
 				}
 				// Not found!  This is bad.
 				else {
-					$version_info['file_versions'][$file] = '??';
+					$version_info['root_versions'][$file] = '??';
 				}
 			}
 		}
 
-		// Load all the files in the Sources directory, except this file and the redirect.
+		// Load all the files in the Sources directory, except some vendor libraires, index place holderes and non php files.
 		$sources_dir = new \RecursiveIteratorIterator(
 			new \RecursiveDirectoryIterator(
 				Config::$sourcedir,

--- a/Sources/Actions/Admin/Maintenance.php
+++ b/Sources/Actions/Admin/Maintenance.php
@@ -336,8 +336,7 @@ class Maintenance implements ActionInterface
 
 		// Call the function that'll get all the version info we need.
 		$versionOptions = [
-			'include_ssi' => true,
-			'include_subscriptions' => true,
+			'include_root' => true,
 			'include_tasks' => true,
 			'sort_results' => true,
 		];
@@ -345,6 +344,7 @@ class Maintenance implements ActionInterface
 
 		// Add the new info to the template context.
 		Utils::$context += [
+			'root_versions' => $version_info['root_versions'],
 			'file_versions' => $version_info['file_versions'],
 			'default_template_versions' => $version_info['default_template_versions'],
 			'template_versions' => $version_info['template_versions'],

--- a/Themes/default/Admin.template.php
+++ b/Themes/default/Admin.template.php
@@ -331,8 +331,46 @@ function template_view_versions()
 										</td>
 									</tr>';
 
+	// Now list all the root file versions, starting with the overall version (if all match!).
+	echo '
+									<tr class="windowbg">
+										<td class="half_table">
+											<a href="#" id="Root-link">', Lang::$txt['dvc_root'], '</a>
+										</td>
+										<td class="quarter_table">
+											<em id="yourRoot">??</em>
+										</td>
+										<td class="quarter_table">
+											<em id="currentRoot">??</em>
+										</td>
+									</tr>
+								</tbody>
+							</table>
+
+							<table id="Root" class="table_grid">
+								<tbody>';
+
+	// Loop through every source file displaying its version - using javascript.
+	foreach (Utils::$context['root_versions'] as $filename => $version)
+		echo '
+									<tr class="windowbg">
+										<td class="half_table">
+											', $filename, '
+										</td>
+										<td class="quarter_table">
+											<em id="yourRoot', $filename, '">', $version, '</em>
+										</td>
+										<td class="quarter_table">
+											<em id="currentRoot', $filename, '">??</em>
+										</td>
+									</tr>';
+
 	// Now list all the source file versions, starting with the overall version (if all match!).
 	echo '
+								</tbody>
+							</table>
+							<table id="Root" class="table_grid">
+								<tbody>
 									<tr class="windowbg">
 										<td class="half_table">
 											<a href="#" id="Sources-link">', Lang::$txt['dvc_sources'], '</a>

--- a/Themes/default/languages/Admin.english.php
+++ b/Themes/default/languages/Admin.english.php
@@ -263,6 +263,7 @@ $txt['theme_current_settings'] = 'Current Theme';
 
 $txt['dvc_your'] = 'Your version';
 $txt['dvc_current'] = 'Current version';
+$txt['dvc_root'] = 'Root';
 $txt['dvc_sources'] = 'Sources';
 $txt['dvc_default'] = 'Default Templates';
 $txt['dvc_templates'] = 'Current Templates';

--- a/Themes/default/scripts/admin.js
+++ b/Themes/default/scripts/admin.js
@@ -144,7 +144,7 @@ smf_ViewVersions.prototype.compareVersions = function (sCurrent, sTarget)
 	for (var i = 0; i < 2; i++)
 	{
 		// Clean the version and extract the version parts.
-		var sClean = aCompare[i].toLowerCase().replace(/ /g, '').replace(/2.0rc1-1/, '2.0rc1.1');
+		var sClean = aCompare[i].toLowerCase().replace(/ /g, '');
 		aParts = sClean.match(/(\d+)(?:\.(\d+|))?(?:\.)?(\d+|)(?:(alpha|beta|rc)(\d+|)(?:\.)?(\d+|))?(?:(dev))?(\d+|)/);
 
 		// No matches?
@@ -187,21 +187,24 @@ smf_ViewVersions.prototype.compareVersions = function (sCurrent, sTarget)
 
 smf_ViewVersions.prototype.determineVersions = function ()
 {
-	var oHighYour = {
+	let oHighYour = {
+		Root: '??',
 		Sources: '??',
 		Default: '??',
 		Languages: '??',
 		Templates: '??',
 		Tasks: '??'
 	};
-	var oHighCurrent = {
+	let oHighCurrent = {
+		Root: '??',
 		Sources: '??',
 		Default: '??',
 		Languages: '??',
 		Templates: '??',
 		Tasks: '??'
 	};
-	var oLowVersion = {
+	let oLowVersion = {
+		Root: false,
 		Sources: false,
 		Default: false,
 		Languages: false,
@@ -209,7 +212,8 @@ smf_ViewVersions.prototype.determineVersions = function ()
 		Tasks: false
 	};
 
-	var sSections = [
+	const sSections = [
+		'Root',
 		'Sources',
 		'Default',
 		'Languages',
@@ -302,6 +306,11 @@ smf_ViewVersions.prototype.determineVersions = function ()
 			}
 		}
 	}
+
+	setInnerHTML(document.getElementById('yourRoot'), oLowVersion.Root ? oLowVersion.Root : oHighYour.Root);
+	setInnerHTML(document.getElementById('currentRoot'), oHighCurrent.Root);
+	if (oLowVersion.Root)
+		document.getElementById('yourRoot').className = 'alert';
 
 	setInnerHTML(document.getElementById('yourSources'), oLowVersion.Sources ? oLowVersion.Sources : oHighYour.Sources);
 	setInnerHTML(document.getElementById('currentSources'), oHighCurrent.Sources);


### PR DESCRIPTION
This fixes issues needed to get detailed versions to work correctly.

I've done a change to include a 'root' directory that will hold the cron, subscriptions, ssi, proxy, and any future files at the root of the forum.

To support sources, I changed over to a iterator for sources.  Made things a bit easier actually.  I can do this for the rest if we want.

There is a related PR on the build tools: https://github.com/SimpleMachines/BuildTools/pull/28

SimpleMachines website is updated with that content at the moment.

When the build tool PR merges, this pr can be updated to reference the updated BuildTools repo and then merged.  Or that can be updated any time after as long as its updated before the alpha release.