### PR TITLE
[3.0] Informs reader when a post has bumped an old topic

### DIFF
--- a/Languages/en_US/General.php
+++ b/Languages/en_US/General.php
@@ -984,6 +984,45 @@ $txt['error_old_topic'] = 'Warning: {0, plural,
 	other {this topic has not been posted in for at least # days.}
 }<br>Unless you are sure you want to reply, please consider starting a new topic.';
 
+$txt['bump_notice'] = '{invert, select,
+	true {{unit, select,
+		year {{num, plural,
+			one {# year earlier...}
+			other {# years earlier...}
+		}}
+		month {{num, plural,
+			one {# month earlier...}
+			other {# months earlier...}
+		}}
+		week {{num, plural,
+			one {# week earlier...}
+			other {# weeks earlier...}
+		}}
+		other {{num, plural,
+			one {# day earlier...}
+			other {# days earlier...}
+		}}
+	}}
+	other {{unit, select,
+		year {{num, plural,
+			one {# year later...}
+			other {# years later...}
+		}}
+		month {{num, plural,
+			one {# month later...}
+			other {# months later...}
+		}}
+		week {{num, plural,
+			one {# week later...}
+			other {# weeks later...}
+		}}
+		other {{num, plural,
+			one {# day later...}
+			other {# days later...}
+		}}
+	}}
+}';
+
 $txt['split_selected_posts'] = 'Selected posts ({reset_link})';
 $txt['split_selected_posts_desc'] = 'The posts below will form a new topic after splitting.';
 $txt['split_reset_selection'] = 'reset selection';

--- a/Sources/Actions/Display.php
+++ b/Sources/Actions/Display.php
@@ -35,6 +35,7 @@ use SMF\Poll;
 use SMF\Routable;
 use SMF\Security;
 use SMF\Theme;
+use SMF\TimeInterval;
 use SMF\Topic;
 use SMF\User;
 use SMF\Utils;
@@ -182,6 +183,7 @@ class Display implements ActionInterface, Routable
 	public function prepareDisplayContext(): array|bool
 	{
 		static $counter = null;
+		static $prev_timestamp = null;
 
 		// Remember which message this is.  (ie. reply #83)
 		if ($counter === null) {
@@ -295,6 +297,76 @@ class Display implements ActionInterface, Routable
 				'show' => !empty(Theme::$current->options['display_quick_mod']) && Theme::$current->options['display_quick_mod'] == 1 && $output['can_remove'],
 			],
 		];
+
+		// Should we insert a bump notice?
+		if (
+			!empty(Config::$modSettings['oldTopicDays'])
+			&& (
+				empty(Theme::$current->options['view_newest_first'])
+				? $message->id > Topic::$info->id_first_msg
+				: $message->id < Topic::$info->id_last_msg
+			)
+		) {
+			// On the second and following pages of the topic, we unfortunately
+			// need an extra query for the first post on the page.
+			if (!isset($prev_timestamp)) {
+				$request = Db::$db->query(
+					'',
+					'SELECT poster_time
+					FROM {db_prefix}messages
+					WHERE id_topic = {int:topic}
+						AND poster_time {raw:operator} {int:ts}' . (!Config::$modSettings['postmod_active'] || User::$me->allowedTo('approve_posts') ? '' : '
+						AND (approved = {int:is_approved}' . (User::$me->is_guest ? '' : ' OR id_member = {int:me}') . ')') . '
+					ORDER BY id_msg {raw:order}
+					LIMIT 1',
+					[
+						'ts' => $message->poster_time,
+						'operator' => !empty(Theme::$current->options['view_newest_first']) ? '>' : '<',
+						'topic' => Topic::$info->id,
+						'me' => User::$me->id,
+						'is_approved' => 1,
+						'order' => !empty(Theme::$current->options['view_newest_first']) ? 'ASC' : 'DESC',
+					],
+				);
+
+				$row = current(Db::$db->fetch_all($request));
+				$prev_timestamp = $row['poster_time'];
+
+				Db::$db->free_result($request);
+			}
+
+			$since = date_create('@' . $prev_timestamp)->diff(date_create('@' . $message->poster_time));
+
+			if ($since->format('%a') > Config::$modSettings['oldTopicDays']) {
+				if ($since->format('%y') > 0) {
+					$num = $since->format('%y');
+					$unit = 'year';
+				} elseif ($since->format('%m') > 1) {
+					$num = $since->format('%m');
+					$unit = 'month';
+				} elseif ($since->format('%a') > 14) {
+					$num = strval(intval(floor($since->format('%a') / 7)));
+					$unit = 'week';
+				} else {
+					$num = $since->format('%a');
+					$unit = 'day';
+				}
+
+				$since = TimeInterval::createFromDateInterval($since);
+
+				$output['bump_notice'] = '<time class="bump_notice" datetime="' . (string) $since . '" title="' . $since->localize() . '">' . Lang::getTxt(
+					'bump_notice',
+					[
+						'num' => $num,
+						'unit' => $unit,
+						'invert' => $since->invert ? 'true' : 'false',
+					],
+					file: 'General',
+				) . '</time>';
+			}
+		}
+
+		$prev_timestamp = $message->poster_time;
 
 		if (empty(Theme::$current->options['view_newest_first'])) {
 			$counter++;

--- a/Themes/default/Display.template.php
+++ b/Themes/default/Display.template.php
@@ -434,11 +434,21 @@ function template_single_post($message)
 		Utils::$context['ignoredMsgs'][] = $message['id'];
 	}
 
-	// Show the message anchor and a "new" anchor if this message is new.
+	// Show a "new" anchor if this message is new.
+	if (!empty($message['first_new']) && $message['id'] != Utils::$context['first_message']) {
+		echo '
+				<a id="new"></a>';
+	}
+
+	// Inform the reader if this message bumped an old topic.
+	if (!empty($message['bump_notice'])) {
+		echo '
+				' . $message['bump_notice'];
+	}
+
+	// Show the message.
 	echo '
 				<div class="', $message['css_class'], '" id="msg' . $message['id'] . '">
-					', $message['id'] != Utils::$context['first_message'] ? '
-					' . ($message['first_new'] ? '<a id="new"></a>' : '') : '', '
 					<div class="post_wrapper">';
 
 	// Show information about the poster of this message.

--- a/Themes/default/css/index.css
+++ b/Themes/default/css/index.css
@@ -3505,6 +3505,15 @@ img.avatar {
 	font-style: italic;
 	padding: 2px 4px 0 4px;
 }
+.bump_notice {
+	display: block;
+	margin-top: 1em;
+	padding: 0.5em 0;
+	border-top: 1px solid #ddd;
+	border-bottom: 1px solid #ddd;
+	text-align: center;
+	font-style: italic;
+}
 /* PMs postinfo */
 #personal_messages .keyinfo .postinfo {
 	flex-direction: column;


### PR DESCRIPTION
This one comes from a list of good ideas shared with me by @Arantor a while ago. Notice the nice little "_6 months later..._" message:

<img width="666" alt="Screenshot 2025-03-24 at 8 02 23 PM" src="https://github.com/user-attachments/assets/b76712d5-9439-4b70-befd-a0e9bf80c3c8" />

This message will be shown between posts only when the time elapsed between their post dates is greater than the "Time before topic is warned as old on reply" setting. 

The message doesn't state the exact amount of time that has passed. Instead, it rounds the value down to the nearest reasonable unit of time: 
- If more than a year has passed, the message says "X years later..."
- If more than a month has passed, the message says "X months later..."
- If more than 14 days have passed, the message says "X weeks later..."
- Otherwise, the message says "X days later..."

If the user has enabled the option to show the most recent posts first (i.e. reverse chronological order), then the message changes from "X years later..." to "X years earlier..."