### PR TITLE
[2.1] Calculates DB datatype sizes & defaults more intelligently

### DIFF
--- a/Sources/DbPackages-mysql.php
+++ b/Sources/DbPackages-mysql.php
@@ -449,7 +449,7 @@ function smf_db_change_column($table_name, $old_column, $column_info)
 		$column_info['auto'] = $old_info['auto'];
 	if (!isset($column_info['type']))
 		$column_info['type'] = $old_info['type'];
-	if (!isset($column_info['size']) || !is_numeric($column_info['size']))
+	if (!array_key_exists('size', $column_info) || (!is_numeric($column_info['size']) && !is_null($column_info['size'])))
 		$column_info['size'] = $old_info['size'];
 	if (!isset($column_info['unsigned']) || !in_array($column_info['type'], array('int', 'tinyint', 'smallint', 'mediumint', 'bigint')))
 		$column_info['unsigned'] = '';
@@ -458,6 +458,13 @@ function smf_db_change_column($table_name, $old_column, $column_info)
 	// (Unspecified = no default whatsoever = column is not nullable with a value of null...)
 	if (($column_info['not_null'] === true) && !$column_info['drop_default'] && array_key_exists('default', $column_info) && is_null($column_info['default']))
 		unset($column_info['default']);
+
+	// These types cannot have a default value.
+	if (in_array($column_info['type'], ['text', 'tinytext', 'mediumtext', 'longtext', 'blob', 'tinyblob', 'mediumblob', 'longblob', 'json', 'geometry']))
+	{
+		$column_info['drop_default'] = true;
+		unset($column_info['default']);
+	}
 
 	list ($type, $size) = $smcFunc['db_calculate_type']($column_info['type'], $column_info['size']);
 
@@ -697,8 +704,15 @@ function smf_db_calculate_type($type_name, $type_size = null, $reverse = false)
 		else
 			$type_name = $types[$type_name];
 	}
-	elseif ($type_name == 'boolean')
+
+	if (
+		// We can't have a zero size.
+		$type_size === 0
+		// Always set size to null for types that don't use them.
+		|| in_array($type_name, ['boolean', 'bool', 'integer', 'int', 'tinyint', 'smallint', 'mediumint', 'bigint', 'tinytext', 'mediumtext', 'longtext', 'tinyblob', 'mediumblob', 'longblob', 'enum', 'set', 'json', 'geometry'])
+	) {
 		$type_size = null;
+	}
 
 	return array($type_name, $type_size);
 }
@@ -891,6 +905,13 @@ function smf_db_create_query_column($column)
 	global $smcFunc;
 
 	$column = array_change_key_case($column);
+
+	// These types cannot have a default value.
+	if (in_array($column_info['type'], ['text', 'tinytext', 'mediumtext', 'longtext', 'blob', 'tinyblob', 'mediumblob', 'longblob', 'json', 'geometry']))
+	{
+		$column_info['drop_default'] = true;
+		unset($column_info['default']);
+	}
 
 	// Auto increment is easy here!
 	if (!empty($column['auto']))

--- a/Sources/DbPackages-postgresql.php
+++ b/Sources/DbPackages-postgresql.php
@@ -489,7 +489,7 @@ function smf_db_change_column($table_name, $old_column, $column_info)
 		$column_info['auto'] = $old_info['auto'];
 	if (!isset($column_info['type']))
 		$column_info['type'] = $old_info['type'];
-	if (!isset($column_info['size']) || !is_numeric($column_info['size']))
+	if (!array_key_exists('size', $column_info) || (!is_numeric($column_info['size']) && !is_null($column_info['size'])))
 		$column_info['size'] = $old_info['size'];
 	if (!isset($column_info['unsigned']) || !in_array($column_info['type'], array('int', 'tinyint', 'smallint', 'mediumint', 'bigint')))
 		$column_info['unsigned'] = '';
@@ -794,9 +794,14 @@ function smf_db_calculate_type($type_name, $type_size = null, $reverse = false)
 		$type_name = $types[$type_name];
 	}
 
-	// Only char fields got size
-	if (strpos($type_name, 'char') === false)
+	if (
+		// We can't have a zero size.
+		$type_size === 0
+		// Only char fields have a size.
+		|| !str_contains($type_name, 'char')
+	) {
 		$type_size = null;
+	}
 
 	return array($type_name, $type_size);
 }


### PR DESCRIPTION
Fixes #8577 for 2.1

- If the type of a column is being set to something that does not take a size value, the size will be forced to null.
- If the type of a column is being changed (via `$smcFunc['db_change_column']`) from one type that takes a size to another that also takes a size, the size will be retained unless a size value is explicitly set in the info passed to `$smcFunc['db_change_column']`.
- Unlike before, if the size is explicitly set to null in the info passed to `$smcFunc['db_change_column']`, the null value will be used rather than the old size value.