### PR TITLE
Points all the empty backward compatibility files to Subs-Compat.php

### DIFF
--- a/Sources/News.php
+++ b/Sources/News.php
@@ -17,6 +17,6 @@ if (!defined('SMF')) {
 	die('No direct access...');
 }
 
-class_exists('SMF\\Actions\\Feed');
+require_once SMF\Config::$sourcedir . '/Subs-Compat.php';
 
 ?>

--- a/Sources/PersonalMessage.php
+++ b/Sources/PersonalMessage.php
@@ -17,6 +17,6 @@ if (!defined('SMF')) {
 	die('No direct access...');
 }
 
-class_exists('SMF\\Actions\\PersonalMessage');
+require_once SMF\Config::$sourcedir . '/Subs-Compat.php';
 
 ?>

--- a/Sources/Profile-Actions.php
+++ b/Sources/Profile-Actions.php
@@ -17,9 +17,6 @@ if (!defined('SMF')) {
 	die('No direct access...');
 }
 
-class_exists('\\SMF\\Actions\\Profile\\Activate');
-class_exists('\\SMF\\Actions\\Profile\\Delete');
-class_exists('\\SMF\\Actions\\Profile\\IssueWarning');
-class_exists('\\SMF\\Actions\\Profile\\PaidSubs');
+require_once SMF\Config::$sourcedir . '/Subs-Compat.php';
 
 ?>

--- a/Sources/Profile-Modify.php
+++ b/Sources/Profile-Modify.php
@@ -17,16 +17,6 @@ if (!defined('SMF')) {
 	die('No direct access...');
 }
 
-class_exists('\\SMF\\Alert');
-class_exists('\\SMF\\Profile');
-class_exists('\\SMF\\Actions\\Profile\\Account');
-class_exists('\\SMF\\Actions\\Profile\\BuddyIgnoreLists');
-class_exists('\\SMF\\Actions\\Profile\\ForumProfile');
-class_exists('\\SMF\\Actions\\Profile\\GroupMembership');
-class_exists('\\SMF\\Actions\\Profile\\IgnoreBoards');
-class_exists('\\SMF\\Actions\\Profile\\Notification');
-class_exists('\\SMF\\Actions\\Profile\\TFADisable');
-class_exists('\\SMF\\Actions\\Profile\\TFASetup');
-class_exists('\\SMF\\Actions\\Profile\\ThemeOptions');
+require_once SMF\Config::$sourcedir . '/Subs-Compat.php';
 
 ?>

--- a/Sources/Profile-View.php
+++ b/Sources/Profile-View.php
@@ -17,13 +17,6 @@ if (!defined('SMF')) {
 	die('No direct access...');
 }
 
-class_exists('\\SMF\\Alert');
-class_exists('\\SMF\\Actions\\Profile\\ShowAlerts');
-class_exists('\\SMF\\Actions\\Profile\\ShowPosts');
-class_exists('\\SMF\\Actions\\Profile\\StatPanel');
-class_exists('\\SMF\\Actions\\Profile\\Summary');
-class_exists('\\SMF\\Actions\\Profile\\Tracking');
-class_exists('\\SMF\\Actions\\Profile\\ViewWarning');
-class_exists('\\SMF\\Actions\\TrackIP');
+require_once SMF\Config::$sourcedir . '/Subs-Compat.php';
 
 ?>

--- a/Sources/ScheduledTasks.php
+++ b/Sources/ScheduledTasks.php
@@ -17,8 +17,6 @@ if (!defined('SMF')) {
 	die('No direct access...');
 }
 
-class_exists('SMF\\Mail');
-class_exists('SMF\\TaskRunner');
-class_exists('SMF\\Theme');
+require_once SMF\Config::$sourcedir . '/Subs-Compat.php';
 
 ?>

--- a/Sources/Search.php
+++ b/Sources/Search.php
@@ -17,8 +17,6 @@ if (!defined('SMF')) {
 	die('No direct access...');
 }
 
-class_exists('SMF\\Actions\\Search');
-class_exists('SMF\\Actions\\Search2');
-class_exists('SMF\\Actions\\SearchResult');
+require_once SMF\Config::$sourcedir . '/Subs-Compat.php';
 
 ?>

--- a/Sources/Subs-Admin.php
+++ b/Sources/Subs-Admin.php
@@ -17,4 +17,6 @@ if (!defined('SMF')) {
 	die('No direct access...');
 }
 
+require_once SMF\Config::$sourcedir . '/Subs-Compat.php';
+
 ?>

--- a/Sources/Subs-Auth.php
+++ b/Sources/Subs-Auth.php
@@ -17,4 +17,6 @@ if (!defined('SMF')) {
 	die('No direct access...');
 }
 
+require_once SMF\Config::$sourcedir . '/Subs-Compat.php';
+
 ?>

--- a/Sources/Subs-BoardIndex.php
+++ b/Sources/Subs-BoardIndex.php
@@ -17,4 +17,6 @@ if (!defined('SMF')) {
 	die('No direct access...');
 }
 
+require_once SMF\Config::$sourcedir . '/Subs-Compat.php';
+
 ?>

--- a/Sources/Subs-Boards.php
+++ b/Sources/Subs-Boards.php
@@ -17,4 +17,6 @@ if (!defined('SMF')) {
 	die('No direct access...');
 }
 
+require_once SMF\Config::$sourcedir . '/Subs-Compat.php';
+
 ?>

--- a/Sources/Subs-Calendar.php
+++ b/Sources/Subs-Calendar.php
@@ -17,4 +17,6 @@ if (!defined('SMF')) {
 	die('No direct access...');
 }
 
+require_once SMF\Config::$sourcedir . '/Subs-Compat.php';
+
 ?>

--- a/Sources/Subs-Categories.php
+++ b/Sources/Subs-Categories.php
@@ -17,4 +17,6 @@ if (!defined('SMF')) {
 	die('No direct access...');
 }
 
+require_once SMF\Config::$sourcedir . '/Subs-Compat.php';
+
 ?>

--- a/Sources/Subs-Charset.php
+++ b/Sources/Subs-Charset.php
@@ -17,4 +17,6 @@ if (!defined('SMF')) {
 	die('No direct access...');
 }
 
+require_once SMF\Config::$sourcedir . '/Subs-Compat.php';
+
 ?>

--- a/Sources/Subs-Editor.php
+++ b/Sources/Subs-Editor.php
@@ -17,4 +17,6 @@ if (!defined('SMF')) {
 	die('No direct access...');
 }
 
+require_once SMF\Config::$sourcedir . '/Subs-Compat.php';
+
 ?>

--- a/Sources/Subs-Graphics.php
+++ b/Sources/Subs-Graphics.php
@@ -17,4 +17,6 @@ if (!defined('SMF')) {
 	die('No direct access...');
 }
 
+require_once SMF\Config::$sourcedir . '/Subs-Compat.php';
+
 ?>

--- a/Sources/Subs-List.php
+++ b/Sources/Subs-List.php
@@ -17,4 +17,6 @@ if (!defined('SMF')) {
 	die('No direct access...');
 }
 
+require_once SMF\Config::$sourcedir . '/Subs-Compat.php';
+
 ?>

--- a/Sources/Subs-Membergroups.php
+++ b/Sources/Subs-Membergroups.php
@@ -17,4 +17,6 @@ if (!defined('SMF')) {
 	die('No direct access...');
 }
 
+require_once SMF\Config::$sourcedir . '/Subs-Compat.php';
+
 ?>

--- a/Sources/Subs-Members.php
+++ b/Sources/Subs-Members.php
@@ -17,4 +17,6 @@ if (!defined('SMF')) {
 	die('No direct access...');
 }
 
+require_once SMF\Config::$sourcedir . '/Subs-Compat.php';
+
 ?>

--- a/Sources/Subs-MembersOnline.php
+++ b/Sources/Subs-MembersOnline.php
@@ -17,4 +17,6 @@ if (!defined('SMF')) {
 	die('No direct access...');
 }
 
+require_once SMF\Config::$sourcedir . '/Subs-Compat.php';
+
 ?>

--- a/Sources/Subs-MessageIndex.php
+++ b/Sources/Subs-MessageIndex.php
@@ -17,4 +17,6 @@ if (!defined('SMF')) {
 	die('No direct access...');
 }
 
+require_once SMF\Config::$sourcedir . '/Subs-Compat.php';
+
 ?>

--- a/Sources/Subs-Package.php
+++ b/Sources/Subs-Package.php
@@ -17,4 +17,6 @@ if (!defined('SMF')) {
 	die('No direct access...');
 }
 
+require_once SMF\Config::$sourcedir . '/Subs-Compat.php';
+
 ?>

--- a/Sources/Subs-ReportedContent.php
+++ b/Sources/Subs-ReportedContent.php
@@ -17,4 +17,6 @@ if (!defined('SMF')) {
 	die('No direct access...');
 }
 
+require_once SMF\Config::$sourcedir . '/Subs-Compat.php';
+
 ?>

--- a/Sources/Subs-Sound.php
+++ b/Sources/Subs-Sound.php
@@ -17,4 +17,6 @@ if (!defined('SMF')) {
 	die('No direct access...');
 }
 
+require_once SMF\Config::$sourcedir . '/Subs-Compat.php';
+
 ?>

--- a/Sources/Subs-Timezones.php
+++ b/Sources/Subs-Timezones.php
@@ -17,4 +17,6 @@ if (!defined('SMF')) {
 	die('No direct access...');
 }
 
+require_once SMF\Config::$sourcedir . '/Subs-Compat.php';
+
 ?>


### PR DESCRIPTION
These files only exist in order to avoid errors when old mods try to include them when looking for functions that no exist only in Subs-Compat.php