### PR TITLE
[3.0] Clamps timestamps to accepted range in SMF\Time methods and improves handling of the [time] BBCode 

### DIFF
--- a/Sources/Time.php
+++ b/Sources/Time.php
@@ -196,6 +196,10 @@ class Time extends \DateTime implements \ArrayAccess
 
 		$datetime = self::sanitize($datetime);
 
+		if (str_starts_with($datetime, '@')) {
+			$datetime = '@' . min(max((int) ltrim($datetime, '@'), PHP_INT_MIN), PHP_INT_MAX);
+		}
+
 		if (
 			// If $datetime was a Unix timestamp, set the time zone to the one
 			// we were told to use. Honestly, it's a mystery why the \DateTime


### PR DESCRIPTION
-  [Clamps timestamps to accepted range in SMF\Time methods](https://github.com/SimpleMachines/SMF/pull/8385/commits/55de927708bc3ce019da330aa9a26a9043b1b748) is like #8384, but for SMF 3.0.
- [Improves handling of the [time] BBCode](https://github.com/SimpleMachines/SMF/pull/8385/commits/8b1a6ddc29dba730e8ee5cf2a77a395614efb8e1) makes the `[time]` BBCode much more capable and user friendly by allowing the BBCode to contain parsable date strings (even in the user's own language) rather than just raw Unix timestamps.