### PR TITLE
Raises minimum database versions

### DIFF
--- a/other/install.php
+++ b/other/install.php
@@ -67,7 +67,7 @@ require_once Config::$sourcedir . '/Subs-Compat.php';
 $databases = [
 	'mysql' => [
 		'name' => 'MySQL',
-		'version' => '5.6.0',
+		'version' => '8.0.35',
 		'version_check' => function () {
 			if (!function_exists('mysqli_fetch_row')) {
 				return false;
@@ -96,7 +96,7 @@ $databases = [
 	],
 	'postgresql' => [
 		'name' => 'PostgreSQL',
-		'version' => '9.6',
+		'version' => '12.17',
 		'version_check' => function () {
 			$request = pg_query(Db::$db->connection, 'SELECT version()');
 			list($version) = pg_fetch_row($request);

--- a/other/upgrade.php
+++ b/other/upgrade.php
@@ -53,7 +53,7 @@ $GLOBALS['required_php_version'] = '8.0.0';
 $databases = [
 	'mysql' => [
 		'name' => 'MySQL',
-		'version' => '5.6.0',
+		'version' => '8.0.35',
 		'version_check' => function () {
 			if (!function_exists('mysqli_fetch_row')) {
 				return false;
@@ -65,7 +65,7 @@ $databases = [
 	],
 	'postgresql' => [
 		'name' => 'PostgreSQL',
-		'version' => '9.6',
+		'version' => '12.17',
 		'version_check' => function () {
 			if (!function_exists('pg_version')) {
 				return false;


### PR DESCRIPTION
Does anyone see a reason not to do this?

FYI:
- MySQL 8.0.x is still supported, and 8.0.35 is the latest release in that branch.
- PostgreSQL 12.x is still supported, and 12.17 is the latest release in that branch.