### PR TITLE
Cleanup phpDoc statements

### DIFF
--- a/Sources/ActionSuffixRouter.php
+++ b/Sources/ActionSuffixRouter.php
@@ -39,9 +39,6 @@ trait ActionSuffixRouter
 	 * Builds a routing path based on URL query parameters.
 	 *
 	 * @param array $params URL query parameters.
-	 * @param bool $append If true, the action route will be appended to the
-	 *    topic or board route indicated by the topic or board params.
-	 *    Default: false.
 	 * @return array Contains two elements: ['route' => [], 'params' => []].
 	 *    The 'route' element contains the routing path. The 'params' element
 	 *    contains any $params that weren't incorporated into the route.

--- a/Sources/Actions/Activate.php
+++ b/Sources/Actions/Activate.php
@@ -76,7 +76,7 @@ class Activate implements ActionInterface, Routable
 	private User $member;
 
 	/**
-	 * @var User
+	 * @var bool $email_change
 	 *
 	 * Whether the member's email address was changed.
 	 */

--- a/Sources/Actions/Admin/Bans.php
+++ b/Sources/Actions/Admin/Bans.php
@@ -2388,7 +2388,7 @@ class Bans implements ActionInterface
 	 * Doesn't clean the inputs.
 	 *
 	 * @param array|int $items_ids The triggers to remove.
-	 * @param int $group_id The ID of the group these triggers are associated with.
+	 * @param null|int $group_id The ID of the group these triggers are associated with.
 	 *    If null, the triggers will be deleted from all groups.
 	 * @return bool Whether the operation was successful.
 	 */

--- a/Sources/Actions/Admin/Themes.php
+++ b/Sources/Actions/Admin/Themes.php
@@ -1367,7 +1367,7 @@ class Themes implements ActionInterface
 	 * the new theme's name.
 	 * Ends execution with ErrorHandler::fatalLang() on any error.
 	 *
-	 * @return array The newly created theme's info.
+	 * @return array|null The newly created theme's info.
 	 */
 	protected function installFile(): ?array
 	{

--- a/Sources/Actions/BackwardCompatibility.php
+++ b/Sources/Actions/BackwardCompatibility.php
@@ -25,8 +25,9 @@ trait BackwardCompatibility
 	 * Called by Subs-Compat.php BackwardCompatibility wrapper functions to provide subaction
 	 * execution for existing mods
 	 *
-	 * @param null|string $sa
-	 * @param bool $return_config
+	 * @param null|string $sa The subaction
+	 * @param bool $return_config Whether to return the config info
+	 * @param null|string $activity
 	 * @return null|array
 	 */
 	public static function subActionProvider(?string $sa = null, bool $return_config = false, ?string $activity = null): ?array

--- a/Sources/Actions/Calendar.php
+++ b/Sources/Actions/Calendar.php
@@ -1840,7 +1840,7 @@ class Calendar implements ActionInterface, Routable
 	 * and returns the requested user if the token is valid. Otherwise, returns
 	 * the current user.
 	 *
-	 * @return SMF\User whose permissions should be used for exporting events.
+	 * @return User whose permissions should be used for exporting events.
 	 */
 	protected function authenticateForExport(): User
 	{

--- a/Sources/Actions/Feed.php
+++ b/Sources/Actions/Feed.php
@@ -268,9 +268,9 @@ class Feed implements ActionInterface, Routable
 	/**
 	 * Constructor.
 	 *
-	 * @param string $subaction Sets the sub-action to call.
+	 * @param null|string $subaction Sets the sub-action to call.
 	 *     If null, will try $_GET['sa'] and then the default sub-action.
-	 * @param int $member The member whose data is being requested.
+	 * @param null|int $member The member whose data is being requested.
 	 *     If null, will try $_GET['u'] and then User::$me->id.
 	 */
 	public function __construct(?string $subaction = null, ?int $member = null)
@@ -3053,7 +3053,7 @@ class Feed implements ActionInterface, Routable
 	/**
 	 * Sets the member property. This is the ID of the person viewing it or the person whose profile feed we're viewing
 	 *
-	 * @param ?int The member ID
+	 * @param null|int $member The member ID
 	 */
 	protected function setMember(?int $member = 0): void
 	{

--- a/Sources/Actions/GenericAction.php
+++ b/Sources/Actions/GenericAction.php
@@ -55,8 +55,6 @@ class GenericAction implements ActionInterface
 
 	/**
 	 * Executes the indicated callable.
-	 *
-	 * @param callable $current_action A callable.
 	 */
 	public function execute(): void
 	{

--- a/Sources/Actions/Like.php
+++ b/Sources/Actions/Like.php
@@ -87,7 +87,7 @@ class Like implements ActionInterface, Routable
 	protected bool $js = false;
 
 	/**
-	 * @var string
+	 * @var string|null
 	 *
 	 * If filled, its value will contain a string matching a key
 	 * on a language var Lang::$txt[$this->error]

--- a/Sources/Actions/Post.php
+++ b/Sources/Actions/Post.php
@@ -380,9 +380,6 @@ class Post implements ActionInterface, Routable
 	 * Builds a routing path based on URL query parameters.
 	 *
 	 * @param array $params URL query parameters.
-	 * @param bool $append If true, the action route will be appended to the
-	 *    topic or board route indicated by the topic or board params.
-	 *    Default: false.
 	 * @return array Contains two elements: ['route' => [], 'params' => []].
 	 *    The 'route' element contains the routing path. The 'params' element
 	 *    contains any $params that weren't incorporated into the route.

--- a/Sources/Actions/Recent.php
+++ b/Sources/Actions/Recent.php
@@ -90,7 +90,7 @@ class Recent implements ActionInterface, Routable
 	protected int $total_posts = 0;
 
 	/**
-	 * @var array
+	 * @var array|null
 	 *
 	 * IDs of some recent messages.
 	 */

--- a/Sources/Actions/XmlHttp.php
+++ b/Sources/Actions/XmlHttp.php
@@ -151,7 +151,7 @@ class XmlHttp implements ActionInterface, Routable
 	 * Handles retrieving previews of news items, newsletters, signatures and warnings.
 	 * Calls the appropriate function based on $_POST['item']
 	 *
-	 * @return void|bool Returns false if $_POST['item'] isn't set or isn't valid
+	 * @return null|bool Returns false if $_POST['item'] isn't set or isn't valid
 	 */
 	public function previews(): ?bool
 	{

--- a/Sources/Alert.php
+++ b/Sources/Alert.php
@@ -209,7 +209,7 @@ class Alert implements \ArrayAccess
 	protected static array $qb = [];
 
 	/**
-	 * @var bool $formats_finalized
+	 * @var bool
 	 *
 	 * Whether self::$link_formats has been finalized.
 	 */

--- a/Sources/Alert.php
+++ b/Sources/Alert.php
@@ -209,7 +209,7 @@ class Alert implements \ArrayAccess
 	protected static array $qb = [];
 
 	/**
-	 * @var array
+	 * @var bool $formats_finalized
 	 *
 	 * Whether self::$link_formats has been finalized.
 	 */
@@ -812,8 +812,8 @@ class Alert implements \ArrayAccess
 	 * @param int $memID The ID of the member.
 	 * @param bool|array $to_fetch Alerts to fetch: true/false for all/unread,
 	 *    or a list of one or more alert IDs.
-	 * @param array $limit Maximum number of alerts to fetch (0 for no limit).
-	 * @param array $offset Number of alerts to skip for pagination.
+	 * @param int $limit Maximum number of alerts to fetch (0 for no limit).
+	 * @param int $offset Number of alerts to skip for pagination.
 	 *    Ignored if $to_fetch is a list of IDs.
 	 * @return array An array of instances of this class.
 	 */
@@ -888,8 +888,8 @@ class Alert implements \ArrayAccess
 	 * @param int $memID The ID of the member.
 	 * @param bool|array $to_fetch Alerts to fetch: true/false for all/unread,
 	 *    or a list of one or more IDs.
-	 * @param array $limit Maximum number of alerts to fetch (0 for no limit).
-	 * @param array $offset Number of alerts to skip for pagination. Ignored if
+	 * @param int $limit Maximum number of alerts to fetch (0 for no limit).
+	 * @param int $offset Number of alerts to skip for pagination. Ignored if
 	 *    $to_fetch is a list of IDs.
 	 * @param bool $with_avatar Whether to load the avatar of the alert sender.
 	 * @param bool $show_links Whether to show links in the constituent parts of
@@ -1440,11 +1440,11 @@ class Alert implements \ArrayAccess
 	/**
 	 * Checks whether a member can see the topics that some alerts refer to.
 	 *
+	 * @param array $possible_topics Key-value pairs of alert IDs and topic IDs.
 	 * @param int $memID ID of the member.
 	 * @param bool $simple If true, do nothing beyond checking the access.
 	 *    If false, also get some info about the topic in question.
 	 *    Default: false.
-	 * @param array $possible_msgs Key-value pairs of alert IDs and topic IDs.
 	 * @return array Key-value pairs of alert IDs and visibility status.
 	 */
 	protected static function checkTopicAccess(array $possible_topics, int $memID, bool $simple = false): array

--- a/Sources/Attachment.php
+++ b/Sources/Attachment.php
@@ -614,11 +614,11 @@ class Attachment implements \ArrayAccess
 	/**
 	 * Loads existing attachments by member ID.
 	 *
+	 * @param array|int $members The ID numbers of one or more members.
 	 * @param int $approval_status One of this class's APPROVED_* constants.
 	 *     Default: self::APPROVED_TRUE.
 	 * @param bool $get_thumbs Whether to get the thumbnail image dimensions.
 	 *     Default: true.
-	 * @param array|int $ids The ID numbers of one or more members.
 	 * @return array Instances of this class for the loaded attachments.
 	 */
 	public static function loadByMember(array|int $members, int $approval_status = self::APPROVED_TRUE, bool $get_thumbs = true): array

--- a/Sources/Autolinker.php
+++ b/Sources/Autolinker.php
@@ -348,7 +348,7 @@ class Autolinker
 	 * detected URLs in the string, and the values are the URLs themselves.
 	 *
 	 * @param string $string The string to examine.
-	 * @param bool bool $plaintext_only If true, only look for plain text URLs.
+	 * @param bool $plaintext_only If true, only look for plain text URLs.
 	 * @return array Positional info about any detected URLs.
 	 */
 	public function detectUrls(string $string, bool $plaintext_only = false): array
@@ -441,7 +441,7 @@ class Autolinker
 	 * addresses themselves.
 	 *
 	 * @param string $string The string to examine.
-	 * @param bool bool $plaintext_only If true, only look for plain text email
+	 * @param bool $plaintext_only If true, only look for plain text email
 	 *    addresses.
 	 * @return array Positional info about any detected email addresses.
 	 */

--- a/Sources/BBCode/BBCode.php
+++ b/Sources/BBCode/BBCode.php
@@ -125,7 +125,7 @@ abstract class BBCode implements \ArrayAccess, BBCodeInterface
 	public ?array $parameters;
 
 	/**
-	 * @var string
+	 * @var string|null
 	 *
 	 * A regular expression to test immediately after the tag's '=', ' ' or ']'.
 	 *
@@ -134,7 +134,7 @@ abstract class BBCode implements \ArrayAccess, BBCodeInterface
 	public ?string $test;
 
 	/**
-	 * @var string
+	 * @var string|null
 	 *
 	 * Content to be inserted for this BBCode.
 	 *
@@ -154,7 +154,7 @@ abstract class BBCode implements \ArrayAccess, BBCodeInterface
 	public ?string $content;
 
 	/**
-	 * @var string
+	 * @var string|null
 	 *
 	 * HTML (or whatever) to insert before the BBCode's content.
 	 *
@@ -173,7 +173,7 @@ abstract class BBCode implements \ArrayAccess, BBCodeInterface
 	public ?string $before;
 
 	/**
-	 * @var string
+	 * @var string|null
 	 *
 	 * Similar to $before in every way, except that it is used when the tag is
 	 * closed.
@@ -181,7 +181,7 @@ abstract class BBCode implements \ArrayAccess, BBCodeInterface
 	public ?string $after;
 
 	/**
-	 * @var string
+	 * @var string|null
 	 *
 	 * Used in place of $content when the tag is disabled.
 	 *
@@ -191,7 +191,7 @@ abstract class BBCode implements \ArrayAccess, BBCodeInterface
 	public ?string $disabled_content;
 
 	/**
-	 * @var string
+	 * @var string|null
 	 *
 	 * Used in place of $before when the tag is disabled.
 	 *
@@ -201,7 +201,7 @@ abstract class BBCode implements \ArrayAccess, BBCodeInterface
 	public ?string $disabled_before;
 
 	/**
-	 * @var string
+	 * @var string|null
 	 *
 	 * Used in place of $after when the tag is disabled.
 	 *

--- a/Sources/BBCode/Spoiler1.php
+++ b/Sources/BBCode/Spoiler1.php
@@ -55,7 +55,7 @@ class Spoiler1 extends BBCode
 	];
 
 	/**
-	 * @var string
+	 * @var string|null
 	 *
 	 * HTML to insert before the BBCode's content.
 	 *
@@ -67,7 +67,9 @@ class Spoiler1 extends BBCode
 	public ?string $before = '<span class="bbc_inline_spoiler" title="{txt_spoiler_toggle}"><button type="button" title="{txt_spoiler_toggle}" tabindex="0"></button><span>';
 
 	/**
+	 * @var string|null
 	 *
+	 * HTML to insert after the BBCode's content
 	 */
 	public ?string $after = '</span></span>';
 

--- a/Sources/BBCode/Spoiler1.php
+++ b/Sources/BBCode/Spoiler1.php
@@ -67,9 +67,7 @@ class Spoiler1 extends BBCode
 	public ?string $before = '<span class="bbc_inline_spoiler" title="{txt_spoiler_toggle}"><button type="button" title="{txt_spoiler_toggle}" tabindex="0"></button><span>';
 
 	/**
-	 * @var string|null
 	 *
-	 * HTML to insert after the BBCode's content
 	 */
 	public ?string $after = '</span></span>';
 

--- a/Sources/Board.php
+++ b/Sources/Board.php
@@ -315,7 +315,7 @@ class Board implements \ArrayAccess, Routable
 	 **************************/
 
 	/**
-	 * @var int
+	 * @var int|null
 	 *
 	 * ID number of the board being viewed.
 	 *
@@ -326,7 +326,7 @@ class Board implements \ArrayAccess, Routable
 	public static ?int $board_id;
 
 	/**
-	 * @var self
+	 * @var self|null
 	 *
 	 * Instance of this class for board we are currently in.
 	 */
@@ -1414,7 +1414,7 @@ class Board implements \ArrayAccess, Routable
 	 * updates the statistics to reflect the new situation.
 	 *
 	 * @param array $boards_to_remove The boards to remove
-	 * @param int $moveChildrenTo The ID of the board to move the child boards to (null to remove the child boards, 0 to make them a top-level board)
+	 * @param null|int $moveChildrenTo The ID of the board to move the child boards to (null to remove the child boards, 0 to make them a top-level board)
 	 */
 	public static function delete(array $boards_to_remove, ?int $moveChildrenTo = null): void
 	{

--- a/Sources/Cache/APIs/FileBased.php
+++ b/Sources/Cache/APIs/FileBased.php
@@ -203,8 +203,7 @@ class FileBased extends CacheApi implements CacheApiInterface
 	/**
 	 * Sets the $cachedir or uses the SMF default $cachedir..
 	 *
-	 * @param string $dir A valid path
-	 * @return bool If this was successful or not.
+	 * @param null|string $dir A valid path
 	 */
 	public function setCachedir(?string $dir = null): void
 	{

--- a/Sources/Cache/APIs/Sqlite.php
+++ b/Sources/Cache/APIs/Sqlite.php
@@ -171,9 +171,7 @@ class Sqlite extends CacheApi implements CacheApiInterface
 	/**
 	 * Sets the $cachedir or uses the SMF default $cachedir..
 	 *
-	 * @param string $dir A valid path
-	 *
-	 * @return bool If this was successful or not.
+	 * @param string|null $dir A valid path
 	 */
 	public function setCachedir(?string $dir = null): void
 	{

--- a/Sources/Cache/CacheApi.php
+++ b/Sources/Cache/CacheApi.php
@@ -269,7 +269,7 @@ abstract class CacheApi
 	/**
 	 * Gets the latest version of SMF this is compatible with.
 	 *
-	 * @return string the value of $key.
+	 * @return string|bool the compatible version or false if it's not compatible.
 	 */
 	public function getCompatibleVersion(): string|bool
 	{
@@ -279,7 +279,7 @@ abstract class CacheApi
 	/**
 	 * Gets the min version that we support.
 	 *
-	 * @return string the value of $key.
+	 * @return string|int the minimum supported version.
 	 */
 	public function getMinimumVersion(): string|int
 	{
@@ -289,7 +289,7 @@ abstract class CacheApi
 	/**
 	 * Gets the Version of the Caching API.
 	 *
-	 * @return string the value of $key.
+	 * @return string|bool the version of the caching API
 	 */
 	public function getVersion(): string|bool
 	{

--- a/Sources/Calendar/Birthday.php
+++ b/Sources/Calendar/Birthday.php
@@ -116,7 +116,7 @@ class Birthday extends Event
 	/**
 	 * Loads a member's birthday.
 	 *
-	 * @param int|array $id ID number of the member.
+	 * @param int $id ID number of the member.
 	 * @param bool $is_topic Ignored.
 	 * @param bool $use_permissions Ignored.
 	 * @return array Instances of this class for the loaded events.

--- a/Sources/Calendar/Event.php
+++ b/Sources/Calendar/Event.php
@@ -102,7 +102,7 @@ class Event implements \ArrayAccess
 	public Time $start;
 
 	/**
-	 * @var SMF\TimeInterval
+	 * @var TimeInterval
 	 *
 	 * A TimeInterval object representing the duration of each occurrence of
 	 * the event.

--- a/Sources/Calendar/EventAdjustment.php
+++ b/Sources/Calendar/EventAdjustment.php
@@ -41,7 +41,7 @@ class EventAdjustment
 	public bool $affects_future = false;
 
 	/**
-	 * @var SMF\TimeInterval
+	 * @var TimeInterval|null
 	 *
 	 * A TimeInterval object representing how much to the adjust the start of
 	 * the affected occurrences compared to their original start date.
@@ -49,7 +49,7 @@ class EventAdjustment
 	public ?TimeInterval $offset;
 
 	/**
-	 * @var SMF\TimeInterval
+	 * @var TimeInterval|null
 	 *
 	 * A TimeInterval object representing the duration of the affected
 	 * occurrences of the event.
@@ -57,14 +57,14 @@ class EventAdjustment
 	public ?TimeInterval $duration;
 
 	/**
-	 * @var string
+	 * @var string|null
 	 *
 	 * Location for the affected occurrences of this event.
 	 */
 	public ?string $location;
 
 	/**
-	 * @var string
+	 * @var string|null
 	 *
 	 * Title for the affected occurrences of the event.
 	 */
@@ -77,7 +77,7 @@ class EventAdjustment
 	/**
 	 * Constructor.
 	 *
-	 * @param int $id The ID string of the first affected event occurrence.
+	 * @param string $id The ID string of the first affected event occurrence.
 	 * @param bool $affects_future Whether future occurrences are also affected.
 	 *    Default: false.
 	 * @param ?array $offset Array representation of SMF\TimeInterval data.

--- a/Sources/Calendar/EventOccurrence.php
+++ b/Sources/Calendar/EventOccurrence.php
@@ -53,14 +53,14 @@ class EventOccurrence implements \ArrayAccess
 	public int $id_event;
 
 	/**
-	 * @var SMF\Time
+	 * @var Time
 	 *
 	 * A Time object representing the start of this occurrence of the event.
 	 */
 	public Time $start;
 
 	/**
-	 * @var SMF\Time
+	 * @var EventAdjustment
 	 *
 	 * An EventAdjustment object representing changes made to this occurrence of
 	 * the event, if any.
@@ -93,7 +93,7 @@ class EventOccurrence implements \ArrayAccess
 	];
 
 	/**
-	 * @var SMF\Time
+	 * @var Time
 	 *
 	 * A Time object representing the unadjusted start of this occurrence.
 	 */
@@ -108,7 +108,6 @@ class EventOccurrence implements \ArrayAccess
 	 *
 	 * @param int $id_event The ID number of the parent event.
 	 * @param array $props Properties to set for this occurrence.
-	 * @return EventOccurrence An instance of this class.
 	 */
 	public function __construct(int $id_event = 0, array $props = [])
 	{

--- a/Sources/Calendar/Holiday.php
+++ b/Sources/Calendar/Holiday.php
@@ -54,7 +54,6 @@ class Holiday extends Event
 	 *
 	 * @param int $id The ID number of the event.
 	 * @param array $props Properties to set for this event.
-	 * @return object An instance of this class.
 	 */
 	public function __construct(int $id = 0, array $props = [])
 	{
@@ -138,7 +137,7 @@ class Holiday extends Event
 	/**
 	 * Loads holidays by ID number.
 	 *
-	 * @param int|array $id ID number of the holiday event.
+	 * @param int $id ID number of the holiday event.
 	 * @param bool $is_topic Ignored.
 	 * @param bool $use_permissions Ignored.
 	 * @return array Instances of this class for the loaded events.

--- a/Sources/Calendar/RRule.php
+++ b/Sources/Calendar/RRule.php
@@ -587,6 +587,7 @@ class RRule implements \Stringable
 	 * Gets the description without any BYSETPOS considerations.
 	 *
 	 * @param \DateTimeInterface $start
+	 * @return string A comma-separated list of descriptions
 	 */
 	protected function getDescriptionNormal(\DateTimeInterface $start): string
 	{
@@ -609,6 +610,7 @@ class RRule implements \Stringable
 	 * Gets the description with BYSETPOS considerations.
 	 *
 	 * @param \DateTimeInterface $start
+	 * @return string
 	 */
 	protected function getDescriptionBySetPos(\DateTimeInterface $start): string
 	{

--- a/Sources/Calendar/RecurrenceIterator.php
+++ b/Sources/Calendar/RecurrenceIterator.php
@@ -310,12 +310,12 @@ class RecurrenceIterator implements \Iterator
 	 *    it automatically based on the UNTIL value of the RRule. If this is
 	 *    null and the RRule's UNTIL value is null, default is TYPE_ABSOLUTE.
 	 *
-	 * @param ?array $rdates Arbitrary dates to add to the recurrence set.
+	 * @param array $rdates Arbitrary dates to add to the recurrence set.
 	 *    Elements must be arrays containing an instance of \DateTimeInterface
 	 *    and an optional \DateInterval.
 	 *    Used to make exceptions to the general recurrence rule.
 	 *
-	 * @param ?array $exdates Dates to exclude from the recurrence set.
+	 * @param array $exdates Dates to exclude from the recurrence set.
 	 *    Elements must be instances of \DateTimeInterface.
 	 *    Used to make exceptions to the general recurrence rule.
 	 */
@@ -1188,7 +1188,7 @@ class RecurrenceIterator implements \Iterator
 	 * recurs at minute 0 and minute 30 of every hour.
 	 *
 	 * @param \DateTime $current An occurrence of the event to expand.
-	 * @param string $break_after Name of a $this->by element. Used during
+	 * @param string|null $break_after Name of a $this->by element. Used during
 	 *    recursive calls to this method.
 	 * @return Generator<\DateTimeImmutable>
 	 */
@@ -1416,7 +1416,7 @@ class RecurrenceIterator implements \Iterator
 	 *
 	 * @param \DateTime $current An occurrence of the event to expand.
 	 * @param array $expansion_values Values from the byday rule.
-	 * @param string The abbreviated name of the $current occurrence's weekday.
+	 * @param string $current_value The abbreviated name of the $current occurrence's weekday.
 	 * @return Generator<\DateTimeImmutable>
 	 */
 	private function expandMonthByDay(\DateTime $current, array $expansion_values, string $current_value): \Generator
@@ -1563,7 +1563,7 @@ class RecurrenceIterator implements \Iterator
 	 *
 	 * @param \DateTime $current An occurrence of the event to expand.
 	 * @param array $expansion_values Values from the byday rule.
-	 * @param string The abbreviated name of the $current occurrence's weekday.
+	 * @param string $current_value The abbreviated name of the $current occurrence's weekday.
 	 * @return Generator<\DateTimeImmutable>
 	 */
 	private function expandYearByDay(\DateTime $current, array $expansion_values, string $current_value): \Generator

--- a/Sources/Calendar/VTimeZone.php
+++ b/Sources/Calendar/VTimeZone.php
@@ -395,7 +395,7 @@ abstract class VTimeZone
 	 *
 	 * @param string $tzid A time zone identifier string.
 	 * @throws \ValueError if $tzid is not a valid time zone identifier.
-	 * @return array An instance of this class.
+	 * @return self An instance of this class.
 	 */
 	public static function load(string $tzid): self
 	{

--- a/Sources/Category.php
+++ b/Sources/Category.php
@@ -523,7 +523,7 @@ class Category implements \ArrayAccess
 	 * updates the statistics to reflect the new situation.
 	 *
 	 * @param array $categories The IDs of the categories to delete
-	 * @param int $moveBoardsTo The ID of the category to move any boards to or null to delete the boards
+	 * @param null|int $moveBoardsTo The ID of the category to move any boards to or null to delete the boards
 	 */
 	public static function delete(array $categories, ?int $moveBoardsTo = null): void
 	{

--- a/Sources/Config.php
+++ b/Sources/Config.php
@@ -2220,7 +2220,7 @@ class Config
 	 * and it performs safety checks before acting. The result is an array of
 	 * the values as recorded in the settings file.
 	 *
-	 * @param int|float $mtime Timestamp of last known good configuration.
+	 * @param int|float|null $mtime Timestamp of last known good configuration.
 	 *    Defaults to time SMF started.
 	 * @param string $settingsFile The settings file.
 	 *    Defaults to SMF's standard Settings.php.

--- a/Sources/Cookie.php
+++ b/Sources/Cookie.php
@@ -157,19 +157,19 @@ class Cookie
 	/**
 	 * Constructor.
 	 *
-	 * @param string $name Name of the cookie.
+	 * @param null|string $name Name of the cookie.
 	 * @param mixed $custom_data Data to include in the cookie.
-	 * @param int $expires When the cookie expires.
+	 * @param null|int $expires When the cookie expires.
 	 *    If not set, determined automatically.
-	 * @param string $domain The domain of the site where the cookie is used.
+	 * @param null|string $domain The domain of the site where the cookie is used.
 	 *    If not set, determined automatically.
-	 * @param string $path The part of the site where the cookie is used.
+	 * @param null|string $path The part of the site where the cookie is used.
 	 *    If not set, determined automatically.
 	 * @param bool $secure Whether cookie must be secure.
 	 *    If not set, determined by Config::$modSettings['secureCookies'].
 	 * @param bool $httponly Whether cookie can only be used for HTTP requests.
 	 *    If not set, determined by Config::$modSettings['httponlyCookies'].
-	 * @param string $samesite Value for the cookie's 'SameSite' attribute.
+	 * @param null|string $samesite Value for the cookie's 'SameSite' attribute.
 	 *    If not set, determined by Config::$modSettings['samesiteCookies'].
 	 */
 	public function __construct(

--- a/Sources/Db/APIs/MySQL.php
+++ b/Sources/Db/APIs/MySQL.php
@@ -2495,8 +2495,8 @@ class MySQL extends DatabaseApi implements DatabaseApiInterface
 	 * @param string $error_message The error message
 	 * @param string $log_message The message to log
 	 * @param string|int|bool $error_type What type of error this is
-	 * @param string $file The file the error occurred in
-	 * @param int $line What line of $file the code which generated the error is on
+	 * @param null|string $file The file the error occurred in
+	 * @param null|int $line What line of $file the code which generated the error is on
 	 * @return array Returns an array with the file and line if $error_type is
 	 *    'return'. Otherwise, just dies.
 	 */

--- a/Sources/Db/APIs/PostgreSQL.php
+++ b/Sources/Db/APIs/PostgreSQL.php
@@ -2498,8 +2498,8 @@ class PostgreSQL extends DatabaseApi implements DatabaseApiInterface
 	 * @param string $error_message The error message
 	 * @param string $log_message The message to log
 	 * @param string|int|bool $error_type What type of error this is
-	 * @param string $file The file the error occurred in
-	 * @param int $line What line of $file the code which generated the error is on
+	 * @param string|null $file The file the error occurred in
+	 * @param int|null $line What line of $file the code which generated the error is on
 	 * @return array Returns an array with the file and line if $error_type is
 	 *    'return'. Otherwise, just dies.
 	 */

--- a/Sources/Db/DatabaseApiInterface.php
+++ b/Sources/Db/DatabaseApiInterface.php
@@ -26,7 +26,7 @@ interface DatabaseApiInterface
 	 * @param string $identifier An identifier. Only used in PostgreSQL.
 	 * @param string $db_string The database string
 	 * @param array $db_values = array() The values to be inserted into the string
-	 * @param object $connection = null The connection to use (null to use $db_connection)
+	 * @param null|object $connection = null The connection to use (null to use $db_connection)
 	 * @return object|bool Returns a query result resource (for SELECT queries), true (for UPDATE queries) or false if the query failed.
 	 */
 	public function query(string $identifier, string $db_string, array $db_values = [], ?object $connection = null): object|bool;
@@ -36,7 +36,7 @@ interface DatabaseApiInterface
 	 *
 	 * @param string $db_string The database string.
 	 * @param array $db_values An array of values to be injected into the string.
-	 * @param object $connection = null The connection to use (null to use $db_connection).
+	 * @param null|object $connection = null The connection to use (null to use $db_connection).
 	 * @return string The string with the values inserted.
 	 */
 	public function quote(string $db_string, array $db_values, ?object $connection = null): string;
@@ -44,16 +44,16 @@ interface DatabaseApiInterface
 	/**
 	 * Fetch the next row of a result set as an enumerated array.
 	 *
-	 * @param object $request A query result resource.
-	 * @return array|false One row of data, with numeric keys.
+	 * @param object $result A query result resource.
+	 * @return array|false|null One row of data, with numeric keys.
 	 */
 	public function fetch_row(object $result): array|false|null;
 
 	/**
 	 * Fetch the next row of a result set as an associative array.
 	 *
-	 * @param object $request A query result resource.
-	 * @return array One row of data, with string keys.
+	 * @param object $result A query result resource.
+	 * @return array|false|null One row of data, with string keys.
 	 */
 	public function fetch_assoc(object $result): array|false|null;
 
@@ -93,7 +93,7 @@ interface DatabaseApiInterface
 	 * @param array $keys The keys for the table. Must not empty in replace mode.
 	 * @param int $returnmode 0 = nothing, 1 = last row ID, 2 = all row IDs.
 	 *    Default: 0.
-	 * @param object $connection The connection to use.
+	 * @param null|object $connection The connection to use.
 	 *    If null, $db_connection is used.
 	 * @return int|array|null Null if $returnmode is 0, the ID of the most
 	 *    recently inserted row if $returnmode is 1, or the IDS of all the
@@ -105,8 +105,8 @@ interface DatabaseApiInterface
 	 * Gets the ID of the most recently inserted row.
 	 *
 	 * @param string $table The table (only used for Postgres)
-	 * @param string $field = null The specific field (not used here)
-	 * @param object $connection = null The connection (if null, $db_connection is used)
+	 * @param null|string $field = null The specific field (not used here)
+	 * @param null|object $connection = null The connection (if null, $db_connection is used)
 	 * @return int The ID of the most recently inserted row
 	 */
 	public function insert_id(string $table, ?string $field = null, ?object $connection = null): int;
@@ -130,7 +130,7 @@ interface DatabaseApiInterface
 	 * @param string $set A string containing the SET instructions for the update query.
 	 * @param string $where A string containing any WHERE conditions for the update query.
 	 * @param array $db_values The values to be inserted into the compiled query string.
-	 * @param object $connection The connection to use (if null, $db_connection will be used).
+	 * @param null|object $connection The connection to use (if null, $db_connection will be used).
 	 * @return bool True if the update was successful, otherwise false.
 	 */
 	public function update_from(array $table, array $from_tables, string $set, string $where, array $db_values, ?object $connection = null): bool;
@@ -138,7 +138,7 @@ interface DatabaseApiInterface
 	/**
 	 * Gets the number of rows in a result set.
 	 *
-	 * @param object $request A query result resource.
+	 * @param object $result A query result resource.
 	 * @return int The number of rows in the result.
 	 */
 	public function num_rows(object $result): int;
@@ -147,7 +147,7 @@ interface DatabaseApiInterface
 	 * Adjusts the result pointer to an arbitrary row in a query result.
 	 *
 	 * @param int $offset The row offset.
-	 * @param object $request A query result resource.
+	 * @param object $result A query result resource.
 	 * @return bool True on success, or false on failure.
 	 */
 	public function data_seek(object $result, int $offset): bool;
@@ -155,7 +155,7 @@ interface DatabaseApiInterface
 	/**
 	 * Gets the number of fields in a result set.
 	 *
-	 * @param object $request A query result resource.
+	 * @param object $result A query result resource.
 	 * @return int The number of fields (columns) in the result.
 	 */
 	public function num_fields(object $result): int;
@@ -164,8 +164,8 @@ interface DatabaseApiInterface
 	 * Escapes special characters in a string for use in an SQL statement,
 	 * taking into account the current character set of the connection.
 	 *
-	 * @param object $connection = null The connection to use (null to use $db_connection).
-	 * @param string The unescaped string.
+	 * @param string $string The string to escape
+	 * @param null|object $connection The connection to use (null to use $db_connection).
 	 * @return string The escaped string.
 	 */
 	public function escape_string(string $string, ?object $connection = null): string;
@@ -173,7 +173,7 @@ interface DatabaseApiInterface
 	/**
 	 * Reverses the escape_string function.
 	 *
-	 * @param string The escaped string.
+	 * @param string $string The escaped string.
 	 * @return string The unescaped string.
 	 */
 	public function unescape_string(string $string): string;
@@ -190,7 +190,7 @@ interface DatabaseApiInterface
 	/**
 	 * Gets information, such as the version, about the database server.
 	 *
-	 * @param object $connection The connection to use (if null, $db_connection is used)
+	 * @param null|object $connection The connection to use (if null, $db_connection is used)
 	 * @return string The server info.
 	 */
 	public function server_info(?object $connection = null): string;
@@ -200,7 +200,7 @@ interface DatabaseApiInterface
 	 *
 	 * @todo PostgreSQL requires a $result param, not a $connection.
 	 *
-	 * @param object $connection A connection to use (if null, $db_connection is used)
+	 * @param null|object $connection A connection to use (if null, $db_connection is used)
 	 * @return int The number of affected rows.
 	 */
 	public function affected_rows(?object $connection = null): int;
@@ -209,7 +209,7 @@ interface DatabaseApiInterface
 	 * Do a transaction.
 	 *
 	 * @param string $type The step to perform (i.e. 'begin', 'commit', 'rollback')
-	 * @param object $connection The connection to use (if null, $db_connection is used)
+	 * @param null|object $connection The connection to use (if null, $db_connection is used)
 	 * @return bool True if successful, false otherwise
 	 */
 	public function transaction(string $type = 'commit', ?object $connection = null): bool;
@@ -228,7 +228,7 @@ interface DatabaseApiInterface
 	 * Does nothing on PostgreSQL.
 	 *
 	 * @param string &$database The database
-	 * @param object $connection The connection object (if null, $db_connection is used)
+	 * @param null|object $connection The connection object (if null, $db_connection is used)
 	 * @return bool Whether the database was selected
 	 */
 	public function select(string $database, ?object $connection = null): bool;
@@ -263,7 +263,7 @@ interface DatabaseApiInterface
 	/**
 	 * Pings a server connection, and tries to reconnect if necessary.
 	 *
-	 * @param object $connection The connection object (if null, $db_connection is used)
+	 * @param null|object $connection The connection object (if null, $db_connection is used)
 	 * @return bool True on success, or false on failure.
 	 */
 	public function ping(?object $connection = null): bool;
@@ -274,7 +274,7 @@ interface DatabaseApiInterface
 	 * $error_array must have the following keys in order:
 	 * id_member, log_time, ip, url, message, session, error_type, file, line, backtrace
 	 *
-	 * @param array Information about the error.
+	 * @param array $error_array Information about the error.
 	 */
 	public function error_insert(array $error_array): void;
 
@@ -351,7 +351,7 @@ interface DatabaseApiInterface
 	 * This function optimizes a table.
 	 *
 	 * @param string $table The table to be optimized
-	 * @return int How much space was gained
+	 * @return int|float How much space was gained
 	 */
 	public function optimize_table(string $table): int|float;
 
@@ -405,7 +405,7 @@ interface DatabaseApiInterface
 	 * @param string $identifier A query identifier
 	 * @param string $db_string The query text
 	 * @param array $db_values An array of values to pass to $this->query()
-	 * @param object $connection The current DB connection resource
+	 * @param null|object $connection The current DB connection resource
 	 * @return resource The query result resource from $this->query()
 	 */
 	public function search_query(string $identifier, string $db_string, array $db_values = [], ?object $connection = null): object|bool;
@@ -464,7 +464,7 @@ interface DatabaseApiInterface
 	 * Get the schema formatted name for a type.
 	 *
 	 * @param string $type_name The data type (int, varchar, smallint, etc.)
-	 * @param int $type_size The size (8, 255, etc.)
+	 * @param null|int $type_size The size (8, 255, etc.)
 	 * @param bool $reverse
 	 * @return array An array containing the appropriate type and size for this DB type
 	 */

--- a/Sources/Diff/Diff.php
+++ b/Sources/Diff/Diff.php
@@ -1637,7 +1637,7 @@ abstract class Diff
 	 * @param array $matching Pairs of substring numbers that do indeed match.
 	 * @param int $i The current key in $possible matches.
 	 * @param int $match A value from $possible matches[$i].
-	 * @return Whether this combination of $i and $match can be inserted in the
+	 * @return bool Whether this combination of $i and $match can be inserted in the
 	 *    correct order for the overall $matching list.
 	 */
 	protected function checkMatchOrder(
@@ -2278,7 +2278,7 @@ abstract class Diff
 	 * @param array $change The change that didn't match.
 	 * @param array $lines Lines of the original string.
 	 * @param array $disallowed Lines numbers that cannot be chosen.
-	 * @return array An altered version of $change, or false on error.
+	 * @return array|false An altered version of $change, or false on error.
 	 */
 	protected function fixL1(array $change, array $lines, array $disallowed): array|false
 	{
@@ -2463,8 +2463,7 @@ abstract class Diff
 	/**
 	 * Helper for $this->formatHtml() that fixes any mangled markup changes.
 	 *
-	 * @param array $del Deletions.
-	 * @param array $ins Insertions.
+	 * @param string $formatted A formatted string
 	 * @return string The formatted changes.
 	 */
 	protected function formatMarkup(string $formatted): string

--- a/Sources/Diff/EditDiff.php
+++ b/Sources/Diff/EditDiff.php
@@ -41,7 +41,7 @@ class EditDiff extends Diff
 	 *******************/
 
 	/**
-	 * @var string
+	 * @var int
 	 *
 	 * The ID of the member who made the edit.
 	 */
@@ -91,8 +91,9 @@ class EditDiff extends Diff
 	 * @param ?string $str1 The original string.
 	 * @param ?string $str2 The modified string.
 	 * @param ?string $time1 Timestamp to use for the original string.
-	 * @param ?string $name The name of the member who made the edit.
-	 * @param ?string $reason The reason for the edit, if any.
+	 * @param int $id The ID of the person who made the edit
+	 * @param string $name The name of the member who made the edit.
+	 * @param string $reason The reason for the edit, if any.
 	 */
 	public function __construct(
 		?string $str1 = null,

--- a/Sources/Editor.php
+++ b/Sources/Editor.php
@@ -51,28 +51,28 @@ class Editor implements \ArrayAccess
 	public string $value;
 
 	/**
-	 * @var string
+	 * @var bool
 	 *
 	 * Whether WYSIWYG mode is initially on or off.
 	 */
 	public bool $rich_active;
 
 	/**
-	 * @var string
+	 * @var bool
 	 *
 	 * Whether to show the smiley box.
 	 */
 	public bool $disable_smiley_box;
 
 	/**
-	 * @var string
+	 * @var int
 	 *
 	 * Column width of the editor's input area.
 	 */
 	public int $columns;
 
 	/**
-	 * @var string
+	 * @var int
 	 *
 	 * Row height of the editor's input area.
 	 */

--- a/Sources/ErrorHandler.php
+++ b/Sources/ErrorHandler.php
@@ -610,7 +610,7 @@ class ErrorHandler
 	 * @uses template_fatal_error()
 	 *
 	 * @param string $error_message The error message
-	 * @param string $error_code An error code
+	 * @param null|string $error_code An error code
 	 */
 	protected static function setupFatalContext(string $error_message, ?string $error_code = null): void
 	{

--- a/Sources/Graphics/Image.php
+++ b/Sources/Graphics/Image.php
@@ -120,7 +120,7 @@ class Image
 	public int|float $width;
 
 	/**
-	 * @var int
+	 * @var int|float
 	 *
 	 * Height of the image in pixels.
 	 *
@@ -200,8 +200,8 @@ class Image
 	 * If $source contains raw image data, it will be validated and then saved
 	 * to a temporary local file.
 	 *
-	 * @param $source Either the path or URL of an image, or raw image data.
-	 * @param $strict If true, die with error if $source is not a valid image.
+	 * @param string $source Either the path or URL of an image, or raw image data.
+	 * @param bool $strict If true, die with error if $source is not a valid image.
 	 *    If false, silently set properties to empty values. Default: false.
 	 */
 	public function __construct(string $source, bool $strict = false)

--- a/Sources/Group.php
+++ b/Sources/Group.php
@@ -1168,8 +1168,6 @@ class Group implements \ArrayAccess
 	 * @param bool $perms_checked Whether we've already checked permissions.
 	 * @param bool $ignore_protected Whether to ignore the protected status of
 	 *    protected groups.
-	 * @param mixed The groups to remove the member(s) from. If null, the
-	 *    specified members are stripped from all their membergroups.
 	 * @return bool Whether the operation was successful.
 	 */
 	public function removeMembers(int|array $members, bool $perms_checked = false, bool $ignore_protected = false): bool
@@ -1472,7 +1470,7 @@ class Group implements \ArrayAccess
 	 *
 	 * Results are saved in $this->num_permissions and also returned.
 	 *
-	 * @param int $profile Which permission profile to count permissions for.
+	 * @param int|null $profile Which permission profile to count permissions for.
 	 *    If set to 1 or higher, count board permissions for that profile.
 	 *    If set to 0, count general permissions only.
 	 *    If null, count general permissions and board permissions for the
@@ -2622,7 +2620,7 @@ class Group implements \ArrayAccess
 	 * Returns the icons formatted for display.
 	 *
 	 * @param self $group An instance of this class.
-	 * @return bool Whether the group is a post-count based group.
+	 * @return string The formatted icon or an empty string if the group doesn't have one
 	 */
 	protected static function formatIcons(self $group): string
 	{

--- a/Sources/Lang.php
+++ b/Sources/Lang.php
@@ -562,10 +562,10 @@ class Lang
 	 * @param ?string $file Name of a language file to load. This is not needed
 	 *    when $var is 'helptxt', 'editortxt', 'tztxt', or 'txtBirthdayEmails'.
 	 *    Default: null.
-	 * @param ?string $lang A specific language to load $file from. If empty,
+	 * @param string $lang A specific language to load $file from. If empty,
 	 *    defaults to the current user's preferred language.
 	 * @throws \ValueError if $var is invalid.
-	 * @return string The string to display to the user.
+	 * @return bool Whether or not the specified language string exists
 	 */
 	public static function txtExists(string|array $txt_key, string $var = 'txt', ?string $file = null, string $lang = ''): bool
 	{
@@ -679,7 +679,7 @@ class Lang
 	 * @param ?string $file Name of a language file to load. This is not needed
 	 *    when $var is 'helptxt', 'editortxt', 'tztxt', or 'txtBirthdayEmails'.
 	 *    Default: null.
-	 * @param ?string $lang A specific language to load $file from. If empty,
+	 * @param string $lang A specific language to load $file from. If empty,
 	 *    defaults to the current user's preferred language.
 	 * @throws \ValueError if $var is invalid.
 	 * @return string|array The string to display to the user, or an array

--- a/Sources/Localization/AsciiTransliterator.php
+++ b/Sources/Localization/AsciiTransliterator.php
@@ -35,7 +35,7 @@ class AsciiTransliterator
 	 ****************************/
 
 	/**
-	 * @var object
+	 * @var \Transliterator $transliterator
 	 *
 	 * An instance of \Transliterator to be used by self::intl().
 	 */

--- a/Sources/Localization/AsciiTransliterator.php
+++ b/Sources/Localization/AsciiTransliterator.php
@@ -35,7 +35,7 @@ class AsciiTransliterator
 	 ****************************/
 
 	/**
-	 * @var \Transliterator $transliterator
+	 * @var \Transliterator
 	 *
 	 * An instance of \Transliterator to be used by self::intl().
 	 */

--- a/Sources/Localization/MessageFormatter.php
+++ b/Sources/Localization/MessageFormatter.php
@@ -496,7 +496,7 @@ class MessageFormatter
 	 * support SMF on servers that do not have the intl extension installed.
 	 *
 	 * @param int|float|string $number A number.
-	 * @param istring $skeleton The ICU number skeleton.
+	 * @param string $skeleton The ICU number skeleton.
 	 * @return string A formatted number.
 	 */
 	protected static function applyNumberSkeleton(int|float|string $number, string $skeleton): string

--- a/Sources/Mail.php
+++ b/Sources/Mail.php
@@ -34,8 +34,8 @@ class Mail
 	 * @param array|string $to The email(s) to send to
 	 * @param string $subject Email subject, expected to have entities, and slashes, but not be parsed
 	 * @param string $message Email body, expected to have slashes, no htmlentities
-	 * @param string $from The address to use for replies
-	 * @param string $message_id If specified, it will be used as local part of the Message-ID header.
+	 * @param null|string $from The address to use for replies
+	 * @param null|string $message_id If specified, it will be used as local part of the Message-ID header.
 	 * @param bool $send_html Whether or not the message is HTML vs. plain text
 	 * @param int $priority The priority of the message
 	 * @param bool $hotmail_fix Whether to apply the "hotmail fix"
@@ -999,7 +999,7 @@ class Mail
 	 *
 	 * @param string $type The type. Types supported are 'approval', 'activation', and 'standard'.
 	 * @param int $memberID The ID of the member
-	 * @param string $member_name The name of the member (if null, it is pulled from the database)
+	 * @param null|string $member_name The name of the member (if null, it is pulled from the database)
 	 */
 	public static function adminNotify(string $type, int $memberID, ?string $member_name = null): void
 	{

--- a/Sources/MailAgent/APIs/SMTP.php
+++ b/Sources/MailAgent/APIs/SMTP.php
@@ -232,7 +232,7 @@ class SMTP extends MailAgent implements MailAgentInterface
 	 *
 	 * @param ?string $message The message to send
 	 * @param ?string $code The expected response code
-	 * @param string $response The response from the SMTP server
+	 * @param string|null $response The response from the SMTP server
 	 * @return bool|string Whether it responded as such.
 	 */
 	private function serverParse(?string $message, ?string $code, ?string &$response = null): bool|string

--- a/Sources/MailAgent/MailAgent.php
+++ b/Sources/MailAgent/MailAgent.php
@@ -114,7 +114,8 @@ abstract class MailAgent
 	 * @param string $to
 	 * @param string $subject
 	 * @param string $message Message should be formatted with html/plain text.
-	 * @param array $headers Any additional headers.
+	 * @param string $headers Any additional headers
+	 * @return bool Always returns false
 	 */
 	public function send(string $to, string $subject, string $message, string $headers): bool
 	{
@@ -142,7 +143,7 @@ abstract class MailAgent
 	 * Is our SMF version supported with this Agent.
 	 *
 	 * @param string $smfVersion
-	 * @return string the value of $key.
+	 * @return bool Whether the specified version is compatible
 	 */
 	public function isCompatible(string $smfVersion): bool
 	{

--- a/Sources/Msg.php
+++ b/Sources/Msg.php
@@ -1863,7 +1863,7 @@ class Msg implements \ArrayAccess, Routable
 	/**
 	 * Approve (or not) some posts... without permission checks...
 	 *
-	 * @param array $msgs Array of message ids
+	 * @param array|int $msgs Array of message ids or the ID of a single message
 	 * @param bool $approve Whether to approve the posts (if false, posts are unapproved)
 	 * @param bool $notify Whether to notify users
 	 * @return bool Whether the operation was successful

--- a/Sources/PackageManager/FtpConnection.php
+++ b/Sources/PackageManager/FtpConnection.php
@@ -395,7 +395,7 @@ class FtpConnection
 	 * Determines the current directory we are in
 	 *
 	 * @param string $file The name of a file
-	 * @param string $listing A directory listing or null to generate one
+	 * @param null|string $listing A directory listing or null to generate one
 	 * @return string|bool The name of the file or false if it wasn't found
 	 */
 	public function locate(string $file, ?string $listing = null): string|bool
@@ -473,7 +473,7 @@ class FtpConnection
 	 * Detects the current path
 	 *
 	 * @param string $filesystem_path The full path from the filesystem
-	 * @param string $lookup_file The name of a file in the specified path
+	 * @param null|string $lookup_file The name of a file in the specified path
 	 * @return array An array of detected info - username, path from FTP root and whether or not the current path was found
 	 */
 	public function detect_path(string $filesystem_path, ?string $lookup_file = null): array

--- a/Sources/PackageManager/PackageUtils.php
+++ b/Sources/PackageManager/PackageUtils.php
@@ -296,7 +296,7 @@ class PackageUtils
 	 * @param ?string $destination Null to display a listing of files in the archive, the destination for the files in the archive or the name of a single file to display (if $single_file is true)
 	 * @param bool $single_file If true, returns the contents of the file specified by destination or false if the file can't be found (default value is false).
 	 * @param bool $overwrite If true, will overwrite files with newer modification times. Default is false.
-	 * @param array $files_to_extract
+	 * @param null|array $files_to_extract
 	 * @return mixed If destination is null, return a short array of a few file details optionally delimited by $files_to_extract. If $single_file is true, return contents of a file as a string; false otherwise
 	 */
 	public static function readZipData(string $data, ?string $destination, bool $single_file = false, bool $overwrite = false, ?array $files_to_extract = null): mixed

--- a/Sources/PackageManager/XmlArray.php
+++ b/Sources/PackageManager/XmlArray.php
@@ -48,7 +48,7 @@ class XmlArray
 	 *
 	 * @param string|array $data The xml data or an array of, unless is_clone is true.
 	 * @param bool $auto_trim Used to automatically trim textual data.
-	 * @param int $level The debug level. Specifies whether notices should be generated for missing elements and attributes.
+	 * @param int|null $level The debug level. Specifies whether notices should be generated for missing elements and attributes.
 	 * @param bool $is_clone default false. If is_clone is true, the  XmlArray is cloned from another - used internally only.
 	 */
 	public function __construct(string|array $data, bool $auto_trim = false, ?int $level = null, bool $is_clone = false)
@@ -100,7 +100,7 @@ class XmlArray
 	 *
 	 * @param string $path The path to the element to fetch
 	 * @param bool $get_elements Whether to include elements
-	 * @return string The value or attribute of the specified element
+	 * @return string|bool The value or attribute of the specified element
 	 */
 	public function fetch(string $path, bool $get_elements = false): string|bool
 	{
@@ -302,7 +302,7 @@ class XmlArray
 	 * Example use:
 	 *  echo $this->create_xml();
 	 *
-	 * @param string $path The path to the element. (optional)
+	 * @param string|null $path The path to the element. (optional)
 	 * @return string Xml-formatted string.
 	 */
 	public function create_xml(?string $path = null): string
@@ -332,7 +332,7 @@ class XmlArray
 	 * Example use:
 	 *  print_r($xml->to_array());
 	 *
-	 * @param string $path The path to output.
+	 * @param string|null $path The path to output.
 	 * @return array An array of XML data
 	 */
 	public function to_array(?string $path = null): array

--- a/Sources/Parser.php
+++ b/Sources/Parser.php
@@ -508,7 +508,7 @@ abstract class Parser
 	/**
 	 * Adjusts a BBCode definition so that it outputs its disabled version.
 	 *
-	 * @param BBCode $code A BBCode definition.
+	 * @param BBCode $code_def A BBCode definition.
 	 * @return BBCode The disabled version of the BBCode definition.
 	 */
 	protected function disableCode(BBCode $code_def): BBCode

--- a/Sources/Parsers/BBCodeParser.php
+++ b/Sources/Parsers/BBCodeParser.php
@@ -108,7 +108,7 @@ class BBCodeParser extends Parser
 	private ?int $pos1 = null;
 
 	/**
-	 * @var int
+	 * @var int|null
 	 *
 	 * Previous value of $this->pos.
 	 */
@@ -384,7 +384,7 @@ class BBCodeParser extends Parser
 	/**
 	 * Parse bulletin board code in a string.
 	 *
-	 * @param string|bool $message The string to parse.
+	 * @param string $message The string to parse.
 	 * @param bool $smileys Whether to parse smileys. Default: true.
 	 * @param string|int $cache_id The cache ID.
 	 *    If $cache_id is left empty, an ID will be generated automatically.
@@ -1296,7 +1296,7 @@ class BBCodeParser extends Parser
 	/**
 	 * Replaces {txt_*} tokens with Lang::$txt strings.
 	 *
-	 * @param string $data A string that might contain {txt_*} tokens.
+	 * @param string $string A string that might contain {txt_*} tokens.
 	 * @return string The string with Lang::$txt string values.
 	 */
 	public static function insertTxt(string $string): string

--- a/Sources/Parsers/MarkdownParser.php
+++ b/Sources/Parsers/MarkdownParser.php
@@ -744,7 +744,7 @@ class MarkdownParser extends Parser
 	 * the string was already processed by the SMF\Parsers\BBCodeParser class.
 	 *
 	 * @param string $string The string to parse.
-	 * @param string $from_bbcode_parser Whether the string was the output from
+	 * @param bool $from_bbcode_parser Whether the string was the output from
 	 *    the SMF\Parsers\BBCodeParser class.
 	 * @param array $options Parser options. Recognized options are:
 	 *    - 'hard_breaks':
@@ -889,8 +889,7 @@ class MarkdownParser extends Parser
 	 *    Value should be bitmask of this class's BR_* constants.
 	 *    If null, uses the value of Config::$modSettings['markdown_brs'].
 	 *    Ignored when output is BBCode. Default: null.
-	 * @throws \ValueError if $output_type is invalid.
-	 * @return object An instance of this class.
+	 * @return MarkdownParser An instance of this class.
 	 */
 	public static function load(int $output_type = self::OUTPUT_HTML, ?int $hard_breaks = null): self
 	{
@@ -1218,7 +1217,6 @@ class MarkdownParser extends Parser
 	 * Tests whether a line is part of an indented code block.
 	 *
 	 * @param array $line_info Info about the current line.
-	 * @param int $o Key of the current block in $this->open.
 	 * @return bool Whether this line is part of an indented code block.
 	 */
 	protected function testIsIndentedCode(array $line_info): bool

--- a/Sources/Permissions/PermissionProfile.php
+++ b/Sources/Permissions/PermissionProfile.php
@@ -333,7 +333,7 @@ class PermissionProfile
 	 *
 	 * @param int $copy_from ID of the profile to duplicate.
 	 * @param string $name Name for the new profile.
-	 * @return self A new instance of this class, or null on error.
+	 * @return self|null A new instance of this class, or null on error.
 	 */
 	public static function copy(int $copy_from, string $name): ?self
 	{

--- a/Sources/Permissions/UserPermissionSet.php
+++ b/Sources/Permissions/UserPermissionSet.php
@@ -223,7 +223,7 @@ class UserPermissionSet
 	/**
 	 * Checks whether the user has been granted the specified permissions.
 	 *
-	 * @param string $permission_names The names of the permissions to check.
+	 * @param string|array $permission_names The names of the permissions to check.
 	 * @param bool $any If true, will return true if the user has any of the
 	 *    specified permissions. If false, will return true only if the user
 	 *    has all of the specified permissions. Default: false.
@@ -266,7 +266,7 @@ class UserPermissionSet
 	 *
 	 * These changes do not survive beyond the current script execution run.
 	 *
-	 * @param string|array $permission_name The name of the permission to grant.
+	 * @param string|array $permission_names The name of the permission to grant.
 	 */
 	public function grant(string|array $permission_names): void
 	{
@@ -285,7 +285,7 @@ class UserPermissionSet
 	 *
 	 * These changes do not survive beyond the current script execution run.
 	 *
-	 * @param string $permission_name The name of the permission to deny.
+	 * @param string $permission_names The name of the permission to deny.
 	 */
 	public function deny(string|array $permission_names): void
 	{
@@ -383,7 +383,7 @@ class UserPermissionSet
 	 * Calls the integrate_allowed_to_general hook so that mods can grant custom
 	 * permissions.
 	 *
-	 * @param string $permission_names The names of the permissions to check.
+	 * @param array $permission_names The names of the permissions to check.
 	 */
 	protected function integrateAllowedToGeneral(array $permission_names): void
 	{

--- a/Sources/PersonalMessage/PM.php
+++ b/Sources/PersonalMessage/PM.php
@@ -412,7 +412,7 @@ class PM implements \ArrayAccess
 
 	/**
 	 * Checks whether the current user can see this personal message.
-	 * @param string $folders The folders to check
+	 * @param string $folders The folders to check: 'inbox', 'sent', or 'both'.
 	 * @return bool
 	 */
 	public function canAccess(string $folders = 'both'): bool

--- a/Sources/PersonalMessage/PM.php
+++ b/Sources/PersonalMessage/PM.php
@@ -412,7 +412,7 @@ class PM implements \ArrayAccess
 
 	/**
 	 * Checks whether the current user can see this personal message.
-	 *
+	 * @param string $folders The folders to check
 	 * @return bool
 	 */
 	public function canAccess(string $folders = 'both'): bool
@@ -1619,7 +1619,7 @@ class PM implements \ArrayAccess
 	/**
 	 * Delete the specified personal messages.
 	 *
-	 * @param array|null $personal_messages An array containing the IDs of PMs to delete or null to delete all of them
+	 * @param int|array|null $personal_messages An array containing the IDs of PMs to delete or null to delete all of them
 	 * @param string|null $folder Which "folder" to delete PMs from - 'sent' to delete them from the outbox, null or anything else to delete from the inbox
 	 * @param array|int|null $owner An array of IDs of users whose PMs are being deleted, the ID of a single user or null to use the current user's ID
 	 */

--- a/Sources/PersonalMessage/Received.php
+++ b/Sources/PersonalMessage/Received.php
@@ -181,8 +181,6 @@ class Received implements \ArrayAccess
 
 	/**
 	 * Applies a label to this PM.
-	 *
-	 * @return array The label IDs.
 	 */
 	public function addLabel(int $label_id): void
 	{
@@ -207,8 +205,6 @@ class Received implements \ArrayAccess
 
 	/**
 	 * Removes a label from this PM.
-	 *
-	 * @return array The label IDs.
 	 */
 	public function removeLabel(int $label_id): void
 	{

--- a/Sources/Poll.php
+++ b/Sources/Poll.php
@@ -796,7 +796,7 @@ class Poll implements \ArrayAccess
 	 * Checks permissions and sanitizes input before doing anything.
 	 *
 	 * @param array &$errors Will hold errors encountered while creating the poll.
-	 * @return self An instance of this class, or null on failure.
+	 * @return self|null An instance of this class, or null on failure.
 	 */
 	public static function create(array &$errors = []): ?self
 	{
@@ -1052,8 +1052,6 @@ class Poll implements \ArrayAccess
 
 	/**
 	 * Sets object properties based on retrieved database rows.
-	 *
-	 * @param array $row A row from the database.
 	 */
 	protected function initNewPoll(): void
 	{

--- a/Sources/Profile.php
+++ b/Sources/Profile.php
@@ -168,7 +168,7 @@ class Profile extends User implements \ArrayAccess
 	public static int $memID;
 
 	/**
-	 * @var object
+	 * @var self
 	 *
 	 * Instance of this class for the member whose profile is being viewed.
 	 */
@@ -1811,7 +1811,7 @@ class Profile extends User implements \ArrayAccess
 	 * @param int $type Whether $users contains IDs, names, or email addresses.
 	 *    Possible values are this class's LOAD_BY_* constants.
 	 *    If $users is not set, this will be ignored.
-	 * @param string $dataset Ignored.
+	 * @param string|null $dataset Ignored.
 	 * @return array The IDs of the loaded members.
 	 */
 	public static function load(mixed $users = [], int $type = self::LOAD_BY_ID, ?string $dataset = null): array
@@ -2992,7 +2992,7 @@ class Profile extends User implements \ArrayAccess
 	 * - mails the new password to the email address of the user.
 	 * - if username is not set, only a new password is generated and sent.
 	 *
-	 * @param string $username The new username. If set, also checks the validity of the username
+	 * @param string|null $username The new username. If set, also checks the validity of the username
 	 */
 	protected function resetPassword(?string $username = null): void
 	{

--- a/Sources/Punycode.php
+++ b/Sources/Punycode.php
@@ -68,7 +68,7 @@ class Punycode
 	/**
 	 * Encode table
 	 *
-	 * @param array
+	 * @var array
 	 */
 	protected static $encodeTable = [
 		'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l',
@@ -79,7 +79,7 @@ class Punycode
 	/**
 	 * Decode table
 	 *
-	 * @param array
+	 * @var array
 	 */
 	protected static $decodeTable = [
 		'a' => 0, 'b' => 1, 'c' => 2, 'd' => 3, 'e' => 4, 'f' => 5,
@@ -93,7 +93,7 @@ class Punycode
 	/**
 	 * Character encoding
 	 *
-	 * @param string
+	 * @var string
 	 */
 	protected $encoding;
 
@@ -101,21 +101,21 @@ class Punycode
 	 * Whether to use Non-Transitional Processing.
 	 * Setting this to true breaks backward compatibility with IDNA2003.
 	 *
-	 * @param bool
+	 * @var bool
 	 */
 	protected $nonTransitional = false;
 
 	/**
 	 * Whether to use STD3 ASCII rules.
 	 *
-	 * @param bool
+	 * @var bool
 	 */
 	protected $std3 = false;
 
 	/**
 	 * Constructor
 	 *
-	 * @param string $encoding Character encoding
+	 * @var string $encoding Character encoding
 	 */
 	public function __construct(string $encoding = 'UTF-8')
 	{

--- a/Sources/ReCaptcha/RequestMethod/Curl.php
+++ b/Sources/ReCaptcha/RequestMethod/Curl.php
@@ -42,10 +42,10 @@ class Curl
 
     /**
      * @see http://php.net/curl_init
-     * @param string $url
-     * @return resource cURL handle
+     * @param ?string $url
+     * @return \CurlHandle|false cURL handle
      */
-    public function init($url = null)
+    public function init(?string $url = null)
     {
         return curl_init($url);
     }
@@ -64,7 +64,7 @@ class Curl
     /**
      * @see http://php.net/curl_exec
      * @param resource $ch
-     * @return mixed
+     * @return bool|string
      */
     public function exec($ch)
     {

--- a/Sources/ReCaptcha/RequestMethod/CurlPost.php
+++ b/Sources/ReCaptcha/RequestMethod/CurlPost.php
@@ -60,10 +60,10 @@ class CurlPost implements RequestMethod
     /**
      * Only needed if you want to override the defaults
      *
-     * @param Curl $curl Curl resource
-     * @param string $siteVerifyUrl URL for reCAPTCHA siteverify API
+     * @param null|Curl $curl Curl resource
+     * @param null|string $siteVerifyUrl URL for reCAPTCHA siteverify API
      */
-    public function __construct(Curl $curl = null, $siteVerifyUrl = null)
+    public function __construct(?Curl $curl = null, ?string $siteVerifyUrl = null)
     {
         $this->curl = (is_null($curl)) ? new Curl() : $curl;
         $this->siteVerifyUrl = (is_null($siteVerifyUrl)) ? ReCaptcha::SITE_VERIFY_URL : $siteVerifyUrl;

--- a/Sources/ReCaptcha/RequestMethod/SocketPost.php
+++ b/Sources/ReCaptcha/RequestMethod/SocketPost.php
@@ -54,10 +54,10 @@ class SocketPost implements RequestMethod
     /**
      * Only needed if you want to override the defaults
      *
-     * @param \ReCaptcha\RequestMethod\Socket $socket optional socket, injectable for testing
-     * @param string $siteVerifyUrl URL for reCAPTCHA siteverify API
+     * @param \ReCaptcha\RequestMethod\Socket|null $socket optional socket, injectable for testing
+     * @param string|null $siteVerifyUrl URL for reCAPTCHA siteverify API
      */
-    public function __construct(Socket $socket = null, $siteVerifyUrl = null)
+    public function __construct(?Socket $socket = null, ?string $siteVerifyUrl = null)
     {
         $this->socket = (is_null($socket)) ? new Socket() : $socket;
         $this->siteVerifyUrl = (is_null($siteVerifyUrl)) ? ReCaptcha::SITE_VERIFY_URL : $siteVerifyUrl;

--- a/Sources/Search/APIs/Custom.php
+++ b/Sources/Search/APIs/Custom.php
@@ -893,7 +893,7 @@ class Custom extends SearchApi implements SearchApiInterface
 	 * returned integer array.
 	 *
 	 * @param string $string A string.
-	 * @param int $bytes_per_word Byte-length of the returned integers.
+	 * @param int|null $bytes_per_word Byte-length of the returned integers.
 	 *    Defaults to custom search index's 'bytes_per_word' value, or 4 if that
 	 *    is not set. Allowed values range between 1 and PHP_INT_SIZE.
 	 * @return array Unique integers for each word in $string.

--- a/Sources/Search/SearchApiInterface.php
+++ b/Sources/Search/SearchApiInterface.php
@@ -50,7 +50,7 @@ interface SearchApiInterface
 	/**
 	 * Gets whether the index for this API exists.
 	 *
-	 * @return string Either 'exists', 'partial', 'none', or null for APIs that
+	 * @return string|null Either 'exists', 'partial', 'none', or null for APIs that
 	 *    don't use an index.
 	 */
 	public function getStatus(): ?string;
@@ -126,8 +126,8 @@ interface SearchApiInterface
 	 *
 	 * @param int $id_topic The ID of the topic that messages where merged into
 	 * @param array $topics The ID(s) of the merged topic(s)
-	 * @param array $msgs The ID(s) of the merged messages(s)
-	 * @param ?string Optional rename all subjects for all messages.
+	 * @param array $affected_msgs The ID(s) of the merged messages(s)
+	 * @param ?string $subject Optional rename all subjects for all messages.
 	 */
 	public function topicMerge(int $id_topic, array $topics, array $affected_msgs, ?string $subject): void;
 
@@ -135,7 +135,7 @@ interface SearchApiInterface
 	 * Callback when a topic is merged.
 	 *
 	 * @param int $id_topic The ID of the topic that messages where merged into
-	 * @param array $msgs The ID(s) of the merged messages(s)
+	 * @param array $affected_msgs The ID(s) of the merged messages(s)
 	 */
 	public function topicSplit(int $id_topic, array $affected_msgs): void;
 
@@ -177,7 +177,6 @@ interface SearchApiInterface
 	 * @param array $excludedIndexWords Indexed words that should be excluded
 	 * @param array $participants
 	 * @param array $searchArray
-	 * @return mixed
 	 */
 	public function searchQuery(array $query_params, array $searchWords, array $excludedIndexWords, array &$participants, array &$searchArray): void;
 

--- a/Sources/Security.php
+++ b/Sources/Security.php
@@ -32,7 +32,7 @@ class Security
 	 * Hashes the user's password
 	 *
 	 * @param string $password The unhashed password
-	 * @param int $cost The cost
+	 * @param int|null $cost The cost
 	 * @return string The hashed password
 	 */
 	public static function hashPassword(string $password, ?int $cost = null): string
@@ -570,7 +570,7 @@ class Security
 	/**
 	 * This sets the X-Frame-Options header.
 	 *
-	 * @param string $override An option to override (either 'SAMEORIGIN' or 'DENY')
+	 * @param string|null $override An option to override (either 'SAMEORIGIN' or 'DENY')
 	 * @since 2.1
 	 */
 	public static function frameOptionsHeader(?string $override = null): void

--- a/Sources/ServerSideIncludes.php
+++ b/Sources/ServerSideIncludes.php
@@ -455,7 +455,7 @@ class ServerSideIncludes
 	 *
 	 * @param string $query_where The WHERE clause for the query
 	 * @param array $query_where_params An array of parameters for the WHERE clause
-	 * @param int $query_limit The maximum number of rows to return
+	 * @param int|string $query_limit The maximum number of rows to return
 	 * @param string $query_order The ORDER BY clause for the query
 	 * @param string $output_method The output method. If 'echo', displays the posts, otherwise returns an array of info about them.
 	 * @param bool $limit_body If true, will only show the first 384 characters of the post rather than all of it
@@ -1197,7 +1197,7 @@ class ServerSideIncludes
 	 *
 	 * Alias: ssi_fetchGroupMembers()
 	 *
-	 * @param int $group_id The ID of the group to get members from
+	 * @param int|null $group_id The ID of the group to get members from
 	 * @param string $output_method The output method. If 'echo', returns a list of group members, otherwise returns an array of info about them.
 	 * @return ?array Displays a list of group members or returns an array of info about them, depending on output_method.
 	 */
@@ -1229,7 +1229,7 @@ class ServerSideIncludes
 	 *
 	 * Alias: ssi_queryMembers()
 	 *
-	 * @param string $query_where The info for the WHERE clause of the query
+	 * @param string|null $query_where The info for the WHERE clause of the query
 	 * @param array $query_where_params The parameters for the WHERE clause
 	 * @param string|int $query_limit The number of rows to return or an empty string to return all
 	 * @param string $query_order The info for the ORDER BY clause of the query
@@ -2466,8 +2466,8 @@ class ServerSideIncludes
 	 *
 	 * Alias: ssi_checkPassword()
 	 *
-	 * @param int|string $id The ID or username of a user
-	 * @param string $password The password to check
+	 * @param int|string|null $id The ID or username of a user
+	 * @param string|null $password The password to check
 	 * @param bool $is_username If true, treats $id as a username rather than a user ID
 	 * @return bool Whether or not the password is correct.
 	 */

--- a/Sources/Slug.php
+++ b/Sources/Slug.php
@@ -28,7 +28,7 @@ class Slug implements \Stringable
 	 **************************/
 
 	/**
-	 * @var array
+	 * @var self
 	 *
 	 * The slug in the requested URL, if any.
 	 *

--- a/Sources/Subs-Compat.php
+++ b/Sources/Subs-Compat.php
@@ -2813,6 +2813,8 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 
 	/**
 	 * Handles the account section of the profile
+	 *
+	 * @param int $memID The ID of the member
 	 */
 	function account(): void
 	{
@@ -2825,6 +2827,8 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 
 	/**
 	 * Activate an account.
+	 *
+	 * @param int $memID The ID of the member whose account we're activating
 	 */
 	function activateAccount(): void
 	{
@@ -2837,6 +2841,8 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 
 	/**
 	 * Set up the requirements for the alerts popup - the area that shows all the alerts just quickly for the current user.
+	 *
+	 * @param int $memID The ID of the member'
 	 */
 	function alerts_popup(): void
 	{
@@ -2849,6 +2855,8 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 
 	/**
 	 * Show all the users buddies, as well as a add/delete interface.
+	 *
+	 * @param int $memID The ID of the member
 	 */
 	function editBuddyIgnoreLists(): void
 	{
@@ -2883,6 +2891,8 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 
 	/**
 	 * Present a screen to make sure the user wants to be deleted
+	 *
+	 * @param int $memID The member ID
 	 */
 	function deleteAccount(): void
 	{
@@ -2972,6 +2982,8 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 
 	/**
 	 * Downloads exported profile data file.
+	 *
+	 * @param int $uid The ID of the member whose data we're exporting.
 	 */
 	function download_export_file(): void
 	{
@@ -2984,6 +2996,8 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 
 	/**
 	 * Handles the main "Forum Profile" section of the profile
+	 *
+	 * @param int $memID The ID of the member
 	 */
 	function forumProfile(): void
 	{
@@ -2996,6 +3010,8 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 
 	/**
 	 * Function to allow the user to choose group membership etc...
+	 *
+	 * @param int $memID The ID of the member
 	 */
 	function groupMembership(): void
 	{
@@ -3089,6 +3105,8 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 
 	/**
 	 * Display the notifications and settings for changes.
+	 *
+	 * @param int $memID The ID of the member
 	 */
 	function notification(): void
 	{
@@ -3166,6 +3184,8 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 
 	/**
 	 * Function for doing all the paid subscription stuff - kinda.
+	 *
+	 * @param int $memID The ID of the member whose subscription we're viewing
 	 */
 	function subscriptions(): void
 	{
@@ -3178,6 +3198,8 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 
 	/**
 	 * Set up the requirements for the profile popup - the area that is shown as the popup menu for the current user.
+	 *
+	 * @param int $memID The ID of the member
 	 */
 	function profile_popup(): void
 	{
@@ -3333,6 +3355,8 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 
 	/**
 	 * Provides interface to disable two-factor authentication in SMF
+	 *
+	 * @param int $memID The ID of the member
 	 */
 	function tfadisable(): void
 	{
@@ -3357,6 +3381,8 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 
 	/**
 	 * Handles the "Look and Layout" section of the profile
+	 *
+	 * @param int $memID The ID of the member
 	 */
 	function theme(): void
 	{
@@ -3588,8 +3614,8 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	/**
 	 * This keeps track of all registered handling functions for auto suggest functionality and passes execution to them.
 	 *
-	 * @param ?string $suggest_type
-	 * @return ?bool Returns whether the callback function is registered if $suggest_type isn't null
+	 * @param bool $checkRegistered If set to something other than null, checks whether the callback function is registered
+	 * @return ?bool Returns whether the callback function is registered if $checkRegistereds isn't null
 	 */
 	function AutoSuggestHandler(?string $suggest_type = null): ?bool
 	{
@@ -3622,6 +3648,8 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 
 	/**
 	 * Provides a list of possible SMF versions to use in emulation
+	 *
+	 * @return array An array of data for displaying the suggestionss
 	 */
 	function AutoSuggest_Search_SMFVersions(): void
 	{
@@ -4276,7 +4304,10 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	 * It requires that the session hash is sent as well, to prevent automatic logouts by images or javascript.
 	 * It redirects back to $_SESSION['logout_url'], if it exists.
 	 * It is accessed via ?action=logout;session_var=...
-     */
+	 *
+	 * @param bool $internal If true, it doesn't check the session
+	 * @param bool $redirect Whether or not to redirect the user after they log out
+	 */
 	function Logout(): void
 	{
 		SMF\Actions\Logout::call();
@@ -5593,7 +5624,7 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	 * @param int $time The timestamp of the last DB error
 	 * @return bool True If we could succesfully put the file or not.
 	 */
-	function updateDbLastError(int $time) : bool
+	function updateDbLastError(int $time): bool
 	{
 		return SMF\Config::updateDbLastError($time);
 	}
@@ -6345,7 +6376,7 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	 * Check if the PM is available to the current user.
 	 *
 	 * @param int $pmID The ID of the PM
-	 * @param string $folders Which folders this is valued for - can be 'inbox', 'outbox' or 'in_or_outbox'
+	 * @param string $folders Which folders this is valid for. Can be 'inbox', 'sent', or 'both'.
 	 * @return bool Whether the PM is accessible in that folder for the current user
 	 */
 	function isAccessiblePM(int $pmID, string $folders = 'both'): bool
@@ -7301,7 +7332,7 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	 * Recursively get a list of boards.
 	 * Used by getBoardTree
 	 *
-	 * @param array &$ist The board list
+	 * @param array &$list The board list
 	 * @param array &$tree The board tree
 	 */
 	function recursiveBoards(&$list, &$tree): void
@@ -8284,6 +8315,7 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	 * Delete a menu.
 	 *
 	 * @param int|string $id The ID of the menu to destroy or 'last' for the most recent one
+	 * @return bool|void False if the menu doesn't exist, nothing otherwise
 	 */
 	function destroyMenu(int|string $id = 'last'): void
 	{
@@ -8711,14 +8743,14 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	 * Compares existance request variables against an array.
 	 *
 	 * The input array is associative, where keys denote accepted values
-	 * in a request variable denoted by `$req_val`. Values can be:
+	 * in a request variable denoted by `$value_list`. Values can be:
 	 *
 	 * - another associative array where at least one key must be found
 	 *   in the request and their values are accepted request values.
 	 * - A scalar value, in which case no furthur checks are done.
 	 *
-	 * @param array $value_list
-	 * @param string $var
+	 * @param array $value_list Accepted values
+	 * @param string $var Name of the $_REQUEST variable to check.
 	 *
 	 * @return bool whether any of the criteria was satisfied
 	 */
@@ -10554,7 +10586,7 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	 * Loads an array of users' data by ID or member_name.
 	 *
 	 * @param array|string $users An array of users by id or name or a single username/id
-	 * @param int $type
+	 * @param bool $is_name Whether $users contains names
 	 * @param string|null $dataset What kind of data to load (normal, profile, minimal)
 	 * @return array The ids of the members loaded
 	 */
@@ -10823,7 +10855,7 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	 * - calls itself recursively if necessary.
 	 *
 	 * @param array|string $var The string or array of strings to add entites to
-	 * @param int $flags Bitmask of flags to pass to htmlspecialchars()
+	 * @param int $level Which level we're at within the array (if called recursively)
 	 * @param string $encoding Character encoding
 	 * @return array|string The string or array of strings with entities added
 	 */
@@ -10854,6 +10886,7 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	 * - may call itself recursively if needed.
 	 *
 	 * @param array|string $var The string or array of strings to trim
+	 * @param int $level = 0 How we're at within the array (if called recursively)'
 	 * @return array|string The trimmed string or array of trimmed strings
 	 */
 	function htmltrim__recursive(array|string $var): array|string
@@ -11024,6 +11057,7 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	 *
 	 * @param array $array The array to truncate
 	 * @param int $max_length The upperbound on the length.
+	 * @param int $deep How many levels in a multidimensional array should the function take into account.
 	 * @return array The truncated array
 	 */
 	function truncate_array(array $array, int $max_length = 1900): array
@@ -11034,6 +11068,7 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	/**
 	 * array_length Recursive
 	 * @param array $array
+	 * @param int $deep How many levels should the function go
 	 * @return int
 	 */
 	function array_length(array $array): int
@@ -11350,7 +11385,7 @@ if (!function_exists('smf_crc32')) {
 	 * @param string $number
 	 * @return int The crc32 polynomial of $number
 	 */
-	function smf_crc32($number)
+	function smf_crc32($number): int
 	{
 		$crc = crc32($number);
 

--- a/Sources/Subs-Compat.php
+++ b/Sources/Subs-Compat.php
@@ -896,8 +896,8 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	 * If add_to_post_count is set, the member's post count is increased.
 	 *
 	 * @param int $memID The ID of the original poster
-	 * @param bool|string $email If set, should be the email of the poster
-	 * @param bool|string $membername If set, the membername of the poster
+	 * @param string|null $email If set, should be the email of the poster
+	 * @param string|null $membername If set, the membername of the poster
 	 * @param bool $post_count Whether to adjust post counts
 	 * @return array An array containing the number of messages, topics and reports updated
 	 */
@@ -1378,7 +1378,6 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	 * Redirects to ?action=admin;area=news;sa=mailingmembers after everything has been sent.
 	 * @uses template_email_members_send()
 	 *
-	 * @param bool $clean_only If set, it will only clean the variables, put them in context, then return.
 	 */
 	function SendMailing(): void
 	{
@@ -1488,7 +1487,7 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	/**
 	 * This function updates the permissions of any groups based off this group.
 	 *
-	 * @param null|array $parents The parent groups
+	 * @param int|null|array $parents The parent groups
 	 * @param null|int $profile the ID of a permissions profile to update
 	 * @return ?bool Returns nothing if successful or false if there are no child groups to update
 	 */
@@ -2814,8 +2813,6 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 
 	/**
 	 * Handles the account section of the profile
-	 *
-	 * @param int $memID The ID of the member
 	 */
 	function account(): void
 	{
@@ -2828,8 +2825,6 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 
 	/**
 	 * Activate an account.
-	 *
-	 * @param int $memID The ID of the member whose account we're activating
 	 */
 	function activateAccount(): void
 	{
@@ -2842,8 +2837,6 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 
 	/**
 	 * Set up the requirements for the alerts popup - the area that shows all the alerts just quickly for the current user.
-	 *
-	 * @param int $memID The ID of the member
 	 */
 	function alerts_popup(): void
 	{
@@ -2856,8 +2849,6 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 
 	/**
 	 * Show all the users buddies, as well as a add/delete interface.
-	 *
-	 * @param int $memID The ID of the member
 	 */
 	function editBuddyIgnoreLists(): void
 	{
@@ -2892,8 +2883,6 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 
 	/**
 	 * Present a screen to make sure the user wants to be deleted
-	 *
-	 * @param int $memID The member ID
 	 */
 	function deleteAccount(): void
 	{
@@ -2983,8 +2972,6 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 
 	/**
 	 * Downloads exported profile data file.
-	 *
-	 * @param int $uid The ID of the member whose data we're exporting.
 	 */
 	function download_export_file(): void
 	{
@@ -2997,8 +2984,6 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 
 	/**
 	 * Handles the main "Forum Profile" section of the profile
-	 *
-	 * @param int $memID The ID of the member
 	 */
 	function forumProfile(): void
 	{
@@ -3011,8 +2996,6 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 
 	/**
 	 * Function to allow the user to choose group membership etc...
-	 *
-	 * @param int $memID The ID of the member
 	 */
 	function groupMembership(): void
 	{
@@ -3106,8 +3089,6 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 
 	/**
 	 * Display the notifications and settings for changes.
-	 *
-	 * @param int $memID The ID of the member
 	 */
 	function notification(): void
 	{
@@ -3185,8 +3166,6 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 
 	/**
 	 * Function for doing all the paid subscription stuff - kinda.
-	 *
-	 * @param int $memID The ID of the user whose subscriptions we're viewing
 	 */
 	function subscriptions(): void
 	{
@@ -3199,8 +3178,6 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 
 	/**
 	 * Set up the requirements for the profile popup - the area that is shown as the popup menu for the current user.
-	 *
-	 * @param int $memID The ID of the member
 	 */
 	function profile_popup(): void
 	{
@@ -3356,8 +3333,6 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 
 	/**
 	 * Provides interface to disable two-factor authentication in SMF
-	 *
-	 * @param int $memID The ID of the member
 	 */
 	function tfadisable(): void
 	{
@@ -3370,8 +3345,6 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 
 	/**
 	 * Provides interface to setup Two Factor Auth in SMF
-	 *
-	 * @param int $memID The ID of the member
 	 */
 	function tfasetup(): void
 	{
@@ -3384,8 +3357,6 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 
 	/**
 	 * Handles the "Look and Layout" section of the profile
-	 *
-	 * @param int $memID The ID of the member
 	 */
 	function theme(): void
 	{
@@ -3398,8 +3369,6 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 
 	/**
 	 * Loads up the information for the "track user" section of the profile
-	 *
-	 * @param int $memID The ID of the member
 	 */
 	function tracking(): void
 	{
@@ -3619,8 +3588,8 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	/**
 	 * This keeps track of all registered handling functions for auto suggest functionality and passes execution to them.
 	 *
-	 * @param bool $checkRegistered If set to something other than null, checks whether the callback function is registered
-	 * @return ?bool Returns whether the callback function is registered if $checkRegistered isn't null
+	 * @param ?string $suggest_type
+	 * @return ?bool Returns whether the callback function is registered if $suggest_type isn't null
 	 */
 	function AutoSuggestHandler(?string $suggest_type = null): ?bool
 	{
@@ -3633,8 +3602,6 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 
 	/**
 	 * Search for a member - by real_name or member_name by default.
-	 *
-	 * @return array An array of information for displaying the suggestions
 	 */
 	function AutoSuggest_Search_Member(): void
 	{
@@ -3645,8 +3612,6 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 
 	/**
 	 * Search for a membergroup by name
-	 *
-	 * @return array An array of information for displaying the suggestions
 	 */
 	function AutoSuggest_Search_MemberGroups(): void
 	{
@@ -3657,8 +3622,6 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 
 	/**
 	 * Provides a list of possible SMF versions to use in emulation
-	 *
-	 * @return array An array of data for displaying the suggestions
 	 */
 	function AutoSuggest_Search_SMFVersions(): void
 	{
@@ -4131,7 +4094,7 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	 *
 	 * @param array &$members The IDs of the members
 	 * @param int $membergroup The ID of the group
-	 * @param int $limit How many members to show (null for no limit)
+	 * @param int|null $limit How many members to show (null for no limit)
 	 * @return bool True if there are more members to display, false otherwise
 	 */
 	function listMembergroupMembers_Href(array &$members, int $membergroup, ?int $limit = null): bool
@@ -4313,10 +4276,7 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	 * It requires that the session hash is sent as well, to prevent automatic logouts by images or javascript.
 	 * It redirects back to $_SESSION['logout_url'], if it exists.
 	 * It is accessed via ?action=logout;session_var=...
-	 *
-	 * @param bool $internal If true, it doesn't check the session
-	 * @param bool $redirect Whether or not to redirect the user after they log out
-	 */
+     */
 	function Logout(): void
 	{
 		SMF\Actions\Logout::call();
@@ -4443,7 +4403,7 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	 *
 	 * @param int|array $members A user id or an array of (integer) user ids to load preferences for
 	 * @param string|array $prefs An empty string to load all preferences, or a string (or array) of preference name(s) to load
-	 * @param bool $process_default Whether to apply the default values to the members' values or not.
+	 * @param bool $process_defaults Whether to apply the default values to the members' values or not.
 	 * @return array An array of user ids => array (pref name -> value), with user id 0 representing the defaults
 	 */
 	function getNotifyPrefs(int|array $members, string|array $prefs = '', bool $process_defaults = false): array
@@ -5601,8 +5561,8 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	 *
 	 * @param string $file The filepath of the file where the data should be written.
 	 * @param string $data The data to be written to $file.
-	 * @param string $backup_file The filepath where the backup should be saved. Default null.
-	 * @param int $mtime If modification time of $file is more recent than this Unix timestamp, the write operation will abort. Defaults to time that the script started execution.
+	 * @param string|null $backup_file The filepath where the backup should be saved. Default null.
+	 * @param int|null $mtime If modification time of $file is more recent than this Unix timestamp, the write operation will abort. Defaults to time that the script started execution.
 	 * @param bool $append If true, the data will be appended instead of overwriting the existing content of the file. Default false.
 	 * @return bool Whether the write operation succeeded or not.
 	 */
@@ -5617,7 +5577,7 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	 * @todo Add special handling for objects?
 	 *
 	 * @param mixed $var The variable to export
-	 * @return mixed A PHP-parseable representation of the variable's value
+	 * @return string A PHP-parseable representation of the variable's value
 	 */
 	function smf_var_export(mixed $var)
 	{
@@ -5631,10 +5591,9 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	 * - If it fails Settings.php will assume 0
 	 *
 	 * @param int $time The timestamp of the last DB error
-	 * @param bool True If we should update the current db_last_error context as well.  This may be useful in cases where the current context needs to know a error was logged since the last check.
 	 * @return bool True If we could succesfully put the file or not.
 	 */
-	function updateDbLastError(int $time)
+	function updateDbLastError(int $time) : bool
 	{
 		return SMF\Config::updateDbLastError($time);
 	}
@@ -5767,8 +5726,8 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	 * - the file would have the format preferred_format if possible, otherwise the default format is jpeg.
 	 * - the function makes sure that all non-essential image contents are disposed.
 	 *
-	 * @param string $fileName The path to the file
-	 * @param int $preferred_format The preferred format - 0 to automatically determine, 1 for gif, 2 for jpg, 3 for png, 6 for bmp and 15 for wbmp
+	 * @param string $source The path to the file
+	 * @param int $preferred_type The preferred format - 0 to automatically determine, 1 for gif, 2 for jpg, 3 for png, 6 for bmp and 15 for wbmp
 	 * @return bool Whether the reencoding was successful
 	 */
 	function reencodeImage(string $source, int $preferred_type = 0): bool
@@ -5780,8 +5739,8 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	 * Searches through the file to see if there's potentially harmful non-binary content.
 	 * - if extensiveCheck is true, searches for asp/php short tags as well.
 	 *
-	 * @param string $fileName The path to the file
-	 * @param bool $extensiveCheck Whether to perform extensive checks
+	 * @param string $source The path to the file
+	 * @param bool $extensive Whether to perform extensive checks
 	 * @return bool Whether the image appears to be safe
 	 */
 	function checkImageContents(string $source, bool $extensive = false): bool
@@ -5792,7 +5751,7 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	/**
 	 * Searches through an SVG file to see if there's potentially harmful content.
 	 *
-	 * @param string $fileName The path to the file.
+	 * @param string $source The path to the file.
 	 * @return bool Whether the image appears to be safe.
 	 */
 	function checkSvgContents(string $source): bool
@@ -5810,7 +5769,7 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	 * @param string $destination The path to the destination image
 	 * @param int $max_width The maximum allowed width
 	 * @param int $max_height The maximum allowed height
-	 * @param int $preferred_format - The preferred format (0 to use jpeg, 1 for gif, 2 to force jpeg, 3 for png, 6 for bmp and 15 for wbmp)
+	 * @param int $preferred_type - The preferred format (0 to use jpeg, 1 for gif, 2 to force jpeg, 3 for png, 6 for bmp and 15 for wbmp)
 	 * @return bool Whether it succeeded.
 	 */
 	function resizeImageFile(
@@ -5832,7 +5791,7 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	 *
 	 * Uses Imagemagick (IMagick or MagickWand extension) or GD
 	 *
-	 * @param resource $source The source image
+	 * @param string $source The source image
 	 * @param string $destination The path to the destination image
 	 * @param int $src_width The width of the source image
 	 * @param int $src_height The height of the source image
@@ -5863,7 +5822,7 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	 * Reads an archive from either a remote location or from the local filesystem.
 	 *
 	 * @param string $gzfilename The path to the tar.gz file
-	 * @param string $destination The path to the desitnation directory
+	 * @param string|null $destination The path to the desitnation directory
 	 * @param bool $single_file If true returns the contents of the file specified by destination if it exists
 	 * @param bool $overwrite Whether to overwrite existing files
 	 * @param null|array $files_to_extract Specific files to extract
@@ -5937,7 +5896,7 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	 * @param string $destination Null to display a listing of files in the archive, the destination for the files in the archive or the name of a single file to display (if $single_file is true)
 	 * @param bool $single_file If true, returns the contents of the file specified by destination or false if the file can't be found (default value is false).
 	 * @param bool $overwrite If true, will overwrite files with newer modication times. Default is false.
-	 * @param array $files_to_extract
+	 * @param array|null $files_to_extract
 	 * @return mixed If destination is null, return a short array of a few file details optionally delimited by $files_to_extract. If $single_file is true, return contents of a file as a string; false otherwise
 	 */
 	function read_zip_data(
@@ -6331,7 +6290,7 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	 * @param string $subject Should have no slashes and no html entities
 	 * @param string $message Should have no slashes and no html entities
 	 * @param bool $store_outbox Whether to store it in the sender's outbox
-	 * @param array $from An array with the id, name, and username of the member.
+	 * @param array|null $from An array with the id, name, and username of the member.
 	 * @param int $pm_head The ID of the chain being replied to - if any.
 	 * @return array An array with log entries telling how many recipients were successful and which recipients it failed to send to.
 	 */
@@ -6375,7 +6334,7 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	 *
 	 * @param array $error_types An array of strings indicating which type of errors occurred
 	 * @param array $named_recipients
-	 * @param $recipient_ids
+	 * @param array $recipient_ids
 	 */
 	function messagePostError(array $error_types, array $named_recipients, array $recipient_ids = []): void
 	{
@@ -6386,7 +6345,7 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	 * Check if the PM is available to the current user.
 	 *
 	 * @param int $pmID The ID of the PM
-	 * @param string $validFor Which folders this is valud for - can be 'inbox', 'outbox' or 'in_or_outbox'
+	 * @param string $folders Which folders this is valued for - can be 'inbox', 'outbox' or 'in_or_outbox'
 	 * @return bool Whether the PM is accessible in that folder for the current user
 	 */
 	function isAccessiblePM(int $pmID, string $folders = 'both'): bool
@@ -6616,7 +6575,7 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	/**
 	 * Checks whether a string is already normalized to a given form.
 	 *
-	 * @param string|array $string A string of UTF-8 characters.
+	 * @param string $string A string of UTF-8 characters.
 	 * @param string $form One of 'd', 'c', 'kd', 'kc', or 'kc_casefold'
 	 * @return bool Whether the string is already normalized to the given form.
 	 */
@@ -6662,9 +6621,8 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	 * - URL must be supplied in lowercase
 	 *
 	 * @param string $url The URL
-	 * @param string $post_data The data to post to the given URL
+	 * @param string|array $post_data The data to post to the given URL
 	 * @param bool $keep_alive Whether to send keepalive info
-	 * @param int $redirection_level How many levels of redirection
 	 * @return string|false The fetched data or false on failure
 	 */
 	function fetch_web_data(string $url, string|array $post_data = [], bool $keep_alive = false): string|false
@@ -6680,9 +6638,9 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	 * Fetch the alerts a member currently has.
 	 *
 	 * @param int $memID The ID of the member.
-	 * @param mixed $to_fetch Alerts to fetch: true/false for all/unread, or a list of one or more IDs.
-	 * @param array $limit Maximum number of alerts to fetch (0 for no limit).
-	 * @param array $offset Number of alerts to skip for pagination. Ignored if $to_fetch is a list of IDs.
+	 * @param int|bool|array $to_fetch Alerts to fetch: true/false for all/unread, or a list of one or more IDs.
+	 * @param int $limit Maximum number of alerts to fetch (0 for no limit).
+	 * @param int $offset Number of alerts to skip for pagination. Ignored if $to_fetch is a list of IDs.
 	 * @param bool $with_avatar Whether to load the avatar of the alert sender.
 	 * @param bool $show_links Whether to show links in the constituent parts of the alert meessage.
 	 * @return array An array of information about the fetched alerts.
@@ -6721,7 +6679,7 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	 *
 	 * @param array|int $members The user IDs.
 	 * @param bool|int $read To mark as read or unread, 1 for read, 0 or any other value different than 1 for unread.
-	 * @param array|int $toMark The ID of a single alert or an array of IDs. The function will convert single integers to arrays for better handling.
+	 * @param array|int $to_mark The ID of a single alert or an array of IDs. The function will convert single integers to arrays for better handling.
 	 * @return int How many alerts remain unread
 	 */
 	function alert_mark(array|int $members, array|int $to_mark, bool|int $read): int
@@ -6734,9 +6692,9 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	/**
 	 * Deletes a single or a group of alerts by ID
 	 *
-	 * @param int|array The ID of a single alert to delete or an array containing the IDs of multiple alerts. The function will convert integers into an array for better handling.
-	 * @param bool|int $memID The user ID. Used to update the user unread alerts count.
-	 * @return ?int If the $memID param is set, returns the new amount of unread alerts.
+	 * @param int|array $ids The ID of a single alert to delete or an array containing the IDs of multiple alerts. The function will convert integers into an array for better handling.
+	 * @param int|array $members The user ID. Used to update the user unread alerts count.
+	 * @return ?int If the $members param is set, returns the new amount of unread alerts.
 	 */
 	function alert_delete(int|array $ids, int|array $members = []): ?int
 	{
@@ -6884,7 +6842,7 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	 *
 	 * @param int $attachID the attachment ID to load info from.
 	 *
-	 * @return mixed If succesful, it will return an array of loaded data. String, most likely a $txt key if there was some error.
+	 * @return array|string If succesful, it will return an array of loaded data. String, most likely a $txt key if there was some error.
 	 */
 	function parseAttachBBC(int $attachID = 0): array|string
 	{
@@ -6896,7 +6854,7 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	 *
 	 * @param int $attachID the attachment ID to load info from.
 	 *
-	 * @return array
+	 * @return SMF\Attachment|array
 	 */
 	function getAttachMsgInfo(int $attachID): SMF\Attachment|array
 	{
@@ -6921,7 +6879,7 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	/**
 	 * prepare the Attachment api for all messages
 	 *
-	 * @param int array $msgIDs the message ID to load info from.
+	 * @param array $msgIDs the message ID to load info from.
 	 */
 	function prepareAttachsByMsg(array $msgIDs): void
 	{
@@ -7010,7 +6968,7 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	 * @param bool $smileys Whether to parse smileys as well
 	 * @param string $cache_id The cache ID
 	 * @param array $parse_tags If set, only parses these tags rather than all of them
-	 * @return string The parsed message
+	 * @return string|array If $message is false, an array of available bbcodes, otherwise the parsed message
 	 */
 	function parse_bbc(
 		string|bool $message,
@@ -7056,7 +7014,7 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	 * Converts HTML to BBC
 	 * As of SMF 2.1, only used by ManageBoards.php (and possibly mods)
 	 *
-	 * @param string $text Text containing HTML
+	 * @param string $string Text containing HTML
 	 * @return string The text with html converted to bbc
 	 */
 	function html_to_bbc(string $string): string
@@ -7147,7 +7105,7 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	 * updates the statistics to reflect the new situation.
 	 *
 	 * @param array $boards_to_remove The boards to remove
-	 * @param int $moveChildrenTo The ID of the board to move the child boards to (null to remove the child boards, 0 to make them a top-level board)
+	 * @param int|null $moveChildrenTo The ID of the board to move the child boards to (null to remove the child boards, 0 to make them a top-level board)
 	 */
 	function deleteBoards(array $boards_to_remove, ?int $moveChildrenTo = null): void
 	{
@@ -7299,7 +7257,7 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	 * updates the statistics to reflect the new situation.
 	 *
 	 * @param array $categories The IDs of the categories to delete
-	 * @param int $moveBoardsTo The ID of the category to move any boards to or null to delete the boards
+	 * @param int|null $moveBoardsTo The ID of the category to move any boards to or null to delete the boards
 	 */
 	function deleteCategories(array $categories, ?int $moveBoardsTo = null): void
 	{
@@ -7343,8 +7301,8 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	 * Recursively get a list of boards.
 	 * Used by getBoardTree
 	 *
-	 * @param array &$_boardList The board list
-	 * @param array &$_tree The board tree
+	 * @param array &$ist The board list
+	 * @param array &$tree The board tree
 	 */
 	function recursiveBoards(&$list, &$tree): void
 	{
@@ -7464,7 +7422,7 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	 * Will load a draft if selected is supplied via post
 	 *
 	 * @param int $member_id ID of the member to show drafts for.
-	 * @param bool|inr $reply_to ID of the topic or PM being replied to.
+	 * @param int $reply_to ID of the topic or PM being replied to.
 	 * @param int $draft_type The type of drafts to show: 0 = post, 1 = PM.
 	 * @return bool False if the drafts couldn't be loaded, nothing otherwise
 	 */
@@ -7501,7 +7459,7 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	/**
 	 * Creates a box that can be used for richedit stuff like BBC, Smileys etc.
 	 *
-	 * @param array $editorOptions Various options for the editor
+	 * @param array $options Various options for the editor
 	 */
 	function create_control_richedit(array $options): SMF\Editor
 	{
@@ -7771,7 +7729,7 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	 * Convert a single IP to a ranged IP.
 	 * internal function used to convert a user-readable format to a format suitable for the database.
 	 *
-	 * @param string $fullip The full IP
+	 * @param string $addr The full IP
 	 * @return array An array of IP parts
 	 */
 	function ip2range(string $addr): array
@@ -7786,8 +7744,8 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	 * @example
 	 * range2ip(array(10, 10, 10, 0), array(10, 10, 20, 255)) returns '10.10.10-20.*
 	 *
-	 * @param array $low The low end of the range in IPv4 format
-	 * @param array $high The high end of the range in IPv4 format
+	 * @param string $low The low end of the range in IPv4 format
+	 * @param string $high The high end of the range in IPv4 format
 	 * @return string A string indicating the range
 	 */
 	function range2ip(string $low, string $high): string
@@ -7799,7 +7757,7 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	 * Check the given String if he is a valid IPv4 or IPv6
 	 * return true or false
 	 *
-	 * @param string $IPString
+	 * @param string $ip
 	 *
 	 * @return bool
 	 */
@@ -7833,7 +7791,7 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	/**
 	 * Converts an IP address into binary
 	 *
-	 * @param string $ip_address An IP address in IPv4, IPv6 or decimal notation
+	 * @param string $ip An IP address in IPv4, IPv6 or decimal notation
 	 * @return string|false The IP address in binary or false
 	 */
 	function inet_ptod(string $ip): string|bool
@@ -7844,8 +7802,8 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	/**
 	 * Converts a binary version of an IP address into a readable format
 	 *
-	 * @param string $bin An IP address in IPv4, IPv6 (Either string (postgresql) or binary (other databases))
-	 * @return string|false The IP address in presentation format or false on error
+	 * @param string $ip An IP address in IPv4, IPv6 (Either string (postgresql) or binary (other databases))
+	 * @return string The IP address in presentation format or false on error
 	 */
 	function inet_dtop(string $ip): string
 	{
@@ -7855,9 +7813,9 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	/**
 	 * Expands a IPv6 address to its full form.
 	 *
-	 * @param string $addr The IPv6 address
-	 * @param bool $strict_check Whether to check the length of the expanded address for compliance
-	 * @return string|bool The expanded IPv6 address or false if $strict_check is true and the result isn't valid
+	 * @param string $ip The IPv6 address
+	 * @param bool $return_bool_if_invalid Whether to check the length of the expanded address for compliance
+	 * @return string|bool The expanded IPv6 address or false if $return_bool_if_invalid is true and the result isn't valid
 	 */
 	function expandIPv6(string $ip, bool $return_bool_if_invalid = true): string|bool
 	{
@@ -7890,7 +7848,8 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	/**
 	 * Create a new list
 	 *
-	 * @param array $listOptions An array of options for the list - 'id', 'columns', 'items_per_page', 'get_count', etc.
+	 * @param array $options An array of options for the list - 'id', 'columns', 'items_per_page', 'get_count', etc.
+	 * @return SMF\ItemList
 	 */
 	function createList(array $options): SMF\ItemList
 	{
@@ -7973,8 +7932,8 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	 *   for example, it might display "1 234,50".
 	 * - caches the formatting data from the setting for optimization.
 	 *
-	 * @param float $number A number
-	 * @param bool|int $override_decimal_count If set, will use the specified number of decimal places. Otherwise it's automatically determined
+	 * @param int|float $number A number
+	 * @param null|int $decimals If set, will use the specified number of decimal places. Otherwise it's automatically determined
 	 * @return string A formatted number
 	 */
 	function comma_format(int|float $number, ?int $decimals = null): string
@@ -8129,8 +8088,8 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	 * @param array $to The email(s) to send to
 	 * @param string $subject Email subject, expected to have entities, and slashes, but not be parsed
 	 * @param string $message Email body, expected to have slashes, no htmlentities
-	 * @param string $from The address to use for replies
-	 * @param string $message_id If specified, it will be used as local part of the Message-ID header.
+	 * @param string|null $from The address to use for replies
+	 * @param string|null $message_id If specified, it will be used as local part of the Message-ID header.
 	 * @param bool $send_html Whether or not the message is HTML vs. plain text
 	 * @param int $priority The priority of the message
 	 * @param bool $hotmail_fix Whether to apply the "hotmail fix"
@@ -8211,7 +8170,7 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	 * @param bool $with_charset Whether we're specifying a charset ($custom_charset must be set here)
 	 * @param bool $hotmail_fix Whether to apply the hotmail fix  (all higher ASCII characters are converted to HTML entities to assure proper display of the mail)
 	 * @param string $line_break The linebreak
-	 * @param string $custom_charset If set, it uses this character set
+	 * @param string|null $custom_charset If set, it uses this character set
 	 * @return array An array containing the character set, the converted string and the transport method.
 	 */
 	function mimespecialchars(
@@ -8280,7 +8239,7 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	 *
 	 * @param string $type The type. Types supported are 'approval', 'activation', and 'standard'.
 	 * @param int $memberID The ID of the member
-	 * @param string $member_name The name of the member (if null, it is pulled from the database)
+	 * @param string|null $member_name The name of the member (if null, it is pulled from the database)
 	 */
 	function adminNotify(string $type, int $memberID, ?string $member_name = null): void
 	{
@@ -8312,8 +8271,8 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	/**
 	 * Create a menu.
 	 *
-	 * @param array $menuData An array of menu data
-	 * @param array $menuOptions An array of menu options
+	 * @param array $data An array of menu data
+	 * @param array $options An array of menu options
 	 * @return bool|array False if nothing to show or an array of info about the selected menu item
 	 */
 	function createMenu(array $data, array $options = []): array|false
@@ -8324,8 +8283,7 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	/**
 	 * Delete a menu.
 	 *
-	 * @param string $menu_id The ID of the menu to destroy or 'last' for the most recent one
-	 * @return bool|void False if the menu doesn't exist, nothing otherwise
+	 * @param int|string $id The ID of the menu to destroy or 'last' for the most recent one
 	 */
 	function destroyMenu(int|string $id = 'last'): void
 	{
@@ -8376,7 +8334,7 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	 *
 	 * @param string $message The message
 	 * @param string $myTag The tag
-	 * @param string $protocols The protocols
+	 * @param array $protocols The protocols
 	 * @param bool $embeddedUrl Whether it *can* be set to something
 	 * @param bool $hasEqualSign Whether it *is* set to something
 	 * @param bool $hasExtra Whether it can have extra cruft after the begin tag.
@@ -8704,7 +8662,7 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	 * @param int $id The ID of the member
 	 * @param string $area The area of the profile these fields are in
 	 * @param bool $sanitize = true Whether or not to sanitize the data
-	 * @param bool $returnErrors Whether or not to return any error information
+	 * @param bool $return_errors Whether or not to return any error information
 	 * @return ?array Returns nothing or returns an array of error info if $returnErrors is true
 	 */
 	function makeCustomFieldChanges(int $id, string $area, bool $sanitize = true, bool $return_errors = false): ?array
@@ -8759,8 +8717,8 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	 *   in the request and their values are accepted request values.
 	 * - A scalar value, in which case no furthur checks are done.
 	 *
-	 * @param array $array
-	 * @param string $req_var request variable
+	 * @param array $value_list
+	 * @param string $var
 	 *
 	 * @return bool whether any of the criteria was satisfied
 	 */
@@ -8876,7 +8834,7 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	 *
 	 * @param string $username The username. Ignored since 3.0.
 	 * @param string $password The unhashed password
-	 * @param int $cost The cost
+	 * @param int|null $cost The cost
 	 * @return string The hashed password
 	 */
 	function hash_password(string $username, string $password, ?int $cost = null): string
@@ -8964,7 +8922,7 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	/**
 	 * This sets the X-Frame-Options header.
 	 *
-	 * @param string $override An option to override (either 'SAMEORIGIN' or 'DENY')
+	 * @param string|null $override An option to override (either 'SAMEORIGIN' or 'DENY')
 	 * @since 2.1
 	 */
 	function frameOptionsHeader(?string $override = null)
@@ -9052,7 +9010,7 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	 * Show the SMF version.
 	 *
 	 * @param string $output_method If 'echo', displays the version, otherwise returns it
-	 * @return void|string Returns nothing if output_method is 'echo', otherwise returns the version
+	 * @return null|string Returns nothing if output_method is 'echo', otherwise returns the version
 	 */
 	function ssi_version($output_method = 'echo')
 	{
@@ -9063,7 +9021,7 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	 * Show the full SMF version string.
 	 *
 	 * @param string $output_method If 'echo', displays the full version string, otherwise returns it
-	 * @return void|string Returns nothing if output_method is 'echo', otherwise returns the version string
+	 * @return null|string Returns nothing if output_method is 'echo', otherwise returns the version string
 	 */
 	function ssi_full_version($output_method = 'echo')
 	{
@@ -9074,7 +9032,7 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	 * Show the SMF software year.
 	 *
 	 * @param string $output_method If 'echo', displays the software year, otherwise returns it
-	 * @return void|string Returns nothing if output_method is 'echo', otherwise returns the software year
+	 * @return null|string Returns nothing if output_method is 'echo', otherwise returns the software year
 	 */
 	function ssi_software_year($output_method = 'echo')
 	{
@@ -9085,7 +9043,7 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	 * Show the forum copyright. Only used in our ssi_examples files.
 	 *
 	 * @param string $output_method If 'echo', displays the forum copyright, otherwise returns it
-	 * @return void|string Returns nothing if output_method is 'echo', otherwise returns the copyright string
+	 * @return null|string Returns nothing if output_method is 'echo', otherwise returns the copyright string
 	 */
 	function ssi_copyright($output_method = 'echo')
 	{
@@ -9096,7 +9054,7 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	 * Display a welcome message, like: Hey, User, you have 0 messages, 0 are new.
 	 *
 	 * @param string $output_method The output method. If 'echo', will display everything. Otherwise returns an array of user info.
-	 * @return void|array Displays a welcome message or returns an array of user data depending on output_method.
+	 * @return null|\SMF\User Displays a welcome message or returns a User object depending on output_method.
 	 */
 	function ssi_welcome($output_method = 'echo')
 	{
@@ -9317,7 +9275,7 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	/**
 	 * Get all members in the specified group
 	 *
-	 * @param int $group_id The ID of the group to get members from
+	 * @param int|null $group_id The ID of the group to get members from
 	 * @param string $output_method The output method. If 'echo', returns a list of group members, otherwise returns an array of info about them.
 	 * @return ?array Displays a list of group members or returns an array of info about them, depending on output_method.
 	 */
@@ -9330,7 +9288,7 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	 * Pulls info about members based on the specified parameters. Used by other
 	 * functions to eliminate duplication.
 	 *
-	 * @param string $query_where The info for the WHERE clause of the query
+	 * @param string|null $query_where The info for the WHERE clause of the query
 	 * @param array $query_where_params The parameters for the WHERE clause
 	 * @param string|int $query_limit The number of rows to return or an empty string to return all
 	 * @param string $query_order The info for the ORDER BY clause of the query
@@ -9500,9 +9458,9 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	 * Shows today's calendar items (events, birthdays and holidays)
 	 *
 	 * @param string $output_method The output method. If 'echo', displays a list of calendar items, otherwise returns an array of info about them.
-	 * @return array|string|null Displays a list of calendar items or returns an array of info about them depending on output_method
+	 * @return array|null|string Displays a list of calendar items or returns an array of info about them depending on output_method
 	 */
-	function ssi_todaysCalendar(string $output_method = 'echo'): ?array
+	function ssi_todaysCalendar(string $output_method = 'echo'): array|null|string
 	{
 		return SMF\ServerSideIncludes::todaysCalendar($output_method);
 	}
@@ -9548,8 +9506,8 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	/**
 	 * Checks whether the specified password is correct for the specified user.
 	 *
-	 * @param int|string $id The ID or username of a user
-	 * @param string $password The password to check
+	 * @param int|null $id The ID of a user
+	 * @param string|null $password The password to check
 	 * @param bool $is_username If true, treats $id as a username rather than a user ID
 	 * @return bool Whether or not the password is correct.
 	 */
@@ -9591,7 +9549,7 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	 * Calculate the next time the passed tasks should be triggered.
 	 *
 	 * @param string|array $tasks The ID of a single task or an array of tasks
-	 * @param bool $forceUpdate Whether to force the tasks to run now
+	 * @param bool $force_update Whether to force the tasks to run now
 	 */
 	function CalculateNextTrigger(string|array $tasks = [], bool $force_update = false): void
 	{
@@ -9631,7 +9589,7 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	 * @param string $template_name The name of the template to load
 	 * @param array|string $style_sheets The name of a single stylesheet or an array of names of stylesheets to load
 	 * @param bool $fatal If true, dies with an error message if the template cannot be found
-	 * @return bool Whether or not the template was loaded
+	 * @return bool|null Whether or not the template was loaded
 	 */
 	function loadTemplate(string $template_name, string|array $style_sheets = [], bool $fatal = true): ?bool
 	{
@@ -9971,7 +9929,7 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	 *
 	 * @deprecated since 2.1
 	 * @param bool $use_user_offset This parameter is deprecated and nonfunctional
-	 * @param int $timestamp A timestamp (null to use current time)
+	 * @param int|null $timestamp A timestamp (null to use current time)
 	 * @return int Seconds since the Unix epoch
 	 */
 	function forum_time(bool $use_user_offset = true, ?int $timestamp = null): int
@@ -9986,7 +9944,7 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	/**
 	 * Get a list of time zones.
 	 *
-	 * @param string $when The date/time for which to calculate the time zone values.
+	 * @param int|string $when The date/time for which to calculate the time zone values.
 	 *		May be a Unix timestamp or any string that strtotime() can understand.
 	 *		Defaults to 'now'.
 	 * @return array An array of time zone identifiers and label text.
@@ -10001,7 +9959,7 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	 * (e.g. "America/Denver") onto the user-friendly "meta-zone" labels that
 	 * most people think of as time zones (e.g. "Mountain Time").
 	 *
-	 * @param string $when The date/time used to determine fallback values.
+	 * @param int|string $when The date/time used to determine fallback values.
 	 *		May be a Unix timestamp or any string that strtotime() can understand.
 	 *		Defaults to 'now'.
 	 * @return array An array relating time zones to "meta-zones"
@@ -10016,7 +9974,7 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	 * to population and/or political significance.
 	 *
 	 * @param string $country_code The two-character ISO-3166 code for a country.
-	 * @param string $when The date/time used to determine fallback values.
+	 * @param int|string $when The date/time used to determine fallback values.
 	 *		May be a Unix timestamp or any string that strtotime() can understand.
 	 *		Defaults to 'now'.
 	 * @return array An array relating time zones to "meta-zones"
@@ -10043,7 +10001,7 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	 * the TZDB changelog at https://data.iana.org/time-zones/tzdb/NEWS
 	 *
 	 * @param array $tzids The time zone identifiers to check.
-	 * @param string $when The date/time used to determine substitute values.
+	 * @param int|string $when The date/time used to determine substitute values.
 	 *		May be a Unix timestamp or any string that strtotime() can understand.
 	 *		Defaults to 'now'.
 	 * @return array Substitute values for any missing time zone identifiers.
@@ -10328,7 +10286,7 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	 *
 	 * Returns array with keys query_wanna_see_board and query_see_board
 	 *
-	 * @param int $userid of the user
+	 * @param int $id of the user
 	 */
 	function build_query_board(int $id): array
 	{
@@ -10378,7 +10336,7 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	/**
 	 * Gets a member's selected time zone identifier
 	 *
-	 * @param int $id_member The member id to look up. If not provided, the current user's id will be used.
+	 * @param int|null $id_member The member id to look up. If not provided, the current user's id will be used.
 	 * @return string The time zone identifier string for the user's time zone.
 	 */
 	function getUserTimezone(?int $id_member = null): string
@@ -10437,7 +10395,7 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	 * @param int $current_id_member The ID of the current member (to avoid false positives with the current member)
 	 * @param bool $is_name Whether we're checking against reserved names or just usernames
 	 * @param bool $fatal Whether to die with a fatal error if the name is reserved
-	 * @return bool|void False if name is not reserved, otherwise true if $fatal is false or dies with a fatal_lang_error if $fatal is true
+	 * @return bool False if name is not reserved, otherwise true if $fatal is false or dies with a fatal_lang_error if $fatal is true
 	 */
 	function isReservedName(string $name, int $current_id_member = 0, bool $is_name = true, bool $fatal = true): bool
 	{
@@ -10486,7 +10444,7 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	 * Takes possible moderators (on board 'board_id') into account.
 	 *
 	 * @param string $permission The permission to check
-	 * @param int $board_id If set, checks permission for that specific board
+	 * @param int|null $board_id If set, checks permission for that specific board
 	 * @return array An array containing the IDs of the members having that permission
 	 */
 	function membersAllowedTo(string $permission, ?int $board_id = null): array
@@ -10502,7 +10460,7 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	 * The function takes different permission settings into account.
 	 *
 	 * @param string $permission The permission to check
-	 * @param int $board_id = null If set, checks permissions for the specified board
+	 * @param int|null $board_id = null If set, checks permissions for the specified board
 	 * @return array An array containing two arrays - 'allowed', which has which groups are allowed to do it and 'denied' which has the groups that are denied
 	 */
 	function groupsAllowedTo(string $permission, ?int $board_id = null): array
@@ -10596,11 +10554,11 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	 * Loads an array of users' data by ID or member_name.
 	 *
 	 * @param array|string $users An array of users by id or name or a single username/id
-	 * @param bool $is_name Whether $users contains names
-	 * @param string $set What kind of data to load (normal, profile, minimal)
+	 * @param int $type
+	 * @param string|null $dataset What kind of data to load (normal, profile, minimal)
 	 * @return array The ids of the members loaded
 	 */
-	function loadMemberData($users = [], int $type = SMF\User::LOAD_BY_ID, ?string $dataset = null): array
+	function loadMemberData(array|string $users = [], int $type = SMF\User::LOAD_BY_ID, ?string $dataset = null): array
 	{
 		$loaded = SMF\User::load($users, $type, $dataset);
 
@@ -10673,7 +10631,7 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	 * Checks if the user is banned, and if so dies with an error.
 	 * Caches this information for optimization purposes.
 	 *
-	 * @param bool $forceCheck Whether to force a recheck
+	 * @param bool $force_check Whether to force a recheck
 	 */
 	function is_not_banned(bool $force_check = false): void
 	{
@@ -10699,7 +10657,7 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	 * Increment the hit counters for the specified ban ID's (if any.)
 	 *
 	 * @param array $ban_ids The IDs of the bans
-	 * @param string $email The email address associated with the user that triggered this hit
+	 * @param string|null $email The email address associated with the user that triggered this hit
 	 */
 	function log_ban(array $ban_ids = [], ?string $email = null): void
 	{
@@ -10713,7 +10671,7 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	 * Uses the adminLogin() function of Subs-Auth.php if they need to login, which saves all request (post and get) data.
 	 *
 	 * @param string $type What type of session this is
-	 * @param string $force When true, require a password even if we normally wouldn't
+	 * @param bool $force When true, require a password even if we normally wouldn't
 	 * @return ?string Returns 'session_verify_fail' if verification failed
 	 */
 	function validateSession(string $type = 'admin', bool $force = false): ?string
@@ -10747,7 +10705,7 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	 * Always returns true if the user is an administrator.
 	 *
 	 * @param string|array $permission A single permission to check or an array of permissions to check
-	 * @param int|array $boards The ID of a board or an array of board IDs if we want to check board-level permissions
+	 * @param int|array|null $boards The ID of a board or an array of board IDs if we want to check board-level permissions
 	 * @param bool $any Whether to check for permission on at least one board instead of all boards
 	 * @return bool Whether the user has the specified permission
 	 */
@@ -10770,7 +10728,7 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	 * If they are a guest and cannot do it, this calls is_not_guest().
 	 *
 	 * @param string|array $permission A single permission to check or an array of permissions to check
-	 * @param int|array $boards The ID of a single board or an array of board IDs if we're checking board-level permissions (null otherwise)
+	 * @param int|array|null $boards The ID of a single board or an array of board IDs if we're checking board-level permissions (null otherwise)
 	 * @param bool $any Whether to check for permission on at least one board instead of all boards
 	 */
 	function isAllowedTo(string|array $permission, int|array|null $boards = null, bool $any = false): bool
@@ -10865,10 +10823,11 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	 * - calls itself recursively if necessary.
 	 *
 	 * @param array|string $var The string or array of strings to add entites to
-	 * @param int $level Which level we're at within the array (if called recursively)
+	 * @param int $flags Bitmask of flags to pass to htmlspecialchars()
+	 * @param string $encoding Character encoding
 	 * @return array|string The string or array of strings with entities added
 	 */
-	function htmlspecialchars__recursive(array|string $var, int $flags = ENT_COMPAT, $encoding = 'UTF-8'): array|string
+	function htmlspecialchars__recursive(array|string $var, int $flags = ENT_COMPAT, string $encoding = 'UTF-8'): array|string
 	{
 		return SMF\Utils::htmlspecialcharsRecursive($var, $flags, $encoding);
 	}
@@ -10895,7 +10854,6 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	 * - may call itself recursively if needed.
 	 *
 	 * @param array|string $var The string or array of strings to trim
-	 * @param int $level = 0 How deep we're at within the array (if called recursively)
 	 * @return array|string The trimmed string or array of trimmed strings
 	 */
 	function htmltrim__recursive(array|string $var): array|string
@@ -10924,7 +10882,7 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	 * Chops a string into words and prepares them to be inserted into (or searched from) the database.
 	 *
 	 * @param string $string The text to split into words
-	 * @param int $max_length The maximum number of characters per word
+	 * @param int|null $max_length The maximum number of characters per word
 	 * @param bool $encrypt Whether to encrypt the results
 	 * @return array An array of ints or words depending on $encrypt
 	 */
@@ -10965,8 +10923,8 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	 * matches.
 	 *
 	 * @param array $strings An array of strings to make a regex for.
-	 * @param string $delim An optional delimiter character to pass to preg_quote().
-	 * @param bool $returnArray If true, returns an array of regexes.
+	 * @param string|null $delim An optional delimiter character to pass to preg_quote().
+	 * @param bool $return_array If true, returns an array of regexes.
 	 * @return string|array One or more regular expressions to match any of the input strings.
 	 */
 	function build_regex(array $strings, ?string $delim = null, bool $return_array = false): string|array
@@ -11065,8 +11023,7 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	 * Truncate an array to a specified length
 	 *
 	 * @param array $array The array to truncate
-	 * @param int $max_length The upperbound on the length
-	 * @param int $deep How levels in an multidimensional array should the function take into account.
+	 * @param int $max_length The upperbound on the length.
 	 * @return array The truncated array
 	 */
 	function truncate_array(array $array, int $max_length = 1900): array
@@ -11077,7 +11034,6 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	/**
 	 * array_length Recursive
 	 * @param array $array
-	 * @param int $deep How many levels should the function
 	 * @return int
 	 */
 	function array_length(array $array): int
@@ -11089,8 +11045,8 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	 * Wrapper function for json_decode() with error handling.
 	 *
 	 * @param string $json The string to decode.
-	 * @param bool $returnAsArray To return the decoded string as an array or an object, SMF only uses Arrays but to keep on compatibility with json_decode its set to false as default.
-	 * @param bool $logIt To specify if the error will be logged if theres any.
+	 * @param bool $associative To return the decoded string as an array or an object, SMF only uses Arrays but to keep on compatibility with json_decode its set to false as default.
+	 * @param bool $should_log To specify if the error will be logged if theres any.
 	 * @return array Either an empty array or the decoded data as an array.
 	 */
 	function smf_json_decode(string $json, bool $associative = false, bool $should_log = true): mixed
@@ -11124,7 +11080,7 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	 * Attempts to determine the MIME type of some data or a file.
 	 *
 	 * @param string $data The data to check, or the path or URL of a file to check.
-	 * @param string $is_path If true, $data is a path or URL to a file.
+	 * @param bool $is_path If true, $data is a path or URL to a file.
 	 * @return string|bool A MIME type, or false if we cannot determine it.
 	 */
 	function get_mime_type(string $data, bool $is_path = false): string|bool
@@ -11137,7 +11093,7 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	 *
 	 * @param string $data The data to check, or the path or URL of a file to check.
 	 * @param string $type_pattern A regex pattern to match the acceptable MIME types.
-	 * @param string $is_path If true, $data is a path or URL to a file.
+	 * @param bool $is_path If true, $data is a path or URL to a file.
 	 * @return int 1 if the detected MIME type matches the pattern, 0 if it doesn't, or 2 if we can't check.
 	 */
 	function check_mime_type(string $data, string $type_pattern, bool $is_path = false): int
@@ -11148,8 +11104,7 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	/**
 	 * Tries different modes to make file/dirs writable. Wrapper function for chmod()
 	 *
-	 * @param string $file The file/dir full path.
-	 * @param int $value Not needed, added for legacy reasons.
+	 * @param string $path The file/dir full path.
 	 * @return bool  true if the file/dir is already writable or the function was able to make it writable, false if the function couldn't make the file/dir writable.
 	 */
 	function smf_chmod(string $path): bool
@@ -11393,7 +11348,7 @@ if (!function_exists('smf_crc32')) {
 	 * https://php.net/crc32#79567
 	 *
 	 * @param string $number
-	 * @return string The crc32 polynomial of $number
+	 * @return int The crc32 polynomial of $number
 	 */
 	function smf_crc32($number)
 	{

--- a/Sources/Subscriptions/PayPal/Payment.php
+++ b/Sources/Subscriptions/PayPal/Payment.php
@@ -275,7 +275,7 @@ class Payment
 	/**
 	 * A private function to find out the subscription details.
 	 *
-	 * @return bool|void False on failure, otherwise just sets $_POST['item_number']
+	 * @return bool False on failure, otherwise just sets $_POST['item_number'] and returns true
 	 */
 	private function _findSubscription(): bool
 	{

--- a/Sources/TOTP/Auth.php
+++ b/Sources/TOTP/Auth.php
@@ -61,7 +61,7 @@ class Auth
 	 * Initialize the object and set up the lookup table
 	 *     Optionally the Initialization key
 	 *
-	 * @param string $initKey Initialization key
+	 * @param null|string $initKey Initialization key
 	 */
 	public function __construct(?string $initKey = null)
 	{
@@ -218,9 +218,9 @@ class Auth
 	 * Validate the given code
 	 *
 	 * @param string $code Code entered by user
-	 * @param string $initKey Initialization key
-	 * @param string $timestamp Timestamp for calculation
-	 * @param int $range Seconds before/after to validate hash against
+	 * @param null|string $initKey Initialization key
+	 * @param null|string $timestamp Timestamp for calculation
+	 * @param null|string $range Seconds before/after to validate hash against
 	 * @throws \InvalidArgumentException If incorrect code length
 	 * @return bool Pass/fail of validation
 	 */
@@ -248,8 +248,8 @@ class Auth
 	/**
 	 * Generate a one-time code
 	 *
-	 * @param string $initKey Initialization key [optional]
-	 * @param string $timestamp Timestamp for calculation [optional]
+	 * @param null|string $initKey Initialization key [optional]
+	 * @param null|string $timestamp Timestamp for calculation [optional]
 	 * @return string Generated code/hash
 	 */
 	public function generateOneTime(?string $initKey = null, ?string $timestamp = null): string

--- a/Sources/Tasks/UpdateUnicode.php
+++ b/Sources/Tasks/UpdateUnicode.php
@@ -840,7 +840,7 @@ class UpdateUnicode extends BackgroundTask
 	/**
 	 * Deletes a directory and its contents.
 	 *
-	 * @param string Path to directory
+	 * @param string $dir_path Path to directory
 	 */
 	private function deltree(string $dir_path): void
 	{

--- a/Sources/Time.php
+++ b/Sources/Time.php
@@ -180,7 +180,7 @@ class Time extends \DateTime implements \ArrayAccess
 	 *
 	 * @param string $datetime A date/time string that PHP can understand, or a
 	 *    Unix timestamp.
-	 * @param \DateTimeZone|string $timezone The time zone of $datetime, either
+	 * @param \DateTimeZone|string|null $timezone The time zone of $datetime, either
 	 *    as a \DateTimeZone object or as a time zone identifier string.
 	 *    Defaults to the current user's time zone.
 	 */
@@ -457,11 +457,11 @@ class Time extends \DateTime implements \ArrayAccess
 	 *
 	 *  - %c, %x, %X: Output will always use ISO 8601 format.
 	 *
-	 * @param string $format The format string to use. Defaults to the current
+	 * @param string|null $format The format string to use. Defaults to the current
 	 *    user's preferred time format.
-	 * @param bool $relative Whether to show "yesterday" and "today" for recent
+	 * @param bool|null $relative Whether to show "yesterday" and "today" for recent
 	 *    dates. Defaults to true if $format is empty, or false otherwise.
-	 * @param bool $strftime True if $format uses strftime format specifiers,
+	 * @param bool|null $strftime True if $format uses strftime format specifiers,
 	 *    false if it uses DateTime format specifiers. If null, attempts to
 	 *    detect the format type automatically.
 	 * @return string The formatted date and time.
@@ -722,7 +722,8 @@ class Time extends \DateTime implements \ArrayAccess
 	 *
 	 * @param \DateTimeZone|string $timezone The desired time zone. Can be a
 	 *    \DateTimeZone object or a valid time zone identifier string.
-	 * @return staitc An reference to this object.
+	 * @throws \ValueError if $timezone is invalid
+	 * @return static reference to this object.
 	 */
 	public function setTimezone(\DateTimeZone|string $timezone): static
 	{
@@ -748,7 +749,7 @@ class Time extends \DateTime implements \ArrayAccess
 	 *
 	 * @param string $datetime A date/time string that PHP can understand, or a
 	 *    Unix timestamp.
-	 * @param \DateTimeZone|string $timezone The time zone of $datetime, either
+	 * @param \DateTimeZone|string|null $timezone The time zone of $datetime, either
 	 *    as a \DateTimeZone object or as a time zone identifier string.
 	 *    Defaults to the current user's time zone.
 	 * @return self An instance of this class.
@@ -761,8 +762,8 @@ class Time extends \DateTime implements \ArrayAccess
 	/**
 	 * Convert a \DateTimeInterface object to a Time object.
 	 *
-	 * @param string $object A \DateTimeInterface object.
-	 * @param Time A Time object.
+	 * @param \DateTimeInterface $object A \DateTimeInterface object.
+	 * @return static
 	 */
 	public static function createFromInterface(\DateTimeInterface $object): static
 	{
@@ -772,8 +773,7 @@ class Time extends \DateTime implements \ArrayAccess
 	/**
 	 * Convert a \DateTime object to a Time object.
 	 *
-	 * @param string $object A \DateTime object.
-	 * @param Time A Time object.
+	 * @param \DateTime $object A \DateTime object.
 	 */
 	public static function createFromMutable(\DateTime $object): static
 	{
@@ -783,8 +783,7 @@ class Time extends \DateTime implements \ArrayAccess
 	/**
 	 * Convert a \DateTimeImmutable object to a Time object.
 	 *
-	 * @param string $object A \DateTimeImmutable object.
-	 * @param Time A Time object.
+	 * @param \DateTimeImmutable $object A \DateTimeImmutable object.
 	 */
 	public static function createFromImmutable(\DateTimeImmutable $object): static
 	{

--- a/Sources/Time.php
+++ b/Sources/Time.php
@@ -763,7 +763,7 @@ class Time extends \DateTime implements \ArrayAccess
 	 * Convert a \DateTimeInterface object to a Time object.
 	 *
 	 * @param \DateTimeInterface $object A \DateTimeInterface object.
-	 * @return static
+	 * @return static An instance of this class
 	 */
 	public static function createFromInterface(\DateTimeInterface $object): static
 	{
@@ -774,6 +774,7 @@ class Time extends \DateTime implements \ArrayAccess
 	 * Convert a \DateTime object to a Time object.
 	 *
 	 * @param \DateTime $object A \DateTime object.
+	 * @return static An instance of this class
 	 */
 	public static function createFromMutable(\DateTime $object): static
 	{
@@ -784,6 +785,7 @@ class Time extends \DateTime implements \ArrayAccess
 	 * Convert a \DateTimeImmutable object to a Time object.
 	 *
 	 * @param \DateTimeImmutable $object A \DateTimeImmutable object.
+	 * @return static An instance of this class
 	 */
 	public static function createFromImmutable(\DateTimeImmutable $object): static
 	{

--- a/Sources/TimeInterval.php
+++ b/Sources/TimeInterval.php
@@ -324,7 +324,7 @@ class TimeInterval extends \DateInterval implements \Stringable
 	/**
 	 * Convert a \DateInterval object into a TimeInterval object.
 	 *
-	 * @param string $object A \DateInterval object.
+	 * @param \DateInterval $object A \DateInterval object.
 	 * @return TimeInterval A TimeInterval object.
 	 */
 	public static function createFromDateInterval(\DateInterval $object): static

--- a/Sources/TimeZone.php
+++ b/Sources/TimeZone.php
@@ -1666,7 +1666,7 @@ class TimeZone extends \DateTimeZone
 	/**
 	 * Returns this time zone's abbreviations (if any).
 	 *
-	 * @param string $when The date/time we are interested in.
+	 * @param int|string $when The date/time we are interested in.
 	 *    May be a Unix timestamp or any string that strtotime() can understand.
 	 *    Defaults to 'now'.
 	 * @return array The time zone's abbreviations.
@@ -1687,7 +1687,7 @@ class TimeZone extends \DateTimeZone
 	/**
 	 * Returns the "meta-zone" for this time zone at the given timestamp.
 	 *
-	 * @param string $when The date/time we are interested in.
+	 * @param int|string $when The date/time we are interested in.
 	 *    May be a Unix timestamp or any string that strtotime() can understand.
 	 *    Defaults to 'now'.
 	 * @return string The $tztxt variable for this time zone's "meta-zone".
@@ -1729,7 +1729,7 @@ class TimeZone extends \DateTimeZone
 	/**
 	 * Returns the "meta-zone" label for this time zone at the given timestamp.
 	 *
-	 * @param string $when The date/time we are interested in.
+	 * @param int|string $when The date/time we are interested in.
 	 *    May be a Unix timestamp or any string that strtotime() can understand.
 	 *    Defaults to 'now'.
 	 * @return string The $tztxt value for this time zone's "meta-zone".
@@ -2153,7 +2153,7 @@ class TimeZone extends \DateTimeZone
 	 * Given a start time in any format that strtotime can understand, gets the
 	 * Unix timestamps for a date range starting then and ending one year later.
 	 *
-	 * @param string $when The date/time used to determine substitute values.
+	 * @param int|string $when The date/time used to determine substitute values.
 	 *    May be a Unix timestamp or any string that strtotime() can understand.
 	 *    Defaults to 'now'.
 	 * @return array The start and end timestamps, in that order.
@@ -2221,7 +2221,7 @@ class TimeZone extends \DateTimeZone
 	 * Builds a list of time zone transitions for all "meta-zones" starting from
 	 * $when until one year later.
 	 *
-	 * @param string $when The date/time used to determine substitute values.
+	 * @param int|string $when The date/time used to determine substitute values.
 	 *    May be a Unix timestamp or any string that strtotime() can understand.
 	 *    Defaults to 'now'.
 	 */

--- a/Sources/Topic.php
+++ b/Sources/Topic.php
@@ -383,7 +383,6 @@ class Topic implements \ArrayAccess, Routable
 	 *
 	 * @param int $id The ID number of the topic.
 	 * @param array $props Properties to set for this topic.
-	 * @return object An instance of this class.
 	 */
 	public function __construct(int $id, array $props = [])
 	{
@@ -671,7 +670,6 @@ class Topic implements \ArrayAccess, Routable
 	/**
 	 * Gets the IDs of messages in this topic that the current user likes.
 	 *
-	 * @param int $topic The topic ID to fetch the info from.
 	 * @return array IDs of messages in this topic that the current user likes.
 	 */
 	public function getLikedMsgs(): array

--- a/Sources/Unicode/Utf8String.php
+++ b/Sources/Unicode/Utf8String.php
@@ -68,7 +68,7 @@ class Utf8String implements \Stringable
 	 * Constructor.
 	 *
 	 * @param string $string The string.
-	 * @param string $language Two-character locale code for the language of
+	 * @param string|null $language Two-character locale code for the language of
 	 *    this string. If null, assumes the language currently in use by SMF
 	 *    (meaning the user's language, falling back to the forum's default).
 	 */
@@ -992,7 +992,7 @@ class Utf8String implements \Stringable
 	 * This is just syntactical sugar to ease method chaining.
 	 *
 	 * @param string $string The string.
-	 * @param string $language Two-character locale code for the language of
+	 * @param string|null $language Two-character locale code for the language of
 	 *    this string.
 	 * @return object An instance of this class.
 	 */

--- a/Sources/User.php
+++ b/Sources/User.php
@@ -1502,7 +1502,7 @@ class User implements \ArrayAccess
 	 * with a message telling them why. If $message is empty, a default message
 	 * will be used.
 	 *
-	 * @param string $message The message to display to the guest.
+	 * @param string|null $message The message to display to the guest.
 	 * @param bool $log Whether to log what they were trying to do.
 	 */
 	public function kickIfGuest(?string $message = null, bool $log = true): void
@@ -1847,7 +1847,7 @@ class User implements \ArrayAccess
 	 * Increments the hit counters for the specified ban ID's (if any).
 	 *
 	 * @param array $ban_ids The IDs of the bans.
-	 * @param string $email The email address associated with the user that
+	 * @param string|null $email The email address associated with the user that
 	 *    triggered this hit. If not set, uses the current user's email address.
 	 */
 	public function logBan(array $ban_ids = [], ?string $email = null): void
@@ -2224,7 +2224,7 @@ class User implements \ArrayAccess
 	 * If the user is a guest and cannot do it, calls $this->kickIfGuest().
 	 *
 	 * @param string|array $permissions One or more permissions to check.
-	 * @param int|array $boards The ID of a board or an array of board IDs if we
+	 * @param int|array|null $boards The ID of a board or an array of board IDs if we
 	 *    want to check board-level permissions
 	 * @param bool $any Whether to check for permission on at least one board
 	 *    instead of all the passed boards.
@@ -2434,7 +2434,7 @@ class User implements \ArrayAccess
 	 * @param mixed $users Users specified by ID, name, or email address.
 	 * @param int $type Whether $users contains IDs, names, or email addresses.
 	 *    Possible values are this class's LOAD_BY_* constants.
-	 * @param string $dataset What kind of data to load: 'profile', 'normal',
+	 * @param string|null $dataset What kind of data to load: 'profile', 'normal',
 	 *    'basic', 'minimal'. Leave null for a dynamically determined default.
 	 * @return array Instances of this class for the loaded users.
 	 */
@@ -2474,7 +2474,7 @@ class User implements \ArrayAccess
 	 * Reloads an array of users, specified by ID number.
 	 *
 	 * @param int|array $users One or more users specified by ID.
-	 * @param string $dataset What kind of data to load: 'profile', 'normal',
+	 * @param string|null $dataset What kind of data to load: 'profile', 'normal',
 	 *    'basic', 'minimal'. Leave null for a dynamically determined default.
 	 * @return array The ids of the loaded members.
 	 */
@@ -2978,7 +2978,7 @@ class User implements \ArrayAccess
 	/**
 	 * Gets a member's selected time zone identifier
 	 *
-	 * @param int $id_member The member id to look up. If not provided, the current user's id will be used.
+	 * @param int|null $id_member The member id to look up. If not provided, the current user's id will be used.
 	 * @return string The time zone identifier string for the user's time zone.
 	 */
 	public static function getTimezone(?int $id_member = null): string
@@ -3795,7 +3795,7 @@ class User implements \ArrayAccess
 	 * Pass in 0 as a special case to fetch moderators on all boards.
 	 *
 	 * @param string $permission The permission to check.
-	 * @param int $board_id If set, checks permission for that specific board.
+	 * @param int|null $board_id If set, checks permission for that specific board.
 	 * @return array IDs of the members who have that permission.
 	 */
 	public static function getAllowedTo(string $permission, ?int $board_id = null): array
@@ -3929,7 +3929,7 @@ class User implements \ArrayAccess
 	/**
 	 * Constructor. Protected in order to force instantiation via User::load().
 	 *
-	 * @param int $id The ID number of the user, or null for current user.
+	 * @param int|null $id The ID number of the user, or null for current user.
 	 * @param string|null $dataset What kind of data to load.
 	 *    Can be one of 'profile', 'normal', 'basic', or 'minimal'.
 	 *    If left null, the default depends on the value of $id:

--- a/Sources/Utils.php
+++ b/Sources/Utils.php
@@ -724,7 +724,7 @@ class Utils
 	 *
 	 * @param string $string The input string.
 	 * @param int $offset Offset where substring will start.
-	 * @param int $length Maximum length, in characters, of the substring.
+	 * @param int|null $length Maximum length, in characters, of the substring.
 	 * @return string The substring.
 	 */
 	public static function entitySubstr(string $string, int $offset, ?int $length = null): string
@@ -1001,7 +1001,7 @@ class Utils
 	 * array in order to test all possible matches.
 	 *
 	 * @param array $strings An array of strings to make a regex for.
-	 * @param string $delim Optional delimiter character to pass to preg_quote().
+	 * @param string|null $delim Optional delimiter character to pass to preg_quote().
 	 * @param bool $return_array If true, returns an array of regexes.
 	 * @return string|array One or more regular expressions to match any of the
 	 *    input strings.
@@ -1830,7 +1830,7 @@ class Utils
 	 * Attempts to determine the MIME type of some data or a file.
 	 *
 	 * @param string $data The data to check, or the path or URL of a file to check.
-	 * @param string $is_path If true, $data is a path or URL to a file.
+	 * @param bool $is_path If true, $data is a path or URL to a file.
 	 * @return string|false A MIME type, or false if we cannot determine it.
 	 */
 	public static function getMimeType(string $data, bool $is_path = false): string|false
@@ -2178,7 +2178,7 @@ class Utils
 	 *
 	 * @param string $data The data to print
 	 * @param string $type The content type. Defaults to JSON.
-	 * @return bool|void If $data is empty, false is returned, otherwise the response is sent and execution stopped.
+	 * @return bool|null If $data is empty, false is returned, otherwise the response is sent and execution stopped.
 	 */
 	public static function serverResponse(string $data = '', string $type = 'Content-Type: application/json'): ?bool
 	{

--- a/Sources/Uuid.php
+++ b/Sources/Uuid.php
@@ -202,7 +202,7 @@ class Uuid implements \Stringable
 	protected static string $node;
 
 	/**
-	 * @var object
+	 * @var \DateTimeZone
 	 *
 	 * A \DateTimeZone object for UTC.
 	 */
@@ -231,7 +231,7 @@ class Uuid implements \Stringable
 	 * preserve or enforce a particular position in a sorting sequence, so the
 	 * ability to do so is available.
 	 *
-	 * @param int $version The UUID version to create.
+	 * @param int|null $version The UUID version to create.
 	 * @param mixed $input Input for the UUID generator, if applicable.
 	 */
 	public function __construct(?int $version = null, mixed $input = null)
@@ -404,7 +404,7 @@ class Uuid implements \Stringable
 	 * This is just syntactical sugar to simplify method chaining and procedural
 	 * coding styles, much like `date_create()` does for `new \DateTime()`.
 	 *
-	 * @param int $version The UUID version to create.
+	 * @param int|null $version The UUID version to create.
 	 * @param mixed $input Input for the UUID generator, if applicable.
 	 * @return Uuid A new Uuid object.
 	 */
@@ -932,7 +932,7 @@ class Uuid implements \Stringable
 	/**
 	 * Sets $this->timestamp to a microsecond-precision Unix timestamp.
 	 *
-	 * @param \Stringable|string|int|float $input A timestamp or date string.
+	 * @param \Stringable|string|int|float|null $input A timestamp or date string.
 	 *    Default: 'now'.
 	 */
 	protected function setTimestamp(\Stringable|string|int|float|null $input = 'now'): void

--- a/Sources/Uuid.php
+++ b/Sources/Uuid.php
@@ -932,10 +932,10 @@ class Uuid implements \Stringable
 	/**
 	 * Sets $this->timestamp to a microsecond-precision Unix timestamp.
 	 *
-	 * @param \Stringable|string|int|float|null $input A timestamp or date string.
+	 * @param \Stringable|string|int|float $input A timestamp or date string.
 	 *    Default: 'now'.
 	 */
-	protected function setTimestamp(\Stringable|string|int|float|null $input = 'now'): void
+	protected function setTimestamp(\Stringable|string|int|float $input = 'now'): void
 	{
 		$input = (string) $input;
 

--- a/Sources/Verifier.php
+++ b/Sources/Verifier.php
@@ -139,7 +139,7 @@ class Verifier implements \ArrayAccess
 	public int $tracking = 0;
 
 	/**
-	 * @var string
+	 * @var string|null
 	 *
 	 *
 	 */
@@ -187,7 +187,6 @@ class Verifier implements \ArrayAccess
 	 *
 	 * @param array $options Options for the verification control.
 	 * @param bool $do_test Whether to check to see if the user entered the code correctly.
-	 * @return bool|array False if there's nothing to show, true if everything went well or an array containing error indicators if the test failed.
 	 */
 	public function __construct(array $options, bool $do_test = false)
 	{

--- a/Sources/WebFetch/APIs/CurlFetcher.php
+++ b/Sources/WebFetch/APIs/CurlFetcher.php
@@ -276,7 +276,7 @@ class CurlFetcher extends WebFetchApi
 	 *  - Called as ->result() will return the full final array.
 	 *  - Called as ->result('body') to return the page source of the result.
 	 *
-	 * @param string $area Used to return an area such as body, header, error.
+	 * @param null|string $area Used to return an area such as body, header, error.
 	 * @return mixed The response
 	 */
 	public function result(?string $area = null): mixed
@@ -297,7 +297,7 @@ class CurlFetcher extends WebFetchApi
 	 *  - Can be called as ->result_raw(x) where x is a specific loop's result.
 	 *  - Call as ->result_raw() for everything.
 	 *
-	 * @param int $response_number Which response to get, or null for all.
+	 * @param null|int $response_number Which response to get, or null for all.
 	 * @return array The specified response or all the responses.
 	 */
 	public function resultRaw(?int $response_number = null): array

--- a/Sources/WebFetch/APIs/FtpFetcher.php
+++ b/Sources/WebFetch/APIs/FtpFetcher.php
@@ -86,8 +86,8 @@ class FtpFetcher extends WebFetchApi
 	/**
 	 * Constructor.
 	 *
-	 * @param string $user User name to connect with. If null, uses 'anonymous'.
-	 * @param string $email Email address to connect with. Defaults to
+	 * @param null|string $user User name to connect with. If null, uses 'anonymous'.
+	 * @param null|string $email Email address to connect with. Defaults to
 	 *    Config::$webmaster_email, or 'nobody@example.com' if that is not set.
 	 */
 	public function __construct(?string $user = null, ?string $email = null)
@@ -188,7 +188,7 @@ class FtpFetcher extends WebFetchApi
 	 *  - Called as ->result() will return the full final array.
 	 *  - Called as ->result('body') to return the page source of the result.
 	 *
-	 * @param string $area Used to return an area such as body, header, error.
+	 * @param null|string $area Used to return an area such as body, header, error.
 	 * @return mixed The response
 	 */
 	public function result(?string $area = null): mixed
@@ -205,7 +205,7 @@ class FtpFetcher extends WebFetchApi
 	 * Since this class doesn't support redirects, this method is practically
 	 * useless, but it's required to comply with FetcherApiInterface.
 	 *
-	 * @param int $response_number Which response to get, or null for all.
+	 * @param null|int $response_number Which response to get, or null for all.
 	 * @return array The specified response or all the responses.
 	 */
 	public function resultRaw(?int $response_number = null): array

--- a/Sources/WebFetch/APIs/SocketFetcher.php
+++ b/Sources/WebFetch/APIs/SocketFetcher.php
@@ -364,7 +364,7 @@ class SocketFetcher extends WebFetchApi
 	 *  - Called as ->result() will return the full final array.
 	 *  - Called as ->result('body') to return the page source of the result.
 	 *
-	 * @param string $area Used to return an area such as body, header, error.
+	 * @param string|null $area Used to return an area such as body, header, error.
 	 * @return mixed The response.
 	 */
 	public function result(?string $area = null): mixed
@@ -385,7 +385,7 @@ class SocketFetcher extends WebFetchApi
 	 *  - Can be called as ->result_raw(x) where x is a specific loop's result.
 	 *  - Call as ->result_raw() for everything.
 	 *
-	 * @param int $response_number Which response to get, or null for all.
+	 * @param int|null $response_number Which response to get, or null for all.
 	 * @return array The specified response or all the responses.
 	 */
 	public function resultRaw(?int $response_number = null): array

--- a/Sources/WebFetch/WebFetchApiInterface.php
+++ b/Sources/WebFetch/WebFetchApiInterface.php
@@ -28,8 +28,8 @@ interface WebFetchApiInterface
 	 *    Passed arrays will be converted to a POST string joined with &'s.
 	 *
 	 * @param string $url the site we are going to fetch
-	 * @param array|string $post_data any post data as form name => value
-	 * @return object A reference to the object for method chaining.
+	 * @param array $post_data any post data as form name => value
+	 * @return object|null A reference to the object for method chaining.
 	 */
 	public function request(string $url, array $post_data = []): ?object;
 
@@ -39,7 +39,7 @@ interface WebFetchApiInterface
 	 *  - called as ->result() will return the full final array.
 	 *  - called as ->result('body') to return the page source of the result.
 	 *
-	 * @param string $area Used to return an area such as body, header, error.
+	 * @param string|null $area Used to return an area such as body, header, error.
 	 * @return mixed The response.
 	 */
 	public function result(?string $area = null): mixed;
@@ -50,7 +50,7 @@ interface WebFetchApiInterface
 	 *  - Can be called as ->result_raw(x) where x is a specific loop's result.
 	 *  - Call as ->result_raw() for everything.
 	 *
-	 * @param int $response_number Which response to get, or null for all.
+	 * @param int|null $response_number Which response to get, or null for all.
 	 * @return array The specified response or all the responses.
 	 */
 	public function resultRaw(?int $response_number = null): array;

--- a/Sources/ZxcvbnPhp/Matchers/ReverseDictionaryMatch.php
+++ b/Sources/ZxcvbnPhp/Matchers/ReverseDictionaryMatch.php
@@ -14,7 +14,7 @@ class ReverseDictionaryMatch extends DictionaryMatch
     /**
      * Match occurences of reversed dictionary words in password.
      *
-     * @param string $password
+     * @param $password
      * @param array $userInputs
      * @param array $rankedDictionaries
      * @return ReverseDictionaryMatch[]

--- a/Sources/ZxcvbnPhp/Matchers/ReverseDictionaryMatch.php
+++ b/Sources/ZxcvbnPhp/Matchers/ReverseDictionaryMatch.php
@@ -14,7 +14,7 @@ class ReverseDictionaryMatch extends DictionaryMatch
     /**
      * Match occurences of reversed dictionary words in password.
      *
-     * @param $password
+     * @param string $password
      * @param array $userInputs
      * @param array $rankedDictionaries
      * @return ReverseDictionaryMatch[]

--- a/Sources/ZxcvbnPhp/TimeEstimator.php
+++ b/Sources/ZxcvbnPhp/TimeEstimator.php
@@ -13,7 +13,7 @@ namespace ZxcvbnPhp;
 class TimeEstimator
 {
     /**
-     * @param float $guesses
+     * @param $guesses
      * @return array
      */
     public function estimateAttackTimes(float $guesses): array

--- a/Sources/ZxcvbnPhp/TimeEstimator.php
+++ b/Sources/ZxcvbnPhp/TimeEstimator.php
@@ -13,7 +13,7 @@ namespace ZxcvbnPhp;
 class TimeEstimator
 {
     /**
-     * @param int|float $guesses
+     * @param float $guesses
      * @return array
      */
     public function estimateAttackTimes(float $guesses): array

--- a/Sources/minify/src/CSS.php
+++ b/Sources/minify/src/CSS.php
@@ -292,12 +292,12 @@ class CSS extends Minify
      * Minify the data.
      * Perform CSS optimizations.
      *
-     * @param string[optional] $path    Path to write the data to
-     * @param string[] $parents Parent paths, for circular reference checks
+     * @param string|null $path    Path to write the data to
+     * @param array $parents Parent paths, for circular reference checks
      *
      * @return string The minified data
      */
-    public function execute($path = null, $parents = array())
+    public function execute(?string $path = null, array $parents = array()) : string
     {
         $content = '';
 

--- a/Sources/minify/src/CSS.php
+++ b/Sources/minify/src/CSS.php
@@ -292,12 +292,12 @@ class CSS extends Minify
      * Minify the data.
      * Perform CSS optimizations.
      *
-     * @param string|null $path    Path to write the data to
-     * @param array $parents Parent paths, for circular reference checks
+     * @param string[optional] $path    Path to write the data to
+     * @param string[] $parents Parent paths, for circular reference checks
      *
      * @return string The minified data
      */
-    public function execute(?string $path = null, array $parents = array()) : string
+    public function execute($path = null, array $parents = array()) : string
     {
         $content = '';
 

--- a/Sources/minify/src/JS.php
+++ b/Sources/minify/src/JS.php
@@ -143,11 +143,11 @@ class JS extends Minify
      * Minify the data.
      * Perform JS optimizations.
      *
-     * @param string[optional] $path Path to write the data to
+     * @param string|null $path Path to write the data to
      *
      * @return string The minified data
      */
-    public function execute($path = null)
+    public function execute(?string $path = null) : string
     {
         $content = '';
 

--- a/Sources/minify/src/JS.php
+++ b/Sources/minify/src/JS.php
@@ -143,11 +143,11 @@ class JS extends Minify
      * Minify the data.
      * Perform JS optimizations.
      *
-     * @param string|null $path Path to write the data to
+     * @param string[optional] $path Path to write the data to
      *
      * @return string The minified data
      */
-    public function execute(?string $path = null) : string
+    public function execute($path = null) : string
     {
         $content = '';
 

--- a/Sources/minify/src/Minify.php
+++ b/Sources/minify/src/Minify.php
@@ -143,11 +143,11 @@ abstract class Minify
     /**
      * Minify the data & (optionally) saves it to a file.
      *
-     * @param string|null $path Path to write the data to
+     * @param string[optional] $path Path to write the data to
      *
      * @return string The minified data
      */
-    public function minify(?string $path = null) : string
+    public function minify($path = null) : string
     {
         $content = $this->execute($path);
 
@@ -165,12 +165,12 @@ abstract class Minify
     /**
      * Minify & gzip the data & (optionally) saves it to a file.
      *
-     * @param string|null $path  Path to write the data to
-     * @param int         $level Compression level, from 0 to 9
+     * @param string[optionl] $path  Path to write the data to
+     * @param int[optional] $level Compression level, from 0 to 9
      *
      * @return string The minified & gzipped data
      */
-    public function gzip(?string $path = null, int $level = 9) : string
+    public function gzip($path = null, $level = 9) : string
     {
         $content = $this->execute($path);
         $content = gzencode($content, $level, FORCE_GZIP);
@@ -201,7 +201,7 @@ abstract class Minify
     /**
      * Minify the data.
      *
-     * @param string|null $path Path to write the data to
+     * @param string[optional] $path Path to write the data to
      *
      * @return string The minified data
      */
@@ -214,7 +214,7 @@ abstract class Minify
      *
      * @return string
      */
-    protected function load(string $data) : string
+    protected function load($data) : string
     {
         // check if the data is a file
         if ($this->canImportFile($data)) {
@@ -421,10 +421,10 @@ abstract class Minify
      * and after doing all other minifying, we can restore the original content
      * via restoreStrings().
      *
-     * @param string $chars
-     * @param string $placeholderPrefix
+     * @param string[optional] $chars
+     * @param string[optional] $placeholderPrefix
      */
-    protected function extractStrings(string $chars = '\'"', string $placeholderPrefix = '')
+    protected function extractStrings($chars = '\'"', $placeholderPrefix = '')
     {
         // PHP only supports $this inside anonymous functions since 5.4
         $minifier = $this;

--- a/Sources/minify/src/Minify.php
+++ b/Sources/minify/src/Minify.php
@@ -143,11 +143,11 @@ abstract class Minify
     /**
      * Minify the data & (optionally) saves it to a file.
      *
-     * @param string[optional] $path Path to write the data to
+     * @param string|null $path Path to write the data to
      *
      * @return string The minified data
      */
-    public function minify($path = null)
+    public function minify(?string $path = null) : string
     {
         $content = $this->execute($path);
 
@@ -165,12 +165,12 @@ abstract class Minify
     /**
      * Minify & gzip the data & (optionally) saves it to a file.
      *
-     * @param string[optional] $path  Path to write the data to
-     * @param int[optional]    $level Compression level, from 0 to 9
+     * @param string|null $path  Path to write the data to
+     * @param int         $level Compression level, from 0 to 9
      *
      * @return string The minified & gzipped data
      */
-    public function gzip($path = null, $level = 9)
+    public function gzip(?string $path = null, int $level = 9) : string
     {
         $content = $this->execute($path);
         $content = gzencode($content, $level, FORCE_GZIP);
@@ -201,11 +201,11 @@ abstract class Minify
     /**
      * Minify the data.
      *
-     * @param string[optional] $path Path to write the data to
+     * @param string|null $path Path to write the data to
      *
      * @return string The minified data
      */
-    abstract public function execute($path = null);
+    abstract public function execute(?string $path = null) : string;
 
     /**
      * Load data.
@@ -214,7 +214,7 @@ abstract class Minify
      *
      * @return string
      */
-    protected function load($data)
+    protected function load(string $data) : string
     {
         // check if the data is a file
         if ($this->canImportFile($data)) {
@@ -421,10 +421,10 @@ abstract class Minify
      * and after doing all other minifying, we can restore the original content
      * via restoreStrings().
      *
-     * @param string[optional] $chars
-     * @param string[optional] $placeholderPrefix
+     * @param string $chars
+     * @param string $placeholderPrefix
      */
-    protected function extractStrings($chars = '\'"', $placeholderPrefix = '')
+    protected function extractStrings(string $chars = '\'"', string $placeholderPrefix = '')
     {
         // PHP only supports $this inside anonymous functions since 5.4
         $minifier = $this;

--- a/other/Settings.php
+++ b/other/Settings.php
@@ -15,7 +15,7 @@
 
 ########## Maintenance ##########
 /**
- * @var int 0, 1, 2
+ * @var int
  *
  * The maintenance "mode":
  * 0: Disable maintenance mode. This is the default.


### PR DESCRIPTION
#### Description
This massive PR fixes various issues with phpDoc tags:
- Ensures property type in @bool tags matches function declaration
- Removes tags for non-existent parameters
- Ensures return type speciifed in docs matches actual return type
