### PR TITLE
Fix issue with news feeds

### DIFF
--- a/Sources/Actions/Feed.php
+++ b/Sources/Actions/Feed.php
@@ -494,7 +494,7 @@ class Feed implements ActionInterface
 
 		// Get the associative array representing the xml.
 		if (!empty(CacheApi::$enable) && (!User::$me->is_guest || CacheApi::$enable >= 3)) {
-			$this->data = CacheApi::get('xmlfeed-' . $this->format . ':' . (User::$me->is_guest ? '' : User::$me->id . '-') . $cachekey, 240);
+			$this->data = CacheApi::get('xmlfeed-' . $this->format . ':' . (User::$me->is_guest ? '' : User::$me->id . '-') . $cachekey, 240) ?? [];
 		}
 
 		if (empty($this->data)) {

--- a/Sources/Actions/Feed.php
+++ b/Sources/Actions/Feed.php
@@ -1140,6 +1140,7 @@ class Feed implements ActionInterface
 
 		$done = false;
 		$loops = 0;
+		$current_board = isset(Board::$info) ? Board::$info->id : 0;
 
 		while (!$done) {
 			$optimize_msg = implode(' AND ', $this->optimize_msg);
@@ -1158,7 +1159,7 @@ class Feed implements ActionInterface
 				LIMIT {int:limit}',
 				[
 					'limit' => $this->limit,
-					'current_board' => Board::$info->id,
+					'current_board' => $current_board,
 					'is_approved' => 1,
 					'optimize_msg' => $optimize_msg,
 				],
@@ -1209,7 +1210,7 @@ class Feed implements ActionInterface
 			LIMIT {int:limit}',
 			[
 				'limit' => $this->limit,
-				'current_board' => Board::$info->id,
+				'current_board' => $current_board,
 				'message_list' => $messages,
 			],
 		);


### PR DESCRIPTION
#### Description
The code didn't take into account whether the cache actually contained data, leading to an error since you can't assign null to a property that's supposed to be an array
After fixing the above issue, the queries generated "Attempt to read property "id" of null" warnings because we always try to pass Board::$info->id as a query parameter even when we're not looking at a board feed