### PR TITLE
[3.0] Various Fixes

### DIFF
--- a/Sources/Actions/Feed.php
+++ b/Sources/Actions/Feed.php
@@ -1761,12 +1761,12 @@ class Feed implements ActionInterface
 				[
 					'tag' => 'last-login',
 					'attributes' => ['label' => Lang::$txt['lastLoggedIn'], 'UTC' => Time::gmstrftime('%F %T', $profile['last_login_timestamp'])],
-					'content' => Time::create('@' . User::$me->last_login_timestamp, new \DateTimeZone(Config::$modSettings['default_timezone']))->format(null, false),
+					'content' => Time::create('@' . $profile['last_login_timestamp'], new \DateTimeZone(Config::$modSettings['default_timezone']))->format(null, false),
 				],
 				[
 					'tag' => 'registered',
 					'attributes' => ['label' => Lang::$txt['date_registered'], 'UTC' => Time::gmstrftime('%F %T', $profile['registered_timestamp'])],
-					'content' => Time::create('@' . User::$me->last_login_timestamp, new \DateTimeZone(Config::$modSettings['default_timezone']))->format(null, false),
+					'content' => Time::create('@' . $profile['registered_timestamp'], new \DateTimeZone(Config::$modSettings['default_timezone']))->format(null, false),
 				],
 				[
 					'tag' => 'avatar',

--- a/Sources/Actions/Feed.php
+++ b/Sources/Actions/Feed.php
@@ -1761,12 +1761,12 @@ class Feed implements ActionInterface
 				[
 					'tag' => 'last-login',
 					'attributes' => ['label' => Lang::$txt['lastLoggedIn'], 'UTC' => Time::gmstrftime('%F %T', $profile['last_login_timestamp'])],
-					'content' => Time::create('@' . $row['last_login_timestamp'], new \DateTimeZone(Config::$modSettings['default_timezone']))->format(null, false),
+					'content' => Time::create('@' . User::$me->last_login_timestamp, new \DateTimeZone(Config::$modSettings['default_timezone']))->format(null, false),
 				],
 				[
 					'tag' => 'registered',
 					'attributes' => ['label' => Lang::$txt['date_registered'], 'UTC' => Time::gmstrftime('%F %T', $profile['registered_timestamp'])],
-					'content' => Time::create('@' . $row['registered_timestamp'], new \DateTimeZone(Config::$modSettings['default_timezone']))->format(null, false),
+					'content' => Time::create('@' . User::$me->last_login_timestamp, new \DateTimeZone(Config::$modSettings['default_timezone']))->format(null, false),
 				],
 				[
 					'tag' => 'avatar',

--- a/Sources/Alert.php
+++ b/Sources/Alert.php
@@ -647,7 +647,7 @@ class Alert implements \ArrayAccess
 
 		foreach ($members as $memID) {
 			foreach (['checkMsgAccess' => 'possible_msgs', 'checkTopicAccess' => 'possible_topics'] as $method => $variable) {
-				$visibility = self::$method(${$variable}[$memID] ?? [], $memID, true);
+				$visibility = self::$method(${$variable}[$memID] ?? [], (int) $memID, true);
 
 				if (!empty($visibility)) {
 					foreach ($props_batch as &$props) {
@@ -672,8 +672,8 @@ class Alert implements \ArrayAccess
 			$inserts[$alert->id] = [
 				$alert->timestamp,
 				$alert->member,
-				$alert->member_started,
-				$alert->member_name,
+				isset($alert->member_started) ? $alert->member_started : 0,
+				isset($alert->member_name) ? $alert->member_name : '',
 				$alert->content_type,
 				$alert->content_id,
 				$alert->content_action,

--- a/Sources/PackageManager/XmlArray.php
+++ b/Sources/PackageManager/XmlArray.php
@@ -229,6 +229,11 @@ class XmlArray
 				$lvl = null;
 			}
 
+			// Nothing found, nothing exists.
+			if (empty($array)) {
+				return false;
+			}
+
 			// Find this element.
 			$array = $this->_path($array, $el, $lvl, true);
 		}

--- a/Sources/Tasks/ExportProfileData.php
+++ b/Sources/Tasks/ExportProfileData.php
@@ -1902,7 +1902,7 @@ class ExportProfileData extends BackgroundTask
 	/**
 	 * Adjusts some parse_bbc() parameters for the special case of XML exports.
 	 */
-	public static function pre_parsebbc_xml(string &$message, array &$smileys, string &$cache_id, array &$parse_tags, array &$cache_key_extras): void
+	public static function pre_parsebbc_xml(string &$message, bool &$smileys, string &$cache_id, array &$parse_tags, array &$cache_key_extras): void
 	{
 		$cache_id = '';
 

--- a/Sources/Tasks/ExportProfileData.php
+++ b/Sources/Tasks/ExportProfileData.php
@@ -886,7 +886,7 @@ class ExportProfileData extends BackgroundTask
 		// Avoid leaving files in an inconsistent state.
 		ignore_user_abort(true);
 
-		$this->time_limit = (ini_get('safe_mode') === false && @set_time_limit(Taskrunner::MAX_CLAIM_THRESHOLD) !== false) ? Taskrunner::MAX_CLAIM_THRESHOLD : ini_get('max_execution_time');
+		$this->time_limit = (int) ((ini_get('safe_mode') === false && @set_time_limit(Taskrunner::MAX_CLAIM_THRESHOLD) !== false) ? Taskrunner::MAX_CLAIM_THRESHOLD : ini_get('max_execution_time'));
 
 		// This could happen if the user manually changed the URL params of the export request.
 		if ($this->_details['format'] == 'HTML' && (!class_exists('DOMDocument') || !class_exists('XSLTProcessor'))) {
@@ -976,7 +976,7 @@ class ExportProfileData extends BackgroundTask
 		$feed = new Feed($datatype, $uid);
 		$feed->format = 'smf';
 		$feed->ascending = true;
-		$feed->limit = !empty(Config::$modSettings['export_rate']) ? Config::$modSettings['export_rate'] : 250;
+		$feed->limit = !empty(Config::$modSettings['export_rate']) ? (int) Config::$modSettings['export_rate'] : 250;
 		$feed->start_after = $start[$datatype];
 
 		Theme::loadEssential();
@@ -996,7 +996,7 @@ class ExportProfileData extends BackgroundTask
 
 		$export_dir_slash = Config::$modSettings['export_dir'] . DIRECTORY_SEPARATOR;
 
-		$idhash = hash_hmac('sha1', $uid, Config::getAuthSecret());
+		$idhash = hash_hmac('sha1', (string) $uid, Config::getAuthSecret());
 		$idhash_ext = $idhash . '.' . $this->_details['format_settings']['extension'];
 
 		// Increment the file number until we reach one that doesn't exist.
@@ -1361,7 +1361,7 @@ class ExportProfileData extends BackgroundTask
 
 		// Find any completed files that don't yet have the stylesheet embedded in them.
 		$export_dir_slash = Config::$modSettings['export_dir'] . DIRECTORY_SEPARATOR;
-		$idhash = hash_hmac('sha1', $this->_details['uid'], Config::getAuthSecret());
+		$idhash = hash_hmac('sha1', (string) $this->_details['uid'], Config::getAuthSecret());
 		$idhash_ext = $idhash . '.' . $this->_details['format_settings']['extension'];
 
 		$test_length = strlen($this->stylesheet . Utils::$context['feed']['footer']);
@@ -1503,7 +1503,7 @@ class ExportProfileData extends BackgroundTask
 			// Let mods adjust the XSLT variables.
 			IntegrationHook::call('integrate_export_xslt_variables', [&$xslt_variables, $this->_details['format']]);
 
-			$idhash = hash_hmac('sha1', $this->_details['uid'], Config::getAuthSecret());
+			$idhash = hash_hmac('sha1', (string) $this->_details['uid'], Config::getAuthSecret());
 			$xslt_variables['dltoken'] = [
 				'value' => hash_hmac('sha1', $idhash, Config::getAuthSecret()),
 			];
@@ -1531,7 +1531,7 @@ class ExportProfileData extends BackgroundTask
 				if (isset($var['xpath'])) {
 					$this->xslt_stylesheet['variables'] .= ' select="' . $var['value'] . '"/>';
 				} else {
-					$this->xslt_stylesheet['variables'] .= '>' . (!empty($var['no_cdata_parse']) ? $var['value'] : Feed::cdataParse($var['value'])) . '</xsl:' . $element . '>';
+					$this->xslt_stylesheet['variables'] .= '>' . (!empty($var['no_cdata_parse']) ? $var['value'] : Feed::cdataParse((string) $var['value'])) . '</xsl:' . $element . '>';
 				}
 			}
 
@@ -1883,7 +1883,7 @@ class ExportProfileData extends BackgroundTask
 	 * Adjusts some parse_bbc() parameters for the special case of HTML and
 	 * XML_XSLT exports.
 	 */
-	public static function pre_parsebbc_html(string &$message, array &$smileys, string &$cache_id, array &$parse_tags, array &$cache_key_extras): void
+	public static function pre_parsebbc_html(string &$message, bool &$smileys, string &$cache_id, array &$parse_tags, array &$cache_key_extras): void
 	{
 		$cache_id = '';
 
@@ -1922,7 +1922,7 @@ class ExportProfileData extends BackgroundTask
 	/**
 	 * Reverses changes made by pre_parsebbc()
 	 */
-	public static function post_parsebbc(string &$message, array &$smileys, string &$cache_id, array &$parse_tags): void
+	public static function post_parsebbc(string &$message, bool &$smileys, string &$cache_id, array &$parse_tags): void
 	{
 		foreach (['disabledBBC', 'smileys_url', 'attachmentThumbnails'] as $var) {
 			if (isset(self::$real_modSettings[$var])) {
@@ -1934,7 +1934,7 @@ class ExportProfileData extends BackgroundTask
 	/**
 	 * Adjusts certain BBCodes for the special case of exports.
 	 */
-	public static function bbc_codes(array &$codes, bool &$no_autolink_tags): void
+	public static function bbc_codes(array &$codes, array &$no_autolink_tags): void
 	{
 		foreach ($codes as &$code) {
 			// To make the "Select" link work we'd need to embed a bunch more JS. Not worth it.

--- a/Sources/User.php
+++ b/Sources/User.php
@@ -3009,7 +3009,7 @@ class User implements \ArrayAccess
 					$val = 'CASE ';
 
 					foreach ($members as $k => $v) {
-						$val .= 'WHEN id_member = ' . $v . ' THEN ' . Alert::count($v, true) . ' ';
+						$val .= 'WHEN id_member = ' . $v . ' THEN ' . Alert::count((int) $v, true) . ' ';
 					}
 
 					$val = $val . ' END';


### PR DESCRIPTION
- Fix XmlArray to return false when we get an empty string for $action in `exist` method.  Fixes #8014
- Various errors were discovered running the export profile.  Fixes #8013 
- Alert needs to check `member_started` and member_name are initialized before usage.
- Various casting errors
- Actions/Feed. was using `$row` instead of `$profile` logic.