### PR TITLE
[3.0] Remove references to post_autosave_draft permission

### DIFF
--- a/Languages/en_US/Reports.php
+++ b/Languages/en_US/Reports.php
@@ -58,7 +58,6 @@ $txt['board_perms_name_post_unapproved_topics'] = 'Post unapproved topics';
 $txt['board_perms_name_post_unapproved_replies_any'] = 'Post unapproved replies in any topic';
 $txt['board_perms_name_post_unapproved_replies_own'] = 'Post unapproved replies in own topic';
 $txt['board_perms_name_post_draft'] = 'Save drafts of posts';
-$txt['board_perms_name_post_autosave_draft'] = 'Automatically save drafts of posts';
 $txt['board_perms_name_remove_any'] = 'Remove any topic';
 $txt['board_perms_name_remove_own'] = 'Remove own topics';
 $txt['board_perms_name_report_any'] = 'Report any post';

--- a/Sources/Actions/Post.php
+++ b/Sources/Actions/Post.php
@@ -1744,7 +1744,7 @@ class Post implements ActionInterface, Routable
 		// Are post drafts enabled?
 		Utils::$context['drafts_type'] = 'post';
 		Utils::$context['drafts_save'] = !empty(Config::$modSettings['drafts_post_enabled']) && User::$me->allowedTo('post_draft');
-		Utils::$context['drafts_autosave'] = !empty(Utils::$context['drafts_save']) && !empty(Config::$modSettings['drafts_autosave_enabled']) && User::$me->allowedTo('post_autosave_draft') && !empty(Theme::$current->options['drafts_autosave_enabled']);
+		Utils::$context['drafts_autosave'] = !empty(Utils::$context['drafts_save']) && !empty(Config::$modSettings['drafts_autosave_enabled']) && !empty(Theme::$current->options['drafts_autosave_enabled']);
 
 		// Build a list of drafts that they can load in to the editor
 		if (!empty(Utils::$context['drafts_save'])) {


### PR DESCRIPTION
References to it being a removed permission are being kept

Fixes #8839