### PR TITLE
Fix "undefined index" errors on TFA login

### DIFF
--- a/Sources/User.php
+++ b/Sources/User.php
@@ -4632,7 +4632,7 @@ class User implements \ArrayAccess
 
 			self::$loaded[$id] = $this;
 
-			if (!isset(self::$profiles[$id]) || self::$dataset_levels[self::$profiles[$id]['dataset']] < self::$dataset_levels[$dataset ?? 'normal']) {
+			if (!empty(self::$profiles[$id]) || self::$dataset_levels[self::$profiles[$id]['dataset']] < self::$dataset_levels[$dataset ?? 'normal']) {
 				self::loadUserData((array) $id, self::LOAD_BY_ID, $dataset ?? 'normal');
 			}
 


### PR DESCRIPTION
#### Description
When TFA is enabled, when you're on the screen asking for your TFA code, `self::$profiles` is empty for the current user id, causing undefined index errors.

### Issues References
1. Fixes #7983
