### PR TITLE
3.0/caching issues

### DIFF
--- a/Sources/Cache/APIs/Sqlite.php
+++ b/Sources/Cache/APIs/Sqlite.php
@@ -109,7 +109,7 @@ class Sqlite extends CacheApi implements CacheApiInterface
 		if ($value === null) {
 			$query = 'DELETE FROM cache WHERE key = \'' . $this->cacheDB->escapeString($key) . '\';';
 		} else {
-			$query = 'REPLACE INTO cache VALUES (\'' . $this->cacheDB->escapeString($key) . '\', \'' . $this->cacheDB->escapeString($value) . '\', ' . $ttl . ');';
+			$query = 'REPLACE INTO cache VALUES (\'' . $this->cacheDB->escapeString($key) . '\', \'' . $this->cacheDB->escapeString(is_bool($value) ? strval(intval($value)) : $value) . '\', ' . $ttl . ');';
 		}
 		$result = $this->cacheDB->exec($query);
 

--- a/Sources/Cache/CacheApi.php
+++ b/Sources/Cache/CacheApi.php
@@ -543,12 +543,12 @@ abstract class CacheApi
 		self::$count_hits++;
 
 		if (isset(Config::$db_show_debug) && Config::$db_show_debug === true) {
-			self::$hits[self::$count_hits] = ['k' => $key, 'd' => 'put', 's' => $value === null ? 0 : strlen((string) Utils::jsonEncode($value))];
+			self::$hits[self::$count_hits] = ['k' => $key, 'd' => 'put', 's' => $value === null ? 0 : strlen(serialize($value))];
 			$st = microtime(true);
 		}
 
 		// The API will handle the rest.
-		$value = $value === null ? null : Utils::jsonEncode($value);
+		$value = $value === null ? null : serialize($value);
 		self::$loadedApi->putData($key, $value, $ttl);
 
 		if (class_exists('SMF\\IntegrationHook', false)) {
@@ -605,7 +605,11 @@ abstract class CacheApi
 		}
 
 		if (is_string($value)) {
-			return Utils::jsonDecode($value, true);
+			try {
+				$temp = @unserialize($value);
+				$value = $temp;
+			} catch (\Throwable $e) {
+			}
 		}
 
 		return $value;

--- a/Sources/Cache/CacheApi.php
+++ b/Sources/Cache/CacheApi.php
@@ -543,7 +543,7 @@ abstract class CacheApi
 		self::$count_hits++;
 
 		if (isset(Config::$db_show_debug) && Config::$db_show_debug === true) {
-			self::$hits[self::$count_hits] = ['k' => $key, 'd' => 'put', 's' => $value === null ? 0 : strlen(Utils::jsonEncode($value))];
+			self::$hits[self::$count_hits] = ['k' => $key, 'd' => 'put', 's' => $value === null ? 0 : strlen((string) Utils::jsonEncode($value))];
 			$st = microtime(true);
 		}
 
@@ -608,8 +608,7 @@ abstract class CacheApi
 			return Utils::jsonDecode($value, true);
 		}
 
-			return $value;
-
+		return $value;
 	}
 }
 

--- a/Sources/Config.php
+++ b/Sources/Config.php
@@ -979,7 +979,7 @@ class Config
 		Cache\CacheApi::load();
 
 		// Try to load it from the cache first; it'll never get cached if the setting is off.
-		if (($temp = Cache\CacheApi::get('modSettings', 90)) !== null) {
+		if (is_array($temp = Cache\CacheApi::get('modSettings', 90))) {
 			self::$modSettings = $temp;
 		} else {
 			self::$modSettings = [];


### PR DESCRIPTION
Fixes some issues with caching.

First, there were some problems with the Sqlite cache API that have been fixed in 17f9186.

Second, and more importantly, 17fdb6e changes how we convert cached data to strings. Instead of using json_encode() and json_decode(), we are now using serialize() and unserialize(). This is necessary because in SMF 3.0 we need to cache objects. For example, when caching recent events, we pass a collection of SMF\Calendar\EventOccurrence objects to be cached. Encoding that to JSON loses data and the objects cannot be reconstructed when retrieved, resulting in nasty errors.