### PR TITLE
Fixes regex to check for embedded PHP tags in SVG content

### DIFF
--- a/Sources/Graphics/Image.php
+++ b/Sources/Graphics/Image.php
@@ -954,7 +954,7 @@ class Image
 			// No embedded PHP tags allowed.
 			// Harmless if the SVG is just the src of an img element, but very
 			// bad if the SVG is embedded inline into the HTML document.
-			'/<(php)?[?]|[?]>/i',
+			'/<[?](php|=|\s)|[?]>/i',
 		];
 
 		$prev_chunk = '';


### PR DESCRIPTION
Like #8671, but for SMF 3.0