### PR TITLE
The "(no primary membergroup)" option was missing when editing profiles

### DIFF
--- a/Sources/Profile.php
+++ b/Sources/Profile.php
@@ -1218,7 +1218,6 @@ class Profile extends User implements \ArrayAccess
 			&& (
 				stristr($this->avatar['url'], 'gravatar://')
 				|| !empty(Config::$modSettings['gravatarOverride'])
-				// Gravatar?
 			)
 		) {
 			$this->formatted['avatar'] += [

--- a/Sources/Profile.php
+++ b/Sources/Profile.php
@@ -1212,6 +1212,7 @@ class Profile extends User implements \ArrayAccess
 			'allow_gravatar' => !empty(Config::$modSettings['gravatarEnabled']),
 		];
 
+		// Gravatar?
 		if (
 			$this->formatted['avatar']['allow_gravatar']
 			&& (

--- a/Sources/Profile.php
+++ b/Sources/Profile.php
@@ -1212,12 +1212,12 @@ class Profile extends User implements \ArrayAccess
 			'allow_gravatar' => !empty(Config::$modSettings['gravatarEnabled']),
 		];
 
-		// Gravatar?
 		if (
 			$this->formatted['avatar']['allow_gravatar']
 			&& (
 				stristr($this->avatar['url'], 'gravatar://')
 				|| !empty(Config::$modSettings['gravatarOverride'])
+				// Gravatar?
 			)
 		) {
 			$this->formatted['avatar'] += [
@@ -1388,7 +1388,18 @@ class Profile extends User implements \ArrayAccess
 		}
 
 		// For the templates.
-		Utils::$context['member_groups'] = $this->assignable_groups;
+		Utils::$context['member_groups'] = array_merge(
+			[
+				0 => [
+					'id' => 0,
+					'name' => Lang::$txt['no_primary_membergroup'],
+					'is_primary' => $this->data['id_group'] == 0,
+					'can_be_additional' => false,
+					'can_be_primary' => true,
+				]
+			],
+			$this->assignable_groups
+		);
 
 		return true;
 	}


### PR DESCRIPTION
The "(no primary membergroup)" option was missing from the profile, preventing you from being able to remove a member's primary group. I discovered this while trying to demote a test account from administrator to a regular user.