### PR TITLE
Workaround for a CrowdIn limitation regard offset values

### DIFF
--- a/Languages/en_US/General.php
+++ b/Languages/en_US/General.php
@@ -49,7 +49,7 @@ $txt['ordinal_spellout'] = '{0, selectordinal,
 	few {#rd}
 	other {#th}
 }';
-// Interprets ordinal numbers as counting from the end. For example, "2" becomes "2nd to last".
+// Interprets ordinal numbers as counting from the end. For example, "2" becomes "2nd to last". Note that some languages need to change the offset value from "offset:0" to "offset:1", but CrowdIn does not allow translators to do that. To work around this limitation, translators can set the value of the "ordinal_last_offset" string to "1". Then SMF will replace "offset:0" with "offset:1" in this string at runtime.
 $txt['ordinal_last'] = '{0, selectordinal, offset:0
 	=1 {last}
 	one {#st to last}
@@ -57,7 +57,7 @@ $txt['ordinal_last'] = '{0, selectordinal, offset:0
 	few {#rd to last}
 	other {#th to last}
 }';
-// Interprets ordinal numbers as counting from the end, but spelling out values less than 10. For example, "2" becomes "second to last", but "22" becomes "22nd to last".
+// Interprets ordinal numbers as counting from the end, but spelling out values less than 10. For example, "2" becomes "second to last", but "22" becomes "22nd to last". Note that some languages need to change the offset value from "offset:0" to "offset:1", but CrowdIn does not allow translators to do that. To work around this limitation, translators can set the value of the "ordinal_last_offset" string to "1". Then SMF will replace "offset:0" with "offset:1" in this string at runtime.
 $txt['ordinal_spellout_last'] = '{0, selectordinal, offset:0
 	=1 {last}
 	=2 {second to last}
@@ -73,6 +73,8 @@ $txt['ordinal_spellout_last'] = '{0, selectordinal, offset:0
 	few {#rd to last}
 	other {#th to last}
 }';
+// Offset to apply when formatting "ordinal_last" and "ordinal_spellout_last" values. This is a workaround for a CrowdIn limitation that won't let translators change the offset value in those strings. For example, setting this to "1" will cause SMF to change "offset:0" to "offset:1" in those strings at runtime.
+$txt['ordinal_last_offset'] = '0';
 
 // Formats for time units.
 $txt['number_of_years'] = '{0, plural,

--- a/Sources/Lang.php
+++ b/Sources/Lang.php
@@ -559,6 +559,20 @@ class Lang
 			return $target;
 		}
 
+		// Workaround for a CrowdIn limitation that won't allow translators to
+		// change offset values in strings.
+		if (
+			count($txt_key) === 0
+			&& in_array($txt_key[0], ['ordinal_last', 'ordinal_spellout_last'])
+			&& isset(self::$txt['ordinal_last_offset'])
+		) {
+			$target = str_replace(
+				'offset:0',
+				'offset:' . self::$txt['ordinal_last_offset'],
+				$target,
+			);
+		}
+
 		return self::formatText($target, $args);
 	}
 


### PR DESCRIPTION
Since #8119 was not enough to address the CrowdIn limitation that prevents translators from changing the offset value in the "ordinal_last" and "ordinal_spellout_last" strings, this implements a workaround to change the offset value at runtime in SMF itself.