### PR TITLE
Missing parameter causes an error

### DIFF
--- a/Sources/Alert.php
+++ b/Sources/Alert.php
@@ -783,7 +783,7 @@ class Alert implements \ArrayAccess
 			$params['ids'] = $ids;
 		}
 
-		foreach (self::queryData($selects, $params, $joins, $where, $order, $limit) as $row) {
+		foreach (self::queryData($selects, $params, $joins, $where, $order, $group, $limit) as $row) {
 			$row['id_alert'] = (int) $row['id_alert'];
 
 			$members[] = (int) $row['id_member'];


### PR DESCRIPTION
The $group parameter was never passed to the queryData function, leading to an error