### PR TITLE
Makes the [center] BBC work when wrapped around tables

### DIFF
--- a/Themes/default/css/index.css
+++ b/Themes/default/css/index.css
@@ -410,6 +410,9 @@ blockquote cite::before {
 	font: inherit;
 	color: inherit;
 }
+.centertext .bbc_table {
+    margin: auto;
+}
 .bbc_table td {
 	font: inherit;
 	color: inherit;


### PR DESCRIPTION
Without this CSS tweak, `[center][table]...[/table][/center]` doesn't work as expected.

See https://www.simplemachines.org/community/index.php?msg=4166332