### PR TITLE
 [3.0] Support persistent connections in memcached implementation

### DIFF
--- a/Sources/Cache/APIs/MemcachedImplementation.php
+++ b/Sources/Cache/APIs/MemcachedImplementation.php
@@ -90,7 +90,7 @@ class MemcachedImplementation extends CacheApi implements CacheApiInterface
 	 */
 	public function connect(): bool
 	{
-		$this->memcached = new Memcached();
+		$this->memcached = Config::$db_persist ? new Memcached($this->prefix) : new Memcached();
 
 		return $this->addServers();
 	}


### PR DESCRIPTION
If you pass the first parameter while creating the memcached object, this will persist in the connections.  Otherwise, the connection is discarded when the page is loaded.