### PR TITLE
[3.0] Remove deprecated mysqli_ping

### DIFF
--- a/Sources/Db/APIs/MySQL.php
+++ b/Sources/Db/APIs/MySQL.php
@@ -731,7 +731,19 @@ class MySQL extends DatabaseApi implements DatabaseApiInterface
 	 */
 	public function ping(?object $connection = null): bool
 	{
-		return mysqli_ping($connection ?? $this->connection);
+		try {
+			mysqli_query($connection ?? $this->connection, 'DO 1');
+		} catch (\Exception) {
+			// If we specified a connection, don't connect.
+			if ($connection !== null) {
+				return false;
+			}
+
+			// Try to restart, This is not fatal as we expect a boolean return.
+			$this->connect($this->user, $this->passwd, ['non_fatal' => true]);
+		}
+
+		return $this->connection !== null;
 	}
 
 	/**

--- a/Sources/Db/APIs/MySQL.php
+++ b/Sources/Db/APIs/MySQL.php
@@ -729,26 +729,6 @@ class MySQL extends DatabaseApi implements DatabaseApiInterface
 	/**
 	 *
 	 */
-	public function ping(?object $connection = null): bool
-	{
-		try {
-			mysqli_query($connection ?? $this->connection, 'DO 1');
-		} catch (\Exception) {
-			// If we specified a connection, don't connect.
-			if ($connection !== null) {
-				return false;
-			}
-
-			// Try to restart, This is not fatal as we expect a boolean return.
-			$this->connect($this->user, $this->passwd, ['non_fatal' => true]);
-		}
-
-		return $this->connection !== null;
-	}
-
-	/**
-	 *
-	 */
 	public function error_insert(array $error_array): void
 	{
 		// Without a database we can't do anything.

--- a/Sources/Db/APIs/PostgreSQL.php
+++ b/Sources/Db/APIs/PostgreSQL.php
@@ -730,14 +730,6 @@ class PostgreSQL extends DatabaseApi implements DatabaseApiInterface
 	/**
 	 *
 	 */
-	public function ping(?object $connection = null): bool
-	{
-		return pg_ping($connection ?? $this->connection);
-	}
-
-	/**
-	 *
-	 */
 	public function error_insert(array $error_array): void
 	{
 		// Without a database we can't do anything.

--- a/Sources/Db/DatabaseApiInterface.php
+++ b/Sources/Db/DatabaseApiInterface.php
@@ -268,14 +268,6 @@ interface DatabaseApiInterface
 	public function is_resource(mixed $result): bool;
 
 	/**
-	 * Pings a server connection, and tries to reconnect if necessary.
-	 *
-	 * @param null|object $connection The connection object (if null, $db_connection is used)
-	 * @return bool True on success, or false on failure.
-	 */
-	public function ping(?object $connection = null): bool;
-
-	/**
 	 * Save errors in the database safely.
 	 *
 	 * $error_array must have the following keys in order:

--- a/Sources/Maintenance/Maintenance.php
+++ b/Sources/Maintenance/Maintenance.php
@@ -120,7 +120,7 @@ class Maintenance
 	public static string $query_string = '';
 
 	/**
-	 * @var \SMF\Maintenance\Tools\ToolsInterface
+	 * @var \SMF\Maintenance\Tools\ToolsInterface|\SMF\Maintenance\Tools\Upgrade|\SMF\Maintenance\Tools\Install
 	 *
 	 * Object containing the tool we are working with.
 	 */
@@ -547,9 +547,6 @@ class Maintenance
 		// Make the connection...
 		if (empty(Db::$db) || !(Db::$db instanceof Db)) {
 			Db::load(['non_fatal' => true]);
-		} else {
-			// If we've returned here, ping/reconnect to be safe
-			Db::$db->ping();
 		}
 
 		// Oh dear god!!

--- a/Sources/Maintenance/Tools/ToolsBase.php
+++ b/Sources/Maintenance/Tools/ToolsBase.php
@@ -217,7 +217,7 @@ abstract class ToolsBase
 			$db_class = '\\SMF\\Db\\APIs\\' . substr($entry, 0, -4);
 			$db = new $db_class();
 
-			if (!($db instanceof \SMF\Db\DatabaseApi) || !$db->isSupported()) {
+			if (!($db instanceof Db) || !$db->isSupported()) {
 				continue;
 			}
 
@@ -608,7 +608,7 @@ abstract class ToolsBase
 
 		try {
 			Config::updateModSettings($change_array, $update);
-		} catch (\Thowable $e) {
+		} catch (\Exception $e) {
 			$this->logProgress(Lang::getTxt('log_failed_with_error', ['error' => $e->getMessage()], file: 'Maintenance'));
 		}
 


### PR DESCRIPTION
In PHP 8.4 this was deprecated
With the mysqlnd driver, reconnect is ignored
A SO post indicates that as of PHP 8.2, it throws an error when the connection is down

Another solution can be just to remove the ping entirely.

Fixes #8659