### PR TITLE
Fixes undefined array key errors when modifying a message

### DIFF
--- a/Sources/Msg.php
+++ b/Sources/Msg.php
@@ -1751,9 +1751,9 @@ class Msg implements \ArrayAccess
 			'id_topic' => $topicOptions['id'],
 		];
 		$possible_topic_columns = [
-			'sticky_mode' => ['int' => 'is_sticky'],
-			'lock_mode' => ['int' => 'locked'],
-			'poll' =>  ['int' => 'id_poll'],
+			'sticky_mode' => ['int', 'is_sticky'],
+			'lock_mode' => ['int', 'locked'],
+			'poll' =>  ['int', 'id_poll'],
 		];
 
 		// This allows mods to skip sending notifications if they don't want to.


### PR DESCRIPTION
Bug was introduced in #8318.

@live627 