### PR TITLE
[2.1] Allow line terminators when parsing package-info xml

### DIFF
--- a/Sources/Class-Package.php
+++ b/Sources/Class-Package.php
@@ -363,10 +363,10 @@ class xmlArray
 		);
 
 		// Loop until we're out of data.
-		while ($data != '')
+		while ($data !== '')
 		{
 			// Find and remove the next tag.
-			preg_match('/\A<([\w\-:]+)((?:\s+.+?)?)([\s]?\/)?' . '>/', $data, $match);
+			preg_match('/\A<([\w\-:]+)((?:\s+[\s\S]+?)?)([\s]?\/)?' . '>/', $data, $match);
 			if (isset($match[0]))
 				$data = preg_replace('/' . preg_quote($match[0], '/') . '/s', '', $data, 1);
 


### PR DESCRIPTION
This PR replaces the dot . instruction for [\s\S] to allow white space chars in the capturing group

Fixes #8195