### PR TITLE
Fix error when logging out with TFA enabled

### DIFF
--- a/Sources/Actions/Logout.php
+++ b/Sources/Actions/Logout.php
@@ -124,7 +124,7 @@ class Logout extends Login2
 		if (!empty(Config::$modSettings['tfa_mode']) && !empty(User::$me->id) && !empty($_COOKIE[Config::$cookiename . '_tfa'])) {
 			list(, , $exp) = Utils::jsonDecode($_COOKIE[Config::$cookiename . '_tfa'], true);
 
-			Cookie::setTFACookie((int) $exp - time(), $salt, Cookie::encrypt(User::$me->tfa_backup, $salt));
+			Cookie::setTFACookie((int) $exp - time(), User::$me->id, Cookie::encrypt(User::$me->tfa_backup, $salt));
 		}
 
 		session_destroy();


### PR DESCRIPTION
#### Description
This fixes an error when logging out with TFA enabled. The code is passing the password salt as the member ID rather than the actual member ID, which causes an error since the code is expecting an int rather than a string.