### PR TITLE
Fixes AJAX calls when index.php is hidden

### DIFF
--- a/Themes/default/scripts/script.js
+++ b/Themes/default/scripts/script.js
@@ -1429,6 +1429,11 @@ function smf_itemPos(itemHandle)
 // This function takes the script URL and prepares it to allow the query string to be appended to it.
 function smf_prepareScriptUrl(sUrl)
 {
+	// Ensure index.php is in the URL even when the option to hide it is enabled.
+	if (sUrl.indexOf('/index.php') == -1) {
+		sUrl = sUrl + '/index.php';
+	}
+
 	return sUrl.indexOf('?') == -1 ? sUrl + '?' : sUrl + (sUrl.charAt(sUrl.length - 1) == '?' || sUrl.charAt(sUrl.length - 1) == '&' || sUrl.charAt(sUrl.length - 1) == ';' ? '' : ';');
 }
 


### PR DESCRIPTION
I noticed that when friendly URLs are enabled _and_ the option to hide index.php is enabled, at least some of our AJAX calls would fail (for example, fetching message previews). According to my tests, it appears that something happening at the Apache level under those conditions was causing the POST data to be discarded before anything ever reached PHP.

The simplest and most reliable way to fix this is to simply make sure that `/index.php` is always included in the `smf_scripturl` JavaScript variable, so that's what this fix does.