### PR TITLE
More backcompat fixes

### DIFF
--- a/Sources/Actions/Announce.php
+++ b/Sources/Actions/Announce.php
@@ -18,6 +18,7 @@ namespace SMF\Actions;
 use SMF\ActionInterface;
 use SMF\ActionRouter;
 use SMF\ActionTrait;
+use SMF\BackwardCompatibility;
 use SMF\Board;
 use SMF\BrowserDetector;
 use SMF\Config;

--- a/Sources/Actions/Calendar.php
+++ b/Sources/Actions/Calendar.php
@@ -17,6 +17,7 @@ namespace SMF\Actions;
 
 use SMF\ActionInterface;
 use SMF\ActionTrait;
+use SMF\BackwardCompatibility;
 use SMF\Board;
 use SMF\BrowserDetector;
 use SMF\Cache\CacheApi;

--- a/Sources/Actions/Groups.php
+++ b/Sources/Actions/Groups.php
@@ -16,6 +16,7 @@ namespace SMF\Actions;
 use SMF\ActionInterface;
 use SMF\ActionRouter;
 use SMF\ActionTrait;
+use SMF\BackwardCompatibility;
 use SMF\Config;
 use SMF\Db\DatabaseApi as Db;
 use SMF\ErrorHandler;

--- a/Sources/Actions/Help.php
+++ b/Sources/Actions/Help.php
@@ -18,6 +18,7 @@ namespace SMF\Actions;
 use SMF\ActionInterface;
 use SMF\ActionRouter;
 use SMF\ActionTrait;
+use SMF\BackwardCompatibility;
 use SMF\Config;
 use SMF\IntegrationHook;
 use SMF\Lang;

--- a/Sources/Actions/Memberlist.php
+++ b/Sources/Actions/Memberlist.php
@@ -18,6 +18,7 @@ namespace SMF\Actions;
 use SMF\ActionInterface;
 use SMF\ActionRouter;
 use SMF\ActionTrait;
+use SMF\BackwardCompatibility;
 use SMF\Config;
 use SMF\Db\DatabaseApi as Db;
 use SMF\ErrorHandler;

--- a/Sources/Actions/PersonalMessage.php
+++ b/Sources/Actions/PersonalMessage.php
@@ -18,6 +18,7 @@ namespace SMF\Actions;
 use SMF\ActionInterface;
 use SMF\ActionRouter;
 use SMF\ActionTrait;
+use SMF\BackwardCompatibility;
 use SMF\BrowserDetector;
 use SMF\Cache\CacheApi;
 use SMF\Config;

--- a/Sources/Actions/Post.php
+++ b/Sources/Actions/Post.php
@@ -19,6 +19,7 @@ use SMF\ActionInterface;
 use SMF\ActionSuffixRouter;
 use SMF\ActionTrait;
 use SMF\Attachment;
+use SMF\BackwardCompatibility;
 use SMF\Board;
 use SMF\Cache\CacheApi;
 use SMF\Calendar\Event;

--- a/Sources/Actions/ReportToMod.php
+++ b/Sources/Actions/ReportToMod.php
@@ -18,6 +18,7 @@ namespace SMF\Actions;
 use SMF\ActionInterface;
 use SMF\ActionRouter;
 use SMF\ActionTrait;
+use SMF\BackwardCompatibility;
 use SMF\Config;
 use SMF\Db\DatabaseApi as Db;
 use SMF\ErrorHandler;

--- a/Sources/Actions/TopicMerge.php
+++ b/Sources/Actions/TopicMerge.php
@@ -19,6 +19,7 @@ namespace SMF\Actions;
 
 use SMF\ActionInterface;
 use SMF\ActionTrait;
+use SMF\BackwardCompatibility;
 use SMF\Board;
 use SMF\Cache\CacheApi;
 use SMF\Config;

--- a/Sources/Actions/TopicSplit.php
+++ b/Sources/Actions/TopicSplit.php
@@ -21,6 +21,7 @@ use SMF\ActionInterface;
 use SMF\ActionSuffixRouter;
 use SMF\ActionTrait;
 use SMF\Autolinker;
+use SMF\BackwardCompatibility;
 use SMF\Board;
 use SMF\Config;
 use SMF\Db\DatabaseApi as Db;

--- a/Sources/Actions/XmlHttp.php
+++ b/Sources/Actions/XmlHttp.php
@@ -19,6 +19,7 @@ use SMF\ActionInterface;
 use SMF\ActionRouter;
 use SMF\Actions\Admin\News;
 use SMF\ActionTrait;
+use SMF\BackwardCompatibility;
 use SMF\Board;
 use SMF\Config;
 use SMF\Db\DatabaseApi as Db;


### PR DESCRIPTION
#### Description
Fixes files that have the SMF\Actions namespace with a "use BackwardCompatibility" statement but no "use SMF\BackwardCompatibility".
