### PR TITLE
Properly fix undefined index errors on action=logintfa

### DIFF
--- a/Sources/User.php
+++ b/Sources/User.php
@@ -4612,7 +4612,7 @@ class User implements \ArrayAccess
 
 			self::$loaded[$id] = $this;
 
-			if (!empty(self::$profiles[$id]) || self::$dataset_levels[self::$profiles[$id]['dataset']] < self::$dataset_levels[$dataset ?? 'normal']) {
+			if (empty(self::$profiles[$id]) || self::$dataset_levels[self::$profiles[$id]['dataset']] < self::$dataset_levels[$dataset ?? 'normal']) {
 				self::loadUserData((array) $id, self::LOAD_BY_ID, $dataset ?? 'normal');
 			}
 


### PR DESCRIPTION
#### Description
My initial fix for the "undefined index" errors on the TFA lgoin screen in #8001 ignored the fact that we're using || instead of &&, so it didn't actually fix the issue - we're still checking for `self::$profiles[$id]['dataset']` even if `self::$profiles[$id]` is empty (set but an empty array). Using empty()  instead of !empty() fixes the logic.

Properly fixes #7983 this time.