### PR TITLE
[3.0] Allow tasks to be defined as single running instances

### DIFF
--- a/Sources/TaskRunner.php
+++ b/Sources/TaskRunner.php
@@ -616,7 +616,7 @@ class TaskRunner
 	 * Checks if a task is locked into a single instance.
 	 * While checking, we obtain a exclusive lock to run this task.
 	 *
-	 * @param \SMF_BackgroundTask $task
+	 * @param SMF\Tasks\BackgroundTask $task
 	 * @return bool True if we obtained a lock, false otherwse.
 	 */
 	protected function tryTaskLock(SMF_BackgroundTask $task): bool

--- a/Sources/TaskRunner.php
+++ b/Sources/TaskRunner.php
@@ -647,7 +647,7 @@ class TaskRunner
 	 *
 	 * @param \SMF_BackgroundTask $task
 	 */
-	protected function unlockTask(SMF_BackgroundTask $task): void
+	protected function unlockTask(BackgroundTask $task): void
 	{
 		$token_file = Config::$cachedir . DIRECTORY_SEPARATOR . md5($task::class) . '.lock';
 

--- a/Sources/TaskRunner.php
+++ b/Sources/TaskRunner.php
@@ -17,7 +17,7 @@ namespace SMF;
 
 use SMF\Db\DatabaseApi as Db;
 use SMF\Tasks\ScheduledTask;
-use SMF_BackgroundTask;
+use SMF\Tasks\BackgroundTask;
 
 /**
  * Runs background tasks (a.k.a. cron jobs), including scheduled tasks.

--- a/Sources/TaskRunner.php
+++ b/Sources/TaskRunner.php
@@ -573,7 +573,7 @@ class TaskRunner
 		}
 
 		// Normally, the class should be specified using its fully qualified name.
-		if (class_exists($task_details['task_class']) && is_subclass_of($task_details['task_class'], SMF_BackgroundTask::class)) {
+		if (class_exists($task_details['task_class']) && is_subclass_of($task_details['task_class'], BackgroundTask::class)) {
 			$details = empty($task_details['task_data']) ? [] : Utils::jsonDecode($task_details['task_data'], true);
 
 			$bgtask = new $task_details['task_class']($details);

--- a/Sources/TaskRunner.php
+++ b/Sources/TaskRunner.php
@@ -16,6 +16,8 @@ declare(strict_types=1);
 namespace SMF;
 
 use SMF\Db\DatabaseApi as Db;
+use SMF\Tasks\ScheduledTask;
+use SMF_BackgroundTask;
 
 /**
  * Runs background tasks (a.k.a. cron jobs), including scheduled tasks.
@@ -108,6 +110,12 @@ class TaskRunner
 			'class' => 'SMF\\Tasks\\PruneLogTopics',
 		],
 	];
+
+	/*********************
+	 * Internal properties
+	 *********************/
+
+	protected $fp = null;
 
 	/****************
 	 * Public methods
@@ -565,22 +573,18 @@ class TaskRunner
 		}
 
 		// Normally, the class should be specified using its fully qualified name.
-		if (class_exists($task_details['task_class']) && is_subclass_of($task_details['task_class'], 'SMF\\Tasks\\BackgroundTask')) {
+		if (class_exists($task_details['task_class']) && is_subclass_of($task_details['task_class'], SMF_BackgroundTask::class)) {
 			$details = empty($task_details['task_data']) ? [] : Utils::jsonDecode($task_details['task_data'], true);
 
 			$bgtask = new $task_details['task_class']($details);
-
-			$success = $bgtask->execute();
 		}
 		// Just in case a mod or something specified a task without giving the namespace.
-		elseif (class_exists('SMF\\Tasks\\' . $task_details['task_class']) && is_subclass_of('SMF\\Tasks\\' . $task_details['task_class'], 'SMF\\Tasks\\BackgroundTask')) {
+		elseif (class_exists('SMF\\Tasks\\' . $task_details['task_class']) && is_subclass_of('SMF\\Tasks\\' . $task_details['task_class'], SMF_BackgroundTask::class)) {
 			$details = empty($task_details['task_data']) ? [] : Utils::jsonDecode($task_details['task_data'], true);
 
 			$task_class = 'SMF\\Tasks\\' . $task_details['task_class'];
 
 			$bgtask = new $task_class($details);
-
-			$success = $bgtask->execute();
 		}
 		// Uh-oh...
 		else {
@@ -590,13 +594,71 @@ class TaskRunner
 			return true;
 		}
 
+		// The task may only allow a single instance, stop it.
+		if (!$this->tryTaskLock($bgtask)) {
+			return false;
+		}
+
+		$success = $bgtask->execute();
+
+		$this->unlockTask($bgtask);
+
 		// For scheduled tasks, log it and update our next scheduled task time.
-		if (is_subclass_of($bgtask, 'SMF\\Tasks\\ScheduledTask')) {
+		if (is_subclass_of($bgtask, ScheduledTask::class)) {
 			$bgtask->log();
 			Tasks\ScheduledTask::updateNextTaskTime();
 		}
 
 		return $success;
+	}
+
+	/**
+	 * Checks if a task is locked into a single instance.
+	 * While checking, we obtain a exclusive lock to run this task.
+	 *
+	 * @param \SMF_BackgroundTask $task
+	 * @return bool True if we obtained a lock, false otherwse.
+	 */
+	protected function tryTaskLock(SMF_BackgroundTask $task): bool
+	{
+		// If this task allows multiple instances, its never locked.
+		if (empty($task->allow_only_single_instance)) {
+			return true;
+		}
+
+		$token_file = Config::$cachedir . DIRECTORY_SEPARATOR . md5($task::class) . '.lock';
+
+		// File exists, but its old.
+		if (file_exists($token_file) && (filectime($token_file) + MAX_CLAIM_THRESHOLD) <= time()) {
+			@unlink($token_file);
+		}
+
+		// Try to obtain a exclusive lock.
+		return (bool) (
+			!file_exists($token_file)
+			&& ($this->fp = fopen($token_file, 'c'))
+			&& flock($this->fp, LOCK_EX)
+		);
+	}
+
+	/**
+	 * Releases a lock on a task.
+	 * Does not check if the task allows mulitple instances, checks if we have any resource or file in use.
+	 *
+	 * @param \SMF_BackgroundTask $task
+	 */
+	protected function unlockTask(SMF_BackgroundTask $task): void
+	{
+		$token_file = Config::$cachedir . DIRECTORY_SEPARATOR . md5($task::class) . '.lock';
+
+		if (is_resource($this->fp)) {
+			flock($this->fp, LOCK_UN);
+			fclose($this->fp);
+		}
+
+		if (file_exists($token_file)) {
+			unlink($token_file);
+		}
 	}
 
 	/**

--- a/Sources/TaskRunner.php
+++ b/Sources/TaskRunner.php
@@ -645,7 +645,7 @@ class TaskRunner
 	 * Releases a lock on a task.
 	 * Does not check if the task allows mulitple instances, checks if we have any resource or file in use.
 	 *
-	 * @param \SMF_BackgroundTask $task
+	 * @param SMF\Tasks\BackgroundTask $task
 	 */
 	protected function unlockTask(BackgroundTask $task): void
 	{

--- a/Sources/TaskRunner.php
+++ b/Sources/TaskRunner.php
@@ -606,7 +606,7 @@ class TaskRunner
 		// For scheduled tasks, log it and update our next scheduled task time.
 		if (is_subclass_of($bgtask, ScheduledTask::class)) {
 			$bgtask->log();
-			Tasks\ScheduledTask::updateNextTaskTime();
+			ScheduledTask::updateNextTaskTime();
 		}
 
 		return $success;

--- a/Sources/TaskRunner.php
+++ b/Sources/TaskRunner.php
@@ -619,7 +619,7 @@ class TaskRunner
 	 * @param SMF\Tasks\BackgroundTask $task
 	 * @return bool True if we obtained a lock, false otherwse.
 	 */
-	protected function tryTaskLock(SMF_BackgroundTask $task): bool
+	protected function tryTaskLock(BackgroundTask $task): bool
 	{
 		// If this task allows multiple instances, its never locked.
 		if (empty($task->allow_only_single_instance)) {

--- a/Sources/TaskRunner.php
+++ b/Sources/TaskRunner.php
@@ -579,7 +579,7 @@ class TaskRunner
 			$bgtask = new $task_details['task_class']($details);
 		}
 		// Just in case a mod or something specified a task without giving the namespace.
-		elseif (class_exists('SMF\\Tasks\\' . $task_details['task_class']) && is_subclass_of('SMF\\Tasks\\' . $task_details['task_class'], SMF_BackgroundTask::class)) {
+		elseif (class_exists('SMF\\Tasks\\' . $task_details['task_class']) && is_subclass_of('SMF\\Tasks\\' . $task_details['task_class'], BackgroundTask::class)) {
 			$details = empty($task_details['task_data']) ? [] : Utils::jsonDecode($task_details['task_data'], true);
 
 			$task_class = 'SMF\\Tasks\\' . $task_details['task_class'];

--- a/Sources/Tasks/BackgroundTask.php
+++ b/Sources/Tasks/BackgroundTask.php
@@ -32,6 +32,19 @@ abstract class BackgroundTask
 	public const RECEIVE_NOTIFY_EMAIL = 0x02;
 	public const RECEIVE_NOTIFY_ALERT = 0x01;
 
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 * If this is true, we only allow a single instance of this task to ever run at once.
+	 * If another is found, we will not run the task yet.
+	 * This does not delete the task, as it will be marked as failed to run.
+	 *
+	 * @var bool
+	 */
+	public bool $allow_only_single_instance = false;
+
 	/*********************
 	 * Internal properties
 	 *********************/

--- a/Sources/Tasks/UpdateUnicode.php
+++ b/Sources/Tasks/UpdateUnicode.php
@@ -60,6 +60,11 @@ class UpdateUnicode extends BackgroundTask
 	 */
 	public $unicodedir = '';
 
+	/**
+	 * @var bool Only allow a single insstance to run.
+	 */
+	public bool $allow_only_single_instance = true;
+
 	/*********************
 	 * Internal properties
 	 *********************/


### PR DESCRIPTION
@Sesquipedalian I had started to write this before the other PRs went up, but figured I should send this to see if there is interest.
This was my solution to the race condition by allowing tasks to define if they should only run once and if so, issue a lock file and hold onto it while they run.
We can improve on it and define other tasks that should also be single instance runners.