### PR TITLE
[3.0] Makes all properties of SMF\Url nullable

### DIFF
--- a/Sources/Url.php
+++ b/Sources/Url.php
@@ -51,53 +51,53 @@ class Url implements \Stringable
 	public ?string $scheme = null;
 
 	/**
-	 * @var string
+	 * @var ?string
 	 *
 	 * The host component of the URL.
 	 */
-	public string $host;
+	public ?string $host = null;
 
 	/**
-	 * @var int
+	 * @var ?int
 	 *
 	 * The port component of the URL.
 	 */
-	public int $port;
+	public ?int $port = null;
 
 	/**
-	 * @var string
+	 * @var ?string
 	 *
 	 * The user component of the URL.
 	 */
-	public string $user;
+	public ?string $user = null;
 
 	/**
-	 * @var string
+	 * @var ?string
 	 *
 	 * The password component of the URL.
 	 */
-	public string $pass;
+	public ?string $pass = null;
 
 	/**
-	 * @var string
+	 * @var ?string
 	 *
 	 * The path component of the URL.
 	 */
-	public string $path;
+	public ?string $path = null;
 
 	/**
-	 * @var string
+	 * @var ?string
 	 *
 	 * The query component of the URL.
 	 */
-	public string $query;
+	public ?string $query = null;
 
 	/**
-	 * @var string
+	 * @var ?string
 	 *
 	 * The fragment component of the URL.
 	 */
-	public string $fragment;
+	public ?string $fragment = null;
 
 	/**************************
 	 * Public static properties


### PR DESCRIPTION
While checking whether SMF 3.0 needed an equivalent to #8782 (it doesn't), I noticed a different issue. Under certain circumstances we might end up checking the values of SMF\Url properties that had not been initialized. The easiest and most universal fix for that is to make them all nullable. All existing code that uses `isset()` on those properties will work just like before, and code that assumes the properties have been initialized will work correctly too.