### PR TITLE
Enables parallel runners for PHP-CS-Fixer

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -195,6 +195,7 @@ return (new PhpCsFixer\Config())
 		],
 	])
 	->setIndent("\t")
+	->setParallelConfig(PhpCsFixer\Runner\Parallel\ParallelConfigFactory::detect())
 	->setFinder($finder);
 
 ?>


### PR DESCRIPTION
PHP-CS-Fixer is much faster when parallel runners are enabled. However, the documentation does note that this may not work on all systems. So if this change turns out to be a problem for any of us, we can revert it.