### PR TITLE
2.1/merge topic link

### DIFF
--- a/Sources/MoveTopic.php
+++ b/Sources/MoveTopic.php
@@ -266,7 +266,7 @@ function MoveTopic2()
 	{
 		// Replace tokens with links in the reason.
 		$reason_replacements = array(
-			$txt['movetopic_auto_board'] => '[url="' . $scripturl . '?board=' . $_POST['toboard'] . '.0"]' . $board_name . '[/url]',
+			$txt['movetopic_auto_board'] => '[url=&quot;' . $scripturl . '?board=' . $_POST['toboard'] . '.0&quot;]' . $board_name . '[/url]',
 			$txt['movetopic_auto_topic'] => '[iurl]' . $scripturl . '?topic=' . $topic . '.0[/iurl]',
 		);
 
@@ -277,7 +277,7 @@ function MoveTopic2()
 
 			// Make sure we catch both languages in the reason.
 			$reason_replacements += array(
-				$txt['movetopic_auto_board'] => '[url="' . $scripturl . '?board=' . $_POST['toboard'] . '.0"]' . $board_name . '[/url]',
+				$txt['movetopic_auto_board'] => '[url=&quot;' . $scripturl . '?board=' . $_POST['toboard'] . '.0&quot;]' . $board_name . '[/url]',
 				$txt['movetopic_auto_topic'] => '[iurl]' . $scripturl . '?topic=' . $topic . '.0[/iurl]',
 			);
 		}

--- a/Sources/SplitTopics.php
+++ b/Sources/SplitTopics.php
@@ -1401,7 +1401,7 @@ function MergeExecute($topics = array())
 	{
 		// Replace tokens with links in the reason.
 		$reason_replacements = array(
-			$txt['movetopic_auto_topic'] => '[iurl="' . $scripturl . '?topic=' . $id_topic . '.0"]' . $target_subject . '[/iurl]',
+			$txt['movetopic_auto_topic'] => '[iurl=&quot;' . $scripturl . '?topic=' . $id_topic . '.0&quot;]' . $target_subject . '[/iurl]',
 		);
 
 		// Should be in the boardwide language.
@@ -1411,7 +1411,7 @@ function MergeExecute($topics = array())
 
 			// Make sure we catch both languages in the reason.
 			$reason_replacements += array(
-				$txt['movetopic_auto_topic'] => '[iurl="' . $scripturl . '?topic=' . $id_topic . '.0"]' . $target_subject . '[/iurl]',
+				$txt['movetopic_auto_topic'] => '[iurl=&quot;' . $scripturl . '?topic=' . $id_topic . '.0&quot;]' . $target_subject . '[/iurl]',
 			);
 		}
 


### PR DESCRIPTION
Fixes #8249 

71e79e6 fixes the problem that was causing the broken BBC to be created.

However, since we know that bad data now exists out there in the world, dfe8091 also allows parse_bbc() to recognize and handle literal quotation marks around the parameters of unparsed_equals and parsed_equals BBC types. That will allow the links in the existing redirection topics to work.