### PR TITLE
[3.0] Refactors how we manage permissions and member groups

### DIFF
--- a/Languages/en_US/ManageMembers.php
+++ b/Languages/en_US/ManageMembers.php
@@ -78,7 +78,7 @@ $txt['membergroups_members_deadmin_confirm'] = 'Are you sure you wish to remove 
 
 $txt['membergroups_postgroups'] = 'Post groups';
 $txt['membergroups_settings'] = 'Membergroup Settings';
-$txt['groups_manage_membergroups'] = 'Groups allowed to change membergroups';
+$txt['groups_manage_membergroups'] = 'Groups allowed to manage and assign membergroups';
 $txt['membergroups_select_permission_type'] = 'Select permission profile';
 $txt['membergroups_images_url'] = 'Themes/default/images/membericons/';
 $txt['membergroups_select_visible_boards'] = 'Show boards';

--- a/Sources/Actions/Admin/ACP.php
+++ b/Sources/Actions/Admin/ACP.php
@@ -1720,7 +1720,7 @@ class ACP implements ActionInterface, Routable
 	public static function emailAdmins(string $template, array $replacements = [], array $additional_recipients = []): void
 	{
 		// Load all members which are effectively admins.
-		$members = User::membersAllowedTo('admin_forum');
+		$members = User::getAllowedTo('admin_forum');
 
 		// Load their alert preferences
 		$prefs = Notify::getNotifyPrefs($members, 'announcements', true);

--- a/Sources/Actions/Admin/Boards.php
+++ b/Sources/Actions/Admin/Boards.php
@@ -28,6 +28,7 @@ use SMF\IntegrationHook;
 use SMF\Lang;
 use SMF\Menu;
 use SMF\Parser;
+use SMF\Permissions\PermissionProfile;
 use SMF\SecurityToken;
 use SMF\Theme;
 use SMF\Url;
@@ -434,7 +435,7 @@ class Boards implements ActionInterface
 		Category::getTree();
 
 		// For editing the profile we'll need this.
-		Permissions::loadPermissionProfiles();
+		PermissionProfile::loadContext();
 
 		// People with manage-boards are special.
 		$groups = User::groupsAllowedTo('manage_boards', null);

--- a/Sources/Actions/Admin/Boards.php
+++ b/Sources/Actions/Admin/Boards.php
@@ -438,8 +438,7 @@ class Boards implements ActionInterface
 		PermissionProfile::loadContext();
 
 		// People with manage-boards are special.
-		$groups = User::groupsAllowedTo('manage_boards', null);
-		Utils::$context['board_managers'] = $groups['allowed'];
+		Utils::$context['board_managers'] = Group::getAllowedTo('manage_boards');
 
 		// id_board must be a number....
 		$_REQUEST['boardid'] = isset($_REQUEST['boardid']) ? (int) $_REQUEST['boardid'] : 0;

--- a/Sources/Actions/Admin/Membergroups.php
+++ b/Sources/Actions/Admin/Membergroups.php
@@ -660,9 +660,7 @@ class Membergroups implements ActionInterface
 		}
 
 		// People who can manage boards are a bit special.
-		$board_managers = User::groupsAllowedTo('manage_boards', null);
-
-		Utils::$context['can_manage_boards'] = in_array($group->id, $board_managers['allowed']);
+		Utils::$context['can_manage_boards'] = in_array($group->id, Group::getAllowedTo('manage_boards'));
 
 		// Can this group moderate any boards?
 		Utils::$context['is_moderator_group'] = $group->is_moderator_group;

--- a/Sources/Actions/Admin/Membergroups.php
+++ b/Sources/Actions/Admin/Membergroups.php
@@ -339,151 +339,33 @@ class Membergroups implements ActionInterface
 
 			IntegrationHook::call('integrate_pre_add_membergroup', []);
 
-			$id_group = Db::$db->insert(
-				'',
-				'{db_prefix}membergroups',
-				[
-					'description' => 'string',
-					'group_name' => 'string-80',
-					'min_posts' => 'int',
-					'icons' => 'string',
-					'online_color' => 'string',
-					'group_type' => 'int',
-				],
-				[
-					[
-						'',
-						Utils::htmlspecialchars($_POST['group_name'], ENT_QUOTES),
-						($postCountBasedGroup ? (int) $_POST['min_posts'] : '-1'),
-						'1#icon.png',
-						'',
-						$_POST['group_type'],
-					],
-				],
-				['id_group'],
-				1,
-			);
+			$group = new Group(null, [
+				'name' => Utils::htmlspecialchars($_POST['group_name'], ENT_QUOTES),
+				'description' => '',
+				'online_color' => '',
+				'min_posts' => ($postCountBasedGroup ? (int) $_POST['min_posts'] : -1),
+				'raw_icons' => '1#icon.png',
+				'type' => $_POST['group_type'],
+			]);
 
-			IntegrationHook::call('integrate_add_membergroup', [$id_group, $postCountBasedGroup]);
-
-			// Update the post groups now, if this is a post group!
-			if (($_POST['min_posts'] ?? -1) != -1) {
-				Logging::updateStats('postgroups');
-			}
-
-			// You cannot set permissions for post groups if they are disabled.
-			if ($postCountBasedGroup && empty(Config::$modSettings['permission_enable_postgroups'])) {
-				$_POST['perm_type'] = '';
-			}
+			// The integrate_add_membergroup hook has been moved into Group::save()
+			$group->save();
 
 			if ($_POST['perm_type'] == 'predefined') {
-				// Set default permission level.
-				Permissions::setPermissionLevel($_POST['level'], $id_group, 'null');
+				try {
+					$level = constant(Permission::class . '::GROUP_LEVEL_' . strtoupper($_POST['level']));
+				} catch (\Throwable $e) {
+					ErrorHandler::fatalLang('no_access', false);
+				}
+
+				$group->setPermissionsByLevel($level);
 			}
 			// Copy or inherit the permissions!
 			elseif ($_POST['perm_type'] == 'copy' || $_POST['perm_type'] == 'inherit') {
-				$copy_id = $_POST['perm_type'] == 'copy' ? (int) $_POST['copyperm'] : (int) $_POST['inheritperm'];
-
-				@list($copy_from) = Group::load($copy_id);
-
-				if (!isset($copy_from)) {
-					ErrorHandler::fatalLang('membergroup_does_not_exist');
-				}
-
-				// Protected groups are... well, protected!
-				if (!User::$me->allowedTo('admin_forum') && $copy_from->type == Group::TYPE_PROTECTED) {
-					ErrorHandler::fatalLang('membergroup_does_not_exist');
-				}
-
-				// Don't allow copying of a real privileged person!
-				$illegal_permissions = Permission::getUnassignable();
-
-				$inserts = [];
-				$request = Db::$db->query(
-					'',
-					'SELECT permission, add_deny
-					FROM {db_prefix}permissions
-					WHERE id_group = {int:copy_from}',
-					[
-						'copy_from' => $copy_id,
-					],
+				$group->copyPermissionsFrom(
+					$_POST['perm_type'] == 'copy' ? (int) $_POST['copyperm'] : (int) $_POST['inheritperm'],
+					$_POST['perm_type'] == 'inherit',
 				);
-
-				while ($row = Db::$db->fetch_assoc($request)) {
-					if (empty($illegal_permissions) || !in_array($row['permission'], $illegal_permissions)) {
-						$inserts[] = [$id_group, $row['permission'], $row['add_deny']];
-					}
-				}
-				Db::$db->free_result($request);
-
-				if (!empty($inserts)) {
-					Db::$db->insert(
-						'insert',
-						'{db_prefix}permissions',
-						['id_group' => 'int', 'permission' => 'string', 'add_deny' => 'int'],
-						$inserts,
-						['id_group', 'permission'],
-					);
-				}
-
-				$inserts = [];
-				$request = Db::$db->query(
-					'',
-					'SELECT id_profile, permission, add_deny
-					FROM {db_prefix}board_permissions
-					WHERE id_group = {int:copy_from}',
-					[
-						'copy_from' => $copy_id,
-					],
-				);
-
-				while ($row = Db::$db->fetch_assoc($request)) {
-					$inserts[] = [$id_group, $row['id_profile'], $row['permission'], $row['add_deny']];
-				}
-				Db::$db->free_result($request);
-
-				if (!empty($inserts)) {
-					Db::$db->insert(
-						'insert',
-						'{db_prefix}board_permissions',
-						['id_group' => 'int', 'id_profile' => 'int', 'permission' => 'string', 'add_deny' => 'int'],
-						$inserts,
-						['id_group', 'id_profile', 'permission'],
-					);
-				}
-
-				// Also get some membergroup information if we're copying and not copying from guests...
-				if ($copy_id > 0 && $_POST['perm_type'] == 'copy') {
-					// ...and update the new membergroup with it.
-					Db::$db->query(
-						'',
-						'UPDATE {db_prefix}membergroups
-						SET
-							online_color = {string:online_color},
-							max_messages = {int:max_messages},
-							icons = {string:icons}
-						WHERE id_group = {int:current_group}',
-						[
-							'max_messages' => $copy_from->max_messages,
-							'current_group' => $id_group,
-							'online_color' => $copy_from->online_color,
-							'icons' => $copy_from->icons,
-						],
-					);
-				}
-				// If inheriting say so...
-				elseif ($_POST['perm_type'] == 'inherit') {
-					Db::$db->query(
-						'',
-						'UPDATE {db_prefix}membergroups
-						SET id_parent = {int:copy_from}
-						WHERE id_group = {int:current_group}',
-						[
-							'copy_from' => $copy_id,
-							'current_group' => $id_group,
-						],
-					);
-				}
 			}
 
 			// Make sure all boards selected are stored in a proper array.
@@ -508,8 +390,8 @@ class Membergroups implements ActionInterface
 						[
 							'board_list' => $changed_boards[$board_action],
 							'blank_string' => '',
-							'group_id_string' => (string) $id_group,
-							'comma_group' => ',' . $id_group,
+							'group_id_string' => (string) $group->id,
+							'comma_group' => ',' . $group->id,
 							'column' => $board_action == 'allow' ? 'member_groups' : 'deny_member_groups',
 						],
 					);
@@ -522,7 +404,7 @@ class Membergroups implements ActionInterface
 							AND deny = {int:deny}',
 						[
 							'board_list' => $changed_boards[$board_action],
-							'group_id' => $id_group,
+							'group_id' => $group->id,
 							'deny' => $board_action == 'allow' ? 0 : 1,
 						],
 					);
@@ -530,7 +412,7 @@ class Membergroups implements ActionInterface
 					$insert = [];
 
 					foreach ($changed_boards[$board_action] as $board_id) {
-						$insert[] = [$id_group, $board_id, $board_action == 'allow' ? 0 : 1];
+						$insert[] = [$group->id, $board_id, $board_action == 'allow' ? 0 : 1];
 					}
 
 					Db::$db->insert(
@@ -557,7 +439,7 @@ class Membergroups implements ActionInterface
 			Logging::logAction('add_group', ['group' => Utils::htmlspecialchars($_POST['group_name'])], 'admin');
 
 			// Go change some more settings.
-			Utils::redirectexit('action=admin;area=membergroups;sa=edit;group=' . $id_group);
+			Utils::redirectexit('action=admin;area=membergroups;sa=edit;group=' . $group->id);
 		}
 
 		// Just show the 'add membergroup' screen.

--- a/Sources/Actions/Admin/Membergroups.php
+++ b/Sources/Actions/Admin/Membergroups.php
@@ -27,6 +27,7 @@ use SMF\ItemList;
 use SMF\Lang;
 use SMF\Logging;
 use SMF\Menu;
+use SMF\Permissions\Permission;
 use SMF\SecurityToken;
 use SMF\Theme;
 use SMF\User;
@@ -395,7 +396,7 @@ class Membergroups implements ActionInterface
 				}
 
 				// Don't allow copying of a real privileged person!
-				$illegal_permissions = Permissions::loadIllegalPermissions();
+				$illegal_permissions = Permission::getUnassignable();
 
 				$inserts = [];
 				$request = Db::$db->query(

--- a/Sources/Actions/Admin/Permissions.php
+++ b/Sources/Actions/Admin/Permissions.php
@@ -28,6 +28,7 @@ use SMF\Group;
 use SMF\IntegrationHook;
 use SMF\Lang;
 use SMF\Menu;
+use SMF\Permissions\Permission;
 use SMF\SecurityToken;
 use SMF\Theme;
 use SMF\User;
@@ -45,16 +46,6 @@ class Permissions implements ActionInterface
 	/*****************
 	 * Class constants
 	 *****************/
-
-	public const GROUP_LEVEL_RESTRICT = 0;
-	public const GROUP_LEVEL_STANDARD = 1;
-	public const GROUP_LEVEL_MODERATOR = 2;
-	public const GROUP_LEVEL_MAINTENANCE = 3;
-
-	public const BOARD_LEVEL_STANDARD = 0;
-	public const BOARD_LEVEL_LOCKED = 1;
-	public const BOARD_LEVEL_PUBLISH = 2;
-	public const BOARD_LEVEL_FREE = 3;
 
 	public const PROFILE_DEFAULT = 1;
 	public const PROFILE_NO_POLLS = 2;
@@ -156,13 +147,6 @@ class Permissions implements ActionInterface
 		'post',
 	];
 
-	/**
-	 * @var array
-	 *
-	 * Convenience array listing hidden permissions.
-	 */
-	public static array $hidden;
-
 	/*********************
 	 * Internal properties
 	 *********************/
@@ -184,744 +168,12 @@ class Permissions implements ActionInterface
 		],
 	];
 
-	/****************************
-	 * Internal static properties
-	 ****************************/
-
-	/**
-	 * @var array
-	 *
-	 * List of all known permissions.
-	 * Protected to force access via getPermissions().
-	 *
-	 * Mods can add to this list using the integrate_permission_list hook.
-	 *
-	 * For each permission, the available keys and their meaning are as follows:
-	 *
-	 *  - generic_name: This is used to group own/any variants together. For
-	 *        permissions that don't have own/any variants, this is can be left
-	 *        unset. The default is the same as the permission name.
-	 *
-	 *  - own_any: Indicates whether this is the "own" or the "any" variant of
-	 *        the generic permission. Not applicable for permissions that don't
-	 *        have own/any variants.
-	 *
-	 *  - view_group: Name of the group to show the permission within on the
-	 *        profile profile editing page.
-	 *
-	 *  - scope: Either 'board' for permissions that apply at the board level,
-	 *        or 'global' for permissions that apply everywhere.
-	 *
-	 *  - group_level: Used by the predefined permission profiles to indicate
-	 *        the minimum group level that this permission should be granted at.
-	 *
-	 *  - board_level: Used by the predefined permission profiles to indicate
-	 *        the minimum board level that this permission should be granted at.
-	 *
-	 *  - hidden: If true, permission should not be shown in the UI.
-	 *
-	 *  - label: Indicates the Lang::$txt string to use as the generic label for
-	 *         this permission. Defaults to 'permissionname_' . generic_name.
-	 *
-	 *  - vsprintf: Arguments passed to Lang::formatText() at runtime to generate
-	 *        the finalized form of the label string.
-	 *
-	 *  - never_guests: If true, this permission can never be granted to guests.
-	 *
-	 *  - assignee_prerequisites: Permissions that someone must already have at
-	 *        least one of before they can be granted this permission.
-	 *
-	 *  - assigner_prerequisites: Permissions that someone must have at least
-	 *        one of before they can grant this permission to anyone.
-	 */
-	protected static array $permissions = [
-		'access_mod_center' => [
-			'view_group' => 'maintenance',
-			'scope' => 'global',
-			'group_level' => self::GROUP_LEVEL_MODERATOR,
-			'never_guests' => true,
-		],
-		'admin_forum' => [
-			'view_group' => 'maintenance',
-			'scope' => 'global',
-			'group_level' => self::GROUP_LEVEL_MAINTENANCE,
-			'never_guests' => true,
-			'assigner_prerequisites' => ['admin_forum'],
-		],
-		'announce_topic' => [
-			'view_group' => 'topic',
-			'scope' => 'board',
-			'never_guests' => true,
-		],
-		'approve_posts' => [
-			'view_group' => 'general_board',
-			'scope' => 'board',
-			'group_level' => self::GROUP_LEVEL_MODERATOR,
-			'board_level' => self::BOARD_LEVEL_FREE,
-			'never_guests' => true,
-		],
-		'bbc_cowsay' => [
-			'view_group' => 'bbc',
-			'scope' => 'global',
-			'hidden' => true,
-			'vsprintf' => ['permissionname_bbc', ['cowsay']],
-		],
-		'bbc_html' => [
-			'view_group' => 'bbc',
-			'scope' => 'global',
-			'group_level' => self::GROUP_LEVEL_MAINTENANCE,
-			'vsprintf' => ['permissionname_bbc', ['html']],
-			'never_guests' => true,
-			'assignee_prerequisites' => [
-				'admin_forum',
-				'manage_membergroups',
-				'manage_permissions',
-			],
-			'assigner_prerequisites' => ['admin_forum'],
-		],
-		'calendar_edit_own' => [
-			'generic_name' => 'calendar_edit',
-			'own_any' => 'own',
-			'view_group' => 'calendar',
-			'scope' => 'global',
-			'group_level' => self::GROUP_LEVEL_MODERATOR,
-			'never_guests' => true,
-		],
-		'calendar_edit_any' => [
-			'generic_name' => 'calendar_edit',
-			'own_any' => 'any',
-			'view_group' => 'calendar',
-			'scope' => 'global',
-			'group_level' => self::GROUP_LEVEL_MAINTENANCE,
-			'never_guests' => true,
-		],
-		'calendar_post' => [
-			'view_group' => 'calendar',
-			'scope' => 'global',
-			'group_level' => self::GROUP_LEVEL_MODERATOR,
-		],
-		'calendar_view' => [
-			'view_group' => 'calendar',
-			'scope' => 'global',
-			'group_level' => self::GROUP_LEVEL_RESTRICT,
-		],
-		'delete_own' => [
-			'generic_name' => 'delete',
-			'own_any' => 'own',
-			'view_group' => 'post',
-			'scope' => 'board',
-			'group_level' => self::GROUP_LEVEL_RESTRICT,
-			'board_level' => self::BOARD_LEVEL_PUBLISH,
-			'never_guests' => true,
-		],
-		'delete_any' => [
-			'generic_name' => 'delete',
-			'own_any' => 'any',
-			'view_group' => 'post',
-			'scope' => 'board',
-			'group_level' => self::GROUP_LEVEL_MODERATOR,
-			'board_level' => self::BOARD_LEVEL_FREE,
-			'never_guests' => true,
-		],
-		'delete_replies' => [
-			'view_group' => 'topic',
-			'scope' => 'board',
-			'board_level' => self::BOARD_LEVEL_PUBLISH,
-			'never_guests' => true,
-		],
-		'edit_news' => [
-			'view_group' => 'maintenance',
-			'scope' => 'global',
-			'group_level' => self::GROUP_LEVEL_MAINTENANCE,
-			'never_guests' => true,
-		],
-		'issue_warning' => [
-			'view_group' => 'member_admin',
-			'scope' => 'global',
-			'group_level' => self::GROUP_LEVEL_MODERATOR,
-			'never_guests' => true,
-		],
-		'likes_like' => [
-			'view_group' => 'likes',
-			'scope' => 'global',
-			'group_level' => self::GROUP_LEVEL_STANDARD,
-			'never_guests' => true,
-		],
-		'lock_own' => [
-			'generic_name' => 'lock',
-			'own_any' => 'own',
-			'view_group' => 'topic',
-			'scope' => 'board',
-			'group_level' => self::GROUP_LEVEL_STANDARD,
-			'board_level' => self::BOARD_LEVEL_PUBLISH,
-			'never_guests' => true,
-		],
-		'lock_any' => [
-			'generic_name' => 'lock',
-			'own_any' => 'any',
-			'view_group' => 'topic',
-			'scope' => 'board',
-			'group_level' => self::GROUP_LEVEL_MODERATOR,
-			'board_level' => self::BOARD_LEVEL_FREE,
-			'never_guests' => true,
-		],
-		'make_sticky' => [
-			'view_group' => 'topic',
-			'scope' => 'board',
-			'group_level' => self::GROUP_LEVEL_MODERATOR,
-			'board_level' => self::BOARD_LEVEL_FREE,
-			'never_guests' => true,
-		],
-		'manage_attachments' => [
-			'view_group' => 'maintenance',
-			'scope' => 'global',
-			'group_level' => self::GROUP_LEVEL_MAINTENANCE,
-			'never_guests' => true,
-		],
-		'manage_bans' => [
-			'view_group' => 'member_admin',
-			'scope' => 'global',
-			'group_level' => self::GROUP_LEVEL_MAINTENANCE,
-			'never_guests' => true,
-		],
-		'manage_boards' => [
-			'view_group' => 'maintenance',
-			'scope' => 'global',
-			'group_level' => self::GROUP_LEVEL_MAINTENANCE,
-			'never_guests' => true,
-		],
-		'manage_membergroups' => [
-			'view_group' => 'member_admin',
-			'scope' => 'global',
-			'group_level' => self::GROUP_LEVEL_MAINTENANCE,
-			'never_guests' => true,
-			'assigner_prerequisites' => ['manage_membergroups'],
-		],
-		'manage_permissions' => [
-			'view_group' => 'member_admin',
-			'scope' => 'global',
-			'group_level' => self::GROUP_LEVEL_MAINTENANCE,
-			'never_guests' => true,
-			'assigner_prerequisites' => ['manage_permissions'],
-		],
-		'manage_smileys' => [
-			'view_group' => 'maintenance',
-			'scope' => 'global',
-			'group_level' => self::GROUP_LEVEL_MAINTENANCE,
-			'never_guests' => true,
-		],
-		'mention' => [
-			'view_group' => 'mentions',
-			'scope' => 'global',
-			'group_level' => self::GROUP_LEVEL_STANDARD,
-		],
-		'merge_any' => [
-			'view_group' => 'topic',
-			'scope' => 'board',
-			'group_level' => self::GROUP_LEVEL_MODERATOR,
-			'board_level' => self::BOARD_LEVEL_FREE,
-			'never_guests' => true,
-		],
-		'moderate_board' => [
-			'view_group' => 'general_board',
-			'scope' => 'board',
-			'never_guests' => true,
-		],
-		'moderate_forum' => [
-			'view_group' => 'member_admin',
-			'scope' => 'global',
-			'group_level' => self::GROUP_LEVEL_MAINTENANCE,
-			'never_guests' => true,
-		],
-		'modify_own' => [
-			'generic_name' => 'modify',
-			'own_any' => 'own',
-			'view_group' => 'post',
-			'scope' => 'board',
-			'group_level' => self::GROUP_LEVEL_RESTRICT,
-			'board_level' => self::BOARD_LEVEL_PUBLISH,
-			'never_guests' => true,
-		],
-		'modify_any' => [
-			'generic_name' => 'modify',
-			'own_any' => 'any',
-			'view_group' => 'post',
-			'scope' => 'board',
-			'group_level' => self::GROUP_LEVEL_MODERATOR,
-			'board_level' => self::BOARD_LEVEL_FREE,
-			'never_guests' => true,
-		],
-		'modify_replies' => [
-			'view_group' => 'topic',
-			'scope' => 'board',
-			'board_level' => self::BOARD_LEVEL_PUBLISH,
-			'never_guests' => true,
-		],
-		'move_own' => [
-			'generic_name' => 'move',
-			'own_any' => 'own',
-			'view_group' => 'topic',
-			'scope' => 'board',
-			'never_guests' => true,
-		],
-		'move_any' => [
-			'generic_name' => 'move',
-			'own_any' => 'any',
-			'view_group' => 'topic',
-			'scope' => 'board',
-			'group_level' => self::GROUP_LEVEL_MODERATOR,
-			'never_guests' => true,
-		],
-		'pm_draft' => [
-			'view_group' => 'pm',
-			'scope' => 'global',
-			'never_guests' => true,
-		],
-		'pm_read' => [
-			'view_group' => 'pm',
-			'scope' => 'global',
-			'group_level' => self::GROUP_LEVEL_STANDARD,
-			'never_guests' => true,
-		],
-		'pm_send' => [
-			'view_group' => 'pm',
-			'scope' => 'global',
-			'group_level' => self::GROUP_LEVEL_STANDARD,
-			'never_guests' => true,
-		],
-		'poll_add_own' => [
-			'generic_name' => 'poll_add',
-			'own_any' => 'own',
-			'view_group' => 'poll',
-			'scope' => 'board',
-			'group_level' => self::GROUP_LEVEL_STANDARD,
-			'board_level' => self::BOARD_LEVEL_PUBLISH,
-			'never_guests' => true,
-		],
-		'poll_add_any' => [
-			'generic_name' => 'poll_add',
-			'own_any' => 'any',
-			'view_group' => 'poll',
-			'scope' => 'board',
-			'group_level' => self::GROUP_LEVEL_MODERATOR,
-			'board_level' => self::BOARD_LEVEL_FREE,
-			'never_guests' => true,
-		],
-		'poll_edit_own' => [
-			'generic_name' => 'poll_edit',
-			'own_any' => 'own',
-			'view_group' => 'poll',
-			'scope' => 'board',
-			'group_level' => self::GROUP_LEVEL_STANDARD,
-			'board_level' => self::BOARD_LEVEL_PUBLISH,
-			'never_guests' => true,
-		],
-		'poll_edit_any' => [
-			'generic_name' => 'poll_edit',
-			'own_any' => 'any',
-			'view_group' => 'poll',
-			'scope' => 'board',
-			'group_level' => self::GROUP_LEVEL_MODERATOR,
-			'board_level' => self::BOARD_LEVEL_FREE,
-			'never_guests' => true,
-		],
-		'poll_lock_own' => [
-			'generic_name' => 'poll_lock',
-			'own_any' => 'own',
-			'view_group' => 'poll',
-			'scope' => 'board',
-			'never_guests' => true,
-		],
-		'poll_lock_any' => [
-			'generic_name' => 'poll_lock',
-			'own_any' => 'any',
-			'view_group' => 'poll',
-			'scope' => 'board',
-			'group_level' => self::GROUP_LEVEL_MODERATOR,
-			'board_level' => self::BOARD_LEVEL_FREE,
-			'never_guests' => true,
-		],
-		'poll_post' => [
-			'view_group' => 'poll',
-			'scope' => 'board',
-			'group_level' => self::GROUP_LEVEL_STANDARD,
-			'board_level' => self::BOARD_LEVEL_PUBLISH,
-		],
-		'poll_remove_own' => [
-			'generic_name' => 'poll_remove',
-			'own_any' => 'own',
-			'view_group' => 'poll',
-			'scope' => 'board',
-			'board_level' => self::BOARD_LEVEL_PUBLISH,
-			'never_guests' => true,
-		],
-		'poll_remove_any' => [
-			'generic_name' => 'poll_remove',
-			'own_any' => 'any',
-			'view_group' => 'poll',
-			'scope' => 'board',
-			'group_level' => self::GROUP_LEVEL_MODERATOR,
-			'board_level' => self::BOARD_LEVEL_FREE,
-			'never_guests' => true,
-		],
-		'poll_view' => [
-			'view_group' => 'poll',
-			'scope' => 'board',
-			'group_level' => self::GROUP_LEVEL_RESTRICT,
-			'board_level' => self::BOARD_LEVEL_LOCKED,
-		],
-		'poll_vote' => [
-			'view_group' => 'poll',
-			'scope' => 'board',
-			'group_level' => self::GROUP_LEVEL_STANDARD,
-			'board_level' => self::BOARD_LEVEL_PUBLISH,
-		],
-		'post_attachment' => [
-			'view_group' => 'attachment',
-			'scope' => 'board',
-			'group_level' => self::GROUP_LEVEL_STANDARD,
-			'board_level' => self::BOARD_LEVEL_PUBLISH,
-		],
-		'post_draft' => [
-			'view_group' => 'topic',
-			'scope' => 'board',
-			'never_guests' => true,
-		],
-		'post_new' => [
-			'view_group' => 'topic',
-			'scope' => 'board',
-			'group_level' => self::GROUP_LEVEL_RESTRICT,
-			'board_level' => self::BOARD_LEVEL_PUBLISH,
-		],
-		'post_reply_own' => [
-			'generic_name' => 'post_reply',
-			'own_any' => 'own',
-			'view_group' => 'topic',
-			'scope' => 'board',
-			'group_level' => self::GROUP_LEVEL_RESTRICT,
-			'board_level' => self::BOARD_LEVEL_PUBLISH,
-		],
-		'post_reply_any' => [
-			'generic_name' => 'post_reply',
-			'own_any' => 'any',
-			'view_group' => 'topic',
-			'scope' => 'board',
-			'group_level' => self::GROUP_LEVEL_RESTRICT,
-			'board_level' => self::BOARD_LEVEL_PUBLISH,
-		],
-		'post_unapproved_attachments' => [
-			'view_group' => 'attachment',
-			'scope' => 'board',
-		],
-		'post_unapproved_replies_own' => [
-			'generic_name' => 'post_unapproved_replies',
-			'own_any' => 'own',
-			'view_group' => 'topic',
-			'scope' => 'board',
-		],
-		'post_unapproved_replies_any' => [
-			'generic_name' => 'post_unapproved_replies',
-			'own_any' => 'any',
-			'view_group' => 'topic',
-			'scope' => 'board',
-		],
-		'post_unapproved_topics' => [
-			'view_group' => 'topic',
-			'scope' => 'board',
-		],
-		'profile_blurb_own' => [
-			'generic_name' => 'profile_blurb',
-			'own_any' => 'own',
-			'view_group' => 'profile',
-			'scope' => 'global',
-			'never_guests' => true,
-		],
-		'profile_blurb_any' => [
-			'generic_name' => 'profile_blurb',
-			'own_any' => 'any',
-			'view_group' => 'profile',
-			'scope' => 'global',
-			'never_guests' => true,
-		],
-		'profile_displayed_name_own' => [
-			'generic_name' => 'profile_displayed_name',
-			'own_any' => 'own',
-			'view_group' => 'profile_account',
-			'scope' => 'global',
-			'never_guests' => true,
-		],
-		'profile_displayed_name_any' => [
-			'generic_name' => 'profile_displayed_name',
-			'own_any' => 'any',
-			'view_group' => 'profile_account',
-			'scope' => 'global',
-			'group_level' => self::GROUP_LEVEL_MAINTENANCE,
-			'never_guests' => true,
-		],
-		'profile_extra_own' => [
-			'generic_name' => 'profile_extra',
-			'own_any' => 'own',
-			'view_group' => 'profile',
-			'scope' => 'global',
-			'group_level' => self::GROUP_LEVEL_STANDARD,
-			'never_guests' => true,
-		],
-		'profile_extra_any' => [
-			'generic_name' => 'profile_extra',
-			'own_any' => 'any',
-			'view_group' => 'profile',
-			'scope' => 'global',
-			'group_level' => self::GROUP_LEVEL_MAINTENANCE,
-			'never_guests' => true,
-		],
-		'profile_forum_own' => [
-			'generic_name' => 'profile_forum',
-			'own_any' => 'own',
-			'view_group' => 'profile',
-			'scope' => 'global',
-			'group_level' => self::GROUP_LEVEL_STANDARD,
-			'never_guests' => true,
-		],
-		'profile_forum_any' => [
-			'generic_name' => 'profile_forum',
-			'own_any' => 'any',
-			'view_group' => 'profile',
-			'scope' => 'global',
-			'never_guests' => true,
-		],
-		'profile_gravatar' => [
-			'view_group' => 'profile',
-			'scope' => 'global',
-			'group_level' => self::GROUP_LEVEL_STANDARD,
-			'never_guests' => true,
-		],
-		'profile_identity_own' => [
-			'generic_name' => 'profile_identity',
-			'own_any' => 'own',
-			'view_group' => 'profile_account',
-			'scope' => 'global',
-			'group_level' => self::GROUP_LEVEL_RESTRICT,
-			'never_guests' => true,
-		],
-		'profile_identity_any' => [
-			'generic_name' => 'profile_identity',
-			'own_any' => 'any',
-			'view_group' => 'profile_account',
-			'scope' => 'global',
-			'group_level' => self::GROUP_LEVEL_MAINTENANCE,
-			'never_guests' => true,
-		],
-		'profile_password_own' => [
-			'generic_name' => 'profile_password',
-			'own_any' => 'own',
-			'view_group' => 'profile_account',
-			'scope' => 'global',
-			'group_level' => self::GROUP_LEVEL_STANDARD,
-			'never_guests' => true,
-		],
-		'profile_password_any' => [
-			'generic_name' => 'profile_password',
-			'own_any' => 'any',
-			'view_group' => 'profile_account',
-			'scope' => 'global',
-			'group_level' => self::GROUP_LEVEL_MAINTENANCE,
-			'never_guests' => true,
-		],
-		'profile_remote_avatar' => [
-			'view_group' => 'profile',
-			'scope' => 'global',
-			'group_level' => self::GROUP_LEVEL_STANDARD,
-			'never_guests' => true,
-		],
-		'profile_remove_own' => [
-			'generic_name' => 'profile_remove',
-			'own_any' => 'own',
-			'view_group' => 'profile_account',
-			'scope' => 'global',
-			'group_level' => self::GROUP_LEVEL_STANDARD,
-			'never_guests' => true,
-		],
-		'profile_remove_any' => [
-			'generic_name' => 'profile_remove',
-			'own_any' => 'any',
-			'view_group' => 'profile_account',
-			'scope' => 'global',
-			'never_guests' => true,
-		],
-		'profile_server_avatar' => [
-			'view_group' => 'profile',
-			'scope' => 'global',
-			'group_level' => self::GROUP_LEVEL_STANDARD,
-			'never_guests' => true,
-		],
-		'profile_signature_own' => [
-			'generic_name' => 'profile_signature',
-			'own_any' => 'own',
-			'view_group' => 'profile',
-			'scope' => 'global',
-			'group_level' => self::GROUP_LEVEL_STANDARD,
-			'never_guests' => true,
-		],
-		'profile_signature_any' => [
-			'generic_name' => 'profile_signature',
-			'own_any' => 'any',
-			'view_group' => 'profile',
-			'scope' => 'global',
-			'group_level' => self::GROUP_LEVEL_MAINTENANCE,
-			'never_guests' => true,
-		],
-		'profile_title_own' => [
-			'generic_name' => 'profile_title',
-			'own_any' => 'own',
-			'view_group' => 'profile',
-			'scope' => 'global',
-			'never_guests' => true,
-		],
-		'profile_title_any' => [
-			'generic_name' => 'profile_title',
-			'own_any' => 'any',
-			'view_group' => 'profile',
-			'scope' => 'global',
-			'group_level' => self::GROUP_LEVEL_MAINTENANCE,
-			'never_guests' => true,
-		],
-		'profile_upload_avatar' => [
-			'view_group' => 'profile',
-			'scope' => 'global',
-			'group_level' => self::GROUP_LEVEL_STANDARD,
-			'never_guests' => true,
-		],
-		'profile_view' => [
-			'view_group' => 'profile',
-			'scope' => 'global',
-			'group_level' => self::GROUP_LEVEL_STANDARD,
-		],
-		'profile_website_own' => [
-			'generic_name' => 'profile_website',
-			'own_any' => 'own',
-			'view_group' => 'profile',
-			'scope' => 'global',
-			'group_level' => self::GROUP_LEVEL_STANDARD,
-			'never_guests' => true,
-		],
-		'profile_website_any' => [
-			'generic_name' => 'profile_website',
-			'own_any' => 'any',
-			'view_group' => 'profile',
-			'scope' => 'global',
-			'group_level' => self::GROUP_LEVEL_MAINTENANCE,
-			'never_guests' => true,
-		],
-		'remove_own' => [
-			'generic_name' => 'remove',
-			'own_any' => 'own',
-			'view_group' => 'topic',
-			'scope' => 'board',
-			'group_level' => self::GROUP_LEVEL_STANDARD,
-			'board_level' => self::BOARD_LEVEL_PUBLISH,
-			'never_guests' => true,
-		],
-		'remove_any' => [
-			'generic_name' => 'remove',
-			'own_any' => 'any',
-			'view_group' => 'topic',
-			'scope' => 'board',
-			'group_level' => self::GROUP_LEVEL_MODERATOR,
-			'board_level' => self::BOARD_LEVEL_FREE,
-			'never_guests' => true,
-		],
-		'report_any' => [
-			'view_group' => 'post',
-			'scope' => 'board',
-			'group_level' => self::GROUP_LEVEL_RESTRICT,
-			'board_level' => self::BOARD_LEVEL_LOCKED,
-			'never_guests' => true,
-		],
-		'report_user' => [
-			'view_group' => 'profile',
-			'scope' => 'global',
-			'group_level' => self::GROUP_LEVEL_STANDARD,
-			'never_guests' => true,
-		],
-		'search_posts' => [
-			'view_group' => 'general',
-			'scope' => 'global',
-			'group_level' => self::GROUP_LEVEL_RESTRICT,
-		],
-		'send_mail' => [
-			'view_group' => 'member_admin',
-			'scope' => 'global',
-			'never_guests' => true,
-		],
-		'split_any' => [
-			'view_group' => 'topic',
-			'scope' => 'board',
-			'group_level' => self::GROUP_LEVEL_MODERATOR,
-			'board_level' => self::BOARD_LEVEL_FREE,
-			'never_guests' => true,
-		],
-		'view_attachments' => [
-			'view_group' => 'attachment',
-			'scope' => 'board',
-			'group_level' => self::GROUP_LEVEL_STANDARD,
-			'board_level' => self::BOARD_LEVEL_LOCKED,
-		],
-		'view_mlist' => [
-			'view_group' => 'general',
-			'scope' => 'global',
-			'group_level' => self::GROUP_LEVEL_STANDARD,
-		],
-		'view_stats' => [
-			'view_group' => 'general',
-			'scope' => 'global',
-			'group_level' => self::GROUP_LEVEL_RESTRICT,
-		],
-		'view_warning_own' => [
-			'generic_name' => 'view_warning',
-			'own_any' => 'own',
-			'view_group' => 'profile_account',
-			'scope' => 'global',
-		],
-		'view_warning_any' => [
-			'generic_name' => 'view_warning',
-			'own_any' => 'any',
-			'view_group' => 'profile_account',
-			'scope' => 'global',
-		],
-		'who_view' => [
-			'view_group' => 'general',
-			'scope' => 'global',
-			'group_level' => self::GROUP_LEVEL_RESTRICT,
-		],
-	];
-
-	/**
-	 * @var bool
-	 *
-	 * Whether self::$permissions has already be processed by getPermissions().
-	 */
-	protected static bool $processed = false;
-
-	/**
-	 * @var array
-	 *
-	 * Convenience array listing permissions that guests may never have.
-	 */
-	protected static array $never_guests = [];
-
 	/**
 	 * @var array
 	 *
 	 * Convenience array listing permissions that certain groups may not have.
 	 */
 	protected static array $excluded = [];
-
-	/**
-	 * @var array
-	 *
-	 * Convenience array listing permissions that the current user can't change.
-	 */
-	protected static array $illegal = [];
 
 	/****************
 	 * Public methods
@@ -987,7 +239,7 @@ class Permissions implements ActionInterface
 		Utils::$context['page_title'] = Lang::getTxt('permissions_title', file: 'ManagePermissions');
 
 		// Load all the permissions. We'll need them for the advanced options.
-		self::loadAllPermissions();
+		self::loadPermissionsContext();
 
 		// Also load profiles, we may want to reset.
 		self::loadPermissionProfiles();
@@ -1115,10 +367,6 @@ class Permissions implements ActionInterface
 		// Clear out any cached authority.
 		Config::updateModSettings(['settings_updated' => time()]);
 
-		self::loadIllegalPermissions();
-		self::loadIllegalGuestPermissions();
-		self::loadIllegalBBCHtmlGroups();
-
 		// Set a predefined permission profile.
 		if (!empty($_POST['predefined'])) {
 			$this->quickSetPredefined();
@@ -1190,8 +438,8 @@ class Permissions implements ActionInterface
 		}
 
 		$illegal_permissions = array_merge(
-			self::loadIllegalPermissions(),
-			$_GET['group'] == -1 ? self::loadIllegalGuestPermissions() : [],
+			Permission::getUnassignable(),
+			$_GET['group'] == -1 ? Permission::getNonGuestPermissions() : [],
 		);
 
 		$give_perms = [
@@ -1623,124 +871,6 @@ class Permissions implements ActionInterface
 	}
 
 	/**
-	 * Gets the list of all known permissions.
-	 *
-	 * This method contains the integrate_permissions_list hook, which is the
-	 * recommended way to add new permissions to SMF.
-	 *
-	 * @return array Finalized version of self::$permissions
-	 */
-	public static function getPermissions(): array
-	{
-		if (!empty(self::$processed)) {
-			return self::$permissions;
-		}
-
-		IntegrationHook::call('integrate_permissions_list', [&self::$permissions]);
-
-		// In case a mod screwed things up...
-		if (!in_array('html', Utils::$context['restricted_bbc'])) {
-			Utils::$context['restricted_bbc'][] = 'html';
-		}
-
-		// Add the permissions for the restricted BBCodes
-		foreach (Utils::$context['restricted_bbc'] as $bbc) {
-			if (isset(self::$permissions['bbc_' . $bbc])) {
-				continue;
-			}
-
-			self::$permissions['bbc_' . $bbc] = [
-				'has_own_any' => false,
-				'view_group' => 'bbc',
-				'scope' => 'global',
-				'vsprintf' => ['permissionname_bbc', [$bbc]],
-			];
-		}
-
-		// If the calendar is disabled, disable the related permissions.
-		if (empty(Config::$modSettings['cal_enabled'])) {
-			self::$permissions['calendar_view']['hidden'] = true;
-			self::$permissions['calendar_post']['hidden'] = true;
-			self::$permissions['calendar_edit_own']['hidden'] = true;
-			self::$permissions['calendar_edit_any']['hidden'] = true;
-		}
-
-		// If warnings are disabled, disable the related permissions.
-		if (Config::$modSettings['warning_settings'][0] == 0) {
-			self::$permissions['issue_warning']['hidden'] = true;
-			self::$permissions['view_warning_own']['hidden'] = true;
-			self::$permissions['view_warning_any']['hidden'] = true;
-		}
-
-		// If post moderation is disabled, disable the related permissions.
-		if (!Config::$modSettings['postmod_active']) {
-			self::$permissions['approve_posts']['hidden'] = true;
-			self::$permissions['post_unapproved_topics']['hidden'] = true;
-			self::$permissions['post_unapproved_replies_own']['hidden'] = true;
-			self::$permissions['post_unapproved_replies_any']['hidden'] = true;
-			self::$permissions['post_unapproved_attachments']['hidden'] = true;
-		}
-		// If post moderation is enabled, these are named differently...
-		else {
-			// Relabel the topics permissions
-			self::$permissions['post_new']['label'] = 'auto_approve_topics';
-
-			// Relabel the reply permissions
-			self::$permissions['post_reply_own']['label'] = 'auto_approve_replies';
-			self::$permissions['post_reply_any']['label'] = 'auto_approve_replies';
-
-			// Relabel the attachment permissions
-			self::$permissions['post_attachment']['label'] = 'auto_approve_attachments';
-		}
-
-		// If attachments are disabled, disable the related permissions.
-		if (empty(Config::$modSettings['attachmentEnable'])) {
-			self::$permissions['manage_attachments']['hidden'] = true;
-			self::$permissions['view_attachments']['hidden'] = true;
-			self::$permissions['post_unapproved_attachments']['hidden'] = true;
-			self::$permissions['post_attachment']['hidden'] = true;
-		}
-
-		// If likes are disabled, disable the related permission.
-		if (empty(Config::$modSettings['enable_likes'])) {
-			self::$permissions['likes_like']['hidden'] = true;
-		}
-
-		// If mentions are disabled, disable the related permission.
-		if (empty(Config::$modSettings['enable_mentions'])) {
-			self::$permissions['mention']['hidden'] = true;
-		}
-
-		// If Gravatars are disabled, disable the related permission.
-		if (empty(Config::$modSettings['gravatarEnabled'])) {
-			self::$permissions['profile_gravatar']['hidden'] = true;
-		}
-
-		// Finalize various values.
-		foreach (self::$permissions as $permission => &$perm_info) {
-			$perm_info['generic_name'] = $perm_info['generic_name'] ?? $permission;
-			$perm_info['hidden'] = !empty($perm_info['hidden']);
-			$perm_info['never_guests'] = !empty($perm_info['never_guests']);
-			$perm_info['assignee_prerequisites'] = $perm_info['assignee_prerequisites'] ?? [];
-			$perm_info['assigner_prerequisites'] = $perm_info['assigner_prerequisites'] ?? [];
-
-			$perm_info['label'] = $perm_info['label'] ?? 'permissionname_' . $perm_info['generic_name'];
-
-			// Do we need to dynamically generate the label string?
-			if (!empty($perm_info['vsprintf'])) {
-				Lang::setTxt(
-					$perm_info['label'],
-					Lang::txtExists($perm_info['vsprintf'][0], file: 'ManagePermissions')
-					? Lang::getTxt($perm_info['vsprintf'][0], $perm_info['vsprintf'][1], file: 'ManagePermissions')
-					: Lang::formatText($perm_info['vsprintf'][0], $perm_info['vsprintf'][1]),
-				);
-			}
-		}
-
-		return self::$permissions;
-	}
-
-	/**
 	 * Set the permission level for a specific profile, group, or group for a profile.
 	 *
 	 * @param string $level The level ('restrict', 'standard', etc.)
@@ -1749,10 +879,6 @@ class Permissions implements ActionInterface
 	 */
 	public static function setPermissionLevel(string $level, int $group, string|int $profile = 'null'): void
 	{
-		self::loadIllegalPermissions();
-		self::loadIllegalGuestPermissions();
-		self::loadIllegalBBCHtmlGroups();
-
 		// Levels by group... restrict, standard, moderator, maintenance.
 		$group_levels = [
 			'board' => ['inherit' => []],
@@ -1761,43 +887,43 @@ class Permissions implements ActionInterface
 		// Levels by board... standard, publish, free.
 		$board_levels = ['inherit' => []];
 
-		foreach (self::getPermissions() as $permission => $perm_info) {
-			if (isset($perm_info['group_level'])) {
-				switch ($perm_info['group_level']) {
-					case self::GROUP_LEVEL_RESTRICT:
-						$group_levels[$perm_info['scope']]['restrict'][] = $permission;
+		foreach (Permission::getAll() as $perm) {
+			if (isset($perm->group_level)) {
+				switch ($perm->group_level) {
+					case Permission::GROUP_LEVEL_RESTRICT:
+						$group_levels[$perm->scope]['restrict'][] = $perm->name;
 						// no break
 
-					case self::GROUP_LEVEL_STANDARD:
-						$group_levels[$perm_info['scope']]['standard'][] = $permission;
+					case Permission::GROUP_LEVEL_STANDARD:
+						$group_levels[$perm->scope]['standard'][] = $perm->name;
 						// no break
 
-					case self::GROUP_LEVEL_MODERATOR:
-						$group_levels[$perm_info['scope']]['moderator'][] = $permission;
+					case Permission::GROUP_LEVEL_MODERATOR:
+						$group_levels[$perm->scope]['moderator'][] = $perm->name;
 						// no break
 
-					case self::GROUP_LEVEL_MAINTENANCE:
-						$group_levels[$perm_info['scope']]['maintenance'][] = $permission;
+					case Permission::GROUP_LEVEL_MAINTENANCE:
+						$group_levels[$perm->scope]['maintenance'][] = $perm->name;
 						break;
 				}
 			}
 
-			if (isset($perm_info['board_level'])) {
-				switch ($perm_info['board_level']) {
-					case self::BOARD_LEVEL_STANDARD:
-						$board_levels['standard'][] = $permission;
+			if (isset($perm->board_level)) {
+				switch ($perm->board_level) {
+					case Permission::BOARD_LEVEL_STANDARD:
+						$board_levels['standard'][] = $perm->name;
 						// no break
 
-					case self::BOARD_LEVEL_LOCKED:
-						$board_levels['locked'][] = $permission;
+					case Permission::BOARD_LEVEL_LOCKED:
+						$board_levels['locked'][] = $perm->name;
 						// no break
 
-					case self::BOARD_LEVEL_PUBLISH:
-						$board_levels['publish'][] = $permission;
+					case Permission::BOARD_LEVEL_PUBLISH:
+						$board_levels['publish'][] = $perm->name;
 						// no break
 
-					case self::BOARD_LEVEL_FREE:
-						$board_levels['free'][] = $permission;
+					case Permission::BOARD_LEVEL_FREE:
+						$board_levels['free'][] = $perm->name;
 						break;
 				}
 			}
@@ -1808,11 +934,10 @@ class Permissions implements ActionInterface
 		// Make sure we're not granting someone too many permissions!
 		foreach (['global', 'board'] as $scope) {
 			foreach ($group_levels[$scope][$level] as $k => $permission) {
-				if (in_array($permission, self::$illegal ?? [])) {
-					unset($group_levels[$scope][$level][$k]);
-				}
-
-				if (in_array($group, self::$excluded[$permission] ?? [])) {
+				if (
+					!Permission::get($permission)->canAssign()
+					|| !Permission::get($permission)->canBeGrantedTo($group)
+				) {
 					unset($group_levels[$scope][$level][$k]);
 				}
 			}
@@ -1833,10 +958,10 @@ class Permissions implements ActionInterface
 				'',
 				'DELETE FROM {db_prefix}permissions
 				WHERE id_group = {int:current_group}
-				' . (empty(self::$illegal) ? '' : ' AND permission NOT IN ({array_string:illegal_permissions})'),
+				' . (empty(Permission::getUnassignable()) ? '' : ' AND permission NOT IN ({array_string:illegal_permissions})'),
 				[
 					'current_group' => $group,
-					'illegal_permissions' => !empty(self::$illegal) ? self::$illegal : [],
+					'illegal_permissions' => Permission::getUnassignable(),
 				],
 			);
 			Db::$db->query(
@@ -1984,7 +1109,7 @@ class Permissions implements ActionInterface
 		}
 
 		// Make sure Config::$modSettings['board_manager_groups'] is up to date.
-		if (!in_array('manage_boards', self::$illegal)) {
+		if (Permission::get('manage_boards')->canAssign()) {
 			self::updateBoardManagers();
 		}
 	}
@@ -2053,47 +1178,22 @@ class Permissions implements ActionInterface
 			}
 		}
 
-		// Make sure we honor the "illegal guest permissions"
-		self::loadIllegalGuestPermissions();
-
-		// Only special people can have this permission
-		if (in_array('bbc_html', $permissions)) {
-			self::loadIllegalBBCHtmlGroups();
-		}
-
-		// Are any of these permissions that guests can't have?
-		$non_guest_perms = array_intersect(str_replace(['_any', '_own'], '', $permissions), self::$never_guests);
-
-		foreach ($non_guest_perms as $permission) {
-			if (!isset(self::$excluded[$permission]) || !in_array(-1, self::$excluded[$permission])) {
-				self::$excluded[$permission][] = -1;
-			}
-		}
-
-		// Any explicitly excluded groups for this call?
-		if (!empty($excluded_groups)) {
-			// Make sure this is an array of integers
-			$excluded_groups = array_filter(
-				(array) $excluded_groups,
-				function ($v) {
-					return is_int($v) || is_string($v) && (string) intval($v) === $v;
-				},
-			);
-
-			foreach ($permissions as $permission) {
-				self::$excluded[$permission] = array_unique(array_merge(self::$excluded[$permission], $excluded_groups));
-			}
-		}
+		// Make sure this is an array of integers.
+		// Can't blindly cast to int because we don't want invalid ones to become 0.
+		$excluded_groups = array_map('intval', array_filter(
+			(array) $excluded_groups,
+			fn($v) => is_int($v) || is_string($v) && intval($v) == $v,
+		));
 
 		// Some permissions cannot be given to certain groups. Remove the groups.
 		foreach ($permissions as $permission) {
-			if (!isset(self::$excluded[$permission])) {
-				continue;
-			}
-
-			foreach (self::$excluded[$permission] as $group_id) {
-				if (isset(Utils::$context[$permission][$group_id])) {
-					unset(Utils::$context[$permission][$group_id]);
+			foreach ($groups as $group) {
+				if (
+					in_array($group->id, $excluded_groups)
+					|| !Permission::get($permission)->canAssign()
+					|| !Permission::get($permission)->canBeGrantedTo($group->id)
+				) {
+					unset(Utils::$context[$permission][$group->id]);
 				}
 			}
 
@@ -2138,13 +1238,6 @@ class Permissions implements ActionInterface
 		User::$me->checkSession();
 		SecurityToken::validate('admin-mp');
 
-		// Check they can't do certain things.
-		self::loadIllegalPermissions();
-
-		if (in_array('bbc_html', $permissions)) {
-			self::loadIllegalBBCHtmlGroups();
-		}
-
 		$insert_rows = [];
 
 		foreach ($permissions as $permission) {
@@ -2157,7 +1250,11 @@ class Permissions implements ActionInterface
 					continue;
 				}
 
-				if (in_array($value, ['on', 'deny']) && (empty(self::$illegal) || !in_array($permission, self::$illegal))) {
+				if (
+					in_array($value, ['on', 'deny'])
+					&& Permission::get($permission)->canAssign()
+					&& ($value === 'on' ? Permission::get($permission)->canBeGrantedTo((int) $id_group) : true)
+				) {
 					$insert_rows[] = [(int) $id_group, $permission, $value == 'on' ? 1 : 0];
 				}
 			}
@@ -2168,9 +1265,9 @@ class Permissions implements ActionInterface
 			'',
 			'DELETE FROM {db_prefix}permissions
 			WHERE permission IN ({array_string:permissions})
-				' . (empty(self::$illegal) ? '' : ' AND permission NOT IN ({array_string:illegal_permissions})'),
+				' . (empty(Permission::getUnassignable()) ? '' : ' AND permission NOT IN ({array_string:illegal_permissions})'),
 			[
-				'illegal_permissions' => !empty(self::$illegal) ? self::$illegal : [],
+				'illegal_permissions' => Permission::getUnassignable(),
 				'permissions' => $permissions,
 			],
 		);
@@ -2190,7 +1287,7 @@ class Permissions implements ActionInterface
 		self::updateChildPermissions([], -1);
 
 		// Make sure Config::$modSettings['board_manager_groups'] is up to date.
-		if (!in_array('manage_boards', self::$illegal)) {
+		if (Permission::get('manage_boards')->canAssign()) {
 			self::updateBoardManagers();
 		}
 
@@ -2355,48 +1452,6 @@ class Permissions implements ActionInterface
 		return true;
 	}
 
-	/**
-	 * Loads a list of permissions that the current user cannot grant.
-	 *
-	 * @return array Permissions that the current user cannot grant.
-	 */
-	public static function loadIllegalPermissions(): array
-	{
-		foreach (self::getPermissions() as $permission => $perm_info) {
-			if (!empty($perm_info['assigner_prerequisites']) && !User::$me->allowedTo($perm_info['assigner_prerequisites'])) {
-				self::$illegal[] = $permission;
-				self::$illegal[] = $perm_info['generic_name'];
-			}
-		}
-
-		self::$illegal = array_unique(self::$illegal);
-
-		// Call the deprecated integrate_load_illegal_permissions hook.
-		self::integrateLoadIllegalPermissions();
-
-		return self::$illegal;
-	}
-
-	/**
-	 * Populates self::$hidden with a list of hidden permissions.
-	 */
-	public static function buildHidden(): void
-	{
-		if (isset(self::$hidden)) {
-			return;
-		}
-
-		foreach (self::getPermissions() as $permission => $perm_info) {
-			if (!empty($perm_info['hidden'])) {
-				self::$hidden[] = $permission;
-			}
-		}
-
-		// Backward compatibility.
-		Utils::$context['hidden_permissions'] = self::$hidden;
-	}
-
-
 	/******************
 	 * Internal methods
 	 ******************/
@@ -2527,15 +1582,14 @@ class Permissions implements ActionInterface
 			foreach ($_POST['group'] as $group_id) {
 				foreach ($target_perm as $perm => $add_deny) {
 					// No dodgy permissions please!
-					if (in_array($perm, self::$illegal)) {
+					if (
+						!Permission::get($perm)->canAssign()
+						|| !Permission::get($perm)->canBeGrantedTo($group_id)
+					) {
 						continue;
 					}
 
-					if (in_array($group_id, self::$excluded[$perm] ?? [])) {
-						continue;
-					}
-
-					if ($group_id != 1 && $group_id != 3) {
+					if ($group_id != Group::ADMIN && $group_id != Group::MOD) {
 						$inserts[] = [$perm, $group_id, $add_deny];
 					}
 				}
@@ -2546,10 +1600,10 @@ class Permissions implements ActionInterface
 				'',
 				'DELETE FROM {db_prefix}permissions
 				WHERE id_group IN ({array_int:group_list})
-					' . (empty(self::$illegal) ? '' : ' AND permission NOT IN ({array_string:illegal_permissions})'),
+					' . (empty(Permission::getUnassignable()) ? '' : ' AND permission NOT IN ({array_string:illegal_permissions})'),
 				[
 					'group_list' => $_POST['group'],
-					'illegal_permissions' => self::$illegal,
+					'illegal_permissions' => Permission::getUnassignable(),
 				],
 			);
 
@@ -2591,7 +1645,7 @@ class Permissions implements ActionInterface
 		foreach ($_POST['group'] as $group_id) {
 			foreach ($target_perm as $perm => $add_deny) {
 				// Are these for guests?
-				if ($group_id == -1 && in_array($perm, self::$never_guests)) {
+				if ($group_id == -1 && in_array($perm, Permission::getNonGuestPermissions())) {
 					continue;
 				}
 
@@ -2651,18 +1705,16 @@ class Permissions implements ActionInterface
 					'DELETE FROM {db_prefix}permissions
 					WHERE id_group IN ({array_int:current_group_list})
 						AND permission = {string:current_permission}
-						' . (empty(self::$illegal) ? '' : ' AND permission NOT IN ({array_string:illegal_permissions})'),
+						' . (empty(Permission::getUnassignable()) ? '' : ' AND permission NOT IN ({array_string:illegal_permissions})'),
 					[
 						'current_group_list' => $_POST['group'],
 						'current_permission' => $permission,
-						'illegal_permissions' => self::$illegal,
+						'illegal_permissions' => Permission::getUnassignable(),
 					],
 				);
 
-				// Did these changes make anyone lose eligibility for the bbc_html permission?
-				$bbc_html_groups = array_diff($_POST['group'], self::$excluded['bbc_html']);
-
-				if (!empty($bbc_html_groups)) {
+				// Check whether anyone lost their eligibility for the bbc_html permission.
+				if (array_intersect($_POST['group'], Permission::get('bbc_html')->eligibleGroups()) !== []) {
 					self::removeIllegalBBCHtmlPermission(true);
 				}
 			} else {
@@ -2686,11 +1738,11 @@ class Permissions implements ActionInterface
 			$perm_change = [];
 
 			foreach ($_POST['group'] as $groupID) {
-				if (isset(self::$excluded[$permission]) && in_array($groupID, self::$excluded[$permission])) {
+				if (!Permission::get($permission)->canBeGrantedTo($groupID)) {
 					continue;
 				}
 
-				if ($scope == 'global' && $groupID != 1 && $groupID != 3 && !in_array($permission, self::$illegal)) {
+				if ($scope == 'global' && $groupID != Group::ADMIN && $groupID != Group::MOD && Permission::get($permission)->canAssign()) {
 					$perm_change[] = [$permission, $groupID, $add_deny];
 				} elseif ($scope != 'global') {
 					$perm_change[] = [$permission, $groupID, $pid, $add_deny];
@@ -2872,7 +1924,7 @@ class Permissions implements ActionInterface
 	 */
 	protected function setOnOff(): void
 	{
-		self::loadAllPermissions();
+		self::loadPermissionsContext();
 		Utils::$context['hidden_perms'] = [];
 
 		// Loop through each permission and set whether it's on, off, or denied.
@@ -3204,19 +2256,10 @@ class Permissions implements ActionInterface
 	/**
 	 * Load permissions into Utils::$context['permissions'].
 	 */
-	protected static function loadAllPermissions(): void
+	protected static function loadPermissionsContext(): void
 	{
-		// We need to know what permissions we can't give to guests.
-		self::loadIllegalGuestPermissions();
-
-		// We also need to know which groups can't be given the bbc_html permission.
-		self::loadIllegalBBCHtmlGroups();
-
 		// Call the deprecated integrate_load_permissions hook.
 		self::integrateLoadPermissions();
-
-		// Figure out which permissions should be hidden.
-		self::buildHidden();
 
 		Utils::$context['permissions'] = [];
 
@@ -3246,37 +2289,40 @@ class Permissions implements ActionInterface
 			}
 		}
 
-		foreach (self::getPermissions() as $permission => $perm_info) {
+		foreach (Permission::getAll() as $permission) {
 			// If this permission shouldn't be given to certain groups (e.g. guests), don't.
-			foreach ([$permission, $perm_info['generic_name']] as $perm) {
-				if (isset(Utils::$context['group']['id']) && in_array(Utils::$context['group']['id'], self::$excluded[$perm] ?? [])) {
-					continue 2;
-				}
+			if (isset(Utils::$context['group']['id']) && !$permission->canBeGrantedTo(Utils::$context['group']['id'])) {
+				continue;
 			}
 
 			// What column should this be located in?
-			$position = (int) (!in_array($perm_info['view_group'], self::$left_permission_groups));
+			$position = (int) (!in_array($permission->view_group, self::$left_permission_groups));
 
 			// For legibility reasons...
-			$view_group_perms = &Utils::$context['permissions'][$perm_info['scope']]['columns'][$position][$perm_info['view_group']]['permissions'];
+			$view_group_perms = &Utils::$context['permissions'][$permission->scope]['columns'][$position][$permission->view_group]['permissions'];
 
-			if (!isset($view_group_perms[$perm_info['generic_name']])) {
-				$view_group_perms[$perm_info['generic_name']] = [
-					'id' => $perm_info['generic_name'],
-					'name' => Lang::getTxt($perm_info['label'], file: 'ManagePermissions+ManageMembers'),
-					'show_help' => Lang::txtExists('permissionhelp_' . $perm_info['generic_name'], file: 'ManagePermissions'),
-					'note' => Lang::txtExists('permissionnote_' . $perm_info['generic_name'], file: 'ManagePermissions') ? Lang::getTxt('permissionnote_' . $perm_info['generic_name'], file: 'ManagePermissions') : '',
-					'hidden' => !empty($perm_info['hidden']),
+			if (!isset($view_group_perms[$permission->generic_name])) {
+				$view_group_perms[$permission->generic_name] = [
+					'id' => $permission->generic_name,
+					'name' => Lang::getTxt($permission->label, file: 'ManagePermissions+ManageMembers'),
+					'show_help' => Lang::txtExists('permissionhelp_' . $permission->generic_name, file: 'ManagePermissions'),
+					'note' => Lang::txtExists('permissionnote_' . $permission->generic_name, file: 'ManagePermissions') ? Lang::getTxt('permissionnote_' . $permission->generic_name, file: 'ManagePermissions') : '',
+					'hidden' => !empty($permission->hidden),
 				];
 			}
 
-			$view_group_perms[$perm_info['generic_name']]['has_own_any'] = isset($perm_info['own_any']);
+			$view_group_perms[$permission->generic_name]['has_own_any'] = isset($permission->own_any);
 
-			if (isset($perm_info['own_any'])) {
-				$view_group_perms[$perm_info['generic_name']][$perm_info['own_any']] = [
+			if (isset($permission->own_any)) {
+				$view_group_perms[$permission->generic_name][$permission->own_any] = [
 					'id' => $permission,
-					'name' => Lang::getTxt('permissionname_' . $permission, file: 'ManagePermissions'),
+					'name' => Lang::getTxt('permissionname_' . $permission->name, file: 'ManagePermissions'),
 				];
+			}
+
+			// For backward compatibility purposes only.
+			if ($permission->hidden) {
+				Utils::$context['hidden_permissions'][] = $permission->name;
 			}
 		}
 
@@ -3305,79 +2351,6 @@ class Permissions implements ActionInterface
 	}
 
 	/**
-	 * Loads the permissions that cannot be given to guests.
-	 *
-	 * Stores the permissions in self::$never_guests.
-	 * Also populates self::$excluded with the info.
-	 *
-	 * @return array A copy of self::$never_guests.
-	 */
-	protected static function loadIllegalGuestPermissions(): array
-	{
-		// Find the permissions that guests may never have.
-		foreach (self::getPermissions() as $permission => $perm_info) {
-			if (!empty($perm_info['never_guests'])) {
-				self::$never_guests[] = $permission;
-
-				if (isset($perm_info['generic_name'])) {
-					self::$never_guests[] = $perm_info['generic_name'];
-				}
-			}
-		}
-
-		self::$never_guests = array_unique(self::$never_guests);
-
-		// Call the deprecated integrate_load_illegal_guest_permissions hook.
-		self::integrateLoadIllegalGuestPermissions();
-
-		// Also add this info to self::$excluded to make life easier for everyone
-		foreach (self::$never_guests as $permission) {
-			if (empty(self::$excluded[$permission]) || !in_array($permission, self::$excluded[$permission])) {
-				self::$excluded[$permission][] = -1;
-			}
-		}
-
-		return self::$never_guests;
-	}
-
-	/**
-	 * Loads a list of membergroups who cannot be granted the bbc_html permission.
-	 * Stores the groups in self::$excluded['bbc_html'].
-	 *
-	 * @return array A copy of self::$excluded['bbc_html'].
-	 */
-	protected static function loadIllegalBBCHtmlGroups(): array
-	{
-		self::$excluded['bbc_html'] = [-1, 0];
-
-		$request = Db::$db->query(
-			'',
-			'SELECT id_group
-			FROM {db_prefix}membergroups
-			WHERE id_group != {int:admin} AND id_group NOT IN (
-				SELECT DISTINCT id_group
-				FROM {db_prefix}permissions
-				WHERE permission IN ({array_string:permissions})
-					AND add_deny = {int:add}
-			)',
-			[
-				'permissions' => self::$permissions['bbc_html']['assignee_prerequisites'],
-				'add' => 1,
-				'admin' => Group::ADMIN,
-			],
-		);
-
-		while ($row = Db::$db->fetch_assoc($request)) {
-			self::$excluded['bbc_html'][] = $row['id_group'];
-		}
-		Db::$db->free_result($request);
-
-		self::$excluded['bbc_html'] = array_unique(self::$excluded['bbc_html']);
-
-		return self::$excluded['bbc_html'];
-	}
-
-	/**
 	 * Removes the bbc_html permission from anyone who shouldn't have it.
 	 *
 	 * @param bool $reload Before acting, refresh the list of membergroups who
@@ -3385,18 +2358,14 @@ class Permissions implements ActionInterface
 	 */
 	protected static function removeIllegalBBCHtmlPermission(bool $reload = false): void
 	{
-		if (empty(self::$excluded['bbc_html']) || $reload) {
-			self::loadIllegalBBCHtmlGroups();
-		}
-
 		Db::$db->query(
 			'',
 			'DELETE FROM {db_prefix}permissions
-			WHERE id_group IN ({array_int:current_group_list})
+			WHERE id_group IN ({array_int:ineligible_groups})
 				AND permission = {string:current_permission}
 				AND add_deny = {int:add}',
 			[
-				'current_group_list' => self::$excluded['bbc_html'],
+				'ineligible_groups' => Permission::ineligibleGroups('bbc_html', true),
 				'current_permission' => 'bbc_html',
 				'add' => 1,
 			],
@@ -3417,7 +2386,8 @@ class Permissions implements ActionInterface
 	/**
 	 * Calls the deprecated integrate_load_permissions hook.
 	 *
-	 * MOD AUTHORS: Please update your code to use integrate_permissions_list.
+	 * MOD AUTHORS: Please update your code to use integrate_permissions_list,
+	 * which can be found in SMF\Permissions\Permission::getAll()
 	 *
 	 * @deprecated 3.0
 	 */
@@ -3435,14 +2405,14 @@ class Permissions implements ActionInterface
 		$hidden_permissions = [];
 		$relabel_permissions = [];
 
-		foreach (self::getPermissions() as $permission => $perm_info) {
-			$permissions_by_scope[$perm_info['scope']][$perm_info['generic_name']] = [
-				!empty($perm_info['own_any']),
-				$perm_info['view_group'],
+		foreach (Permission::getAll() as $perm) {
+			$permissions_by_scope[$perm->scope][$perm->generic_name] = [
+				!empty($perm->own_any),
+				$perm->view_group,
 			];
 
-			if (!empty($perm_info['hidden'])) {
-				$hidden_permissions[] = $perm_info['generic_name'];
+			if (!empty($perm->hidden)) {
+				$hidden_permissions[] = $perm->generic_name;
 			}
 		}
 
@@ -3454,30 +2424,34 @@ class Permissions implements ActionInterface
 
 		// If the hook made changes, sync them back to our master list.
 		foreach ($permissions_by_scope as $scope => $permissions) {
-			foreach ($permissions as $permission => $perm_info) {
+			foreach ($permissions as $generic_name => $perm_info) {
 				$is_new = true;
 
 				foreach (['', '_own', '_any'] as $suffix) {
-					if (isset(self::$permissions[$permission . $suffix])) {
-						$is_new = false;
-
-						self::$permissions[$permission . $suffix]['view_group'] = $perm_info[1];
+					try {
+						$permission = Permission::get($generic_name . $suffix);
+					} catch (\Throwable $e) {
+						continue;
 					}
+
+					$is_new = false;
+					$permission->view_group = $perm_info[1];
+					unset($permission);
 				}
 
 				if ($is_new) {
-					$new_ids = $perm_info[0] ? [$permission . '_own', $permission . '_any'] : [$permission];
+					$new_ids = $perm_info[0] ? [$generic_name . '_own', $generic_name . '_any'] : [$generic_name];
 
 					foreach ($new_ids as $id) {
-						self::$permissions[$id] = [
-							'generic_name' => $permission,
+						(new Permission($id, [
+							'generic_name' => $generic_name,
 							'own_any' => $perm_info[0] ? substr($id, -3) : null,
 							'view_group' => $perm_info[1],
 							'scope' => $scope === 'board' ? 'board' : 'global',
-							'hidden' => in_array($permission, $hidden_permissions),
-							'label' => 'permissionname_' . $permission,
-							'never_guests' => in_array($permission, self::$never_guests),
-						];
+							'hidden' => in_array($generic_name, $hidden_permissions),
+							'label' => 'permissionname_' . $generic_name,
+							'never_guests' => in_array($generic_name, Permission::getNonGuestPermissions()),
+						]))->addToKnownPermissions();
 					}
 				}
 			}
@@ -3485,105 +2459,29 @@ class Permissions implements ActionInterface
 
 		foreach ($hidden_permissions as $permission) {
 			foreach (['', '_own', '_any'] as $suffix) {
-				if (isset(self::$permissions[$permission . $suffix])) {
-					self::$permissions[$permission . $suffix]['hidden'] = true;
+				try {
+					$permission = Permission::get($permission . $suffix);
+				} catch (\Throwable $e) {
+					continue;
 				}
+
+				$permission->hidden = true;
+				unset($permission);
 			}
 		}
 
 		foreach ($relabel_permissions as $permission => $label) {
 			foreach (['', '_own', '_any'] as $suffix) {
-				if (isset(self::$permissions[$permission . $suffix])) {
-					self::$permissions[$permission . $suffix]['label'] = $label;
+				try {
+					$permission = Permission::get($permission . $suffix);
+				} catch (\Throwable $e) {
+					continue;
 				}
+
+				$permission->label = $label;
+				unset($permission);
 			}
 		}
-	}
-
-	/**
-	 * Calls the deprecated integrate_load_illegal_permissions hook.
-	 *
-	 * MOD AUTHORS: Please update your code to use integrate_permissions_list.
-	 *
-	 * @deprecated 3.0
-	 */
-	protected static function integrateLoadIllegalPermissions(): void
-	{
-		// Don't bother if nothing is using this hook.
-		if (empty(Config::$backward_compatibility) || empty(Config::$modSettings['integrate_load_illegal_permissions'])) {
-			return;
-		}
-
-		// This context variable exists only for the sake of the hook.
-		Utils::$context['illegal_permissions'] = &self::$illegal;
-
-		// Track whether the hook makes any changes.
-		$temp = Utils::jsonEncode(self::$illegal);
-
-		// Give mods access to this list.
-		IntegrationHook::call('integrate_load_illegal_permissions');
-
-		// If the hook added anything, sync that back to our master list.
-		// Because this hook can't tell us what the prerequisites are, we assume
-		// that the permission can only be granted by admins.
-		if ($temp != Utils::jsonEncode(self::$illegal)) {
-			foreach (self::$illegal as $permission) {
-				foreach (['', '_own', '_any'] as $suffix) {
-					if (isset(self::$permissions[$permission . $suffix]) && !isset(self::$permissions[$permission . $suffix]['assigner_prerequisites'])) {
-						self::$permissions[$permission . $suffix]['assigner_prerequisites'] = ['admin_forum'];
-					}
-				}
-			}
-		}
-
-		// We don't need this anymore.
-		unset(Utils::$context['illegal_permissions']);
-	}
-
-	/**
-	 * Calls the deprecated integrate_load_illegal_guest_permissions hook.
-	 *
-	 * MOD AUTHORS: Please update your code to use integrate_permissions_list.
-	 *
-	 * @deprecated 3.0
-	 */
-	protected static function integrateLoadIllegalGuestPermissions(): void
-	{
-		// Don't bother if nothing is using this hook.
-		if (empty(Config::$backward_compatibility) || empty(Config::$modSettings['integrate_load_illegal_guest_permissions'])) {
-			return;
-		}
-
-		// This context variable exists only for the sake of the hook.
-		Utils::$context['non_guest_permissions'] = &self::$never_guests;
-
-		// Track whether the hook makes any changes.
-		$temp = Utils::jsonEncode(self::$never_guests);
-
-		// Give mods access to this list.
-		IntegrationHook::call('integrate_load_illegal_guest_permissions');
-
-		// If the hook changed anything, sync that back to our master list.
-		if ($temp != Utils::jsonEncode(self::$never_guests)) {
-			// Did the hook add a permission to self::$never_guests?
-			foreach (self::$never_guests as $permission) {
-				foreach (['', '_own', '_any'] as $suffix) {
-					if (isset(self::$permissions[$permission . $suffix])) {
-						self::$permissions[$permission . $suffix]['never_guests'] = true;
-					}
-				}
-			}
-
-			// Did the hook remove a permission from self::$never_guests?
-			foreach (self::$permissions as $permission => $perm_info) {
-				if (!in_array($perm_info['generic_name'], self::$never_guests)) {
-					self::$permissions[$permission]['never_guests'] = false;
-				}
-			}
-		}
-
-		// We don't need this anymore.
-		unset(Utils::$context['non_guest_permissions']);
 	}
 }
 

--- a/Sources/Actions/Admin/Permissions.php
+++ b/Sources/Actions/Admin/Permissions.php
@@ -1785,19 +1785,19 @@ class Permissions implements ActionInterface
 			if (isset($perm_info['board_level'])) {
 				switch ($perm_info['board_level']) {
 					case self::BOARD_LEVEL_STANDARD:
-						$group_levels[$perm_info['scope']]['standard'][] = $permission;
+						$board_levels['standard'][] = $permission;
 						// no break
 
 					case self::BOARD_LEVEL_LOCKED:
-						$group_levels[$perm_info['scope']]['locked'][] = $permission;
+						$board_levels['locked'][] = $permission;
 						// no break
 
 					case self::BOARD_LEVEL_PUBLISH:
-						$group_levels[$perm_info['scope']]['publish'][] = $permission;
+						$board_levels['publish'][] = $permission;
 						// no break
 
 					case self::BOARD_LEVEL_FREE:
-						$group_levels[$perm_info['scope']]['free'][] = $permission;
+						$board_levels['free'][] = $permission;
 						break;
 				}
 			}

--- a/Sources/Actions/Admin/Permissions.php
+++ b/Sources/Actions/Admin/Permissions.php
@@ -1149,6 +1149,14 @@ class Permissions implements ActionInterface
 		Config::updateModSettings(['settings_updated' => time()]);
 	}
 
+	/**
+	 * Makes sure Config::$modSettings['board_manager_groups'] is up to date.
+	 */
+	public static function updateBoardManagers(): void
+	{
+		Config::updateModSettings(['board_manager_groups' => implode(',', Group::getAllowedTo('manage_boards'))], true);
+	}
+
 	/******************
 	 * Internal methods
 	 ******************/
@@ -1237,12 +1245,10 @@ class Permissions implements ActionInterface
 			Utils::redirectexit('action=admin;area=permissions;pid=' . $_REQUEST['pid']);
 		}
 
-		foreach ($_POST['group'] as $group_id) {
-			if (!empty($_REQUEST['pid'])) {
-				self::setPermissionLevel($_POST['predefined'], $group_id, $_REQUEST['pid']);
-			} else {
-				self::setPermissionLevel($_POST['predefined'], $group_id);
-			}
+		$level = constant(Permission::class . '::GROUP_LEVEL_' . strtoupper($_POST['predefined']));
+
+		foreach (Group::load(array_map('intval', $_POST['group'])) as $group) {
+			$group->setPermissionsByLevel($level, (int) ($_REQUEST['pid'] ?? PermissionProfile::DEFAULT));
 		}
 	}
 
@@ -1693,14 +1699,6 @@ class Permissions implements ActionInterface
 				}
 			}
 		}
-	}
-
-	/**
-	 * Makes sure Config::$modSettings['board_manager_groups'] is up to date.
-	 */
-	protected static function updateBoardManagers(): void
-	{
-		Config::updateModSettings(['board_manager_groups' => implode(',', Group::getAllowedTo('manage_boards'))], true);
 	}
 
 	/**

--- a/Sources/Actions/Admin/Permissions.php
+++ b/Sources/Actions/Admin/Permissions.php
@@ -28,6 +28,7 @@ use SMF\Group;
 use SMF\IntegrationHook;
 use SMF\Lang;
 use SMF\Menu;
+use SMF\Permissions\GroupPermissionSet;
 use SMF\Permissions\Permission;
 use SMF\Permissions\PermissionProfile;
 use SMF\SecurityToken;
@@ -427,7 +428,7 @@ class Permissions implements ActionInterface
 			ErrorHandler::fatalLang('cannot_edit_permissions_inherited');
 		}
 
-		$permission_profile = PermissionProfile::load($_GET['pid']);
+		$permission_profile = PermissionProfile::load($_GET['pid'] === 0 ? PermissionProfile::DEFAULT : $_GET['pid']);
 
 		// Permission profile needs to be valid.
 		if (!($permission_profile instanceof PermissionProfile)) {
@@ -439,65 +440,46 @@ class Permissions implements ActionInterface
 			ErrorHandler::fatalLang('no_access', false);
 		}
 
-		$illegal_permissions = array_merge(
-			Permission::getUnassignable(),
-			$_GET['group'] == -1 ? Permission::getNonGuestPermissions() : [],
-		);
+		// Update the permissions.
+		if (is_array($_POST['perm'] ?? null)) {
+			// Load the relevant permission set.
+			$set = current(GroupPermissionSet::load($permission_profile->id, $_GET['group']));
 
-		$give_perms = [
-			'global' => [],
-			'board' => [],
-		];
+			// Update the permission set.
+			foreach ($set->permissions as $name => $old_value) {
+				$permission = Permission::get($name);
 
-		// Prepare all permissions that were set or denied for addition to the DB.
-		if (isset($_POST['perm']) && is_array($_POST['perm'])) {
-			foreach ($_POST['perm'] as $scope => $perm_array) {
-				if (!is_array($perm_array)) {
+				// Only change global permissions when $_GET['pid'] is 0.
+				if ($permission->scope === 'global' && $_GET['pid'] !== 0) {
 					continue;
 				}
 
-				foreach ($perm_array as $permission => $value) {
-					if ($value != 'on' && $value != 'deny') {
-						continue;
-					}
+				switch ($_POST['perm'][$permission->scope][$name] ?? null) {
+					case 'on':
+						$set->permissions[$name] = 1;
+						break;
 
-					// Don't allow people to escalate themselves!
-					if (in_array($permission, $illegal_permissions)) {
-						continue;
-					}
+					case 'deny':
+						$set->permissions[$name] = 0;
+						break;
 
-					$give_perms[$scope][] = [
-						$_GET['group'],
-						$permission,
-						(int) ($value == 'on'),
-					];
+					default:
+						$set->permissions[$name] = null;
+						break;
 				}
 			}
+
+			// Save the permission set.
+			$set->save();
 		}
-
-		// Insert the general permissions.
-		if ($_GET['group'] != Group::MOD && empty($_GET['pid'])) {
-			$this->updateGlobalPermissions($_GET['group'], $give_perms, $illegal_permissions);
-		}
-
-		// Insert the board permissions.
-		$this->updateBoardPermissions($_GET['group'], $give_perms, $illegal_permissions, $_GET['pid']);
-
-		// Update any inherited permissions as required.
-		self::updateChildPermissions($_GET['group'], $_GET['pid']);
-
-		// Ensure that no one has bbc_html permission who shouldn't.
-		self::removeIllegalBBCHtmlPermission();
 
 		// Ensure Config::$modSettings['board_manager_groups'] is up to date.
-		if (!in_array('manage_boards', $illegal_permissions)) {
-			self::updateBoardManagers();
-		}
+		self::updateBoardManagers();
 
 		// Clear cached permissions.
 		Config::updateModSettings(['settings_updated' => time()]);
 
-		Utils::redirectexit('action=admin;area=permissions;pid=' . $_GET['pid']);
+		Utils::redirectexit('action=admin;area=permissions' . (!empty($_GET['pid']) ? ';pid=' . $_GET['pid'] : ''));
 	}
 
 	/**
@@ -714,20 +696,19 @@ class Permissions implements ActionInterface
 			$group->getChildren();
 
 			// Add some custom properties.
-			$group->new_topic = 'disallow';
-			$group->replies_own = 'disallow';
-			$group->replies_any = 'disallow';
-			$group->attachment = 'disallow';
+			foreach ($this->postmod_maps as $permission_group => $data) {
+				$group->{$permission_group} = 'disallow';
+			}
 
 			Utils::$context['profile_groups'][$group->id] = $group;
 		}
 
-		// What are the permissions we are querying?
-		$all_permissions = [];
-
-		foreach ($this->postmod_maps as $perm_set) {
-			$all_permissions = array_merge($all_permissions, $perm_set);
-		}
+		// Load all the permission sets.
+		$sets = GroupPermissionSet::load(
+			Utils::$context['current_profile'],
+			array_keys(Utils::$context['profile_groups']),
+			true,
+		);
 
 		// If we're saving the changes then do just that - save them.
 		if (
@@ -754,87 +735,51 @@ class Permissions implements ActionInterface
 				}
 			} elseif (Config::$modSettings['postmod_active']) {
 				// We're not saving a new setting - and if it's still enabled we have more work to do.
+				foreach ($sets as $set) {
+					foreach ($this->postmod_maps as $permission_group => $data) {
+						if (!isset($_POST[$permission_group][$set->group])) {
+							continue;
+						}
 
-				// Start by deleting all the permissions relevant.
-				Db::$db->query(
-					'',
-					'DELETE FROM {db_prefix}board_permissions
-					WHERE id_profile = {int:current_profile}
-						AND permission IN ({array_string:permissions})
-						AND id_group IN ({array_int:profile_group_list})',
-					[
-						'profile_group_list' => array_keys(Utils::$context['profile_groups']),
-						'current_profile' => Utils::$context['current_profile'],
-						'permissions' => $all_permissions,
-					],
-				);
+						foreach ($set->permissions as $permission_name => $value) {
+							if (!in_array($permission_name, $data)) {
+								continue;
+							}
 
-				// Do it group by group.
-				$new_permissions = [];
-
-				foreach (Utils::$context['profile_groups'] as $id => $group) {
-					foreach ($this->postmod_maps as $index => $data) {
-						if (isset($_POST[$index][$group->id])) {
-							if ($_POST[$index][$group->id] == 'allow') {
-								// Give them both sets for fun.
-								$new_permissions[] = [Utils::$context['current_profile'], $group->id, $data[0], 1];
-
-								$new_permissions[] = [Utils::$context['current_profile'], $group->id, $data[1], 1];
-							} elseif ($_POST[$index][$group->id] == 'moderate') {
-								$new_permissions[] = [Utils::$context['current_profile'], $group->id, $data[1], 1];
+							if (
+								$_POST[$permission_group][$set->group] == 'allow'
+								|| (
+									$_POST[$permission_group][$set->group] == 'moderate'
+									&& $permission_name === $data[1]
+								)
+							) {
+								$set->permissions[$permission_name] = 1;
 							}
 						}
 					}
-				}
 
-				// Insert new permissions.
-				if (!empty($new_permissions)) {
-					Db::$db->insert(
-						'',
-						'{db_prefix}board_permissions',
-						['id_profile' => 'int', 'id_group' => 'int', 'permission' => 'string', 'add_deny' => 'int'],
-						$new_permissions,
-						['id_profile', 'id_group', 'permission'],
-					);
+					$set->save();
 				}
 			}
 		}
 
-		// Now get all the permissions!
-		$request = Db::$db->query(
-			'',
-			'SELECT id_group, permission, add_deny
-			FROM {db_prefix}board_permissions
-			WHERE id_profile = {int:current_profile}
-				AND permission IN ({array_string:permissions})
-				AND id_group IN ({array_int:profile_group_list})',
-			[
-				'profile_group_list' => array_keys(Utils::$context['profile_groups']),
-				'current_profile' => Utils::$context['current_profile'],
-				'permissions' => $all_permissions,
-			],
-		);
-
-		while ($row = Db::$db->fetch_assoc($request)) {
-			foreach ($this->postmod_maps as $key => $data) {
-				foreach ($data as $index => $perm) {
-					if ($perm == $row['permission']) {
-						// Only bother if it's not denied.
-						if ($row['add_deny']) {
-							// Full allowance?
-							if ($index == 0) {
-								Utils::$context['profile_groups'][$row['id_group']][$key] = 'allow';
-							}
-							// Otherwise only bother with moderate if not on allow.
-							elseif (Utils::$context['profile_groups'][$row['id_group']][$key] != 'allow') {
-								Utils::$context['profile_groups'][$row['id_group']][$key] = 'moderate';
-							}
+		// Add the status for each permission to our context array.
+		foreach ($sets as $set) {
+			foreach ($this->postmod_maps as $permission_group => $data) {
+				foreach ($data as $key => $permission_name) {
+					if (!empty($set->permissions[$permission_name])) {
+						// Full allowance?
+						if ($key == 0) {
+							Utils::$context['profile_groups'][$set->group][$permission_group] = 'allow';
+						}
+						// Otherwise only bother with moderate if not on allow.
+						elseif (Utils::$context['profile_groups'][$set->group][$permission_group] != 'allow') {
+							Utils::$context['profile_groups'][$set->group][$permission_group] = 'moderate';
 						}
 					}
 				}
 			}
 		}
-		Db::$db->free_result($request);
 
 		SecurityToken::create('admin-mppm');
 	}
@@ -945,62 +890,25 @@ class Permissions implements ActionInterface
 
 		// Setting group permissions.
 		if ($profile === 'null' && $group !== 'null') {
-			$group = (int) $group;
-
 			if (empty($group_levels['global'][$level])) {
 				return;
 			}
 
-			Db::$db->query(
-				'',
-				'DELETE FROM {db_prefix}permissions
-				WHERE id_group = {int:current_group}
-				' . (empty(Permission::getUnassignable()) ? '' : ' AND permission NOT IN ({array_string:illegal_permissions})'),
-				[
-					'current_group' => $group,
-					'illegal_permissions' => Permission::getUnassignable(),
-				],
-			);
-			Db::$db->query(
-				'',
-				'DELETE FROM {db_prefix}board_permissions
-				WHERE id_group = {int:current_group}
-					AND id_profile = {int:default_profile}',
-				[
-					'current_group' => $group,
-					'default_profile' => 1,
-				],
-			);
+			$set = current(GroupPermissionSet::load(PermissionProfile::DEFAULT, (int) $group));
 
-			$group_inserts = [];
+			foreach ($set->permissions as $permission_name => $value) {
+				// Make sure we're not granting someone too many permissions!
+				if (
+					!Permission::get($permission_name)->canAssign()
+					|| !Permission::get($permission_name)->canBeGrantedTo($set->group)
+				) {
+					continue;
+				}
 
-			foreach ($group_levels['global'][$level] as $permission) {
-				$group_inserts[] = [$group, $permission];
+				$set->permissions[$permission_name] = in_array($permission_name, $group_levels['global'][$level]) || in_array($permission_name, $group_levels['board'][$level]) ? 1 : null;
 			}
 
-			Db::$db->insert(
-				'insert',
-				'{db_prefix}permissions',
-				['id_group' => 'int', 'permission' => 'string'],
-				$group_inserts,
-				['id_group'],
-			);
-
-			$board_inserts = [];
-
-			foreach ($group_levels['board'][$level] as $permission) {
-				$board_inserts[] = [1, $group, $permission];
-			}
-
-			Db::$db->insert(
-				'insert',
-				'{db_prefix}board_permissions',
-				['id_profile' => 'int', 'id_group' => 'int', 'permission' => 'string'],
-				$board_inserts,
-				['id_profile', 'id_group'],
-			);
-
-			self::removeIllegalBBCHtmlPermission();
+			$set->save();
 		}
 		// Setting profile permissions for a specific group.
 		elseif (
@@ -1009,37 +917,21 @@ class Permissions implements ActionInterface
 			&& PermissionProfile::load((int) $profile) !== null
 			&& PermissionProfile::load((int) $profile)->canModify()
 		) {
-			$group = (int) $group;
-			$profile = (int) $profile;
+			$set = current(GroupPermissionSet::load((int) $profile, (int) $group));
 
-			if (!empty($group_levels['global'][$level])) {
-				Db::$db->query(
-					'',
-					'DELETE FROM {db_prefix}board_permissions
-					WHERE id_group = {int:current_group}
-						AND id_profile = {int:current_profile}',
-					[
-						'current_group' => $group,
-						'current_profile' => $profile,
-					],
-				);
-			}
-
-			if (!empty($group_levels['board'][$level])) {
-				$board_inserts = [];
-
-				foreach ($group_levels['board'][$level] as $permission) {
-					$board_inserts[] = [$profile, $group, $permission];
+			foreach ($set->permissions as $permission_name => $value) {
+				// Make sure we're not granting someone too many permissions!
+				if (
+					!Permission::get($permission_name)->canAssign()
+					|| !Permission::get($permission_name)->canBeGrantedTo($set->group)
+				) {
+					continue;
 				}
 
-				Db::$db->insert(
-					'insert',
-					'{db_prefix}board_permissions',
-					['id_profile' => 'int', 'id_group' => 'int', 'permission' => 'string'],
-					$board_inserts,
-					['id_profile', 'id_group'],
-				);
+				$set->permissions[$permission_name] = in_array($permission_name, $group_levels['board'][$level]) ? 1 : null;
 			}
+
+			$set->save();
 		}
 		// Setting profile permissions for all groups.
 		elseif (
@@ -1048,67 +940,26 @@ class Permissions implements ActionInterface
 			&& PermissionProfile::load((int) $profile) !== null
 			&& PermissionProfile::load((int) $profile)->canModify()
 		) {
-			$profile = (int) $profile;
-
-			Db::$db->query(
-				'',
-				'DELETE FROM {db_prefix}board_permissions
-				WHERE id_profile = {int:current_profile}',
-				[
-					'current_profile' => $profile,
-				],
+			$groups = array_filter(
+				Group::getAll(),
+				fn($group) => $group === Group::REGULAR || $group > Group::MOD,
 			);
 
-			if (empty($board_levels[$level])) {
-				return;
-			}
+			foreach (GroupPermissionSet::load((int) $profile, $groups) as $set) {
+				foreach ($set->permissions as $permission_name => $value) {
+					// Make sure we're not granting someone too many permissions!
+					if (
+						!Permission::get($permission_name)->canAssign()
+						|| !Permission::get($permission_name)->canBeGrantedTo($set->group)
+					) {
+						continue;
+					}
 
-			// Get all the groups...
-			$request = Db::$db->query(
-				'',
-				'SELECT id_group
-				FROM {db_prefix}membergroups
-				WHERE id_group > {int:moderator_group}
-				ORDER BY min_posts, CASE WHEN id_group < {int:newbie_group} THEN id_group ELSE {int:newbie_group} END, group_name',
-				[
-					'moderator_group' => Group::MOD,
-					'newbie_group' => Group::NEWBIE,
-				],
-			);
-
-			while ($row = Db::$db->fetch_row($request)) {
-				$group = $row[0];
-
-				$board_inserts = [];
-
-				foreach ($board_levels[$level] as $permission) {
-					$board_inserts[] = [$profile, $group, $permission];
+					$set->permissions[$permission_name] = in_array($permission_name, $board_levels[$level] ?? []) ? 1 : null;
 				}
 
-				Db::$db->insert(
-					'insert',
-					'{db_prefix}board_permissions',
-					['id_profile' => 'int', 'id_group' => 'int', 'permission' => 'string'],
-					$board_inserts,
-					['id_profile', 'id_group'],
-				);
+				$set->save();
 			}
-			Db::$db->free_result($request);
-
-			// Add permissions for ungrouped members.
-			$board_inserts = [];
-
-			foreach ($board_levels[$level] as $permission) {
-				$board_inserts[] = [$profile, 0, $permission];
-			}
-
-			Db::$db->insert(
-				'insert',
-				'{db_prefix}board_permissions',
-				['id_profile' => 'int', 'id_group' => 'int', 'permission' => 'string'],
-				$board_inserts,
-				['id_profile', 'id_group'],
-			);
 		}
 		// $profile and $group are both null!
 		else {
@@ -1148,6 +999,19 @@ class Permissions implements ActionInterface
 			return;
 		}
 
+		// Make sure this is an array of integers.
+		// Can't blindly cast to int because we don't want invalid ones to become 0.
+		$excluded_groups = array_unique(array_merge(
+			[Group::ADMIN, Group::MOD],
+			array_map(
+				'intval',
+				array_filter(
+					(array) $excluded_groups,
+					fn($v) => is_int($v) || is_string($v) && intval($v) == $v,
+				),
+			),
+		));
+
 		$query_customizations = [
 			'where' => [
 				'mg.id_group NOT IN ({array_int:excluded_groups})',
@@ -1172,39 +1036,34 @@ class Permissions implements ActionInterface
 			Group::load([], $query_customizations),
 		);
 
-		Group::loadPermissionsBatch(array_map(fn($group) => $group->id, $groups), 0);
+		foreach (
+			GroupPermissionSet::load(
+				PermissionProfile::DEFAULT,
+				array_map(fn($group) => $group->id, $groups),
+			) as $set
+		) {
+			$group = Group::$loaded[$set->group];
 
-		foreach ($permissions as $permission) {
-			foreach ($groups as $group) {
+			foreach ($permissions as $permission) {
+				if (
+					Permission::get($permission)->scope !== 'global'
+					|| !Permission::get($permission)->canAssign()
+					|| !Permission::get($permission)->canBeGrantedTo($group->id)
+				) {
+					continue;
+				}
+
 				Utils::$context[$permission][$group->id] = [
 					'id' => $group->id,
 					'name' => $group->name,
 					'is_postgroup' => $group->min_posts > -1,
-					'status' => !isset($group->permissions['general'][$permission]) ? 'off' : ($group->permissions['general'][$permission] === 1 ? 'on' : 'deny'),
+					'status' => !isset($set->permissions[$permission]) ? 'off' : ($set->permissions[$permission] === 1 ? 'on' : 'deny'),
 				];
 			}
 		}
 
-		// Make sure this is an array of integers.
-		// Can't blindly cast to int because we don't want invalid ones to become 0.
-		$excluded_groups = array_map('intval', array_filter(
-			(array) $excluded_groups,
-			fn($v) => is_int($v) || is_string($v) && intval($v) == $v,
-		));
-
-		// Some permissions cannot be given to certain groups. Remove the groups.
+		// There's no point showing a form with nobody in it.
 		foreach ($permissions as $permission) {
-			foreach ($groups as $group) {
-				if (
-					in_array($group->id, $excluded_groups)
-					|| !Permission::get($permission)->canAssign()
-					|| !Permission::get($permission)->canBeGrantedTo($group->id)
-				) {
-					unset(Utils::$context[$permission][$group->id]);
-				}
-			}
-
-			// There's no point showing a form with nobody in it
 			if (empty(Utils::$context[$permission])) {
 				unset(Utils::$context['config_vars'][$permission], Utils::$context[$permission]);
 			}
@@ -1245,53 +1104,42 @@ class Permissions implements ActionInterface
 		User::$me->checkSession();
 		SecurityToken::validate('admin-mp');
 
-		$insert_rows = [];
+		$groups = [];
 
-		foreach ($permissions as $permission) {
-			if (!isset($_POST[$permission])) {
-				continue;
+		foreach ($permissions as $permission_name) {
+			if (isset($_POST[$permission_name])) {
+				$groups = array_unique(array_merge($groups, array_map('intval', array_keys($_POST[$permission_name]))));
 			}
+		}
 
-			foreach ($_POST[$permission] as $id_group => $value) {
-				if ($value == 'on' && !empty(Utils::$context['excluded_permissions'][$permission]) && in_array($id_group, Utils::$context['excluded_permissions'][$permission])) {
+		foreach (GroupPermissionSet::load(PermissionProfile::DEFAULT, $groups) as $set) {
+			foreach ($permissions as $permission_name) {
+				$permission = Permission::get($permission_name);
+
+				if ($permission->scope !== 'global' || !$permission->canAssign()) {
 					continue;
 				}
 
+				$new_value = !isset($_POST[$permission->name][$set->group]) ? null : ($_POST[$permission->name][$set->group] == 'on' ? 1 : 0);
+
 				if (
-					in_array($value, ['on', 'deny'])
-					&& Permission::get($permission)->canAssign()
-					&& ($value === 'on' ? Permission::get($permission)->canBeGrantedTo((int) $id_group) : true)
+					$new_value === 1
+					&& (
+						!$permission->canBeGrantedTo($set->group)
+						|| in_array(
+							$set->group,
+							Utils::$context['excluded_permissions'][$permission->name] ?? [],
+						)
+					)
 				) {
-					$insert_rows[] = [(int) $id_group, $permission, $value == 'on' ? 1 : 0];
+					$new_value === null;
 				}
+
+				$set->permissions[$permission->name] = $new_value;
 			}
+
+			$set->save();
 		}
-
-		// Remove the old permissions...
-		Db::$db->query(
-			'',
-			'DELETE FROM {db_prefix}permissions
-			WHERE permission IN ({array_string:permissions})
-				' . (empty(Permission::getUnassignable()) ? '' : ' AND permission NOT IN ({array_string:illegal_permissions})'),
-			[
-				'illegal_permissions' => Permission::getUnassignable(),
-				'permissions' => $permissions,
-			],
-		);
-
-		// ...and replace them with new ones.
-		if (!empty($insert_rows)) {
-			Db::$db->insert(
-				'insert',
-				'{db_prefix}permissions',
-				['id_group' => 'int', 'permission' => 'string', 'add_deny' => 'int'],
-				$insert_rows,
-				['id_group', 'permission'],
-			);
-		}
-
-		// Do a full child update.
-		self::updateChildPermissions([], -1);
 
 		// Make sure Config::$modSettings['board_manager_groups'] is up to date.
 		if (Permission::get('manage_boards')->canAssign()) {
@@ -1299,135 +1147,6 @@ class Permissions implements ActionInterface
 		}
 
 		Config::updateModSettings(['settings_updated' => time()]);
-	}
-
-	/**
-	 * This function updates the permissions of any groups based off this group.
-	 *
-	 * @param int|array $parents The parent groups.
-	 * @param int $profile The ID of a permissions profile to update
-	 * @return bool Returns true if successful or false if there are no
-	 *    child groups to update.
-	 */
-	public static function updateChildPermissions(int|array|null $parents = null, ?int $profile = null): bool
-	{
-		// All the parent groups to sort out.
-		$parents = array_unique(array_map('intval', (array) $parents));
-
-		$parent_groups = Group::load($parents);
-
-		$children = [];
-		$child_groups = [];
-
-		foreach ($parent_groups as $parent_group) {
-			$parent_group->getChildren();
-
-			$children[$parent_group->id] = array_keys($parent_group->children);
-			$child_groups = array_merge($child_groups, array_keys($parent_group->children));
-		}
-
-		$parents = array_map(fn($parent_group) => $parent_group->id, $parent_groups);
-
-		// Not a sausage, or a child?
-		if (empty($children)) {
-			return false;
-		}
-
-		// First off, are we doing general permissions?
-		if ($profile < 1 || $profile === null) {
-			// Fetch all the parent permissions.
-			$permissions = [];
-			$request = Db::$db->query(
-				'',
-				'SELECT id_group, permission, add_deny
-				FROM {db_prefix}permissions
-				WHERE id_group IN ({array_int:parent_list})',
-				[
-					'parent_list' => $parents,
-				],
-			);
-
-			while ($row = Db::$db->fetch_assoc($request)) {
-				foreach ($children[$row['id_group']] as $child) {
-					$permissions[] = [$child, $row['permission'], $row['add_deny']];
-				}
-			}
-			Db::$db->free_result($request);
-
-			if (!empty($child_groups)) {
-				Db::$db->query(
-					'',
-					'DELETE FROM {db_prefix}permissions
-					WHERE id_group IN ({array_int:child_groups})',
-					[
-						'child_groups' => $child_groups,
-					],
-				);
-			}
-
-			// Finally insert.
-			if (!empty($permissions)) {
-				Db::$db->insert(
-					'insert',
-					'{db_prefix}permissions',
-					['id_group' => 'int', 'permission' => 'string', 'add_deny' => 'int'],
-					$permissions,
-					['id_group', 'permission'],
-				);
-			}
-		}
-
-		// Then, what about board profiles?
-		if ($profile != -1) {
-			$profile_query = $profile === null ? '' : ' AND id_profile = {int:current_profile}';
-
-			// Again, get all the parent permissions.
-			$permissions = [];
-			$request = Db::$db->query(
-				'',
-				'SELECT id_profile, id_group, permission, add_deny
-				FROM {db_prefix}board_permissions
-				WHERE id_group IN ({array_int:parent_groups})
-					' . $profile_query,
-				[
-					'parent_groups' => $parents,
-					'current_profile' => $profile !== null && $profile ? $profile : 1,
-				],
-			);
-
-			while ($row = Db::$db->fetch_assoc($request)) {
-				foreach ($children[$row['id_group']] as $child) {
-					$permissions[] = [$child, $row['id_profile'], $row['permission'], $row['add_deny']];
-				}
-			}
-			Db::$db->free_result($request);
-
-			if (!empty($child_groups)) {
-				Db::$db->query(
-					'',
-					'DELETE FROM {db_prefix}board_permissions
-					WHERE id_group IN ({array_int:child_groups})
-						' . $profile_query,
-					[
-						'child_groups' => $child_groups,
-						'current_profile' => $profile !== null && $profile ? $profile : 1,
-					],
-				);
-			}
-
-			// Do the insert.
-			if (!empty($permissions)) {
-				Db::$db->insert(
-					'insert',
-					'{db_prefix}board_permissions',
-					['id_group' => 'int', 'id_profile' => 'int', 'permission' => 'string', 'add_deny' => 'int'],
-					$permissions,
-					['id_group', 'id_profile', 'permission'],
-				);
-			}
-		}
-
-		return true;
 	}
 
 	/******************
@@ -1491,7 +1210,19 @@ class Permissions implements ActionInterface
 			];
 		}
 
-		Group::countPermissionsBatch(array_keys(Utils::$context['groups']), isset($_REQUEST['pid']) ? (int) $_REQUEST['pid'] : null);
+		foreach (Utils::$context['groups'] as $group) {
+			$group->countPermissions(isset($_REQUEST['pid']) ? (int) $_REQUEST['pid'] : null);
+
+			// A few overrides.
+			if ($group->id === Group::GUEST) {
+				$group->num_permissions['denied'] = '(' . Lang::getTxt('permissions_none', file: 'ManagePermissions') . ')';
+			}
+
+			if ($group->id === Group::ADMIN) {
+				$group->num_permissions['allowed'] = '(' . Lang::getTxt('permissions_all', file: 'ManagePermissions') . ')';
+				$group->num_permissions['denied'] = '(' . Lang::getTxt('permissions_none', file: 'ManagePermissions') . ')';
+			}
+		}
 	}
 
 	/**
@@ -1522,141 +1253,45 @@ class Permissions implements ActionInterface
 	 */
 	protected function quickCopyFrom(): void
 	{
-		$pid = max(1, $_REQUEST['pid']);
+		$pid = max(PermissionProfile::DEFAULT, (int) $_REQUEST['pid']);
 
 		// Just checking the input.
 		if (!is_numeric($_POST['copy_from'])) {
 			Utils::redirectexit('action=admin;area=permissions;pid=' . $_REQUEST['pid']);
 		}
 
+		$_POST['copy_from'] = (int) $_POST['copy_from'];
+
 		// Make sure the group we're copying to is never included.
-		$_POST['group'] = array_diff($_POST['group'], [$_POST['copy_from']]);
+		$_POST['group'] = array_diff(array_map('intval', $_POST['group']), [$_POST['copy_from']]);
 
 		// No groups left? Too bad.
 		if (empty($_POST['group'])) {
 			Utils::redirectexit('action=admin;area=permissions;pid=' . $_REQUEST['pid']);
 		}
 
-		if (empty($_REQUEST['pid'])) {
-			// Retrieve current permissions of group.
-			$target_perm = [];
-			$request = Db::$db->query(
-				'',
-				'SELECT permission, add_deny
-				FROM {db_prefix}permissions
-				WHERE id_group = {int:copy_from}',
-				[
-					'copy_from' => $_POST['copy_from'],
-				],
-			);
+		$from_set = current(GroupPermissionSet::load($pid, $_POST['copy_from']));
 
-			while ($row = Db::$db->fetch_assoc($request)) {
-				$target_perm[$row['permission']] = $row['add_deny'];
-			}
-			Db::$db->free_result($request);
-
-			$inserts = [];
-
-			foreach ($_POST['group'] as $group_id) {
-				foreach ($target_perm as $perm => $add_deny) {
-					// No dodgy permissions please!
-					if (
-						!Permission::get($perm)->canAssign()
-						|| !Permission::get($perm)->canBeGrantedTo($group_id)
-					) {
-						continue;
-					}
-
-					if ($group_id != Group::ADMIN && $group_id != Group::MOD) {
-						$inserts[] = [$perm, $group_id, $add_deny];
-					}
-				}
-			}
-
-			// Delete the previous permissions...
-			Db::$db->query(
-				'',
-				'DELETE FROM {db_prefix}permissions
-				WHERE id_group IN ({array_int:group_list})
-					' . (empty(Permission::getUnassignable()) ? '' : ' AND permission NOT IN ({array_string:illegal_permissions})'),
-				[
-					'group_list' => $_POST['group'],
-					'illegal_permissions' => Permission::getUnassignable(),
-				],
-			);
-
-			if (!empty($inserts)) {
-				// ..and insert the new ones.
-				Db::$db->insert(
-					'',
-					'{db_prefix}permissions',
-					[
-						'permission' => 'string', 'id_group' => 'int', 'add_deny' => 'int',
-					],
-					$inserts,
-					['permission', 'id_group'],
-				);
-			}
-		}
-
-		// Now do the same for the board permissions.
-		$target_perm = [];
-		$request = Db::$db->query(
-			'',
-			'SELECT permission, add_deny
-			FROM {db_prefix}board_permissions
-			WHERE id_group = {int:copy_from}
-				AND id_profile = {int:current_profile}',
-			[
-				'copy_from' => $_POST['copy_from'],
-				'current_profile' => $pid,
-			],
-		);
-
-		while ($row = Db::$db->fetch_assoc($request)) {
-			$target_perm[$row['permission']] = $row['add_deny'];
-		}
-		Db::$db->free_result($request);
-
-		$inserts = [];
-
-		foreach ($_POST['group'] as $group_id) {
-			foreach ($target_perm as $perm => $add_deny) {
-				// Are these for guests?
-				if ($group_id == -1 && in_array($perm, Permission::getNonGuestPermissions())) {
+		foreach (GroupPermissionSet::load($pid, $_POST['group']) as $to_set) {
+			foreach ($from_set->permissions as $permission_name => $value) {
+				// Only do global permissions if $_REQUEST['pid'] was empty.
+				if (Permission::get($permission_name)->scope === 'global' && !empty($_REQUEST['pid'])) {
 					continue;
 				}
 
-				$inserts[] = [$perm, $group_id, $pid, $add_deny];
+				// No dodgy permissions please!
+				if (
+					!Permission::get($permission_name)->canAssign()
+					|| !Permission::get($permission_name)->canBeGrantedTo($to_set->group)
+				) {
+					continue;
+				}
+
+				$to_set->permissions[$permission_name] = $value;
 			}
+
+			$to_set->save();
 		}
-
-		// Delete the previous global board permissions...
-		Db::$db->query(
-			'',
-			'DELETE FROM {db_prefix}board_permissions
-			WHERE id_group IN ({array_int:current_group_list})
-				AND id_profile = {int:current_profile}',
-			[
-				'current_group_list' => $_POST['group'],
-				'current_profile' => $pid,
-			],
-		);
-
-		// And insert the copied permissions.
-		if (!empty($inserts)) {
-			// ..and insert the new ones.
-			Db::$db->insert(
-				'',
-				'{db_prefix}board_permissions',
-				['permission' => 'string', 'id_group' => 'int', 'id_profile' => 'int', 'add_deny' => 'int'],
-				$inserts,
-				['permission', 'id_group', 'id_profile'],
-			);
-		}
-
-		// Update any children out there!
-		self::updateChildPermissions($_POST['group'], $_REQUEST['pid']);
 	}
 
 	/**
@@ -1666,92 +1301,32 @@ class Permissions implements ActionInterface
 	 */
 	protected function quickSetPermission(): void
 	{
-		$pid = max(1, $_REQUEST['pid']);
+		$pid = max(PermissionProfile::DEFAULT, (int) $_REQUEST['pid']);
+
+		$groups = array_map('intval', (array) $_POST['group']);
 
 		// Unpack two variables that were transported.
 		list($scope, $permission) = explode('/', $_POST['permissions']);
 
 		// Check whether our input is within expected range.
-		if (!in_array($_POST['add_remove'], ['add', 'clear', 'deny']) || !in_array($scope, ['global', 'board'])) {
+		if (
+			!in_array($_POST['add_remove'], ['add', 'clear', 'deny'])
+			|| !in_array($scope, ['global', 'board'])
+			|| !Permission::get($permission)->canAssign()
+			|| Permission::get($permission)->scope !== $scope
+		) {
 			Utils::redirectexit('action=admin;area=permissions;pid=' . $_REQUEST['pid']);
 		}
 
-		if ($_POST['add_remove'] == 'clear') {
-			if ($scope == 'global') {
-				Db::$db->query(
-					'',
-					'DELETE FROM {db_prefix}permissions
-					WHERE id_group IN ({array_int:current_group_list})
-						AND permission = {string:current_permission}
-						' . (empty(Permission::getUnassignable()) ? '' : ' AND permission NOT IN ({array_string:illegal_permissions})'),
-					[
-						'current_group_list' => $_POST['group'],
-						'current_permission' => $permission,
-						'illegal_permissions' => Permission::getUnassignable(),
-					],
-				);
-
-				// Check whether anyone lost their eligibility for the bbc_html permission.
-				if (array_intersect($_POST['group'], Permission::get('bbc_html')->eligibleGroups()) !== []) {
-					self::removeIllegalBBCHtmlPermission(true);
-				}
-			} else {
-				Db::$db->query(
-					'',
-					'DELETE FROM {db_prefix}board_permissions
-					WHERE id_group IN ({array_int:current_group_list})
-						AND id_profile = {int:current_profile}
-						AND permission = {string:current_permission}',
-					[
-						'current_group_list' => $_POST['group'],
-						'current_profile' => $pid,
-						'current_permission' => $permission,
-					],
-				);
+		foreach (GroupPermissionSet::load($pid, $groups) as $set) {
+			if ($_POST['add_remove'] === 'add' && !Permission::get($permission)->canBeGrantedTo($set->group)) {
+				continue;
 			}
+
+			$set->permissions[$permission] = $_POST['add_remove'] === 'add' ? 1 : ($_POST['add_remove'] === 'deny' ? 0 : null);
+
+			$set->save();
 		}
-		// Add a permission (either 'set' or 'deny').
-		else {
-			$add_deny = $_POST['add_remove'] == 'add' ? '1' : '0';
-			$perm_change = [];
-
-			foreach ($_POST['group'] as $groupID) {
-				if (!Permission::get($permission)->canBeGrantedTo($groupID)) {
-					continue;
-				}
-
-				if ($scope == 'global' && $groupID != Group::ADMIN && $groupID != Group::MOD && Permission::get($permission)->canAssign()) {
-					$perm_change[] = [$permission, $groupID, $add_deny];
-				} elseif ($scope != 'global') {
-					$perm_change[] = [$permission, $groupID, $pid, $add_deny];
-				}
-			}
-
-			if (!empty($perm_change)) {
-				if ($scope == 'global') {
-					Db::$db->insert(
-						'replace',
-						'{db_prefix}permissions',
-						['permission' => 'string', 'id_group' => 'int', 'add_deny' => 'int'],
-						$perm_change,
-						['permission', 'id_group'],
-					);
-				}
-				// Board permissions go into the other table.
-				else {
-					Db::$db->insert(
-						'replace',
-						'{db_prefix}board_permissions',
-						['permission' => 'string', 'id_group' => 'int', 'id_profile' => 'int', 'add_deny' => 'int'],
-						$perm_change,
-						['permission', 'id_group', 'id_profile'],
-					);
-				}
-			}
-		}
-
-		// Another child update!
-		self::updateChildPermissions($_POST['group'], $_REQUEST['pid']);
 	}
 
 	/**
@@ -1855,11 +1430,11 @@ class Permissions implements ActionInterface
 	 */
 	protected function setAllowedDenied(int $group, string $scope = 'global', int $profile = PermissionProfile::DEFAULT): void
 	{
-		$perm_profile = PermissionProfile::load($scope == 'global' ? PermissionProfile::DEFAULT : $profile);
+		$profile = $scope == 'global' ? PermissionProfile::DEFAULT : $profile;
 
 		// General permissions?
 		if ($scope == 'global') {
-			foreach ($perm_profile->getGlobalPermissions()[$group] as $perm => $add_deny) {
+			foreach (current(GroupPermissionSet::load($profile, $group))->permissions as $perm => $add_deny) {
 				if (is_null($add_deny)) {
 					continue;
 				}
@@ -1869,7 +1444,7 @@ class Permissions implements ActionInterface
 		}
 
 		// Fetch current board permissions...
-		foreach ($perm_profile->getBoardPermissions()[$group] as $perm => $add_deny) {
+		foreach (current(GroupPermissionSet::load($profile, $group))->permissions as $perm => $add_deny) {
 			if (is_null($add_deny)) {
 				continue;
 			}
@@ -1930,95 +1505,6 @@ class Permissions implements ActionInterface
 					}
 				}
 			}
-		}
-	}
-
-	/**
-	 * Saves global permissions to the database for the given membergroup.
-	 *
-	 * @param int $group ID of a membergroup.
-	 * @param array $give_perms The permissions this group has been granted.
-	 * @param array $illegal_permissions Permissions that cannot be changed for
-	 *    this group.
-	 */
-	protected function updateGlobalPermissions(int $group, array $give_perms, array $illegal_permissions): void
-	{
-		// First, delete all the existing permissions for this group.
-		Db::$db->query(
-			'',
-			'DELETE FROM {db_prefix}permissions
-			WHERE id_group = {int:current_group}
-			' . (empty($illegal_permissions) ? '' : ' AND permission NOT IN ({array_string:illegal_permissions})'),
-			[
-				'current_group' => $group,
-				'illegal_permissions' => $illegal_permissions,
-			],
-		);
-
-		// This should already have been done, but just in case...
-		foreach ($give_perms['global'] as $k => $v) {
-			if (in_array($v[1], $illegal_permissions)) {
-				unset($give_perms['global'][$k]);
-			}
-		}
-
-		// Now grant this group whichever permissions it can have.
-		if (!empty($give_perms['global'])) {
-			Db::$db->insert(
-				'replace',
-				'{db_prefix}permissions',
-				['id_group' => 'int', 'permission' => 'string', 'add_deny' => 'int'],
-				$give_perms['global'],
-				['id_group', 'permission'],
-			);
-		}
-	}
-
-	/**
-	 * Saves board permissions to the database for the given membergroup.
-	 *
-	 * @param int $group ID of a membergroup.
-	 * @param array $give_perms The permissions this group has been granted.
-	 * @param array $illegal_permissions Permissions that cannot be changed for
-	 *    this group.
-	 * @param int $profileid ID of a permission profile.
-	 */
-	protected function updateBoardPermissions(int $group, array $give_perms, array $illegal_permissions, int $profileid): void
-	{
-		$profileid = max(1, $profileid);
-
-		// Again, we start by clearing all the permissions for this group.
-		Db::$db->query(
-			'',
-			'DELETE FROM {db_prefix}board_permissions
-			WHERE id_group = {int:current_group}
-				AND id_profile = {int:current_profile}',
-			[
-				'current_group' => $group,
-				'current_profile' => $profileid,
-			],
-		);
-
-		// This should already have been done, but just in case...
-		foreach ($give_perms['board'] as $k => $v) {
-			if (in_array($v[1], $illegal_permissions)) {
-				unset($give_perms['board'][$k]);
-			}
-		}
-
-		// Grant them whichever permissions they are now allowed to have.
-		if (!empty($give_perms['board'])) {
-			foreach ($give_perms['board'] as $k => $v) {
-				$give_perms['board'][$k][] = $profileid;
-			}
-
-			Db::$db->insert(
-				'replace',
-				'{db_prefix}board_permissions',
-				['id_group' => 'int', 'permission' => 'string', 'add_deny' => 'int', 'id_profile' => 'int'],
-				$give_perms['board'],
-				['id_group', 'permission', 'id_profile'],
-			);
 		}
 	}
 
@@ -2207,28 +1693,6 @@ class Permissions implements ActionInterface
 				}
 			}
 		}
-	}
-
-	/**
-	 * Removes the bbc_html permission from anyone who shouldn't have it.
-	 *
-	 * @param bool $reload Before acting, refresh the list of membergroups who
-	 *    cannot be granted the bbc_html permission
-	 */
-	protected static function removeIllegalBBCHtmlPermission(bool $reload = false): void
-	{
-		Db::$db->query(
-			'',
-			'DELETE FROM {db_prefix}permissions
-			WHERE id_group IN ({array_int:ineligible_groups})
-				AND permission = {string:current_permission}
-				AND add_deny = {int:add}',
-			[
-				'ineligible_groups' => Permission::ineligibleGroups('bbc_html', true),
-				'current_permission' => 'bbc_html',
-				'add' => 1,
-			],
-		);
 	}
 
 	/**

--- a/Sources/Actions/Admin/Permissions.php
+++ b/Sources/Actions/Admin/Permissions.php
@@ -29,6 +29,7 @@ use SMF\IntegrationHook;
 use SMF\Lang;
 use SMF\Menu;
 use SMF\Permissions\Permission;
+use SMF\Permissions\PermissionProfile;
 use SMF\SecurityToken;
 use SMF\Theme;
 use SMF\User;
@@ -42,17 +43,6 @@ class Permissions implements ActionInterface
 	use ActionTrait;
 
 	use BackwardCompatibility;
-
-	/*****************
-	 * Class constants
-	 *****************/
-
-	public const PROFILE_DEFAULT = 1;
-	public const PROFILE_NO_POLLS = 2;
-	public const PROFILE_REPLY_ONLY = 3;
-	public const PROFILE_READ_ONLY = 4;
-	public const PROFILE_PREDEFINED = [1, 2, 3, 4];
-	public const PROFILE_UNMODIFIABLE = [2, 3, 4];
 
 	/*******************
 	 * Public properties
@@ -242,7 +232,7 @@ class Permissions implements ActionInterface
 		self::loadPermissionsContext();
 
 		// Also load profiles, we may want to reset.
-		self::loadPermissionProfiles();
+		PermissionProfile::loadContext();
 
 		// Expand or collapse the advanced options?
 		Utils::$context['show_advanced_options'] = empty(Utils::$context['admin_preferences']['app']);
@@ -250,7 +240,7 @@ class Permissions implements ActionInterface
 		$this->setGroupsContext();
 
 		// We can modify any permission set, except for the ones we can't.
-		Utils::$context['can_modify'] = empty($_REQUEST['pid']) || !in_array((int) $_REQUEST['pid'], self::PROFILE_UNMODIFIABLE);
+		Utils::$context['can_modify'] = PermissionProfile::load((int) ($_REQUEST['pid'] ?? PermissionProfile::DEFAULT)) !== null && PermissionProfile::load((int) ($_REQUEST['pid'] ?? PermissionProfile::DEFAULT))->canModify();
 
 		// Load the proper template.
 		Utils::$context['sub_template'] = 'permission_index';
@@ -273,7 +263,9 @@ class Permissions implements ActionInterface
 			$changes = [];
 
 			foreach ($_POST['boardprofile'] as $p_board => $profile) {
-				$changes[(int) $profile][] = (int) $p_board;
+				if (PermissionProfile::load((int) $profile) !== null) {
+					$changes[(int) $profile][] = (int) $p_board;
+				}
 			}
 
 			if (!empty($changes)) {
@@ -295,7 +287,7 @@ class Permissions implements ActionInterface
 		}
 
 		// Load all permission profiles.
-		self::loadPermissionProfiles();
+		PermissionProfile::loadContext();
 
 		// Get the board tree.
 		Category::getTree();
@@ -312,7 +304,7 @@ class Permissions implements ActionInterface
 
 			foreach (Category::$boardList[$catid] as $boardid) {
 				if (!isset(Utils::$context['profiles'][Board::$loaded[$boardid]->profile])) {
-					Board::$loaded[$boardid]->profile = self::PROFILE_DEFAULT;
+					Board::$loaded[$boardid]->profile = PermissionProfile::DEFAULT;
 				}
 
 				Utils::$context['categories'][$catid]['boards'][$boardid] = [
@@ -331,8 +323,8 @@ class Permissions implements ActionInterface
 	}
 
 	/**
-	 * Handles permission modification actions from the upper part of the
-	 * permission manager index.
+	 * Handles permission modification actions from the "advanced options"
+	 * section of the permission manager index.
 	 */
 	public function quick(): void
 	{
@@ -360,7 +352,10 @@ class Permissions implements ActionInterface
 		$_REQUEST['pid'] = (int) ($_REQUEST['pid'] ?? 0);
 
 		// Sorry, but that one can't be modified.
-		if (in_array($_REQUEST['pid'], self::PROFILE_UNMODIFIABLE)) {
+		if (
+			PermissionProfile::load($_REQUEST['pid']) === null
+			|| !PermissionProfile::load($_REQUEST['pid'])->canModify()
+		) {
 			ErrorHandler::fatalLang('no_access', false);
 		}
 
@@ -423,18 +418,25 @@ class Permissions implements ActionInterface
 		$_GET['pid'] = (int) $_GET['pid'];
 
 		// Group needs to be valid.
-		if ($_GET['group'] < -1) {
-			ErrorHandler::fatalLang('no_access', false);
-		}
-
-		// No, you can't modify this permission profile.
-		if (in_array($_GET['pid'], self::PROFILE_UNMODIFIABLE)) {
+		if ($_GET['group'] < Group::GUEST) {
 			ErrorHandler::fatalLang('no_access', false);
 		}
 
 		// Verify this isn't inherited.
-		if ($this->getParentGroup($_GET['group']) != Group::NONE) {
+		if (current(Group::load($_GET['group']))->parent != Group::NONE) {
 			ErrorHandler::fatalLang('cannot_edit_permissions_inherited');
+		}
+
+		$permission_profile = PermissionProfile::load($_GET['pid']);
+
+		// Permission profile needs to be valid.
+		if (!($permission_profile instanceof PermissionProfile)) {
+			ErrorHandler::fatalLang('no_access', false);
+		}
+
+		// No, you can't modify this permission profile.
+		if (!$permission_profile->canModify()) {
+			ErrorHandler::fatalLang('no_access', false);
 		}
 
 		$illegal_permissions = array_merge(
@@ -474,7 +476,7 @@ class Permissions implements ActionInterface
 		}
 
 		// Insert the general permissions.
-		if ($_GET['group'] != 3 && empty($_GET['pid'])) {
+		if ($_GET['group'] != Group::MOD && empty($_GET['pid'])) {
 			$this->updateGlobalPermissions($_GET['group'], $give_perms, $illegal_permissions);
 		}
 
@@ -623,40 +625,32 @@ class Permissions implements ActionInterface
 		}
 
 		// Clearly, we'll need this!
-		self::loadPermissionProfiles();
+		PermissionProfile::loadContext();
 
 		// Work out what ones are in use.
-		$request = Db::$db->query(
-			'',
-			'SELECT id_profile, COUNT(*) AS board_count
-			FROM {db_prefix}boards
-			GROUP BY id_profile',
-			[
-			],
-		);
-
-		while ($row = Db::$db->fetch_assoc($request)) {
-			if (isset(Utils::$context['profiles'][$row['id_profile']])) {
-				Utils::$context['profiles'][$row['id_profile']]['in_use'] = true;
-				Utils::$context['profiles'][$row['id_profile']]['boards'] = $row['board_count'];
-				Utils::$context['profiles'][$row['id_profile']]['boards_text'] = Lang::getTxt('permissions_profile_used_by_count', [$row['board_count']], file: 'ManagePermissions');
-			}
+		foreach (PermissionProfile::loadAll() as $profile) {
+			Utils::$context['profiles'][$profile->id]['in_use'] = !empty($profile->boards());
+			Utils::$context['profiles'][$profile->id]['boards'] = count($profile->boards());
+			Utils::$context['profiles'][$profile->id]['boards_text'] = Lang::getTxt(
+				'permissions_profile_used_by_count',
+				[count($profile->boards())],
+				file: 'ManagePermissions',
+			);
 		}
-		Db::$db->free_result($request);
 
 		// What can we do with these?
 		Utils::$context['can_rename_something'] = false;
 
-		foreach (Utils::$context['profiles'] as $id => $profile) {
+		foreach (PermissionProfile::loadAll() as $profile) {
 			// Can't rename the special ones.
-			Utils::$context['profiles'][$id]['can_rename'] = !in_array($id, self::PROFILE_PREDEFINED);
+			Utils::$context['profiles'][$profile->id]['can_rename'] = !$profile->isPredefined();
 
-			if (Utils::$context['profiles'][$id]['can_rename']) {
+			if (Utils::$context['profiles'][$profile->id]['can_rename']) {
 				Utils::$context['can_rename_something'] = true;
 			}
 
 			// You can only delete it if you can rename it AND it's not in use.
-			Utils::$context['profiles'][$id]['can_delete'] = !in_array($id, self::PROFILE_PREDEFINED) && empty($profile['in_use']);
+			Utils::$context['profiles'][$profile->id]['can_delete'] = !$profile->isPredefined() && empty($profile->boards());
 		}
 
 		SecurityToken::create('admin-mpp');
@@ -675,7 +669,7 @@ class Permissions implements ActionInterface
 		Utils::$context['current_profile'] = isset($_REQUEST['pid']) ? (int) $_REQUEST['pid'] : 1;
 
 		// Load all the permission profiles.
-		self::loadPermissionProfiles();
+		PermissionProfile::loadContext();
 
 		IntegrationHook::call('integrate_post_moderation_mapping', [&$this->postmod_maps]);
 
@@ -736,7 +730,10 @@ class Permissions implements ActionInterface
 		}
 
 		// If we're saving the changes then do just that - save them.
-		if (!empty($_POST['save_changes']) && !in_array(Utils::$context['current_profile'], self::PROFILE_UNMODIFIABLE)) {
+		if (
+			!empty($_POST['save_changes'])
+			&& PermissionProfile::load(Utils::$context['current_profile'])->canModify()
+		) {
 			SecurityToken::validate('admin-mppm');
 
 			// First, are we saving a new value for enabled post moderation?
@@ -1006,7 +1003,12 @@ class Permissions implements ActionInterface
 			self::removeIllegalBBCHtmlPermission();
 		}
 		// Setting profile permissions for a specific group.
-		elseif ($profile !== 'null' && $group !== 'null' && !in_array($profile, self::PROFILE_UNMODIFIABLE)) {
+		elseif (
+			$profile !== 'null'
+			&& $group !== 'null'
+			&& PermissionProfile::load((int) $profile) !== null
+			&& PermissionProfile::load((int) $profile)->canModify()
+		) {
 			$group = (int) $group;
 			$profile = (int) $profile;
 
@@ -1040,7 +1042,12 @@ class Permissions implements ActionInterface
 			}
 		}
 		// Setting profile permissions for all groups.
-		elseif ($profile !== 'null' && $group === 'null' && !in_array($profile, self::PROFILE_UNMODIFIABLE)) {
+		elseif (
+			$profile !== 'null'
+			&& $group === 'null'
+			&& PermissionProfile::load((int) $profile) !== null
+			&& PermissionProfile::load((int) $profile)->canModify()
+		) {
 			$profile = (int) $profile;
 
 			Db::$db->query(
@@ -1292,35 +1299,6 @@ class Permissions implements ActionInterface
 		}
 
 		Config::updateModSettings(['settings_updated' => time()]);
-	}
-
-	/**
-	 * Load permissions profiles.
-	 */
-	public static function loadPermissionProfiles(): void
-	{
-		Utils::$context['profiles'] = [];
-
-		$request = Db::$db->query(
-			'',
-			'SELECT id_profile, profile_name
-			FROM {db_prefix}permission_profiles
-			ORDER BY id_profile',
-			[
-			],
-		);
-
-		while ($row = Db::$db->fetch_assoc($request)) {
-			$row['id_profile'] = (int) $row['id_profile'];
-
-			Utils::$context['profiles'][$row['id_profile']] = [
-				'id' => $row['id_profile'],
-				'name' => Lang::txtExists('permissions_profile_' . $row['profile_name'], file: 'ManagePermissions') ? Lang::getTxt('permissions_profile_' . $row['profile_name'], file: 'ManagePermissions') : $row['profile_name'],
-				'can_modify' => !in_array($row['id_profile'], self::PROFILE_UNMODIFIABLE),
-				'unformatted_name' => $row['profile_name'],
-			];
-		}
-		Db::$db->free_result($request);
 	}
 
 	/**
@@ -1832,23 +1810,23 @@ class Permissions implements ActionInterface
 	 */
 	protected function setProfileContext(): void
 	{
-		self::loadPermissionProfiles();
+		PermissionProfile::loadContext();
 
 		Utils::$context['profile']['id'] = (int) ($_GET['pid'] ?? 0);
 
 		// If this is a moderator and they are editing "no profile" then we only do boards.
-		if (Utils::$context['group']['id'] == 3 && empty(Utils::$context['profile']['id'])) {
+		if (Utils::$context['group']['id'] == Group::MOD && empty(Utils::$context['profile']['id'])) {
 			// For sanity just check they have no general permissions.
 			Db::$db->query(
 				'',
 				'DELETE FROM {db_prefix}permissions
 				WHERE id_group = {int:moderator_group}',
 				[
-					'moderator_group' => 3,
+					'moderator_group' => Group::MOD,
 				],
 			);
 
-			Utils::$context['profile']['id'] = self::PROFILE_DEFAULT;
+			Utils::$context['profile']['id'] = PermissionProfile::DEFAULT;
 		}
 
 		Utils::$context['permission_type'] = empty(Utils::$context['profile']['id']) ? 'global' : 'board';
@@ -1871,49 +1849,33 @@ class Permissions implements ActionInterface
 	 *
 	 * @param int $group ID number of a membergroup.
 	 * @param string $scope Either 'global' or 'board'. If this is 'global', the
-	 *    $profile param will always be treated as 1.
+	 *    $profile param will always be treated as PermissionProfile::DEFAULT.
 	 * @param int $profile Permission profile to use. Only applicable when the
 	 *    $scope param is set to 'board'.
 	 */
-	protected function setAllowedDenied(int $group, string $scope = 'global', int $profile = 1): void
+	protected function setAllowedDenied(int $group, string $scope = 'global', int $profile = PermissionProfile::DEFAULT): void
 	{
+		$perm_profile = PermissionProfile::load($scope == 'global' ? PermissionProfile::DEFAULT : $profile);
+
 		// General permissions?
 		if ($scope == 'global') {
-			$profile = 1;
+			foreach ($perm_profile->getGlobalPermissions()[$group] as $perm => $add_deny) {
+				if (is_null($add_deny)) {
+					continue;
+				}
 
-			$result = Db::$db->query(
-				'',
-				'SELECT permission, add_deny
-				FROM {db_prefix}permissions
-				WHERE id_group = {int:current_group}',
-				[
-					'current_group' => $group,
-				],
-			);
-
-			while ($row = Db::$db->fetch_assoc($result)) {
-				$this->allowed_denied['global'][empty($row['add_deny']) ? 'denied' : 'allowed'][] = $row['permission'];
+				$this->allowed_denied['global'][empty($add_deny) ? 'denied' : 'allowed'][] = $perm;
 			}
-			Db::$db->free_result($result);
 		}
 
 		// Fetch current board permissions...
-		$result = Db::$db->query(
-			'',
-			'SELECT permission, add_deny
-			FROM {db_prefix}board_permissions
-			WHERE id_group = {int:current_group}
-				AND id_profile = {int:current_profile}',
-			[
-				'current_group' => $group,
-				'current_profile' => $profile,
-			],
-		);
+		foreach ($perm_profile->getBoardPermissions()[$group] as $perm => $add_deny) {
+			if (is_null($add_deny)) {
+				continue;
+			}
 
-		while ($row = Db::$db->fetch_assoc($result)) {
-			$this->allowed_denied['board'][empty($row['add_deny']) ? 'denied' : 'allowed'][] = $row['permission'];
+			$this->allowed_denied['board'][empty($add_deny) ? 'denied' : 'allowed'][] = $perm;
 		}
-		Db::$db->free_result($result);
 	}
 
 	/**
@@ -1969,42 +1931,6 @@ class Permissions implements ActionInterface
 				}
 			}
 		}
-	}
-
-	/**
-	 * Gets the parent membergroup of the given membergroup.
-	 *
-	 * This is used to determine permission inheritance.
-	 *
-	 * @param int $group ID of a membergroup.
-	 * @return int The ID of the parent membergroup, or -2 if it has no parent.
-	 */
-	protected function getParentGroup(int $group): int
-	{
-		if ($group == -1 || $group == 0) {
-			return -2;
-		}
-
-		$request = Db::$db->query(
-			'',
-			'SELECT id_parent
-			FROM {db_prefix}membergroups
-			WHERE id_group = {int:current_group}
-			LIMIT 1',
-			[
-				'current_group' => $group,
-			],
-		);
-
-		if (Db::$db->num_rows($request) === 0) {
-			ErrorHandler::fatalLang('no_access', false);
-		}
-
-		list($parent) = Db::$db->fetch_row($request);
-
-		Db::$db->free_result($request);
-
-		return (int) $parent;
 	}
 
 	/**
@@ -2107,52 +2033,7 @@ class Permissions implements ActionInterface
 		User::$me->checkSession();
 		SecurityToken::validate('admin-mpp');
 
-		$_POST['copy_from'] = (int) $_POST['copy_from'];
-		$_POST['profile_name'] = Utils::htmlspecialchars($_POST['profile_name']);
-
-		// Insert the profile itself.
-		$profile_id = Db::$db->insert(
-			'',
-			'{db_prefix}permission_profiles',
-			[
-				'profile_name' => 'string',
-			],
-			[
-				[
-					$_POST['profile_name'],
-				],
-			],
-			['id_profile'],
-			1,
-		);
-
-		// Load the permissions from the one it's being copied from.
-		$inserts = [];
-
-		$request = Db::$db->query(
-			'',
-			'SELECT id_group, permission, add_deny
-			FROM {db_prefix}board_permissions
-			WHERE id_profile = {int:copy_from}',
-			[
-				'copy_from' => $_POST['copy_from'],
-			],
-		);
-
-		while ($row = Db::$db->fetch_assoc($request)) {
-			$inserts[] = [$profile_id, $row['id_group'], $row['permission'], $row['add_deny']];
-		}
-		Db::$db->free_result($request);
-
-		if (!empty($inserts)) {
-			Db::$db->insert(
-				'insert',
-				'{db_prefix}board_permissions',
-				['id_profile' => 'int', 'id_group' => 'int', 'permission' => 'string', 'add_deny' => 'int'],
-				$inserts,
-				['id_profile', 'id_group', 'permission'],
-			);
-		}
+		PermissionProfile::copy((int) $_POST['copy_from'], Utils::htmlspecialchars($_POST['profile_name']));
 	}
 
 	/**
@@ -2181,19 +2062,13 @@ class Permissions implements ActionInterface
 				continue;
 			}
 
-			$value = Utils::htmlspecialchars($value);
-
-			if (trim($value) != '' && !in_array($id, self::PROFILE_PREDEFINED)) {
-				Db::$db->query(
-					'',
-					'UPDATE {db_prefix}permission_profiles
-					SET profile_name = {string:profile_name}
-					WHERE id_profile = {int:current_profile}',
-					[
-						'current_profile' => $id,
-						'profile_name' => $value,
-					],
-				);
+			if (
+				Utils::htmlTrim($value) != ''
+				&& ($profile = PermissionProfile::load($id)) !== null
+				&& !$profile->isPredefined()
+			) {
+				$profile->name = Utils::htmlspecialchars($value);
+				$profile->save();
 			}
 		}
 	}
@@ -2215,38 +2090,22 @@ class Permissions implements ActionInterface
 
 		$profiles = [];
 
-		foreach (array_map('intval', $_POST['delete_profile']) as $profile) {
-			if ($profile > 0 && !in_array($profile, self::PROFILE_PREDEFINED)) {
-				$profiles[] = $profile;
+		foreach (array_map('intval', $_POST['delete_profile']) as $id) {
+			if (
+				$id <= 0
+				|| ($profile = PermissionProfile::load($id)) === null
+				|| $profile->isPredefined()
+				|| !empty($profile->boards())
+			) {
+				ErrorHandler::fatalLang('no_access', false);
 			}
+
+			$profiles[] = $profile;
 		}
 
-		// Verify it's not in use...
-		$request = Db::$db->query(
-			'',
-			'SELECT id_board
-			FROM {db_prefix}boards
-			WHERE id_profile IN ({array_int:profile_list})
-			LIMIT 1',
-			[
-				'profile_list' => $profiles,
-			],
-		);
-
-		if (Db::$db->num_rows($request) != 0) {
-			ErrorHandler::fatalLang('no_access', false);
+		foreach ($profiles as $profile) {
+			$profile->delete();
 		}
-		Db::$db->free_result($request);
-
-		// Oh well, delete.
-		Db::$db->query(
-			'',
-			'DELETE FROM {db_prefix}permission_profiles
-			WHERE id_profile IN ({array_int:profile_list})',
-			[
-				'profile_list' => $profiles,
-			],
-		);
 	}
 
 	/*************************

--- a/Sources/Actions/Admin/Permissions.php
+++ b/Sources/Actions/Admin/Permissions.php
@@ -1700,10 +1700,7 @@ class Permissions implements ActionInterface
 	 */
 	protected static function updateBoardManagers(): void
 	{
-		$board_managers = User::groupsAllowedTo('manage_boards', null);
-		$board_managers = implode(',', $board_managers['allowed']);
-
-		Config::updateModSettings(['board_manager_groups' => $board_managers], true);
+		Config::updateModSettings(['board_manager_groups' => implode(',', Group::getAllowedTo('manage_boards'))], true);
 	}
 
 	/**

--- a/Sources/Actions/Admin/Permissions.php
+++ b/Sources/Actions/Admin/Permissions.php
@@ -450,7 +450,7 @@ class Permissions implements ActionInterface
 				$permission = Permission::get($name);
 
 				// Only change global permissions when $_GET['pid'] is 0.
-				if ($permission->scope === 'global' && $_GET['pid'] !== 0) {
+				if ($permission->scope !== ($_GET['pid'] === 0 ? 'global' : 'board')) {
 					continue;
 				}
 
@@ -1211,7 +1211,7 @@ class Permissions implements ActionInterface
 		}
 
 		foreach (Utils::$context['groups'] as $group) {
-			$group->countPermissions(isset($_REQUEST['pid']) ? (int) $_REQUEST['pid'] : null);
+			$group->countPermissions(isset($_REQUEST['pid']) ? (int) $_REQUEST['pid'] : 0);
 
 			// A few overrides.
 			if ($group->id === Group::GUEST) {

--- a/Sources/Actions/Admin/Reports.php
+++ b/Sources/Actions/Admin/Reports.php
@@ -623,10 +623,10 @@ class Reports implements ActionInterface
 	public function staff(): void
 	{
 		// Get a list of global moderators (i.e. members with moderation powers).
-		$global_mods = array_intersect(User::membersAllowedTo('moderate_board', 0), User::membersAllowedTo('approve_posts', 0), User::membersAllowedTo('remove_any', 0), User::membersAllowedTo('modify_any', 0));
+		$global_mods = array_intersect(User::getAllowedTo('moderate_board', 0), User::getAllowedTo('approve_posts', 0), User::getAllowedTo('remove_any', 0), User::getAllowedTo('modify_any', 0));
 
 		// How about anyone else who is special?
-		$allStaff = array_merge(User::membersAllowedTo('admin_forum'), User::membersAllowedTo('manage_membergroups'), User::membersAllowedTo('manage_permissions'), $global_mods);
+		$allStaff = array_merge(User::getAllowedTo('admin_forum'), User::getAllowedTo('manage_membergroups'), User::getAllowedTo('manage_permissions'), $global_mods);
 
 		// Make sure everyone is there once - no admin less important than any other!
 		$allStaff = array_unique($allStaff);

--- a/Sources/Actions/Admin/Reports.php
+++ b/Sources/Actions/Admin/Reports.php
@@ -27,6 +27,7 @@ use SMF\Group;
 use SMF\IntegrationHook;
 use SMF\Lang;
 use SMF\Menu;
+use SMF\Permissions\Permission;
 use SMF\Permissions\PermissionProfile;
 use SMF\Theme;
 use SMF\Time;
@@ -427,7 +428,10 @@ class Reports implements ActionInterface
 			Group::LOAD_NORMAL | (int) !empty(Config::$modSettings['permission_enable_postgroups']),
 			[Group::ADMIN],
 		);
-		Group::loadPermissionsBatch(array_map(fn($group) => $group->id, $group_data), null, true);
+
+		foreach ($groups_data as $group) {
+			$group->loadPermissions();
+		}
 
 		// Certain permissions should not really be shown.
 		$disabled_permissions = [];
@@ -448,9 +452,12 @@ class Reports implements ActionInterface
 			if ($group->parent === Group::NONE && ($inc == [] || in_array($group->id, $inc))) {
 				$groups[$group->id] = $group->name;
 
-				foreach ($group->permissions['board_profiles'] as $id_profile => $board_profile) {
-					foreach ($board_profile as $permission => $add_deny) {
-						if (in_array($permission, $disabled_permissions)) {
+				foreach ($group->permission_sets as $id_profile => $board_profile) {
+					foreach ($board_profile->permissions as $permission => $value) {
+						if (
+							in_array($permission, $disabled_permissions)
+							|| Permission::get($permission)->scope !== 'board'
+						) {
 							continue;
 						}
 
@@ -458,7 +465,19 @@ class Reports implements ActionInterface
 							$data[$id_profile][$permission] = ['col' => Lang::txtExists('board_perms_name_' . $permission, file: 'Reports') ? Lang::getTxt('board_perms_name_' . $permission, file: 'Reports') : $permission];
 						}
 
-						$data[$id_profile][$permission][$group->id] = $add_deny ? '&#x2705;' : '&#x1F6AB;';
+						switch ($value) {
+							case 1:
+								$data[$id_profile][$permission][$group->id] = '&#x2705;';
+								break;
+
+							case 0:
+								$data[$id_profile][$permission][$group->id] = '&#x1F6AB;';
+								break;
+
+							default:
+								$data[$id_profile][$permission][$group->id] = '&mdash;';
+								break;
+						}
 					}
 				}
 			}
@@ -530,7 +549,10 @@ class Reports implements ActionInterface
 			Group::LOAD_NORMAL | (int) !empty(Config::$modSettings['permission_enable_postgroups']),
 			[Group::ADMIN, Group::MOD],
 		);
-		Group::loadPermissionsBatch(array_map(fn($group) => $group->id, $group_data), 0);
+
+		foreach ($groups_data as $group) {
+			$group->loadPermissions();
+		}
 
 		// Certain permissions should not really be shown.
 		$disabled_permissions = [];
@@ -552,8 +574,11 @@ class Reports implements ActionInterface
 			if ($group->parent === Group::NONE && ($inc == [] || in_array($group->id, $inc))) {
 				$groups[$group->id] = $group->name;
 
-				foreach ($group->permissions['general'] as $permission => $add_deny) {
-					if (in_array($permission, $disabled_permissions)) {
+				foreach ($group->permission_sets[PermissionProfile::DEFAULT]->permissions as $permission => $value) {
+					if (
+						in_array($permission, $disabled_permissions)
+						|| Permission::get($permission)->scope !== 'global'
+					) {
 						continue;
 					}
 
@@ -565,7 +590,19 @@ class Reports implements ActionInterface
 						}
 					}
 
-					$data[$permission][$group->id] = $add_deny ? '&#x2705;' : '&#x1F6AB;';
+					switch ($value) {
+						case 1:
+							$data[$permission][$group->id] = '&#x2705;';
+							break;
+
+						case 0:
+							$data[$permission][$group->id] = '&#x1F6AB;';
+							break;
+
+						default:
+							$data[$permission][$group->id] = '&mdash;';
+							break;
+					}
 				}
 			}
 		}

--- a/Sources/Actions/Admin/Reports.php
+++ b/Sources/Actions/Admin/Reports.php
@@ -27,6 +27,7 @@ use SMF\Group;
 use SMF\IntegrationHook;
 use SMF\Lang;
 use SMF\Menu;
+use SMF\Permissions\PermissionProfile;
 use SMF\Theme;
 use SMF\Time;
 use SMF\User;
@@ -234,7 +235,7 @@ class Reports implements ActionInterface
 			[Group::ADMIN, Group::MOD],
 		);
 
-		Permissions::loadPermissionProfiles();
+		PermissionProfile::loadContext();
 
 		// Get all the themes...
 		Utils::$context['themes'] = [];
@@ -407,7 +408,7 @@ class Reports implements ActionInterface
 	 */
 	public function boardPerms(): void
 	{
-		Permissions::loadPermissionProfiles();
+		PermissionProfile::loadContext();
 
 		$inc = [];
 

--- a/Sources/Actions/Profile/Main.php
+++ b/Sources/Actions/Profile/Main.php
@@ -581,7 +581,7 @@ class Main implements ActionInterface, Routable
 		// Group management isn't actually a permission. But we need it to be for this, so we need a phantom permission.
 		// And we care about what the current user can do, not what the user whose profile it is.
 		if (User::$me->mod_cache['gq'] != '0=1') {
-			User::$me->permissions[] = 'approve_group_requests';
+			User::$me->permission_sets[0]->grant('approve_group_requests');
 		}
 
 		// If paid subscriptions are enabled, make sure we actually have at least one subscription available...

--- a/Sources/Actions/Profile/Notification.php
+++ b/Sources/Actions/Profile/Notification.php
@@ -419,7 +419,12 @@ class Notification implements ActionInterface
 
 		// Now we have to do some permissions testing - but only if we're not loading this from the admin center
 		if (!empty(Profile::$member->id)) {
-			$group_permissions = ['manage_membergroups'];
+			// Disable membergroup requests if this user can't moderate any groups.
+			if (empty(Profile::$member->groupsCanModerate())) {
+				unset($this->alert_types['members']['request_group']);
+			}
+
+			$group_permissions = [];
 			$board_permissions = [];
 
 			foreach ($this->alert_types as $group => $items) {
@@ -435,24 +440,6 @@ class Notification implements ActionInterface
 			}
 
 			$member_groups = User::getGroupsWithPermissions($group_permissions, $board_permissions);
-
-			if (empty($member_groups['manage_membergroups']['allowed'])) {
-				$request = Db::$db->query(
-					'',
-					'SELECT COUNT(*)
-					FROM {db_prefix}group_moderators
-					WHERE id_member = {int:memID}',
-					[
-						'memID' => Profile::$member->id,
-					],
-				);
-				list($is_group_moderator) = Db::$db->fetch_row($request);
-				Db::$db->free_result($request);
-
-				if (empty($is_group_moderator)) {
-					unset($this->alert_types['members']['request_group']);
-				}
-			}
 
 			foreach ($this->alert_types as $group => $items) {
 				foreach ($items as $alert_key => $alert_value) {

--- a/Sources/Actions/Profile/Notification.php
+++ b/Sources/Actions/Profile/Notification.php
@@ -424,31 +424,14 @@ class Notification implements ActionInterface
 				unset($this->alert_types['members']['request_group']);
 			}
 
-			$group_permissions = [];
-			$board_permissions = [];
-
+			// Disable any types that this user doesn't have the permissions for.
 			foreach ($this->alert_types as $group => $items) {
 				foreach ($items as $alert_key => $alert_value) {
-					if (isset($alert_value['permission'])) {
-						if (empty($alert_value['permission']['is_board'])) {
-							$group_permissions[] = $alert_value['permission']['name'];
-						} else {
-							$board_permissions[] = $alert_value['permission']['name'];
-						}
-					}
-				}
-			}
-
-			$member_groups = User::getGroupsWithPermissions($group_permissions, $board_permissions);
-
-			foreach ($this->alert_types as $group => $items) {
-				foreach ($items as $alert_key => $alert_value) {
-					if (isset($alert_value['permission'])) {
-						$allowed = count(array_intersect(Profile::$member->groups, $member_groups[$alert_value['permission']['name']]['allowed'])) != 0;
-
-						if (!$allowed) {
-							unset($this->alert_types[$group][$alert_key]);
-						}
+					if (
+						isset($alert_value['permission'])
+						&& !Profile::$member->allowedTo($alert_value['permission']['name'], $alert_value['permission']['is_board'] ? Board::getAll() : null, true)
+					) {
+						unset($this->alert_types[$group][$alert_key]);
 					}
 				}
 

--- a/Sources/Actions/Profile/ShowPermissions.php
+++ b/Sources/Actions/Profile/ShowPermissions.php
@@ -21,6 +21,7 @@ use SMF\ActionTrait;
 use SMF\Board;
 use SMF\Db\DatabaseApi as Db;
 use SMF\Lang;
+use SMF\Permissions\PermissionProfile;
 use SMF\Profile;
 use SMF\Theme;
 use SMF\User;
@@ -59,7 +60,7 @@ class ShowPermissions implements ActionInterface
 		}
 
 		// Load all the permission profiles.
-		Permissions::loadPermissionProfiles();
+		PermissionProfile::loadContext();
 
 		$board = empty(Board::$info->id) ? 0 : (int) Board::$info->id;
 		Utils::$context['board'] = $board;

--- a/Sources/Actions/Register.php
+++ b/Sources/Actions/Register.php
@@ -284,7 +284,7 @@ class Register implements ActionInterface, Routable
 			User::$me->is_owner = true;
 
 			// Here, and here only, emulate the permissions the user would have to do this.
-			User::$me->permissions = array_merge(User::$me->permissions, ['profile_account_own', 'profile_extra_own', 'profile_other_own', 'profile_password_own', 'profile_website_own', 'profile_blurb']);
+			User::$me->permission_sets[0]->grant(['profile_account_own', 'profile_extra_own', 'profile_other_own', 'profile_password_own', 'profile_website_own', 'profile_blurb']);
 			$reg_fields = explode(',', Config::$modSettings['registration_fields']);
 
 			// Website is a little different

--- a/Sources/Board.php
+++ b/Sources/Board.php
@@ -1747,11 +1747,18 @@ class Board implements \ArrayAccess, Routable
 	 */
 	public static function getModeratorGroups(array $boards): array
 	{
-		if (empty($boards)) {
-			return [];
+		$groups = [];
+
+		foreach ($boards as $key => $board) {
+			if (isset(self::$loaded[$board]->moderator_groups)) {
+				$groups[$board] = self::$loaded[$board]->moderator_groups;
+				unset($boards[$key]);
+			}
 		}
 
-		$groups = [];
+		if (empty($boards)) {
+			return $groups;
+		}
 
 		$request = Db::$db->query(
 			'',

--- a/Sources/Config.php
+++ b/Sources/Config.php
@@ -1121,9 +1121,7 @@ class Config
 
 		// Ensure we know who can manage boards.
 		if (!isset(self::$modSettings['board_manager_groups'])) {
-			$board_managers = User::groupsAllowedTo('manage_boards', null);
-			$board_managers = implode(',', $board_managers['allowed']);
-			self::updateModSettings(['board_manager_groups' => $board_managers]);
+			self::updateModSettings(['board_manager_groups' => implode(',', Group::getAllowedTo('manage_boards'))]);
 		}
 
 		// Is post moderation alive and well? Everywhere else assumes this has been defined, so let's make sure it is.

--- a/Sources/Group.php
+++ b/Sources/Group.php
@@ -2041,6 +2041,49 @@ class Group implements \ArrayAccess
 		return self::$all_groups;
 	}
 
+	/**
+	 * Returns the IDs of all groups and whether the specified permissions are
+	 * allowed, disallowed, or denied for each group.
+	 *
+	 * @param string|array $permissions One or more permissions to check.
+	 * @param ?int $board_or_profile ID of either a board or of a permission
+	 *    profile. If null, the default permission profile will be used.
+	 *    Default: null.
+	 * @param bool $is_profile Set this to true if $board_or_profile is a
+	 *    permission profile ID. Means nothing if $board_or_profile is null.
+	 *    Default: false.
+	 * @return array
+	 */
+	public static function getAllWithPermissions(string|array $permissions, ?int $board_or_profile = null, bool $is_profile = false): array
+	{
+		if (!isset($board_or_profile)) {
+			$profile = PermissionProfile::DEFAULT;
+		} elseif ($is_profile) {
+			$profile = current(PermissionProfile::load($board_or_profile));
+			$profile = $profile instanceof PermissionProfile ? $profile->id : PermissionProfile::DEFAULT;
+		} else {
+			$profile = current(PermissionProfile::loadByBoard($board_or_profile));
+			$profile = $profile instanceof PermissionProfile ? $profile->id : PermissionProfile::DEFAULT;
+		}
+
+		$permissions = (array) $permissions;
+
+		$groups = [];
+
+		foreach (GroupPermissionSet::load($profile, self::getAll()) as $set) {
+			foreach ($permissions as $permission) {
+				$groups[$set->group][$permission] = $set->permissions[$permission];
+			}
+		}
+
+		// Maybe a mod needs to tweak the list of allowed groups on the fly?
+		IntegrationHook::call('integrate_groups_with_permissions', [&$groups, $permissions, $board]);
+
+		// Call the deprecated integrate_groups_allowed_to hook.
+		self::integrateGroupsAllowedTo($groups, $permissions, $board);
+
+		return $groups;
+	}
 
 	/**
 	 * Returns the IDs of groups that have the specified permissions.
@@ -2538,6 +2581,57 @@ class Group implements \ArrayAccess
 			yield $row;
 		}
 		Db::$db->free_result($request);
+	}
+
+	/**
+	 * Calls the deprecated integrate_groups_allowed_to hook.
+	 *
+	 * MOD AUTHORS: Update your code to use integrate_groups_with_permissions,
+	 * which can be found in SMF\Group::getAllWithPermissions()
+	 *
+	 * @deprecated 3.0
+	 *
+	 * @param array &$groups Info about the permission values for some groups.
+	 * @param array $permissions The permissions to check.
+	 * @param ?int $board Optional board ID. Default: null.
+	 */
+	protected static function integrateGroupsAllowedTo(array &$groups, array $permissions, ?int $board = null): void
+	{
+		if (empty(Config::$backward_compatibility) || empty(Config::$modSettings['integrate_groups_allowed_to'])) {
+			return;
+		}
+
+		foreach ($permissions as $permission) {
+			$allowed_denied = [];
+
+			foreach ($groups as $group => $group_permissions) {
+				switch ($group_permissions[$permission] ?? null) {
+					case 1:
+						$allowed_denied['allowed'][] = $group;
+						break;
+
+					case 0:
+						$allowed_denied['denied'][] = $group;
+						break;
+
+					default:
+						$allowed_denied['disallowed'][] = $group;
+						break;
+				}
+			}
+
+			IntegrationHook::call('integrate_groups_allowed_to', [&$allowed_denied, $permission, $board]);
+
+			foreach ($groups as $group => $group_permissions) {
+				if (in_array($allowed_denied['allowed'])) {
+					$groups[$group][$permission] = 1;
+				} elseif (in_array($allowed_denied['denied'])) {
+					$groups[$group][$permission] = 0;
+				} else {
+					$groups[$group][$permission] = null;
+				}
+			}
+		}
 	}
 }
 

--- a/Sources/Group.php
+++ b/Sources/Group.php
@@ -1309,7 +1309,7 @@ class Group implements \ArrayAccess
 				SET id_group = {int:regular_member}
 				WHERE id_group = {int:current_group}',
 				[
-					'regular_member' => 0,
+					'regular_member' => self::REGULAR,
 					'current_group' => $this->id,
 				],
 			);
@@ -1378,7 +1378,7 @@ class Group implements \ArrayAccess
 				SET id_group = {int:regular_member}
 				WHERE id_group = {int:current_group}',
 				[
-					'regular_member' => 0,
+					'regular_member' => self::REGULAR,
 					'current_group' => $this->id,
 				],
 			);
@@ -1623,7 +1623,7 @@ class Group implements \ArrayAccess
 		$ids = array_unique(array_map('intval', (array) $ids));
 
 		// The guest and regular member groups require special handling.
-		$guest_and_reg = array_intersect([-1, 0], $ids);
+		$guest_and_reg = array_intersect([self::GUEST, self::REGULAR], $ids);
 
 		if (!empty($guest_and_reg)) {
 			foreach ($guest_and_reg as $id) {
@@ -1642,7 +1642,7 @@ class Group implements \ArrayAccess
 		$where = $query_customizations['where'] ?? [];
 		$order = $query_customizations['order'] ?? [
 			'min_posts',
-			'CASE WHEN id_group < 4 THEN id_group ELSE 4 END',
+			'CASE WHEN id_group < ' . self::NEWBIE . ' THEN id_group ELSE ' . self::NEWBIE . ' END',
 			'group_name',
 		];
 		$group = $query_customizations['group'] ?? [];
@@ -1688,7 +1688,7 @@ class Group implements \ArrayAccess
 		$query_customizations = [
 			'order' => [
 				'min_posts',
-				'CASE WHEN id_group < 4 THEN id_group ELSE 4 END',
+				'CASE WHEN id_group < ' . self::NEWBIE . ' THEN id_group ELSE ' . self::NEWBIE . ' END',
 				'group_name',
 			],
 		];
@@ -1707,12 +1707,12 @@ class Group implements \ArrayAccess
 		if ($include & self::LOAD_NORMAL) {
 			// Do we want the guest group?
 			if (!in_array(self::GUEST, $exclude)) {
-				$loaded = array_merge($loaded, self::load(-1));
+				$loaded = array_merge($loaded, self::load(self::GUEST));
 			}
 
 			// Do we want the regular members group?
 			if (!in_array(self::REGULAR, $exclude)) {
-				$loaded = array_merge($loaded, self::load(0));
+				$loaded = array_merge($loaded, self::load(self::REGULAR));
 			}
 		}
 
@@ -1751,18 +1751,18 @@ class Group implements \ArrayAccess
 	public static function loadAssignable(): array
 	{
 		$loaded = [
-			new self(0),
+			new self(self::REGULAR),
 		];
 
 		$query_customizations = [
 			'where' => [
-				'id_group != 3',
+				'id_group != ' . self::MOD,
 				'min_posts = -1',
 				'id_group NOT IN ({array_int:unassignable})',
 			],
 			'order' => [
 				'min_posts',
-				'CASE WHEN id_group < 4 THEN id_group ELSE 4 END',
+				'CASE WHEN id_group < ' . self::NEWBIE . ' THEN id_group ELSE ' . self::NEWBIE . ' END',
 				'group_name',
 			],
 			'params' => [
@@ -2282,7 +2282,7 @@ class Group implements \ArrayAccess
 			WHERE group_type IN ({array_int:is_protected})
 				OR min_posts > -1',
 			[
-				'is_protected' => !User::$me->allowedTo('manage_membergroups') ? [self::REGULAR, self::ADMIN] : [self::ADMIN],
+				'is_protected' => !User::$me->allowedTo('manage_membergroups') ? [self::TYPE_PRIVATE, self::TYPE_PROTECTED] : [self::TYPE_PROTECTED],
 			],
 		);
 

--- a/Sources/Group.php
+++ b/Sources/Group.php
@@ -337,13 +337,14 @@ class Group implements \ArrayAccess
 	/**
 	 * Constructor.
 	 *
-	 * @param int $id The ID number of the group.
+	 * @param ?int $id The ID number of the group. Can be set to null when
+	 *    creating a brand new group that will be saved to the database.
 	 * @param array $props Properties to set for this group. If empty, will be
 	 *    loaded from the database automatically.
 	 */
-	public function __construct(int $id, array $props = [])
+	public function __construct(?int $id, array $props = [])
 	{
-		if ($id > self::REGULAR && empty($props)) {
+		if (isset($id) && $id > self::REGULAR && empty($props)) {
 			$request = Db::$db->query(
 				'',
 				'SELECT *
@@ -358,8 +359,13 @@ class Group implements \ArrayAccess
 			Db::$db->free_result($request);
 		}
 
-		$this->id = $id;
 		$this->set($props);
+
+		if (!isset($id)) {
+			return;
+		}
+
+		$this->id = $id;
 		self::$loaded[$this->id] = $this;
 
 		// Some special cases.
@@ -396,7 +402,7 @@ class Group implements \ArrayAccess
 	public function __set(string $prop, mixed $value): void
 	{
 		// Special handling for the icons.
-		if ($prop === 'icons' && is_string($value)) {
+		if (($prop === 'icons' || $prop === 'raw_icons') && is_string($value)) {
 			$prop = 'raw_icons';
 
 			if (preg_match('/^\d+#/', $value)) {
@@ -423,8 +429,6 @@ class Group implements \ArrayAccess
 
 		// Saving a new group.
 		if (empty($this->id)) {
-			IntegrationHook::call('integrate_pre_add_membergroup', []);
-
 			$columns = [
 				'group_name' => 'string-80',
 				'description' => 'string',
@@ -463,6 +467,11 @@ class Group implements \ArrayAccess
 			self::$loaded[$this->id] = $this;
 
 			IntegrationHook::call('integrate_add_membergroup', [$this->id, $this->min_posts > -1]);
+
+			// Update the post groups now, if this is a post group!
+			if ($this->min_posts > -1) {
+				Logging::updateStats('postgroups');
+			}
 		}
 		// Updating an existing group.
 		else {
@@ -550,6 +559,11 @@ class Group implements \ArrayAccess
 		// Did we make some post group changes?
 		if ($this->min_posts > -1) {
 			Logging::updateStats('postgroups');
+		}
+
+		// Make sure Config::$modSettings['board_manager_groups'] is up to date.
+		if (Permission::get('manage_boards')->canAssign()) {
+			Permissions::updateBoardManagers();
 		}
 
 		// Rebuild the group cache.
@@ -1526,6 +1540,155 @@ class Group implements \ArrayAccess
 		}
 
 		return $this->num_permissions;
+	}
+
+	/**
+	 * Set this group's permissions according to a predefined permission level.
+	 *
+	 * @param int $level One of the Permission::GROUP_LEVEL_* constants.
+	 * @param int $profile ID of a permission profile. Default: 1
+	 */
+	public function setPermissionsByLevel(int $level, int $profile = PermissionProfile::DEFAULT): void
+	{
+		// Cannot set permissions for post groups if they are disabled.
+		if ($this->min_posts > -1 && empty(Config::$modSettings['permission_enable_postgroups'])) {
+			return;
+		}
+
+		// Check that the level is valid.
+		if (!in_array($level, [Permission::GROUP_LEVEL_RESTRICT, Permission::GROUP_LEVEL_STANDARD, Permission::GROUP_LEVEL_MODERATOR, Permission::GROUP_LEVEL_MAINTENANCE])) {
+			return;
+		}
+
+		// Reset all cached permissions.
+		Config::updateModSettings(['settings_updated' => time()]);
+
+		$set = current(GroupPermissionSet::load($profile, (int) $group));
+
+		foreach ($set->permissions as $permission_name => $value) {
+			$permission = Permission::get($permission_name);
+
+			if (
+				// Skip any that don't have a group level.
+				!isset($permission->group_level)
+				// Make sure we're not granting someone too many permissions!
+				|| !$permission->canAssign()
+				|| !$permission->canBeGrantedTo($set->group)
+			) {
+				continue;
+			}
+
+			$set->permissions[$permission_name] = $permission->group_level <= $level ? 1 : null;
+		}
+
+		$set->save();
+	}
+
+	/**
+	 * Set this group's permissions to match those of another group, and
+	 * optionally make this group a child of that other group.
+	 *
+	 * @param int $other_group ID of the group to copy permissions from.
+	 * @param bool $inherit If true, make this group a child of $other_group.
+	 *    Default: false.
+	 */
+	public function copyPermissionsFrom(int $other_group, bool $inherit = false): void
+	{
+		// Cannot set permissions for post groups if they are disabled.
+		if ($this->min_posts > -1 && empty(Config::$modSettings['permission_enable_postgroups'])) {
+			return;
+		}
+
+		$copy_from = current(self::load($other_group));
+
+		if (!($copy_from instanceof self)) {
+			ErrorHandler::fatalLang('membergroup_does_not_exist');
+		}
+
+		// Protected groups are... well, protected!
+		if (!User::$me->allowedTo('admin_forum') && $copy_from->type == self::TYPE_PROTECTED) {
+			ErrorHandler::fatalLang('membergroup_does_not_exist');
+		}
+
+		// Don't allow copying of a real privileged person!
+		$illegal_permissions = Permission::getUnassignable();
+
+		// Copy the global permissions.
+		$inserts = [];
+
+		$request = Db::$db->query(
+			'',
+			'SELECT permission, add_deny
+			FROM {db_prefix}permissions
+			WHERE id_group = {int:copy_from}',
+			[
+				'copy_from' => $other_group,
+			],
+		);
+
+		while ($row = Db::$db->fetch_assoc($request)) {
+			if (empty($illegal_permissions) || !in_array($row['permission'], $illegal_permissions)) {
+				$inserts[] = [$this->id, $row['permission'], $row['add_deny']];
+			}
+		}
+
+		Db::$db->free_result($request);
+
+		if (!empty($inserts)) {
+			Db::$db->insert(
+				'replace',
+				'{db_prefix}permissions',
+				['id_group' => 'int', 'permission' => 'string', 'add_deny' => 'int'],
+				$inserts,
+				['id_group', 'permission'],
+			);
+		}
+
+		// Copy the board permissions.
+		$inserts = [];
+
+		$request = Db::$db->query(
+			'',
+			'SELECT id_profile, permission, add_deny
+			FROM {db_prefix}board_permissions
+			WHERE id_group = {int:copy_from}',
+			[
+				'copy_from' => $other_group,
+			],
+		);
+
+		while ($row = Db::$db->fetch_assoc($request)) {
+			$inserts[] = [$this->id, $row['id_profile'], $row['permission'], $row['add_deny']];
+		}
+
+		Db::$db->free_result($request);
+
+		if (!empty($inserts)) {
+			Db::$db->insert(
+				'replace',
+				'{db_prefix}board_permissions',
+				['id_group' => 'int', 'id_profile' => 'int', 'permission' => 'string', 'add_deny' => 'int'],
+				$inserts,
+				['id_group', 'id_profile', 'permission'],
+			);
+		}
+
+		// Also get some membergroup information if we're copying and not copying from guests...
+		if ($other_group > 0 && !$inherit) {
+			// ...and update the new membergroup with it.
+			$this->set([
+				'max_messages' => $copy_from->max_messages,
+				'online_color' => $copy_from->online_color,
+				'raw_icons' => $copy_from->raw_icons,
+			]);
+
+			$this->save();
+		}
+		// If inheriting say so...
+		elseif ($inherit) {
+			$this->set(['parent' => $other_group]);
+			$this->save();
+		}
 	}
 
 	/**

--- a/Sources/Group.php
+++ b/Sources/Group.php
@@ -18,6 +18,7 @@ namespace SMF;
 use SMF\Actions\Admin\Permissions;
 use SMF\Cache\CacheApi;
 use SMF\Db\DatabaseApi as Db;
+use SMF\Permissions\GroupPermissionSet;
 use SMF\Permissions\Permission;
 use SMF\Permissions\PermissionProfile;
 
@@ -228,36 +229,23 @@ class Group implements \ArrayAccess
 	/**
 	 * @var array
 	 *
-	 * Permissions that this group has.
-	 *
-	 * Contains two sub-arrays, 'general' and 'board_profiles'.
-	 *
-	 * General permissions are listed as key-value pairs where the keys are
-	 * permission names and values are integers.
-	 *
-	 * Board permissions are listed with the keys being permission profile IDs,
-	 * the values being sub-arrays containing key-value pairs similar to what is
-	 * used for the general permissions.
-	 *
-	 * As in the database table itself, 0 means denied and 1 means allowed.
-	 * A permission that is not listed at all is neither granted nor denied.
+	 * Permission sets for this group.
 	 */
-	public array $permissions = [
-		'general' => [],
-		'board_profiles' => [],
-	];
+	public array $permission_sets = [];
 
 	/**
 	 * @var array
 	 *
-	 * The numbers of allowed and denied permissions that this group has.
+	 * The numbers of allowed, disallowed, and denied permissions that this
+	 * group has.
 	 *
-	 * Contains two sub-arrays, 'allowed' and 'denied'.
+	 * Contains three sub-arrays, 'allowed', 'disallowed', and 'denied'.
 	 *
 	 * This is typically only used by SMF\Actions\Admin\Permissions.
 	 */
 	public array $num_permissions = [
 		'allowed' => 0,
+		'disallowed' => 0,
 		'denied' => 0,
 	];
 
@@ -546,9 +534,17 @@ class Group implements \ArrayAccess
 			);
 		}
 
-		// Update permissions of any groups that inherit from this group.
-		if ($this->parent === self::NONE) {
-			Permissions::updateChildPermissions($this->id);
+		// (Re)load and save all of this group's permissions.
+		// This ensures that permissions for any groups that inherit from this
+		// one are up to date.
+		foreach (
+			GroupPermissionSet::load(
+				array_map(fn($profile) => $profile->id, PermissionProfile::loadAll()),
+				$this->id,
+				true,
+			) as $set
+		) {
+			$set->save();
 		}
 
 		// Did we make some post group changes?
@@ -1445,65 +1441,16 @@ class Group implements \ArrayAccess
 	/**
 	 * Loads the permissions for this group.
 	 *
-	 * Results are saved in $this->permissions and also returned.
+	 * Results are saved in $this->permission_sets.
 	 *
 	 * @param int $profile Which permissions profile to get permissions for.
-	 *    If set to 1 or higher, get permissions for that permissions profile.
-	 *    If set to 0, get general permissions.
-	 *    If null, get all permissions.
+	 *    Default: PermissionProfile::DEFAULT.
 	 * @param bool $reload If true, force a reload from the database.
-	 * @return array A copy of $this->permissions.
+	 *    Default: false.
 	 */
-	public function loadPermissions(?int $profile = null, bool $reload = false): array
+	public function loadPermissions(int $profile = PermissionProfile::DEFAULT, bool $reload = false): void
 	{
-		// General permissions.
-		if (empty($profile)) {
-			if (empty($this->permissions['general']) || $reload) {
-				$this->permissions['general'] = PermissionProfile::load(PermissionProfile::DEFAULT)->getGlobalPermissions()[$this->id];
-			}
-		}
-
-		// If profile is zero, we only wanted general permissions.
-		if ($profile === 0) {
-			return $this->permissions;
-		}
-
-		// Don't reload unnecessarily.
-		if (isset($profile, $this->permissions['board_profiles'][$profile]) && !$reload) {
-			return $this->permissions;
-		}
-
-		// One board profile.
-		if ($profile !== null && PermissionProfile::load($profile) !== null) {
-			$this->permissions['board_profiles'][$profile] = PermissionProfile::load($profile)->getBoardPermissions()[$this->id];
-
-			return $this->permissions;
-		}
-
-		// Have we already loaded some board permissions?
-		if (!$reload && !empty($this->permissions['board_profiles'])) {
-			$excluded_profiles = array_keys($this->permissions['board_profiles']);
-		}
-
-		// All board profiles.
-		$request = Db::$db->query(
-			'',
-			'SELECT id_profile, permission, add_deny
-			FROM {db_prefix}board_permissions
-			WHERE id_group = {int:this_group}' . (isset($excluded_profiles) ? '
-				AND id_profile NOT IN ({array_int:excluded_profiles})' : ''),
-			[
-				'this_group' => $this->id,
-				'excluded_profiles' => $excluded_profiles ?? [0],
-			],
-		);
-
-		while ($row = Db::$db->fetch_assoc($request)) {
-			$this->permissions['board_profiles'][(int) $row['id_profile']][$row['permission']] = (int) $row['add_deny'];
-		}
-		Db::$db->free_result($request);
-
-		return $this->permissions;
+		$this->permission_sets[$profile] = current(GroupPermissionSet::load($profile, $this->id, $reload));
 	}
 
 	/**
@@ -1511,15 +1458,72 @@ class Group implements \ArrayAccess
 	 *
 	 * Results are saved in $this->num_permissions and also returned.
 	 *
-	 * @param int $profile Which permissions profile to get permissions for.
-	 *    If set to 1 or higher, get permissions for that permissions profile.
-	 *    If set to 0, get general permissions.
-	 *    If null, get all permissions.
+	 * @param int $profile Which permission profile to count permissions for.
+	 *    If set to 1 or higher, count board permissions for that profile.
+	 *    If set to 0, count general permissions only.
+	 *    If null, count general permissions and board permissions for the
+	 *    default permission profile.
 	 * @return array A copy of $this->num_permissions.
 	 */
 	public function countPermissions(?int $profile = null): array
 	{
-		self::countPermissionsBatch([$this->id], $profile);
+		$this->num_permissions = [
+			'allowed' => 0,
+			'disallowed' => 0,
+			'denied' => 0,
+		];
+
+		if (empty($profile)) {
+			if (!isset($this->permission_sets[PermissionProfile::DEFAULT])) {
+				$this->loadPermissions(PermissionProfile::DEFAULT);
+			}
+
+			$this->num_permissions['allowed'] += count(array_filter(
+				$this->permission_sets[PermissionProfile::DEFAULT]->permissions,
+				fn($v, $k) => $v === 1 && Permission::get($k)->scope === 'global' && !Permission::get($k)->hidden,
+				ARRAY_FILTER_USE_BOTH,
+			));
+
+			$this->num_permissions['disallowed'] += count(array_filter(
+				$this->permission_sets[PermissionProfile::DEFAULT]->permissions,
+				fn($v, $k) => $v === null && Permission::get($k)->scope === 'global' && !Permission::get($k)->hidden,
+				ARRAY_FILTER_USE_BOTH,
+			));
+
+			$this->num_permissions['denied'] += count(array_filter(
+				$this->permission_sets[PermissionProfile::DEFAULT]->permissions,
+				fn($v, $k) => $v === 0 && Permission::get($k)->scope === 'global' && !Permission::get($k)->hidden,
+				ARRAY_FILTER_USE_BOTH,
+			));
+		}
+
+		if (!empty($profile) || $profile === null) {
+			if ($profile === null) {
+				$profile = PermissionProfile::DEFAULT;
+			}
+
+			if (!isset($this->permission_sets[$profile])) {
+				$this->loadPermissions($profile);
+			}
+
+			$this->num_permissions['allowed'] += count(array_filter(
+				$this->permission_sets[$profile]->permissions,
+				fn($v, $k) => $v === 1 && Permission::get($k)->scope === 'board' && !Permission::get($k)->hidden,
+				ARRAY_FILTER_USE_BOTH,
+			));
+
+			$this->num_permissions['disallowed'] += count(array_filter(
+				$this->permission_sets[$profile]->permissions,
+				fn($v, $k) => $v === null && Permission::get($k)->scope === 'board' && !Permission::get($k)->hidden,
+				ARRAY_FILTER_USE_BOTH,
+			));
+
+			$this->num_permissions['denied'] += count(array_filter(
+				$this->permission_sets[$profile]->permissions,
+				fn($v, $k) => $v === 0 && Permission::get($k)->scope === 'board' && !Permission::get($k)->hidden,
+				ARRAY_FILTER_USE_BOTH,
+			));
+		}
 
 		return $this->num_permissions;
 	}
@@ -2001,194 +2005,6 @@ class Group implements \ArrayAccess
 		}
 
 		return $counts;
-	}
-
-	/**
-	 * Like $this->loadPermissions(), except that this is more efficient when
-	 * working on a batch of groups.
-	 *
-	 * Groups that have not already been loaded will be skipped.
-	 *
-	 * Results are saved in $this->permissions for each group and also returned.
-	 *
-	 * @param array $group_ids IDs of the groups to get permissions for.
-	 * @param int $profile Which permissions profile to get permissions for.
-	 *    If set to 1 or higher, get permissions for that permissions profile.
-	 *    If set to 0, get general permissions only.
-	 *    If null, get all permissions.
-	 * @param bool $reload If true, force a reload from the database.
-	 * @return array Copies of $this->permissions for all the groups.
-	 */
-	public static function loadPermissionsBatch(array $group_ids, ?int $profile = null, bool $reload = false): array
-	{
-		$get_general = [];
-		$get_board = [];
-
-		$group_ids = array_intersect(array_unique(array_map('intval', $group_ids)), array_keys(self::$loaded));
-
-		// Figure out which groups we need to get info for.
-		foreach ($group_ids as $key => $group_id) {
-			// Profile is 0 or null and general perms haven't been loaded or should be reloaded.
-			if (empty($profile) && (empty(self::$loaded[$group_id]->permissions['general']) || $reload)) {
-				$get_general[] = $group_id;
-			}
-
-			// Profile is null, or it's not 0 and either hasn't been loaded or should be reloaded.
-			if (!isset($profile) || (!empty($profile) && (!isset(self::$loaded[$group_id]->permissions['board_profiles'][$profile]) || $reload))) {
-				$get_board[] = $group_id;
-			}
-		}
-
-		// General permissions.
-		if (!empty($get_general)) {
-			$request = Db::$db->query(
-				'',
-				'SELECT id_group, permission, add_deny
-				FROM {db_prefix}permissions
-				WHERE id_group IN ({array_int:groups})',
-				[
-					'groups' => $get_general,
-				],
-			);
-
-			while ($row = Db::$db->fetch_assoc($request)) {
-				self::$loaded[(int) $row['id_group']]->permissions['general'][$row['permission']] = (int) $row['add_deny'];
-			}
-			Db::$db->free_result($request);
-		}
-
-		// Board permissions.
-		if (!empty($get_board)) {
-			// Get board permissions.
-			$request = Db::$db->query(
-				'',
-				'SELECT id_profile, id_group, permission, add_deny
-				FROM {db_prefix}board_permissions
-				WHERE id_group IN ({array_int:groups})' . (isset($profile) ? '
-					AND id_profile = {int:profile}' : ''),
-				[
-					'groups' => $get_board,
-					'profile' => $profile ?? 0,
-				],
-			);
-
-			while ($row = Db::$db->fetch_assoc($request)) {
-				$row['id_profile'] = (int) $row['id_profile'];
-				$row['id_group'] = (int) $row['id_group'];
-				$row['add_deny'] = (int) $row['add_deny'];
-
-				// If we're loading all profiles, but not reloading, don't overwrite existing data.
-				if (!isset($profile) && !$reload && isset(self::$loaded[$row['id_group']]->permissions['board_profiles'][$row['id_profile']])) {
-					continue;
-				}
-
-				self::$loaded[$row['id_group']]->permissions['board_profiles'][$row['id_profile']][$row['permission']] = $row['add_deny'];
-			}
-			Db::$db->free_result($request);
-		}
-
-		$all_loaded_permissions = [];
-
-		foreach ($group_ids as $group_id) {
-			$all_loaded_permissions[$group_id] = self::$loaded[$group_id]->permissions;
-		}
-
-		return $all_loaded_permissions;
-	}
-
-	/**
-	 * Like $this->countPermissions(), except that this is more efficient when
-	 * working on a batch of groups.
-	 *
-	 * Groups that have not already been loaded will be skipped.
-	 *
-	 * Results are saved in $this->num_permissions for each group and also
-	 * returned.
-	 *
-	 * @param array $group_ids IDs of the groups to count permissions for.
-	 * @param int $profile Which permissions profile to count permissions for.
-	 *    If set to 1 or higher, count permissions for that permissions profile.
-	 *    If set to 0, count general permissions only.
-	 *    If null, count general permissions and the default profile.
-	 * @return array Copies of $this->num_permissions for all the groups.
-	 */
-	public static function countPermissionsBatch(array $group_ids, ?int $profile = null): array
-	{
-		// If null or 0, we want general permissions.
-		if (empty($profile)) {
-			$request = Db::$db->query(
-				'',
-				'SELECT id_group, COUNT(*) AS num_permissions, add_deny
-				FROM {db_prefix}permissions
-				' . (empty(Permission::getHidden()) ? '' : ' WHERE permission NOT IN ({array_string:hidden_permissions})') . '
-				GROUP BY id_group, add_deny',
-				[
-					'hidden_permissions' => Permission::getHidden(),
-				],
-			);
-
-			while ($row = Db::$db->fetch_assoc($request)) {
-				$row['id_group'] = (int) $row['id_group'];
-
-				if (!isset(self::$loaded[$row['id_group']])) {
-					continue;
-				}
-
-				if (!empty($row['add_deny']) || $row['id_group'] != self::GUEST) {
-					self::$loaded[$row['id_group']]->num_permissions[empty($row['add_deny']) ? 'denied' : 'allowed'] = $row['num_permissions'];
-				}
-			}
-			Db::$db->free_result($request);
-		}
-
-		// For board permissions, null means the same as default.
-		if ($profile === null) {
-			$profile = PermissionProfile::DEFAULT;
-		}
-
-		if (!empty($profile)) {
-			$request = Db::$db->query(
-				'',
-				'SELECT id_profile, id_group, COUNT(*) AS num_permissions, add_deny
-				FROM {db_prefix}board_permissions
-				WHERE id_profile = {int:current_profile}
-				GROUP BY id_profile, id_group, add_deny',
-				[
-					'current_profile' => $profile,
-				],
-			);
-
-			while ($row = Db::$db->fetch_assoc($request)) {
-				$row['id_group'] = (int) $row['id_group'];
-
-				if (!isset(self::$loaded[$row['id_group']])) {
-					continue;
-				}
-
-				if (!empty($row['add_deny']) || $row['id_group'] != self::GUEST) {
-					self::$loaded[$row['id_group']]->num_permissions[empty($row['add_deny']) ? 'denied' : 'allowed'] += $row['num_permissions'];
-				}
-			}
-			Db::$db->free_result($request);
-		}
-
-		// A few overrides.
-		if (isset(self::$loaded[self::GUEST])) {
-			self::$loaded[self::GUEST]->num_permissions['denied'] = '(' . Lang::getTxt('permissions_none', file: 'ManagePermissions') . ')';
-		}
-
-		if (isset(self::$loaded[self::ADMIN])) {
-			self::$loaded[self::ADMIN]->num_permissions['allowed'] = '(' . Lang::getTxt('permissions_all', file: 'ManagePermissions') . ')';
-			self::$loaded[self::ADMIN]->num_permissions['denied'] = '(' . Lang::getTxt('permissions_none', file: 'ManagePermissions') . ')';
-		}
-
-		$all_counted_permissions = [];
-
-		foreach ($group_ids as $group_id) {
-			$all_counted_permissions[$group_id] = self::$loaded[$group_id]->num_permissions;
-		}
-
-		return $all_counted_permissions;
 	}
 
 	/**

--- a/Sources/Group.php
+++ b/Sources/Group.php
@@ -18,6 +18,7 @@ namespace SMF;
 use SMF\Actions\Admin\Permissions;
 use SMF\Cache\CacheApi;
 use SMF\Db\DatabaseApi as Db;
+use SMF\Permissions\Permission;
 
 /**
  * Represents a member group.
@@ -332,6 +333,13 @@ class Group implements \ArrayAccess
 	 * IDs of all post-count based groups.
 	 */
 	protected static array $post_groups;
+
+	/**
+	 * @var array
+	 *
+	 * IDs of all groups.
+	 */
+	protected static array $all_groups;
 
 	/****************
 	 * Public methods
@@ -2113,20 +2121,16 @@ class Group implements \ArrayAccess
 	 */
 	public static function countPermissionsBatch(array $group_ids, ?int $profile = null): array
 	{
-		if (!isset(Permissions::$hidden)) {
-			Permissions::buildHidden();
-		}
-
 		// If null or 0, we want general permissions.
 		if (empty($profile)) {
 			$request = Db::$db->query(
 				'',
 				'SELECT id_group, COUNT(*) AS num_permissions, add_deny
 				FROM {db_prefix}permissions
-				' . (empty(Permissions::$hidden) ? '' : ' WHERE permission NOT IN ({array_string:hidden_permissions})') . '
+				' . (empty(Permission::getHidden()) ? '' : ' WHERE permission NOT IN ({array_string:hidden_permissions})') . '
 				GROUP BY id_group, add_deny',
 				[
-					'hidden_permissions' => Permissions::$hidden,
+					'hidden_permissions' => Permission::getHidden(),
 				],
 			);
 
@@ -2192,6 +2196,40 @@ class Group implements \ArrayAccess
 		}
 
 		return $all_counted_permissions;
+	}
+
+	/**
+	 * Returns the IDs of all groups.
+	 *
+	 * @return array IDs of all groups.
+	 */
+	public static function getAll(): array
+	{
+		if (!isset(self::$all_groups)) {
+			self::$all_groups = [
+				Group::GUEST,
+				Group::REGULAR,
+				Group::ADMIN,
+				Group::GLOBAL_MOD,
+				Group::MOD,
+				Group::NEWBIE,
+			];
+
+			$request = Db::$db->query(
+				'',
+				'SELECT id_group
+				FROM {db_prefix}membergroups',
+				[],
+			);
+
+			while ($row = Db::$db->fetch_assoc($request)) {
+				self::$all_groups[] = (int) $row['id_group'];
+			}
+
+			self::$all_groups = array_unique(self::$all_groups);
+		}
+
+		return self::$all_groups;
 	}
 
 	/**

--- a/Sources/Group.php
+++ b/Sources/Group.php
@@ -19,6 +19,7 @@ use SMF\Actions\Admin\Permissions;
 use SMF\Cache\CacheApi;
 use SMF\Db\DatabaseApi as Db;
 use SMF\Permissions\Permission;
+use SMF\Permissions\PermissionProfile;
 
 /**
  * Represents a member group.
@@ -1458,30 +1459,24 @@ class Group implements \ArrayAccess
 		// General permissions.
 		if (empty($profile)) {
 			if (empty($this->permissions['general']) || $reload) {
-				$request = Db::$db->query(
-					'',
-					'SELECT permission, add_deny
-					FROM {db_prefix}permissions
-					WHERE id_group = {int:this_group}',
-					[
-						'this_group' => $this->id,
-					],
-				);
-
-				while ($row = Db::$db->fetch_assoc($request)) {
-					$this->permissions['general'][$row['permission']] = (int) $row['add_deny'];
-				}
-				Db::$db->free_result($request);
+				$this->permissions['general'] = PermissionProfile::load(PermissionProfile::DEFAULT)->getGlobalPermissions()[$this->id];
 			}
 		}
 
 		// If profile is zero, we only wanted general permissions.
-		if (isset($profile) && $profile === 0) {
+		if ($profile === 0) {
 			return $this->permissions;
 		}
 
 		// Don't reload unnecessarily.
-		if (isset($profile, $this->permissions['board_profiles'][$profile])   && !$reload) {
+		if (isset($profile, $this->permissions['board_profiles'][$profile]) && !$reload) {
+			return $this->permissions;
+		}
+
+		// One board profile.
+		if ($profile !== null && PermissionProfile::load($profile) !== null) {
+			$this->permissions['board_profiles'][$profile] = PermissionProfile::load($profile)->getBoardPermissions()[$this->id];
+
 			return $this->permissions;
 		}
 
@@ -1490,17 +1485,15 @@ class Group implements \ArrayAccess
 			$excluded_profiles = array_keys($this->permissions['board_profiles']);
 		}
 
-		// Get board permissions.
+		// All board profiles.
 		$request = Db::$db->query(
 			'',
 			'SELECT id_profile, permission, add_deny
 			FROM {db_prefix}board_permissions
-			WHERE id_group = {int:this_group}' . (isset($profile) ? '
-				AND id_profile = {int:profile}' : '') . (isset($excluded_profiles) ? '
+			WHERE id_group = {int:this_group}' . (isset($excluded_profiles) ? '
 				AND id_profile NOT IN ({array_int:excluded_profiles})' : ''),
 			[
 				'this_group' => $this->id,
-				'profile' => $profile ?? 0,
 				'excluded_profiles' => $excluded_profiles ?? [0],
 			],
 		);
@@ -2150,7 +2143,7 @@ class Group implements \ArrayAccess
 
 		// For board permissions, null means the same as default.
 		if ($profile === null) {
-			$profile = Permissions::PROFILE_DEFAULT;
+			$profile = PermissionProfile::DEFAULT;
 		}
 
 		if (!empty($profile)) {

--- a/Sources/Group.php
+++ b/Sources/Group.php
@@ -2041,6 +2041,43 @@ class Group implements \ArrayAccess
 		return self::$all_groups;
 	}
 
+
+	/**
+	 * Returns the IDs of groups that have the specified permissions.
+	 *
+	 * @param array|string $permissions One or more permissions to check.
+	 * @param int $profile ID of a permission profile. Default: 1.
+	 * @param bool $any If true, will return groups that have any of the
+	 *    specified permissions. If false, will return groups that have
+	 *    all of the specified permissions. Default: false.
+	 * @throws \ValueError if $profile is invalid.
+	 * @return array IDs of groups that have the specified permissions.
+	 */
+	public static function getAllowedTo(array|string $permissions, int $profile = PermissionProfile::DEFAULT, bool $any = false): array
+	{
+		if (!(PermissionProfile::load($profile) instanceof PermissionProfile)) {
+			throw new \ValueError();
+		}
+
+		$permissions = (array) $permissions;
+
+		$groups = [];
+
+		foreach (GroupPermissionSet::load(self::getAll(), $profile) as $set) {
+			$can = !$any;
+
+			foreach ($permissions as $permission) {
+				$can = $any ? ($can || ($set->permissions[$permission] ?? false)) : ($can && ($set->permissions[$permission] ?? false));
+			}
+
+			if ($can) {
+				$groups[] = $set->group;
+			}
+		}
+
+		return $groups;
+	}
+
 	/**
 	 * Returns the IDs of all post-count based groups.
 	 *

--- a/Sources/Group.php
+++ b/Sources/Group.php
@@ -585,7 +585,6 @@ class Group implements \ArrayAccess
 			'SELECT name
 			FROM {db_prefix}subscriptions
 			WHERE id_group = {int:this_group}
-				OR FIND_IN_SET({int:this_group}, additional_groups) != 0
 			ORDER BY name',
 			[
 				'this_group' => $this->id,

--- a/Sources/Permissions/GroupPermissionSet.php
+++ b/Sources/Permissions/GroupPermissionSet.php
@@ -8,7 +8,7 @@
  * @copyright 2025 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 2
+ * @version 3.0 Alpha 3
  */
 
 declare(strict_types=1);

--- a/Sources/Permissions/GroupPermissionSet.php
+++ b/Sources/Permissions/GroupPermissionSet.php
@@ -1,0 +1,501 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2025 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 2
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Permissions;
+
+use SMF\Cache\CacheApi;
+use SMF\Config;
+use SMF\Db\DatabaseApi as Db;
+use SMF\Group;
+
+/**
+ * Keeps track of which permissions are allowed for a particular membergroup
+ * in a particular permission profile.
+ */
+class GroupPermissionSet
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 * @var int
+	 *
+	 * ID of the permission profile that this permission set is for.
+	 */
+	public int $profile;
+
+	/**
+	 * @var int
+	 *
+	 * ID of the group that this permission set is for.
+	 */
+	public int $group;
+
+	/**
+	 * @var array
+	 *
+	 * List of permission names and whether they are allowed.
+	 *
+	 * Keys are permission names.
+	 * Values can be 1 for allowed, null for not allowed, or 0 for denied.
+	 *
+	 * To update permissions in the database, simply change their values here
+	 * and then call the save() method.
+	 */
+	public array $permissions = [];
+
+	/****************************
+	 * Internal static properties
+	 ****************************/
+
+	/**
+	 * @var array
+	 *
+	 * All loaded instances of this class.
+	 */
+	private static array $loaded = [];
+
+	/**
+	 * @var bool
+	 *
+	 * Whether to load permission info from the database during construction.
+	 *
+	 * This is always true except during one phase of PermissionSet::load()
+	 * and should be regarded as an implementation detail.
+	 */
+	private static bool $query_during_construction = true;
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 *
+	 * Loads permission data for the given profile and group.
+	 *
+	 * @param int $profile ID of the permission profile that this is for.
+	 * @param int $group ID of the group that this is for.
+	 */
+	public function __construct(int $profile, int $group)
+	{
+		$this->group = $group;
+		$this->profile = $profile;
+
+		self::$loaded[$profile][$group] = $this;
+
+		if (self::$query_during_construction) {
+			if ($profile === PermissionProfile::DEFAULT) {
+				self::loadGlobalPermissionData([$group]);
+			}
+
+			self::loadBoardPermissionData([$profile], [$group]);
+		}
+	}
+
+	/**
+	 * Update the permissions in the database for this profile and group (as
+	 * well as for any groups that inherit from this one).
+	 *
+	 * Performs safety checks before saving and silently skips any permissions
+	 * that cannot or should not be saved.
+	 */
+	public function save(): void
+	{
+		// There is no need to save for admin.
+		if ($this->group === Group::ADMIN) {
+			return;
+		}
+
+		$group = current(Group::load($this->group));
+
+		// Inherited permissions cannot be edited.
+		if ($group->parent != Group::NONE) {
+			return;
+		}
+
+		// Do any groups inherit permissions from this group?
+		$group_ids = array_merge([$this->group], array_keys($group->getChildren()));
+
+		// Save global permissions.
+		if ($this->profile === PermissionProfile::DEFAULT) {
+			$illegal = [];
+			$inserts = [];
+
+			foreach (Permission::getAll() as $permission) {
+				if ($permission->scope !== 'global') {
+					continue;
+				}
+
+				if (!$permission->canAssign() || !$permission->canBeGrantedTo($this->group)) {
+					$illegal[] = $permission->name;
+					continue;
+				}
+
+				if (!isset($this->permissions[$permission->name])) {
+					continue;
+				}
+
+				foreach ($group_ids as $group_id) {
+					// This shouldn't happen anyway, but just in case...
+					if ($group_id === Group::MOD) {
+						continue;
+					}
+
+					$inserts[] = [
+						$group_id,
+						$permission->name,
+						$this->permissions[$permission->name],
+					];
+				}
+			}
+
+			// First, delete all the existing permissions for this group and its children.
+			Db::$db->query(
+				'',
+				'DELETE FROM {db_prefix}permissions
+				WHERE id_group IN ({array_int:groups})
+					AND permission NOT IN ({array_string:illegal})',
+				[
+					'groups' => $group_ids,
+					'illegal' => empty($illegal) ? [''] : $illegal,
+				],
+			);
+
+			// Now grant this group and its children whichever permissions they can have.
+			Db::$db->insert(
+				'replace',
+				'{db_prefix}permissions',
+				[
+					'id_group' => 'int',
+					'permission' => 'string',
+					'add_deny' => 'int',
+				],
+				$inserts,
+				['id_group', 'permission'],
+			);
+		}
+
+		// Save board permissions.
+		$illegal = [];
+		$inserts = [];
+
+		foreach (Permission::getAll() as $permission) {
+			if ($permission->scope !== 'board') {
+				continue;
+			}
+
+			if (!$permission->canAssign() || !$permission->canBeGrantedTo($this->group)) {
+				$illegal[] = $permission->name;
+				continue;
+			}
+
+			if (!isset($this->permissions[$permission->name])) {
+				continue;
+			}
+
+			foreach ($group_ids as $group_id) {
+				$inserts[] = [
+					$group_id,
+					$permission->name,
+					$this->permissions[$permission->name],
+					$this->profile,
+				];
+			}
+		}
+
+		// Again, we start by clearing all the permissions for this group and its children.
+		Db::$db->query(
+			'',
+			'DELETE FROM {db_prefix}board_permissions
+			WHERE id_group IN ({array_int:groups})
+				AND id_profile = {int:profile}
+				AND permission NOT IN ({array_string:illegal})',
+			[
+				'groups' => $group_ids,
+				'profile' => $this->profile,
+				'illegal' => empty($illegal) ? [''] : $illegal,
+			],
+		);
+
+		// Grant them whichever permissions they are now allowed to have.
+		Db::$db->insert(
+			'replace',
+			'{db_prefix}board_permissions',
+			[
+				'id_group' => 'int',
+				'permission' => 'string',
+				'add_deny' => 'int',
+				'id_profile' => 'int',
+			],
+			$inserts,
+			['id_group', 'permission', 'id_profile'],
+		);
+	}
+
+	/***********************
+	 * Public static methods
+	 ***********************/
+
+	/**
+	 * Loads permission sets for one or more groups in one or more profiles.
+	 *
+	 * When dealing with multiple groups, this is more efficient than
+	 * individually constructing a new instance for each group and profile.
+	 *
+	 * @param array|int $profiles IDs of one or more permission profiles.
+	 * @param array|int $groups IDs of one or more groups.
+	 * @param bool $refresh Set to true to force a reload from the database.
+	 * @return array Instances of this class.
+	 */
+	public static function load(array|int $profiles, array|int $groups, bool $refresh = false): array
+	{
+		$loaded = [];
+
+		// Ensure all profile and group IDs are integers.
+		$profiles = array_map('intval', array_filter((array) $profiles, 'is_numeric'));
+		$groups = array_map('intval', array_filter((array) $groups, 'is_numeric'));
+
+		$query_groups = [];
+
+		foreach ($profiles as $profile) {
+			foreach ($groups as $group) {
+				// Skip any that have already been loaded, unless told to refresh.
+				if (isset(self::$loaded[$profile][$group]) && !$refresh) {
+					$loaded[] = self::$loaded[$profile][$group];
+
+					continue;
+				}
+
+				$query_groups[] = $group;
+
+				// Don't run queries during object construction because we are going
+				// to query the database separately below.
+				self::$query_during_construction = false;
+
+				// Initialize the objects.
+				$loaded[] = new self($profile, $group);
+
+				// Restore this to its normal value.
+				self::$query_during_construction = true;
+			}
+		}
+
+		if (!empty($query_groups)) {
+			// Global permissions.
+			if (in_array(PermissionProfile::DEFAULT, $profiles)) {
+				self::loadGlobalPermissionData($query_groups);
+			}
+
+			// Board permissions.
+			self::loadBoardPermissionData($profiles, $query_groups);
+		}
+
+		return $loaded;
+	}
+
+	/*************************
+	 * Internal static methods
+	 *************************/
+
+	/**
+	 * Loads global permission data.
+	 *
+	 * @param array $groups IDs of one or more groups.
+	 */
+	protected static function loadGlobalPermissionData(array $groups): void
+	{
+		$groups = array_intersect($groups, array_keys(self::$loaded[PermissionProfile::DEFAULT]));
+
+		// By definition, the moderator group cannot have global permissions.
+		$groups = array_diff($groups, [Group::MOD]);
+
+		// Admins can do everything.
+		if (in_array(Group::ADMIN, $groups)) {
+			foreach (Permission::getAll() as $permission) {
+				if ($permission->scope === 'global') {
+					self::$loaded[PermissionProfile::DEFAULT][Group::ADMIN]->permissions[$permission->name] = 1;
+				}
+			}
+
+			$groups = array_diff($groups, [Group::ADMIN]);
+		}
+
+		// Can we get the permissions from the cache?
+		foreach ($groups as $g => $group) {
+			if (($set = CacheApi::get('permissions_global:' . $group, 240)) !== null) {
+				self::$loaded[PermissionProfile::DEFAULT][$group] = $set;
+				unset($groups[$g]);
+			}
+		}
+
+		// If there's nothing left to look up, we're done.
+		if (empty($groups)) {
+			return;
+		}
+
+		// Look up the permissions for each group.
+		$request = Db::$db->query(
+			'',
+			'SELECT id_group, permission, add_deny
+			FROM {db_prefix}permissions
+			WHERE id_group IN ({array_int:groups})',
+			[
+				'groups' => $groups,
+			],
+		);
+
+		while ($row = Db::$db->fetch_assoc($request)) {
+			self::$loaded[PermissionProfile::DEFAULT][(int) $row['id_group']]->permissions[$row['permission']] = (int) $row['add_deny'];
+		}
+
+		Db::$db->free_result($request);
+
+		// If the option to deny permissions is disabled, turn any denied ones into disallowed ones.
+		if (empty(Config::$modSettings['permission_enable_deny'])) {
+			foreach ($groups as $group) {
+				self::$loaded[PermissionProfile::DEFAULT][$group]->permissions = array_map(
+					fn($value) => $value === 0 ? null : $value,
+					self::$loaded[PermissionProfile::DEFAULT][$group]->permissions,
+				);
+			}
+		}
+
+		// Fill any unlisted permissions with an explicit null value.
+		foreach (Permission::getAll() as $permission) {
+			if ($permission->scope !== 'global') {
+				continue;
+			}
+
+			foreach ($groups as $group) {
+				self::$loaded[PermissionProfile::DEFAULT][$group]->permissions[$permission->name] = self::$loaded[PermissionProfile::DEFAULT][$group]->permissions[$permission->name] ?? null;
+			}
+		}
+
+		// Cache each group's permissions.
+		foreach (self::$loaded[PermissionProfile::DEFAULT] as $group => $set) {
+			CacheApi::put('permissions_global:' . $group, $set, 240);
+		}
+	}
+
+	/**
+	 * Loads boad permission data.
+	 *
+	 * @param array $profiles IDs of one or more permission profiles.
+	 * @param array $groups IDs of one or more groups.
+	 */
+	protected static function loadBoardPermissionData(array $profiles, array $groups): void
+	{
+		// Admins can do everything.
+		if (in_array(Group::ADMIN, $groups)) {
+			foreach (Permission::getAll() as $permission) {
+				if ($permission->scope === 'board') {
+					foreach ($profiles as $profile) {
+						self::$loaded[$profile][Group::ADMIN]->permissions[$permission->name] = 1;
+					}
+				}
+			}
+
+			$groups = array_diff($groups, [Group::ADMIN]);
+		}
+
+		// Can we get the permissions from the cache?
+		if (CacheApi::$enable >= 2) {
+			foreach ($groups as $g => $group) {
+				$hits = 0;
+
+				foreach ($profiles as $p => $profile) {
+					if (($set = CacheApi::get('permissions_board:' . $profile . '-' . $group, 240)) !== null) {
+						self::$loaded[$profile][$group] = $set;
+						$hits++;
+					}
+				}
+
+				if ($hits = count($profiles)) {
+					unset($groups[$g]);
+				}
+			}
+		}
+
+		// If there's nothing left to look up, we're done.
+		if (empty($groups)) {
+			return;
+		}
+
+		// Look up the permissions for each group.
+		$request = Db::$db->query(
+			'',
+			'SELECT id_group, id_profile, permission, add_deny
+			FROM {db_prefix}board_permissions
+			WHERE id_group IN ({array_int:groups})
+				AND id_profile IN ({array_int:profiles})',
+			[
+				'groups' => $groups,
+				'profiles' => $profiles,
+			],
+		);
+
+		while ($row = Db::$db->fetch_assoc($request)) {
+			if (!isset(self::$loaded[(int) $row['id_profile']][(int) $row['id_group']])) {
+				continue;
+			}
+
+			self::$loaded[(int) $row['id_profile']][(int) $row['id_group']]->permissions[$row['permission']] = (int) $row['add_deny'];
+		}
+
+		Db::$db->free_result($request);
+
+		// If the option to deny permissions is disabled, turn any denied ones into disallowed ones.
+		if (empty(Config::$modSettings['permission_enable_deny'])) {
+			foreach ($profiles as $profile) {
+				foreach ($groups as $group) {
+					self::$loaded[$profile][$group]->permissions = array_map(
+						fn($value) => $value === 0 ? null : $value,
+						self::$loaded[$profile][$group]->permissions,
+					);
+				}
+			}
+		}
+
+		// Fill any unlisted permissions with an explicit null value.
+		foreach (Permission::getAll() as $permission) {
+			if ($permission->scope !== 'board') {
+				continue;
+			}
+
+			foreach ($profiles as $profile) {
+				foreach ($groups as $group) {
+					if (!isset(self::$loaded[$profile][$group])) {
+						continue;
+					}
+
+					self::$loaded[$profile][$group]->permissions[$permission->name] = self::$loaded[$profile][$group]->permissions[$permission->name] ?? null;
+				}
+			}
+		}
+
+		// Cache each group's permissions for each profile.
+		if (CacheApi::$enable >= 2) {
+			foreach ($profiles as $profile) {
+				foreach (self::$loaded[$profile] as $group => $set) {
+					CacheApi::put('permissions_board:' . $profile . '-' . $group, $set, 240);
+				}
+			}
+		}
+	}
+}
+
+?>

--- a/Sources/Permissions/Permission.php
+++ b/Sources/Permissions/Permission.php
@@ -8,7 +8,7 @@
  * @copyright 2025 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 2
+ * @version 3.0 Alpha 3
  */
 
 declare(strict_types=1);

--- a/Sources/Permissions/Permission.php
+++ b/Sources/Permissions/Permission.php
@@ -1077,6 +1077,7 @@ class Permission implements \ArrayAccess
 		IntegrationHook::call('integrate_permissions_list', [&self::$permissions]);
 
 		self::integrateHeavyPermissionsSession();
+		self::integrateLoadPermissionLevels();
 
 		// In case a mod screwed things up...
 		if (!in_array('html', Utils::$context['restricted_bbc'])) {
@@ -1379,6 +1380,120 @@ class Permission implements \ArrayAccess
 
 		// We don't need this anymore.
 		unset(Utils::$context['illegal_permissions']);
+	}
+
+	/**
+	 * Calls the deprecated integrate_load_permission_levels hook.
+	 *
+	 * MOD AUTHORS: Please update your code to use integrate_permissions_list
+	 * to set any permission's group_level or board_level parameter.
+	 *
+	 * @deprecated 3.0
+	 */
+	protected static function integrateLoadPermissionLevels(): void
+	{
+		// Don't bother if nothing is using this hook.
+		if (empty(Config::$backward_compatibility) || empty(Config::$modSettings['integrate_load_permission_levels'])) {
+			return;
+		}
+
+		// Levels by group... restrict, standard, moderator, maintenance.
+		$group_levels = [
+			'board' => ['inherit' => []],
+			'group' => ['inherit' => []],
+		];
+		// Levels by board... standard, publish, free.
+		$board_levels = ['inherit' => []];
+
+		foreach (self::$permissions as $perm) {
+			if (isset($perm['group_level'])) {
+				switch ($perm['group_level']) {
+					case self::GROUP_LEVEL_RESTRICT:
+						$group_levels[$perm['scope']]['restrict'][] = $perm['name'];
+						// no break
+
+					case self::GROUP_LEVEL_STANDARD:
+						$group_levels[$perm['scope']]['standard'][] = $perm['name'];
+						// no break
+
+					case self::GROUP_LEVEL_MODERATOR:
+						$group_levels[$perm['scope']]['moderator'][] = $perm['name'];
+						// no break
+
+					case self::GROUP_LEVEL_MAINTENANCE:
+						$group_levels[$perm['scope']]['maintenance'][] = $perm['name'];
+						break;
+				}
+			}
+
+			if (isset($perm['board_level'])) {
+				switch ($perm['board_level']) {
+					case self::BOARD_LEVEL_STANDARD:
+						$board_levels['standard'][] = $perm['name'];
+						// no break
+
+					case self::BOARD_LEVEL_LOCKED:
+						$board_levels['locked'][] = $perm['name'];
+						// no break
+
+					case self::BOARD_LEVEL_PUBLISH:
+						$board_levels['publish'][] = $perm['name'];
+						// no break
+
+					case self::BOARD_LEVEL_FREE:
+						$board_levels['free'][] = $perm['name'];
+						break;
+				}
+			}
+		}
+
+		IntegrationHook::call('integrate_load_permission_levels', [&$group_levels, &$board_levels]);
+
+		foreach ($group_levels as $scope => $levels) {
+			foreach ($levels as $level => $permissions) {
+				foreach ($permissions as $permission) {
+					switch ($level) {
+						case 'restrict':
+							self::$permissions[$permission]['group_level'] = self::GROUP_LEVEL_RESTRICT;
+							break;
+
+						case 'standard':
+							self::$permissions[$permission]['group_level'] = self::GROUP_LEVEL_STANDARD;
+							break;
+
+						case 'moderator':
+							self::$permissions[$permission]['group_level'] = self::GROUP_LEVEL_MODERATOR;
+							break;
+
+						case 'maintenance':
+							self::$permissions[$permission]['group_level'] = self::GROUP_LEVEL_MAINTENANCE;
+							break;
+					}
+				}
+			}
+		}
+
+		foreach ($board_levels as $level => $permissions) {
+			foreach ($permissions as $permission) {
+				switch ($level) {
+					case 'standard':
+						self::$permissions[$permission]['board_level'] = self::BOARD_LEVEL_STANDARD;
+						break;
+
+					case 'locked':
+						self::$permissions[$permission]['board_level'] = self::BOARD_LEVEL_LOCKED;
+						break;
+
+					case 'publish':
+						self::$permissions[$permission]['board_level'] = self::BOARD_LEVEL_PUBLISH;
+						break;
+
+					case 'free':
+						self::$permissions[$permission]['board_level'] = self::BOARD_LEVEL_FREE;
+						break;
+				}
+			}
+		}
 	}
 }
 

--- a/Sources/Permissions/Permission.php
+++ b/Sources/Permissions/Permission.php
@@ -1008,16 +1008,8 @@ class Permission implements \ArrayAccess
 					$this->eligibility[$group] = true;
 				}
 			} else {
-				foreach (Group::getAll() as $group) {
-					$this->eligibility[$group] = false;
-				}
-
-				foreach (User::getGroupsWithPermissions($this->assignee_prerequisites) as $prerequisite) {
-					// We only pay attention to 'allowed' here because a group can
-					// be granted this permission if it has any of the prerequisites.
-					foreach ($prerequisite['allowed'] as $group) {
-						$this->eligibility[$group] = true;
-					}
+				foreach (GroupPermissionSet::load(PermissionProfile::DEFAULT, Group::getAll()) as $set) {
+					$this->eligibility[$set->group] = count($this->assignee_prerequisites) === count(array_filter($this->assignee_prerequisites, fn($prereq) => !empty($set->permissions[$prereq])));
 				}
 			}
 

--- a/Sources/Permissions/Permission.php
+++ b/Sources/Permissions/Permission.php
@@ -1,0 +1,1393 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2025 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 2
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Permissions;
+
+use SMF\ArrayAccessHelper;
+use SMF\Config;
+use SMF\Group;
+use SMF\IntegrationHook;
+use SMF\Lang;
+use SMF\User;
+use SMF\Utils;
+
+/**
+ * Represents a single permission
+ */
+class Permission implements \ArrayAccess
+{
+	use ArrayAccessHelper;
+
+	/*****************
+	 * Class constants
+	 *****************/
+
+	public const GROUP_LEVEL_RESTRICT = 0;
+	public const GROUP_LEVEL_STANDARD = 1;
+	public const GROUP_LEVEL_MODERATOR = 2;
+	public const GROUP_LEVEL_MAINTENANCE = 3;
+
+	public const BOARD_LEVEL_STANDARD = 0;
+	public const BOARD_LEVEL_LOCKED = 1;
+	public const BOARD_LEVEL_PUBLISH = 2;
+	public const BOARD_LEVEL_FREE = 3;
+
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 * @var string
+	 *
+	 * The name of this permission.
+	 */
+	public string $name;
+
+	/**
+	 * @var string
+	 *
+	 * Either 'board' for permissions that apply at the board level, or 'global'
+	 * for permissions that apply everywhere.
+	 */
+	public string $scope;
+
+	/**
+	 * @var string
+	 *
+	 * This is used to group own/any variants together. For permissions that
+	 * don't have own/any variants, this is the same as the permission name.
+	 */
+	public string $generic_name;
+
+	/**
+	 * @var ?string
+	 *
+	 * Indicates whether this is the "own" or the "any" variant of the generic
+	 * permission. Not applicable for permissions that don't have own/any
+	 * variants.
+	 */
+	public ?string $own_any = null;
+
+	/**
+	 * @var ?int
+	 *
+	 * Used by the predefined permission profiles to indicate the minimum group
+	 * level that this permission should be granted at.
+	 */
+	public ?int $group_level = null;
+
+	/**
+	 * @var ?int
+	 *
+	 * Used by the predefined permission profiles to indicate the minimum board
+	 * level that this permission should be granted at.
+	 */
+	public ?int $board_level = null;
+
+	/**
+	 * @var bool
+	 *
+	 * If true, this permission can never be granted to guests.
+	 */
+	public bool $never_guests = false;
+
+	/**
+	 * @var array
+	 *
+	 * Permissions that someone must already have at least one of before they
+	 * can be granted this permission.
+	 *
+	 * Only global permissions can be prerequisites.
+	 */
+	public array $assignee_prerequisites = [];
+
+	/**
+	 * @var array
+	 *
+	 * Permissions that someone must have all of before they can grant this
+	 * permission to anyone.
+	 *
+	 * Only global permissions can be prerequisites.
+	 *
+	 * For obvious reasons, the 'manage_permissions' permission is always a
+	 * prerequisite for assigning permissions, and therefore does not need to
+	 * be listed in this property.
+	 */
+	public array $assigner_prerequisites = [];
+
+	/**
+	 * @var bool
+	 *
+	 * If true, permission should not be shown in the UI.
+	 */
+	public bool $hidden = false;
+
+	/**
+	 * @var bool
+	 *
+	 * If true, user's session should be validated before performing an action
+	 * that requires this permission.
+	 */
+	public bool $heavy = false;
+
+	/**
+	 * @var string
+	 *
+	 * Name of the group to show the permission within on the profile editing
+	 * page.
+	 */
+	public string $view_group = '';
+
+	/**
+	 * @var string
+	 *
+	 * Indicates the Lang::$txt string to use as the generic label for this
+	 * permission. Defaults to 'permissionname_' . generic_name.
+	 */
+	public string $label;
+
+	/**
+	 * @var array
+	 *
+	 * Arguments passed to Lang::formatText() at runtime to dynamically generate
+	 * the finalized form of the label string.
+	 *
+	 * For example, the definition for the 'bbc_html' permission contains
+	 * `'vsprintf' => ['permissionname_bbc', ['html']]`. This will cause the
+	 * string Lang::$txt['permissionname_bbc_html'] to be created by inserting
+	 * the string 'html' into Lang::$txt['permissionname_bbc'].
+	 *
+	 * FYI, this is called 'vsprintf' for historical reasons.
+	 */
+	public array $vsprintf = [];
+
+	/*********************
+	 * Internal properties
+	 *********************/
+
+	/**
+	 * @var bool
+	 *
+	 * Remembers query results from $this->canAssign().
+	 */
+	private bool $can_assign;
+
+	/**
+	 * @var array
+	 *
+	 * Remembers query results from $this->eligibleGroups().
+	 */
+	private array $eligibility;
+
+	/****************************
+	 * Internal static properties
+	 ****************************/
+
+	/**
+	 * @var array
+	 *
+	 * Definitions of all known permissions and their properties.
+	 * Protected to force access via getPermissions().
+	 *
+	 * Mods can add to this list using the integrate_permission_list hook.
+	 */
+	protected static array $permissions = [
+		'access_mod_center' => [
+			'view_group' => 'maintenance',
+			'scope' => 'global',
+			'group_level' => self::GROUP_LEVEL_MODERATOR,
+			'never_guests' => true,
+		],
+		'admin_forum' => [
+			'view_group' => 'maintenance',
+			'scope' => 'global',
+			'group_level' => self::GROUP_LEVEL_MAINTENANCE,
+			'never_guests' => true,
+			'assigner_prerequisites' => ['admin_forum'],
+			'heavy' => true,
+		],
+		'announce_topic' => [
+			'view_group' => 'topic',
+			'scope' => 'board',
+			'never_guests' => true,
+		],
+		'approve_posts' => [
+			'view_group' => 'general_board',
+			'scope' => 'board',
+			'group_level' => self::GROUP_LEVEL_MODERATOR,
+			'board_level' => self::BOARD_LEVEL_FREE,
+			'never_guests' => true,
+		],
+		'bbc_cowsay' => [
+			'view_group' => 'bbc',
+			'scope' => 'global',
+			'hidden' => true,
+			'vsprintf' => ['permissionname_bbc', ['cowsay']],
+		],
+		'bbc_html' => [
+			'view_group' => 'bbc',
+			'scope' => 'global',
+			'group_level' => self::GROUP_LEVEL_MAINTENANCE,
+			'vsprintf' => ['permissionname_bbc', ['html']],
+			'never_guests' => true,
+			'assignee_prerequisites' => [
+				'admin_forum',
+				'manage_membergroups',
+				'manage_permissions',
+			],
+			'assigner_prerequisites' => ['admin_forum'],
+		],
+		'calendar_edit_own' => [
+			'generic_name' => 'calendar_edit',
+			'own_any' => 'own',
+			'view_group' => 'calendar',
+			'scope' => 'global',
+			'group_level' => self::GROUP_LEVEL_MODERATOR,
+			'never_guests' => true,
+		],
+		'calendar_edit_any' => [
+			'generic_name' => 'calendar_edit',
+			'own_any' => 'any',
+			'view_group' => 'calendar',
+			'scope' => 'global',
+			'group_level' => self::GROUP_LEVEL_MAINTENANCE,
+			'never_guests' => true,
+		],
+		'calendar_post' => [
+			'view_group' => 'calendar',
+			'scope' => 'global',
+			'group_level' => self::GROUP_LEVEL_MODERATOR,
+		],
+		'calendar_view' => [
+			'view_group' => 'calendar',
+			'scope' => 'global',
+			'group_level' => self::GROUP_LEVEL_RESTRICT,
+		],
+		'delete_own' => [
+			'generic_name' => 'delete',
+			'own_any' => 'own',
+			'view_group' => 'post',
+			'scope' => 'board',
+			'group_level' => self::GROUP_LEVEL_RESTRICT,
+			'board_level' => self::BOARD_LEVEL_PUBLISH,
+			'never_guests' => true,
+		],
+		'delete_any' => [
+			'generic_name' => 'delete',
+			'own_any' => 'any',
+			'view_group' => 'post',
+			'scope' => 'board',
+			'group_level' => self::GROUP_LEVEL_MODERATOR,
+			'board_level' => self::BOARD_LEVEL_FREE,
+			'never_guests' => true,
+		],
+		'delete_replies' => [
+			'view_group' => 'topic',
+			'scope' => 'board',
+			'board_level' => self::BOARD_LEVEL_PUBLISH,
+			'never_guests' => true,
+		],
+		'edit_news' => [
+			'view_group' => 'maintenance',
+			'scope' => 'global',
+			'group_level' => self::GROUP_LEVEL_MAINTENANCE,
+			'never_guests' => true,
+			'heavy' => true,
+		],
+		'issue_warning' => [
+			'view_group' => 'member_admin',
+			'scope' => 'global',
+			'group_level' => self::GROUP_LEVEL_MODERATOR,
+			'never_guests' => true,
+		],
+		'likes_like' => [
+			'view_group' => 'likes',
+			'scope' => 'global',
+			'group_level' => self::GROUP_LEVEL_STANDARD,
+			'never_guests' => true,
+		],
+		'lock_own' => [
+			'generic_name' => 'lock',
+			'own_any' => 'own',
+			'view_group' => 'topic',
+			'scope' => 'board',
+			'group_level' => self::GROUP_LEVEL_STANDARD,
+			'board_level' => self::BOARD_LEVEL_PUBLISH,
+			'never_guests' => true,
+		],
+		'lock_any' => [
+			'generic_name' => 'lock',
+			'own_any' => 'any',
+			'view_group' => 'topic',
+			'scope' => 'board',
+			'group_level' => self::GROUP_LEVEL_MODERATOR,
+			'board_level' => self::BOARD_LEVEL_FREE,
+			'never_guests' => true,
+		],
+		'make_sticky' => [
+			'view_group' => 'topic',
+			'scope' => 'board',
+			'group_level' => self::GROUP_LEVEL_MODERATOR,
+			'board_level' => self::BOARD_LEVEL_FREE,
+			'never_guests' => true,
+		],
+		'manage_attachments' => [
+			'view_group' => 'maintenance',
+			'scope' => 'global',
+			'group_level' => self::GROUP_LEVEL_MAINTENANCE,
+			'never_guests' => true,
+			'heavy' => true,
+		],
+		'manage_bans' => [
+			'view_group' => 'member_admin',
+			'scope' => 'global',
+			'group_level' => self::GROUP_LEVEL_MAINTENANCE,
+			'never_guests' => true,
+			'heavy' => true,
+		],
+		'manage_boards' => [
+			'view_group' => 'maintenance',
+			'scope' => 'global',
+			'group_level' => self::GROUP_LEVEL_MAINTENANCE,
+			'never_guests' => true,
+			'heavy' => true,
+		],
+		'manage_membergroups' => [
+			'view_group' => 'member_admin',
+			'scope' => 'global',
+			'group_level' => self::GROUP_LEVEL_MAINTENANCE,
+			'never_guests' => true,
+			'assigner_prerequisites' => ['manage_membergroups'],
+			'heavy' => true,
+		],
+		'manage_permissions' => [
+			'view_group' => 'member_admin',
+			'scope' => 'global',
+			'group_level' => self::GROUP_LEVEL_MAINTENANCE,
+			'never_guests' => true,
+			'heavy' => true,
+		],
+		'manage_smileys' => [
+			'view_group' => 'maintenance',
+			'scope' => 'global',
+			'group_level' => self::GROUP_LEVEL_MAINTENANCE,
+			'never_guests' => true,
+			'heavy' => true,
+		],
+		'mention' => [
+			'view_group' => 'mentions',
+			'scope' => 'global',
+			'group_level' => self::GROUP_LEVEL_STANDARD,
+		],
+		'merge_any' => [
+			'view_group' => 'topic',
+			'scope' => 'board',
+			'group_level' => self::GROUP_LEVEL_MODERATOR,
+			'board_level' => self::BOARD_LEVEL_FREE,
+			'never_guests' => true,
+		],
+		'moderate_board' => [
+			'view_group' => 'general_board',
+			'scope' => 'board',
+			'never_guests' => true,
+		],
+		'moderate_forum' => [
+			'view_group' => 'member_admin',
+			'scope' => 'global',
+			'group_level' => self::GROUP_LEVEL_MAINTENANCE,
+			'never_guests' => true,
+			'heavy' => true,
+		],
+		'modify_own' => [
+			'generic_name' => 'modify',
+			'own_any' => 'own',
+			'view_group' => 'post',
+			'scope' => 'board',
+			'group_level' => self::GROUP_LEVEL_RESTRICT,
+			'board_level' => self::BOARD_LEVEL_PUBLISH,
+			'never_guests' => true,
+		],
+		'modify_any' => [
+			'generic_name' => 'modify',
+			'own_any' => 'any',
+			'view_group' => 'post',
+			'scope' => 'board',
+			'group_level' => self::GROUP_LEVEL_MODERATOR,
+			'board_level' => self::BOARD_LEVEL_FREE,
+			'never_guests' => true,
+		],
+		'modify_replies' => [
+			'view_group' => 'topic',
+			'scope' => 'board',
+			'board_level' => self::BOARD_LEVEL_PUBLISH,
+			'never_guests' => true,
+		],
+		'move_own' => [
+			'generic_name' => 'move',
+			'own_any' => 'own',
+			'view_group' => 'topic',
+			'scope' => 'board',
+			'never_guests' => true,
+		],
+		'move_any' => [
+			'generic_name' => 'move',
+			'own_any' => 'any',
+			'view_group' => 'topic',
+			'scope' => 'board',
+			'group_level' => self::GROUP_LEVEL_MODERATOR,
+			'never_guests' => true,
+		],
+		'pm_draft' => [
+			'view_group' => 'pm',
+			'scope' => 'global',
+			'never_guests' => true,
+		],
+		'pm_read' => [
+			'view_group' => 'pm',
+			'scope' => 'global',
+			'group_level' => self::GROUP_LEVEL_STANDARD,
+			'never_guests' => true,
+		],
+		'pm_send' => [
+			'view_group' => 'pm',
+			'scope' => 'global',
+			'group_level' => self::GROUP_LEVEL_STANDARD,
+			'never_guests' => true,
+		],
+		'poll_add_own' => [
+			'generic_name' => 'poll_add',
+			'own_any' => 'own',
+			'view_group' => 'poll',
+			'scope' => 'board',
+			'group_level' => self::GROUP_LEVEL_STANDARD,
+			'board_level' => self::BOARD_LEVEL_PUBLISH,
+			'never_guests' => true,
+		],
+		'poll_add_any' => [
+			'generic_name' => 'poll_add',
+			'own_any' => 'any',
+			'view_group' => 'poll',
+			'scope' => 'board',
+			'group_level' => self::GROUP_LEVEL_MODERATOR,
+			'board_level' => self::BOARD_LEVEL_FREE,
+			'never_guests' => true,
+		],
+		'poll_edit_own' => [
+			'generic_name' => 'poll_edit',
+			'own_any' => 'own',
+			'view_group' => 'poll',
+			'scope' => 'board',
+			'group_level' => self::GROUP_LEVEL_STANDARD,
+			'board_level' => self::BOARD_LEVEL_PUBLISH,
+			'never_guests' => true,
+		],
+		'poll_edit_any' => [
+			'generic_name' => 'poll_edit',
+			'own_any' => 'any',
+			'view_group' => 'poll',
+			'scope' => 'board',
+			'group_level' => self::GROUP_LEVEL_MODERATOR,
+			'board_level' => self::BOARD_LEVEL_FREE,
+			'never_guests' => true,
+		],
+		'poll_lock_own' => [
+			'generic_name' => 'poll_lock',
+			'own_any' => 'own',
+			'view_group' => 'poll',
+			'scope' => 'board',
+			'never_guests' => true,
+		],
+		'poll_lock_any' => [
+			'generic_name' => 'poll_lock',
+			'own_any' => 'any',
+			'view_group' => 'poll',
+			'scope' => 'board',
+			'group_level' => self::GROUP_LEVEL_MODERATOR,
+			'board_level' => self::BOARD_LEVEL_FREE,
+			'never_guests' => true,
+		],
+		'poll_post' => [
+			'view_group' => 'poll',
+			'scope' => 'board',
+			'group_level' => self::GROUP_LEVEL_STANDARD,
+			'board_level' => self::BOARD_LEVEL_PUBLISH,
+		],
+		'poll_remove_own' => [
+			'generic_name' => 'poll_remove',
+			'own_any' => 'own',
+			'view_group' => 'poll',
+			'scope' => 'board',
+			'board_level' => self::BOARD_LEVEL_PUBLISH,
+			'never_guests' => true,
+		],
+		'poll_remove_any' => [
+			'generic_name' => 'poll_remove',
+			'own_any' => 'any',
+			'view_group' => 'poll',
+			'scope' => 'board',
+			'group_level' => self::GROUP_LEVEL_MODERATOR,
+			'board_level' => self::BOARD_LEVEL_FREE,
+			'never_guests' => true,
+		],
+		'poll_view' => [
+			'view_group' => 'poll',
+			'scope' => 'board',
+			'group_level' => self::GROUP_LEVEL_RESTRICT,
+			'board_level' => self::BOARD_LEVEL_LOCKED,
+		],
+		'poll_vote' => [
+			'view_group' => 'poll',
+			'scope' => 'board',
+			'group_level' => self::GROUP_LEVEL_STANDARD,
+			'board_level' => self::BOARD_LEVEL_PUBLISH,
+		],
+		'post_attachment' => [
+			'view_group' => 'attachment',
+			'scope' => 'board',
+			'group_level' => self::GROUP_LEVEL_STANDARD,
+			'board_level' => self::BOARD_LEVEL_PUBLISH,
+		],
+		'post_draft' => [
+			'view_group' => 'topic',
+			'scope' => 'board',
+			'never_guests' => true,
+		],
+		'post_new' => [
+			'view_group' => 'topic',
+			'scope' => 'board',
+			'group_level' => self::GROUP_LEVEL_RESTRICT,
+			'board_level' => self::BOARD_LEVEL_PUBLISH,
+		],
+		'post_reply_own' => [
+			'generic_name' => 'post_reply',
+			'own_any' => 'own',
+			'view_group' => 'topic',
+			'scope' => 'board',
+			'group_level' => self::GROUP_LEVEL_RESTRICT,
+			'board_level' => self::BOARD_LEVEL_PUBLISH,
+		],
+		'post_reply_any' => [
+			'generic_name' => 'post_reply',
+			'own_any' => 'any',
+			'view_group' => 'topic',
+			'scope' => 'board',
+			'group_level' => self::GROUP_LEVEL_RESTRICT,
+			'board_level' => self::BOARD_LEVEL_PUBLISH,
+		],
+		'post_unapproved_attachments' => [
+			'view_group' => 'attachment',
+			'scope' => 'board',
+		],
+		'post_unapproved_replies_own' => [
+			'generic_name' => 'post_unapproved_replies',
+			'own_any' => 'own',
+			'view_group' => 'topic',
+			'scope' => 'board',
+		],
+		'post_unapproved_replies_any' => [
+			'generic_name' => 'post_unapproved_replies',
+			'own_any' => 'any',
+			'view_group' => 'topic',
+			'scope' => 'board',
+		],
+		'post_unapproved_topics' => [
+			'view_group' => 'topic',
+			'scope' => 'board',
+		],
+		'profile_blurb_own' => [
+			'generic_name' => 'profile_blurb',
+			'own_any' => 'own',
+			'view_group' => 'profile',
+			'scope' => 'global',
+			'never_guests' => true,
+		],
+		'profile_blurb_any' => [
+			'generic_name' => 'profile_blurb',
+			'own_any' => 'any',
+			'view_group' => 'profile',
+			'scope' => 'global',
+			'never_guests' => true,
+		],
+		'profile_displayed_name_own' => [
+			'generic_name' => 'profile_displayed_name',
+			'own_any' => 'own',
+			'view_group' => 'profile_account',
+			'scope' => 'global',
+			'never_guests' => true,
+		],
+		'profile_displayed_name_any' => [
+			'generic_name' => 'profile_displayed_name',
+			'own_any' => 'any',
+			'view_group' => 'profile_account',
+			'scope' => 'global',
+			'group_level' => self::GROUP_LEVEL_MAINTENANCE,
+			'never_guests' => true,
+		],
+		'profile_extra_own' => [
+			'generic_name' => 'profile_extra',
+			'own_any' => 'own',
+			'view_group' => 'profile',
+			'scope' => 'global',
+			'group_level' => self::GROUP_LEVEL_STANDARD,
+			'never_guests' => true,
+		],
+		'profile_extra_any' => [
+			'generic_name' => 'profile_extra',
+			'own_any' => 'any',
+			'view_group' => 'profile',
+			'scope' => 'global',
+			'group_level' => self::GROUP_LEVEL_MAINTENANCE,
+			'never_guests' => true,
+		],
+		'profile_forum_own' => [
+			'generic_name' => 'profile_forum',
+			'own_any' => 'own',
+			'view_group' => 'profile',
+			'scope' => 'global',
+			'group_level' => self::GROUP_LEVEL_STANDARD,
+			'never_guests' => true,
+		],
+		'profile_forum_any' => [
+			'generic_name' => 'profile_forum',
+			'own_any' => 'any',
+			'view_group' => 'profile',
+			'scope' => 'global',
+			'never_guests' => true,
+		],
+		'profile_gravatar' => [
+			'view_group' => 'profile',
+			'scope' => 'global',
+			'group_level' => self::GROUP_LEVEL_STANDARD,
+			'never_guests' => true,
+		],
+		'profile_identity_own' => [
+			'generic_name' => 'profile_identity',
+			'own_any' => 'own',
+			'view_group' => 'profile_account',
+			'scope' => 'global',
+			'group_level' => self::GROUP_LEVEL_RESTRICT,
+			'never_guests' => true,
+		],
+		'profile_identity_any' => [
+			'generic_name' => 'profile_identity',
+			'own_any' => 'any',
+			'view_group' => 'profile_account',
+			'scope' => 'global',
+			'group_level' => self::GROUP_LEVEL_MAINTENANCE,
+			'never_guests' => true,
+		],
+		'profile_password_own' => [
+			'generic_name' => 'profile_password',
+			'own_any' => 'own',
+			'view_group' => 'profile_account',
+			'scope' => 'global',
+			'group_level' => self::GROUP_LEVEL_STANDARD,
+			'never_guests' => true,
+		],
+		'profile_password_any' => [
+			'generic_name' => 'profile_password',
+			'own_any' => 'any',
+			'view_group' => 'profile_account',
+			'scope' => 'global',
+			'group_level' => self::GROUP_LEVEL_MAINTENANCE,
+			'never_guests' => true,
+		],
+		'profile_remote_avatar' => [
+			'view_group' => 'profile',
+			'scope' => 'global',
+			'group_level' => self::GROUP_LEVEL_STANDARD,
+			'never_guests' => true,
+		],
+		'profile_remove_own' => [
+			'generic_name' => 'profile_remove',
+			'own_any' => 'own',
+			'view_group' => 'profile_account',
+			'scope' => 'global',
+			'group_level' => self::GROUP_LEVEL_STANDARD,
+			'never_guests' => true,
+		],
+		'profile_remove_any' => [
+			'generic_name' => 'profile_remove',
+			'own_any' => 'any',
+			'view_group' => 'profile_account',
+			'scope' => 'global',
+			'never_guests' => true,
+		],
+		'profile_server_avatar' => [
+			'view_group' => 'profile',
+			'scope' => 'global',
+			'group_level' => self::GROUP_LEVEL_STANDARD,
+			'never_guests' => true,
+		],
+		'profile_signature_own' => [
+			'generic_name' => 'profile_signature',
+			'own_any' => 'own',
+			'view_group' => 'profile',
+			'scope' => 'global',
+			'group_level' => self::GROUP_LEVEL_STANDARD,
+			'never_guests' => true,
+		],
+		'profile_signature_any' => [
+			'generic_name' => 'profile_signature',
+			'own_any' => 'any',
+			'view_group' => 'profile',
+			'scope' => 'global',
+			'group_level' => self::GROUP_LEVEL_MAINTENANCE,
+			'never_guests' => true,
+		],
+		'profile_title_own' => [
+			'generic_name' => 'profile_title',
+			'own_any' => 'own',
+			'view_group' => 'profile',
+			'scope' => 'global',
+			'never_guests' => true,
+		],
+		'profile_title_any' => [
+			'generic_name' => 'profile_title',
+			'own_any' => 'any',
+			'view_group' => 'profile',
+			'scope' => 'global',
+			'group_level' => self::GROUP_LEVEL_MAINTENANCE,
+			'never_guests' => true,
+		],
+		'profile_upload_avatar' => [
+			'view_group' => 'profile',
+			'scope' => 'global',
+			'group_level' => self::GROUP_LEVEL_STANDARD,
+			'never_guests' => true,
+		],
+		'profile_view' => [
+			'view_group' => 'profile',
+			'scope' => 'global',
+			'group_level' => self::GROUP_LEVEL_STANDARD,
+		],
+		'profile_website_own' => [
+			'generic_name' => 'profile_website',
+			'own_any' => 'own',
+			'view_group' => 'profile',
+			'scope' => 'global',
+			'group_level' => self::GROUP_LEVEL_STANDARD,
+			'never_guests' => true,
+		],
+		'profile_website_any' => [
+			'generic_name' => 'profile_website',
+			'own_any' => 'any',
+			'view_group' => 'profile',
+			'scope' => 'global',
+			'group_level' => self::GROUP_LEVEL_MAINTENANCE,
+			'never_guests' => true,
+		],
+		'remove_own' => [
+			'generic_name' => 'remove',
+			'own_any' => 'own',
+			'view_group' => 'topic',
+			'scope' => 'board',
+			'group_level' => self::GROUP_LEVEL_STANDARD,
+			'board_level' => self::BOARD_LEVEL_PUBLISH,
+			'never_guests' => true,
+		],
+		'remove_any' => [
+			'generic_name' => 'remove',
+			'own_any' => 'any',
+			'view_group' => 'topic',
+			'scope' => 'board',
+			'group_level' => self::GROUP_LEVEL_MODERATOR,
+			'board_level' => self::BOARD_LEVEL_FREE,
+			'never_guests' => true,
+		],
+		'report_any' => [
+			'view_group' => 'post',
+			'scope' => 'board',
+			'group_level' => self::GROUP_LEVEL_RESTRICT,
+			'board_level' => self::BOARD_LEVEL_LOCKED,
+			'never_guests' => true,
+		],
+		'report_user' => [
+			'view_group' => 'profile',
+			'scope' => 'global',
+			'group_level' => self::GROUP_LEVEL_STANDARD,
+			'never_guests' => true,
+		],
+		'search_posts' => [
+			'view_group' => 'general',
+			'scope' => 'global',
+			'group_level' => self::GROUP_LEVEL_RESTRICT,
+		],
+		'send_mail' => [
+			'view_group' => 'member_admin',
+			'scope' => 'global',
+			'never_guests' => true,
+		],
+		'split_any' => [
+			'view_group' => 'topic',
+			'scope' => 'board',
+			'group_level' => self::GROUP_LEVEL_MODERATOR,
+			'board_level' => self::BOARD_LEVEL_FREE,
+			'never_guests' => true,
+		],
+		'view_attachments' => [
+			'view_group' => 'attachment',
+			'scope' => 'board',
+			'group_level' => self::GROUP_LEVEL_STANDARD,
+			'board_level' => self::BOARD_LEVEL_LOCKED,
+		],
+		'view_mlist' => [
+			'view_group' => 'general',
+			'scope' => 'global',
+			'group_level' => self::GROUP_LEVEL_STANDARD,
+		],
+		'view_stats' => [
+			'view_group' => 'general',
+			'scope' => 'global',
+			'group_level' => self::GROUP_LEVEL_RESTRICT,
+		],
+		'view_warning_own' => [
+			'generic_name' => 'view_warning',
+			'own_any' => 'own',
+			'view_group' => 'profile_account',
+			'scope' => 'global',
+		],
+		'view_warning_any' => [
+			'generic_name' => 'view_warning',
+			'own_any' => 'any',
+			'view_group' => 'profile_account',
+			'scope' => 'global',
+		],
+		'who_view' => [
+			'view_group' => 'general',
+			'scope' => 'global',
+			'group_level' => self::GROUP_LEVEL_RESTRICT,
+		],
+	];
+
+	/**
+	 * @var array
+	 *
+	 * Convenience array listing permissions that guests may never have.
+	 */
+	protected static array $non_guest_permissions = [];
+
+	/**
+	 * @var array
+	 *
+	 * Convenience array listing permissions that the current user can't assign.
+	 */
+	protected static array $unassignable = [];
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 *
+	 * @param string $name The name of the permission.
+	 * @param array $props Other properties of the permission.
+	 */
+	public function __construct(string $name, array $props)
+	{
+		$this->name = $name;
+		$this->set($props);
+
+		// Finalize various values.
+		$this->generic_name = $this->generic_name ?? $this->name;
+		$this->scope = $this->scope ?? 'global';
+		$this->hidden = !empty($this->hidden);
+		$this->never_guests = !empty($this->never_guests);
+		$this->label = $this->label ?? 'permissionname_' . $this->generic_name;
+
+		// Do we need to dynamically generate the label string?
+		if (!empty($this->vsprintf)) {
+			if (Lang::txtExists($this->vsprintf[0], file: 'ManagePermissions')) {
+				Lang::setTxt(
+					$this->label,
+					Lang::getTxt(
+						$this->vsprintf[0],
+						$this->vsprintf[1],
+						file: 'ManagePermissions',
+					),
+				);
+			} else {
+				Lang::setTxt(
+					$this->label,
+					Lang::formatText(
+						$this->vsprintf[0],
+						$this->vsprintf[1],
+					),
+				);
+			}
+		}
+	}
+
+	/**
+	 * Tells this instance to add itself to the list of known permissions.
+	 *
+	 * @return self Returns this instance for method chaining.
+	 */
+	public function addToKnownPermissions(): self
+	{
+		self::$permissions[$this->name] = $this;
+
+		// Only global permissions can be prerequisites.
+		if (!empty($this->assigner_prerequisites)) {
+			$this->assigner_prerequisites = array_filter(
+				$this->assigner_prerequisites,
+				fn($prereq) => self::$permissions[$prereq]['scope'] === 'global',
+			);
+		}
+
+		if (!empty($this->assignee_prerequisites)) {
+			$this->assignee_prerequisites = array_filter(
+				$this->assignee_prerequisites,
+				fn($prereq) => self::$permissions[$prereq]['scope'] === 'global',
+			);
+		}
+
+		return $this;
+	}
+
+	/**
+	 * Checks whether the current user can assign this permission.
+	 *
+	 * To be able to assign a permission, the current user must have the
+	 * 'manage_permissions' permission as well as all other permissions listed
+	 * in $this->assigner_prerequisites.
+	 *
+	 * @return bool Whether the current user can assign this permission.
+	 */
+	public function canAssign(): bool
+	{
+		if (!isset($this->can_assign)) {
+			$this->can_assign = User::$me->allowedTo(array_merge(['manage_permissions'], $this->assigner_prerequisites));
+		}
+
+		return $this->can_assign;
+	}
+
+	/**
+	 * Checks whether this permission can be granted to the specified group.
+	 *
+	 * @param int $group The ID of a membergroup.
+	 * @param bool $refresh Reload data from the database. Default: false.
+	 * @return bool Whether the group can be granted this permission.
+	 */
+	public function canBeGrantedTo(int $group, bool $refresh = false): bool
+	{
+		if ($group <= Group::GUEST && $this->never_guests) {
+			return false;
+		}
+
+		$this->eligibleGroups($refresh);
+
+		return !empty($this->eligibility[$group]);
+	}
+
+	/**
+	 * Gets the IDs of all the groups that can have this permission.
+	 *
+	 * @param bool $refresh Reload data from the database. Default: false.
+	 * @return array All the groups that can have this permission.
+	 */
+	public function eligibleGroups(bool $refresh = false): array
+	{
+		if (!isset($this->eligibility) || $refresh) {
+			if (empty($this->assignee_prerequisites)) {
+				foreach (Group::getAll() as $group) {
+					$this->eligibility[$group] = true;
+				}
+			} else {
+				foreach (Group::getAll() as $group) {
+					$this->eligibility[$group] = false;
+				}
+
+				foreach (User::getGroupsWithPermissions($this->assignee_prerequisites) as $prerequisite) {
+					// We only pay attention to 'allowed' here because a group can
+					// be granted this permission if it has any of the prerequisites.
+					foreach ($prerequisite['allowed'] as $group) {
+						$this->eligibility[$group] = true;
+					}
+				}
+			}
+
+			// Obviously...
+			$this->eligibility[Group::ADMIN] = true;
+
+			if ($this->never_guests) {
+				$this->eligibility[Group::GUEST] = false;
+			}
+		}
+
+		return array_keys(array_filter($this->eligibility));
+	}
+
+	/**
+	 * Gets the IDs of all the groups that cannot have this permission.
+	 *
+	 * @param bool $refresh Reload data from the database. Default: false.
+	 * @return array All the groups that cannot have this permission.
+	 */
+	public function ineligibleGroups(bool $refresh = false): array
+	{
+		$this->eligibleGroups($refresh);
+
+		return array_keys(array_filter($this->eligibility, fn($eligible) => !$eligible));
+	}
+
+	/***********************
+	 * Public static methods
+	 ***********************/
+
+	/**
+	 * Gets an instance of this class for the specified permission.
+	 *
+	 * @param string $name The name of the permission.
+	 * @throws \ValueError if the specified permission does not exist.
+	 * @return self An instance of this class.
+	 */
+	public static function get(string $name): self
+	{
+		self::getAll();
+
+		if (!isset(self::$permissions[$name])) {
+			throw new \ValueError();
+		}
+
+		return self::$permissions[$name];
+	}
+
+	/**
+	 * Gets the list of all known permissions.
+	 *
+	 * This method contains the integrate_permissions_list hook, which is the
+	 * recommended way to add new permissions to SMF.
+	 *
+	 * @return array Instances of this class for all known permissions.
+	 */
+	public static function getAll(): array
+	{
+		// Avoid unnecessary repetition.
+		if (reset(self::$permissions) instanceof self) {
+			return self::$permissions;
+		}
+
+		IntegrationHook::call('integrate_permissions_list', [&self::$permissions]);
+
+		self::integrateHeavyPermissionsSession();
+
+		// In case a mod screwed things up...
+		if (!in_array('html', Utils::$context['restricted_bbc'])) {
+			Utils::$context['restricted_bbc'][] = 'html';
+		}
+
+		// Add the permissions for the restricted BBCodes
+		foreach (Utils::$context['restricted_bbc'] as $bbc) {
+			if (isset(self::$permissions['bbc_' . $bbc])) {
+				continue;
+			}
+
+			self::$permissions['bbc_' . $bbc] = [
+				'has_own_any' => false,
+				'view_group' => 'bbc',
+				'scope' => 'global',
+				'vsprintf' => ['permissionname_bbc', [$bbc]],
+			];
+		}
+
+		// If the calendar is disabled, disable the related permissions.
+		if (empty(Config::$modSettings['cal_enabled'])) {
+			self::$permissions['calendar_view']['hidden'] = true;
+			self::$permissions['calendar_post']['hidden'] = true;
+			self::$permissions['calendar_edit_own']['hidden'] = true;
+			self::$permissions['calendar_edit_any']['hidden'] = true;
+		}
+
+		// If warnings are disabled, disable the related permissions.
+		if (Config::$modSettings['warning_settings'][0] == 0) {
+			self::$permissions['issue_warning']['hidden'] = true;
+			self::$permissions['view_warning_own']['hidden'] = true;
+			self::$permissions['view_warning_any']['hidden'] = true;
+		}
+
+		// If post moderation is disabled, disable the related permissions.
+		if (!Config::$modSettings['postmod_active']) {
+			self::$permissions['approve_posts']['hidden'] = true;
+			self::$permissions['post_unapproved_topics']['hidden'] = true;
+			self::$permissions['post_unapproved_replies_own']['hidden'] = true;
+			self::$permissions['post_unapproved_replies_any']['hidden'] = true;
+			self::$permissions['post_unapproved_attachments']['hidden'] = true;
+		}
+		// If post moderation is enabled, these are named differently...
+		else {
+			// Relabel the topics permissions
+			self::$permissions['post_new']['label'] = 'auto_approve_topics';
+
+			// Relabel the reply permissions
+			self::$permissions['post_reply_own']['label'] = 'auto_approve_replies';
+			self::$permissions['post_reply_any']['label'] = 'auto_approve_replies';
+
+			// Relabel the attachment permissions
+			self::$permissions['post_attachment']['label'] = 'auto_approve_attachments';
+		}
+
+		// If attachments are disabled, disable the related permissions.
+		if (empty(Config::$modSettings['attachmentEnable'])) {
+			self::$permissions['manage_attachments']['hidden'] = true;
+			self::$permissions['view_attachments']['hidden'] = true;
+			self::$permissions['post_unapproved_attachments']['hidden'] = true;
+			self::$permissions['post_attachment']['hidden'] = true;
+		}
+
+		// If likes are disabled, disable the related permission.
+		if (empty(Config::$modSettings['enable_likes'])) {
+			self::$permissions['likes_like']['hidden'] = true;
+		}
+
+		// If mentions are disabled, disable the related permission.
+		if (empty(Config::$modSettings['enable_mentions'])) {
+			self::$permissions['mention']['hidden'] = true;
+		}
+
+		// If Gravatars are disabled, disable the related permission.
+		if (empty(Config::$modSettings['gravatarEnabled'])) {
+			self::$permissions['profile_gravatar']['hidden'] = true;
+		}
+
+		// Important: do the ones with prerequisites last.
+		uasort(
+			self::$permissions,
+			fn($a, $b) => (!empty($a['assigner_prerequisites']) || !empty($a['assignee_prerequisites'])) <=> (!empty($b['assigner_prerequisites']) || !empty($b['assignee_prerequisites'])),
+		);
+
+		// Now convert everything into instances of this class.
+		foreach (self::$permissions as $name => $props) {
+			(new self($name, $props))->addToKnownPermissions();
+		}
+
+		return self::$permissions;
+	}
+
+	/**
+	 * Returns the names of permissions that the current user cannot assign.
+	 *
+	 * @return array Permissions that the current user cannot assign.
+	 */
+	public static function getUnassignable(): array
+	{
+		if (empty(self::$unassignable)) {
+			foreach (self::getAll() as $perm) {
+				if (!$perm->canAssign()) {
+					self::$unassignable[] = $perm->name;
+					self::$unassignable[] = $perm->generic_name;
+				}
+			}
+
+			self::$unassignable = array_unique(self::$unassignable);
+
+			// Call the deprecated integrate_load_illegal_permissions hook.
+			self::integrateLoadIllegalPermissions(self::$unassignable);
+		}
+
+		return self::$unassignable;
+	}
+
+	/**
+	 * Returns the names of hidden permissions.
+	 *
+	 * @return array Hidden permissions.
+	 */
+	public static function getHidden(): array
+	{
+		return array_map(
+			fn($perm) => $perm->name,
+			array_filter(
+				self::getAll(),
+				fn($perm) => $perm->hidden,
+			),
+		);
+	}
+
+	/**
+	 * Returns the names of permissions that guests cannot have.
+	 *
+	 * @return array Names of permissions that guests cannot have.
+	 */
+	public static function getNonGuestPermissions(): array
+	{
+		if (empty(self::$non_guest_permissions)) {
+			self::getAll();
+
+			self::$non_guest_permissions = [];
+
+			foreach (self::$permissions as $perm) {
+				if ($perm->never_guests) {
+					self::$non_guest_permissions[] = $perm->name;
+					self::$non_guest_permissions[] = $perm->generic_name;
+				}
+			}
+
+			self::$non_guest_permissions = array_unique(self::$non_guest_permissions);
+
+			// Call the deprecated integrate_load_illegal_guest_permissions hook.
+			self::$non_guest_permissions = self::integrateLoadIllegalGuestPermissions(self::$non_guest_permissions);
+		}
+
+		return self::$non_guest_permissions;
+	}
+
+	/*************************
+	 * Internal static methods
+	 *************************/
+
+	/**
+	 * Calls the deprecated integrate_heavy_permissions_session hook.
+	 *
+	 * MOD AUTHORS: Please update your code to use integrate_permissions_list
+	 * to set any permission's 'heavy' parameter.
+	 *
+	 * @deprecated 3.0
+	 */
+	protected static function integrateHeavyPermissionsSession(): void
+	{
+		// Don't bother if nothing is using this hook.
+		if (empty(Config::$backward_compatibility) || empty(Config::$modSettings['integrate_heavy_permissions_session'])) {
+			return;
+		}
+
+		$heavy_permissions = array_keys(
+			array_filter(
+				self::$permissions,
+				fn($permission) => !empty($permission['heavy']),
+			),
+		);
+
+		IntegrationHook::call('integrate_heavy_permissions_session', [&$heavy_permissions]);
+
+		foreach ($heavy_permissions as $permission) {
+			self::$permissions[$permission]['heavy'] = true;
+		}
+	}
+
+	/**
+	 * Calls the deprecated integrate_load_illegal_guest_permissions hook.
+	 *
+	 * MOD AUTHORS: Please update your code to use integrate_permissions_list
+	 * to set any permission's 'never_guests' parameter.
+	 *
+	 * @deprecated 3.0
+	 */
+	protected static function integrateLoadIllegalGuestPermissions(): void
+	{
+		// Don't bother if nothing is using this hook.
+		if (empty(Config::$backward_compatibility) || empty(Config::$modSettings['integrate_load_illegal_guest_permissions'])) {
+			return;
+		}
+
+		// This context variable exists only for the sake of the hook.
+		Utils::$context['non_guest_permissions'] = self::$non_guest_permissions;
+
+		// Track whether the hook makes any changes.
+		$temp = Utils::jsonEncode(Utils::$context['non_guest_permissions']);
+
+		// Give mods access to this list.
+		IntegrationHook::call('integrate_load_illegal_guest_permissions');
+
+		// If the hook changed anything, sync that back to our master list.
+		if ($temp != Utils::jsonEncode(Utils::$context['non_guest_permissions'])) {
+			// Did the hook add a permission to Utils::$context['non_guest_permissions']?
+			foreach (Utils::$context['non_guest_permissions'] as $permission) {
+				foreach (['', '_own', '_any'] as $suffix) {
+					if (isset(self::$permissions[$permission . $suffix])) {
+						self::$permissions[$permission . $suffix]->never_guests = true;
+					}
+				}
+			}
+
+			// Did the hook remove a permission from Utils::$context['non_guest_permissions']?
+			foreach (self::getAll() as $permission => $perm) {
+				if (!in_array($perm->generic_name, Utils::$context['non_guest_permissions'])) {
+					self::$permissions[$permission]->never_guests = false;
+				}
+			}
+
+			// Now rebuild the list.
+			foreach (self::$permissions as $perm) {
+				if ($perm->never_guests) {
+					self::$non_guest_permissions[] = $perm->name;
+					self::$non_guest_permissions[] = $perm->generic_name;
+				}
+			}
+
+			self::$non_guest_permissions = array_unique(self::$non_guest_permissions);
+		}
+
+		// We don't need this anymore.
+		unset(Utils::$context['non_guest_permissions']);
+	}
+
+	/**
+	 * Calls the deprecated integrate_load_illegal_permissions hook.
+	 *
+	 * MOD AUTHORS: Please update your code to use integrate_permissions_list
+	 * to set any permission's 'assigner_prerequisites' parameter.
+	 *
+	 * @deprecated 3.0
+	 */
+	protected static function integrateLoadIllegalPermissions(): void
+	{
+		// Don't bother if nothing is using this hook.
+		if (empty(Config::$backward_compatibility) || empty(Config::$modSettings['integrate_load_illegal_permissions'])) {
+			return;
+		}
+
+		// This context variable exists only for the sake of the hook.
+		Utils::$context['illegal_permissions'] = self::$unassignable;
+
+		// Track whether the hook makes any changes.
+		$temp = Utils::jsonEncode(self::$unassignable);
+
+		// Give mods access to this list.
+		IntegrationHook::call('integrate_load_illegal_permissions');
+
+		// If the hook added anything, sync that back to our master list.
+		// Because this hook can't tell us what the prerequisites are, we assume
+		// that the permission can only be granted by admins.
+		if ($temp != Utils::jsonEncode(self::$unassignable)) {
+			foreach (Utils::$context['illegal_permissions'] as $permission) {
+				foreach (['', '_own', '_any'] as $suffix) {
+					if (isset(self::$permissions[$permission . $suffix])) {
+						self::$permissions[$permission . $suffix]->assigner_prerequisites[] = 'admin_forum';
+					}
+				}
+			}
+
+			// Now rebuild the list.
+			self::$unassignable = [];
+
+			foreach (self::getAll() as $perm) {
+				if (!empty($perm->assigner_prerequisites) && !User::$me->allowedTo($perm->assigner_prerequisites)) {
+					self::$unassignable[] = $perm->name;
+					self::$unassignable[] = $perm->generic_name;
+				}
+			}
+
+			self::$unassignable = array_unique(self::$unassignable);
+		}
+
+		// We don't need this anymore.
+		unset(Utils::$context['illegal_permissions']);
+	}
+}
+
+?>

--- a/Sources/Permissions/PermissionProfile.php
+++ b/Sources/Permissions/PermissionProfile.php
@@ -8,7 +8,7 @@
  * @copyright 2025 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 2
+ * @version 3.0 Alpha 3
  */
 
 declare(strict_types=1);

--- a/Sources/Permissions/PermissionProfile.php
+++ b/Sources/Permissions/PermissionProfile.php
@@ -63,20 +63,13 @@ class PermissionProfile
 	private array $boards;
 
 	/**
-	 * @var array
+	 * @var int
 	 *
-	 * Multidimensional array listing permission status for all global
-	 * permissions for all groups.
-	 */
-	private array $global_permissions;
-
-	/**
-	 * @var array
+	 * ID of the profile that this one was copied from.
 	 *
-	 * Multidimensional array listing permission status for all board
-	 * permissions for all groups.
+	 * Only set during self::copy().
 	 */
-	private array $board_permissions;
+	private int $copied_from;
 
 	/****************************
 	 * Internal static properties
@@ -117,29 +110,13 @@ class PermissionProfile
 				1,
 			);
 
-			if (!empty($this->board_permissions)) {
-				foreach ($this->board_permissions as $group => $permissions) {
-					foreach ($permissions as $permission => $value) {
-						if (is_int($value)) {
-							$inserts[] = [$this->id, $group, $permission, $value];
-						}
-					}
+			if (!empty($this->copied_from)) {
+				foreach (GroupPermissionSet::load($this->copied_from, Group::getAll()) as $set) {
+					$set->profile = $this->id;
+					$set->save();
 				}
 
-				if (!empty($inserts)) {
-					Db::$db->insert(
-						'insert',
-						'{db_prefix}board_permissions',
-						[
-							'id_profile' => 'int',
-							'id_group' => 'int',
-							'permission' => 'string',
-							'add_deny' => 'int',
-						],
-						$inserts,
-						['id_profile', 'id_group', 'permission'],
-					);
-				}
+				unset($this->copied_from);
 			}
 
 			self::$loaded[$this->id] = $this;
@@ -238,92 +215,6 @@ class PermissionProfile
 		}
 
 		return $this->boards;
-	}
-
-	/**
-	 * Get the allowed/not allowed/denied status for all global permissions
-	 * for all groups.
-	 *
-	 * Note that this only returns a meaningful result for the default profile.
-	 * For all other profiles, an empty array is returned.
-	 *
-	 * @return array Multidimensional array where the keys are group IDs and the
-	 *    values are lists of permissions and the allowed/not allowed/denied
-	 *    status that the group has for that permission.
-	 */
-	public function getGlobalPermissions(): array
-	{
-		if ($this->id !== self::DEFAULT) {
-			return [];
-		}
-
-		if (!isset($this->global_permissions)) {
-			$request = Db::$db->query(
-				'',
-				'SELECT id_group, permission, add_deny
-				FROM {db_prefix}permissions',
-				[],
-			);
-
-			while ($row = Db::$db->fetch_assoc($request)) {
-				$this->global_permissions[(int) $row['id_group']][$row['permission']] = (int) $row['add_deny'];
-			}
-
-			Db::$db->free_result($request);
-
-			foreach (Group::getAll() as $id_group) {
-				foreach (Permission::getAll() as $permission) {
-					if ($permission->scope !== 'global') {
-						continue;
-					}
-
-					$this->global_permissions[$id_group][$permission->name] = $id_group === Group::ADMIN ? 1 : ($this->global_permissions[$id_group][$permission->name] ?? null);
-				}
-			}
-		}
-
-		return $this->global_permissions;
-	}
-
-	/**
-	 * Get the allowed/not allowed/denied status for all board permissions
-	 * for all groups.
-	 *
-	 * @return array Multidimensional array where the keys are group IDs and the
-	 *    values are lists of permissions and the allowed/not allowed/denied
-	 *    status that the group has for that permission.
-	 */
-	public function getBoardPermissions(): array
-	{
-		if (!isset($this->board_permissions)) {
-			$request = Db::$db->query(
-				'',
-				'SELECT id_group, permission, add_deny
-				FROM {db_prefix}board_permissions
-				WHERE id_profile = {int:profile}',
-				[
-					'profile' => $this->id,
-				],
-			);
-
-			while ($row = Db::$db->fetch_assoc($request)) {
-				$this->board_permissions[(int) $row['id_group']][$row['permission']] = (int) $row['add_deny'];
-			}
-
-			Db::$db->free_result($request);
-
-			foreach (Group::getAll() as $id_group) {
-				foreach (Permission::getAll() as $permission) {
-					if ($permission->scope !== 'board') {
-						continue;
-					}
-
-					$this->board_permissions[$id_group][$permission->name] = $id_group === Group::ADMIN ? 1 : ($this->board_permissions[$id_group][$permission->name] ?? null);
-				}
-			}
-		}
-
-		return $this->board_permissions;
 	}
 
 	/***********************
@@ -449,14 +340,11 @@ class PermissionProfile
 			return null;
 		}
 
-		$source_profile->getBoardPermissions();
-
-		$new_profile = clone $source_profile;
-		$new_profile->id = 0;
-		$new_profile->name = $name;
+		$new_profile = new self(0, $name);
+		$new_profile->copied_from = $source_profile->id;
 
 		// Saving will set the new ID, propagate the permissions, and add the
-		// new profile to list of loaded profiles.
+		// new profile to the list of loaded profiles.
 		$new_profile->save();
 
 		return $new_profile;

--- a/Sources/Permissions/PermissionProfile.php
+++ b/Sources/Permissions/PermissionProfile.php
@@ -1,0 +1,466 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2025 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 2
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Permissions;
+
+use SMF\Db\DatabaseApi as Db;
+use SMF\Lang;
+use SMF\Utils;
+
+/**
+ * Represents a permission profile.
+ */
+class PermissionProfile
+{
+	/*****************
+	 * Class constants
+	 *****************/
+
+	public const DEFAULT = 1;
+	public const NO_POLLS = 2;
+	public const REPLY_ONLY = 3;
+	public const READ_ONLY = 4;
+
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 * @var int
+	 *
+	 * The ID of this permission profile.
+	 */
+	public int $id;
+
+	/**
+	 * @var string
+	 *
+	 * The raw name of this permission profile.
+	 */
+	public string $name;
+
+	/*********************
+	 * Internal properties
+	 *********************/
+
+	/**
+	 * @var array
+	 *
+	 * Boards where this profile is used.
+	 */
+	private array $boards;
+
+	/**
+	 * @var array
+	 *
+	 * Multidimensional array listing permission status for all global
+	 * permissions for all groups.
+	 */
+	private array $global_permissions;
+
+	/**
+	 * @var array
+	 *
+	 * Multidimensional array listing permission status for all board
+	 * permissions for all groups.
+	 */
+	private array $board_permissions;
+
+	/****************************
+	 * Internal static properties
+	 ****************************/
+
+	/**
+	 * @var array
+	 *
+	 * All loaded instances of this class.
+	 */
+	private static array $loaded = [];
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct(int $id, string $name)
+	{
+		$this->id = $id;
+		$this->name = $name;
+	}
+
+	/**
+	 * Save this permission profile to the database.
+	 */
+	public function save(): void
+	{
+		if (empty($this->id)) {
+			$this->id = Db::$db->insert(
+				'',
+				'{db_prefix}permission_profiles',
+				['profile_name' => 'string'],
+				[[$this->name]],
+				['id_profile'],
+				1,
+			);
+
+			if (!empty($this->board_permissions)) {
+				foreach ($this->board_permissions as $group => $permissions) {
+					foreach ($permissions as $permission => $value) {
+						if (is_int($value)) {
+							$inserts[] = [$this->id, $group, $permission, $value];
+						}
+					}
+				}
+
+				if (!empty($inserts)) {
+					Db::$db->insert(
+						'insert',
+						'{db_prefix}board_permissions',
+						[
+							'id_profile' => 'int',
+							'id_group' => 'int',
+							'permission' => 'string',
+							'add_deny' => 'int',
+						],
+						$inserts,
+						['id_profile', 'id_group', 'permission'],
+					);
+				}
+			}
+
+			self::$loaded[$this->id] = $this;
+		} else {
+			Db::$db->query(
+				'',
+				'UPDATE {db_prefix}permission_profiles
+				SET profile_name = {string:profile_name}
+				WHERE id_profile = {int:current_profile}',
+				[
+					'current_profile' => $this->id,
+					'profile_name' => $this->name,
+				],
+			);
+
+			// This will only ever be called if an expected profile was deleted.
+			if (Db::$db->affected_rows() == 0) {
+				Db::$db->insert(
+					'ignore',
+					'{db_prefix}permission_profiles',
+					['id_profile' => 'int', 'profile_name' => 'string'],
+					[[$this->id, $this->name]],
+					['id_profile'],
+				);
+			}
+		}
+	}
+
+	/**
+	 * Deletes this permission profile.
+	 *
+	 * @return bool Whether the operation was successful.
+	 */
+	public function delete(): bool
+	{
+		// Can't delete predefined profiles or profiles that are in use.
+		if ($this->isPredefined() || !empty($this->boards())) {
+			return false;
+		}
+
+		Db::$db->query(
+			'',
+			'DELETE FROM {db_prefix}permission_profiles
+			WHERE id_profile = {int:profile}',
+			[
+				'profile' => $this->id,
+			],
+		);
+
+		unset(self::$loaded[$this->id]);
+
+		return true;
+	}
+
+	/**
+	 * Checks whether this permission profile can be modified.
+	 *
+	 * @return bool Whether this permission profile can be modified.
+	 */
+	public function canModify(): bool
+	{
+		return !in_array($this->id, [self::NO_POLLS, self::REPLY_ONLY, self::READ_ONLY]);
+	}
+
+	/**
+	 * Checks whether this permission profile is predefined.
+	 *
+	 * @return bool Whether this permission profile is predefined.
+	 */
+	public function isPredefined(): bool
+	{
+		return in_array($this->id, [self::DEFAULT, self::NO_POLLS, self::REPLY_ONLY, self::READ_ONLY]);
+	}
+
+	/**
+	 * Gets the boards where this profile is used.
+	 *
+	 * @return array IDs of boards that use this profile.
+	 */
+	public function boards(): array
+	{
+		if (!isset($this->boards)) {
+			$request = Db::$db->query(
+				'',
+				'SELECT id_board
+				FROM {db_prefix}boards
+				WHERE id_profile = {int:profile}',
+				[
+					'profile' => $this->id,
+				],
+			);
+
+			$this->boards = array_map(fn($row) => (int) $row['id_board'], Db::$db->fetch_all($request));
+
+			Db::$db->free_result($request);
+		}
+
+		return $this->boards;
+	}
+
+	/**
+	 * Get the allowed/not allowed/denied status for all global permissions
+	 * for all groups.
+	 *
+	 * Note that this only returns a meaningful result for the default profile.
+	 * For all other profiles, an empty array is returned.
+	 *
+	 * @return array Multidimensional array where the keys are group IDs and the
+	 *    values are lists of permissions and the allowed/not allowed/denied
+	 *    status that the group has for that permission.
+	 */
+	public function getGlobalPermissions(): array
+	{
+		if ($this->id !== self::DEFAULT) {
+			return [];
+		}
+
+		if (!isset($this->global_permissions)) {
+			$request = Db::$db->query(
+				'',
+				'SELECT id_group, permission, add_deny
+				FROM {db_prefix}permissions',
+				[],
+			);
+
+			while ($row = Db::$db->fetch_assoc($request)) {
+				$this->global_permissions[(int) $row['id_group']][$row['permission']] = (int) $row['add_deny'];
+			}
+
+			Db::$db->free_result($request);
+
+			foreach (Group::getAll() as $id_group) {
+				foreach (Permission::getAll() as $permission) {
+					if ($permission->scope !== 'global') {
+						continue;
+					}
+
+					$this->global_permissions[$id_group][$permission->name] = $id_group === Group::ADMIN ? 1 : ($this->global_permissions[$id_group][$permission->name] ?? null);
+				}
+			}
+		}
+
+		return $this->global_permissions;
+	}
+
+	/**
+	 * Get the allowed/not allowed/denied status for all board permissions
+	 * for all groups.
+	 *
+	 * @return array Multidimensional array where the keys are group IDs and the
+	 *    values are lists of permissions and the allowed/not allowed/denied
+	 *    status that the group has for that permission.
+	 */
+	public function getBoardPermissions(): array
+	{
+		if (!isset($this->board_permissions)) {
+			$request = Db::$db->query(
+				'',
+				'SELECT id_group, permission, add_deny
+				FROM {db_prefix}board_permissions
+				WHERE id_profile = {int:profile}',
+				[
+					'profile' => $this->id,
+				],
+			);
+
+			while ($row = Db::$db->fetch_assoc($request)) {
+				$this->board_permissions[(int) $row['id_group']][$row['permission']] = (int) $row['add_deny'];
+			}
+
+			Db::$db->free_result($request);
+
+			foreach (Group::getAll() as $id_group) {
+				foreach (Permission::getAll() as $permission) {
+					if ($permission->scope !== 'board') {
+						continue;
+					}
+
+					$this->board_permissions[$id_group][$permission->name] = $id_group === Group::ADMIN ? 1 : ($this->board_permissions[$id_group][$permission->name] ?? null);
+				}
+			}
+		}
+
+		return $this->board_permissions;
+	}
+
+	/***********************
+	 * Public static methods
+	 ***********************/
+
+	/**
+	 * Loads the specified permission profile.
+	 *
+	 * @param string|int $id_or_name The ID number or name of the profile.
+	 * @return ?self An instance of this class, or null on error.
+	 */
+	public static function load(string|int $id_or_name): ?self
+	{
+		// Loading them all is cheap, so we might as well do so.
+		foreach (self::loadAll() as $profile) {
+			if ($profile->id === $id_or_name || $profile->name === $id_or_name) {
+				return $profile;
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Loads all known permission profiles.
+	 *
+	 * @return array Instances of this class.
+	 */
+	public static function loadAll(): array
+	{
+		// Avoid unnecessary repetition.
+		if (!empty(self::$loaded)) {
+			return self::$loaded;
+		}
+
+		$request = Db::$db->query(
+			'',
+			'SELECT p.id_profile, p.profile_name, b.id_board
+			FROM {db_prefix}permission_profiles AS p
+			LEFT JOIN {db_prefix}boards AS b ON (p.id_profile = b.id_profile)',
+			[],
+		);
+
+		while ($row = Db::$db->fetch_assoc($request)) {
+			$id = (int) $row['id_profile'];
+
+			if (!isset(self::$loaded[$id])) {
+				self::$loaded[$id] = new self($id, $row['profile_name']);
+			}
+
+			if (!is_null($row['id_board'])) {
+				self::$loaded[$id]->boards[] = (int) $row['id_board'];
+			}
+		}
+
+		Db::$db->free_result($request);
+
+		// Just in case the predefined ones somehow went missing from the database...
+		foreach ([self::DEFAULT => 'default', self::NO_POLLS => 'no_polls', self::REPLY_ONLY => 'reply_only', self::READ_ONLY => 'read_only'] as $id => $name) {
+			if (!isset(self::$loaded[$id])) {
+				self::$loaded[$id] = new self($id, $name);
+				self::$loaded[$id]->save();
+			}
+		}
+
+		return self::$loaded;
+	}
+
+	/**
+	 * Loads the permission profiles for the specified boards.
+	 *
+	 * @param int|array $boards IDs of one or more boards.
+	 * @return array Key-value pairs where keys are board IDs and values are
+	 *    instances of this class.
+	 */
+	public static function loadByBoard(int|array $boards): array
+	{
+		$boards = (array) $boards;
+
+		$loaded = [];
+
+		foreach (self::loadAll() as $profile) {
+			foreach ($profile->boards() as $board) {
+				if (in_array($board, $boards)) {
+					$loaded[$board] = $profile;
+				}
+			}
+		}
+
+		ksort($loaded);
+
+		return $loaded;
+	}
+
+	/**
+	 * Populates Utils::$context['profiles'] with info for all profiles.
+	 */
+	public static function loadContext(): void
+	{
+		Utils::$context['profiles'] = [];
+
+		foreach (self::loadAll() as $profile) {
+			Utils::$context['profiles'][$profile->id] = [
+				'id' => $profile->id,
+				'name' => Lang::txtExists('permissions_profile_' . $profile->name, file: 'ManagePermissions') ? Lang::getTxt('permissions_profile_' . $profile->name, file: 'ManagePermissions') : $profile->name,
+				'can_modify' => $profile->canModify(),
+				'unformatted_name' => $profile->name,
+			];
+		}
+	}
+
+	/**
+	 * Creates a new permission profile by copying an existing one.
+	 *
+	 * @param int $copy_from ID of the profile to duplicate.
+	 * @param string $name Name for the new profile.
+	 * @return self A new instance of this class, or null on error.
+	 */
+	public static function copy(int $copy_from, string $name): ?self
+	{
+		if (($source_profile = PermissionProfile::load($copy_from)) === null) {
+			return null;
+		}
+
+		$source_profile->getBoardPermissions();
+
+		$new_profile = clone $source_profile;
+		$new_profile->id = 0;
+		$new_profile->name = $name;
+
+		// Saving will set the new ID, propagate the permissions, and add the
+		// new profile to list of loaded profiles.
+		$new_profile->save();
+
+		return $new_profile;
+	}
+}
+
+?>

--- a/Sources/Permissions/UserPermissionSet.php
+++ b/Sources/Permissions/UserPermissionSet.php
@@ -8,7 +8,7 @@
  * @copyright 2025 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 2
+ * @version 3.0 Alpha 3
  */
 
 declare(strict_types=1);
@@ -263,7 +263,7 @@ class UserPermissionSet
 	/**
 	 * Temporarily grants one or more permissions to this user.
 	 *
-	 * These changes not survive beyond the current script execution run.
+	 * These changes do not survive beyond the current script execution run.
 	 *
 	 * @param string|array $permission_name The name of the permission to grant.
 	 */
@@ -279,7 +279,7 @@ class UserPermissionSet
 	/**
 	 * Temporarily removes one or more permissions from this user.
 	 *
-	 * These changes not survive beyond the current script execution run.
+	 * These changes do not survive beyond the current script execution run.
 	 *
 	 * @param string $permission_name The name of the permission to deny.
 	 */
@@ -342,12 +342,13 @@ class UserPermissionSet
 			}
 		}
 	}
+
 	/***********************
 	 * Public static methods
 	 ***********************/
 
 	/**
-	 *
+	 * Loads the permission sets for the given user on the given boards.
 	 *
 	 * @param User $user The user that this permission set is for.
 	 * @param array $boards IDs of zero or more boards.

--- a/Sources/Permissions/UserPermissionSet.php
+++ b/Sources/Permissions/UserPermissionSet.php
@@ -1,0 +1,429 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2025 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 2
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Permissions;
+
+use SMF\Board;
+use SMF\IntegrationHook;
+use SMF\User;
+
+/**
+ * Keeps track of which permissions are allowed for a particular user in a
+ * particular permission profile.
+ */
+class UserPermissionSet
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 * @var User
+	 *
+	 * Instance of SMF\User that this permission set is for.
+	 */
+	public User $user;
+
+	/**
+	 * @var PermissionProfile
+	 *
+	 * Instance of SMF\Permissions\PermissionProfile that this permission set
+	 * is for.
+	 */
+	public PermissionProfile $profile;
+
+	/**
+	 * @var array
+	 *
+	 * List of permission names and whether they are allowed.
+	 *
+	 * Keys are permission names.
+	 * Values can be 1 for allowed, null for not allowed, or 0 for denied.
+	 */
+	public array $permissions = [];
+
+	/**************************
+	 * Public static properties
+	 **************************/
+
+	/**
+	 * @var array
+	 *
+	 * Permissions to deny to users who are banned from posting.
+	 */
+	public static array $post_ban_permissions = [
+		'admin_forum',
+		'calendar_edit_any',
+		'calendar_edit_own',
+		'calendar_post',
+		'delete_any',
+		'delete_own',
+		'delete_replies',
+		'edit_news',
+		'lock_any',
+		'lock_own',
+		'make_sticky',
+		'manage_attachments',
+		'manage_bans',
+		'manage_boards',
+		'manage_membergroups',
+		'manage_permissions',
+		'manage_smileys',
+		'merge_any',
+		'moderate_forum',
+		'modify_any',
+		'modify_own',
+		'modify_replies',
+		'move_any',
+		'pm_send',
+		'poll_add_any',
+		'poll_add_own',
+		'poll_edit_any',
+		'poll_edit_own',
+		'poll_lock_any',
+		'poll_lock_own',
+		'poll_post',
+		'poll_remove_any',
+		'poll_remove_own',
+		'post_new',
+		'post_reply_any',
+		'post_reply_own',
+		'post_unapproved_replies_any',
+		'post_unapproved_replies_own',
+		'post_unapproved_topics',
+		'profile_extra_any',
+		'profile_forum_any',
+		'profile_identity_any',
+		'profile_other_any',
+		'profile_signature_any',
+		'profile_title_any',
+		'remove_any',
+		'remove_own',
+		'send_mail',
+		'split_any',
+	];
+
+	/**
+	 * @var array
+	 *
+	 * Permissions to change for users with a high warning level.
+	 */
+	public static array $warn_permissions = [
+		'post_new' => 'post_unapproved_topics',
+		'post_reply_own' => 'post_unapproved_replies_own',
+		'post_reply_any' => 'post_unapproved_replies_any',
+		'post_attachment' => 'post_unapproved_attachments',
+	];
+
+	/**
+	 * @var array
+	 *
+	 * Permissions that should only be given to highly trusted members.
+	 */
+	public static array $heavy_permissions = [
+		'admin_forum',
+		'manage_attachments',
+		'manage_smileys',
+		'manage_boards',
+		'edit_news',
+		'moderate_forum',
+		'manage_bans',
+		'manage_membergroups',
+		'manage_permissions',
+	];
+
+	/****************************
+	 * Internal static properties
+	 ****************************/
+
+	/**
+	 * @var array
+	 *
+	 * All loaded instances of this class, keyed by profile.
+	 */
+	private static array $loaded = [];
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 *
+	 * @param User $user The user that this permission set is for.
+	 * @param ?Board $board The board where this permission set applies.
+	 */
+	public function __construct(User $user, ?Board $board = null)
+	{
+		$this->user = $user;
+		$this->profile = PermissionProfile::load($board instanceof Board ? $board->profile : PermissionProfile::DEFAULT);
+
+		$groups = $this->user->groups;
+
+		// If this user is detected as a robot and we have special restrictions
+		// for robots, then add the special robots group to the list.
+		if ($this->user->possibly_robot && !empty(Config::$modSettings['spider_group'])) {
+			$groups[] = (int) Config::$modSettings['spider_group'];
+		}
+
+		// If this user is a moderator for this board, load the moderator permissions.
+		if (
+			$board instanceof Board
+			&& (
+				in_array($this->user->id, $board->moderators)
+				|| array_intersect($board->moderator_groups, $this->user->groups) !== []
+			)
+		) {
+			$groups[] = 3;
+		}
+
+		// Get the general permissions for this user.
+		foreach (GroupPermissionSet::load(PermissionProfile::DEFAULT, $groups) as $group_set) {
+			foreach ($group_set->permissions as $permission => $value) {
+				if (Permission::get($permission)->scope !== 'global') {
+					continue;
+				}
+
+				if (!isset($this->permissions[$permission]) || $value === 0) {
+					$this->permissions[$permission] = $value;
+				}
+			}
+		}
+
+		// Get the board permissions for this user on the specified board.
+		foreach (GroupPermissionSet::load($this->profile->id, $groups) as $group_set) {
+			foreach ($group_set->permissions as $permission => $value) {
+				if (Permission::get($permission)->scope === 'global') {
+					continue;
+				}
+
+				if (!isset($this->permissions[$permission]) || $value === 0) {
+					$this->permissions[$permission] = $value;
+				}
+			}
+		}
+
+		// Add to the list.
+		self::$loaded[$this->user->id][$this->profile->id] = $this;
+	}
+
+	/**
+	 * Checks whether the user has been granted the specified permissions.
+	 *
+	 * @param string $permission_names The names of the permissions to check.
+	 * @param bool $any If true, will return true if the user has any of the
+	 *    specified permissions. If false, will return true only if the user
+	 *    has all of the specified permissions. Default: false.
+	 * @return bool Whether the user has been granted the permissions.
+	 */
+	public function allowedTo(string|array $permission_names, bool $any = false): bool
+	{
+		IntegrationHook::call('integrate_heavy_permissions_session', [&self::$heavy_permissions]);
+
+		$permission_names = (array) $permission_names;
+
+		$this->integrateAllowedToGeneral($permission_names);
+
+		if ($any) {
+			$allowed = false;
+
+			foreach ($permission_names as $permission_name) {
+				if (!empty($this->permissions[$permission_name])) {
+					$allowed = true;
+					break;
+				}
+			}
+		} else {
+			$allowed = true;
+
+			foreach ($permission_names as $permission_name) {
+				if (empty($this->permissions[$permission_name])) {
+					$allowed = false;
+				}
+			}
+		}
+
+		$allowed = $this->integrateAllowedToBoard($allowed, $permission_names, $any);
+
+		return $allowed;
+	}
+
+	/**
+	 * Temporarily grants one or more permissions to this user.
+	 *
+	 * These changes not survive beyond the current script execution run.
+	 *
+	 * @param string|array $permission_name The name of the permission to grant.
+	 */
+	public function grant(string|array $permission_names): void
+	{
+		foreach ((array) $permission_names as $permission_name) {
+			if (is_string($permission_name)) {
+				$this->permissions[$permission_name] = 1;
+			}
+		}
+	}
+
+	/**
+	 * Temporarily removes one or more permissions from this user.
+	 *
+	 * These changes not survive beyond the current script execution run.
+	 *
+	 * @param string $permission_name The name of the permission to deny.
+	 */
+	public function deny(string|array $permission_names): void
+	{
+		foreach ((array) $permission_names as $permission_name) {
+			if (array_key_exists($permission_name, $this->permissions)) {
+				$this->permissions[$permission_name] = null;
+			}
+		}
+	}
+
+	/**
+	 * Adjusts permissions according to ban and warning status.
+	 */
+	public function applyBansAndWarnings(): void
+	{
+		// This only applies to the current user.
+		if ($this->user !== User::$me) {
+			return;
+		}
+
+		// Somehow they got here, at least take away all permissions...
+		if (isset($_SESSION['ban']['cannot_access'])) {
+			foreach ($this->permissions as $permission => $value) {
+				$this->deny($permission);
+			}
+
+			return;
+		}
+
+		// Okay, well, you can watch, but don't touch a thing.
+		if (
+			isset($_SESSION['ban']['cannot_post'])
+			|| (
+				!empty(Config::$modSettings['warning_mute'])
+				&& Config::$modSettings['warning_mute'] <= $this->user->warning
+			)
+		) {
+			IntegrationHook::call('integrate_post_ban_permissions', [&self::$post_ban_permissions]);
+
+			foreach (self::$post_ban_permissions as $permission) {
+				$this->deny($permission);
+			}
+
+			return;
+		}
+
+		// Are they absolutely under moderation?
+		if (
+			!empty(Config::$modSettings['warning_moderate'])
+			&& Config::$modSettings['warning_moderate'] <= $this->user->warning
+		) {
+			// Work out what permissions should change...
+			IntegrationHook::call('integrate_warn_permissions', [&self::$warn_permissions]);
+
+			foreach (self::$warn_permissions as $old => $new) {
+				$this->deny($old);
+				$this->grant($new);
+			}
+		}
+	}
+	/***********************
+	 * Public static methods
+	 ***********************/
+
+	/**
+	 *
+	 *
+	 * @param User $user The user that this permission set is for.
+	 * @param array $boards IDs of zero or more boards.
+	 * @return array Instances of this class.
+	 */
+	public static function load(User $user, array $boards): array
+	{
+		$loaded = [];
+
+		if (empty($boards) || in_array(0, $boards)) {
+			$loaded[PermissionProfile::DEFAULT] = self::$loaded[$user->id][PermissionProfile::DEFAULT] ?? new self($user);
+		}
+
+		if (!empty($boards)) {
+			foreach (Board::load($boards) as $board) {
+				$loaded[$board->profile] = self::$loaded[$user->id][$board->profile] ?? new self($user, $board);
+			}
+		}
+
+		return $loaded;
+	}
+
+	/******************
+	 * Internal methods
+	 ******************/
+
+	/**
+	 * Calls the integrate_allowed_to_general hook so that mods can grant custom
+	 * permissions.
+	 *
+	 * @param string $permission_names The names of the permissions to check.
+	 */
+	protected function integrateAllowedToGeneral(array $permission_names): void
+	{
+		$user_permissions = array_filter(
+			array_keys(
+				array_filter($this->permissions),
+			),
+			function (string $p) {
+				try {
+					return Permission::get($p)->scope === 'global';
+				} catch (\ValueError $e) {
+					return true;
+				}
+			},
+		);
+
+		IntegrationHook::call('integrate_allowed_to_general', [&$user_permissions, $permission_names]);
+
+		foreach ($user_permissions as $permission_name) {
+			$this->grant($permission_name);
+		}
+	}
+
+	/**
+	 * Calls the integrate_allowed_to_board hook so that mods can grant custom
+	 * permissions.
+	 *
+	 * @param bool $allowed Whether the user is allowed based on checks so far.
+	 * @param string $permission_names The names of the permissions to check.
+	 * @param bool $any If true, should return true if the user has any of the
+	 *    specified permissions. If false, should return true only if the user
+	 *    has all of the specified permissions. Default: false.
+	 */
+	protected function integrateAllowedToBoard(bool $allowed, array $permission_names, bool $any): bool
+	{
+		if (empty($this->profile->boards())) {
+			return $allowed;
+		}
+
+		$permission_names = array_filter($permission_names, fn($p) => Permission::get($p)->scope === 'board');
+
+		IntegrationHook::call('integrate_allowed_to_board', [&$allowed, $permission_names, $this->profile->boards(), $any]);
+
+		return $allowed;
+	}
+}
+
+?>

--- a/Sources/Permissions/index.php
+++ b/Sources/Permissions/index.php
@@ -1,0 +1,10 @@
+<?php
+
+// Try to handle it with the upper level index.php. (it should know what to do.)
+if (file_exists(dirname(__DIR__) . '/index.php')) {
+	include dirname(__DIR__) . '/index.php';
+} else {
+	exit;
+}
+
+?>

--- a/Sources/PersonalMessage/PM.php
+++ b/Sources/PersonalMessage/PM.php
@@ -1300,7 +1300,7 @@ class PM implements \ArrayAccess
 		}
 
 		// Load the groups that are allowed to read PMs.
-		$pmReadGroups = User::groupsAllowedTo('pm_read');
+		$pmReadGroups = Group::getAllowedTo('pm_read');
 
 		if (empty(Config::$modSettings['permission_enable_deny'])) {
 			$pmReadGroups['denied'] = [];

--- a/Sources/Poll.php
+++ b/Sources/Poll.php
@@ -866,9 +866,8 @@ class Poll implements \ArrayAccess
 
 		self::$guest_vote_enabled = false;
 
-		if (isset(Board::$info->id)) {
-			$groupsAllowedVote = User::groupsAllowedTo('poll_vote', Board::$info->id);
-			self::$guest_vote_enabled = in_array(-1, $groupsAllowedVote['allowed']);
+		if (isset(Board::$info->profile)) {
+			self::$guest_vote_enabled = in_array(-1, Group::getAllowedTo('poll_vote', Board::$info->profile));
 		}
 
 		return self::$guest_vote_enabled;

--- a/Sources/Subs-Compat.php
+++ b/Sources/Subs-Compat.php
@@ -10635,7 +10635,11 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	 */
 	function banPermissions(): void
 	{
-		SMF\User::$me->adjustPermissions();
+		if (!isset(SMF\User::$me->permission_set)) {
+			SMF\User::$me->loadPermissions();
+		}
+
+		SMF\User::$me->permission_set->applyBansAndWarnings();
 	}
 
 	/**

--- a/Sources/Subs-Compat.php
+++ b/Sources/Subs-Compat.php
@@ -1494,7 +1494,25 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	 */
 	function updateChildPermissions(int|array|null $parents = null, ?int $profile = null): ?bool
 	{
-		return SMF\Actions\Admin\Permissions::updateChildPermissions($parents, $profile);
+		// All the parent groups to sort out.
+		$parents = array_unique(array_map('intval', (array) $parents));
+
+		// If $profile is null or less than 1, use the default profile.
+		$profile = max((int) $profile, SMF\Permissions\PermissionProfile::DEFAULT);
+
+		// (Re)load the permission sets and save them. This is all we need to do
+		// because GroupPermissionSet::save() updates child groups automatically.
+		$sets = SMF\Permissions\GroupPermissionSet::load($profile, $parents, true);
+
+		if (empty($sets)) {
+			return false;
+		}
+
+		foreach ($sets as $set) {
+			$set->save();
+		}
+
+		return true;
 	}
 
 	/**

--- a/Sources/Subs-Compat.php
+++ b/Sources/Subs-Compat.php
@@ -1502,7 +1502,7 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	 */
 	function loadIllegalPermissions(): array
 	{
-		return SMF\Actions\Admin\Permissions::loadIllegalPermissions();
+		return SMF\Permissions\Permission::getUnassignable();
 	}
 
 	/**

--- a/Sources/Subs-Compat.php
+++ b/Sources/Subs-Compat.php
@@ -1482,7 +1482,7 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	 */
 	function loadPermissionProfiles(): void
 	{
-		SMF\Actions\Admin\Permissions::loadPermissionProfiles();
+		SMF\Permissions\PermissionProfile::loadContext();
 	}
 
 	/**

--- a/Sources/Subs-Compat.php
+++ b/Sources/Subs-Compat.php
@@ -10491,7 +10491,7 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	 */
 	function membersAllowedTo(string $permission, ?int $board_id = null): array
 	{
-		return SMF\User::membersAllowedTo($permission, $board_id);
+		return SMF\User::getAllowedTo($permission, $board_id);
 	}
 
 	/**
@@ -10505,30 +10505,66 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	 * @param int $board_id = null If set, checks permissions for the specified board
 	 * @return array An array containing two arrays - 'allowed', which has which groups are allowed to do it and 'denied' which has the groups that are denied
 	 */
-	function groupsAllowedTo(
-		string $permission,
-		?int $board_id = null,
-		bool $simple = true,
-		?int $profile_id = null,
-	): array {
-		return SMF\User::groupsAllowedTo((array) $permission, $board_id, $simple, $profile_id);
+	function groupsAllowedTo(string $permission, ?int $board_id = null): array
+	{
+		$return = [];
+
+		$scope = isset($board_id) ? 'board' : 'global';
+
+		foreach (SMF\Group::getAllWithPermissions($permission, $board_id) as $group => $perms) {
+			foreach ($perms as $perm => $value) {
+				if (SMF\Permissions\Permission::get($perm)->scope !== $scope) {
+					continue;
+				}
+
+				switch ($value) {
+					case 1:
+						$result[$perm]['allowed'][] = $group;
+						break;
+
+					case 0:
+						$result[$perm]['denied'][] = $group;
+						break;
+				}
+			}
+		}
+
+		return $return;
 	}
 
 	/**
 	 * Retrieves a list of membergroups with the given permissions.
 	 *
-	 * @param array $general_permissions
-	 * @param array $board_permissions
-	 * @param int   $profile_id
+	 * @param array $general_permissions General permissions to check.
+	 * @param array $board_permissions Board permissions to check.
+	 * @param int   $profile_id ID of a permission profile.
 	 *
-	 * @return array An array containing two arrays - 'allowed', which has which groups are allowed to do it and 'denied' which has the groups that are denied
+	 * @return array An array containing two arrays: 'allowed', which has which
+	 *    groups are allowed to do it and 'denied' which has the groups that are
+	 *    denied.
 	 */
 	function getGroupsWithPermissions(
 		array $general_permissions = [],
 		array $board_permissions = [],
 		int $profile_id = 1,
 	): array {
-		return SMF\User::getGroupsWithPermissions($general_permissions, $board_permissions, $profile_id);
+		$return = [];
+
+		foreach (SMF\Group::getAllWithPermissions($general_permissions + $board_permissions, $profile_id, true) as $group => $perms) {
+			foreach ($perms as $perm => $value) {
+				switch ($value) {
+					case 1:
+						$result[$perm]['allowed'][] = $group;
+						break;
+
+					case 0:
+						$result[$perm]['denied'][] = $group;
+						break;
+				}
+			}
+		}
+
+		return $return;
 	}
 
 	/**

--- a/Sources/Tasks/ApprovePost_Notify.php
+++ b/Sources/Tasks/ApprovePost_Notify.php
@@ -48,7 +48,7 @@ class ApprovePost_Notify extends BackgroundTask
 		$alert_rows = [];
 
 		// We need to know who can approve this post.
-		$modMembers = User::membersAllowedTo('approve_posts', $topicOptions['board']);
+		$modMembers = User::getAllowedTo('approve_posts', $topicOptions['board']);
 
 		$request = Db::$db->query(
 			'',

--- a/Sources/Tasks/CreateAttachment_Notify.php
+++ b/Sources/Tasks/CreateAttachment_Notify.php
@@ -63,7 +63,7 @@ class CreateAttachment_Notify extends BackgroundTask
 		Db::$db->free_result($request);
 
 		// We need to know who can approve this attachment.
-		$modMembers = User::membersAllowedTo('approve_posts', $id_board);
+		$modMembers = User::getAllowedTo('approve_posts', $id_board);
 
 		$request = Db::$db->query(
 			'',

--- a/Sources/Tasks/EventNew_Notify.php
+++ b/Sources/Tasks/EventNew_Notify.php
@@ -36,7 +36,7 @@ class EventNew_Notify extends BackgroundTask
 	public function execute(): bool
 	{
 		// Get everyone who could be notified - those are the people who can see the calendar.
-		$members = User::membersAllowedTo('calendar_view');
+		$members = User::getAllowedTo('calendar_view');
 
 		// Don't alert the event creator
 		if (!empty($this->_details['sender_id'])) {

--- a/Sources/Tasks/GroupReq_Notify.php
+++ b/Sources/Tasks/GroupReq_Notify.php
@@ -57,7 +57,7 @@ class GroupReq_Notify extends BackgroundTask
 		Db::$db->free_result($request);
 
 		// Make sure anyone who can moderate_membergroups gets notified as well
-		$moderators = array_unique(array_merge($moderators, User::membersAllowedTo('manage_membergroups')));
+		$moderators = array_unique(array_merge($moderators, User::getAllowedTo('manage_membergroups')));
 
 		if (!empty($moderators)) {
 			// Figure out who wants to be alerted/emailed about this

--- a/Sources/Tasks/MemberReportReply_Notify.php
+++ b/Sources/Tasks/MemberReportReply_Notify.php
@@ -69,9 +69,8 @@ class MemberReportReply_Notify extends BackgroundTask
 			return true;
 		}
 
-		// We need to know who can moderate this board - and therefore who can see this report.
-		// First up, people who have moderate_board in the board this topic was in.
-		$members = User::membersAllowedTo('moderate_forum');
+		// We need to know who can moderate members and therefore who can see this report.
+		$members = User::getAllowedTo('moderate_forum');
 
 		// Having successfully figured this out, now let's get the preferences of everyone.
 		$prefs = Notify::getNotifyPrefs($members, 'member_report_reply', true);

--- a/Sources/Tasks/MemberReport_Notify.php
+++ b/Sources/Tasks/MemberReport_Notify.php
@@ -40,7 +40,7 @@ class MemberReport_Notify extends BackgroundTask
 	public function execute(): bool
 	{
 		// Anyone with moderate_forum can see this report
-		$members = User::membersAllowedTo('moderate_forum');
+		$members = User::getAllowedTo('moderate_forum');
 
 		// And don't send it to them if they're the one who reported it.
 		$members = array_diff($members, [$this->_details['sender_id']]);

--- a/Sources/Tasks/MsgReportReply_Notify.php
+++ b/Sources/Tasks/MsgReportReply_Notify.php
@@ -71,7 +71,7 @@ class MsgReportReply_Notify extends BackgroundTask
 
 		// We need to know who can moderate this board - and therefore who can see this report.
 		// First up, people who have moderate_board in the board this topic was in.
-		$members = User::membersAllowedTo('moderate_board', $this->_details['board_id']);
+		$members = User::getAllowedTo('moderate_board', $this->_details['board_id']);
 
 		// Second, anyone assigned to be a moderator of this board directly.
 		$request = Db::$db->query(

--- a/Sources/Tasks/MsgReport_Notify.php
+++ b/Sources/Tasks/MsgReport_Notify.php
@@ -41,7 +41,7 @@ class MsgReport_Notify extends BackgroundTask
 	{
 		// We need to know who can moderate this board - and therefore who can see this report.
 		// First up, people who have moderate_board in the board this topic was in.
-		$members = User::membersAllowedTo('moderate_board', (int) $this->_details['board_id']);
+		$members = User::getAllowedTo('moderate_board', (int) $this->_details['board_id']);
 
 		// Second, anyone assigned to be a moderator of this board directly.
 		$request = Db::$db->query(

--- a/Sources/Tasks/Register_Notify.php
+++ b/Sources/Tasks/Register_Notify.php
@@ -38,7 +38,7 @@ class Register_Notify extends BackgroundTask
 	public function execute(): bool
 	{
 		// Get everyone who could be notified.
-		$members = User::membersAllowedTo('moderate_forum');
+		$members = User::getAllowedTo('moderate_forum');
 
 		// Having successfully figured this out, now let's get the preferences of everyone.
 		$prefs = Notify::getNotifyPrefs($members, 'member_register', true);

--- a/Sources/User.php
+++ b/Sources/User.php
@@ -22,6 +22,7 @@ use SMF\Actions\Logout;
 use SMF\Actions\Moderation\ReportedContent;
 use SMF\Cache\CacheApi;
 use SMF\Db\DatabaseApi as Db;
+use SMF\Permissions\Permission;
 use SMF\PersonalMessage\PM;
 
 /**
@@ -2429,14 +2430,13 @@ class User implements \ArrayAccess
 	 *
 	 * If the user is a guest and cannot do it, calls $this->kickIfGuest().
 	 *
-	 * @param string|array $permission A single permission to check or an array
-	 *    of permissions to check.
+	 * @param string|array $permissions One or more permissions to check.
 	 * @param int|array $boards The ID of a board or an array of board IDs if we
 	 *    want to check board-level permissions
 	 * @param bool $any Whether to check for permission on at least one board
 	 *    instead of all the passed boards.
 	 */
-	public function isAllowedTo(string|array $permission, int|array|null $boards = null, bool $any = false): void
+	public function isAllowedTo(string|array $permissions, int|array|null $boards = null, bool $any = false): void
 	{
 		// This only applies to the current user.
 		if ($this->id !== User::$my_id) {
@@ -2444,15 +2444,12 @@ class User implements \ArrayAccess
 		}
 
 		// Make it an array, even if a string was passed.
-		$permission = (array) $permission;
-		$boards = (array) $boards;
-
-		IntegrationHook::call('integrate_heavy_permissions_session', [&self::$heavy_permissions]);
+		$permissions = (array) $permissions;
 
 		// Check the permission and return an error...
-		if (!$this->allowedTo($permission, $boards, $any)) {
+		if (!$this->allowedTo($permissions, $boards, $any)) {
 			// Pick the last array entry as the permission shown as the error.
-			$error_permission = array_shift($permission);
+			$error_permission = array_shift($permissions);
 
 			// If they are a guest, show a login. (because the error might be gone if they do!)
 			if ($this->is_guest) {
@@ -2472,10 +2469,12 @@ class User implements \ArrayAccess
 		}
 
 		// If you're doing something on behalf of some "heavy" permissions,
-		// validate your session. (Take out the heavy permissions, and if you
-		// can't do anything but those, you need a validated session.)
-		if (!$this->allowedTo(array_diff($permission, self::$heavy_permissions), $boards)) {
-			$this->validateSession();
+		// validate your session.
+		foreach ($permissions as $permission) {
+			if (Permission::get($permission)->heavy) {
+				$this->validateSession();
+				break;
+			}
 		}
 	}
 

--- a/Sources/User.php
+++ b/Sources/User.php
@@ -1349,7 +1349,7 @@ class User implements \ArrayAccess
 	/**
 	 * Loads the mod cache data.
 	 *
-	 * Stores the information on the current users moderation powers in
+	 * Stores the information on the current user's moderation powers in
 	 * User::$me->mod_cache and $_SESSION['mc'].
 	 */
 	public function loadModCache(): void
@@ -1364,7 +1364,8 @@ class User implements \ArrayAccess
 			$this->rebuildModCache();
 		}
 
-		// Now that we have the mod cache taken care of lets setup a cache for the number of mod reports still open
+		// Now that we have the mod cache taken care of, let's setup a cache
+		// for the number of mod reports still open.
 		if (
 			isset($_SESSION['rc']['reports'], $_SESSION['rc']['member_reports'])
 			&& $_SESSION['rc']['time'] > Config::$modSettings['last_mod_report_action']

--- a/Sources/User.php
+++ b/Sources/User.php
@@ -832,6 +832,13 @@ class User implements \ArrayAccess
 	/**
 	 * @var array
 	 *
+	 * Cache for the groupsCanModerate() method.
+	 */
+	private array $groups_can_moderate;
+
+	/**
+	 * @var array
+	 *
 	 * Alternate names for some object properties.
 	 */
 	protected array $prop_aliases = [
@@ -2354,6 +2361,66 @@ class User implements \ArrayAccess
 		Db::$db->free_result($request);
 
 		return $this->accessible_boards;
+	}
+
+	/**
+	 * Gets a list of membergroups that this user can moderate.
+	 *
+	 * @param bool $ignore_protected Whether to ignore the protected status of
+	 *    protected groups. Only applicable when this user can manage groups but
+	 *    is not an admin. Default: false.
+	 * @return array A list of zero or more membergroup IDs.
+	 */
+	public function groupsCanModerate(bool $ignore_protected = false): array
+	{
+		// $ignore_protected only ever matters in this one scenario.
+		if (
+			$ignore_protected
+			&& !$this->allowedTo('admin_forum')
+			&& $this->allowedTo('manage_membergroups')
+		) {
+			return Group::getAll();
+		}
+
+		if (isset($this->groups_can_moderate)) {
+			return $this->groups_can_moderate;
+		}
+
+		if ($this->is_guest) {
+			$this->groups_can_moderate = [];
+		} elseif ($this->allowedTo('admin_forum')) {
+			$this->groups_can_moderate = Group::getAll();
+		} elseif ($this->allowedTo('manage_membergroups')) {
+			$request = Db::$db->query(
+				'',
+				'SELECT id_group
+				FROM {db_prefix}groups
+				WHERE group_type != {int:protected}',
+				[
+					'protected' => Group::TYPE_PROTECTED,
+				],
+			);
+
+			$this->groups_can_moderate = array_map(fn($row) => $row['id_group'], Db::$db->fetch_all($request));
+
+			Db::$db->free_result($request);
+		} else {
+			$request = Db::$db->query(
+				'',
+				'SELECT id_group
+				FROM {db_prefix}group_moderators
+				WHERE id_member = {int:member}',
+				[
+					'member' => $this->id,
+				],
+			);
+
+			$this->groups_can_moderate = array_map(fn($row) => $row['id_group'], Db::$db->fetch_all($request));
+
+			Db::$db->free_result($request);
+		}
+
+		return $this->groups_can_moderate;
 	}
 
 	/***********************

--- a/Sources/User.php
+++ b/Sources/User.php
@@ -825,6 +825,13 @@ class User implements \ArrayAccess
 	/**
 	 * @var array
 	 *
+	 * Cache for the boardsCanAccess() method.
+	 */
+	private array $accessible_boards;
+
+	/**
+	 * @var array
+	 *
 	 * Alternate names for some object properties.
 	 */
 	protected array $prop_aliases = [
@@ -2285,81 +2292,68 @@ class User implements \ArrayAccess
 		$boards = [];
 		$deny_boards = [];
 
-		// Arrays are nice, most of the time.
-		$permissions = (array) $permissions;
+		$permissions = array_filter((array) $permissions, fn($p) => Permission::get($p)->scope === 'board');
 
-		// Administrators are all powerful.
-		if ($this->is_admin) {
-			if ($simple) {
-				return [0];
+		foreach (PermissionProfile::loadAll() as $profile) {
+			if (empty($profile->boards)) {
+				continue;
 			}
+
+			$set = UserPermissionSet::load($user, reset($profile->boards));
 
 			foreach ($permissions as $permission) {
-				$boards[$permission] = [0];
-			}
-
-			return $boards;
-		}
-
-		// All groups the user is in except 'moderator'.
-		$groups = array_diff($this->groups, [3]);
-
-		$request = Db::$db->query(
-			'',
-			'SELECT b.id_board, bp.add_deny' . ($simple ? '' : ', bp.permission') . '
-			FROM {db_prefix}board_permissions AS bp
-				INNER JOIN {db_prefix}boards AS b ON (b.id_profile = bp.id_profile)
-				LEFT JOIN {db_prefix}moderators AS mods ON (mods.id_board = b.id_board AND mods.id_member = {int:current_member})
-				LEFT JOIN {db_prefix}moderator_groups AS modgs ON (modgs.id_board = b.id_board AND modgs.id_group IN ({array_int:group_list}))
-			WHERE bp.id_group IN ({array_int:group_list}, {int:moderator_group})
-				AND bp.permission IN ({array_string:permissions})
-				AND (mods.id_member IS NOT NULL OR modgs.id_group IS NOT NULL OR bp.id_group != {int:moderator_group})' .
-				($check_access ? ' AND {query_see_board}' : ''),
-			[
-				'current_member' => $this->id,
-				'group_list' => $groups,
-				'moderator_group' => 3,
-				'permissions' => $permissions,
-			],
-		);
-
-		while ($row = Db::$db->fetch_assoc($request)) {
-			if ($simple) {
-				if (empty($row['add_deny'])) {
-					$deny_boards[] = $row['id_board'];
+				if ($set->allowedTo($permission)) {
+					$boards[$permission] = array_merge($boards[$permission] ?? [], $profile->boards);
 				} else {
-					$boards[] = $row['id_board'];
-				}
-			} else {
-				if (empty($row['add_deny'])) {
-					$deny_boards[$row['permission']][] = $row['id_board'];
-				} else {
-					$boards[$row['permission']][] = $row['id_board'];
+					$deny_boards[$permission] = array_merge($deny_boards[$permission] ?? [], $profile->boards);
 				}
 			}
 		}
-		Db::$db->free_result($request);
+
+		$check_access = $check_access && !$this->can_manage_boards;
+
+		if ($check_access) {
+			foreach ($boards as $permission => $board_list) {
+				$boards[$permission] = array_intersect($board_list, $this->boardsCanAccess());
+			}
+		}
 
 		if ($simple) {
-			$boards = array_unique(array_values(array_diff($boards, $deny_boards)));
-		} else {
-			foreach ($permissions as $permission) {
-				// Never had it to start with.
-				if (empty($boards[$permission])) {
-					$boards[$permission] = [];
-				} else {
-					// Or it may have been removed.
-					$deny_boards[$permission] = $deny_boards[$permission] ?? [];
-
-					$boards[$permission] = array_unique(array_values(array_diff($boards[$permission], $deny_boards[$permission])));
-				}
-			}
+			$boards = array_reduce($boards, fn($carry, $item) => $carry = array_unique(array_merge($carry, $item)), []);
 		}
 
 		// Maybe a mod needs to tweak the list of allowed boards on the fly?
 		IntegrationHook::call('integrate_boards_allowed_to', [&$boards, $deny_boards, $permissions, $check_access, $simple]);
 
 		return $boards;
+	}
+
+	/**
+	 * Gets a list of boards that this user can access.
+	 *
+	 * @return array A list of board IDs.
+	 */
+	public function boardsCanAccess(): array
+	{
+		if (isset($this->accessible_boards)) {
+			return $this->accessible_boards;
+		}
+
+		$request = Db::$db->query(
+			'',
+			'SELECT id_board
+			FROM {db_prefix}boards
+			WHERE {raw:can_access}',
+			[
+				'can_access' => $this->query_see_board,
+			],
+		);
+
+		$this->accessible_boards = array_map(fn($row) => $row['id_board'], Db::$db->fetch_all($request));
+
+		Db::$db->free_result($request);
+
+		return $this->accessible_boards;
 	}
 
 	/***********************

--- a/Sources/User.php
+++ b/Sources/User.php
@@ -3725,27 +3725,32 @@ class User implements \ArrayAccess
 	}
 
 	/**
-	 * Retrieves a list of members that have a given permission,
-	 * either on a given board or in general.
+	 * Retrieves a list of members that have a given permission, either on a
+	 * given board or in general.
 	 *
-	 * Will check for a board permission if $board_id is set, and any
-	 * moderators assigned to that board will be fetched in addition
-	 * to global moderators.  Pass in 0 as a special case to fetch
-	 * moderators on all boards.
+	 * Will check for a board permission if $board_id is set, and any moderators
+	 * assigned to that board will be fetched in addition to global moderators.
+	 * Pass in 0 as a special case to fetch moderators on all boards.
 	 *
 	 * @param string $permission The permission to check.
 	 * @param int $board_id If set, checks permission for that specific board.
 	 * @return array IDs of the members who have that permission.
 	 */
-	public static function membersAllowedTo(string $permission, ?int $board_id = null): array
+	public static function getAllowedTo(string $permission, ?int $board_id = null): array
 	{
-		$member_groups = self::groupsAllowedTo($permission, $board_id);
+		$member_groups = Group::getAllWithPermissions($permission, $board_id);
 
-		$include_moderators = in_array(3, $member_groups['allowed']) && $board_id !== null;
-		$include_groups = array_diff($member_groups['allowed'], [3]);
+		$include_moderators = $member_groups[Group::MOD][$permission] === 1 && $board_id !== null;
+		$include_groups = array_keys(array_filter(
+			$member_groups,
+			fn($permissions, $group) => $permissions[$permission] === 1 && $group !== Group::MOD,
+		));
 
-		$exclude_moderators = in_array(3, $member_groups['denied']) && $board_id !== null;
-		$exclude_groups = array_diff($member_groups['denied'], [3]);
+		$exclude_moderators = $member_groups[Group::MOD][$permission] === 0 && $board_id !== null;
+		$exclude_groups = array_keys(array_filter(
+			$member_groups,
+			fn($permissions, $group) => $permissions[$permission] === 0 && $group !== Group::MOD,
+		));
 
 		$request = Db::$db->query(
 			'',
@@ -3783,210 +3788,6 @@ class User implements \ArrayAccess
 		Db::$db->free_result($request);
 
 		return $members;
-	}
-
-	/**
-	 * Retrieves a list of membergroups that have the given permission(s),
-	 * either on a given board or in general.
-	 *
-	 * If $board_id is set, a board permission is assumed.
-	 *
-	 * @param array|string $permissions The permission(s) to check.
-	 * @param int $board_id If set, checks permissions for the specified board.
-	 * @param bool $simple If true, and $permission contains a single permission
-	 *    to check, the returned array will contain only the relevant sub-array
-	 *    for that permission. Default: true.
-	 * @param int $profile_id The permission profile for the board.
-	 *    If not set, will be looked up automatically.
-	 * @return array Multidimensional array where each key is a permission name
-	 *    and each value is an array containing to sub-arrays: 'allowed', which
-	 *    lists the groups that have the permission, and 'denied', which lists
-	 *    the groups that are denied the permission. However, if $simple is true
-	 *    and only one permission was asked for, the returned value will contain
-	 *    only the relevant sub-array for that permission.
-	 */
-	public static function groupsAllowedTo(array|string $permissions, ?int $board_id = null, bool $simple = true, ?int $profile_id = null): array
-	{
-		$permissions = (array) $permissions;
-
-		$group_permissions = [];
-		$board_permissions = [];
-
-		foreach ($permissions as $permission) {
-			// Admins are allowed to do anything.
-			$member_groups[$permission] = [
-				'allowed' => [1],
-				'denied' => [],
-			];
-		}
-
-		// No board means we're dealing with general permissions.
-		if (!isset($board_id)) {
-			$request = Db::$db->query(
-				'',
-				'SELECT id_group, permission, add_deny
-				FROM {db_prefix}permissions
-				WHERE permission IN ({array_string:permissions})',
-				[
-					'permissions' => $permissions,
-				],
-			);
-
-			while ($row = Db::$db->fetch_assoc($request)) {
-				$group_permissions[] = $row['permission'];
-
-				$member_groups[$row['permission']][$row['add_deny'] ? 'allowed' : 'denied'][] = $row['id_group'];
-			}
-			Db::$db->free_result($request);
-
-			$group_permissions = array_unique($group_permissions);
-		}
-
-		// If given a board, we need its permission profile.
-		if (!isset($profile_id) && isset($board_id)) {
-			$board_id = (int) $board_id;
-
-			// First get the profile of the given board.
-			if (isset(Board::$info->id) && Board::$info->id == $board_id) {
-				$profile_id = Board::$info->profile;
-			} elseif ($board_id !== 0) {
-				$request = Db::$db->query(
-					'',
-					'SELECT id_profile
-					FROM {db_prefix}boards
-					WHERE id_board = {int:id_board}
-					LIMIT 1',
-					[
-						'id_board' => $board_id,
-					],
-				);
-
-				if (Db::$db->num_rows($request) == 0) {
-					Db::$db->free_result($request);
-					ErrorHandler::fatalLang('no_board');
-				}
-				list($profile_id) = Db::$db->fetch_row($request);
-				Db::$db->free_result($request);
-			} else {
-				$profile_id = 1;
-			}
-		}
-
-		if (isset($profile_id)) {
-			$request = Db::$db->query(
-				'',
-				'SELECT id_group, permission, add_deny
-				FROM {db_prefix}board_permissions
-				WHERE permission IN ({array_string:permissions})
-					AND id_profile = {int:profile_id}',
-				[
-					'profile_id' => $profile_id,
-					'permissions' => $permissions,
-				],
-			);
-
-			while ($row = Db::$db->fetch_assoc($request)) {
-				$board_permissions[] = $row['permission'];
-
-				$member_groups[$row['permission']][$row['add_deny'] ? 'allowed' : 'denied'][] = $row['id_group'];
-			}
-			Db::$db->free_result($request);
-
-			$board_permissions = array_unique($board_permissions);
-
-			// Inherit any moderator permissions as needed.
-			$moderator_groups = [];
-
-			if (isset(Board::$info->id, Board::$info->moderator_groups) && $board_id == Board::$info->id) {
-				$moderator_groups = array_keys(Board::$info->moderator_groups);
-			} elseif (isset($board_id) && $board_id !== 0) {
-				// Get the groups that can moderate this board
-				$request = Db::$db->query(
-					'',
-					'SELECT id_group
-					FROM {db_prefix}moderator_groups
-					WHERE id_board = {int:board_id}',
-					[
-						'board_id' => $board_id,
-					],
-				);
-
-				while ($row = Db::$db->fetch_assoc($request)) {
-					$moderator_groups[] = $row['id_group'];
-				}
-				Db::$db->free_result($request);
-			}
-
-			// Inherit any additional permissions from the moderators group.
-			foreach ($moderator_groups as $mod_group) {
-				foreach ($board_permissions as $permission) {
-					// If they're not specifically allowed, but the moderator group is,
-					// then allow it.
-					if (in_array(3, $member_groups[$permission]['allowed']) && !in_array($mod_group, $member_groups[$permission]['allowed'])) {
-						$member_groups[$permission]['allowed'][] = $mod_group;
-					}
-
-					// They're not denied, but the moderator group is, so deny it.
-					if (in_array(3, $member_groups[$permission]['denied']) && !in_array($mod_group, $member_groups[$permission]['denied'])) {
-						$member_groups[$permission]['denied'][] = $mod_group;
-					}
-				}
-			}
-		}
-
-		// Finalize the data.
-		foreach ($permissions as $permission) {
-			foreach (['allowed', 'denied'] as $k) {
-				$member_groups[$permission][$k] = array_unique($member_groups[$permission][$k]);
-			}
-
-			// Maybe a mod needs to tweak the list of allowed groups on the fly?
-			IntegrationHook::call('integrate_groups_allowed_to', [&$member_groups[$permission], $permission, $board_id]);
-
-			// Denied is never allowed.
-			$member_groups[$permission]['allowed'] = array_diff($member_groups[$permission]['allowed'], $member_groups[$permission]['denied']);
-		}
-
-		if ($simple && count($member_groups) === 1) {
-			return reset($member_groups);
-		}
-
-		return $member_groups;
-	}
-
-	/**
-	 * Similar to self::groupsAllowedTo, except that:
-	 *
-	 * 1. It allows looking up any arbitrary combination of general permissions
-	 *    and board permissions in one call.
-	 *
-	 * 2. When looking up board permissions, the ID of a permission profile must
-	 *    be provided, rather than the ID of a board.
-	 *
-	 * 3. There is no $simple option.
-	 *
-	 * @param array $general_permissions The general permissions to check.
-	 * @param array $board_permissions The board permissions to check.
-	 * @param int $profile_id The permission profile for the board permissions.
-	 *    Default: 1
-	 * @return array Multidimensional array where each key is a permission name
-	 *    and each value is an array containing to sub-arrays: 'allowed', which
-	 *    lists the groups that have the permission, and 'denied', which lists
-	 *    the groups that are denied the permission.
-	 */
-	public static function getGroupsWithPermissions(array $general_permissions = [], array $board_permissions = [], int $profile_id = 1): array
-	{
-		$member_groups = [];
-
-		if (!empty($general_permissions)) {
-			$member_groups = self::groupsAllowedTo($general_permissions, null, false);
-		}
-
-		if (!empty($board_permissions)) {
-			$member_groups = array_merge($member_groups, self::groupsAllowedTo($board_permissions, null, false, $profile_id));
-		}
-
-		return $member_groups;
 	}
 
 	/**

--- a/Sources/User.php
+++ b/Sources/User.php
@@ -23,6 +23,8 @@ use SMF\Actions\Moderation\ReportedContent;
 use SMF\Cache\CacheApi;
 use SMF\Db\DatabaseApi as Db;
 use SMF\Permissions\Permission;
+use SMF\Permissions\PermissionProfile;
+use SMF\Permissions\UserPermissionSet;
 use SMF\PersonalMessage\PM;
 
 /**
@@ -564,9 +566,15 @@ class User implements \ArrayAccess
 	/**
 	 * @var array
 	 *
-	 * Permissions that this user has been granted.
+	 * A collection of UserPermissionSet instances, organized by board.
+	 *
+	 * The UserPermissionSet for this user's global (a.k.a. general) permissions
+	 * is stored in $this->permission_sets[0].
+	 *
+	 * Otherwise, keys are board IDs and values are UserPermissionSet instances
+	 * for those boards.
 	 */
-	public array $permissions = [];
+	public array $permission_sets;
 
 	/**
 	 * @var int
@@ -782,92 +790,6 @@ class User implements \ArrayAccess
 		'website_url',
 	];
 
-	/**
-	 * @var array
-	 *
-	 * Permissions to deny to users who are banned from posting.
-	 */
-	public static array $post_ban_permissions = [
-		'admin_forum',
-		'calendar_edit_any',
-		'calendar_edit_own',
-		'calendar_post',
-		'delete_any',
-		'delete_own',
-		'delete_replies',
-		'edit_news',
-		'lock_any',
-		'lock_own',
-		'make_sticky',
-		'manage_attachments',
-		'manage_bans',
-		'manage_boards',
-		'manage_membergroups',
-		'manage_permissions',
-		'manage_smileys',
-		'merge_any',
-		'moderate_forum',
-		'modify_any',
-		'modify_own',
-		'modify_replies',
-		'move_any',
-		'pm_send',
-		'poll_add_any',
-		'poll_add_own',
-		'poll_edit_any',
-		'poll_edit_own',
-		'poll_lock_any',
-		'poll_lock_own',
-		'poll_post',
-		'poll_remove_any',
-		'poll_remove_own',
-		'post_new',
-		'post_reply_any',
-		'post_reply_own',
-		'post_unapproved_replies_any',
-		'post_unapproved_replies_own',
-		'post_unapproved_topics',
-		'profile_extra_any',
-		'profile_forum_any',
-		'profile_identity_any',
-		'profile_other_any',
-		'profile_signature_any',
-		'profile_title_any',
-		'remove_any',
-		'remove_own',
-		'send_mail',
-		'split_any',
-	];
-
-	/**
-	 * @var array
-	 *
-	 * Permissions to change for users with a high warning level.
-	 */
-	public static array $warn_permissions = [
-		'post_new' => 'post_unapproved_topics',
-		'post_reply_own' => 'post_unapproved_replies_own',
-		'post_reply_any' => 'post_unapproved_replies_any',
-		'post_attachment' => 'post_unapproved_attachments',
-	];
-
-	/**
-	 * @var array
-	 *
-	 * Permissions that should only be given to highly trusted members.
-	 */
-	public static array $heavy_permissions = [
-		'admin_forum',
-		'manage_attachments',
-		'manage_smileys',
-		'manage_boards',
-		'edit_news',
-		'moderate_forum',
-		'manage_bans',
-		'manage_membergroups',
-		'manage_permissions',
-	];
-
 	/*********************
 	 * Internal properties
 	 *********************/
@@ -974,143 +896,64 @@ class User implements \ArrayAccess
 	/**
 	 * Load this user's permissions.
 	 */
-	public function loadPermissions(): void
+	public function loadPermissions(int|array|null $boards = null): void
 	{
-		if ($this->is_admin) {
-			$this->can_mod = true;
-			$this->can_manage_boards = true;
-
-			$this->adjustPermissions();
-
-			return;
+		if ($boards === []) {
+			$boards = null;
 		}
 
-		if (!empty(CacheApi::$enable)) {
-			$cache_groups = $this->groups;
-			asort($cache_groups);
-			$cache_groups = implode(',', $cache_groups);
-
-			// If it's a spider then cache it separately.
-			if ($this->possibly_robot) {
-				$cache_groups .= '-spider';
+		foreach (
+			UserPermissionSet::load(
+				$this,
+				array_filter(
+					array_unique(
+						array_merge(
+							[0],
+							(array) ($boards ?? Board::$info->id ?? 0),
+						),
+					),
+					fn($board) => !isset($this->permission_sets[$board]),
+				),
+			) as $set
+		) {
+			if ($set->profile->id === PermissionProfile::DEFAULT) {
+				$this->permission_sets[0] = $set;
 			}
 
-			if (
-				CacheApi::$enable >= 2
-				&& !empty(Board::$info->id)
-				&& ($temp = CacheApi::get('permissions:' . $cache_groups . ':' . Board::$info->id, 240)) != null
-				&& time() - 240 > Config::$modSettings['settings_updated']
-			) {
-				list($this->permissions) = $temp;
-				$this->adjustPermissions();
-
-				return;
-			}
-
-			if (
-				($temp = CacheApi::get('permissions:' . $cache_groups, 240)) != null
-				&& time() - 240 > Config::$modSettings['settings_updated']
-			) {
-				list($this->permissions, $removals) = $temp;
+			foreach ($set->profile->boards() as $id_board) {
+				$this->permission_sets[$id_board] = $set;
 			}
 		}
 
-		// If it is detected as a robot, and we are restricting permissions as a special group - then implement this.
-		$spider_restrict = $this->possibly_robot && !empty(Config::$modSettings['spider_group']) ? ' OR (id_group = {int:spider_group} AND add_deny = 0)' : '';
-
-		if (empty($this->permissions)) {
-			// Get the general permissions.
-			$removals = [];
-			$request = Db::$db->query(
-				'',
-				'SELECT permission, add_deny
-				FROM {db_prefix}permissions
-				WHERE id_group IN ({array_int:member_groups})
-					' . $spider_restrict,
-				[
-					'member_groups' => $this->groups,
-					'spider_group' => !empty(Config::$modSettings['spider_group']) ? Config::$modSettings['spider_group'] : 0,
-				],
-			);
-
-			while ($row = Db::$db->fetch_assoc($request)) {
-				if (empty($row['add_deny'])) {
-					$removals[] = $row['permission'];
-				} else {
-					$this->permissions[] = $row['permission'];
-				}
-			}
-			Db::$db->free_result($request);
-
-			if (isset($cache_groups)) {
-				CacheApi::put('permissions:' . $cache_groups, [$this->permissions, $removals], 240);
-			}
-		}
-
-		// Get the board permissions.
-		if (!empty(Board::$info->id)) {
-			// Make sure the board (if any) has been loaded by Board::load().
-			if (!isset(Board::$info->profile)) {
-				ErrorHandler::fatalLang('no_board');
-			}
-
-			$request = Db::$db->query(
-				'',
-				'SELECT permission, add_deny
-				FROM {db_prefix}board_permissions
-				WHERE (id_group IN ({array_int:member_groups})
-					' . $spider_restrict . ')
-					AND id_profile = {int:id_profile}',
-				[
-					'member_groups' => $this->groups,
-					'id_profile' => Board::$info->profile,
-					'spider_group' => !empty(Config::$modSettings['spider_group']) ? Config::$modSettings['spider_group'] : 0,
-				],
-			);
-
-			while ($row = Db::$db->fetch_assoc($request)) {
-				if (empty($row['add_deny'])) {
-					$removals[] = $row['permission'];
-				} else {
-					$this->permissions[] = $row['permission'];
-				}
-			}
-			Db::$db->free_result($request);
-		}
-
-		// Remove all the permissions they shouldn't have ;).
-		if (!empty(Config::$modSettings['permission_enable_deny'])) {
-			$this->permissions = array_diff($this->permissions, $removals);
-		}
-
-		if (isset($cache_groups) && !empty(Board::$info->id) && CacheApi::$enable >= 2) {
-			CacheApi::put('permissions:' . $cache_groups . ':' . Board::$info->id, [$this->permissions, null], 240);
-		}
-
-		// Banned?  Watch, don't touch..
-		$this->adjustPermissions();
-
-		// Load the mod cache so we can know what additional boards they should see, but no sense in doing it for guests
-		if (!$this->is_guest && $this->id === self::$my_id) {
-			if (!isset($_SESSION['mc']) || $_SESSION['mc']['time'] <= Config::$modSettings['settings_updated']) {
-				$this->rebuildModCache();
-			} else {
-				$this->mod_cache = $_SESSION['mc'];
-			}
-
-			// This is a useful phantom permission added to the current user, and only the current user while they are logged in.
-			// For example this drastically simplifies certain changes to the profile area.
-			$this->permissions[] = 'is_not_guest';
-
-			// And now some backwards compatibility stuff for mods and whatnot that aren't expecting the new permissions.
-			$this->permissions[] = 'profile_view_own';
-
-			if (in_array('profile_view', $this->permissions)) {
-				$this->permissions[] = 'profile_view_any';
-			}
+		if (!isset($boards)) {
+			$this->loadModCache();
 
 			// A user can mod if they have permission to see the mod center, or they are a board/group/approval moderator.
-			$this->can_mod = in_array('access_mod_center', $this->permissions) || ($this->mod_cache['gq'] ?? '0=1') != '0=1' || ($this->mod_cache['bq'] ?? '0=1') != '0=1' || (Config::$modSettings['postmod_active'] && !empty($this->mod_cache['ap']));
+			$this->can_mod = (
+				$this->is_admin
+				|| $this->permission_sets[0]->allowedTo('access_mod_center')
+				|| ($this->mod_cache['gq'] ?? '0=1') != '0=1'
+				|| ($this->mod_cache['bq'] ?? '0=1') != '0=1'
+				|| (
+					Config::$modSettings['postmod_active']
+					&& !empty($this->mod_cache['ap'])
+				)
+			);
+
+			if (!$this->is_guest && $this === self::$me) {
+				// This is a useful phantom permission added to the current user,
+				// and only the current user while they are logged in. For example
+				// this drastically simplifies certain changes to the profile area.
+				$this->permission_sets[0]->grant('is_not_guest');
+
+				// And now some backwards compatibility stuff for mods and whatnot
+				// that aren't expecting the new permissions.
+				$this->permission_sets[0]->grant('profile_view_own');
+
+				if ($this->permission_sets[0]->allowedTo('profile_view')) {
+					$this->permission_sets[0]->grant('profile_view_any');
+				}
+			}
 		}
 	}
 
@@ -1486,6 +1329,41 @@ class User implements \ArrayAccess
 			}
 
 			$_SESSION['timeOnlineUpdated'] = time();
+		}
+	}
+
+	/**
+	 * Loads the mod cache data.
+	 *
+	 * Stores the information on the current users moderation powers in
+	 * User::$me->mod_cache and $_SESSION['mc'].
+	 */
+	public function loadModCache(): void
+	{
+		if (
+			isset($_SESSION['mc'])
+			&& $_SESSION['mc']['time'] > Config::$modSettings['settings_updated']
+			&& $_SESSION['mc']['id'] == $this->id
+		) {
+			$this->mod_cache = $_SESSION['mc'];
+		} else {
+			$this->rebuildModCache();
+		}
+
+		// Now that we have the mod cache taken care of lets setup a cache for the number of mod reports still open
+		if (
+			isset($_SESSION['rc']['reports'], $_SESSION['rc']['member_reports'])
+			&& $_SESSION['rc']['time'] > Config::$modSettings['last_mod_report_action']
+			&& $_SESSION['rc']['id'] == $this->id
+		) {
+			Utils::$context['open_mod_reports'] = $_SESSION['rc']['reports'];
+			Utils::$context['open_member_reports'] = $_SESSION['rc']['member_reports'];
+		} elseif ($_SESSION['mc']['bq'] != '0=1') {
+			Utils::$context['open_mod_reports'] = ReportedContent::recountOpenReports('posts');
+			Utils::$context['open_member_reports'] = ReportedContent::recountOpenReports('members');
+		} else {
+			Utils::$context['open_mod_reports'] = 0;
+			Utils::$context['open_member_reports'] = 0;
 		}
 	}
 
@@ -1946,8 +1824,8 @@ class User implements \ArrayAccess
 		}
 
 		// Fix up the banning permissions.
-		if (isset($this->permissions)) {
-			$this->adjustPermissions();
+		if (isset($this->permissions_set)) {
+			$this->permissions_set->applyBansAndWarnings();
 		}
 	}
 
@@ -2001,66 +1879,6 @@ class User implements \ArrayAccess
 					'ban_ids' => $ban_ids,
 				],
 			);
-		}
-	}
-
-	/**
-	 * Fix permissions according to ban and warning status.
-	 *
-	 * Applies any states of banning and/or warning moderation by removing
-	 * permissions the user cannot have.
-	 */
-	public function adjustPermissions(): void
-	{
-		// This only applies to the current user.
-		if ($this->id !== User::$my_id) {
-			return;
-		}
-
-		// Somehow they got here, at least take away all permissions...
-		if (isset($_SESSION['ban']['cannot_access'])) {
-			$this->permissions = [];
-		}
-		// Okay, well, you can watch, but don't touch a thing.
-		elseif (isset($_SESSION['ban']['cannot_post']) || (!empty(Config::$modSettings['warning_mute']) && Config::$modSettings['warning_mute'] <= $this->warning)) {
-			IntegrationHook::call('integrate_post_ban_permissions', [&self::$post_ban_permissions]);
-
-			$this->permissions = array_diff($this->permissions, self::$post_ban_permissions);
-		}
-		// Are they absolutely under moderation?
-		elseif (!empty(Config::$modSettings['warning_moderate']) && Config::$modSettings['warning_moderate'] <= $this->warning) {
-			// Work out what permissions should change...
-			IntegrationHook::call('integrate_warn_permissions', [&self::$warn_permissions]);
-
-			foreach (self::$warn_permissions as $old => $new) {
-				if (!in_array($old, $this->permissions)) {
-					unset(self::$warn_permissions[$old]);
-				} else {
-					$this->permissions[] = $new;
-				}
-			}
-
-			$this->permissions = array_diff($this->permissions, array_keys(self::$warn_permissions));
-		}
-
-		// @todo Find a better place to call this? Needs to be after permissions loaded!
-		// Finally, some bits we cache in the session because it saves queries.
-		if (isset($_SESSION['mc']) && $_SESSION['mc']['time'] > Config::$modSettings['settings_updated'] && $_SESSION['mc']['id'] == $this->id) {
-			$this->mod_cache = $_SESSION['mc'];
-		} else {
-			$this->rebuildModCache();
-		}
-
-		// Now that we have the mod cache taken care of lets setup a cache for the number of mod reports still open
-		if (isset($_SESSION['rc']['reports'], $_SESSION['rc']['member_reports'])   && $_SESSION['rc']['time'] > Config::$modSettings['last_mod_report_action'] && $_SESSION['rc']['id'] == $this->id) {
-			Utils::$context['open_mod_reports'] = $_SESSION['rc']['reports'];
-			Utils::$context['open_member_reports'] = $_SESSION['rc']['member_reports'];
-		} elseif ($_SESSION['mc']['bq'] != '0=1') {
-			Utils::$context['open_mod_reports'] = ReportedContent::recountOpenReports('posts');
-			Utils::$context['open_member_reports'] = ReportedContent::recountOpenReports('members');
-		} else {
-			Utils::$context['open_mod_reports'] = 0;
-			Utils::$context['open_member_reports'] = 0;
 		}
 	}
 
@@ -2304,27 +2122,27 @@ class User implements \ArrayAccess
 	}
 
 	/**
-	 * Checks whether the user has a given permissions (e.g. 'post_new').
+	 * Checks whether the user has the specified permissions (e.g. 'post_new').
 	 *
 	 * If $boards is specified, checks those boards instead of the current one.
 	 *
-	 * If $any is true, will return true if the user has the permission on any
-	 * of the specified boards
+	 * If $any is true, will return true if the user has any of the specified
+	 * permissions on any of the specified boards.
 	 *
 	 * Always returns true if the user is an administrator.
 	 *
-	 * @param string|array $permission A single permission to check or an array
-	 *    of permissions to check.
-	 * @param int|array $boards The ID of a board or an array of board IDs if we
-	 *    want to check board-level permissions
-	 * @param bool $any Whether to check for permission on at least one board
-	 *    instead of all the passed boards.
+	 * @param string|array $permissions One or more permissions to check.
+	 * @param int|array|null $boards The IDs of one or more boards, or null for
+	 *    the current board. Default: null.
+	 * @param bool $any If true, will return true if the user has any of the
+	 *    specified permissions. If false, will return true only if the user
+	 *    has all of the specified permissions. Default: false.
 	 * @return bool Whether the user has the specified permission.
 	 */
-	public function allowedTo(string|array $permission, int|array|null $boards = null, bool $any = false): bool
+	public function allowedTo(string|array $permissions, int|array|null $boards = null, bool $any = false): bool
 	{
 		// You're always allowed to do nothing. (Unless you're a working man, MR. LAZY :P!)
-		if (empty($permission)) {
+		if (empty($permissions)) {
 			return true;
 		}
 
@@ -2333,85 +2151,48 @@ class User implements \ArrayAccess
 			return true;
 		}
 
-		// Let's ensure this is an array.
-		$permission = (array) $permission;
+		// Let's ensure these are arrays.
+		$permissions = (array) $permissions;
+		$boards = array_filter(
+			array_map(
+				fn($b) => max(0, (int) $b),
+				(array) ($boards ?? Board::$info->id ?? []),
+			),
+		);
 
-		// Are we checking the _current_ board, or some other boards?
-		if ($boards === null || $boards === []) {
-			$user_permissions = (array) $this->permissions;
-
-			// Allow temporary overrides for general permissions?
-			IntegrationHook::call('integrate_allowed_to_general', [&$user_permissions, $permission]);
-
-			return array_intersect($permission, $user_permissions) != [];
-		}
-
-		$boards = (array) $boards;
-
-		$cache_key = hash('md5', $this->id . '-' . implode(',', $permission) . '-' . implode(',', $boards) . '-' . (int) $any);
+		// Avoid unnecessary repetition.
+		$cache_key = implode(',', $permissions) . '-' . implode(',', $boards) . '-' . (int) $any;
 
 		if (isset($this->perm_cache[$cache_key])) {
 			return !empty($this->perm_cache[$cache_key]);
 		}
 
-		$request = Db::$db->query(
-			'',
-			'SELECT MIN(bp.add_deny) AS add_deny
-			FROM {db_prefix}boards AS b
-				INNER JOIN {db_prefix}board_permissions AS bp ON (bp.id_profile = b.id_profile)
-				LEFT JOIN {db_prefix}moderators AS mods ON (mods.id_board = b.id_board AND mods.id_member = {int:current_member})
-				LEFT JOIN {db_prefix}moderator_groups AS modgs ON (modgs.id_board = b.id_board AND modgs.id_group IN ({array_int:group_list}))
-			WHERE b.id_board IN ({array_int:board_list})
-				AND bp.id_group IN ({array_int:group_list}, {int:moderator_group})
-				AND bp.permission IN ({array_string:permission_list})
-				AND (mods.id_member IS NOT NULL OR modgs.id_group IS NOT NULL OR bp.id_group != {int:moderator_group})
-			GROUP BY b.id_board',
-			[
-				'current_member' => $this->id,
-				'board_list' => $boards,
-				'group_list' => $this->groups,
-				'moderator_group' => 3,
-				'permission_list' => $permission,
-			],
-		);
+		// Separate the board permissions from the global permissions.
+		$board_permissions = array_filter($permissions, fn($p) => Permission::get($p)->scope === 'board');
+		$global_permissions = array_diff($permissions, $board_permissions);
 
-		if ($any) {
-			$result = false;
+		// Assume false until proven otherwise.
+		$allowed = false;
 
-			while ($row = Db::$db->fetch_assoc($request)) {
-				$result = !empty($row['add_deny']);
-
-				if ($result == true) {
-					break;
-				}
-			}
-			Db::$db->free_result($request);
-
-			$return = $result;
-		}
-		// Make sure they can do it on all of the boards.
-		elseif (Db::$db->num_rows($request) != count($boards)) {
-			Db::$db->free_result($request);
-
-			$return = false;
-		} else {
-			$result = true;
-
-			while ($row = Db::$db->fetch_assoc($request)) {
-				$result &= !empty($row['add_deny']);
-			}
-			Db::$db->free_result($request);
-
-			$return = $result;
+		// Check any requested global permissions.
+		if (!empty($global_permissions)) {
+			$this->loadPermissions(0);
+			$allowed = $this->permission_sets[0]->allowedTo($global_permissions, $any);
 		}
 
-		// Allow temporary overrides for board permissions?
-		IntegrationHook::call('integrate_allowed_to_board', [&$return, $permission, $boards, $any]);
+		// Check any requested board permissions.
+		if (!empty($board_permissions) && !empty($boards)) {
+			$this->loadPermissions($boards);
 
-		$this->perm_cache[$cache_key] = $return;
+			foreach ($boards as $board) {
+				$allowed_here = $this->permission_sets[$board]->allowedTo($board_permissions, $any);
+				$allowed = $any ? ($allowed || $allowed_here) : ($allowed && $allowed_here);
+			}
+		}
 
-		// If the query returned 1, they can do it... otherwise, they can't.
-		return (bool) $return;
+		$this->perm_cache[$cache_key] = $allowed;
+
+		return $allowed;
 	}
 
 	/**
@@ -4486,7 +4267,7 @@ class User implements \ArrayAccess
 		);
 
 		// Info about stuff related to permissions.
-		// Note that we set $this->permissions elsewhere.
+		// Note that we populate $this->permission_sets elsewhere.
 		$this->warning = (int) ($profile['warning'] ?? 0);
 		$this->can_manage_boards = !empty($this->is_admin) || (!empty(Config::$modSettings['board_manager_groups']) && !empty($this->groups) && count(array_intersect($this->groups, explode(',', Config::$modSettings['board_manager_groups']))) > 0);
 

--- a/Themes/default/ManagePermissions.template.php
+++ b/Themes/default/ManagePermissions.template.php
@@ -170,7 +170,7 @@ function template_permission_index()
 
 		foreach (Utils::$context['permissions'] as $permissionType)
 		{
-			if ($permissionType['id'] == 'global' && !empty(Utils::$context['profile']))
+			if (($permissionType['id'] == 'global') == (!empty(Utils::$context['profile'])))
 				continue;
 
 			foreach ($permissionType['columns'] as $column)
@@ -503,21 +503,6 @@ function template_modify_group()
 
 	// Draw out the main bits.
 	template_modify_group_display(Utils::$context['permission_type']);
-
-	// If this is general permissions also show the default profile.
-	if (Utils::$context['permission_type'] == 'global')
-	{
-		echo '
-			<br>
-			<div class="cat_bar">
-				<h3 class="catbg">', Lang::getTxt('permissions_board', file: 'ManagePermissions'), '</h3>
-			</div>
-			<div class="information">
-				', Lang::getTxt('permissions_board_desc', file: 'ManagePermissions'), '
-			</div>';
-
-		template_modify_group_display('board');
-	}
 
 	if (Utils::$context['profile']['can_modify'])
 		echo '


### PR DESCRIPTION
These changes refactor how we manage permissions and member groups in order to behave in a much more object-oriented way.

This has been on my personal to-do list for a while. The old code for managing permissions worked, yes, but it was still very much a procedural monstrosity stuffed into an ill-fitting OOP suit. This new code actually deserves to be called object-oriented and is _so_ much easier to understand and work with.