### PR TITLE
Update GitHub Actions

### DIFF
--- a/.github/workflows/crowdin_wf.yml
+++ b/.github/workflows/crowdin_wf.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Checkout
       # This prevents all the forks from attempting to run the interface...
       if: env.CROWDIN_API_TOKEN != null
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: crowdin-action
       # This prevents all the forks from attempting to run the interface...

--- a/.github/workflows/crowdin_wf_next.yml
+++ b/.github/workflows/crowdin_wf_next.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Checkout
       # This prevents all the forks from attempting to run the interface...
       if: env.CROWDIN_API_TOKEN != null
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: crowdin-action
       # This prevents all the forks from attempting to run the interface...

--- a/.github/workflows/label-cleanup.yml
+++ b/.github/workflows/label-cleanup.yml
@@ -11,7 +11,7 @@ jobs:
     if: github.event.pull_request.merged
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v6
+      - uses: actions/github-script@v7
         with:
           script: |
             const labels = [

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -15,7 +15,7 @@ jobs:
 
     - name: Cache Composer packages
       id: composer-cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: vendor
         key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
@@ -48,7 +48,7 @@ jobs:
 
     name: PHP ${{ matrix.php }} Syntax Check
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Setup PHP ${{ matrix.php }}
       uses: shivammathur/setup-php@v2
@@ -58,7 +58,7 @@ jobs:
 
     - name: Cache Composer packages
       id: composer-cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: vendor
         key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Cache Composer packages
       id: composer-cache


### PR DESCRIPTION
I'm seeing this on our GitHub Actions
```
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, actions/cache@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```