### PR TITLE
[3.0] Various fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ attachments/
 Themes/default/css/minified*.css
 Themes/default/scripts/minified*.js
 Themes/default/scripts/minified_deferred*.js
+Themes/default/scripts/autolinker.js
 custom_avatar/
 !custom_avatar/index.php
 !custom_avatar/blank.png

--- a/Sources/Actions/Unread.php
+++ b/Sources/Actions/Unread.php
@@ -580,7 +580,7 @@ class Unread implements ActionInterface, Routable
 
 		// If the supplied start value was invalid, redirect to the correct one.
 		if ($_REQUEST['start'] != Utils::$context['start']) {
-			Utils::redirectexit(sprintf(Utils::$context['page_index']->base_url, $start));
+			Utils::redirectexit(sprintf(Utils::$context['page_index']->base_url, Utils::$context['start']));
 		}
 
 		Utils::$context['current_page'] = floor(Utils::$context['start'] / Utils::$context['topics_per_page']);

--- a/Sources/Autolinker.php
+++ b/Sources/Autolinker.php
@@ -509,7 +509,7 @@ class Autolinker
 
 				foreach ($detected_urls as $pos => $url) {
 					$new_string .= substr($string, $prev_pos + $prev_len, $pos - ($prev_pos + $prev_len));
-					$prev_pos = $pos;
+					$prev_pos = (int) $pos;
 					$prev_len = strlen($url);
 
 					// If this isn't a clean URL, leave it alone.

--- a/Sources/Calendar/Birthday.php
+++ b/Sources/Calendar/Birthday.php
@@ -161,7 +161,7 @@ class Birthday extends Event
 	 * @param string $high_date The high end of the range, inclusive, in YYYY-MM-DD format.
 	 * @param bool $use_permissions Ignored.
 	 * @param array $query_customizations Customizations to the SQL query.
-	 * @return Generator<Event> Iterating over result gives Event instances.
+	 * @return \Generator<Event> Iterating over result gives Event instances.
 	 */
 	public static function get(string $low_date, string $high_date, bool $use_permissions = true, array $query_customizations = []): \Generator
 	{
@@ -245,7 +245,7 @@ class Birthday extends Event
 	 * @param string $high_date The high end of the range, inclusive, in YYYY-MM-DD format.
 	 * @param bool $use_permissions Whether to use permissions. Default: true.
 	 * @param array $query_customizations Customizations to the SQL query.
-	 * @return Generator<EventOccurrence> Iterating over result gives
+	 * @return \Generator<EventOccurrence> Iterating over result gives
 	 *    EventOccurrence instances.
 	 */
 	public static function getOccurrencesInRange(string $low_date, string $high_date, bool $use_permissions = true, array $query_customizations = []): \Generator
@@ -328,7 +328,7 @@ class Birthday extends Event
 	 * @param int|string $limit Maximum number of results to retrieve.
 	 *    If this is left empty, all results will be retrieved.
 	 *
-	 * @return Generator<array> Iterating over the result gives database rows.
+	 * @return \Generator<array> Iterating over the result gives database rows.
 	 */
 	protected static function queryData(array $selects, array $params = [], array $joins = [], array $where = [], array $order = [], array $group = [], int|string $limit = 0): \Generator
 	{

--- a/Sources/Diff/Diff.php
+++ b/Sources/Diff/Diff.php
@@ -586,7 +586,7 @@ abstract class Diff
 				array_splice(
 					$lines,
 					$change['l1'],
-					$change['l2'] - $change['l1'] + 1,
+					(int) $change['l2'] - $change['l1'] + 1,
 					$this->formatDelIns(
 						$change[$reverse ? 'new' : 'old'],
 						$change[$reverse ? 'old' : 'new'],
@@ -1081,7 +1081,7 @@ abstract class Diff
 		$word_offsets = array_map('intval', array_keys($changes));
 
 		foreach ($changes as $c => $change) {
-			$this_end = $c + count($change['old']);
+			$this_end = (int) $c + count($change['old']);
 			$next_start = next($word_offsets);
 
 			if ($next_start <= $this_end) {
@@ -1758,7 +1758,7 @@ abstract class Diff
 				implode('', $bifurcated['suffix2']),
 			);
 
-			return $lcs;
+			return (int) $lcs;
 		}
 
 		// Once we reach the point where bifurcating doesn't help any further,
@@ -2198,7 +2198,7 @@ abstract class Diff
 			);
 
 			// Initially assume we want $context number of following lines.
-			$after_start = $changes[$c]['l1'] + count($this->splitLines($changes[$c]['old'])) - 1;
+			$after_start = (int) $changes[$c]['l1'] + count($this->splitLines($changes[$c]['old'])) - 1;
 			$after_length = $context;
 
 			if (isset($lines1[$after_start + 1])) {

--- a/Sources/Diff/FullDiff.php
+++ b/Sources/Diff/FullDiff.php
@@ -1192,7 +1192,7 @@ class FullDiff extends Diff
 		$diff->changes = self::redistributeContextLines($diff->changes);
 
 		// Deal with '\ No newline at end of file'
-		$diff->changes = self::fixFinalLineEndings($no_newline_at_end, $diff->changes, $section);
+		$diff->changes = self::fixFinalLineEndings($no_newline_at_end, $diff->changes);
 
 		// Do all the cleanup the constructor normally would.
 		$diff->changes = $diff->consolidate($diff->changes);
@@ -1339,7 +1339,7 @@ class FullDiff extends Diff
 		$diff->changes = self::redistributeContextLines($diff->changes);
 
 		// Deal with '\ No newline at end of file'
-		$diff->changes = self::fixFinalLineEndings($no_newline_at_end, $diff->changes, $section);
+		$diff->changes = self::fixFinalLineEndings($no_newline_at_end, $diff->changes);
 
 		// Do all the cleanup the constructor normally would.
 		$diff->changes = $diff->consolidate($diff->changes);
@@ -1518,22 +1518,21 @@ class FullDiff extends Diff
 	 *
 	 * @param array $where Info about which change parts have no final newline.
 	 * @param array $changes The diff's complete set of changes.
-	 * @param string $section Which section
 	 * @return array Updated $changes.
 	 */
-	protected static function fixFinalLineEndings(array $where, array $changes, string $section): array
+	protected static function fixFinalLineEndings(array $where, array $changes): array
 	{
 		foreach ($where as $part => $should_trim) {
 			if ($should_trim) {
 				$last_c = array_key_last($changes);
 
-				$temp = array_pop($changes[$last_c][$section]);
+				$temp = array_pop($changes[$last_c][$part]);
 
 				if (str_ends_with($temp, "\n")) {
 					$temp = substr($temp, 0, -1);
 				}
 
-				array_push($changes[$last_c][$section], $temp);
+				array_push($changes[$last_c][$part], $temp);
 			}
 		}
 

--- a/Sources/Diff/FullDiff.php
+++ b/Sources/Diff/FullDiff.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 
 namespace SMF\Diff;
 
+use SMF\Time;
 use SMF\Utils;
 
 /**

--- a/Sources/Diff/FullDiff.php
+++ b/Sources/Diff/FullDiff.php
@@ -379,7 +379,7 @@ class FullDiff extends Diff
 				array_unshift($output, 'optional' . "\n");
 			}
 
-			array_unshift($output, 'diff --smf ' . $path1 . ' ' . $path2 . "\n");
+			array_unshift($output, 'diff --smf ' . $this->label1 . ' ' . $this->label2 . "\n");
 		}
 
 		if (empty($this->changes)) {

--- a/Sources/Diff/FullDiff.php
+++ b/Sources/Diff/FullDiff.php
@@ -1192,7 +1192,7 @@ class FullDiff extends Diff
 		$diff->changes = self::redistributeContextLines($diff->changes);
 
 		// Deal with '\ No newline at end of file'
-		$diff->changes = self::fixFinalLineEndings($no_newline_at_end, $diff->changes);
+		$diff->changes = self::fixFinalLineEndings($no_newline_at_end, $diff->changes, $section);
 
 		// Do all the cleanup the constructor normally would.
 		$diff->changes = $diff->consolidate($diff->changes);
@@ -1339,7 +1339,7 @@ class FullDiff extends Diff
 		$diff->changes = self::redistributeContextLines($diff->changes);
 
 		// Deal with '\ No newline at end of file'
-		$diff->changes = self::fixFinalLineEndings($no_newline_at_end, $diff->changes);
+		$diff->changes = self::fixFinalLineEndings($no_newline_at_end, $diff->changes, $section);
 
 		// Do all the cleanup the constructor normally would.
 		$diff->changes = $diff->consolidate($diff->changes);
@@ -1518,9 +1518,10 @@ class FullDiff extends Diff
 	 *
 	 * @param array $where Info about which change parts have no final newline.
 	 * @param array $changes The diff's complete set of changes.
+	 * @param string $section Which section
 	 * @return array Updated $changes.
 	 */
-	protected static function fixFinalLineEndings(array $where, array $changes): array
+	protected static function fixFinalLineEndings(array $where, array $changes, string $section): array
 	{
 		foreach ($where as $part => $should_trim) {
 			if ($should_trim) {

--- a/Sources/Diff/FullDiff.php
+++ b/Sources/Diff/FullDiff.php
@@ -1344,7 +1344,7 @@ class FullDiff extends Diff
 		// Do all the cleanup the constructor normally would.
 		$diff->changes = $diff->consolidate($diff->changes);
 		$diff->changes = $diff->wordsToStrings($diff->changes);
-		$diff->changes = array_filter($diff->changes, fn($c) => !empty($c['old']) || !empty($c['new']));
+		$diff->changes = array_filter(array: $diff->changes, callback: fn($c) => !empty($c['old']) || !empty($c['new']));
 		$diff->changes = array_values($diff->changes);
 
 		return [$diff];

--- a/Sources/Localization/MessageFormatter.php
+++ b/Sources/Localization/MessageFormatter.php
@@ -183,7 +183,7 @@ class MessageFormatter
 								// Try to guess the currency based on country.
 								else {
 									require_once Config::$sourcedir . '/Unicode/Currencies.php';
-									$country_currencies = country_currencies();
+									$country_currencies = function_exists('country_currencies') ? country_currencies() : [];
 
 									// If the admin wants to prioritize a certain country, use that.
 									if (!empty(Config::$modSettings['timezone_priority_countries'])) {

--- a/Sources/Parsers/MarkdownParser.php
+++ b/Sources/Parsers/MarkdownParser.php
@@ -1349,13 +1349,15 @@ class MarkdownParser extends Parser
 	 * Tests whether a line closes a blockquote.
 	 *
 	 * @param array $line_info Info about the current line.
+	 * @param int $last_container
+	 * @param int $o
 	 * @return bool Whether this line closes a blockquote.
 	 */
 	protected function testClosesQuote(array $line_info, int $last_container, int $o): bool
 	{
 		return (
 			$line_info['string'] === $this->line_info[$line_info['linenum']]['string']
-			&& !$this->testOpensQuote($line_info, $last_container, $o)
+			&& !$this->testOpensQuote($line_info)
 			&& !in_array('p', $line_info['possible_types'])
 		);
 	}

--- a/Sources/Parsers/MarkdownParser.php
+++ b/Sources/Parsers/MarkdownParser.php
@@ -317,15 +317,6 @@ class MarkdownParser extends Parser
 	 */
 	public int $output_type = self::OUTPUT_HTML;
 
-	/**
-	 * @var int
-	 *
-	 * How to render line breaks.
-	 *
-	 * Value should be a bitmask of this class's BR_* constants.
-	 */
-	public int $hard_breaks = 0;
-
 	/*********************
 	 * Internal properties
 	 *********************/
@@ -885,19 +876,15 @@ class MarkdownParser extends Parser
 	 * @param int $output_type The type of output to generate.
 	 *    Value must be one of this class's OUTPUT_* constants.
 	 *    Default: self::OUTPUT_HTML.
-	 * @param ?int $hard_breaks How to handle line breaks in HTML output.
-	 *    Value should be bitmask of this class's BR_* constants.
-	 *    If null, uses the value of Config::$modSettings['markdown_brs'].
-	 *    Ignored when output is BBCode. Default: null.
 	 * @return MarkdownParser An instance of this class.
 	 */
-	public static function load(int $output_type = self::OUTPUT_HTML, ?int $hard_breaks = null): self
+	public static function load(int $output_type = self::OUTPUT_HTML): self
 	{
-		if (!isset(self::$parsers[$output_type][$hard_breaks])) {
-			self::$parsers[$output_type][$hard_breaks] = new self($output_type);
+		if (!isset(self::$parsers[$output_type])) {
+			self::$parsers[$output_type] = new self($output_type);
 		}
 
-		return self::$parsers[$output_type][$hard_breaks];
+		return self::$parsers[$output_type];
 	}
 
 	/******************

--- a/Sources/Parsers/MarkdownParser.php
+++ b/Sources/Parsers/MarkdownParser.php
@@ -4090,9 +4090,12 @@ class MarkdownParser extends Parser
 	 * @param string|bool|null $method Either (a) a boolean to return, (b) null
 	 *     to do nothing, or (c) the name of a method, possibly prepended by '!'
 	 *     if the boolean inverse of the method's results are desired.
-	 * @return A callable, a boolean, or null.
+	 * @return callable|false|null
+	 * 		- Null - Invalid method provided.
+	 * 		- False - Method can not be located.
+	 * 		- Callable - All other conditions.
 	 */
-	protected function getMethod(string|bool|null $method): mixed
+	protected function getMethod(string|bool|null $method): callable|bool|null
 	{
 		if (is_null($method)) {
 			return null;

--- a/Sources/Parsers/MarkdownParser.php
+++ b/Sources/Parsers/MarkdownParser.php
@@ -768,7 +768,7 @@ class MarkdownParser extends Parser
 
 		// If the load average is too high, don't parse the Markdown.
 		if ($this->highLoadAverage()) {
-			return $this->message;
+			return $string;
 		}
 
 		if ($from_bbcode_parser) {

--- a/Sources/Parsers/MarkdownParser.php
+++ b/Sources/Parsers/MarkdownParser.php
@@ -893,10 +893,8 @@ class MarkdownParser extends Parser
 	 */
 	public static function load(int $output_type = self::OUTPUT_HTML, ?int $hard_breaks = null): self
 	{
-		$hard_breaks = $hard_breaks ?? (int) (Config::$modSettings['markdown_brs'] ?? 0);
-
 		if (!isset(self::$parsers[$output_type][$hard_breaks])) {
-			self::$parsers[$output_type][$hard_breaks] = new self($output_type, $hard_breaks);
+			self::$parsers[$output_type][$hard_breaks] = new self($output_type);
 		}
 
 		return self::$parsers[$output_type][$hard_breaks];

--- a/Sources/Parsers/MarkdownParser.php
+++ b/Sources/Parsers/MarkdownParser.php
@@ -317,6 +317,15 @@ class MarkdownParser extends Parser
 	 */
 	public int $output_type = self::OUTPUT_HTML;
 
+	/**
+	 * @var int
+	 *
+	 * How to render line breaks.
+	 *
+	 * Value should be a bitmask of this class's BR_* constants.
+	 */
+	public int $hard_breaks = 0;
+
 	/*********************
 	 * Internal properties
 	 *********************/

--- a/Sources/User.php
+++ b/Sources/User.php
@@ -1104,7 +1104,7 @@ class User implements \ArrayAccess
 			$this->formatted['custom_fields'] = [];
 
 			if (!isset(Utils::$context['display_fields'])) {
-				Utils::$context['display_fields'] = Utils::jsonDecode(Config::$modSettings['displayFields'], true);
+				Utils::$context['display_fields'] = Utils::jsonDecode(Config::$modSettings['displayFields'], true) ?? [];
 			}
 
 			foreach (Utils::$context['display_fields'] as $custom) {

--- a/Sources/User.php
+++ b/Sources/User.php
@@ -1104,7 +1104,7 @@ class User implements \ArrayAccess
 			$this->formatted['custom_fields'] = [];
 
 			if (!isset(Utils::$context['display_fields'])) {
-				Utils::$context['display_fields'] = Utils::jsonDecode(Config::$modSettings['displayFields'], true) ?? [];
+				Utils::$context['display_fields'] = Utils::jsonDecode(Config::$modSettings['displayFields'] ?? '[]', true);
 			}
 
 			foreach (Utils::$context['display_fields'] as $custom) {


### PR DESCRIPTION
Odds and ends I found while reading some of the code.  If I need to revert any changes or do separate PRs, I can.  Just a lot of little stuff and didn't want to create a dozen PRs

- .gitignore
    - 	Add Autolinker.js to ignore files
- Action\Unread
    - 	$start was undefined
- Calendar\Birthday
    - 	PHP Doc update to use \Generator to prevent IDE confusion
- Diff\Diff
    - 	A few instances where the type casting may lead to a non-integer.
- Diff\FullDiff
    - 	Time was not declared in our Use statement
    - 	Can not use a positional argument after a named argument
    - 	Changed $path1 and $path2 as they where undefined
    - 	Added $section to fixFinalLineEndings as it was missing
- Localization\MessageFormater
    - 	Ensure that country_currencies exists before using it, or fall back for safety.
- Markdown Parser
    - 	Change the usage of $this->message to $string as it does not exist
    - 	load() Attempted to use a 2nd parameter for the construct, which does not exist
    - 	Improve type hinting and PHP Doc on getMethod so our IDE knows what is going on
- Autolinker
    - 	Ensure $pos is an int
- User
    - 	Always ensure that display_fields is an array if null.