### PR TITLE
3.0/search stopwords multilang

### DIFF
--- a/Sources/Actions/Admin/Search.php
+++ b/Sources/Actions/Admin/Search.php
@@ -23,6 +23,7 @@ use SMF\Db\DatabaseApi as Db;
 use SMF\IntegrationHook;
 use SMF\Lang;
 use SMF\Menu;
+use SMF\Parser;
 use SMF\Search\SearchApi;
 use SMF\SecurityToken;
 use SMF\Theme;
@@ -344,7 +345,7 @@ class Search implements ActionInterface
 			'',
 
 			// Allow the admin to set stopwords.
-			['large_text', 'search_stopwords_custom', 'rows' => 8, 'subtext' => '<span class="infobox block">' . Lang::getTxt('search_stopwords_permanent', ['list' => implode(', ', SearchApi::getLangStopWords())]) . '</span>'],
+			['large_text', 'search_stopwords_custom', 'rows' => 8, 'subtext' => '<span class="infobox block">' . Lang::getTxt('search_stopwords_permanent', ['list' => Parser::transform('[tt]' . implode('[/tt], [tt]', SearchApi::getLangStopWords()) . '[/tt]', Parser::INPUT_BBC)]) . '</span>'],
 		];
 
 		// Do any mods want access?

--- a/Sources/Actions/Admin/Search.php
+++ b/Sources/Actions/Admin/Search.php
@@ -129,11 +129,8 @@ class Search implements ActionInterface
 			if (isset($_POST['search_stopwords_custom'])) {
 				$_POST['search_stopwords_custom'] = array_diff(
 					preg_split('/[\s,]+/u', $_POST['search_stopwords_custom']),
-					explode(',', Lang::$txt['search_stopwords'] ?? ''),
-					explode(',', Config::$modSettings['search_stopwords_parsed'] ?? ''),
+					SearchApi::getLangStopWords(),
 				);
-
-				sort($_POST['search_stopwords_custom']);
 
 				$_POST['search_stopwords_custom'] = implode(',', array_map([Utils::class, 'htmlspecialchars'], $_POST['search_stopwords_custom']));
 			}
@@ -333,13 +330,6 @@ class Search implements ActionInterface
 	 */
 	public static function getConfigVars(): array
 	{
-		$permanent_stopwords = array_unique(array_merge(
-			explode(',', Lang::$txt['search_stopwords'] ?? ''),
-			explode(',', Config::$modSettings['search_stopwords_parsed'] ?? ''),
-		));
-
-		sort($permanent_stopwords);
-
 		// What are we editing anyway?
 		$config_vars = [
 			// Permission...
@@ -354,7 +344,7 @@ class Search implements ActionInterface
 			'',
 
 			// Allow the admin to set stopwords.
-			['large_text', 'search_stopwords_custom', 'rows' => 8, 'subtext' => '<span class="infobox block">' . Lang::getTxt('search_stopwords_permanent', ['list' => implode(', ', $permanent_stopwords)]) . '</span>'],
+			['large_text', 'search_stopwords_custom', 'rows' => 8, 'subtext' => '<span class="infobox block">' . Lang::getTxt('search_stopwords_permanent', ['list' => implode(', ', SearchApi::getLangStopWords())]) . '</span>'],
 		];
 
 		// Do any mods want access?

--- a/Sources/Search/APIs/Custom.php
+++ b/Sources/Search/APIs/Custom.php
@@ -405,7 +405,15 @@ class Custom extends SearchApi implements SearchApiInterface
 	{
 		if (isset($msgOptions['body'])) {
 			$customIndexSettings = Utils::jsonDecode(Config::$modSettings['search_custom_index_config'], true);
-			$stopwords = empty(Config::$modSettings['search_stopwords']) ? [] : explode(',', Config::$modSettings['search_stopwords']);
+			$stopwords = array_filter(
+				array_unique(
+					array_merge(
+						explode(',', Config::$modSettings['search_stopwords'] ?? ''),
+						self::getLangStopWords(),
+					),
+				),
+				'strlen',
+			);
 			$old_body = $msgOptions['old_body'] ?? '';
 
 			// create thew new and old index
@@ -745,7 +753,21 @@ class Custom extends SearchApi implements SearchApiInterface
 			if (Utils::$context['index_settings']['bytes_per_word'] < 4) {
 				Utils::$context['step'] = 3;
 			} else {
-				$stop_words = Utils::$context['start'] === 0 || empty(Config::$modSettings['search_stopwords']) ? [] : explode(',', Config::$modSettings['search_stopwords']);
+				if (Utils::$context['start'] === 0) {
+					$stop_words = [];
+				} else {
+					$stop_words = array_filter(
+						array_unique(
+							array_merge(
+								explode(',', Config::$modSettings['search_stopwords'] ?? ''),
+								self::getLangStopWords(),
+							),
+						),
+						'strlen',
+					);
+
+					sort($stop_words);
+				}
 
 				$stop = time() + 3;
 
@@ -773,7 +795,7 @@ class Custom extends SearchApi implements SearchApiInterface
 					}
 					Db::$db->free_result($request);
 
-					Config::updateModSettings(['search_stopwords' => implode(',', $stop_words)]);
+					Config::updateModSettings(['search_stopwords' => implode(',', array_diff($stop_words, self::getLangStopWords()))]);
 
 					if (!empty($stop_words)) {
 						Db::$db->query(

--- a/Sources/Search/APIs/Parsed.php
+++ b/Sources/Search/APIs/Parsed.php
@@ -777,7 +777,7 @@ class Parsed extends SearchApi implements SearchApiInterface
 		$stopwords = array_map(fn($w) => Utils::normalize(Utils::entityDecode($w, true)), $stopwords);
 
 		Config::updateModSettings([
-			'search_stopwords_parsed' => implode(',', $stopwords),
+			'search_stopwords_parsed' => implode(',', array_diff($stopwords, self::getLangStopWords())),
 			'search_stopwords_parsed_updated' => time(),
 		]);
 	}
@@ -797,13 +797,11 @@ class Parsed extends SearchApi implements SearchApiInterface
 	 */
 	protected function setBlacklistedWords(): void
 	{
-		// Blacklist any stopwords for the current language.
-		if (isset(Lang::$txt['search_stopwords'])) {
-			$this->blacklisted_words = array_unique(array_merge(
-				$this->blacklisted_words,
-				array_map('trim', explode(',', Lang::$txt['search_stopwords'])),
-			));
-		}
+		// Blacklist any stopwords for the installed languages.
+		$this->blacklisted_words = array_unique(array_merge(
+			$this->blacklisted_words,
+			self::getLangStopWords(),
+		));
 
 		// Blacklist any stopwords that we found automatically.
 		if (isset(Config::$modSettings['search_stopwords_parsed'])) {

--- a/Sources/Search/SearchApi.php
+++ b/Sources/Search/SearchApi.php
@@ -125,7 +125,7 @@ abstract class SearchApi implements SearchApiInterface
 	 * Words to ignore when searching.
 	 *
 	 * Populated with the contents of:
-	 *  - Lang::$txt['search_stopwords']
+	 *  - Lang::$txt['search_stopwords'] for all installed languages.
 	 *  - Config::$modSettings['search_stopwords']
 	 *  - Config::$modSettings['search_stopwords_custom']
 	 *  - All known BBCode tags
@@ -952,6 +952,32 @@ abstract class SearchApi implements SearchApiInterface
 		return $loadedApis;
 	}
 
+	/**
+	 * Gets a list of all the words in Lang::$txt['search_stopwords'] for all
+	 * installed language packs.
+	 */
+	final public static function getLangStopWords(): array
+	{
+		$permanent_stopwords = [];
+
+		foreach (array_keys(Lang::get()) as $lang) {
+			Lang::load('Search', $lang, true);
+
+			$permanent_stopwords = array_merge(
+				$permanent_stopwords,
+				Utils::htmlTrimRecursive(explode(',', Lang::$txt['search_stopwords'] ?? '')),
+			);
+		}
+
+		Lang::load('Search', '', true);
+
+		$permanent_stopwords = array_filter(array_unique($permanent_stopwords), 'strlen');
+
+		sort($permanent_stopwords);
+
+		return $permanent_stopwords;
+	}
+
 	/******************
 	 * Internal methods
 	 ******************/
@@ -979,13 +1005,11 @@ abstract class SearchApi implements SearchApiInterface
 	 */
 	protected function setBlacklistedWords(): void
 	{
-		// Blacklist any stopwords for the current language.
-		if (isset(Lang::$txt['search_stopwords'])) {
-			$this->blacklisted_words = array_unique(array_merge(
-				$this->blacklisted_words,
-				array_map('trim', explode(',', Lang::$txt['search_stopwords'])),
-			));
-		}
+		// Blacklist any stopwords for the installed languages.
+		$this->blacklisted_words = array_unique(array_merge(
+			$this->blacklisted_words,
+			self::getLangStopWords(),
+		));
 
 		// Blacklist any stopwords that the admin set manually.
 		if (isset(Config::$modSettings['search_stopwords_custom'])) {


### PR DESCRIPTION
Includes stopwords from all installed language packs in the stopwords lists used by search APIs, and improves the formatting used to display the list of permanent stopwords to the admin in the search settings page of the admin control panel.