### PR TITLE
GMail semicolon encoding issue #8128 bugfix

### DIFF
--- a/Sources/QueryString.php
+++ b/Sources/QueryString.php
@@ -228,8 +228,8 @@ class QueryString
 		}
 
 		// Some mail providers like to encode semicolons in activation URLs...
-		if (!empty($_REQUEST['action']) && substr($_SERVER['QUERY_STRING'], 0, 18) == 'action=activate%3b') {
-			header('location: ' . Config::$scripturl . '?' . str_replace('%3b', ';', $_SERVER['QUERY_STRING']));
+		if (!empty($_REQUEST['action']) && substr(strtolower($_SERVER['QUERY_STRING']), 0, 18) == 'action=activate%3b') {
+			header('location: ' . Config::$scripturl . '?' . str_ireplace('%3b', ';', $_SERVER['QUERY_STRING']));
 
 			exit;
 		}


### PR DESCRIPTION
Fixes issue, where GMail encodes semicolons with %3B but SMF only detects %3b. 
For example /index.php?action=activate%3Bu=1358%3Bcode=dxxxxxxxxx9