### PR TITLE
[3.0] Fix quotes in names for mention handling

### DIFF
--- a/Sources/Mentions.php
+++ b/Sources/Mentions.php
@@ -246,6 +246,7 @@ class Mentions
 		while ($row = Db::$db->fetch_assoc($request)) {
 			if (!isset($existing_mentions[$row['id_member']]) && stripos($body, static::$char . $row['real_name']) === false) {
 				$break = true;
+
 				// SMF 2.1 would store names containing single quotes escaped, 3.0 does not. Compatbility.
 				if (Config::$backward_compatibility && !isset($existing_mentions[$row['id_member']]) && stripos($body, Utils::htmlspecialchars(static::$char . $row['real_name'], ENT_QUOTES)) !== false) {
 					$row['real_name'] = Utils::htmlspecialchars($row['real_name'], ENT_QUOTES);
@@ -485,6 +486,7 @@ class Mentions
 
 			for ($i = 1; $i <= $count; $i++) {
 				$names[] = Utils::htmlspecialchars(Utils::htmlTrim(implode('', array_slice($match, 0, $i))));
+
 				// SMF 2.1 would store names containing single quotes escaped, 3.0 does not. Compatbility.
 				if (Config::$backward_compatibility) {
 					$names[] = Utils::htmlspecialchars(Utils::htmlTrim(implode('', array_slice($match, 0, $i))), ENT_QUOTES);

--- a/Sources/Mentions.php
+++ b/Sources/Mentions.php
@@ -245,7 +245,16 @@ class Mentions
 
 		while ($row = Db::$db->fetch_assoc($request)) {
 			if (!isset($existing_mentions[$row['id_member']]) && stripos($body, static::$char . $row['real_name']) === false) {
-				continue;
+				$break = true;
+				// SMF 2.1 would store names containing single quotes escaped, 3.0 does not. Compatbility.
+				if (Config::$backward_compatibility && !isset($existing_mentions[$row['id_member']]) && stripos($body, Utils::htmlspecialchars(static::$char . $row['real_name'], ENT_QUOTES)) !== false) {
+					$row['real_name'] = Utils::htmlspecialchars($row['real_name'], ENT_QUOTES);
+					$break = false;
+				}
+
+				if ($break) {
+					continue;
+				}
 			}
 
 			$members[$row['id_member']] = [
@@ -476,6 +485,10 @@ class Mentions
 
 			for ($i = 1; $i <= $count; $i++) {
 				$names[] = Utils::htmlspecialchars(Utils::htmlTrim(implode('', array_slice($match, 0, $i))));
+				// SMF 2.1 would store names containing single quotes escaped, 3.0 does not. Compatbility.
+				if (Config::$backward_compatibility) {
+					$names[] = Utils::htmlspecialchars(Utils::htmlTrim(implode('', array_slice($match, 0, $i))), ENT_QUOTES);
+				}
 			}
 		}
 

--- a/Themes/default/scripts/mentions.js
+++ b/Themes/default/scripts/mentions.js
@@ -43,6 +43,25 @@ var atwhoConfig = {
 					callback(callbackArray);
 				}
 			});
+		},
+		tplEval: function (tpl, map, caller) {
+			var error, error1, template;
+			template = tpl;
+			try {
+			  if (typeof tpl !== 'string') {
+				template = tpl(map);
+			  }
+			  /* When SCEditor is disabled, inserted names may contain some HTML if it was escaped. */
+			  if (caller == 'onInsert') {
+			  	map['name'] = map['name'].toString().replace("&#034;", '"').replace('&#39;', "'");
+			  }
+			  return template.replace(/\$\{([^\}]*)\}/g, function(tag, key, pos) {
+				return map[key];
+			  });
+			} catch (error1) {
+			  error = error1;
+			  return "";
+			}
 		}
 	}
 };


### PR DESCRIPTION
Fixes #8820

Big note, 2.1 handled names differently, so a bit of compatibility had to be added here.

If #8132 is accepted, then it needs to ensure it doesn't reintroduce this issue.

@Sesquipedalian I am not happy with how the fix had to come out for handling the entities issue.  If you have a better idea, please chime in or introduce an alternative PR.
I tested by changing a member's name to `Apasta'fee`.  In SMF 2.1, the database value is `Apasta&#39;fee` and in 3.0 it is `Apasta'fee`.  2.1 and 3.0 both handle a double quote the same by encoding it (i.e., `Double&quot;Quotes`)
