### PR TITLE
[3.0] Changes type of backtrace col of log_errors table from VARCHAR to TEXT

### DIFF
--- a/Languages/en_US/ManageMaintenance.php
+++ b/Languages/en_US/ManageMaintenance.php
@@ -118,7 +118,7 @@ $txt['error_url'] = 'URL of page causing the error';
 $txt['error_message'] = 'Error message';
 $txt['error_file'] = 'File';
 $txt['error_line'] = 'Line';
-$txt['error_file_and_line'] = '{file} (Line {line, number, integer})';
+$txt['error_file_and_line'] = '{file} (Line {line, number, :: group-off})';
 $txt['clear_filter'] = 'Clear filter';
 $txt['remove_selection'] = 'Remove selection';
 $txt['remove_filtered_results'] = 'Remove all filtered results';
@@ -133,7 +133,7 @@ $txt['filter_only_file'] = 'Only show the errors from this file';
 $txt['apply_filter_of_type'] = 'Apply filter of type: {list}';
 $txt['backtrace_title'] = 'Backtrace information';
 // argument(s): error message, function, filename, line nr, filehash, Config::$scripturl
-$txt['backtrace_info'] = '<b>#{0, number, integer}</b>: {1}()<br>Called from <a href="{5}?action=admin;area=logs;sa=errorlog;file={4};line={3, number, integer}" onclick="return reqWin(this.href, 600, 480, false);">{2} on line {3, number, integer}</a>';
+$txt['backtrace_info'] = '<b>#{0, number, integer}</b>: {1}()<br>Called from <a href="{5}?action=admin;area=logs;sa=errorlog;file={4};line={3, number, :: group-off}" onclick="return reqWin(this.href, 600, 480, false);">{2} on line {3, number, :: group-off}</a>';
 $txt['backtrace_info_internal_function'] = '<b>#{0, number, integer}</b>: {1}()<br>Called from [internal function]';
 
 $txt['errortype_all'] = 'All errors';

--- a/Sources/Db/APIs/MySQL.php
+++ b/Sources/Db/APIs/MySQL.php
@@ -170,20 +170,19 @@ class MySQL extends DatabaseApi implements DatabaseApiInterface
 
 		// First, we clean strings out of the query, reduce whitespace, lowercase, and trim - so we can check it over.
 		if (!$this->disableQueryCheck) {
-			$clean = trim(strtolower(preg_replace($allowed_comments_from, $allowed_comments_to, $db_string)));
+			$clean = trim(strtolower((string) preg_replace($allowed_comments_from, $allowed_comments_to, $db_string)));
 
-			// Comments?  We don't use comments in our queries, we leave 'em outside!
-			if (strpos($clean, '/*') > 2 || str_contains($clean, '--') || str_contains($clean, ';')) {
-				$fail = true;
-			}
-			// Trying to change passwords, slow us down, or something?
-			elseif (str_contains($clean, 'sleep') && preg_match('~(^|[^a-z])sleep($|[^[_a-z])~s', $clean) != 0) {
-				$fail = true;
-			} elseif (str_contains($clean, 'benchmark') && preg_match('~(^|[^a-z])benchmark($|[^[a-z])~s', $clean) != 0) {
-				$fail = true;
-			}
-
-			if (!empty($fail)) {
+			if (
+				// Empty string?
+				$clean === ''
+				// Comments?  We don't use comments in our queries, we leave 'em outside!
+				|| strpos($clean, '/*') > 2
+				|| str_contains($clean, '--')
+				|| str_contains($clean, ';')
+				// Trying to change passwords, slow us down, or something?
+				|| preg_match('~(^|[^a-z])sleep($|[^[_a-z])~s', $clean)
+				|| preg_match('~(^|[^a-z])benchmark($|[^[a-z])~s', $clean)
+			) {
 				$this->error_backtrace('No direct access...', 'No direct access...' . "\n" . $db_string, E_USER_ERROR, __FILE__, __LINE__);
 			}
 		}

--- a/Sources/Db/APIs/MySQL.php
+++ b/Sources/Db/APIs/MySQL.php
@@ -149,7 +149,7 @@ class MySQL extends DatabaseApi implements DatabaseApiInterface
 		self::$count++;
 
 		if (!$this->disableQueryCheck && str_contains($db_string, '\'') && empty($db_values['security_override'])) {
-			$this->error_backtrace('No direct access...', 'Illegal character (\') used in query...', true, __FILE__, __LINE__);
+			$this->error_backtrace('Invalid query string', 'Illegal character (\') used in query:' . "\n" . $db_string, true, __FILE__, __LINE__);
 		}
 
 		// Use "ORDER BY null" to prevent Mysql doing filesorts for Group By clauses without an Order By
@@ -183,7 +183,7 @@ class MySQL extends DatabaseApi implements DatabaseApiInterface
 				|| preg_match('~(^|[^a-z])sleep($|[^[_a-z])~s', $clean)
 				|| preg_match('~(^|[^a-z])benchmark($|[^[a-z])~s', $clean)
 			) {
-				$this->error_backtrace('No direct access...', 'No direct access...' . "\n" . $db_string, E_USER_ERROR, __FILE__, __LINE__);
+				$this->error_backtrace('Invalid query string', 'Invalid query string:' . "\n" . $db_string, E_USER_ERROR, __FILE__, __LINE__);
 			}
 		}
 

--- a/Sources/Db/APIs/PostgreSQL.php
+++ b/Sources/Db/APIs/PostgreSQL.php
@@ -196,7 +196,7 @@ class PostgreSQL extends DatabaseApi implements DatabaseApiInterface
 		$this->replace_result = 0;
 
 		if (!$this->disableQueryCheck && str_contains($db_string, '\'') && empty($db_values['security_override'])) {
-			$this->error_backtrace('No direct access...', 'Illegal character (\') used in query...', true, __FILE__, __LINE__);
+			$this->error_backtrace('Invalid query string', 'Illegal character (\') used in query:' . "\n" . $db_string, true, __FILE__, __LINE__);
 		}
 
 		// Use "ORDER BY null" to prevent Mysql doing filesorts for Group By clauses without an Order By
@@ -230,7 +230,7 @@ class PostgreSQL extends DatabaseApi implements DatabaseApiInterface
 				|| preg_match('~(^|[^a-z])sleep($|[^[_a-z])~s', $clean)
 				|| preg_match('~(^|[^a-z])benchmark($|[^[a-z])~s', $clean)
 			) {
-				$this->error_backtrace('No direct access...', 'No direct access...' . "\n" . $db_string, E_USER_ERROR, __FILE__, __LINE__);
+				$this->error_backtrace('Invalid query string', 'Invalid query string:' . "\n" . $db_string, E_USER_ERROR, __FILE__, __LINE__);
 			}
 		}
 

--- a/Sources/Db/APIs/PostgreSQL.php
+++ b/Sources/Db/APIs/PostgreSQL.php
@@ -217,20 +217,19 @@ class PostgreSQL extends DatabaseApi implements DatabaseApiInterface
 
 		// First, we clean strings out of the query, reduce whitespace, lowercase, and trim - so we can check it over.
 		if (!$this->disableQueryCheck) {
-			$clean = trim(strtolower(preg_replace($allowed_comments_from, $allowed_comments_to, $db_string)));
+			$clean = trim(strtolower((string) preg_replace($allowed_comments_from, $allowed_comments_to, $db_string)));
 
-			// Comments?  We don't use comments in our queries, we leave 'em outside!
-			if (strpos($clean, '/*') > 2 || str_contains($clean, '--') || str_contains($clean, ';')) {
-				$fail = true;
-			}
-			// Trying to change passwords, slow us down, or something?
-			elseif (str_contains($clean, 'sleep') && preg_match('~(^|[^a-z])sleep($|[^[_a-z])~s', $clean) != 0) {
-				$fail = true;
-			} elseif (str_contains($clean, 'benchmark') && preg_match('~(^|[^a-z])benchmark($|[^[a-z])~s', $clean) != 0) {
-				$fail = true;
-			}
-
-			if (!empty($fail)) {
+			if (
+				// Empty string?
+				$clean === ''
+				// Comments?  We don't use comments in our queries, we leave 'em outside!
+				|| strpos($clean, '/*') > 2
+				|| str_contains($clean, '--')
+				|| str_contains($clean, ';')
+				// Trying to change passwords, slow us down, or something?
+				|| preg_match('~(^|[^a-z])sleep($|[^[_a-z])~s', $clean)
+				|| preg_match('~(^|[^a-z])benchmark($|[^[a-z])~s', $clean)
+			) {
 				$this->error_backtrace('No direct access...', 'No direct access...' . "\n" . $db_string, E_USER_ERROR, __FILE__, __LINE__);
 			}
 		}

--- a/Sources/Db/Schema/v3_0/LogErrors.php
+++ b/Sources/Db/Schema/v3_0/LogErrors.php
@@ -102,10 +102,8 @@ class LogErrors extends Table
 			),
 			'backtrace' => new Column(
 				name: 'backtrace',
-				type: 'varchar',
-				size: 10000,
+				type: 'text',
 				not_null: true,
-				default: '',
 			),
 		];
 


### PR DESCRIPTION
1. Used TEXT to store the backtrace data in the log_errors table. The array of backtrace info can get large when it contains fully qualified class names.
2. Fixes a minor bug where line number in the error logs were being localized (e.g. having commas inserted into them), which broke links pointing to line numbers.
3. Makes some code in the db query check more concise.
4. Improves the error messages that are shown for invalid query strings.