### PR TITLE
[3.0] Automatically populate robots.txt

### DIFF
--- a/Languages/en_US/Help.php
+++ b/Languages/en_US/Help.php
@@ -570,6 +570,7 @@ $helptxt['show_spider_online'] = 'This setting allows you to select whether spid
 			As above except only Administrators can see spider status - to all other users spiders appear as guests.
 		</li>
 	</ul>';
+$helptxt['robots_txt'] = 'The robots.txt file is used to implement the <a href="https://www.rfc-editor.org/rfc/rfc9309.html" class="bbc_link">Robots Exclusion Protocol</a>, a standard used by websites to indicate to search engine spiders and other web robots which portions of the website they are allowed to visit. This file is typically located in your website’s root directory.<br><br>SMF adds some rules to this file in order to guide spiders away from URLs that they should not bother to crawl. This improves efficiency and reduces server load when a spider is crawling your forum.';
 
 $helptxt['birthday_email'] = 'Choose the index of the birthday email message to use. A preview will be shown in the Email Subject and Email Body fields.<br><strong>Note:</strong> Selecting this setting does not automatically enable birthday emails. To enable birthday emails use the <a href="{scripturl}?action=admin;area=scheduledtasks;{session_var}={session_id}" target="_blank" rel="noopener">Scheduled Tasks</a> page and enable the birthday email task.';
 $helptxt['pm_bcc'] = 'When sending a personal message you can choose to add a recipient as BCC (Blind Carbon Copy). BCC recipients do not have their identities revealed to the other recipients of the message.';

--- a/Languages/en_US/Search.php
+++ b/Languages/en_US/Search.php
@@ -180,4 +180,9 @@ $txt['spider_stats_select_month'] = 'Jump to Month';
 $txt['spider_stats_page_hits'] = 'Page Hits';
 $txt['spider_stats_no_entries'] = 'There are currently no spider statistics available.';
 
+$txt['robots_txt'] = 'Add SMF rules to robots.txt';
+$txt['robots_txt_info'] = 'Enter the path to your robots.txt file so that SMF can append rules to it.';
+$txt['robots_txt_auto'] = 'Detect path';
+$txt['robots_txt_not_writable'] = 'The robots.txt file is not writable.';
+
 ?>

--- a/Sources/Actions/Admin/SearchEngines.php
+++ b/Sources/Actions/Admin/SearchEngines.php
@@ -1190,7 +1190,9 @@ class SearchEngines implements ActionInterface
 			'*' => [
 				'allow' => [],
 				'disallow' => [
-					Url::create(Config::$scripturl)->path . '?msg=*',
+					Url::create(Config::$scripturl)->path . '?msg=',
+					'*PHPSESSID=',
+					'*;topicseen',
 				],
 			],
 		];


### PR DESCRIPTION
Provides SMF with the ability to add rules to robots.txt. 
- Adds a new setting, `Config::$modSettings['robots_txt']`, with the path to the robots.txt file.
- To assist admins, the relevant ACP page offers to populate the setting with the correct path.
- When a valid and writable path is saved in this setting, SMF will find the file and add rules to it as necessary.
- If the path is not writable, the admin will be warned and SMF will not attempt to update the file.
- If the path is writable, SMF adds rules to tell all spiders that they should ignore URLs that match the pattern `/path/to/index.php?msg=` (where `/path/to/index.php` will be set to the appropriate value for the individual forum instance), as well as URLs containing `PHPSESSID` or `;topicseen`.
- Redundancy checks are performed to ensure that if a rule is already present in the file, it will not be added again.

Fixes #8367