### PR TITLE
[3.0] Implements BBCode permissions

### DIFF
--- a/Languages/en_US/Admin.php
+++ b/Languages/en_US/Admin.php
@@ -626,6 +626,8 @@ $txt['legacyBBC'] = 'Legacy BBC tags';
 $txt['bbcTagsToUse'] = 'Enabled BBC tags';
 $txt['enabled_bbc_select'] = 'Select the tags which are allowed to be used';
 $txt['enabled_bbc_select_all'] = 'Select all tags';
+$txt['restricted_bbc'] = 'Restricted BBC tags';
+$txt['bbc_title_restricted_bbc'] = 'Select the tags that require permission to use';
 $txt['groups_can_use'] = 'Membergroups allowed to use {0}';
 
 $txt['enableMarkdown'] = 'Enable Markdown';

--- a/Languages/en_US/Help.php
+++ b/Languages/en_US/Help.php
@@ -677,4 +677,7 @@ $helptxt['requireAgreement'] = 'This setting is recommended to be enabled in ord
 $helptxt['requirePolicyAgreement'] = 'This setting is recommended to be enabled in order to comply with the rules of the <a href="https://ec.europa.eu/info/law/law-topic/data-protection/eu-data-protection-rules_en" target="_blank" rel="noopener" class="bbc_link">GDPR</a>.';
 $helptxt['gravatar'] = 'Gravatar is Globally Recognized Avatars. Register an account at <a href="https://www.gravatar.com" target="_blank" rel="noopener">https://www.gravatar.com</a> to select an avatar image. This avatar is then available at every site that supports gravatars. If you do not have a gravatar account, a default image will be used.';
 
+$helptxt['restricted_bbc'] = 'When a BBCode is marked as restricted, you can configure permissions to control who is allowed to use that BBCode in their posts.';
+$helptxt['restricted_bbc_forced'] = 'The restrictions on the {0} BBCode cannot be turned off.';
+
 ?>

--- a/Sources/Actions/Admin/ACP.php
+++ b/Sources/Actions/Admin/ACP.php
@@ -1004,6 +1004,7 @@ class ACP implements ActionInterface, Routable
 				Utils::$context['bbc_sections'][$bbcSection] = [
 					'title' => Lang::getTxt(Lang::txtExists('bbc_title_' . $bbcSection, file: 'Admin') ? 'bbc_title_' . $bbcSection : 'enabled_bbc_select', file: 'Admin'),
 					'disabled' => empty(Config::$modSettings['bbc_disabled_' . $bbcSection]) ? [] : Config::$modSettings['bbc_disabled_' . $bbcSection],
+					'forced' => !empty(Utils::$context['bbc_forced_' . $bbcSection]) ? Utils::$context['bbc_forced_' . $bbcSection] : [],
 					'all_selected' => empty(Config::$modSettings['bbc_disabled_' . $bbcSection]),
 					'columns' => [],
 				];
@@ -1027,7 +1028,7 @@ class ACP implements ActionInterface, Routable
 
 					Utils::$context['bbc_sections'][$bbcSection]['columns'][$col][] = [
 						'tag' => $tag,
-						'show_help' => Lang::txtExists('tag_' . $tag, var: 'helptxt'),
+						'show_help' => Lang::txtExists('tag_' . $tag, var: 'helptxt') || in_array($tag, Utils::$context['bbc_sections'][$bbcSection]['forced']),
 					];
 
 					$i++;

--- a/Sources/Actions/Admin/Features.php
+++ b/Sources/Actions/Admin/Features.php
@@ -180,12 +180,7 @@ class Features implements ActionInterface
 		Config::$modSettings['collapse_blank_lines'] = (int) !((Config::$modSettings['markdown_brs'] ?? 0) & MarkdownParser::BR_LINES);
 		Config::$modSettings['collapse_single_breaks'] = (int) !((Config::$modSettings['markdown_brs'] ?? 0) & MarkdownParser::BR_IN_PARAGRAPHS);
 
-		$extra = '';
-
-		if (isset($_REQUEST['cowsay'])) {
-			$config_vars[] = ['permissions', 'bbc_cowsay', 'text_label' => Lang::getTxt('groups_can_use', ['[cowsay]'], file: 'Admin')];
-			$extra = ';cowsay';
-		}
+		$extra = isset($_REQUEST['cowsay']) ? ';cowsay' : '';
 
 		// Saving?
 		if (isset($_GET['save'])) {
@@ -253,6 +248,9 @@ class Features implements ActionInterface
 					return !isset($config_var[1]) || $config_var[1] != 'legacyBBC';
 				},
 			);
+
+			// Figure out which BBC are restricted.
+			$_POST['restricted_bbc_enabledTags'] = array_diff($bbcTags, !isset($_POST['restricted_bbc_enabledTags']) ? [] : (array) $_POST['restricted_bbc_enabledTags']);
 
 			// Save the Markdown collapse_* settings as a bitmask.
 			$config_vars[] = ['int', 'markdown_brs'];
@@ -1687,13 +1685,35 @@ class Features implements ActionInterface
 			['check', 'enablePostHTML'],
 			['check', 'autoLinkUrls'],
 			'',
-
 			['bbc', 'disabledBBC'],
-
-			// This one is actually pretend...
 			['bbc', 'legacyBBC', 'help' => 'legacy_bbc'],
+			['bbc', 'restricted_bbc', 'help' => 'restricted_bbc'],
+		];
 
-			// Markdown settings
+		// Permissions for restricted BBC
+		if (!empty(Utils::$context['restricted_bbc'])) {
+			Config::$modSettings['bbc_disabled_restricted_bbc'] = array_diff(
+				array_unique(array_map(fn($code) => $code['tag'], Parser::getBBCodes())),
+				Utils::$context['restricted_bbc'],
+			);
+
+			Utils::$context['bbc_forced_restricted_bbc'] = empty(Config::$modSettings['restricted_bbc']) ? Utils::$context['restricted_bbc'] : array_diff(Utils::$context['restricted_bbc'], explode(',', Config::$modSettings['restricted_bbc']));
+
+			foreach (Utils::$context['restricted_bbc'] as $bbc) {
+				$config_vars[] = [
+					'permissions',
+					'bbc_' . $bbc,
+					'text_label' => Lang::getTxt('groups_can_use', ['[' . $bbc . ']'], file: 'Admin'),
+				];
+			}
+
+			if (isset($_REQUEST['cowsay'])) {
+				$config_vars[] = ['permissions', 'bbc_cowsay', 'text_label' => Lang::getTxt('groups_can_use', ['[cowsay]'], file: 'Admin')];
+			}
+		}
+
+		// Markdown settings
+		$config_vars = array_merge($config_vars, [
 			[
 				'title',
 				'markdown_settings',
@@ -1702,24 +1722,7 @@ class Features implements ActionInterface
 			['check', 'enableMarkdown', 'onchange' => 'document.getElementById(\'collapse_blank_lines\').disabled = !this.checked; document.getElementById(\'collapse_single_breaks\').disabled = !this.checked;'],
 			['check', 'collapse_blank_lines', 'disabled' => empty(Config::$modSettings['enableMarkdown'])],
 			['check', 'collapse_single_breaks', 'disabled' => empty(Config::$modSettings['enableMarkdown'])],
-		];
-
-		// Permissions for restricted BBC
-		if (!empty(Utils::$context['restricted_bbc'])) {
-			$config_vars[] = '';
-		}
-
-		foreach (Utils::$context['restricted_bbc'] as $bbc) {
-			$config_vars[] = [
-				'permissions',
-				'bbc_' . $bbc,
-				'text_label' => Lang::getTxt('groups_can_use', ['[' . $bbc . ']'], file: 'Admin'),
-			];
-		}
-
-		Utils::$context['settings_post_javascript'] = '
-			toggleBBCDisabled(\'disabledBBC\', ' . (empty(Config::$modSettings['enableBBC']) ? 'true' : 'false') . ');
-			toggleBBCDisabled(\'legacyBBC\', ' . (empty(Config::$modSettings['enableBBC']) ? 'true' : 'false') . ');';
+		]);
 
 		IntegrationHook::call('integrate_modify_bbc_settings', [&$config_vars]);
 

--- a/Sources/Actions/HelpAdmin.php
+++ b/Sources/Actions/HelpAdmin.php
@@ -82,6 +82,15 @@ class HelpAdmin implements ActionInterface, Routable
 			Utils::$context['help_text'] = Lang::getTxt($_GET['help'], var: 'helptxt');
 		} elseif (Lang::txtExists($_GET['help'])) {
 			Utils::$context['help_text'] = Lang::getTxt($_GET['help']);
+		} elseif (
+			substr($_GET['help'], 0, 4) === 'tag_'
+			&& User::$me->allowedTo('admin_forum')
+			&& in_array(
+				substr($_GET['help'], 4),
+				empty(Config::$modSettings['restricted_bbc']) ? Utils::$context['restricted_bbc'] : array_diff(Utils::$context['restricted_bbc'], explode(',', Config::$modSettings['restricted_bbc'])),
+			)
+		) {
+			Utils::$context['help_text'] = Lang::getTxt('restricted_bbc_forced', ['<span class="bbc_tt">[' . substr($_GET['help'], 4) . ']</span>'], var: 'helptxt');
 		} else {
 			ErrorHandler::fatalLang('not_found', false, [], 404);
 		}

--- a/Sources/Editor.php
+++ b/Sources/Editor.php
@@ -672,6 +672,23 @@ class Editor implements \ArrayAccess
 			'hr' => 'horizontalrule',
 		];
 
+		// Disable the buttons for any BBC that this user is not allowed to use.
+		foreach (Utils::$context['restricted_bbc'] as $tag) {
+			if (!User::$me->allowedTo('bbc_' . $tag)) {
+				if ($tag === 'list') {
+					$context['disabled_tags']['bulletlist'] = true;
+					$context['disabled_tags']['orderedlist'] = true;
+				} elseif ($tag === 'float') {
+					$context['disabled_tags']['floatleft'] = true;
+					$context['disabled_tags']['floatright'] = true;
+				} elseif (isset($editor_tag_map[$tag])) {
+					Utils::$context['disabled_tags'][$editor_tag_map[$tag]] = true;
+				}
+
+				Utils::$context['disabled_tags'][$tag] = true;
+			}
+		}
+
 		// Allow mods to modify BBC buttons.
 		IntegrationHook::call('integrate_bbc_buttons', [&self::$bbc_tags, &$editor_tag_map, &self::$disabled_tags]);
 
@@ -829,7 +846,7 @@ class Editor implements \ArrayAccess
 			'bbcodeTrim' => false,
 		];
 
-		if (!empty(Config::$modSettings['autoLinkUrls'])) {
+		if (!empty(Config::$modSettings['autoLinkUrls']) && User::$me->allowedTo('bbc_url')) {
 			$this->sce_options['plugins'] = 'autolinker';
 			Autolinker::createJavaScriptFile();
 			Theme::loadJavaScriptFile('autolinker.js', ['minimize' => true], 'smf_autolinker');

--- a/Sources/Utils.php
+++ b/Sources/Utils.php
@@ -335,6 +335,10 @@ class Utils
 
 		// Load up our $context['server'] data for backwards compatibility
 		Sapi::load();
+
+		if (!empty(Config::$modSettings['restricted_bbc'])) {
+			self::$context['restricted_bbc'] = array_unique(array_merge(self::$context['restricted_bbc'], explode(',', Config::$modSettings['restricted_bbc'])));
+		}
 	}
 
 	/**

--- a/Themes/default/Admin.template.php
+++ b/Themes/default/Admin.template.php
@@ -999,7 +999,7 @@ function template_show_settings()
 						foreach ($bbcColumn as $bbcTag)
 							echo '
 												<li class="list_bbc floatleft">
-													<input type="checkbox" name="', $config_var['name'], '_enabledTags[]" id="tag_', $config_var['name'], '_', $bbcTag['tag'], '" value="', $bbcTag['tag'], '"', !in_array($bbcTag['tag'], Utils::$context['bbc_sections'][$config_var['name']]['disabled']) ? ' checked' : '', '> <label for="tag_', $config_var['name'], '_', $bbcTag['tag'], '">', $bbcTag['tag'], '</label>', $bbcTag['show_help'] ? ' (<a href="' . Config::$scripturl . '?action=helpadmin;help=tag_' . $bbcTag['tag'] . '" onclick="return reqOverlayDiv(this.href);">?</a>)' : '', '
+													<input type="checkbox" name="', $config_var['name'], '_enabledTags[]" id="tag_', $config_var['name'], '_', $bbcTag['tag'], '" value="', $bbcTag['tag'], '"', !in_array($bbcTag['tag'], Utils::$context['bbc_sections'][$config_var['name']]['disabled']) ? ' checked' : '', in_array($bbcTag['tag'], Utils::$context['bbc_sections'][$config_var['name']]['forced']) ? ' disabled' : '', '> <label for="tag_', $config_var['name'], '_', $bbcTag['tag'], '">', $bbcTag['tag'], '</label>', $bbcTag['show_help'] ? ' <a href="' . Config::$scripturl . '?action=helpadmin;help=tag_' . $bbcTag['tag'] . '" onclick="return reqOverlayDiv(this.href);" class="main_icons help"></a>' : '', '
 												</li>';
 					}
 					echo '					</ul>


### PR DESCRIPTION
This essentially just refactors https://custom.simplemachines.org/index.php?mod=4299 and makes it part of SMF's standard features.

As said in that mod's ReadMe:

> ... allows the admin to set permissions for BBCodes. Any standard or custom BBCodes can be given permissions using this mod.
> **Settings**
> There are two settings to control BBCode permissions.
> First, the "Restricted BBC" setting allows you to control which BBCodes will require permission to use and which will not.
> Then, a separate setting is created for each restricted BBCode that allows you to set the permissions for that BBCode.

The one notable improvement compared to the mod is that, because SMF 3.0 does autolinking in the editor rather than during output, it is now possible to selectively turn off autolinking during the input stage for users who do not have permission to use the [url] BBCode.