### PR TITLE
Fixes case mismatch when fetching column names in smf_db_create_table

### DIFF
--- a/Sources/DbPackages-mysql.php
+++ b/Sources/DbPackages-mysql.php
@@ -254,6 +254,7 @@ function smf_db_create_table($table_name, $columns, $indexes = array(), $paramet
 
 		while ($row = $smcFunc['db_fetch_assoc']($request))
 		{
+			$row = array_change_key_case($row, CASE_LOWER);
 			$same_col[] = $row['column_name'];
 		}
 


### PR DESCRIPTION
Fixes #7626