### PR TITLE
3.0/autolinker fixes

### DIFF
--- a/Sources/Autolinker.php
+++ b/Sources/Autolinker.php
@@ -790,7 +790,7 @@ class Autolinker
 		$regexes['email'] = self::load()->getJavaScriptEmailRegex();
 
 		// Don't autolink if the URL is inside a Markdown link construct.
-		$md_lookbehind = !empty(Config::$modSettings['enableMarkdown']) ? '(?<!\[[^\]]*\](?:\(|:[ \t\u00A0\u1680\u180E\u2000-\u200A\u202F\u205F\u3000]*\n?[ \t\u00A0\u1680\u180E\u2000-\u200A\u202F\u205F\u3000]*))' : '';
+		$md_lookbehind = !empty(Config::$modSettings['enableMarkdown']) ? '(?<!\[[^\]]*\](?:\(|:[ \t\u00A0\u1680\u180E\u2000-\u200A\u202F\u205F\u3000]*\n?[ \t\u00A0\u1680\u180E\u2000-\u200A\u202F\u205F\u3000]*)|\[i?url(?:=[^\]]*)?\])' : '(?<!\[i?url(?:=[^\]]*)?\])';
 
 		foreach ($regexes as $key => $value) {
 			$js[] = 'autolinker_regexes.set(' . Utils::escapeJavaScript($key) . ', new RegExp(' . Utils::escapeJavaScript($md_lookbehind . $value) . ', "giu"));';

--- a/Sources/Autolinker.php
+++ b/Sources/Autolinker.php
@@ -416,7 +416,7 @@ class Autolinker
 
 			// Overwrite all BBC markup elements.
 			$string = preg_replace_callback(
-				'/\[[^\]]*\]/i' . ($this->encoding === 'UTF-8' ? 'u' : ''),
+				'~\[/?' . Parser::getBBCodeTagsRegex() . '[^\]]*\]~i' . ($this->encoding === 'UTF-8' ? 'u' : ''),
 				fn ($matches) => str_repeat(' ', strlen($matches[0])),
 				$string,
 			);

--- a/Sources/Autolinker.php
+++ b/Sources/Autolinker.php
@@ -384,7 +384,11 @@ class Autolinker
 
 		// An entity right after the URL can break the autolinker.
 		$this->setEntitiesRegex();
-		$string = preg_replace('~(' . $this->entities_regex . ')*(?=\s|$)~u', ' ', $string);
+		$string = preg_replace_callback(
+			'~(' . $this->entities_regex . ')*(?=\s|$)~u',
+			fn ($matches) => str_repeat(' ', strlen($matches[0])),
+			$string,
+		);
 
 		$this->setUrlRegex();
 

--- a/Sources/Parser.php
+++ b/Sources/Parser.php
@@ -355,6 +355,16 @@ abstract class Parser
 	}
 
 	/**
+	 * Gets a regular expression to match all known BBC tags.
+	 *
+	 * @return string Regular expression to match all BBCode tags.
+	 */
+	public static function getBBCodeTagsRegex(): string
+	{
+		return BBcodeParser::load()->getAllTagsRegex();
+	}
+
+	/**
 	 * Highlight any code.
 	 *
 	 * Uses PHP's highlight_string() to highlight PHP syntax.

--- a/Themes/default/scripts/jquery.sceditor.smf.js
+++ b/Themes/default/scripts/jquery.sceditor.smf.js
@@ -544,8 +544,8 @@
 				url[0] = '//' + url[0];
 			}
 
-			// Wrap the URL in BBC tags.
-			editor.insert('[' + bbc_tag + '="' + url[0] + '"]', '[/' + bbc_tag + ']');
+			// Insert the URL.
+			editor.wysiwygEditorInsertHtml('<a data-type="' + bbc_tag + '" href="' + url[0] + '">' + url[0] + '</a>');
 		}
 
 		// Helper for this.signalKeydownEvent.


### PR DESCRIPTION
- Don't change the length of strings while detecting URLs
- Fixes a couple of bugs when autolinking in the editor
- Fixes autolinker's detection of URLs containing square brackets