### PR TITLE
Only set timezone for Unix timestamps if actually was a Unix timestamp

### DIFF
--- a/Sources/Time.php
+++ b/Sources/Time.php
@@ -206,7 +206,9 @@ class Time extends \DateTime implements \ArrayAccess
 
 		// If $datetime was a Unix timestamp, force the time zone to be the one we were told to use.
 		// Honestly, it's a mystery why the \DateTime class doesn't do this itself already...
-		$this->setTimezone($timezone ?? self::$user_tz);
+		if (str_starts_with($datetime, '@')) {
+			$this->setTimezone($timezone ?? self::$user_tz);
+		}
 	}
 
 	/**


### PR DESCRIPTION
If the intended time zone for a new SMF\Time object was indicated by including the time zone identifier in the string passed as the first argument, rather than as a \DateTimeZone object passed as the second argument, then SMF\Time would automatically change the time zone of the constructed object to the user's time zone.