### PR TITLE
[2.1] Keep PHP 7 compatibility

### DIFF
--- a/Sources/Subs-Db-mysql.php
+++ b/Sources/Subs-Db-mysql.php
@@ -844,7 +844,7 @@ function smf_db_insert($method, $table, $columns, $data, $keys, $returnmode = 0,
 
 				foreach ($columns as $column_name => $type)
 				{
-					if (str_contains($type, 'string-'))
+					if (strpos($type, 'string-') !== false)
 						$where_string[] = $column_name . ' = ' . sprintf('SUBSTRING({string:%1$s}, 1, ' . substr($type, 7) . ')', $column_name);
 					else
 						$where_string[] = $column_name . ' = ' . sprintf('{%1$s:%2$s}', $type, $column_name);


### PR DESCRIPTION
Does SMF uses a polyfill? I couldn't find a reference to it. If it does, please disregard this PR.

Currently SMF 2.1 list PHP 7.0 as its minimum supported version, however while working on a mod, I found a call to [str_contains()](https://www.php.net/manual/en/function.str-contains.php) which is only available since PHP 8.

This PR changes it to strpos()