### PR TITLE
[3.0] Fixes a few places where Markdown support caused unwanted `<p>` elements

### DIFF
--- a/Sources/Actions/Groups.php
+++ b/Sources/Actions/Groups.php
@@ -352,7 +352,10 @@ class Groups implements ActionInterface, Routable
 			$group->description = Parser::transform(
 				string: $group->description,
 				input_types: Parser::INPUT_BBC | Parser::INPUT_MARKDOWN,
-				options: ['parse_tags' => Utils::$context['description_allowed_tags']],
+				options: [
+					'parse_tags' => Utils::$context['description_allowed_tags'],
+					'no_paragraphs' => true,
+				],
 			);
 
 			$groups[$group->id] = $group;

--- a/Sources/Board.php
+++ b/Sources/Board.php
@@ -879,7 +879,10 @@ class Board implements \ArrayAccess, Routable
 				self::$parsed_descriptions[$this->id] = Parser::transform(
 					string: $this->description,
 					input_types: Parser::INPUT_BBC | Parser::INPUT_MARKDOWN,
-					options: ['parse_tags' => Utils::$context['description_allowed_tags']],
+					options: [
+						'parse_tags' => Utils::$context['description_allowed_tags'],
+						'no_paragraphs' => true,
+					],
 				);
 
 				CacheApi::put('parsed_boards_descriptions', self::$parsed_descriptions, 864000);
@@ -890,7 +893,10 @@ class Board implements \ArrayAccess, Routable
 			$this->description = Parser::transform(
 				string: $this->description,
 				input_types: Parser::INPUT_BBC | Parser::INPUT_MARKDOWN,
-				options: ['parse_tags' => Utils::$context['description_allowed_tags']],
+				options: [
+					'parse_tags' => Utils::$context['description_allowed_tags'],
+					'no_paragraphs' => true,
+				],
 			);
 		}
 	}

--- a/Sources/Category.php
+++ b/Sources/Category.php
@@ -230,7 +230,10 @@ class Category implements \ArrayAccess
 				self::$parsed_descriptions[$this->id] = Parser::transform(
 					string: $this->description,
 					input_types: Parser::INPUT_BBC | Parser::INPUT_MARKDOWN,
-					options: ['parse_tags' => Utils::$context['description_allowed_tags']],
+					options: [
+						'parse_tags' => Utils::$context['description_allowed_tags'],
+						'no_paragraphs' => true,
+					],
 				);
 
 				CacheApi::put('parsed_category_descriptions', self::$parsed_descriptions, 864000);
@@ -241,7 +244,10 @@ class Category implements \ArrayAccess
 			$this->description = Parser::transform(
 				string: $this->description,
 				input_types: Parser::INPUT_BBC | Parser::INPUT_MARKDOWN,
-				options: ['parse_tags' => Utils::$context['description_allowed_tags']],
+				options: [
+					'parse_tags' => Utils::$context['description_allowed_tags'],
+					'no_paragraphs' => true,
+				],
 			);
 		}
 	}

--- a/Sources/Parser.php
+++ b/Sources/Parser.php
@@ -160,6 +160,7 @@ abstract class Parser
 		'parse_tags' => [],
 		'for_print' => false,
 		'hard_breaks' => null,
+		'no_paragraphs' => false,
 		'str_replace' => [],
 		'preg_replace' => [],
 	];
@@ -324,6 +325,11 @@ abstract class Parser
 
 		// Do the job.
 		self::$results[$cache_key] = $handlers[$output_type]($string, $input_types, $options);
+
+		// Change paragraphs back to breaks if that option was given.
+		if ($options['no_paragraphs']) {
+			self::$results[$cache_key] = preg_replace(['~<p>(.*?)</p>~u', '~<br>$~u'], ['$1<br>', ''], self::$results[$cache_key]);
+		}
 
 		// Cache the output if it took some time...
 		if (!empty(CacheApi::$enable) && microtime(true) - $cache_t > pow(50, -CacheApi::$enable)) {

--- a/Sources/Poll.php
+++ b/Sources/Poll.php
@@ -365,7 +365,7 @@ class Poll implements \ArrayAccess
 		$this->formatted = [
 			'id' => $this->id ?? 0,
 			'image' => 'normal_' . (empty($this->voting_locked) ? 'poll' : 'locked_poll'),
-			'question' => Parser::transform($this->question),
+			'question' => Parser::transform($this->question, options: ['no_paragraphs' => true]),
 			'max_votes' => $this->max_votes,
 			'total_votes' => $this->total_voters,
 			'guest_vote' => $this->guest_vote,
@@ -422,7 +422,7 @@ class Poll implements \ArrayAccess
 			$bar = round(($option->votes * 100) / $divisor, $precision);
 			$barWide = $bar == 0 ? 1 : floor(($bar * 8) / 3);
 
-			$label = Parser::transform($option->label);
+			$label = Parser::transform($option->label, options: ['no_paragraphs' => true]);
 
 			// Now add it to the poll's contextual theme data.
 			$this->formatted['choices'][$i] = [

--- a/Sources/Verifier.php
+++ b/Sources/Verifier.php
@@ -626,7 +626,7 @@ class Verifier implements \ArrayAccess
 
 			$this->questions[] = [
 				'id' => $q,
-				'q' => Utils::adjustHeadingLevels(Parser::transform($row['question']), null),
+				'q' => Utils::adjustHeadingLevels(Parser::transform($row['question'], options: ['no_paragraphs' => true]), null),
 				'is_error' => !empty($incorrectQuestions) && in_array($q, $incorrectQuestions),
 				// Remember a previous submission?
 				'a' => isset($_REQUEST[$this->id . '_vv'], $_REQUEST[$this->id . '_vv']['q'], $_REQUEST[$this->id . '_vv']['q'][$q]) ? Utils::htmlspecialchars($_REQUEST[$this->id . '_vv']['q'][$q]) : '',


### PR DESCRIPTION
Adds an option for Parser::transform() to prevent HTML `<p>` elements from appearing in the output, and leverages that to fix output in a few places.