### PR TITLE
Fix some PM bugs

### DIFF
--- a/Sources/PersonalMessage/PM.php
+++ b/Sources/PersonalMessage/PM.php
@@ -531,9 +531,8 @@ class PM implements \ArrayAccess
 		$limit = $query_customizations['limit'] ?? count($ids);
 		$params = $query_customizations['params'] ?? [];
 
-		if (!empty($ids)) {
-			$params['ids'] = array_filter(array_unique(array_map('intval', $ids)));
-		}
+		// There will never be an ID 0, but SMF doesn't like empty arrays when you tell it to expect an array of integers...
+		$params['ids'] = empty($ids) ? [0] : array_filter(array_unique(array_map('intval', $ids)));
 
 		foreach(self::queryData($selects, $params, $joins, $where, $order, $group, $limit) as $row) {
 			$id = (int) $row['id_pm'];

--- a/Sources/PersonalMessage/Popup.php
+++ b/Sources/PersonalMessage/Popup.php
@@ -65,7 +65,7 @@ class Popup
 			}
 
 			// Now, actually fetch me some PMs.
-			foreach (PM::load($pms, false) as $pm) {
+			foreach (PM::load($pms) as $pm) {
 				// Make sure we track the senders. We have some work to do for them.
 				if (!empty($pm->member_from)) {
 					$senders[] = $pm->member_from;

--- a/Sources/PersonalMessage/Received.php
+++ b/Sources/PersonalMessage/Received.php
@@ -525,6 +525,7 @@ class Received implements \ArrayAccess
 		}
 
 		$joins = [];
+		self::$recent[$paramskey] = [];
 
 		$where = [
 			'pmr.id_member = {int:me}',

--- a/Sources/PersonalMessage/Received.php
+++ b/Sources/PersonalMessage/Received.php
@@ -524,8 +524,9 @@ class Received implements \ArrayAccess
 			return self::$recent[$paramskey];
 		}
 
-		$joins = [];
 		self::$recent[$paramskey] = [];
+
+		$joins = [];
 
 		$where = [
 			'pmr.id_member = {int:me}',

--- a/Sources/PersonalMessage/Search.php
+++ b/Sources/PersonalMessage/Search.php
@@ -321,7 +321,7 @@ class Search
 		// Sort out the page index.
 		Utils::$context['page_index'] = new PageIndex(
 			Config::$scripturl . '?action=pm;sa=search2;params=' . $this->compressed_params,
-			$_GET['start'],
+			((int) $_GET['start'] ?? 0),
 			Utils::$context['num_results'],
 			$this->per_page,
 			false,

--- a/Sources/PersonalMessage/Search.php
+++ b/Sources/PersonalMessage/Search.php
@@ -321,7 +321,7 @@ class Search
 		// Sort out the page index.
 		Utils::$context['page_index'] = new PageIndex(
 			Config::$scripturl . '?action=pm;sa=search2;params=' . $this->compressed_params,
-			((int) $_GET['start'] ?? 0),
+			(int) ($_GET['start'] ?? 0),
 			Utils::$context['num_results'],
 			$this->per_page,
 			false,


### PR DESCRIPTION
This fixes four different PM-related bugs:
* Error while trying to view a label for which no messages existed (including inbox)
* Error while viewing search results if $_GET['start'] wasn't set
* Error while searching PMs if no messages matched the given parameters
* The PM popup wouldn't load because of a bad parameter being passed to the function to load messages