### PR TITLE
Fixes some bugs in WebFetchApi

### DIFF
--- a/Sources/WebFetch/APIs/CurlFetcher.php
+++ b/Sources/WebFetch/APIs/CurlFetcher.php
@@ -133,14 +133,14 @@ class CurlFetcher extends WebFetchApi
 	 */
 	private $default_options = [
 		// Get returned value as a string (don't output it).
-		CURLOPT_RETURNTRANSFER  => 1,
+		CURLOPT_RETURNTRANSFER  => true,
 
 		// We need the headers to do our own redirect.
-		CURLOPT_HEADER          => 1,
+		CURLOPT_HEADER          => true,
 
 		// Don't follow. We will do it ourselves so safe mode and open_basedir
 		// will dig it.
-		CURLOPT_FOLLOWLOCATION  => 0,
+		CURLOPT_FOLLOWLOCATION  => false,
 
 		// Set a normal looking user agent.
 		CURLOPT_USERAGENT       => SMF_USER_AGENT,
@@ -158,13 +158,13 @@ class CurlFetcher extends WebFetchApi
 		CURLOPT_ENCODING        => 'gzip,deflate',
 
 		// Stop curl from verifying the peer's certificate.
-		CURLOPT_SSL_VERIFYPEER  => 0,
+		CURLOPT_SSL_VERIFYPEER  => false,
 
 		// Stop curl from verifying the peer's host.
 		CURLOPT_SSL_VERIFYHOST  => 0,
 
 		// No post data. This will change if some is passed to request().
-		CURLOPT_POST            => 0,
+		CURLOPT_POST            => false,
 	];
 
 	/****************
@@ -393,7 +393,7 @@ class CurlFetcher extends WebFetchApi
 
 		// POST data options, here we don't allow any override.
 		if (isset($this->post_data)) {
-			$this->options[CURLOPT_POST] = 1;
+			$this->options[CURLOPT_POST] = true;
 			$this->options[CURLOPT_POSTFIELDS] = $this->post_data;
 		}
 	}

--- a/Sources/WebFetch/APIs/CurlFetcher.php
+++ b/Sources/WebFetch/APIs/CurlFetcher.php
@@ -151,9 +151,6 @@ class CurlFetcher extends WebFetchApi
 		// A page should load in this amount of time.
 		CURLOPT_TIMEOUT         => 90,
 
-		// Stop after this many redirects.
-		CURLOPT_MAXREDIRS       => 5,
-
 		// Accept gzip and decode it.
 		CURLOPT_ENCODING        => 'gzip,deflate',
 
@@ -184,6 +181,17 @@ class CurlFetcher extends WebFetchApi
 		// Initialize class variables
 		$this->max_redirect = intval($max_redirect);
 		$this->user_options = $options;
+
+		// This class handles redirections itself.
+		if (!empty($this->user_options[CURLOPT_MAXREDIRS])) {
+			$this->max_redirect = $this->user_options[CURLOPT_MAXREDIRS];
+			unset($this->user_options[CURLOPT_MAXREDIRS]);
+		}
+
+		if (!empty($this->user_options[CURLOPT_FOLLOWLOCATION])) {
+			$this->max_redirect = max(3, $this->max_redirect);
+			$this->user_options[CURLOPT_FOLLOWLOCATION] = false;
+		}
 	}
 
 	/**

--- a/Sources/WebFetch/APIs/SocketFetcher.php
+++ b/Sources/WebFetch/APIs/SocketFetcher.php
@@ -84,16 +84,16 @@ class SocketFetcher extends WebFetchApi
 	 */
 	public $response = [];
 
-	/*********************
-	 * Internal properties
-	 *********************/
-
 	/**
 	 * @var bool
 	 *
 	 * Whether to keep the socket connection open after the initial request.
 	 */
-	private bool $keep_alive;
+	public bool $keep_alive = false;
+
+	/*********************
+	 * Internal properties
+	 *********************/
 
 	/**
 	 * @var bool

--- a/Sources/WebFetch/WebFetchApi.php
+++ b/Sources/WebFetch/WebFetchApi.php
@@ -125,7 +125,7 @@ abstract class WebFetchApi implements WebFetchApiInterface
 			$class = __NAMESPACE__ . '\\APIs\\' . $class;
 
 			$fetcher = new $class();
-			$fetcher->request($url);
+			$fetcher->request($url, $post_data);
 
 			if ($fetcher->result('success')) {
 				break;


### PR DESCRIPTION
1. Ensures that we don't ignore the $post_data parameter in WebFetchApi::fetch().
2. Uses correct value types in CurlFetcher::$default_options.
3. Ensures that the CurlFetcher class always handles redirection itself.
4. Respects the $keep_alive parameter in WebFetchApi::fetch().