### PR TITLE
[2.1] Hooks list add support for leading backslash namespaces

### DIFF
--- a/Sources/ManageMaintenance.php
+++ b/Sources/ManageMaintenance.php
@@ -2109,10 +2109,11 @@ function get_integration_hooks_data($start, $per_page, $sort, $filtered_hooks, $
 	foreach ($filtered_hooks as $hook => $functions)
 		foreach ($functions as $rawFunc)
 		{
-			$hookParsedData = parse_integration_hook($hook, $rawFunc);
+			$hookParsedData = parse_integration_hook($hook, $rawFunc, $function_list);
 
 			// Handle hooks pointing outside the sources directory.
 			$absPath_clean =  rtrim($hookParsedData['absPath'], '!');
+
 			if ($absPath_clean != '' && !isset($files[$absPath_clean]) && file_exists($absPath_clean))
 				$function_list += get_defined_functions_in_file($absPath_clean);
 
@@ -2167,9 +2168,10 @@ function get_integration_hooks()
  *
  * @param string $hook
  * @param string $rawData A string as it was saved to the DB.
+ * @param array $functionList A list of functions found on previously parsed files
  * @return array everything found in the string itself
  */
-function parse_integration_hook(string $hook, string $rawData)
+function parse_integration_hook(string $hook, string $rawData, array $functionList)
 {
 	global $boarddir, $settings, $sourcedir;
 
@@ -2226,6 +2228,18 @@ function parse_integration_hook(string $hook, string $rawData)
 
 	else
 		$hookData['call'] = $hookData['pureFunc'] = $modFunc;
+
+	$hookData['call'] = ltrim($hookData['call'], '\\');
+
+	// One last chance, perhaps the file was included in another way
+	if ($hookData['absPath'] === '' && isset($functionList[$hookData['call']]))
+	{
+		$hookData['absPath'] = strtr(strtr(trim($functionList[$hookData['call']]), [
+			'$boarddir' => $boarddir,
+			'$sourcedir' => $sourcedir,
+			'$themedir' => $settings['theme_dir'] ?? ''
+		]), '\\', '/');
+	}
 
 	return $hookData;
 }

--- a/Sources/ManageMaintenance.php
+++ b/Sources/ManageMaintenance.php
@@ -2109,7 +2109,7 @@ function get_integration_hooks_data($start, $per_page, $sort, $filtered_hooks, $
 	foreach ($filtered_hooks as $hook => $functions)
 		foreach ($functions as $rawFunc)
 		{
-			$hookParsedData = parse_integration_hook($hook, $rawFunc, $function_list);
+			$hookParsedData = parse_integration_hook($hook, $rawFunc);
 
 			// Handle hooks pointing outside the sources directory.
 			$absPath_clean =  rtrim($hookParsedData['absPath'], '!');
@@ -2168,10 +2168,9 @@ function get_integration_hooks()
  *
  * @param string $hook
  * @param string $rawData A string as it was saved to the DB.
- * @param array $functionList A list of functions found on previously parsed files
  * @return array everything found in the string itself
  */
-function parse_integration_hook(string $hook, string $rawData, array $functionList)
+function parse_integration_hook(string $hook, string $rawData)
 {
 	global $boarddir, $settings, $sourcedir;
 
@@ -2230,16 +2229,6 @@ function parse_integration_hook(string $hook, string $rawData, array $functionLi
 		$hookData['call'] = $hookData['pureFunc'] = $modFunc;
 
 	$hookData['call'] = ltrim($hookData['call'], '\\');
-
-	// One last chance, perhaps the file was included in another way
-	if ($hookData['absPath'] === '' && isset($functionList[$hookData['call']]))
-	{
-		$hookData['absPath'] = strtr(strtr(trim($functionList[$hookData['call']]), [
-			'$boarddir' => $boarddir,
-			'$sourcedir' => $sourcedir,
-			'$themedir' => $settings['theme_dir'] ?? ''
-		]), '\\', '/');
-	}
 
 	return $hookData;
 }


### PR DESCRIPTION
By default, hook list  in maintenance relies on the file property to determinate if a hook is  enable/active via setting its abs path.

For larger mods or mods that relies on autoloaders the file property might not be defined for all hooks, making them appear as "the hook has not been found" on the hook list.

This PR adds a check to see if a hook has its correspondence with the list of already loaded functions, if found it sets its absPath which in return the hook list will correctly list them as active.