### PR TITLE
[3.0] Allow us to move on from a socket failure for fetching

### DIFF
--- a/Sources/WebFetch/APIs/SocketFetcher.php
+++ b/Sources/WebFetch/APIs/SocketFetcher.php
@@ -212,20 +212,20 @@ class SocketFetcher extends WebFetchApi
 
 		// I want this, from there, and I may or may not bother you for more later.
 		if (empty($post_data)) {
-			fwrite($this->fp, 'GET ' . $path_and_query . ' HTTP/1.1' . $this->line_break);
-			fwrite($this->fp, 'Host: ' . $url->host . $this->line_break);
-			fwrite($this->fp, 'User-Agent: ' . SMF_USER_AGENT . $this->line_break);
-			fwrite($this->fp, 'Connection: ' . ($this->keep_alive ? 'keep-alive' : 'close') . $this->line_break);
-			fwrite($this->fp, $this->line_break);
+			fwrite($this->fp, 'GET ' . $path_and_query . ' HTTP/1.1' . $this->line_break) || throw new \Exception('Failed to write to socket');
+			fwrite($this->fp, 'Host: ' . $url->host . $this->line_break) || throw new \Exception('Failed to write to socket');
+			fwrite($this->fp, 'User-Agent: ' . SMF_USER_AGENT . $this->line_break) || throw new \Exception('Failed to write to socket');
+			fwrite($this->fp, 'Connection: ' . ($this->keep_alive ? 'keep-alive' : 'close') . $this->line_break) || throw new \Exception('Failed to write to socket');
+			fwrite($this->fp, $this->line_break) || throw new \Exception('Failed to write to socket');
 		} else {
-			fwrite($this->fp, 'POST ' . $path_and_query . ' HTTP/1.1' . $this->line_break);
-			fwrite($this->fp, 'Host: ' . $url->host . $this->line_break);
-			fwrite($this->fp, 'User-Agent: ' . SMF_USER_AGENT . $this->line_break);
-			fwrite($this->fp, 'Connection: ' . ($this->keep_alive ? 'keep-alive' : 'close') . $this->line_break);
-			fwrite($this->fp, 'Content-Type: application/x-www-form-urlencoded' . $this->line_break);
-			fwrite($this->fp, 'Content-Length: ' . strlen($post_data) . $this->line_break);
-			fwrite($this->fp, $this->line_break);
-			fwrite($this->fp, $post_data);
+			fwrite($this->fp, 'POST ' . $path_and_query . ' HTTP/1.1' . $this->line_break) || throw new \Exception('Failed to write to socket');
+			fwrite($this->fp, 'Host: ' . $url->host . $this->line_break) || throw new \Exception('Failed to write to socket');
+			fwrite($this->fp, 'User-Agent: ' . SMF_USER_AGENT . $this->line_break) || throw new \Exception('Failed to write to socket');
+			fwrite($this->fp, 'Connection: ' . ($this->keep_alive ? 'keep-alive' : 'close') . $this->line_break) || throw new \Exception('Failed to write to socket');
+			fwrite($this->fp, 'Content-Type: application/x-www-form-urlencoded' . $this->line_break) || throw new \Exception('Failed to write to socket');
+			fwrite($this->fp, 'Content-Length: ' . strlen($post_data) . $this->line_break) || throw new \Exception('Failed to write to socket');
+			fwrite($this->fp, $this->line_break) || throw new \Exception('Failed to write to socket');
+			fwrite($this->fp, $post_data) || throw new \Exception('Failed to write to socket');
 		}
 
 		$response = fgets($this->fp, 768);

--- a/Sources/WebFetch/WebFetchApi.php
+++ b/Sources/WebFetch/WebFetchApi.php
@@ -147,8 +147,13 @@ abstract class WebFetchApi implements WebFetchApiInterface
 					self::$still_alive[(string) $url] = $fetcher;
 				}
 
-				// Make the request.
-				$fetcher->request($url, $post_data);
+				// Make the request, if it fails, move on.
+				try {
+					$fetcher->request($url, $post_data);
+				}
+				catch (\Exception $ex) {
+					continue;
+				}
 
 				// If keep_alive was turned off during the request, we don't
 				// need to maintain this instance after we're done the request.

--- a/Sources/WebFetch/WebFetchApi.php
+++ b/Sources/WebFetch/WebFetchApi.php
@@ -150,8 +150,7 @@ abstract class WebFetchApi implements WebFetchApiInterface
 				// Make the request, if it fails, move on.
 				try {
 					$fetcher->request($url, $post_data);
-				}
-				catch (\Exception $ex) {
+				} catch (\Exception $ex) {
 					continue;
 				}
 


### PR DESCRIPTION
Fixes #8313

I kept the try/catch block in the main class, so that other APIs could also be written to do the same thing.