### PR TITLE
[3.0] Sundry debugger improvements

### DIFF
--- a/Sources/Actions/Agreement.php
+++ b/Sources/Actions/Agreement.php
@@ -19,6 +19,7 @@ use SMF\ActionInterface;
 use SMF\ActionRouter;
 use SMF\ActionTrait;
 use SMF\Config;
+use SMF\Debug\DebugUtils;
 use SMF\Diff\EditDiff;
 use SMF\ErrorHandler;
 use SMF\Lang;
@@ -129,7 +130,7 @@ class Agreement implements ActionInterface, Routable
 		Theme::loadTemplate('EditHistory');
 
 		// We do not want to output debug information here.
-		Config::$db_show_debug = false;
+		DebugUtils::disable();
 
 		// We only want to output our little layer here.
 		Utils::$context['template_layers'] = [];

--- a/Sources/Actions/Like.php
+++ b/Sources/Actions/Like.php
@@ -22,6 +22,7 @@ use SMF\Alert;
 use SMF\Cache\CacheApi;
 use SMF\Config;
 use SMF\Db\DatabaseApi as Db;
+use SMF\Debug\DebugUtils;
 use SMF\IntegrationHook;
 use SMF\Lang;
 use SMF\OutputTypeInterface;
@@ -291,7 +292,7 @@ class Like implements ActionInterface, Routable
 
 		// We do not want to output debug information here.
 		if ($this->js) {
-			Config::$db_show_debug = false;
+			DebugUtils::disable();
 		}
 	}
 

--- a/Sources/Actions/Profile/AlertsPopup.php
+++ b/Sources/Actions/Profile/AlertsPopup.php
@@ -19,6 +19,7 @@ use SMF\ActionInterface;
 use SMF\ActionTrait;
 use SMF\Alert;
 use SMF\Config;
+use SMF\Debug\DebugUtils;
 use SMF\User;
 use SMF\Utils;
 
@@ -39,7 +40,7 @@ class AlertsPopup implements ActionInterface
 	public function execute(): void
 	{
 		// We do not want to output debug information here.
-		Config::$db_show_debug = false;
+		DebugUtils::disable();
 
 		// We only want to output our little layer here.
 		Utils::$context['template_layers'] = [];

--- a/Sources/Actions/Profile/Notification.php
+++ b/Sources/Actions/Profile/Notification.php
@@ -22,6 +22,7 @@ use SMF\Alert;
 use SMF\Board;
 use SMF\Config;
 use SMF\Db\DatabaseApi as Db;
+use SMF\Debug\DebugUtils;
 use SMF\ErrorHandler;
 use SMF\IntegrationHook;
 use SMF\ItemList;
@@ -527,7 +528,7 @@ class Notification implements ActionInterface
 	public function markRead(): void
 	{
 		// We do not want to output debug information here.
-		Config::$db_show_debug = false;
+		DebugUtils::disable();
 
 		// We only want to output our little layer here.
 		Utils::$context['template_layers'] = [];

--- a/Sources/Actions/Profile/Popup.php
+++ b/Sources/Actions/Profile/Popup.php
@@ -18,6 +18,7 @@ namespace SMF\Actions\Profile;
 use SMF\ActionInterface;
 use SMF\ActionTrait;
 use SMF\Config;
+use SMF\Debug\DebugUtils;
 use SMF\IntegrationHook;
 use SMF\Lang;
 use SMF\Menu;
@@ -122,7 +123,7 @@ class Popup implements ActionInterface
 		);
 
 		// We do not want to output debug information here.
-		Config::$db_show_debug = false;
+		DebugUtils::disable();
 
 		// We only want to output our little layer here.
 		Utils::$context['template_layers'] = [];

--- a/Sources/Actions/ShowMsgHistory.php
+++ b/Sources/Actions/ShowMsgHistory.php
@@ -17,7 +17,7 @@ namespace SMF\Actions;
 
 use SMF\ActionInterface;
 use SMF\ActionTrait;
-use SMF\Config;
+use SMF\Debug\DebugUtils;
 use SMF\Msg;
 use SMF\Parser;
 use SMF\Routable;
@@ -54,7 +54,7 @@ class ShowMsgHistory implements ActionInterface, Routable
 		Theme::loadTemplate('EditHistory');
 
 		// We do not want to output debug information here.
-		Config::$db_show_debug = false;
+		DebugUtils::disable();
 
 		// We only want to output our little layer here.
 		Utils::$context['template_layers'] = [];

--- a/Sources/Actions/ViewQuery.php
+++ b/Sources/Actions/ViewQuery.php
@@ -206,6 +206,7 @@ class ViewQuery implements ActionInterface, Routable
 				} elseif ($vendor == 'PostgreSQL') {
 					$result = Db::$db->query('(ANALYZE, FORMAT JSON) ' . $select);
 				} elseif ($vendor == 'MySQL' && version_compare($version, '8.3.0', '>=')) {
+					Db::$db->query('SET explain_json_format_version=2');
 					$result = Db::$db->query('EXPLAIN ANALYZE FORMAT=JSON ' . $select);
 				} else {
 					$formatJson = false;

--- a/Sources/Actions/ViewQuery.php
+++ b/Sources/Actions/ViewQuery.php
@@ -62,7 +62,7 @@ class ViewQuery implements ActionInterface, Routable
 	public function execute(): void
 	{
 		// We should have debug mode enabled, as well as something to display!
-		if (!isset(Config::$db_show_debug) || Config::$db_show_debug !== true || !isset($_SESSION['debug'])) {
+		if (!DebugUtils::isDebugEnabled() || !isset($_SESSION['debug'])) {
 			ErrorHandler::fatalLang('no_access', false);
 		}
 

--- a/Sources/Cache/CacheApi.php
+++ b/Sources/Cache/CacheApi.php
@@ -17,6 +17,7 @@ namespace SMF\Cache;
 
 use SMF\BackwardCompatibility;
 use SMF\Config;
+use SMF\Debug\DebugUtils;
 use SMF\IntegrationHook;
 use SMF\Utils;
 
@@ -559,7 +560,7 @@ abstract class CacheApi
 
 		self::$count_hits++;
 
-		if (isset(Config::$db_show_debug) && Config::$db_show_debug === true) {
+		if (DebugUtils::isDebugEnabled()) {
 			self::$hits[self::$count_hits] = ['k' => $key, 'd' => 'put', 's' => $value === null ? 0 : \strlen(serialize($value))];
 			$st = microtime(true);
 		}
@@ -572,7 +573,7 @@ abstract class CacheApi
 			IntegrationHook::call('cache_put_data', [&$key, &$value, &$ttl]);
 		}
 
-		if (isset(Config::$db_show_debug) && Config::$db_show_debug === true) {
+		if (DebugUtils::isDebugEnabled()) {
 			self::$hits[self::$count_hits]['t'] = microtime(true) - $st;
 		}
 	}
@@ -594,7 +595,7 @@ abstract class CacheApi
 
 		self::$count_hits++;
 
-		if (isset(Config::$db_show_debug) && Config::$db_show_debug === true) {
+		if (DebugUtils::isDebugEnabled()) {
 			self::$hits[self::$count_hits] = ['k' => $key, 'd' => 'get'];
 			$st = microtime(true);
 			$original_key = $key;
@@ -603,7 +604,7 @@ abstract class CacheApi
 		// Ask the API to get the data.
 		$value = self::$loadedApi->getData($key, $ttl);
 
-		if (isset(Config::$db_show_debug) && Config::$db_show_debug === true) {
+		if (DebugUtils::isDebugEnabled()) {
 			self::$hits[self::$count_hits]['t'] = microtime(true) - $st;
 			self::$hits[self::$count_hits]['s'] = isset($value) ? \strlen((string) $value) : 0;
 

--- a/Sources/Db/APIs/MySQL.php
+++ b/Sources/Db/APIs/MySQL.php
@@ -18,6 +18,7 @@ namespace SMF\Db\APIs;
 use SMF\Config;
 use SMF\Db\DatabaseApi;
 use SMF\Db\DatabaseApiInterface;
+use SMF\Debug\DebugUtils;
 use SMF\ErrorHandler;
 use SMF\IP;
 use SMF\Lang;
@@ -198,7 +199,7 @@ class MySQL extends DatabaseApi implements DatabaseApiInterface
 		}
 
 		// Debugging.
-		if ($this->show_debug) {
+		if (DebugUtils::isDebugEnabled()) {
 			// Get the file and line number this function was called.
 			list($file, $line) = $this->error_backtrace('', '', 'return', __FILE__, __LINE__);
 
@@ -233,7 +234,7 @@ class MySQL extends DatabaseApi implements DatabaseApiInterface
 			if (isset(User::$me) && User::$me->allowedTo('admin_forum')) {
 				$error_message = nl2br($query_error) . '<br>' . Lang::getTxt('file', file: 'General') . ': ' . $file . '<br>' . Lang::getTxt('line', file: 'General') . ': ' . $line;
 
-				if ($this->show_debug) {
+				if (DebugUtils::isDebugEnabled()) {
 					$error_message .= '<br><br>' . nl2br($db_string);
 				}
 			}
@@ -243,7 +244,7 @@ class MySQL extends DatabaseApi implements DatabaseApiInterface
 		}
 
 		// Debugging.
-		if ($this->show_debug) {
+		if (DebugUtils::isDebugEnabled()) {
 			self::$cache[self::$count]['t'] = microtime(true) - $st;
 		}
 
@@ -2537,7 +2538,7 @@ class MySQL extends DatabaseApi implements DatabaseApiInterface
 		}
 
 		// Ignore some errors and strict mode warnings when we are not debugging.
-		mysqli_report(Config::$db_show_debug ? MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT : MYSQLI_REPORT_OFF);
+		mysqli_report(DebugUtils::isDebugEnabled() ? MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT : MYSQLI_REPORT_OFF);
 
 		$success = false;
 

--- a/Sources/Db/APIs/PostgreSQL.php
+++ b/Sources/Db/APIs/PostgreSQL.php
@@ -18,6 +18,7 @@ namespace SMF\Db\APIs;
 use SMF\Config;
 use SMF\Db\DatabaseApi;
 use SMF\Db\DatabaseApiInterface;
+use SMF\Debug\DebugUtils;
 use SMF\ErrorHandler;
 use SMF\IP;
 use SMF\Lang;
@@ -261,7 +262,7 @@ class PostgreSQL extends DatabaseApi implements DatabaseApiInterface
 		}
 
 		// Debugging.
-		if ($this->show_debug) {
+		if (DebugUtils::isDebugEnabled()) {
 			// Get the file and line number this function was called.
 			list($file, $line) = $this->error_backtrace('', '', 'return', __FILE__, __LINE__);
 
@@ -281,7 +282,7 @@ class PostgreSQL extends DatabaseApi implements DatabaseApiInterface
 		$this->last_result = @pg_query($connection, $db_string);
 
 		// Debugging.
-		if ($this->show_debug) {
+		if (DebugUtils::isDebugEnabled()) {
 			self::$cache[self::$count]['t'] = microtime(true) - $st;
 		}
 

--- a/Sources/Db/DatabaseApi.php
+++ b/Sources/Db/DatabaseApi.php
@@ -153,13 +153,6 @@ abstract class DatabaseApi
 	/**
 	 * @var bool
 	 *
-	 * Local copy of Config::$db_show_debug.
-	 */
-	public bool $show_debug;
-
-	/**
-	 * @var bool
-	 *
 	 * Local copy of Config::$modSettings['disableQueryCheck'].
 	 */
 	public bool $disableQueryCheck;
@@ -352,10 +345,6 @@ abstract class DatabaseApi
 
 		if (!isset($this->persist)) {
 			$this->persist = !empty(Config::$db_persist);
-		}
-
-		if (!isset($this->show_debug)) {
-			$this->show_debug = !empty(Config::$db_show_debug);
 		}
 
 		if (!isset($this->disableQueryCheck)) {

--- a/Sources/Debug/DebugUtils.php
+++ b/Sources/Debug/DebugUtils.php
@@ -228,6 +228,14 @@ class DebugUtils
 		return isset(Config::$db_show_debug) && Config::$db_show_debug === true;
 	}
 
+	/**
+	 * Turns off debugging.
+	 */
+	public static function disable(): void
+	{
+		Config::$db_show_debug = false;
+	}
+
 	/*************************
 	 * Internal static methods
 	 *************************/

--- a/Sources/Debug/DebugUtils.php
+++ b/Sources/Debug/DebugUtils.php
@@ -176,10 +176,17 @@ class DebugUtils
 	 *    in `self::$debug_context`.
 	 * @param string $value The value to append to the `source` array of the
 	 *    debug context entry.
+	 * @param ?string $key Optional string key under which to store `$value`
+	 *    inside `self::$logged[$lang_key]`. If not set, a numeric key will be
+	 *    used. Default: null.
 	 */
-	public static function addDebugSource(string $lang_key, string $value): void
+	public static function addDebugSource(string $lang_key, string $value, ?string $key = null): void
 	{
-		self::$logged[$lang_key][] = $value;
+		if (isset($key)) {
+			self::$logged[$lang_key][$key] = $value;
+		} else {
+			self::$logged[$lang_key][] = $value;
+		}
 	}
 
 	/**

--- a/Sources/Debug/DebugUtils.php
+++ b/Sources/Debug/DebugUtils.php
@@ -23,14 +23,15 @@ use SMF\Lang;
 use SMF\Utils;
 
 /**
- * This class provides utilities for debugging, including functions for highlighting JSON and SQL strings,
- * and managing debug context entries.
+ * This class provides utilities for debugging, including functions for
+ * highlighting JSON and SQL strings, and managing debug context entries.
  *
  * To add debug context:
  * - Use the `addDebugContext` method.
  * - Parameters:
  *   - $lang_key (string): The language key under which to store the information.
- *   - $value (DebugContextEntry): An instance of DebugContextEntry containing all the necessary data.
+ *   - $value (DebugContextEntry): An instance of DebugContextEntry containing
+ *     all the necessary data.
  *
  * Example:
  * ```php
@@ -40,8 +41,10 @@ use SMF\Utils;
  * To add a debug source:
  * - Use the `addDebugSource` method.
  * - Parameters:
- *   - $lang_key (string): The language key identifying the debug context entry to update.
- *   - $value (string): The value to append to the `source` array of the debug context entry.
+ *   - $lang_key (string): The language key identifying the debug context entry
+ *     to update.
+ *   - $value (string): The value to append to the `source` array of the debug
+ *     context entry.
  *
  * Example:
  * ```php
@@ -162,13 +165,17 @@ class DebugUtils
 	/**
 	 * Appends a value to the source array of a specific debug context entry.
 	 *
-	 * This method is used to dynamically add individual debug information to an existing
-	 * entry in the debug context. **Important:** Ensure that all `addDebugInfo` calls
-	 * are made before setting the final debug context via `addDebugContext`.
+	 * This method is used to dynamically add individual debug information to an
+	 * existing entry in the debug context.
 	 *
-	 * @param string $lang_key The language key identifying the debug context entry to update.
-	 *    This key corresponds to a specific debug entry stored in `self::$debug_context`.
-	 * @param string $value The value to append to the `source` array of the debug context entry.
+	 * **Important:** Ensure that all `addDebugInfo` calls are made before
+	 * setting the final debug context via `addDebugContext`.
+	 *
+	 * @param string $lang_key The language key identifying the debug context
+	 *    entry to update. This key corresponds to a specific debug entry stored
+	 *    in `self::$debug_context`.
+	 * @param string $value The value to append to the `source` array of the
+	 *    debug context entry.
 	 */
 	public static function addDebugSource(string $lang_key, string $value): void
 	{
@@ -178,9 +185,11 @@ class DebugUtils
 	/**
 	 * Adds information to the debug context.
 	 *
-	 * @param string $lang_key The language key under which to store the information.
-	 *    This key corresponds to the language strings used for rendering debug details.
-	 * @param DebugContextEntry $value The debug context entry containing all the necessary data.
+	 * @param string $lang_key The language key under which to store the
+	 *    information. This key corresponds to the language strings used for
+	 *    rendering debug details.
+	 * @param DebugContextEntry $value The debug context entry containing all
+	 *    the necessary data.
 	 */
 	public static function addDebugContext(string $lang_key, DebugContextEntry $value): void
 	{
@@ -196,6 +205,10 @@ class DebugUtils
 			$_SESSION['view_queries'] ??= 0;
 			$files = self::getIncludedFilesInfo();
 			$warnings = self::collectQueryWarnings();
+
+			foreach (self::$logged as $lang_key => $items) {
+				self::$logged[$lang_key] = array_unique(array_merge($items, Utils::$context['debug'][$lang_key] ?? []));
+			}
 
 			self::createDebugContext($files);
 			self::outputDebugInformation($warnings);
@@ -287,22 +300,18 @@ class DebugUtils
 
 		self::addDebugContext('debug_templates', new DebugContextEntry(
 			source: self::$logged['templates'],
-			open: true,
 		));
 
 		self::addDebugContext('debug_subtemplates', new DebugContextEntry(
 			source: self::$logged['sub_templates'],
-			open: true,
 		));
 
 		self::addDebugContext('debug_language_files', new DebugContextEntry(
 			source: self::$logged['language_files'],
-			open: true,
 		));
 
 		self::addDebugContext('debug_stylesheets', new DebugContextEntry(
 			source: self::$logged['sheets'],
-			open: true,
 		));
 
 		self::addDebugContext('debug_hooks', new DebugContextEntry(
@@ -398,21 +407,17 @@ class DebugUtils
 				continue;
 			}
 
-			$source = array_merge(
-				Utils::$context['debug'][$lang_key] ?? [],
-				self::$logged[$lang_key] ?? [],
-				$info->source ?? [],
-			);
-
 			if ($info->extra_before) {
 				echo $info->extra_before;
-			} elseif ($source == [] || ($info->toggle === false)) {
+			} elseif (empty($info->source) || ($info->toggle === false)) {
 				echo '<div>';
 			}
 
-			if ($source != []) {
+			unset($additional_info);
+
+			if (!empty($info->source)) {
 				$additional_info = \sprintf(
-					'%1$s' . implode('%2$s%3$s%1$s', $source) . '%2$s',
+					'%1$s' . implode('%2$s%3$s%1$s', $info->source) . '%2$s',
 					$info->before_source,
 					$info->after_source,
 					$info->glue_sources,
@@ -432,28 +437,27 @@ class DebugUtils
 			echo Lang::getTxt(
 				$lang_key,
 				[
-					'num' => $info->num ?? \count($source),
+					'num' => $info->num ?? \count($info->source ?? []),
 					'additional_info' => $additional_info ?? '',
 				] + ($info->extra_lang_params ?? []),
 			);
 
 			if ($info->extra_after) {
 				echo $info->extra_after;
-			} elseif ($source == [] || ($info->toggle === false)) {
+			} elseif (empty($info->source) || ($info->toggle === false)) {
 				echo '</div>';
 			}
 			echo "\n\t\t";
 		}
 
 		echo '
-		<br>
 		<a href="', Config::$scripturl, '?action=viewquery" target="_blank" rel="noopener">', $warnings == 0 ? Lang::getTxt('debug_queries_used', [(int) Db::$count]) : Lang::getTxt('debug_queries_used_and_warnings', [(int) Db::$count, $warnings]), '</a><br>
-		<br>';
+		<br>
+		<a href="' . Config::$scripturl . '?action=viewquery;sa=hide">', Lang::$txt['debug_' . (empty($_SESSION['view_queries']) ? 'show' : 'hide') . '_queries'], '</a>';
 
 		self::outputQueryDebugInfo();
 
 		echo '
-		<a href="' . Config::$scripturl . '?action=viewquery;sa=hide">', Lang::$txt['debug_' . (empty($_SESSION['view_queries']) ? 'show' : 'hide') . '_queries'], '</a>
 	</div></body></html>';
 	}
 

--- a/Sources/Debug/DebugUtils.php
+++ b/Sources/Debug/DebugUtils.php
@@ -213,10 +213,6 @@ class DebugUtils
 			$files = self::getIncludedFilesInfo();
 			$warnings = self::collectQueryWarnings();
 
-			foreach (self::$logged as $lang_key => $items) {
-				self::$logged[$lang_key] = array_unique(array_merge($items, Utils::$context['debug'][$lang_key] ?? []));
-			}
-
 			self::createDebugContext($files);
 			self::outputDebugInformation($warnings);
 		}

--- a/Sources/ErrorHandler.php
+++ b/Sources/ErrorHandler.php
@@ -21,6 +21,7 @@ namespace SMF;
 
 use SMF\Cache\CacheApi;
 use SMF\Db\DatabaseApi as Db;
+use SMF\Debug\DebugUtils;
 use SMF\ServerSideIncludes as SSI;
 
 /**
@@ -104,7 +105,7 @@ class ErrorHandler
 			}
 		}
 
-		if (isset(Config::$db_show_debug) && Config::$db_show_debug === true) {
+		if (DebugUtils::isDebugEnabled()) {
 			// Commonly, undefined indexes will occur inside attributes; try to show them anyway!
 			if ($error_level % 255 != E_ERROR) {
 				$temporary = ob_get_contents();
@@ -207,7 +208,7 @@ class ErrorHandler
 		$error_call++;
 
 		// Collect a backtrace
-		if (!isset(Config::$db_show_debug) || Config::$db_show_debug === false) {
+		if (!DebugUtils::isDebugEnabled()) {
 			$backtrace = $backtrace ?? debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
 		} else {
 			// This is how to keep the args but skip the objects.

--- a/Sources/IntegrationHook.php
+++ b/Sources/IntegrationHook.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 namespace SMF;
 
 use SMF\Db\DatabaseApi as Db;
+use SMF\Debug\DebugUtils;
 
 /**
  * Handles adding, removing, and calling hooked integration functions.
@@ -79,8 +80,8 @@ class IntegrationHook
 
 		$this->ignore_errors = $ignore_errors ?? !empty(Utils::$context['ignore_hook_errors']);
 
-		if (!empty(Config::$db_show_debug)) {
-			Utils::$context['debug']['hooks'][] = $this->name;
+		if (DebugUtils::isDebugEnabled()) {
+			DebugUtils::addDebugSource('hooks', $this->name);
 		}
 
 		if (empty(Config::$modSettings[$this->name])) {

--- a/Sources/Lang.php
+++ b/Sources/Lang.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 namespace SMF;
 
 use SMF\Cache\CacheApi;
+use SMF\Debug\DebugUtils;
 use SMF\Localization\MessageFormatter;
 
 /**
@@ -300,8 +301,12 @@ class Lang
 					$found = true;
 
 					// Keep track of what we're up to, soldier.
-					if (!empty(Config::$db_show_debug)) {
-						Utils::$context['debug']['language_files'][implode('|', $file)] = (Config::$languagesdir == $file[0] ? basename($file[0]) : ltrim(str_replace(array_map('dirname', self::$dirs), '', $file[0]), '/')) . '/' . $file[2] . '/' . $file[1] . '.php';
+					if (DebugUtils::isDebugEnabled()) {
+						DebugUtils::addDebugSource(
+							lang_key: 'language_files',
+							key: implode('|', $file),
+							value: (Config::$languagesdir == $file[0] ? basename($file[0]) : ltrim(str_replace(array_map('dirname', self::$dirs), '', $file[0]), '/')) . '/' . $file[2] . '/' . $file[1] . '.php',
+						);
 					}
 
 					// Load the strings into our properties.
@@ -1067,8 +1072,12 @@ class Lang
 				}
 
 				// Keep track of what we're up to, soldier.
-				if (!empty(Config::$db_show_debug)) {
-					Utils::$context['debug']['language_files'][implode('|', $file)] = (Config::$languagesdir == $file[0] ? basename($file[0]) : ltrim(str_replace(array_map('dirname', self::$dirs), '', $file[0]), '/')) . '/' . $file[1] . '.' . $oldLanguage . '.php';
+				if (DebugUtils::isDebugEnabled()) {
+					DebugUtils::addDebugSource(
+						lang_key: 'language_files',
+						key: implode('|', $file),
+						value: (Config::$languagesdir == $file[0] ? basename($file[0]) : ltrim(str_replace(array_map('dirname', self::$dirs), '', $file[0]), '/')) . '/' . $file[1] . '.' . $oldLanguage . '.php',
+					);
 				}
 			}
 		}

--- a/Sources/Lang.php
+++ b/Sources/Lang.php
@@ -301,7 +301,7 @@ class Lang
 
 					// Keep track of what we're up to, soldier.
 					if (!empty(Config::$db_show_debug)) {
-						Utils::$context['debug']['language_files'][implode('|', $file)] = (Config::$languagesdir == $file[0] ? basename($file[0]) : ltrim(str_replace(array_map('dirname', Theme::$current->settings['template_dirs']), '', $file[0]), '/')) . '/' . $file[2] . '/' . $file[1] . '.php';
+						Utils::$context['debug']['language_files'][implode('|', $file)] = (Config::$languagesdir == $file[0] ? basename($file[0]) : ltrim(str_replace(array_map('dirname', self::$dirs), '', $file[0]), '/')) . '/' . $file[2] . '/' . $file[1] . '.php';
 					}
 
 					// Load the strings into our properties.
@@ -1068,7 +1068,7 @@ class Lang
 
 				// Keep track of what we're up to, soldier.
 				if (!empty(Config::$db_show_debug)) {
-					Utils::$context['debug']['language_files'][implode('|', $file)] = (Config::$languagesdir == $file[0] ? basename($file[0]) : ltrim(str_replace(array_map('dirname', Theme::$current->settings['template_dirs']), '', $file[0]), '/')) . '/' . $file[1] . '.' . $oldLanguage . '.php';
+					Utils::$context['debug']['language_files'][implode('|', $file)] = (Config::$languagesdir == $file[0] ? basename($file[0]) : ltrim(str_replace(array_map('dirname', self::$dirs), '', $file[0]), '/')) . '/' . $file[1] . '.' . $oldLanguage . '.php';
 				}
 			}
 		}

--- a/Sources/PersonalMessage/Popup.php
+++ b/Sources/PersonalMessage/Popup.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 namespace SMF\PersonalMessage;
 
 use SMF\Config;
+use SMF\Debug\DebugUtils;
 use SMF\Theme;
 use SMF\Time;
 use SMF\User;
@@ -40,7 +41,7 @@ class Popup
 		}
 
 		// We do not want to output debug information here.
-		Config::$db_show_debug = false;
+		DebugUtils::disable();
 
 		// We only want to output our little layer here.
 		Utils::$context['template_layers'] = [];

--- a/Sources/Search/APIs/Custom.php
+++ b/Sources/Search/APIs/Custom.php
@@ -17,6 +17,7 @@ namespace SMF\Search\APIs;
 
 use SMF\Config;
 use SMF\Db\DatabaseApi as Db;
+use SMF\Debug\DebugUtils;
 use SMF\Lang;
 use SMF\Menu;
 use SMF\Sapi;
@@ -119,7 +120,7 @@ class Custom extends SearchApi implements SearchApiInterface
 			return 'partial';
 		}
 
-		return !empty(Config::$db_show_debug) ? 'none' : 'hidden';
+		return DebugUtils::isDebugEnabled() ? 'none' : 'hidden';
 	}
 
 	/**

--- a/Sources/ServerSideIncludes.php
+++ b/Sources/ServerSideIncludes.php
@@ -18,6 +18,7 @@ namespace SMF;
 use SMF\Cache\CacheApi;
 use SMF\Calendar\Event;
 use SMF\Db\DatabaseApi as Db;
+use SMF\Debug\DebugUtils;
 
 /**
  * Performs all the necessary setup and security checks for SSI access, and
@@ -189,7 +190,7 @@ class ServerSideIncludes
 			}
 		}
 
-		$this->error_reporting = error_reporting(!empty(Config::$db_show_debug) ? E_ALL : E_ALL & ~E_DEPRECATED);
+		$this->error_reporting = error_reporting(DebugUtils::isDebugEnabled() ? E_ALL : E_ALL & ~E_DEPRECATED);
 
 		if (!isset($this->gzip)) {
 			$this->gzip = !empty(Config::$modSettings['enableCompressedOutput']);

--- a/Sources/TaskRunner.php
+++ b/Sources/TaskRunner.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 namespace SMF;
 
 use SMF\Db\DatabaseApi as Db;
+use SMF\Debug\DebugUtils;
 use SMF\Tasks\BackgroundTask;
 use SMF\Tasks\ScheduledTask;
 
@@ -162,7 +163,7 @@ class TaskRunner
 				$_SERVER['SERVER_PROTOCOL'] = 'HTTP/1.0';
 			}
 
-			Config::$db_show_debug = false;
+			DebugUtils::disable();
 
 			Db::load();
 

--- a/Sources/Theme.php
+++ b/Sources/Theme.php
@@ -18,6 +18,7 @@ namespace SMF;
 use SMF\Actions\Notify;
 use SMF\Cache\CacheApi;
 use SMF\Db\DatabaseApi as Db;
+use SMF\Debug\DebugUtils;
 use SMF\WebFetch\WebFetchApi;
 
 /**
@@ -420,8 +421,8 @@ class Theme
 		}
 
 		if ($loaded) {
-			if (!empty(Config::$db_show_debug)) {
-				Utils::$context['debug']['templates'][] = basename($template_dir) . '/' . $template_name . '.template.php';
+			if (DebugUtils::isDebugEnabled()) {
+				DebugUtils::addDebugSource('templates', basename($template_dir) . '/' . $template_name . '.template.php');
 			}
 
 			// If they have specified an initialization function for this template, go ahead and call it now.
@@ -508,8 +509,8 @@ class Theme
 		$template_name = \is_array($sub_template_name) ? $sub_template_name[0] : $sub_template_name;
 
 		// Add the sub-template to the debug context if debugging is enabled.
-		if (!empty(Config::$db_show_debug)) {
-			Utils::$context['debug']['sub_templates'][] = $template_name;
+		if (DebugUtils::isDebugEnabled()) {
+			DebugUtils::addDebugSource('sub_templates', $template_name);
 		}
 
 		// Determine the template function name and any associated parameters.
@@ -1687,12 +1688,12 @@ class Theme
 				}
 			}
 
-			if (!empty(Config::$db_show_debug)) {
+			if (DebugUtils::isDebugEnabled()) {
 				// Try to keep only what's useful.
 				$repl = [Config::$boardurl . '/Themes/' => '', Config::$boardurl . '/' => ''];
 
 				foreach (Utils::$context[$css_group . '_files'] as $file) {
-					Utils::$context['debug']['sheets'][] = strtr($file['fileUrl'], $repl);
+					DebugUtils::addDebugSource('sheets', strtr($file['fileUrl'], $repl));
 				}
 			}
 

--- a/Sources/Utils.php
+++ b/Sources/Utils.php
@@ -2275,7 +2275,7 @@ class Utils
 		header('location: ' . str_replace(' ', '%20', $setLocation), true, $permanent ? 301 : 302);
 
 		// Debugging.
-		if (!empty(Config::$db_show_debug)) {
+		if (DebugUtils::isDebugEnabled()) {
 			$_SESSION['debug_redirect'] = Db::$cache;
 		}
 

--- a/Sources/Utils.php
+++ b/Sources/Utils.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 namespace SMF;
 
 use SMF\Db\DatabaseApi as Db;
+use SMF\Debug\DebugUtils;
 
 /**
  * Holds some widely used stuff, like $context and $smcFunc.
@@ -342,6 +343,10 @@ class Utils
 
 		if (!empty(Config::$modSettings['restricted_bbc'])) {
 			self::$context['restricted_bbc'] = array_unique(array_merge(self::$context['restricted_bbc'], explode(',', Config::$modSettings['restricted_bbc'])));
+		}
+
+		if (!empty(Config::$backward_compatibility) && DebugUtils::isDebugEnabled()) {
+			self::$context['debug'] = &DebugUtils::$logged;
 		}
 	}
 
@@ -2493,8 +2498,12 @@ class Utils
 					Utils::$context['instances'][$class] = new $class();
 
 					// Optionally track instance creation for debugging.
-					if (!empty(Config::$db_show_debug)) {
-						Utils::$context['debug']['instances'][$class] = $class;
+					if (DebugUtils::isDebugEnabled()) {
+						DebugUtils::addDebugSource(
+							lang_key: 'instances',
+							key: $class,
+							value: $class,
+						);
 					}
 				}
 

--- a/Sources/Utils.php
+++ b/Sources/Utils.php
@@ -2204,7 +2204,7 @@ class Utils
 		}
 
 		// Don't need extra stuff...
-		Config::$db_show_debug = false;
+		DebugUtils::disable();
 
 		// Kill anything else.
 		ob_end_clean();


### PR DESCRIPTION
- [Replaces theme setting var with Lang::$dirs in Lang::load()](https://github.com/SimpleMachines/SMF/commit/7d03d64406fc10f1787ce5299c5ac835d28180e0)
    - Fixes the issue that @live627 reported in the internal forum when trying to run the upgrader.
- [Fixes error in SMF\Actions\ViewQuery on MySQL](https://github.com/SimpleMachines/SMF/commit/e5f3c350ccb3319cc339cbf53344c96442f49531)
    - `EXPLAIN ANALYZE FORMAT=JSON` only works on MySQL when `explain_json_format_version` is set to `2`.
- [Fixes some issues in SMF\Debug\DebugUtils](https://github.com/SimpleMachines/SMF/commit/70d28170441da51ffaa4dcccb7bc99938e88e0aa)
    - Debug data at the bottom of the page wasn't displaying correctly for a few different reasons. This fixes them.

The remainder of the commits in this PR move us to a place where DebugUtils is solely responsible for managing debug status and information:
- Instead of appending items to `Utils::$context['debug']`, we call `DebugUtils::addDebugSource()`.
- Instead of running tests against the value of `Config::$db_show_debug`, we call `DebugUtils::isDebugEnabled()`.
- Instead of manipulating the value of `Config::$db_show_debug` when we want to disable debugging, we call `DebugUtils::disable()`.