### PR TITLE
[3.0] Change load average to percent based results

### DIFF
--- a/Languages/en_US/ManageSettings.php
+++ b/Languages/en_US/ManageSettings.php
@@ -152,7 +152,7 @@ $txt['cache_memcached_settings'] = 'Memcache/Memcached settings';
 $txt['cache_memcached_servers'] = 'Memcache/Memcached servers';
 $txt['cache_memcached_servers_subtext'] = 'Example: 127.0.0.1:11211,127.0.0.2';
 
-$txt['loadavg_warning'] = 'Please note: the settings below are to be edited with care. Setting any of them too low may render your forum <strong>unusable</strong>! The current load average is <strong>{0, number, :: .00}</strong>';
+$txt['loadavg_warning'] = 'Please note: the settings below are to be edited with care. Setting any of them too low may render your forum <strong>unusable</strong>!';
 $txt['loadavg_enable'] = 'Enable load balancing by load averages';
 $txt['loadavg_auto_opt'] = 'Threshold to disabling automatic database optimization';
 $txt['loadavg_search'] = 'Threshold to disabling search';
@@ -163,8 +163,9 @@ $txt['loadavg_userstats'] = 'Threshold to disabling showing user statistics';
 $txt['loadavg_bbc'] = 'Threshold to disabling BBC formatting when showing posts';
 $txt['loadavg_forum'] = 'Threshold to disabling the forum <strong>completely</strong>';
 $txt['loadavg_disabled_windows'] = 'Load balancing support is not available on Windows.';
-$txt['loadavg_disabled_osx'] = 'Load balancing support is not available on OS:X.';
 $txt['loadavg_disabled_conf'] = 'Load balancing support is disabled by your host configuration.';
+$txt['loadavg_current_load'] = 'The current load average is <strong>{load_average, number, :: percent}</strong>';
+$txt['loadavg_processors']  = 'CPU(s) detected: {cpu_count, number}';
 
 $txt['setting_password_strength'] = 'Required strength for user passwords';
 $txt['setting_password_strength_low'] = 'Low';

--- a/Sources/Actions/Admin/Server.php
+++ b/Sources/Actions/Admin/Server.php
@@ -95,14 +95,14 @@ class Server implements ActionInterface
 	 * Default values for load balancing options.
 	 */
 	public const LOADAVG_DEFAULT_VALUES = [
-		'loadavg_auto_opt' => 20.0,
-		'loadavg_search' => 30.0,
-		'loadavg_allunread' => 40.0,
-		'loadavg_unreadreplies' => 40.0,
-		'loadavg_show_posts' => 40.0,
-		'loadavg_userstats' => 50.0,
-		'loadavg_bbc' => 60.0,
-		'loadavg_forum' => 85.0,
+		'loadavg_auto_opt' => 50.0,
+		'loadavg_search' => 300.0,
+		'loadavg_allunread' => 200.0,
+		'loadavg_unreadreplies' => 200.0,
+		'loadavg_show_posts' => 200.0,
+		'loadavg_userstats' => 150.0,
+		'loadavg_bbc' => 700.0,
+		'loadavg_forum' => 1000.0,
 	];
 
 	/*******************

--- a/Sources/Actions/Admin/Server.php
+++ b/Sources/Actions/Admin/Server.php
@@ -95,14 +95,14 @@ class Server implements ActionInterface
 	 * Default values for load balancing options.
 	 */
 	public const LOADAVG_DEFAULT_VALUES = [
-		'loadavg_auto_opt' => 1.0,
-		'loadavg_search' => 2.5,
-		'loadavg_allunread' => 2.0,
-		'loadavg_unreadreplies' => 3.5,
-		'loadavg_show_posts' => 2.0,
-		'loadavg_userstats' => 10.0,
-		'loadavg_bbc' => 30.0,
-		'loadavg_forum' => 40.0,
+		'loadavg_auto_opt' => 20.0,
+		'loadavg_search' => 30.0,
+		'loadavg_allunread' => 40.0,
+		'loadavg_unreadreplies' => 40.0,
+		'loadavg_show_posts' => 40.0,
+		'loadavg_userstats' => 50.0,
+		'loadavg_bbc' => 60.0,
+		'loadavg_forum' => 85.0,
 	];
 
 	/*******************
@@ -596,17 +596,14 @@ class Server implements ActionInterface
 			if (isset($_GET['save'])) {
 				$_SESSION['adm-save'] = Utils::$context['settings_message']['label'];
 			}
-		} elseif (self::$loadAverageDisabled && stripos(PHP_OS, 'darwin') === 0) {
-			Utils::$context['settings_message']['label'] = Lang::getTxt('loadavg_disabled_osx', file: 'ManageSettings');
-
-			if (isset($_GET['save'])) {
-				$_SESSION['adm-save'] = Utils::$context['settings_message']['label'];
-			}
 		} elseif (!self::$loadAverageDisabled) {
-			Utils::$context['settings_message']['label'] = Lang::getTxt('loadavg_warning', [Sapi::getLoadAverage()], file: 'ManageSettings');
+			Utils::$context['settings_message']['label'] = Lang::getTxt('loadavg_warning', file: 'ManageSettings');
 		}
 
-		$config_vars = self::loadBalancingConfigVars();
+		$config_vars = array_merge([
+			['desc', 'loadavg_current_load', 'text_label' => Lang::getTxt('loadavg_current_load', ['load_average' => Sapi::getLoadAverage()], file: 'ManageSettings')],
+			['desc', 'loadavg_processors', 'text_label' => Lang::getTxt('loadavg_processors', ['cpu_count' => Sapi::getCpuCount()], file: 'ManageSettings')],
+		], self::loadBalancingConfigVars());
 
 		Utils::$context['post_url'] = Config::$scripturl . '?action=admin;area=serversettings;sa=loads;save';
 		Utils::$context['settings_title'] = Lang::getTxt('load_balancing_settings', file: 'Admin');

--- a/Sources/Sapi.php
+++ b/Sources/Sapi.php
@@ -492,50 +492,60 @@ class Sapi
 	 * If all attempts fail, return 1.
 	 * Always ensure we have at least 1 CPU, as this is used in math functions.
 	 *
+	 * @param bool $update Update the db backed cache value.
 	 * @return int Number of CPUs detected.
 	 */
-	public static function getCpuCount(): int
+	public static function getCpuCount(bool $update = false): int
 	{
 		if (self::$cpu_count !== null) {
 			return self::$cpu_count;
 		}
 
-		// Avoid using wmic commands, otherwise this would work as a fallback: wmic computersystem get NumberOfLogicalProcessors
-		if (self::isOS(self::OS_WINDOWS)) {
-			return self::$cpu_count = min((int) getenv('NUMBER_OF_PROCESSORS') ?? 1, 1);
+		if (!$update && isset(Config::$modSettings['cpu_count'])) {
+			return (int) Config::$modSettings['cpu_count'];
 		}
 
 		try {
+			// Avoid using wmic commands, otherwise this would work as a fallback: wmic computersystem get NumberOfLogicalProcessors
+			if (self::isOS(self::OS_WINDOWS)) {
+				self::$cpu_count = min((int) getenv('NUMBER_OF_PROCESSORS') ?? 1, 1);
+			}
 			// Apple is special, check sysctl
-			if (self::isOS(self::OS_MAC)) {
+			elseif (self::isOS(self::OS_MAC)) {
 				if (($cpu_count = @shell_exec('sysctl -n hw.physicalcpu')) !== null && preg_match('~\d~i', $cpu_count, $matches) !== 0) {
-					return self::$cpu_count = min((int) $cpu_count, 1);
+					self::$cpu_count = min((int) $cpu_count, 1);
 				}
 			}
 			// On most Linux distros, we can runn nproc.
 			elseif (($cpu_count = @shell_exec('nproc --all')) !== null && preg_match('~\d~i', $cpu_count, $matches) !== 0) {
-				return self::$cpu_count = min((int) $cpu_count, 1);
+				self::$cpu_count = min((int) $cpu_count, 1);
 			}
 
 			// This works for both Mac and Linux, however it actually reports online cpus, not total CPUs.
 			// Could also use _NPROCESSORS_CONF which is processors configured.
-			if (($cpu_count = @shell_exec('getconf _NPROCESSORS_ONLN')) !== null && preg_match('~\d~i', $cpu_count, $matches) !== 0) {
-				return self::$cpu_count = min((int) $cpu_count, 1);
+			if (empty(self::$cpu_count) && !self::isOS(self::OS_WINDOWS) && ($cpu_count = @shell_exec('getconf _NPROCESSORS_ONLN')) !== null && preg_match('~\d~i', $cpu_count, $matches) !== 0) {
+				self::$cpu_count = min((int) $cpu_count, 1);
 			}
 
 			// Borrowed from: https://www.php.net/manual/en/function.sys-getloadavg.php#129847
 			// Maybe consider using awk to simplify this: grep -m 1 'cpu cores' /proc/cpuinfo | awk -F: '{print $2}'
-			if (file_exists('/proc/cpuinfo')) {
+			if (empty(self::$cpu_count) && !self::isOS(self::OS_WINDOWS) && file_exists('/proc/cpuinfo')) {
 				preg_match_all('/^processor/m', file_get_contents('/proc/cpuinfo'), $matches);
 
 				if (isset($matches[0])) {
-					return self::$cpu_count = min(count($matches[0]), 1);
+					self::$cpu_count = min(count($matches[0]), 1);
 				}
 			}
 		} catch (\Exception $ex) {
 		}
 
-		// No CPUs found, I think we have at least one.
-		return self::$cpu_count = 1;
+		// No CPUs found, I think we have at least one. Avoids divide by zero errors.
+		if (empty(self::$cpu_count)) {
+			self::$cpu_count = 1;
+		}
+
+		Config::updateModSettings(['cpu_count' => self::$cpu_count]);
+
+		return self::$cpu_count;
 	}
 }

--- a/Sources/Sapi.php
+++ b/Sources/Sapi.php
@@ -84,6 +84,13 @@ class Sapi
 	 */
 	protected static ?float $current_load = null;
 
+	/**
+	 * @var int
+	 *
+	 * Number of CPUs detected
+	 */
+	protected static ?int $cpu_count = null;
+
 	/***********************
 	 * Public static methods
 	 ***********************/
@@ -443,19 +450,19 @@ class Sapi
 
 			// sys_getloadavg returns false on failure.
 			if ($current_load !== false) {
-				return self::$current_load = (float) $current_load[0];
+				return self::$current_load = (float) $current_load[0] / self::getCpuCount();
 			}
 
 			// Most Linux distros offer a nice file that we can read.
 			$current_load = @file_get_contents('/proc/loadavg');
 
 			if (!empty($current_load) && preg_match('~^([^ ]+?) ([^ ]+?) ([^ ]+)~', $current_load, $matches) !== 0) {
-				return self::$current_load = (float) $matches[1];
+				return self::$current_load = (float) $matches[1] / self::getCpuCount();
 			}
 
 			// On both Linux and Unix (e.g. macOS), we can we can check shell_exec('uptime').
 			if (($current_load = @shell_exec('uptime')) !== null && preg_match('~load averages?: (\d+\.\d+)~i', $current_load, $matches) !== 0) {
-				return self::$current_load = (float) $matches[1];
+				return self::$current_load = (float) $matches[1] / self::getCpuCount();
 			}
 		} catch (\Exception $ex) {
 		}
@@ -476,5 +483,59 @@ class Sapi
 		}
 
 		return self::getLoadAverage() >= (float) $threshold;
+	}
+
+	/**
+	 * Returns the number of CPUs as reported by the system.
+	 * On Windows we check getenv, do not use wmic as its slow.
+	 * On linux we first attempt with nproc and then fall back to parsing /proc/cpuinfo.
+	 * If all attempts fail, return 1.
+	 * Always ensure we have at least 1 CPU, as this is used in math functions.
+	 *
+	 * @return int Number of CPUs detected.
+	 */
+	public static function getCpuCount(): int
+	{
+		if (self::$cpu_count !== null) {
+			return self::$cpu_count;
+		}
+
+		// Avoid using wmic commands, otherwise this would work as a fallback: wmic computersystem get NumberOfLogicalProcessors
+		if (self::isOS(self::OS_WINDOWS)) {
+			return self::$cpu_count = min((int) getenv('NUMBER_OF_PROCESSORS') ?? 1, 1);
+		}
+
+		try {
+			// Apple is special, check sysctl
+			if (self::isOS(self::OS_MAC)) {
+				if (($cpu_count = @shell_exec('sysctl -n hw.physicalcpu')) !== null && preg_match('~\d~i', $cpu_count, $matches) !== 0) {
+					return self::$cpu_count = min((int) $cpu_count, 1);
+				}
+			}
+			// On most Linux distros, we can runn nproc.
+			elseif (($cpu_count = @shell_exec('nproc --all')) !== null && preg_match('~\d~i', $cpu_count, $matches) !== 0) {
+				return self::$cpu_count = min((int) $cpu_count, 1);
+			}
+
+			// This works for both Mac and Linux, however it actually reports online cpus, not total CPUs.
+			// Could also use _NPROCESSORS_CONF which is processors configured.
+			if (($cpu_count = @shell_exec('getconf _NPROCESSORS_ONLN')) !== null && preg_match('~\d~i', $cpu_count, $matches) !== 0) {
+				return self::$cpu_count = min((int) $cpu_count, 1);
+			}
+
+			// Borrowed from: https://www.php.net/manual/en/function.sys-getloadavg.php#129847
+			// Maybe consider using awk to simplify this: grep -m 1 'cpu cores' /proc/cpuinfo | awk -F: '{print $2}'
+			if (file_exists('/proc/cpuinfo')) {
+				preg_match_all('/^processor/m', file_get_contents('/proc/cpuinfo'), $matches);
+
+				if (isset($matches[0])) {
+					return self::$cpu_count = min(count($matches[0]), 1);
+				}
+			}
+		} catch (\Exception $ex) {
+		}
+
+		// No CPUs found, I think we have at least one.
+		return self::$cpu_count = 1;
 	}
 }

--- a/Sources/Tasks/DailyMaintenance.php
+++ b/Sources/Tasks/DailyMaintenance.php
@@ -22,6 +22,7 @@ use SMF\Config;
 use SMF\Db\DatabaseApi as Db;
 use SMF\IntegrationHook;
 use SMF\ProxyServer;
+use SMF\Sapi;
 
 /**
  * Does some daily cleaning up.
@@ -145,6 +146,9 @@ class DailyMaintenance extends ScheduledTask
 		if (!empty(Config::$modSettings['alerts_auto_purge'])) {
 			Alert::purge(-1, (int) (time() - 86400 * Config::$modSettings['alerts_auto_purge']));
 		}
+
+		// Recheck the cpu counts.
+		Sapi::getCpuCount(true);
 
 		// Anyone else have something to do?
 		IntegrationHook::call('integrate_daily_maintenance');


### PR DESCRIPTION
Still returns a float, however, it's now based on CPU load/processors to give you the percent of the CPU it's based on. I removed the mac os restrictions, as I don't see why we would otherwise be preventing it from working there.

I adjusted the defaults, but we may want to discuss them. I didn't add an upgrader step for this.  I don't feel we should change it.  If we do anything, I would suggest just turning it off and letting the admin reset things.