### PR TITLE
[3.0] Some string recasts needed for exports

### DIFF
--- a/Sources/Actions/Profile/ExportDownload.php
+++ b/Sources/Actions/Profile/ExportDownload.php
@@ -173,7 +173,7 @@ class ExportDownload implements ActionInterface
 
 		$this->export_dir_slash = Config::$modSettings['export_dir'] . DIRECTORY_SEPARATOR;
 
-		$this->idhash = hash_hmac('sha1', Utils::$context['id_member'], Config::getAuthSecret());
+		$this->idhash = hash_hmac('sha1', (string) Utils::$context['id_member'], Config::getAuthSecret());
 		$this->dltoken = hash_hmac('sha1', $this->idhash, Config::getAuthSecret());
 
 		$this->part = isset($_GET['part']) ? (int) $_GET['part'] : 1;

--- a/Sources/Tasks/ExportProfileData.php
+++ b/Sources/Tasks/ExportProfileData.php
@@ -1267,7 +1267,7 @@ class ExportProfileData extends BackgroundTask
 
 		// Determine which files, if any, are ready to be transformed.
 		$export_dir_slash = Config::$modSettings['export_dir'] . DIRECTORY_SEPARATOR;
-		$idhash = hash_hmac('sha1', $this->_details['uid'], Config::getAuthSecret());
+		$idhash = hash_hmac('sha1', (string) $this->_details['uid'], Config::getAuthSecret());
 		$idhash_ext = $idhash . '.' . $this->_details['format_settings']['extension'];
 
 		$new_exportfiles = [];


### PR DESCRIPTION
While testing #8244 , I found two minor unrelated issues with the export.  This PR addresses both.

When requesting html exports, the task would hang, leaving this in the PHP error log, and an entry in background_tasks:
```
PHP Fatal error:  Uncaught TypeError: hash_hmac(): Argument #2 ($data) must be of type string, int given in D:\wamp64\www\84van30\Sources\Tasks\ExportProfileData.php:1270
Stack trace:
#0 D:\wamp64\www\84van30\Sources\Tasks\ExportProfileData.php(1270): hash_hmac('sha1', 1, Object(SensitiveParameterValue))
#1 D:\wamp64\www\84van30\Sources\Tasks\ExportProfileData.php(930): SMF\Tasks\ExportProfileData->exportHtml()
#2 D:\wamp64\www\84van30\Sources\TaskRunner.php(565): SMF\Tasks\ExportProfileData->execute()
#3 D:\wamp64\www\84van30\Sources\TaskRunner.php(201): SMF\TaskRunner->performTask(Array)
#4 D:\wamp64\www\84van30\cron.php(32): SMF\TaskRunner->execute()
#5 {main}
  thrown in D:\wamp64\www\84van30\Sources\Tasks\ExportProfileData.php on line 1270
```

When requesting xml exports, the task would appear to complete, and generate an export file for download, but when you opened the export it contained this:
```
Fatal error:  Uncaught TypeError: hash_hmac(): Argument #2 ($data) must be of type string, int given in D:\wamp64\www\84van30\Sources\Actions\Profile\ExportDownload.php:176
Stack trace:
#0 D:\wamp64\www\84van30\Sources\Actions\Profile\ExportDownload.php(176): hash_hmac('sha1', 6, Object(SensitiveParameterValue))
#1 D:\wamp64\www\84van30\Sources\ActionTrait.php(44): SMF\Actions\Profile\ExportDownload->__construct()
#2 D:\wamp64\www\84van30\Sources\ActionTrait.php(55): SMF\Actions\Profile\ExportDownload::load()
#3 [internal function]: SMF\Actions\Profile\ExportDownload::call(6)
#4 D:\wamp64\www\84van30\Sources\Actions\Profile\Main.php(683): call_user_func(Array, 6)
#5 D:\wamp64\www\84van30\Sources\ActionTrait.php(55): SMF\Actions\Profile\Main->execute()
#6 [internal function]: SMF\Actions\Profile\Main::call()
#7 D:\wamp64\www\84van30\Sources\Forum.php(264): call_user_func(Array)
#8 D:\wamp64\www\84van30\index.php(149): SMF\Forum->execute()
#9 {main}
  thrown in D:\wamp64\www\84van30\Sources\Actions\Profile\ExportDownload.php on line 176
```

Tested in 3.0 with current GH code, both test OK.
