### PR TITLE
[2.1] Better fix for tables wrapped in left, center, or right BBCodes

### DIFF
--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -1858,8 +1858,8 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 			),
 			array(
 				'tag' => 'center',
-				'before' => '<div class="centertext"><div class="inline_block">',
-				'after' => '</div></div>',
+				'before' => '<div class="centertext">',
+				'after' => '</div>',
 				'block_level' => true,
 			),
 			array(
@@ -2296,8 +2296,8 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 			),
 			array(
 				'tag' => 'right',
-				'before' => '<div class="righttext"><div class="inline_block">',
-				'after' => '</div></div>',
+				'before' => '<div class="righttext">',
+				'after' => '</div>',
 				'block_level' => true,
 			),
 			array(

--- a/Themes/default/css/index.css
+++ b/Themes/default/css/index.css
@@ -410,6 +410,14 @@ blockquote cite::before {
 	font: inherit;
 	color: inherit;
 }
+.lefttext .bbc_table,
+.centertext .bbc_table {
+	margin-right: auto;
+}
+.righttext .bbc_table,
+.centertext .bbc_table {
+	margin-left: auto;
+}
 .bbc_table td {
 	font: inherit;
 	color: inherit;


### PR DESCRIPTION
The previous attempt to fix tables wrapped in left, center, or right BBCodes ended up causing problems for YouTube embeds wrapped in left, center, or right BBCodes.

Fixes #8755
