### PR TITLE
[3.0] Rewrite file cache to use SplFileObject

### DIFF
--- a/Sources/Cache/APIs/FileBased.php
+++ b/Sources/Cache/APIs/FileBased.php
@@ -252,6 +252,7 @@ class FileBased extends CacheApi implements CacheApiInterface
 
 			if (!$fp->flock(LOCK_SH)) {
 				$fp = null;
+
 				return false;
 			}
 
@@ -265,8 +266,7 @@ class FileBased extends CacheApi implements CacheApiInterface
 			$fp = null;
 
 			return $string;
-		}
-		catch (\Exception $ex) {
+		} catch (\Exception $ex) {
 			if ($fp !== null) {
 				$fp->flock(LOCK_UN);
 				$fp = null;
@@ -283,6 +283,7 @@ class FileBased extends CacheApi implements CacheApiInterface
 
 			if (!$fp->flock(LOCK_EX)) {
 				$fp = null;
+
 				return false;
 			}
 
@@ -302,8 +303,7 @@ class FileBased extends CacheApi implements CacheApiInterface
 			$fp = null;
 
 			return $bytes;
-		}
-		catch (\Exception $ex) {
+		} catch (\Exception $ex) {
 			if ($fp !== null) {
 				$fp->flock(LOCK_UN);
 				$fp = null;

--- a/Sources/Cache/APIs/FileBased.php
+++ b/Sources/Cache/APIs/FileBased.php
@@ -247,22 +247,30 @@ class FileBased extends CacheApi implements CacheApiInterface
 
 	private function readFile(string $file): mixed
 	{
-		if (($fp = @fopen($file, 'rb')) !== false) {
-			if (!flock($fp, LOCK_SH)) {
-				fclose($fp);
+		try {
+			$fp = new \SplFileObject($file, 'rb');
 
+			if (!$fp->flock(LOCK_SH)) {
+				$fp = null;
 				return false;
 			}
+
 			$string = '';
 
-			while (!feof($fp)) {
-				$string .= fread($fp, 8192);
+			while (!$fp->eof()) {
+				$string .= $fp->fgets();
 			}
 
-			flock($fp, LOCK_UN);
-			fclose($fp);
+			$fp->flock(LOCK_UN);
+			$fp = null;
 
 			return $string;
+		}
+		catch (\Exception $ex) {
+			if ($fp !== null) {
+				$fp->flock(LOCK_UN);
+				$fp = null;
+			}
 		}
 
 		return false;
@@ -270,28 +278,36 @@ class FileBased extends CacheApi implements CacheApiInterface
 
 	private function writeFile(string $file, mixed $string): mixed
 	{
-		if (($fp = fopen($file, 'cb')) !== false) {
-			if (!flock($fp, LOCK_EX)) {
-				fclose($fp);
+		try {
+			$fp = new \SplFileObject($file, 'cb');
 
+			if (!$fp->flock(LOCK_EX)) {
+				$fp = null;
 				return false;
 			}
-			ftruncate($fp, 0);
+
+			$fp->ftruncate(0);
 			$bytes = 0;
 			$pieces = str_split($string, 8192);
 
 			foreach ($pieces as $piece) {
-				if (($val = fwrite($fp, $piece, 8192)) !== false) {
+				if (($val = $fp->fwrite($piece, 8192)) !== false) {
 					$bytes += $val;
 				} else {
 					return false;
 				}
 			}
-			fflush($fp);
-			flock($fp, LOCK_UN);
-			fclose($fp);
+			$fp->fflush();
+			$fp->flock(LOCK_UN);
+			$fp = null;
 
 			return $bytes;
+		}
+		catch (\Exception $ex) {
+			if ($fp !== null) {
+				$fp->flock(LOCK_UN);
+				$fp = null;
+			}
 		}
 
 		return false;


### PR DESCRIPTION
Updates file-based cache to use SplFileObject for improved error catching

Fixes #7422

SplFileObject, when it encounters errors, throws them, typically a RuntimeException. Or it just returns false as expected.