### PR TITLE
[2.1] Fixes illegal string offset 'type' error in legalise_bbc()

### DIFF
--- a/Sources/Subs-Editor.php
+++ b/Sources/Subs-Editor.php
@@ -1289,7 +1289,7 @@ function legalise_bbc($text)
 								break;
 
 							// Still a block tag was open not equal to this tag.
-							$addClosingTags[] = $element['type'];
+							$addClosingTags[] = $element;
 						}
 
 						if (!empty($addClosingTags))


### PR DESCRIPTION
Fixes #8583 