### PR TITLE
Implements SMF\Db\DatabaseApi::update_from()

### DIFF
--- a/Sources/Db/APIs/MySQL.php
+++ b/Sources/Db/APIs/MySQL.php
@@ -263,7 +263,7 @@ class MySQL extends DatabaseApi implements DatabaseApiInterface
 				}
 			}
 
-			ErrorHandler::log(Lang::$txt['database_error'] . ': ' . $query_error . (!empty(Config::$modSettings['enableErrorQueryLogging']) ? "\n\n$db_string" : ''), 'database', $file, $line);
+			ErrorHandler::log(Lang::$txt['database_error'] . ': ' . $query_error . (!empty(Config::$modSettings['enableErrorQueryLogging']) ? "\n\n{$db_string}" : ''), 'database', $file, $line);
 			ErrorHandler::fatal($error_message, false);
 		}
 
@@ -610,7 +610,7 @@ class MySQL extends DatabaseApi implements DatabaseApiInterface
 	/**
 	 * {@inheritDoc}
 	 */
-	public function error(object $connection = null): string
+	public function error(?object $connection = null): string
 	{
 		if (!(($connection ?? $this->connection) instanceof \mysqli)) {
 			return '';

--- a/Sources/Db/APIs/MySQL.php
+++ b/Sources/Db/APIs/MySQL.php
@@ -540,6 +540,41 @@ class MySQL extends DatabaseApi implements DatabaseApiInterface
 	/**
 	 * {@inheritDoc}
 	 */
+	public function update_from(array $table, array $from_tables, string $set, string $where, array $db_values, ?object $connection = null): bool
+	{
+		if (empty($table['name']) || empty($table['alias']) || empty($set)) {
+			return false;
+		}
+
+		$joins = [];
+
+		foreach ($from_tables as $ft) {
+			if (empty($ft['name']) || empty($ft['alias']) || empty($ft['condition'])) {
+				continue;
+			}
+
+			$joins[] = 'JOIN ' . $ft['name'] . ' AS ' . $ft['alias'] . ' ON (' . $ft['condition'] . ')';
+		}
+
+		if (empty($joins)) {
+			return false;
+		}
+
+		return $this->query(
+			'',
+			'UPDATE ' . $table['name'] . ' AS ' . $table['alias'] . '
+				' . implode('
+				', $joins) . '
+			SET ' . $set . (!empty($where) ? '
+			WHERE ' . $where : ''),
+			$db_values,
+			$connection,
+		);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
 	public function num_rows(object $result): int
 	{
 		return mysqli_num_rows($result);

--- a/Sources/Db/DatabaseApiInterface.php
+++ b/Sources/Db/DatabaseApiInterface.php
@@ -95,6 +95,30 @@ interface DatabaseApiInterface
 	public function insert_id(string $table, ?string $field = null, ?object $connection = null): int;
 
 	/**
+	 * Updates data in a table, using data from other tables.
+	 *
+	 * @todo Use this for updating topics, maintenance, repairing boards, etc.
+	 *
+	 * @param array $table Info about the table to be updated.
+	 *    Example: ['name' => '{db_prefix}foo', 'alias' => 'f']
+	 * @param array $from_tables Info about the tables to get data from.
+	 *    Example:
+	 *    [
+	 *        [
+	 *            'name' => '{db_prefix}bar',
+	 *            'alias' => 'b',
+	 *            'condition' => 'f.baz = b.qux',
+	 *        ]
+	 *    ]
+	 * @param string $set A string containing the SET instructions for the update query.
+	 * @param string $where A string containing any WHERE conditions for the update query.
+	 * @param array $db_values The values to be inserted into the compiled query string.
+	 * @param object $connection The connection to use (if null, $db_connection will be used).
+	 * @return bool True if the update was successful, otherwise false.
+	 */
+	public function update_from(array $table, array $from_tables, string $set, string $where, array $db_values, ?object $connection = null): bool;
+
+	/**
 	 * Gets the number of rows in a result set.
 	 *
 	 * @param object $request A query result resource.


### PR DESCRIPTION
This method can be used to update data in one table directly from data in another table. It will be useful for some changes coming in later pull requests.

