### PR TITLE
Exit out of thumbnail creation if it fails

### DIFF
--- a/Sources/Attachment.php
+++ b/Sources/Attachment.php
@@ -2073,7 +2073,7 @@ class Attachment implements \ArrayAccess
 
 						$image = new Image($filename, true);
 
-						if (!empty($image->source) && ($thumb = $image->createThumbnail(Config::$modSettings['attachmentThumbWidth'], Config::$modSettings['attachmentThumbHeight'])) !== false) {
+						if (!empty($image->source) && ($thumb = $image->createThumbnail((int) Config::$modSettings['attachmentThumbWidth'], (int) Config::$modSettings['attachmentThumbHeight'])) !== false) {
 							// So what folder are we putting this image in?
 							if (!empty(Config::$modSettings['currentAttachmentUploadDir'])) {
 								if (!is_array(Config::$modSettings['attachmentUploadDir'])) {

--- a/Sources/Graphics/Image.php
+++ b/Sources/Graphics/Image.php
@@ -450,6 +450,7 @@ class Image
 
 		$max_width = (int) round($max_width);
 		$max_height = (int) round($max_height);
+		$success = false;
 
 		// Do the job using ImageMagick.
 		if (extension_loaded('imagick') && isset(self::IMAGETYPE_TO_IMAGICK[$preferred_type])) {
@@ -458,6 +459,10 @@ class Image
 		// Do the job using GD.
 		elseif (extension_loaded('gd')) {
 			$success = $this->resizeUsingGD($destination, $max_width, $max_height, $preferred_type);
+		}
+
+		if (!$success) {
+			return false;
 		}
 
 		// Update properties to refer to the new image.


### PR DESCRIPTION
Fixes #8649

The issue found in #8649 is realpath() is returning false and attempting to assign that to $this->source, which is not allowed.  Both GD and ImageMagick failed to create a thumbnail.