### PR TITLE
[3.0] Improve load average detection

### DIFF
--- a/Sources/Actions/Admin/Server.php
+++ b/Sources/Actions/Admin/Server.php
@@ -603,7 +603,7 @@ class Server implements ActionInterface
 				$_SESSION['adm-save'] = Utils::$context['settings_message']['label'];
 			}
 		} elseif (!self::$loadAverageDisabled) {
-			Utils::$context['settings_message']['label'] = Lang::getTxt('loadavg_warning', [Config::$modSettings['load_average']], file: 'ManageSettings');
+			Utils::$context['settings_message']['label'] = Lang::getTxt('loadavg_warning', [Sapi::getLoadAverage()], file: 'ManageSettings');
 		}
 
 		$config_vars = self::loadBalancingConfigVars();
@@ -1298,27 +1298,7 @@ class Server implements ActionInterface
 		// Assume we can't until proven otherwise.
 		self::$loadAverageDisabled = true;
 
-		// Windows, so we can't.
-		if (DIRECTORY_SEPARATOR === '\\') {
-			return self::$loadAverageDisabled;
-		}
-
-		// Most Linux distros offer a nice file that we can read.
-		Config::$modSettings['load_average'] = @file_get_contents('/proc/loadavg');
-
-		if (!empty(Config::$modSettings['load_average']) && preg_match('~^([^ ]+?) ([^ ]+?) ([^ ]+)~', Config::$modSettings['load_average'], $matches) !== 0) {
-			Config::$modSettings['load_average'] = (float) $matches[1];
-		}
-		// On both Linux and Unix (e.g. macOS), we can we can check shell_exec('uptime').
-		elseif ((Config::$modSettings['load_average'] = @shell_exec('uptime')) !== null && preg_match('~load averages?: (\d+\.\d+)~i', Config::$modSettings['load_average'], $matches) !== 0) {
-			Config::$modSettings['load_average'] = (float) $matches[1];
-		}
-		// No shell_exec('uptime') and no /proc/loadavg, so we can't check.
-		else {
-			unset(Config::$modSettings['load_average']);
-		}
-
-		if (!empty(Config::$modSettings['load_average']) || (isset(Config::$modSettings['load_average']) && Config::$modSettings['load_average'] === 0.0)) {
+		if (!Sapi::isOS(Sapi::OS_WINDOWS) && Sapi::getLoadAverage() >= 0.0) {
 			self::$loadAverageDisabled = false;
 		}
 

--- a/Sources/Actions/Profile/ShowPosts.php
+++ b/Sources/Actions/Profile/ShowPosts.php
@@ -32,6 +32,7 @@ use SMF\Msg;
 use SMF\PageIndex;
 use SMF\Parser;
 use SMF\Profile;
+use SMF\Sapi;
 use SMF\Theme;
 use SMF\Time;
 use SMF\User;
@@ -105,11 +106,7 @@ class ShowPosts implements ActionInterface
 		$this->setPageTitle();
 
 		// Is the load average too high to allow searching just now?
-		if (
-			!empty(Utils::$context['load_average'])
-			&& !empty(Config::$modSettings['loadavg_show_posts'])
-			&& Utils::$context['load_average'] >= Config::$modSettings['loadavg_show_posts']
-		) {
+		if (Sapi::isOverloaded(Config::$modSettings['loadavg_show_posts'] ?? null)) {
 			ErrorHandler::fatalLang('loadavg_show_posts_disabled', false);
 		}
 

--- a/Sources/Actions/Profile/StatPanel.php
+++ b/Sources/Actions/Profile/StatPanel.php
@@ -24,6 +24,7 @@ use SMF\IntegrationHook;
 use SMF\Lang;
 use SMF\Menu;
 use SMF\Profile;
+use SMF\Sapi;
 use SMF\User;
 use SMF\Utils;
 
@@ -52,7 +53,7 @@ class StatPanel implements ActionInterface
 		];
 
 		// Is the load average too high to allow searching just now?
-		if (!empty(Utils::$context['load_average']) && !empty(Config::$modSettings['loadavg_userstats']) && Utils::$context['load_average'] >= Config::$modSettings['loadavg_userstats']) {
+		if (Sapi::isOverloaded(Config::$modSettings['loadavg_userstats'] ?? null)) {
 			ErrorHandler::fatalLang('loadavg_userstats_disabled', false);
 		}
 

--- a/Sources/Actions/Search.php
+++ b/Sources/Actions/Search.php
@@ -25,6 +25,7 @@ use SMF\ErrorHandler;
 use SMF\IntegrationHook;
 use SMF\Lang;
 use SMF\Routable;
+use SMF\Sapi;
 use SMF\Search\SearchApi;
 use SMF\Theme;
 use SMF\User;
@@ -57,7 +58,7 @@ class Search implements ActionInterface, Routable
 	public function execute(): void
 	{
 		// Is the load average too high to allow searching just now?
-		if (!empty(Utils::$context['load_average']) && !empty(Config::$modSettings['loadavg_search']) && Utils::$context['load_average'] >= Config::$modSettings['loadavg_search']) {
+		if (Sapi::isOverloaded(Config::$modSettings['loadavg_search'] ?? null)) {
 			ErrorHandler::fatalLang('loadavg_search_disabled', false);
 		}
 

--- a/Sources/Actions/Search2.php
+++ b/Sources/Actions/Search2.php
@@ -25,6 +25,7 @@ use SMF\IntegrationHook;
 use SMF\Lang;
 use SMF\PageIndex;
 use SMF\Routable;
+use SMF\Sapi;
 use SMF\Search\SearchApi;
 use SMF\Search\SearchResult;
 use SMF\Security;
@@ -264,7 +265,7 @@ class Search2 implements ActionInterface, Routable
 	 */
 	protected function checkLoadAverage(): void
 	{
-		if (!empty(Utils::$context['load_average']) && !empty(Config::$modSettings['loadavg_search']) && Utils::$context['load_average'] >= Config::$modSettings['loadavg_search']) {
+		if (Sapi::isOverloaded(Config::$modSettings['loadavg_search'] ?? null)) {
 			ErrorHandler::fatalLang('loadavg_search_disabled', false);
 		}
 	}

--- a/Sources/Actions/Unread.php
+++ b/Sources/Actions/Unread.php
@@ -26,6 +26,7 @@ use SMF\IntegrationHook;
 use SMF\Lang;
 use SMF\PageIndex;
 use SMF\Routable;
+use SMF\Sapi;
 use SMF\Theme;
 use SMF\User;
 use SMF\Utils;
@@ -278,10 +279,8 @@ class Unread implements ActionInterface, Routable
 		$this->linktree_name = Lang::getTxt('unread_topics_visit', file: 'General');
 		$this->action_url = Config::$scripturl . '?action=unread';
 
-		if (Utils::$context['showing_all_topics']) {
-			$this->checkLoadAverageAll();
-		} else {
-			$this->checkLoadAverage();
+		if (Sapi::isOverloaded(Utils::$context['showing_all_topics'] ? Config::$modSettings['loadavg_allunread'] ?? null : Config::$modSettings['loadavg_unread'] ?? null)) {
+			ErrorHandler::fatalLang(Utils::$context['showing_all_topics'] ? 'loadavg_allunread_disabled' : 'loadavg_unread_disabled', false);
 		}
 
 		Theme::loadTemplate('Recent');
@@ -293,42 +292,6 @@ class Unread implements ActionInterface, Routable
 
 		foreach (Utils::$context['stable_icons'] as $icon) {
 			Utils::$context['icon_sources'][$icon] = 'images_url';
-		}
-	}
-
-	/**
-	 * Checks that the load averages aren't too high to show unread posts.
-	 */
-	protected function checkLoadAverage(): void
-	{
-		if (empty(Utils::$context['load_average'])) {
-			return;
-		}
-
-		if (empty(Config::$modSettings['loadavg_unread'])) {
-			return;
-		}
-
-		if (Utils::$context['load_average'] >= Config::$modSettings['loadavg_unread']) {
-			ErrorHandler::fatalLang('loadavg_unread_disabled', false);
-		}
-	}
-
-	/**
-	 * Checks that the load averages aren't too high to show all unread posts.
-	 */
-	protected function checkLoadAverageAll(): void
-	{
-		if (empty(Utils::$context['load_average'])) {
-			return;
-		}
-
-		if (empty(Config::$modSettings['loadavg_allunread'])) {
-			return;
-		}
-
-		if (Utils::$context['load_average'] >= Config::$modSettings['loadavg_allunread']) {
-			ErrorHandler::fatalLang('loadavg_allunread_disabled', false);
 		}
 	}
 

--- a/Sources/Actions/UnreadReplies.php
+++ b/Sources/Actions/UnreadReplies.php
@@ -18,7 +18,6 @@ namespace SMF\Actions;
 use SMF\Board;
 use SMF\Config;
 use SMF\Db\DatabaseApi as Db;
-use SMF\ErrorHandler;
 use SMF\Lang;
 use SMF\Theme;
 use SMF\User;
@@ -71,24 +70,6 @@ class UnreadReplies extends Unread
 		Utils::$context['page_title'] = Lang::getTxt('unread_replies', file: 'General');
 		$this->linktree_name = Lang::getTxt('unread_replies', file: 'General');
 		$this->action_url = Config::$scripturl . '?action=unreadreplies';
-	}
-
-	/**
-	 * Checks that the load averages aren't too high to show unread replies.
-	 */
-	protected function checkLoadAverage(): void
-	{
-		if (empty(Utils::$context['load_average'])) {
-			return;
-		}
-
-		if (empty(Config::$modSettings['loadavg_unreadreplies'])) {
-			return;
-		}
-
-		if (Utils::$context['load_average'] >= Config::$modSettings['loadavg_unreadreplies']) {
-			ErrorHandler::fatalLang('loadavg_unreadreplies_disabled', false);
-		}
 	}
 
 	/**

--- a/Sources/Config.php
+++ b/Sources/Config.php
@@ -1118,27 +1118,13 @@ class Config
 
 		// Check the load averages?
 		if (!empty(self::$modSettings['loadavg_enable'])) {
-			if ((self::$modSettings['load_average'] = Cache\CacheApi::get('loadavg', 90)) == null) {
-				self::$modSettings['load_average'] = @file_get_contents('/proc/loadavg');
+			self::$modSettings['load_average'] = Sapi::getLoadAverage();
 
-				if (!empty(self::$modSettings['load_average']) && preg_match('~^([^ ]+?) ([^ ]+?) ([^ ]+)~', self::$modSettings['load_average'], $matches) != 0) {
-					self::$modSettings['load_average'] = (float) $matches[1];
-				} elseif ((self::$modSettings['load_average'] = @shell_exec('uptime')) != null && preg_match('~load averages?: (\d+\.\d+)~i', self::$modSettings['load_average'], $matches) != 0) {
-					self::$modSettings['load_average'] = (float) $matches[1];
-				} else {
-					unset(self::$modSettings['load_average']);
-				}
-
-				if (!empty(self::$modSettings['load_average']) || self::$modSettings['load_average'] === 0.0) {
-					Cache\CacheApi::put('loadavg', self::$modSettings['load_average'], 90);
-				}
-			}
-
-			if (!empty(self::$modSettings['load_average']) || self::$modSettings['load_average'] === 0.0) {
+			if (self::$modSettings['load_average'] >= 0.00) {
 				IntegrationHook::call('integrate_load_average', [self::$modSettings['load_average']]);
 			}
 
-			if (!empty(self::$modSettings['loadavg_forum']) && !empty(self::$modSettings['load_average']) && self::$modSettings['load_average'] >= self::$modSettings['loadavg_forum']) {
+			if (Sapi::isOverloaded(self::$modSettings['loadavg_forum'])) {
 				ErrorHandler::displayLoadAvgError();
 			}
 		}

--- a/Sources/Parser.php
+++ b/Sources/Parser.php
@@ -417,13 +417,13 @@ abstract class Parser
 	 ******************/
 
 	/**
-	 * Checks whether the server's load average is too high to parse BBCode.
+	 * Checks whether the server's load average is too high to parse BBCode/Markdown.
 	 *
 	 * @return bool Whether the load average is too high.
 	 */
 	protected function highLoadAverage(): bool
 	{
-		return !empty(Utils::$context['load_average']) && !empty(Config::$modSettings['bbc']) && Utils::$context['load_average'] >= Config::$modSettings['bbc'];
+		return Sapi::isOverloaded(Config::$modSettings['bbc'] ?? null);
 	}
 
 	/**

--- a/Sources/PersonalMessage/Search.php
+++ b/Sources/PersonalMessage/Search.php
@@ -22,6 +22,7 @@ use SMF\IntegrationHook;
 use SMF\Lang;
 use SMF\Menu;
 use SMF\PageIndex;
+use SMF\Sapi;
 use SMF\Search\SearchApi;
 use SMF\Theme;
 use SMF\User;
@@ -241,7 +242,7 @@ class Search
 	 */
 	public function performSearch(): void
 	{
-		if (!empty(Utils::$context['load_average']) && !empty(Config::$modSettings['loadavg_search']) && Utils::$context['load_average'] >= Config::$modSettings['loadavg_search']) {
+		if (Sapi::isOverloaded(Config::$modSettings['loadavg_search'] ?? null)) {
 			ErrorHandler::fatalLang('loadavg_search_disabled', false);
 		}
 

--- a/Sources/Sapi.php
+++ b/Sources/Sapi.php
@@ -77,6 +77,13 @@ class Sapi
 	 */
 	protected static string $temp_dir;
 
+	/**
+	 * @var float
+	 *
+	 * Current system load
+	 */
+	protected static ?float $current_load = null;
+
 	/***********************
 	 * Public static methods
 	 ***********************/
@@ -399,5 +406,73 @@ class Sapi
 			} catch (\Exception $e) {
 			}
 		}
+	}
+
+	/**
+	 * Determiens the load average.
+	 * On windows we return -0.01.
+	 * On Linux we attempt to use sys_getloadavg, fall back to traditional reading of /proc/loadavg.
+	 * If we can't load the load average, we return -0.01
+	 * Linux Note: The returned value is a percent represented as a float. However, the percent
+	 * 	can exceed 1.00 (100%) if more than 1 cpu is present. In a 4 cpu system, the max would
+	 * 	be 400% or 4.00.
+	 *
+	 * @return float
+	 */
+	public static function getLoadAverage(): float
+	{
+		if (self::$current_load !== null) {
+			return self::$current_load;
+		}
+
+		/*
+		 * It is possible to get Windows load average using a method such as:
+		 * 		wmic cpu get loadpercentage /all /format:value
+		 * 		typeperf -sc 1 "\Processor(_Total)\% Processor Time"
+		 * However this is slow to respond
+		 */
+		if (self::isOS(self::OS_WINDOWS)) {
+			return self::$current_load = -0.01;
+		}
+
+		try {
+			// False | array[0 => 1 minute, 1 => 5 minute, 2 => 15 minute].
+			$current_load = sys_getloadavg();
+
+			// sys_getloadavg returns false on failure.
+			if ($current_load !== false) {
+				return self::$current_load = (float) $current_load[0];
+			}
+
+			// Most Linux distros offer a nice file that we can read.
+			$current_load = @file_get_contents('/proc/loadavg');
+
+			if (!empty($current_load) && preg_match('~^([^ ]+?) ([^ ]+?) ([^ ]+)~', $current_load, $matches) !== 0) {
+				return self::$current_load = (float) $matches[1];
+			}
+
+			// On both Linux and Unix (e.g. macOS), we can we can check shell_exec('uptime').
+			if (($current_load = @shell_exec('uptime')) !== null && preg_match('~load averages?: (\d+\.\d+)~i', $current_load, $matches) !== 0) {
+				return self::$current_load = (float) $matches[1];
+			}
+		} catch (\Exception $ex) {
+		}
+
+		// No sys_getloadavg, shell_exec('uptime') and no /proc/loadavg, so we can't check.
+		return self::$current_load = -0.01;
+	}
+
+	/**
+	 * Checks if the server load meets a threshold.
+	 *
+	 * @param null|int|float|string $threshold
+	 */
+	public static function isOverloaded(int|float|string|null $threshold): bool
+	{
+		if (empty($threshold)) {
+			return false;
+		}
+
+		return self::getLoadAverage() >= (float) $threshold;
 	}
 }

--- a/Sources/Theme.php
+++ b/Sources/Theme.php
@@ -195,8 +195,8 @@ class Theme
 		Utils::$context['current_subaction'] = $_REQUEST['sa'] ?? null;
 		Utils::$context['can_register'] = empty(Config::$modSettings['registration_method']) || Config::$modSettings['registration_method'] != 3;
 
-		if (isset(Config::$modSettings['load_average'])) {
-			Utils::$context['load_average'] = Config::$modSettings['load_average'];
+		if (Sapi::getLoadAverage() >= 0.00) {
+			Utils::$context['load_average'] = Sapi::getLoadAverage();
 		}
 
 		$this->loadTemplatesAndLangFiles();


### PR DESCRIPTION
This improves the load average detection by moving the logic into Sapi. A new function is added to simplify calls to checking if the server is overloaded Additionally it attempts to make use of the built in sys_getloadavg(), with checks incase a server admin has disabled it.

This will Fix #7397, although that is marked as a 2.1 bug.

A note about linux was added and how load is calculated.  We could run `nproc` and divide that by the load.  But Linux admins are used to the logic and it would just confuse more server admins than help.

A note about Windows support was included.  I attempted to check the speed of commands, but they where slow.  On my i9-10850k running at idle, I ran those commands through Measure-Command powershell function and they would take 100+ milliseconds to complete.  Not ideal to add 0.1+ load time just to calculate the server load.  Wmic is known to be slow to process commands.