### PR TITLE
[3.0] Ports over a few fixes from 2.1

### DIFF
--- a/Sources/Actions/Admin/Maintenance.php
+++ b/Sources/Actions/Admin/Maintenance.php
@@ -1890,14 +1890,6 @@ class Maintenance implements ActionInterface
 			$hooks_filters[] = '<option' . ($current_filter == $hook ? ' selected ' : '') . ' value="' . $hook . '">' . $hook . '</option>';
 		}
 
-		if (!empty($hooks_filters)) {
-			Utils::$context['insert_after_template'] .= '
-			<script>
-				var hook_name_header = document.getElementById(\'header_list_integration_hooks_hook_name\');
-				hook_name_header.innerHTML += ' . Utils::escapeJavaScript('<select style="margin-left:15px;" onchange="window.location=(\'' . Config::$scripturl . '?action=admin;area=maintain;sa=hooks\' + (this.value ? \';filter=\' + this.value : \'\'));"><option value="">' . Lang::$txt['hooks_reset_filter'] . '</option>' . implode('', $hooks_filters) . '</select>') . ';
-			</script>';
-		}
-
 		if (!empty($_REQUEST['do']) && isset($_REQUEST['hook'], $_REQUEST['function'])) {
 			User::$me->checkSession('request');
 			SecurityToken::validate('admin-hook', 'request');
@@ -2032,6 +2024,15 @@ class Maintenance implements ActionInterface
 						<li><span class="main_icons posts"></span> ' . Lang::$txt['hooks_disable_legend_temp'] . '</li>
 						<li><span class="main_icons error"></span> ' . Lang::$txt['hooks_disable_legend_temp_missing'] . '</li>
 					</ul>',
+				],
+				[
+					'position' => 'above_column_headers',
+					'value' => '
+					<select onchange="window.location=(\'' . Config::$scripturl . '?action=admin;area=maintain;sa=hooks\' + (this.value ? \';filter=\' + this.value : \'\'));">
+						<option value="">' . Lang::$txt['hooks_reset_filter'] . '</option>
+						' . implode('', $hooks_filters) . '
+					</select>',
+					'class' => 'floatright',
 				],
 			],
 		];

--- a/Sources/Actions/Admin/Themes.php
+++ b/Sources/Actions/Admin/Themes.php
@@ -1585,6 +1585,8 @@ class Themes implements ActionInterface
 	 */
 	protected function installDir(): array
 	{
+		$_REQUEST['theme_dir'] = rtrim($_REQUEST['theme_dir'], '\\/');
+
 		// Cannot use the theme dir as a theme dir.
 		if (!isset($_REQUEST['theme_dir']) || empty($_REQUEST['theme_dir']) || rtrim(realpath($_REQUEST['theme_dir']), '/\\') == realpath(Utils::$context['themedir'])) {
 			ErrorHandler::fatalLang('theme_install_invalid_dir', false);

--- a/Sources/Actions/Admin/Themes.php
+++ b/Sources/Actions/Admin/Themes.php
@@ -2149,7 +2149,7 @@ class Themes implements ActionInterface
 					if (filetype($path . '/' . $object) == 'dir') {
 						$this->deltree($path . '/' . $object);
 					} else {
-						unlink($path . '/' . $object);
+						@unlink($path . '/' . $object);
 					}
 				}
 			}
@@ -2157,7 +2157,7 @@ class Themes implements ActionInterface
 
 		reset($objects);
 
-		return rmdir($path);
+		return @rmdir($path);
 	}
 
 	/**

--- a/Themes/default/css/index.css
+++ b/Themes/default/css/index.css
@@ -1487,7 +1487,8 @@ ul li.greeting {
 #display_jump_to_select,
 #message_index_jump_to_select,
 #search_jump_to_select,
-#quick_mod_jump_to_select {
+#quick_mod_jump_to_select,
+#list_integration_hooks select {
 	width: 29ch;
 }
 


### PR DESCRIPTION
- Hide PHP errors from failing to remove files/dirs when removing theme
- Move hooks filter above table
- Remove any trailing slashes from directory path during theme install 