### PR TITLE
[2.1] Add check against huge dates in [quote]/[time]

### DIFF
--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -2267,7 +2267,7 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 				'parameters' => array(
 					'author' => array('match' => '([^<>]{1,192}?)'),
 					'link' => array('match' => '(?:board=\d+;)?((?:topic|threadid)=[\dmsg#\./]{1,40}(?:;start=[\dmsg#\./]{1,40})?|msg=\d+?|action=profile;u=\d+)'),
-					'date' => array('match' => '(\d+)', 'validate' => 'timeformat'),
+					'date' => array('match' => '(\d{1,18})', 'validate' => 'timeformat'),
 				),
 				'before' => '<blockquote><cite><a href="' . $scripturl . '?{link}">' . $txt['quote_from'] . ': {author} ' . $txt['search_on'] . ' {date}</a></cite>',
 				'after' => '</blockquote>',
@@ -2386,7 +2386,7 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 				'content' => '$1',
 				'validate' => function(&$tag, &$data, $disabled)
 				{
-					if (is_numeric($data))
+					if (preg_match('~^\d{1,18}$~', $data) === 1)
 						$data = timeformat($data);
 
 					$tag['content'] = '<span class="bbc_time">$1</span>';


### PR DESCRIPTION
This stops 500 errors and pages being inaccessible from viewing a `[quote]` or `[time]` tag with a huge timestamp. The fix is to limit the timestamp to 18 digits, as described in #7768.

Fixes #7768.

Ref: https://www.simplemachines.org/community/index.php?topic=585036.0