### PR TITLE
TypeError when formatting currency

### DIFF
--- a/Sources/Localization/MessageFormatter.php
+++ b/Sources/Localization/MessageFormatter.php
@@ -21,6 +21,8 @@ use SMF\Time;
 use SMF\User;
 use SMF\Utils;
 
+use function SMF\Unicode\currencies;
+
 /**
  * Provides the ability to process ICU MessageFormat strings, regardless whether
  * the host has the intl extension installed.


### PR DESCRIPTION
Need to know which  namespace to look for when calling `currencies();`

```php
// Language file
$txt['sample'] = 'You have {0, number, :: +! K currency/GBP} left.';

// Source code
\SMF\Lang::getTxt('sample', [45.18]);
```