### PR TITLE
[3.0] Uses more reliable ways to stop autocomplete from accidentally clobbering profile data when admin edits other members' profile pages

### DIFF
--- a/Sources/Profile.php
+++ b/Sources/Profile.php
@@ -437,9 +437,10 @@ class Profile extends User implements \ArrayAccess
 				},
 			],
 			'email_address' => [
-				'type' => 'email',
+				'type' => User::$me->is_owner || (User::$me->allowedTo('moderate_forum') && isset($_GET['change_email'])) ? 'email' : 'label',
 				'label' => Lang::$txt['user_email_address'],
 				'subtext' => Lang::$txt['valid_email'],
+				'postinput' => !User::$me->is_owner && User::$me->allowedTo('moderate_forum') && !isset($_GET['change_email']) ? '<a href="' . Config::$scripturl . '?action=profile;u=' . $this->id . ';area=account;change_email" class="button smalltext">' . Lang::$txt['username_change'] . '</a>' : '',
 				'log_change' => true,
 				'permission' => 'profile_password',
 				'js_submit' => !empty(Config::$modSettings['send_validation_onChange']) ? '
@@ -549,7 +550,7 @@ class Profile extends User implements \ArrayAccess
 			'member_name' => [
 				'type' => User::$me->allowedTo('admin_forum') && isset($_GET['changeusername']) ? 'text' : 'label',
 				'label' => Lang::$txt['username'],
-				'subtext' => User::$me->allowedTo('admin_forum') && !isset($_GET['changeusername']) ? '[<a href="' . Config::$scripturl . '?action=profile;u=' . $this->id . ';area=account;changeusername" style="font-style: italic;">' . Lang::$txt['username_change'] . '</a>]' : '',
+				'postinput' => User::$me->allowedTo('admin_forum') && !isset($_GET['changeusername']) ? '<a href="' . Config::$scripturl . '?action=profile;u=' . $this->id . ';area=account;changeusername" class="button smalltext">' . Lang::$txt['username_change'] . '</a>' : '',
 				'log_change' => true,
 				'permission' => 'profile_identity',
 				'prehtml' => User::$me->allowedTo('admin_forum') && isset($_GET['changeusername']) ? '<div class="alert">' . Lang::$txt['username_warning'] . '</div>' : '',
@@ -585,9 +586,10 @@ class Profile extends User implements \ArrayAccess
 				},
 			],
 			'passwrd1' => [
-				'type' => 'password',
+				'type' => User::$me->is_owner || (User::$me->allowedTo('moderate_forum') && isset($_GET['change_password'])) ? 'password' : 'label',
 				'label' => Lang::$txt['choose_pass'],
 				'subtext' => Lang::$txt['password_strength'],
+				'postinput' => !User::$me->is_owner && User::$me->allowedTo('moderate_forum') && !isset($_GET['change_password']) ? '<a href="' . Config::$scripturl . '?action=profile;u=' . $this->id . ';area=account;change_password" class="button smalltext">' . Lang::$txt['username_change'] . '</a>' : '',
 				'size' => 20,
 				'value' => '',
 				'permission' => 'profile_password',
@@ -621,7 +623,7 @@ class Profile extends User implements \ArrayAccess
 				},
 			],
 			'passwrd2' => [
-				'type' => 'password',
+				'type' => User::$me->is_owner || (User::$me->allowedTo('moderate_forum') && isset($_GET['change_password'])) ? 'password' : 'hidden',
 				'label' => Lang::$txt['verify_pass'],
 				'size' => 20,
 				'value' => '',

--- a/Themes/default/Profile.template.php
+++ b/Themes/default/Profile.template.php
@@ -1440,10 +1440,6 @@ function template_edit_options()
 
 	echo '
 		<form action="', $url, '" method="post" accept-charset="UTF-8" name="creator" id="creator" enctype="multipart/form-data"', (Utils::$context['menu_item_selected'] == 'account' ? ' autocomplete="off"' : ''), '>
-			<div style="height:0;overflow:hidden;">
-				<input type="text" id="autocompleteFakeName">
-				<input type="password" id="autocompleteFakePassword">
-			</div>
 			<div class="cat_bar">
 				<h3 class="catbg profile_hd">';
 

--- a/Themes/default/css/index.css
+++ b/Themes/default/css/index.css
@@ -1114,6 +1114,10 @@ html[lang="el-GR"] .inline_mod_check {
 	margin: 0;
 	padding: 0;
 }
+.button.smalltext {
+	font-size: 0.6em;
+	padding: 0 5px;
+}
 
 /* Styles for the general looks of the theme.
 ------------------------------------------------------- */


### PR DESCRIPTION
In 2.1, the theme includes hidden username and password fields on some profile pages. This is done because the autocomplete features of some browsers will incorrectly fill in the username and password fields on profile pages where they shouldn't. The hidden fields were an attempt to give the autocomplete a different target so that it (hopefully) wouldn't clobber the data in fields where autocomplete should not happen.

In particular, we resorted to these sorts of hacks because we wanted to prevent the browser from automatically filling in the email and password fields on the Account Settings page when an admin was editing a member's profile, because that could cause the member's profile data to be changed to the admin's own data.

Unfortunately, this approach has never worked reliably across all major browsers—and frankly, it shouldn't. It's a bad idea to try to fight the browser using awkward hacks like this. If we don't want those fields to be filled in automatically, we should use a more reliable approach that doesn't need to fight against the browser.

So, this PR gets rid of the hidden fields and instead protects the email and password field from being accidentally overwritten by making them uneditable until the admin clicks a button to make them editable. (However, if you are viewing your own profile, the fields are editable by default, because it's fine if autocomplete fills in your own info in your own profile.)

<img width="589" alt="Screenshot 2025-03-24 at 7 50 26 PM" src="https://github.com/user-attachments/assets/c385a37a-51e7-4303-aecc-40b2e7751c6e" />
