### PR TITLE
Enable BBC on subscription descriptions

### DIFF
--- a/Sources/ManagePaid.php
+++ b/Sources/ManagePaid.php
@@ -1943,7 +1943,7 @@ function loadSubscriptions()
 		$context['subscriptions'][$row['id_subscribe']] = array(
 			'id' => $row['id_subscribe'],
 			'name' => $row['name'],
-			'desc' => $row['description'],
+			'desc' => parse_bbc($row['description']),
 			'cost' => $cost,
 			'real_cost' => $row['cost'],
 			'length' => $length,


### PR DESCRIPTION
Fixes #8356

SMF 2.0 where this worked did not cleanup html entities on saving a description, this was changed in 2.1 and broke html. Simple fix is to just allow BBC here.