### PR TITLE
Avoids truncating in the middle of entities in text2words

### DIFF
--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -5329,7 +5329,7 @@ function text2words($text, $max_chars = 20, $encrypt = false)
 		$returned_words = array();
 		foreach ($words as $word)
 			if (($word = trim($word, '-_\'')) !== '')
-				$returned_words[] = $max_chars === null ? $word : substr($word, 0, $max_chars);
+				$returned_words[] = $max_chars === null ? $word : $smcFunc['truncate']($word, $max_chars);
 
 		// Filter out all words that occur more than once.
 		return array_unique($returned_words);


### PR DESCRIPTION
Fixes #6405

Patch for 2.1.5 should include code to find and fix broken entities in log_search_subjects table.