### PR TITLE
[3.0] Remove not_null from package server extra column

### DIFF
--- a/Sources/Db/Schema/v3_0/PackageServers.php
+++ b/Sources/Db/Schema/v3_0/PackageServers.php
@@ -89,7 +89,6 @@ class PackageServers extends Table
 			'extra' => new Column(
 				name: 'extra',
 				type: 'text',
-				not_null: true,
 			),
 		];
 


### PR DESCRIPTION
The extra column should be allowed to be empty