### PR TITLE
Fixes detection of duplicate BBCodes in BBCodeParser::integrateBBC()

### DIFF
--- a/Sources/BBCode/GenericBBCode.php
+++ b/Sources/BBCode/GenericBBCode.php
@@ -37,7 +37,7 @@ class GenericBBCode extends BBCode
 	 * When this is set to something callable, it will be called from within
 	 * $this->validate().
 	 */
-	public mixed $validationCallback = false;
+	public mixed $validation_callback = false;
 
 	/**************************
 	 * Public static properties
@@ -172,7 +172,7 @@ class GenericBBCode extends BBCode
 		}
 
 		if (isset($definition['validate'])) {
-			$this->validationCallback = $definition['validate'];
+			$this->validation_callback = $definition['validate'];
 		}
 	}
 
@@ -181,12 +181,12 @@ class GenericBBCode extends BBCode
 	 */
 	public function validate(BBCodeInterface &$bbc, array|string &$data, array $disabled, array $params): void
 	{
-		if (is_string($this->validationCallback)) {
-			$this->validationCallback = Utils::getCallable($this->validationCallback);
+		if (is_string($this->validation_callback)) {
+			$this->validation_callback = Utils::getCallable($this->validation_callback);
 		}
 
-		if (is_callable($this->validationCallback)) {
-			call_user_func_array($this->validationCallback, [&$bbc, &$data, $disabled, $params]);
+		if (is_callable($this->validation_callback)) {
+			call_user_func_array($this->validation_callback, [&$bbc, &$data, $disabled, $params]);
 		}
 	}
 }

--- a/Sources/Parsers/BBCodeParser.php
+++ b/Sources/Parsers/BBCodeParser.php
@@ -2862,11 +2862,14 @@ class BBCodeParser extends Parser
 
 			// Reverse order because mods typically append to the array.
 			foreach (array_reverse(array_keys(self::$codes)) as $i) {
-				$value = self::$codes[$i];
+				$value = clone self::$codes[$i];
 
 				// Closures cannot be serialized, but they can be reflected.
-				if (($value->validate ?? null) instanceof \Closure) {
-					$value->validate = (string) new \ReflectionFunction($value->validate);
+				if (
+					$value instanceof GenericBBCode
+					&& ($value->validation_callback ?? null) instanceof \Closure
+				) {
+					$value->validation_callback = (string) new \ReflectionFunction($value->validation_callback);
 				}
 
 				$serialized = serialize($value);


### PR DESCRIPTION
The old version of this code broke when we refactored BBCodes into classes.