### PR TITLE
Enable Parser on subscription descriptions

### DIFF
--- a/Sources/Actions/Admin/Subscriptions.php
+++ b/Sources/Actions/Admin/Subscriptions.php
@@ -25,6 +25,7 @@ use SMF\IntegrationHook;
 use SMF\ItemList;
 use SMF\Lang;
 use SMF\Menu;
+use SMF\Parser;
 use SMF\SecurityToken;
 use SMF\TaskRunner;
 use SMF\Theme;
@@ -1512,7 +1513,7 @@ class Subscriptions implements ActionInterface
 			self::$all[$row['id_subscribe']] = [
 				'id' => $row['id_subscribe'],
 				'name' => $row['name'],
-				'desc' => $row['description'],
+				'desc' => Parser::transform(Utils::entityDecode($row['description'])),
 				'cost' => $cost,
 				'real_cost' => $row['cost'],
 				'length' => $length,


### PR DESCRIPTION
Fixes #8356

SMF 2.0, where this worked, did not clean up HTML entities when saving a description. This was changed in 2.1 and broke HTML. A simple fix is to just allow the parser here.