### PR TITLE
[3.0] Fix quotefast failures

### DIFF
--- a/Sources/Actions/QuoteFast.php
+++ b/Sources/Actions/QuoteFast.php
@@ -19,6 +19,7 @@ use SMF\ActionInterface;
 use SMF\ActionRouter;
 use SMF\ActionTrait;
 use SMF\Config;
+use SMF\ErrorHandler;
 use SMF\IntegrationHook;
 use SMF\Lang;
 use SMF\Msg;
@@ -85,20 +86,20 @@ class QuoteFast implements ActionInterface, Routable
 				'm.id_msg IN ({array_int:message_list})',
 			],
 			'order' => [],
-			'params' => [
-				'not_locked' => 0,
-			],
+			'params' => [],
 		];
 
 		$bq = User::$me->mod_cache['bq'];
 
-		if (isset($_REQUEST['modify']) || $bq != '1=1') {
+		if (isset($_REQUEST['modify']) && $bq != '1=1') {
+			$query_customizations['params']['not_locked'] = 0;
 			$query_customizations['where'][] = 't.locked = {int:not_locked}' . ($bq == '0=1' || $bq == '1=1' ? '' : ' OR m.' . $bq);
 		}
 
 		$row = current(Msg::load((int) $_REQUEST['quote'], $query_customizations));
 
 		if ($row === false) {
+			ErrorHandler::fatalLang('no_message', false);
 			return;
 		}
 


### PR DESCRIPTION
The logic is greatly different from what it was for 2.1.  Hopefully, this resolves it.

On another note, when we get an error during the XML process, the Ajax logic does not drop into an error condition because a response was received (even for an error 500) and still tries to process it.  I did not try to address that here.  In all honesty updating our Ajax logic to use JSON responses in my mind is when we ensure that is addressed.