### PR TITLE
[3.0] Remove unused member_groups col from query

### DIFF
--- a/Sources/Tasks/CreatePost_Notify.php
+++ b/Sources/Tasks/CreatePost_Notify.php
@@ -162,7 +162,7 @@ class CreatePost_Notify extends BackgroundTask
 				mem.email_address, mem.lngfile, mem.pm_ignore_list,
 				mem.id_group, mem.id_post_group, mem.additional_groups,
 				mem.time_format, mem.time_offset, mem.timezone,
-				b.member_groups, t.id_member_started, t.id_member_updated
+				t.id_member_started, t.id_member_updated
 			FROM {db_prefix}log_notify AS ln
 				INNER JOIN {db_prefix}members AS mem ON (ln.id_member = mem.id_member)
 				LEFT JOIN {db_prefix}topics AS t ON (t.id_topic = ln.id_topic)


### PR DESCRIPTION
Fixes #8300 

Looks like this was a simple omission from some previous cleanup & simplification.

Tests OK & gets rid of that annoying error...