### PR TITLE
Improvements to Diff::apply()

### DIFF
--- a/Sources/Diff/Diff.php
+++ b/Sources/Diff/Diff.php
@@ -424,11 +424,23 @@ abstract class Diff
 	/**
 	 * Given the original string, constructs the modified string.
 	 *
+	 * The $dynamic_context parameter can be used to increase the likelihood of
+	 * success when lines in the immediate context of a change have been altered
+	 * unexpectedly. When this option is enabled, the matching algorithm will
+	 * initially try to match the change including all surrounding context, but
+	 * if that fails then it will progressively give up one line of context at
+	 * a time until it finds a match or runs out of context lines. Enabling this
+	 * option is especially helpful when applying patches to files that may have
+	 * been altered by third-party modifications.
+	 *
 	 * @param string $str1 The original string.
+	 * @param bool $dynamic_context Whether to allow the matching algorithm to
+	 *    dynamically adjust the number of context lines it considers when
+	 *    attempting to find a match for each change. Default: false.
 	 * @throws \ValueError if given a string it cannot work with.
 	 * @return string The modified string.
 	 */
-	public function apply(string $str1): string
+	public function apply(string $str1, bool $dynamic_context = false): string
 	{
 		$changes = $this->changes;
 
@@ -441,37 +453,24 @@ abstract class Diff
 		$broken_changes = [];
 		$affected_line_numbers = [];
 
-		// Verify that the existing content is as expected.
+		// Find the correct place to apply the change.
 		foreach (array_reverse($changes, true) as $c => $change) {
-			if (!$this->verify($change, $lines)) {
-				$broken_changes[$c] = $change;
+			$change = $this->fixL1($change, $lines, $affected_line_numbers, $dynamic_context);
+
+			if ($change === false) {
+				$broken_changes[$c] = $changes[$c];
 				continue;
 			}
+
+			$changes[$c] = $change;
 
 			$affected_line_numbers = array_merge(
 				$affected_line_numbers,
 				range(
 					$change['l1'] ?? 0,
-					($change['l1'] ?? 0) + count($this->splitLines($change['old'])) - 1,
+					($change['l1'] ?? 0) + count($this->splitLines($change['old'], PREG_SPLIT_NO_EMPTY)),
 				),
 			);
-		}
-
-		// If there was unexpected content, try to adapt.
-		foreach ($broken_changes as $c => $change) {
-			if (($change = $this->fixL1($change, $lines, $affected_line_numbers)) !== false) {
-				unset($broken_changes[$c]);
-
-				$changes[$c] = $change;
-
-				$affected_line_numbers = array_merge(
-					$affected_line_numbers,
-					range(
-						$change['l1'],
-						$change['l1'] + count($this->splitLines($change['old'])) - 1,
-					),
-				);
-			}
 		}
 
 		if (!empty($broken_changes)) {
@@ -2223,64 +2222,18 @@ abstract class Diff
 	}
 
 	/**
-	 * Helper for $this->apply() that checks whether a change can be applied.
-	 *
-	 * @param array $change The change to verify.
-	 * @param array $lines Lines of the original string.
-	 * @return bool Whether the change can be applied.
-	 */
-	protected function verify(array $change, array $lines): bool
-	{
-		$substring = implode('', array_slice(
-			$lines,
-			$change['l1'] ?? 0,
-			count($this->splitLines($change['old'])),
-		));
-
-		// If there is unexpected content at this position, the change cannot be applied.
-		if ($change['old'] !== mb_substr($substring, $change['offset'], mb_strlen($change['old']))) {
-			return false;
-		}
-
-		// If this is an insertion with no deletion, try to check the context.
-		if ($change['old'] === '') {
-			if (isset($change['before'])) {
-				$before = $change['before'] === '' ? [] : $this->splitLines($change['before'], PREG_SPLIT_NO_EMPTY);
-
-				foreach (array_reverse($before) as $b => $before_line) {
-					if (($lines[$change['l1'] - $b - 1] ?? null) !== $before_line) {
-						return false;
-					}
-				}
-			}
-
-			if (isset($change['after'])) {
-				$after = $change['after'] === '' ? [] : $this->splitLines($change['after'], PREG_SPLIT_NO_EMPTY);
-
-				$l_last = $change['l1'] + count($this->splitLines($change['old'])) - 1;
-
-				foreach ($after as $a => $after_line) {
-					if (($lines[$l_last + $a] ?? null) !== $after_line) {
-						return false;
-					}
-				}
-			}
-		}
-
-		// Tests passed.
-		return true;
-	}
-
-	/**
 	 * Helper for $this->apply() that uses heuristics to try to find the correct
-	 * line number for a change when $str1 contains unexpected content.
+	 * line number for a change.
 	 *
 	 * @param array $change The change that didn't match.
 	 * @param array $lines Lines of the original string.
 	 * @param array $disallowed Lines numbers that cannot be chosen.
+	 * @param bool $dynamic_context Whether to allow the matching algorithm to
+	 *    dynamically adjust the number of context lines it considers when
+	 *    attempting to find a match for each change.
 	 * @return array|false An altered version of $change, or false on error.
 	 */
-	protected function fixL1(array $change, array $lines, array $disallowed): array|false
+	protected function fixL1(array $change, array $lines, array $disallowed, bool $dynamic_context): array|false
 	{
 		// Number to add to $l1 to get the last line number in a block of affected text.
 		$last_offset = count($this->splitLines($change['old'])) - 1;
@@ -2334,7 +2287,99 @@ abstract class Diff
 			}
 		}
 
-		// Do we need to keep going?
+		// No matches found.
+		if (count($possible_matches) === 0) {
+			return false;
+		}
+
+		// Determine how many context lines to use.
+		foreach ($this->changes as $c => $change) {
+			// If any changes are inline, use no context lines.
+			if ($change['offset'] !== 0) {
+				$max_before_context = 0;
+				$max_after_context = 0;
+				break;
+			}
+
+			$max_before_context = max(
+				$max_before_context ?? 0,
+				count($this->splitLines($change['before'] ?? '', PREG_SPLIT_NO_EMPTY)),
+			);
+
+			$max_after_context = max(
+				$max_after_context ?? 0,
+				count($this->splitLines($change['after'] ?? '', PREG_SPLIT_NO_EMPTY)),
+			);
+		}
+
+		$total_context = $max_total_context = $max_before_context + $max_after_context;
+
+		// If possible, use the context lines to choose the best possible match.
+		do {
+			$before_context = $max_before_context;
+			$after_context = $max_after_context - ($max_total_context - $total_context);
+			$temp_possible_matches = $possible_matches;
+
+			for ($i = 0; $i < $total_context; $i++) {
+				if (isset($change['before'])) {
+					$before = $this->splitLines($change['before'], PREG_SPLIT_NO_EMPTY);
+					$before = array_slice($before, $before_context * -1, $before_context);
+
+					foreach ($temp_possible_matches as $m => $l1) {
+						foreach (array_reverse($before) as $b => $before_line) {
+							if (($lines[$l1 - $b - 1] ?? null) !== $before_line) {
+								unset($temp_possible_matches[$m]);
+								continue 2;
+							}
+						}
+					}
+				}
+
+				if (isset($change['after'])) {
+					$after = $this->splitLines($change['after'], PREG_SPLIT_NO_EMPTY);
+					$after = array_slice($after, 0, $after_context);
+
+					foreach ($temp_possible_matches as $m => $l1) {
+						$l_last = $l1 + $last_offset;
+
+						foreach ($after as $a => $after_line) {
+							if (($lines[$l_last + $a] ?? null) !== $after_line) {
+								unset($temp_possible_matches[$m]);
+								continue 2;
+							}
+						}
+					}
+				}
+
+				switch (count($temp_possible_matches)) {
+					case 1:
+						// Found it!
+						$possible_matches = $temp_possible_matches;
+						break 2;
+
+					default:
+						if ($before_context === 0 && $after_context === 0) {
+							$possible_matches = $temp_possible_matches;
+							break 2;
+						}
+						break;
+				}
+
+				if ($before_context === 0 || $after_context === $max_after_context) {
+					break;
+				}
+
+				$before_context--;
+				$after_context++;
+			}
+		} while (
+			// If dynamic context is enabled, retry until we find some matches
+			// or we have reduced the number of context lines to zero.
+			$dynamic_context
+			&& count($temp_possible_matches) === 0
+			&& --$total_context >= 0
+		);
+
 		switch (count($possible_matches)) {
 			case 0:
 				return false;
@@ -2343,40 +2388,6 @@ abstract class Diff
 				$change['l1'] = reset($possible_matches);
 
 				return $change;
-		}
-
-		// Can we use context lines to figure out which possible match to choose?
-		if (isset($change['before'])) {
-			$before = $change['before'] === '' ? [] : $this->splitLines($change['before'], PREG_SPLIT_NO_EMPTY);
-
-			foreach ($possible_matches as $m => $l1) {
-				foreach (array_reverse($before) as $b => $before_line) {
-					if (($lines[$l1 - $b - 1] ?? null) !== $before_line) {
-						unset($possible_matches[$m]);
-						continue 2;
-					}
-				}
-			}
-		}
-
-		if (isset($change['after'])) {
-			$after = $change['after'] === '' ? [] : $this->splitLines($change['after'], PREG_SPLIT_NO_EMPTY);
-
-			foreach ($possible_matches as $m => $l1) {
-				$l_last = $l1 + $last_offset;
-
-				foreach ($after as $a => $after_line) {
-					if (($lines[$l_last + $a] ?? null) !== $after_line) {
-						unset($possible_matches[$m]);
-						continue 2;
-					}
-				}
-			}
-		}
-
-		switch (count($possible_matches)) {
-			case 0:
-				return false;
 
 			default:
 				// If we still have multiple matches, prefer the one closest to the expected position.

--- a/Sources/Diff/Diff.php
+++ b/Sources/Diff/Diff.php
@@ -450,54 +450,59 @@ abstract class Diff
 			$lines = [];
 		}
 
-		$broken_changes = [];
-		$affected_line_numbers = [];
-
 		// Find the correct place to apply the change.
-		foreach (array_reverse($changes, true) as $c => $change) {
-			$change = $this->fixL1($change, $lines, $affected_line_numbers, $dynamic_context);
+		// This is not applicable to EditDiffs.
+		if (is_string($this->changes[0]['old'])) {
+			$broken_changes = [];
+			$affected_line_numbers = [];
 
-			if ($change === false) {
-				$broken_changes[$c] = $changes[$c];
-				continue;
+			foreach (array_reverse($changes, true) as $c => $change) {
+				$change = $this->fixL1($change, $lines, $affected_line_numbers, $dynamic_context);
+
+				if ($change === false) {
+					$broken_changes[$c] = $changes[$c];
+					continue;
+				}
+
+				$changes[$c] = $change;
+
+				$affected_line_numbers = array_merge(
+					$affected_line_numbers,
+					range(
+						$change['l1'] ?? 0,
+						($change['l1'] ?? 0) + count($this->splitLines($change['old'], PREG_SPLIT_NO_EMPTY)),
+					),
+				);
 			}
 
-			$changes[$c] = $change;
+			if (!empty($broken_changes)) {
+				ksort($broken_changes);
 
-			$affected_line_numbers = array_merge(
-				$affected_line_numbers,
-				range(
-					$change['l1'] ?? 0,
-					($change['l1'] ?? 0) + count($this->splitLines($change['old'], PREG_SPLIT_NO_EMPTY)),
-				),
-			);
-		}
-
-		if (!empty($broken_changes)) {
-			ksort($broken_changes);
-
-			// Include info about the changes that couldn't be applied
-			// so that the caller knows exactly what went wrong.
-			throw new \ValueError(json_encode($broken_changes));
+				// Include info about the changes that couldn't be applied
+				// so that the caller knows exactly what went wrong.
+				throw new \ValueError(json_encode($broken_changes));
+			}
 		}
 
 		// Do the job.
 		$str2 = '';
 
 		foreach (array_reverse($changes) as $change) {
+			$old_length = is_int($change['old']) ? $change['old'] : mb_strlen($change['old']);
+
 			if (isset($lines[$change['l1']])) {
 				$substring = implode('', array_splice($lines, $change['l1']));
 
 				$str2 =
 					mb_substr($substring, 0, $change['offset']) .
 					$change['new'] .
-					mb_substr($substring, $change['offset'] + mb_strlen($change['old'])) .
+					mb_substr($substring, $change['offset'] + $old_length) .
 					$str2;
 			} else {
 				$str2 =
 					mb_substr($str2, 0, $change['offset']) .
 					$change['new'] .
-					mb_substr($str2, $change['offset'] + mb_strlen($change['old']));
+					mb_substr($str2, $change['offset'] + $old_length);
 			}
 		}
 

--- a/Sources/Diff/EditDiff.php
+++ b/Sources/Diff/EditDiff.php
@@ -217,26 +217,4 @@ class EditDiff extends Diff
 			$this->reason,
 		];
 	}
-
-	/**
-	 *
-	 */
-	public function apply(string $str1): string
-	{
-		$lines = $this->splitLines($str1);
-
-		$str2 = '';
-
-		foreach (array_reverse($this->changes) as $change) {
-			if (isset($lines[$change['l1']])) {
-				$substring = implode('', array_splice($lines, $change['l1']));
-
-				$str2 = mb_substr($substring, 0, $change['offset']) . $change['new'] . mb_substr($substring, $change['offset'] + $change['old']) . $str2;
-			} else {
-				$str2 = mb_substr($str2, 0, $change['offset']) . $change['new'] . mb_substr($str2, $change['offset'] + $change['old']);
-			}
-		}
-
-		return implode('', $lines) . $str2;
-	}
 }

--- a/Sources/Diff/FullDiff.php
+++ b/Sources/Diff/FullDiff.php
@@ -65,10 +65,13 @@ class FullDiff extends Diff
 	 * Given the modified string, reconstructs the original string.
 	 *
 	 * @param string $str2 The modified string.
+	 * @param bool $dynamic_context Whether to allow the matching algorithm to
+	 *    dynamically adjust the number of context lines it considers when
+	 *    attempting to find a match for each change. Default: false.
 	 * @throws \ValueError if given a string it cannot work with.
 	 * @return string The original string.
 	 */
-	public function revert(string $str2): string
+	public function revert(string $str2, bool $dynamic_context = false): string
 	{
 		$real_changes = $this->changes;
 
@@ -81,7 +84,7 @@ class FullDiff extends Diff
 		}
 
 		try {
-			$str1 = $this->apply($str2);
+			$str1 = $this->apply($str2, $dynamic_context);
 		} catch (\ValueError $e) {
 			$this->changes = $real_changes;
 

--- a/Sources/PackageManager/PackageUtils.php
+++ b/Sources/PackageManager/PackageUtils.php
@@ -2181,9 +2181,9 @@ class PackageUtils
 			// Apply the changes to the file content.
 			try {
 				if ($undo) {
-					$target_content = $original = $diff->revert($modified);
+					$target_content = $original = $diff->revert($modified, true);
 				} else {
-					$target_content = $modified = $diff->apply($original);
+					$target_content = $modified = $diff->apply($original, true);
 				}
 			} catch (\ValueError $e) {
 				$failed_changes = Utils::jsonDecode($e->getMessage(), true);
@@ -2242,9 +2242,9 @@ class PackageUtils
 
 				try {
 					if ($undo) {
-						$target_content = $original = $diff->revert($modified);
+						$target_content = $original = $diff->revert($modified, true);
 					} else {
-						$target_content = $modified = $diff->apply($original);
+						$target_content = $modified = $diff->apply($original, true);
 					}
 
 					$diff->changes = $real_changes;


### PR DESCRIPTION
Two issues were raised in #8670:

1. When multiple match locations were possible while applying a patch, context lines were not taken into consideration if the line numbers matched one of the possible locations, even when the context lines would have indicated that one of the other possible locations was the better choice. 
2. Using context lines in a strict fashion (i.e. the way most diff implementations usually do) would greatly increase the likelihood of encountering conflicts when patching files that have been altered by third-party modifications.

This PR addresses both issues:

1. Context lines are now considered whenever there are multiple possible matches. Line numbers are only used as tie-breakers when multiple matches are found even when context is considered.
2. The new `$dynamic_context` parameter for `Diff::apply()` improves the likelihood of success when no matches are found due to conflicts in the surrounding context of a change. When this option is enabled, the matching algorithm will initially try to match the full context, but if no matches are found, the algorithm will try again using one less line of context. It will repeat this process, progressively dropping more lines of context each time, until it finds a match or runs out of context lines.

Fixes #8670 