### PR TITLE
Adds support for `{uuid:...}` as a database query token

### DIFF
--- a/Sources/Db/APIs/MySQL.php
+++ b/Sources/Db/APIs/MySQL.php
@@ -23,6 +23,7 @@ use SMF\IP;
 use SMF\Lang;
 use SMF\User;
 use SMF\Utils;
+use SMF\Uuid;
 
 /**
  * Interacts with MySQL databases.
@@ -2215,6 +2216,21 @@ class MySQL extends DatabaseApi implements DatabaseApiInterface
 
 			case 'raw':
 				return (string) $replacement;
+
+			case 'uuid':
+				if ($replacement instanceof Uuid) {
+					return sprintf('UUID_TO_BIN(\'%1$s\')', strval($replacement));
+				}
+
+				$uuid = @Uuid::createFromString($replacement, false);
+
+				if (in_array($replacement, [(string) $uuid, $uuid->getShortForm(), $uuid->getBinary()])) {
+					return sprintf('UUID_TO_BIN(\'%1$s\')', (string) $uuid);
+				}
+
+				$this->error_backtrace('Wrong value type sent to the database. UUID expected. (' . $matches[2] . ')', '', E_USER_ERROR, __FILE__, __LINE__);
+
+				break;
 
 			case 'inet':
 				if ($replacement == 'null' || $replacement == '') {

--- a/Sources/Db/APIs/PostgreSQL.php
+++ b/Sources/Db/APIs/PostgreSQL.php
@@ -23,6 +23,7 @@ use SMF\IP;
 use SMF\Lang;
 use SMF\User;
 use SMF\Utils;
+use SMF\Uuid;
 
 /**
  * Interacts with PostgreSQL databases.
@@ -2327,6 +2328,21 @@ class PostgreSQL extends DatabaseApi implements DatabaseApiInterface
 
 			case 'raw':
 				return (string) $replacement;
+
+			case 'uuid':
+				if ($replacement instanceof Uuid) {
+					return sprintf('\'%1$s\'::uuid', (string) $replacement);
+				}
+
+				$uuid = @Uuid::createFromString($replacement, false);
+
+				if (in_array($replacement, [(string) $uuid, $uuid->getShortForm(), $uuid->getBinary()])) {
+					return sprintf('\'%1$s\'::uuid', (string) $uuid);
+				}
+
+				$this->error_backtrace('Wrong value type sent to the database. UUID expected. (' . $matches[2] . ')', '', E_USER_ERROR, __FILE__, __LINE__);
+
+				break;
 
 			case 'inet':
 				if ($replacement == 'null' || $replacement == '') {


### PR DESCRIPTION
Adds support for using `{uuid:...}` as a database query type token in the replacement__callback() methods of our DatabaseApi classes. 

This allows us to perform input sanitization on SMF\Uuid objects and/or plain UUID strings that are passed as parameters to queries.

Example:
```
Db::$db->query(
	'',
	'UPDATE {db_prefix}tablename
	SET foo = {uuid:bar}
	WHERE id = {int:id_number}'
	[
		'id_number' => 1,
		'bar' = new Uuid(7),
	]
);
```

Prior to this PR, the best we could have done would have been to cast the Uuid object to a string and then used `{string:bar}` in the query. That was inadequate for two reasons:

1. Treating UUIDs as strings would not have provided any guarantee that the value of the `bar` parameter really was a UUID.
2. Treating UUIDs as strings would have prevented us from using optimized data types for storing UUIDs. In PostgreSQL, it is best to store UUIDs using the dedicated UUID data type. In MySQL, it is best to store UUIDs in raw binary form.

-----

@albertlast: I don't have a PostgreSQL instance up and running at the moment. Could you please test to verify that this code behaves as expected on PostgreSQL? 

To do that, please:

1. Create a table in your SMF database something like this, and then insert a row into it.
```
CREATE TABLE tablename (
	id serial primary key,
	foo uuid not null
);
```

2. Run the example code given earlier in this post and make sure it works as expected. The results should be that a new UUIDv7 is stored in the foo column of row 1.
