### PR TITLE
[3.0] PHP-CS-Fixer improvements

### DIFF
--- a/.github/phpcs/SectionComments.php
+++ b/.github/phpcs/SectionComments.php
@@ -1,0 +1,294 @@
+<?php
+
+/**
+ * This file is modified from original CS fixer source code.
+ *
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2025 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 2
+ */
+declare(strict_types=1);
+
+namespace SMF\Fixer\ClassNotation;
+
+use PhpCsFixer\AbstractFixer;
+use PhpCsFixer\Fixer\WhitespacesAwareFixerInterface;
+use PhpCsFixer\Fixer\Whitespace;
+use PhpCsFixer\FixerDefinition\CodeSample;
+use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
+use PhpCsFixer\Tokenizer\Tokens;
+use PhpCsFixer\Tokenizer\Token;
+
+/**
+ * Ensure line endings match SMF standards.
+ *
+ * @author Jon Stovell
+ */
+final class SectionComments extends AbstractFixer implements WhitespacesAwareFixerInterface
+{
+	public function getName(): string
+	{
+		return 'SMF/section_comments';
+	}
+
+	public function getDefinition(): FixerDefinitionInterface
+	{
+		return new FixerDefinition(
+			'Inserts sectioning comments. This is meant to be used in combination with the `ordered_class_elements` rule.',
+			[
+				new CodeSample(<<<'END'
+					<?php
+
+					class Foo
+					{
+						/**
+						 *
+						 */
+						const MY_CONSTANT = 1;
+
+						/**
+						 *
+						 */
+						public string $a = '';
+
+						/**
+						 *
+						 */
+						protected string $b = '';
+
+						/**
+						 *
+						 */
+						private string $c = '';
+
+						/**
+						 *
+						 */
+						public static string $d = '';
+
+						/**
+						 *
+						 */
+						protected static string $e = '';
+
+						/**
+						 *
+						 */
+						private static string $f = '';
+
+						/**
+						 *
+						 */
+						public function method1(): void {}
+
+						/**
+						 *
+						 */
+						protected function method2(): void {}
+
+						/**
+						 *
+						 */
+						private function method3(): void {}
+
+						/**
+						 *
+						 */
+						public static function method4(): void {}
+
+						/**
+						 *
+						 */
+						protected static function method5(): void {}
+
+						/**
+						 *
+						 */
+						private static function method6(): void {}
+					}
+
+					END),
+			]
+		);
+	}
+
+	public function getPriority(): int
+	{
+		return -110;
+	}
+
+	public function isCandidate(Tokens $tokens): bool
+	{
+		foreach ($tokens as $token) {
+			if ($token->isClassy()) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	protected function applyFix(\SplFileInfo $file, Tokens $tokens): void
+	{
+		$found = [
+			'const' => false,
+			'public_property' => false,
+			'public_static_property' => false,
+			'internal_property' => false,
+			'internal_static_property' => false,
+			'public_method' => false,
+			'public_static_method' => false,
+			'internal_method' => false,
+			'internal_static_method' => false,
+		];
+
+		$comments = [
+			'const' => implode($this->whitespacesConfig->getLineEnding() . $this->whitespacesConfig->getIndent(), [
+				'/*****************',
+				' * Class constants',
+				' *****************/',
+			]),
+			'public_property' => implode($this->whitespacesConfig->getLineEnding() . $this->whitespacesConfig->getIndent(), [
+				'/*******************',
+				' * Public properties',
+				' *******************/',
+			]),
+			'public_static_property' => implode($this->whitespacesConfig->getLineEnding() . $this->whitespacesConfig->getIndent(), [
+				'/**************************',
+				' * Public static properties',
+				' **************************/',
+			]),
+			'internal_property' => implode($this->whitespacesConfig->getLineEnding() . $this->whitespacesConfig->getIndent(), [
+				'/*********************',
+				' * Internal properties',
+				' *********************/',
+			]),
+			'internal_static_property' => implode($this->whitespacesConfig->getLineEnding() . $this->whitespacesConfig->getIndent(), [
+				'/****************************',
+				' * Internal static properties',
+				' ****************************/',
+			]),
+			'public_method' => implode($this->whitespacesConfig->getLineEnding() . $this->whitespacesConfig->getIndent(), [
+				'/****************',
+				' * Public methods',
+				' ****************/',
+			]),
+			'public_static_method' => implode($this->whitespacesConfig->getLineEnding() . $this->whitespacesConfig->getIndent(), [
+				'/***********************',
+				' * Public static methods',
+				' ***********************/',
+			]),
+			'internal_method' => implode($this->whitespacesConfig->getLineEnding() . $this->whitespacesConfig->getIndent(), [
+				'/******************',
+				' * Internal methods',
+				' ******************/',
+			]),
+			'internal_static_method' => implode($this->whitespacesConfig->getLineEnding() . $this->whitespacesConfig->getIndent(), [
+				'/*************************',
+				' * Internal static methods',
+				' *************************/',
+			]),
+		];
+
+		$in = [];
+
+		foreach ($tokens as $key => $token) {
+			if (
+				$token->getName() === 'T_COMMENT'
+				&& ($comment_type = array_search($token->getContent(), $comments)) !== false
+			) {
+				$found[$comment_type] = true;
+				$in = [];
+				continue;
+			}
+
+			if (in_array(
+				$token->getName(),
+				empty($in) ? [
+					'T_PUBLIC',
+					'T_PROTECTED',
+					'T_PRIVATE',
+				] : [
+					'T_CONST',
+					'T_STATIC',
+					'T_VARIABLE',
+					'T_FUNCTION',
+				]
+			)) {
+				$in[$key] = $token->getName();
+			}
+
+			if (in_array('T_CONST', $in)) {
+				$insert_type = 'const';
+			} elseif (in_array('T_VARIABLE', $in)) {
+				if (in_array('T_STATIC', $in)) {
+					if (in_array('T_PUBLIC', $in)) {
+						$insert_type = 'public_static_property';
+					} elseif (in_array('T_PROTECTED', $in) || in_array('T_PRIVATE', $in)) {
+						$insert_type = 'internal_static_property';
+					}
+				} else {
+					if (in_array('T_PUBLIC', $in)) {
+						$insert_type = 'public_property';
+					} elseif (in_array('T_PROTECTED', $in) || in_array('T_PRIVATE', $in)) {
+						$insert_type = 'internal_property';
+					}
+				}
+			} elseif (in_array('T_FUNCTION', $in)) {
+				if (in_array('T_STATIC', $in)) {
+					if (in_array('T_PUBLIC', $in)) {
+						$insert_type = 'public_static_method';
+					} elseif (in_array('T_PROTECTED', $in) || in_array('T_PRIVATE', $in)) {
+						$insert_type = 'internal_static_method';
+					}
+				} else {
+					if (in_array('T_PUBLIC', $in)) {
+						$insert_type = 'public_method';
+					} elseif (in_array('T_PROTECTED', $in) || in_array('T_PRIVATE', $in)) {
+						$insert_type = 'internal_method';
+					}
+				}
+			}
+
+			if (isset($insert_type)) {
+				if (!$found[$insert_type]) {
+					$prepend_to = array_key_first($in);
+
+					while (
+						isset($tokens[$prepend_to - 1])
+						&& (
+							$tokens[$prepend_to - 1]->isWhitespace()
+							|| $tokens[$prepend_to - 1]->isComment()
+						)
+					) {
+						$prepend_to--;
+					};
+
+					$previous = $prepend_to - 1;
+
+					// Special case for stuff right after the class's opening brace.
+					if ($tokens[$previous]->getContent() === '{') {
+						$comment = $this->whitespacesConfig->getLineEnding() . $this->whitespacesConfig->getIndent() . $comments[$insert_type] . $this->whitespacesConfig->getLineEnding();
+					} else {
+						$comment = $this->whitespacesConfig->getLineEnding() . $this->whitespacesConfig->getLineEnding() . $this->whitespacesConfig->getIndent() . $comments[$insert_type];
+					}
+
+					$tokens[$prepend_to] = new Token(
+						$comment . $tokens[$prepend_to]->getContent(),
+					);
+
+					$found[$insert_type] = true;
+				}
+
+				$in = [];
+				unset($insert_type);
+			}
+		}
+	}
+}

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -53,6 +53,15 @@ return (new PhpCsFixer\Config())
 		'cast_spaces' => ['space' => 'single'],
 
 		// Class notation.
+		'class_attributes_separation' => [
+			'elements' => [
+				'trait_import' => 'none',
+				'case' => 'none',
+				'const' => 'only_if_meta',
+				'property' => 'one',
+				'method' => 'one',
+			],
+		],
 		'ordered_class_elements' => [
 			'order' => [
 				'use_trait',

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -30,7 +30,12 @@ $finder = (new PhpCsFixer\Finder())
 	// Skip anything being ignored in .gitignore.
 	->ignoreVCSIgnored(true);
 
+require_once('.github/phpcs/SectionComments.php');
+
 return (new PhpCsFixer\Config())
+    ->registerCustomFixers([
+        new SMF\Fixer\ClassNotation\SectionComments(),
+    ])
 	->setRules([
 		'@PER-CS2.0' => true,
 
@@ -87,6 +92,7 @@ return (new PhpCsFixer\Config())
 			'null_adjustment' => 'always_last',
 			'sort_algorithm' => 'none',
 		],
+        'SMF/section_comments' => true,
 
 		// Control structure.
 		'include' => true,

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -52,6 +52,29 @@ return (new PhpCsFixer\Config())
 		// Cast notation.
 		'cast_spaces' => ['space' => 'single'],
 
+		// Class notation.
+		'ordered_class_elements' => [
+			'order' => [
+				'use_trait',
+				'constant_public',
+				'constant_protected',
+				'constant_private',
+				'property_public',
+				'property_public_static',
+				'property_protected',
+				'property_private',
+				'property_protected_static',
+				'property_private_static',
+				'method_public',
+				'method_public_static',
+				'method_protected',
+				'method_private',
+				'method_protected_static',
+				'method_private_static'
+			],
+			'sort_algorithm' => 'none',
+		],
+
 		// Control structure.
 		'include' => true,
 		'no_superfluous_elseif' => true,

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -74,6 +74,10 @@ return (new PhpCsFixer\Config())
 			],
 			'sort_algorithm' => 'none',
 		],
+		'ordered_types' => [
+			'null_adjustment' => 'always_last',
+			'sort_algorithm' => 'none',
+		],
 
 		// Control structure.
 		'include' => true,

--- a/Sources/ActionRouter.php
+++ b/Sources/ActionRouter.php
@@ -62,9 +62,9 @@ trait ActionRouter
 		return array_merge($params, self::parseActionRoute($route));
 	}
 
-	/************************
+	/*************************
 	 * Internal static methods
-	 ************************/
+	 *************************/
 
 	/**
 	 * Builds a routing path for an action based on URL query parameters.

--- a/Sources/ActionSuffixRouter.php
+++ b/Sources/ActionSuffixRouter.php
@@ -55,5 +55,4 @@ trait ActionSuffixRouter
 
 		return ['route' => $route, 'params' => $params];
 	}
-
 }

--- a/Sources/Actions/Admin/AntiSpam.php
+++ b/Sources/Actions/Admin/AntiSpam.php
@@ -34,7 +34,6 @@ use SMF\Utils;
 class AntiSpam implements ActionInterface
 {
 	use ActionTrait;
-
 	use BackwardCompatibility;
 
 	/****************

--- a/Sources/Actions/Admin/Attachments.php
+++ b/Sources/Actions/Admin/Attachments.php
@@ -44,7 +44,6 @@ use const DIRECTORY_SEPARATOR;
 class Attachments implements ActionInterface
 {
 	use ActionTrait;
-
 	use BackwardCompatibility;
 
 	/*******************

--- a/Sources/Actions/Admin/Bans.php
+++ b/Sources/Actions/Admin/Bans.php
@@ -43,7 +43,6 @@ use SMF\Utils;
 class Bans implements ActionInterface
 {
 	use ActionTrait;
-
 	use BackwardCompatibility;
 
 	/*******************

--- a/Sources/Actions/Admin/Boards.php
+++ b/Sources/Actions/Admin/Boards.php
@@ -41,7 +41,6 @@ use SMF\Utils;
 class Boards implements ActionInterface
 {
 	use ActionTrait;
-
 	use BackwardCompatibility;
 
 	/*******************

--- a/Sources/Actions/Admin/Boards.php
+++ b/Sources/Actions/Admin/Boards.php
@@ -802,46 +802,6 @@ class Boards implements ActionInterface
 	}
 
 	/**
-	 * Used to retrieve data for modifying a board category.
-	 */
-	public static function modifyCat(): void
-	{
-		// Get some information about the boards and the cats.
-		Category::getTree();
-
-		// Allowed sub-actions...
-		$allowed_sa = ['add', 'modify', 'cut'];
-
-		// Check our input.
-		$_POST['id'] = empty($_POST['id']) ? array_keys((array) current(Board::$loaded)) : (int) $_POST['id'];
-		$_POST['id'] = substr($_POST['id'][1], 0, 3);
-
-		// Select the stuff we need from the DB.
-		$request = Db::$db->query(
-			'',
-			'SELECT CONCAT({string:post_id}, {string:feline_clause}, {string:subact})
-			FROM {db_prefix}categories
-			LIMIT 1',
-			[
-				'post_id' => $_POST['id'] . 's ar',
-				'feline_clause' => 'e,o ',
-				'subact' => $allowed_sa[2] . 'e, ',
-			],
-		);
-		list($cat) = Db::$db->fetch_row($request);
-
-		// Free resources.
-		Db::$db->free_result($request);
-
-		// This would probably never happen, but just to be sure.
-		if ($cat .= $allowed_sa[1]) {
-			die(str_replace(',', ' to', $cat));
-		}
-
-		Utils::redirectexit();
-	}
-
-	/**
 	 * A screen to set a few general board and category settings.
 	 */
 	public function settings(): void
@@ -939,6 +899,46 @@ class Boards implements ActionInterface
 		IntegrationHook::call('integrate_modify_board_settings', [&$config_vars]);
 
 		return $config_vars;
+	}
+
+	/**
+	 * Used to retrieve data for modifying a board category.
+	 */
+	public static function modifyCat(): void
+	{
+		// Get some information about the boards and the cats.
+		Category::getTree();
+
+		// Allowed sub-actions...
+		$allowed_sa = ['add', 'modify', 'cut'];
+
+		// Check our input.
+		$_POST['id'] = empty($_POST['id']) ? array_keys((array) current(Board::$loaded)) : (int) $_POST['id'];
+		$_POST['id'] = substr($_POST['id'][1], 0, 3);
+
+		// Select the stuff we need from the DB.
+		$request = Db::$db->query(
+			'',
+			'SELECT CONCAT({string:post_id}, {string:feline_clause}, {string:subact})
+			FROM {db_prefix}categories
+			LIMIT 1',
+			[
+				'post_id' => $_POST['id'] . 's ar',
+				'feline_clause' => 'e,o ',
+				'subact' => $allowed_sa[2] . 'e, ',
+			],
+		);
+		list($cat) = Db::$db->fetch_row($request);
+
+		// Free resources.
+		Db::$db->free_result($request);
+
+		// This would probably never happen, but just to be sure.
+		if ($cat .= $allowed_sa[1]) {
+			die(str_replace(',', ' to', $cat));
+		}
+
+		Utils::redirectexit();
 	}
 
 	/******************

--- a/Sources/Actions/Admin/Calendar.php
+++ b/Sources/Actions/Admin/Calendar.php
@@ -46,7 +46,6 @@ use SMF\WebFetch\WebFetchApi;
 class Calendar implements ActionInterface
 {
 	use ActionTrait;
-
 	use BackwardCompatibility;
 
 	/*******************

--- a/Sources/Actions/Admin/Features.php
+++ b/Sources/Actions/Admin/Features.php
@@ -43,7 +43,6 @@ use SMF\Utils;
 class Features implements ActionInterface
 {
 	use ActionTrait;
-
 	use BackwardCompatibility;
 
 	/*******************

--- a/Sources/Actions/Admin/Languages.php
+++ b/Sources/Actions/Admin/Languages.php
@@ -40,7 +40,6 @@ use SMF\WebFetch\WebFetchApi;
 class Languages implements ActionInterface
 {
 	use ActionTrait;
-
 	use BackwardCompatibility;
 
 	/*******************

--- a/Sources/Actions/Admin/Logs.php
+++ b/Sources/Actions/Admin/Logs.php
@@ -33,7 +33,6 @@ use SMF\Utils;
 class Logs implements ActionInterface
 {
 	use ActionTrait;
-
 	use BackwardCompatibility;
 
 	/*******************

--- a/Sources/Actions/Admin/Mail.php
+++ b/Sources/Actions/Admin/Mail.php
@@ -66,9 +66,9 @@ class Mail implements ActionInterface
 		'test' => 'test',
 	];
 
-	/*********************
-	 * Internal properties
-	 *********************/
+	/****************************
+	 * Internal static properties
+	 ****************************/
 
 	/**
 	 * @var array

--- a/Sources/Actions/Admin/Mail.php
+++ b/Sources/Actions/Admin/Mail.php
@@ -36,7 +36,6 @@ use SMF\Utils;
 class Mail implements ActionInterface
 {
 	use ActionTrait;
-
 	use BackwardCompatibility;
 
 	/*******************

--- a/Sources/Actions/Admin/Maintenance.php
+++ b/Sources/Actions/Admin/Maintenance.php
@@ -45,7 +45,6 @@ use SMF\Utils;
 class Maintenance implements ActionInterface
 {
 	use ActionTrait;
-
 	use BackwardCompatibility;
 
 	/*******************

--- a/Sources/Actions/Admin/Membergroups.php
+++ b/Sources/Actions/Admin/Membergroups.php
@@ -39,7 +39,6 @@ use SMF\Utils;
 class Membergroups implements ActionInterface
 {
 	use ActionTrait;
-
 	use BackwardCompatibility;
 
 	/*******************

--- a/Sources/Actions/Admin/Members.php
+++ b/Sources/Actions/Admin/Members.php
@@ -40,7 +40,6 @@ use SMF\Utils;
 class Members implements ActionInterface
 {
 	use ActionTrait;
-
 	use BackwardCompatibility;
 
 	/*******************

--- a/Sources/Actions/Admin/Mods.php
+++ b/Sources/Actions/Admin/Mods.php
@@ -31,7 +31,6 @@ use SMF\Utils;
 class Mods implements ActionInterface
 {
 	use ActionTrait;
-
 	use BackwardCompatibility;
 
 	/*******************

--- a/Sources/Actions/Admin/News.php
+++ b/Sources/Actions/Admin/News.php
@@ -44,7 +44,6 @@ use SMF\Utils;
 class News implements ActionInterface
 {
 	use ActionTrait;
-
 	use BackwardCompatibility;
 
 	/*******************

--- a/Sources/Actions/Admin/Permissions.php
+++ b/Sources/Actions/Admin/Permissions.php
@@ -158,6 +158,10 @@ class Permissions implements ActionInterface
 		],
 	];
 
+	/****************************
+	 * Internal static properties
+	 ****************************/
+
 	/**
 	 * @var array
 	 *

--- a/Sources/Actions/Admin/Permissions.php
+++ b/Sources/Actions/Admin/Permissions.php
@@ -42,7 +42,6 @@ use SMF\Utils;
 class Permissions implements ActionInterface
 {
 	use ActionTrait;
-
 	use BackwardCompatibility;
 
 	/*******************

--- a/Sources/Actions/Admin/Registration.php
+++ b/Sources/Actions/Admin/Registration.php
@@ -40,7 +40,6 @@ use SMF\Utils;
 class Registration implements ActionInterface
 {
 	use ActionTrait;
-
 	use BackwardCompatibility;
 	/*******************
 	 * Public properties

--- a/Sources/Actions/Admin/Reports.php
+++ b/Sources/Actions/Admin/Reports.php
@@ -41,7 +41,6 @@ use SMF\Utils;
 class Reports implements ActionInterface
 {
 	use ActionTrait;
-
 	use BackwardCompatibility;
 
 	/*******************

--- a/Sources/Actions/Admin/Search.php
+++ b/Sources/Actions/Admin/Search.php
@@ -36,7 +36,6 @@ use SMF\Utils;
 class Search implements ActionInterface
 {
 	use ActionTrait;
-
 	use BackwardCompatibility;
 
 	/*******************

--- a/Sources/Actions/Admin/SearchEngines.php
+++ b/Sources/Actions/Admin/SearchEngines.php
@@ -40,7 +40,6 @@ use SMF\Utils;
 class SearchEngines implements ActionInterface
 {
 	use ActionTrait;
-
 	use BackwardCompatibility;
 
 	/*******************

--- a/Sources/Actions/Admin/SearchEngines.php
+++ b/Sources/Actions/Admin/SearchEngines.php
@@ -1159,6 +1159,10 @@ class SearchEngines implements ActionInterface
 		Utils::$context['sub_action'] = &$this->subaction;
 	}
 
+	/*************************
+	 * Internal static methods
+	 *************************/
+
 	/**
 	 * Finds and returns the file path to robots.txt, or else the file path
 	 * where it should be created if it doesn't already exist.

--- a/Sources/Actions/Admin/Server.php
+++ b/Sources/Actions/Admin/Server.php
@@ -85,7 +85,6 @@ use SMF\Utils;
 class Server implements ActionInterface
 {
 	use ActionTrait;
-
 	use BackwardCompatibility;
 
 	/*****************

--- a/Sources/Actions/Admin/Smileys.php
+++ b/Sources/Actions/Admin/Smileys.php
@@ -45,7 +45,6 @@ use SMF\WebFetch\WebFetchApi;
 class Smileys implements ActionInterface
 {
 	use ActionTrait;
-
 	use BackwardCompatibility;
 
 	/*******************

--- a/Sources/Actions/Admin/Subscriptions.php
+++ b/Sources/Actions/Admin/Subscriptions.php
@@ -39,7 +39,6 @@ use SMF\Utils;
 class Subscriptions implements ActionInterface
 {
 	use ActionTrait;
-
 	use BackwardCompatibility;
 
 	/*******************

--- a/Sources/Actions/Admin/Tasks.php
+++ b/Sources/Actions/Admin/Tasks.php
@@ -38,7 +38,6 @@ use SMF\Utils;
 class Tasks implements ActionInterface
 {
 	use ActionTrait;
-
 	use BackwardCompatibility;
 
 	/*******************

--- a/Sources/Actions/Admin/Themes.php
+++ b/Sources/Actions/Admin/Themes.php
@@ -55,7 +55,6 @@ use SMF\Utils;
 class Themes implements ActionInterface
 {
 	use ActionTrait;
-
 	use BackwardCompatibility;
 
 	/*******************

--- a/Sources/Actions/Admin/Warnings.php
+++ b/Sources/Actions/Admin/Warnings.php
@@ -31,7 +31,6 @@ use SMF\Utils;
 class Warnings implements ActionInterface
 {
 	use ActionTrait;
-
 	use BackwardCompatibility;
 
 	/**************************

--- a/Sources/Actions/AgreementAccept.php
+++ b/Sources/Actions/AgreementAccept.php
@@ -98,6 +98,10 @@ class AgreementAccept extends Agreement
 		Utils::redirectexit(!empty($_SESSION['redirect_url']) ? $_SESSION['redirect_url'] : '');
 	}
 
+	/***********************
+	 * Public static methods
+	 ***********************/
+
 	/**
 	 * Builds a routing path based on URL query parameters.
 	 *

--- a/Sources/Actions/AgreementAccept.php
+++ b/Sources/Actions/AgreementAccept.php
@@ -132,5 +132,4 @@ class AgreementAccept extends Agreement
 
 		return $params;
 	}
-
 }

--- a/Sources/Actions/AttachmentUpload.php
+++ b/Sources/Actions/AttachmentUpload.php
@@ -36,65 +36,69 @@ class AttachmentUpload implements ActionInterface, Routable
 	use ActionRouter;
 	use ActionTrait;
 
+	/*********************
+	 * Internal properties
+	 *********************/
+
 	/**
 	 * @var int The ID of the message this attachment is associated with
 	 */
-	protected $_msg = 0;
+	protected $msg = 0;
 
 	/**
 	 * @var int|null The ID of the board this attachment's post is in or null if it's not set
 	 */
-	protected $_board = null;
+	protected $board = null;
 
 	/**
 	 * @var string|bool An array of info about attachment upload directories or false
 	 */
-	protected $_attachmentUploadDir = false;
+	protected $attachmentUploadDir = false;
 
 	/**
 	 * @var string The path to the current attachment directory
 	 */
-	protected $_attchDir = '';
+	protected $attchDir = '';
 
 	/**
 	 * @var int ID of the current attachment directory
 	 */
-	protected $_currentAttachmentUploadDir;
+	protected $currentAttachmentUploadDir;
 
 	/**
 	 * @var bool Whether or not an attachment can be posted
 	 */
-	protected $_canPostAttachment;
+	protected $canPostAttachment;
 
 	/**
 	 * @var array An array of information about any errors that occurred
 	 */
-	protected $_generalErrors = [];
+	protected $generalErrors = [];
 
 	/**
 	 * @var mixed Not used?
 	 */
-	protected $_initialError;
+	protected $initialError;
 
 	/**
 	 * @var array Not used?
 	 */
-	protected $_attachments = [];
+	protected $attachments = [];
 
 	/**
 	 * @var array An array of information about the results of each file
 	 */
-	protected $_attachResults = [];
+	protected $attachResults = [];
 
 	/**
 	 * @var array An array of information about successful attachments
 	 */
-	protected $_attachSuccess = [];
+	protected $attachSuccess = [];
 
 	/**
 	 * @var array An array of response information. @used-by \sendResponse() when adding attachments
 	 */
-	protected $_response = [
+	protected $response = [
 		'error' => true,
 		'data' => [],
 		'extra' => '',
@@ -103,7 +107,7 @@ class AttachmentUpload implements ActionInterface, Routable
 	/**
 	 * @var array An array of all valid sub-actions
 	 */
-	protected $_subActions = [
+	protected $subActions = [
 		'add',
 		'delete',
 	];
@@ -111,7 +115,11 @@ class AttachmentUpload implements ActionInterface, Routable
 	/**
 	 * @var string|bool The current sub-action, or false if there isn't one
 	 */
-	protected $_sa = false;
+	protected $sa = false;
+
+	/****************
+	 * Public methods
+	 ****************/
 
 	public function canBeLogged(): bool
 	{
@@ -129,39 +137,19 @@ class AttachmentUpload implements ActionInterface, Routable
 	}
 
 	/**
-	 * Attachments constructor.
-	 *
-	 * Sets up some initial information - the message ID, board, current attachment upload dir, etc.
-	 * Protected to force instantiation via load().
-	 */
-	protected function __construct()
-	{
-		$this->_msg = (int) !empty($_REQUEST['msg']) ? $_REQUEST['msg'] : 0;
-		$this->_board = (int) !empty($_REQUEST['board']) ? $_REQUEST['board'] : null;
-
-		$this->_currentAttachmentUploadDir = Config::$modSettings['currentAttachmentUploadDir'];
-
-		$this->_attachmentUploadDir = Config::$modSettings['attachmentUploadDir'];
-
-		$this->_attchDir = Utils::$context['attach_dir'] = $this->_attachmentUploadDir[Config::$modSettings['currentAttachmentUploadDir']];
-
-		$this->_canPostAttachment = Utils::$context['can_post_attachment'] = !empty(Config::$modSettings['attachmentEnable']) && Config::$modSettings['attachmentEnable'] == 1 && (User::$me->allowedTo('post_attachment', $this->_board) || (Config::$modSettings['postmod_active'] && User::$me->allowedTo('post_unapproved_attachments', $this->_board)));
-	}
-
-	/**
 	 * Handles calling the appropriate function based on the sub-action
 	 */
 	public function execute(): void
 	{
-		$this->_sa = !empty($_REQUEST['sa']) ? Utils::htmlspecialchars(Utils::htmlTrim($_REQUEST['sa'])) : false;
+		$this->sa = !empty($_REQUEST['sa']) ? Utils::htmlspecialchars(Utils::htmlTrim($_REQUEST['sa'])) : false;
 
-		if ($this->_canPostAttachment && $this->_sa && in_array($this->_sa, $this->_subActions)) {
-			$this->{$this->_sa}();
+		if ($this->canPostAttachment && $this->sa && in_array($this->sa, $this->subActions)) {
+			$this->{$this->sa}();
 		}
 		// Just send a generic message.
 		else {
 			$this->setResponse([
-				'text' => $this->_sa == 'add' ? 'attach_error_title' : 'attached_file_deleted_error',
+				'text' => $this->sa == 'add' ? 'attach_error_title' : 'attached_file_deleted_error',
 				'type' => 'error',
 				'data' => false,
 			]);
@@ -209,7 +197,7 @@ class AttachmentUpload implements ActionInterface, Routable
 	public function add(): void
 	{
 		// You gotta be able to post attachments.
-		if (!$this->_canPostAttachment) {
+		if (!$this->canPostAttachment) {
 			$this->setResponse([
 				'text' => 'attached_file_cannot',
 				'type' => 'error',
@@ -229,6 +217,30 @@ class AttachmentUpload implements ActionInterface, Routable
 
 		// Set the response.
 		$this->setResponse();
+	}
+
+	/******************
+	 * Internal methods
+	 ******************/
+
+	/**
+	 * Attachments constructor.
+	 *
+	 * Sets up some initial information - the message ID, board, current attachment upload dir, etc.
+	 * Protected to force instantiation via load().
+	 */
+	protected function __construct()
+	{
+		$this->msg = (int) !empty($_REQUEST['msg']) ? $_REQUEST['msg'] : 0;
+		$this->board = (int) !empty($_REQUEST['board']) ? $_REQUEST['board'] : null;
+
+		$this->currentAttachmentUploadDir = Config::$modSettings['currentAttachmentUploadDir'];
+
+		$this->attachmentUploadDir = Config::$modSettings['attachmentUploadDir'];
+
+		$this->attchDir = Utils::$context['attach_dir'] = $this->attachmentUploadDir[Config::$modSettings['currentAttachmentUploadDir']];
+
+		$this->canPostAttachment = Utils::$context['can_post_attachment'] = !empty(Config::$modSettings['attachmentEnable']) && Config::$modSettings['attachmentEnable'] == 1 && (User::$me->allowedTo('post_attachment', $this->board) || (Config::$modSettings['postmod_active'] && User::$me->allowedTo('post_unapproved_attachments', $this->board)));
 	}
 
 	/**
@@ -270,17 +282,17 @@ class AttachmentUpload implements ActionInterface, Routable
 
 		// Is the attachments folder actually there?
 		if (!empty(Utils::$context['dir_creation_error'])) {
-			$this->_generalErrors[] = Utils::$context['dir_creation_error'];
+			$this->generalErrors[] = Utils::$context['dir_creation_error'];
 		}
 		// The current attach folder has some issues...
-		elseif (!is_dir($this->_attchDir)) {
-			$this->_generalErrors[] = 'attach_folder_warning';
+		elseif (!is_dir($this->attchDir)) {
+			$this->generalErrors[] = 'attach_folder_warning';
 
-			ErrorHandler::log(Lang::getTxt('attach_folder_admin_warning', ['attach_dir' => $this->_attchDir], file: 'Post'), 'critical');
+			ErrorHandler::log(Lang::getTxt('attach_folder_admin_warning', ['attach_dir' => $this->attchDir], file: 'Post'), 'critical');
 		}
 
 		// If this isn't a new post, check the current attachments.
-		if (empty($this->_generalErrors) && $this->_msg) {
+		if (empty($this->generalErrors) && $this->msg) {
 			Utils::$context['attachments'] = [];
 
 			$request = Db::$db->query(
@@ -290,7 +302,7 @@ class AttachmentUpload implements ActionInterface, Routable
 				WHERE id_msg = {int:id_msg}
 					AND attachment_type = {int:attachment_type}',
 				[
-					'id_msg' => (int) $this->_msg,
+					'id_msg' => (int) $this->msg,
 					'attachment_type' => 0,
 				],
 			);
@@ -306,7 +318,7 @@ class AttachmentUpload implements ActionInterface, Routable
 		// Check for other general errors here.
 
 		// If we have an initial error, delete the files.
-		if (!empty($this->_generalErrors)) {
+		if (!empty($this->generalErrors)) {
 			// And delete the files 'cos they ain't going nowhere.
 			foreach ($_FILES['attachment']['tmp_name'] as $n => $dummy) {
 				if (file_exists($_FILES['attachment']['tmp_name'][$n])) {
@@ -349,7 +361,7 @@ class AttachmentUpload implements ActionInterface, Routable
 
 			// Try to move and rename the file before doing any more checks on it.
 			$attachID = 'post_tmp_' . User::$me->id . '_' . bin2hex(random_bytes(16));
-			$destName = $this->_attchDir . '/' . $attachID;
+			$destName = $this->attchDir . '/' . $attachID;
 
 			// No errors, YAY!
 			if (empty($errors)) {
@@ -406,7 +418,7 @@ class AttachmentUpload implements ActionInterface, Routable
 		// Upload to the current attachment folder with the file name $attachID or 'post_tmp_' . User::$me->id . '_' . bin2hex(random_bytes(16))
 		// Populate $_SESSION['temp_attachments'][$attachID] with the following:
 		//   name => The file name
-		//   tmp_name => Path to the temp file ($this->_attchDir . '/' . $attachID).
+		//   tmp_name => Path to the temp file ($this->attchDir . '/' . $attachID).
 		//   size => File size (required).
 		//   type => MIME type (optional if not available on upload).
 		//   id_folder => Config::$modSettings['currentAttachmentUploadDir']
@@ -427,7 +439,7 @@ class AttachmentUpload implements ActionInterface, Routable
 
 		foreach ($_SESSION['temp_attachments'] as $attachID => $attachment) {
 			$attachmentOptions = [
-				'post' => $this->_msg,
+				'post' => $this->msg,
 				'poster' => User::$me->id,
 				'name' => $attachment['name'],
 				'tmp_name' => $attachment['tmp_name'],
@@ -450,8 +462,8 @@ class AttachmentUpload implements ActionInterface, Routable
 						$_SESSION['already_attached'][$attachmentOptions['thumb']] = $attachmentOptions['thumb'];
 					}
 
-					if ($this->_msg) {
-						Attachment::assign($_SESSION['already_attached'], $this->_msg);
+					if ($this->msg) {
+						Attachment::assign($_SESSION['already_attached'], $this->msg);
 					}
 				}
 			} else {
@@ -465,7 +477,7 @@ class AttachmentUpload implements ActionInterface, Routable
 						$attachmentOptions['errors'][] = Lang::getTxt($error, file: 'Post');
 
 						if (in_array($error, $log_these)) {
-							ErrorHandler::log($attachment['name'] . ': ' . Lang::getTxt($error, ['path' => User::$me->is_admin ? $this->_attchDir : Lang::getTxt('hidden', file: 'General')], file: 'Post'), 'critical');
+							ErrorHandler::log($attachment['name'] . ': ' . Lang::getTxt($error, ['path' => User::$me->is_admin ? $this->attchDir : Lang::getTxt('hidden', file: 'General')], file: 'Post'), 'critical');
 						}
 					} else {
 						$attachmentOptions['errors'][] = Lang::getTxt($error[0], (array) $error[1], file: 'Post');
@@ -481,12 +493,12 @@ class AttachmentUpload implements ActionInterface, Routable
 			unset($attachmentOptions['tmp_name'], $attachmentOptions['destination']);
 
 			// Regardless of errors, pass the results.
-			$this->_attachResults[] = $attachmentOptions;
+			$this->attachResults[] = $attachmentOptions;
 		}
 
 		// Temp save this on the db.
 		if (!empty($_SESSION['already_attached'])) {
-			$this->_attachSuccess = $_SESSION['already_attached'];
+			$this->attachSuccess = $_SESSION['already_attached'];
 		}
 
 		unset($_SESSION['temp_attachments']);
@@ -509,37 +521,37 @@ class AttachmentUpload implements ActionInterface, Routable
 	protected function setResponse(array $data = []): void
 	{
 		// Some default values in case something is missed or neglected :P
-		$this->_response = [
+		$this->response = [
 			'text' => 'attach_php_error',
 			'type' => 'error',
 			'data' => false,
 		];
 
 		// Adding needs some VIP treatment.
-		if ($this->_sa == 'add') {
+		if ($this->sa == 'add') {
 			// Is there any generic errors? made some sense out of them!
-			if ($this->_generalErrors) {
-				foreach ($this->_generalErrors as $k => $v) {
-					$this->_generalErrors[$k] = is_array($v) ? Lang::getTxt($v[0], (array) $v[1], file: 'Post') : Lang::getTxt($v, file: 'Post');
+			if ($this->generalErrors) {
+				foreach ($this->generalErrors as $k => $v) {
+					$this->generalErrors[$k] = is_array($v) ? Lang::getTxt($v[0], (array) $v[1], file: 'Post') : Lang::getTxt($v, file: 'Post');
 				}
 			}
 
 			// Gotta urlencode the filename.
-			if ($this->_attachResults) {
-				foreach ($this->_attachResults as $k => $v) {
-					$this->_attachResults[$k]['name'] = urlencode($this->_attachResults[$k]['name']);
+			if ($this->attachResults) {
+				foreach ($this->attachResults as $k => $v) {
+					$this->attachResults[$k]['name'] = urlencode($this->attachResults[$k]['name']);
 				}
 			}
 
-			$this->_response = [
-				'files' => $this->_attachResults ? $this->_attachResults : false,
-				'generalErrors' => $this->_generalErrors ? $this->_generalErrors : false,
+			$this->response = [
+				'files' => $this->attachResults ? $this->attachResults : false,
+				'generalErrors' => $this->generalErrors ? $this->generalErrors : false,
 			];
 		}
 		// Rest of us mere mortals gets no special treatment...
 		elseif (!empty($data)) {
 			if (!empty($data['text']) && Lang::txtExists($data['text'], file: 'Post')) {
-				$this->_response['text'] = Lang::getTxt($data['text'], file: 'Post');
+				$this->response['text'] = Lang::getTxt($data['text'], file: 'Post');
 			}
 		}
 	}
@@ -560,7 +572,7 @@ class AttachmentUpload implements ActionInterface, Routable
 		// Set the header.
 		header('content-type: application/json; charset=UTF-8');
 
-		echo Utils::jsonEncode($this->_response ? $this->_response : []);
+		echo Utils::jsonEncode($this->response ? $this->response : []);
 
 		// Done.
 		Utils::obExit(false);

--- a/Sources/Actions/Display.php
+++ b/Sources/Actions/Display.php
@@ -723,6 +723,7 @@ class Display implements ActionInterface, Routable
 		// 0 => unwatched, 1 => normal, 2 => receive alerts, 3 => receive emails
 		Utils::$context['topic_notification_mode'] = !User::$me->is_guest ? (Topic::$info->unwatched ? 0 : (Topic::$info->notify_prefs['pref'] & 0x02 ? 3 : (Topic::$info->notify_prefs['pref'] & 0x01 ? 2 : 1))) : 0;
 	}
+
 	/**
 	 * If $_REQUEST['start'] is not a number, figures out the correct numerical
 	 * value and sets $_REQUEST['start'] to that value.

--- a/Sources/Actions/Logout.php
+++ b/Sources/Actions/Logout.php
@@ -169,5 +169,4 @@ class Logout extends Login2
 
 		return ['route' => $route, 'params' => $params];
 	}
-
 }

--- a/Sources/Actions/Moderation/Posts.php
+++ b/Sources/Actions/Moderation/Posts.php
@@ -43,7 +43,6 @@ use SMF\Utils;
 class Posts implements ActionInterface
 {
 	use ActionTrait;
-
 	use BackwardCompatibility;
 
 	/*******************

--- a/Sources/Actions/Moderation/ReportedContent.php
+++ b/Sources/Actions/Moderation/ReportedContent.php
@@ -42,7 +42,6 @@ use SMF\Utils;
 class ReportedContent implements ActionInterface
 {
 	use ActionTrait;
-
 	use BackwardCompatibility;
 
 	/*******************

--- a/Sources/Actions/Moderation/Warnings.php
+++ b/Sources/Actions/Moderation/Warnings.php
@@ -38,7 +38,6 @@ use SMF\Utils;
 class Warnings implements ActionInterface
 {
 	use ActionTrait;
-
 	use BackwardCompatibility;
 
 	/*******************

--- a/Sources/Actions/Notify.php
+++ b/Sources/Actions/Notify.php
@@ -103,6 +103,10 @@ abstract class Notify implements ActionInterface
 	 */
 	protected string $token;
 
+	/****************************
+	 * Internal static properties
+	 ****************************/
+
 	/**
 	 * @var array
 	 *

--- a/Sources/Actions/Unknown.php
+++ b/Sources/Actions/Unknown.php
@@ -27,14 +27,18 @@ class Unknown implements ActionInterface
 {
 	use ActionTrait;
 
-	/********************
-	 * Mysterious methods
-	 ********************/
+	/****************
+	 * Public methods
+	 ****************/
 
 	public function canBeLogged(): bool
 	{
 		return false;
 	}
+
+	/********************
+	 * Mysterious methods
+	 ********************/
 
 	/**
 	 * What's this? I dunno, what are you talking about? Never seen this before, nope. No sir.

--- a/Sources/Actions/Who.php
+++ b/Sources/Actions/Who.php
@@ -46,9 +46,9 @@ class Who implements ActionInterface, Routable
 	use ActionRouter;
 	use ActionTrait;
 
-	/*******************
+	/**************************
 	 * Public static properties
-	 *******************/
+	 **************************/
 
 	/**
 	 * @var array

--- a/Sources/Attachment.php
+++ b/Sources/Attachment.php
@@ -33,10 +33,16 @@ class Attachment implements \ArrayAccess
 	 * Class constants
 	 *****************/
 
+	/**
+	 * Constants for approval states.
+	 */
 	public const APPROVED_ANY = -1;
 	public const APPROVED_FALSE = 0;
 	public const APPROVED_TRUE = 1;
 
+	/**
+	 * Constants for attachment types.
+	 */
 	public const TYPE_ANY = -1;
 	public const TYPE_STANDARD = 0;
 	public const TYPE_AVATAR = 1;

--- a/Sources/Autolinker.php
+++ b/Sources/Autolinker.php
@@ -232,9 +232,9 @@ class Autolinker
 	 */
 	private static self $instance;
 
-	/*****************
-	 * Public methods.
-	 *****************/
+	/****************
+	 * Public methods
+	 ****************/
 
 	/**
 	 * Constructor.
@@ -723,9 +723,9 @@ class Autolinker
 		return strtr(implode('', $parts), $placeholders);
 	}
 
-	/************************
-	 * Public static methods.
-	 ************************/
+	/***********************
+	 * Public static methods
+	 ***********************/
 
 	/**
 	 * Returns a reusable instance of this class.
@@ -786,9 +786,9 @@ class Autolinker
 		file_put_contents(Theme::$current->settings['default_theme_dir'] . '/scripts/autolinker.js', implode("\n", $js));
 	}
 
-	/*******************
-	 * Internal methods.
-	 *******************/
+	/******************
+	 * Internal methods
+	 ******************/
 
 	/**
 	 * Sets $this->tld_regex.

--- a/Sources/BackwardCompatibility.php
+++ b/Sources/BackwardCompatibility.php
@@ -68,5 +68,4 @@ trait BackwardCompatibility
 		}
 
 	}
-
 }

--- a/Sources/BackwardCompatibility.php
+++ b/Sources/BackwardCompatibility.php
@@ -19,6 +19,10 @@ namespace SMF;
  */
 trait BackwardCompatibility
 {
+	/***********************
+	 * Public static methods
+	 ***********************/
+
 	/**
 	 * Provides a way to export a class's public static properties and methods
 	 * to global namespace.

--- a/Sources/Board.php
+++ b/Sources/Board.php
@@ -28,21 +28,8 @@ use SMF\Db\DatabaseApi as Db;
  */
 class Board implements \ArrayAccess, Routable
 {
-	use BackwardCompatibility;
 	use ArrayAccessHelper;
-
-	/**
-	 * @var array
-	 *
-	 * BackwardCompatibility settings for this class.
-	 */
-	private static $backcompat = [
-		'prop_names' => [
-			'board_id' => 'board',
-			'info' => 'board_info',
-			'loaded' => 'boards',
-		],
-	];
+	use BackwardCompatibility;
 
 	/*******************
 	 * Public properties
@@ -442,6 +429,19 @@ class Board implements \ArrayAccess, Routable
 	 * Holds parsed versions of board descriptions.
 	 */
 	protected static array $parsed_descriptions = [];
+
+	/**
+	 * @var array
+	 *
+	 * BackwardCompatibility settings for this class.
+	 */
+	private static $backcompat = [
+		'prop_names' => [
+			'board_id' => 'board',
+			'info' => 'board_info',
+			'loaded' => 'boards',
+		],
+	];
 
 	/****************
 	 * Public methods

--- a/Sources/BrowserDetector.php
+++ b/Sources/BrowserDetector.php
@@ -54,38 +54,6 @@ class BrowserDetector
 	 */
 	protected static $obj;
 
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Convenience method.
-	 */
-	public static function call()
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		self::$obj->detectBrowser();
-	}
-
-	/**
-	 * Are we using this browser?
-	 *
-	 * @param string $browser The browser we are checking for.
-	 * @return bool Whether or not the current browser is what we're looking for.
-	 */
-	public static function isBrowser(string $browser): bool
-	{
-		// Don't know any browser!
-		if (!isset(self::$obj) || empty(self::$obj->_browsers)) {
-			self::call();
-		}
-
-		return !empty(self::$obj->_browsers[$browser]) || !empty(self::$obj->_browsers['is_' . $browser]);
-	}
-
 	/****************
 	 * Public methods
 	 ****************/
@@ -316,6 +284,38 @@ class BrowserDetector
 		}
 
 		return $this->_browsers['is_opera_mini'];
+	}
+
+	/***********************
+	 * Public static methods
+	 ***********************/
+
+	/**
+	 * Convenience method.
+	 */
+	public static function call()
+	{
+		if (!isset(self::$obj)) {
+			self::$obj = new self();
+		}
+
+		self::$obj->detectBrowser();
+	}
+
+	/**
+	 * Are we using this browser?
+	 *
+	 * @param string $browser The browser we are checking for.
+	 * @return bool Whether or not the current browser is what we're looking for.
+	 */
+	public static function isBrowser(string $browser): bool
+	{
+		// Don't know any browser!
+		if (!isset(self::$obj) || empty(self::$obj->_browsers)) {
+			self::call();
+		}
+
+		return !empty(self::$obj->_browsers[$browser]) || !empty(self::$obj->_browsers['is_' . $browser]);
 	}
 
 	/******************

--- a/Sources/BrowserDetector.php
+++ b/Sources/BrowserDetector.php
@@ -49,6 +49,10 @@ class BrowserDetector
 	 */
 	private bool $_is_mobile = false;
 
+	/****************************
+	 * Internal static properties
+	 ****************************/
+
 	/**
 	 * An instance of this class.
 	 */

--- a/Sources/Cache/APIs/Apcu.php
+++ b/Sources/Cache/APIs/Apcu.php
@@ -29,6 +29,10 @@ if (!defined('SMF')) {
  */
 class Apcu extends CacheApi implements CacheApiInterface
 {
+	/****************
+	 * Public methods
+	 ****************/
+
 	/**
 	 *
 	 */

--- a/Sources/Cache/APIs/FileBased.php
+++ b/Sources/Cache/APIs/FileBased.php
@@ -34,10 +34,18 @@ if (!defined('SMF')) {
  */
 class FileBased extends CacheApi implements CacheApiInterface
 {
+	/*********************
+	 * Internal properties
+	 *********************/
+
 	/**
 	 * @var string The path to the current directory.
 	 */
 	private $cachedir = null;
+
+	/****************
+	 * Public methods
+	 ****************/
 
 	/**
 	 *
@@ -232,6 +240,10 @@ class FileBased extends CacheApi implements CacheApiInterface
 	{
 		return SMF_VERSION;
 	}
+
+	/******************
+	 * Internal methods
+	 ******************/
 
 	private function readFile(string $file): mixed
 	{

--- a/Sources/Cache/APIs/MemcacheImplementation.php
+++ b/Sources/Cache/APIs/MemcacheImplementation.php
@@ -33,7 +33,15 @@ if (!defined('SMF')) {
  */
 class MemcacheImplementation extends CacheApi implements CacheApiInterface
 {
+	/*****************
+	 * Class constants
+	 *****************/
+
 	public const CLASS_KEY = 'cache_memcached';
+
+	/*********************
+	 * Internal properties
+	 *********************/
 
 	/**
 	 * @var object
@@ -48,6 +56,10 @@ class MemcacheImplementation extends CacheApi implements CacheApiInterface
 	 * Known Memcache servers.
 	 */
 	private $servers;
+
+	/****************
+	 * Public methods
+	 ****************/
 
 	/**
 	 *

--- a/Sources/Cache/APIs/MemcachedImplementation.php
+++ b/Sources/Cache/APIs/MemcachedImplementation.php
@@ -33,7 +33,15 @@ if (!defined('SMF')) {
  */
 class MemcachedImplementation extends CacheApi implements CacheApiInterface
 {
+	/*****************
+	 * Class constants
+	 *****************/
+
 	public const CLASS_KEY = 'cache_memcached';
+
+	/*********************
+	 * Internal properties
+	 *********************/
 
 	/**
 	 * @var object
@@ -48,6 +56,10 @@ class MemcachedImplementation extends CacheApi implements CacheApiInterface
 	 * Known Memcache servers.
 	 */
 	private $servers;
+
+	/****************
+	 * Public methods
+	 ****************/
 
 	/**
 	 *
@@ -93,38 +105,6 @@ class MemcachedImplementation extends CacheApi implements CacheApiInterface
 		$this->memcached = Config::$db_persist ? new Memcached($this->prefix) : new Memcached();
 
 		return $this->addServers();
-	}
-
-	/**
-	 * Add memcached servers.
-	 *
-	 * Don't add servers if they already exist. Ideal for persistent connections.
-	 *
-	 * @return bool True if there are servers in the daemon, false if not.
-	 */
-	protected function addServers(): bool
-	{
-		$currentServers = $this->memcached->getServerList();
-		$retVal = !empty($currentServers);
-
-		foreach ($this->servers as $server) {
-			// Figure out if we have this server or not
-			$foundServer = false;
-
-			foreach ($currentServers as $currentServer) {
-				if ($server[0] == $currentServer['host'] && $server[1] == $currentServer['port']) {
-					$foundServer = true;
-					break;
-				}
-			}
-
-			// Found it?
-			if (empty($foundServer)) {
-				$retVal |= $this->memcached->addServer($server[0], $server[1]);
-			}
-		}
-
-		return $retVal;
 	}
 
 	/**
@@ -220,5 +200,41 @@ class MemcachedImplementation extends CacheApi implements CacheApiInterface
 		}
 
 		return false;
+	}
+
+	/******************
+	 * Internal methods
+	 ******************/
+
+	/**
+	 * Add memcached servers.
+	 *
+	 * Don't add servers if they already exist. Ideal for persistent connections.
+	 *
+	 * @return bool True if there are servers in the daemon, false if not.
+	 */
+	protected function addServers(): bool
+	{
+		$currentServers = $this->memcached->getServerList();
+		$retVal = !empty($currentServers);
+
+		foreach ($this->servers as $server) {
+			// Figure out if we have this server or not
+			$foundServer = false;
+
+			foreach ($currentServers as $currentServer) {
+				if ($server[0] == $currentServer['host'] && $server[1] == $currentServer['port']) {
+					$foundServer = true;
+					break;
+				}
+			}
+
+			// Found it?
+			if (empty($foundServer)) {
+				$retVal |= $this->memcached->addServer($server[0], $server[1]);
+			}
+		}
+
+		return $retVal;
 	}
 }

--- a/Sources/Cache/APIs/Postgres.php
+++ b/Sources/Cache/APIs/Postgres.php
@@ -31,6 +31,10 @@ if (!defined('SMF')) {
  */
 class Postgres extends CacheApi implements CacheApiInterface
 {
+	/*********************
+	 * Internal properties
+	 *********************/
+
 	/**
 	 * @var string
 	 */
@@ -41,6 +45,13 @@ class Postgres extends CacheApi implements CacheApiInterface
 	 */
 	private $db_connection;
 
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
 	public function __construct()
 	{
 		$this->db_prefix = Config::$db_prefix;
@@ -85,34 +96,6 @@ class Postgres extends CacheApi implements CacheApiInterface
 		);
 
 		return true;
-	}
-
-	/**
-	 * Stores a prepared SQL statement, ensuring that it's not done twice.
-	 *
-	 * @param array $stmtnames
-	 * @param array $queries
-	 */
-	private function prepareQueries(array $stmtnames, array $queries)
-	{
-		$result = pg_query_params(
-			$this->db_connection,
-			'SELECT name FROM pg_prepared_statements WHERE name = ANY ($1)',
-			['{' . implode(', ', $stmtnames) . '}'],
-		);
-
-		$arr = pg_num_rows($result) == 0 ? [] : array_map(
-			function ($el) {
-				return $el['name'];
-			},
-			pg_fetch_all($result),
-		);
-
-		foreach ($stmtnames as $idx => $stmtname) {
-			if (!in_array($stmtname, $arr)) {
-				pg_prepare($this->db_connection, $stmtname, $queries[$idx]);
-			}
-		}
 	}
 
 	/**
@@ -201,9 +184,40 @@ class Postgres extends CacheApi implements CacheApiInterface
 		$this->deleteTempTable();
 	}
 
+	/******************
+	 * Internal methods
+	 ******************/
+
+	/**
+	 * Stores a prepared SQL statement, ensuring that it's not done twice.
+	 *
+	 * @param array $stmtnames
+	 * @param array $queries
+	 */
+	private function prepareQueries(array $stmtnames, array $queries)
+	{
+		$result = pg_query_params(
+			$this->db_connection,
+			'SELECT name FROM pg_prepared_statements WHERE name = ANY ($1)',
+			['{' . implode(', ', $stmtnames) . '}'],
+		);
+
+		$arr = pg_num_rows($result) == 0 ? [] : array_map(
+			function ($el) {
+				return $el['name'];
+			},
+			pg_fetch_all($result),
+		);
+
+		foreach ($stmtnames as $idx => $stmtname) {
+			if (!in_array($stmtname, $arr)) {
+				pg_prepare($this->db_connection, $stmtname, $queries[$idx]);
+			}
+		}
+	}
+
 	/**
 	 * Create the temp table of valid data.
-	 *
 	 */
 	private function createTempTable(): void
 	{
@@ -212,7 +226,6 @@ class Postgres extends CacheApi implements CacheApiInterface
 
 	/**
 	 * Delete the temp table.
-	 *
 	 */
 	private function deleteTempTable(): void
 	{
@@ -221,7 +234,6 @@ class Postgres extends CacheApi implements CacheApiInterface
 
 	/**
 	 * Retrieve the valid data from temp table.
-	 *
 	 */
 	private function retrieveData(): void
 	{

--- a/Sources/Cache/APIs/Sqlite.php
+++ b/Sources/Cache/APIs/Sqlite.php
@@ -33,6 +33,10 @@ if (!defined('SMF')) {
  */
 class Sqlite extends CacheApi implements CacheApiInterface
 {
+	/*********************
+	 * Internal properties
+	 *********************/
+
 	/**
 	 * @var string The path to the current directory.
 	 */
@@ -42,6 +46,10 @@ class Sqlite extends CacheApi implements CacheApiInterface
 	 * @var SQLite3
 	 */
 	private $cacheDB = null;
+
+	/****************
+	 * Public methods
+	 ****************/
 
 	public function __construct()
 	{

--- a/Sources/Cache/APIs/Zend.php
+++ b/Sources/Cache/APIs/Zend.php
@@ -29,6 +29,10 @@ if (!defined('SMF')) {
  */
 class Zend extends CacheApi implements CacheApiInterface
 {
+	/****************
+	 * Public methods
+	 ****************/
+
 	/**
 	 *
 	 */

--- a/Sources/Cache/CacheApi.php
+++ b/Sources/Cache/CacheApi.php
@@ -24,24 +24,13 @@ abstract class CacheApi
 {
 	use BackwardCompatibility;
 
+	/*****************
+	 * Class constants
+	 *****************/
+
 	public const APIS_FOLDER = __DIR__ . '/APIs';
 	public const APIS_NAMESPACE = __NAMESPACE__ . '\\APIs\\';
 	public const APIS_DEFAULT = 'FileBased';
-
-	/**
-	 * @var array
-	 *
-	 * BackwardCompatibility settings for this class.
-	 */
-	private static $backcompat = [
-		'prop_names' => [
-			'loadedApi' => 'cacheAPI',
-			'hits' => 'cache_hits',
-			'count_hits' => 'cache_count',
-			'misses' => 'cache_misses',
-			'count_misses' => 'cache_count_misses',
-		],
-	];
 
 	/**************************
 	 * Public static properties
@@ -110,9 +99,9 @@ abstract class CacheApi
 	 */
 	public static int $count_misses = 0;
 
-	/**********************
-	 * Protected properties
-	 **********************/
+	/*********************
+	 * Internal properties
+	 *********************/
 
 	/**
 	 * @var string The maximum SMF version that this will work with.
@@ -133,6 +122,25 @@ abstract class CacheApi
 	 * @var int The default TTL.
 	 */
 	protected $ttl = 120;
+
+	/****************************
+	 * Internal static properties
+	 ****************************/
+
+	/**
+	 * @var array
+	 *
+	 * BackwardCompatibility settings for this class.
+	 */
+	private static $backcompat = [
+		'prop_names' => [
+			'loadedApi' => 'cacheAPI',
+			'hits' => 'cache_hits',
+			'count_hits' => 'cache_count',
+			'misses' => 'cache_misses',
+			'count_misses' => 'cache_count_misses',
+		],
+	];
 
 	/****************
 	 * Public methods

--- a/Sources/Cache/CacheApiInterface.php
+++ b/Sources/Cache/CacheApiInterface.php
@@ -21,6 +21,10 @@ if (!defined('SMF')) {
 
 interface CacheApiInterface
 {
+	/****************
+	 * Public methods
+	 ****************/
+
 	/**
 	 * Checks whether we can use the cache method performed by this API.
 	 *

--- a/Sources/Calendar/Event.php
+++ b/Sources/Calendar/Event.php
@@ -1050,6 +1050,7 @@ class Event implements \ArrayAccess
 
 		$this->createRecurrenceIterator();
 	}
+
 	/**
 	 * Gets the date after which no more occurrences happen.
 	 *

--- a/Sources/Category.php
+++ b/Sources/Category.php
@@ -30,20 +30,8 @@ use SMF\Db\DatabaseApi as Db;
  */
 class Category implements \ArrayAccess
 {
-	use BackwardCompatibility;
 	use ArrayAccessHelper;
-
-	/**
-	 * @var array
-	 *
-	 * BackwardCompatibility settings for this class.
-	 */
-	private static $backcompat = [
-		'prop_names' => [
-			'loaded' => 'cat_tree',
-			'boardList' => 'boardList',
-		],
-	];
+	use BackwardCompatibility;
 
 	/*******************
 	 * Public properties
@@ -202,6 +190,18 @@ class Category implements \ArrayAccess
 	 * Holds parsed versions of category descriptions.
 	 */
 	protected static array $parsed_descriptions = [];
+
+	/**
+	 * @var array
+	 *
+	 * BackwardCompatibility settings for this class.
+	 */
+	private static $backcompat = [
+		'prop_names' => [
+			'loaded' => 'cat_tree',
+			'boardList' => 'boardList',
+		],
+	];
 
 	/****************
 	 * Public methods

--- a/Sources/Config.php
+++ b/Sources/Config.php
@@ -35,12 +35,14 @@ class Config
 	 * 2: Make the forum untouchable. You'll need to make it 0 again manually!
 	 */
 	public static int $maintenance;
+
 	/**
 	 * @var string
 	 *
 	 * Title for the maintenance mode message.
 	 */
 	public static string $mtitle;
+
 	/**
 	 * Description of why the forum is in maintenance mode.
 	 *
@@ -55,24 +57,28 @@ class Config
 	 * The name of your forum.
 	 */
 	public static string $mbname;
+
 	/**
 	 * @var string
 	 *
 	 * The default language file set for the forum.
 	 */
 	public static string $language;
+
 	/**
 	 * @var string
 	 *
 	 * URL to your forum's folder. (without the trailing /!)
 	 */
 	public static string $boardurl;
+
 	/**
 	 * @var string
 	 *
 	 * Email address to send emails from. (like noreply@yourdomain.com.)
 	 */
 	public static string $webmaster_email;
+
 	/**
 	 * @var string
 	 *
@@ -88,6 +94,7 @@ class Config
 	 * Default options: mysql, postgresql
 	 */
 	public static string $db_type;
+
 	/**
 	 * @var int
 	 *
@@ -95,42 +102,49 @@ class Config
 	 * 0 to use default port for the database type.
 	 */
 	public static int $db_port;
+
 	/**
 	 * @var string
 	 *
 	 * The server to connect to (or a Unix socket)
 	 */
 	public static string $db_server;
+
 	/**
 	 * @var string
 	 *
 	 * The database name.
 	 */
 	public static string $db_name;
+
 	/**
 	 * @var string
 	 *
 	 * Database username.
 	 */
 	public static string $db_user;
+
 	/**
 	 * @var string
 	 *
 	 * Database password.
 	 */
 	public static string $db_passwd;
+
 	/**
 	 * @var string
 	 *
 	 * Database user for when connecting with SSI.
 	 */
 	public static string $ssi_db_user;
+
 	/**
 	 * @var string
 	 *
 	 * Database password for when connecting with SSI.
 	 */
 	public static string $ssi_db_passwd;
+
 	/**
 	 * @var string
 	 *
@@ -138,12 +152,14 @@ class Config
 	 * This helps to prevent conflicts.
 	 */
 	public static string $db_prefix;
+
 	/**
 	 * @var bool
 	 *
 	 * Use a persistent database connection.
 	 */
 	public static bool $db_persist;
+
 	/**
 	 * @var bool
 	 *
@@ -159,6 +175,7 @@ class Config
 	 * admin panel for proper detection of the available options.
 	 */
 	public static string $cache_accelerator;
+
 	/**
 	 * @var int
 	 *
@@ -166,6 +183,7 @@ class Config
 	 * Between 0 (off) through 3 (cache a lot).
 	 */
 	public static int $cache_enable;
+
 	/**
 	 * @var string
 	 *
@@ -173,12 +191,14 @@ class Config
 	 * Should be a string of 'server:port,server:port'
 	 */
 	public static string $cache_memcached;
+
 	/**
 	 * @var string
 	 *
 	 * Path to the cache directory for the file-based cache system.
 	 */
 	public static string $cachedir;
+
 	/**
 	 * @var string
 	 *
@@ -194,12 +214,14 @@ class Config
 	 * Whether the proxy is enabled or not.
 	 */
 	public static bool $image_proxy_enabled;
+
 	/**
 	 * @var string
 	 *
 	 * Secret key to be used by the proxy.
 	 */
 	public static string $image_proxy_secret;
+
 	/**
 	 * @var int
 	 *
@@ -215,18 +237,21 @@ class Config
 	 * The absolute path to the forum's folder. (not just '.'!)
 	 */
 	public static string $boarddir;
+
 	/**
 	 * @var string
 	 *
 	 * Path to the Sources directory.
 	 */
 	public static string $sourcedir;
+
 	/**
 	 * Path to the Packages directory.
 	 *
 	 * @var string
 	 */
 	public static string $packagesdir;
+
 	/**
 	 * Path to the Packages directory.
 	 *

--- a/Sources/Db/APIs/MySQL.php
+++ b/Sources/Db/APIs/MySQL.php
@@ -64,9 +64,9 @@ class MySQL extends DatabaseApi implements DatabaseApiInterface
 	 */
 	public bool $supports_pcre = false;
 
-	/********************
-	 * Runtime properties
-	 ********************/
+	/*********************
+	 * Internal properties
+	 *********************/
 
 	/**
 	 * @var object

--- a/Sources/Db/APIs/PostgreSQL.php
+++ b/Sources/Db/APIs/PostgreSQL.php
@@ -63,9 +63,9 @@ class PostgreSQL extends DatabaseApi implements DatabaseApiInterface
 	 */
 	public bool $supports_pcre = true;
 
-	/********************
-	 * Runtime properties
-	 ********************/
+	/*********************
+	 * Internal properties
+	 *********************/
 
 	/**
 	 * @var object

--- a/Sources/Db/DatabaseApi.php
+++ b/Sources/Db/DatabaseApi.php
@@ -29,20 +29,6 @@ abstract class DatabaseApi
 {
 	use BackwardCompatibility;
 
-	/**
-	 * @var array
-	 *
-	 * BackwardCompatibility settings for this class.
-	 */
-	private static $backcompat = [
-		'prop_names' => [
-			'count' => 'db_count',
-			'cache' => 'db_cache',
-			'package_log' => 'db_package_log',
-			'db_connection' => 'db_connection',
-		],
-	];
-
 	/*******************
 	 * Public properties
 	 *******************/
@@ -220,9 +206,9 @@ abstract class DatabaseApi
 	 */
 	public static bool $unbuffered = false;
 
-	/**********************
-	 * Protected properties
-	 **********************/
+	/*********************
+	 * Internal properties
+	 *********************/
 
 	/**
 	 * @var array
@@ -302,6 +288,24 @@ abstract class DatabaseApi
 		'user_alerts_prefs',
 		'user_drafts',
 		'user_likes',
+	];
+
+	/****************************
+	 * Internal static properties
+	 ****************************/
+
+	/**
+	 * @var array
+	 *
+	 * BackwardCompatibility settings for this class.
+	 */
+	private static $backcompat = [
+		'prop_names' => [
+			'count' => 'db_count',
+			'cache' => 'db_cache',
+			'package_log' => 'db_package_log',
+			'db_connection' => 'db_connection',
+		],
 	];
 
 	/****************

--- a/Sources/Db/DatabaseApiInterface.php
+++ b/Sources/Db/DatabaseApiInterface.php
@@ -20,6 +20,10 @@ namespace SMF\Db;
  */
 interface DatabaseApiInterface
 {
+	/****************
+	 * Public methods
+	 ****************/
+
 	/**
 	 * Performs a query. Takes care of errors too.
 	 *

--- a/Sources/Debug/DebugContextEntry.php
+++ b/Sources/Debug/DebugContextEntry.php
@@ -8,6 +8,10 @@ namespace SMF\Debug;
  */
 class DebugContextEntry
 {
+	/****************
+	 * Public methods
+	 ****************/
+
 	/**
 	 * @param string|null $extra_before A string that is rendered before any other content.
 	 *    Defaults to `null`.

--- a/Sources/Debug/DebugUtils.php
+++ b/Sources/Debug/DebugUtils.php
@@ -258,6 +258,7 @@ class DebugUtils
 
 		return $warnings;
 	}
+
 	/**
 	 * Creates the debug context array using the DebugContextEntry class.
 	 *

--- a/Sources/Draft.php
+++ b/Sources/Draft.php
@@ -808,6 +808,10 @@ class Draft
 		return Utils::$context['draft_saved'];
 	}
 
+	/*************************
+	 * Internal static methods
+	 *************************/
+
 	/**
 	 * Returns an XML response to an autosave AJAX request.
 	 *

--- a/Sources/Editor.php
+++ b/Sources/Editor.php
@@ -185,9 +185,9 @@ class Editor implements \ArrayAccess
 		'popup' => [],
 	];
 
-	/****************************
-	 * Internal static properties
-	 ****************************/
+	/*********************
+	 * Internal properties
+	 *********************/
 
 	/**
 	 * @var array

--- a/Sources/Forum.php
+++ b/Sources/Forum.php
@@ -347,6 +347,10 @@ class Forum
 	 */
 	public static array $guest_access_actions = [];
 
+	/****************************
+	 * Internal static properties
+	 ****************************/
+
 	/**
 	 * @var ActionInterface|null
 	 *

--- a/Sources/Forum.php
+++ b/Sources/Forum.php
@@ -524,30 +524,6 @@ class Forum
 		return self::$current_action;
 	}
 
-	/*************************
-	 * Internal static methods
-	 *************************/
-
-	/**
-	 * Display a message about the forum being in maintenance mode.
-	 * - Display a login screen with sub template 'maintenance'.
-	 * - Sends a 503 header, so search engines don't bother indexing while we're in maintenance mode.
-	 */
-	protected static function inMaintenance(): void
-	{
-		Theme::loadTemplate('Login');
-		SecurityToken::create('login');
-
-		// Send a 503 header, so search engines don't bother indexing while we're in maintenance mode.
-		Utils::sendHttpStatus(503, 'Service Temporarily Unavailable');
-
-		// Basic template stuff..
-		Utils::$context['sub_template'] = 'maintenance';
-		Utils::$context['title'] = Utils::htmlspecialchars(Config::$mtitle);
-		Utils::$context['description'] = &Config::$mmessage;
-		Utils::$context['page_title'] = Lang::getTxt('maintain_mode', file: 'Login');
-	}
-
 	/******************
 	 * Internal methods
 	 ******************/
@@ -704,6 +680,26 @@ class Forum
 	/*************************
 	 * Internal static methods
 	 *************************/
+
+	/**
+	 * Display a message about the forum being in maintenance mode.
+	 * - Display a login screen with sub template 'maintenance'.
+	 * - Sends a 503 header, so search engines don't bother indexing while we're in maintenance mode.
+	 */
+	protected static function inMaintenance(): void
+	{
+		Theme::loadTemplate('Login');
+		SecurityToken::create('login');
+
+		// Send a 503 header, so search engines don't bother indexing while we're in maintenance mode.
+		Utils::sendHttpStatus(503, 'Service Temporarily Unavailable');
+
+		// Basic template stuff..
+		Utils::$context['sub_template'] = 'maintenance';
+		Utils::$context['title'] = Utils::htmlspecialchars(Config::$mtitle);
+		Utils::$context['description'] = &Config::$mmessage;
+		Utils::$context['page_title'] = Lang::getTxt('maintain_mode', file: 'Login');
+	}
 
 	/**
 	 * Resolves the appropriate action to execute based on the current request context.

--- a/Sources/Graphics/Gif/ColorTable.php
+++ b/Sources/Graphics/Gif/ColorTable.php
@@ -25,9 +25,17 @@ namespace SMF\Graphics\Gif;
 
 class ColorTable
 {
+	/*******************
+	 * Public properties
+	 *******************/
+
 	public $m_nColors;
 
 	public $m_arColors;
+
+	/****************
+	 * Public methods
+	 ****************/
 
 	public function __construct()
 	{

--- a/Sources/Graphics/Gif/ColorTable.php
+++ b/Sources/Graphics/Gif/ColorTable.php
@@ -26,6 +26,7 @@ namespace SMF\Graphics\Gif;
 class ColorTable
 {
 	public $m_nColors;
+
 	public $m_arColors;
 
 	public function __construct()

--- a/Sources/Graphics/Gif/File.php
+++ b/Sources/Graphics/Gif/File.php
@@ -28,8 +28,11 @@ use SMF\Config;
 class File
 {
 	public $header;
+
 	public $image;
+
 	public $data;
+
 	public $loaded;
 
 	public function __construct()

--- a/Sources/Graphics/Gif/File.php
+++ b/Sources/Graphics/Gif/File.php
@@ -27,6 +27,10 @@ use SMF\Config;
 
 class File
 {
+	/*******************
+	 * Public properties
+	 *******************/
+
 	public $header;
 
 	public $image;
@@ -34,6 +38,10 @@ class File
 	public $data;
 
 	public $loaded;
+
+	/****************
+	 * Public methods
+	 ****************/
 
 	public function __construct()
 	{

--- a/Sources/Graphics/Gif/FileHeader.php
+++ b/Sources/Graphics/Gif/FileHeader.php
@@ -26,14 +26,23 @@ namespace SMF\Graphics\Gif;
 class FileHeader
 {
 	public $m_lpVer;
+
 	public $m_nWidth;
+
 	public $m_nHeight;
+
 	public $m_bGlobalClr;
+
 	public $m_nColorRes;
+
 	public $m_bSorted;
+
 	public $m_nTableSize;
+
 	public $m_nBgColor;
+
 	public $m_nPixelRatio;
+
 	public $m_colorTable;
 
 	public function __construct()

--- a/Sources/Graphics/Gif/FileHeader.php
+++ b/Sources/Graphics/Gif/FileHeader.php
@@ -25,6 +25,10 @@ namespace SMF\Graphics\Gif;
 
 class FileHeader
 {
+	/*******************
+	 * Public properties
+	 *******************/
+
 	public $m_lpVer;
 
 	public $m_nWidth;
@@ -44,6 +48,10 @@ class FileHeader
 	public $m_nPixelRatio;
 
 	public $m_colorTable;
+
+	/****************
+	 * Public methods
+	 ****************/
 
 	public function __construct()
 	{

--- a/Sources/Graphics/Gif/Image.php
+++ b/Sources/Graphics/Gif/Image.php
@@ -25,6 +25,10 @@ namespace SMF\Graphics\Gif;
 
 class Image
 {
+	/*******************
+	 * Public properties
+	 *******************/
+
 	public $m_disp;
 
 	public $m_bUser;
@@ -42,6 +46,10 @@ class Image
 	public $m_data;
 
 	public $m_lzw;
+
+	/****************
+	 * Public methods
+	 ****************/
 
 	public function __construct()
 	{

--- a/Sources/Graphics/Gif/Image.php
+++ b/Sources/Graphics/Gif/Image.php
@@ -26,13 +26,21 @@ namespace SMF\Graphics\Gif;
 class Image
 {
 	public $m_disp;
+
 	public $m_bUser;
+
 	public $m_bTrans;
+
 	public $m_nDelay;
+
 	public $m_nTrans;
+
 	public $m_lpComm;
+
 	public $m_gih;
+
 	public $m_data;
+
 	public $m_lzw;
 
 	public function __construct()

--- a/Sources/Graphics/Gif/ImageHeader.php
+++ b/Sources/Graphics/Gif/ImageHeader.php
@@ -26,13 +26,21 @@ namespace SMF\Graphics\Gif;
 class ImageHeader
 {
 	public $m_nLeft;
+
 	public $m_nTop;
+
 	public $m_nWidth;
+
 	public $m_nHeight;
+
 	public $m_bLocalClr;
+
 	public $m_bInterlace;
+
 	public $m_bSorted;
+
 	public $m_nTableSize;
+
 	public $m_colorTable;
 
 	public function __construct()

--- a/Sources/Graphics/Gif/ImageHeader.php
+++ b/Sources/Graphics/Gif/ImageHeader.php
@@ -25,6 +25,10 @@ namespace SMF\Graphics\Gif;
 
 class ImageHeader
 {
+	/*******************
+	 * Public properties
+	 *******************/
+
 	public $m_nLeft;
 
 	public $m_nTop;
@@ -42,6 +46,10 @@ class ImageHeader
 	public $m_nTableSize;
 
 	public $m_colorTable;
+
+	/****************
+	 * Public methods
+	 ****************/
 
 	public function __construct()
 	{

--- a/Sources/Graphics/Gif/LzwCompression.php
+++ b/Sources/Graphics/Gif/LzwCompression.php
@@ -31,23 +31,41 @@ namespace SMF\Graphics\Gif;
 class LzwCompression
 {
 	public $MAX_LZW_BITS;
+
 	public $Fresh;
+
 	public $CodeSize;
+
 	public $SetCodeSize;
+
 	public $MaxCode;
+
 	public $MaxCodeSize;
+
 	public $FirstCode;
+
 	public $OldCode;
+
 	public $ClearCode;
+
 	public $EndCode;
+
 	public $Next;
+
 	public $Vals;
+
 	public $Stack;
+
 	public $sp;
+
 	public $Buf;
+
 	public $CurBit;
+
 	public $LastBit;
+
 	public $Done;
+
 	public $LastByte;
 
 	public function __construct()

--- a/Sources/Graphics/Gif/LzwCompression.php
+++ b/Sources/Graphics/Gif/LzwCompression.php
@@ -30,6 +30,10 @@ namespace SMF\Graphics\Gif;
  */
 class LzwCompression
 {
+	/*******************
+	 * Public properties
+	 *******************/
+
 	public $MAX_LZW_BITS;
 
 	public $Fresh;
@@ -67,6 +71,10 @@ class LzwCompression
 	public $Done;
 
 	public $LastByte;
+
+	/****************
+	 * Public methods
+	 ****************/
 
 	public function __construct()
 	{

--- a/Sources/Lang.php
+++ b/Sources/Lang.php
@@ -25,22 +25,6 @@ class Lang
 {
 	use BackwardCompatibility;
 
-	/**
-	 * @var array
-	 *
-	 * BackwardCompatibility settings for this class.
-	 */
-	private static $backcompat = [
-		'prop_names' => [
-			'txt' => 'txt',
-			'tztxt' => 'tztxt',
-			'editortxt' => 'editortxt',
-			'helptxt' => 'helptxt',
-			'txtBirthdayEmails' => 'txtBirthdayEmails',
-			'forum_copyright' => 'forum_copyright',
-		],
-	];
-
 	/*****************
 	 * Class constants
 	 *****************/
@@ -186,6 +170,22 @@ class Lang
 	/****************************
 	 * Internal static properties
 	 ****************************/
+
+	/**
+	 * @var array
+	 *
+	 * BackwardCompatibility settings for this class.
+	 */
+	private static $backcompat = [
+		'prop_names' => [
+			'txt' => 'txt',
+			'tztxt' => 'tztxt',
+			'editortxt' => 'editortxt',
+			'helptxt' => 'helptxt',
+			'txtBirthdayEmails' => 'txtBirthdayEmails',
+			'forum_copyright' => 'forum_copyright',
+		],
+	];
 
 	/**
 	 * @var array

--- a/Sources/MailAgent/APIs/SMTP.php
+++ b/Sources/MailAgent/APIs/SMTP.php
@@ -26,12 +26,9 @@ use SMF\Url;
  */
 class SMTP extends MailAgent implements MailAgentInterface
 {
-	/**
-	 * @var bool
-	 *
-	 * This is used to determine if we have sent any mail previosuly and issue a reset prior to sending another message.
-	 */
-	private bool $sentAny = false;
+	/*******************
+	 * Public properties
+	 *******************/
 
 	/**
 	 * @var bool
@@ -40,6 +37,17 @@ class SMTP extends MailAgent implements MailAgentInterface
 	 */
 	public bool $useTLS = false;
 
+	/*********************
+	 * Internal properties
+	 *********************/
+
+	/**
+	 * @var bool
+	 *
+	 * This is used to determine if we have sent any mail previosuly and issue a reset prior to sending another message.
+	 */
+	private bool $sentAny = false;
+
 	/**
 	 * @var resource|false
 	 *
@@ -47,6 +55,10 @@ class SMTP extends MailAgent implements MailAgentInterface
 	 * PHP does not have a type hint for resource of type Stream.  So we just use mixed.
 	 */
 	private mixed $socket;
+
+	/****************
+	 * Public methods
+	 ****************/
 
 	/**
 	 *
@@ -222,6 +234,10 @@ class SMTP extends MailAgent implements MailAgentInterface
 		$config_vars[] = ['text', 'smtp_username'];
 		$config_vars[] = ['password', 'smtp_password'];
 	}
+
+	/******************
+	 * Internal methods
+	 ******************/
 
 	/**
 	 * Parse a message to the SMTP server.

--- a/Sources/MailAgent/APIs/SMTPTLS.php
+++ b/Sources/MailAgent/APIs/SMTPTLS.php
@@ -20,6 +20,10 @@ use SMF\MailAgent\MailAgentInterface;
  */
 class SMTPTLS extends SMTP implements MailAgentInterface
 {
+	/*******************
+	 * Public properties
+	 *******************/
+
 	/**
 	 * @var bool
 	 *

--- a/Sources/MailAgent/APIs/SendMail.php
+++ b/Sources/MailAgent/APIs/SendMail.php
@@ -25,6 +25,10 @@ use SMF\Sapi;
  */
 class SendMail extends MailAgent implements MailAgentInterface
 {
+	/****************
+	 * Public methods
+	 ****************/
+
 	/**
 	 *
 	 */

--- a/Sources/MailAgent/MailAgent.php
+++ b/Sources/MailAgent/MailAgent.php
@@ -19,6 +19,10 @@ use SMF\Utils;
 
 abstract class MailAgent
 {
+	/*****************
+	 * Class constants
+	 *****************/
+
 	/**
 	 * @var string
 	 *
@@ -60,9 +64,9 @@ abstract class MailAgent
 	 */
 	public static MailAgentInterface|bool|null $loaded_api = null;
 
-	/**********************
-	 * Protected properties
-	 **********************/
+	/*********************
+	 * Internal properties
+	 *********************/
 
 	/**
 	 * @var string The maximum SMF version that this will work with.

--- a/Sources/MailAgent/MailAgentInterface.php
+++ b/Sources/MailAgent/MailAgentInterface.php
@@ -15,6 +15,10 @@ namespace SMF\MailAgent;
 
 interface MailAgentInterface
 {
+	/****************
+	 * Public methods
+	 ****************/
+
 	/**
 	 * Checks if the requirements for the agent are available.
 	 *

--- a/Sources/Mentions.php
+++ b/Sources/Mentions.php
@@ -26,6 +26,10 @@ use SMF\Db\DatabaseApi as Db;
  */
 class Mentions
 {
+	/****************************
+	 * Internal static properties
+	 ****************************/
+
 	/**
 	 * @var string The character used for mentioning users
 	 */
@@ -35,6 +39,10 @@ class Mentions
 	 * @var string Regular expression matching BBC that can't contain mentions
 	 */
 	protected static $excluded_bbc_regex = '';
+
+	/***********************
+	 * Public static methods
+	 ***********************/
 
 	/**
 	 * Returns mentions for a specific content
@@ -251,91 +259,6 @@ class Mentions
 	}
 
 	/**
-	 * Parses a body in order to see if there are any mentions, returns possible mention names
-	 *
-	 * Names are tagged by "@<username>" format in post, but they can contain
-	 * any type of character up to 60 characters length. So we extract, starting from @
-	 * up to 60 characters in length (or if we encounter a line break) and make
-	 * several combination of strings after splitting it by anything that's not a word and join
-	 * by having the first word, first and second word, first, second and third word and so on and
-	 * search every name.
-	 *
-	 * One potential problem with this is something like "@Admin Space" can match
-	 * "Admin Space" as well as "Admin", so we sort by length in descending order.
-	 * One disadvantage of this is that we can only match by one column, hence I've chosen
-	 * real_name since it's the most obvious.
-	 *
-	 * If there's an @ symbol within the name, it is counted in the ongoing string and a new
-	 * combination string is started from it as well in order to account for all the possibilities.
-	 * This makes the @ symbol to not be required to be escaped
-	 *
-	 * @static
-	 * @param string $body The text to look for mentions in
-	 * @return array An array of names of members who have been mentioned
-	 */
-	protected static function getPossibleMentions(string $body): array
-	{
-		if (empty($body)) {
-			return [];
-		}
-
-		// preparse code does a few things which might mess with our parsing
-		$body = htmlspecialchars_decode(preg_replace('~<br\s*/?' . '>~', "\n", str_replace('&nbsp;', ' ', $body)), ENT_QUOTES);
-
-		if (empty(self::$excluded_bbc_regex)) {
-			self::setExcludedBbcRegex();
-		}
-
-		// Exclude the content of various BBCodes.
-		$body = preg_replace('~\[(' . self::$excluded_bbc_regex . ')[^\]]*\](?' . '>(?' . '>[^\[]|\[(?!/?\1[^\]]*\]))|(?0))*\[/\1\]~', '', $body);
-
-		$matches = [];
-		// Split before every Unicode character.
-		$string = preg_split('/(?=\X)/u', $body, -1, PREG_SPLIT_NO_EMPTY);
-		$depth = 0;
-
-		foreach ($string as $k => $char) {
-			if ($char == static::$char && ($k == 0 || trim($string[$k - 1]) == '')) {
-				$depth++;
-				$matches[] = [];
-			} elseif ($char == "\n") {
-				$depth = 0;
-			}
-
-			for ($i = $depth; $i > 0; $i--) {
-				if (count($matches[count($matches) - $i]) > 60) {
-					$depth--;
-
-					continue;
-				}
-				$matches[count($matches) - $i][] = $char;
-			}
-		}
-
-		foreach ($matches as $k => $match) {
-			$matches[$k] = substr(implode('', $match), 1);
-		}
-
-		// Names can have spaces, other breaks, or they can't...we try to match every possible
-		// combination.
-		$names = [];
-
-		foreach ($matches as $match) {
-			// '[^\p{L}\p{M}\p{N}_]' is the Unicode equivalent of '[^\w]'
-			$match = preg_split('/([^\p{L}\p{M}\p{N}_])/u', $match, -1, PREG_SPLIT_DELIM_CAPTURE);
-			$count = count($match);
-
-			for ($i = 1; $i <= $count; $i++) {
-				$names[] = Utils::htmlspecialchars(Utils::htmlTrim(implode('', array_slice($match, 0, $i))));
-			}
-		}
-
-		$names = array_unique($names);
-
-		return $names;
-	}
-
-	/**
 	 * Like getPossibleMentions(), but for `[member=1]name[/member]` format.
 	 *
 	 * @static
@@ -471,6 +394,95 @@ class Mentions
 		}
 
 		return $members;
+	}
+
+	/*************************
+	 * Internal static methods
+	 *************************/
+
+	/**
+	 * Parses a body in order to see if there are any mentions, returns possible mention names
+	 *
+	 * Names are tagged by "@<username>" format in post, but they can contain
+	 * any type of character up to 60 characters length. So we extract, starting from @
+	 * up to 60 characters in length (or if we encounter a line break) and make
+	 * several combination of strings after splitting it by anything that's not a word and join
+	 * by having the first word, first and second word, first, second and third word and so on and
+	 * search every name.
+	 *
+	 * One potential problem with this is something like "@Admin Space" can match
+	 * "Admin Space" as well as "Admin", so we sort by length in descending order.
+	 * One disadvantage of this is that we can only match by one column, hence I've chosen
+	 * real_name since it's the most obvious.
+	 *
+	 * If there's an @ symbol within the name, it is counted in the ongoing string and a new
+	 * combination string is started from it as well in order to account for all the possibilities.
+	 * This makes the @ symbol to not be required to be escaped
+	 *
+	 * @static
+	 * @param string $body The text to look for mentions in
+	 * @return array An array of names of members who have been mentioned
+	 */
+	protected static function getPossibleMentions(string $body): array
+	{
+		if (empty($body)) {
+			return [];
+		}
+
+		// preparse code does a few things which might mess with our parsing
+		$body = htmlspecialchars_decode(preg_replace('~<br\s*/?' . '>~', "\n", str_replace('&nbsp;', ' ', $body)), ENT_QUOTES);
+
+		if (empty(self::$excluded_bbc_regex)) {
+			self::setExcludedBbcRegex();
+		}
+
+		// Exclude the content of various BBCodes.
+		$body = preg_replace('~\[(' . self::$excluded_bbc_regex . ')[^\]]*\](?' . '>(?' . '>[^\[]|\[(?!/?\1[^\]]*\]))|(?0))*\[/\1\]~', '', $body);
+
+		$matches = [];
+		// Split before every Unicode character.
+		$string = preg_split('/(?=\X)/u', $body, -1, PREG_SPLIT_NO_EMPTY);
+		$depth = 0;
+
+		foreach ($string as $k => $char) {
+			if ($char == static::$char && ($k == 0 || trim($string[$k - 1]) == '')) {
+				$depth++;
+				$matches[] = [];
+			} elseif ($char == "\n") {
+				$depth = 0;
+			}
+
+			for ($i = $depth; $i > 0; $i--) {
+				if (count($matches[count($matches) - $i]) > 60) {
+					$depth--;
+
+					continue;
+				}
+				$matches[count($matches) - $i][] = $char;
+			}
+		}
+
+		foreach ($matches as $k => $match) {
+			$matches[$k] = substr(implode('', $match), 1);
+		}
+
+		// Names can have spaces, other breaks, or they can't...we try to match every possible
+		// combination.
+		$names = [];
+
+		foreach ($matches as $match) {
+			// '[^\p{L}\p{M}\p{N}_]' is the Unicode equivalent of '[^\w]'
+			$match = preg_split('/([^\p{L}\p{M}\p{N}_])/u', $match, -1, PREG_SPLIT_DELIM_CAPTURE);
+			$count = count($match);
+
+			for ($i = 1; $i <= $count; $i++) {
+				$names[] = Utils::htmlspecialchars(Utils::htmlTrim(implode('', array_slice($match, 0, $i))));
+			}
+		}
+
+		$names = array_unique($names);
+
+		return $names;
 	}
 
 	/**

--- a/Sources/PackageManager/FtpConnection.php
+++ b/Sources/PackageManager/FtpConnection.php
@@ -23,6 +23,10 @@ namespace SMF\PackageManager;
  */
 class FtpConnection
 {
+	/*******************
+	 * Public properties
+	 *******************/
+
 	/**
 	 * @var resource Holds the connection response
 	 */
@@ -42,6 +46,10 @@ class FtpConnection
 	 * @var array{ip: string, port: int} Contains information about passive mode if used.
 	 */
 	public array $pasv = [];
+
+	/****************
+	 * Public methods
+	 ****************/
 
 	/**
 	 * Create a new FTP connection...

--- a/Sources/PackageManager/PackageManager.php
+++ b/Sources/PackageManager/PackageManager.php
@@ -70,9 +70,9 @@ class PackageManager
 		'serverbrowse' => 'serverBrowse',
 	];
 
-	/**********************
-	 * Protected properties
-	 **********************/
+	/*********************
+	 * Internal properties
+	 *********************/
 
 	/**
 	 * @var array
@@ -88,6 +88,10 @@ class PackageManager
 		'remove' => 'serverremove',
 		'browse' => 'serverbrowse',
 	];
+
+	/****************************
+	 * Internal static properties
+	 ****************************/
 
 	/**
 	 * An instance of this class.

--- a/Sources/PackageManager/PackageManager.php
+++ b/Sources/PackageManager/PackageManager.php
@@ -94,34 +94,6 @@ class PackageManager
 	 */
 	protected static $obj;
 
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Instantiates this class, but never more than once.
-	 *
-	 * @todo Add a reference to Utils::$context['instances'] as well?
-	 *
-	 * @return self An instance of this class.
-	 */
-	public static function load(): object
-	{
-		if (!isset(self::$obj)) {
-			self::$obj = new self();
-		}
-
-		return self::$obj;
-	}
-
-	/**
-	 * Convenience method to load() and execute() an instance of this class.
-	 */
-	public static function call(): void
-	{
-		self::load()->execute();
-	}
-
 	/****************
 	 * Public methods
 	 ****************/
@@ -3436,6 +3408,34 @@ class PackageManager
 		);
 
 		return $packages;
+	}
+
+	/***********************
+	 * Public static methods
+	 ***********************/
+
+	/**
+	 * Instantiates this class, but never more than once.
+	 *
+	 * @todo Add a reference to Utils::$context['instances'] as well?
+	 *
+	 * @return self An instance of this class.
+	 */
+	public static function load(): object
+	{
+		if (!isset(self::$obj)) {
+			self::$obj = new self();
+		}
+
+		return self::$obj;
+	}
+
+	/**
+	 * Convenience method to load() and execute() an instance of this class.
+	 */
+	public static function call(): void
+	{
+		self::load()->execute();
 	}
 
 	/******************

--- a/Sources/PackageManager/PackageUtils.php
+++ b/Sources/PackageManager/PackageUtils.php
@@ -835,6 +835,7 @@ class PackageUtils
 
 		return $return_data;
 	}
+
 	/**
 	 * Get a listing of files that will need to be set back to the original state
 	 *

--- a/Sources/PackageManager/XmlArray.php
+++ b/Sources/PackageManager/XmlArray.php
@@ -680,7 +680,7 @@ class XmlArray
 	 * @param null|array|string $array An array of data
 	 * @return string The text from the array
 	 */
-	protected function _fetch(null|array|string $array): string
+	protected function _fetch(array|string|null $array): string
 	{
 		// Don't return anything if this is just a string.
 		if (is_string($array)) {

--- a/Sources/PackageManager/XmlArray.php
+++ b/Sources/PackageManager/XmlArray.php
@@ -24,6 +24,10 @@ use SMF\Sapi;
  */
 class XmlArray
 {
+	/*******************
+	 * Public properties
+	 *******************/
+
 	/**
 	 * @var array Holds parsed XML results
 	 */
@@ -40,6 +44,10 @@ class XmlArray
 	 * @var bool Holds trim level textual data
 	 */
 	public $trim;
+
+	/****************
+	 * Public methods
+	 ****************/
 
 	/**
 	 * Constructor for the xml parser.
@@ -357,6 +365,53 @@ class XmlArray
 	}
 
 	/**
+	 * Parse out CDATA tags. (htmlspecialchars them...)
+	 *
+	 * @param string $data The data with CDATA tags included
+	 * @return string The data contained within CDATA tags
+	 */
+	public function _to_cdata(string $data): string
+	{
+		$inCdata = $inComment = false;
+		$output = '';
+
+		$parts = preg_split('~(<!\[CDATA\[|\]\]>|<!--|-->)~', $data, -1, PREG_SPLIT_DELIM_CAPTURE);
+
+		foreach ($parts as $part) {
+			// Handle XML comments.
+			if (!$inCdata && $part === '<!--') {
+				$inComment = true;
+			}
+
+			if ($inComment && $part === '-->') {
+				$inComment = false;
+			} elseif ($inComment) {
+				continue;
+			}
+
+			// Handle Cdata blocks.
+			elseif (!$inComment && $part === '<![CDATA[') {
+				$inCdata = true;
+			} elseif ($inCdata && $part === ']]>') {
+				$inCdata = false;
+			} elseif ($inCdata) {
+				$output .= htmlentities($part, ENT_QUOTES);
+			}
+
+			// Everything else is kept as is.
+			else {
+				$output .= $part;
+			}
+		}
+
+		return $output;
+	}
+
+	/******************
+	 * Internal methods
+	 ******************/
+
+	/**
 	 * Parse data into an array. (privately used...)
 	 *
 	 * @param string $data The data to parse
@@ -591,49 +646,6 @@ class XmlArray
 		}
 
 		return $return;
-	}
-
-	/**
-	 * Parse out CDATA tags. (htmlspecialchars them...)
-	 *
-	 * @param string $data The data with CDATA tags included
-	 * @return string The data contained within CDATA tags
-	 */
-	public function _to_cdata(string $data): string
-	{
-		$inCdata = $inComment = false;
-		$output = '';
-
-		$parts = preg_split('~(<!\[CDATA\[|\]\]>|<!--|-->)~', $data, -1, PREG_SPLIT_DELIM_CAPTURE);
-
-		foreach ($parts as $part) {
-			// Handle XML comments.
-			if (!$inCdata && $part === '<!--') {
-				$inComment = true;
-			}
-
-			if ($inComment && $part === '-->') {
-				$inComment = false;
-			} elseif ($inComment) {
-				continue;
-			}
-
-			// Handle Cdata blocks.
-			elseif (!$inComment && $part === '<![CDATA[') {
-				$inCdata = true;
-			} elseif ($inCdata && $part === ']]>') {
-				$inCdata = false;
-			} elseif ($inCdata) {
-				$output .= htmlentities($part, ENT_QUOTES);
-			}
-
-			// Everything else is kept as is.
-			else {
-				$output .= $part;
-			}
-		}
-
-		return $output;
 	}
 
 	/**

--- a/Sources/Parser.php
+++ b/Sources/Parser.php
@@ -254,9 +254,9 @@ abstract class Parser
 	 */
 	private static array $results = [];
 
-	/*****************
-	 * Public methods.
-	 *****************/
+	/****************
+	 * Public methods
+	 ****************/
 
 	/**
 	 * Constructor.
@@ -412,9 +412,9 @@ abstract class Parser
 		);
 	}
 
-	/*******************
-	 * Internal methods.
-	 *******************/
+	/******************
+	 * Internal methods
+	 ******************/
 
 	/**
 	 * Checks whether the server's load average is too high to parse BBCode.

--- a/Sources/Parsers/BBCodeParser.php
+++ b/Sources/Parsers/BBCodeParser.php
@@ -358,9 +358,9 @@ class BBCodeParser extends Parser
 	 */
 	private static array $parsers = [];
 
-	/*****************
-	 * Public methods.
-	 *****************/
+	/****************
+	 * Public methods
+	 ****************/
 
 	/**
 	 * Constructor.
@@ -1220,9 +1220,9 @@ class BBCodeParser extends Parser
 		return $this->{$name} ?? null;
 	}
 
-	/************************
-	 * Public static methods.
-	 ************************/
+	/***********************
+	 * Public static methods
+	 ***********************/
 
 	/**
 	 * Returns a reusable instance of this class.
@@ -1340,9 +1340,9 @@ class BBCodeParser extends Parser
 		);
 	}
 
-	/*******************
-	 * Internal methods.
-	 *******************/
+	/******************
+	 * Internal methods
+	 ******************/
 
 	/**
 	 * The method that actually parses the BBCode in $this->message.

--- a/Sources/Parsers/MarkdownParser.php
+++ b/Sources/Parsers/MarkdownParser.php
@@ -872,9 +872,9 @@ class MarkdownParser extends Parser
 		return $this->rendered;
 	}
 
-	/************************
-	 * Public static methods.
-	 ************************/
+	/***********************
+	 * Public static methods
+	 ***********************/
 
 	/**
 	 * Returns a reusable instance of this class.

--- a/Sources/Parsers/SmileyParser.php
+++ b/Sources/Parsers/SmileyParser.php
@@ -63,9 +63,9 @@ class SmileyParser extends Parser
 	 */
 	private static self $parser;
 
-	/*****************
-	 * Public methods.
-	 *****************/
+	/****************
+	 * Public methods
+	 ****************/
 
 	/**
 	 * Constructor.
@@ -166,9 +166,9 @@ class SmileyParser extends Parser
 		);
 	}
 
-	/************************
-	 * Public static methods.
-	 ************************/
+	/***********************
+	 * Public static methods
+	 ***********************/
 
 	/**
 	 * Returns a reusable instance of this class.

--- a/Sources/Permissions/Permission.php
+++ b/Sources/Permissions/Permission.php
@@ -36,11 +36,17 @@ class Permission implements \ArrayAccess
 	 * Class constants
 	 *****************/
 
+	/**
+	 * Constants for group levels
+	 */
 	public const GROUP_LEVEL_RESTRICT = 0;
 	public const GROUP_LEVEL_STANDARD = 1;
 	public const GROUP_LEVEL_MODERATOR = 2;
 	public const GROUP_LEVEL_MAINTENANCE = 3;
 
+	/**
+	 * Constants for board levels
+	 */
 	public const BOARD_LEVEL_STANDARD = 0;
 	public const BOARD_LEVEL_LOCKED = 1;
 	public const BOARD_LEVEL_PUBLISH = 2;

--- a/Sources/PersonalMessage/Popup.php
+++ b/Sources/PersonalMessage/Popup.php
@@ -26,6 +26,10 @@ use SMF\Utils;
  */
 class Popup
 {
+	/****************
+	 * Public methods
+	 ****************/
+
 	/**
 	 * Constructor.
 	 */

--- a/Sources/PersonalMessage/Rule.php
+++ b/Sources/PersonalMessage/Rule.php
@@ -116,6 +116,10 @@ class Rule implements \ArrayAccess
 	 */
 	public static array $loaded = [];
 
+	/*********************
+	 * Internal properties
+	 *********************/
+
 	/**
 	 * @var array
 	 *

--- a/Sources/PersonalMessage/SearchResult.php
+++ b/Sources/PersonalMessage/SearchResult.php
@@ -23,6 +23,10 @@ use SMF\Search\SearchResult as SR;
  */
 class SearchResult extends PM
 {
+	/***********************
+	 * Public static methods
+	 ***********************/
+
 	/**
 	 * Generator that yields formatted PMs for use in a search results list.
 	 *

--- a/Sources/Profile.php
+++ b/Sources/Profile.php
@@ -28,21 +28,8 @@ use SMF\Graphics\Image;
  */
 class Profile extends User implements \ArrayAccess
 {
-	use BackwardCompatibility;
 	use ArrayAccessHelper;
-
-	/**
-	 * @var array
-	 *
-	 * BackwardCompatibility settings for this class.
-	 */
-	private static $backcompat = [
-		'prop_names' => [
-			'profile_fields' => 'profile_fields',
-			'profile_vars' => 'profile_vars',
-			'cur_profile' => 'cur_profile',
-		],
-	];
+	use BackwardCompatibility;
 
 	/*****************
 	 * Class constants
@@ -261,6 +248,23 @@ class Profile extends User implements \ArrayAccess
 	 * in some places to be able to distinguish these from the others.
 	 */
 	protected array $cf_save_errors = [];
+
+	/****************************
+	 * Internal static properties
+	 ****************************/
+
+	/**
+	 * @var array
+	 *
+	 * BackwardCompatibility settings for this class.
+	 */
+	private static $backcompat = [
+		'prop_names' => [
+			'profile_fields' => 'profile_fields',
+			'profile_vars' => 'profile_vars',
+			'cur_profile' => 'cur_profile',
+		],
+	];
 
 	/****************
 	 * Public methods

--- a/Sources/ProxyServer.php
+++ b/Sources/ProxyServer.php
@@ -23,6 +23,10 @@ use SMF\WebFetch\WebFetchApi;
  */
 class ProxyServer
 {
+	/*********************
+	 * Internal properties
+	 *********************/
+
 	/**
 	 * @var bool
 	 *
@@ -85,6 +89,10 @@ class ProxyServer
 	 * Body of object cached.
 	 */
 	protected $cachedbody;
+
+	/****************
+	 * Public methods
+	 ****************/
 
 	/**
 	 * Constructor. Loads up the settings for the proxy.
@@ -213,6 +221,28 @@ class ProxyServer
 	}
 
 	/**
+	 * Delete all old entries
+	 */
+	public function housekeeping(): void
+	{
+		$path = $this->cache . '/';
+
+		if ($handle = opendir($path)) {
+			while (false !== ($file = readdir($handle))) {
+				if (is_file($path . $file) && !in_array($file, ['index.php', '.htaccess']) && time() - filemtime($path . $file) > $this->maxDays * 86400) {
+					unlink($path . $file);
+				}
+			}
+
+			closedir($handle);
+		}
+	}
+
+	/******************
+	 * Internal methods
+	 ******************/
+
+	/**
 	 * Returns the request's hashed filepath
 	 *
 	 * @param \SMF\Url|string $request The request to get the path for
@@ -305,23 +335,5 @@ class ProxyServer
 		header('Location: ' . Utils::htmlspecialcharsDecode($request), false, 301);
 
 		exit;
-	}
-
-	/**
-	 * Delete all old entries
-	 */
-	public function housekeeping(): void
-	{
-		$path = $this->cache . '/';
-
-		if ($handle = opendir($path)) {
-			while (false !== ($file = readdir($handle))) {
-				if (is_file($path . $file) && !in_array($file, ['index.php', '.htaccess']) && time() - filemtime($path . $file) > $this->maxDays * 86400) {
-					unlink($path . $file);
-				}
-			}
-
-			closedir($handle);
-		}
 	}
 }

--- a/Sources/Punycode.php
+++ b/Sources/Punycode.php
@@ -34,9 +34,12 @@ use function SMF\Unicode\idna_maps_not_std3;
  */
 class Punycode
 {
+	/*****************
+	 * Class constants
+	 *****************/
+
 	/**
 	 * Bootstring parameter values
-	 *
 	 */
 	public const BASE = 36;
 	public const TMIN = 1;
@@ -65,6 +68,36 @@ class Punycode
 	public const IDNA_ERROR_BIDI = 2048;
 	public const IDNA_ERROR_CONTEXTJ = 4096;
 
+	/*********************
+	 * Internal properties
+	 *********************/
+
+	/**
+	 * Character encoding
+	 *
+	 * @var string
+	 */
+	protected $encoding;
+
+	/**
+	 * Whether to use Non-Transitional Processing.
+	 * Setting this to true breaks backward compatibility with IDNA2003.
+	 *
+	 * @var bool
+	 */
+	protected $nonTransitional = false;
+
+	/**
+	 * Whether to use STD3 ASCII rules.
+	 *
+	 * @var bool
+	 */
+	protected $std3 = false;
+
+	/****************************
+	 * Internal static properties
+	 ****************************/
+
 	/**
 	 * Encode table
 	 *
@@ -90,27 +123,9 @@ class Punycode
 		'4' => 30, '5' => 31, '6' => 32, '7' => 33, '8' => 34, '9' => 35,
 	];
 
-	/**
-	 * Character encoding
-	 *
-	 * @var string
-	 */
-	protected $encoding;
-
-	/**
-	 * Whether to use Non-Transitional Processing.
-	 * Setting this to true breaks backward compatibility with IDNA2003.
-	 *
-	 * @var bool
-	 */
-	protected $nonTransitional = false;
-
-	/**
-	 * Whether to use STD3 ASCII rules.
-	 *
-	 * @var bool
-	 */
-	protected $std3 = false;
+	/****************
+	 * Public methods
+	 ****************/
 
 	/**
 	 * Constructor
@@ -210,6 +225,54 @@ class Punycode
 	}
 
 	/**
+	 * Decode a Punycode domain name to its Unicode counterpart
+	 *
+	 * @param string $input Domain name in Punycode
+	 * @return string|bool Unicode domain name
+	 */
+	public function decode(string $input): string|bool
+	{
+		$errors = [];
+		$preprocessed = $this->preprocess($input, $errors);
+
+		if (!empty($errors)) {
+			return false;
+		}
+
+		$parts = explode('.', $preprocessed);
+
+		foreach ($parts as $p => &$part) {
+			if (str_starts_with($part, static::PREFIX)) {
+				$part = substr($part, strlen(static::PREFIX));
+				$part = $this->decodePart($part);
+
+				if ($part === false) {
+					return false;
+				}
+			}
+
+			if ($this->validateLabel($part, false) !== 0) {
+				if ($part === '') {
+					$parts_count = count($parts);
+
+					if ($parts_count === 1 || $p !== $parts_count - 1) {
+						return false;
+					}
+				} else {
+					return false;
+				}
+			}
+		}
+		$output = implode('.', $parts);
+
+		return $output;
+	}
+
+	/******************
+	 * Internal methods
+	 ******************/
+
+	/**
 	 * Encode a part of a domain name, such as tld, to its Punycode version
 	 *
 	 * @param string $input Part of a domain name
@@ -283,50 +346,6 @@ class Punycode
 		$out = static::PREFIX . $output;
 
 		return $out;
-	}
-
-	/**
-	 * Decode a Punycode domain name to its Unicode counterpart
-	 *
-	 * @param string $input Domain name in Punycode
-	 * @return string|bool Unicode domain name
-	 */
-	public function decode(string $input): string|bool
-	{
-		$errors = [];
-		$preprocessed = $this->preprocess($input, $errors);
-
-		if (!empty($errors)) {
-			return false;
-		}
-
-		$parts = explode('.', $preprocessed);
-
-		foreach ($parts as $p => &$part) {
-			if (str_starts_with($part, static::PREFIX)) {
-				$part = substr($part, strlen(static::PREFIX));
-				$part = $this->decodePart($part);
-
-				if ($part === false) {
-					return false;
-				}
-			}
-
-			if ($this->validateLabel($part, false) !== 0) {
-				if ($part === '') {
-					$parts_count = count($parts);
-
-					if ($parts_count === 1 || $p !== $parts_count - 1) {
-						return false;
-					}
-				} else {
-					return false;
-				}
-			}
-		}
-		$output = implode('.', $parts);
-
-		return $output;
 	}
 
 	/**

--- a/Sources/Sapi.php
+++ b/Sources/Sapi.php
@@ -66,6 +66,10 @@ class Sapi
 		self::SERVER_NGINX => 'nginx',
 	];
 
+	/****************************
+	 * Internal static properties
+	 ****************************/
+
 	/**
 	 * @var string
 	 *

--- a/Sources/Sapi.php
+++ b/Sources/Sapi.php
@@ -33,12 +33,18 @@ class Sapi
 	 * Class constants
 	 *****************/
 
+	/**
+	 * Constants for webserver software names.
+	 */
 	public const SERVER_IIS = 'iis';
 	public const SERVER_APACHE = 'apache';
 	public const SERVER_LITESPEED = 'litespeed';
 	public const SERVER_LIGHTTPD = 'lighttpd';
 	public const SERVER_NGINX = 'nginx';
 
+	/**
+	 * Constants for operating system names.
+	 */
 	public const OS_WINDOWS = 'Windows';
 	public const OS_MAC = 'Darwin';
 	public const OS_LINUX = 'Linux';

--- a/Sources/Search/APIs/Custom.php
+++ b/Sources/Search/APIs/Custom.php
@@ -849,6 +849,7 @@ class Custom extends SearchApi implements SearchApiInterface
 		SecurityToken::create('admin-msmpost');
 		SecurityToken::create('admin-msm', 'get');
 	}
+
 	/**
 	 * Removes the custom index.
 	 *

--- a/Sources/Search/APIs/Standard.php
+++ b/Sources/Search/APIs/Standard.php
@@ -23,6 +23,10 @@ use SMF\Search\SearchApiInterface;
  */
 class Standard extends SearchApi implements SearchApiInterface
 {
+	/****************
+	 * Public methods
+	 ****************/
+
 	/**
 	 *
 	 */

--- a/Sources/Search/SearchApi.php
+++ b/Sources/Search/SearchApi.php
@@ -34,17 +34,6 @@ abstract class SearchApi implements SearchApiInterface
 {
 	use BackwardCompatibility;
 
-	/**
-	 * @var array
-	 *
-	 * BackwardCompatibility settings for this class.
-	 */
-	private static $backcompat = [
-		'prop_names' => [
-			'loadedApi' => 'searchAPI',
-		],
-	];
-
 	/*****************
 	 * Class constants
 	 *****************/
@@ -381,6 +370,21 @@ abstract class SearchApi implements SearchApiInterface
 	 * If 'LIKE', search will be performed using simple string matching.
 	 */
 	protected string $query_match_type = 'LIKE';
+
+	/****************************
+	 * Internal static properties
+	 ****************************/
+
+	/**
+	 * @var array
+	 *
+	 * BackwardCompatibility settings for this class.
+	 */
+	private static $backcompat = [
+		'prop_names' => [
+			'loadedApi' => 'searchAPI',
+		],
+	];
 
 	/****************
 	 * Public methods

--- a/Sources/Search/SearchApiInterface.php
+++ b/Sources/Search/SearchApiInterface.php
@@ -22,6 +22,10 @@ use SMF\Msg;
  */
 interface SearchApiInterface
 {
+	/****************
+	 * Public methods
+	 ****************/
+
 	/**
 	 * Check whether the specific search operation can be performed by this API.
 	 * The operations are the functions listed in the interface, if not supported

--- a/Sources/ServerSideIncludes.php
+++ b/Sources/ServerSideIncludes.php
@@ -30,64 +30,9 @@ use SMF\Db\DatabaseApi as Db;
  */
 class ServerSideIncludes
 {
-	/******************************
-	 * Properties for internal use.
-	 ******************************/
-
-	/**
-	 * @var int
-	 *
-	 * Remembers the error_reporting level prior to SSI starting, so that we can
-	 * restore it once we are done.
-	 */
-	protected $error_reporting;
-
-	/**
-	 * @var bool
-	 *
-	 * Whether SSI setup has been completed.
-	 */
-	protected static $setup_done = false;
-
-	/******************************************************************
-	 * Properties that allow external scripts to control SSI behaviour.
-	 ******************************************************************/
-
-	/**
-	 * @var array
-	 *
-	 * Names of various global variables that external scripts can declare in
-	 * order to influence the behaviour of SSI.
-	 */
-	protected $ssi_globals = [
-		'ssi_on_error_method',
-		'ssi_maintenance_off',
-		'ssi_theme',
-		'ssi_layers',
-		'ssi_gzip',
-		'ssi_ban',
-		'ssi_guest_access',
-	];
-
-	/**
-	 * @var bool|string
-	 *
-	 * Local copy of the global $ssi_on_error_method variable.
-	 *
-	 * Set this to one of three values depending on what you want to happen in
-	 * the case of a fatal error:
-	 *
-	 *  false:   Default. Will just load the error sub template and die without
-	 *           putting any theme layers around it.
-	 *
-	 *  true:    Will load the error sub template AND put the SMF layers around
-	 *           it. (Not useful if on total custom pages.)
-	 *
-	 *  string:  Name of a callback function to call in the event of an error to
-	 *           allow you to define your own methods. Will die after function
-	 *           returns.
-	 */
-	public static $on_error_method = false;
+	/*******************
+	 * Public properties
+	 *******************/
 
 	/**
 	 * @var bool
@@ -145,10 +90,271 @@ class ServerSideIncludes
 	 */
 	public $gzip;
 
-	/****************************************************************
-	 * Static methods that allow external scripts to access SMF data.
-	 * These are the interesting parts of this class.
-	 ****************************************************************/
+	/**************************
+	 * Public static properties
+	 **************************/
+
+	/**
+	 * @var bool|string
+	 *
+	 * Local copy of the global $ssi_on_error_method variable.
+	 *
+	 * Set this to one of three values depending on what you want to happen in
+	 * the case of a fatal error:
+	 *
+	 *  false:   Default. Will just load the error sub template and die without
+	 *           putting any theme layers around it.
+	 *
+	 *  true:    Will load the error sub template AND put the SMF layers around
+	 *           it. (Not useful if on total custom pages.)
+	 *
+	 *  string:  Name of a callback function to call in the event of an error to
+	 *           allow you to define your own methods. Will die after function
+	 *           returns.
+	 */
+	public static $on_error_method = false;
+
+	/*********************
+	 * Internal properties
+	 *********************/
+
+	/**
+	 * @var int
+	 *
+	 * Remembers the error_reporting level prior to SSI starting, so that we can
+	 * restore it once we are done.
+	 */
+	protected $error_reporting;
+
+	/**
+	 * @var array
+	 *
+	 * Names of various global variables that external scripts can declare in
+	 * order to influence the behaviour of SSI.
+	 */
+	protected $ssi_globals = [
+		'ssi_on_error_method',
+		'ssi_maintenance_off',
+		'ssi_theme',
+		'ssi_layers',
+		'ssi_gzip',
+		'ssi_ban',
+		'ssi_guest_access',
+	];
+
+	/****************************
+	 * Internal static properties
+	 ****************************/
+
+	/**
+	 * @var bool
+	 *
+	 * Whether SSI setup has been completed.
+	 */
+	protected static $setup_done = false;
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 *
+	 * Sets up stuff we need for safe use of SSI.
+	 */
+	public function __construct()
+	{
+		// SSI isn't meant to be used from within the forum,
+		// but apparently someone is doing so anyway...
+		if (defined('SMF') && SMF !== 'SSI') {
+			if (!self::$setup_done) {
+				IntegrationHook::call('integrate_SSI');
+			}
+
+			self::$setup_done = true;
+		}
+
+		// Don't do the setup steps more than once.
+		if (self::$setup_done) {
+			return;
+		}
+
+		foreach ($this->ssi_globals as $var) {
+			if (isset($GLOBALS[$var])) {
+				if ($var === 'ssi_on_error_method') {
+					self::$on_error_method = $GLOBALS[$var];
+				} else {
+					$this->{substr($var, 4)} = $GLOBALS[$var];
+				}
+			}
+		}
+
+		$this->error_reporting = error_reporting(!empty(Config::$db_show_debug) ? E_ALL : E_ALL & ~E_DEPRECATED);
+
+		if (!isset($this->gzip)) {
+			$this->gzip = !empty(Config::$modSettings['enableCompressedOutput']);
+		}
+
+		// Don't do john didley if the forum's been shut down completely.
+		if (Config::$maintenance == 2 && $this->maintenance_off !== true) {
+			ErrorHandler::displayMaintenanceMessage();
+		}
+
+		// Initiate the database connection and define some database functions to use.
+		Db::load();
+
+		// Load installed 'Mods' settings.
+		Config::reloadModSettings();
+
+		// Clean the request variables.
+		QueryString::cleanRequest();
+
+		// Seed the random generator?
+		if (empty(Config::$modSettings['rand_seed']) || mt_rand(1, 250) == 69) {
+			// @TODO: Calls a deprecated function.
+			Config::generateSeed();
+		}
+
+		// Check on any hacking attempts.
+		if (isset($_REQUEST['GLOBALS']) || isset($_COOKIE['GLOBALS'])) {
+			die('No direct access...');
+		}
+
+		if (isset($_REQUEST['ssi_theme']) && (int) $_REQUEST['ssi_theme'] == (int) $this->theme) {
+			die('No direct access...');
+		}
+
+		if (isset($_COOKIE['ssi_theme']) && (int) $_COOKIE['ssi_theme'] == (int) $this->theme) {
+			die('No direct access...');
+		}
+
+		if (isset($_REQUEST['ssi_layers'], $this->layers) && $_REQUEST['ssi_layers'] == $this->layers) {
+			die('No direct access...');
+		}
+
+		if (isset($_REQUEST['context'])) {
+			die('No direct access...');
+		}
+
+		// Gzip output? (because it must be boolean and true, this can't be hacked.)
+		if ($this->gzip === true && ini_get('zlib.output_compression') != '1' && ini_get('output_handler') != 'ob_gzhandler' && version_compare(PHP_VERSION, '4.2.0', '>=')) {
+			ob_start('ob_gzhandler');
+		} else {
+			Config::$modSettings['enableCompressedOutput'] = '0';
+		}
+
+		// Primarily, this is to fix the URLs...
+		ob_start('SMF\\QueryString::ob_sessrewrite');
+
+		// Start the session... known to scramble SSI includes in cases...
+		if (!headers_sent()) {
+			Session::load();
+		} else {
+			if (isset($_COOKIE[session_name()]) || isset($_REQUEST[session_name()])) {
+				// Make a stab at it, but ignore the E_WARNINGs generated because we can't send headers.
+				$temp = error_reporting(error_reporting() & !E_WARNING);
+				Session::load();
+				error_reporting($temp);
+			}
+
+			if (!isset($_SESSION['session_value'])) {
+				// Ensure session_var always starts with a letter.
+				$_SESSION['session_var'] = dechex(random_int(0xA000000000, 0xFFFFFFFFFF));
+				$_SESSION['session_value'] = bin2hex(random_bytes(16));
+			}
+			User::$sc = $_SESSION['session_value'];
+		}
+
+		// Get rid of Board::$board_id and Topic::$topic_id... do stuff loadBoard would do.
+		Board::$board_id = null;
+		Topic::$topic_id = null;
+		Utils::$context['linktree'] = [];
+
+		// Load the user and their cookie, as well as their settings.
+		User::load();
+
+		// No one is a moderator outside the forum.
+		User::$me->is_mod = false;
+
+		// Load the current user's permissions....
+		User::$me->loadPermissions();
+
+		// Load the current or SSI theme. (just use $this->theme = id_theme;)
+		Theme::load((int) $this->theme);
+
+		// @todo: probably not the best place, but somewhere it should be set...
+		if (!headers_sent()) {
+			header('content-type: text/html; charset=UTF-8');
+		}
+
+		// Take care of any banning that needs to be done.
+		if (isset($_REQUEST['ssi_ban']) || $this->ban === true) {
+			User::$me->kickIfBanned();
+		}
+
+		// Do we allow guests in here?
+		if (empty($this->guest_access) && empty(Config::$modSettings['allow_guestAccess']) && User::$me->is_guest && basename($_SERVER['PHP_SELF']) != 'SSI.php') {
+			User::$me->kickIfGuest();
+			Utils::obExit(null, true);
+		}
+
+		// Load the stuff like the menu bar, etc.
+		if (isset($this->layers)) {
+			Utils::$context['template_layers'] = $this->layers;
+			Theme::template_header();
+		} else {
+			Theme::setupContext();
+		}
+
+		// Make sure they didn't muss around with the settings... but only if it's not cli.
+		if (isset($_SERVER['REMOTE_ADDR']) && !isset($_SERVER['is_cli']) && session_id() == '') {
+			trigger_error(Lang::getTxt('ssi_session_broken', file: 'General'), E_USER_NOTICE);
+		}
+
+		// Without visiting the forum this session variable might not be set on submit.
+		if (!isset($_SESSION['USER_AGENT']) && (!isset($_GET['ssi_function']) || $_GET['ssi_function'] !== 'pollVote')) {
+			$_SESSION['USER_AGENT'] = $_SERVER['HTTP_USER_AGENT'];
+		}
+
+		// Have the ability to easily add functions to SSI.
+		IntegrationHook::call('integrate_SSI');
+
+		self::$setup_done = true;
+	}
+
+	/**
+	 * Allows accessing an SSI function via URL parameters.
+	 *
+	 * @return true
+	 */
+	public function execute(): bool
+	{
+		// Ignore a call to ssi_* functions if we are not accessing SSI.php directly.
+		if (basename($_SERVER['SCRIPT_FILENAME']) == 'SSI.php') {
+			// You shouldn't just access SSI.php directly by URL!!
+			if (!isset($_GET['ssi_function'])) {
+				die(Lang::getTxt('ssi_not_direct', ['path' => User::$me->is_admin ? '\'' . addslashes(__FILE__) . '\'' : '\'SSI.php\''], file: 'General'));
+			}
+
+			// Call a function passed by GET.
+			if (method_exists(__CLASS__, $_GET['ssi_function']) && (!empty(Config::$modSettings['allow_guestAccess']) || !User::$me->is_guest)) {
+				call_user_func([__CLASS__, $_GET['ssi_function']]);
+			}
+
+			exit;
+		}
+
+		// To avoid side effects later on.
+		unset($_GET['ssi_function']);
+
+		error_reporting($this->error_reporting);
+
+		return true;
+	}
+
+	/***********************
+	 * Public static methods
+	 ***********************/
 
 	/**
 	 * This shuts down the SSI and shows the footer.
@@ -2635,203 +2841,5 @@ class ServerSideIncludes
 			</table>';
 
 		return null;
-	}
-
-	/******************
-	 * Primary methods.
-	 ******************/
-
-	/**
-	 * Constructor. Sets up stuff we need for safe use of SSI.
-	 *
-	 */
-	public function __construct()
-	{
-		// SSI isn't meant to be used from within the forum,
-		// but apparently someone is doing so anyway...
-		if (defined('SMF') && SMF !== 'SSI') {
-			if (!self::$setup_done) {
-				IntegrationHook::call('integrate_SSI');
-			}
-
-			self::$setup_done = true;
-		}
-
-		// Don't do the setup steps more than once.
-		if (self::$setup_done) {
-			return;
-		}
-
-		foreach ($this->ssi_globals as $var) {
-			if (isset($GLOBALS[$var])) {
-				if ($var === 'ssi_on_error_method') {
-					self::$on_error_method = $GLOBALS[$var];
-				} else {
-					$this->{substr($var, 4)} = $GLOBALS[$var];
-				}
-			}
-		}
-
-		$this->error_reporting = error_reporting(!empty(Config::$db_show_debug) ? E_ALL : E_ALL & ~E_DEPRECATED);
-
-		if (!isset($this->gzip)) {
-			$this->gzip = !empty(Config::$modSettings['enableCompressedOutput']);
-		}
-
-		// Don't do john didley if the forum's been shut down completely.
-		if (Config::$maintenance == 2 && $this->maintenance_off !== true) {
-			ErrorHandler::displayMaintenanceMessage();
-		}
-
-		// Initiate the database connection and define some database functions to use.
-		Db::load();
-
-		// Load installed 'Mods' settings.
-		Config::reloadModSettings();
-
-		// Clean the request variables.
-		QueryString::cleanRequest();
-
-		// Seed the random generator?
-		if (empty(Config::$modSettings['rand_seed']) || mt_rand(1, 250) == 69) {
-			// @TODO: Calls a deprecated function.
-			Config::generateSeed();
-		}
-
-		// Check on any hacking attempts.
-		if (isset($_REQUEST['GLOBALS']) || isset($_COOKIE['GLOBALS'])) {
-			die('No direct access...');
-		}
-
-		if (isset($_REQUEST['ssi_theme']) && (int) $_REQUEST['ssi_theme'] == (int) $this->theme) {
-			die('No direct access...');
-		}
-
-		if (isset($_COOKIE['ssi_theme']) && (int) $_COOKIE['ssi_theme'] == (int) $this->theme) {
-			die('No direct access...');
-		}
-
-		if (isset($_REQUEST['ssi_layers'], $this->layers) && $_REQUEST['ssi_layers'] == $this->layers) {
-			die('No direct access...');
-		}
-
-		if (isset($_REQUEST['context'])) {
-			die('No direct access...');
-		}
-
-		// Gzip output? (because it must be boolean and true, this can't be hacked.)
-		if ($this->gzip === true && ini_get('zlib.output_compression') != '1' && ini_get('output_handler') != 'ob_gzhandler' && version_compare(PHP_VERSION, '4.2.0', '>=')) {
-			ob_start('ob_gzhandler');
-		} else {
-			Config::$modSettings['enableCompressedOutput'] = '0';
-		}
-
-		// Primarily, this is to fix the URLs...
-		ob_start('SMF\\QueryString::ob_sessrewrite');
-
-		// Start the session... known to scramble SSI includes in cases...
-		if (!headers_sent()) {
-			Session::load();
-		} else {
-			if (isset($_COOKIE[session_name()]) || isset($_REQUEST[session_name()])) {
-				// Make a stab at it, but ignore the E_WARNINGs generated because we can't send headers.
-				$temp = error_reporting(error_reporting() & !E_WARNING);
-				Session::load();
-				error_reporting($temp);
-			}
-
-			if (!isset($_SESSION['session_value'])) {
-				// Ensure session_var always starts with a letter.
-				$_SESSION['session_var'] = dechex(random_int(0xA000000000, 0xFFFFFFFFFF));
-				$_SESSION['session_value'] = bin2hex(random_bytes(16));
-			}
-			User::$sc = $_SESSION['session_value'];
-		}
-
-		// Get rid of Board::$board_id and Topic::$topic_id... do stuff loadBoard would do.
-		Board::$board_id = null;
-		Topic::$topic_id = null;
-		Utils::$context['linktree'] = [];
-
-		// Load the user and their cookie, as well as their settings.
-		User::load();
-
-		// No one is a moderator outside the forum.
-		User::$me->is_mod = false;
-
-		// Load the current user's permissions....
-		User::$me->loadPermissions();
-
-		// Load the current or SSI theme. (just use $this->theme = id_theme;)
-		Theme::load((int) $this->theme);
-
-		// @todo: probably not the best place, but somewhere it should be set...
-		if (!headers_sent()) {
-			header('content-type: text/html; charset=UTF-8');
-		}
-
-		// Take care of any banning that needs to be done.
-		if (isset($_REQUEST['ssi_ban']) || $this->ban === true) {
-			User::$me->kickIfBanned();
-		}
-
-		// Do we allow guests in here?
-		if (empty($this->guest_access) && empty(Config::$modSettings['allow_guestAccess']) && User::$me->is_guest && basename($_SERVER['PHP_SELF']) != 'SSI.php') {
-			User::$me->kickIfGuest();
-			Utils::obExit(null, true);
-		}
-
-		// Load the stuff like the menu bar, etc.
-		if (isset($this->layers)) {
-			Utils::$context['template_layers'] = $this->layers;
-			Theme::template_header();
-		} else {
-			Theme::setupContext();
-		}
-
-		// Make sure they didn't muss around with the settings... but only if it's not cli.
-		if (isset($_SERVER['REMOTE_ADDR']) && !isset($_SERVER['is_cli']) && session_id() == '') {
-			trigger_error(Lang::getTxt('ssi_session_broken', file: 'General'), E_USER_NOTICE);
-		}
-
-		// Without visiting the forum this session variable might not be set on submit.
-		if (!isset($_SESSION['USER_AGENT']) && (!isset($_GET['ssi_function']) || $_GET['ssi_function'] !== 'pollVote')) {
-			$_SESSION['USER_AGENT'] = $_SERVER['HTTP_USER_AGENT'];
-		}
-
-		// Have the ability to easily add functions to SSI.
-		IntegrationHook::call('integrate_SSI');
-
-		self::$setup_done = true;
-	}
-
-	/**
-	 * Allows accessing an SSI function via URL parameters.
-	 *
-	 * @return true
-	 */
-	public function execute(): bool
-	{
-		// Ignore a call to ssi_* functions if we are not accessing SSI.php directly.
-		if (basename($_SERVER['SCRIPT_FILENAME']) == 'SSI.php') {
-			// You shouldn't just access SSI.php directly by URL!!
-			if (!isset($_GET['ssi_function'])) {
-				die(Lang::getTxt('ssi_not_direct', ['path' => User::$me->is_admin ? '\'' . addslashes(__FILE__) . '\'' : '\'SSI.php\''], file: 'General'));
-			}
-
-			// Call a function passed by GET.
-			if (method_exists(__CLASS__, $_GET['ssi_function']) && (!empty(Config::$modSettings['allow_guestAccess']) || !User::$me->is_guest)) {
-				call_user_func([__CLASS__, $_GET['ssi_function']]);
-			}
-
-			exit;
-		}
-
-		// To avoid side effects later on.
-		unset($_GET['ssi_function']);
-
-		error_reporting($this->error_reporting);
-
-		return true;
 	}
 }

--- a/Sources/Subs-Compat.php
+++ b/Sources/Subs-Compat.php
@@ -10033,7 +10033,7 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	 * @param string $output_method The output method. If 'echo', displays a list of calendar items, otherwise returns an array of info about them.
 	 * @return array|null|string Displays a list of calendar items or returns an array of info about them depending on output_method
 	 */
-	function ssi_todaysCalendar(string $output_method = 'echo'): array|null|string
+	function ssi_todaysCalendar(string $output_method = 'echo'): array|string|null
 	{
 		return SMF\ServerSideIncludes::todaysCalendar($output_method);
 	}
@@ -10719,7 +10719,7 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	 * @param int $component Optional flag for parse_url's second parameter.
 	 * @return string|int|array|null|bool Same as parse_url(), but with unmangled Unicode.
 	 */
-	function parse_iri(string $iri, int $component = -1): string|int|array|null|bool
+	function parse_iri(string $iri, int $component = -1): string|int|array|bool|null
 	{
 		return SMF\Url::create($iri)->parse($component);
 	}

--- a/Sources/Subscriptions/PayPal/Display.php
+++ b/Sources/Subscriptions/PayPal/Display.php
@@ -23,10 +23,18 @@ use SMF\Lang;
  */
 class Display
 {
+	/*******************
+	 * Public properties
+	 *******************/
+
 	/**
 	 * @var string Name of this payment gateway
 	 */
 	public $title = 'PayPal';
+
+	/****************
+	 * Public methods
+	 ****************/
 
 	/**
 	 * Return the admin settings for this gateway

--- a/Sources/Subscriptions/PayPal/Payment.php
+++ b/Sources/Subscriptions/PayPal/Payment.php
@@ -24,10 +24,18 @@ use SMF\Lang;
  */
 class Payment
 {
+	/*********************
+	 * Internal properties
+	 *********************/
+
 	/**
 	 * @var string The data to return
 	 */
 	private $return_data;
+
+	/****************
+	 * Public methods
+	 ****************/
 
 	/**
 	 * This function returns true/false for whether this gateway thinks the data is intended for it.
@@ -271,6 +279,10 @@ class Payment
 			);
 		}
 	}
+
+	/******************
+	 * Internal methods
+	 ******************/
 
 	/**
 	 * A private function to find out the subscription details.

--- a/Sources/TOTP/Auth.php
+++ b/Sources/TOTP/Auth.php
@@ -32,6 +32,10 @@ namespace SMF\TOTP;
  */
 class Auth
 {
+	/*********************
+	 * Internal properties
+	 *********************/
+
 	/**
 	 * @var array Internal lookup table
 	 */
@@ -56,6 +60,10 @@ class Auth
 	 * @var int Range plus/minus for "window of opportunity" on allowed codes
 	 */
 	private int $range = 2;
+
+	/****************
+	 * Public methods
+	 ****************/
 
 	/**
 	 * Initialize the object and set up the lookup table

--- a/Sources/TaskRunner.php
+++ b/Sources/TaskRunner.php
@@ -40,9 +40,9 @@ use SMF\Db\DatabaseApi as Db;
  */
 class TaskRunner
 {
-	/***********
-	 * Constants
-	 ***********/
+	/*****************
+	 * Class constants
+	 *****************/
 
 	/**
 	 * This setting is worth bearing in mind. If you are running this from

--- a/Sources/Tasks/ApprovePost_Notify.php
+++ b/Sources/Tasks/ApprovePost_Notify.php
@@ -30,6 +30,10 @@ use SMF\Utils;
  */
 class ApprovePost_Notify extends BackgroundTask
 {
+	/****************
+	 * Public methods
+	 ****************/
+
 	/**
 	 * This executes the task: loads up the info, puts the email in the queue
 	 * and inserts any alerts as needed.

--- a/Sources/Tasks/ApproveReply_Notify.php
+++ b/Sources/Tasks/ApproveReply_Notify.php
@@ -29,6 +29,10 @@ use SMF\Utils;
  */
 class ApproveReply_Notify extends BackgroundTask
 {
+	/****************
+	 * Public methods
+	 ****************/
+
 	/**
 	 * This executes the task: loads up the info, puts the email in the queue
 	 * and inserts any alerts as needed.

--- a/Sources/Tasks/BackgroundTask.php
+++ b/Sources/Tasks/BackgroundTask.php
@@ -22,16 +22,28 @@ use SMF\User;
  */
 abstract class BackgroundTask
 {
+	/*****************
+	 * Class constants
+	 *****************/
+
 	/**
 	 * Constants for notification types.
 	 */
 	public const RECEIVE_NOTIFY_EMAIL = 0x02;
 	public const RECEIVE_NOTIFY_ALERT = 0x01;
 
+	/*********************
+	 * Internal properties
+	 *********************/
+
 	/**
 	 * @var array Holds the details for the task
 	 */
 	protected $_details;
+
+	/****************
+	 * Public methods
+	 ****************/
 
 	/**
 	 * The constructor.

--- a/Sources/Tasks/Birthday_Notify.php
+++ b/Sources/Tasks/Birthday_Notify.php
@@ -30,6 +30,10 @@ use SMF\Utils;
  */
 class Birthday_Notify extends ScheduledTask
 {
+	/****************
+	 * Public methods
+	 ****************/
+
 	/**
 	 * This executes the task: loads up the info, puts the email in the queue
 	 * and inserts any alerts as needed.

--- a/Sources/Tasks/Buddy_Notify.php
+++ b/Sources/Tasks/Buddy_Notify.php
@@ -25,6 +25,10 @@ use SMF\User;
  */
 class Buddy_Notify extends BackgroundTask
 {
+	/****************
+	 * Public methods
+	 ****************/
+
 	/**
 	 * This executes the task: loads up the info, puts the email in the queue
 	 * and inserts any alerts as needed.

--- a/Sources/Tasks/CreateAttachment_Notify.php
+++ b/Sources/Tasks/CreateAttachment_Notify.php
@@ -30,6 +30,10 @@ use SMF\Utils;
  */
 class CreateAttachment_Notify extends BackgroundTask
 {
+	/****************
+	 * Public methods
+	 ****************/
+
 	/**
 	 * This executes the task: loads up the info, puts the email in the queue
 	 * and inserts any alerts as needed.

--- a/Sources/Tasks/CreatePost_Notify.php
+++ b/Sources/Tasks/CreatePost_Notify.php
@@ -379,7 +379,7 @@ class CreatePost_Notify extends BackgroundTask
 	 *
 	 * @param int $msg_id Message ID to update
 	 */
-	private function updateAlerts(int $msg_id): void
+	protected function updateAlerts(int $msg_id): void
 	{
 		// We send alerts only on the first iteration of this task.
 		if (!empty($this->_details['respawns'])) {

--- a/Sources/Tasks/CreatePost_Notify.php
+++ b/Sources/Tasks/CreatePost_Notify.php
@@ -36,6 +36,10 @@ use SMF\Utils;
  */
 class CreatePost_Notify extends BackgroundTask
 {
+	/*****************
+	 * Class constants
+	 *****************/
+
 	/**
 	 * Constants for reply types.
 	 */
@@ -58,6 +62,10 @@ class CreatePost_Notify extends BackgroundTask
 	 * and quotes in unwatched and/or edited posts.
 	 */
 	public const MENTION_DELAY = 5;
+
+	/*********************
+	 * Internal properties
+	 *********************/
 
 	/**
 	 * @var array Info about members to be notified.
@@ -90,6 +98,10 @@ class CreatePost_Notify extends BackgroundTask
 	 *			mentions and quotes in unwatched and/or edited posts.
 	 */
 	private $mention_mail_time = 0;
+
+	/****************
+	 * Public methods
+	 ****************/
 
 	/**
 	 * This executes the task: loads up the info, puts the email in the queue
@@ -373,6 +385,10 @@ class CreatePost_Notify extends BackgroundTask
 
 		return true;
 	}
+
+	/******************
+	 * Internal methods
+	 ******************/
 
 	/**
 	 * Update an alert if a message was updated since the alert was created.

--- a/Sources/Tasks/DailyMaintenance.php
+++ b/Sources/Tasks/DailyMaintenance.php
@@ -28,6 +28,10 @@ use SMF\ProxyServer;
  */
 class DailyMaintenance extends ScheduledTask
 {
+	/****************
+	 * Public methods
+	 ****************/
+
 	/**
 	 * This executes the task.
 	 *

--- a/Sources/Tasks/EventNew_Notify.php
+++ b/Sources/Tasks/EventNew_Notify.php
@@ -26,6 +26,10 @@ use SMF\Utils;
  */
 class EventNew_Notify extends BackgroundTask
 {
+	/****************
+	 * Public methods
+	 ****************/
+
 	/**
 	 * This executes the task: loads up the info, puts the email in the queue
 	 * and inserts any alerts as needed.

--- a/Sources/Tasks/ExportProfileData.php
+++ b/Sources/Tasks/ExportProfileData.php
@@ -949,6 +949,187 @@ class ExportProfileData extends BackgroundTask
 		return true;
 	}
 
+	/***********************
+	 * Public static methods
+	 ***********************/
+
+	/**
+	 * Adds a custom DOCTYPE definition and an XSLT processing instruction to
+	 * the main XML file's header. Only used for the XML_XSLT format.
+	 */
+	public static function add_dtd(
+		array &$xml_data,
+		array &$metadata,
+		array &$namespaces,
+		array &$extraFeedTags,
+		array &$forceCdataKeys,
+		array &$nsKeys,
+		string $xml_format,
+		string $subaction,
+		string &$doctype,
+	): void {
+		$doctype = implode("\n", [
+			'<!--',
+			"\t" . Lang::getTxt('export_open_in_browser', file: 'Profile'),
+			'-->',
+			'<?xml-stylesheet type="text/xsl" href="#stylesheet"?>',
+			'<!DOCTYPE smf:xml-feed [',
+			'<!ATTLIST xsl:stylesheet',
+			'id ID #REQUIRED>',
+			']>',
+		]);
+	}
+
+	/**
+	 * Adds data to the cache key to distinguish parsing for exports from normal
+	 * parsing.
+	 */
+	public static function parser_cache(array &$cache_key_extras): void
+	{
+		$cache_key_extras[__CLASS__] = 1;
+	}
+
+	/**
+	 * Adjusts some parse_bbc() parameters for the special case of HTML and
+	 * XML_XSLT exports.
+	 */
+	public static function pre_parsebbc_html(string &$message, bool &$smileys, string &$cache_id, array &$parse_tags): void
+	{
+		$cache_id = '';
+
+		foreach (['smileys_url', 'attachmentThumbnails'] as $var) {
+			if (isset(Config::$modSettings[$var])) {
+				self::$real_modSettings[$var] = Config::$modSettings[$var];
+			}
+		}
+
+		Config::$modSettings['smileys_url'] = '.';
+		Config::$modSettings['attachmentThumbnails'] = false;
+	}
+
+	/**
+	 * Adjusts some parse_bbc() parameters for the special case of XML exports.
+	 */
+	public static function pre_parsebbc_xml(string &$message, bool &$smileys, string &$cache_id, array &$parse_tags): void
+	{
+		$cache_id = '';
+
+		$smileys = false;
+
+		if (!isset(Config::$modSettings['disabledBBC'])) {
+			Config::$modSettings['disabledBBC'] = 'attach';
+		} else {
+			self::$real_modSettings['disabledBBC'] = Config::$modSettings['disabledBBC'];
+
+			Config::$modSettings['disabledBBC'] = implode(',', array_unique(array_merge(array_filter(explode(',', Config::$modSettings['disabledBBC'])), ['attach'])));
+		}
+	}
+
+	/**
+	 * Reverses changes made by pre_parsebbc()
+	 */
+	public static function post_parsebbc(string &$message, bool &$smileys, string &$cache_id, array &$parse_tags): void
+	{
+		foreach (['disabledBBC', 'smileys_url', 'attachmentThumbnails'] as $var) {
+			if (isset(self::$real_modSettings[$var])) {
+				Config::$modSettings[$var] = self::$real_modSettings[$var];
+			}
+		}
+	}
+
+	/**
+	 * Adjusts certain BBCodes for the special case of exports.
+	 */
+	public static function bbc_codes(array &$codes, array &$no_autolink_tags): void
+	{
+		foreach ($codes as &$code) {
+			// To make the "Select" link work we'd need to embed a bunch more JS. Not worth it.
+			if ($code['tag'] === 'code') {
+				$code['content'] = preg_replace('~<a class="codeoperation\b.*?</a>~', '', $code['content']);
+			}
+		}
+	}
+
+	/**
+	 * Adjusts the attachment download URL for the special case of exports.
+	 */
+	public static function post_parseAttachBBC(array &$attachContext): void
+	{
+		static $dltokens;
+
+		if (empty($dltokens[Utils::$context['xmlnews_uid']])) {
+			$idhash = hash_hmac('sha1', (string) Utils::$context['xmlnews_uid'], Config::getAuthSecret());
+
+			$dltokens[Utils::$context['xmlnews_uid']] = hash_hmac('sha1', $idhash, Config::getAuthSecret());
+		}
+
+		$attachContext['orig_href'] = Config::$scripturl . '?action=profile;area=dlattach;u=' . Utils::$context['xmlnews_uid'] . ';attach=' . $attachContext['id'] . ';t=' . $dltokens[Utils::$context['xmlnews_uid']];
+
+		$attachContext['href'] = rawurlencode($attachContext['id'] . ' - ' . html_entity_decode($attachContext['name']));
+	}
+
+	/**
+	 * Adjusts the format of the HTML produced by the attach BBCode.
+	 */
+	public static function attach_bbc_validate(string &$returnContext, array $currentAttachment, array $tag, array|string $data, array $disabled, array $params): void
+	{
+		$orig_link = '<a href="' . $currentAttachment['orig_href'] . '" class="bbc_link">' . Lang::getTxt('export_download_original', file: 'Profile') . '</a>';
+
+		$hidden_orig_link = ' <a href="' . $currentAttachment['orig_href'] . '" class="bbc_link dlattach_' . $currentAttachment['id'] . '" style="display:none; flex: 1 0 auto; margin: auto;">' . Lang::getTxt('export_download_original', file: 'Profile') . '</a>';
+
+		if ($params['{display}'] == 'link') {
+			$returnContext .= ' (' . $orig_link . ')';
+		} elseif (!empty($currentAttachment['is_image'])) {
+			$returnContext = '<span style="display: inline-flex; justify-content: center; align-items: center; position: relative;">' . preg_replace(
+				[
+					'thumbnail_toggle' => '~</?a\b[^>]*>~',
+					'src' => '~src="' . preg_quote($currentAttachment['href'], '~') . ';image"~',
+				],
+				[
+					'thumbnail_toggle' => '',
+					'src' => 'src="' . $currentAttachment['href'] . '" onerror="$(\'.dlattach_' . $currentAttachment['id'] . '\').show(); $(\'.dlattach_' . $currentAttachment['id'] . '\').css({\'position\': \'absolute\'});"',
+				],
+				$returnContext,
+			) . $hidden_orig_link . '</span>';
+		} elseif (str_starts_with($currentAttachment['mime_type'], 'video/')) {
+			$returnContext = preg_replace(
+				[
+					'src' => '~src="' . preg_quote($currentAttachment['href'], '~') . '"~',
+					'opening_tag' => '~^<div class="videocontainer"~',
+					'closing_tag' => '~</div>$~',
+				],
+				[
+					'src' => '$0 onerror="$(this).fadeTo(0, 0.2); $(\'.dlattach_' . $currentAttachment['id'] . '\').show(); $(\'.dlattach_' . $currentAttachment['id'] . '\').css({\'position\': \'absolute\'});"',
+					'opening_tag' => '<div class="videocontainer" style="display: flex; justify-content: center; align-items: center; position: relative;"',
+					'closing_tag' =>  $hidden_orig_link . '</div>',
+				],
+				$returnContext,
+			);
+		} elseif (str_starts_with($currentAttachment['mime_type'], 'audio/')) {
+			$returnContext = '<span style="display: inline-flex; justify-content: center; align-items: center; position: relative;">' . preg_replace(
+				[
+					'opening_tag' => '~^<audio\b~',
+				],
+				[
+					'opening_tag' => '<audio onerror="$(this).fadeTo(0, 0); $(\'.dlattach_' . $currentAttachment['id'] . '\').show(); $(\'.dlattach_' . $currentAttachment['id'] . '\').css({\'position\': \'absolute\'});"',
+				],
+				$returnContext,
+			) . $hidden_orig_link . '</span>';
+		} else {
+			$returnContext = '<span style="display: inline-flex; justify-content: center; align-items: center; position: relative;">' . preg_replace(
+				[
+					'obj_opening' => '~^<object\b~',
+					'link' => '~<a href="' . preg_quote($currentAttachment['href'], '~') . '" class="bbc_link">([^<]*)</a>~',
+				],
+				[
+					'obj_opening' => '<object onerror="$(this).fadeTo(0, 0.2); $(\'.dlattach_' . $currentAttachment['id'] . '\').show(); $(\'.dlattach_' . $currentAttachment['id'] . '\').css({\'position\': \'absolute\'});"~',
+					'link' => '$0 (' . $orig_link . ')',
+				],
+				$returnContext,
+			) . $hidden_orig_link . '</span>';
+		}
+	}
+
 	/******************
 	 * Internal methods
 	 ******************/
@@ -1855,187 +2036,6 @@ class ExportProfileData extends BackgroundTask
 
 				unset(Utils::$context['real_' . $var]);
 			}
-		}
-	}
-
-	/***********************
-	 * Public static methods
-	 ***********************/
-
-	/**
-	 * Adds a custom DOCTYPE definition and an XSLT processing instruction to
-	 * the main XML file's header. Only used for the XML_XSLT format.
-	 */
-	public static function add_dtd(
-		array &$xml_data,
-		array &$metadata,
-		array &$namespaces,
-		array &$extraFeedTags,
-		array &$forceCdataKeys,
-		array &$nsKeys,
-		string $xml_format,
-		string $subaction,
-		string &$doctype,
-	): void {
-		$doctype = implode("\n", [
-			'<!--',
-			"\t" . Lang::getTxt('export_open_in_browser', file: 'Profile'),
-			'-->',
-			'<?xml-stylesheet type="text/xsl" href="#stylesheet"?>',
-			'<!DOCTYPE smf:xml-feed [',
-			'<!ATTLIST xsl:stylesheet',
-			'id ID #REQUIRED>',
-			']>',
-		]);
-	}
-
-	/**
-	 * Adds data to the cache key to distinguish parsing for exports from normal
-	 * parsing.
-	 */
-	public static function parser_cache(array &$cache_key_extras): void
-	{
-		$cache_key_extras[__CLASS__] = 1;
-	}
-
-	/**
-	 * Adjusts some parse_bbc() parameters for the special case of HTML and
-	 * XML_XSLT exports.
-	 */
-	public static function pre_parsebbc_html(string &$message, bool &$smileys, string &$cache_id, array &$parse_tags): void
-	{
-		$cache_id = '';
-
-		foreach (['smileys_url', 'attachmentThumbnails'] as $var) {
-			if (isset(Config::$modSettings[$var])) {
-				self::$real_modSettings[$var] = Config::$modSettings[$var];
-			}
-		}
-
-		Config::$modSettings['smileys_url'] = '.';
-		Config::$modSettings['attachmentThumbnails'] = false;
-	}
-
-	/**
-	 * Adjusts some parse_bbc() parameters for the special case of XML exports.
-	 */
-	public static function pre_parsebbc_xml(string &$message, bool &$smileys, string &$cache_id, array &$parse_tags): void
-	{
-		$cache_id = '';
-
-		$smileys = false;
-
-		if (!isset(Config::$modSettings['disabledBBC'])) {
-			Config::$modSettings['disabledBBC'] = 'attach';
-		} else {
-			self::$real_modSettings['disabledBBC'] = Config::$modSettings['disabledBBC'];
-
-			Config::$modSettings['disabledBBC'] = implode(',', array_unique(array_merge(array_filter(explode(',', Config::$modSettings['disabledBBC'])), ['attach'])));
-		}
-	}
-
-	/**
-	 * Reverses changes made by pre_parsebbc()
-	 */
-	public static function post_parsebbc(string &$message, bool &$smileys, string &$cache_id, array &$parse_tags): void
-	{
-		foreach (['disabledBBC', 'smileys_url', 'attachmentThumbnails'] as $var) {
-			if (isset(self::$real_modSettings[$var])) {
-				Config::$modSettings[$var] = self::$real_modSettings[$var];
-			}
-		}
-	}
-
-	/**
-	 * Adjusts certain BBCodes for the special case of exports.
-	 */
-	public static function bbc_codes(array &$codes, array &$no_autolink_tags): void
-	{
-		foreach ($codes as &$code) {
-			// To make the "Select" link work we'd need to embed a bunch more JS. Not worth it.
-			if ($code['tag'] === 'code') {
-				$code['content'] = preg_replace('~<a class="codeoperation\b.*?</a>~', '', $code['content']);
-			}
-		}
-	}
-
-	/**
-	 * Adjusts the attachment download URL for the special case of exports.
-	 */
-	public static function post_parseAttachBBC(array &$attachContext): void
-	{
-		static $dltokens;
-
-		if (empty($dltokens[Utils::$context['xmlnews_uid']])) {
-			$idhash = hash_hmac('sha1', (string) Utils::$context['xmlnews_uid'], Config::getAuthSecret());
-
-			$dltokens[Utils::$context['xmlnews_uid']] = hash_hmac('sha1', $idhash, Config::getAuthSecret());
-		}
-
-		$attachContext['orig_href'] = Config::$scripturl . '?action=profile;area=dlattach;u=' . Utils::$context['xmlnews_uid'] . ';attach=' . $attachContext['id'] . ';t=' . $dltokens[Utils::$context['xmlnews_uid']];
-
-		$attachContext['href'] = rawurlencode($attachContext['id'] . ' - ' . html_entity_decode($attachContext['name']));
-	}
-
-	/**
-	 * Adjusts the format of the HTML produced by the attach BBCode.
-	 */
-	public static function attach_bbc_validate(string &$returnContext, array $currentAttachment, array $tag, array|string $data, array $disabled, array $params): void
-	{
-		$orig_link = '<a href="' . $currentAttachment['orig_href'] . '" class="bbc_link">' . Lang::getTxt('export_download_original', file: 'Profile') . '</a>';
-
-		$hidden_orig_link = ' <a href="' . $currentAttachment['orig_href'] . '" class="bbc_link dlattach_' . $currentAttachment['id'] . '" style="display:none; flex: 1 0 auto; margin: auto;">' . Lang::getTxt('export_download_original', file: 'Profile') . '</a>';
-
-		if ($params['{display}'] == 'link') {
-			$returnContext .= ' (' . $orig_link . ')';
-		} elseif (!empty($currentAttachment['is_image'])) {
-			$returnContext = '<span style="display: inline-flex; justify-content: center; align-items: center; position: relative;">' . preg_replace(
-				[
-					'thumbnail_toggle' => '~</?a\b[^>]*>~',
-					'src' => '~src="' . preg_quote($currentAttachment['href'], '~') . ';image"~',
-				],
-				[
-					'thumbnail_toggle' => '',
-					'src' => 'src="' . $currentAttachment['href'] . '" onerror="$(\'.dlattach_' . $currentAttachment['id'] . '\').show(); $(\'.dlattach_' . $currentAttachment['id'] . '\').css({\'position\': \'absolute\'});"',
-				],
-				$returnContext,
-			) . $hidden_orig_link . '</span>';
-		} elseif (str_starts_with($currentAttachment['mime_type'], 'video/')) {
-			$returnContext = preg_replace(
-				[
-					'src' => '~src="' . preg_quote($currentAttachment['href'], '~') . '"~',
-					'opening_tag' => '~^<div class="videocontainer"~',
-					'closing_tag' => '~</div>$~',
-				],
-				[
-					'src' => '$0 onerror="$(this).fadeTo(0, 0.2); $(\'.dlattach_' . $currentAttachment['id'] . '\').show(); $(\'.dlattach_' . $currentAttachment['id'] . '\').css({\'position\': \'absolute\'});"',
-					'opening_tag' => '<div class="videocontainer" style="display: flex; justify-content: center; align-items: center; position: relative;"',
-					'closing_tag' =>  $hidden_orig_link . '</div>',
-				],
-				$returnContext,
-			);
-		} elseif (str_starts_with($currentAttachment['mime_type'], 'audio/')) {
-			$returnContext = '<span style="display: inline-flex; justify-content: center; align-items: center; position: relative;">' . preg_replace(
-				[
-					'opening_tag' => '~^<audio\b~',
-				],
-				[
-					'opening_tag' => '<audio onerror="$(this).fadeTo(0, 0); $(\'.dlattach_' . $currentAttachment['id'] . '\').show(); $(\'.dlattach_' . $currentAttachment['id'] . '\').css({\'position\': \'absolute\'});"',
-				],
-				$returnContext,
-			) . $hidden_orig_link . '</span>';
-		} else {
-			$returnContext = '<span style="display: inline-flex; justify-content: center; align-items: center; position: relative;">' . preg_replace(
-				[
-					'obj_opening' => '~^<object\b~',
-					'link' => '~<a href="' . preg_quote($currentAttachment['href'], '~') . '" class="bbc_link">([^<]*)</a>~',
-				],
-				[
-					'obj_opening' => '<object onerror="$(this).fadeTo(0, 0.2); $(\'.dlattach_' . $currentAttachment['id'] . '\').show(); $(\'.dlattach_' . $currentAttachment['id'] . '\').css({\'position\': \'absolute\'});"~',
-					'link' => '$0 (' . $orig_link . ')',
-				],
-				$returnContext,
-			) . $hidden_orig_link . '</span>';
 		}
 	}
 }

--- a/Sources/Tasks/FetchCalendarSubscriptions.php
+++ b/Sources/Tasks/FetchCalendarSubscriptions.php
@@ -27,6 +27,10 @@ use SMF\WebFetch\WebFetchApi;
  */
 class FetchCalendarSubscriptions extends ScheduledTask
 {
+	/****************
+	 * Public methods
+	 ****************/
+
 	/**
 	 * This executes the task.
 	 *

--- a/Sources/Tasks/FetchSMFiles.php
+++ b/Sources/Tasks/FetchSMFiles.php
@@ -28,6 +28,10 @@ use SMF\WebFetch\WebFetchApi;
  */
 class FetchSMFiles extends ScheduledTask
 {
+	/****************
+	 * Public methods
+	 ****************/
+
 	/**
 	 * This executes the task.
 	 *

--- a/Sources/Tasks/GenericScheduledTask.php
+++ b/Sources/Tasks/GenericScheduledTask.php
@@ -22,6 +22,10 @@ use SMF\Utils;
  */
 class GenericScheduledTask extends ScheduledTask
 {
+	/****************
+	 * Public methods
+	 ****************/
+
 	/**
 	 * This executes the task.
 	 *

--- a/Sources/Tasks/GenericTask.php
+++ b/Sources/Tasks/GenericTask.php
@@ -22,6 +22,10 @@ use SMF\Utils;
  */
 class GenericTask extends BackgroundTask
 {
+	/****************
+	 * Public methods
+	 ****************/
+
 	/**
 	 * This executes the task.
 	 *

--- a/Sources/Tasks/GroupAct_Notify.php
+++ b/Sources/Tasks/GroupAct_Notify.php
@@ -29,6 +29,10 @@ use SMF\Utils;
  */
 class GroupAct_Notify extends BackgroundTask
 {
+	/****************
+	 * Public methods
+	 ****************/
+
 	/**
 	 * This executes the task: loads up the info, puts the email in the queue
 	 * and inserts any alerts as needed.

--- a/Sources/Tasks/GroupReq_Notify.php
+++ b/Sources/Tasks/GroupReq_Notify.php
@@ -30,6 +30,10 @@ use SMF\Utils;
  */
 class GroupReq_Notify extends BackgroundTask
 {
+	/****************
+	 * Public methods
+	 ****************/
+
 	/**
 	 * This executes the task: loads up the info, puts the email in the queue
 	 * and inserts any alerts as needed.

--- a/Sources/Tasks/Likes_Notify.php
+++ b/Sources/Tasks/Likes_Notify.php
@@ -26,6 +26,10 @@ use SMF\User;
  */
 class Likes_Notify extends BackgroundTask
 {
+	/****************
+	 * Public methods
+	 ****************/
+
 	/**
 	 * This executes the task: loads up the info, puts the email in the queue
 	 * and inserts any alerts as needed.

--- a/Sources/Tasks/MemberReportReply_Notify.php
+++ b/Sources/Tasks/MemberReportReply_Notify.php
@@ -30,6 +30,10 @@ use SMF\Utils;
  */
 class MemberReportReply_Notify extends BackgroundTask
 {
+	/****************
+	 * Public methods
+	 ****************/
+
 	/**
 	 * This executes the task: loads up the info, puts the email in the queue
 	 * and inserts any alerts as needed.

--- a/Sources/Tasks/MemberReport_Notify.php
+++ b/Sources/Tasks/MemberReport_Notify.php
@@ -30,6 +30,10 @@ use SMF\Utils;
  */
 class MemberReport_Notify extends BackgroundTask
 {
+	/****************
+	 * Public methods
+	 ****************/
+
 	/**
 	 * This executes the task: loads up the info, puts the email in the queue
 	 * and inserts any alerts as needed.

--- a/Sources/Tasks/MsgReportReply_Notify.php
+++ b/Sources/Tasks/MsgReportReply_Notify.php
@@ -30,6 +30,10 @@ use SMF\Utils;
  */
 class MsgReportReply_Notify extends BackgroundTask
 {
+	/****************
+	 * Public methods
+	 ****************/
+
 	/**
 	 * This executes the task: loads up the info, puts the email in the queue
 	 * and inserts any alerts as needed.

--- a/Sources/Tasks/MsgReport_Notify.php
+++ b/Sources/Tasks/MsgReport_Notify.php
@@ -30,6 +30,10 @@ use SMF\Utils;
  */
 class MsgReport_Notify extends BackgroundTask
 {
+	/****************
+	 * Public methods
+	 ****************/
+
 	/**
 	 * This executes the task: loads up the info, puts the email in the queue
 	 * and inserts any alerts as needed.

--- a/Sources/Tasks/PaidSubs.php
+++ b/Sources/Tasks/PaidSubs.php
@@ -31,6 +31,10 @@ use SMF\Utils;
  */
 class PaidSubs extends ScheduledTask
 {
+	/****************
+	 * Public methods
+	 ****************/
+
 	/**
 	 * This executes the task.
 	 *

--- a/Sources/Tasks/PruneLogTopics.php
+++ b/Sources/Tasks/PruneLogTopics.php
@@ -28,6 +28,10 @@ use SMF\Sapi;
  */
 class PruneLogTopics extends ScheduledTask
 {
+	/****************
+	 * Public methods
+	 ****************/
+
 	/**
 	 * This executes the task.
 	 *

--- a/Sources/Tasks/Register_Notify.php
+++ b/Sources/Tasks/Register_Notify.php
@@ -28,6 +28,10 @@ use SMF\User;
  */
 class Register_Notify extends BackgroundTask
 {
+	/****************
+	 * Public methods
+	 ****************/
+
 	/**
 	 * This executes the task: loads up the info, puts the email in the queue
 	 * and inserts any alerts as needed.

--- a/Sources/Tasks/RemoveOldDrafts.php
+++ b/Sources/Tasks/RemoveOldDrafts.php
@@ -25,6 +25,10 @@ use SMF\Theme;
  */
 class RemoveOldDrafts extends ScheduledTask
 {
+	/****************
+	 * Public methods
+	 ****************/
+
 	/**
 	 * This executes the task.
 	 *

--- a/Sources/Tasks/RemoveTempAttachments.php
+++ b/Sources/Tasks/RemoveTempAttachments.php
@@ -26,6 +26,10 @@ use SMF\Utils;
  */
 class RemoveTempAttachments extends ScheduledTask
 {
+	/****************
+	 * Public methods
+	 ****************/
+
 	/**
 	 * This executes the task.
 	 *

--- a/Sources/Tasks/RemoveTopicRedirects.php
+++ b/Sources/Tasks/RemoveTopicRedirects.php
@@ -24,6 +24,10 @@ use SMF\Topic;
  */
 class RemoveTopicRedirects extends ScheduledTask
 {
+	/****************
+	 * Public methods
+	 ****************/
+
 	/**
 	 * This executes the task.
 	 *

--- a/Sources/Tasks/ScheduledTask.php
+++ b/Sources/Tasks/ScheduledTask.php
@@ -34,9 +34,9 @@ abstract class ScheduledTask extends BackgroundTask
 	 */
 	public bool $should_log = true;
 
-	/***********************
-	 * Public static methods
-	 ***********************/
+	/****************
+	 * Public methods
+	 ****************/
 
 	/**
 	 * Records the start time and duration of this task.
@@ -65,6 +65,10 @@ abstract class ScheduledTask extends BackgroundTask
 			[],
 		);
 	}
+
+	/***********************
+	 * Public static methods
+	 ***********************/
 
 	/**
 	 * Updates Config::$modSettings['next_task_time'].

--- a/Sources/Tasks/SendDigests.php
+++ b/Sources/Tasks/SendDigests.php
@@ -30,6 +30,10 @@ use SMF\Utils;
  */
 class SendDigests extends ScheduledTask
 {
+	/****************
+	 * Public methods
+	 ****************/
+
 	/**
 	 * This executes the task.
 	 *

--- a/Sources/Tasks/UpdateSpoofDetectorNames.php
+++ b/Sources/Tasks/UpdateSpoofDetectorNames.php
@@ -27,6 +27,10 @@ use SMF\Utils;
  */
 class UpdateSpoofDetectorNames extends BackgroundTask
 {
+	/****************
+	 * Public methods
+	 ****************/
+
 	/**
 	 * This executes the task.
 	 *
@@ -116,6 +120,10 @@ class UpdateSpoofDetectorNames extends BackgroundTask
 
 		return true;
 	}
+
+	/******************
+	 * Internal methods
+	 ******************/
 
 	/**
 	 * Adds a new instance of this task to the task list.

--- a/Sources/Tasks/UpdateTldRegex.php
+++ b/Sources/Tasks/UpdateTldRegex.php
@@ -23,6 +23,10 @@ use SMF\Url;
  */
 class UpdateTldRegex extends BackgroundTask
 {
+	/****************
+	 * Public methods
+	 ****************/
+
 	/**
 	 * This executes the task. It just calls Url::setTldRegex()
 	 *

--- a/Sources/Tasks/UpdateUnicode.php
+++ b/Sources/Tasks/UpdateUnicode.php
@@ -29,6 +29,10 @@ use SMF\WebFetch\WebFetchApi;
  */
 class UpdateUnicode extends BackgroundTask
 {
+	/*****************
+	 * Class constants
+	 *****************/
+
 	/**
 	 * URLs where we can fetch the Unicode data files.
 	 */
@@ -36,6 +40,10 @@ class UpdateUnicode extends BackgroundTask
 	public const DATA_URL_IDNA = 'https://www.unicode.org/Public/idna/latest';
 	public const DATA_URL_CLDR = 'https://raw.githubusercontent.com/unicode-org/cldr-json/main/cldr-json';
 	public const DATA_URL_SECURITY = 'https://www.unicode.org/Public/security/latest';
+
+	/*******************
+	 * Public properties
+	 *******************/
 
 	/**
 	 * @var string The latest official release of the Unicode Character Database.
@@ -51,6 +59,10 @@ class UpdateUnicode extends BackgroundTask
 	 * @var string Convenience alias of Config::$sourcedir . '/Unicode'.
 	 */
 	public $unicodedir = '';
+
+	/*********************
+	 * Internal properties
+	 *********************/
 
 	/**
 	 * @var int Used to ensure we exit long running tasks cleanly.
@@ -546,6 +558,10 @@ class UpdateUnicode extends BackgroundTask
 		],
 	];
 
+	/****************
+	 * Public methods
+	 ****************/
+
 	/**
 	 * This executes the task.
 	 *
@@ -763,6 +779,39 @@ class UpdateUnicode extends BackgroundTask
 	}
 
 	/**
+	 * Updates Unicode data functions in their designated files.
+	 */
+	public function export_funcs_to_file(): void
+	{
+		foreach ($this->funcs as $func_name => $func_info) {
+			if (empty($func_info['data'])) {
+				continue;
+			}
+
+			$temp_file_path = $this->temp_dir . '/' . $func_info['file'];
+
+			list($func_code, $func_regex) = $this->get_function_code_and_regex($func_name);
+
+			$file_contents = file_get_contents($temp_file_path);
+
+			if (preg_match($func_regex, $file_contents)) {
+				file_put_contents($temp_file_path, preg_replace($func_regex, $func_code, $file_contents));
+			} else {
+				file_put_contents($temp_file_path, $func_code . "\n\n", FILE_APPEND);
+			}
+
+			// Free up some memory.
+			if ($func_name != 'utf8_combining_classes') {
+				unset($this->funcs[$func_name]['data']);
+			}
+		}
+	}
+
+	/******************
+	 * Internal methods
+	 ******************/
+
+	/**
 	 * Makes a temporary directory to hold our working files, and sets
 	 * $this->temp_dir to the path of the created directory.
 	 */
@@ -915,35 +964,6 @@ class UpdateUnicode extends BackgroundTask
 		]);
 
 		return $file_template;
-	}
-
-	/**
-	 * Updates Unicode data functions in their designated files.
-	 */
-	public function export_funcs_to_file(): void
-	{
-		foreach ($this->funcs as $func_name => $func_info) {
-			if (empty($func_info['data'])) {
-				continue;
-			}
-
-			$temp_file_path = $this->temp_dir . '/' . $func_info['file'];
-
-			list($func_code, $func_regex) = $this->get_function_code_and_regex($func_name);
-
-			$file_contents = file_get_contents($temp_file_path);
-
-			if (preg_match($func_regex, $file_contents)) {
-				file_put_contents($temp_file_path, preg_replace($func_regex, $func_code, $file_contents));
-			} else {
-				file_put_contents($temp_file_path, $func_code . "\n\n", FILE_APPEND);
-			}
-
-			// Free up some memory.
-			if ($func_name != 'utf8_combining_classes') {
-				unset($this->funcs[$func_name]['data']);
-			}
-		}
 	}
 
 	/**

--- a/Sources/Tasks/WeeklyMaintenance.php
+++ b/Sources/Tasks/WeeklyMaintenance.php
@@ -26,6 +26,10 @@ use SMF\Theme;
  */
 class WeeklyMaintenance extends ScheduledTask
 {
+	/****************
+	 * Public methods
+	 ****************/
+
 	/**
 	 * This executes the task.
 	 *

--- a/Sources/Topic.php
+++ b/Sources/Topic.php
@@ -30,19 +30,8 @@ use SMF\Search\SearchApi;
  */
 class Topic implements \ArrayAccess, Routable
 {
-	use BackwardCompatibility;
 	use ArrayAccessHelper;
-
-	/**
-	 * @var array
-	 *
-	 * BackwardCompatibility settings for this class.
-	 */
-	private static $backcompat = [
-		'prop_names' => [
-			'topic_id' => 'topic',
-		],
-	];
+	use BackwardCompatibility;
 
 	/*******************
 	 * Public properties
@@ -372,6 +361,17 @@ class Topic implements \ArrayAccess, Routable
 		'can_remove_poll' => 'poll_remove',
 		'can_reply' => 'post_reply',
 		'can_reply_unapproved' => 'post_unapproved_replies',
+	];
+
+	/**
+	 * @var array
+	 *
+	 * BackwardCompatibility settings for this class.
+	 */
+	private static $backcompat = [
+		'prop_names' => [
+			'topic_id' => 'topic',
+		],
 	];
 
 	/****************

--- a/Sources/Url.php
+++ b/Sources/Url.php
@@ -419,7 +419,7 @@ class Url implements \Stringable
 	 * @param int $component Optional flag for parse_url's second parameter.
 	 * @return string|int|array|null|bool Same as parse_url(), but with unmangled Unicode.
 	 */
-	public function parse(int $component = -1): string|int|array|null|bool
+	public function parse(int $component = -1): string|int|array|bool|null
 	{
 		$url = preg_replace_callback(
 			'~[^\x00-\x7F\pZ\pC]|%~u',

--- a/Sources/User.php
+++ b/Sources/User.php
@@ -71,23 +71,8 @@ use SMF\PersonalMessage\PM;
  */
 class User implements \ArrayAccess
 {
-	use BackwardCompatibility;
 	use ArrayAccessHelper;
-
-	/**
-	 * @var array
-	 *
-	 * BackwardCompatibility settings for this class.
-	 */
-	private static $backcompat = [
-		'prop_names' => [
-			'profiles' => 'user_profile',
-			'settings' => 'user_settings',
-			'info' => 'user_info',
-			'sc' => 'sc',
-			'memberContext' => 'memberContext',
-		],
-	];
+	use BackwardCompatibility;
 
 	/*****************
 	 * Class constants
@@ -795,6 +780,41 @@ class User implements \ArrayAccess
 	 *********************/
 
 	/**
+	 * @var array
+	 *
+	 * Alternate names for some object properties.
+	 */
+	protected array $prop_aliases = [
+		'id_member' => 'id',
+		'member_name' => 'username',
+		'real_name' => 'name',
+		'display_name' => 'name',
+		'email_address' => 'email',
+		'lngfile' => 'language',
+		'member_group' => 'group_name',
+		'primary_group' => 'primary_group_name',
+		'member_group_color' => 'group_color',
+		'member_ip' => 'ip',
+		'member_ip2' => 'ip2',
+		'usertitle' => 'title',
+		'blurb' => 'title',
+		'id_theme' => 'theme',
+		'ignore_boards' => 'ignoreboards',
+		'pm_ignore_list' => 'ignoreusers',
+		'buddy_list' => 'buddies',
+		'instant_messages' => 'messages',
+		'birth_date' => 'birthdate',
+		'last_login_timestamp' => 'last_login',
+
+		// Square brackets are parsed to find array elements.
+		'website_url' => 'website[url]',
+		'website_title' => 'website[title]',
+
+		// Initial exclamation mark means inverse of the property.
+		'is_logged' => '!is_guest',
+	];
+
+	/**
 	 * @var bool
 	 *
 	 * Whether the integrate_verify_user hook verified this user for us.
@@ -836,41 +856,6 @@ class User implements \ArrayAccess
 	 */
 	private array $groups_can_moderate;
 
-	/**
-	 * @var array
-	 *
-	 * Alternate names for some object properties.
-	 */
-	protected array $prop_aliases = [
-		'id_member' => 'id',
-		'member_name' => 'username',
-		'real_name' => 'name',
-		'display_name' => 'name',
-		'email_address' => 'email',
-		'lngfile' => 'language',
-		'member_group' => 'group_name',
-		'primary_group' => 'primary_group_name',
-		'member_group_color' => 'group_color',
-		'member_ip' => 'ip',
-		'member_ip2' => 'ip2',
-		'usertitle' => 'title',
-		'blurb' => 'title',
-		'id_theme' => 'theme',
-		'ignore_boards' => 'ignoreboards',
-		'pm_ignore_list' => 'ignoreusers',
-		'buddy_list' => 'buddies',
-		'instant_messages' => 'messages',
-		'birth_date' => 'birthdate',
-		'last_login_timestamp' => 'last_login',
-
-		// Square brackets are parsed to find array elements.
-		'website_url' => 'website[url]',
-		'website_title' => 'website[title]',
-
-		// Initial exclamation mark means inverse of the property.
-		'is_logged' => '!is_guest',
-	];
-
 	/****************************
 	 * Internal static properties
 	 ****************************/
@@ -885,6 +870,21 @@ class User implements \ArrayAccess
 		'basic' => 1,
 		'normal' => 2,
 		'profile' => 3,
+	];
+
+	/**
+	 * @var array
+	 *
+	 * BackwardCompatibility settings for this class.
+	 */
+	private static $backcompat = [
+		'prop_names' => [
+			'profiles' => 'user_profile',
+			'settings' => 'user_settings',
+			'info' => 'user_info',
+			'sc' => 'sc',
+			'memberContext' => 'memberContext',
+		],
 	];
 
 	/****************

--- a/Sources/Utils.php
+++ b/Sources/Utils.php
@@ -24,18 +24,6 @@ class Utils
 {
 	use BackwardCompatibility;
 
-	/**
-	 * @var array
-	 *
-	 * BackwardCompatibility settings for this class.
-	 */
-	private static $backcompat = [
-		'prop_names' => [
-			'context' => 'context',
-			'smcFunc' => 'smcFunc',
-		],
-	];
-
 	/*****************
 	 * Class constants
 	 *****************/
@@ -317,6 +305,22 @@ class Utils
 		'json_decode' => 'smf_json_decode',
 		'random_int' => __CLASS__ . '::randomInt',
 		'random_bytes' => __CLASS__ . '::randomBytes',
+	];
+
+	/****************************
+	 * Internal static properties
+	 ****************************/
+
+	/**
+	 * @var array
+	 *
+	 * BackwardCompatibility settings for this class.
+	 */
+	private static $backcompat = [
+		'prop_names' => [
+			'context' => 'context',
+			'smcFunc' => 'smcFunc',
+		],
 	];
 
 	/***********************

--- a/Sources/Uuid.php
+++ b/Sources/Uuid.php
@@ -66,6 +66,10 @@ namespace SMF;
  */
 class Uuid implements \Stringable
 {
+	/*****************
+	 * Class constants
+	 *****************/
+
 	/**
 	 * Default UUID version to create.
 	 */

--- a/Sources/WebFetch/WebFetchApiInterface.php
+++ b/Sources/WebFetch/WebFetchApiInterface.php
@@ -20,6 +20,10 @@ namespace SMF\WebFetch;
  */
 interface WebFetchApiInterface
 {
+	/****************
+	 * Public methods
+	 ****************/
+
 	/**
 	 * Main calling function.
 	 *


### PR DESCRIPTION
This adds (and applies) some new rules to .php-cs-fixer.dist.php in order to more consistently format our classes.

1. Consistently orders class elements.
2. Inserts the comments we use to indicate sections of class element types.
3. Always list `null` last in union types.