### PR TITLE
[3.0] Fix eval return; set dir consistently throughnout

### DIFF
--- a/Sources/Config.php
+++ b/Sources/Config.php
@@ -1697,6 +1697,14 @@ class Config
 
 					if (!empty($setting_def['raw_default']) && $setting_def['default'] !== '') {
 						$var_pattern[] = preg_replace('/\s+/', '\s+', preg_quote($setting_def['default'], '~'));
+
+						if (str_contains($setting_def['default'], 'dirname(__FILE__)')) {
+							$var_pattern[] = preg_replace('/\s+/', '\s+', preg_quote(str_replace('dirname(__FILE__)', '__DIR__', $setting_def['default']), '~'));
+						}
+
+						if (str_contains($setting_def['default'], '__DIR__')) {
+							$var_pattern[] = preg_replace('/\s+/', '\s+', preg_quote(str_replace('__DIR__', 'dirname(__FILE__)', $setting_def['default']), '~'));
+						}
 					}
 
 					$var_pattern = array_unique($var_pattern);

--- a/Sources/Config.php
+++ b/Sources/Config.php
@@ -682,7 +682,7 @@ class Config
 				 * Path to the cache directory for the file-based cache system.
 				 */
 				END,
-			'default' => 'dirname(__FILE__) . \'/cache\'',
+			'default' => '__DIR__ . \'/cache\'',
 			'raw_default' => true,
 			'type' => 'string',
 		],
@@ -745,7 +745,7 @@ class Config
 				 * The absolute path to the forum's folder. (not just '.'!)
 				 */
 				END,
-			'default' => 'dirname(__FILE__)',
+			'default' => '__DIR__',
 			'raw_default' => true,
 			'type' => 'string',
 		],
@@ -757,7 +757,7 @@ class Config
 				 * Path to the Sources directory.
 				 */
 				END,
-			'default' => 'dirname(__FILE__) . \'/Sources\'',
+			'default' => '__DIR__ . \'/Sources\'',
 			'raw_default' => true,
 			'type' => 'string',
 		],
@@ -769,7 +769,7 @@ class Config
 				 * Path to the Packages directory.
 				 */
 				END,
-			'default' => 'dirname(__FILE__) . \'/Packages\'',
+			'default' => '__DIR__ . \'/Packages\'',
 			'raw_default' => true,
 			'type' => 'string',
 		],
@@ -920,7 +920,7 @@ class Config
 						'__DIR__' => var_export(dirname(SMF_SETTINGS_FILE), true),
 					]);
 
-					self::${$var} = eval($default . ';');
+					self::${$var} = eval('return ' . $default . ';');
 				} else {
 					self::${$var} = $def['default'];
 				}
@@ -1697,14 +1697,6 @@ class Config
 
 					if (!empty($setting_def['raw_default']) && $setting_def['default'] !== '') {
 						$var_pattern[] = preg_replace('/\s+/', '\s+', preg_quote($setting_def['default'], '~'));
-
-						if (str_contains($setting_def['default'], 'dirname(__FILE__)')) {
-							$var_pattern[] = preg_replace('/\s+/', '\s+', preg_quote(str_replace('dirname(__FILE__)', '__DIR__', $setting_def['default']), '~'));
-						}
-
-						if (str_contains($setting_def['default'], '__DIR__')) {
-							$var_pattern[] = preg_replace('/\s+/', '\s+', preg_quote(str_replace('__DIR__', 'dirname(__FILE__)', $setting_def['default']), '~'));
-						}
 					}
 
 					$var_pattern = array_unique($var_pattern);

--- a/other/Settings.php
+++ b/other/Settings.php
@@ -173,7 +173,7 @@ $cache_memcached = '';
  *
  * Path to the cache directory for the file-based cache system.
  */
-$cachedir = dirname(__FILE__) . '/cache';
+$cachedir = __DIR__ . '/cache';
 
 ########## Image Proxy ##########
 /**
@@ -202,25 +202,25 @@ $image_proxy_maxsize = 5192;
  *
  * The absolute path to the forum's folder. (not just '.'!)
  */
-$boarddir = dirname(__FILE__);
+$boarddir = __DIR__;
 /**
  * @var string
  *
  * Path to the Sources directory.
  */
-$sourcedir = dirname(__FILE__) . '/Sources';
+$sourcedir = __DIR__ . '/Sources';
 /**
  * @var string
  *
  * Path to the Packages directory.
  */
-$packagesdir = dirname(__FILE__) . '/Packages';
+$packagesdir = __DIR__ . '/Packages';
 /**
  * @var string
  *
  * Path to the language directory.
  */
-$languagesdir = dirname(__FILE__) . '/Languages';
+$languagesdir = __DIR__ . '/Languages';
 
 ######### Modification Support #########
 /**
@@ -242,7 +242,7 @@ $backward_compatibility = 0;
  */
 $db_character_set = 'utf8';
 
-if (file_exists(dirname(__FILE__) . '/install.php'))
+if (file_exists(__DIR__ . '/install.php'))
 {
 	$secure = false;
 	if (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on')

--- a/other/Settings_bak.php
+++ b/other/Settings_bak.php
@@ -173,7 +173,7 @@ $cache_memcached = '';
  *
  * Path to the cache directory for the file-based cache system.
  */
-$cachedir = dirname(__FILE__) . '/cache';
+$cachedir = __DIR__ . '/cache';
 
 ########## Image Proxy ##########
 /**
@@ -202,25 +202,25 @@ $image_proxy_maxsize = 5192;
  *
  * The absolute path to the forum's folder. (not just '.'!)
  */
-$boarddir = dirname(__FILE__);
+$boarddir = __DIR__;
 /**
  * @var string
  *
  * Path to the Sources directory.
  */
-$sourcedir = dirname(__FILE__) . '/Sources';
+$sourcedir = __DIR__ . '/Sources';
 /**
  * @var string
  *
  * Path to the Packages directory.
  */
-$packagesdir = dirname(__FILE__) . '/Packages';
+$packagesdir = __DIR__ . '/Packages';
 /**
  * @var string
  *
  * Path to the language directory.
  */
-$languagesdir = dirname(__FILE__) . '/Languages';
+$languagesdir = __DIR__ . '/Languages';
 
 ######### Modification Support #########
 /**
@@ -242,7 +242,7 @@ $backward_compatibility = 0;
  */
 $db_character_set = 'utf8';
 
-if (file_exists(dirname(__FILE__) . '/install.php'))
+if (file_exists(__DIR__ . '/install.php'))
 {
 	$secure = false;
 	if (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on')


### PR DESCRIPTION
Partial for #8293 - this addresses the null assignment.

This also addresses some inconsistencies, sometimes __DIR__ was used and sometimes dirname(__FILE__) was used, when they were both doing the same thing.

There was some logic in there that oddly reversed them...(???)  Tore that out.  