### PR TITLE
Fix `TypeError` in RepairBoards

### DIFF
--- a/Sources/Actions/Admin/RepairBoards.php
+++ b/Sources/Actions/Admin/RepairBoards.php
@@ -2087,7 +2087,7 @@ class RepairBoards implements ActionInterface
 	 *
 	 * @param array $result Search result id
 	 */
-	protected function fixMissingCachedSubject(array $result): void
+	protected function fixMissingCachedSubject(\mysqli_result $result): void
 	{
 		$inserts = [];
 

--- a/Sources/Actions/Admin/RepairBoards.php
+++ b/Sources/Actions/Admin/RepairBoards.php
@@ -2085,7 +2085,7 @@ class RepairBoards implements ActionInterface
 	/**
 	 * Callback to fix missing log_search_subjects entries for a topic.
 	 *
-	 * @param array $result Search result id
+	 * @param mysqli_result $result Search result
 	 */
 	protected function fixMissingCachedSubject(\mysqli_result $result): void
 	{


### PR DESCRIPTION
Looks like this type is only passed to `fix_full_processing`,  and this is the only function that  uses it