### PR TITLE
Attempts to fix the PHP-CS-Fixer workflow

### DIFF
--- a/.github/workflows/php-cs-fixer.yml
+++ b/.github/workflows/php-cs-fixer.yml
@@ -16,9 +16,9 @@ jobs:
         id: changed-files
         run: |
           if ${{ github.event_name == 'pull_request' }}; then
-            echo "all_changed_files_count=$(git diff --name-only -r HEAD^1 HEAD | xargs | grep '\.php$')" >> $GITHUB_OUTPUT
+            echo "all_changed_files_count=$(git diff HEAD --name-only | xargs | grep '\.php$')" >> $GITHUB_OUTPUT
           else
-            echo "all_changed_files_count=$(git diff --name-only ${{ github.event.before }} ${{ github.event.after }} | xargs | grep '\.php$')" >> $GITHUB_OUTPUT
+            echo "all_changed_files_count=$(git diff ${{ github.event.before }}...${{ github.event.after }} --name-only | xargs | grep '\.php$')" >> $GITHUB_OUTPUT
           fi
 
       - name: Get extra arguments for PHP-CS-Fixer


### PR DESCRIPTION
It was failing during the "Get Changed Files" step, with this error message:
```
fatal: ambiguous argument 'HEAD^1': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
```

I think this PR will fix it.