### PR TITLE
[2.1] Fix a semi colon usage on a switch statement

### DIFF
--- a/Sources/Load.php
+++ b/Sources/Load.php
@@ -247,7 +247,7 @@ function reloadSettings()
 						break;
 
 					case 'lower':
-					case 'fold';
+					case 'fold':
 						$string = strtolower($string);
 						break;
 


### PR DESCRIPTION
Deprecated in PHP 8.5.

I don't see any other PHP 8.5 deprecations that would be flagged for us
https://wiki.php.net/rfc/deprecations_php_8_5

One did come close, and that was the cast types for non-standard names ("integer" for example), but all the uses we have pass through settype, and that failed to get approval.  Might be a good one just to clean up in 3.0 in case it comes around again.

Another thing to point out, there will be new warnings, but that will require runtime to notice, as static analysis won't be able to find these easily
https://wiki.php.net/rfc/warnings-php-8-5
