### PR TITLE
membersAllowedTo was returning an array of 'id_member' => {member_id} values rather than an array of member IDs

### DIFF
--- a/Sources/User.php
+++ b/Sources/User.php
@@ -4037,7 +4037,9 @@ class User implements \ArrayAccess
 				'member_group_denied_implode' => implode(', mem.additional_groups) != 0 OR FIND_IN_SET(', $member_groups['denied']),
 			],
 		);
-		$members = Db::$db->fetch_all($request);
+
+		// We only want the member IDs, not id_member
+		$members = array_values(Db::$db->fetch_all($request));
 		Db::$db->free_result($request);
 
 		return $members;


### PR DESCRIPTION
3.0 uses fetch_all to get the member IDs from the query in membersAllowedTo. The problem is this gets us an array of arrays (each one containing an 'id_member' key and member ID value), rather than just a simple array of member IDs, which causes problems elsewhere. Since we already know we want all rows, it's easier to just use array_values() instead of manually looping through the results one at a time.