### PR TITLE
Automatically fall back to en_US when Config::$language is invalid

### DIFF
--- a/Sources/Config.php
+++ b/Sources/Config.php
@@ -931,6 +931,15 @@ class Config
 			self::$languagesdir = self::$boarddir . '/Languages';
 		}
 
+		// Make absolutely sure the language is legitimate.
+		if (empty(self::$language) || !is_dir(self::$languagesdir . '/' . self::$language)) {
+			self::$language = self::$settings_defs['language']['default'];
+
+			if (!is_dir(self::$languagesdir . '/' . self::$language)) {
+				die('Language files not found.');
+			}
+		}
+
 		// Make absolutely sure the cache directory is defined and writable.
 		if (empty(self::$cachedir) || !is_dir(self::$cachedir) || !is_writable(self::$cachedir)) {
 			if (is_dir(self::$boarddir . '/cache') && is_writable(self::$boarddir . '/cache')) {


### PR DESCRIPTION
This is a follow-up to #8563. It should catch any situation where something tries to set Config::$language to an invalid value.