### PR TITLE
[3.0] Fix Group Membership Requests

### DIFF
--- a/Sources/Actions/Admin/Membergroups.php
+++ b/Sources/Actions/Admin/Membergroups.php
@@ -640,7 +640,10 @@ class Membergroups implements ActionInterface
 			ErrorHandler::fatalLang('membergroup_does_not_exist', false);
 		}
 
-		@list($group) = Group::load($_REQUEST['group']);
+		$groups = Group::load((int) $_REQUEST['group']);
+
+		/** @var \SMF\Group $group */
+		$group = array_shift($groups);
 
 		if (!isset($group) || !($group instanceof Group)) {
 			ErrorHandler::fatalLang('membergroup_does_not_exist', false);

--- a/Sources/Actions/Groups.php
+++ b/Sources/Actions/Groups.php
@@ -257,9 +257,10 @@ class Groups implements ActionInterface
 		}
 
 		// Load up the group details.
-		@list($group) = Group::load($_REQUEST['group']);
+		$groups = Group::load($_REQUEST['group']);
 
-		if (empty($group->id)) {
+		/** @var \SMF\Group $group */
+		if ($groups == [] || !($group = $groups[$_REQUEST['group']]) || empty($group->id)) {
 			ErrorHandler::fatalLang('membergroup_does_not_exist', false);
 		}
 
@@ -364,9 +365,10 @@ class Groups implements ActionInterface
 
 			// Do the updates...
 			if (!empty($members)) {
-				@list($group) = Group::load((int) $_REQUEST['group']);
+				$groups = Group::load((int) $_REQUEST['group']);
 
-				if ($group instanceof Group) {
+			/** @var \SMF\Group $group */
+			if ($groups != [] && ($group = $groups[(int) $_REQUEST['group']]) && $group instanceof Group) {
 					$group->addMembers($members, isset($_POST['additional']) ? 'only_additional' : 'auto', true);
 				}
 			}
@@ -514,10 +516,16 @@ class Groups implements ActionInterface
 
 				if (!empty($members_to_add)) {
 					foreach ($members_to_add as $group_id => $members) {
-						@list($group) = Group::load((int) $group_id);
+						$groups = Group::load((int) $group_id);
 
-						if ($group instanceof Group) {
-							$group->addMembers($members);
+						$result = false;
+						/** @var \SMF\Group $group */
+						if ($groups != [] && ($group = $groups[$group_id]) && $group instanceof Group) {
+							$result = $group->addMembers($members);
+						}
+
+						if (!$result) {
+							ErrorHandler::fatalLang('membergroup_does_not_exist', false);
 						}
 					}
 				}

--- a/Sources/Actions/Profile/GroupMembership.php
+++ b/Sources/Actions/Profile/GroupMembership.php
@@ -106,8 +106,8 @@ class GroupMembership implements ActionInterface
 		$open_requests = Db::$db->fetch_all($request);
 		Db::$db->free_result($request);
 		
-		$open_requests = array_map(function($v) {
-			return (int) $v['id_group'];
+		$open_requests = array_map(function($request) {
+			return (int) $request['id_group'];
 		}, $open_requests);
 
 		// Show the assignable groups in the templates.

--- a/Sources/Actions/Profile/GroupMembership.php
+++ b/Sources/Actions/Profile/GroupMembership.php
@@ -105,6 +105,10 @@ class GroupMembership implements ActionInterface
 		);
 		$open_requests = Db::$db->fetch_all($request);
 		Db::$db->free_result($request);
+		
+		$open_requests = array_map(function($v) {
+			return (int) $v['id_group'];
+		}, $open_requests);
 
 		// Show the assignable groups in the templates.
 		foreach (Profile::$member->current_and_assignable_groups as $id => $group) {
@@ -114,17 +118,17 @@ class GroupMembership implements ActionInterface
 			}
 
 			// Are they in this group?
-			$member_or_available = in_array($id, Profile::$member->groups) ? 'member' : 'available';
+			$member_or_available = in_array($group->id, Profile::$member->groups) ? 'member' : 'available';
 
 			// Can't join private or protected groups.
 			if ($group->type < Group::TYPE_REQUESTABLE && $member_or_available == 'available') {
 				continue;
 			}
 
-			Utils::$context['groups'][$member_or_available][$id] = $group;
+			Utils::$context['groups'][$member_or_available][$group->id] = $group;
 
 			// Do they have a pending request to join this group?
-			Utils::$context['groups'][$member_or_available][$id]->pending = in_array($id, $open_requests);
+			Utils::$context['groups'][$member_or_available][$group->id]->pending = in_array($group->id, $open_requests);
 		}
 
 		// If needed, add "Regular Members" on the end.

--- a/Sources/Group.php
+++ b/Sources/Group.php
@@ -1017,20 +1017,24 @@ class Group implements \ArrayAccess
 		// new additional group.
 		$set_primary = [];
 		$set_additional = [];
+		$member_ids = [];
 
+		/** @var \SMF\User $member */
 		foreach ($members as $key => $member) {
+			$member_ids = $member->id;
+
 			// Forcing primary.
 			if ($type === 'force_primary') {
-				if (User::$loaded[$member]->group_id !== $this->id) {
+				if (User::$loaded[$member->id]->group_id !== $this->id) {
 					$set_primary[] = $member;
 				}
 			}
 			// They're already in this group.
-			elseif (in_array($this->id, User::$loaded[$member]->groups)) {
+			elseif (in_array($this->id, User::$loaded[$member->id]->groups)) {
 				continue;
 			}
 			// They have a different primary group.
-			elseif (User::$loaded[$member]->group_id !== self::REGULAR) {
+			elseif (User::$loaded[$member->id]->group_id !== self::REGULAR) {
 				// Skip if we only want to set their primary group.
 				if ($type === 'only_primary') {
 					continue;
@@ -1064,15 +1068,16 @@ class Group implements \ArrayAccess
 
 			$to_set = [];
 
+			/** @var \SMF\User $member */
 			foreach ($set_primary as $member) {
-				$new_additional_groups = array_diff(User::$loaded[$member]->groups, [$this->id, User::$loaded[$member]->post_group_id]);
+				$new_additional_groups = array_diff(User::$loaded[$member->id]->groups, [$this->id, User::$loaded[$member->id]->post_group_id]);
 				sort($new_additional_groups);
 
 				$to_set[implode(',', $new_additional_groups)][] = $member->id;
 			}
 
-			foreach ($to_set as $new_additional_groups => $member_ids) {
-				User::updateMemberData($member_ids, [
+			foreach ($to_set as $new_additional_groups => $mems) {
+				User::updateMemberData($mems, [
 					'id_group' => $this->id,
 					'additional_groups' => $new_additional_groups,
 				]);
@@ -1088,39 +1093,44 @@ class Group implements \ArrayAccess
 		Config::updateModSettings(['settings_updated' => time()]);
 
 		if (!empty($set_primary)) {
-			User::updateMemberData($set_primary, ['id_group' => $this->id]);
+			$primarys = array_map(function (\SMF\User $member) {
+				return $member->id;
+			}, $set_primary);
+			User::updateMemberData($primarys, ['id_group' => $this->id]);
 		}
 
 		if (!empty($set_additional)) {
 			$to_set = [];
 
+			/** @var \SMF\User $member */
 			foreach ($set_additional as $member) {
-				$new_additional_groups = array_unique(array_merge(User::$loaded[$member]->additional_groups, [$this->id]));
+				$new_additional_groups = array_unique(array_merge(User::$loaded[$member->id]->additional_groups, [$this->id]));
 				sort($new_additional_groups);
 
 				$to_set[implode(',', $new_additional_groups)][] = $member->id;
 			}
 
-			foreach ($to_set as $new_additional_groups => $member_ids) {
-				User::updateMemberData($member_ids, ['additional_groups' => $new_additional_groups]);
+			foreach ($to_set as $new_additional_groups => $mems) {
+				User::updateMemberData($mems, ['additional_groups' => $new_additional_groups]);
 			}
 		}
 
 		// For historical reasons, the hook expects an array rather than just the name string.
 		$group_names = [$this->id => $this->name];
 
-		IntegrationHook::call('integrate_add_members_to_group', [$members, $this->id, &$group_names]);
+		IntegrationHook::call('integrate_add_members_to_group', [$member_ids, $this->id, &$group_names]);
 
 		// Update their postgroup statistics.
-		Logging::updateStats('postgroups', $members);
+		Logging::updateStats('postgroups', $member_ids);
 
 		// Log the data.
+		/** @var \SMF\User $member */
 		foreach ($members as $member) {
 			Logging::logAction(
 				'added_to_group',
 				[
 					'group' => $this->name,
-					'member' => $member,
+					'member' => $member->id,
 				],
 				'admin',
 			);
@@ -1646,9 +1656,9 @@ class Group implements \ArrayAccess
 
 			if (isset(self::$loaded[$row['id_group']])) {
 				self::$loaded[$row['id_group']]->set($row);
-				$loaded[] = self::$loaded[$row['id_group']];
+				$loaded[$row['id_group']] = self::$loaded[$row['id_group']];
 			} else {
-				$loaded[] = new self($row['id_group'], $row);
+				$loaded[$row['id_group']] = new self($row['id_group'], $row);
 			}
 		}
 
@@ -1757,7 +1767,8 @@ class Group implements \ArrayAccess
 			],
 		];
 
-		$loaded = array_merge($loaded, self::load([], $query_customizations));
+		// Do not use array merge here, does not maintain key association.
+		$loaded += self::load([], $query_customizations);
 
 		// Return the instances we just loaded.
 		return $loaded;

--- a/Sources/Group.php
+++ b/Sources/Group.php
@@ -1203,6 +1203,9 @@ class Group implements \ArrayAccess
 
 		// Load the user info for the members being removed.
 		$members = User::load($members, User::LOAD_BY_ID, 'minimal');
+		$members = array_map(function (\SMF\User $mem){
+			return $mem->id;
+		}, $members);
 
 		// Figure out which members should have their primary group changed and
 		// which should have their additional groups changed.

--- a/Sources/Group.php
+++ b/Sources/Group.php
@@ -1076,8 +1076,8 @@ class Group implements \ArrayAccess
 				$to_set[implode(',', $new_additional_groups)][] = $member->id;
 			}
 
-			foreach ($to_set as $new_additional_groups => $mems) {
-				User::updateMemberData($mems, [
+			foreach ($to_set as $new_additional_groups => $member_ids) {
+				User::updateMemberData($member_ids, [
 					'id_group' => $this->id,
 					'additional_groups' => $new_additional_groups,
 				]);

--- a/Sources/Profile.php
+++ b/Sources/Profile.php
@@ -1381,18 +1381,18 @@ class Profile extends User implements \ArrayAccess
 		}
 
 		// For the templates.
-		Utils::$context['member_groups'] = array_merge(
-			[
-				0 => [
-					'id' => 0,
-					'name' => Lang::$txt['no_primary_membergroup'],
-					'is_primary' => $this->data['id_group'] == 0,
-					'can_be_additional' => false,
-					'can_be_primary' => true,
-				],
+		Utils::$context['member_groups'] = [
+			0 => [
+				'id' => 0,
+				'name' => Lang::$txt['no_primary_membergroup'],
+				'is_primary' => $this->data['id_group'] == 0,
+				'can_be_additional' => false,
+				'can_be_primary' => true,
 			],
-			$this->assignable_groups,
-		);
+		];
+	
+		// Do not use array merge here, does not maintain key association.
+		Utils::$context['member_groups'] += $this->assignable_groups;
 
 		return true;
 	}


### PR DESCRIPTION
Fixes #7949
Fixes #7950

@Oldiesmann Please test this
@Sesquipedalian I don't like how the fix turned out, but I didn't see a better fix.

The major issue stems from a concept in Sources\Group.php, the `load()`.
In various places in our group logic, we assumed `load()` would return
- An array of IDs for the group
- The keys would be the group ID
- That when calling load with only one ID, we could do a list to pop off the first group.

Neither case was true.  We returned an array of objects of SMF\Group.  The key was not the group ID, but the next ID, which makes list() work, but breaks other logic.
Some of the logic in `load()` assumed that `$loaded[$id_group]`, yet then assigned it to the array with `[]`.  Only lines apart. 
I aligned it with how SMF\User does it just for uniformity.  But because of this change, it could have far-reaching effects.

The second major issue was that when you do array_merge, you lose key associations.  So I had to use `+=` logic. This means that if any of the same keys exist on both sides, the right side of the logic is lost.

A third issue was that the `addMembers` logic was silently failing and SMF just happily assumed it worked.  I added a check but didn't add a better error message right now.  If we need one, we can.

A fourth issue is that we assumed `Db::$db->fetch_all()` would return an array of the ids in such fashion `[1,2,3,5]`, when in fact it returned them as `[0 => ['id_group' = 1], 1 => ['id_group' = 2']....]`.  A simple array map fixes this.

In many places, because we assumed that `load()` is returning IDs, not objects, we incorrectly assumed we could just use it like that.  However, that is causing the issues.  I added hints that should help most IDEs recognize that we are working with an object, not an int/array.

