### PR TITLE
[2.1] Update the URLs for RIPE and LACNIC

### DIFF
--- a/Sources/Profile-View.php
+++ b/Sources/Profile-View.php
@@ -2545,11 +2545,11 @@ function TrackIP($memID = 0)
 			),
 			'lacnic' => array(
 				'name' => $txt['whois_lacnic'],
-				'url' => 'https://lacnic.net/cgi-bin/lacnic/whois?query=' . $context['ip'],
+				'url' => 'https://query.milacnic.lacnic.net/search?id=' . $context['ip'],
 			),
 			'ripe' => array(
 				'name' => $txt['whois_ripe'],
-				'url' => 'https://apps.db.ripe.net/search/query.html?searchtext=' . $context['ip'],
+				'url' => 'https://apps.db.ripe.net/db-web-ui/query?searchtext=' . $context['ip'],
 			),
 		);
 	}


### PR DESCRIPTION
#### Description
Update the URLs for whois search for both RIPE and LACNIC

### Issues References (Fixes|Related|Closes)
1.  Fixes #7957 (for 2.1)