### PR TITLE
fix:  Move setting avatar logic before checking for hook usage

### DIFF
--- a/Sources/Profile-View.php
+++ b/Sources/Profile-View.php
@@ -459,12 +459,21 @@ function fetch_alerts($memID, $to_fetch = false, $limit = 0, $offset = 0, $with_
 		else
 			unset($alerts[$id_alert]['visible']);
 
+		// For developer convenience.
+		$alert = &$alerts[$id_alert];
+
+		// If we loaded the sender's profile, we may as well use it.
+		$sender_id = !empty($alert['sender_id']) ? $alert['sender_id'] : 0;
+		if (isset($user_profile[$sender_id]))
+			$alert['sender_name'] = $user_profile[$sender_id]['real_name'];
+
+		// If requested, include the sender's avatar data.
+		if ($with_avatar && !empty($senders[$sender_id]))
+			$alert['sender'] = $senders[$sender_id];
+
 		// Did a mod already take care of this one?
 		if (!empty($alerts[$id_alert]['text']))
 			continue;
-
-		// For developer convenience.
-		$alert = &$alerts[$id_alert];
 
 		// The info in extra might outdated if the topic was moved, the message's subject was changed, etc.
 		if (!empty($alert['content_data']))
@@ -518,15 +527,6 @@ function fetch_alerts($memID, $to_fetch = false, $limit = 0, $offset = 0, $with_
 			if (isset($user_profile[$alert['extra']['user_id']]))
 				$alert['extra']['user_name'] = $user_profile[$alert['extra']['user_id']]['real_name'];
 		}
-
-		// If we loaded the sender's profile, we may as well use it.
-		$sender_id = !empty($alert['sender_id']) ? $alert['sender_id'] : 0;
-		if (isset($user_profile[$sender_id]))
-			$alert['sender_name'] = $user_profile[$sender_id]['real_name'];
-
-		// If requested, include the sender's avatar data.
-		if ($with_avatar && !empty($senders[$sender_id]))
-			$alert['sender'] = $senders[$sender_id];
 
 		// Next, build the message strings.
 		foreach ($formats as $msg_type => $format_info)


### PR DESCRIPTION
Currently there is a check on Profie-View when trying to build u the text for the alert:

```
		// Did a mod already take care of this one?
		if (!empty($alerts[$id_alert]['text']))
			continue;
```
			

The check is assuming that someone using the integrate_fetch_alerts already build their own text key which is OK, however, the check also prevents setting the 'sender' key with the profile data from the sender_id already loaded previously.

This forces whoever uses the integrate_fetch_alerts hook to load their own sender_id profile data which means adding extra queries for data that is already available.

This PR simply moves the code for populating 'sender' key before the check to 'text'