### PR TITLE
[2.1] Move hooks filter above table

### DIFF
--- a/Sources/ManageMaintenance.php
+++ b/Sources/ManageMaintenance.php
@@ -818,7 +818,7 @@ function AdminBoardRecount()
 	validateToken(!isset($_REQUEST['step']) ? 'admin-maint' : 'admin-boardrecount');
 	$context['not_done_token'] = 'admin-boardrecount';
 	createToken($context['not_done_token']);
-	
+
 	$context['page_title'] = $txt['not_done_title'];
 	$context['continue_post_data'] = '';
 	$context['continue_countdown'] = 3;
@@ -1867,13 +1867,6 @@ function list_integration_hooks()
 	foreach ($hooks as $hook => $functions)
 		$hooks_filters[] = '<option' . ($current_filter == $hook ? ' selected ' : '') . ' value="' . $hook . '">' . $hook . '</option>';
 
-	if (!empty($hooks_filters))
-		$context['insert_after_template'] .= '
-		<script>
-			var hook_name_header = document.getElementById(\'header_list_integration_hooks_hook_name\');
-			hook_name_header.innerHTML += ' . JavaScriptEscape('<select style="margin-left:15px;" onchange="window.location=(\'' . $scripturl . '?action=admin;area=maintain;sa=hooks\' + (this.value ? \';filter=\' + this.value : \'\'));"><option value="">' . $txt['hooks_reset_filter'] . '</option>' . implode('', $hooks_filters) . '</select>') . ';
-		</script>';
-
 	if (!empty($_REQUEST['do']) && isset($_REQUEST['hook']) && isset($_REQUEST['function']))
 	{
 		checkSession('request');
@@ -2018,6 +2011,15 @@ function list_integration_hooks()
 					<li><span class="main_icons posts"></span> ' . $txt['hooks_disable_legend_temp'] . '</li>
 					<li><span class="main_icons error"></span> ' . $txt['hooks_disable_legend_temp_missing'] . '</li>
 				</ul>'
+			),
+			array(
+				'position' => 'above_column_headers',
+				'value' => '
+				<select onchange="window.location=(\'' . $scripturl . '?action=admin;area=maintain;sa=hooks\' + (this.value ? \';filter=\' + this.value : \'\'));">
+					<option value="">' . $txt['hooks_reset_filter'] . '</option>
+					' . implode('', $hooks_filters) . '
+				</select>',
+				'class' => 'floatright',
 			),
 		),
 	);

--- a/Themes/default/css/index.css
+++ b/Themes/default/css/index.css
@@ -1441,7 +1441,8 @@ ul li.greeting {
 #display_jump_to_select,
 #message_index_jump_to_select,
 #search_jump_to_select,
-#quick_mod_jump_to_select {
+#quick_mod_jump_to_select,
+#list_integration_hooks select {
 	width: 29ch;
 	overflow: hidden;
 }


### PR DESCRIPTION
Sometimes the hooks table layout is broken due to too long hook names. Moving the filter from the table header upwards solves this problem.

Before this change:
![sshot-11](https://github.com/SimpleMachines/SMF/assets/229402/058a8545-7489-47b3-ada5-8b1067762ded)

After:
![sshot-12](https://github.com/SimpleMachines/SMF/assets/229402/e0a93b3e-1fb0-439b-9ed7-dc2194433ce6)
