### PR TITLE
[3.0] Makes approve_group_requests a real (albeit special) permission

### DIFF
--- a/Sources/Actions/Profile/Main.php
+++ b/Sources/Actions/Profile/Main.php
@@ -578,12 +578,6 @@ class Main implements ActionInterface, Routable
 			ErrorHandler::fatalLang('no_access', false);
 		}
 
-		// Group management isn't actually a permission. But we need it to be for this, so we need a phantom permission.
-		// And we care about what the current user can do, not what the user whose profile it is.
-		if (User::$me->mod_cache['gq'] != '0=1') {
-			User::$me->permission_sets[0]->grant('approve_group_requests');
-		}
-
 		// If paid subscriptions are enabled, make sure we actually have at least one subscription available...
 		Utils::$context['subs_available'] = false;
 

--- a/Sources/Permissions/Permission.php
+++ b/Sources/Permissions/Permission.php
@@ -242,6 +242,14 @@ class Permission implements \ArrayAccess
 			'scope' => 'board',
 			'never_guests' => true,
 		],
+		'approve_group_requests' => [
+			'scope' => 'global',
+			'hidden' => true,
+			'never_guests' => true,
+			// This permission isn't permanently assignable.
+			// It is granted to group moderators only while they are logged in.
+			'can_assign' => false,
+		],
 		'approve_posts' => [
 			'view_group' => 'general_board',
 			'scope' => 'board',

--- a/Sources/User.php
+++ b/Sources/User.php
@@ -945,6 +945,11 @@ class User implements \ArrayAccess
 		if (!isset($boards)) {
 			$this->loadModCache();
 
+			// Can this user approve group requests?
+			if (($this->mod_cache['gq'] ?? '0=1') != '0=1') {
+				$this->permission_sets[0]->grant('approve_group_requests');
+			}
+
 			// A user can mod if they have permission to see the mod center, or they are a board/group/approval moderator.
 			$this->can_mod = (
 				$this->is_admin


### PR DESCRIPTION
Fixes an unknown permission error message that could occur under certain circumstances during AJAX requests.