### PR TITLE
[3.0] Fix unparsed text warning while posting

### DIFF
--- a/Sources/Actions/Post.php
+++ b/Sources/Actions/Post.php
@@ -899,9 +899,7 @@ class Post implements ActionInterface, Routable
 		Db::$db->free_result($request);
 
 		if (!empty(Utils::$context['new_replies'])) {
-			Lang::setTxt('error_new_replies', Lang::getTxt('error_new_replies' . (isset($_GET['last_msg']) ? '_reading' : ''), [Utils::$context['new_replies']], file: 'Post'));
-
-			$this->errors[] = 'new_replies';
+			$this->errors[] = ['new_replies' . (isset($_GET['last_msg']) ? '_reading' : ''), Utils::$context['new_replies']];
 
 			Config::$modSettings['topicSummaryPosts'] = Utils::$context['new_replies'] > Config::$modSettings['topicSummaryPosts'] ? max(Config::$modSettings['topicSummaryPosts'], 5) : Config::$modSettings['topicSummaryPosts'];
 		}


### PR DESCRIPTION
I couldn't figure out why setTxt didn't work in this example.  Dumping the var out after it ran shows it is set, but by the time it returns to the main Post function, that is lost.  This works. since we can accept a parameter anyways.