### PR TITLE
[3.0] Improve admin search time

### DIFF
--- a/Sources/Actions/Admin/Find.php
+++ b/Sources/Actions/Admin/Find.php
@@ -240,6 +240,10 @@ class Find implements ActionInterface
 		Utils::$context['page_title'] = Lang::getTxt('admin_search_results', file: 'Admin');
 		Utils::$context['search_results'] = [];
 
+		// Load all the languages first, not doing so slow.
+		// Do not use the $file param in any Lang calls.
+		Lang::load(implode('+', $this->language_files));
+
 		$search_term = strtolower(Utils::htmlspecialcharsDecode(Utils::$context['search_term']));
 
 		// Go through all the search data trying to find this text!
@@ -255,12 +259,12 @@ class Find implements ActionInterface
 					if (
 						stripos($term, $search_term) !== false
 						|| (
-							Lang::txtExists($term, file: implode('+', $this->language_files))
-							&& stripos(Lang::getTxt($term, file: implode('+', $this->language_files)), $search_term) !== false
+							Lang::txtExists($term)
+							&& stripos(Lang::getTxt($term), $search_term) !== false
 						)
 						|| (
-							Lang::txtExists('setting_' . $term, file: implode('+', $this->language_files))
-							&& stripos(Lang::getTxt('setting_' . $term, file: implode('+', $this->language_files)), $search_term) !== false
+							Lang::txtExists('setting_' . $term)
+							&& stripos(Lang::getTxt('setting_' . $term), $search_term) !== false
 						)
 					) {
 						$found = $term;
@@ -270,7 +274,7 @@ class Find implements ActionInterface
 
 				if ($found) {
 					// Format the name - and remove any descriptions the entry may have.
-					$name = Lang::txtExists($found, file: 'Admin') ? Lang::getTxt($found, file: 'Admin') : (Lang::txtExists('setting_' . $found, file: 'Admin') ? Lang::getTxt('setting_' . $found, file: 'Admin') : (!empty($item['alttxt']) ? $item['alttxt'] : $found));
+					$name = Lang::txtExists($found) ? Lang::getTxt($found) : (Lang::txtExists('setting_' . $found) ? Lang::getTxt('setting_' . $found) : (!empty($item['alttxt']) ? $item['alttxt'] : $found));
 
 					$name = preg_replace('~<(?:div|span)\sclass="smalltext">.+?</(?:div|span)>~', '', $name);
 

--- a/Sources/Lang.php
+++ b/Sources/Lang.php
@@ -410,6 +410,11 @@ class Lang
 			self::$already_loaded[$name] = $lang;
 		}
 
+		// We loaded a batch of files? Indicate that as well.
+		if (strpos($filename, '+') !== false) {
+			self::$already_loaded[$filename] = $lang;
+		}
+
 		// Return the language actually loaded.
 		return $lang;
 	}


### PR DESCRIPTION
Fixes #8812

The issue exists for a few reasons.
`lang:txtExists` checks for already loaded differently than `getTxt`.  `txtExists` only checks the `$filename` and doesn't take into account that when we called the `load` we set the checks on existing files per file, not per batch/group when using the `+`.  `getTxt` checks by seeing if the actual key exists, well at least the first one in the array.

The main solution is the first as @live627 pointed out and to call the `load` outside the loop.  Then remove the references to the `$file` parameter, which prevents the logic from including and loading the same language files a few thousand times.  This brought us from about 10 seconds to half a second.

A secondary fix that does offer a improvement (from about 10 seconds to 3.5 seconds without the previous fix) is when loading a batch/group of files, store that result as well.

