### PR TITLE
[3.0] Lock all actions to a specific version

### DIFF
--- a/.github/workflows/crowdin_wf.yml
+++ b/.github/workflows/crowdin_wf.yml
@@ -30,13 +30,13 @@ jobs:
     - name: Checkout
       # This prevents all the forks from attempting to run the interface...
       if: env.CROWDIN_API_TOKEN != null
-      uses: actions/checkout@v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #4.2.2
 
     - name: crowdin-action
       # This prevents all the forks from attempting to run the interface...
       if: env.CROWDIN_API_TOKEN != null
       # You need to pin to a specific version for some reason...
-      uses: crowdin/github-action@v1
+      uses: crowdin/github-action@2cc7959c565767d6bc118118d6df3b63bf361370 #2.6.1
       with:
         # Push sources (the english files) to CrowdIn; do not push translations (non-english) in either direction
         upload_sources: true

--- a/.github/workflows/crowdin_wf_next.yml
+++ b/.github/workflows/crowdin_wf_next.yml
@@ -34,13 +34,12 @@ jobs:
     - name: Checkout
       # This prevents all the forks from attempting to run the interface...
       if: env.CROWDIN_API_TOKEN != null
-      uses: actions/checkout@v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #4.2.2
 
     - name: crowdin-action
       # This prevents all the forks from attempting to run the interface...
       if: env.CROWDIN_API_TOKEN != null
-      # You need to pin to a specific version for some reason...
-      uses: crowdin/github-action@v1
+      uses: crowdin/github-action@2cc7959c565767d6bc118118d6df3b63bf361370 #2.6.1
       with:
         # Push sources (the english files) to CrowdIn; do not push translations (non-english) in either direction
         upload_sources: true

--- a/.github/workflows/php-cs-fixer.yml
+++ b/.github/workflows/php-cs-fixer.yml
@@ -10,7 +10,7 @@ jobs:
     name: PHP-CS-Fixer
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #4.2.2
 
       - name: Get changed files
         id: changed-files

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -3,7 +3,7 @@ name: PHP Check
 on:
   push:
     branches:
-      - release-2.1
+      - release-3.0
   pull_request:
 
 jobs:
@@ -11,11 +11,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #4.2.2
 
     - name: Cache Composer packages
       id: composer-cache
-      uses: actions/cache@v4
+      uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf #4.2.2
       with:
         path: vendor
         key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
@@ -45,17 +45,17 @@ jobs:
 
     name: PHP ${{ matrix.php }} Syntax Check
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #4.2.2
 
     - name: Setup PHP ${{ matrix.php }}
-      uses: shivammathur/setup-php@v2
+      uses: shivammathur/setup-php@9e72090525849c5e82e596468b86eb55e9cc5401 #2.32.0
       with:
         php-version: ${{ matrix.php }}
         coverage: none
 
     - name: Cache Composer packages
       id: composer-cache
-      uses: actions/cache@v4
+      uses: actions/cache@cache@d4323d4df104b026a6aa633fdb11d772146be0bf #4.2.2
       with:
         path: vendor
         key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}

--- a/.github/workflows/update-year.yml
+++ b/.github/workflows/update-year.yml
@@ -9,7 +9,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #4.2.2
 
     - name: Set current year environment variable
       run: echo "CURRENT_YEAR=$(date +'%Y')" >> $GITHUB_ENV
@@ -34,7 +34,7 @@ jobs:
           sed -i "s/@copyright [0-9]\{4\}/@copyright ${{ env.CURRENT_YEAR }}/" $file
         done
 
-    - name: Update year in PHP files 
+    - name: Update year in PHP files
       run: |
         for file in SSI.php proxy.php cron.php index.php other/*.php; do
           sed -i "s/@copyright [0-9]\{4\}/@copyright ${{ env.CURRENT_YEAR }}/" $file
@@ -42,7 +42,7 @@ jobs:
         done
 
     - name: Create Pull Request
-      uses: peter-evans/create-pull-request@v7
+      uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e #7.0.8
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         commit-message: Update year to ${{ env.CURRENT_YEAR }}


### PR DESCRIPTION
In light of recent compromise of a github action, I am proposing we change all actions to reference the SHA-1 immutable id rather than a tag which can be overridden.