### PR TITLE
Fix a typo and two minor permissions-related issues

### DIFF
--- a/Sources/Permissions/PermissionProfile.php
+++ b/Sources/Permissions/PermissionProfile.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 namespace SMF\Permissions;
 
 use SMF\Db\DatabaseApi as Db;
+use SMF\Group;
 use SMF\Lang;
 use SMF\Utils;
 

--- a/Sources/Permissions/UserPermissionSet.php
+++ b/Sources/Permissions/UserPermissionSet.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 namespace SMF\Permissions;
 
 use SMF\Board;
+use SMF\Config;
 use SMF\IntegrationHook;
 use SMF\User;
 
@@ -408,7 +409,7 @@ class UserPermissionSet
 	 * permissions.
 	 *
 	 * @param bool $allowed Whether the user is allowed based on checks so far.
-	 * @param string $permission_names The names of the permissions to check.
+	 * @param array $permission_names The names of the permissions to check.
 	 * @param bool $any If true, should return true if the user has any of the
 	 *    specified permissions. If false, should return true only if the user
 	 *    has all of the specified permissions. Default: false.


### PR DESCRIPTION
#### Description
Fix two issues caused by moving permissions to its own namespace and also a typo in the docs for a function