### PR TITLE
PHP 8.4 compatibility

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: [ 7.0, 7.1, 7.2, 7.3, 7.4, 8.0, 8.1, 8.2, 8.3, 8.4 ]
+        php: [ 7.1, 7.2, 7.3, 7.4, 8.0, 8.1, 8.2, 8.3, 8.4 ]
 
     name: PHP ${{ matrix.php }} Syntax Check
     steps:

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: [ 7.0, 7.1, 7.2, 7.3, 7.4, 8.0, 8.1 ]
+        php: [ 7.0, 7.1, 7.2, 7.3, 7.4, 8.0, 8.1, 8.2, 8.3, 8.4 ]
 
     name: PHP ${{ matrix.php }} Syntax Check
     steps:

--- a/Sources/ReCaptcha/ReCaptcha.php
+++ b/Sources/ReCaptcha/ReCaptcha.php
@@ -130,7 +130,7 @@ class ReCaptcha
      * @param RequestMethod $requestMethod method used to send the request. Defaults to POST.
      * @throws \RuntimeException if $secret is invalid
      */
-    public function __construct($secret, RequestMethod $requestMethod = null)
+    public function __construct($secret, ?RequestMethod $requestMethod = null)
     {
         if (empty($secret)) {
             throw new \RuntimeException('No secret provided');

--- a/Sources/ReCaptcha/RequestMethod/CurlPost.php
+++ b/Sources/ReCaptcha/RequestMethod/CurlPost.php
@@ -63,7 +63,7 @@ class CurlPost implements RequestMethod
      * @param Curl $curl Curl resource
      * @param string $siteVerifyUrl URL for reCAPTCHA siteverify API
      */
-    public function __construct(Curl $curl = null, $siteVerifyUrl = null)
+    public function __construct(?Curl $curl = null, $siteVerifyUrl = null)
     {
         $this->curl = (is_null($curl)) ? new Curl() : $curl;
         $this->siteVerifyUrl = (is_null($siteVerifyUrl)) ? ReCaptcha::SITE_VERIFY_URL : $siteVerifyUrl;

--- a/Sources/ReCaptcha/RequestMethod/SocketPost.php
+++ b/Sources/ReCaptcha/RequestMethod/SocketPost.php
@@ -57,7 +57,7 @@ class SocketPost implements RequestMethod
      * @param \ReCaptcha\RequestMethod\Socket $socket optional socket, injectable for testing
      * @param string $siteVerifyUrl URL for reCAPTCHA siteverify API
      */
-    public function __construct(Socket $socket = null, $siteVerifyUrl = null)
+    public function __construct(?Socket $socket = null, $siteVerifyUrl = null)
     {
         $this->socket = (is_null($socket)) ? new Socket() : $socket;
         $this->siteVerifyUrl = (is_null($siteVerifyUrl)) ? ReCaptcha::SITE_VERIFY_URL : $siteVerifyUrl;

--- a/other/install.php
+++ b/other/install.php
@@ -24,7 +24,7 @@ define('SMF_USER_AGENT', 'Mozilla/5.0 (' . php_uname('s') . ' ' . php_uname('m')
 if (!defined('TIME_START'))
 	define('TIME_START', microtime(true));
 
-$GLOBALS['required_php_version'] = '7.0.0';
+$GLOBALS['required_php_version'] = '7.1.0';
 
 // Don't have PHP support, do you?
 // ><html dir="ltr"><head><title>Error!</title></head><body>Sorry, this installer requires PHP!<div style="display: none;">

--- a/other/requirements.md
+++ b/other/requirements.md
@@ -4,7 +4,8 @@
 ### PHP Version Support
 | MIN SMF VERSION | MAX SMF VERSION | MIN PHP VERSION | MAX PHP VERSION |
 | ------ | ------ | ------ | ------ |
-| 2.1    | LATEST | 7.0.0  | 8.1.0  |
+| 2.1.5  | LATEST | 7.1.0  | 8.4.0  |
+| 2.1    | 2.1.4  | 7.0.0  | 8.1.0  |
 
 ### Undocumented Version Support
 - Versions below miniumn listed above are not supported

--- a/other/upgrade.php
+++ b/other/upgrade.php
@@ -30,7 +30,7 @@ if (!defined('TIME_START'))
  *
  * @var string
  */
-$GLOBALS['required_php_version'] = '7.0.0';
+$GLOBALS['required_php_version'] = '7.1.0';
 
 /**
  * A list of supported database systems.


### PR DESCRIPTION
Updates the PHP versions that we lint against.

Fixes #8676. In the process, this also raises our minimum supported version of PHP from 7.0 to PHP 7.1

If and when Google updates the official ReCaptcha library to make it compatible with PHP 8.4, we can drop it in.