### PR TITLE
Improves performance in Lang::txtExists() && Lang::getTxt(), plus other fixes

### DIFF
--- a/Sources/Actions/Admin/ACP.php
+++ b/Sources/Actions/Admin/ACP.php
@@ -743,6 +743,7 @@ class ACP implements ActionInterface, Routable
 		$menu = new Menu($this->admin_areas, [
 			'do_big_icons' => true,
 			'disable_hook_call' => true,
+			'lang_file' => 'Admin',
 		]);
 
 		// Nothing valid?
@@ -759,14 +760,14 @@ class ACP implements ActionInterface, Routable
 		if (isset($menu->current_area) && $menu->current_area != 'index') {
 			Utils::$context['linktree'][] = [
 				'url' => Config::$scripturl . '?action=admin;area=' . $menu->current_area . ';' . Utils::$context['session_var'] . '=' . Utils::$context['session_id'],
-				'name' => $menu->include_data['label'],
+				'name' => Lang::txtExists($menu->include_data['label']) ? Lang::getTxt($menu->include_data['label']) : $menu->include_data['label'],
 			];
 		}
 
 		if (!empty($menu->current_subsection) && $menu->include_data['subsections'][$menu->current_subsection]['label'] != $menu->include_data['label']) {
 			Utils::$context['linktree'][] = [
 				'url' => Config::$scripturl . '?action=admin;area=' . $menu->current_area . ';sa=' . $menu->current_subsection . ';' . Utils::$context['session_var'] . '=' . Utils::$context['session_id'],
-				'name' => $menu->include_data['subsections'][$menu->current_subsection]['label'],
+				'name' => Lang::txtExists($menu->include_data['subsections'][$menu->current_subsection]['label']) ? Lang::getTxt($menu->include_data['subsections'][$menu->current_subsection]['label']) : $menu->include_data['subsections'][$menu->current_subsection]['label'],
 			];
 		}
 
@@ -1897,10 +1898,6 @@ class ACP implements ActionInterface, Routable
 		array_walk_recursive(
 			$this->admin_areas,
 			function (&$value, $key) {
-				if (in_array($key, ['title', 'label'])) {
-					$value = Lang::txtExists($value, file: 'Admin') ? Lang::getTxt($value, file: 'Admin') : $value;
-				}
-
 				if (is_string($value)) {
 					$value = strtr($value, [
 						'{scripturl}' => Config::$scripturl,

--- a/Sources/Actions/Admin/Find.php
+++ b/Sources/Actions/Admin/Find.php
@@ -216,12 +216,12 @@ class Find implements ActionInterface
 		// Go through the admin menu structure trying to find suitably named areas!
 		foreach (Menu::$loaded['admin']['sections'] as $section) {
 			foreach ($section['areas'] as $menu_key => $menu_item) {
-				$search_data['sections'][] = [$menu_item['label'], 'area=' . $menu_key];
+				$search_data['sections'][] = [$menu_item['txt_key'], 'area=' . $menu_key];
 
 				if (!empty($menu_item['subsections'])) {
 					foreach ($menu_item['subsections'] as $key => $sublabel) {
-						if (isset($sublabel['label'])) {
-							$search_data['sections'][] = [$sublabel['label'], 'area=' . $menu_key . ';sa=' . $key];
+						if (isset($sublabel['txt_key'])) {
+							$search_data['sections'][] = [$sublabel['txt_key'], 'area=' . $menu_key . ';sa=' . $key];
 						}
 					}
 				}

--- a/Sources/Actions/Admin/Find.php
+++ b/Sources/Actions/Admin/Find.php
@@ -106,6 +106,8 @@ class Find implements ActionInterface
 	 * add the language file to this array via the integrate_admin_search hook.
 	 */
 	public array $language_files = [
+		'General',
+		'Admin',
 		'Drafts',
 		'Help',
 		'Login',

--- a/Sources/Actions/Admin/Find.php
+++ b/Sources/Actions/Admin/Find.php
@@ -244,6 +244,9 @@ class Find implements ActionInterface
 
 		$search_term = strtolower(Utils::htmlspecialcharsDecode(Utils::$context['search_term']));
 
+		// Avoid imploding these strings on every Lang call below.
+		Lang::load(implode('+', $this->language_files), force_reload: true);
+
 		// Go through all the search data trying to find this text!
 		foreach ($search_data as $section => $data) {
 			foreach ($data as $item) {
@@ -257,12 +260,12 @@ class Find implements ActionInterface
 					if (
 						stripos($term, $search_term) !== false
 						|| (
-							Lang::txtExists($term, file: implode('+', $this->language_files))
-							&& stripos(Lang::getTxt($term, file: implode('+', $this->language_files)), $search_term) !== false
+							Lang::txtExists($term)
+							&& stripos(Lang::getTxt($term), $search_term) !== false
 						)
 						|| (
-							Lang::txtExists('setting_' . $term, file: implode('+', $this->language_files))
-							&& stripos(Lang::getTxt('setting_' . $term, file: implode('+', $this->language_files)), $search_term) !== false
+							Lang::txtExists('setting_' . $term)
+							&& stripos(Lang::getTxt('setting_' . $term), $search_term) !== false
 						)
 					) {
 						$found = $term;

--- a/Sources/Actions/Admin/Find.php
+++ b/Sources/Actions/Admin/Find.php
@@ -272,7 +272,7 @@ class Find implements ActionInterface
 
 				if ($found) {
 					// Format the name - and remove any descriptions the entry may have.
-					$name = Lang::txtExists($found, file: 'Admin') ? Lang::getTxt($found, file: 'Admin') : (Lang::txtExists('setting_' . $found, file: 'Admin') ? Lang::getTxt('setting_' . $found, file: 'Admin') : (!empty($item['alttxt']) ? $item['alttxt'] : $found));
+					$name = Lang::txtExists($found) ? Lang::getTxt($found) : (Lang::txtExists('setting_' . $found) ? Lang::getTxt('setting_' . $found) : (!empty($item['alttxt']) ? $item['alttxt'] : $found));
 
 					$name = preg_replace('~<(?:div|span)\sclass="smalltext">.+?</(?:div|span)>~', '', $name);
 

--- a/Sources/Actions/Moderation/Main.php
+++ b/Sources/Actions/Moderation/Main.php
@@ -265,6 +265,7 @@ class Main implements ActionInterface, Routable
 		$menuOptions = [
 			'action' => 'moderate',
 			'disable_url_session_check' => true,
+			'lang_file' => 'ModerationCenter',
 		];
 
 		$menu = new Menu($this->moderation_areas, $menuOptions);
@@ -300,14 +301,14 @@ class Main implements ActionInterface, Routable
 		if (isset($menu->current_area) && $menu->current_area != 'index') {
 			Utils::$context['linktree'][] = [
 				'url' => Config::$scripturl . '?action=moderate;area=' . $menu->current_area,
-				'name' => $menu->include_data['label'],
+				'name' => Lang::txtExists($menu->include_data['label']) ? Lang::getTxt($menu->include_data['label']) : $menu->include_data['label'],
 			];
 		}
 
 		if (!empty($menu->current_subsection) && $menu->include_data['subsections'][$menu->current_subsection]['label'] != $menu->include_data['label']) {
 			Utils::$context['linktree'][] = [
 				'url' => Config::$scripturl . '?action=moderate;area=' . $menu->current_area . ';sa=' . $menu->current_subsection,
-				'name' => $menu->include_data['subsections'][$menu->current_subsection]['label'],
+				'name' => Lang::txtExists($menu->include_data['subsections'][$menu->current_subsection]['label']) ? Lang::getTxt($menu->include_data['subsections'][$menu->current_subsection]['label']) : $menu->include_data['subsections'][$menu->current_subsection]['label'],
 			];
 		}
 	}
@@ -429,10 +430,6 @@ class Main implements ActionInterface, Routable
 		array_walk_recursive(
 			$this->moderation_areas,
 			function (&$value, $key) {
-				if (in_array($key, ['title', 'label'])) {
-					$value = Lang::txtExists($value, file: 'ModerationCenter') ? Lang::getTxt($value, file: 'ModerationCenter') : $value;
-				}
-
 				if (is_string($value)) {
 						$value = strtr($value, [
 							'{scripturl}' => Config::$scripturl,

--- a/Sources/Actions/Profile/Main.php
+++ b/Sources/Actions/Profile/Main.php
@@ -620,14 +620,14 @@ class Main implements ActionInterface, Routable
 		if (!empty($menu->include_data['label'])) {
 			Utils::$context['linktree'][] = [
 				'url' => Config::$scripturl . '?action=profile' . (Profile::$member->id != User::$me->id ? ';u=' . Profile::$member->id : '') . ';area=' . $menu->current_area,
-				'name' => $menu->include_data['label'],
+				'name' => Lang::txtExists($menu->include_data['label']) ? Lang::getTxt($menu->include_data['label']) : $menu->include_data['label'],
 			];
 		}
 
 		if (!empty($menu->current_subsection) && $menu->include_data['subsections'][$menu->current_subsection]['label'] != $menu->include_data['label']) {
 			Utils::$context['linktree'][] = [
 				'url' => Config::$scripturl . '?action=profile' . (Profile::$member->id != User::$me->id ? ';u=' . Profile::$member->id : '') . ';area=' . $menu->current_area . ';sa=' . $menu->current_subsection,
-				'name' => $menu->include_data['subsections'][$menu->current_subsection]['label'],
+				'name' => Lang::txtExists($menu->include_data['subsections'][$menu->current_subsection]['label']) ? Lang::getTxt($menu->include_data['subsections'][$menu->current_subsection]['label']) : $menu->include_data['subsections'][$menu->current_subsection]['label'],
 			];
 		}
 
@@ -848,10 +848,6 @@ class Main implements ActionInterface, Routable
 		array_walk_recursive(
 			$this->profile_areas,
 			function (&$value, $key) {
-				if (in_array($key, ['title', 'label'])) {
-					$value = Lang::txtExists($value, file: 'Profile') ? Lang::getTxt($value, file: 'Profile') : $value;
-				}
-
 				if (is_string($value)) {
 					$value = strtr($value, [
 						'{scripturl}' => Config::$scripturl,
@@ -943,6 +939,7 @@ class Main implements ActionInterface, Routable
 			'extra_url_parameters' => [
 				'u' => Profile::$member->id,
 			],
+			'lang_file' => 'Profile',
 		];
 
 		// Actually create the menu!

--- a/Sources/Lang.php
+++ b/Sources/Lang.php
@@ -602,39 +602,9 @@ class Lang
 			throw new \ValueError();
 		}
 
-		// Can we guess the file based on $var?
-		if (!isset($file)) {
-			switch ($var) {
-				case 'tztxt':
-					$file = 'Timezones';
-					break;
+		$txt_key = array_values((array) $txt_key);
 
-				case 'editortxt':
-					$file = 'Editor';
-					break;
-
-				case 'helptxt':
-					$file = 'Help';
-					break;
-
-				case 'txtBirthdayEmails':
-					$file = 'EmailTemplates';
-					break;
-			}
-		}
-
-		// Load the specified file.
-		if (is_string($file) && !isset(self::$already_loaded[$file])) {
-			self::load($file, $lang, force_reload: true);
-
-			if (!str_contains($file, 'Modifications')) {
-				self::load('Modifications', $lang, fatal: false, force_reload: true);
-			}
-
-			if (!str_contains($file, 'ThemeStrings')) {
-				self::load('ThemeStrings', $lang, fatal: false, force_reload: true);
-			}
-		}
+		self::loadFileForGetTxt($file, $var, $txt_key, '');
 
 		$target = &self::${$var};
 
@@ -734,58 +704,7 @@ class Lang
 			$lang = User::$me->language ?? self::$default;
 		}
 
-		// Can we guess the file based on $var?
-		if (!isset($file)) {
-			switch ($var) {
-				case 'tztxt':
-					$file = 'Timezones';
-					break;
-
-				case 'editortxt':
-					$file = 'Editor';
-					break;
-
-				case 'helptxt':
-					$file = 'Help';
-					break;
-
-				case 'txtBirthdayEmails':
-					$file = 'EmailTemplates';
-					break;
-			}
-		}
-
-		// Check whether we need to load the specified file.
-		if (
-			is_string($file)
-			&& (
-				// If we haven't loaded the file yet, do so now.
-				!isset(self::$loaded_keys[$var][$txt_key[0]])
-
-				// If we loaded it for a different language, reload for the right language.
-				|| self::$loaded_keys[$var][$txt_key[0]]['lang'] !== $lang
-
-				// In the event of key conflicts between different files, give
-				// them the string from the requested file. HOWEVER, if the key
-				// was overwritten in the Modifications or ThemeStrings language
-				// files, then keep that version instead.
-				|| (
-					self::$loaded_keys[$var][$txt_key[0]]['file'] !== $file
-					&& self::$loaded_keys[$var][$txt_key[0]]['file'] !== 'ThemeStrings'
-					&& self::$loaded_keys[$var][$txt_key[0]]['file'] !== 'Modifications'
-				)
-			)
-		) {
-			self::load($file, $lang, force_reload: true);
-
-			if (!str_contains($file, 'Modifications')) {
-				self::load('Modifications', $lang, fatal: false, force_reload: true);
-			}
-
-			if (!str_contains($file, 'ThemeStrings')) {
-				self::load('ThemeStrings', $lang, fatal: false, force_reload: true);
-			}
-		}
+		self::loadFileForGetTxt($file, $var, $txt_key, $lang);
 
 		// Don't waste time when getting a simple string.
 		if ($args === [] && count($txt_key) === 1) {
@@ -1147,6 +1066,97 @@ class Lang
 		}
 
 		return $found;
+	}
+
+	/*************************
+	 * Internal static methods
+	 *************************/
+
+	/**
+	 * Helper for Lang::txtExists() and Lang::getTxt() that handles loading the
+	 * requested file or files.
+	 *
+	 * @param ?string $file Name of a language file to load. This is not needed
+	 *    when $var is 'helptxt', 'editortxt', 'tztxt', or 'txtBirthdayEmails'.
+	 *    To load multiple files, concatenate their names using '+'.
+	 * @param string $var Name of the array to search in. Allowed values are
+	 *    'txt', 'helptxt', 'editortxt', 'tztxt', and 'txtBirthdayEmails'.
+	 * @param string|array $txt_key The key of the Lang::${$var} array that
+	 *    contains the desired string. If this is an array, each item of the
+	 *    array will be used as a sub-key to drill down into deeper levels of
+	 *    the overall array.
+	 * @param string $lang A specific language to load $file from. Use an empty
+	 *    string if the language doesn't matter.
+	 */
+	private static function loadFileForGetTxt(?string $file, string $var, array $txt_key, string $lang): void
+	{
+		// Can we guess the file based on $var?
+		if (!isset($file)) {
+			switch ($var) {
+				case 'tztxt':
+					$file = 'Timezones';
+					break;
+
+				case 'editortxt':
+					$file = 'Editor';
+					break;
+
+				case 'helptxt':
+					$file = 'Help';
+					break;
+
+				case 'txtBirthdayEmails':
+					$file = 'EmailTemplates';
+					break;
+
+				default:
+					// No file specified, so there's nothing else to do.
+					return;
+			}
+		}
+
+		// Get the list of files.
+		$files = array_unique(array_merge(
+			array_filter(explode('+', $file ?? '')),
+			// Append these files to the list because they might override the
+			// normal value.
+			['ThemeStrings', 'Modifications'],
+		));
+
+		// The string has not been loaded.
+		if (!isset(self::$loaded_keys[$var][$txt_key[0]])) {
+			self::load(
+				filename: implode('+', $files),
+				lang: $lang,
+			);
+
+			return;
+		}
+
+		// The string has been loaded but did not come from an expected file.
+		if (!in_array(self::$loaded_keys[$var][$txt_key[0]]['file'], $files)) {
+			self::load(
+				filename: implode('+', $files),
+				lang: $lang,
+				force_reload: true,
+			);
+
+			return;
+		}
+
+		// The string has been loaded from an expected file, but in the wrong language.
+		if (
+			!empty($lang)
+			&& self::$loaded_keys[$var][$txt_key[0]]['lang'] !== $lang
+		) {
+			self::load(
+				filename: self::$loaded_keys[$var][$txt_key[0]]['file'],
+				lang: $lang,
+				force_reload: true,
+			);
+
+			return;
+		}
 	}
 }
 

--- a/Sources/Lang.php
+++ b/Sources/Lang.php
@@ -231,7 +231,7 @@ class Lang
 	 * back to English as a last resort.
 	 *
 	 * @param string $filename The name of a language file, without the file
-	 *    extension.
+	 *    extension. To load multiple files, concatenate their names using '+'.
 	 * @param string $lang A specific language to load this file from.
 	 * @param bool $fatal Whether to die with an error if it can't be loaded.
 	 * @param bool $force_reload Whether to load the file again if it's already
@@ -582,20 +582,19 @@ class Lang
 	/**
 	 * Checks whether the specified language string exists.
 	 *
-	 * @param string|array $txt_key The key of the Lang::$txt array to check.
+	 * @param string|array $txt_key The key of the Lang::${$var} array to check.
 	 *    If this is an array, each item of the array will be used as a sub-key
 	 *    to drill down into deeper levels of the overall array.
 	 * @param string $var Name of the array to search in. Default: 'txt'.
 	 *    Other possible values are 'helptxt', 'editortxt', and 'tztxt'.
 	 * @param ?string $file Name of a language file to load. This is not needed
 	 *    when $var is 'helptxt', 'editortxt', 'tztxt', or 'txtBirthdayEmails'.
+	 *    To load multiple files, concatenate their names using '+'.
 	 *    Default: null.
-	 * @param string $lang A specific language to load $file from. If empty,
-	 *    defaults to the current user's preferred language.
 	 * @throws \ValueError if $var is invalid.
-	 * @return bool Whether or not the specified language string exists
+	 * @return bool Whether or not the specified language string exists.
 	 */
-	public static function txtExists(string|array $txt_key, string $var = 'txt', ?string $file = null, string $lang = ''): bool
+	public static function txtExists(string|array $txt_key, string $var = 'txt', ?string $file = null): bool
 	{
 		// Validate $var.
 		if (!in_array($var, ['txt', 'tztxt', 'editortxt', 'helptxt', 'txtBirthdayEmails'])) {
@@ -625,7 +624,7 @@ class Lang
 	 *
 	 * Used for dynamically generated strings.
 	 *
-	 * @param string|array $txt_key The key of the Lang::$txt array that
+	 * @param string|array $txt_key The key of the Lang::${$var} array that
 	 *    contains the desired string. If this is an array, each item of the
 	 *    array will be used as a sub-key to drill down into deeper levels of
 	 *    the overall array.
@@ -674,7 +673,7 @@ class Lang
 	 * requested string. The method can handle argument substitution for both
 	 * MessageFormat and sprintf format strings.
 	 *
-	 * @param string|array $txt_key The key of the Lang::$txt array that
+	 * @param string|array $txt_key The key of the Lang::${$var} array that
 	 *    contains the desired string. If this is an array, each item of the
 	 *    array will be used as a sub-key to drill down into deeper levels of
 	 *    the overall array.
@@ -684,6 +683,7 @@ class Lang
 	 *    Default: 'txt'.
 	 * @param ?string $file Name of a language file to load. This is not needed
 	 *    when $var is 'helptxt', 'editortxt', 'tztxt', or 'txtBirthdayEmails'.
+	 *    To load multiple files, concatenate their names using '+'.
 	 *    Default: null.
 	 * @param string $lang A specific language to load $file from. If empty,
 	 *    defaults to the current user's preferred language.

--- a/Sources/Lang.php
+++ b/Sources/Lang.php
@@ -310,17 +310,35 @@ class Lang
 							continue;
 						}
 
-						// Add the strings to the appropriate array.
-						self::${$var} = array_merge(self::${$var}, ${$var});
+						foreach (${$var} as $key => $value) {
+							// Don't overwrite strings from Modifications or ThemeStrings
+							// unless $force_reload is true.
+							if (
+								!$force_reload
+								&& array_key_exists($key, self::$loaded_keys[$var] ?? [])
+								&& self::$loaded_keys[$var][$key]['file'] !== $file[1]
+								&& (
+									// Modifications takes precedence over all others.
+									self::$loaded_keys[$var][$key]['file'] === 'Modifications'
+									// ThemeStrings takes precedence over all except Modifications.
+									|| (
+										self::$loaded_keys[$var][$key]['file'] === 'ThemeStrings'
+										&& $file[1] !== 'Modifications'
+									)
+								)
+							) {
+								continue;
+							}
 
-						// Keep track of where these strings came from.
-						self::$loaded_keys[$var] = array_merge(
-							self::$loaded_keys[$var] ?? [],
-							array_combine(
-								array_keys(${$var}),
-								array_fill(0, count(${$var}), ['file' => $file[1], 'lang' => $file[2]]),
-							),
-						);
+							// Add the string to the appropriate array.
+							self::${$var}[$key] = $value;
+
+							// Keep track of where this string came from.
+							self::$loaded_keys[$var][$key] = [
+								'file' => $file[1],
+								'lang' => $file[2],
+							];
+						}
 
 						unset(${$var});
 					}

--- a/Sources/Lang.php
+++ b/Sources/Lang.php
@@ -269,12 +269,17 @@ class Lang
 
 			foreach (self::$dirs as $dir) {
 				$attempts[] = [$dir, $name, $lang];
-				$attempts[] = [$dir, $name, self::$default];
-			}
 
-			// Fall back to English if none of the preferred languages can be found.
-			if (empty(Config::$modSettings['disable_language_fallback']) && !in_array('en_US', [$lang, self::$default])) {
-				foreach (self::$dirs as $dir) {
+				if ($lang !== self::$default) {
+					$attempts[] = [$dir, $name, self::$default];
+				}
+
+				// Fall back to English if none of the preferred languages can be found.
+				if (
+					empty(Config::$modSettings['disable_language_fallback'])
+					&& 'en_US' !== self::$default
+					&& 'en_US' !== $lang
+				) {
 					$attempts[] = [$dir, $name, 'en_US'];
 				}
 			}

--- a/Sources/Mail.php
+++ b/Sources/Mail.php
@@ -1047,8 +1047,8 @@ class Mail
 	public static function loadEmailTemplate(string $template, array $replacements = [], string $lang = '', bool $loadLang = true): array
 	{
 		if (
-			!Lang::txtExists($template . '_subject', file: 'EmailTemplates', lang: $loadLang ? $lang : '')
-			|| !Lang::txtExists($template . '_body', file: 'EmailTemplates', lang: $loadLang ? $lang : '')
+			!Lang::txtExists($template . '_subject', file: 'EmailTemplates')
+			|| !Lang::txtExists($template . '_body', file: 'EmailTemplates')
 		) {
 			ErrorHandler::fatalLang('email_no_template', 'template', [$template]);
 		}
@@ -1056,7 +1056,7 @@ class Mail
 		$ret = [
 			'subject' => Lang::getTxt($template . '_subject', file: 'EmailTemplates', lang: $loadLang ? $lang : ''),
 			'body' => Lang::getTxt($template . '_body', file: 'EmailTemplates', lang: $loadLang ? $lang : ''),
-			'is_html' => Lang::txtExists($template . '_html', file: 'EmailTemplates', lang: $loadLang ? $lang : ''),
+			'is_html' => Lang::txtExists($template . '_html', file: 'EmailTemplates'),
 		];
 
 		// Add in the default replacements.

--- a/Sources/Menu.php
+++ b/Sources/Menu.php
@@ -293,6 +293,10 @@ class Menu implements \ArrayAccess
 		// In most cases, referring to a menu by the associated action is easiest.
 		self::$loaded[$this->current_action] = $this;
 
+		if (!isset($this->options['lang_file'])) {
+			$this->options['lang_file'] = 'General';
+		}
+
 		/*
 		 * Allow extending *any* menu with a single hook.
 		 *
@@ -468,7 +472,8 @@ class Menu implements \ArrayAccess
 
 		$this->sections[$this->section_id] = [
 			'id' => $this->section_id,
-			'title' => $section['title'],
+			'txt_key' => $section['title'],
+			'title' => Lang::txtExists($section['title'], file: $this->options['lang_file']) ? Lang::getTxt($section['title'], file: $this->options['lang_file']) : $section['title'],
 			'amt' => $section['amt'] ?? null,
 			'areas' => [],
 			'selected' => false,
@@ -498,7 +503,7 @@ class Menu implements \ArrayAccess
 			return;
 		}
 
-		if (!isset($area['label']) && (!Lang::txtExists($this->area_id) || isset($area['select']))) {
+		if (!isset($area['label']) && (!Lang::txtExists($this->area_id, file: $this->options['lang_file']) || isset($area['select']))) {
 			$this->setCurrentSectionAndArea();
 
 			return;
@@ -519,7 +524,8 @@ class Menu implements \ArrayAccess
 		// Define the new area.
 		$this->sections[$this->section_id]['areas'][$this->area_id] = [
 			'id' => $this->area_id,
-			'label' => $area['label'] ?? (Lang::txtExists($this->area_id) ? Lang::getTxt($this->area_id) : $this->area_id),
+			'txt_key' => $area['label'] ?? $this->area_id,
+			'label' => isset($area['label']) && Lang::txtExists($area['label'], file: $this->options['lang_file']) ? Lang::getTxt($area['label'], file: $this->options['lang_file']) : (Lang::txtExists($this->area_id, file: $this->options['lang_file']) ? Lang::getTxt($this->area_id, file: $this->options['lang_file']) : $this->area_id),
 			'url' => $area['custom_url'] ?? $this->base_url . ';area=' . $this->area_id,
 			'amt' => $area['amt'] ?? null,
 			'subsections' => [],
@@ -591,7 +597,8 @@ class Menu implements \ArrayAccess
 		// Define the new subsection.
 		$this_area['subsections'][$this->subsection_id] = [
 			'id' => $this->subsection_id,
-			'label' => $subsection['label'],
+			'txt_key' => $subsection['label'],
+			'label' => Lang::txtExists($subsection['label'], file: $this->options['lang_file']) ? Lang::getTxt($subsection['label'], file: $this->options['lang_file']) : $subsection['label'],
 			'url' => $subsection['url'] ?? $this->base_url . ';area=' . $this->area_id . ';sa=' . $this->subsection_id,
 			'amt' => $subsection['amt'] ?? null,
 			'selected' => false,

--- a/Sources/Parsers/BBCodeParser.php
+++ b/Sources/Parsers/BBCodeParser.php
@@ -1323,7 +1323,6 @@ class BBCodeParser extends Parser
 						&& Lang::txtExists(
 							substr($matches[1], strlen($var) + 1),
 							var: $var,
-							lang: self::$locale,
 						)
 					) {
 						return Lang::getTxt(


### PR DESCRIPTION
Fixes #8812
Closes #8842

1. Improves performance in SMF\Lang::txtExists() && SMF\Lang::getTxt() and makes some other minor improvements in SMF\Lang methods:
    - [Avoid redundant loading attempts in Lang::load()](https://github.com/SimpleMachines/SMF/pull/8844/commits/029ae108bf8484ee3365363da2b1076ff0dd9bfa) 
    - [Avoid overwriting mod & theme strings unless forced](https://github.com/SimpleMachines/SMF/pull/8844/commits/f501ec2b8261a5e85b7dbdabab41cc611c138630) 
    - [Improve performance in Lang::txtExists() & Lang::getTxt()](https://github.com/SimpleMachines/SMF/pull/8844/commits/fe815f4e39893a2cf72ac5bdb2eb23647ab60bba) 
    - [Remove useless $lang param from Lang::txtExists() & fix documentation](https://github.com/SimpleMachines/SMF/pull/8844/commits/d53ea6ce8224d3fb8631613a76a13609f2181d12) 
3. Fixes several things that were wrong in SMF\Actions\Admin\Find, such as trying to load strings based on their values rather than their keys.
    - [Sets menu titles & labels at a later stage in the process](https://github.com/SimpleMachines/SMF/pull/8844/commits/3783be07609fd25d1d20bb2379d471ea13a00075) 
    - [Adds General and Admin to SMF\Actions\Admin\Find::$language_files](https://github.com/SimpleMachines/SMF/pull/8844/commits/96036deca87f66d2750747cda37ec35325043271) 
    - [Use txt_key, not label, in admin search data](https://github.com/SimpleMachines/SMF/pull/8844/commits/c9831b3616fdf8c8c80e91d8d49a00cda17afe26) 
    - [Found string might not be from Admin language file](https://github.com/SimpleMachines/SMF/pull/8844/commits/512389790de8111c76939250986486cfc30807bb) 
    - [No need to implode() repeatedly](https://github.com/SimpleMachines/SMF/pull/8844/commits/610846d68e64346d85261eeba7a8eab6b59d00d2)