### PR TITLE
Error when (un)liking something

### DIFF
--- a/Sources/Actions/Like.php
+++ b/Sources/Actions/Like.php
@@ -321,7 +321,10 @@ class Like implements ActionInterface
 			);
 
 			if (Db::$db->num_rows($request) == 1) {
-				list($this->id_topic, $topicOwner) = Db::$db->fetch_row($request);
+				// fetch_row always results in an array of strings...
+				$row = Db::$db->fetch_row($request);
+				$this->id_topic = (int) $row[0];
+				$topicOwner = (int) $row[1];
 			}
 			Db::$db->free_result($request);
 


### PR DESCRIPTION
The "mysqli_fetch_row" function always returns an array of strings regardless of the datatype. This causes problems when trying to set a property that's supposed to be an int...