### PR TITLE
[3.0] Improves SMF\TimeZone::getMetaZone()

### DIFF
--- a/Sources/TimeZone.php
+++ b/Sources/TimeZone.php
@@ -1715,9 +1715,13 @@ class TimeZone extends \DateTimeZone
 				$tzgeo['country_code'],
 				Lang::getTxt(
 					'generic_timezone',
-					[Lang::getTxt(['iso3166', $tzgeo['country_code']], file: 'Timezones')],
+					[
+						Lang::getTxt(['iso3166', $tzgeo['country_code']], file: 'Timezones'),
+						'%1$s',
+					],
 					var: 'tztxt',
 				),
+				var: 'tztxt',
 			);
 
 			return $tzgeo['country_code'];

--- a/Sources/TimeZone.php
+++ b/Sources/TimeZone.php
@@ -1714,10 +1714,23 @@ class TimeZone extends \DateTimeZone
 		}
 
 		// Doesn't match any existing metazone. Can we build a custom one?
+
+		// Etc/* is straightforward.
+		if (str_starts_with($this->getName(), 'Etc/')) {
+			Lang::setTxt(
+				$this->getName(),
+				'UTC' . $this->getAbbreviations()[0],
+				var: 'tztxt',
+			);
+
+			return $this->getName();
+		}
+
+		// If this is the only time zone it its country, call it that country's time.
 		$tzgeo = $this->getLocation();
 		$country_tzids = self::getSortedTzidsForCountry($tzgeo['country_code']);
 
-		if (count($country_tzids) === 1) {
+		if ($country_tzids === [$this->getName()]) {
 			Lang::setTxt(
 				$tzgeo['country_code'],
 				Lang::getTxt(
@@ -1734,7 +1747,23 @@ class TimeZone extends \DateTimeZone
 			return $tzgeo['country_code'];
 		}
 
-		return '';
+		// Otherwise, create a meta-zone just for this oddball time zone.
+		if (!Lang::txtExists($this->getName(), var: 'tztxt')) {
+			Lang::setTxt(
+				$this->getName(),
+				Lang::getTxt(
+					'generic_timezone',
+					[
+						$this->getLabel(),
+						'%1$s',
+					],
+					var: 'tztxt',
+				),
+				var: 'tztxt',
+			);
+		}
+
+		return $this->getName();
 	}
 
 	/**

--- a/Sources/TimeZone.php
+++ b/Sources/TimeZone.php
@@ -1696,6 +1696,13 @@ class TimeZone extends \DateTimeZone
 	{
 		list($when, $later) = self::getTimeRange($when);
 
+		if (
+			isset(self::$metazones[$this->getName()])
+			&& Lang::txtExists(self::$metazones[$this->getName()], var: 'tztxt')
+		) {
+			return self::$metazones[$this->getName()];
+		}
+
 		if (empty(self::$metazone_transitions[$when])) {
 			self::buildMetaZoneTransitions($when);
 		}


### PR DESCRIPTION
Fixes #8817 

Also just generally improves robustness when making custom meta-zones for time zones that don't have one for whatever reason.