### PR TITLE
[3.0] Fixes broken AJAX responses

### DIFF
--- a/Sources/Actions/GenericAction.php
+++ b/Sources/Actions/GenericAction.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2025 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 2
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Actions;
+
+use SMF\ActionInterface;
+use SMF\ActionTrait;
+
+/**
+ * An action for executing arbitrary callables.
+ *
+ * This is intended for cases where old mods declare a bare function as the
+ * callable for a custom action.
+ */
+class GenericAction implements ActionInterface
+{
+	use ActionTrait;
+
+	/*********************
+	 * Internal properties
+	 *********************/
+
+	/**
+	 * @var callable
+	 *
+	 * The callable to be executed.
+	 */
+	private $current_action;
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Sets the callable to be executed in $this->execute().
+	 *
+	 * @param callable $current_action A callable.
+	 */
+	public function setCallable(callable $current_action): void
+	{
+		$this->current_action = $current_action;
+	}
+
+	/**
+	 * Executes the indicated callable.
+	 *
+	 * @param callable $current_action A callable.
+	 */
+	public function execute(): void
+	{
+		call_user_func($this->current_action);
+	}
+}
+
+?>

--- a/Sources/Forum.php
+++ b/Sources/Forum.php
@@ -447,22 +447,18 @@ class Forum
 	{
 		$this->init();
 
-		$requested_action = $_REQUEST['action'] ?? null;
-		$current_action = $this->findAction($requested_action);
+		self::getCurrentAction();
 
-		if (is_a($current_action, ActionInterface::class, true)) {
-			$action = call_user_func([$current_action, 'load']);
-			self::$current_action = $action;
-
-			// Perform operations on the action object before execute() is called.
-			IntegrationHook::call('integrate_init_action', [$action]);
+		// Perform operations on the action object before its execute() is called.
+		if (isset(self::$current_action)) {
+			IntegrationHook::call('integrate_init_action', [self::$current_action]);
 		}
 
 		$this->preflight();
 
-		if (isset($action)) {
-			$action->execute();
-		} elseif (is_callable($current_action)) {
+		if (isset(self::$current_action)) {
+			self::$current_action->execute();
+		} elseif (is_callable($current_action = self::findAction($_REQUEST['action'] ?? null))) {
 			call_user_func($current_action);
 		} else {
 			ErrorHandler::fatalLang('not_found', false, [], 404);
@@ -511,6 +507,14 @@ class Forum
 	 */
 	public static function getCurrentAction(): ?ActionInterface
 	{
+		if (!isset(self::$current_action)) {
+			$current_action = self::findAction($_REQUEST['action'] ?? null);
+
+			if (is_a($current_action, ActionInterface::class, true)) {
+				self::$current_action = call_user_func([$current_action, 'load']);
+			}
+		}
+
 		return self::$current_action;
 	}
 
@@ -684,6 +688,10 @@ class Forum
 		}
 	}
 
+	/*************************
+	 * Internal static methods
+	 *************************/
+
 	/**
 	 * Resolves the appropriate action to execute based on the current request context.
 	 *
@@ -691,7 +699,7 @@ class Forum
 	 *  - A string representing a class implementing ActionInterface.
 	 *  - A callable string representing a static method (e.g., `'Class::method'`).
 	 */
-	protected function findAction(?string $action): string|callable|false
+	protected static function findAction(?string $action): string|callable|false
 	{
 		// If no action was supplied, is there an implied action?
 		if (empty($action)) {

--- a/Sources/Forum.php
+++ b/Sources/Forum.php
@@ -458,8 +458,6 @@ class Forum
 
 		if (isset(self::$current_action)) {
 			self::$current_action->execute();
-		} elseif (is_callable($current_action = self::findAction($_REQUEST['action'] ?? null))) {
-			call_user_func($current_action);
 		} else {
 			ErrorHandler::fatalLang('not_found', false, [], 404);
 		}
@@ -512,6 +510,9 @@ class Forum
 
 			if (is_a($current_action, ActionInterface::class, true)) {
 				self::$current_action = call_user_func([$current_action, 'load']);
+			} elseif (is_callable($current_action)) {
+				self::$current_action = Actions\GenericAction::load();
+				self::$current_action->setCallable($current_action);
 			}
 		}
 

--- a/Sources/Msg.php
+++ b/Sources/Msg.php
@@ -1742,7 +1742,7 @@ class Msg implements \ArrayAccess, Routable
 		}
 
 		// Anyone quoted or mentioned?
-		$quoted_members = Mentions::getQuotedMembers($msgOptions['body'], (int) $posterOptions['id']);
+		$quoted_members = Mentions::getQuotedMembers($msgOptions['body'] ?? '', (int) $posterOptions['id']);
 		$quoted_modifications = Mentions::modifyMentions('quote', (int) $msgOptions['id'], $quoted_members, (int) $posterOptions['id']);
 
 		if (!empty($quoted_modifications['added'])) {

--- a/Sources/Theme.php
+++ b/Sources/Theme.php
@@ -2056,7 +2056,7 @@ class Theme
 		);
 
 		// See if there is any extra param to check.
-		$requires_xml = false;
+		$requires_xml = Forum::getCurrentAction()?->getOutputType() instanceof OutputTypes\Xml;
 
 		foreach ($this->extraParams as $key => $extra) {
 			if (isset($_REQUEST[$extra])) {
@@ -2066,17 +2066,16 @@ class Theme
 			}
 		}
 
+		// Attempt to load language files.
+		Lang::load('General+ThemeStrings+Modifications', '', false);
+
 		// Output is fully XML, so no need for the index template.
 		if (isset($_REQUEST['xml']) && (in_array(Utils::$context['current_action'], $this->xmlActions) || $requires_xml)) {
 			self::loadTemplate('Xml');
 			Utils::$context['template_layers'] = [];
 		}
-
-		// Attempt to load language files.
-		Lang::load('General+ThemeStrings+Modifications', '', false);
-
 		// These actions don't require the index template at all.
-		if (!empty(Utils::$context['simple_action'])) {
+		elseif (!empty(Utils::$context['simple_action'])) {
 			Utils::$context['template_layers'] = [];
 		} else {
 			// Custom templates to load, or just default?

--- a/Sources/Utils.php
+++ b/Sources/Utils.php
@@ -2412,11 +2412,10 @@ class Utils
 				Theme::template_footer();
 
 				// Add $db_show_debug = true; to Settings.php if you want to show the debugging information.
-				if (Forum::getCurrentAction()?->isSimpleAction() === false
-					|| (
-						Forum::getCurrentAction() === null
-						&& !isset($_REQUEST['xml'])
-					)
+				if (
+					Forum::getCurrentAction()?->isSimpleAction() === false
+					&& !(Forum::getCurrentAction()?->getOutputType() instanceof OutputTypes\Xml)
+					&& !isset($_REQUEST['xml'])
 				) {
 					Logging::displayDebug();
 				}


### PR DESCRIPTION
- [Fixes bootstrapping issue when calling Forum::getCurrentAction()](https://github.com/SimpleMachines/SMF/commit/201b1d5af1609aa233cf318b412ec00557d71d44)
    - `Forum::getCurrentAction()` is called during `Theme::load()`, before `Forum::$current_action` has been set. This caused problems for actions that produce XML output.
    - Now `Forum::getCurrentAction()` will figure out the value for `Forum::$current_action` if it has not already been set. Even `Forum::execute()` now calls `Forum::getCurrentAction()` in order to do this job.
-  [Implements SMF\Actions\GenericAction](https://github.com/SimpleMachines/SMF/commit/2d51c0ed537cf6a7803b6f70e9f35c4187b74c2d)
    - This is intended for cases where old mods declare a bare function as the callable for a custom action. Essentially, if we discover during `Forum::getCurrentAction()` that the specified action wants to call a simple callable rather than the execute method of a class that implements ActionInterface, then we create an instance of `Actions\GenericAction` and tell it to call the indicated callable in its execute method. This ensures that `Forum::$current_action` always ends up being an instance of ActionInterface.
- [Fixes broken AJAX responses](https://github.com/SimpleMachines/SMF/commit/37bb5e86d4503811d273078ba6a5f5931c68e786)
    - AJAX responses were not returning well-formed XML. Some of the underlying reasons for that were dealt with in the commits above, but there was more to be fixed. This PR does that.
- [Fixes type error when passing to Mentions::getQuotedMembers()](https://github.com/SimpleMachines/SMF/commit/220a1d9bb013d47fe76fa04c6fb40ce5cf85c241)
    - When using `?action=quotefast;modify;...` to edit topic subjects from the message index, an error was generated because a null value was being passed to  `Mentions::getQuotedMembers()` where a string was expected.