### PR TITLE
Displays friendly URLs correctly in error log

### DIFF
--- a/Sources/Actions/Admin/ErrorLog.php
+++ b/Sources/Actions/Admin/ErrorLog.php
@@ -27,6 +27,7 @@ use SMF\Parser;
 use SMF\SecurityToken;
 use SMF\Theme;
 use SMF\Time;
+use SMF\Url;
 use SMF\User;
 use SMF\Utils;
 
@@ -232,7 +233,7 @@ class ErrorLog implements ActionInterface
 				'time' => Time::create('@' . $row['log_time'])->format(),
 				'timestamp' => $row['log_time'],
 				'url' => [
-					'html' => Utils::htmlspecialchars(!str_contains($row['url'], 'cron.php') ? (str_starts_with($row['url'], '?') ? Config::$scripturl : '') . $row['url'] : $row['url']),
+					'html' => Utils::htmlspecialchars((Url::create($row['url'])->isValid() ? '' : Config::$boardurl) . $row['url']),
 					'href' => base64_encode(Db::$db->escape_wildcard_string($row['url'])),
 				],
 				'message' => [


### PR DESCRIPTION
Fixes #8440

Previously we had attempted to be clever about figuring out what parts of the URL to record in the log and then about how to reconstruct the complete URL when displaying the log.

Now we keep it simple: 

- When recording, if the URL starts with Config::$boardurl, we chop off Config::$boardurl and save the remainder. If the URL does not start with Config::$boardurl for whatever reason, we record the whole URL. 

- When displaying, if the recorded value is a complete URL, we display it as-is. Otherwise, we prepend Config::$boardurl to it.

This does mean that people who have not enabled the option to hide index.php in their URLs will have `/index.php` at the start of all the recorded values in the `url` field of the error log table. But that's really not a big deal.