### PR TITLE
[3.0] change mysqli_report to be enabled during debugging

### DIFF
--- a/Sources/Db/APIs/MySQL.php
+++ b/Sources/Db/APIs/MySQL.php
@@ -2496,8 +2496,8 @@ class MySQL extends DatabaseApi implements DatabaseApiInterface
 			ErrorHandler::displayDbError();
 		}
 
-		// This was the default prior to PHP 8.1, and all our code assumes it.
-		mysqli_report(MYSQLI_REPORT_OFF);
+		// Ignore some errors and strict mode warnings when we are not debugging.
+		mysqli_report(Config::$db_show_debug ? MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT : MYSQLI_REPORT_OFF);
 
 		$success = false;
 


### PR DESCRIPTION
When mysqli_report first changed in 8.1, we disabled it i #7126

We have since improved our database standards to fix any issues that strict mode would generate.

This change sets it so when using db_show_debug, we enable the errors/strict mode.  This should ensure that during development processes, we do not introduce any new issues that are being silently ignored.

It would be nice to add `MYSQLI_REPORT_INDEX` to the list, but it seems we can't yet.  It reports no index for a basic `select * from smf_settings`, which while true is not something we can fix due to the table design.