### PR TITLE
Fix various upgrade issues

### DIFF
--- a/other/upgrade_2-1_PostgreSQL.sql
+++ b/other/upgrade_2-1_PostgreSQL.sql
@@ -392,8 +392,8 @@ if (version_compare(trim(strtolower(@Config::$modSettings['smfVersion'])), '2.1.
     while ($row = Db::$db->fetch_assoc($request))
     {
         $inserts[] = array(
-            'name' => Utils::htmlspecialchars(strip_tags(SMF\Parser::transform($row['name'], SMF\Parser::OUTPUT_BBC)),
-            'description' => Utils::htmlspecialchars(strip_tags(SMF\Parser::transform($row['description'], SMF\Parser::OUTPUT_BBC)),
+            'name' => Utils::htmlspecialchars(strip_tags(SMF\Parser::transform($row['name'], SMF\Parser::OUTPUT_BBC))),
+            'description' => Utils::htmlspecialchars(strip_tags(SMF\Parser::transform($row['description'], SMF\Parser::OUTPUT_BBC))),
             'id' => $row['id'],
         );
     }
@@ -541,7 +541,7 @@ ALTER TABLE {$db_prefix}attachments
 ---{
 
 // Need to know a few things first.
-$custom_av_dir = !empty(Config::$modSettings['custom_avatar_dir']) ? Config::$modSettings['custom_avatar_dir'] : Config::boarddir .'/custom_avatar';
+$custom_av_dir = !empty(Config::$modSettings['custom_avatar_dir']) ? Config::$modSettings['custom_avatar_dir'] : Config::$boarddir .'/custom_avatar';
 
 // This little fellow has to cooperate...
 if (!is_writable($custom_av_dir))
@@ -560,22 +560,22 @@ if (!is_writable($custom_av_dir))
 }
 
 // If we already are using a custom dir, delete the predefined one.
-if (realpath($custom_av_dir) != realpath(Config::boarddir .'/custom_avatar'))
+if (realpath($custom_av_dir) != realpath(Config::$boarddir .'/custom_avatar'))
 {
 	// Borrow custom_avatars index.php file.
 	if (!file_exists($custom_av_dir . '/index.php'))
-		@rename(Config::boarddir .'/custom_avatar/index.php', $custom_av_dir .'/index.php');
+		@rename(Config::$boarddir .'/custom_avatar/index.php', $custom_av_dir .'/index.php');
 	else
-		@unlink(Config::boarddir . '/custom_avatar/index.php');
+		@unlink(Config::$boarddir . '/custom_avatar/index.php');
 
 	// Borrow blank.png as well
 	if (!file_exists($custom_av_dir . '/blank.png'))
-		@rename(Config::boarddir . '/custom_avatar/blank.png', $custom_av_dir . '/blank.png');
+		@rename(Config::$boarddir . '/custom_avatar/blank.png', $custom_av_dir . '/blank.png');
 	else
-		@unlink(Config::boarddir . '/custom_avatar/blank.png');
+		@unlink(Config::$boarddir . '/custom_avatar/blank.png');
 
 	// Attempt to delete the directory.
-	@rmdir(Config::boarddir .'/custom_avatar');
+	@rmdir(Config::$boarddir .'/custom_avatar');
 }
 
 $request = upgrade_query("
@@ -1617,7 +1617,7 @@ $request = Db::$db->query('', '
 // Check which themes exist in the filesystem & save off their IDs
 // Don't delete default theme(start with 1 in the array), & make sure to delete old core theme
 $known_themes = array('1');
-$core_dir = Config::boarddir . '/Themes/core';
+$core_dir = Config::$boarddir . '/Themes/core';
 while ($row = Db::$db->fetch_assoc($request))	{
 	if ($row['value'] != $core_dir && is_dir($row['value'])) {
 		$known_themes[] = $row['id_theme'];

--- a/other/upgrade_3-0_PostgreSQL.sql
+++ b/other/upgrade_3-0_PostgreSQL.sql
@@ -866,7 +866,7 @@ ADD COLUMN IF NOT EXISTS smf_version VARCHAR(5) NOT NULL DEFAULT '';
 /******************************************************************************/
 
 ---# Improving search results storage
-ALTER TABLE {$db_prefix}log_search_results DROP PRIMARY KEY;
+ALTER TABLE {$db_prefix}log_search_results DROP CONSTRAINT {$db_prefix}log_search_results_pkey;
 ALTER TABLE {$db_prefix}log_search_results ADD PRIMARY KEY (id_search, id_topic, id_msg);
 ---#
 
@@ -878,14 +878,14 @@ ALTER TABLE {$db_prefix}log_search_results ADD PRIMARY KEY (id_search, id_topic,
 UPDATE {$db_prefix}settings
 SET value =
 	CASE
-		WHEN value = 0
+		WHEN value = '0'
 			THEN 'SendMail'
-		WHEN value = 1
+		WHEN value = '1'
 			THEN 'SMTP'
-		WHEN value = 2
+		WHEN value = '2'
 			THEN 'SMTPTLS'
 		ELSE
 			value
 		END
 WHERE variable = 'mail_type'
-	AND value IN (0,1,2);
+	AND value IN ('0','1','2');


### PR DESCRIPTION
This fixes various issues I found while upgrading a local test board from 2.1 to 3.0 on PostgreSQL 17:
- a few missing ) that caused parse errors
- config::boarddir instead of config::$boarddir
- Postgres doesn't have an operator to compare int and text values, so just use strings for those