### PR TITLE
Fix search issues

### DIFF
--- a/Sources/Search/APIs/Custom.php
+++ b/Sources/Search/APIs/Custom.php
@@ -213,10 +213,9 @@ class Custom extends SearchApi implements SearchApiInterface
 			if ($request !== false && Db::$db->num_rows($request) == 1) {
 				$row = Db::$db->fetch_assoc($request);
 				$this->size = (int) $row['Data_length'] + (int) $row['Index_length'];
+				Db::$db->free_result($request);
 			}
 		}
-
-		Db::$db->free_result($request);
 
 		return $this->size;
 	}

--- a/Sources/Search/APIs/Parsed.php
+++ b/Sources/Search/APIs/Parsed.php
@@ -190,8 +190,8 @@ class Parsed extends SearchApi implements SearchApiInterface
 		if (Db::$db->title === POSTGRE_TITLE) {
 
 			// Postgres will throw an error if the tables don't exist, so check first
-			$search_tables = Db::$db->list_tables(Db::$db->name, 'log_search%');
-			if (array_intersect(['log_search_dictionary', 'log_search_parsed'], $search_tables) == []) {
+			$search_tables = Db::$db->list_tables(Db::$db->name, Db::$db->prefix . 'log_search%');
+			if (array_intersect([Db::$db->prefix . 'log_search_dictionary', Db::$db->prefix . 'log_search_parsed'], $search_tables) == []) {
 				return $this->size;
 			}
 

--- a/Sources/Search/APIs/Parsed.php
+++ b/Sources/Search/APIs/Parsed.php
@@ -188,6 +188,13 @@ class Parsed extends SearchApi implements SearchApiInterface
 		$this->size = 0;
 
 		if (Db::$db->title === POSTGRE_TITLE) {
+
+			// Postgres will throw an error if the tables don't exist, so check first
+			$search_tables = Db::$db->list_tables(Db::$db->name, 'log_search%');
+			if (array_intersect(['log_search_dictionary', 'log_search_parsed'], $search_tables) == []) {
+				return $this->size;
+			}
+
 			$request = Db::$db->query(
 				'',
 				'SELECT (

--- a/Sources/Search/APIs/Parsed.php
+++ b/Sources/Search/APIs/Parsed.php
@@ -191,6 +191,7 @@ class Parsed extends SearchApi implements SearchApiInterface
 
 			// Postgres will throw an error if the tables don't exist, so check first
 			$search_tables = Db::$db->list_tables(Db::$db->name, Db::$db->prefix . 'log_search%');
+
 			if (array_intersect([Db::$db->prefix . 'log_search_dictionary', Db::$db->prefix . 'log_search_parsed'], $search_tables) == []) {
 				return $this->size;
 			}
@@ -210,6 +211,8 @@ class Parsed extends SearchApi implements SearchApiInterface
 			while ($row = Db::$db->fetch_assoc($request)) {
 				$this->size = (int) $row['total_size'];
 			}
+
+			Db::$db->free_result($request);
 		} else {
 			$request = Db::$db->query(
 				'',


### PR DESCRIPTION
This fixes two issues related to calculating the size of a search index.

1. PostgreSQL will throw an error if you try to get the size of something that doesn't exist. In order to properly handle actual database errors in the future, check to make sure the tables actually exist first (also because it's a simple operation).

2. For the custom index, we try to free the result regardless of whether we got one in the first place, which causes an error. This affects MySQL as well as Postgres.

On a related note, we need to properly handle database errors better - a query causing an error that leads to the request object being false instead of what we're looking for shouldn't cause a fatal PHP error.