### PR TITLE
[3.0] Fix caching issue with objects

### DIFF
--- a/Sources/Cache/APIs/FileBased.php
+++ b/Sources/Cache/APIs/FileBased.php
@@ -85,8 +85,8 @@ class FileBased extends CacheApi implements CacheApiInterface
 
 		// SMF Data returns $value and $expired.  $expired has a unix timestamp of when this expires.
 		if (file_exists($file) && ($raw = $this->readFile($file)) !== false) {
-			if (($value = Utils::jsonDecode($raw, true, false)) !== [] && isset($value['expiration']) && $value['expiration'] >= time()) {
-				return $value['value'];
+			if (($value = Utils::jsonDecode($raw, false, false)) !== null && isset($value->expiration) && $value->expiration >= time()) {
+				return $value->value;
 			}
 
 			@unlink($file);

--- a/Sources/Cache/APIs/FileBased.php
+++ b/Sources/Cache/APIs/FileBased.php
@@ -85,7 +85,7 @@ class FileBased extends CacheApi implements CacheApiInterface
 
 		// SMF Data returns $value and $expired.  $expired has a unix timestamp of when this expires.
 		if (file_exists($file) && ($raw = $this->readFile($file)) !== false) {
-			if (($value = Utils::jsonDecode($raw, false, false)) !== null && isset($value->expiration) && $value->expiration >= time()) {
+			if (($value = Utils::jsonDecode($raw, false, 512, 0, false)) !== null && isset($value->expiration) && $value->expiration >= time()) {
 				return $value->value;
 			}
 

--- a/Sources/Cache/CacheApi.php
+++ b/Sources/Cache/CacheApi.php
@@ -600,7 +600,13 @@ abstract class CacheApi
 			IntegrationHook::call('cache_get_data', [&$key, &$ttl, &$value]);
 		}
 
-		return empty($value) ? null : Utils::jsonDecode($value, true);
+		if (empty($value)) {
+			return null;
+		} else if (is_string($value)) {
+			return Utils::jsonDecode($value, true);
+		} else {
+			return $value;
+		}
 	}
 }
 

--- a/Sources/Cache/CacheApi.php
+++ b/Sources/Cache/CacheApi.php
@@ -588,7 +588,7 @@ abstract class CacheApi
 
 		if (isset(Config::$db_show_debug) && Config::$db_show_debug === true) {
 			self::$hits[self::$count_hits]['t'] = microtime(true) - $st;
-			self::$hits[self::$count_hits]['s'] = isset($value) ? strlen($value) : 0;
+			self::$hits[self::$count_hits]['s'] = isset($value) ? strlen((string) $value) : 0;
 
 			if (empty($value)) {
 				self::$count_misses++;

--- a/Sources/Config.php
+++ b/Sources/Config.php
@@ -1044,7 +1044,7 @@ class Config
 			}
 
 			if (!is_array(self::$modSettings['attachmentUploadDir'])) {
-				$attachmentUploadDir = Utils::jsonDecode(self::$modSettings['attachmentUploadDir'], true, false);
+				$attachmentUploadDir = Utils::jsonDecode(self::$modSettings['attachmentUploadDir'], true, 512, 0, false);
 
 				self::$modSettings['attachmentUploadDir'] = !empty($attachmentUploadDir) ? $attachmentUploadDir : self::$modSettings['attachmentUploadDir'];
 			}

--- a/Sources/Cookie.php
+++ b/Sources/Cookie.php
@@ -303,7 +303,7 @@ class Cookie
 		}
 
 		// Other cookies.
-		$data = Utils::jsonDecode($_COOKIE[$name], true, false);
+		$data = Utils::jsonDecode($_COOKIE[$name], true, 512, 0, false);
 
 		if (json_last_error() !== JSON_ERROR_NONE) {
 			$data = $_COOKIE[$name];

--- a/Sources/Subs-Compat.php
+++ b/Sources/Subs-Compat.php
@@ -5642,7 +5642,12 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 
 	function smf_json_decode(string $json, bool $associative = false, bool $should_log = true): mixed
 	{
-		return Utils::jsonDecode($json, $associative, $should_log);
+		// In older versions, we accepted a mixed $json and would return if it was not a string.
+		if (empty($json) || !is_string($json)) {
+			return $json;
+		}
+
+		return Utils::jsonDecode($json, $associative, 512, 0, $should_log);
 	}
 
 	function safe_serialize(mixed $value): string

--- a/Sources/User.php
+++ b/Sources/User.php
@@ -4777,7 +4777,7 @@ class User implements \ArrayAccess
 
 		if (isset($_COOKIE[Config::$cookiename])) {
 			// First try 2.1 json-format cookie
-			$cookie_data = Utils::jsonDecode($_COOKIE[Config::$cookiename], true, false);
+			$cookie_data = Utils::jsonDecode($_COOKIE[Config::$cookiename], true, 512, 0, false);
 
 			// Legacy format (for recent 2.0 --> 2.1 upgrades)
 			if (empty($cookie_data)) {

--- a/Sources/Utils.php
+++ b/Sources/Utils.php
@@ -139,7 +139,7 @@ class Utils
 		'normalize' => __CLASS__ . '::normalize',
 		'truncate' => __CLASS__ . '::truncate',
 		'json_encode' => __CLASS__ . '::jsonEncode',
-		'json_decode' => __CLASS__ . '::jsonDecode',
+		'json_decode' => __CLASS__ . '::backcompat_smf_json_decode',
 		'random_int' => __CLASS__ . '::randomInt',
 		'random_bytes' => __CLASS__ . '::randomBytes',
 	];
@@ -1228,6 +1228,10 @@ class Utils
 	 * @param ?bool $associative Whether to force JSON objects to be returned as
 	 *    associative arrays. SMF nearly always wants this to be true, but for
 	 *    the sake of consistency with json_decode(), the default is null.
+	 * @param int $depth Maximum nesting depth of the structure being decoded.
+	 *    The value must be greater than 0, and less than or equal to 2147483647.
+	 * @param int $flags Bitmask of JSON_BIGINT_AS_STRING, JSON_INVALID_UTF8_IGNORE,
+	 *     JSON_INVALID_UTF8_SUBSTITUTE, JSON_OBJECT_AS_ARRAY, JSON_THROW_ON_ERROR
 	 * @param bool $should_log Whether to log errors. Default: true.
 	 * @return mixed The decoded data.
 	 */
@@ -2271,6 +2275,27 @@ class Utils
 		}
 
 		return $callable;
+	}
+
+	/**
+	 * Backward compatibilty wrapper for the smf_json_decode() method.
+	 *
+	 * @deprecated 3.0 - Only exists for $smcFunc backwards wrapper.
+	 * @param mixed $json The string to decode.
+	 * @param bool $associative Whether to force JSON objects to be returned as
+	 *    associative arrays. SMF nearly always wants this to be true, but for
+	 *    the sake of consistency with json_decode(), the default is false.
+	 * @param bool $should_log Whether to log errors. Default: true.
+	 * @return mixed The decoded data.
+	 */
+	public static function backcompat_smf_json_decode(mixed $json, bool $associative = false, bool $should_log = true): mixed
+	{
+		// In older versions, we accepted a mixed $json and would return if it was not a string.
+		if (empty($json) || !is_string($json)) {
+			return $json;
+		}
+
+		return Utils::jsonDecode($json, $associative, 512, 0, $should_log);
 	}
 
 	/*************************

--- a/Sources/Utils.php
+++ b/Sources/Utils.php
@@ -139,7 +139,7 @@ class Utils
 		'normalize' => __CLASS__ . '::normalize',
 		'truncate' => __CLASS__ . '::truncate',
 		'json_encode' => __CLASS__ . '::jsonEncode',
-		'json_decode' => __CLASS__ . '::backcompat_smf_json_decode',
+		'json_decode' => 'smf_json_decode',
 		'random_int' => __CLASS__ . '::randomInt',
 		'random_bytes' => __CLASS__ . '::randomBytes',
 	];
@@ -2275,27 +2275,6 @@ class Utils
 		}
 
 		return $callable;
-	}
-
-	/**
-	 * Backward compatibilty wrapper for the smf_json_decode() method.
-	 *
-	 * @deprecated 3.0 - Only exists for $smcFunc backwards wrapper.
-	 * @param mixed $json The string to decode.
-	 * @param bool $associative Whether to force JSON objects to be returned as
-	 *    associative arrays. SMF nearly always wants this to be true, but for
-	 *    the sake of consistency with json_decode(), the default is false.
-	 * @param bool $should_log Whether to log errors. Default: true.
-	 * @return mixed The decoded data.
-	 */
-	public static function backcompat_smf_json_decode(mixed $json, bool $associative = false, bool $should_log = true): mixed
-	{
-		// In older versions, we accepted a mixed $json and would return if it was not a string.
-		if (empty($json) || !is_string($json)) {
-			return $json;
-		}
-
-		return Utils::jsonDecode($json, $associative, 512, 0, $should_log);
 	}
 
 	/*************************

--- a/Sources/Utils.php
+++ b/Sources/Utils.php
@@ -1224,21 +1224,29 @@ class Utils
 	/**
 	 * Wrapper function for json_decode() with error handling.
 	 *
-	 * @param mixed $json The string to decode.
-	 * @param bool $associative Whether to force JSON objects to be returned as
+	 * @param string $json The string to decode.
+	 * @param ?bool $associative Whether to force JSON objects to be returned as
 	 *    associative arrays. SMF nearly always wants this to be true, but for
-	 *    the sake of consistency with json_decode(), the default is false.
+	 *    the sake of consistency with json_decode(), the default is null.
 	 * @param bool $should_log Whether to log errors. Default: true.
 	 * @return mixed The decoded data.
 	 */
-	public static function jsonDecode(mixed $json, bool $associative = false, bool $should_log = true): mixed
+	public static function jsonDecode(string $json, ?bool $associative = null, int $depth = 512, int $flags = 0, bool $should_log = true): mixed
 	{
 		// Come on...
-		if (empty($json) || !is_string($json)) {
-			return [];
+		if (empty($json)) {
+			return null;
 		}
 
-		$return_value = @json_decode($json, $associative);
+		// We do this to align with PHP's default when the JSON_THROW_ON_ERROR flag is specified
+		try {
+			$return_value = json_decode($json, $associative, $depth, $flags);
+		}
+		catch (\Exception $excepection){
+			if (($flags & JSON_THROW_ON_ERROR) == JSON_THROW_ON_ERROR){
+				throw $excepection;
+			}
+		}
 
 		// Use this instead of json_last_error_msg() so that we can translate
 		// the error messages for the admin.
@@ -1286,8 +1294,8 @@ class Utils
 				ErrorHandler::log(Lang::$txt['json_' . $json_error], 'critical');
 			}
 
-			// Everyone expects an array.
-			return [];
+			// Null should be returned in all cases where json can not be decoded.
+			return null;
 		}
 
 		return $return_value;
@@ -1303,9 +1311,10 @@ class Utils
 	 * @param mixed $value The value to encode.
 	 * @param int $flags Bitmask of flags for json_encode(). Default: 0.
 	 * @param int $depth Maximum depth. Default: 512.
-	 * @return mixed The decoded data.
+	 * @return string|bool The decoded data.
+	 * @todo PHP 8.2 The return should be string|false
 	 */
-	public static function jsonEncode(mixed $value, int $flags = 0, int $depth = 512): mixed
+	public static function jsonEncode(mixed $value, int $flags = 0, int $depth = 512): string|bool
 	{
 		return json_encode($value, $flags, $depth);
 	}

--- a/Sources/Utils.php
+++ b/Sources/Utils.php
@@ -1224,14 +1224,14 @@ class Utils
 	/**
 	 * Wrapper function for json_decode() with error handling.
 	 *
-	 * @param string $json The string to decode.
+	 * @param mixed $json The string to decode.
 	 * @param bool $associative Whether to force JSON objects to be returned as
 	 *    associative arrays. SMF nearly always wants this to be true, but for
 	 *    the sake of consistency with json_decode(), the default is false.
 	 * @param bool $should_log Whether to log errors. Default: true.
 	 * @return mixed The decoded data.
 	 */
-	public static function jsonDecode(string $json, bool $associative = false, bool $should_log = true): mixed
+	public static function jsonDecode(mixed $json, bool $associative = false, bool $should_log = true): mixed
 	{
 		// Come on...
 		if (empty($json) || !is_string($json)) {


### PR DESCRIPTION
Fixes #7991

4 things are being done to correct this:
1. use a native object in the FileBased setup (We could skip this, but why not)
2. The CacheApi::Get() now handles returning the $value if its a non string. 
3. The hits tracker needs to convert the $value to a string always.
4. Utils::jsonEncode and Utils::jsonDecode now align to PHP's native json_encode and json_decode.