### PR TITLE
[3.0] Update the URLs for RIPE and LACNIC

### DIFF
--- a/Sources/Actions/TrackIP.php
+++ b/Sources/Actions/TrackIP.php
@@ -346,11 +346,11 @@ class TrackIP implements ActionInterface
 				],
 				'lacnic' => [
 					'name' => Lang::$txt['whois_lacnic'],
-					'url' => 'https://lacnic.net/cgi-bin/lacnic/whois?query=' . Utils::$context['ip'],
+					'url' => 'https://query.milacnic.lacnic.net/search?id=' . Utils::$context['ip'],
 				],
 				'ripe' => [
 					'name' => Lang::$txt['whois_ripe'],
-					'url' => 'https://apps.db.ripe.net/search/query.html?searchtext=' . Utils::$context['ip'],
+					'url' => 'https://apps.db.ripe.net/db-web-ui/query?searchtext=' . Utils::$context['ip'],
 				],
 			];
 		}


### PR DESCRIPTION
#### Description
Update the URLs for whois search for both RIPE and LACNIC

### Issues References (Fixes|Related|Closes)
1.  Fixes #7957 (for 3.0)
