### PR TITLE
[3.0] Regular users could not edit own profile

### DIFF
--- a/Sources/Actions/Profile/Main.php
+++ b/Sources/Actions/Profile/Main.php
@@ -1033,7 +1033,7 @@ class Main implements ActionInterface, Routable
 		}
 
 		if (isset($security_checks['permission'])) {
-			User::$me->isAllowedTo($security_checks['permission']);
+			User::$me->isAllowedTo($security_checks['permission'], any: true);
 		}
 
 		// Create a token if needed.

--- a/Sources/Menu.php
+++ b/Sources/Menu.php
@@ -451,7 +451,7 @@ class Menu implements \ArrayAccess
 			return false;
 		}
 
-		return !(isset($menu_item['permission']) && !User::$me->allowedTo($menu_item['permission']));
+		return !(isset($menu_item['permission']) && !User::$me->allowedTo($menu_item['permission'], any: true));
 	}
 
 	/**


### PR DESCRIPTION
Permissions is an array, and we want to allow them if they have any of the permissions, not all.

To reproduce this, simply try to edit your "own profile" as a standard user with permissions granted to do so.