### PR TITLE
[3.0] Implements concurrency protection for tasks

### DIFF
--- a/Sources/TaskRunner.php
+++ b/Sources/TaskRunner.php
@@ -138,12 +138,6 @@ class TaskRunner
 				ErrorHandler::displayMaintenanceMessage();
 			}
 
-			// Have we already turned this off? If so, exist gracefully.
-			// @todo Remove this? It's a bad idea to ever disable background tasks.
-			if (file_exists(Config::$cachedir . '/cron.lock')) {
-				$this->obExit();
-			}
-
 			Security::frameOptionsHeader();
 
 			// Before we go any further, if this is not a CLI request, we need to do some checking.
@@ -575,6 +569,10 @@ class TaskRunner
 
 			$bgtask = new $task_details['task_class']($details);
 
+			if (!$bgtask->canExecute()) {
+				return true;
+			}
+
 			$success = $bgtask->execute();
 		}
 		// Just in case a mod or something specified a task without giving the namespace.
@@ -587,6 +585,10 @@ class TaskRunner
 			$task_class = 'SMF\\Tasks\\' . $task_details['task_class'];
 
 			$bgtask = new $task_class($details);
+
+			if (!$bgtask->canExecute()) {
+				return true;
+			}
 
 			$success = $bgtask->execute();
 		}
@@ -603,6 +605,9 @@ class TaskRunner
 			$bgtask->log();
 			Tasks\ScheduledTask::updateNextTaskTime();
 		}
+
+		// Trigger the destructor now.
+		unset($bgtask);
 
 		return $success;
 	}

--- a/Sources/TaskRunner.php
+++ b/Sources/TaskRunner.php
@@ -565,32 +565,14 @@ class TaskRunner
 			class_exists($task_details['task_class'])
 			&& is_subclass_of($task_details['task_class'], BackgroundTask::class)
 		) {
-			$details = empty($task_details['task_data']) ? [] : Utils::jsonDecode($task_details['task_data'], true);
-
-			$bgtask = new $task_details['task_class']($details);
-
-			if (!$bgtask->canExecute()) {
-				return true;
-			}
-
-			$success = $bgtask->execute();
+			$task_class = $task_details['task_class'];
 		}
 		// Just in case a mod or something specified a task without giving the namespace.
 		elseif (
 			class_exists('SMF\\Tasks\\' . $task_details['task_class'])
 			&& is_subclass_of('SMF\\Tasks\\' . $task_details['task_class'], BackgroundTask::class)
 		) {
-			$details = empty($task_details['task_data']) ? [] : Utils::jsonDecode($task_details['task_data'], true);
-
 			$task_class = 'SMF\\Tasks\\' . $task_details['task_class'];
-
-			$bgtask = new $task_class($details);
-
-			if (!$bgtask->canExecute()) {
-				return true;
-			}
-
-			$success = $bgtask->execute();
 		}
 		// Uh-oh...
 		else {
@@ -599,6 +581,16 @@ class TaskRunner
 			// So we clear it from the queue.
 			return true;
 		}
+
+		$details = empty($task_details['task_data']) ? [] : Utils::jsonDecode($task_details['task_data'], true);
+
+		$bgtask = new $task_class($details);
+
+		if (!$bgtask->canExecute()) {
+			return true;
+		}
+
+		$success = $bgtask->execute();
 
 		// For scheduled tasks, log it and update our next scheduled task time.
 		if (is_subclass_of($bgtask, ScheduledTask::class)) {

--- a/Sources/TaskRunner.php
+++ b/Sources/TaskRunner.php
@@ -16,6 +16,8 @@ declare(strict_types=1);
 namespace SMF;
 
 use SMF\Db\DatabaseApi as Db;
+use SMF\Tasks\BackgroundTask;
+use SMF\Tasks\ScheduledTask;
 
 /**
  * Runs background tasks (a.k.a. cron jobs), including scheduled tasks.
@@ -323,7 +325,7 @@ class TaskRunner
 			$bgtask = new $task_details['task_class']($task_details['task_data']);
 
 			// If the instance isn't actually a scheduled task, skip it.
-			if (!is_subclass_of($bgtask, 'SMF\\Tasks\\ScheduledTask')) {
+			if (!is_subclass_of($bgtask, ScheduledTask::class)) {
 				continue;
 			}
 
@@ -565,7 +567,10 @@ class TaskRunner
 		}
 
 		// Normally, the class should be specified using its fully qualified name.
-		if (class_exists($task_details['task_class']) && is_subclass_of($task_details['task_class'], 'SMF\\Tasks\\BackgroundTask')) {
+		if (
+			class_exists($task_details['task_class'])
+			&& is_subclass_of($task_details['task_class'], BackgroundTask::class)
+		) {
 			$details = empty($task_details['task_data']) ? [] : Utils::jsonDecode($task_details['task_data'], true);
 
 			$bgtask = new $task_details['task_class']($details);
@@ -573,7 +578,10 @@ class TaskRunner
 			$success = $bgtask->execute();
 		}
 		// Just in case a mod or something specified a task without giving the namespace.
-		elseif (class_exists('SMF\\Tasks\\' . $task_details['task_class']) && is_subclass_of('SMF\\Tasks\\' . $task_details['task_class'], 'SMF\\Tasks\\BackgroundTask')) {
+		elseif (
+			class_exists('SMF\\Tasks\\' . $task_details['task_class'])
+			&& is_subclass_of('SMF\\Tasks\\' . $task_details['task_class'], BackgroundTask::class)
+		) {
 			$details = empty($task_details['task_data']) ? [] : Utils::jsonDecode($task_details['task_data'], true);
 
 			$task_class = 'SMF\\Tasks\\' . $task_details['task_class'];
@@ -591,7 +599,7 @@ class TaskRunner
 		}
 
 		// For scheduled tasks, log it and update our next scheduled task time.
-		if (is_subclass_of($bgtask, 'SMF\\Tasks\\ScheduledTask')) {
+		if (is_subclass_of($bgtask, ScheduledTask::class)) {
 			$bgtask->log();
 			Tasks\ScheduledTask::updateNextTaskTime();
 		}

--- a/Sources/Tasks/BackgroundTask.php
+++ b/Sources/Tasks/BackgroundTask.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 
 namespace SMF\Tasks;
 
+use SMF\TaskRunner;
 use SMF\User;
 
 /**
@@ -76,5 +77,45 @@ abstract class BackgroundTask
 		$loaded_ids = array_map(fn($member) => $member->id, User::load($user_ids, User::LOAD_BY_ID, 'minimal'));
 
 		return array_intersect_key(User::$profiles, array_flip($loaded_ids));
+	}
+
+	/******************
+	 * Internal methods
+	 ******************/
+
+	/**
+	 * Adds a new instance of this task to the task list.
+	 *
+	 * @param array $details The $details array for the new task instance.
+	 *    This should typically be an updated copy of $this->_details.
+	 * @param int $time Unix timestamp indicating when the new task instance
+	 *    should be executed. In practice, the execution will almost always
+	 *    happen sometime later this, but is guaranteed not to happen earlier.
+	 *    If this is set to a value in the past, such as 0, the new task will
+	 *    be executed at the first available opportunity.
+	 *    Default: 0.
+	 */
+	protected function respawn(array $details, int $time = 0): void
+	{
+		Db::$db->insert(
+			method: 'insert',
+			table: '{db_prefix}background_tasks',
+			columns: [
+				'task_class' => 'string-255',
+				'task_data' => 'string',
+				'claimed_time' => 'int',
+			],
+			data: [
+				[
+					get_class($this),
+					json_encode($details),
+					// Subtract TaskRunner::MAX_CLAIM_THRESHOLD because TaskRunner
+					// won't try to re-run a task until that many seconds after
+					// the task's claimed_time value.
+					max(0, $time - TaskRunner::MAX_CLAIM_THRESHOLD),
+				],
+			],
+			keys: ['id_task'],
+		);
 	}
 }

--- a/Sources/Tasks/BackgroundTask.php
+++ b/Sources/Tasks/BackgroundTask.php
@@ -37,9 +37,11 @@ abstract class BackgroundTask
 	 *********************/
 
 	/**
-	 * @var array Holds the details for the task
+	 * @var array
+	 *
+	 * Holds the details for the task
 	 */
-	protected $_details;
+	protected array $_details;
 
 	/****************
 	 * Public methods
@@ -56,14 +58,14 @@ abstract class BackgroundTask
 	}
 
 	/**
-	 * The function to actually execute a task
+	 * The function to actually execute a task.
 	 *
 	 * @return mixed
 	 */
 	abstract public function execute();
 
 	/**
-	 * Loads minimal info for the previously loaded user ids
+	 * Loads minimal info for the previously loaded user ids.
 	 *
 	 * @param array $user_ids
 	 * @throws \Exception

--- a/Sources/Tasks/BackgroundTask.php
+++ b/Sources/Tasks/BackgroundTask.php
@@ -15,6 +15,8 @@ declare(strict_types=1);
 
 namespace SMF\Tasks;
 
+use SMF\Config;
+use SMF\Sapi;
 use SMF\TaskRunner;
 use SMF\User;
 
@@ -38,6 +40,32 @@ abstract class BackgroundTask
 	 *********************/
 
 	/**
+	 * @var bool
+	 *
+	 * Whether multiple instances of this task can safely run simultaneously.
+	 *
+	 * By default this operates at the class level, meaning that setting this
+	 * property to false will prevent multiple instances of this class from
+	 * executing concurrently at all ever.
+	 *
+	 * However, child classes can narrow this behaviour by including more
+	 * specific information in the md5 hash portion of the lock file's name.
+	 * For example, if both the class name and a user's ID number were included
+	 * in the hashed value, then setting $this->allow_concurrent to false would
+	 * prevent multiple instances of the task from working on the same user's
+	 * data at the same time; concurrent instances working on other users' data
+	 * would still be allowed.
+	 */
+	protected bool $allow_concurrent = true;
+
+	/**
+	 * @var string
+	 *
+	 * Path to the lock file for this task.
+	 */
+	protected string $lockfile;
+
+	/**
 	 * @var array
 	 *
 	 * Holds the details for the task
@@ -56,6 +84,16 @@ abstract class BackgroundTask
 	public function __construct(array $details)
 	{
 		$this->_details = $details;
+
+		$this->lockfile = Sapi::getTempDir() . DIRECTORY_SEPARATOR . Config::$modSettings['forum_uuid'] . '-' . md5(get_class($this)) . '.lock';
+	}
+
+	/**
+	 * The destructor.
+	 */
+	public function __destruct()
+	{
+		$this->unlock();
 	}
 
 	/**
@@ -79,9 +117,85 @@ abstract class BackgroundTask
 		return array_intersect_key(User::$profiles, array_flip($loaded_ids));
 	}
 
+	/**
+	 * Determines whether it is safe to execute this task.
+	 *
+	 * @return bool Whether it is safe to execute the task.
+	 */
+	public function canExecute(): bool
+	{
+		// Assume yes until proven otherwise.
+		$can_execute = true;
+
+		// Concurrency protection.
+		if (!$this->allow_concurrent) {
+			$can_execute = $this->lock();
+		}
+
+		return $can_execute;
+	}
+
 	/******************
 	 * Internal methods
 	 ******************/
+
+	/**
+	 * Checks whether another instance of this task has already created a lock.
+	 *
+	 * @return bool True if we are locked out, false if we are not.
+	 */
+	protected function alreadyLocked(): bool
+	{
+		// This shouldn't happen, but just in case...
+		if (is_dir($this->lockfile)) {
+			return true;
+		}
+
+		return (
+			is_file($this->lockfile)
+			&& file_get_contents($this->lockfile) !== (string) getmypid()
+			// Ignore stale lock files.
+			&& filemtime($this->lockfile) > (time() - TaskRunner::MAX_CLAIM_THRESHOLD * 2)
+		);
+	}
+
+	/**
+	 * Attempts to lock task execution so that no concurrent instances of the
+	 * task can be executed.
+	 *
+	 * @return bool Whether the operation was successful.
+	 */
+	protected function lock(): bool
+	{
+		if ($this->alreadyLocked()) {
+			return false;
+		}
+
+		try {
+			return @file_put_contents($this->lockfile, (string) getmypid(), LOCK_EX) !== false;
+		} catch (\Throwable $e) {
+			return false;
+		}
+	}
+
+	/**
+	 * Attempts to unlock task execution so that other instances of the current
+	 * task can execute.
+	 *
+	 * @return bool Whether the operation was successful.
+	 */
+	protected function unlock(): bool
+	{
+		if ($this->alreadyLocked()) {
+			return false;
+		}
+
+		try {
+			return !is_file($this->lockfile) || @unlink($this->lockfile);
+		} catch (\Throwable $e) {
+			return false;
+		}
+	}
 
 	/**
 	 * Adds a new instance of this task to the task list.

--- a/Sources/Tasks/CreatePost_Notify.php
+++ b/Sources/Tasks/CreatePost_Notify.php
@@ -24,7 +24,6 @@ use SMF\Lang;
 use SMF\Mail;
 use SMF\Mentions;
 use SMF\Parser;
-use SMF\TaskRunner;
 use SMF\Theme;
 use SMF\User;
 use SMF\Utils;
@@ -367,23 +366,7 @@ class CreatePost_Notify extends BackgroundTask
 			}
 
 			if ($new_details['respawns']++ < 10) {
-				Db::$db->insert(
-					'',
-					'{db_prefix}background_tasks',
-					[
-						'task_class' => 'string',
-						'task_data' => 'string',
-						'claimed_time' => 'int',
-					],
-					[
-						[
-							'SMF\\Tasks\\CreatePost_Notify',
-							Utils::jsonEncode($new_details),
-							max(0, $this->mention_mail_time - TaskRunner::MAX_CLAIM_THRESHOLD),
-						],
-					],
-					['id_task'],
-				);
+				$this->respawn($new_details, $this->mention_mail_time);
 			}
 		}
 

--- a/Sources/Tasks/CreatePost_Notify.php
+++ b/Sources/Tasks/CreatePost_Notify.php
@@ -68,7 +68,9 @@ class CreatePost_Notify extends BackgroundTask
 	 *********************/
 
 	/**
-	 * @var array Info about members to be notified.
+	 * @var array
+	 *
+	 * Info about members to be notified.
 	 */
 	private $members = [
 		// These three contain nested arrays of member info.
@@ -84,18 +86,24 @@ class CreatePost_Notify extends BackgroundTask
 	];
 
 	/**
-	 * @var array Alerts to be inserted into the alerts table.
+	 * @var array
+	 *
+	 * Alerts to be inserted into the alerts table.
 	 */
 	private $alert_rows = [];
 
 	/**
-	 * @var array Members' notification and alert preferences.
+	 * @var array
+	 *
+	 * Members' notification and alert preferences.
 	 */
 	private $prefs = [];
 
 	/**
-	 * @var int Timestamp after which email notifications should be sent about
-	 *			mentions and quotes in unwatched and/or edited posts.
+	 * @var int
+	 *
+	 * Timestamp after which email notifications should be sent about mentions
+	 * and quotes in unwatched and/or edited posts.
 	 */
 	private $mention_mail_time = 0;
 

--- a/Sources/Tasks/ExportProfileData.php
+++ b/Sources/Tasks/ExportProfileData.php
@@ -20,7 +20,6 @@ use SMF\Actions\Feed;
 use SMF\Actions\Profile\Export;
 use SMF\Cache\CacheApi;
 use SMF\Config;
-use SMF\Db\DatabaseApi as Db;
 use SMF\ErrorHandler;
 use SMF\IntegrationHook;
 use SMF\Lang;
@@ -80,7 +79,14 @@ class ExportProfileData extends BackgroundTask
 	 *
 	 * Info to create a follow-up background task, if necessary.
 	 */
-	private array $next_task = [];
+	private array $new_details = [];
+
+	/**
+	 * @var int
+	 *
+	 * How long to wait before running a follow-up task.
+	 */
+	private int $delay = 0;
 
 	/**
 	 * @var int
@@ -942,14 +948,8 @@ class ExportProfileData extends BackgroundTask
 		}
 
 		// If necessary, create a new background task to continue the export process.
-		if (!empty($this->next_task)) {
-			Db::$db->insert(
-				'insert',
-				'{db_prefix}background_tasks',
-				['task_file' => 'string-255', 'task_class' => 'string-255', 'task_data' => 'string', 'claimed_time' => 'int'],
-				[$this->next_task],
-				[],
-			);
+		if (!empty($this->new_details)) {
+			$this->respawn($this->new_details, time() + $this->delay);
 		}
 
 		ignore_user_abort(false);
@@ -1161,7 +1161,6 @@ class ExportProfileData extends BackgroundTask
 
 		// Setup.
 		$done = false;
-		$delay = 0;
 		$datatypes = array_keys($included);
 
 		$feed = new Feed($datatype, $uid);
@@ -1320,7 +1319,7 @@ class ExportProfileData extends BackgroundTask
 				if ($check_diskspace && disk_free_space(Config::$modSettings['export_dir']) - $minspace <= strlen(implode('', Utils::$context['feed']) . ($this->stylesheet ?? ''))) {
 					ErrorHandler::log(Lang::getTxt('export_low_diskspace', [Config::$modSettings['export_min_diskspace_pct']], file: 'Errors'));
 
-					$delay = 86400;
+					$this->delay = 86400;
 				} else {
 					// We need a file to write to, of course.
 					if (!file_exists($tempfile)) {
@@ -1355,7 +1354,7 @@ class ExportProfileData extends BackgroundTask
 
 					// Write failed. We'll try again next time.
 					if (empty($bytes_written)) {
-						$delay = Taskrunner::MAX_CLAIM_THRESHOLD;
+						$this->delay = Taskrunner::MAX_CLAIM_THRESHOLD;
 						break;
 					}
 
@@ -1407,7 +1406,7 @@ class ExportProfileData extends BackgroundTask
 		else {
 			$start[$datatype] = $progress[$datatype];
 
-			$new_details = [
+			$this->new_details = [
 				'format' => $this->_details['format'],
 				'uid' => $uid,
 				'lang' => $lang,
@@ -1421,10 +1420,8 @@ class ExportProfileData extends BackgroundTask
 			];
 
 			if (!empty($new_item_count)) {
-				$new_details['item_count'] = $new_item_count;
+				$this->new_details['item_count'] = $new_item_count;
 			}
-
-			$this->next_task = [__FILE__, __CLASS__, Utils::jsonEncode($new_details), time() - Taskrunner::MAX_CLAIM_THRESHOLD + $delay];
 
 			if (!file_exists($tempfile)) {
 				Feed::build('smf', [], $feed->metadata, 'profile');
@@ -1504,13 +1501,11 @@ class ExportProfileData extends BackgroundTask
 			// When deadlines loom, sometimes the best solution is procrastination.
 			if (++$i < $num_files && TIME_START + $this->time_limit < $finished + $max_transform_time * 2) {
 				// After all, there's always next time.
-				if (empty($this->next_task)) {
+				if (empty($this->new_details)) {
 					$progressfile = $export_dir_slash . $idhash_ext . '.progress.json';
 
-					$new_details = $this->_details;
-					$new_details['start'] = Utils::jsonDecode(file_get_contents($progressfile), true);
-
-					$this->next_task = [__FILE__, __CLASS__, Utils::jsonEncode($new_details), time() - Taskrunner::MAX_CLAIM_THRESHOLD];
+					$this->new_details = $this->_details;
+					$this->new_details['start'] = Utils::jsonDecode(file_get_contents($progressfile), true);
 				}
 
 				// So let's just relax and take a well deserved...

--- a/Sources/Tasks/ExportProfileData.php
+++ b/Sources/Tasks/ExportProfileData.php
@@ -75,6 +75,11 @@ class ExportProfileData extends BackgroundTask
 	 *********************/
 
 	/**
+	 *
+	 */
+	protected bool $allow_concurrent = false;
+
+	/**
 	 * @var array
 	 *
 	 * Info to create a follow-up background task, if necessary.
@@ -883,6 +888,21 @@ class ExportProfileData extends BackgroundTask
 	/****************
 	 * Public methods
 	 ****************/
+
+	/**
+	 * The constructor.
+	 *
+	 * @param array $details The details for the task
+	 */
+	public function __construct(array $details)
+	{
+		parent::__construct($details);
+
+		// Include the user ID in the md5 hash because we only want to prevent
+		// concurrent tasks from working on the same user's data simultaneously.
+		// It's fine to have concurrent tasks working on different users' data.
+		$this->lockfile = Sapi::getTempDir() . DIRECTORY_SEPARATOR . Config::$modSettings['forum_uuid'] . '-' . md5(get_class($this) . $this->_details['uid']) . '.lock';
+	}
 
 	/**
 	 * This is the main dispatcher for the class.

--- a/Sources/Tasks/ExportProfileData.php
+++ b/Sources/Tasks/ExportProfileData.php
@@ -76,17 +76,23 @@ class ExportProfileData extends BackgroundTask
 	 *********************/
 
 	/**
-	 * @var array Info to create a follow-up background task, if necessary.
+	 * @var array
+	 *
+	 * Info to create a follow-up background task, if necessary.
 	 */
 	private array $next_task = [];
 
 	/**
-	 * @var int Used to ensure we exit long running tasks cleanly.
+	 * @var int
+	 *
+	 * Used to ensure we exit long running tasks cleanly.
 	 */
 	private int $time_limit = 30;
 
 	/**
-	 * @var array The XSLT stylesheet, broken up into logical parts.
+	 * @var array
+	 *
+	 * The XSLT stylesheet, broken up into logical parts.
 	 */
 	private array $xslt_stylesheet = [
 		// Header for the stylesheet. Default value assumes that the stylesheet
@@ -853,7 +859,9 @@ class ExportProfileData extends BackgroundTask
 	];
 
 	/**
-	 * @var string The XSLT stylesheet as a single string.
+	 * @var string
+	 *
+	 * The XSLT stylesheet as a single string.
 	 */
 	private string $stylesheet;
 

--- a/Sources/Tasks/UpdateSpoofDetectorNames.php
+++ b/Sources/Tasks/UpdateSpoofDetectorNames.php
@@ -114,37 +114,9 @@ class UpdateSpoofDetectorNames extends BackgroundTask
 		}
 
 		if ($this->_details['last_member_id'] < Config::$modSettings['latestMember']) {
-			$this->respawn();
+			$this->respawn($this->_details);
 		}
 
 		return true;
-	}
-
-	/******************
-	 * Internal methods
-	 ******************/
-
-	/**
-	 * Adds a new instance of this task to the task list.
-	 */
-	private function respawn(): void
-	{
-		Db::$db->insert(
-			'insert',
-			'{db_prefix}background_tasks',
-			[
-				'task_class' => 'string-255',
-				'task_data' => 'string',
-				'claimed_time' => 'int',
-			],
-			[
-				[
-					get_class($this),
-					json_encode($this->_details),
-					0,
-				],
-			],
-			[],
-		);
 	}
 }

--- a/Sources/Tasks/UpdateSpoofDetectorNames.php
+++ b/Sources/Tasks/UpdateSpoofDetectorNames.php
@@ -27,6 +27,15 @@ use SMF\Utils;
  */
 class UpdateSpoofDetectorNames extends BackgroundTask
 {
+	/*********************
+	 * Internal properties
+	 *********************/
+
+	/**
+	 *
+	 */
+	protected bool $allow_concurrent = false;
+
 	/****************
 	 * Public methods
 	 ****************/

--- a/Sources/Tasks/UpdateUnicode.php
+++ b/Sources/Tasks/UpdateUnicode.php
@@ -46,58 +46,78 @@ class UpdateUnicode extends BackgroundTask
 	 *******************/
 
 	/**
-	 * @var string The latest official release of the Unicode Character Database.
+	 * @var string
+	 *
+	 * The latest official release of the Unicode Character Database.
 	 */
-	public $ucd_version = '';
+	public string $ucd_version = '';
 
 	/**
-	 * @var string Path to temporary working directory.
+	 * @var string
+	 *
+	 * Path to temporary working directory.
 	 */
-	public $temp_dir = '';
+	public string $temp_dir = '';
 
 	/**
-	 * @var string Convenience alias of Config::$sourcedir . '/Unicode'.
+	 * @var string
+	 *
+	 * Convenience alias of Config::$sourcedir . '/Unicode'.
 	 */
-	public $unicodedir = '';
+	public string $unicodedir = '';
 
 	/*********************
 	 * Internal properties
 	 *********************/
 
 	/**
-	 * @var int Used to ensure we exit long running tasks cleanly.
+	 * @var int
+	 *
+	 * Used to ensure we exit long running tasks cleanly.
 	 */
-	private $time_limit = 30;
+	private int $time_limit = 30;
 
 	/**
-	 * @var array Key-value pairs of character decompositions.
+	 * @var array
+	 *
+	 * Key-value pairs of character decompositions.
 	 */
-	private $full_decomposition_maps = [];
+	private array $full_decomposition_maps = [];
 
 	/**
-	 * @var array Character properties used during normalization.
+	 * @var array
+	 *
+	 * Character properties used during normalization.
 	 */
-	private $derived_normalization_props = [];
+	private array $derived_normalization_props = [];
 
 	/**
-	 * @var array Assorted info about Unicode characters.
+	 * @var array
+	 *
+	 * Assorted info about Unicode characters.
 	 */
-	private $char_data = [];
+	private array $char_data = [];
 
 	/**
-	 * @var array Statistical info about character scripts (e.g. Latin, Greek, Cyrillic, etc.)
+	 * @var array
+	 *
+	 * Statistical info about character scripts (e.g. Latin, Greek, Cyrillic, etc.)
 	 */
-	private $script_stats = [];
+	private array $script_stats = [];
 
 	/**
-	 * @var array Tracks associations between character scripts' short and long names.
+	 * @var array
+	 *
+	 * Tracks associations between character scripts' short and long names.
 	 */
-	private $script_aliases = [];
+	private array $script_aliases = [];
 
 	/**
-	 * @var array Info about functions to build in SMF's Unicode data files.
+	 * @var array
+	 *
+	 * Info about functions to build in SMF's Unicode data files.
 	 */
-	private $funcs = [
+	private array $funcs = [
 		[
 			'file' => 'Metadata.php',
 			'regex' => '/if \(!defined\(\'SMF_UNICODE_VERSION\'\)\)(?:\s*{)?\n\tdefine\(\'SMF_UNICODE_VERSION\', \'\d+(\.\d+)*\'\);(?:\n})?/',
@@ -511,9 +531,11 @@ class UpdateUnicode extends BackgroundTask
 	];
 
 	/**
-	 * @var array Files to fetch from unicode.org.
+	 * @var array
+	 *
+	 * Files to fetch from unicode.org.
 	 */
-	private $prefetch = [
+	private array $prefetch = [
 		self::DATA_URL_UCD => [
 			'CaseFolding.txt',
 			'DerivedAge.txt',
@@ -777,21 +799,21 @@ class UpdateUnicode extends BackgroundTask
 			// Updating Unicode data means we need to update the spoof detector names.
 			if (empty($this->_details['files_only'])) {
 				Db::$db->insert(
-					'insert',
-					'{db_prefix}background_tasks',
-					[
+					method: 'insert',
+					table: '{db_prefix}background_tasks',
+					columns: [
 						'task_class' => 'string',
 						'task_data' => 'string',
 						'claimed_time' => 'int',
 					],
-					[
+					data: [
 						[
-							'SMF\\Tasks\\UpdateSpoofDetectorNames',
+							UpdateSpoofDetectorNames::class,
 							json_encode(['last_member_id' => 0]),
 							0,
 						],
 					],
-					['id_task'],
+					keys: ['id_task'],
 				);
 			}
 		}
@@ -851,7 +873,7 @@ class UpdateUnicode extends BackgroundTask
 
 			// Needs to be a writable directory.
 			if (!is_dir($this->temp_dir) || !Utils::makeWritable($this->temp_dir)) {
-				$this->temp_dir = null;
+				$this->temp_dir = '';
 			}
 		}
 	}
@@ -992,12 +1014,13 @@ class UpdateUnicode extends BackgroundTask
 	}
 
 	/**
-	 * Builds complete code for the specified element in $this->funcs
-	 * to be inserted into the relevant PHP file. Also builds a regex
-	 * to check whether a copy of the function is already present
-	 * in the file.
+	 * Builds complete code for the specified element in $this->funcs to be
+	 * inserted into the relevant PHP file. Also builds a regex to check whether
+	 * a copy of the function is already present in the file.
 	 *
-	 * @param string|int $func_name Key of an element in $this->funcs.  If an int is provided, it is considered raw code such as a header, and does not replace a function in the file.
+	 * @param string|int $func_name Key of an element in $this->funcs. If an int
+	 *    is provided, it is considered raw code such as a header, and does not
+	 *    replace a function in the file.
 	 *
 	 * @return array PHP code and a regular expression.
 	 */
@@ -1145,7 +1168,7 @@ class UpdateUnicode extends BackgroundTask
 			return true;
 		}
 
-		return version_compare($this->ucd_version, SMF_UNICODE_VERSION, '>=');
+		return !defined('SMF_UNICODE_VERSION') ? true : version_compare($this->ucd_version, SMF_UNICODE_VERSION, '>=');
 	}
 
 	/**

--- a/Sources/Tasks/UpdateUnicode.php
+++ b/Sources/Tasks/UpdateUnicode.php
@@ -665,24 +665,11 @@ class UpdateUnicode extends BackgroundTask
 				$max_fetch_time = max($max_fetch_time, microtime(true) - $fetch_start);
 
 				// If prefetch is taking a really long time, pause and try again later.
-				if ($local_file === false || microtime(true) - TIME_START >= $this->time_limit - $max_fetch_time) {
-					Db::$db->insert(
-						'',
-						'{db_prefix}background_tasks',
-						[
-							'task_class' => 'string',
-							'task_data' => 'string',
-							'claimed_time' => 'int',
-						],
-						[
-							[
-								'SMF\\Tasks\\Update_Unicode',
-								'',
-								time() - MAX_CLAIM_THRESHOLD,
-							],
-						],
-						['id_task'],
-					);
+				if (
+					$local_file === false
+					|| microtime(true) - TIME_START >= $this->time_limit - $max_fetch_time
+				) {
+					$this->respawn($this->_details);
 
 					return true;
 				}

--- a/Sources/Tasks/UpdateUnicode.php
+++ b/Sources/Tasks/UpdateUnicode.php
@@ -71,6 +71,11 @@ class UpdateUnicode extends BackgroundTask
 	 *********************/
 
 	/**
+	 *
+	 */
+	protected bool $allow_concurrent = false;
+
+	/**
 	 * @var int
 	 *
 	 * Used to ensure we exit long running tasks cleanly.
@@ -592,21 +597,6 @@ class UpdateUnicode extends BackgroundTask
 		if (empty($this->temp_dir)) {
 			return true;
 		}
-
-		// Prevent race conditions.
-		if (is_file($this->temp_dir . DIRECTORY_SEPARATOR . 'lock')) {
-			return true;
-		}
-
-		if (!@touch($this->temp_dir . DIRECTORY_SEPARATOR . 'lock')) {
-			return true;
-		}
-
-		register_shutdown_function(function () {
-			if (file_exists($this->temp_dir . DIRECTORY_SEPARATOR . 'lock')) {
-				unlink($this->temp_dir . DIRECTORY_SEPARATOR . 'lock');
-			}
-		});
 
 		// Do we even need to update?
 		if (!$this->should_update()) {


### PR DESCRIPTION
1. Generalizes the fix from #8570, using ideas from @jdarwood007's #8756, so that tasks that should not run concurrent instances can configure themselves to prevent that.
2. Implements SMF\Tasks\BackgroundTask::respawn() so that any task that needs that ability can access it simply and consistently. (Previously, several tasks implemented their own, slightly differing versions of this.)