### PR TITLE
[3.0] Ensure Atom title is marked as html

### DIFF
--- a/Sources/Actions/Feed.php
+++ b/Sources/Actions/Feed.php
@@ -923,6 +923,7 @@ class Feed implements ActionInterface, Routable
 						[
 							'tag' => 'title',
 							'content' => $row['subject'],
+							'attributes' => ['type' => 'html'],
 							'cdata' => true,
 						],
 						[
@@ -973,7 +974,7 @@ class Feed implements ActionInterface, Routable
 						],
 						[
 							'tag' => 'id',
-							'content' => $uuid,
+							'content' => Config::$scripturl . '?msg=' . $row['id_msg'],
 						],
 						[
 							'tag' => 'link',
@@ -1363,6 +1364,7 @@ class Feed implements ActionInterface, Routable
 						[
 							'tag' => 'title',
 							'content' => $row['subject'],
+							'attributes' => ['type' => 'html'],
 							'cdata' => true,
 						],
 						[
@@ -1413,7 +1415,7 @@ class Feed implements ActionInterface, Routable
 						],
 						[
 							'tag' => 'id',
-							'content' => $uuid,
+							'content' => Config::$scripturl . '?msg=' . $row['id_msg'],
 						],
 						[
 							'tag' => 'link',

--- a/Sources/Actions/Feed.php
+++ b/Sources/Actions/Feed.php
@@ -974,7 +974,7 @@ class Feed implements ActionInterface, Routable
 						],
 						[
 							'tag' => 'id',
-							'content' => Config::$scripturl . '?msg=' . $row['id_msg'],
+							'content' => 'urn:uuid:' . $uuid,
 						],
 						[
 							'tag' => 'link',
@@ -1415,7 +1415,7 @@ class Feed implements ActionInterface, Routable
 						],
 						[
 							'tag' => 'id',
-							'content' => Config::$scripturl . '?msg=' . $row['id_msg'],
+							'content' => 'urn:uuid:' . $uuid,
 						],
 						[
 							'tag' => 'link',


### PR DESCRIPTION
Fixes #8338

Note that the Atom RFC (4287) also says that the ID should be a URI, so we can't use a UUID.