### PR TITLE
Adds offset:0 to selectordinal constuct for $txt['ordinal_last']

### DIFF
--- a/Languages/en_US/General.php
+++ b/Languages/en_US/General.php
@@ -50,7 +50,7 @@ $txt['ordinal_spellout'] = '{0, selectordinal,
 	other {#th}
 }';
 // Interprets ordinal numbers as counting from the end. For example, "2" becomes "2nd to last".
-$txt['ordinal_last'] = '{0, selectordinal,
+$txt['ordinal_last'] = '{0, selectordinal, offset:0
 	=1 {last}
 	one {#st to last}
 	two {#nd to last}
@@ -58,7 +58,7 @@ $txt['ordinal_last'] = '{0, selectordinal,
 	other {#th to last}
 }';
 // Interprets ordinal numbers as counting from the end, but spelling out values less than 10. For example, "2" becomes "second to last", but "22" becomes "22nd to last".
-$txt['ordinal_spellout_last'] = '{0, selectordinal,
+$txt['ordinal_spellout_last'] = '{0, selectordinal, offset:0
 	=1 {last}
 	=2 {second to last}
 	=3 {third to last}


### PR DESCRIPTION
This is an attempt to work around a CrowdIn issue where it would complain if translators tried to add offset:1 to the construct. If we're lucky, CrowdIn won't complain if offset:0 is changed to offset:1 in some translations.