### PR TITLE
[3.0]: Add `integrate_build_route` hook

### DIFF
--- a/Sources/ActionRouter.php
+++ b/Sources/ActionRouter.php
@@ -59,13 +59,11 @@ trait ActionRouter
 	 */
 	public static function parseRoute(array $route, array $params = []): array
 	{
-		$params = array_merge($params, self::parseActionRoute($route));
-
-		return $params;
+		return array_merge($params, self::parseActionRoute($route));
 	}
 
 	/************************
-	 * Interal static methods
+	 * Internal static methods
 	 ************************/
 
 	/**
@@ -84,6 +82,8 @@ trait ActionRouter
 	 */
 	protected static function buildActionRoute(array &$params): array
 	{
+		$route = [];
+
 		if (str_starts_with(self::class, 'SMF\\Actions')) {
 			if (!isset($params['action'])) {
 				foreach (Forum::$actions as $action => $info) {
@@ -131,7 +131,7 @@ trait ActionRouter
 	 * For all other actions, the second element of the route path is mapped to
 	 * the 'sa' parameter.
 	 *
-	 * The route is passed by reference and route path elements are removed from
+	 * The route passed by reference and route path elements are removed from
 	 * the route when recognized. This lets wrapper methods continue parsing the
 	 * remainder of the route without worrying about duplicate elements.
 	 *

--- a/Sources/ActionTrait.php
+++ b/Sources/ActionTrait.php
@@ -27,7 +27,7 @@ trait ActionTrait
 	 * An instance of this class.
 	 * This is used by the load() method to prevent multiple instantiations.
 	 */
-	protected static self $obj;
+	protected static $obj;
 
 	/****************
 	 * Public methods

--- a/Sources/QueryString.php
+++ b/Sources/QueryString.php
@@ -617,6 +617,8 @@ class QueryString
 			$route_base = 'msgs';
 		}
 
+		IntegrationHook::call('integrate_build_route', [&$route_base, $params]);
+
 		if (
 			isset($route_base, self::$route_parsers[$route_base])
 			&& method_exists(self::$route_parsers[$route_base], 'buildRoute')


### PR DESCRIPTION
While testing the ability to add new routes, I discovered that there is no way to add routes for URLs like `/index.php?page=somepage` and similar ones. This hook provides that capability.