### PR TITLE
[3.0] Adds support for generated columns to database APIs

### DIFF
--- a/Sources/Db/APIs/MySQL.php
+++ b/Sources/Db/APIs/MySQL.php
@@ -2833,6 +2833,16 @@ class MySQL extends DatabaseApi implements DatabaseApiInterface
 	{
 		$column = array_change_key_case($column);
 
+		// Is this a generated column?
+		if (isset($column['generation_expression'])) {
+			$generated = ' GENERATED ALWAYS AS (' . $column['generation_expression'] . ') ' . (!empty($column['stored']) ? 'STORED' : 'VIRTUAL');
+
+			// These are never used for generated columns.
+			unset($column['not_null'], $column['default'], $column['auto']);
+		} else {
+			$generated = '';
+		}
+
 		// Auto increment is easy here!
 		if (!empty($column['auto'])) {
 			$default = 'auto_increment';
@@ -2861,15 +2871,15 @@ class MySQL extends DatabaseApi implements DatabaseApiInterface
 		$column['size'] = isset($column['size']) && is_numeric($column['size']) ? $column['size'] : null;
 		list($type, $size) = $this->calculate_type($column['type'], (int) $column['size']);
 
-		// Allow unsigned integers (mysql only)
-		$unsigned = in_array($type, ['int', 'tinyint', 'smallint', 'mediumint', 'bigint']) && !empty($column['unsigned']) ? 'unsigned ' : '';
-
 		if ($size > 0) {
-			$type = $type . '(' . $size . ')';
+			$type .= '(' . $size . ')';
 		}
 
+		// Allow unsigned integers (mysql only)
+		$type .= in_array($type, ['int', 'tinyint', 'smallint', 'mediumint', 'bigint']) && !empty($column['unsigned']) ? ' unsigned' : '';
+
 		// Now just put it together!
-		return '`' . $column['name'] . '` ' . $type . ' ' . (!empty($unsigned) ? $unsigned : '') . (!empty($column['not_null']) ? 'NOT NULL' : '') . ' ' . $default;
+		return '`' . $column['name'] . '` ' . $type . ' ' . $generated . (!empty($column['not_null']) ? ' NOT NULL' : '') . ' ' . $default;
 	}
 
 	/**

--- a/Sources/Db/APIs/MySQL.php
+++ b/Sources/Db/APIs/MySQL.php
@@ -1132,105 +1132,110 @@ class MySQL extends DatabaseApi implements DatabaseApiInterface
 	/**
 	 *
 	 */
-	public function table_sql(string $tableName): string
+	public function table_sql(string $table_name): string
 	{
-		$tableName = str_replace('{db_prefix}', $this->prefix, $tableName);
-
-		// This will be needed...
-		$crlf = "\r\n";
+		$structure = $this->table_structure($table_name);
 
 		// Drop it if it exists.
-		$schema_create = 'DROP TABLE IF EXISTS `' . $tableName . '`;' . $crlf . $crlf;
+		$schema_create = 'DROP TABLE IF EXISTS ' . '`' . $structure['name'] . '`;';
+		$schema_create .= "\n\n";
 
 		// Start the create table...
-		$schema_create .= 'CREATE TABLE ' . '`' . $tableName . '` (' . $crlf;
+		$schema_create .= 'CREATE TABLE ' . '`' . $structure['name'] . '` (';
+		$schema_create .= "\n";
 
-		// Find all the fields.
-		$result = $this->query(
-			'SHOW FIELDS
-			FROM `{raw:table}`',
-			[
-				'table' => $tableName,
-			],
-		);
+		$inner_lines = [];
 
-		while ($row = $this->fetch_assoc($result)) {
-			// Make the CREATE for this column.
-			$schema_create .= ' `' . $row['Field'] . '` ' . $row['Type'] . ($row['Null'] != 'YES' ? ' NOT NULL' : '');
+		foreach ($structure['columns'] as $column) {
+			$line = '  `' . $column['name'] . '` ' . $column['type'];
 
-			// Add a default...?
-			if (!empty($row['Default']) || $row['Null'] !== 'YES') {
-				// Make a special case of auto-timestamp.
-				if ($row['Default'] == 'CURRENT_TIMESTAMP') {
-					$schema_create .= ' /*!40102 NOT NULL default CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP */';
+			if (is_numeric($column['size'])) {
+				$line .= '(' . $column['size'] . ')';
+			}
+
+			if (!empty($column['unsigned'])) {
+				$line .= ' unsigned';
+			}
+
+			if (!empty($column['generation_expression'])) {
+				$line .= ' GENERATED ALWAYS AS (' . $this->unescape_string($column['generation_expression']) . ') ' . (!empty($column['stored']) ? 'STORED' : 'VIRTUAL');
+			}
+
+			if (!empty($column['not_null'])) {
+				$line .= ' NOT NULL';
+			}
+
+			if (
+				empty($column['generation_expression'])
+				&& (
+					!is_null($column['default'])
+					|| empty($column['not_null'])
+				)
+			) {
+				$line .= ' DEFAULT';
+
+				if (is_null($column['default'])) {
+					$line .= ' NULL';
+				} elseif (is_numeric($column['default'])) {
+					$line .= ' ' . $column['default'];
+				} else {
+					$line .= ' \'' . $column['default'] . '\'';
 				}
-				// Text shouldn't have a default.
-				elseif ($row['Default'] !== null) {
-					// If this field is numeric the default needs no escaping.
-					$type = strtolower($row['Type']);
-					$isNumericColumn = str_contains($type, 'int') || str_contains($type, 'bool') || str_contains($type, 'bit') || str_contains($type, 'float') || str_contains($type, 'double') || str_contains($type, 'decimal');
-
-					$schema_create .= ' default ' . ($isNumericColumn ? $row['Default'] : '\'' . $this->escape_string($row['Default']) . '\'');
-				}
 			}
 
-			// And now any extra information. (such as auto_increment.)
-			$schema_create .= ($row['Extra'] != '' ? ' ' . $row['Extra'] : '') . ',' . $crlf;
-		}
-		$this->free_result($result);
-
-		// Take off the last comma.
-		$schema_create = substr($schema_create, 0, -strlen($crlf) - 1);
-
-		// Find the keys.
-		$result = $this->query(
-			'SHOW KEYS
-			FROM `{raw:table}`',
-			[
-				'table' => $tableName,
-			],
-		);
-		$indexes = [];
-
-		while ($row = $this->fetch_assoc($result)) {
-			// IS this a primary key, unique index, or regular index?
-			$row['Key_name'] = $row['Key_name'] == 'PRIMARY' ? 'PRIMARY KEY' : (empty($row['Non_unique']) ? 'UNIQUE ' : ($row['Comment'] == 'FULLTEXT' || (isset($row['Index_type']) && $row['Index_type'] == 'FULLTEXT') ? 'FULLTEXT ' : 'KEY ')) . '`' . $row['Key_name'] . '`';
-
-			// Is this the first column in the index?
-			if (empty($indexes[$row['Key_name']])) {
-				$indexes[$row['Key_name']] = [];
+			if (!empty($column['auto'])) {
+				$line .= ' AUTO_INCREMENT';
 			}
 
-			// A sub part, like only indexing 15 characters of a varchar.
-			if (!empty($row['Sub_part'])) {
-				$indexes[$row['Key_name']][$row['Seq_in_index']] = '`' . $row['Column_name'] . '`(' . $row['Sub_part'] . ')';
-			} else {
-				$indexes[$row['Key_name']][$row['Seq_in_index']] = '`' . $row['Column_name'] . '`';
-			}
-		}
-		$this->free_result($result);
-
-		// Build the CREATEs for the keys.
-		foreach ($indexes as $keyname => $columns) {
-			// Ensure the columns are in proper order.
-			ksort($columns);
-
-			$schema_create .= ',' . $crlf . ' ' . $keyname . ' (' . implode(', ', $columns) . ')';
+			$inner_lines[] = $line;
 		}
 
-		// Now just get the comment and engine... (InnoDB, etc.)
-		$result = $this->query(
-			'SHOW TABLE STATUS
-			LIKE {string:table}',
-			[
-				'table' => strtr($tableName, ['_' => '\\_', '%' => '\\%']),
-			],
-		);
-		$row = $this->fetch_assoc($result);
-		$this->free_result($result);
+		foreach ($structure['indexes'] as $index) {
+			$line = '  ';
 
-		// Probably InnoDB.... and it might have a comment.
-		$schema_create .= $crlf . ') ENGINE=' . $row['Engine'] . ' ROW_FORMAT=' . $row['Row_format'] . ' COLLATE=' . $row['Collation'] . ($row['Comment'] != '' ? ' COMMENT="' . $row['Comment'] . '"' : '');
+			switch ($index['type']) {
+				case 'primary':
+					$line .= 'PRIMARY KEY';
+					break;
+
+				case 'unique':
+					$line .= 'UNIQUE KEY `' . $index['name'] . '`';
+					break;
+
+				case 'fulltext':
+					$line .= 'FULLTEXT KEY `' . $index['name'] . '`';
+					break;
+
+				default:
+					$line .= 'KEY `' . $index['name'] . '`';
+					break;
+			 }
+
+			 $line .= ' (`' . implode('`, `', $index['columns']) . '`)';
+
+			 $inner_lines[] = $line;
+		}
+
+		$schema_create .= implode(",\n", $inner_lines) . "\n";
+		$schema_create .= ')';
+
+		if (!empty($structure['engine'])) {
+			$schema_create .= ' ENGINE=' . $structure['engine'];
+		}
+
+		if (!empty($structure['row_format'])) {
+			$schema_create .= ' ROW_FORMAT=' . $structure['row_format'];
+		}
+
+		if (!empty($structure['collation'])) {
+			$schema_create .= ' COLLATE=' . $structure['collation'];
+		}
+
+		if (!empty($structure['comment'])) {
+			$schema_create .= ' COMMENT="' . $structure['comment'] . '"';
+		}
+
+		$schema_create .= "\n";
 
 		return $schema_create;
 	}
@@ -2012,11 +2017,13 @@ class MySQL extends DatabaseApi implements DatabaseApiInterface
 		$this->free_result($table_status);
 
 		return [
-			'name' => $parsed_table_name,
+			'name' => $real_table_name,
 			'columns' => is_null($row) ? [] : $this->list_columns($table_name, true),
 			'indexes' => is_null($row) ? [] : $this->list_indexes($table_name, true),
 			'engine' => is_null($row) ? '' : $row['Engine'],
 			'row_format' => is_null($row) ? '' : $row['Row_format'],
+			'collation' => is_null($row) ? '' : $row['Collation'],
+			'comment' => is_null($row) ? '' : $row['Comment'],
 		];
 	}
 
@@ -2137,11 +2144,6 @@ class MySQL extends DatabaseApi implements DatabaseApiInterface
 					$indexes[$row['Key_name']]['columns'][] = $row['Column_name'] . '(' . $row['Sub_part'] . ')';
 				} else {
 					$indexes[$row['Key_name']]['columns'][] = $row['Column_name'];
-				}
-
-				if (str_contains($row['Extra'], 'GENERATED')) {
-					$columns[$row['Field']]['generation_expression'] = $row['generation_expression'];
-					$columns[$row['Field']]['stored'] = str_contains($row['Extra'], 'STORED');
 				}
 			}
 		}

--- a/Sources/Db/APIs/MySQL.php
+++ b/Sources/Db/APIs/MySQL.php
@@ -1623,17 +1623,17 @@ class MySQL extends DatabaseApi implements DatabaseApiInterface
 		}
 
 		// Get the right bits.
-		if (isset($column_info['drop_default']) && !empty($column_info['drop_default'])) {
-			$column_info['drop_default'] = true;
-		} else {
-			$column_info['drop_default'] = false;
-		}
+		$column_info['drop_default'] = !empty($column_info['drop_default']);
 
 		if (!isset($column_info['name'])) {
 			$column_info['name'] = $old_column;
 		}
 
-		if (!array_key_exists('default', $column_info) && array_key_exists('default', $old_info) && empty($column_info['drop_default'])) {
+		if (
+			!array_key_exists('default', $column_info)
+			&& array_key_exists('default', $old_info)
+			&& !$column_info['drop_default']
+		) {
 			$column_info['default'] = $old_info['default'];
 		}
 
@@ -1657,16 +1657,43 @@ class MySQL extends DatabaseApi implements DatabaseApiInterface
 			$column_info['unsigned'] = '';
 		}
 
+		foreach (['generation_expression', 'stored'] as $key) {
+			if (!array_key_exists($key, $column_info) && array_key_exists($key, $old_info)) {
+				$column_info[$key] = $old_info[$key];
+			}
+		}
+
+		// Default values and such are inapplicable to generated columns.
+		if (isset($column_info['generation_expression'])) {
+			$column_info['drop_default'] = true;
+			unset($column_info['default'], $column_info['not_null'], $column_info['auto']);
+		}
+
 		// If truly unspecified, make that clear, otherwise, might be confused with NULL...
 		// (Unspecified = no default whatsoever = column is not nullable with a value of null...)
-		if (($column_info['not_null'] === true) && !$column_info['drop_default'] && array_key_exists('default', $column_info) && is_null($column_info['default'])) {
+		if (
+			!empty($column_info['not_null'])
+			&& empty($column_info['drop_default'])
+			&& array_key_exists('default', $column_info)
+			&& is_null($column_info['default'])
+		) {
+			unset($column_info['default']);
+		}
+
+		// These types cannot have a default value.
+		if (in_array($column_info['type'], ['blob', 'text', 'json', 'geometry'])) {
+			$column_info['drop_default'] = true;
 			unset($column_info['default']);
 		}
 
 		list($type, $size) = $this->calculate_type($column_info['type'], (int) $column_info['size']);
 
+		if ($size !== null) {
+			$type .= '(' . $size . ')';
+		}
+
 		// Allow for unsigned integers (mysql only)
-		$unsigned = in_array($type, ['int', 'tinyint', 'smallint', 'mediumint', 'bigint']) && !empty($column_info['unsigned']) ? 'unsigned ' : '';
+		$type .= in_array($type, ['int', 'tinyint', 'smallint', 'mediumint', 'bigint']) && !empty($column_info['unsigned']) ? ' unsigned' : '';
 
 		// If you need to drop the default, that needs its own thing...
 		// Must be done first, in case the default type is inconsistent with the other changes.
@@ -1693,14 +1720,12 @@ class MySQL extends DatabaseApi implements DatabaseApiInterface
 			}
 		}
 
-		if ($size !== null) {
-			$type = $type . '(' . $size . ')';
-		}
+		// Is this a generated column?
+		$generated = !isset($column_info['generation_expression']) ? '' : ' GENERATED ALWAYS AS (' . $column_info['generation_expression'] . ') ' . (!empty($column_info['stored']) ? 'STORED' : 'VIRTUAL');
 
 		$result = $this->query(
 			'ALTER TABLE ' . $short_table_name . '
-			CHANGE COLUMN `' . $old_column . '` `' . $column_info['name'] . '` ' . $type . ' ' .
-				(!empty($unsigned) ? $unsigned : '') . (!empty($column_info['not_null']) ? 'NOT NULL' : '') . ' ' .
+			CHANGE COLUMN `' . $old_column . '` `' . $column_info['name'] . '` ' . $type . $generated . (!empty($column_info['not_null']) ? ' NOT NULL' : '') . ' ' .
 				$default_clause . ' ' .
 				(empty($column_info['auto']) ? '' : 'auto_increment') . ' ',
 			[

--- a/Sources/Db/APIs/MySQL.php
+++ b/Sources/Db/APIs/MySQL.php
@@ -2005,7 +2005,7 @@ class MySQL extends DatabaseApi implements DatabaseApiInterface
 		$database = !empty($match[2]) ? $match[2] : $this->name;
 
 		$result = $this->query(
-			'SELECT column_name "Field", COLUMN_TYPE "Type", is_nullable "Null", COLUMN_KEY "Key" , column_default "Default", extra "Extra"
+			'SELECT column_name "Field", COLUMN_TYPE "Type", is_nullable "Null", COLUMN_KEY "Key" , column_default "Default", extra "Extra", generation_expression "generation_expression"
 			FROM information_schema.columns
 			WHERE table_name = {string:table_name}
 				AND table_schema = {string:db_name}
@@ -2050,6 +2050,11 @@ class MySQL extends DatabaseApi implements DatabaseApiInterface
 				if (isset($unsigned)) {
 					$columns[$row['Field']]['unsigned'] = $unsigned;
 					unset($unsigned);
+				}
+
+				if (str_contains($row['Extra'], 'GENERATED')) {
+					$columns[$row['Field']]['generation_expression'] = $row['generation_expression'];
+					$columns[$row['Field']]['stored'] = str_contains($row['Extra'], 'STORED');
 				}
 			}
 		}
@@ -2107,6 +2112,11 @@ class MySQL extends DatabaseApi implements DatabaseApiInterface
 					$indexes[$row['Key_name']]['columns'][] = $row['Column_name'] . '(' . $row['Sub_part'] . ')';
 				} else {
 					$indexes[$row['Key_name']]['columns'][] = $row['Column_name'];
+				}
+
+				if (str_contains($row['Extra'], 'GENERATED')) {
+					$columns[$row['Field']]['generation_expression'] = $row['generation_expression'];
+					$columns[$row['Field']]['stored'] = str_contains($row['Extra'], 'STORED');
 				}
 			}
 		}

--- a/Sources/Db/APIs/PostgreSQL.php
+++ b/Sources/Db/APIs/PostgreSQL.php
@@ -1536,17 +1536,17 @@ class PostgreSQL extends DatabaseApi implements DatabaseApiInterface
 		}
 
 		// Get the right bits.
-		if (isset($column_info['drop_default']) && !empty($column_info['drop_default'])) {
-			$column_info['drop_default'] = true;
-		} else {
-			$column_info['drop_default'] = false;
-		}
+		$column_info['drop_default'] = !empty($column_info['drop_default']);
 
 		if (!isset($column_info['name'])) {
 			$column_info['name'] = $old_column;
 		}
 
-		if (!array_key_exists('default', $column_info) && array_key_exists('default', $old_info) && empty($column_info['drop_default'])) {
+		if (
+			!array_key_exists('default', $column_info)
+			&& array_key_exists('default', $old_info)
+			&& !$column_info['drop_default']
+		) {
 			$column_info['default'] = $old_info['default'];
 		}
 
@@ -1570,9 +1570,26 @@ class PostgreSQL extends DatabaseApi implements DatabaseApiInterface
 			$column_info['unsigned'] = '';
 		}
 
+		foreach (['generation_expression', 'stored'] as $key) {
+			if (!array_key_exists($key, $column_info) && array_key_exists($key, $old_info)) {
+				$column_info[$key] = $old_info[$key];
+			}
+		}
+
+		// Default values and such are inapplicable to generated columns.
+		if (isset($column_info['generation_expression'])) {
+			$column_info['drop_default'] = true;
+			unset($column_info['default'], $column_info['not_null'], $column_info['auto']);
+		}
+
 		// If truly unspecified, make that clear, otherwise, might be confused with NULL...
 		// (Unspecified = no default whatsoever = column is not nullable with a value of null...)
-		if (($column_info['not_null'] === true) && !$column_info['drop_default'] && array_key_exists('default', $column_info) && is_null($column_info['default'])) {
+		if (
+			!empty($column_info['not_null'])
+			&& empty($column_info['drop_default'])
+			&& array_key_exists('default', $column_info)
+			&& is_null($column_info['default'])
+		) {
 			unset($column_info['default']);
 		}
 
@@ -1599,31 +1616,51 @@ class PostgreSQL extends DatabaseApi implements DatabaseApiInterface
 			);
 		}
 
-		// What about a change in type?
-		if (isset($column_info['type']) && ($column_info['type'] != $old_info['type'] || (isset($column_info['size']) && $column_info['size'] != $old_info['size']))) {
+		// What about a change in type, or a change to/from a generated column?
+		if (
+			(
+				isset($column_info['type'])
+				&& (
+					$column_info['type'] != $old_info['type']
+					|| (
+						isset($column_info['size'])
+						&& $column_info['size'] != $old_info['size']
+					)
+				)
+			)
+			|| $column_info['generation_expression'] ?? '' !== $old_info['generation_expression'] ?? ''
+		) {
 			$column_info['size'] = isset($column_info['size']) && is_numeric($column_info['size']) ? $column_info['size'] : null;
+
 			list($type, $size) = $this->calculate_type($column_info['type'], (int) $column_info['size']);
 
 			if ($size !== null) {
-				$type = $type . '(' . $size . ')';
+				$type .= '(' . $size . ')';
 			}
+
+			$generated = !isset($column_info['generation_expression']) ? '' : ' GENERATED ALWAYS AS (' . $column_info['generation_expression'] . ') STORED';
 
 			// The alter is a pain.
 			$this->transaction('begin');
+
 			$this->query(
 				'ALTER TABLE ' . $short_table_name . '
-				ADD COLUMN ' . $column_info['name'] . '_tempxx ' . $type,
+				ADD COLUMN ' . $column_info['name'] . '_tempxx ' . $type . $generated,
 				[
 					'security_override' => true,
 				],
 			);
-			$this->query(
-				'UPDATE ' . $short_table_name . '
-				SET ' . $column_info['name'] . '_tempxx = CAST(' . $column_info['name'] . ' AS ' . $type . ')',
-				[
-					'security_override' => true,
-				],
-			);
+
+			if (empty($generated)) {
+				$this->query(
+					'UPDATE ' . $short_table_name . '
+					SET ' . $column_info['name'] . '_tempxx = CAST(' . $column_info['name'] . ' AS ' . $type . ')',
+					[
+						'security_override' => true,
+					],
+				);
+			}
+
 			$this->query(
 				'ALTER TABLE ' . $short_table_name . '
 				DROP COLUMN ' . $column_info['name'],
@@ -1631,6 +1668,7 @@ class PostgreSQL extends DatabaseApi implements DatabaseApiInterface
 					'security_override' => true,
 				],
 			);
+
 			$this->query(
 				'ALTER TABLE ' . $short_table_name . '
 				RENAME COLUMN ' . $column_info['name'] . '_tempxx TO ' . $column_info['name'],
@@ -1638,6 +1676,7 @@ class PostgreSQL extends DatabaseApi implements DatabaseApiInterface
 					'security_override' => true,
 				],
 			);
+
 			$this->transaction('commit');
 		}
 

--- a/Sources/Db/APIs/PostgreSQL.php
+++ b/Sources/Db/APIs/PostgreSQL.php
@@ -1979,7 +1979,7 @@ class PostgreSQL extends DatabaseApi implements DatabaseApiInterface
 		$database = !empty($match[2]) ? $match[2] : $this->name;
 
 		$result = $this->query(
-			'SELECT column_name, column_default, is_nullable, data_type, character_maximum_length
+			'SELECT column_name, column_default, is_nullable, data_type, character_maximum_length, is_generated, generation_expression
 			FROM information_schema.columns
 			WHERE table_schema = {string:schema_public}
 				AND table_name = {string:table_name}
@@ -2020,6 +2020,12 @@ class PostgreSQL extends DatabaseApi implements DatabaseApiInterface
 					'size' => $size,
 					'auto' => $auto,
 				];
+
+				if ($row['is_generated'] !== 'NEVER') {
+					$columns[$row['column_name']]['generation_expression'] = $row['generation_expression'];
+					// Generated columns are always stored in PostgreSQL.
+					$columns[$row['column_name']]['stored'] = true;
+				}
 			}
 		}
 		$this->free_result($result);

--- a/Sources/Db/APIs/PostgreSQL.php
+++ b/Sources/Db/APIs/PostgreSQL.php
@@ -1359,17 +1359,33 @@ class PostgreSQL extends DatabaseApi implements DatabaseApiInterface
 			$type = $type . '(' . $size . ')';
 		}
 
+		// Is this a generated column?
+		if (isset($column['generation_expression'])) {
+			// PostgreSQL only supports stored generated columns, not virtual ones.
+			$generated = ' GENERATED ALWAYS AS (' . $column['generation_expression'] . ') STORED';
+
+			// These are never used for generated columns.
+			unset($column['not_null'], $column['default'], $column['auto']);
+		} else {
+			$generated = '';
+		}
+
 		// Now add the thing!
 		$this->query(
 			'ALTER TABLE ' . $short_table_name . '
-			ADD COLUMN ' . $column_info['name'] . ' ' . $type,
+			ADD COLUMN ' . $column_info['name'] . ' ' . $type . $generated,
 			[
 				'security_override' => true,
 			],
 		);
 
 		// If there's more attributes they need to be done via a change on PostgreSQL.
-		unset($column_info['type'], $column_info['size']);
+		unset(
+			$column_info['type'],
+			$column_info['size'],
+			$column_info['generation_expression'],
+			$column_info['stored'],
+		);
 
 		if (count($column_info) != 1) {
 			return $this->change_column($table_name, $column_info['name'], $column_info);
@@ -1803,6 +1819,17 @@ class PostgreSQL extends DatabaseApi implements DatabaseApiInterface
 		foreach ($columns as $column) {
 			$column = array_change_key_case($column);
 
+			// Is this a generated column?
+			if (isset($column['generation_expression'])) {
+				// PostgreSQL only supports stored generated columns, not virtual ones.
+				$generated = ' GENERATED ALWAYS AS (' . $column['generation_expression'] . ') STORED';
+
+				// These are never used for generated columns.
+				unset($column['not_null'], $column['default'], $column['auto']);
+			} else {
+				$generated = '';
+			}
+
 			// If we have an auto increment do it!
 			if (!empty($column['auto'])) {
 				if (!$old_table_exists) {
@@ -1843,7 +1870,7 @@ class PostgreSQL extends DatabaseApi implements DatabaseApiInterface
 			}
 
 			// Now just put it together!
-			$table_query .= "\n\t\"" . $column['name'] . '" ' . $type . ' ' . (!empty($column['not_null']) ? 'NOT NULL' : '') . ' ' . $default . ',';
+			$table_query .= "\n\t\"" . $column['name'] . '" ' . $type . $generated . (!empty($column['not_null']) ? ' NOT NULL' : '') . ' ' . $default . ',';
 		}
 
 		// Loop through the indexes next...

--- a/Sources/Db/APIs/PostgreSQL.php
+++ b/Sources/Db/APIs/PostgreSQL.php
@@ -1018,18 +1018,15 @@ class PostgreSQL extends DatabaseApi implements DatabaseApiInterface
 	/**
 	 *
 	 */
-	public function table_sql(string $tableName): string
+	public function table_sql(string $table_name): string
 	{
-		$tableName = str_replace('{db_prefix}', $this->prefix, $tableName);
-
-		// This will be needed...
-		$crlf = "\r\n";
+		$table_name = str_replace('{db_prefix}', $this->prefix, $table_name);
 
 		// Drop it if it exists.
-		$schema_create = 'DROP TABLE IF EXISTS ' . $tableName . ';' . $crlf . $crlf;
+		$schema_create = 'DROP TABLE IF EXISTS ' . $table_name . ';' . "\n\n";
 
 		// Start the create table...
-		$schema_create .= 'CREATE TABLE ' . $tableName . ' (' . $crlf;
+		$schema_create .= 'CREATE TABLE ' . $table_name . ' (' . "\n";
 		$index_create = '';
 		$seq_create = '';
 
@@ -1040,7 +1037,7 @@ class PostgreSQL extends DatabaseApi implements DatabaseApiInterface
 			WHERE table_name = {string:table}
 			ORDER BY ordinal_position',
 			[
-				'table' => $tableName,
+				'table' => $table_name,
 			],
 		);
 
@@ -1070,23 +1067,28 @@ class PostgreSQL extends DatabaseApi implements DatabaseApiInterface
 						FROM {raw:table}',
 						[
 							'column' => $row['column_name'],
-							'table' => $tableName,
+							'table' => $table_name,
 						],
 					);
 					list($max_ind) = $this->fetch_row($count_req);
 					$this->free_result($count_req);
+
 					// Get the right bloody start!
-					$seq_create .= 'CREATE SEQUENCE ' . $matches[1] . ' START WITH ' . ($max_ind + 1) . ';' . $crlf . $crlf;
+					$seq_create .= 'CREATE SEQUENCE ' . $matches[1] . ' START WITH ' . ($max_ind + 1) . ';' . "\n\n";
 				}
 			}
 
-			$schema_create .= ',' . $crlf;
+			$schema_create .= ',' . "\n";
 		}
 		$this->free_result($result);
 
 		// Take off the last comma.
-		$schema_create = substr($schema_create, 0, -strlen($crlf) - 1);
+		$schema_create = substr($schema_create, 0, -2);
 
+		// Finish it off!
+		$schema_create .= "\n" . ');';
+
+		// Now the indexes.
 		$result = $this->query(
 			'SELECT pg_get_indexdef(i.indexrelid) AS inddef
 			FROM pg_class AS c
@@ -1094,13 +1096,13 @@ class PostgreSQL extends DatabaseApi implements DatabaseApiInterface
 				INNER JOIN pg_class AS c2 ON (c2.oid = i.indexrelid)
 			WHERE c.relname = {string:table} AND i.indisprimary is {raw:pk}',
 			[
-				'table' => $tableName,
+				'table' => $table_name,
 				'pk'	=> 'false',
 			],
 		);
 
 		while ($row = $this->fetch_assoc($result)) {
-			$index_create .= $crlf . $row['inddef'] . ';';
+			$index_create .= "\n" . $row['inddef'] . ';';
 		}
 		$this->free_result($result);
 
@@ -1108,20 +1110,17 @@ class PostgreSQL extends DatabaseApi implements DatabaseApiInterface
 			'SELECT pg_get_constraintdef(c.oid) as pkdef
 			FROM pg_constraint as c
 			WHERE c.conrelid::regclass::text = {string:table} AND
-				c.contype = {string:constraintType}',
+				c.contype = {string:constraint_type}',
 			[
-				'table' 			=> $tableName,
-				'constraintType'	=> 'p',
+				'table' 			=> $table_name,
+				'constraint_type'	=> 'p',
 			],
 		);
 
 		while ($row = $this->fetch_assoc($result)) {
-			$index_create .= $crlf . 'ALTER TABLE ' . $tableName . ' ADD ' . $row['pkdef'] . ';';
+			$index_create .= "\n" . 'ALTER TABLE ' . $table_name . ' ADD ' . $row['pkdef'] . ';';
 		}
 		$this->free_result($result);
-
-		// Finish it off!
-		$schema_create .= $crlf . ');';
 
 		return $seq_create . $schema_create . $index_create;
 	}

--- a/Sources/Db/DatabaseApiInterface.php
+++ b/Sources/Db/DatabaseApiInterface.php
@@ -363,11 +363,10 @@ interface DatabaseApiInterface
 	/**
 	 * Dumps the schema (CREATE) for a table.
 	 *
-	 * @todo why is this needed for?
-	 * @param string $tableName The name of the table
-	 * @return string The "CREATE TABLE" SQL string for this table
+	 * @param string $table_name The name of the table.
+	 * @return string The "CREATE TABLE" SQL string for this table.
 	 */
-	public function table_sql(string $tableName): string;
+	public function table_sql(string $table_name): string;
 
 	/**
 	 * This function lists all tables in the database.

--- a/Sources/Db/DatabaseApiInterface.php
+++ b/Sources/Db/DatabaseApiInterface.php
@@ -347,7 +347,8 @@ interface DatabaseApiInterface
 	 *
 	 * @param string $table The name of the table to backup
 	 * @param string $backup_table The name of the backup table for this table
-	 * @return resource|false -the request handle to the table creation query, false if it failed.
+	 * @return object|false The request handle to the table creation query, or
+	 *    false if it failed.
 	 */
 	public function backup_table(string $table, string $backup_table): object|bool;
 
@@ -370,11 +371,12 @@ interface DatabaseApiInterface
 
 	/**
 	 * This function lists all tables in the database.
-	 * The listing could be filtered according to $filter.
 	 *
-	 * @param string|bool $db string The database name or false to use the current DB
-	 * @param string|bool $filter String to filter by or false to list all tables
-	 * @return array An array of table names
+	 * The listing can be filtered according to $filter.
+	 *
+	 * @param string|bool $db The database name or false to use the current DB.
+	 * @param string|bool $filter String to filter by or false to list all.
+	 * @return array An array of table names.
 	 */
 	public function list_tables(string|bool $db = false, string|bool $filter = false): array;
 

--- a/Sources/Db/Schema/GeneratedColumn.php
+++ b/Sources/Db/Schema/GeneratedColumn.php
@@ -1,0 +1,89 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema;
+
+use SMF\Db\DatabaseApi as Db;
+
+/**
+ * Represents a generated column in a database table.
+ *
+ * @see https://dev.mysql.com/doc/refman/en/create-table-generated-columns.html
+ * @see https://www.postgresql.org/docs/current/ddl-generated-columns.html
+ */
+class GeneratedColumn extends Column
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 * @var string
+	 *
+	 * The expression used to generate the value.
+	 */
+	public string $generation_expression;
+
+	/**
+	 * @var bool
+	 *
+	 * Whether the generated value should be stored.
+	 *
+	 * Will always be true for PostgreSQL databases, because PostgreSQL does not
+	 * support virtual generated columns.
+	 */
+	public bool $stored;
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 *
+	 * @param string $name Name of the column.
+	 * @param string $type Data type of the column.
+	 * @param string $generation_expression The expression used to generate the
+	 *    value.
+	 * @param bool $stored Whether the generated value should be stored.
+	 *    For PostgreSQL databases, this value will always be forced to true.
+	 * @param ?int $size Size of the column.
+	 *    Only applicable to some data types.
+	 * @param ?bool $unsigned Whether the column uses unsigned numerical values.
+	 *    Only used by MySQL.
+	 * @param ?string $charset The character set for string data.
+	 *    Only applicable to string types. If null, will be set automatically.
+	 */
+	public function __construct(
+		string $name,
+		string $type,
+		string $generation_expression,
+		bool $stored,
+		?int $size = null,
+		?bool $unsigned = null,
+		?string $charset = null,
+	) {
+		parent::__construct(
+			name: $name,
+			type: $type,
+			size: $size,
+			unsigned: $unsigned,
+			charset: $charset,
+		);
+
+		$this->generation_expression = $generation_expression;
+		$this->stored = Db::$db->title === POSTGRE_TITLE ? true : $stored;
+	}
+}

--- a/Sources/Db/Schema/Table.php
+++ b/Sources/Db/Schema/Table.php
@@ -212,7 +212,7 @@ class Table
 				continue;
 			}
 
-			foreach (['name', 'size', 'unsigned', 'not_null', 'default', 'auto'] as $prop) {
+			foreach (['name', 'size', 'unsigned', 'generated_expression', 'stored', 'not_null', 'default', 'auto'] as $prop) {
 				if (($structure['columns'][$col->name][$prop] ?? null) != ($col->{$prop} ?? null)) {
 					$columns_to_change[$col->name] = $col;
 					continue 2;


### PR DESCRIPTION
This PR adds support for generated columns in our database APIs.

Generated columns are now understood and handled by the following methods:

- SMF\Db\DatabaseApi::list_columns()
- SMF\Db\DatabaseApi::change_column()
- SMF\Db\DatabaseApi::add_column()
- SMF\Db\DatabaseApi::create_table()
- SMF\Db\Schema\Table::normalize()

This PR also adds a new SMF\Db\Schema\GeneratedColumn class that extends SMF\Db\Schema\Column in order to support generated columns.

Finally, this PR fixes some issues with the SMF\Db\DatabaseApi::table_sql() method (especially the MySQL version).

Unfortunately, there is no easy way to test this PR by itself, because nothing in the current code makes use of generated columns. However, #8780, which implements edit history for posts, does make use of generated columns, so it is possible to test these changes by testing that PR.