### PR TITLE
[3.0] Address install loop

### DIFF
--- a/other/install.php
+++ b/other/install.php
@@ -1093,7 +1093,7 @@ function ForumSettings()
 			'packagesdir' => $path . '/Packages',
 			'languagesdir' => $path . '/Languages',
 			'mbname' => strtr($_POST['mbname'], ['\"' => '"']),
-			'language' => substr($_SESSION['installer_temp_lang'], 8, -4),
+			'language' => $_SESSION['installer_temp_lang'],
 			'image_proxy_secret' => bin2hex(random_bytes(10)),
 			'image_proxy_enabled' => !empty($_POST['force_ssl']),
 			'auth_secret' => bin2hex(random_bytes(32)),


### PR DESCRIPTION
Fixes #8559 

I think taking the substring here is a byproduct of ye olde bygone days...  

What it's doing today is taking substr('en_US', 8, -4), which is an empty string.  

Confirmed by testing that this gets rid of my loop issues.