### PR TITLE
Ensures fix_utf8mb4 has been applied to strings before saving to db

### DIFF
--- a/Sources/Load.php
+++ b/Sources/Load.php
@@ -115,10 +115,12 @@ function reloadSettings()
 		{
 			return (string) $string;
 		};
-	$fix_utf8mb4 = function($string) use ($utf8, $smcFunc)
+	$smcFunc['fix_utf8mb4'] = function($string) use ($utf8, $smcFunc)
 	{
 		if (!$utf8 || $smcFunc['db_mb4'])
 			return $string;
+
+		$string = (string) $string;
 
 		$i = 0;
 		$len = strlen($string);
@@ -162,11 +164,11 @@ function reloadSettings()
 			$num = $string[0] === 'x' ? hexdec(substr($string, 1)) : (int) $string;
 			return $num < 0x20 || $num > 0x10FFFF || ($num >= 0xD800 && $num <= 0xDFFF) || $num === 0x202E || $num === 0x202D ? '' : '&#' . $num . ';';
 		},
-		'htmlspecialchars' => function($string, $quote_style = ENT_COMPAT, $charset = 'ISO-8859-1') use ($ent_check, $utf8, $fix_utf8mb4, &$smcFunc)
+		'htmlspecialchars' => function($string, $quote_style = ENT_COMPAT, $charset = 'ISO-8859-1') use ($ent_check, $utf8, &$smcFunc)
 		{
 			$string = $smcFunc['normalize']($string);
 
-			return $fix_utf8mb4($ent_check(htmlspecialchars($string, $quote_style, $utf8 ? 'UTF-8' : $charset)));
+			return $smcFunc['fix_utf8mb4']($ent_check(htmlspecialchars($string, $quote_style, $utf8 ? 'UTF-8' : $charset)));
 		},
 		'htmltrim' => function($string) use ($utf8, $ent_check)
 		{
@@ -234,7 +236,7 @@ function reloadSettings()
 		{
 			return $smcFunc['convert_case']($string, 'ucwords');
 		},
-		'convert_case' => function($string, $case, $simple = false, $form = 'c') use (&$smcFunc, $utf8, $ent_check, $fix_utf8mb4, $sourcedir)
+		'convert_case' => function($string, $case, $simple = false, $form = 'c') use (&$smcFunc, $utf8, $ent_check, $sourcedir)
 		{
 			if (!$utf8)
 			{
@@ -295,7 +297,7 @@ function reloadSettings()
 				}
 			}
 
-			return $fix_utf8mb4($string);
+			return $smcFunc['fix_utf8mb4']($string);
 		},
 		'json_decode' => 'smf_json_decode',
 		'json_encode' => 'json_encode',

--- a/Sources/Subs-Db-mysql.php
+++ b/Sources/Subs-Db-mysql.php
@@ -212,7 +212,7 @@ function smf_db_replacement__callback($matches)
 
 		case 'string':
 		case 'text':
-			return sprintf('\'%1$s\'', mysqli_real_escape_string($connection, $replacement));
+			return sprintf('\'%1$s\'', mysqli_real_escape_string($connection, isset($smcFunc['fix_utf8mb4']) ? $smcFunc['fix_utf8mb4']($replacement) : $replacement));
 			break;
 
 		case 'array_int':
@@ -243,7 +243,7 @@ function smf_db_replacement__callback($matches)
 					smf_db_error_backtrace('Database error, given array of string values is empty. (' . $matches[2] . ')', '', E_USER_ERROR, __FILE__, __LINE__);
 
 				foreach ($replacement as $key => $value)
-					$replacement[$key] = sprintf('\'%1$s\'', mysqli_real_escape_string($connection, $value));
+					$replacement[$key] = sprintf('\'%1$s\'', mysqli_real_escape_string($connection, isset($smcFunc['fix_utf8mb4']) ? $smcFunc['fix_utf8mb4']($value) : $value));
 
 				return implode(', ', $replacement);
 			}


### PR DESCRIPTION
Fixes #7776

- Renames `$fix_utf8mb4()` to `$smcFunc['fix_utf8mb4']()` so that it can be accessed outside of `reloadSettings()`
- Uses `$smcFunc['fix_utf8mb4']()` in Subs-Db-mysql.php to ensure four byte Unicode characters are always escaped correctly. This is safe because running `$smcFunc['fix_utf8mb4']()` multiple times on the same string doesn't change anything again.