### PR TITLE
[2.1] Fix ReduceMailQueue task for Postgres

### DIFF
--- a/Sources/ScheduledTasks.php
+++ b/Sources/ScheduledTasks.php
@@ -741,7 +741,7 @@ function ReduceMailQueue($number = false, $override_limit = false, $force_send =
 
 	// Random emails from the queue..
 	if (!empty($ids)) {
-		$request = $smcFunc['db_query']('', '
+		$request = $smcFunc['db_query']('random_mail', '
 			SELECT id_mail, recipient, body, subject, headers, send_html, time_sent, private, priority
 			FROM {db_prefix}mail_queue
 			WHERE id_mail NOT IN ({array_int:ids})

--- a/Sources/Subs-Db-postgresql.php
+++ b/Sources/Subs-Db-postgresql.php
@@ -353,6 +353,9 @@ function smf_db_query($identifier, $db_string, $db_values = array(), $connection
 		'profile_board_stats' => array(
 			'~COUNT\(\*\) \/ MAX\(b.num_posts\)~' => 'CAST(COUNT(*) AS DECIMAL) / CAST(b.num_posts AS DECIMAL)',
 		),
+		'random_mail' => array(
+			'~ORDER BY RAND\(\)~' => 'ORDER BY RANDOM()',
+		),
 	);
 
 	// Special optimizer Hints


### PR DESCRIPTION
Signed-off-by: Michael Eshom <oldiesmann@gmail.com>

#### Description
PostgreSQL uses RANDOM() instead of RAND(), causing the query to find random emails to send to fail

### Issues References 
1. Fixes #8795
