### PR TITLE
[3.0] Various fixes

### DIFF
--- a/Sources/Actions/BoardIndex.php
+++ b/Sources/Actions/BoardIndex.php
@@ -296,7 +296,7 @@ class BoardIndex implements ActionInterface, Routable
 		if (!empty($board_index_options['set_latest_post'])) {
 			$latest_post = [
 				'timestamp' => 0,
-				'ref' => 0,
+				'ref' => [],
 			];
 		}
 

--- a/Sources/Actions/Calendar.php
+++ b/Sources/Actions/Calendar.php
@@ -279,16 +279,16 @@ class Calendar implements ActionInterface, Routable
 		}
 
 		// Load up the previous and next months.
-		Utils::$context['calendar_grid_current'] = self::getCalendarGrid($curPage['start_date'], $calendarOptions, false, false);
+		Utils::$context['calendar_grid_current'] = self::getCalendarGrid($curPage['start_date'], $calendarOptions, false);
 
 		// Only show previous month if it isn't pre-January of the min-year
 		if (Utils::$context['calendar_grid_current']['previous_calendar']['year'] > Config::$modSettings['cal_minyear'] || $curPage['month'] != 1) {
-			Utils::$context['calendar_grid_prev'] = self::getCalendarGrid(Utils::$context['calendar_grid_current']['previous_calendar']['start_date'], $calendarOptions, true, false);
+			Utils::$context['calendar_grid_prev'] = self::getCalendarGrid(Utils::$context['calendar_grid_current']['previous_calendar']['start_date'], $calendarOptions, true);
 		}
 
 		// Only show next month if it isn't post-December of the max-year
 		if (Utils::$context['calendar_grid_current']['next_calendar']['year'] < Config::$modSettings['cal_maxyear'] || $curPage['month'] != 12) {
-			Utils::$context['calendar_grid_next'] = self::getCalendarGrid(Utils::$context['calendar_grid_current']['next_calendar']['start_date'], $calendarOptions, false, false);
+			Utils::$context['calendar_grid_next'] = self::getCalendarGrid(Utils::$context['calendar_grid_current']['next_calendar']['start_date'], $calendarOptions, false);
 		}
 
 		// Basic template stuff.
@@ -742,7 +742,7 @@ class Calendar implements ActionInterface, Routable
 		// RFC 5545 requires "\r\n", not just "\n".
 		$file['content'] = implode("\r\n", $file['content']);
 
-		$file['size'] = strlen($file['content']);
+		$file['size'] = strlen((string) $file['content']);
 
 		// Send it.
 		Utils::emitFile($file);

--- a/Sources/Autoloader.php
+++ b/Sources/Autoloader.php
@@ -55,7 +55,8 @@ spl_autoload_register(function ($class) {
 		if (isset($_SERVER['SCRIPT_NAME'])) {
 			$boarddir = dirname($_SERVER['SCRIPT_NAME']);
 		} elseif (!empty(debug_backtrace())) {
-			$boarddir = dirname(array_pop(debug_backtrace())['file']);
+			$bt = debug_backtrace();
+			$boarddir = dirname(array_pop($bt)['file']);
 		} else {
 			$boarddir = dirname($sourcedir);
 		}

--- a/Sources/Board.php
+++ b/Sources/Board.php
@@ -811,7 +811,6 @@ class Board implements \ArrayAccess, Routable
 
 			default:
 				throw new \Exception(Lang::getTxt('modify_board_move_to_incorrect', [$move_to], file: 'Errors'));
-				break;
 		}
 
 		// Get a list of children of this board.

--- a/Sources/Cache/APIs/Postgres.php
+++ b/Sources/Cache/APIs/Postgres.php
@@ -41,7 +41,7 @@ class Postgres extends CacheApi implements CacheApiInterface
 	private $db_prefix;
 
 	/**
-	 * @var resource result of pg_connect.
+	 * @var \Pgsql\Connection result of pg_connect.
 	 */
 	private $db_connection;
 

--- a/Sources/Db/APIs/MySQL.php
+++ b/Sources/Db/APIs/MySQL.php
@@ -103,6 +103,20 @@ class MySQL extends DatabaseApi implements DatabaseApiInterface
 	 */
 	protected $supports_cte;
 
+	/**
+	 * @var string
+	 *
+	 * MySQL username.
+	 */
+	private $user;
+
+	/**
+	 * @var string
+	 *
+	 * MySQL password.
+	 */
+	private $passwd;
+
 	/****************
 	 * Public methods
 	 ****************/
@@ -2561,6 +2575,10 @@ class MySQL extends DatabaseApi implements DatabaseApiInterface
 			$this->connection,
 			'SET SESSION sql_mode = \'' . implode(',', $sql_mode) . '\'',
 		);
+
+		// We will need this for a autoreconnect later.
+		$this->user = $user;
+		$this->passwd = $passwd;
 	}
 
 	/**
@@ -2766,6 +2784,9 @@ class MySQL extends DatabaseApi implements DatabaseApiInterface
 				$this->error_backtrace('Undefined type used in the database query. (' . $matches[1] . ':' . $matches[2] . ')', '', false, __FILE__, __LINE__);
 				break;
 		}
+
+		// We reached a impossible location, but static anlaysis doesnt know that.
+		throw new \Exception();
 	}
 
 	/**

--- a/Sources/Db/APIs/PostgreSQL.php
+++ b/Sources/Db/APIs/PostgreSQL.php
@@ -20,6 +20,7 @@ use SMF\Db\DatabaseApi;
 use SMF\Db\DatabaseApiInterface;
 use SMF\ErrorHandler;
 use SMF\IP;
+use SMF\Lang;
 use SMF\User;
 use SMF\Utils;
 use SMF\Uuid;
@@ -2317,7 +2318,7 @@ class PostgreSQL extends DatabaseApi implements DatabaseApiInterface
 
 	public function checkConfiguration(): bool
 	{
-		$result = Db::$db->query(
+		$result = $this->query(
 			'show standard_conforming_strings',
 			[
 				'db_error_skip' => true,
@@ -2325,12 +2326,12 @@ class PostgreSQL extends DatabaseApi implements DatabaseApiInterface
 		);
 
 		if ($result !== false) {
-			$row = Db::$db->fetch_assoc($result);
+			$row = $this->fetch_assoc($result);
 
 			if ($row['standard_conforming_strings'] !== 'on') {
 				throw new \Exception(Lang::$txt['error_pg_scs']);
 			}
-			Db::$db->free_result($result);
+			$this->free_result($result);
 		}
 
 		return true;

--- a/Sources/Db/APIs/PostgreSQL.php
+++ b/Sources/Db/APIs/PostgreSQL.php
@@ -2714,7 +2714,8 @@ class PostgreSQL extends DatabaseApi implements DatabaseApiInterface
 				break;
 		}
 
-		return '';
+		// We reached a impossible location, but static anlaysis doesnt know that.
+		throw new \Exception();
 	}
 
 	/**

--- a/Sources/Db/DatabaseApi.php
+++ b/Sources/Db/DatabaseApi.php
@@ -24,6 +24,7 @@ use SMF\Uuid;
 
 /**
  * Class DatabaseApi
+ * @mixin DatabaseApiInterface
  */
 abstract class DatabaseApi
 {

--- a/Sources/Permissions/UserPermissionSet.php
+++ b/Sources/Permissions/UserPermissionSet.php
@@ -231,15 +231,17 @@ class UserPermissionSet
 				&& Config::$modSettings['warning_mute'] <= $this->user->warning
 			)
 		) {
+			$post_ban_permissions = [];
+
 			foreach (Permission::getAll() as $permission) {
 				if (!empty($permission->never_banned)) {
 					$post_ban_permissions[] = $permission->name;
 				}
 			}
 
-			IntegrationHook::call('integrate_post_ban_permissions', [&self::$post_ban_permissions]);
+			IntegrationHook::call('integrate_post_ban_permissions', [&$post_ban_permissions]);
 
-			foreach (self::$post_ban_permissions as $permission) {
+			foreach ($post_ban_permissions as $permission) {
 				$this->deny($permission);
 			}
 

--- a/Sources/Subs-Compat.php
+++ b/Sources/Subs-Compat.php
@@ -174,7 +174,7 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	function ModifyAntispamSettings(bool $return_config = false): ?array
 	{
 		if (!empty($return_config)) {
-			return SMF\Actions\Admin\Attachments::getConfigVars();
+			return SMF\Actions\Admin\AntiSpam::getConfigVars();
 		}
 
 		return SMF\Actions\Admin\AntiSpam::call();
@@ -226,7 +226,7 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	function ManageAttachmentSettings(bool $return_config = false): ?array
 	{
 		if (!empty($return_config)) {
-			return SMF\Actions\Admin\Attachments::getConfigVars();
+			return SMF\Actions\Admin\Attachments::attachConfigVars();
 		}
 
 		$obj = SMF\Actions\Admin\Attachments::load();
@@ -246,7 +246,7 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	function ManageAvatarSettings(bool $return_config = false): ?array
 	{
 		if (!empty($return_config)) {
-			return SMF\Actions\Admin\Attachments::getConfigVars();
+			return SMF\Actions\Admin\Attachments::avatarConfigVars();
 		}
 
 		$obj = SMF\Actions\Admin\Attachments::load();
@@ -553,7 +553,7 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	function ModifyCalendarSettings(bool $return_config = false): ?array
 	{
 		if (!empty($return_config)) {
-			return SMF\Actions\Admin\Attachments::getConfigVars();
+			return SMF\Actions\Admin\Calendar::getConfigVars();
 		}
 
 		$obj = SMF\Actions\Admin\Calendar::load();
@@ -866,7 +866,7 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	function AdminLogs(bool $return_config = false): ?array
 	{
 		if (!empty($return_config)) {
-			return SMF\Actions\Admin\Attachments::getConfigVars();
+			return SMF\Actions\Admin\Logs::getConfigVars();
 		}
 
 		return SMF\Actions\Admin\Logs::call();
@@ -1825,7 +1825,7 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	function ModifyPostSettings(bool $return_config = false): ?array
 	{
 		if (!empty($return_config)) {
-			return SMF\Actions\Admin\Posts::getConfigVars();
+			return SMF\Actions\Admin\Posts::postConfigVars();
 		}
 
 		$obj = SMF\Actions\Admin\Posts::load();
@@ -1845,7 +1845,7 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	function ModifyTopicSettings(bool $return_config = false): ?array
 	{
 		if (!empty($return_config)) {
-			return SMF\Actions\Admin\Posts::getConfigVars();
+			return SMF\Actions\Admin\Posts::topicConfigVars();
 		}
 
 		$obj = SMF\Actions\Admin\Posts::load();
@@ -1865,7 +1865,7 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	function ModifyDraftSettings(bool $return_config = false): ?array
 	{
 		if (!empty($return_config)) {
-			return SMF\Actions\Admin\Posts::getConfigVars();
+			return SMF\Actions\Admin\Posts::draftConfigVars();
 		}
 
 		$obj = SMF\Actions\Admin\Posts::load();
@@ -2113,7 +2113,7 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	function EditSearchSettings(bool $return_config = false): ?array
 	{
 		if (!empty($return_config)) {
-			return SMF\Actions\Admin\Attachments::getConfigVars();
+			return SMF\Actions\Admin\Search::getConfigVars();
 		}
 
 		$obj = SMF\Actions\Admin\Search::load();
@@ -2869,7 +2869,7 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	function ModifyWarningSettings(bool $return_config = false): ?array
 	{
 		if (!empty($return_config)) {
-			return SMF\Actions\Admin\Attachments::getConfigVars();
+			return SMF\Actions\Admin\Warnings::getConfigVars();
 		}
 
 		return SMF\Actions\Admin\Warnings::call();
@@ -4068,7 +4068,7 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 		$obj->suggest_type = 'member';
 		$obj->execute();
 
-		return Utils::$context['xml_data'];
+		return SMF\Utils::$context['xml_data'];
 	}
 
 	/**
@@ -4082,7 +4082,7 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 		$obj->suggest_type = 'membergroups';
 		$obj->execute();
 
-		return Utils::$context['xml_data'];
+		return SMF\Utils::$context['xml_data'];
 	}
 
 	/**
@@ -4096,7 +4096,7 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 		$obj->suggest_type = 'versions';
 		$obj->execute();
 
-		return Utils::$context['xml_data'];
+		return SMF\Utils::$context['xml_data'];
 	}
 
 	/******************************
@@ -4286,7 +4286,6 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 			$selected_date,
 			$calendarOptions,
 			$is_previous,
-			$has_picker,
 		);
 	}
 
@@ -4405,7 +4404,7 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	function removeHolidays(array $holiday_ids): void
 	{
 		foreach ($holiday_ids as $holiday_id) {
-			Calendar\Holiday::remove($holiday_id);
+			SMF\Calendar\Holiday::remove($holiday_id);
 		}
 	}
 
@@ -4530,21 +4529,6 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	function cdata_parse(string $data, string $ns = '', bool $force = false): string
 	{
 		return SMF\Actions\Feed::cdataParse($data, $ns, $force);
-	}
-
-	/******************************
-	 * Begin SMF\Actions\FindMember
-	 ******************************/
-
-	/**
-	 * Called by index.php?action=findmember.
-	 * - is used as a popup for searching members.
-	 * - uses sub template find_members of the Help template.
-	 * - also used to add members for PM's sent using wap2/imode protocol.
-	 */
-	function JSMembers(): void
-	{
-		SMF\Actions\FindMember::call();
 	}
 
 	/**************************
@@ -4827,7 +4811,7 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	 * Retrieves results of the request passed to it
 	 * Puts results of request into the context for the sub template.
 	 *
-	 * @param resource $request An SQL result resource
+	 * @param resource|object $request An SQL result resource
 	 */
 	function printMemberListRows($request): void
 	{
@@ -5775,7 +5759,7 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	function TrackIP(int $memID = 0): void
 	{
 		if ($memID === 0) {
-			$memID = User::$me->id;
+			$memID = SMF\User::$me->id;
 		}
 
 		if ((SMF\Profile::$member->id ?? NAN) !== $memID) {
@@ -6240,7 +6224,7 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	 */
 	function getSvgSize(string $filepath): array
 	{
-		$image = new Image($filepath);
+		$image = new SMF\Graphics\Image($filepath);
 
 		if ($image->mime_type !== 'image/svg+xml') {
 			return ['width' => null, 'height' => null];
@@ -6261,7 +6245,7 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	 */
 	function createThumbnail(string $source, int $max_width, int $max_height): bool
 	{
-		return ((new Image($source))->createThumbnail($max_width, $max_height) !== false);
+		return ((new SMF\Graphics\Image($source))->createThumbnail($max_width, $max_height) !== false);
 	}
 
 	/**
@@ -6276,7 +6260,7 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	 */
 	function reencodeImage(string $source, int $preferred_type = 0): bool
 	{
-		return (new Image($source))->reencode($preferred_type);
+		return (new SMF\Graphics\Image($source))->reencode($preferred_type);
 	}
 
 	/**
@@ -6289,7 +6273,7 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	 */
 	function checkImageContents(string $source, bool $extensive = false): bool
 	{
-		return (new Image($source))->check($extensive);
+		return (new SMF\Graphics\Image($source))->check($extensive);
 	}
 
 	/**
@@ -6300,7 +6284,7 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	 */
 	function checkSvgContents(string $source): bool
 	{
-		return (new Image($source))->check();
+		return (new SMF\Graphics\Image($source))->check();
 	}
 
 	/**
@@ -6323,7 +6307,7 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 		int $max_height,
 		int $preferred_type = 0,
 	): bool {
-		return (new Image($source))->resize($destination, $max_width, $max_height, $preferred_type);
+		return (new SMF\Graphics\Image($source))->resize($destination, $max_width, $max_height, $preferred_type);
 	}
 
 	/**
@@ -6355,7 +6339,7 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 		bool $force_resize = false,
 		int $preferred_type = 0,
 	): bool {
-		return (new Image($source))->resize($destination, $max_width, $max_height, $preferred_type);
+		return (new SMF\Graphics\Image($source))->resize($destination, $max_width, $max_height, $preferred_type);
 	}
 
 	/***************************************
@@ -6517,9 +6501,9 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	/**
 	 * Get a listing of files that will need to be set back to the original state
 	 *
-	 * @param null $dummy1
-	 * @param null $dummy2
-	 * @param null $dummy3
+	 * @param mixed $dummy1
+	 * @param mixed $dummy2
+	 * @param mixed $dummy3
 	 * @param bool $do_change
 	 * @return array An array of info about the files that need to be restored back to their original state
 	 */
@@ -7231,7 +7215,16 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	{
 		SMF\Alert::mark($members, $to_mark, (bool) $read);
 
-		return SMF\Alert::count($memID, $unread);
+		if (is_int($members)) {
+			return SMF\Alert::count($members, !((bool) $read));
+		}
+
+		$count = 0;
+		array_walk($members, function ($memID) use ($count, $read) {
+			$count += SMF\Alert::count($memID, !((bool) $read));
+		});
+
+		return $count;
 	}
 
 	/**
@@ -7861,7 +7854,8 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 		} elseif (isset($tree['node']['id'])) {
 			$list = SMF\Category::$boardList[(int) $tree['node']['id']];
 		} elseif (isset($tree['category'])) {
-			SMF\Category::recursiveBoards($list, SMF\Board::load((int) $tree['id']));
+			$tree = SMF\Board::load((int) $tree['id']);
+			SMF\Category::recursiveBoards($list, $tree);
 		}
 	}
 
@@ -7985,7 +7979,7 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	function ShowDrafts(int $member_id, int $reply_to = 0, int $draft_type = 0): bool
 	{
 		if ($draft_type === 1) {
-			return SMF\DraftPM::showInEditor($member_id, $reply_to);
+			return \SMF\PersonalMessage\DraftPM::showInEditor($member_id, $reply_to);
 		}
 
 		return SMF\Draft::showInEditor($member_id, $reply_to);
@@ -8002,7 +7996,7 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	function showProfileDrafts(int $memID, int $draft_type = 0): void
 	{
 		if ($draft_type === 1) {
-			SMF\DraftPM::showInProfile($memID);
+			\SMF\PersonalMessage\DraftPM::showInProfile($memID);
 		}
 
 		SMF\Draft::showInProfile($memID);
@@ -8508,11 +8502,11 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	 */
 	function writeLog(bool $force = false): void
 	{
-		if (!isset(User::$me)) {
+		if (!isset(SMF\User::$me)) {
 			return;
 		}
 
-		User::$me->logOnline($force);
+		SMF\User::$me->logOnline($force);
 	}
 
 	/**
@@ -10807,7 +10801,7 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	 */
 	function url_to_iri(string $url): string|bool
 	{
-		$iri = SMF\Url::create($iri);
+		$iri = SMF\Url::create($url);
 		$iri->toUtf8();
 
 		return (string) $iri === '' ? false : (string) $iri;
@@ -10822,7 +10816,7 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	 * @param string $url The original URL of the requested resource
 	 * @return string The URL to use
 	 */
-	function get_proxied_url(string $url): SMF\Url
+	function get_proxied_url(string $url): string
 	{
 		return (string) SMF\Url::create($url)->proxied();
 	}
@@ -11336,7 +11330,7 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	{
 		// You're never allowed to do something if your data hasn't been loaded yet!
 		if (!isset(SMF\User::$me)) {
-			return false;
+			return [];
 		}
 
 		return SMF\User::$me->boardsAllowedTo($permissions, $check_access, $simple);
@@ -11752,9 +11746,9 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	 *
 	 * @param mixed $input The string containing a function name or a static call. The function can also accept a closure, object or a callable array (object/class, valid_callable)
 	 * @param bool $return If true, the function will not call the function/method but instead will return the formatted string.
-	 * @return string|array|bool Either a string or an array that contains a callable function name or an array with a class and method to call. False if the given string cannot produce a callable var.
+	 * @return void|string|array|bool Either a string or an array that contains a callable function name or an array with a class and method to call. False if the given string cannot produce a callable var.
 	 */
-	function call_helper(mixed $input, bool $return = false): mixed
+	function call_helper(mixed $input, bool $return = false)
 	{
 		$callable = SMF\Utils::getCallable($input);
 

--- a/Sources/Subs-Compat.php
+++ b/Sources/Subs-Compat.php
@@ -7979,7 +7979,7 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	function ShowDrafts(int $member_id, int $reply_to = 0, int $draft_type = 0): bool
 	{
 		if ($draft_type === 1) {
-			return \SMF\PersonalMessage\DraftPM::showInEditor($member_id, $reply_to);
+			return SMF\PersonalMessage\DraftPM::showInEditor($member_id, $reply_to);
 		}
 
 		return SMF\Draft::showInEditor($member_id, $reply_to);
@@ -7996,7 +7996,7 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	function showProfileDrafts(int $memID, int $draft_type = 0): void
 	{
 		if ($draft_type === 1) {
-			\SMF\PersonalMessage\DraftPM::showInProfile($memID);
+			SMF\PersonalMessage\DraftPM::showInProfile($memID);
 		}
 
 		SMF\Draft::showInProfile($memID);

--- a/Sources/Theme.php
+++ b/Sources/Theme.php
@@ -2483,7 +2483,7 @@ class Theme
 							echo '</pre><div style="background-color: #ffb0b5;"><pre style="margin: 0;">';
 						}
 
-						echo '<span style="color: black;">', sprintf('%' . strlen($n) . 's', $line), ':</span> ';
+						echo '<span style="color: black;">', sprintf('%' . strlen((string) $n) . 's', $line), ':</span> ';
 
 						if (isset($data2[$line]) && $data2[$line] != '') {
 							echo str_starts_with($data2[$line], '</') ? preg_replace('~^</[^>]+>~', '', $data2[$line]) : $last_line . $data2[$line];

--- a/Sources/Uuid.php
+++ b/Sources/Uuid.php
@@ -718,8 +718,6 @@ class Uuid implements \Stringable
 						// POSIX systems can actually do this.
 						$id = posix_getgid();
 					} else {
-						// On non-POSIX systems, fall back to user ID because
-						// getmygid() returns nothing useful on non-POSIX systems.
 						throw new \ValueError('uuid_group_non_posix');
 					}
 					break;

--- a/Sources/Uuid.php
+++ b/Sources/Uuid.php
@@ -721,9 +721,6 @@ class Uuid implements \Stringable
 						// On non-POSIX systems, fall back to user ID because
 						// getmygid() returns nothing useful on non-POSIX systems.
 						throw new \ValueError('uuid_group_non_posix');
-
-						$id = getmyuid();
-						$domain = 0;
 					}
 					break;
 
@@ -736,7 +733,6 @@ class Uuid implements \Stringable
 				// Unknown domain.
 				default:
 					throw new \Exception(Lang::getTxt('uuid_unknown_domain', [$domain], file: 'Errors'));
-					break;
 			}
 		}
 


### PR DESCRIPTION
Working on another PR, but these issues popped up in static analysis.  Lots of issues in Subs-Compat due to a bad copy and paste when setting it up.

- Actions\BoardIndex
	- 'ref' was defined as 0 but used as an array elsewhere.
- Actions\Calendar
	- Attempted to call getCalendarGrid with 4 parameters, only 3 accepted
	- Ensure we have a string for strlen()
- Autoloader
	- Only variables can be passed by reference and array_pop requires a reference.
- Board
	- Do not need to break as we throw a fatal error;
- Subs-Compat
	- alert_mark tried to use $memID which doesn't exist.
	- url_to_iri tried to use $iri which doesn't exist.
	- Various functions called for wrong config vars.
	- Utils,User,Image was not "used"
	- getCalendarGrid tried to use the picker which no longer exists.
	- removeHolidays didn't fully qualify Calendar\Holiday
	- FindMember was removed as it was deprecated in 2.0.
	- recursiveBoards only variables can be passed by reference.
	- ShowDrafts and showProfileDrafts had wrong call for draft pms.
	- get_proxied_url is intended to return string
	- boardsAllowedTo should always return an array
	- call_helper does not always return
- Cache\APIs\Postgres
	- Improve docblock hint as it has been \Pgsql\Connection for some time
- Db\APIs\MySQL
	- $this->user and passwd didn't exist, but we expected it in some conditions.
- Db\APIs\Postgresql
	- Tried to use Db::$db instead of $this
- Db\DatbaseApi
	- Improve hints that we mixin the interface
- Permissions\UserPermissionSet
	- post_ban_permissions didn't exist under self or always.
- Theme
	- Ensure string passed to strlen
- Uuid
	- getHexV2 had unreachable code