### PR TITLE
[3.0] Adds &$mime_type param to SMF\Utils::checkMimeType()

### DIFF
--- a/Languages/en_US/Errors.php
+++ b/Languages/en_US/Errors.php
@@ -596,3 +596,5 @@ $txt['uuid_invalid_string'] = 'Invalid UUID string supplied: {0}';
 $txt['uuid_group_non_posix'] = 'Automatic group domain is unsupported for UUIDv2 on non-POSIX systems. Falling back to user domain.';
 $txt['uuid_unknown_domain'] = 'Cannot generate automatic UUIDv2 for unknown domain: {0}';
 $txt['uuid_timestamp_out_of_range'] = 'Timestamp out of range for UUIDv{0}';
+
+$txt['required_extension_missing'] = 'SMF requires PHP’s {ext} extension. Please enable it in your PHP configuration so that SMF can function correctly.';

--- a/Sources/Graphics/Image.php
+++ b/Sources/Graphics/Image.php
@@ -386,7 +386,7 @@ class Image
 
 		// Update properties to refer to the new image.
 		$this->source = realpath($destination);
-		$this->mime_type = mime_content_type($this->source);
+		$this->mime_type = Utils::getMimeType($this->source, true);
 		$this->pathinfo = pathinfo($this->source);
 		$this->type = $preferred_type;
 		$this->getDimensionsAndOrientation();
@@ -467,7 +467,7 @@ class Image
 
 		// Update properties to refer to the new image.
 		$this->source = realpath($destination);
-		$this->mime_type = mime_content_type($this->source);
+		$this->mime_type = Utils::getMimeType($this->source, true);
 		$this->pathinfo = pathinfo($this->source);
 		$this->type = $preferred_type;
 		$this->getDimensionsAndOrientation();

--- a/Sources/ProxyServer.php
+++ b/Sources/ProxyServer.php
@@ -290,13 +290,7 @@ class ProxyServer
 		}
 
 		// What kind of file did they give us?
-		$finfo = finfo_open(FILEINFO_MIME_TYPE);
-		$mime_type = finfo_buffer($finfo, $image);
-
-		// SVG needs a little extra care
-		if ($ext == 'svg' && \in_array($mime_type, ['text/plain', 'text/xml']) && str_contains($image, '<svg') && str_contains($image, '</svg>')) {
-			$mime_type = 'image/svg+xml';
-		}
+		$mime_type = Utils::getMimeType($image);
 
 		// Make sure the url is returning an image
 		if (!str_starts_with($mime_type, 'image/')) {

--- a/Sources/Subs-Compat.php
+++ b/Sources/Subs-Compat.php
@@ -11667,11 +11667,12 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	 * @param string $data The data to check, or the path or URL of a file to check.
 	 * @param string $type_pattern A regex pattern to match the acceptable MIME types.
 	 * @param bool $is_path If true, $data is a path or URL to a file.
+	 * @param string &mime_type Will be set to the detected MIME type.
 	 * @return int 1 if the detected MIME type matches the pattern, 0 if it doesn't, or 2 if we can't check.
 	 */
-	function check_mime_type(string $data, string $type_pattern, bool $is_path = false): int
+	function check_mime_type(string $data, string $type_pattern, bool $is_path = false, ?string &$mime_type = ''): int
 	{
-		return SMF\Utils::checkMimeType($data, $type_pattern, $is_path);
+		return SMF\Utils::checkMimeType($data, $type_pattern, $is_path, $mime_type);
 	}
 
 	/**

--- a/Sources/Utils.php
+++ b/Sources/Utils.php
@@ -1930,18 +1930,24 @@ class Utils
 	/**
 	 * Checks whether a file or data has the expected MIME type.
 	 *
-	 * @param string $data The data to check, or the path or URL of a file to check.
-	 * @param string $type_pattern A regex pattern to match the acceptable MIME types.
+	 * @param string $data The data to check, or the path or URL of a file to
+	 *    check.
+	 * @param string $type_pattern A regex pattern to match the acceptable MIME
+	 *    types.
 	 * @param bool $is_path If true, $data is a path or URL to a file.
-	 * @return int 1 if the detected MIME type matches the pattern, 0 if it doesn't, or 2 if we can't check.
+	 * @param string &mime_type Will be set to the detected MIME type.
+	 * @return int 1 if the detected MIME type matches the pattern, 0 if it
+	 *    doesn't, or 2 if we can't check.
 	 */
-	public static function checkMimeType(string $data, string $type_pattern, bool $is_path = false): int
+	public static function checkMimeType(string $data, string $type_pattern, bool $is_path = false, ?string &$mime_type = ''): int
 	{
 		// Get the MIME type.
 		$mime_type = self::getMimeType($data, $is_path);
 
 		// Couldn't determine it.
 		if ($mime_type === false) {
+			$mime_type = '';
+
 			return 2;
 		}
 

--- a/Sources/Utils.php
+++ b/Sources/Utils.php
@@ -1845,82 +1845,48 @@ class Utils
 	/**
 	 * Attempts to determine the MIME type of some data or a file.
 	 *
-	 * @param string $data The data to check, or the path or URL of a file to check.
+	 * @param string $data The data to check, or the path or URL of a file to
+	 *    check.
 	 * @param bool $is_path If true, $data is a path or URL to a file.
 	 * @return string|false A MIME type, or false if we cannot determine it.
 	 */
 	public static function getMimeType(string $data, bool $is_path = false): string|false
 	{
-		$finfo_loaded = \extension_loaded('fileinfo');
-		$exif_loaded = \extension_loaded('exif') && \function_exists('image_type_to_mime_type');
+		// Fileinfo extension is required.
+		if (!\extension_loaded('fileinfo')) {
+			ErrorHandler::log(Lang::getTxt('required_extension_missing', ['ext' => 'fileinfo'], file: 'Errors'));
 
-		// Oh well. We tried.
-		if (!$finfo_loaded && !$exif_loaded) {
 			return false;
 		}
 
 		// Start with the 'empty' MIME type.
 		$mime_type = 'application/x-empty';
 
-		if ($finfo_loaded) {
-			// Just some nice, simple data to analyze.
-			if (empty($is_path)) {
-				$mime_type = finfo_buffer(finfo_open(FILEINFO_MIME_TYPE), $data);
+		// Just some nice, simple data to analyze.
+		if (!$is_path) {
+			$mime_type = finfo_buffer(finfo_open(FILEINFO_MIME_TYPE), $data);
+		}
+		// A file, or maybe a URL?
+		else {
+			$path = $data;
+
+			// Local file.
+			if (file_exists($path)) {
+				$mime_type = mime_content_type($path);
 			}
-			// A file, or maybe a URL?
-			else {
-				$path = $data;
+			// URL.
+			elseif ($data = WebFetch\WebFetchApi::fetch($path)) {
+				$mime_type = finfo_buffer(finfo_open(FILEINFO_MIME_TYPE), $data);
 
-				// Local file.
-				if (file_exists($path)) {
-					$mime_type = mime_content_type($path);
-				}
-				// URL.
-				elseif ($data = WebFetch\WebFetchApi::fetch($path)) {
-					$mime_type = finfo_buffer(finfo_open(FILEINFO_MIME_TYPE), $data);
+				// SVG sometimes needs a little extra help.
+				if ($mime_type === 'text/html' && strtolower(pathinfo($path, PATHINFO_EXTENSION)) === 'svg') {
+					// Detection sometimes fails if the <svg> element isn't first.
+					$data = preg_replace('/^([^<]|<(?!svg\b))*/i', '', $data);
 
-					// SVG sometimes needs a little extra help.
-					if ($mime_type === 'text/html' && strtolower(pathinfo($path, PATHINFO_EXTENSION)) === 'svg') {
-						// Detection sometimes fails if the <svg> element isn't first.
-						$data = preg_replace('/^([^<]|<(?!svg\b))*/i', '', $data);
-
-						if (finfo_buffer(finfo_open(FILEINFO_MIME_TYPE), $data) == 'image/svg+xml') {
-							$mime_type = 'image/svg+xml';
-						}
+					if (finfo_buffer(finfo_open(FILEINFO_MIME_TYPE), $data) == 'image/svg+xml') {
+						$mime_type = 'image/svg+xml';
 					}
 				}
-			}
-		}
-		// Workaround using Exif requires a local file.
-		else {
-			// If $data is a URL to fetch, do so.
-			if (!empty($is_path) && !file_exists($data)) {
-				$data = WebFetch\WebFetchApi::fetch($data);
-
-				if ($data === false) {
-					return false;
-				}
-
-				$is_path = false;
-			}
-
-			// If we don't have a local file, create one and use it.
-			if (empty($is_path)) {
-				$temp_file = tempnam(Config::$cachedir, md5($data));
-				file_put_contents($temp_file, $data);
-				$is_path = true;
-				$data = $temp_file;
-			}
-
-			$imagetype = @exif_imagetype($data);
-
-			if (isset($temp_file)) {
-				unlink($temp_file);
-			}
-
-			// Unfortunately, this workaround only works for image files.
-			if ($imagetype !== false) {
-				$mime_type = image_type_to_mime_type($imagetype);
 			}
 		}
 


### PR DESCRIPTION
- Updates the signature of `SMF\Utils::checkMimeType()` and the related backward compatibility function in Subs-Compat.php to match the recent changes in SMF 2.1 (see #8908)
- Removes unneeded fallback code in `SMF\Utils::getMimeType()`. We now require the fileinfo extension, so the fallback that used the exif extension is not longer needed.
- Uses `SMF\Utils::getMimeType()` in more places.