### PR TITLE
Fixes Markdown parsing of underscores that aren't marking emphasis

### DIFF
--- a/Sources/Parsers/MarkdownParser.php
+++ b/Sources/Parsers/MarkdownParser.php
@@ -2657,6 +2657,9 @@ class MarkdownParser extends Parser
 		// Process the emphasis and strikethrough delimiters.
 		$this->parseEmphasis($new_content);
 
+		// Amalgamate contiguous strings again.
+		$this->amalgamateStrings($new_content);
+
 		// Clean up the keys again.
 		$new_content = array_values($new_content);
 


### PR DESCRIPTION
A strings like `_foo_ $foo_bar_baz bar` would previously have been rendered as `<em>foo</em> $foo _ bar _ baz bar`. With this fix, it will be correctly rendered as `<em>foo</em> $foo_bar_baz bar`