### PR TITLE
Hide calendar heading in theme options when calendar is disabled

### DIFF
--- a/Themes/default/Settings.template.php
+++ b/Themes/default/Settings.template.php
@@ -134,7 +134,7 @@ function template_options()
 			'label' => Lang::$txt['pm_remove_inbox_label'],
 			'default' => true,
 		),
-		Lang::$txt['theme_opt_calendar'],
+		!empty(Config::$modSettings['cal_enabled']) ? Lang::$txt['theme_opt_calendar'] : '',
 		array(
 			'id' => 'calendar_default_view',
 			'label' => Lang::$txt['calendar_default_view'],


### PR DESCRIPTION
Fixes #8480