### PR TITLE
[3.0] Remove tasksdir configuration option

### DIFF
--- a/Sources/Config.php
+++ b/Sources/Config.php
@@ -792,7 +792,7 @@ class Config
 				if (!is_dir(realpath($languagesdir)) && is_dir($boarddir . '/Languages'))
 					$languagesdir = $boarddir . '/Languages';
 				END,
-			'search_pattern' => '~\n?(#[^\n]+)?(?:\n\h*if\s*\((?:\!file_exists\(\$(?' . '>boarddir|sourcedir|packagesdir|cachedir|languagesdir)\)|\!is_dir\(realpath\(\$(?' . '>boarddir|sourcedir|packagesdir|cachedir|languagesdir)\)\))[^;]+\n\h*\$(?' . '>boarddir|sourcedir|packagesdir|cachedir|languagesdir)[^\n]+;)+~sm',
+			'search_pattern' => '~\n?(#[^\n]+)?(?:\n\h*if\s*\((?:\!file_exists\(\$(?' . '>boarddir|sourcedir|tasksdir|packagesdir|cachedir|languagesdir)\)|\!is_dir\(realpath\(\$(?' . '>boarddir|sourcedir|tasksdir|packagesdir|cachedir|languagesdir)\)\))[^;]+\n\h*\$(?' . '>boarddir|sourcedir|tasksdir|packagesdir|cachedir|languagesdir)[^\n]+;)+~sm',
 		],
 		'db_character_set' => [
 			'text' => <<<'END'

--- a/Sources/Config.php
+++ b/Sources/Config.php
@@ -777,18 +777,6 @@ class Config
 			'raw_default' => true,
 			'type' => 'string',
 		],
-		'tasksdir' => [
-			'text' => <<<'END'
-				/**
-				 * @var string
-				 *
-				 * Path to the tasks directory.
-				 */
-				END,
-			'default' => '$sourcedir . \'/Tasks\'',
-			'raw_default' => true,
-			'type' => 'string',
-		],
 		[
 			'text' => <<<'END'
 
@@ -797,8 +785,6 @@ class Config
 					$boarddir = dirname(__FILE__);
 				if (!is_dir(realpath($sourcedir)) && is_dir($boarddir . '/Sources'))
 					$sourcedir = $boarddir . '/Sources';
-				if (!is_dir(realpath($tasksdir)) && is_dir($sourcedir . '/Tasks'))
-					$tasksdir = $sourcedir . '/Tasks';
 				if (!is_dir(realpath($packagesdir)) && is_dir($boarddir . '/Packages'))
 					$packagesdir = $boarddir . '/Packages';
 				if (!is_dir(realpath($cachedir)) && is_dir($boarddir . '/cache'))
@@ -806,7 +792,7 @@ class Config
 				if (!is_dir(realpath($languagesdir)) && is_dir($boarddir . '/Languages'))
 					$languagesdir = $boarddir . '/Languages';
 				END,
-			'search_pattern' => '~\n?(#[^\n]+)?(?:\n\h*if\s*\((?:\!file_exists\(\$(?' . '>boarddir|sourcedir|tasksdir|packagesdir|cachedir|languagesdir)\)|\!is_dir\(realpath\(\$(?' . '>boarddir|sourcedir|tasksdir|packagesdir|cachedir|languagesdir)\)\))[^;]+\n\h*\$(?' . '>boarddir|sourcedir|tasksdir|packagesdir|cachedir|languagesdir)[^\n]+;)+~sm',
+			'search_pattern' => '~\n?(#[^\n]+)?(?:\n\h*if\s*\((?:\!file_exists\(\$(?' . '>boarddir|sourcedir|packagesdir|cachedir|languagesdir)\)|\!is_dir\(realpath\(\$(?' . '>boarddir|sourcedir|packagesdir|cachedir|languagesdir)\)\))[^;]+\n\h*\$(?' . '>boarddir|sourcedir|packagesdir|cachedir|languagesdir)[^\n]+;)+~sm',
 		],
 		'db_character_set' => [
 			'text' => <<<'END'
@@ -950,7 +936,7 @@ class Config
 		}
 
 		// Ensure there are no trailing slashes in these settings.
-		foreach (['boardurl', 'boarddir', 'sourcedir', 'packagesdir', 'tasksdir', 'cachedir', 'languagesdir'] as $var) {
+		foreach (['boardurl', 'boarddir', 'sourcedir', 'packagesdir', 'cachedir', 'languagesdir'] as $var) {
 			if (!is_null(self::${$var})) {
 				self::${$var} = rtrim(self::${$var}, '\\/');
 			}
@@ -966,9 +952,8 @@ class Config
 			self::$sourcedir = self::$boarddir . '/Sources';
 		}
 
-		if ((empty(self::$tasksdir) || !is_dir(realpath(self::$tasksdir))) && is_dir(self::$sourcedir . '/Tasks')) {
-			self::$tasksdir = self::$sourcedir . '/Tasks';
-		}
+		// As of 3.0, this is no longer changeable.
+		self::$tasksdir = self::$sourcedir . '/Tasks';
 
 		if ((empty(self::$packagesdir) || !is_dir(realpath(self::$packagesdir))) && is_dir(self::$boarddir . '/Packages')) {
 			self::$packagesdir = self::$boarddir . '/Packages';

--- a/Sources/Config.php
+++ b/Sources/Config.php
@@ -1406,6 +1406,11 @@ class Config
 	{
 		static $mtime;
 
+		// A list of settings from earlier versions of SMF that should be deleted if found.
+		$obsolete_settings = [
+			'tasksdir' => 'string',
+		];
+
 		// Should we try to unescape the strings?
 		if (empty($keep_quotes)) {
 			foreach ($config_vars as $var => $val) {
@@ -1508,6 +1513,11 @@ class Config
 			}
 		}
 
+		// Remove obsolete settings from earlier versions of SMF.
+		foreach ($obsolete_settings as $obs => $type) {
+			unset($new_settings_vars[$obs], $settings_vars[$obs], $config_vars[$obs]);
+		}
+
 		/*******************************
 		 * PART 2: Build substitutions *
 		 *******************************/
@@ -1569,6 +1579,14 @@ class Config
 				'placeholder' => '',
 			],
 		];
+
+		// Remove obsolete settings from earlier versions of SMF.
+		foreach ($obsolete_settings as $obs => $type) {
+			$substitutions[$neg_index--] = [
+				'search_pattern' => '~(/\*\*\h*\n(\h*\*[^\n]*\n)*\h*\*/|(//[^\n]*\n)*)\s*\$' . preg_quote($obs) . '\s*=\s*(' . $type_regex[$type] . ');\n?~',
+				'placeholder' => '',
+			];
+		}
 
 		if (defined('SMF_INSTALLING')) {
 			$substitutions[$neg_index--] = [

--- a/other/Settings.php
+++ b/other/Settings.php
@@ -221,20 +221,12 @@ $packagesdir = dirname(__FILE__) . '/Packages';
  * Path to the language directory.
  */
 $languagesdir = dirname(__FILE__) . '/Languages';
-/**
- * @var string
- *
- * Path to the tasks directory.
- */
-$tasksdir = $sourcedir . '/Tasks';
 
 # Make sure the paths are correct... at least try to fix them.
 if (!is_dir(realpath($boarddir)) && file_exists(dirname(__FILE__) . '/SSI.php'))
 	$boarddir = dirname(__FILE__);
 if (!is_dir(realpath($sourcedir)) && is_dir($boarddir . '/Sources'))
 	$sourcedir = $boarddir . '/Sources';
-if (!is_dir(realpath($tasksdir)) && is_dir($sourcedir . '/Tasks'))
-	$tasksdir = $sourcedir . '/Tasks';
 if (!is_dir(realpath($packagesdir)) && is_dir($boarddir . '/Packages'))
 	$packagesdir = $boarddir . '/Packages';
 if (!is_dir(realpath($cachedir)) && is_dir($boarddir . '/cache'))

--- a/other/Settings_bak.php
+++ b/other/Settings_bak.php
@@ -221,20 +221,12 @@ $packagesdir = dirname(__FILE__) . '/Packages';
  * Path to the language directory.
  */
 $languagesdir = dirname(__FILE__) . '/Languages';
-/**
- * @var string
- *
- * Path to the tasks directory.
- */
-$tasksdir = $sourcedir . '/Tasks';
 
 # Make sure the paths are correct... at least try to fix them.
 if (!is_dir(realpath($boarddir)) && file_exists(dirname(__FILE__) . '/SSI.php'))
 	$boarddir = dirname(__FILE__);
 if (!is_dir(realpath($sourcedir)) && is_dir($boarddir . '/Sources'))
 	$sourcedir = $boarddir . '/Sources';
-if (!is_dir(realpath($tasksdir)) && is_dir($sourcedir . '/Tasks'))
-	$tasksdir = $sourcedir . '/Tasks';
 if (!is_dir(realpath($packagesdir)) && is_dir($boarddir . '/Packages'))
 	$packagesdir = $boarddir . '/Packages';
 if (!is_dir(realpath($cachedir)) && is_dir($boarddir . '/cache'))

--- a/other/install.php
+++ b/other/install.php
@@ -1096,7 +1096,6 @@ function ForumSettings()
 			'cachedir' => $path . '/cache',
 			'packagesdir' => $path . '/Packages',
 			'languagesdir' => $path . '/Languages',
-			'tasksdir' => $path . '/Sources/Tasks',
 			'mbname' => strtr($_POST['mbname'], ['\"' => '"']),
 			'language' => substr($_SESSION['installer_temp_lang'], 8, -4),
 			'image_proxy_secret' => bin2hex(random_bytes(10)),

--- a/other/upgrade.php
+++ b/other/upgrade.php
@@ -1958,6 +1958,36 @@ function DeleteUpgrade()
 		'upgradeData' => null,
 	];
 
+	// Fix case of Tasks directory.
+	if (
+		is_dir(Config::$tasksdir)
+		&& basename(Config::$tasksdir) !== 'Tasks'
+		&& is_writable(Config::$tasksdir)
+		&& is_writable(dirname(Config::$tasksdir))
+	) {
+		// Do 'tasks' and 'Tasks' both exist?
+		if (
+			!empty(fileinode(realpath(dirname(Config::$tasksdir) . '/tasks')))
+			&& !empty(fileinode(realpath(dirname(Config::$tasksdir) . '/Tasks')))
+			&& fileinode(realpath(Config::$tasksdir)) !== fileinode(realpath(dirname(Config::$tasksdir) . '/Tasks'))
+		) {
+			// Move everything in 'Tasks' to 'tasks'.
+			foreach (glob(realpath(dirname(Config::$tasksdir) . '/Tasks') . DIRECTORY_SEPARATOR . '*') as $path) {
+				rename($path, realpath(Config::$tasksdir) . DIRECTORY_SEPARATOR . basename($path));
+			}
+
+			// Now delete 'Tasks'.
+			rmdir(realpath(dirname(Config::$tasksdir) . '/Tasks'));
+		}
+
+		// Rename 'tasks' to 'Tasks'.
+		// Do this in two steps to make sure it works on case insensitive file systems.
+		rename(Config::$tasksdir, dirname(Config::$tasksdir) . DIRECTORY_SEPARATOR . 'Tasks_temp');
+		rename(dirname(Config::$tasksdir) . DIRECTORY_SEPARATOR . 'Tasks_temp', dirname(Config::$tasksdir) . DIRECTORY_SEPARATOR . 'Tasks');
+
+		$changes['tasksdir'] = dirname(Config::$tasksdir) . '/Tasks';
+	}
+
 	// Are we in maintenance mode?
 	if (isset($upcontext['user']['main'])) {
 		if ($command_line) {

--- a/other/upgrade.php
+++ b/other/upgrade.php
@@ -1958,34 +1958,36 @@ function DeleteUpgrade()
 		'upgradeData' => null,
 	];
 
+	clearstatcache();
+	$current_settings = Config::getCurrentSettings(filemtime(SMF_SETTINGS_FILE));
+
 	// Fix case of Tasks directory.
 	if (
-		is_dir(Config::$tasksdir)
-		&& basename(Config::$tasksdir) !== 'Tasks'
-		&& is_writable(Config::$tasksdir)
-		&& is_writable(dirname(Config::$tasksdir))
+		isset($current_settings['tasksdir'])
+		&& is_dir($current_settings['tasksdir'])
+		&& basename($current_settings['tasksdir']) !== 'Tasks'
+		&& is_writable($current_settings['tasksdir'])
+		&& is_writable(dirname($current_settings['tasksdir']))
 	) {
 		// Do 'tasks' and 'Tasks' both exist?
 		if (
-			!empty(fileinode(realpath(dirname(Config::$tasksdir) . '/tasks')))
-			&& !empty(fileinode(realpath(dirname(Config::$tasksdir) . '/Tasks')))
-			&& fileinode(realpath(Config::$tasksdir)) !== fileinode(realpath(dirname(Config::$tasksdir) . '/Tasks'))
+			!empty(fileinode(realpath(dirname($current_settings['tasksdir']) . '/tasks')))
+			&& !empty(fileinode(realpath(dirname($current_settings['tasksdir']) . '/Tasks')))
+			&& fileinode(realpath($current_settings['tasksdir'])) !== fileinode(realpath(dirname($current_settings['tasksdir']) . '/Tasks'))
 		) {
 			// Move everything in 'Tasks' to 'tasks'.
-			foreach (glob(realpath(dirname(Config::$tasksdir) . '/Tasks') . DIRECTORY_SEPARATOR . '*') as $path) {
-				rename($path, realpath(Config::$tasksdir) . DIRECTORY_SEPARATOR . basename($path));
+			foreach (glob(realpath(dirname($current_settings['tasksdir']) . '/Tasks') . DIRECTORY_SEPARATOR . '*') as $path) {
+				rename($path, realpath($current_settings['tasksdir']) . DIRECTORY_SEPARATOR . basename($path));
 			}
 
 			// Now delete 'Tasks'.
-			rmdir(realpath(dirname(Config::$tasksdir) . '/Tasks'));
+			rmdir(realpath(dirname($current_settings['tasksdir']) . '/Tasks'));
 		}
 
 		// Rename 'tasks' to 'Tasks'.
 		// Do this in two steps to make sure it works on case insensitive file systems.
-		rename(Config::$tasksdir, dirname(Config::$tasksdir) . DIRECTORY_SEPARATOR . 'Tasks_temp');
-		rename(dirname(Config::$tasksdir) . DIRECTORY_SEPARATOR . 'Tasks_temp', dirname(Config::$tasksdir) . DIRECTORY_SEPARATOR . 'Tasks');
-
-		$changes['tasksdir'] = dirname(Config::$tasksdir) . '/Tasks';
+		rename($current_settings['tasksdir'], dirname($current_settings['tasksdir']) . DIRECTORY_SEPARATOR . 'Tasks_temp');
+		rename(dirname($current_settings['tasksdir']) . DIRECTORY_SEPARATOR . 'Tasks_temp', dirname($current_settings['tasksdir']) . DIRECTORY_SEPARATOR . 'Tasks');
 	}
 
 	// Are we in maintenance mode?

--- a/other/upgrade.php
+++ b/other/upgrade.php
@@ -1623,11 +1623,6 @@ function UpgradeOptions()
 		$changes['languagesdir'] = fixRelativePath(Config::$boarddir) . '/Languages';
 	}
 
-	// Add support for $tasksdir var.
-	if (empty(Config::$tasksdir)) {
-		$changes['tasksdir'] = fixRelativePath(Config::$sourcedir) . '/Tasks';
-	}
-
 	// Make sure we fix the language as well.
 	if (stristr(Config::$language, '-utf8')) {
 		$changes['language'] = str_ireplace('-utf8', '', Config::$language);
@@ -1962,36 +1957,6 @@ function DeleteUpgrade()
 		'db_error_send' => true,
 		'upgradeData' => null,
 	];
-
-	// Fix case of Tasks directory.
-	if (
-		is_dir(Config::$tasksdir)
-		&& basename(Config::$tasksdir) !== 'Tasks'
-		&& is_writable(Config::$tasksdir)
-		&& is_writable(dirname(Config::$tasksdir))
-	) {
-		// Do 'tasks' and 'Tasks' both exist?
-		if (
-			!empty(fileinode(realpath(dirname(Config::$tasksdir) . '/tasks')))
-			&& !empty(fileinode(realpath(dirname(Config::$tasksdir) . '/Tasks')))
-			&& fileinode(realpath(Config::$tasksdir)) !== fileinode(realpath(dirname(Config::$tasksdir) . '/Tasks'))
-		) {
-			// Move everything in 'Tasks' to 'tasks'.
-			foreach (glob(realpath(dirname(Config::$tasksdir) . '/Tasks') . DIRECTORY_SEPARATOR . '*') as $path) {
-				rename($path, realpath(Config::$tasksdir) . DIRECTORY_SEPARATOR . basename($path));
-			}
-
-			// Now delete 'Tasks'.
-			rmdir(realpath(dirname(Config::$tasksdir) . '/Tasks'));
-		}
-
-		// Rename 'tasks' to 'Tasks'.
-		// Do this in two steps to make sure it works on case insensitive file systems.
-		rename(Config::$tasksdir, dirname(Config::$tasksdir) . DIRECTORY_SEPARATOR . 'Tasks_temp');
-		rename(dirname(Config::$tasksdir) . DIRECTORY_SEPARATOR . 'Tasks_temp', dirname(Config::$tasksdir) . DIRECTORY_SEPARATOR . 'Tasks');
-
-		$changes['tasksdir'] = dirname(Config::$tasksdir) . '/Tasks';
-	}
 
 	// Are we in maintenance mode?
 	if (isset($upcontext['user']['main'])) {


### PR DESCRIPTION
We no longer need this nor should we have it.  All other sub directories in Sources do not have their own option to move the Tasks directory, so it doesn't make sene to allow this