### PR TITLE
      Add ability to add multiple sub-templates 

### DIFF
--- a/Sources/Theme.php
+++ b/Sources/Theme.php
@@ -2209,15 +2209,15 @@ class Theme
 						foreach (self::$current->settings['theme_variants'] as $variant) {
 							Utils::$context['available_themes'][$id_theme]['variants'][$variant] = [
 								'label' => Lang::$txt['variant_' . $variant] ?? $variant,
-						'thumbnail' => file_exists($theme_data['theme_dir'] . '/images/thumbnail_' . $variant . '.png') ? $theme_data['images_url'] . '/thumbnail_' . $variant . '.png' : (file_exists($theme_data['theme_dir'] . '/images/thumbnail.png') ? $theme_data['images_url'] . '/thumbnail.png' : ''),
-					];
-				}
+								'thumbnail' => file_exists($theme_data['theme_dir'] . '/images/thumbnail_' . $variant . '.png') ? $theme_data['images_url'] . '/thumbnail_' . $variant . '.png' : (file_exists($theme_data['theme_dir'] . '/images/thumbnail.png') ? $theme_data['images_url'] . '/thumbnail.png' : ''),
+							];
+						}
 
-				Utils::$context['available_themes'][$id_theme]['selected_variant'] = $_GET['vrt'] ?? (!empty($variant_preferences[$id_theme]) ? $variant_preferences[$id_theme] : (!empty(self::$current->settings['default_variant']) ? self::$current->settings['default_variant'] : self::$current->settings['theme_variants'][0]));
+						Utils::$context['available_themes'][$id_theme]['selected_variant'] = $_GET['vrt'] ?? (!empty($variant_preferences[$id_theme]) ? $variant_preferences[$id_theme] : (!empty(self::$current->settings['default_variant']) ? self::$current->settings['default_variant'] : self::$current->settings['theme_variants'][0]));
 
-				if (!isset(Utils::$context['available_themes'][$id_theme]['variants'][Utils::$context['available_themes'][$id_theme]['selected_variant']]['thumbnail'])) {
-					Utils::$context['available_themes'][$id_theme]['selected_variant'] = self::$current->settings['theme_variants'][0];
-				}
+						if (!isset(Utils::$context['available_themes'][$id_theme]['variants'][Utils::$context['available_themes'][$id_theme]['selected_variant']]['thumbnail'])) {
+							Utils::$context['available_themes'][$id_theme]['selected_variant'] = self::$current->settings['theme_variants'][0];
+						}
 
 						Utils::$context['available_themes'][$id_theme]['thumbnail_href'] = Utils::$context['available_themes'][$id_theme]['variants'][Utils::$context['available_themes'][$id_theme]['selected_variant']]['thumbnail'];
 

--- a/Sources/Theme.php
+++ b/Sources/Theme.php
@@ -401,7 +401,7 @@ class Theme
 	{
 		if (isset(Utils::$context['sub_templates'])) {
 			foreach (Utils::$context['sub_templates'] as $sub_template) {
-				self::loadSubTemplate($sub_template, true);
+				self::loadSubTemplate($sub_template);
 			}
 		} else {
 			self::loadSubTemplate(Utils::$context['sub_template'] ?? 'main');

--- a/Sources/Theme.php
+++ b/Sources/Theme.php
@@ -404,7 +404,7 @@ class Theme
 				self::loadSubTemplate($sub_template, true);
 			}
 		} else {
-			Theme::loadSubTemplate(Utils::$context['sub_template'] ?? 'main');
+			self::loadSubTemplate(Utils::$context['sub_template'] ?? 'main');
 		}
 	}
 

--- a/Sources/Theme.php
+++ b/Sources/Theme.php
@@ -425,7 +425,7 @@ class Theme
 	public static function loadSubTemplate(string|array $sub_template_name, bool|string $fatal = false): void
 	{
 		if (!empty(Config::$db_show_debug)) {
-			Utils::$context['debug']['sub_templates'][] = $sub_template_name;
+			Utils::$context['debug']['sub_templates'][] = is_array($sub_template_name) ? $sub_template_name[0] : $sub_template_name;
 		}
 
 		// Figure out what the template function is named.

--- a/Sources/Theme.php
+++ b/Sources/Theme.php
@@ -2229,15 +2229,15 @@ class Theme
 						foreach (self::$current->settings['theme_variants'] as $variant) {
 							Utils::$context['available_themes'][$id_theme]['variants'][$variant] = [
 								'label' => Lang::$txt['variant_' . $variant] ?? $variant,
-						'thumbnail' => file_exists($theme_data['theme_dir'] . '/images/thumbnail_' . $variant . '.png') ? $theme_data['images_url'] . '/thumbnail_' . $variant . '.png' : (file_exists($theme_data['theme_dir'] . '/images/thumbnail.png') ? $theme_data['images_url'] . '/thumbnail.png' : ''),
-					];
-				}
+								'thumbnail' => file_exists($theme_data['theme_dir'] . '/images/thumbnail_' . $variant . '.png') ? $theme_data['images_url'] . '/thumbnail_' . $variant . '.png' : (file_exists($theme_data['theme_dir'] . '/images/thumbnail.png') ? $theme_data['images_url'] . '/thumbnail.png' : ''),
+							];
+						}
 
-				Utils::$context['available_themes'][$id_theme]['selected_variant'] = $_GET['vrt'] ?? (!empty($variant_preferences[$id_theme]) ? $variant_preferences[$id_theme] : (!empty(self::$current->settings['default_variant']) ? self::$current->settings['default_variant'] : self::$current->settings['theme_variants'][0]));
+						Utils::$context['available_themes'][$id_theme]['selected_variant'] = $_GET['vrt'] ?? (!empty($variant_preferences[$id_theme]) ? $variant_preferences[$id_theme] : (!empty(self::$current->settings['default_variant']) ? self::$current->settings['default_variant'] : self::$current->settings['theme_variants'][0]));
 
-				if (!isset(Utils::$context['available_themes'][$id_theme]['variants'][Utils::$context['available_themes'][$id_theme]['selected_variant']]['thumbnail'])) {
-					Utils::$context['available_themes'][$id_theme]['selected_variant'] = self::$current->settings['theme_variants'][0];
-				}
+						if (!isset(Utils::$context['available_themes'][$id_theme]['variants'][Utils::$context['available_themes'][$id_theme]['selected_variant']]['thumbnail'])) {
+							Utils::$context['available_themes'][$id_theme]['selected_variant'] = self::$current->settings['theme_variants'][0];
+						}
 
 						Utils::$context['available_themes'][$id_theme]['thumbnail_href'] = Utils::$context['available_themes'][$id_theme]['variants'][Utils::$context['available_themes'][$id_theme]['selected_variant']]['thumbnail'];
 

--- a/Sources/Utils.php
+++ b/Sources/Utils.php
@@ -2347,7 +2347,6 @@ class Utils
 						],
 					);
 				}
-
 			}
 
 			// Start up the session URL fixer.
@@ -2385,7 +2384,7 @@ class Utils
 		}
 
 		if ($do_footer) {
-			Theme::loadSubTemplate(Utils::$context['sub_template'] ?? 'main');
+			Theme::loadSubTemplates();
 
 			// Anything special to put out?
 			if (!empty(Utils::$context['insert_after_template']) && !isset($_REQUEST['xml'])) {
@@ -2397,6 +2396,7 @@ class Utils
 				$footer_done = true;
 				Theme::template_footer();
 
+				// Add $db_show_debug = true; to Settings.php if you want to show the debugging information.
 				// (since this is just debugging... it's okay that it's after </html>.)
 				if (!isset($_REQUEST['xml'])) {
 					Logging::displayDebug();


### PR DESCRIPTION
We  have several templates (layers)  that just call others. This commit introduces `Utils::$context['sub_templates']` which  is a simple list of templates to call

Bonus: If a template name is      array, the second element shall  be parametres to pass   to the function. Similar structure to $post_errors in the  Post action.