### PR TITLE
Automatically enable/disable Config::$backward_compatibility as needed for mods

### DIFF
--- a/Sources/Config.php
+++ b/Sources/Config.php
@@ -249,11 +249,15 @@ class Config
 
 	######### Modification Support #########
 	/**
-	 * @var bool
+	 * @var int
 	 *
-	 * Master switch to enable backward compatibility behaviours.
+	 * Master switch to enable backward compatibility behaviours:
+	 * 0: Off. This is the default.
+	 * 1: On. This will be set automatically if an installed modification needs it.
+	 * 2: Forced on. Use this to enable backward compatibility behaviours even when
+	 *    no installed modifications require them. This is usually not necessary.
 	 */
-	public static bool $backward_compatibility = true;
+	public static int $backward_compatibility;
 
 	######### Legacy settings #########
 	/**
@@ -783,13 +787,17 @@ class Config
 
 				######### Modification Support #########
 				/**
-				 * @var bool
+				 * @var int
 				 *
-				 * Master switch to enable backward compatibility behaviours.
+				 * Master switch to enable backward compatibility behaviours:
+				 * 0: Off. This is the default.
+				 * 1: On. This will be set automatically if an installed modification needs it.
+				 * 2: Forced on. Use this to enable backward compatibility behaviours even when
+				 *    no installed modifications require them. This is usually not necessary.
 				 */
 				END,
-			'default' => true,
-			'type' => 'boolean',
+			'default' => 0,
+			'type' => 'integer',
 		],
 		'db_character_set' => [
 			'text' => <<<'END'
@@ -956,7 +964,7 @@ class Config
 
 		// For backward compatibility, make settings available as global variables.
 		// Must do this manually because SMF\BackwardCompatibility is not loaded yet.
-		if (self::$backward_compatibility && !self::$exported) {
+		if (!empty(self::$backward_compatibility) && !self::$exported) {
 			foreach ($settings as $var => $val) {
 				if (property_exists(__CLASS__, $var)) {
 					$GLOBALS[$var] = &self::${$var};

--- a/Sources/Config.php
+++ b/Sources/Config.php
@@ -25,13 +25,6 @@ class Config
 	 * Public static properties
 	 **************************/
 
-	/**
-	 * @var bool
-	 *
-	 * Master switch to enable backward compatibility behaviours.
-	 */
-	public static bool $backward_compatibility = true;
-
 	########## Maintenance ##########
 	/**
 	 * @var int 0, 1, 2
@@ -253,6 +246,14 @@ class Config
 	 * Path to the tasks directory.
 	 */
 	public static string $tasksdir;
+
+	######### Modification Support #########
+	/**
+	 * @var bool
+	 *
+	 * Master switch to enable backward compatibility behaviours.
+	 */
+	public static bool $backward_compatibility = true;
 
 	######### Legacy settings #########
 	/**
@@ -776,6 +777,19 @@ class Config
 			'default' => '__DIR__ . \'/Languages\'',
 			'raw_default' => true,
 			'type' => 'string',
+		],
+		'backward_compatibility' => [
+			'text' => <<<'END'
+
+				######### Modification Support #########
+				/**
+				 * @var bool
+				 *
+				 * Master switch to enable backward compatibility behaviours.
+				 */
+				END,
+			'default' => true,
+			'type' => 'boolean',
 		],
 		'db_character_set' => [
 			'text' => <<<'END'

--- a/Sources/PackageManager/PackageManager.php
+++ b/Sources/PackageManager/PackageManager.php
@@ -1229,8 +1229,12 @@ class PackageManager
 					Db::$db->query(
 						'',
 						'UPDATE {db_prefix}log_packages
-						SET install_state = {int:not_installed}, member_removed = {string:member_name},
-							id_member_removed = {int:current_member}, time_removed = {int:current_time}, sha256_hash = {string:package_hash}
+						SET
+							install_state = {int:not_installed},
+							member_removed = {string:member_name},
+							id_member_removed = {int:current_member},
+							time_removed = {int:current_time},
+							sha256_hash = {string:package_hash}
 						WHERE package_id = {string:package_id}
 							AND id_install = {int:install_id}',
 						[
@@ -1253,8 +1257,12 @@ class PackageManager
 					Db::$db->query(
 						'',
 						'UPDATE {db_prefix}log_packages
-						SET install_state = {int:not_installed}, member_removed = {string:member_name},
-							id_member_removed = {int:current_member}, time_removed = {int:current_time}, sha256_hash = {string:package_hash}
+						SET
+							install_state = {int:not_installed},
+							member_removed = {string:member_name},
+							id_member_removed = {int:current_member},
+							time_removed = {int:current_time},
+							sha256_hash = {string:package_hash}
 						WHERE package_id = {string:package_id}
 							AND version = {string:old_version}',
 						[
@@ -1322,21 +1330,44 @@ class PackageManager
 
 				// Credits tag?
 				$credits_tag = (empty($credits_tag)) ? '' : Utils::jsonEncode($credits_tag);
+
+				// Log that we installed it.
 				Db::$db->insert(
 					'',
 					'{db_prefix}log_packages',
 					[
-						'filename' => 'string', 'name' => 'string', 'package_id' => 'string', 'version' => 'string',
-						'id_member_installed' => 'int', 'member_installed' => 'string', 'time_installed' => 'int',
-						'install_state' => 'int', 'failed_steps' => 'string', 'themes_installed' => 'string',
-						'member_removed' => 'int', 'db_changes' => 'string', 'credits' => 'string',
+						'filename' => 'string',
+						'name' => 'string',
+						'package_id' => 'string',
+						'version' => 'string',
+						'id_member_installed' => 'int',
+						'member_installed' => 'string',
+						'time_installed' => 'int',
+						'install_state' => 'int',
+						'failed_steps' => 'string',
+						'themes_installed' => 'string',
+						'member_removed' => 'int',
+						'db_changes' => 'string',
+						'credits' => 'string',
 						'sha256_hash' => 'string',
+						'smf_version' => 'string',
 					],
 					[
-						$package_filename, $package_name, $package_id, $package_version,
-						User::$me->id, User::$me->name, time(),
-						$is_upgrade ? 2 : 1, $failed_step_insert, $themes_installed,
-						0, $db_changes, $credits_tag, Utils::$context['package_sha256_hash'],
+						$package_filename,
+						$package_name,
+						$package_id,
+						$package_version,
+						User::$me->id,
+						User::$me->name,
+						time(),
+						$is_upgrade ? 2 : 1,
+						$failed_step_insert,
+						$themes_installed,
+						0,
+						$db_changes,
+						$credits_tag,
+						Utils::$context['package_sha256_hash'],
+						Utils::$context['smf_version'],
 					],
 					['id_install'],
 				);

--- a/Sources/PackageManager/SubsPackage.php
+++ b/Sources/PackageManager/SubsPackage.php
@@ -1144,6 +1144,9 @@ class SubsPackage
 			return [];
 		}
 
+		// Keep track of what version of SMF we are emulating (if any).
+		Utils::$context['smf_version'] = preg_replace('/^(\d+\.\d+).*/', '$1', $the_version);
+
 		// Find all the actions in this method - in theory, these should only be allowed actions. (* means all.)
 		$actions = $script->set('*');
 		$return = [];

--- a/other/Settings.php
+++ b/other/Settings.php
@@ -222,6 +222,14 @@ $packagesdir = dirname(__FILE__) . '/Packages';
  */
 $languagesdir = dirname(__FILE__) . '/Languages';
 
+######### Modification Support #########
+/**
+ * @var bool
+ *
+ * Master switch to enable backward compatibility behaviours.
+ */
+$backward_compatibility = true;
+
 ######### Legacy Settings #########
 /**
  * @var string

--- a/other/Settings.php
+++ b/other/Settings.php
@@ -224,11 +224,15 @@ $languagesdir = dirname(__FILE__) . '/Languages';
 
 ######### Modification Support #########
 /**
- * @var bool
+ * @var int
  *
- * Master switch to enable backward compatibility behaviours.
+ * Master switch to enable backward compatibility behaviours:
+ * 0: Off. This is the default.
+ * 1: On. This will be set automatically if an installed modification needs it.
+ * 2: Forced on. Use this to enable backward compatibility behaviours even when
+ *    no installed modifications require them. This is usually not necessary.
  */
-$backward_compatibility = true;
+$backward_compatibility = 0;
 
 ######### Legacy Settings #########
 /**

--- a/other/Settings_bak.php
+++ b/other/Settings_bak.php
@@ -222,6 +222,14 @@ $packagesdir = dirname(__FILE__) . '/Packages';
  */
 $languagesdir = dirname(__FILE__) . '/Languages';
 
+######### Modification Support #########
+/**
+ * @var bool
+ *
+ * Master switch to enable backward compatibility behaviours.
+ */
+$backward_compatibility = true;
+
 ######### Legacy Settings #########
 /**
  * @var string

--- a/other/Settings_bak.php
+++ b/other/Settings_bak.php
@@ -224,11 +224,15 @@ $languagesdir = dirname(__FILE__) . '/Languages';
 
 ######### Modification Support #########
 /**
- * @var bool
+ * @var int
  *
- * Master switch to enable backward compatibility behaviours.
+ * Master switch to enable backward compatibility behaviours:
+ * 0: Off. This is the default.
+ * 1: On. This will be set automatically if an installed modification needs it.
+ * 2: Forced on. Use this to enable backward compatibility behaviours even when
+ *    no installed modifications require them. This is usually not necessary.
  */
-$backward_compatibility = true;
+$backward_compatibility = 0;
 
 ######### Legacy Settings #########
 /**

--- a/other/install_3-0_MySQL.sql
+++ b/other/install_3-0_MySQL.sql
@@ -462,6 +462,7 @@ CREATE TABLE {$db_prefix}log_packages (
 	db_changes TEXT NOT NULL,
 	credits TEXT NOT NULL,
 	sha256_hash TEXT,
+	smf_version VARCHAR(5) NOT NULL DEFAULT '',
 	PRIMARY KEY (id_install),
 	INDEX idx_filename (filename(15))
 ) ENGINE={$engine};

--- a/other/install_3-0_PostgreSQL.sql
+++ b/other/install_3-0_PostgreSQL.sql
@@ -722,6 +722,7 @@ CREATE TABLE {$db_prefix}log_packages (
 	db_changes text NOT NULL,
 	credits text NOT NULL,
 	sha256_hash TEXT,
+	smf_version varchar(5) NOT NULL DEFAULT '',
 	PRIMARY KEY (id_install)
 );
 

--- a/other/upgrade_3-0_MySQL.sql
+++ b/other/upgrade_3-0_MySQL.sql
@@ -969,3 +969,12 @@ Db::$db->add_index(
 ---# Adding new "spoofdetector_censor" setting
 INSERT IGNORE INTO {$db_prefix}settings (variable, value) VALUES ('spoofdetector_censor', '1');
 ---#
+
+/******************************************************************************/
+--- Adding SMF version information to log_packages
+/******************************************************************************/
+
+---# Adding a new column "smf_version" to log_packages table
+ALTER TABLE {$db_prefix}log_packages
+ADD COLUMN smf_version VARCHAR(5) NOT NULL DEFAULT '';
+---#

--- a/other/upgrade_3-0_PostgreSQL.sql
+++ b/other/upgrade_3-0_PostgreSQL.sql
@@ -851,3 +851,12 @@ CREATE INDEX {$db_prefix}idx_spoofdetector_name_id ON {$db_prefix}members (spoof
 ---# Adding new "spoofdetector_censor" setting
 INSERT INTO {$db_prefix}settings (variable, value) VALUES ('spoofdetector_censor', '1') ON CONFLICT DO NOTHING;
 ---#
+
+/******************************************************************************/
+--- Adding SMF version information to log_packages
+/******************************************************************************/
+
+---# Adding a new column "smf_version" to log_packages table
+ALTER TABLE {$db_prefix}log_packages
+ADD COLUMN IF NOT EXISTS smf_version VARCHAR(5) NOT NULL DEFAULT '';
+---#


### PR DESCRIPTION
When I first created the Config::$backward_compatibility setting during the initial OOP refactoring, I made it a hard-coded value with the idea that backward compatibility behaviours would be enabled by default in SMF 3.0, but then in 3.1 they would be disabled by default, and eventually removed entirely.

Ideally, though, we want to avoid the backward compatibility behaviours whenever possible. Since we only need them in order to support modifications that were written for SMF 2.1, it would be better if we only turned them on while such a mod is installed.

Therefore this PR does the following:

1. Makes $backward_compatibility a setting recorded in Settings.php rather than a hard-coded value in Config.php.

2. Adds a column to the log_packages table to record the SMF version that a package was installed for. If the package was installed using version emulation, then the emulated version will be recorded.

3. Allows the package manager to enable or disable the backward compatibility setting as needed for mods.

4. Changes the backward compatibility setting from a boolean to an integer so that admins can set it to 2 in order to force backward compatibility on even when no installed mods need it. This is intended for cases where a third party integration script (as opposed to an installed mod) expects the old SMF behaviour.

The logic that the package manager uses to decide whether to enable Config::$backward_compatibility is pretty simple. Every time a package is installed, upgraded, or uninstalled, the package manager will check the values of log_packages.smf_version for all installed packages. If any of them were installed by emulating SMF 2.1.x or below, then Config::$backward_compatibility will be turned on. If none were installed using emulation, then it will be turned off.

This also means that modification developers will not be able to update the content of their package_info.xml files to claim support for SMF 3.0 unless and until they have in fact rewritten it to properly support 3.0. This is a good thing.

@jdarwood007: If and when this is merged, we will need to update the new installer/upgrader code in #8093 to reflect the database changes in this PR. I will take care of that when the time comes, but I thought I should mention it now for the sake of good communication.