### PR TITLE
Runs PHP-CS-Fixer lint check on changed files only

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,8 @@
         "friendsofphp/php-cs-fixer": "^3.40"
     },
     "scripts": {
-        "lint": "php-cs-fixer check --diff --config .php-cs-fixer.dist.php $(git diff --name-only \"*.php\")",
-        "lint-fix": "php-cs-fixer fix -v --config .php-cs-fixer.dist.php $(git diff --name-only \"*.php\")"
+        "lint": "[ -z \"$(git diff --name-only \"*.php\")\" ] || php-cs-fixer check --diff --config .php-cs-fixer.dist.php $(git diff --name-only \"*.php\")",
+        "lint-fix": "[ -z \"$(git diff --name-only \"*.php\")\" ] || php-cs-fixer fix -v --config .php-cs-fixer.dist.php $(git diff --name-only \"*.php\")"
     },
     "config": {
         "platform": {

--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,8 @@
         "friendsofphp/php-cs-fixer": "^3.40"
     },
     "scripts": {
-        "lint": "php-cs-fixer check --diff",
-        "lint-fix": "php-cs-fixer fix -v"
+        "lint": "php-cs-fixer check --diff --config .php-cs-fixer.dist.php $(git diff --name-only \"*.php\")",
+        "lint-fix": "php-cs-fixer fix -v --config .php-cs-fixer.dist.php $(git diff --name-only \"*.php\")"
     },
     "config": {
         "platform": {


### PR DESCRIPTION
This should fix problems where pull requests would fail lint checks due to problems in files they never touched.