### PR TITLE
Fix caching error on Profile loading

### DIFF
--- a/Sources/User.php
+++ b/Sources/User.php
@@ -5307,6 +5307,10 @@ class User implements \ArrayAccess
 	 */
 	protected static function loadUserData(array $users, int $type = self::LOAD_BY_ID, string $dataset = 'normal'): array
 	{
+		if (!isset(self::$dataset_levels[$dataset])) {
+			$dataset = 'normal';
+		}
+
 		// Keep track of which IDs we load during this run.
 		$loaded_ids = [];
 
@@ -5370,7 +5374,7 @@ class User implements \ArrayAccess
 				}
 
 				// Does the cached data have everything we need?
-				if (is_array($data) && !empty(self::$dataset_levels[$data['dataset']]) && !empty(self::$dataset_levels[$dataset]) && self::$dataset_levels[$data['dataset']] >= self::$dataset_levels[$dataset]) {
+				if (is_array($data) && self::$dataset_levels[$data['dataset'] ?? 'minimal'] >= self::$dataset_levels[$dataset]) {
 					self::$profiles[$id] = $data;
 					$loaded_ids[] = $id;
 					unset($users[$key]);

--- a/Sources/User.php
+++ b/Sources/User.php
@@ -5370,7 +5370,7 @@ class User implements \ArrayAccess
 				}
 
 				// Does the cached data have everything we need?
-				if (self::$dataset_levels[$data['dataset']] >= self::$dataset_levels[$dataset]) {
+				if (is_array($data) && !empty(self::$dataset_levels[$data['dataset']]) && !empty(self::$dataset_levels[$dataset]) && self::$dataset_levels[$data['dataset']] >= self::$dataset_levels[$dataset]) {
 					self::$profiles[$id] = $data;
 					$loaded_ids[] = $id;
 					unset($users[$key]);


### PR DESCRIPTION
To reproduce this
1. Set Caching to level 3
2. Load the board index

Warning: Trying to access array offset on value of type bool in /Sources/User.php on line 5372
Warning: Undefined array key "" in /Sources/User.php on line 5372

This is because $data is not set, which also causes a null compare.