### PR TITLE
Remove a stray reference to Profile\BackwardCompatibility

### DIFF
--- a/Sources/Actions/TrackIP.php
+++ b/Sources/Actions/TrackIP.php
@@ -17,7 +17,6 @@ namespace SMF\Actions;
 
 use SMF\ActionInterface;
 use SMF\ActionRouter;
-use SMF\Actions\Profile\BackwardCompatibility;
 use SMF\ActionTrait;
 use SMF\Config;
 use SMF\Db\DatabaseApi as Db;
@@ -41,7 +40,6 @@ class TrackIP implements ActionInterface, Routable
 {
 	use ActionRouter;
 	use ActionTrait;
-	use BackwardCompatibility;
 
 	/*******************
 	 * Public properties


### PR DESCRIPTION
#### Description
Removes a remaining reference to Profile\BackwardCompatibilitty since it's no longer used