### PR TITLE
Upgr fixes

### DIFF
--- a/other/upgrade.php
+++ b/other/upgrade.php
@@ -2594,7 +2594,7 @@ function protected_alter($change, $substep, $is_test = false)
 			SHOW FULL PROCESSLIST');
 		while ($row = $smcFunc['db_fetch_assoc']($request))
 		{
-			if (strpos($row['Info'], 'ALTER TABLE ' . $db_prefix . $change['table']) !== false && strpos($row['Info'], $change['text']) !== false)
+			if ($row['Info'] !== null && (strpos($row['Info'], 'ALTER TABLE ' . $db_prefix . $change['table']) !== false && strpos($row['Info'], $change['text']) !== false))
 				$found = true;
 		}
 

--- a/other/upgrade.php
+++ b/other/upgrade.php
@@ -715,6 +715,12 @@ function loadEssentialData()
 		return random_bytes($bytes);
 	};
 
+	// This is used in text2words() for old 1.0.x conversions; restoring old logic
+	$smcFunc['truncate'] = function($word, $max_chars)
+	{
+		return substr($word, 0, $max_chars);
+	};
+
 	// We need this for authentication and some upgrade code
 	require_once($sourcedir . '/Subs-Auth.php');
 	require_once($sourcedir . '/Class-Package.php');

--- a/other/upgrade.php
+++ b/other/upgrade.php
@@ -718,7 +718,17 @@ function loadEssentialData()
 	// This is used in text2words() for old 1.0.x conversions; restoring old logic
 	$smcFunc['truncate'] = function($word, $max_chars)
 	{
-		return substr($word, 0, $max_chars);
+		$new_string = '';
+
+		foreach (preg_split('/((?>&.*?;|\X))/u', $string, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY) as $char)
+		{
+			if (strlen($new_string . $char) > $max_chars)
+				break;
+
+			$new_string .= $char;
+		}
+
+		return $new_string;
 	};
 
 	// We need this for authentication and some upgrade code


### PR DESCRIPTION
Fixes #7799 

Also adds $smcFunc['truncate'], used when building log_search_subjects via text2words() in old 1.0.x migrations.  This was causing fatal errors when running the upgrader against 1.0.x & yabbse1.5.5.

Needed to get this line:
https://github.com/SimpleMachines/SMF/blob/454e67f2dc49f05bfa1e978d6d5079ba889116c1/Sources/Subs.php#L5332

To behave like the prior version for the upgrade:
https://github.com/SimpleMachines/SMF/blob/19a9de63d8b895c6f931137bba09c3d5a79caf52/Sources/Subs.php#L5325

Note that $smcFunc['truncate'] is actually pretty involved & factors in entity encoding...  
https://github.com/SimpleMachines/SMF/blob/454e67f2dc49f05bfa1e978d6d5079ba889116c1/Sources/Load.php#L222

But to port over all the portions of Load.php into upgrade.php to make that work felt like overkill.  Opted to just match the prior logic, which has been used for years.