### PR TITLE
[3.0] Removes letter links from member list

### DIFF
--- a/Sources/Actions/Memberlist.php
+++ b/Sources/Actions/Memberlist.php
@@ -294,30 +294,7 @@ class Memberlist implements ActionInterface, Routable
 			$_REQUEST['sort'] = 'real_name';
 		}
 
-		if (!is_numeric($_REQUEST['start'])) {
-			if (preg_match('~^[^\'\\\\/]~u', Utils::strtolower($_REQUEST['start']), $match) === 0) {
-				ErrorHandler::fatal('Are you a wannabe hacker?', false);
-			}
-
-			$_REQUEST['start'] = $match[0];
-
-			$request = Db::$db->query(
-				'substring',
-				'SELECT COUNT(*)
-				FROM {db_prefix}members
-				WHERE LOWER(SUBSTRING(real_name, 1, 1)) < {string:first_letter}
-					AND is_activated = {int:is_activated}',
-				[
-					'is_activated' => User::ACTIVATED,
-					'first_letter' => $_REQUEST['start'],
-				],
-			);
-			list($start) = Db::$db->fetch_row($request);
-			$start = (int) $start;
-			Db::$db->free_result($request);
-		} else {
-			$start = (int) $_REQUEST['start'];
-		}
+		$start = (int) $_REQUEST['start'];
 
 		Utils::$context['letter_links'] = '';
 
@@ -425,20 +402,6 @@ class Memberlist implements ActionInterface, Routable
 		);
 		$this->printRows($request);
 		Db::$db->free_result($request);
-
-		// Add anchors at the start of each letter.
-		if ($_REQUEST['sort'] == 'real_name') {
-			$last_letter = '';
-
-			foreach (Utils::$context['members'] as $i => $dummy) {
-				$this_letter = Utils::strtolower(Utils::entitySubstr(Utils::$context['members'][$i]['name'], 0, 1));
-
-				if ($this_letter != $last_letter && preg_match('~[a-z]~', $this_letter) === 1) {
-					Utils::$context['members'][$i]['sort_letter'] = Utils::htmlspecialchars($this_letter);
-					$last_letter = $this_letter;
-				}
-			}
-		}
 	}
 
 	/**

--- a/Themes/default/Memberlist.template.php
+++ b/Themes/default/Memberlist.template.php
@@ -28,12 +28,7 @@ function template_main()
 		</div>
 		<div class="cat_bar">
 			<h3 class="catbg">
-				<span class="floatleft">', Lang::$txt['members_list'], '</span>';
-
-	if (!isset(Utils::$context['old_search']))
-		echo '
-				<span class="floatright">', Utils::$context['letter_links'], '</span>';
-	echo '
+				<span class="floatleft">', Lang::$txt['members_list'], '</span>
 			</h3>
 		</div>';
 
@@ -74,7 +69,7 @@ function template_main()
 		foreach (Utils::$context['members'] as $member)
 		{
 			echo '
-					<tr class="windowbg"', empty($member['sort_letter']) ? '' : ' id="letter' . $member['sort_letter'] . '"', '>
+					<tr class="windowbg">
 						<td class="is_online centertext">
 							', Utils::$context['can_send_pm'] ? '<a href="' . $member['online']['href'] . '" title="' . $member['online']['text'] . '">' : '', Theme::$current->settings['use_image_buttons'] ? '<span class="' . ($member['online']['is_online'] == 1 ? 'on' : 'off') . '" title="' . $member['online']['text'] . '"></span>' : $member['online']['label'], Utils::$context['can_send_pm'] ? '</a>' : '', '
 						</td>


### PR DESCRIPTION
SMF is an international software package, but this feature on the member list assumed the English alphabet and doesn't play nicely with non-ASCII characters at all. Plus, this feature honestly isn't very useful anyway.