### PR TITLE
"BBcode" is not "BBCode", at least on Linux.

### DIFF
--- a/Sources/Parser.php
+++ b/Sources/Parser.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
 namespace SMF;
 
 use SMF\Cache\CacheApi;
-use SMF\Parsers\BBcodeParser;
+use SMF\Parsers\BBCodeParser;
 use SMF\Parsers\MarkdownParser;
 use SMF\Parsers\SmileyParser;
 


### PR DESCRIPTION
Found a minor typo. This causes a fatal error since it's looking for a "BBcodeParser" class when it's "BBCodeParser" with a capital "C"...