### PR TITLE
[3.0] Fixes illegal string offset 'type' error in BBCodeParser::legalise()

### DIFF
--- a/Sources/Parsers/BBCodeParser.php
+++ b/Sources/Parsers/BBCodeParser.php
@@ -2700,7 +2700,7 @@ class BBCodeParser extends Parser
 								}
 
 								// Still a block tag was open not equal to this tag.
-								$add_closing_tags[] = $element['type'];
+								$add_closing_tags[] = $element;
 							}
 
 							if (!empty($add_closing_tags)) {


### PR DESCRIPTION
Fixes #8911 for 3.0