### PR TITLE
[3.0] Fix blank screens in error log

### DIFF
--- a/Sources/BBCodeParser.php
+++ b/Sources/BBCodeParser.php
@@ -2077,7 +2077,7 @@ class BBCodeParser
 
 		$oldlevel = error_reporting(0);
 
-		$buffer = str_replace(["\n", "\r"], '', @highlight_string($code, true));
+		$buffer = str_replace(["\n", "\r"], ['<br />', ''], @highlight_string($code, true));
 
 		error_reporting($oldlevel);
 

--- a/Sources/BBCodeParser.php
+++ b/Sources/BBCodeParser.php
@@ -2087,6 +2087,10 @@ class BBCodeParser
 		// PHP 8.3 changed the returned HTML.
 		$buffer = preg_replace('/^(<pre>)?<code[^>]*>|<\/code>(<\/pre>)?$/', '', $buffer);
 
+		// Remove line breaks inserted before & after the actual code in php < 8.3
+		$buffer = preg_replace('/^(<span\s[^>]*>)<br \/>/', '$1', $buffer);
+		$buffer = preg_replace('/<br \/>(<span\s[^>]*>)<br \/>$/', '$1', $buffer);
+
 		return strtr($buffer, ['\'' => '&#039;']);
 	}
 

--- a/Sources/BBCodeParser.php
+++ b/Sources/BBCodeParser.php
@@ -2089,7 +2089,7 @@ class BBCodeParser
 
 		// Remove line breaks inserted before & after the actual code in php < 8.3
 		$buffer = preg_replace('/^(<span\s[^>]*>)<br \/>/', '$1', $buffer);
-		$buffer = preg_replace('/<br \/>(<span\s[^>]*>)<br \/>$/', '$1', $buffer);
+		$buffer = preg_replace('/<br \/>(<\/span[^>]*>)<br \/>$/', '$1', $buffer);
 
 		return strtr($buffer, ['\'' => '&#039;']);
 	}


### PR DESCRIPTION
Partial for #8307 

Prior to php 8.3, highlight_string() added some wrapper code before & after the requested code - code tags, spans, etc.  Including line feeds...  Since eols were returned as br tags _within_ the requested code, you could easily strip the wrapper line feeds by mapping \n to ''.  

With 8.3, everything comes back using newlines, both the requested code & the wrapper code, so stripping newlines broke stuff by turning the whole program into one large line...

Two tweaks needed:
 - Translate all newlines into br tags, like in php < 8.3, and as expected by downstream processing
 - Strip br tags inserted before & after the requested code, so code line numbers are still accurate when displayed
 
Tested in php 8.l, 8.2, and 8.3.