### PR TITLE
[3.0] Use attachment type constants

### DIFF
--- a/Sources/Actions/Admin/Attachments.php
+++ b/Sources/Actions/Admin/Attachments.php
@@ -286,7 +286,7 @@ class Attachments implements ActionInterface
 							$link = '<a href="';
 
 							// In case of a custom avatar URL attachments have a fixed directory.
-							if ($rowData['attachment_type'] == 1) {
+							if ($rowData['attachment_type'] == Attachment::TYPE_AVATAR) {
 								$link .= sprintf('%1$s/%2$s', Config::$modSettings['custom_avatar_url'], $rowData['filename']);
 							}
 							// By default avatars are downloaded almost as attachments.
@@ -302,7 +302,7 @@ class Attachments implements ActionInterface
 
 							// Show a popup on click if it's a picture and we know its dimensions.
 							if (!empty($rowData['width']) && !empty($rowData['height'])) {
-								$link .= sprintf(' onclick="return reqWin(this.href' . ($rowData['attachment_type'] == 1 ? '' : ' + \';image\'') . ', %1$d, %2$d, true);"', $rowData['width'] + 20, $rowData['height'] + 20);
+								$link .= sprintf(' onclick="return reqWin(this.href' . ($rowData['attachment_type'] == Attachment::TYPE_AVATAR ? '' : ' + \';image\'') . ', %1$d, %2$d, true);"', $rowData['width'] + 20, $rowData['height'] + 20);
 							}
 
 							$link .= sprintf('>%1$s</a>', preg_replace('~&amp;#(\\\\d{1,7}|x[0-9a-fA-F]{1,6});~', '&#\\\\1;', Utils::htmlspecialchars($rowData['filename'])));
@@ -486,7 +486,7 @@ class Attachments implements ActionInterface
 			WHERE attachment_type = {int:attachment_type}
 				AND id_member = {int:guest_id_member}',
 			[
-				'attachment_type' => 0,
+				'attachment_type' => Attachment::TYPE_STANDARD,
 				'guest_id_member' => 0,
 			],
 		);
@@ -513,7 +513,7 @@ class Attachments implements ActionInterface
 			FROM {db_prefix}attachments
 			WHERE attachment_type != {int:type}',
 			[
-				'type' => 1,
+				'type' => Attachment::TYPE_AVATAR,
 			],
 		);
 		list($attachmentDirSize) = Db::$db->fetch_row($request);
@@ -627,7 +627,7 @@ class Attachments implements ActionInterface
 		// Deleting an attachment?
 		if ($_REQUEST['type'] != 'avatars') {
 			// Get rid of all the old attachments.
-			$messages = Attachment::remove(['attachment_type' => 0, 'poster_time' => (time() - 24 * 60 * 60 * $_POST['age'])], 'messages', true);
+			$messages = Attachment::remove(['attachment_type' => Attachment::TYPE_STANDARD, 'poster_time' => (time() - 24 * 60 * 60 * $_POST['age'])], 'messages', true);
 
 			// Update the messages to reflect the change.
 			if (!empty($messages) && !empty($_POST['notice'])) {
@@ -661,7 +661,7 @@ class Attachments implements ActionInterface
 		User::$me->checkSession('post', 'admin');
 
 		// Find humungous attachments.
-		$messages = Attachment::remove(['attachment_type' => 0, 'size' => 1024 * $_POST['size']], 'messages', true);
+		$messages = Attachment::remove(['attachment_type' => Attachment::TYPE_STANDARD, 'size' => 1024 * $_POST['size']], 'messages', true);
 
 		// And make a note on the post.
 		if (!empty($messages) && !empty($_POST['notice'])) {
@@ -688,7 +688,7 @@ class Attachments implements ActionInterface
 	{
 		User::$me->checkSession('get', 'admin');
 
-		$messages = Attachment::remove(['attachment_type' => 0], '', true);
+		$messages = Attachment::remove(['attachment_type' => Attachment::TYPE_STANDARD], '', true);
 
 		if (!isset($_POST['notice'])) {
 			$_POST['notice'] = Lang::getTxt('attachment_delete_admin', file: 'Admin');
@@ -775,7 +775,7 @@ class Attachments implements ActionInterface
 				FROM {db_prefix}attachments
 				WHERE attachment_type = {int:thumbnail}',
 				[
-					'thumbnail' => 3,
+					'thumbnail' => Attachment::TYPE_THUMB,
 				],
 			);
 			list($thumbnails) = Db::$db->fetch_row($result);
@@ -793,7 +793,7 @@ class Attachments implements ActionInterface
 						AND thumb.attachment_type = {int:thumbnail}
 						AND tparent.id_attach IS NULL',
 					[
-						'thumbnail' => 3,
+						'thumbnail' => Attachment::TYPE_THUMB,
 						'substep' => $_GET['substep'],
 					],
 				);
@@ -825,7 +825,7 @@ class Attachments implements ActionInterface
 							AND attachment_type = {int:attachment_type}',
 						[
 							'to_remove' => $to_remove,
-							'attachment_type' => 3,
+							'attachment_type' => Attachment::TYPE_THUMB,
 						],
 					);
 				}
@@ -926,7 +926,7 @@ class Attachments implements ActionInterface
 
 				while ($row = Db::$db->fetch_assoc($result)) {
 					// Get the filename.
-					if ($row['attachment_type'] == 1) {
+					if ($row['attachment_type'] == Attachment::TYPE_AVATAR) {
 						$filename = Config::$modSettings['custom_avatar_dir'] . '/' . $row['filename'];
 					} else {
 						$filename = Attachment::getFilePath((int) $row['id_attach']);
@@ -1077,7 +1077,7 @@ class Attachments implements ActionInterface
 
 					// If we are repairing remove the file from disk now.
 					if ($fix_errors && in_array('avatar_no_member', $to_fix)) {
-						if ($row['attachment_type'] == 1) {
+						if ($row['attachment_type'] == Attachment::TYPE_AVATAR) {
 							$filename = Config::$modSettings['custom_avatar_dir'] . '/' . $row['filename'];
 						} else {
 							$filename = Attachment::getFilePath((int) $row['id_attach']);
@@ -1148,7 +1148,7 @@ class Attachments implements ActionInterface
 						'no_msg' => 0,
 						'substep' => $_GET['substep'],
 						'ignore_ids' => $ignore_ids,
-						'attach_thumb' => [0, 3],
+						'attach_thumb' => [Attachment::TYPE_STANDARD, Attachment::TYPE_THUMB],
 					],
 				);
 
@@ -1178,7 +1178,7 @@ class Attachments implements ActionInterface
 						[
 							'to_remove' => $to_remove,
 							'no_member' => 0,
-							'attach_thumb' => [0, 3],
+							'attach_thumb' => [Attachment::TYPE_STANDARD, Attachment::TYPE_THUMB],
 						],
 					);
 				}
@@ -1856,7 +1856,7 @@ class Attachments implements ActionInterface
 					AND attachment_type != {int:attachment_type}',
 				[
 					'folder_id' => $_POST['from'],
-					'attachment_type' => 1,
+					'attachment_type' => Attachment::TYPE_AVATAR,
 				],
 			);
 			list($total_progress) = Db::$db->fetch_row($request);
@@ -1905,7 +1905,7 @@ class Attachments implements ActionInterface
 							AND attachment_type != {int:attachment_type}',
 						[
 							'folder_id' => $new_dir,
-							'attachment_type' => 1,
+							'attachment_type' => Attachment::TYPE_AVATAR,
 						],
 					);
 					list($dir_files, $dir_size) = Db::$db->fetch_row($request);
@@ -1921,7 +1921,7 @@ class Attachments implements ActionInterface
 					LIMIT {int:start}, {int:limit}',
 					[
 						'folder' => $_POST['from'],
-						'attachment_type' => 1,
+						'attachment_type' => Attachment::TYPE_AVATAR,
 						'start' => $start,
 						'limit' => $limit,
 					],
@@ -2418,7 +2418,7 @@ class Attachments implements ActionInterface
 				ORDER BY {raw:sort}
 				LIMIT {int:start}, {int:per_page}',
 				[
-					'attachment_type' => $browse_type == 'thumbs' ? '3' : '0',
+					'attachment_type' => $browse_type == 'thumbs' ? Attachment::TYPE_THUMB : Attachment::TYPE_STANDARD,
 					'guest_id_member' => 0,
 					'sort' => $sort,
 					'start' => $start,
@@ -2464,7 +2464,7 @@ class Attachments implements ActionInterface
 				WHERE a.attachment_type = {int:attachment_type}
 					AND a.id_member = {int:guest_id_member}',
 				[
-					'attachment_type' => $browse_type === 'thumbs' ? '3' : '0',
+					'attachment_type' => $browse_type === 'thumbs' ? Attachment::TYPE_THUMB : Attachment::TYPE_STANDARD,
 					'guest_id_member' => 0,
 				],
 			);
@@ -2491,7 +2491,7 @@ class Attachments implements ActionInterface
 			WHERE attachment_type != {int:type}
 			GROUP BY id_folder',
 			[
-				'type' => 1,
+				'type' => Attachment::TYPE_AVATAR,
 			],
 		);
 

--- a/Sources/Actions/AttachmentApprove.php
+++ b/Sources/Actions/AttachmentApprove.php
@@ -62,8 +62,8 @@ class AttachmentApprove implements ActionInterface, Routable
 					AND attachment_type = {int:attachment_type}',
 				[
 					'id_msg' => $id_msg,
-					'is_approved' => 0,
-					'attachment_type' => 0,
+					'is_approved' => Attachment::APPROVED_FALSE,
+					'attachment_type' => Attachment::TYPE_STANDARD,
 				],
 			);
 
@@ -92,8 +92,8 @@ class AttachmentApprove implements ActionInterface, Routable
 				AND a.approved = {int:is_approved}',
 			[
 				'attachments' => $attachments,
-				'attachment_type' => 0,
-				'is_approved' => 0,
+				'attachment_type' => Attachment::TYPE_STANDARD,
+				'is_approved' => Attachment::APPROVED_FALSE,
 			],
 		);
 		$attachments = [];

--- a/Sources/Actions/AttachmentUpload.php
+++ b/Sources/Actions/AttachmentUpload.php
@@ -302,7 +302,7 @@ class AttachmentUpload implements ActionInterface, Routable
 					AND attachment_type = {int:attachment_type}',
 				[
 					'id_msg' => (int) $this->msg,
-					'attachment_type' => 0,
+					'attachment_type' => Attachment::TYPE_STANDARD,
 				],
 			);
 			list(Utils::$context['attachments']['quantity'], Utils::$context['attachments']['total_size']) = Db::$db->fetch_row($request);

--- a/Sources/Actions/Moderation/Posts.php
+++ b/Sources/Actions/Moderation/Posts.php
@@ -476,8 +476,8 @@ class Posts implements ActionInterface
 					' . $approve_query,
 				[
 					'attachments' => $attachments,
-					'not_approved' => 0,
-					'attachment_type' => 0,
+					'not_approved' => Attachment::APPROVED_FALSE,
+					'attachment_type' => Attachment::TYPE_STANDARD,
 				],
 			);
 			$attachments = [];
@@ -770,8 +770,8 @@ class Posts implements ActionInterface
 			ORDER BY {raw:sort}
 			LIMIT {int:start}, {int:items_per_page}',
 			[
-				'not_approved' => 0,
-				'attachment_type' => 0,
+				'not_approved' => Attachment::APPROVED_FALSE,
+				'attachment_type' => Attachment::TYPE_STANDARD,
 				'start' => $start,
 				'sort' => $sort,
 				'items_per_page' => $items_per_page,
@@ -837,8 +837,8 @@ class Posts implements ActionInterface
 				AND {query_see_message_board}
 				' . $approve_query,
 			[
-				'not_approved' => 0,
-				'attachment_type' => 0,
+				'not_approved' => Attachment::APPROVED_FALSE,
+				'attachment_type' => Attachment::TYPE_STANDARD,
 			],
 		);
 		list($total_unapproved_attachments) = Db::$db->fetch_row($request);

--- a/Sources/Actions/Post2.php
+++ b/Sources/Actions/Post2.php
@@ -783,7 +783,7 @@ class Post2 extends Post
 
 			if (!empty($_REQUEST['msg'])) {
 				$attachmentQuery = [
-					'attachment_type' => 0,
+					'attachment_type' => Attachment::TYPE_STANDARD,
 					'id_msg' => (int) $_REQUEST['msg'],
 					'not_id_attach' => $keep_ids,
 				];

--- a/Sources/Actions/Profile/ShowPosts.php
+++ b/Sources/Actions/Profile/ShowPosts.php
@@ -17,6 +17,7 @@ namespace SMF\Actions\Profile;
 
 use SMF\ActionInterface;
 use SMF\ActionTrait;
+use SMF\Attachment;
 use SMF\Autolinker;
 use SMF\Board;
 use SMF\Config;
@@ -495,10 +496,10 @@ class ShowPosts implements ActionInterface
 			LIMIT {int:offset}, {int:limit}',
 			[
 				'boards_list' => $boards_allowed,
-				'attachment_type' => 0,
+				'attachment_type' => Attachment::TYPE_STANDARD,
 				'no_message' => 0,
 				'current_member' => Profile::$member->id,
-				'is_approved' => 1,
+				'is_approved' => Attachment::APPROVED_TRUE,
 				'board' => Board::$info->id ?? 0,
 				'sort' => $sort,
 				'offset' => $start,
@@ -550,10 +551,10 @@ class ShowPosts implements ActionInterface
 				AND t.approved = {int:is_approved}'),
 			[
 				'boards_list' => $boards_allowed,
-				'attachment_type' => 0,
+				'attachment_type' => Attachment::TYPE_STANDARD,
 				'no_message' => 0,
 				'current_member' => Profile::$member->id,
-				'is_approved' => 1,
+				'is_approved' => Attachment::APPROVED_TRUE,
 				'board' => Board::$info->id ?? 0,
 			],
 		);

--- a/Sources/Actions/TopicPrint.php
+++ b/Sources/Actions/TopicPrint.php
@@ -170,8 +170,7 @@ class TopicPrint implements ActionInterface, Routable
 					AND a.attachment_type = {int:attachment_type}',
 				[
 					'message_list' => $messages,
-					'attachment_type' => 0,
-					'is_approved' => 1,
+					'attachment_type' => Attachment::TYPE_STANDARD,
 				],
 			);
 			$temp = [];

--- a/Sources/Attachment.php
+++ b/Sources/Attachment.php
@@ -949,7 +949,7 @@ class Attachment implements \ArrayAccess
 						AND attachment_type = {int:attachment_type}',
 					[
 						'id_msg' => (int) $_REQUEST['msg'],
-						'attachment_type' => 0,
+						'attachment_type' => Attachment::TYPE_STANDARD,
 					],
 				);
 				list(Utils::$context['attachments']['quantity'], Utils::$context['attachments']['total_size']) = Db::$db->fetch_row($request);
@@ -1169,7 +1169,7 @@ class Attachment implements \ArrayAccess
 						AND attachment_type != {int:type}',
 					[
 						'folder_id' => Config::$modSettings['currentAttachmentUploadDir'],
-						'type' => 1,
+						'type' => Attachment::TYPE_AVATAR,
 					],
 				);
 				list(Utils::$context['dir_files'], Utils::$context['dir_size']) = Db::$db->fetch_row($request);
@@ -1609,7 +1609,7 @@ class Attachment implements \ArrayAccess
 				AND a.attachment_type = {int:attachment_type}',
 			[
 				'attachments' => $attachments,
-				'attachment_type' => 0,
+				'attachment_type' => Attachment::TYPE_STANDARD,
 			],
 		);
 		$attachments = [];
@@ -1648,7 +1648,7 @@ class Attachment implements \ArrayAccess
 				AND a.attachment_type = {int:attachment_type}',
 			[
 				'attachments' => $attachments,
-				'attachment_type' => 0,
+				'attachment_type' => Attachment::TYPE_STANDARD,
 			],
 		);
 
@@ -1696,7 +1696,7 @@ class Attachment implements \ArrayAccess
 		// @todo This might need more work!
 		$new_condition = [];
 		$query_parameter = [
-			'thumb_attachment_type' => 3,
+			'thumb_attachment_type' => Attachment::TYPE_THUMB,
 		];
 		$do_logging = [];
 
@@ -1751,7 +1751,7 @@ class Attachment implements \ArrayAccess
 
 		while ($row = Db::$db->fetch_assoc($request)) {
 			// Figure out the "encrypted" filename and unlink it ;).
-			if ($row['attachment_type'] == 1) {
+			if ($row['attachment_type'] == Attachment::TYPE_AVATAR) {
 				// if attachment_type = 1, it's... an avatar in a custom avatars directory.
 				// wasn't it obvious? :P
 				// @todo look again at this.
@@ -1807,7 +1807,7 @@ class Attachment implements \ArrayAccess
 					AND a.attachment_type = {int:attachment_type}',
 				[
 					'attachments' => $do_logging,
-					'attachment_type' => 0,
+					'attachment_type' => Attachment::TYPE_STANDARD,
 				],
 			);
 

--- a/Sources/Config.php
+++ b/Sources/Config.php
@@ -2772,7 +2772,7 @@ class Config
 		}
 
 		if (!isset($db_last_error)) {
-			self::updateDbLastError(0, true);
+			self::updateDbLastError(0);
 		} else {
 			self::$db_last_error = (int) $db_last_error;
 		}

--- a/Sources/Config.php
+++ b/Sources/Config.php
@@ -2772,7 +2772,7 @@ class Config
 		}
 
 		if (!isset($db_last_error)) {
-			self::updateDbLastError(0);
+			self::updateDbLastError(0, true);
 		} else {
 			self::$db_last_error = (int) $db_last_error;
 		}

--- a/Sources/Msg.php
+++ b/Sources/Msg.php
@@ -2764,7 +2764,7 @@ class Msg implements \ArrayAccess, Routable
 
 			// Delete attachment(s) if they exist.
 			$attachmentQuery = [
-				'attachment_type' => 0,
+				'attachment_type' => Attachment::TYPE_STANDARD,
 				'id_msg' => $message,
 			];
 

--- a/Sources/Profile.php
+++ b/Sources/Profile.php
@@ -2681,7 +2681,7 @@ class Profile extends User implements \ArrayAccess
 
 		// Reset the attach ID.
 		$this->data['id_attach'] = 0;
-		$this->data['attachment_type'] = 0;
+		$this->data['attachment_type'] = Attachment::TYPE_STANDARD;
 		$this->data['filename'] = '';
 		Attachment::remove(['id_member' => $this->id]);
 	}
@@ -2722,7 +2722,7 @@ class Profile extends User implements \ArrayAccess
 
 		// Get rid of their old avatar.
 		$this->data['id_attach'] = 0;
-		$this->data['attachment_type'] = 0;
+		$this->data['attachment_type'] = Attachment::TYPE_STANDARD;
 		$this->data['filename'] = '';
 		Attachment::remove(['id_member' => $this->id]);
 	}
@@ -2787,7 +2787,7 @@ class Profile extends User implements \ArrayAccess
 
 		// Remove any attached avatar...
 		$this->data['id_attach'] = 0;
-		$this->data['attachment_type'] = 0;
+		$this->data['attachment_type'] = Attachment::TYPE_STANDARD;
 		$this->data['filename'] = '';
 		Attachment::remove(['id_member' => $this->id]);
 
@@ -2921,7 +2921,7 @@ class Profile extends User implements \ArrayAccess
 		);
 
 		$this->data['filename'] = $image->pathinfo['basename'];
-		$this->data['attachment_type'] = 1;
+		$this->data['attachment_type'] = Attachment::TYPE_AVATAR;
 
 		return null;
 	}

--- a/Sources/ServerSideIncludes.php
+++ b/Sources/ServerSideIncludes.php
@@ -2733,7 +2733,7 @@ class ServerSideIncludes
 				INNER JOIN {db_prefix}topics AS t ON (t.id_topic = m.id_topic)
 				LEFT JOIN {db_prefix}members AS mem ON (mem.id_member = m.id_member)' . (empty(Config::$modSettings['attachmentShowImages']) || empty(Config::$modSettings['attachmentThumbnails']) ? '' : '
 				LEFT JOIN {db_prefix}attachments AS thumb ON (thumb.id_attach = att.id_thumb)') . '
-			WHERE att.attachment_type = 0' . ($attachments_boards === [0] ? '' : '
+			WHERE att.attachment_type = {int:attachment_type}' . ($attachments_boards === [0] ? '' : '
 				AND m.id_board IN ({array_int:boards_can_see})') . (!empty($attachment_ext) ? '
 				AND att.fileext IN ({array_string:attachment_ext})' : '') .
 				(!Config::$modSettings['postmod_active'] || User::$me->allowedTo('approve_posts') ? '' : '
@@ -2743,6 +2743,7 @@ class ServerSideIncludes
 			ORDER BY att.id_attach DESC
 			LIMIT {int:num_attachments}',
 			[
+				'attachment_type' => Attachment::TYPE_STANDARD,
 				'boards_can_see' => $attachments_boards,
 				'attachment_ext' => $attachment_ext,
 				'num_attachments' => $num_attachments,

--- a/Sources/Tasks/CreateAttachment_Notify.php
+++ b/Sources/Tasks/CreateAttachment_Notify.php
@@ -17,6 +17,7 @@ namespace SMF\Tasks;
 
 use SMF\Actions\Notify;
 use SMF\Alert;
+use SMF\Attachment;
 use SMF\Config;
 use SMF\Db\DatabaseApi as Db;
 use SMF\Mail;
@@ -53,8 +54,8 @@ class CreateAttachment_Notify extends BackgroundTask
 				AND a.approved = {int:is_approved}',
 			[
 				'attachment' => $this->_details['id'],
-				'attachment_type' => 0,
-				'is_approved' => 0,
+				'attachment_type' => Attachment::TYPE_STANDARD,
+				'is_approved' => Attachment::APPROVED_FALSE,
 			],
 		);
 

--- a/Sources/Topic.php
+++ b/Sources/Topic.php
@@ -1693,7 +1693,7 @@ class Topic implements \ArrayAccess, Routable
 
 		// Get rid of the attachment, if it exists.
 		$attachmentQuery = [
-			'attachment_type' => 0,
+			'attachment_type' => Attachment::TYPE_STANDARD,
 			'id_topic' => $topics,
 		];
 		Attachment::remove($attachmentQuery, 'messages');

--- a/Sources/User.php
+++ b/Sources/User.php
@@ -4103,7 +4103,7 @@ class User implements \ArrayAccess
 				'original_url' => $profile['avatar_original'] ?? '',
 				'url' => (string) ($profile['avatar'] ?? ''),
 				'filename' => $profile['filename'] ?? '',
-				'custom_dir' => !empty($profile['attachment_type']) && $profile['attachment_type'] == 1,
+				'custom_dir' => !empty($profile['attachment_type']) && $profile['attachment_type'] == Attachment::TYPE_AVATAR,
 				'id_attach' => $profile['id_attach'] ?? 0,
 				'width' => $profile['attachment_width'] ?? null,
 				'height' => $profile['attachment_height'] ?? null,


### PR DESCRIPTION
Update instances of numerical ids with constants for the Attachment type

While looking into #8707, I see that we had a constant for attachment type, but the code references the numerical values for all its checks.  I updated what I could find.