### PR TITLE
Move a bunch of repeat functions to a trait

### DIFF
--- a/Sources/ActionInterface.php
+++ b/Sources/ActionInterface.php
@@ -13,7 +13,7 @@
 
 declare(strict_types=1);
 
-namespace SMF\Actions;
+namespace SMF;
 
 /**
  * Interface for all action classes.

--- a/Sources/ActionTrait.php
+++ b/Sources/ActionTrait.php
@@ -1,0 +1,70 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 1
+ */
+
+declare(strict_types=1);
+
+namespace SMF;
+
+trait ActionTrait
+{
+	/****************************
+	 * Internal static properties
+	 ****************************/
+
+	/**
+	 * @var static
+	 *
+	 * An instance of this class.
+	 * This is used by the load() method to prevent multiple instantiations.
+	 */
+	protected static self $obj;
+
+	/***********************
+	 * Public static methods
+	 ***********************/
+
+	/**
+	 * Static wrapper for constructor.
+	 *
+	 * @return static An instance of this class.
+	 */
+	public static function load(): static
+	{
+		if (!isset(static::$obj)) {
+			static::$obj = new static();
+		}
+
+		return static::$obj;
+	}
+
+	/**
+	 * Convenience method to load() and execute() an instance of this class.
+	 */
+	public static function call(): void
+	{
+		self::load()->execute();
+	}
+
+	/******************
+	 * Internal methods
+	 ******************/
+
+	/**
+	 * Constructor. Protected to force instantiation via self::load().
+	 */
+	protected function __construct()
+	{
+	}
+}
+
+?>

--- a/Sources/Actions/Activate.php
+++ b/Sources/Actions/Activate.php
@@ -15,6 +15,8 @@ declare(strict_types=1);
 
 namespace SMF\Actions;
 
+use SMF\ActionInterface;
+use SMF\ActionTrait;
 use SMF\Config;
 use SMF\Db\DatabaseApi as Db;
 use SMF\ErrorHandler;
@@ -32,6 +34,8 @@ use SMF\Utils;
  */
 class Activate implements ActionInterface
 {
+	use ActionTrait;
+
 	/*******************
 	 * Public properties
 	 *******************/
@@ -56,18 +60,6 @@ class Activate implements ActionInterface
 		'activate' => 'activate',
 		'resend' => 'resend',
 	];
-
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static Activate $obj;
 
 	/****************
 	 * Public methods
@@ -232,32 +224,6 @@ class Activate implements ActionInterface
 			'never_expire' => false,
 			'description' => Lang::$txt['activate_success'],
 		];
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
 	}
 
 	/******************

--- a/Sources/Actions/Admin/ACP.php
+++ b/Sources/Actions/Admin/ACP.php
@@ -15,9 +15,10 @@ declare(strict_types=1);
 
 namespace SMF\Actions\Admin;
 
-use SMF\Actions\ActionInterface;
+use SMF\ActionInterface;
 use SMF\Actions\MessageIndex;
 use SMF\Actions\Notify;
+use SMF\ActionTrait;
 use SMF\BBCodeParser;
 use SMF\Cache\CacheApi;
 use SMF\Config;
@@ -38,6 +39,8 @@ use SMF\Utils;
  */
 class ACP implements ActionInterface
 {
+	use ActionTrait;
+
 	/*******************
 	 * Public properties
 	 *******************/
@@ -706,18 +709,6 @@ class ACP implements ActionInterface
 		],
 	];
 
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static ACP $obj;
-
 	/****************
 	 * Public methods
 	 ****************/
@@ -785,32 +776,6 @@ class ACP implements ActionInterface
 		if (!empty($call)) {
 			call_user_func($call);
 		}
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
 	}
 
 	/**

--- a/Sources/Actions/Admin/AntiSpam.php
+++ b/Sources/Actions/Admin/AntiSpam.php
@@ -15,8 +15,9 @@ declare(strict_types=1);
 
 namespace SMF\Actions\Admin;
 
-use SMF\Actions\ActionInterface;
+use SMF\ActionInterface;
 use SMF\Actions\BackwardCompatibility;
+use SMF\ActionTrait;
 use SMF\Cache\CacheApi;
 use SMF\Config;
 use SMF\Db\DatabaseApi as Db;
@@ -32,19 +33,9 @@ use SMF\Utils;
  */
 class AntiSpam implements ActionInterface
 {
+	use ActionTrait;
+
 	use BackwardCompatibility;
-
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static AntiSpam $obj;
 
 	/****************
 	 * Public methods
@@ -355,32 +346,6 @@ class AntiSpam implements ActionInterface
 		ACP::prepareDBSettingContext($config_vars);
 	}
 
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
-	}
-
 	/**
 	 * Gets the configuration variables for the anti-spam area.
 	 *
@@ -450,17 +415,6 @@ class AntiSpam implements ActionInterface
 		IntegrationHook::call('integrate_spam_settings', [&$config_vars]);
 
 		return $config_vars;
-	}
-
-	/******************
-	 * Internal methods
-	 ******************/
-
-	/**
-	 * Constructor. Protected to force instantiation via self::load().
-	 */
-	protected function __construct()
-	{
 	}
 }
 

--- a/Sources/Actions/Admin/Attachments.php
+++ b/Sources/Actions/Admin/Attachments.php
@@ -19,8 +19,9 @@ declare(strict_types=1);
 
 namespace SMF\Actions\Admin;
 
-use SMF\Actions\ActionInterface;
+use SMF\ActionInterface;
 use SMF\Actions\BackwardCompatibility;
+use SMF\ActionTrait;
 use SMF\Attachment;
 use SMF\Config;
 use SMF\Db\DatabaseApi as Db;
@@ -42,6 +43,8 @@ use const DIRECTORY_SEPARATOR;
  */
 class Attachments implements ActionInterface
 {
+	use ActionTrait;
+
 	use BackwardCompatibility;
 
 	/*******************
@@ -78,18 +81,6 @@ class Attachments implements ActionInterface
 		'attachpaths' => 'paths',
 		'transfer' => 'transfer',
 	];
-
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static Attachments $obj;
 
 	/****************
 	 * Public methods
@@ -2080,32 +2071,6 @@ class Attachments implements ActionInterface
 		}
 
 		Utils::redirectexit('action=admin;area=manageattachments;sa=maintenance#transfer');
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
 	}
 
 	/**

--- a/Sources/Actions/Admin/Bans.php
+++ b/Sources/Actions/Admin/Bans.php
@@ -19,8 +19,9 @@ declare(strict_types=1);
 
 namespace SMF\Actions\Admin;
 
-use SMF\Actions\ActionInterface;
+use SMF\ActionInterface;
 use SMF\Actions\BackwardCompatibility;
+use SMF\ActionTrait;
 use SMF\Config;
 use SMF\Db\DatabaseApi as Db;
 use SMF\ErrorHandler;
@@ -41,6 +42,8 @@ use SMF\Utils;
  */
 class Bans implements ActionInterface
 {
+	use ActionTrait;
+
 	use BackwardCompatibility;
 
 	/*******************
@@ -72,18 +75,6 @@ class Bans implements ActionInterface
 		'edittrigger' => 'editTrigger',
 		'log' => 'log',
 	];
-
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static Bans $obj;
 
 	/****************
 	 * Public methods
@@ -1009,32 +1000,6 @@ class Bans implements ActionInterface
 		Utils::$context['page_title'] = Lang::$txt['ban_log'];
 		Utils::$context['sub_template'] = 'show_list';
 		Utils::$context['default_list'] = 'ban_log';
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
 	}
 
 	/**

--- a/Sources/Actions/Admin/Boards.php
+++ b/Sources/Actions/Admin/Boards.php
@@ -15,8 +15,9 @@ declare(strict_types=1);
 
 namespace SMF\Actions\Admin;
 
-use SMF\Actions\ActionInterface;
+use SMF\ActionInterface;
 use SMF\Actions\BackwardCompatibility;
+use SMF\ActionTrait;
 use SMF\BBCodeParser;
 use SMF\Board;
 use SMF\Category;
@@ -38,6 +39,8 @@ use SMF\Utils;
  */
 class Boards implements ActionInterface
 {
+	use ActionTrait;
+
 	use BackwardCompatibility;
 
 	/*******************
@@ -80,18 +83,6 @@ class Boards implements ActionInterface
 	 *********************/
 
 	// code...
-
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static Boards $obj;
 
 	/****************
 	 * Public methods
@@ -867,32 +858,6 @@ class Boards implements ActionInterface
 
 		// Prepare the settings...
 		ACP::prepareDBSettingContext($config_vars);
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
 	}
 
 	/**

--- a/Sources/Actions/Admin/Calendar.php
+++ b/Sources/Actions/Admin/Calendar.php
@@ -17,9 +17,10 @@ declare(strict_types=1);
 
 namespace SMF\Actions\Admin;
 
-use SMF\Actions\ActionInterface;
+use SMF\ActionInterface;
 use SMF\Actions\BackwardCompatibility;
 use SMF\Actions\Calendar as Cal;
+use SMF\ActionTrait;
 use SMF\Board;
 use SMF\Config;
 use SMF\Db\DatabaseApi as Db;
@@ -38,6 +39,8 @@ use SMF\Utils;
  */
 class Calendar implements ActionInterface
 {
+	use ActionTrait;
+
 	use BackwardCompatibility;
 
 	/*******************
@@ -66,18 +69,6 @@ class Calendar implements ActionInterface
 		'editholiday' => 'edit',
 		'settings' => 'settings',
 	];
-
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static Calendar $obj;
 
 	/****************
 	 * Public methods
@@ -359,32 +350,6 @@ class Calendar implements ActionInterface
 
 		// Prepare the settings...
 		ACP::prepareDBSettingContext($config_vars);
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
 	}
 
 	/**

--- a/Sources/Actions/Admin/EndSession.php
+++ b/Sources/Actions/Admin/EndSession.php
@@ -15,7 +15,8 @@ declare(strict_types=1);
 
 namespace SMF\Actions\Admin;
 
-use SMF\Actions\ActionInterface;
+use SMF\ActionInterface;
+use SMF\ActionTrait;
 use SMF\Utils;
 
 /**
@@ -23,17 +24,7 @@ use SMF\Utils;
  */
 class EndSession implements ActionInterface
 {
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static EndSession $obj;
+	use ActionTrait;
 
 	/****************
 	 * Public methods
@@ -55,43 +46,6 @@ class EndSession implements ActionInterface
 		}
 
 		Utils::redirectexit();
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
-	}
-
-	/******************
-	 * Internal methods
-	 ******************/
-
-	/**
-	 * Constructor. Protected to force instantiation via self::load().
-	 */
-	protected function __construct()
-	{
 	}
 }
 

--- a/Sources/Actions/Admin/ErrorLog.php
+++ b/Sources/Actions/Admin/ErrorLog.php
@@ -15,7 +15,8 @@ declare(strict_types=1);
 
 namespace SMF\Actions\Admin;
 
-use SMF\Actions\ActionInterface;
+use SMF\ActionInterface;
+use SMF\ActionTrait;
 use SMF\BBCodeParser;
 use SMF\Config;
 use SMF\Db\DatabaseApi as Db;
@@ -35,6 +36,8 @@ use SMF\Utils;
  */
 class ErrorLog implements ActionInterface
 {
+	use ActionTrait;
+
 	/*******************
 	 * Public properties
 	 *******************/
@@ -93,18 +96,6 @@ class ErrorLog implements ActionInterface
 			'datatype' => 'int',
 		],
 	];
-
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static ErrorLog $obj;
 
 	/****************
 	 * Public methods
@@ -490,32 +481,6 @@ class ErrorLog implements ActionInterface
 		Lang::load('ManageMaintenance');
 		Utils::$context['template_layers'] = [];
 		Utils::$context['sub_template'] = 'show_backtrace';
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
 	}
 
 	/******************

--- a/Sources/Actions/Admin/Features.php
+++ b/Sources/Actions/Admin/Features.php
@@ -15,9 +15,10 @@ declare(strict_types=1);
 
 namespace SMF\Actions\Admin;
 
-use SMF\Actions\ActionInterface;
+use SMF\ActionInterface;
 use SMF\Actions\BackwardCompatibility;
 use SMF\Actions\Profile\Notification;
+use SMF\ActionTrait;
 use SMF\BBCodeParser;
 use SMF\Config;
 use SMF\Db\DatabaseApi as Db;
@@ -40,6 +41,8 @@ use SMF\Utils;
  */
 class Features implements ActionInterface
 {
+	use ActionTrait;
+
 	use BackwardCompatibility;
 
 	/*******************
@@ -74,18 +77,6 @@ class Features implements ActionInterface
 		'mentions' => 'mentions',
 		'alerts' => 'alerts',
 	];
-
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static Features $obj;
 
 	/****************
 	 * Public methods
@@ -1502,32 +1493,6 @@ class Features implements ActionInterface
 		// Override the description
 		Utils::$context['description'] = Lang::$txt['notifications_desc'];
 		Utils::$context['sub_template'] = 'alert_configuration';
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
 	}
 
 	/**

--- a/Sources/Actions/Admin/Find.php
+++ b/Sources/Actions/Admin/Find.php
@@ -15,7 +15,8 @@ declare(strict_types=1);
 
 namespace SMF\Actions\Admin;
 
-use SMF\Actions\ActionInterface;
+use SMF\ActionInterface;
+use SMF\ActionTrait;
 use SMF\Config;
 use SMF\ErrorHandler;
 use SMF\IntegrationHook;
@@ -32,6 +33,8 @@ use SMF\WebFetch\WebFetchApi;
  */
 class Find implements ActionInterface
 {
+	use ActionTrait;
+
 	/*******************
 	 * Public properties
 	 *******************/
@@ -140,18 +143,6 @@ class Find implements ActionInterface
 		'online' => 'online',
 		'member' => 'member',
 	];
-
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static Find $obj;
 
 	/****************
 	 * Public methods
@@ -363,32 +354,6 @@ class Find implements ActionInterface
 				];
 			}
 		}
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
 	}
 
 	/******************

--- a/Sources/Actions/Admin/Home.php
+++ b/Sources/Actions/Admin/Home.php
@@ -15,9 +15,10 @@ declare(strict_types=1);
 
 namespace SMF\Actions\Admin;
 
-use SMF\Actions\ActionInterface;
+use SMF\ActionInterface;
 use SMF\Actions\Credits;
 use SMF\Actions\Groups;
+use SMF\ActionTrait;
 use SMF\Config;
 use SMF\Lang;
 use SMF\Menu;
@@ -35,6 +36,8 @@ use SMF\Utils;
  */
 class Home implements ActionInterface
 {
+	use ActionTrait;
+
 	/*******************
 	 * Public properties
 	 *******************/
@@ -76,18 +79,6 @@ class Home implements ActionInterface
 		'php',
 		'server',
 	];
-
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static Home $obj;
 
 	/****************
 	 * Public methods
@@ -157,43 +148,6 @@ class Home implements ActionInterface
 		if (Utils::$context['admin_area'] == 'admin') {
 			Theme::loadJavaScriptFile('admin.js', ['defer' => false, 'minimize' => true], 'smf_admin');
 		}
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
-	}
-
-	/******************
-	 * Internal methods
-	 ******************/
-
-	/**
-	 * Constructor. Protected to force instantiation via self::load().
-	 */
-	protected function __construct()
-	{
 	}
 }
 

--- a/Sources/Actions/Admin/Languages.php
+++ b/Sources/Actions/Admin/Languages.php
@@ -15,8 +15,9 @@ declare(strict_types=1);
 
 namespace SMF\Actions\Admin;
 
-use SMF\Actions\ActionInterface;
+use SMF\ActionInterface;
 use SMF\Actions\BackwardCompatibility;
+use SMF\ActionTrait;
 use SMF\Cache\CacheApi;
 use SMF\Config;
 use SMF\Db\DatabaseApi as Db;
@@ -38,6 +39,8 @@ use SMF\WebFetch\WebFetchApi;
  */
 class Languages implements ActionInterface
 {
+	use ActionTrait;
+
 	use BackwardCompatibility;
 
 	/*******************
@@ -68,18 +71,6 @@ class Languages implements ActionInterface
 		'downloadlang' => 'download',
 		'editlang' => 'editEntries',
 	];
-
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static Languages $obj;
 
 	/****************
 	 * Public methods
@@ -1452,32 +1443,6 @@ class Languages implements ActionInterface
 		}
 
 		SecurityToken::create('admin-mlang');
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
 	}
 
 	/**

--- a/Sources/Actions/Admin/Logs.php
+++ b/Sources/Actions/Admin/Logs.php
@@ -15,9 +15,10 @@ declare(strict_types=1);
 
 namespace SMF\Actions\Admin;
 
-use SMF\Actions\ActionInterface;
+use SMF\ActionInterface;
 use SMF\Actions\BackwardCompatibility;
 use SMF\Actions\Moderation\Logs as Modlog;
+use SMF\ActionTrait;
 use SMF\Config;
 use SMF\IntegrationHook;
 use SMF\Lang;
@@ -31,6 +32,8 @@ use SMF\Utils;
  */
 class Logs implements ActionInterface
 {
+	use ActionTrait;
+
 	use BackwardCompatibility;
 
 	/*******************
@@ -112,18 +115,6 @@ class Logs implements ActionInterface
 		'pruneScheduledTaskLog',
 		'pruneSpiderHitLog',
 	];
-
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static Logs $obj;
 
 	/****************
 	 * Public methods
@@ -302,32 +293,6 @@ class Logs implements ActionInterface
 		}
 
 		ACP::prepareDBSettingContext($config_vars);
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
 	}
 
 	/**

--- a/Sources/Actions/Admin/Mail.php
+++ b/Sources/Actions/Admin/Mail.php
@@ -15,8 +15,9 @@ declare(strict_types=1);
 
 namespace SMF\Actions\Admin;
 
-use SMF\Actions\ActionInterface;
+use SMF\ActionInterface;
 use SMF\Actions\BackwardCompatibility;
+use SMF\ActionTrait;
 use SMF\Config;
 use SMF\Db\DatabaseApi as Db;
 use SMF\IntegrationHook;
@@ -33,6 +34,8 @@ use SMF\Utils;
  */
 class Mail implements ActionInterface
 {
+	use ActionTrait;
+
 	use BackwardCompatibility;
 
 	/*******************
@@ -74,18 +77,6 @@ class Mail implements ActionInterface
 	 * This is used internally by the settings() method.
 	 */
 	protected static array $processedBirthdayEmails = [];
-
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static Mail $obj;
 
 	/****************
 	 * Public methods
@@ -371,32 +362,6 @@ class Mail implements ActionInterface
 		if (isset($_GET['result'])) {
 			Utils::$context['result'] = ($_GET['result'] == 'success' ? 'success' : 'failure');
 		}
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
 	}
 
 	/**

--- a/Sources/Actions/Admin/Maintenance.php
+++ b/Sources/Actions/Admin/Maintenance.php
@@ -15,9 +15,10 @@ declare(strict_types=1);
 
 namespace SMF\Actions\Admin;
 
-use SMF\Actions\ActionInterface;
+use SMF\ActionInterface;
 use SMF\Actions\BackwardCompatibility;
 use SMF\Actions\TopicRemove;
+use SMF\ActionTrait;
 use SMF\Cache\CacheApi;
 use SMF\Category;
 use SMF\Config;
@@ -43,6 +44,8 @@ use SMF\Utils;
  */
 class Maintenance implements ActionInterface
 {
+	use ActionTrait;
+
 	use BackwardCompatibility;
 
 	/*******************
@@ -122,18 +125,6 @@ class Maintenance implements ActionInterface
 			'activities' => [],
 		],
 	];
-
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static Maintenance $obj;
 
 	/****************
 	 * Public methods
@@ -2073,32 +2064,6 @@ class Maintenance implements ActionInterface
 		Utils::$context['page_title'] = Lang::$txt['hooks_title_list'];
 		Utils::$context['sub_template'] = 'show_list';
 		Utils::$context['default_list'] = 'list_integration_hooks';
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
 	}
 
 	/**

--- a/Sources/Actions/Admin/Membergroups.php
+++ b/Sources/Actions/Admin/Membergroups.php
@@ -15,8 +15,9 @@ declare(strict_types=1);
 
 namespace SMF\Actions\Admin;
 
-use SMF\Actions\ActionInterface;
+use SMF\ActionInterface;
 use SMF\Actions\BackwardCompatibility;
+use SMF\ActionTrait;
 use SMF\Config;
 use SMF\Db\DatabaseApi as Db;
 use SMF\ErrorHandler;
@@ -36,6 +37,8 @@ use SMF\Utils;
  */
 class Membergroups implements ActionInterface
 {
+	use ActionTrait;
+
 	use BackwardCompatibility;
 
 	/*******************
@@ -70,18 +73,6 @@ class Membergroups implements ActionInterface
 		// This subaction is handled by the Groups action.
 		'members' => ['SMF\\Actions\\Groups::call', 'manage_membergroups'],
 	];
-
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static Membergroups $obj;
 
 	/****************
 	 * Public methods
@@ -936,32 +927,6 @@ class Membergroups implements ActionInterface
 		SecurityToken::create('admin-mp');
 
 		ACP::prepareDBSettingContext($config_vars);
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
 	}
 
 	/**

--- a/Sources/Actions/Admin/Members.php
+++ b/Sources/Actions/Admin/Members.php
@@ -15,8 +15,9 @@ declare(strict_types=1);
 
 namespace SMF\Actions\Admin;
 
-use SMF\Actions\ActionInterface;
+use SMF\ActionInterface;
 use SMF\Actions\BackwardCompatibility;
+use SMF\ActionTrait;
 use SMF\Config;
 use SMF\Db\DatabaseApi as Db;
 use SMF\Group;
@@ -37,6 +38,8 @@ use SMF\Utils;
  */
 class Members implements ActionInterface
 {
+	use ActionTrait;
+
 	use BackwardCompatibility;
 
 	/*******************
@@ -125,18 +128,6 @@ class Members implements ActionInterface
 		'search' => ['search', 'moderate_forum'],
 		'query' => ['view', 'moderate_forum'],
 	];
-
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static Members $obj;
 
 	/****************
 	 * Public methods
@@ -1259,32 +1250,6 @@ class Members implements ActionInterface
 		}
 
 		Utils::redirectexit('action=admin;area=viewmembers;sa=browse;type=' . $_REQUEST['type'] . ';sort=' . $_REQUEST['sort'] . ';filter=' . $current_filter . ';start=' . $_REQUEST['start']);
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
 	}
 
 	/**

--- a/Sources/Actions/Admin/Mods.php
+++ b/Sources/Actions/Admin/Mods.php
@@ -15,8 +15,9 @@ declare(strict_types=1);
 
 namespace SMF\Actions\Admin;
 
-use SMF\Actions\ActionInterface;
+use SMF\ActionInterface;
 use SMF\Actions\BackwardCompatibility;
+use SMF\ActionTrait;
 use SMF\Config;
 use SMF\IntegrationHook;
 use SMF\Lang;
@@ -29,6 +30,8 @@ use SMF\Utils;
  */
 class Mods implements ActionInterface
 {
+	use ActionTrait;
+
 	use BackwardCompatibility;
 
 	/*******************
@@ -55,18 +58,6 @@ class Mods implements ActionInterface
 	public static array $subactions = [
 		'general' => 'general',
 	];
-
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static Mods $obj;
 
 	/****************
 	 * Public methods
@@ -129,32 +120,6 @@ class Mods implements ActionInterface
 
 		// This line is to help mod authors do a search/add after if you want to add something here. Keyword: RED INK IS FOR TEACHERS AND THOSE WHO LIKE PAIN!
 		ACP::prepareDBSettingContext($config_vars);
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
 	}
 
 	/**

--- a/Sources/Actions/Admin/News.php
+++ b/Sources/Actions/Admin/News.php
@@ -15,9 +15,10 @@ declare(strict_types=1);
 
 namespace SMF\Actions\Admin;
 
-use SMF\Actions\ActionInterface;
+use SMF\ActionInterface;
 use SMF\Actions\BackwardCompatibility;
 use SMF\Actions\Notify;
+use SMF\ActionTrait;
 use SMF\BBCodeParser;
 use SMF\Config;
 use SMF\Db\DatabaseApi as Db;
@@ -40,7 +41,7 @@ use SMF\Utils;
 /**
  * This class manages... the news. :P
  */
-class News extends ACP implements ActionInterface
+class News extends ACP
 {
 	use BackwardCompatibility;
 
@@ -222,18 +223,6 @@ class News extends ACP implements ActionInterface
 		'mailingsend' => ['send', 'send_mail'],
 		'settings' => ['settings', 'admin_forum'],
 	];
-
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static News|ACP $obj;
 
 	/****************
 	 * Public methods
@@ -1069,32 +1058,6 @@ class News extends ACP implements ActionInterface
 		SecurityToken::create('admin-mp');
 
 		self::prepareDBSettingContext($config_vars);
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
 	}
 
 	/**

--- a/Sources/Actions/Admin/Permissions.php
+++ b/Sources/Actions/Admin/Permissions.php
@@ -15,9 +15,10 @@ declare(strict_types=1);
 
 namespace SMF\Actions\Admin;
 
-use SMF\Actions\ActionInterface;
+use SMF\ActionInterface;
 use SMF\Actions\BackwardCompatibility;
 use SMF\Actions\Moderation\Posts as PostMod;
+use SMF\ActionTrait;
 use SMF\Board;
 use SMF\Category;
 use SMF\Config;
@@ -37,6 +38,8 @@ use SMF\Utils;
  */
 class Permissions implements ActionInterface
 {
+	use ActionTrait;
+
 	use BackwardCompatibility;
 
 	/*****************
@@ -920,7 +923,7 @@ class Permissions implements ActionInterface
 	 * An instance of this class.
 	 * This is used by the load() method to prevent multiple instantiations.
 	 */
-	protected static Permissions $obj;
+
 
 	/****************
 	 * Public methods
@@ -1565,32 +1568,6 @@ class Permissions implements ActionInterface
 		Db::$db->free_result($request);
 
 		SecurityToken::create('admin-mppm');
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
 	}
 
 	/**

--- a/Sources/Actions/Admin/Posts.php
+++ b/Sources/Actions/Admin/Posts.php
@@ -15,7 +15,8 @@ declare(strict_types=1);
 
 namespace SMF\Actions\Admin;
 
-use SMF\Actions\ActionInterface;
+use SMF\ActionInterface;
+use SMF\ActionTrait;
 use SMF\Config;
 use SMF\Db\DatabaseApi as Db;
 use SMF\ErrorHandler;
@@ -33,6 +34,8 @@ use SMF\Utils;
  */
 class Posts implements ActionInterface
 {
+	use ActionTrait;
+
 	/*******************
 	 * Public properties
 	 *******************/
@@ -60,18 +63,6 @@ class Posts implements ActionInterface
 		'topics' => 'topics',
 		'drafts' => 'drafts',
 	];
-
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static Posts $obj;
 
 	/****************
 	 * Public methods
@@ -322,32 +313,6 @@ class Posts implements ActionInterface
 
 		// Prepare the settings...
 		ACP::prepareDBSettingContext($config_vars);
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
 	}
 
 	/**

--- a/Sources/Actions/Admin/Registration.php
+++ b/Sources/Actions/Admin/Registration.php
@@ -15,9 +15,10 @@ declare(strict_types=1);
 
 namespace SMF\Actions\Admin;
 
-use SMF\Actions\ActionInterface;
+use SMF\ActionInterface;
 use SMF\Actions\BackwardCompatibility;
 use SMF\Actions\Register2;
+use SMF\ActionTrait;
 use SMF\Config;
 use SMF\Db\DatabaseApi as Db;
 use SMF\ErrorHandler;
@@ -38,6 +39,8 @@ use SMF\Utils;
  */
 class Registration implements ActionInterface
 {
+	use ActionTrait;
+
 	use BackwardCompatibility;
 	/*******************
 	 * Public properties
@@ -69,18 +72,6 @@ class Registration implements ActionInterface
 		'reservednames' => ['reservedNames', 'admin_forum'],
 		'settings' => ['settings', 'admin_forum'],
 	];
-
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static Registration $obj;
 
 	/****************
 	 * Public methods
@@ -465,32 +456,6 @@ class Registration implements ActionInterface
 		Config::$modSettings['coppaPost'] = !empty(Config::$modSettings['coppaPost']) ? preg_replace('~<br ?/?' . '>~', "\n", Config::$modSettings['coppaPost']) : '';
 
 		ACP::prepareDBSettingContext($config_vars);
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
 	}
 
 	/**

--- a/Sources/Actions/Admin/RepairBoards.php
+++ b/Sources/Actions/Admin/RepairBoards.php
@@ -15,7 +15,8 @@ declare(strict_types=1);
 
 namespace SMF\Actions\Admin;
 
-use SMF\Actions\ActionInterface;
+use SMF\ActionInterface;
+use SMF\ActionTrait;
 use SMF\Board;
 use SMF\Config;
 use SMF\Db\DatabaseApi as Db;
@@ -34,6 +35,8 @@ use SMF\Utils;
  */
 class RepairBoards implements ActionInterface
 {
+	use ActionTrait;
+
 	/*******************
 	 * Public properties
 	 *******************/
@@ -769,18 +772,6 @@ class RepairBoards implements ActionInterface
 	 */
 	public int $salvage_category;
 
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static RepairBoards $obj;
-
 	/****************
 	 * Public methods
 	 ****************/
@@ -854,32 +845,6 @@ class RepairBoards implements ActionInterface
 			// We are done at this point, dump the token,
 			SecurityToken::validate('admin-repairboards', 'request', false);
 		}
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
 	}
 
 	/******************

--- a/Sources/Actions/Admin/Reports.php
+++ b/Sources/Actions/Admin/Reports.php
@@ -15,8 +15,9 @@ declare(strict_types=1);
 
 namespace SMF\Actions\Admin;
 
-use SMF\Actions\ActionInterface;
+use SMF\ActionInterface;
 use SMF\Actions\BackwardCompatibility;
+use SMF\ActionTrait;
 use SMF\Config;
 use SMF\Db\DatabaseApi as Db;
 use SMF\ErrorHandler;
@@ -36,6 +37,8 @@ use SMF\Utils;
  */
 class Reports implements ActionInterface
 {
+	use ActionTrait;
+
 	use BackwardCompatibility;
 
 	/*******************
@@ -134,18 +137,6 @@ class Reports implements ActionInterface
 	 * Can be either 'rows' or 'cols'.
 	 */
 	protected string $key_method;
-
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static Reports $obj;
 
 	/****************
 	 * Public methods
@@ -943,32 +934,6 @@ class Reports implements ActionInterface
 			$this->addData($staffData);
 		}
 		Db::$db->free_result($request);
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
 	}
 
 	/******************

--- a/Sources/Actions/Admin/Search.php
+++ b/Sources/Actions/Admin/Search.php
@@ -15,8 +15,9 @@ declare(strict_types=1);
 
 namespace SMF\Actions\Admin;
 
-use SMF\Actions\ActionInterface;
+use SMF\ActionInterface;
 use SMF\Actions\BackwardCompatibility;
+use SMF\ActionTrait;
 use SMF\Config;
 use SMF\Db\DatabaseApi as Db;
 use SMF\IntegrationHook;
@@ -33,6 +34,8 @@ use SMF\Utils;
  */
 class Search implements ActionInterface
 {
+	use ActionTrait;
+
 	use BackwardCompatibility;
 
 	/*******************
@@ -61,18 +64,6 @@ class Search implements ActionInterface
 		'weights' => 'weights',
 		'method' => 'method',
 	];
-
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static Search $obj;
 
 	/****************
 	 * Public methods
@@ -311,28 +302,6 @@ class Search implements ActionInterface
 	/***********************
 	 * Public static methods
 	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
-	}
 
 	/**
 	 * Gets the configuration variables for this admin area.

--- a/Sources/Actions/Admin/SearchEngines.php
+++ b/Sources/Actions/Admin/SearchEngines.php
@@ -15,9 +15,10 @@ declare(strict_types=1);
 
 namespace SMF\Actions\Admin;
 
-use SMF\Actions\ActionInterface;
+use SMF\ActionInterface;
 use SMF\Actions\BackwardCompatibility;
 use SMF\Actions\Who;
+use SMF\ActionTrait;
 use SMF\Cache\CacheApi;
 use SMF\Config;
 use SMF\Db\DatabaseApi as Db;
@@ -37,6 +38,8 @@ use SMF\Utils;
  */
 class SearchEngines implements ActionInterface
 {
+	use ActionTrait;
+
 	use BackwardCompatibility;
 
 	/*******************
@@ -73,18 +76,6 @@ class SearchEngines implements ActionInterface
 	 *********************/
 
 	// code...
-
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static SearchEngines $obj;
 
 	/**
 	 * @var string
@@ -767,32 +758,6 @@ class SearchEngines implements ActionInterface
 		}
 
 		SecurityToken::create('admin-ses');
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
 	}
 
 	/**

--- a/Sources/Actions/Admin/Server.php
+++ b/Sources/Actions/Admin/Server.php
@@ -15,8 +15,9 @@ declare(strict_types=1);
 
 namespace SMF\Actions\Admin;
 
-use SMF\Actions\ActionInterface;
+use SMF\ActionInterface;
 use SMF\Actions\BackwardCompatibility;
+use SMF\ActionTrait;
 use SMF\Cache\CacheApi;
 use SMF\Config;
 use SMF\Cookie;
@@ -83,6 +84,8 @@ use SMF\Utils;
  */
 class Server implements ActionInterface
 {
+	use ActionTrait;
+
 	use BackwardCompatibility;
 
 	/*****************
@@ -156,18 +159,6 @@ class Server implements ActionInterface
 	 */
 	public static bool $diskspace_disabled = false;
 
-
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static Server $obj;
 
 	/**
 	 * @var bool
@@ -688,32 +679,6 @@ class Server implements ActionInterface
 		Utils::$context['pinfo'] = $pinfo;
 		Utils::$context['page_title'] = Lang::$txt['admin_server_settings'];
 		Utils::$context['sub_template'] = 'php_info';
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
 	}
 
 	/**

--- a/Sources/Actions/Admin/Smileys.php
+++ b/Sources/Actions/Admin/Smileys.php
@@ -17,9 +17,10 @@ declare(strict_types=1);
 
 namespace SMF\Actions\Admin;
 
-use SMF\Actions\ActionInterface;
+use SMF\ActionInterface;
 use SMF\Actions\BackwardCompatibility;
 use SMF\Actions\MessageIndex;
+use SMF\ActionTrait;
 use SMF\BBCodeParser;
 use SMF\Cache\CacheApi;
 use SMF\Config;
@@ -43,6 +44,8 @@ use SMF\WebFetch\WebFetchApi;
  */
 class Smileys implements ActionInterface
 {
+	use ActionTrait;
+
 	use BackwardCompatibility;
 
 	/*******************
@@ -153,18 +156,6 @@ class Smileys implements ActionInterface
 	 *********************/
 
 	// code...
-
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static Smileys $obj;
 
 	/****************
 	 * Public methods
@@ -2040,32 +2031,6 @@ class Smileys implements ActionInterface
 		SecurityToken::create('admin-mp');
 
 		ACP::prepareDBSettingContext($config_vars);
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
 	}
 
 	/**

--- a/Sources/Actions/Admin/Subscriptions.php
+++ b/Sources/Actions/Admin/Subscriptions.php
@@ -15,8 +15,9 @@ declare(strict_types=1);
 
 namespace SMF\Actions\Admin;
 
-use SMF\Actions\ActionInterface;
+use SMF\ActionInterface;
 use SMF\Actions\BackwardCompatibility;
+use SMF\ActionTrait;
 use SMF\Config;
 use SMF\Db\DatabaseApi as Db;
 use SMF\ErrorHandler;
@@ -37,6 +38,8 @@ use SMF\Utils;
  */
 class Subscriptions implements ActionInterface
 {
+	use ActionTrait;
+
 	use BackwardCompatibility;
 
 	/*******************
@@ -82,18 +85,6 @@ class Subscriptions implements ActionInterface
 	 *********************/
 
 	// code...
-
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static Subscriptions $obj;
 
 	/****************
 	 * Public methods
@@ -1318,32 +1309,6 @@ class Subscriptions implements ActionInterface
 
 		// Prepare the settings...
 		ACP::prepareDBSettingContext($config_vars);
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
 	}
 
 	/**

--- a/Sources/Actions/Admin/Tasks.php
+++ b/Sources/Actions/Admin/Tasks.php
@@ -15,8 +15,9 @@ declare(strict_types=1);
 
 namespace SMF\Actions\Admin;
 
-use SMF\Actions\ActionInterface;
+use SMF\ActionInterface;
 use SMF\Actions\BackwardCompatibility;
+use SMF\ActionTrait;
 use SMF\Config;
 use SMF\Db\DatabaseApi as Db;
 use SMF\ErrorHandler;
@@ -36,6 +37,8 @@ use SMF\Utils;
  */
 class Tasks implements ActionInterface
 {
+	use ActionTrait;
+
 	use BackwardCompatibility;
 
 	/*******************
@@ -65,18 +68,6 @@ class Tasks implements ActionInterface
 		'tasklog' => 'log',
 		'settings' => 'settings',
 	];
-
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static Tasks $obj;
 
 	/****************
 	 * Public methods
@@ -521,32 +512,6 @@ class Tasks implements ActionInterface
 		}
 
 		ACP::prepareDBSettingContext($config_vars);
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
 	}
 
 	/**

--- a/Sources/Actions/Admin/Themes.php
+++ b/Sources/Actions/Admin/Themes.php
@@ -15,8 +15,9 @@ declare(strict_types=1);
 
 namespace SMF\Actions\Admin;
 
-use SMF\Actions\ActionInterface;
+use SMF\ActionInterface;
 use SMF\Actions\BackwardCompatibility;
+use SMF\ActionTrait;
 use SMF\Cache\CacheApi;
 use SMF\Config;
 use SMF\Db\DatabaseApi as Db;
@@ -53,6 +54,8 @@ use SMF\Utils;
  */
 class Themes implements ActionInterface
 {
+	use ActionTrait;
+
 	use BackwardCompatibility;
 
 	/*******************
@@ -87,18 +90,6 @@ class Themes implements ActionInterface
 		'edit' => 'edit',
 		'copy' => 'copy',
 	];
-
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static Themes $obj;
 
 	/****************
 	 * Public methods
@@ -1326,32 +1317,6 @@ class Themes implements ActionInterface
 		}
 
 		Utils::$context['sub_template'] = 'copy_template';
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
 	}
 
 	/******************

--- a/Sources/Actions/Admin/Warnings.php
+++ b/Sources/Actions/Admin/Warnings.php
@@ -15,8 +15,9 @@ declare(strict_types=1);
 
 namespace SMF\Actions\Admin;
 
-use SMF\Actions\ActionInterface;
+use SMF\ActionInterface;
 use SMF\Actions\BackwardCompatibility;
+use SMF\ActionTrait;
 use SMF\Config;
 use SMF\IntegrationHook;
 use SMF\Lang;
@@ -29,6 +30,8 @@ use SMF\Utils;
  */
 class Warnings implements ActionInterface
 {
+	use ActionTrait;
+
 	use BackwardCompatibility;
 
 	/**************************
@@ -41,18 +44,6 @@ class Warnings implements ActionInterface
 	 * Currently enabled moderation settings.
 	 */
 	public static bool $currently_enabled;
-
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static Warnings $obj;
 
 	/****************
 	 * Public methods
@@ -140,32 +131,6 @@ class Warnings implements ActionInterface
 		ACP::prepareDBSettingContext($config_vars);
 	}
 
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
-	}
-
 	/**
 	 * Gets the configuration variables for the warnings area.
 	 *
@@ -222,17 +187,6 @@ class Warnings implements ActionInterface
 		IntegrationHook::call('integrate_warning_settings', [&$config_vars]);
 
 		return $config_vars;
-	}
-
-	/******************
-	 * Internal methods
-	 ******************/
-
-	/**
-	 * Constructor. Protected to force instantiation via self::load().
-	 */
-	protected function __construct()
-	{
 	}
 }
 

--- a/Sources/Actions/Agreement.php
+++ b/Sources/Actions/Agreement.php
@@ -15,6 +15,8 @@ declare(strict_types=1);
 
 namespace SMF\Actions;
 
+use SMF\ActionInterface;
+use SMF\ActionTrait;
 use SMF\BBCodeParser;
 use SMF\Config;
 use SMF\ErrorHandler;
@@ -30,6 +32,8 @@ use SMF\Utils;
  */
 class Agreement implements ActionInterface
 {
+	use ActionTrait;
+
 	/*********************
 	 * Internal properties
 	 *********************/
@@ -40,7 +44,7 @@ class Agreement implements ActionInterface
 	 * An instance of the class.
 	 * This is used by the load() method to prevent multiple instantiations.
 	 */
-	protected static Agreement $obj;
+
 
 	/****************
 	 * Public methods
@@ -78,32 +82,6 @@ class Agreement implements ActionInterface
 		if (isset($_SESSION['old_url'])) {
 			$_SESSION['redirect_url'] = $_SESSION['old_url'];
 		}
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
 	}
 
 	/**
@@ -150,17 +128,6 @@ class Agreement implements ActionInterface
 		Utils::$context['privacy_policy_accepted_date'] = empty(Theme::$current->options['policy_accepted']) ? 0 : Theme::$current->options['policy_accepted'];
 
 		return empty(Theme::$current->options['policy_accepted']) || Config::$modSettings['policy_updated_' . $policy_lang] > Theme::$current->options['policy_accepted'];
-	}
-
-	/******************
-	 * Internal methods
-	 ******************/
-
-	/**
-	 * Constructor. Protected to force instantiation via self::load().
-	 */
-	protected function __construct()
-	{
 	}
 
 	/**

--- a/Sources/Actions/AgreementAccept.php
+++ b/Sources/Actions/AgreementAccept.php
@@ -26,18 +26,6 @@ use SMF\Utils;
  */
 class AgreementAccept extends Agreement
 {
-	/*********************
-	 * Internal properties
-	 *********************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of the class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static AgreementAccept|Agreement $obj;
-
 	/****************
 	 * Public methods
 	 ****************/
@@ -84,43 +72,6 @@ class AgreementAccept extends Agreement
 
 		// Redirect back to chasing those squirrels, er, viewing those memes.
 		Utils::redirectexit(!empty($_SESSION['redirect_url']) ? $_SESSION['redirect_url'] : '');
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
-	}
-
-	/******************
-	 * Internal methods
-	 ******************/
-
-	/**
-	 * Constructor. Protected to force instantiation via self::load().
-	 */
-	protected function __construct()
-	{
 	}
 }
 

--- a/Sources/Actions/Announce.php
+++ b/Sources/Actions/Announce.php
@@ -15,6 +15,8 @@ declare(strict_types=1);
 
 namespace SMF\Actions;
 
+use SMF\ActionInterface;
+use SMF\ActionTrait;
 use SMF\BBCodeParser;
 use SMF\Board;
 use SMF\BrowserDetector;
@@ -35,6 +37,8 @@ use SMF\Utils;
  */
 class Announce implements ActionInterface
 {
+	use ActionTrait;
+
 	use BackwardCompatibility;
 
 	/*******************
@@ -62,18 +66,6 @@ class Announce implements ActionInterface
 		'selectgroup' => 'select',
 		'send' => 'send',
 	];
-
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static Announce $obj;
 
 	/****************
 	 * Public methods
@@ -278,32 +270,6 @@ class Announce implements ActionInterface
 		if (!empty(Config::$modSettings['userLanguage'])) {
 			Lang::load('Post');
 		}
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
 	}
 
 	/******************

--- a/Sources/Actions/AttachmentApprove.php
+++ b/Sources/Actions/AttachmentApprove.php
@@ -15,6 +15,8 @@ declare(strict_types=1);
 
 namespace SMF\Actions;
 
+use SMF\ActionInterface;
+use SMF\ActionTrait;
 use SMF\Attachment;
 use SMF\Db\DatabaseApi as Db;
 use SMF\ErrorHandler;
@@ -26,17 +28,7 @@ use SMF\Utils;
  */
 class AttachmentApprove implements ActionInterface
 {
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static AttachmentApprove $obj;
+	use ActionTrait;
 
 	/****************
 	 * Public methods
@@ -130,43 +122,6 @@ class AttachmentApprove implements ActionInterface
 
 		// Return to the topic....
 		Utils::redirectexit($redirect);
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
-	}
-
-	/******************
-	 * Internal methods
-	 ******************/
-
-	/**
-	 * Constructor. Protected to force instantiation via self::load().
-	 */
-	protected function __construct()
-	{
 	}
 }
 

--- a/Sources/Actions/AttachmentDownload.php
+++ b/Sources/Actions/AttachmentDownload.php
@@ -15,6 +15,8 @@ declare(strict_types=1);
 
 namespace SMF\Actions;
 
+use SMF\ActionInterface;
+use SMF\ActionTrait;
 use SMF\Attachment;
 use SMF\BrowserDetector;
 use SMF\Cache\CacheApi;
@@ -35,6 +37,8 @@ use SMF\Utils;
  */
 class AttachmentDownload implements ActionInterface
 {
+	use ActionTrait;
+
 	/*******************
 	 * Public properties
 	 *******************/
@@ -52,18 +56,6 @@ class AttachmentDownload implements ActionInterface
 	 * Whether to show the thumbnail image, if one is available.
 	 */
 	public bool $showThumb;
-
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static AttachmentDownload $obj;
 
 	/****************
 	 * Public methods
@@ -313,32 +305,6 @@ class AttachmentDownload implements ActionInterface
 		}
 
 		Utils::emitFile($file, $this->showThumb);
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
 	}
 
 	/******************

--- a/Sources/Actions/AttachmentUpload.php
+++ b/Sources/Actions/AttachmentUpload.php
@@ -13,6 +13,8 @@
 
 namespace SMF\Actions;
 
+use SMF\ActionInterface;
+use SMF\ActionTrait;
 use SMF\Attachment;
 use SMF\Config;
 use SMF\Db\DatabaseApi as Db;
@@ -27,6 +29,8 @@ use SMF\Utils;
  */
 class AttachmentUpload implements ActionInterface
 {
+	use ActionTrait;
+
 	/**
 	 * @var int The ID of the message this attachment is associated with
 	 */
@@ -103,35 +107,6 @@ class AttachmentUpload implements ActionInterface
 	 * @var string|bool The current sub-action, or false if there isn't one
 	 */
 	protected $_sa = false;
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 */
-	protected static AttachmentUpload $obj;
-
-	/**
-	 * Wrapper for constructor. Ensures only one instance is created.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
-	}
 
 	/**
 	 * Attachments constructor.

--- a/Sources/Actions/AutoSuggest.php
+++ b/Sources/Actions/AutoSuggest.php
@@ -15,6 +15,8 @@ declare(strict_types=1);
 
 namespace SMF\Actions;
 
+use SMF\ActionInterface;
+use SMF\ActionTrait;
 use SMF\Db\DatabaseApi as Db;
 use SMF\IntegrationHook;
 use SMF\Theme;
@@ -26,6 +28,8 @@ use SMF\Utils;
  */
 class AutoSuggest implements ActionInterface
 {
+	use ActionTrait;
+
 	/*******************
 	 * Public properties
 	 *******************/
@@ -68,18 +72,6 @@ class AutoSuggest implements ActionInterface
 		'membergroups' => 'membergroups',
 		'versions' => 'versions',
 	];
-
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static AutoSuggest $obj;
 
 	/****************
 	 * Public methods
@@ -273,32 +265,6 @@ class AutoSuggest implements ActionInterface
 		}
 
 		return $xml_data;
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
 	}
 
 	/**

--- a/Sources/Actions/BoardIndex.php
+++ b/Sources/Actions/BoardIndex.php
@@ -15,6 +15,8 @@ declare(strict_types=1);
 
 namespace SMF\Actions;
 
+use SMF\ActionInterface;
+use SMF\ActionTrait;
 use SMF\Board;
 use SMF\Cache\CacheApi;
 use SMF\Category;
@@ -39,16 +41,7 @@ use SMF\Utils;
  */
 class BoardIndex implements ActionInterface
 {
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 */
-	protected static BoardIndex $obj;
+	use ActionTrait;
 
 	/****************
 	 * Public methods
@@ -235,32 +228,6 @@ class BoardIndex implements ActionInterface
 					$cache_block[\'data\'][$k][\'timestamp\'] = $post[\'raw_timestamp\'];
 				}',
 		];
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
 	}
 
 	/**

--- a/Sources/Actions/BuddyListToggle.php
+++ b/Sources/Actions/BuddyListToggle.php
@@ -15,6 +15,8 @@ declare(strict_types=1);
 
 namespace SMF\Actions;
 
+use SMF\ActionInterface;
+use SMF\ActionTrait;
 use SMF\Cache\CacheApi;
 use SMF\Db\DatabaseApi as Db;
 use SMF\ErrorHandler;
@@ -29,6 +31,8 @@ use SMF\Utils;
  */
 class BuddyListToggle implements ActionInterface
 {
+	use ActionTrait;
+
 	/*******************
 	 * Public properties
 	 *******************/
@@ -39,18 +43,6 @@ class BuddyListToggle implements ActionInterface
 	 * ID of the user being added or removed from the buddy list.
 	 */
 	public string $userReceiver;
-
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static BuddyListToggle $obj;
 
 	/****************
 	 * Public methods
@@ -111,32 +103,6 @@ class BuddyListToggle implements ActionInterface
 
 		// Redirect back to the profile
 		Utils::redirectexit('action=profile;u=' . $this->userReceiver);
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
 	}
 
 	/******************

--- a/Sources/Actions/Calendar.php
+++ b/Sources/Actions/Calendar.php
@@ -15,6 +15,8 @@ declare(strict_types=1);
 
 namespace SMF\Actions;
 
+use SMF\ActionInterface;
+use SMF\ActionTrait;
 use SMF\Board;
 use SMF\BrowserDetector;
 use SMF\Cache\CacheApi;
@@ -37,6 +39,8 @@ use SMF\Utils;
  */
 class Calendar implements ActionInterface
 {
+	use ActionTrait;
+
 	use BackwardCompatibility;
 
 	/*******************
@@ -77,7 +81,7 @@ class Calendar implements ActionInterface
 	 * An instance of the class.
 	 * This is used by the load() method to prevent multiple instantiations.
 	 */
-	protected static Calendar $obj;
+
 
 	/****************
 	 * Public methods
@@ -639,32 +643,6 @@ class Calendar implements ActionInterface
 				}
 			}
 		}
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
 	}
 
 	/**

--- a/Sources/Actions/CoppaForm.php
+++ b/Sources/Actions/CoppaForm.php
@@ -15,6 +15,8 @@ declare(strict_types=1);
 
 namespace SMF\Actions;
 
+use SMF\ActionInterface;
+use SMF\ActionTrait;
 use SMF\BrowserDetector;
 use SMF\Config;
 use SMF\Db\DatabaseApi as Db;
@@ -28,17 +30,7 @@ use SMF\Utils;
  */
 class CoppaForm implements ActionInterface
 {
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static CoppaForm $obj;
+	use ActionTrait;
 
 	/****************
 	 * Public methods
@@ -132,32 +124,6 @@ class CoppaForm implements ActionInterface
 				'id' => $_GET['member'],
 			];
 		}
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
 	}
 
 	/******************

--- a/Sources/Actions/Credits.php
+++ b/Sources/Actions/Credits.php
@@ -15,6 +15,8 @@ declare(strict_types=1);
 
 namespace SMF\Actions;
 
+use SMF\ActionInterface;
+use SMF\ActionTrait;
 use SMF\Cache\CacheApi;
 use SMF\Config;
 use SMF\Db\DatabaseApi as Db;
@@ -31,6 +33,8 @@ use SMF\Utils;
  */
 class Credits implements ActionInterface
 {
+	use ActionTrait;
+
 	/*******************
 	 * Public properties
 	 *******************/
@@ -41,18 +45,6 @@ class Credits implements ActionInterface
 	 * If true, will not load the sub-template nor the template file.
 	 */
 	public bool $in_admin = false;
-
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static Credits $obj;
 
 	/****************
 	 * Public methods
@@ -413,20 +405,6 @@ class Credits implements ActionInterface
 	/***********************
 	 * Public static methods
 	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
 
 	/**
 	 * Convenience method to load() and execute() an instance of this class.

--- a/Sources/Actions/Display.php
+++ b/Sources/Actions/Display.php
@@ -15,6 +15,8 @@ declare(strict_types=1);
 
 namespace SMF\Actions;
 
+use SMF\ActionInterface;
+use SMF\ActionTrait;
 use SMF\Alert;
 use SMF\Attachment;
 use SMF\Board;
@@ -51,6 +53,8 @@ use SMF\Verifier;
  */
 class Display implements ActionInterface
 {
+	use ActionTrait;
+
 	/*******************
 	 * Public properties
 	 *******************/
@@ -94,17 +98,6 @@ class Display implements ActionInterface
 	 * Might or might not be set.
 	 */
 	private int $virtual_msg;
-
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 */
-	protected static Display $obj;
 
 	/****************
 	 * Public methods
@@ -278,32 +271,6 @@ class Display implements ActionInterface
 		IntegrationHook::call('integrate_prepare_display_context', [&$output, $message, $counter]);
 
 		return $output;
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
 	}
 
 	/******************

--- a/Sources/Actions/DisplayAdminFile.php
+++ b/Sources/Actions/DisplayAdminFile.php
@@ -15,6 +15,8 @@ declare(strict_types=1);
 
 namespace SMF\Actions;
 
+use SMF\ActionInterface;
+use SMF\ActionTrait;
 use SMF\Config;
 use SMF\Db\DatabaseApi as Db;
 use SMF\ErrorHandler;
@@ -26,17 +28,7 @@ use SMF\Utils;
  */
 class DisplayAdminFile implements ActionInterface
 {
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static DisplayAdminFile $obj;
+	use ActionTrait;
 
 	/****************
 	 * Public methods
@@ -94,43 +86,6 @@ class DisplayAdminFile implements ActionInterface
 		header('content-type: ' . $filetype);
 		echo $file_data;
 		Utils::obExit(false);
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
-	}
-
-	/******************
-	 * Internal methods
-	 ******************/
-
-	/**
-	 * Constructor. Protected to force instantiation via self::load().
-	 */
-	protected function __construct()
-	{
 	}
 }
 

--- a/Sources/Actions/Feed.php
+++ b/Sources/Actions/Feed.php
@@ -15,6 +15,8 @@ declare(strict_types=1);
 
 namespace SMF\Actions;
 
+use SMF\ActionInterface;
+use SMF\ActionTrait;
 use SMF\Attachment;
 use SMF\BBCodeParser;
 use SMF\Board;
@@ -60,6 +62,8 @@ use SMF\Utils;
  */
 class Feed implements ActionInterface
 {
+	use ActionTrait;
+
 	/*****************
 	 * Class constants
 	 *****************/
@@ -241,17 +245,6 @@ class Feed implements ActionInterface
 	 * Used to generate globally unique identifiers.
 	 */
 	protected string $host = '';
-
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 */
-	protected static Feed $obj;
 
 	/****************
 	 * Public methods
@@ -2636,28 +2629,6 @@ class Feed implements ActionInterface
 	/***********************
 	 * Public static methods
 	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of the class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of the child class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
-	}
 
 	/**
 	 * Builds the XML from the data.

--- a/Sources/Actions/FindMember.php
+++ b/Sources/Actions/FindMember.php
@@ -15,6 +15,8 @@ declare(strict_types=1);
 
 namespace SMF\Actions;
 
+use SMF\ActionInterface;
+use SMF\ActionTrait;
 use SMF\Config;
 use SMF\PageIndex;
 use SMF\Theme;
@@ -32,17 +34,7 @@ use SMF\Utils;
  */
 class FindMember implements ActionInterface
 {
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static FindMember $obj;
+	use ActionTrait;
 
 	/****************
 	 * Public methods
@@ -108,43 +100,6 @@ class FindMember implements ActionInterface
 		} else {
 			Utils::$context['links']['up'] = Config::$scripturl . '?action=pm;sa=send' . (empty($_REQUEST['u']) ? '' : ';u=' . $_REQUEST['u']);
 		}
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
-	}
-
-	/******************
-	 * Internal methods
-	 ******************/
-
-	/**
-	 * Constructor. Protected to force instantiation via self::load().
-	 */
-	protected function __construct()
-	{
 	}
 }
 

--- a/Sources/Actions/Groups.php
+++ b/Sources/Actions/Groups.php
@@ -13,7 +13,9 @@
 
 namespace SMF\Actions;
 
+use SMF\ActionInterface;
 use SMF\Actions\Moderation\Main as ModCenter;
+use SMF\ActionTrait;
 use SMF\BBCodeParser;
 use SMF\Config;
 use SMF\Db\DatabaseApi as Db;
@@ -35,6 +37,8 @@ use SMF\Utils;
  */
 class Groups implements ActionInterface
 {
+	use ActionTrait;
+
 	use BackwardCompatibility;
 
 	/*******************
@@ -79,18 +83,6 @@ class Groups implements ActionInterface
 	 *  - '?action=moderate;area=viewgroups'
 	 */
 	protected string $action_url = '?action=groups';
-
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var object
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static object $obj;
 
 	/****************
 	 * Public methods
@@ -697,32 +689,6 @@ class Groups implements ActionInterface
 		Menu::$loaded['moderate']->tab_data = [
 			'title' => Lang::$txt['mc_group_requests'],
 		];
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
 	}
 
 	/**

--- a/Sources/Actions/Help.php
+++ b/Sources/Actions/Help.php
@@ -15,6 +15,8 @@ declare(strict_types=1);
 
 namespace SMF\Actions;
 
+use SMF\ActionInterface;
+use SMF\ActionTrait;
 use SMF\Config;
 use SMF\IntegrationHook;
 use SMF\Lang;
@@ -26,6 +28,8 @@ use SMF\Utils;
  */
 class Help implements ActionInterface
 {
+	use ActionTrait;
+
 	use BackwardCompatibility;
 
 	/*******************
@@ -52,18 +56,6 @@ class Help implements ActionInterface
 	public static array $subactions = [
 		'index' => 'index',
 	];
-
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static Help $obj;
 
 	/****************
 	 * Public methods
@@ -115,32 +107,6 @@ class Help implements ActionInterface
 		// Lastly, some minor template stuff.
 		Utils::$context['page_title'] = Lang::$txt['manual_smf_user_help'];
 		Utils::$context['sub_template'] = 'manual';
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
 	}
 
 	/**

--- a/Sources/Actions/HelpAdmin.php
+++ b/Sources/Actions/HelpAdmin.php
@@ -15,6 +15,8 @@ declare(strict_types=1);
 
 namespace SMF\Actions;
 
+use SMF\ActionInterface;
+use SMF\ActionTrait;
 use SMF\Config;
 use SMF\ErrorHandler;
 use SMF\IntegrationHook;
@@ -29,17 +31,7 @@ use SMF\Utils;
  */
 class HelpAdmin implements ActionInterface
 {
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static HelpAdmin $obj;
+	use ActionTrait;
 
 	/****************
 	 * Public methods
@@ -142,43 +134,6 @@ class HelpAdmin implements ActionInterface
 		// Don't show any template layers, just the popup sub template.
 		Utils::$context['template_layers'] = [];
 		Utils::$context['sub_template'] = 'popup';
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
-	}
-
-	/******************
-	 * Internal methods
-	 ******************/
-
-	/**
-	 * Constructor. Protected to force instantiation via self::load().
-	 */
-	protected function __construct()
-	{
 	}
 }
 

--- a/Sources/Actions/JavaScriptModify.php
+++ b/Sources/Actions/JavaScriptModify.php
@@ -15,6 +15,8 @@ declare(strict_types=1);
 
 namespace SMF\Actions;
 
+use SMF\ActionInterface;
+use SMF\ActionTrait;
 use SMF\BBCodeParser;
 use SMF\Board;
 use SMF\Cache\CacheApi;
@@ -37,17 +39,7 @@ use SMF\Utils;
  */
 class JavaScriptModify implements ActionInterface
 {
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static JavaScriptModify $obj;
+	use ActionTrait;
 
 	/****************
 	 * Public methods
@@ -317,32 +309,6 @@ class JavaScriptModify implements ActionInterface
 		} else {
 			Utils::obExit(false);
 		}
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
 	}
 
 	/******************

--- a/Sources/Actions/Like.php
+++ b/Sources/Actions/Like.php
@@ -15,6 +15,8 @@ declare(strict_types=1);
 
 namespace SMF\Actions;
 
+use SMF\ActionInterface;
+use SMF\ActionTrait;
 use SMF\Alert;
 use SMF\Cache\CacheApi;
 use SMF\Config;
@@ -31,6 +33,8 @@ use SMF\Utils;
  */
 class Like implements ActionInterface
 {
+	use ActionTrait;
+
 	/*******************
 	 * Public properties
 	 *******************/
@@ -182,17 +186,6 @@ class Like implements ActionInterface
 	 */
 	protected mixed $data;
 
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 */
-	protected static Like $obj;
-
 	/****************
 	 * Public methods
 	 ****************/
@@ -251,32 +244,6 @@ class Like implements ActionInterface
 	public function get(string $property = ''): mixed
 	{
 		return property_exists($this, $property) ? $this->$property : false;
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Wrapper for constructor. Ensures only one instance is created.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
 	}
 
 	/******************

--- a/Sources/Actions/Login.php
+++ b/Sources/Actions/Login.php
@@ -27,18 +27,6 @@ use SMF\Utils;
  */
 class Login extends Login2
 {
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static Login|Login2 $obj;
-
 	/****************
 	 * Public methods
 	 ****************/
@@ -97,43 +85,6 @@ class Login extends Login2
 
 		// Create a one time token.
 		SecurityToken::create('login');
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
-	}
-
-	/******************
-	 * Internal methods
-	 ******************/
-
-	/**
-	 * Constructor. Protected to force instantiation via self::load().
-	 */
-	protected function __construct()
-	{
 	}
 }
 

--- a/Sources/Actions/Login2.php
+++ b/Sources/Actions/Login2.php
@@ -15,6 +15,8 @@ declare(strict_types=1);
 
 namespace SMF\Actions;
 
+use SMF\ActionInterface;
+use SMF\ActionTrait;
 use SMF\Config;
 use SMF\Cookie;
 use SMF\Db\DatabaseApi as Db;
@@ -33,6 +35,8 @@ use SMF\Utils;
  */
 class Login2 implements ActionInterface
 {
+	use ActionTrait;
+
 	/*******************
 	 * Public properties
 	 *******************/
@@ -59,18 +63,6 @@ class Login2 implements ActionInterface
 		'salt' => 'updateSalt',
 		'check' => 'checkCookie',
 	];
-
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static Login2 $obj;
 
 	/****************
 	 * Public methods
@@ -317,32 +309,6 @@ class Login2 implements ActionInterface
 		}
 
 		$this->DoLogin();
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
 	}
 
 	/**

--- a/Sources/Actions/LoginTFA.php
+++ b/Sources/Actions/LoginTFA.php
@@ -31,18 +31,6 @@ use SMF\Utils;
  */
 class LoginTFA extends Login2
 {
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static LoginTFA|Login2 $obj;
-
 	/****************
 	 * Public methods
 	 ****************/
@@ -122,43 +110,6 @@ class LoginTFA extends Login2
 		Utils::$context['sub_template'] = 'login_tfa';
 		Utils::$context['page_title'] = Lang::$txt['login'];
 		Utils::$context['tfa_url'] = Config::$scripturl . '?action=logintfa';
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
-	}
-
-	/******************
-	 * Internal methods
-	 ******************/
-
-	/**
-	 * Constructor. Protected to force instantiation via self::load().
-	 */
-	protected function __construct()
-	{
 	}
 }
 

--- a/Sources/Actions/Logout.php
+++ b/Sources/Actions/Logout.php
@@ -30,18 +30,6 @@ use SMF\Utils;
  */
 class Logout extends Login2
 {
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static Logout|Login2 $obj;
-
 	/****************
 	 * Public methods
 	 ****************/
@@ -153,20 +141,6 @@ class Logout extends Login2
 	 ***********************/
 
 	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
 	 * Convenience method to load() and execute() an instance of this class.
 	 *
 	 * @param bool $internal If true, it doesn't check the session
@@ -175,17 +149,6 @@ class Logout extends Login2
 	public static function call(bool $internal = false, bool $redirect = true): void
 	{
 		self::load()->execute($internal, $redirect);
-	}
-
-	/******************
-	 * Internal methods
-	 ******************/
-
-	/**
-	 * Constructor. Protected to force instantiation via self::load().
-	 */
-	protected function __construct()
-	{
 	}
 }
 

--- a/Sources/Actions/Memberlist.php
+++ b/Sources/Actions/Memberlist.php
@@ -15,6 +15,8 @@ declare(strict_types=1);
 
 namespace SMF\Actions;
 
+use SMF\ActionInterface;
+use SMF\ActionTrait;
 use SMF\BBCodeParser;
 use SMF\Config;
 use SMF\Db\DatabaseApi as Db;
@@ -33,6 +35,8 @@ use SMF\Utils;
  */
 class Memberlist implements ActionInterface
 {
+	use ActionTrait;
+
 	use BackwardCompatibility;
 
 	/*******************
@@ -87,18 +91,6 @@ class Memberlist implements ActionInterface
 		'all' => 'all',
 		'search' => 'search',
 	];
-
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static Memberlist $obj;
 
 	/****************
 	 * Public methods
@@ -666,32 +658,6 @@ class Memberlist implements ActionInterface
 		// Highlight the correct button, too!
 		unset(Utils::$context['memberlist_buttons']['view_all_members']['active']);
 		Utils::$context['memberlist_buttons']['mlist_search']['active'] = true;
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
 	}
 
 	/**

--- a/Sources/Actions/MessageIndex.php
+++ b/Sources/Actions/MessageIndex.php
@@ -15,6 +15,8 @@ declare(strict_types=1);
 
 namespace SMF\Actions;
 
+use SMF\ActionInterface;
+use SMF\ActionTrait;
 use SMF\BBCodeParser;
 use SMF\Board;
 use SMF\Category;
@@ -37,6 +39,8 @@ use SMF\Utils;
  */
 class MessageIndex implements ActionInterface
 {
+	use ActionTrait;
+
 	/*******************
 	 * Public properties
 	 *******************/
@@ -125,17 +129,6 @@ class MessageIndex implements ActionInterface
 	 */
 	protected bool $ascending_is_default = false;
 
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 */
-	protected static MessageIndex $obj;
-
 	/****************
 	 * Public methods
 	 ****************/
@@ -156,32 +149,6 @@ class MessageIndex implements ActionInterface
 
 		$this->buildQuickMod();
 		$this->buildButtons();
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
 	}
 
 	/**

--- a/Sources/Actions/Moderation/EndSession.php
+++ b/Sources/Actions/Moderation/EndSession.php
@@ -15,7 +15,8 @@ declare(strict_types=1);
 
 namespace SMF\Actions\Moderation;
 
-use SMF\Actions\ActionInterface;
+use SMF\ActionInterface;
+use SMF\ActionTrait;
 use SMF\Utils;
 
 /**
@@ -24,17 +25,7 @@ use SMF\Utils;
  */
 class EndSession implements ActionInterface
 {
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static EndSession $obj;
+	use ActionTrait;
 
 	/****************
 	 * Public methods
@@ -56,43 +47,6 @@ class EndSession implements ActionInterface
 		}
 
 		Utils::redirectexit();
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return object An instance of this class.
-	 */
-	public static function load(): object
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
-	}
-
-	/******************
-	 * Internal methods
-	 ******************/
-
-	/**
-	 * Constructor. Protected to force instantiation via self::load().
-	 */
-	protected function __construct()
-	{
 	}
 }
 

--- a/Sources/Actions/Moderation/Home.php
+++ b/Sources/Actions/Moderation/Home.php
@@ -15,7 +15,8 @@ declare(strict_types=1);
 
 namespace SMF\Actions\Moderation;
 
-use SMF\Actions\ActionInterface;
+use SMF\ActionInterface;
+use SMF\ActionTrait;
 use SMF\BBCodeParser;
 use SMF\Cache\CacheApi;
 use SMF\Config;
@@ -35,6 +36,8 @@ use SMF\Utils;
  */
 class Home implements ActionInterface
 {
+	use ActionTrait;
+
 	/*******************
 	 * Public properties
 	 *******************/
@@ -71,18 +74,6 @@ class Home implements ActionInterface
 			'permissions' => ['can_moderate_users'],
 		],
 	];
-
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static Home $obj;
 
 	/****************
 	 * Public methods
@@ -135,32 +126,6 @@ class Home implements ActionInterface
 		self::integrateModBlocks();
 
 		Utils::$context['admin_prefs'] = !empty(Theme::$current->options['admin_preferences']) ? Utils::jsonDecode(Theme::$current->options['admin_preferences'], true) : [];
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
 	}
 
 	/******************

--- a/Sources/Actions/Moderation/Logs.php
+++ b/Sources/Actions/Moderation/Logs.php
@@ -15,7 +15,8 @@ declare(strict_types=1);
 
 namespace SMF\Actions\Moderation;
 
-use SMF\Actions\ActionInterface;
+use SMF\ActionInterface;
+use SMF\ActionTrait;
 use SMF\Config;
 use SMF\Db\DatabaseApi as Db;
 use SMF\IntegrationHook;
@@ -35,6 +36,8 @@ use SMF\Utils;
  */
 class Logs implements ActionInterface
 {
+	use ActionTrait;
+
 	/*******************
 	 * Public properties
 	 *******************/
@@ -209,18 +212,6 @@ class Logs implements ActionInterface
 	 */
 	protected array $search_info;
 
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static Logs $obj;
-
 	/****************
 	 * Public methods
 	 ****************/
@@ -261,32 +252,6 @@ class Logs implements ActionInterface
 		$this->deleteEntries();
 
 		$this->createList();
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
 	}
 
 	/**

--- a/Sources/Actions/Moderation/Main.php
+++ b/Sources/Actions/Moderation/Main.php
@@ -17,7 +17,8 @@ declare(strict_types=1);
 
 namespace SMF\Actions\Moderation;
 
-use SMF\Actions\ActionInterface;
+use SMF\ActionInterface;
+use SMF\ActionTrait;
 use SMF\Config;
 use SMF\ErrorHandler;
 use SMF\Lang;
@@ -31,6 +32,8 @@ use SMF\Utils;
  */
 class Main implements ActionInterface
 {
+	use ActionTrait;
+
 	/*******************
 	 * Public properties
 	 *******************/
@@ -198,18 +201,6 @@ class Main implements ActionInterface
 		],
 	];
 
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static Main $obj;
-
 	/**
 	 * @var bool
 	 *
@@ -299,32 +290,6 @@ class Main implements ActionInterface
 				'name' => $menu->include_data['subsections'][$menu->current_subsection]['label'],
 			];
 		}
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
 	}
 
 	/**

--- a/Sources/Actions/Moderation/Posts.php
+++ b/Sources/Actions/Moderation/Posts.php
@@ -15,8 +15,9 @@ declare(strict_types=1);
 
 namespace SMF\Actions\Moderation;
 
-use SMF\Actions\ActionInterface;
+use SMF\ActionInterface;
 use SMF\Actions\BackwardCompatibility;
+use SMF\ActionTrait;
 use SMF\Attachment;
 use SMF\BBCodeParser;
 use SMF\Board;
@@ -41,6 +42,8 @@ use SMF\Utils;
  */
 class Posts implements ActionInterface
 {
+	use ActionTrait;
+
 	use BackwardCompatibility;
 
 	/*******************
@@ -70,18 +73,6 @@ class Posts implements ActionInterface
 		'attachments' => 'attachments',
 		'approve' => 'approve',
 	];
-
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static Posts $obj;
 
 	/****************
 	 * Public methods
@@ -687,32 +678,6 @@ class Posts implements ActionInterface
 		}
 
 		Utils::redirectexit('topic=' . Topic::$topic_id . '.msg' . $_REQUEST['msg'] . '#msg' . $_REQUEST['msg']);
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
 	}
 
 	/**

--- a/Sources/Actions/Moderation/ReportedContent.php
+++ b/Sources/Actions/Moderation/ReportedContent.php
@@ -15,8 +15,9 @@ declare(strict_types=1);
 
 namespace SMF\Actions\Moderation;
 
-use SMF\Actions\ActionInterface;
+use SMF\ActionInterface;
 use SMF\Actions\BackwardCompatibility;
+use SMF\ActionTrait;
 use SMF\Alert;
 use SMF\BBCodeParser;
 use SMF\Config;
@@ -40,6 +41,8 @@ use SMF\Utils;
  */
 class ReportedContent implements ActionInterface
 {
+	use ActionTrait;
+
 	use BackwardCompatibility;
 
 	/*******************
@@ -106,18 +109,6 @@ class ReportedContent implements ActionInterface
 	 * Whether the current user has the manage_bans permission.
 	 */
 	protected bool $manage_bans = false;
-
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static ReportedContent $obj;
 
 	/****************
 	 * Public methods
@@ -575,32 +566,6 @@ class ReportedContent implements ActionInterface
 		}
 
 		SecurityToken::create('mod-reportC-edit');
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
 	}
 
 	/**

--- a/Sources/Actions/Moderation/ShowNotice.php
+++ b/Sources/Actions/Moderation/ShowNotice.php
@@ -15,7 +15,8 @@ declare(strict_types=1);
 
 namespace SMF\Actions\Moderation;
 
-use SMF\Actions\ActionInterface;
+use SMF\ActionInterface;
+use SMF\ActionTrait;
 use SMF\BBCodeParser;
 use SMF\Db\DatabaseApi as Db;
 use SMF\ErrorHandler;
@@ -29,17 +30,7 @@ use SMF\Utils;
  */
 class ShowNotice implements ActionInterface
 {
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static ShowNotice $obj;
+	use ActionTrait;
 
 	/****************
 	 * Public methods
@@ -69,32 +60,6 @@ class ShowNotice implements ActionInterface
 		Db::$db->free_result($request);
 
 		Utils::$context['notice_body'] = BBCodeParser::load()->parse(Utils::$context['notice_body'], false);
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
 	}
 
 	/******************

--- a/Sources/Actions/Moderation/Warnings.php
+++ b/Sources/Actions/Moderation/Warnings.php
@@ -15,8 +15,9 @@ declare(strict_types=1);
 
 namespace SMF\Actions\Moderation;
 
-use SMF\Actions\ActionInterface;
+use SMF\ActionInterface;
 use SMF\Actions\BackwardCompatibility;
+use SMF\ActionTrait;
 use SMF\Config;
 use SMF\Db\DatabaseApi as Db;
 use SMF\IntegrationHook;
@@ -36,6 +37,8 @@ use SMF\Utils;
  */
 class Warnings implements ActionInterface
 {
+	use ActionTrait;
+
 	use BackwardCompatibility;
 
 	/*******************
@@ -64,18 +67,6 @@ class Warnings implements ActionInterface
 		'templates' => ['templates', 'issue_warning'],
 		'templateedit' => ['templateEdit', 'issue_warning'],
 	];
-
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static Warnings $obj;
 
 	/****************
 	 * Public methods
@@ -565,32 +556,6 @@ class Warnings implements ActionInterface
 		}
 
 		SecurityToken::create('mod-wt');
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
 	}
 
 	/**

--- a/Sources/Actions/Moderation/WatchedUsers.php
+++ b/Sources/Actions/Moderation/WatchedUsers.php
@@ -15,7 +15,8 @@ declare(strict_types=1);
 
 namespace SMF\Actions\Moderation;
 
-use SMF\Actions\ActionInterface;
+use SMF\ActionInterface;
+use SMF\ActionTrait;
 use SMF\BBCodeParser;
 use SMF\Config;
 use SMF\Db\DatabaseApi as Db;
@@ -33,17 +34,7 @@ use SMF\Utils;
  */
 class WatchedUsers implements ActionInterface
 {
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static WatchedUsers $obj;
+	use ActionTrait;
 
 	/****************
 	 * Public methods
@@ -234,32 +225,6 @@ class WatchedUsers implements ActionInterface
 
 		Utils::$context['sub_template'] = 'show_list';
 		Utils::$context['default_list'] = 'watch_user_list';
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
 	}
 
 	/**

--- a/Sources/Actions/MsgDelete.php
+++ b/Sources/Actions/MsgDelete.php
@@ -15,6 +15,8 @@ declare(strict_types=1);
 
 namespace SMF\Actions;
 
+use SMF\ActionInterface;
+use SMF\ActionTrait;
 use SMF\Board;
 use SMF\Config;
 use SMF\Db\DatabaseApi as Db;
@@ -30,17 +32,7 @@ use SMF\Utils;
  */
 class MsgDelete implements ActionInterface
 {
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static MsgDelete $obj;
+	use ActionTrait;
 
 	/****************
 	 * Public methods
@@ -118,43 +110,6 @@ class MsgDelete implements ActionInterface
 		} else {
 			Utils::redirectexit('topic=' . Topic::$topic_id . '.' . $_REQUEST['start']);
 		}
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
-	}
-
-	/******************
-	 * Internal methods
-	 ******************/
-
-	/**
-	 * Constructor. Protected to force instantiation via self::load().
-	 */
-	protected function __construct()
-	{
 	}
 }
 

--- a/Sources/Actions/Notify.php
+++ b/Sources/Actions/Notify.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 
 namespace SMF\Actions;
 
+use SMF\ActionTrait;
 use SMF\Config;
 use SMF\Db\DatabaseApi as Db;
 use SMF\ErrorHandler;
@@ -33,6 +34,8 @@ use SMF\Utils;
  */
 abstract class Notify
 {
+	use ActionTrait;
+
 	/*****************
 	 * Class constants
 	 *****************/

--- a/Sources/Actions/NotifyAnnouncements.php
+++ b/Sources/Actions/NotifyAnnouncements.php
@@ -21,7 +21,7 @@ use SMF\Utils;
 /**
  * Toggles email notification preferences for announcements.
  */
-class NotifyAnnouncements extends Notify implements ActionInterface
+class NotifyAnnouncements extends Notify
 {
 	/*******************
 	 * Public properties
@@ -33,55 +33,6 @@ class NotifyAnnouncements extends Notify implements ActionInterface
 	 * The notification type that this action handles.
 	 */
 	public string $type = 'announcements';
-
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static NotifyAnnouncements|Notify $obj;
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
-	}
-
-	/******************
-	 * Internal methods
-	 ******************/
-
-	/**
-	 * Constructor. Protected to force instantiation via self::load().
-	 */
-	protected function __construct()
-	{
-	}
 
 	/**
 	 * This does nothing for announcements.

--- a/Sources/Actions/NotifyBoard.php
+++ b/Sources/Actions/NotifyBoard.php
@@ -24,7 +24,7 @@ use SMF\Utils;
 /**
  * Toggles email notification preferences for boards.
  */
-class NotifyBoard extends Notify implements ActionInterface
+class NotifyBoard extends Notify
 {
 	/*******************
 	 * Public properties
@@ -36,55 +36,6 @@ class NotifyBoard extends Notify implements ActionInterface
 	 * The notification type that this action handles.
 	 */
 	public string $type = 'board';
-
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static NotifyBoard|Notify $obj;
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
-	}
-
-	/******************
-	 * Internal methods
-	 ******************/
-
-	/**
-	 * Constructor. Protected to force instantiation via self::load().
-	 */
-	protected function __construct()
-	{
-	}
 
 	/**
 	 * For board and topic, make sure we have the necessary ID.

--- a/Sources/Actions/NotifyTopic.php
+++ b/Sources/Actions/NotifyTopic.php
@@ -25,7 +25,7 @@ use SMF\Utils;
 /**
  * Toggles email notification preferences for topics.
  */
-class NotifyTopic extends Notify implements ActionInterface
+class NotifyTopic extends Notify
 {
 	/*******************
 	 * Public properties
@@ -37,55 +37,6 @@ class NotifyTopic extends Notify implements ActionInterface
 	 * The notification type that this action handles.
 	 */
 	public string $type = 'topic';
-
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var object
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static object $obj;
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
-	}
-
-	/******************
-	 * Internal methods
-	 ******************/
-
-	/**
-	 * Constructor. Protected to force instantiation via self::load().
-	 */
-	protected function __construct()
-	{
-	}
 
 	/**
 	 * For board and topic, make sure we have the necessary ID.

--- a/Sources/Actions/PersonalMessage.php
+++ b/Sources/Actions/PersonalMessage.php
@@ -15,6 +15,8 @@ declare(strict_types=1);
 
 namespace SMF\Actions;
 
+use SMF\ActionInterface;
+use SMF\ActionTrait;
 use SMF\BrowserDetector;
 use SMF\Cache\CacheApi;
 use SMF\Config;
@@ -33,7 +35,6 @@ use SMF\PersonalMessage\{
 	Received,
 	Rule,
 	Search,
-	SearchResult,
 };
 use SMF\Profile;
 use SMF\Theme;
@@ -47,6 +48,8 @@ use SMF\Utils;
  */
 class PersonalMessage implements ActionInterface
 {
+	use ActionTrait;
+
 	use BackwardCompatibility;
 
 	/*****************
@@ -254,18 +257,6 @@ class PersonalMessage implements ActionInterface
 	 * URL to redirect to for the current label.
 	 */
 	protected string $current_label_redirect;
-
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static PersonalMessage $obj;
 
 	/****************
 	 * Public methods
@@ -718,32 +709,6 @@ class PersonalMessage implements ActionInterface
 		}
 
 		Profile::$member->setupContext(['pm_prefs']);
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
 	}
 
 	/******************

--- a/Sources/Actions/Post.php
+++ b/Sources/Actions/Post.php
@@ -15,6 +15,8 @@ declare(strict_types=1);
 
 namespace SMF\Actions;
 
+use SMF\ActionInterface;
+use SMF\ActionTrait;
 use SMF\Attachment;
 use SMF\BBCodeParser;
 use SMF\Board;
@@ -43,6 +45,8 @@ use SMF\Verifier;
  */
 class Post implements ActionInterface
 {
+	use ActionTrait;
+
 	use BackwardCompatibility;
 
 	/*****************
@@ -179,18 +183,6 @@ class Post implements ActionInterface
 	 * Used by getTopicSummary() method to count previous posts.
 	 */
 	protected int $counter = 0;
-
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static Post $obj;
 
 	/****************
 	 * Public methods
@@ -381,32 +373,6 @@ class Post implements ActionInterface
 		}
 
 		IntegrationHook::call('integrate_post_end');
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
 	}
 
 	/**

--- a/Sources/Actions/Post2.php
+++ b/Sources/Actions/Post2.php
@@ -97,18 +97,6 @@ class Post2 extends Post
 	 */
 	protected bool $moderation_action;
 
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static Post2|Post $obj;
-
 	/****************
 	 * Public methods
 	 ****************/
@@ -651,32 +639,6 @@ class Post2 extends Post
 		else {
 			Utils::redirectexit('board=' . Board::$info->id . '.0');
 		}
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
 	}
 
 	/******************

--- a/Sources/Actions/Profile/Account.php
+++ b/Sources/Actions/Profile/Account.php
@@ -15,7 +15,8 @@ declare(strict_types=1);
 
 namespace SMF\Actions\Profile;
 
-use SMF\Actions\ActionInterface;
+use SMF\ActionInterface;
+use SMF\ActionTrait;
 use SMF\Lang;
 use SMF\Profile;
 use SMF\User;
@@ -26,17 +27,7 @@ use SMF\Utils;
  */
 class Account implements ActionInterface
 {
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static Account $obj;
+	use ActionTrait;
 
 	/****************
 	 * Public methods
@@ -77,32 +68,6 @@ class Account implements ActionInterface
 				'secret_answer',
 			],
 		);
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
 	}
 
 	/******************

--- a/Sources/Actions/Profile/Activate.php
+++ b/Sources/Actions/Profile/Activate.php
@@ -15,7 +15,8 @@ declare(strict_types=1);
 
 namespace SMF\Actions\Profile;
 
-use SMF\Actions\ActionInterface;
+use SMF\ActionInterface;
+use SMF\ActionTrait;
 use SMF\Config;
 use SMF\IntegrationHook;
 use SMF\Logging;
@@ -28,17 +29,7 @@ use SMF\Utils;
  */
 class Activate implements ActionInterface
 {
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static Activate $obj;
+	use ActionTrait;
 
 	/****************
 	 * Public methods
@@ -77,32 +68,6 @@ class Activate implements ActionInterface
 			// Make sure we update the stats too.
 			Logging::updateStats('member', false);
 		}
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
 	}
 
 	/******************

--- a/Sources/Actions/Profile/AlertsPopup.php
+++ b/Sources/Actions/Profile/AlertsPopup.php
@@ -15,7 +15,8 @@ declare(strict_types=1);
 
 namespace SMF\Actions\Profile;
 
-use SMF\Actions\ActionInterface;
+use SMF\ActionInterface;
+use SMF\ActionTrait;
 use SMF\Alert;
 use SMF\Config;
 use SMF\Lang;
@@ -27,17 +28,7 @@ use SMF\Utils;
  */
 class AlertsPopup implements ActionInterface
 {
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static AlertsPopup $obj;
+	use ActionTrait;
 
 	/****************
 	 * Public methods
@@ -65,32 +56,6 @@ class AlertsPopup implements ActionInterface
 			// Now fetch me my unread alerts, pronto!
 			Utils::$context['unread_alerts'] = Alert::fetch(User::$me->id, false, !empty($counter) ? User::$me->alerts - $counter : $limit, 0, !isset($_REQUEST['counter']));
 		}
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
 	}
 
 	/******************

--- a/Sources/Actions/Profile/BuddyIgnoreLists.php
+++ b/Sources/Actions/Profile/BuddyIgnoreLists.php
@@ -15,7 +15,8 @@ declare(strict_types=1);
 
 namespace SMF\Actions\Profile;
 
-use SMF\Actions\ActionInterface;
+use SMF\ActionInterface;
+use SMF\ActionTrait;
 use SMF\BBCodeParser;
 use SMF\Config;
 use SMF\Db\DatabaseApi as Db;
@@ -33,6 +34,8 @@ use SMF\Utils;
  */
 class BuddyIgnoreLists implements ActionInterface
 {
+	use ActionTrait;
+
 	use BackwardCompatibility;
 
 	/*******************
@@ -70,18 +73,6 @@ class BuddyIgnoreLists implements ActionInterface
 		'buddies' => 'editBuddies',
 		'ignore' => 'editIgnoreList',
 	];
-
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static BuddyIgnoreLists $obj;
 
 	/****************
 	 * Public methods
@@ -472,32 +463,6 @@ class BuddyIgnoreLists implements ActionInterface
 
 			unset($_SESSION['prf-save']);
 		}
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
 	}
 
 	/******************

--- a/Sources/Actions/Profile/Delete.php
+++ b/Sources/Actions/Profile/Delete.php
@@ -15,8 +15,9 @@ declare(strict_types=1);
 
 namespace SMF\Actions\Profile;
 
-use SMF\Actions\ActionInterface;
+use SMF\ActionInterface;
 use SMF\Actions\Logout;
+use SMF\ActionTrait;
 use SMF\Config;
 use SMF\Db\DatabaseApi as Db;
 use SMF\ErrorHandler;
@@ -33,17 +34,7 @@ use SMF\Utils;
  */
 class Delete implements ActionInterface
 {
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static Delete $obj;
+	use ActionTrait;
 
 	/****************
 	 * Public methods
@@ -243,32 +234,6 @@ class Delete implements ActionInterface
 
 			Utils::redirectexit();
 		}
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
 	}
 
 	/**

--- a/Sources/Actions/Profile/Export.php
+++ b/Sources/Actions/Profile/Export.php
@@ -15,7 +15,8 @@ declare(strict_types=1);
 
 namespace SMF\Actions\Profile;
 
-use SMF\Actions\ActionInterface;
+use SMF\ActionInterface;
+use SMF\ActionTrait;
 use SMF\Config;
 use SMF\Db\DatabaseApi as Db;
 use SMF\ErrorHandler;
@@ -35,6 +36,8 @@ use SMF\Utils;
  */
 class Export implements ActionInterface
 {
+	use ActionTrait;
+
 	/*******************
 	 * Public properties
 	 *******************/
@@ -107,7 +110,7 @@ class Export implements ActionInterface
 	 * An instance of this class.
 	 * This is used by the load() method to prevent multiple instantiations.
 	 */
-	protected static Export $obj;
+
 
 	/****************
 	 * Public methods
@@ -352,32 +355,6 @@ class Export implements ActionInterface
 		Utils::$context['export_profile_data_desc'] = Lang::getTxt('export_profile_data_desc', ['list' => '<li>' . implode('</li><li>', Lang::$txt['export_profile_data_desc_list']) . '</li>']);
 
 		Theme::addJavaScriptVar('completed_formats', '[\'' . implode('\', \'', array_unique($existing_export_formats)) . '\']', false);
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
 	}
 
 	/**

--- a/Sources/Actions/Profile/ExportAttachment.php
+++ b/Sources/Actions/Profile/ExportAttachment.php
@@ -15,8 +15,9 @@ declare(strict_types=1);
 
 namespace SMF\Actions\Profile;
 
-use SMF\Actions\ActionInterface;
+use SMF\ActionInterface;
 use SMF\Actions\AttachmentDownload;
+use SMF\ActionTrait;
 use SMF\Config;
 use SMF\Db\DatabaseApi as Db;
 use SMF\Profile;
@@ -27,6 +28,8 @@ use SMF\Utils;
  */
 class ExportAttachment implements ActionInterface
 {
+	use ActionTrait;
+
 	/*******************
 	 * Public properties
 	 *******************/
@@ -51,18 +54,6 @@ class ExportAttachment implements ActionInterface
 	 * Unique download token for the member whose profile this is.
 	 */
 	public string $dltoken;
-
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static ExportAttachment $obj;
 
 	/****************
 	 * Public methods
@@ -119,32 +110,6 @@ class ExportAttachment implements ActionInterface
 
 		// We should now have what we need to serve the file.
 		AttachmentDownload::call();
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
 	}
 
 	/******************

--- a/Sources/Actions/Profile/ExportDownload.php
+++ b/Sources/Actions/Profile/ExportDownload.php
@@ -15,7 +15,8 @@ declare(strict_types=1);
 
 namespace SMF\Actions\Profile;
 
-use SMF\Actions\ActionInterface;
+use SMF\ActionInterface;
+use SMF\ActionTrait;
 use SMF\Config;
 use SMF\Lang;
 use SMF\Utils;
@@ -25,6 +26,8 @@ use SMF\Utils;
  */
 class ExportDownload implements ActionInterface
 {
+	use ActionTrait;
+
 	/*******************
 	 * Public properties
 	 *******************/
@@ -77,18 +80,6 @@ class ExportDownload implements ActionInterface
 	 * Path to the JSON file that tracks our progress exporting this profile.
 	 */
 	public string $progressfile;
-
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static ExportDownload $obj;
 
 	/****************
 	 * Public methods
@@ -167,32 +158,6 @@ class ExportDownload implements ActionInterface
 
 		// Send the file.
 		Utils::emitFile($file);
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
 	}
 
 	/******************

--- a/Sources/Actions/Profile/ForumProfile.php
+++ b/Sources/Actions/Profile/ForumProfile.php
@@ -15,7 +15,8 @@ declare(strict_types=1);
 
 namespace SMF\Actions\Profile;
 
-use SMF\Actions\ActionInterface;
+use SMF\ActionInterface;
+use SMF\ActionTrait;
 use SMF\Lang;
 use SMF\Profile;
 use SMF\User;
@@ -26,17 +27,7 @@ use SMF\Utils;
  */
 class ForumProfile implements ActionInterface
 {
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static ForumProfile $obj;
+	use ActionTrait;
 
 	/****************
 	 * Public methods
@@ -71,32 +62,6 @@ class ForumProfile implements ActionInterface
 				'website_url',
 			],
 		);
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
 	}
 
 	/******************

--- a/Sources/Actions/Profile/GroupMembership.php
+++ b/Sources/Actions/Profile/GroupMembership.php
@@ -15,7 +15,8 @@ declare(strict_types=1);
 
 namespace SMF\Actions\Profile;
 
-use SMF\Actions\ActionInterface;
+use SMF\ActionInterface;
+use SMF\ActionTrait;
 use SMF\Config;
 use SMF\Db\DatabaseApi as Db;
 use SMF\ErrorHandler;
@@ -30,6 +31,8 @@ use SMF\Utils;
  */
 class GroupMembership implements ActionInterface
 {
+	use ActionTrait;
+
 	/*******************
 	 * Public properties
 	 *******************/
@@ -40,18 +43,6 @@ class GroupMembership implements ActionInterface
 	 * The type of change that was made when saving.
 	 */
 	public string $change_type;
-
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static GroupMembership $obj;
 
 	/****************
 	 * Public methods
@@ -258,32 +249,6 @@ class GroupMembership implements ActionInterface
 		// Run the changes through the validation method for group membership.
 		Profile::$member->validateGroups($new_primary, $new_additional_groups ?? []);
 		Profile::$member->new_data['id_group'] = $new_primary;
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
 	}
 
 	/**

--- a/Sources/Actions/Profile/IgnoreBoards.php
+++ b/Sources/Actions/Profile/IgnoreBoards.php
@@ -15,7 +15,8 @@ declare(strict_types=1);
 
 namespace SMF\Actions\Profile;
 
-use SMF\Actions\ActionInterface;
+use SMF\ActionInterface;
+use SMF\ActionTrait;
 use SMF\Category;
 use SMF\Config;
 use SMF\Db\DatabaseApi as Db;
@@ -28,17 +29,7 @@ use SMF\Utils;
  */
 class IgnoreBoards implements ActionInterface
 {
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static IgnoreBoards $obj;
+	use ActionTrait;
 
 	/****************
 	 * Public methods
@@ -127,32 +118,6 @@ class IgnoreBoards implements ActionInterface
 		}
 
 		Profile::$member->loadThemeOptions();
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
 	}
 
 	/******************

--- a/Sources/Actions/Profile/IssueWarning.php
+++ b/Sources/Actions/Profile/IssueWarning.php
@@ -15,7 +15,8 @@ declare(strict_types=1);
 
 namespace SMF\Actions\Profile;
 
-use SMF\Actions\ActionInterface;
+use SMF\ActionInterface;
+use SMF\ActionTrait;
 use SMF\BBCodeParser;
 use SMF\Config;
 use SMF\Db\DatabaseApi as Db;
@@ -34,6 +35,8 @@ use SMF\Utils;
  */
 class IssueWarning implements ActionInterface
 {
+	use ActionTrait;
+
 	use BackwardCompatibility;
 
 	/*******************
@@ -46,18 +49,6 @@ class IssueWarning implements ActionInterface
 	 * This stores any legitimate errors.
 	 */
 	public array $issueErrors = [];
-
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static IssueWarning $obj;
 
 	/****************
 	 * Public methods
@@ -313,32 +304,6 @@ class IssueWarning implements ActionInterface
 				],
 			);
 		}
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
 	}
 
 	/**

--- a/Sources/Actions/Profile/Main.php
+++ b/Sources/Actions/Profile/Main.php
@@ -15,7 +15,8 @@ declare(strict_types=1);
 
 namespace SMF\Actions\Profile;
 
-use SMF\Actions\ActionInterface;
+use SMF\ActionInterface;
+use SMF\ActionTrait;
 use SMF\Config;
 use SMF\Db\DatabaseApi as Db;
 use SMF\ErrorHandler;
@@ -37,6 +38,8 @@ use SMF\Utils;
  */
 class Main implements ActionInterface
 {
+	use ActionTrait;
+
 	/*******************
 	 * Public properties
 	 *******************/
@@ -536,18 +539,6 @@ class Main implements ActionInterface
 	 */
 	public bool $check_password;
 
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static Main $obj;
-
 	/****************
 	 * Public methods
 	 ****************/
@@ -696,32 +687,6 @@ class Main implements ActionInterface
 		if (!isset(Utils::$context['page_title'])) {
 			Utils::$context['page_title'] = trim(Lang::getTxt('profile_page_title', ['current_area' => Lang::getTxt($menu->current_area)]), " \n\r\t\v\x00-");
 		}
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
 	}
 
 	/**

--- a/Sources/Actions/Profile/Notification.php
+++ b/Sources/Actions/Profile/Notification.php
@@ -15,8 +15,9 @@ declare(strict_types=1);
 
 namespace SMF\Actions\Profile;
 
-use SMF\Actions\ActionInterface;
+use SMF\ActionInterface;
 use SMF\Actions\Notify;
+use SMF\ActionTrait;
 use SMF\Alert;
 use SMF\Config;
 use SMF\Db\DatabaseApi as Db;
@@ -37,6 +38,8 @@ use SMF\Utils;
  */
 class Notification implements ActionInterface
 {
+	use ActionTrait;
+
 	use BackwardCompatibility;
 
 	/*******************
@@ -297,18 +300,6 @@ class Notification implements ActionInterface
 		'topics' => 'alert_notifications_topics',
 		'boards' => 'alert_notifications_boards',
 	];
-
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static Notification $obj;
 
 	/****************
 	 * Public methods
@@ -836,32 +827,6 @@ class Notification implements ActionInterface
 
 		// Create the board notification list.
 		new ItemList($list_options);
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
 	}
 
 	/**

--- a/Sources/Actions/Profile/PaidSubs.php
+++ b/Sources/Actions/Profile/PaidSubs.php
@@ -15,8 +15,9 @@ declare(strict_types=1);
 
 namespace SMF\Actions\Profile;
 
-use SMF\Actions\ActionInterface;
+use SMF\ActionInterface;
 use SMF\Actions\Admin\Subscriptions;
+use SMF\ActionTrait;
 use SMF\Config;
 use SMF\Db\DatabaseApi as Db;
 use SMF\ErrorHandler;
@@ -31,17 +32,7 @@ use SMF\Utils;
  */
 class PaidSubs implements ActionInterface
 {
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static PaidSubs $obj;
+	use ActionTrait;
 
 	/****************
 	 * Public methods
@@ -328,32 +319,6 @@ class PaidSubs implements ActionInterface
 		}
 
 		Utils::$context['sub_template'] = 'user_subscription';
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
 	}
 
 	/******************

--- a/Sources/Actions/Profile/Popup.php
+++ b/Sources/Actions/Profile/Popup.php
@@ -15,7 +15,8 @@ declare(strict_types=1);
 
 namespace SMF\Actions\Profile;
 
-use SMF\Actions\ActionInterface;
+use SMF\ActionInterface;
+use SMF\ActionTrait;
 use SMF\Config;
 use SMF\IntegrationHook;
 use SMF\Lang;
@@ -27,6 +28,8 @@ use SMF\Utils;
  */
 class Popup implements ActionInterface
 {
+	use ActionTrait;
+
 	/*******************
 	 * Public properties
 	 *******************/
@@ -97,18 +100,6 @@ class Popup implements ActionInterface
 		],
 	];
 
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static Popup $obj;
-
 	/****************
 	 * Public methods
 	 ****************/
@@ -134,32 +125,6 @@ class Popup implements ActionInterface
 				Utils::$context['profile_items'][] = $item;
 			}
 		}
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
 	}
 
 	/******************

--- a/Sources/Actions/Profile/ShowAlerts.php
+++ b/Sources/Actions/Profile/ShowAlerts.php
@@ -15,7 +15,8 @@ declare(strict_types=1);
 
 namespace SMF\Actions\Profile;
 
-use SMF\Actions\ActionInterface;
+use SMF\ActionInterface;
+use SMF\ActionTrait;
 use SMF\Alert;
 use SMF\Config;
 use SMF\Lang;
@@ -30,19 +31,9 @@ use SMF\Utils;
  */
 class ShowAlerts implements ActionInterface
 {
+	use ActionTrait;
+
 	use BackwardCompatibility;
-
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static ShowAlerts $obj;
 
 	/****************
 	 * Public methods
@@ -196,32 +187,6 @@ class ShowAlerts implements ActionInterface
 			// Redirect.
 			Utils::redirectexit('action=profile;area=showalerts;u=' . User::$me->id . (!empty(Utils::$context['start']) ? ';start=' . Utils::$context['start'] : ''));
 		}
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
 	}
 
 	/******************

--- a/Sources/Actions/Profile/ShowPermissions.php
+++ b/Sources/Actions/Profile/ShowPermissions.php
@@ -15,8 +15,9 @@ declare(strict_types=1);
 
 namespace SMF\Actions\Profile;
 
-use SMF\Actions\ActionInterface;
+use SMF\ActionInterface;
 use SMF\Actions\Admin\Permissions;
+use SMF\ActionTrait;
 use SMF\Board;
 use SMF\Db\DatabaseApi as Db;
 use SMF\Lang;
@@ -30,19 +31,9 @@ use SMF\Utils;
  */
 class ShowPermissions implements ActionInterface
 {
+	use ActionTrait;
+
 	use BackwardCompatibility;
-
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static ShowPermissions $obj;
 
 	/****************
 	 * Public methods
@@ -246,32 +237,6 @@ class ShowPermissions implements ActionInterface
 			$board_perms[$row['permission']]['is_denied'] |= empty($row['add_deny']);
 		}
 		Db::$db->free_result($request);
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
 	}
 
 	/******************

--- a/Sources/Actions/Profile/ShowPosts.php
+++ b/Sources/Actions/Profile/ShowPosts.php
@@ -15,7 +15,8 @@ declare(strict_types=1);
 
 namespace SMF\Actions\Profile;
 
-use SMF\Actions\ActionInterface;
+use SMF\ActionInterface;
+use SMF\ActionTrait;
 use SMF\BBCodeParser;
 use SMF\Board;
 use SMF\Config;
@@ -39,6 +40,8 @@ use SMF\Utils;
  */
 class ShowPosts implements ActionInterface
 {
+	use ActionTrait;
+
 	use BackwardCompatibility;
 
 	/*******************
@@ -68,18 +71,6 @@ class ShowPosts implements ActionInterface
 		'unwatchedtopics' => 'unwatched',
 		'attach' => 'attachments',
 	];
-
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static ShowPosts $obj;
 
 	/****************
 	 * Public methods
@@ -381,32 +372,6 @@ class ShowPosts implements ActionInterface
 
 		// Create the request list.
 		new ItemList($list_options);
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
 	}
 
 	/**

--- a/Sources/Actions/Profile/StatPanel.php
+++ b/Sources/Actions/Profile/StatPanel.php
@@ -15,7 +15,8 @@ declare(strict_types=1);
 
 namespace SMF\Actions\Profile;
 
-use SMF\Actions\ActionInterface;
+use SMF\ActionInterface;
+use SMF\ActionTrait;
 use SMF\Config;
 use SMF\Db\DatabaseApi as Db;
 use SMF\ErrorHandler;
@@ -31,19 +32,9 @@ use SMF\Utils;
  */
 class StatPanel implements ActionInterface
 {
+	use ActionTrait;
+
 	use BackwardCompatibility;
-
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static StatPanel $obj;
 
 	/****************
 	 * Public methods
@@ -274,32 +265,6 @@ class StatPanel implements ActionInterface
 
 		// Custom stats (just add a template_layer to add it to the template!)
 		IntegrationHook::call('integrate_profile_stats', [Profile::$member->id, &Utils::$context['text_stats']]);
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
 	}
 
 	/******************

--- a/Sources/Actions/Profile/Summary.php
+++ b/Sources/Actions/Profile/Summary.php
@@ -15,8 +15,9 @@ declare(strict_types=1);
 
 namespace SMF\Actions\Profile;
 
-use SMF\Actions\ActionInterface;
+use SMF\ActionInterface;
 use SMF\Actions\Who;
+use SMF\ActionTrait;
 use SMF\Config;
 use SMF\Db\DatabaseApi as Db;
 use SMF\IP;
@@ -33,19 +34,9 @@ use SMF\Utils;
  */
 class Summary implements ActionInterface
 {
+	use ActionTrait;
+
 	use BackwardCompatibility;
-
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static Summary $obj;
 
 	/****************
 	 * Public methods
@@ -235,32 +226,6 @@ class Summary implements ActionInterface
 				Utils::$context['print_custom_fields'][Utils::$context['cust_profile_fields_placement'][$custom['placement']]][] = $custom;
 			}
 		}
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
 	}
 
 	/******************

--- a/Sources/Actions/Profile/TFADisable.php
+++ b/Sources/Actions/Profile/TFADisable.php
@@ -15,7 +15,8 @@ declare(strict_types=1);
 
 namespace SMF\Actions\Profile;
 
-use SMF\Actions\ActionInterface;
+use SMF\ActionInterface;
+use SMF\ActionTrait;
 use SMF\Config;
 use SMF\Db\DatabaseApi as Db;
 use SMF\ErrorHandler;
@@ -29,17 +30,7 @@ use SMF\Utils;
  */
 class TFADisable implements ActionInterface
 {
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static TFADisable $obj;
+	use ActionTrait;
 
 	/****************
 	 * Public methods
@@ -84,32 +75,6 @@ class TFADisable implements ActionInterface
 				ErrorHandler::fatalLang('cannot_disable_tfa2', false);
 			}
 		}
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
 	}
 
 	/******************

--- a/Sources/Actions/Profile/TFASetup.php
+++ b/Sources/Actions/Profile/TFASetup.php
@@ -15,7 +15,8 @@ declare(strict_types=1);
 
 namespace SMF\Actions\Profile;
 
-use SMF\Actions\ActionInterface;
+use SMF\ActionInterface;
+use SMF\ActionTrait;
 use SMF\Config;
 use SMF\Cookie;
 use SMF\ErrorHandler;
@@ -32,6 +33,8 @@ use SMF\Utils;
  */
 class TFASetup implements ActionInterface
 {
+	use ActionTrait;
+
 	/*********************
 	 * Internal properties
 	 *********************/
@@ -42,18 +45,6 @@ class TFASetup implements ActionInterface
 	 * An instance of the SMF\TOTP\Auth class.
 	 */
 	protected Tfa $totp;
-
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static TFASetup $obj;
 
 	/****************
 	 * Public methods
@@ -92,32 +83,6 @@ class TFASetup implements ActionInterface
 		}
 
 		Utils::$context['tfa_qr_url'] = $this->totp->getQrCodeUrl(Utils::$context['forum_name'] . ':' . User::$me->name, Utils::$context['tfa_secret']);
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
 	}
 
 	/******************

--- a/Sources/Actions/Profile/ThemeOptions.php
+++ b/Sources/Actions/Profile/ThemeOptions.php
@@ -15,7 +15,8 @@ declare(strict_types=1);
 
 namespace SMF\Actions\Profile;
 
-use SMF\Actions\ActionInterface;
+use SMF\ActionInterface;
+use SMF\ActionTrait;
 use SMF\IntegrationHook;
 use SMF\Lang;
 use SMF\Profile;
@@ -28,17 +29,7 @@ use SMF\Utils;
  */
 class ThemeOptions implements ActionInterface
 {
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static ThemeOptions $obj;
+	use ActionTrait;
 
 	/****************
 	 * Public methods
@@ -74,32 +65,6 @@ class ThemeOptions implements ActionInterface
 				'theme_settings',
 			],
 		);
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
 	}
 
 	/******************

--- a/Sources/Actions/Profile/Tracking.php
+++ b/Sources/Actions/Profile/Tracking.php
@@ -15,8 +15,9 @@ declare(strict_types=1);
 
 namespace SMF\Actions\Profile;
 
-use SMF\Actions\ActionInterface;
+use SMF\ActionInterface;
 use SMF\Actions\TrackIP;
+use SMF\ActionTrait;
 use SMF\BBCodeParser;
 use SMF\Config;
 use SMF\Db\DatabaseApi as Db;
@@ -35,6 +36,8 @@ use SMF\Utils;
  */
 class Tracking implements ActionInterface
 {
+	use ActionTrait;
+
 	use BackwardCompatibility;
 
 	/*******************
@@ -90,18 +93,6 @@ class Tracking implements ActionInterface
 			'moderate_forum',
 		],
 	];
-
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static Tracking $obj;
 
 	/****************
 	 * Public methods
@@ -616,32 +607,6 @@ class Tracking implements ActionInterface
 
 		Utils::$context['sub_template'] = 'show_list';
 		Utils::$context['default_list'] = 'track_logins_list';
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
 	}
 
 	/**

--- a/Sources/Actions/Profile/ViewWarning.php
+++ b/Sources/Actions/Profile/ViewWarning.php
@@ -15,7 +15,8 @@ declare(strict_types=1);
 
 namespace SMF\Actions\Profile;
 
-use SMF\Actions\ActionInterface;
+use SMF\ActionInterface;
+use SMF\ActionTrait;
 use SMF\Config;
 use SMF\ErrorHandler;
 use SMF\ItemList;
@@ -29,19 +30,9 @@ use SMF\Utils;
  */
 class ViewWarning implements ActionInterface
 {
+	use ActionTrait;
+
 	use BackwardCompatibility;
-
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static ViewWarning $obj;
 
 	/****************
 	 * Public methods
@@ -142,32 +133,6 @@ class ViewWarning implements ActionInterface
 				Utils::$context['current_level'] = $limit;
 			}
 		}
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
 	}
 
 	/******************

--- a/Sources/Actions/QuickModeration.php
+++ b/Sources/Actions/QuickModeration.php
@@ -15,6 +15,8 @@ declare(strict_types=1);
 
 namespace SMF\Actions;
 
+use SMF\ActionInterface;
+use SMF\ActionTrait;
 use SMF\Board;
 use SMF\Config;
 use SMF\Db\DatabaseApi as Db;
@@ -30,6 +32,8 @@ use SMF\Utils;
  */
 class QuickModeration implements ActionInterface
 {
+	use ActionTrait;
+
 	/*******************
 	 * Public properties
 	 *******************/
@@ -154,18 +158,6 @@ class QuickModeration implements ActionInterface
 		'restore' => [],
 	];
 
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static QuickModeration $obj;
-
 	/****************
 	 * Public methods
 	 ****************/
@@ -209,32 +201,6 @@ class QuickModeration implements ActionInterface
 		if ($this->should_redirect) {
 			Utils::redirectexit($this->redirect_url);
 		}
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
 	}
 
 	/**

--- a/Sources/Actions/QuickModerationInTopic.php
+++ b/Sources/Actions/QuickModerationInTopic.php
@@ -15,6 +15,8 @@ declare(strict_types=1);
 
 namespace SMF\Actions;
 
+use SMF\ActionInterface;
+use SMF\ActionTrait;
 use SMF\Board;
 use SMF\Config;
 use SMF\Db\DatabaseApi as Db;
@@ -32,6 +34,8 @@ use SMF\Utils;
  */
 class QuickModerationInTopic implements ActionInterface
 {
+	use ActionTrait;
+
 	/*******************
 	 * Public properties
 	 *******************/
@@ -42,18 +46,6 @@ class QuickModerationInTopic implements ActionInterface
 	 * IDs of the messages to act on.
 	 */
 	public array $messages = [];
-
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static QuickModerationInTopic $obj;
 
 	/****************
 	 * Public methods
@@ -74,32 +66,6 @@ class QuickModerationInTopic implements ActionInterface
 		} else {
 			$this->delete();
 		}
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
 	}
 
 	/******************

--- a/Sources/Actions/QuoteFast.php
+++ b/Sources/Actions/QuoteFast.php
@@ -15,6 +15,8 @@ declare(strict_types=1);
 
 namespace SMF\Actions;
 
+use SMF\ActionInterface;
+use SMF\ActionTrait;
 use SMF\Config;
 use SMF\Db\DatabaseApi as Db;
 use SMF\Lang;
@@ -34,17 +36,7 @@ use SMF\Utils;
  */
 class QuoteFast implements ActionInterface
 {
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static QuoteFast $obj;
+	use ActionTrait;
 
 	/****************
 	 * Public methods
@@ -146,32 +138,6 @@ class QuoteFast implements ActionInterface
 				'text' => '',
 			];
 		}
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
 	}
 
 	/******************

--- a/Sources/Actions/Recent.php
+++ b/Sources/Actions/Recent.php
@@ -15,6 +15,8 @@ declare(strict_types=1);
 
 namespace SMF\Actions;
 
+use SMF\ActionInterface;
+use SMF\ActionTrait;
 use SMF\BBCodeParser;
 use SMF\Board;
 use SMF\Cache\CacheApi;
@@ -35,6 +37,8 @@ use SMF\Utils;
  */
 class Recent implements ActionInterface
 {
+	use ActionTrait;
+
 	/*****************
 	 * Class constants
 	 *****************/
@@ -98,18 +102,6 @@ class Recent implements ActionInterface
 		'any' => [],
 	];
 
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static Recent $obj;
-
 	/****************
 	 * Public methods
 	 ****************/
@@ -137,32 +129,6 @@ class Recent implements ActionInterface
 
 		// Allow last minute changes.
 		IntegrationHook::call('integrate_recent_RecentPosts');
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
 	}
 
 	/**

--- a/Sources/Actions/Register.php
+++ b/Sources/Actions/Register.php
@@ -15,6 +15,8 @@ declare(strict_types=1);
 
 namespace SMF\Actions;
 
+use SMF\ActionInterface;
+use SMF\ActionTrait;
 use SMF\BBCodeParser;
 use SMF\Config;
 use SMF\ErrorHandler;
@@ -31,6 +33,8 @@ use SMF\Verifier;
  */
 class Register implements ActionInterface
 {
+	use ActionTrait;
+
 	/*******************
 	 * Public properties
 	 *******************/
@@ -62,18 +66,6 @@ class Register implements ActionInterface
 		'show' => 'show',
 		'usernamecheck' => 'checkUsername',
 	];
-
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static Register $obj;
 
 	/****************
 	 * Public methods
@@ -326,32 +318,6 @@ class Register implements ActionInterface
 		$errors = User::validateUsername(0, Utils::$context['checked_username'], true);
 
 		Utils::$context['valid_username'] = empty($errors);
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
 	}
 
 	/**

--- a/Sources/Actions/Register2.php
+++ b/Sources/Actions/Register2.php
@@ -90,18 +90,6 @@ class Register2 extends Register
 		'show_online',
 	];
 
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static Register2|Register $obj;
-
 	/****************
 	 * Public methods
 	 ****************/
@@ -438,32 +426,6 @@ class Register2 extends Register
 
 			Utils::redirectexit('action=login2;sa=check;member=' . $member_id, Sapi::needsLoginFix());
 		}
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
 	}
 
 	/**
@@ -902,17 +864,6 @@ class Register2 extends Register
 		IntegrationHook::call('integrate_register_after', [$reg_options, $member_id]);
 
 		return $member_id;
-	}
-
-	/******************
-	 * Internal methods
-	 ******************/
-
-	/**
-	 * Constructor. Protected to force instantiation via self::load().
-	 */
-	protected function __construct()
-	{
 	}
 }
 

--- a/Sources/Actions/Reminder.php
+++ b/Sources/Actions/Reminder.php
@@ -15,6 +15,8 @@ declare(strict_types=1);
 
 namespace SMF\Actions;
 
+use SMF\ActionInterface;
+use SMF\ActionTrait;
 use SMF\Config;
 use SMF\ErrorHandler;
 use SMF\IntegrationHook;
@@ -31,6 +33,8 @@ use SMF\Utils;
  */
 class Reminder implements ActionInterface
 {
+	use ActionTrait;
+
 	/*******************
 	 * Public properties
 	 *******************/
@@ -70,18 +74,6 @@ class Reminder implements ActionInterface
 		'setpassword' => 'setPassword',
 		'setpassword2' => 'setPassword2',
 	];
-
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static Reminder $obj;
 
 	/****************
 	 * Public methods
@@ -392,32 +384,6 @@ class Reminder implements ActionInterface
 		];
 
 		SecurityToken::create('login');
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
 	}
 
 	/******************

--- a/Sources/Actions/ReportToMod.php
+++ b/Sources/Actions/ReportToMod.php
@@ -15,6 +15,8 @@ declare(strict_types=1);
 
 namespace SMF\Actions;
 
+use SMF\ActionInterface;
+use SMF\ActionTrait;
 use SMF\Config;
 use SMF\Db\DatabaseApi as Db;
 use SMF\ErrorHandler;
@@ -31,6 +33,8 @@ use SMF\Utils;
  */
 class ReportToMod implements ActionInterface
 {
+	use ActionTrait;
+
 	use BackwardCompatibility;
 
 	/*****************
@@ -96,18 +100,6 @@ class ReportToMod implements ActionInterface
 	 * The text content of the report.
 	 */
 	protected string $comment = '';
-
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static ReportToMod $obj;
 
 	/****************
 	 * Public methods
@@ -301,32 +293,6 @@ class ReportToMod implements ActionInterface
 		} else {
 			$this->reportMember((int) $_POST['u']);
 		}
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
 	}
 
 	/**

--- a/Sources/Actions/RequestMembers.php
+++ b/Sources/Actions/RequestMembers.php
@@ -15,6 +15,8 @@ declare(strict_types=1);
 
 namespace SMF\Actions;
 
+use SMF\ActionInterface;
+use SMF\ActionTrait;
 use SMF\Db\DatabaseApi as Db;
 use SMF\User;
 use SMF\Utils;
@@ -29,6 +31,8 @@ use SMF\Utils;
  */
 class RequestMembers implements ActionInterface
 {
+	use ActionTrait;
+
 	/*******************
 	 * Public properties
 	 *******************/
@@ -39,18 +43,6 @@ class RequestMembers implements ActionInterface
 	 * Search string.
 	 */
 	public string $search = '';
-
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static RequestMembers $obj;
 
 	/****************
 	 * Public methods
@@ -98,32 +90,6 @@ class RequestMembers implements ActionInterface
 		Db::$db->free_result($request);
 
 		Utils::obExit(false);
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
 	}
 
 	/******************

--- a/Sources/Actions/Search.php
+++ b/Sources/Actions/Search.php
@@ -15,6 +15,8 @@ declare(strict_types=1);
 
 namespace SMF\Actions;
 
+use SMF\ActionInterface;
+use SMF\ActionTrait;
 use SMF\Category;
 use SMF\Config;
 use SMF\Db\DatabaseApi as Db;
@@ -32,17 +34,7 @@ use SMF\Verifier;
  */
 class Search implements ActionInterface
 {
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static Search $obj;
+	use ActionTrait;
 
 	/****************
 	 * Public methods
@@ -284,43 +276,6 @@ class Search implements ActionInterface
 		Utils::$context['page_title'] = Lang::$txt['set_parameters'];
 
 		IntegrationHook::call('integrate_search');
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
-	}
-
-	/******************
-	 * Internal methods
-	 ******************/
-
-	/**
-	 * Constructor. Protected to force instantiation via self::load().
-	 */
-	protected function __construct()
-	{
 	}
 }
 

--- a/Sources/Actions/Search2.php
+++ b/Sources/Actions/Search2.php
@@ -15,6 +15,8 @@ declare(strict_types=1);
 
 namespace SMF\Actions;
 
+use SMF\ActionInterface;
+use SMF\ActionTrait;
 use SMF\Config;
 use SMF\Db\DatabaseApi as Db;
 use SMF\ErrorHandler;
@@ -34,6 +36,8 @@ use SMF\Verifier;
  */
 class Search2 implements ActionInterface
 {
+	use ActionTrait;
+
 	/*******************
 	 * Public properties
 	 *******************/
@@ -58,18 +62,6 @@ class Search2 implements ActionInterface
 	 * ID numbers of the authors of the $messages.
 	 */
 	public array $posters = [];
-
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static Search2 $obj;
 
 	/****************
 	 * Public methods
@@ -195,32 +187,6 @@ class Search2 implements ActionInterface
 		IntegrationHook::call('integrate_search_message_context', [&$output, &$message, $counter]);
 
 		return $output;
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
 	}
 
 	/******************

--- a/Sources/Actions/SendActivation.php
+++ b/Sources/Actions/SendActivation.php
@@ -15,6 +15,8 @@ declare(strict_types=1);
 
 namespace SMF\Actions;
 
+use SMF\ActionInterface;
+use SMF\ActionTrait;
 use SMF\Lang;
 use SMF\Theme;
 use SMF\User;
@@ -26,17 +28,7 @@ use SMF\Utils;
  */
 class SendActivation implements ActionInterface
 {
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static SendActivation $obj;
+	use ActionTrait;
 
 	/****************
 	 * Public methods
@@ -59,43 +51,6 @@ class SendActivation implements ActionInterface
 
 		// Aaand we're gone!
 		Utils::obExit();
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
-	}
-
-	/******************
-	 * Internal methods
-	 ******************/
-
-	/**
-	 * Constructor. Protected to force instantiation via self::load().
-	 */
-	protected function __construct()
-	{
 	}
 }
 

--- a/Sources/Actions/SmStats.php
+++ b/Sources/Actions/SmStats.php
@@ -15,7 +15,9 @@ declare(strict_types=1);
 
 namespace SMF\Actions;
 
+use SMF\ActionInterface;
 use SMF\Actions\Admin\ACP;
+use SMF\ActionTrait;
 use SMF\Config;
 use SMF\User;
 
@@ -24,17 +26,7 @@ use SMF\User;
  */
 class SmStats implements ActionInterface
 {
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static SmStats $obj;
+	use ActionTrait;
 
 	/****************
 	 * Public methods
@@ -127,43 +119,6 @@ class SmStats implements ActionInterface
 
 		// Die.
 		die('OK');
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
-	}
-
-	/******************
-	 * Internal methods
-	 ******************/
-
-	/**
-	 * Constructor. Protected to force instantiation via self::load().
-	 */
-	protected function __construct()
-	{
 	}
 }
 

--- a/Sources/Actions/Stats.php
+++ b/Sources/Actions/Stats.php
@@ -15,6 +15,8 @@ declare(strict_types=1);
 
 namespace SMF\Actions;
 
+use SMF\ActionInterface;
+use SMF\ActionTrait;
 use SMF\Cache\CacheApi;
 use SMF\Config;
 use SMF\Db\DatabaseApi as Db;
@@ -31,17 +33,7 @@ use SMF\Utils;
  */
 class Stats implements ActionInterface
 {
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static Stats $obj;
+	use ActionTrait;
 
 	/****************
 	 * Public methods
@@ -809,43 +801,6 @@ class Stats implements ActionInterface
 		}
 
 		$this->getDailyStats(implode(' OR ', $condition_text), $condition_params);
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
-	}
-
-	/******************
-	 * Internal methods
-	 ******************/
-
-	/**
-	 * Constructor. Protected to force instantiation via self::load().
-	 */
-	protected function __construct()
-	{
 	}
 
 	/**

--- a/Sources/Actions/TopicMerge.php
+++ b/Sources/Actions/TopicMerge.php
@@ -17,6 +17,8 @@ declare(strict_types=1);
 
 namespace SMF\Actions;
 
+use SMF\ActionInterface;
+use SMF\ActionTrait;
 use SMF\Board;
 use SMF\Cache\CacheApi;
 use SMF\Config;
@@ -40,6 +42,8 @@ use SMF\Utils;
  */
 class TopicMerge implements ActionInterface
 {
+	use ActionTrait;
+
 	use BackwardCompatibility;
 
 	/*******************
@@ -164,18 +168,6 @@ class TopicMerge implements ActionInterface
 	 *
 	 */
 	protected array $merge_boards = [];
-
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static TopicMerge $obj;
 
 	/****************
 	 * Public methods
@@ -1021,32 +1013,6 @@ class TopicMerge implements ActionInterface
 
 		Utils::$context['page_title'] = Lang::$txt['merge'];
 		Utils::$context['sub_template'] = 'merge_done';
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
 	}
 
 	/**

--- a/Sources/Actions/TopicMove.php
+++ b/Sources/Actions/TopicMove.php
@@ -15,6 +15,8 @@ declare(strict_types=1);
 
 namespace SMF\Actions;
 
+use SMF\ActionInterface;
+use SMF\ActionTrait;
 use SMF\Board;
 use SMF\Config;
 use SMF\Db\DatabaseApi as Db;
@@ -31,17 +33,7 @@ use SMF\Utils;
  */
 class TopicMove implements ActionInterface
 {
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static TopicMove $obj;
+	use ActionTrait;
 
 	/****************
 	 * Public methods
@@ -149,43 +141,6 @@ class TopicMove implements ActionInterface
 
 		// Register this form and get a sequence number in Utils::$context.
 		Security::checkSubmitOnce('register');
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
-	}
-
-	/******************
-	 * Internal methods
-	 ******************/
-
-	/**
-	 * Constructor. Protected to force instantiation via self::load().
-	 */
-	protected function __construct()
-	{
 	}
 }
 

--- a/Sources/Actions/TopicMove2.php
+++ b/Sources/Actions/TopicMove2.php
@@ -15,6 +15,8 @@ declare(strict_types=1);
 
 namespace SMF\Actions;
 
+use SMF\ActionInterface;
+use SMF\ActionTrait;
 use SMF\Board;
 use SMF\Cache\CacheApi;
 use SMF\Config;
@@ -35,17 +37,7 @@ use SMF\Utils;
  */
 class TopicMove2 implements ActionInterface
 {
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static TopicMove2 $obj;
+	use ActionTrait;
 
 	/****************
 	 * Public methods
@@ -312,32 +304,6 @@ class TopicMove2 implements ActionInterface
 		}
 	}
 
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
-	}
-
 	/**
 	 * Called after a topic is moved to update $board_link and $topic_link to point to new location
 	 */
@@ -375,17 +341,6 @@ class TopicMove2 implements ActionInterface
 		$topic_link = '<a href="' . Config::$scripturl . '?topic=' . Topic::$topic_id . '.0">' . $topic_subject . '</a>';
 
 		ErrorHandler::fatalLang('topic_already_moved', false, [$topic_link, $board_link]);
-	}
-
-	/******************
-	 * Internal methods
-	 ******************/
-
-	/**
-	 * Constructor. Protected to force instantiation via self::load().
-	 */
-	protected function __construct()
-	{
 	}
 }
 

--- a/Sources/Actions/TopicPrint.php
+++ b/Sources/Actions/TopicPrint.php
@@ -15,6 +15,8 @@ declare(strict_types=1);
 
 namespace SMF\Actions;
 
+use SMF\ActionInterface;
+use SMF\ActionTrait;
 use SMF\Attachment;
 use SMF\BBCodeParser;
 use SMF\Board;
@@ -36,17 +38,7 @@ use SMF\Utils;
  */
 class TopicPrint implements ActionInterface
 {
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static TopicPrint $obj;
+	use ActionTrait;
 
 	/****************
 	 * Public methods
@@ -224,43 +216,6 @@ class TopicPrint implements ActionInterface
 
 		// Set a canonical URL for this page.
 		Utils::$context['canonical_url'] = Config::$scripturl . '?topic=' . Topic::$topic_id . '.0';
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
-	}
-
-	/******************
-	 * Internal methods
-	 ******************/
-
-	/**
-	 * Constructor. Protected to force instantiation via self::load().
-	 */
-	protected function __construct()
-	{
 	}
 }
 

--- a/Sources/Actions/TopicRemove.php
+++ b/Sources/Actions/TopicRemove.php
@@ -15,6 +15,8 @@ declare(strict_types=1);
 
 namespace SMF\Actions;
 
+use SMF\ActionInterface;
+use SMF\ActionTrait;
 use SMF\Board;
 use SMF\Config;
 use SMF\Db\DatabaseApi as Db;
@@ -30,17 +32,7 @@ use SMF\Utils;
  */
 class TopicRemove implements ActionInterface
 {
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static TopicRemove $obj;
+	use ActionTrait;
 
 	/****************
 	 * Public methods
@@ -110,32 +102,6 @@ class TopicRemove implements ActionInterface
 		}
 
 		Utils::redirectexit('board=' . Board::$info->id . '.0');
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
 	}
 
 	/**
@@ -251,17 +217,6 @@ class TopicRemove implements ActionInterface
 		Logging::logAction('pruned', ['days' => $_POST['maxdays']]);
 
 		Utils::redirectexit('action=admin;area=maintain;sa=topics;done=purgeold');
-	}
-
-	/******************
-	 * Internal methods
-	 ******************/
-
-	/**
-	 * Constructor. Protected to force instantiation via self::load().
-	 */
-	protected function __construct()
-	{
 	}
 
 	/*************************

--- a/Sources/Actions/TopicRestore.php
+++ b/Sources/Actions/TopicRestore.php
@@ -15,6 +15,8 @@ declare(strict_types=1);
 
 namespace SMF\Actions;
 
+use SMF\ActionInterface;
+use SMF\ActionTrait;
 use SMF\Config;
 use SMF\Db\DatabaseApi as Db;
 use SMF\ErrorHandler;
@@ -30,17 +32,7 @@ use SMF\Utils;
  */
 class TopicRestore implements ActionInterface
 {
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static TopicRestore $obj;
+	use ActionTrait;
 
 	/****************
 	 * Public methods
@@ -264,43 +256,6 @@ class TopicRestore implements ActionInterface
 
 		// Just send them to the index if they get here.
 		Utils::redirectexit();
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
-	}
-
-	/******************
-	 * Internal methods
-	 ******************/
-
-	/**
-	 * Constructor. Protected to force instantiation via self::load().
-	 */
-	protected function __construct()
-	{
 	}
 
 	/*************************

--- a/Sources/Actions/TopicSplit.php
+++ b/Sources/Actions/TopicSplit.php
@@ -17,6 +17,8 @@ declare(strict_types=1);
 
 namespace SMF\Actions;
 
+use SMF\ActionInterface;
+use SMF\ActionTrait;
 use SMF\BBCodeParser;
 use SMF\Board;
 use SMF\Config;
@@ -40,6 +42,8 @@ use SMF\Utils;
  */
 class TopicSplit implements ActionInterface
 {
+	use ActionTrait;
+
 	use BackwardCompatibility;
 
 	/*******************
@@ -75,18 +79,6 @@ class TopicSplit implements ActionInterface
 	 *********************/
 
 	// code...
-
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static TopicSplit $obj;
 
 	/****************
 	 * Public methods
@@ -574,32 +566,6 @@ class TopicSplit implements ActionInterface
 		Utils::$context['old_topic'] = Topic::$topic_id;
 		Utils::$context['new_topic'] = $this->splitTopic(Topic::$topic_id, $_SESSION['split_selection'][Topic::$topic_id], $_POST['subname']);
 		Utils::$context['page_title'] = Lang::$txt['split'];
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
 	}
 
 	/**

--- a/Sources/Actions/TrackIP.php
+++ b/Sources/Actions/TrackIP.php
@@ -15,7 +15,9 @@ declare(strict_types=1);
 
 namespace SMF\Actions;
 
+use SMF\ActionInterface;
 use SMF\Actions\Profile\BackwardCompatibility;
+use SMF\ActionTrait;
 use SMF\Config;
 use SMF\Db\DatabaseApi as Db;
 use SMF\ErrorHandler;
@@ -35,6 +37,8 @@ use SMF\Utils;
  */
 class TrackIP implements ActionInterface
 {
+	use ActionTrait;
+
 	use BackwardCompatibility;
 
 	/*******************
@@ -55,18 +59,6 @@ class TrackIP implements ActionInterface
 	 * False if this was called via ?action=profile;area=tracking;sa=ip.
 	 */
 	public bool $standalone;
-
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static TrackIP $obj;
 
 	/****************
 	 * Public methods
@@ -344,32 +336,6 @@ class TrackIP implements ActionInterface
 				],
 			];
 		}
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
 	}
 
 	/**

--- a/Sources/Actions/Unread.php
+++ b/Sources/Actions/Unread.php
@@ -15,6 +15,8 @@ declare(strict_types=1);
 
 namespace SMF\Actions;
 
+use SMF\ActionInterface;
+use SMF\ActionTrait;
 use SMF\Board;
 use SMF\Config;
 use SMF\Db\DatabaseApi as Db;
@@ -31,6 +33,8 @@ use SMF\Utils;
  */
 class Unread implements ActionInterface
 {
+	use ActionTrait;
+
 	/*******************
 	 * Public properties
 	 *******************/
@@ -199,18 +203,6 @@ class Unread implements ActionInterface
 	 */
 	protected int $min_message = 0;
 
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static Unread $obj;
-
 	/****************
 	 * Public methods
 	 ****************/
@@ -242,32 +234,6 @@ class Unread implements ActionInterface
 
 		// Allow helpdesks and bug trackers and what not to add their own unread data (just add a template_layer to show custom stuff in the template!)
 		IntegrationHook::call('integrate_unread_list');
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
 	}
 
 	/******************

--- a/Sources/Actions/UnreadReplies.php
+++ b/Sources/Actions/UnreadReplies.php
@@ -54,44 +54,6 @@ class UnreadReplies extends Unread
 	 */
 	protected bool $is_topics = false;
 
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static UnreadReplies|Unread $obj;
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
-	}
-
 	/******************
 	 * Internal methods
 	 ******************/

--- a/Sources/Actions/VerificationCode.php
+++ b/Sources/Actions/VerificationCode.php
@@ -15,6 +15,8 @@ declare(strict_types=1);
 
 namespace SMF\Actions;
 
+use SMF\ActionInterface;
+use SMF\ActionTrait;
 use SMF\Cache\CacheApi;
 use SMF\Config;
 use SMF\Lang;
@@ -29,6 +31,8 @@ use SMF\Utils;
  */
 class VerificationCode implements ActionInterface
 {
+	use ActionTrait;
+
 	/*******************
 	 * Public properties
 	 *******************/
@@ -46,18 +50,6 @@ class VerificationCode implements ActionInterface
 	 * The verification code.
 	 */
 	public string $code;
-
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static VerificationCode $obj;
 
 	/****************
 	 * Public methods
@@ -115,32 +107,6 @@ class VerificationCode implements ActionInterface
 
 		// We all die one day...
 		die();
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
 	}
 
 	/******************

--- a/Sources/Actions/ViewQuery.php
+++ b/Sources/Actions/ViewQuery.php
@@ -15,6 +15,8 @@ declare(strict_types=1);
 
 namespace SMF\Actions;
 
+use SMF\ActionInterface;
+use SMF\ActionTrait;
 use SMF\Config;
 use SMF\Db\DatabaseApi as Db;
 use SMF\DebugUtils;
@@ -30,17 +32,7 @@ use SMF\Utils;
  */
 class ViewQuery implements ActionInterface
 {
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static ViewQuery $obj;
+	use ActionTrait;
 
 	/****************
 	 * Public methods
@@ -214,43 +206,6 @@ class ViewQuery implements ActionInterface
 </html>';
 
 		Utils::obExit(false);
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
-	}
-
-	/******************
-	 * Internal methods
-	 ******************/
-
-	/**
-	 * Constructor. Protected to force instantiation via self::load().
-	 */
-	protected function __construct()
-	{
 	}
 }
 

--- a/Sources/Actions/Who.php
+++ b/Sources/Actions/Who.php
@@ -15,6 +15,8 @@ declare(strict_types=1);
 
 namespace SMF\Actions;
 
+use SMF\ActionInterface;
+use SMF\ActionTrait;
 use SMF\Config;
 use SMF\Db\DatabaseApi as Db;
 use SMF\ErrorHandler;
@@ -39,6 +41,8 @@ use SMF\Utils;
  */
 class Who implements ActionInterface
 {
+	use ActionTrait;
+
 	/*******************
 	 * Public static properties
 	 *******************/
@@ -92,18 +96,6 @@ class Who implements ActionInterface
 		'viewerrorlog' => ['admin_forum'],
 		'viewmembers' => ['moderate_forum'],
 	];
-
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static Who $obj;
 
 	/****************
 	 * Public methods
@@ -344,32 +336,6 @@ class Who implements ActionInterface
 
 		// any profile fields disabled?
 		Utils::$context['disabled_fields'] = isset(Config::$modSettings['disabled_profile_fields']) ? array_flip(explode(',', Config::$modSettings['disabled_profile_fields'])) : [];
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
 	}
 
 	/**

--- a/Sources/Actions/XmlHttp.php
+++ b/Sources/Actions/XmlHttp.php
@@ -15,7 +15,9 @@ declare(strict_types=1);
 
 namespace SMF\Actions;
 
+use SMF\ActionInterface;
 use SMF\Actions\Admin\News;
+use SMF\ActionTrait;
 use SMF\BBCodeParser;
 use SMF\Board;
 use SMF\Config;
@@ -35,6 +37,8 @@ use SMF\Utils;
  */
 class XmlHttp implements ActionInterface
 {
+	use ActionTrait;
+
 	use BackwardCompatibility;
 
 	/*******************
@@ -63,18 +67,6 @@ class XmlHttp implements ActionInterface
 		'messageicons' => 'messageIcons',
 		'previews' => 'previews',
 	];
-
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var self
-	 *
-	 * An instance of this class.
-	 * This is used by the load() method to prevent multiple instantiations.
-	 */
-	protected static XmlHttp $obj;
 
 	/****************
 	 * Public methods
@@ -371,32 +363,6 @@ class XmlHttp implements ActionInterface
 		}
 
 		Utils::$context['sub_template'] = 'warning';
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Static wrapper for constructor.
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): self
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
 	}
 
 	/******************


### PR DESCRIPTION
No need for constantly implementing the same `load()` and `call()` in every action, we have traits for that.