### PR TITLE
Drop single dimensional array support for data array in insert function

### DIFF
--- a/Sources/Db/APIs/MySQL.php
+++ b/Sources/Db/APIs/MySQL.php
@@ -361,11 +361,6 @@ class MySQL extends DatabaseApi implements DatabaseApiInterface
 			}
 		}
 
-		// Inserting data as a single row can be done as a single array.
-		if (!is_array($data[array_rand($data)])) {
-			$data = [$data];
-		}
-
 		// Create the mold for a single row insert.
 		$insertData = '(';
 

--- a/Sources/Db/APIs/PostgreSQL.php
+++ b/Sources/Db/APIs/PostgreSQL.php
@@ -387,10 +387,6 @@ class PostgreSQL extends DatabaseApi implements DatabaseApiInterface
 		// Force method to lower case
 		$method = strtolower($method);
 
-		if (!is_array($data[array_rand($data)])) {
-			$data = [$data];
-		}
-
 		// Replace the prefix holder with the actual prefix.
 		$table = str_replace('{db_prefix}', $this->prefix, $table);
 

--- a/Sources/Db/DatabaseApiInterface.php
+++ b/Sources/Db/DatabaseApiInterface.php
@@ -76,7 +76,7 @@ interface DatabaseApiInterface
 	 * @param string $method INSERT or REPLACE.
 	 * @param string $table The table (only used for Postgres).
 	 * @param array $columns An array of the columns we're inserting the data into. Should contain 'column' => 'datatype' pairs.
-	 * @param array $data The data to insert.
+	 * @param array[][] $data The data to insert, left rows right columns.
 	 * @param array $keys The keys for the table, needs to be not empty on replace mode.
 	 * @param object $connection = null The connection (if null, $db_connection is used).
 	 * @param int returnmode 0 = nothing(default), 1 = last row id, 2 = all rows id as array.


### PR DESCRIPTION
Since it bugged since 2.1 -> no one mention the issue, we could drop the feature and make the interface more clear.