### PR TITLE
Change the return type of ActionInterface to match that of ActionTrait

### DIFF
--- a/Sources/ActionInterface.php
+++ b/Sources/ActionInterface.php
@@ -42,9 +42,9 @@ interface ActionInterface
 	/**
 	 * Static wrapper for constructor.
 	 *
-	 * @return self An instance of the class.
+	 * @return static An instance of the class.
 	 */
-	public static function load(): self;
+	public static function load(): static;
 
 	/**
 	 * Convenience method to load() and execute() an instance of the class.


### PR DESCRIPTION
phpStorm was complaining that the implementation of ActionInterface::load() wasn't compatible with that of ActionTrait::load(), so this fixes that. @Tyrsson can explain more.