### PR TITLE
[3.0] Always use canonical path when including files

### DIFF
--- a/Languages/en_US/index.php
+++ b/Languages/en_US/index.php
@@ -1,8 +1,8 @@
 <?php
 
 // Try to handle it with the upper level index.php. (it should know what to do.)
-if (file_exists(dirname(__DIR__) . '/index.php')) {
-	include dirname(__DIR__) . '/index.php';
+if (file_exists(dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php')) {
+	include dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php';
 } else {
 	exit;
 }

--- a/Languages/index.php
+++ b/Languages/index.php
@@ -1,8 +1,8 @@
 <?php
 
 // Try to handle it with the upper level index.php. (it should know what to do.)
-if (file_exists(dirname(__DIR__) . '/index.php')) {
-	include dirname(__DIR__) . '/index.php';
+if (file_exists(dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php')) {
+	include dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php';
 } else {
 	exit;
 }

--- a/Packages/backups/index.php
+++ b/Packages/backups/index.php
@@ -1,8 +1,8 @@
 <?php
 
 // Try to handle it with the upper level index.php. (it should know what to do.)
-if (file_exists(dirname(__DIR__) . '/index.php')) {
-	include dirname(__DIR__) . '/index.php';
+if (file_exists(dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php')) {
+	include dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php';
 } else {
 	exit;
 }

--- a/Packages/index.php
+++ b/Packages/index.php
@@ -1,8 +1,8 @@
 <?php
 
 // Try to handle it with the upper level index.php. (it should know what to do.)
-if (file_exists(dirname(__DIR__) . '/index.php')) {
-	include dirname(__DIR__) . '/index.php';
+if (file_exists(dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php')) {
+	include dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php';
 } else {
 	exit;
 }

--- a/SSI.php
+++ b/SSI.php
@@ -36,7 +36,7 @@ if (!defined('SMF')) {
 }
 
 // Initialize.
-require_once __DIR__ . '/index.php';
+require_once __DIR__ . DIRECTORY_SEPARATOR . 'index.php';
 
 $ssi = new SMF\ServerSideIncludes();
 $ssi->execute();

--- a/Smileys/alienine/index.php
+++ b/Smileys/alienine/index.php
@@ -1,8 +1,8 @@
 <?php
 
 // Try to handle it with the upper level index.php. (it should know what to do.)
-if (file_exists(dirname(__DIR__) . '/index.php')) {
-	include dirname(__DIR__) . '/index.php';
+if (file_exists(dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php')) {
+	include dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php';
 } else {
 	exit;
 }

--- a/Smileys/fugue/index.php
+++ b/Smileys/fugue/index.php
@@ -1,8 +1,8 @@
 <?php
 
 // Try to handle it with the upper level index.php. (it should know what to do.)
-if (file_exists(dirname(__DIR__) . '/index.php')) {
-	include dirname(__DIR__) . '/index.php';
+if (file_exists(dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php')) {
+	include dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php';
 } else {
 	exit;
 }

--- a/Smileys/index.php
+++ b/Smileys/index.php
@@ -1,8 +1,8 @@
 <?php
 
 // Try to handle it with the upper level index.php. (it should know what to do.)
-if (file_exists(dirname(__DIR__) . '/index.php')) {
-	include dirname(__DIR__) . '/index.php';
+if (file_exists(dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php')) {
+	include dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php';
 } else {
 	exit;
 }

--- a/Sources/Actions/Admin/ACP.php
+++ b/Sources/Actions/Admin/ACP.php
@@ -780,7 +780,7 @@ class ACP implements ActionInterface, Routable
 
 		// Now - finally - call the right place!
 		if (isset($menu->include_data['file'])) {
-			require_once Config::$sourcedir . '/' . $menu->include_data['file'];
+			require_once Config::canonicalPath(Config::$sourcedir . '/' . $menu->include_data['file']);
 		}
 
 		// Get the right callable.
@@ -1883,7 +1883,7 @@ class ACP implements ActionInterface, Routable
 				]);
 
 				if (file_exists($include)) {
-					require_once $include;
+					require_once Config::canonicalPath($include);
 				}
 			}
 		}

--- a/Sources/Actions/Admin/Find.php
+++ b/Sources/Actions/Admin/Find.php
@@ -194,7 +194,7 @@ class Find implements ActionInterface
 		IntegrationHook::call('integrate_admin_search', [&$this->language_files, &$this->include_files, &$this->settings_search]);
 
 		foreach ($this->include_files as $file) {
-			require_once Config::$sourcedir . '/' . $file . '.php';
+			require_once Config::canonicalPath(Config::$sourcedir . '/' . $file . '.php');
 		}
 
 		/* This is the huge array that defines everything... it's a huge array of items formatted as follows:

--- a/Sources/Actions/Admin/Languages.php
+++ b/Sources/Actions/Admin/Languages.php
@@ -905,7 +905,7 @@ class Languages implements ActionInterface
 		// Quickly load General language entries.
 		$old_txt = Lang::$txt;
 
-		require $general_filename;
+		require Config::canonicalPath($general_filename);
 
 		Utils::$context['lang_file_not_writable_message'] = is_writable($general_filename) ? '' : Lang::getTxt('lang_file_not_writable', ['file' => $general_filename], file: 'ManageSettings');
 

--- a/Sources/Actions/Admin/Logs.php
+++ b/Sources/Actions/Admin/Logs.php
@@ -156,7 +156,7 @@ class Logs implements ActionInterface
 		];
 
 		if (!empty(self::$subactions[$this->subaction][0])) {
-			require_once Config::$sourcedir . '/' . self::$subactions[$this->subaction][0];
+			require_once Config::canonicalPath(Config::$sourcedir . '/' . self::$subactions[$this->subaction][0]);
 		}
 
 		$call = \is_string(self::$subactions[$this->subaction][1]) && method_exists($this, self::$subactions[$this->subaction][1]) ? [$this, self::$subactions[$this->subaction][1]] : Utils::getCallable(self::$subactions[$this->subaction][1]);

--- a/Sources/Actions/Admin/Server.php
+++ b/Sources/Actions/Admin/Server.php
@@ -554,7 +554,7 @@ class Server implements ActionInterface
 			ACP::saveDBSettings($config_vars);
 
 			// Create the new directory, but revert to the previous one if anything goes wrong.
-			require_once Config::$sourcedir . '/Actions/Profile/Export.php';
+			require_once Config::canonicalPath(Config::$sourcedir . '/Actions/Profile/Export.php');
 			create_export_dir($prev_export_dir);
 
 			// Ensure we don't lose track of any existing export files.

--- a/Sources/Actions/Admin/Subscriptions.php
+++ b/Sources/Actions/Admin/Subscriptions.php
@@ -2099,7 +2099,7 @@ class Subscriptions implements ActionInterface
 					fclose($fp);
 
 					if (str_contains($header, '// SMF Payment Gateway: ' . strtolower($matches[1]))) {
-						require_once Config::$sourcedir . '/' . $file;
+						require_once Config::canonicalPath(Config::$sourcedir . '/' . $file);
 
 						$gateways[] = [
 							'filename' => $file,

--- a/Sources/Actions/Admin/index.php
+++ b/Sources/Actions/Admin/index.php
@@ -1,8 +1,8 @@
 <?php
 
 // Try to handle it with the upper level index.php. (it should know what to do.)
-if (file_exists(dirname(__DIR__) . '/index.php')) {
-	include dirname(__DIR__) . '/index.php';
+if (file_exists(dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php')) {
+	include dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php';
 } else {
 	exit;
 }

--- a/Sources/Actions/Moderation/Main.php
+++ b/Sources/Actions/Moderation/Main.php
@@ -240,7 +240,7 @@ class Main implements ActionInterface, Routable
 		$this->createMenu();
 
 		if (isset(Menu::$loaded['moderate']->include_data['file'])) {
-			require_once Config::$sourcedir . '/' . Menu::$loaded['moderate']->include_data['file'];
+			require_once Config::canonicalPath(Config::$sourcedir . '/' . Menu::$loaded['moderate']->include_data['file']);
 		}
 
 		$call = \is_string(Menu::$loaded['moderate']->include_data['function']) && method_exists($this, Menu::$loaded['moderate']->include_data['function']) ? [$this, Menu::$loaded['moderate']->include_data['function']] : Utils::getCallable(Menu::$loaded['moderate']->include_data['function']);

--- a/Sources/Actions/Moderation/index.php
+++ b/Sources/Actions/Moderation/index.php
@@ -1,8 +1,8 @@
 <?php
 
 // Try to handle it with the upper level index.php. (it should know what to do.)
-if (file_exists(dirname(__DIR__) . '/index.php')) {
-	include dirname(__DIR__) . '/index.php';
+if (file_exists(dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php')) {
+	include dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php';
 } else {
 	exit;
 }

--- a/Sources/Actions/Profile/Main.php
+++ b/Sources/Actions/Profile/Main.php
@@ -647,7 +647,7 @@ class Main implements ActionInterface, Routable
 
 		// File to include?
 		if (!empty($menu->include_data['file'])) {
-			require_once Config::$sourcedir . '/' . $menu->include_data['file'];
+			require_once Config::canonicalPath(Config::$sourcedir . '/' . $menu->include_data['file']);
 		}
 
 		// Build the link tree.

--- a/Sources/Actions/Profile/index.php
+++ b/Sources/Actions/Profile/index.php
@@ -1,8 +1,8 @@
 <?php
 
 // Try to handle it with the upper level index.php. (it should know what to do.)
-if (file_exists(dirname(__DIR__) . '/index.php')) {
-	include dirname(__DIR__) . '/index.php';
+if (file_exists(dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php')) {
+	include dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php';
 } else {
 	exit;
 }

--- a/Sources/Actions/Register.php
+++ b/Sources/Actions/Register.php
@@ -281,7 +281,7 @@ class Register implements ActionInterface, Routable
 
 		// Or any standard ones?
 		if (!empty(Config::$modSettings['registration_fields'])) {
-			require_once Config::$sourcedir . '/Profile-Modify.php';
+			require_once Config::canonicalPath(Config::$sourcedir . '/Profile-Modify.php');
 
 			// Setup some important context.
 			Theme::loadTemplate('Profile');

--- a/Sources/Actions/VerificationCode.php
+++ b/Sources/Actions/VerificationCode.php
@@ -683,7 +683,7 @@ class VerificationCode implements ActionInterface, Routable
 		// Include it!
 		header('content-type: image/png');
 
-		include Theme::$current->settings['default_theme_dir'] . '/fonts/' . $random_font . '/' . strtoupper($letter) . '.png';
+		include Config::canonicalPath(Theme::$current->settings['default_theme_dir'] . '/fonts/' . $random_font . '/' . strtoupper($letter) . '.png');
 
 		// Nothing more to come.
 		die();

--- a/Sources/Actions/XmlHttp.php
+++ b/Sources/Actions/XmlHttp.php
@@ -230,7 +230,7 @@ class XmlHttp implements ActionInterface, Routable
 	 */
 	public function sig_preview(): void
 	{
-		require_once Config::$sourcedir . '/Profile-Modify.php';
+		require_once Config::canonicalPath(Config::$sourcedir . '/Profile-Modify.php');
 
 		$user = isset($_POST['user']) ? (int) $_POST['user'] : 0;
 		$is_owner = $user == User::$me->id;

--- a/Sources/Actions/index.php
+++ b/Sources/Actions/index.php
@@ -1,8 +1,8 @@
 <?php
 
 // Try to handle it with the upper level index.php. (it should know what to do.)
-if (file_exists(dirname(__DIR__) . '/index.php')) {
-	include dirname(__DIR__) . '/index.php';
+if (file_exists(dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php')) {
+	include dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php';
 } else {
 	exit;
 }

--- a/Sources/Autoloader.php
+++ b/Sources/Autoloader.php
@@ -65,7 +65,7 @@ spl_autoload_register(function ($class) {
 	// Do any third-party scripts want in on the fun?
 	if (!\defined('SMF_INSTALLING') && class_exists(Config::class, false) && $hook_value !== (Config::$modSettings['integrate_autoload'] ?? '')) {
 		if (!class_exists(IntegrationHook::class, false) && is_file($sourcedir . '/IntegrationHook.php')) {
-			require_once $sourcedir . '/IntegrationHook.php';
+			require_once $sourcedir . DIRECTORY_SEPARATOR . 'IntegrationHook.php';
 		}
 
 		if (class_exists(IntegrationHook::class, false)) {
@@ -99,7 +99,7 @@ spl_autoload_register(function ($class) {
 		// Replace the namespace prefix with the base directory, replace namespace
 		// separators with directory separators in the relative class name, append
 		// with .php
-		$filename = $dirname . strtr($relative_class, '\\', '/') . '.php';
+		$filename = str_replace(['\\', '/'], DIRECTORY_SEPARATOR, $dirname . $relative_class) . '.php';
 
 		// Failsafe: Never load a file named index.php.
 		if (basename($filename) === 'index.php') {

--- a/Sources/BBCode/index.php
+++ b/Sources/BBCode/index.php
@@ -1,8 +1,8 @@
 <?php
 
 // Try to handle it with the upper level index.php. (it should know what to do.)
-if (file_exists(dirname(__DIR__) . '/index.php')) {
-	include dirname(__DIR__) . '/index.php';
+if (file_exists(dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php')) {
+	include dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php';
 } else {
 	exit;
 }

--- a/Sources/Cache/APIs/index.php
+++ b/Sources/Cache/APIs/index.php
@@ -1,8 +1,8 @@
 <?php
 
 // Try to handle it with the upper level index.php. (it should know what to do.)
-if (file_exists(dirname(__DIR__) . '/index.php')) {
-	include dirname(__DIR__) . '/index.php';
+if (file_exists(dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php')) {
+	include dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php';
 } else {
 	exit;
 }

--- a/Sources/Cache/CacheApi.php
+++ b/Sources/Cache/CacheApi.php
@@ -514,7 +514,7 @@ abstract class CacheApi
 			)
 		) {
 			if (!empty($file) && is_file(Config::$sourcedir . '/' . $file)) {
-				require_once Config::$sourcedir . '/' . $file;
+				require_once Config::canonicalPath(Config::$sourcedir . '/' . $file);
 			}
 
 			$cache_block = \call_user_func_array($function, $params);

--- a/Sources/Cache/index.php
+++ b/Sources/Cache/index.php
@@ -1,8 +1,8 @@
 <?php
 
 // Try to handle it with the upper level index.php. (it should know what to do.)
-if (file_exists(dirname(__DIR__) . '/index.php')) {
-	include dirname(__DIR__) . '/index.php';
+if (file_exists(dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php')) {
+	include dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php';
 } else {
 	exit;
 }

--- a/Sources/Calendar/VTimeZones/Africa/index.php
+++ b/Sources/Calendar/VTimeZones/Africa/index.php
@@ -1,8 +1,8 @@
 <?php
 
 // Try to handle it with the upper level index.php. (it should know what to do.)
-if (file_exists(dirname(__DIR__) . '/index.php')) {
-	include dirname(__DIR__) . '/index.php';
+if (file_exists(dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php')) {
+	include dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php';
 } else {
 	exit;
 }

--- a/Sources/Calendar/VTimeZones/America/Argentina/index.php
+++ b/Sources/Calendar/VTimeZones/America/Argentina/index.php
@@ -1,8 +1,8 @@
 <?php
 
 // Try to handle it with the upper level index.php. (it should know what to do.)
-if (file_exists(dirname(__DIR__) . '/index.php')) {
-	include dirname(__DIR__) . '/index.php';
+if (file_exists(dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php')) {
+	include dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php';
 } else {
 	exit;
 }

--- a/Sources/Calendar/VTimeZones/America/Indiana/index.php
+++ b/Sources/Calendar/VTimeZones/America/Indiana/index.php
@@ -1,8 +1,8 @@
 <?php
 
 // Try to handle it with the upper level index.php. (it should know what to do.)
-if (file_exists(dirname(__DIR__) . '/index.php')) {
-	include dirname(__DIR__) . '/index.php';
+if (file_exists(dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php')) {
+	include dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php';
 } else {
 	exit;
 }

--- a/Sources/Calendar/VTimeZones/America/Kentucky/index.php
+++ b/Sources/Calendar/VTimeZones/America/Kentucky/index.php
@@ -1,8 +1,8 @@
 <?php
 
 // Try to handle it with the upper level index.php. (it should know what to do.)
-if (file_exists(dirname(__DIR__) . '/index.php')) {
-	include dirname(__DIR__) . '/index.php';
+if (file_exists(dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php')) {
+	include dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php';
 } else {
 	exit;
 }

--- a/Sources/Calendar/VTimeZones/America/North_Dakota/index.php
+++ b/Sources/Calendar/VTimeZones/America/North_Dakota/index.php
@@ -1,8 +1,8 @@
 <?php
 
 // Try to handle it with the upper level index.php. (it should know what to do.)
-if (file_exists(dirname(__DIR__) . '/index.php')) {
-	include dirname(__DIR__) . '/index.php';
+if (file_exists(dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php')) {
+	include dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php';
 } else {
 	exit;
 }

--- a/Sources/Calendar/VTimeZones/America/index.php
+++ b/Sources/Calendar/VTimeZones/America/index.php
@@ -1,8 +1,8 @@
 <?php
 
 // Try to handle it with the upper level index.php. (it should know what to do.)
-if (file_exists(dirname(__DIR__) . '/index.php')) {
-	include dirname(__DIR__) . '/index.php';
+if (file_exists(dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php')) {
+	include dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php';
 } else {
 	exit;
 }

--- a/Sources/Calendar/VTimeZones/Antarctica/index.php
+++ b/Sources/Calendar/VTimeZones/Antarctica/index.php
@@ -1,8 +1,8 @@
 <?php
 
 // Try to handle it with the upper level index.php. (it should know what to do.)
-if (file_exists(dirname(__DIR__) . '/index.php')) {
-	include dirname(__DIR__) . '/index.php';
+if (file_exists(dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php')) {
+	include dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php';
 } else {
 	exit;
 }

--- a/Sources/Calendar/VTimeZones/Asia/index.php
+++ b/Sources/Calendar/VTimeZones/Asia/index.php
@@ -1,8 +1,8 @@
 <?php
 
 // Try to handle it with the upper level index.php. (it should know what to do.)
-if (file_exists(dirname(__DIR__) . '/index.php')) {
-	include dirname(__DIR__) . '/index.php';
+if (file_exists(dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php')) {
+	include dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php';
 } else {
 	exit;
 }

--- a/Sources/Calendar/VTimeZones/Atlantic/index.php
+++ b/Sources/Calendar/VTimeZones/Atlantic/index.php
@@ -1,8 +1,8 @@
 <?php
 
 // Try to handle it with the upper level index.php. (it should know what to do.)
-if (file_exists(dirname(__DIR__) . '/index.php')) {
-	include dirname(__DIR__) . '/index.php';
+if (file_exists(dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php')) {
+	include dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php';
 } else {
 	exit;
 }

--- a/Sources/Calendar/VTimeZones/Australia/index.php
+++ b/Sources/Calendar/VTimeZones/Australia/index.php
@@ -1,8 +1,8 @@
 <?php
 
 // Try to handle it with the upper level index.php. (it should know what to do.)
-if (file_exists(dirname(__DIR__) . '/index.php')) {
-	include dirname(__DIR__) . '/index.php';
+if (file_exists(dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php')) {
+	include dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php';
 } else {
 	exit;
 }

--- a/Sources/Calendar/VTimeZones/Etc/index.php
+++ b/Sources/Calendar/VTimeZones/Etc/index.php
@@ -1,8 +1,8 @@
 <?php
 
 // Try to handle it with the upper level index.php. (it should know what to do.)
-if (file_exists(dirname(__DIR__) . '/index.php')) {
-	include dirname(__DIR__) . '/index.php';
+if (file_exists(dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php')) {
+	include dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php';
 } else {
 	exit;
 }

--- a/Sources/Calendar/VTimeZones/Europe/index.php
+++ b/Sources/Calendar/VTimeZones/Europe/index.php
@@ -1,8 +1,8 @@
 <?php
 
 // Try to handle it with the upper level index.php. (it should know what to do.)
-if (file_exists(dirname(__DIR__) . '/index.php')) {
-	include dirname(__DIR__) . '/index.php';
+if (file_exists(dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php')) {
+	include dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php';
 } else {
 	exit;
 }

--- a/Sources/Calendar/VTimeZones/Indian/index.php
+++ b/Sources/Calendar/VTimeZones/Indian/index.php
@@ -1,8 +1,8 @@
 <?php
 
 // Try to handle it with the upper level index.php. (it should know what to do.)
-if (file_exists(dirname(__DIR__) . '/index.php')) {
-	include dirname(__DIR__) . '/index.php';
+if (file_exists(dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php')) {
+	include dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php';
 } else {
 	exit;
 }

--- a/Sources/Calendar/VTimeZones/Pacific/index.php
+++ b/Sources/Calendar/VTimeZones/Pacific/index.php
@@ -1,8 +1,8 @@
 <?php
 
 // Try to handle it with the upper level index.php. (it should know what to do.)
-if (file_exists(dirname(__DIR__) . '/index.php')) {
-	include dirname(__DIR__) . '/index.php';
+if (file_exists(dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php')) {
+	include dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php';
 } else {
 	exit;
 }

--- a/Sources/Calendar/VTimeZones/index.php
+++ b/Sources/Calendar/VTimeZones/index.php
@@ -1,8 +1,8 @@
 <?php
 
 // Try to handle it with the upper level index.php. (it should know what to do.)
-if (file_exists(dirname(__DIR__) . '/index.php')) {
-	include dirname(__DIR__) . '/index.php';
+if (file_exists(dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php')) {
+	include dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php';
 } else {
 	exit;
 }

--- a/Sources/Calendar/index.php
+++ b/Sources/Calendar/index.php
@@ -1,8 +1,8 @@
 <?php
 
 // Try to handle it with the upper level index.php. (it should know what to do.)
-if (file_exists(dirname(__DIR__) . '/index.php')) {
-	include dirname(__DIR__) . '/index.php';
+if (file_exists(dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php')) {
+	include dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php';
 } else {
 	exit;
 }

--- a/Sources/Config.php
+++ b/Sources/Config.php
@@ -1190,7 +1190,7 @@ class Config
 				$include = strtr(trim($include), ['$boarddir' => self::$boarddir, '$sourcedir' => self::$sourcedir]);
 
 				if (file_exists($include)) {
-					require_once $include;
+					require_once self::canonicalPath($include);
 				}
 			}
 		}
@@ -2848,6 +2848,129 @@ class Config
 				self::updateModSettings(['cron_last_checked' => time()]);
 			}
 		}
+	}
+
+	/**
+	 * Normalizes directory separators and resolves '.' and '..' in a file path.
+	 *
+	 * The $path does not need to point to an existing file.
+	 *
+	 * If $path does point to an existing file, or if an ancestor directory of
+	 * $path exists, then \realpath() will be used to resolve that part of the
+	 * path, unless the $real parameter is set to false.
+	 *
+	 * @param string $path The file path.
+	 * @param string|bool $base_dir Base directory for relative paths.
+	 *    - If a string, relative paths are prepended with the string and a
+	 *      directory separator. Note that directory separators in this string
+	 *      will be normalized just like in $path.
+	 *    - If true, relative paths are prepended with the current working
+	 *      directory and a directory separator.
+	 *    - If false, relative paths are processed as given.
+	 *    Default: false.
+	 * @param bool $real Whether to get the real path for existing files. This
+	 *    can be set to false if the caller wants to canonicalize a hypothetical
+	 *    path without any possibility of the real file structure interfering
+	 *    with the result.
+	 *    Default: true.
+	 * @return string The canonical file path.
+	 */
+	public static function canonicalPath(string $path, string|bool $base_dir = false, bool $real = true): string
+	{
+		// If $path points to a real file, this is all we need to do.
+		if (!empty($real) && ($realpath = @realpath($path)) !== false) {
+			return $realpath;
+		}
+
+		$base_dir = \is_string($base_dir) ? rtrim(str_replace(['\\', '/'], DIRECTORY_SEPARATOR, $base_dir), DIRECTORY_SEPARATOR) : (!empty($base_dir) ? getcwd() : false);
+
+		$path = trim(str_replace(['\\', '/'], DIRECTORY_SEPARATOR, (string) $path));
+
+		// We need to know the path of the root directory.
+		if (DIRECTORY_SEPARATOR === '/') {
+			$root = '';
+			$is_absolute = str_starts_with($path, DIRECTORY_SEPARATOR);
+		} else {
+			// Windows network shares and devices.
+			if (str_starts_with($path, DIRECTORY_SEPARATOR . DIRECTORY_SEPARATOR)) {
+				if (\in_array(substr($path, 2, 2), ['?' . DIRECTORY_SEPARATOR, '.' . DIRECTORY_SEPARATOR])) {
+					$root = substr($path, 0, strpos($path, DIRECTORY_SEPARATOR, 3));
+				} else {
+					$root = '';
+
+					for ($i = 0; $i < 3; $i++) {
+						$root = substr($path, 0, strpos($path, DIRECTORY_SEPARATOR, \strlen($root) + 1));
+					}
+				}
+			}
+			// Windows absolute DOS-style path.
+			elseif (strpos($path, ':') !== false && strpos($path, DIRECTORY_SEPARATOR) === strpos($path, ':') + 1) {
+				$root = substr($path, 0, strpos($path, DIRECTORY_SEPARATOR));
+			}
+			// Windows relative path.
+			else {
+				$root = substr(getcwd(), 0, strcspn(getcwd(), DIRECTORY_SEPARATOR));
+
+				// If relative to current drive's root, make it absolute.
+				if (strpos($path, DIRECTORY_SEPARATOR) === 0) {
+					$path = $root . $path;
+				}
+			}
+
+			$is_absolute = str_starts_with($path, $root . DIRECTORY_SEPARATOR);
+		}
+
+		// Build canonical path.
+		$canonical_path = '';
+
+		if ($is_absolute) {
+			$path = substr($path, \strlen($root . DIRECTORY_SEPARATOR));
+			$path_parts = [$root];
+		} elseif (\is_string($base_dir)) {
+			$path_parts = explode(DIRECTORY_SEPARATOR, $base_dir);
+		} else {
+			$path_parts = [];
+		}
+
+		foreach (explode(DIRECTORY_SEPARATOR, $path) as $key => $part) {
+			if (empty($part) || $part === '.') {
+				continue;
+			}
+
+			if ($part === '..') {
+				if ($is_absolute && $path_parts === [$root]) {
+					continue;
+				}
+
+				if (empty($path_parts) || $path_parts[0] === '..') {
+					$path_parts[] = $part;
+				} else {
+					array_pop($path_parts);
+				}
+			} else {
+				$path_parts[] = $part;
+			}
+
+			$canonical_path = implode(DIRECTORY_SEPARATOR, $path_parts);
+
+			if (empty($real) || \in_array($canonical_path, ['', '.', '..'])) {
+				continue;
+			}
+
+			// Check for intermediate symlinks.
+			$realpath = @realpath($canonical_path);
+
+			if ($realpath !== false && $realpath !== $canonical_path) {
+				$path_parts = explode(DIRECTORY_SEPARATOR, $realpath);
+			}
+		}
+
+		// Ambiguity is bad.
+		if ($canonical_path === '') {
+			$canonical_path = $is_absolute ? $root . DIRECTORY_SEPARATOR : '.';
+		}
+
+		return $canonical_path;
 	}
 
 	/*************************

--- a/Sources/Config.php
+++ b/Sources/Config.php
@@ -2756,12 +2756,17 @@ class Config
 	 */
 	public static function getDbLastError(): int
 	{
-		if (file_exists(self::$cachedir . '/db_last_error.php')) {
-			include self::$cachedir . '/db_last_error.php';
-		} elseif (file_exists(self::$boarddir . '/cache/db_last_error.php')) {
-			include self::$boarddir . '/cache/db_last_error.php';
-		} elseif (file_exists(self::$boarddir . '/db_last_error.php')) {
-			include self::$boarddir . '/db_last_error.php';
+		foreach (
+			[
+				self::$cachedir,
+				self::$boarddir . DIRECTORY_SEPARATOR . 'cache',
+				self::$boarddir,
+			] as $dir
+		) {
+			if (file_exists($dir . DIRECTORY_SEPARATOR . 'db_last_error.php')) {
+				include $dir . DIRECTORY_SEPARATOR . 'db_last_error.php';
+				break;
+			}
 		}
 
 		if (!isset($db_last_error)) {

--- a/Sources/Db/APIs/index.php
+++ b/Sources/Db/APIs/index.php
@@ -1,8 +1,8 @@
 <?php
 
 // Try to handle it with the upper level index.php. (it should know what to do.)
-if (file_exists(dirname(__DIR__) . '/index.php')) {
-	include dirname(__DIR__) . '/index.php';
+if (file_exists(dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php')) {
+	include dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php';
 } else {
 	exit;
 }

--- a/Sources/Db/Schema/index.php
+++ b/Sources/Db/Schema/index.php
@@ -1,8 +1,8 @@
 <?php
 
 // Try to handle it with the upper level index.php. (it should know what to do.)
-if (file_exists(dirname(__DIR__) . '/index.php')) {
-	include dirname(__DIR__) . '/index.php';
+if (file_exists(dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php')) {
+	include dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php';
 } else {
 	exit;
 }

--- a/Sources/Db/Schema/v2_1/index.php
+++ b/Sources/Db/Schema/v2_1/index.php
@@ -1,8 +1,8 @@
 <?php
 
 // Try to handle it with the upper level index.php. (it should know what to do.)
-if (file_exists(dirname(__DIR__) . '/index.php')) {
-	include dirname(__DIR__) . '/index.php';
+if (file_exists(dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php')) {
+	include dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php';
 } else {
 	exit;
 }

--- a/Sources/Db/Schema/v3_0/index.php
+++ b/Sources/Db/Schema/v3_0/index.php
@@ -1,8 +1,8 @@
 <?php
 
 // Try to handle it with the upper level index.php. (it should know what to do.)
-if (file_exists(dirname(__DIR__) . '/index.php')) {
-	include dirname(__DIR__) . '/index.php';
+if (file_exists(dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php')) {
+	include dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php';
 } else {
 	exit;
 }

--- a/Sources/Db/index.php
+++ b/Sources/Db/index.php
@@ -1,8 +1,8 @@
 <?php
 
 // Try to handle it with the upper level index.php. (it should know what to do.)
-if (file_exists(dirname(__DIR__) . '/index.php')) {
-	include dirname(__DIR__) . '/index.php';
+if (file_exists(dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php')) {
+	include dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php';
 } else {
 	exit;
 }

--- a/Sources/Debug/index.php
+++ b/Sources/Debug/index.php
@@ -1,8 +1,8 @@
 <?php
 
 // Try to handle it with the upper level index.php. (it should know what to do.)
-if (file_exists(dirname(__DIR__) . '/index.php')) {
-	include dirname(__DIR__) . '/index.php';
+if (file_exists(dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php')) {
+	include dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php';
 } else {
 	exit;
 }

--- a/Sources/Diff/index.php
+++ b/Sources/Diff/index.php
@@ -1,8 +1,8 @@
 <?php
 
 // Try to handle it with the upper level index.php. (it should know what to do.)
-if (file_exists(dirname(__DIR__) . '/index.php')) {
-	include dirname(__DIR__) . '/index.php';
+if (file_exists(dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php')) {
+	include dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php';
 } else {
 	exit;
 }

--- a/Sources/Forum.php
+++ b/Sources/Forum.php
@@ -807,7 +807,7 @@ class Forum
 
 		// Otherwise, it was set - so let's go to that action.
 		if (!empty(self::$actions[$action][0])) {
-			require_once Config::$sourcedir . '/' . self::$actions[$action][0];
+			require_once Config::canonicalPath(Config::$sourcedir . '/' . self::$actions[$action][0]);
 		}
 
 		// Do the right thing.

--- a/Sources/Graphics/Gif/File.php
+++ b/Sources/Graphics/Gif/File.php
@@ -184,5 +184,5 @@ class File
 
 // 64-bit only functions?
 if (!\function_exists('smf_crc32')) {
-	require_once Config::$sourcedir . '/Subs-Compat.php';
+	require_once Config::canonicalPath(Config::$sourcedir . '/Subs-Compat.php');
 }

--- a/Sources/Graphics/Gif/index.php
+++ b/Sources/Graphics/Gif/index.php
@@ -1,8 +1,8 @@
 <?php
 
 // Try to handle it with the upper level index.php. (it should know what to do.)
-if (file_exists(dirname(__DIR__) . '/index.php')) {
-	include dirname(__DIR__) . '/index.php';
+if (file_exists(dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php')) {
+	include dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php';
 } else {
 	exit;
 }

--- a/Sources/Graphics/index.php
+++ b/Sources/Graphics/index.php
@@ -1,8 +1,8 @@
 <?php
 
 // Try to handle it with the upper level index.php. (it should know what to do.)
-if (file_exists(dirname(__DIR__) . '/index.php')) {
-	include dirname(__DIR__) . '/index.php';
+if (file_exists(dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php')) {
+	include dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php';
 } else {
 	exit;
 }

--- a/Sources/ItemList.php
+++ b/Sources/ItemList.php
@@ -332,7 +332,7 @@ class ItemList implements \ArrayAccess
 			$this->total_num_items = $this->options['get_count']['value'];
 		} else {
 			if (isset($this->options['get_count']['file'])) {
-				require_once $this->options['get_count']['file'];
+				require_once Config::canonicalPath($this->options['get_count']['file']);
 			}
 
 			$call = Utils::getCallable($this->options['get_count']['function']);
@@ -483,7 +483,7 @@ class ItemList implements \ArrayAccess
 		} else {
 			// Get the file with the function for the item list.
 			if (isset($this->options['get_items']['file'])) {
-				require_once $this->options['get_items']['file'];
+				require_once Config::canonicalPath($this->options['get_items']['file']);
 			}
 
 			$call = Utils::getCallable($this->options['get_items']['function']);

--- a/Sources/Lang.php
+++ b/Sources/Lang.php
@@ -295,7 +295,7 @@ class Lang
 				if (file_exists($file[0] . '/' . $file[2] . '/' . $file[1] . '.php')) {
 					// Include it!
 					// {DIR} / {locale} / {file} .php
-					require $file[0] . '/' . $file[2] . '/' . $file[1] . '.php';
+					require Config::canonicalPath($file[0] . '/' . $file[2] . '/' . $file[1] . '.php');
 
 					// Note that we found it.
 					$found = true;
@@ -305,7 +305,7 @@ class Lang
 						DebugUtils::addDebugSource(
 							lang_key: 'language_files',
 							key: implode('|', $file),
-							value: (Config::$languagesdir == $file[0] ? basename($file[0]) : ltrim(str_replace(array_map('dirname', self::$dirs), '', $file[0]), '/')) . '/' . $file[2] . '/' . $file[1] . '.php',
+							value: Config::canonicalPath((Config::$languagesdir == $file[0] ? basename($file[0]) : ltrim(str_replace(array_map('dirname', self::$dirs), '', $file[0]), '/')) . '/' . $file[2] . '/' . $file[1] . '.php'),
 						);
 					}
 
@@ -582,7 +582,7 @@ class Lang
 						'name' => $langName ?? $entry,
 						'selected' => false,
 						'filename' => $entry,
-						'location' => $language_dir . '/' . $entry . '/General.php',
+						'location' => Config::canonicalPath($language_dir . '/' . $entry . '/General.php'),
 					];
 				}
 				$dir->close();
@@ -1053,7 +1053,7 @@ class Lang
 			$oldLanguage = $locale_to_lang[$file[2]] ?? false;
 
 			if ($oldLanguage !== false && file_exists($file[0] . '/' . $file[1] . '.' . $oldLanguage . '.php')) {
-				require $file[0] . '/' . $file[1] . '.' . $oldLanguage . '.php';
+				require Config::canonicalPath($file[0] . '/' . $file[1] . '.' . $oldLanguage . '.php');
 
 				// Note that we found it.
 				$found = true;

--- a/Sources/Localization/AsciiTransliterator.php
+++ b/Sources/Localization/AsciiTransliterator.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 
 namespace SMF\Localization;
 
+use SMF\Config;
 use SMF\IntegrationHook;
 use SMF\Lang;
 use SMF\Unicode\Utf8String;
@@ -280,7 +281,7 @@ class AsciiTransliterator
 			$ord = mb_ord($char);
 
 			if (file_exists(__DIR__ . '/data/AsciiTransliteration_' . \sprintf('%04d', $ord >> 8) . '.php')) {
-				include_once __DIR__ . '/data/AsciiTransliteration_' . \sprintf('%04d', $ord >> 8) . '.php';
+				include_once Config::canonicalPath(__DIR__ . '/data/AsciiTransliteration_' . \sprintf('%04d', $ord >> 8) . '.php');
 
 				$new_chars[$char_num] = $ascii_transliteration[$ord >> 8][$ord & 255] ?? $char;
 			}

--- a/Sources/Localization/MessageFormatter.php
+++ b/Sources/Localization/MessageFormatter.php
@@ -182,7 +182,8 @@ class MessageFormatter
 								}
 								// Try to guess the currency based on country.
 								else {
-									require_once Config::$sourcedir . '/Unicode/Currencies.php';
+									require_once Config::canonicalPath(Config::$sourcedir . '/Unicode/Currencies.php');
+
 									$country_currencies = \function_exists('country_currencies') ? country_currencies() : [];
 
 									// If the admin wants to prioritize a certain country, use that.
@@ -504,7 +505,7 @@ class MessageFormatter
 
 		// Ensure we have our pluralization rules.
 		if (empty(self::$plural_rules)) {
-			require_once Config::$sourcedir . '/Unicode/Plurals.php';
+			require_once Config::canonicalPath(Config::$sourcedir . '/Unicode/Plurals.php');
 			self::$plural_rules = \SMF\Unicode\plurals();
 		}
 
@@ -835,7 +836,7 @@ class MessageFormatter
 						break;
 
 					case 'currency':
-						require_once Config::$sourcedir . '/Unicode/Currencies.php';
+						require_once Config::canonicalPath(Config::$sourcedir . '/Unicode/Currencies.php');
 
 						$currencies = currencies();
 

--- a/Sources/Localization/data/index.php
+++ b/Sources/Localization/data/index.php
@@ -1,8 +1,8 @@
 <?php
 
 // Try to handle it with the upper level index.php. (it should know what to do.)
-if (file_exists(dirname(__DIR__) . '/index.php')) {
-	include dirname(__DIR__) . '/index.php';
+if (file_exists(dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php')) {
+	include dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php';
 } else {
 	exit;
 }

--- a/Sources/Localization/index.php
+++ b/Sources/Localization/index.php
@@ -1,8 +1,8 @@
 <?php
 
 // Try to handle it with the upper level index.php. (it should know what to do.)
-if (file_exists(dirname(__DIR__) . '/index.php')) {
-	include dirname(__DIR__) . '/index.php';
+if (file_exists(dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php')) {
+	include dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php';
 } else {
 	exit;
 }

--- a/Sources/Mail.php
+++ b/Sources/Mail.php
@@ -735,7 +735,7 @@ class Mail
 			}
 
 			if (!\function_exists('idn_to_ascii')) {
-				require_once Config::$sourcedir . '/Subs-Compat.php';
+				require_once Config::canonicalPath(Config::$sourcedir . '/Subs-Compat.php');
 			}
 
 			$helo = idn_to_ascii($helo, IDNA_DEFAULT, INTL_IDNA_VARIANT_UTS46);

--- a/Sources/MailAgent/APIs/SMTP.php
+++ b/Sources/MailAgent/APIs/SMTP.php
@@ -338,7 +338,7 @@ class SMTP extends MailAgent implements MailAgentInterface
 		}
 
 		if (!\function_exists('idn_to_ascii')) {
-			require_once Config::$sourcedir . '/Subs-Compat.php';
+			require_once Config::canonicalPath(Config::$sourcedir . '/Subs-Compat.php');
 		}
 
 		$helo = idn_to_ascii($helo, IDNA_DEFAULT, INTL_IDNA_VARIANT_UTS46);

--- a/Sources/MailAgent/APIs/index.php
+++ b/Sources/MailAgent/APIs/index.php
@@ -1,8 +1,8 @@
 <?php
 
 // Try to handle it with the upper level index.php. (it should know what to do.)
-if (file_exists(dirname(__DIR__) . '/index.php')) {
-	include dirname(__DIR__) . '/index.php';
+if (file_exists(dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php')) {
+	include dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php';
 } else {
 	exit;
 }

--- a/Sources/MailAgent/index.php
+++ b/Sources/MailAgent/index.php
@@ -1,8 +1,8 @@
 <?php
 
 // Try to handle it with the upper level index.php. (it should know what to do.)
-if (file_exists(dirname(__DIR__) . '/index.php')) {
-	include dirname(__DIR__) . '/index.php';
+if (file_exists(dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php')) {
+	include dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php';
 } else {
 	exit;
 }

--- a/Sources/Maintenance/Cleanup/index.php
+++ b/Sources/Maintenance/Cleanup/index.php
@@ -1,8 +1,8 @@
 <?php
 
 // Try to handle it with the upper level index.php. (it should know what to do.)
-if (file_exists(dirname(__DIR__) . '/index.php')) {
-	include dirname(__DIR__) . '/index.php';
+if (file_exists(dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php')) {
+	include dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php';
 } else {
 	exit;
 }

--- a/Sources/Maintenance/Cleanup/v2_1/index.php
+++ b/Sources/Maintenance/Cleanup/v2_1/index.php
@@ -1,8 +1,8 @@
 <?php
 
 // Try to handle it with the upper level index.php. (it should know what to do.)
-if (file_exists(dirname(__DIR__) . '/index.php')) {
-	include dirname(__DIR__) . '/index.php';
+if (file_exists(dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php')) {
+	include dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php';
 } else {
 	exit;
 }

--- a/Sources/Maintenance/Cleanup/v3_0/index.php
+++ b/Sources/Maintenance/Cleanup/v3_0/index.php
@@ -1,8 +1,8 @@
 <?php
 
 // Try to handle it with the upper level index.php. (it should know what to do.)
-if (file_exists(dirname(__DIR__) . '/index.php')) {
-	include dirname(__DIR__) . '/index.php';
+if (file_exists(dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php')) {
+	include dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php';
 } else {
 	exit;
 }

--- a/Sources/Maintenance/Migration/index.php
+++ b/Sources/Maintenance/Migration/index.php
@@ -1,8 +1,8 @@
 <?php
 
 // Try to handle it with the upper level index.php. (it should know what to do.)
-if (file_exists(dirname(__DIR__) . '/index.php')) {
-	include dirname(__DIR__) . '/index.php';
+if (file_exists(dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php')) {
+	include dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php';
 } else {
 	exit;
 }

--- a/Sources/Maintenance/Migration/v2_1/index.php
+++ b/Sources/Maintenance/Migration/v2_1/index.php
@@ -1,8 +1,8 @@
 <?php
 
 // Try to handle it with the upper level index.php. (it should know what to do.)
-if (file_exists(dirname(__DIR__) . '/index.php')) {
-	include dirname(__DIR__) . '/index.php';
+if (file_exists(dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php')) {
+	include dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php';
 } else {
 	exit;
 }

--- a/Sources/Maintenance/Migration/v3_0/index.php
+++ b/Sources/Maintenance/Migration/v3_0/index.php
@@ -1,8 +1,8 @@
 <?php
 
 // Try to handle it with the upper level index.php. (it should know what to do.)
-if (file_exists(dirname(__DIR__) . '/index.php')) {
-	include dirname(__DIR__) . '/index.php';
+if (file_exists(dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php')) {
+	include dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php';
 } else {
 	exit;
 }

--- a/Sources/Maintenance/Tools/ToolsBase.php
+++ b/Sources/Maintenance/Tools/ToolsBase.php
@@ -246,7 +246,7 @@ abstract class ToolsBase
 	{
 		$db_class = '\\SMF\\Db\\APIs\\' . Db::getClass(Config::$db_type);
 
-		require_once Config::$sourcedir . '/Db/APIs/' . Db::getClass(Config::$db_type) . '.php';
+		require_once Config::canonicalPath(Config::$sourcedir . '/Db/APIs/' . Db::getClass(Config::$db_type) . '.php');
 
 		return new $db_class();
 	}

--- a/Sources/Maintenance/Tools/index.php
+++ b/Sources/Maintenance/Tools/index.php
@@ -1,8 +1,8 @@
 <?php
 
 // Try to handle it with the upper level index.php. (it should know what to do.)
-if (file_exists(dirname(__DIR__) . '/index.php')) {
-	include dirname(__DIR__) . '/index.php';
+if (file_exists(dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php')) {
+	include dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php';
 } else {
 	exit;
 }

--- a/Sources/Maintenance/index.php
+++ b/Sources/Maintenance/index.php
@@ -1,8 +1,8 @@
 <?php
 
 // Try to handle it with the upper level index.php. (it should know what to do.)
-if (file_exists(dirname(__DIR__) . '/index.php')) {
-	include dirname(__DIR__) . '/index.php';
+if (file_exists(dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php')) {
+	include dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php';
 } else {
 	exit;
 }

--- a/Sources/News.php
+++ b/Sources/News.php
@@ -17,4 +17,4 @@ if (!defined('SMF')) {
 	die('No direct access...');
 }
 
-require_once SMF\Config::$sourcedir . '/Subs-Compat.php';
+require_once SMF\Config::$sourcedir . DIRECTORY_SEPARATOR . 'Subs-Compat.php';

--- a/Sources/OutputTypes/index.php
+++ b/Sources/OutputTypes/index.php
@@ -1,8 +1,8 @@
 <?php
 
 // Try to handle it with the upper level index.php. (it should know what to do.)
-if (file_exists(dirname(__DIR__) . '/index.php')) {
-	include dirname(__DIR__) . '/index.php';
+if (file_exists(dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php')) {
+	include dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php';
 } else {
 	exit;
 }

--- a/Sources/PackageManager/PackageManager.php
+++ b/Sources/PackageManager/PackageManager.php
@@ -1135,7 +1135,7 @@ class PackageManager
 							extract($backcompat_globals, EXTR_REFS | EXTR_SKIP);
 						}
 
-						require Config::$packagesdir . '/temp/' . Utils::$context['base_path'] . $action['filename'];
+						require Config::canonicalPath(Config::$packagesdir . '/temp/' . Utils::$context['base_path'] . $action['filename']);
 					}
 				} elseif ($action['type'] == 'credits') {
 					// Time to build the billboard
@@ -1181,7 +1181,7 @@ class PackageManager
 							extract($backcompat_globals, EXTR_REFS | EXTR_SKIP);
 						}
 
-						require Config::$packagesdir . '/temp/' . Utils::$context['base_path'] . $action['filename'];
+						require Config::canonicalPath(Config::$packagesdir . '/temp/' . Utils::$context['base_path'] . $action['filename']);
 					}
 				}
 				// Handle a redirect...

--- a/Sources/PackageManager/PackageUtils.php
+++ b/Sources/PackageManager/PackageUtils.php
@@ -3857,7 +3857,7 @@ class PackageUtils
 	 */
 	private static function smf_crc32(string $number): string
 	{
-		require_once Config::$sourcedir . '/Subs-Compat.php';
+		require_once Config::canonicalPath(Config::$sourcedir . '/Subs-Compat.php');
 
 		return smf_crc32($number);
 	}

--- a/Sources/PackageManager/index.php
+++ b/Sources/PackageManager/index.php
@@ -1,8 +1,8 @@
 <?php
 
 // Try to handle it with the upper level index.php. (it should know what to do.)
-if (file_exists(dirname(__DIR__) . '/index.php')) {
-	include dirname(__DIR__) . '/index.php';
+if (file_exists(dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php')) {
+	include dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php';
 } else {
 	exit;
 }

--- a/Sources/Parsers/index.php
+++ b/Sources/Parsers/index.php
@@ -1,8 +1,8 @@
 <?php
 
 // Try to handle it with the upper level index.php. (it should know what to do.)
-if (file_exists(dirname(__DIR__) . '/index.php')) {
-	include dirname(__DIR__) . '/index.php';
+if (file_exists(dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php')) {
+	include dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php';
 } else {
 	exit;
 }

--- a/Sources/Permissions/index.php
+++ b/Sources/Permissions/index.php
@@ -1,8 +1,8 @@
 <?php
 
 // Try to handle it with the upper level index.php. (it should know what to do.)
-if (file_exists(dirname(__DIR__) . '/index.php')) {
-	include dirname(__DIR__) . '/index.php';
+if (file_exists(dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php')) {
+	include dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php';
 } else {
 	exit;
 }

--- a/Sources/PersonalMessage.php
+++ b/Sources/PersonalMessage.php
@@ -17,4 +17,4 @@ if (!defined('SMF')) {
 	die('No direct access...');
 }
 
-require_once SMF\Config::$sourcedir . '/Subs-Compat.php';
+require_once SMF\Config::$sourcedir . DIRECTORY_SEPARATOR . 'Subs-Compat.php';

--- a/Sources/PersonalMessage/index.php
+++ b/Sources/PersonalMessage/index.php
@@ -1,8 +1,8 @@
 <?php
 
 // Try to handle it with the upper level index.php. (it should know what to do.)
-if (file_exists(dirname(__DIR__) . '/index.php')) {
-	include dirname(__DIR__) . '/index.php';
+if (file_exists(dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php')) {
+	include dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php';
 } else {
 	exit;
 }

--- a/Sources/Profile-Actions.php
+++ b/Sources/Profile-Actions.php
@@ -17,4 +17,4 @@ if (!defined('SMF')) {
 	die('No direct access...');
 }
 
-require_once SMF\Config::$sourcedir . '/Subs-Compat.php';
+require_once SMF\Config::$sourcedir . DIRECTORY_SEPARATOR . 'Subs-Compat.php';

--- a/Sources/Profile-Modify.php
+++ b/Sources/Profile-Modify.php
@@ -17,4 +17,4 @@ if (!defined('SMF')) {
 	die('No direct access...');
 }
 
-require_once SMF\Config::$sourcedir . '/Subs-Compat.php';
+require_once SMF\Config::$sourcedir . DIRECTORY_SEPARATOR . 'Subs-Compat.php';

--- a/Sources/Profile-View.php
+++ b/Sources/Profile-View.php
@@ -17,4 +17,4 @@ if (!defined('SMF')) {
 	die('No direct access...');
 }
 
-require_once SMF\Config::$sourcedir . '/Subs-Compat.php';
+require_once SMF\Config::$sourcedir . DIRECTORY_SEPARATOR . 'Subs-Compat.php';

--- a/Sources/Punycode.php
+++ b/Sources/Punycode.php
@@ -540,7 +540,7 @@ class Punycode
 	 */
 	protected function preprocess(string $domain, array &$errors = []): string
 	{
-		require_once Config::$sourcedir . '/Unicode/Idna.php';
+		require_once Config::canonicalPath(Config::$sourcedir . '/Unicode/Idna.php');
 
 		$regexes = idna_regex();
 		$maps = idna_maps();
@@ -617,7 +617,7 @@ class Punycode
 			return self::IDNA_ERROR_LEADING_COMBINING_MARK;
 		}
 
-		require_once Config::$sourcedir . '/Unicode/Idna.php';
+		require_once Config::canonicalPath(Config::$sourcedir . '/Unicode/Idna.php');
 
 		$regexes = Unicode\idna_regex();
 

--- a/Sources/ReCaptcha/RequestMethod/index.php
+++ b/Sources/ReCaptcha/RequestMethod/index.php
@@ -1,8 +1,8 @@
 <?php
 
 // Try to handle it with the upper level index.php. (it should know what to do.)
-if (file_exists(dirname(__DIR__) . '/index.php')) {
-	include dirname(__DIR__) . '/index.php';
+if (file_exists(dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php')) {
+	include dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php';
 } else {
 	exit;
 }

--- a/Sources/ReCaptcha/index.php
+++ b/Sources/ReCaptcha/index.php
@@ -1,8 +1,8 @@
 <?php
 
 // Try to handle it with the upper level index.php. (it should know what to do.)
-if (file_exists(dirname(__DIR__) . '/index.php')) {
-	include dirname(__DIR__) . '/index.php';
+if (file_exists(dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php')) {
+	include dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php';
 } else {
 	exit;
 }

--- a/Sources/ScheduledTasks.php
+++ b/Sources/ScheduledTasks.php
@@ -17,4 +17,4 @@ if (!defined('SMF')) {
 	die('No direct access...');
 }
 
-require_once SMF\Config::$sourcedir . '/Subs-Compat.php';
+require_once SMF\Config::$sourcedir . DIRECTORY_SEPARATOR . 'Subs-Compat.php';

--- a/Sources/Search.php
+++ b/Sources/Search.php
@@ -17,4 +17,4 @@ if (!defined('SMF')) {
 	die('No direct access...');
 }
 
-require_once SMF\Config::$sourcedir . '/Subs-Compat.php';
+require_once SMF\Config::$sourcedir . DIRECTORY_SEPARATOR . 'Subs-Compat.php';

--- a/Sources/Search/APIs/Parsed.php
+++ b/Sources/Search/APIs/Parsed.php
@@ -1043,7 +1043,7 @@ class Parsed extends SearchApi implements SearchApiInterface
 		$string = mb_decode_numericentity($string, [0x010000, 0x10FFFF, 0, 0xFFFFFF], 'UTF-8');
 
 		// Separate emoji from regular words.
-		require_once Config::$sourcedir . '/Unicode/RegularExpressions.php';
+		require_once Config::canonicalPath(Config::$sourcedir . '/Unicode/RegularExpressions.php');
 		$prop_classes = utf8_regex_properties();
 
 		$string = preg_replace_callback(

--- a/Sources/Search/APIs/index.php
+++ b/Sources/Search/APIs/index.php
@@ -1,8 +1,8 @@
 <?php
 
 // Try to handle it with the upper level index.php. (it should know what to do.)
-if (file_exists(dirname(__DIR__) . '/index.php')) {
-	include dirname(__DIR__) . '/index.php';
+if (file_exists(dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php')) {
+	include dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php';
 } else {
 	exit;
 }

--- a/Sources/Search/SearchApi.php
+++ b/Sources/Search/SearchApi.php
@@ -904,7 +904,7 @@ abstract class SearchApi implements SearchApiInterface
 				continue;
 			}
 
-			require_once $file_info->getPathname();
+			require_once Config::canonicalPath($file_info->getPathname());
 
 			if (!class_exists($class_name, false)) {
 				continue;

--- a/Sources/Search/index.php
+++ b/Sources/Search/index.php
@@ -1,8 +1,8 @@
 <?php
 
 // Try to handle it with the upper level index.php. (it should know what to do.)
-if (file_exists(dirname(__DIR__) . '/index.php')) {
-	include dirname(__DIR__) . '/index.php';
+if (file_exists(dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php')) {
+	include dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php';
 } else {
 	exit;
 }

--- a/Sources/Security.php
+++ b/Sources/Security.php
@@ -530,8 +530,8 @@ class Security
 				<?php
 
 				// Try to handle it with the upper level index.php. (it should know what to do.)
-				if (file_exists(dirname(__DIR__) . '/index.php')) {
-					include dirname(__DIR__) . '/index.php';
+				if (file_exists(dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php')) {
+					include dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php';
 				} else {
 					exit;
 				}
@@ -542,7 +542,7 @@ class Security
 				if (@file_put_contents($path . '/index.php', $contents) !== \strlen($contents)) {
 					$errors[] = 'index-php_cannot_create_file';
 				}
-			} elseif (file_get_contents($path . '/index.php') !== $contents) {
+			} elseif (!\in_array(file_get_contents($path . '/index.php'), [$contents, str_replace('DIRECTORY_SEPARATOR . \'index.php\'', '\'/index.php\'', $contents)])) {
 				$errors[] = 'index-php_exists';
 				continue;
 			}

--- a/Sources/Subs-Admin.php
+++ b/Sources/Subs-Admin.php
@@ -17,4 +17,4 @@ if (!defined('SMF')) {
 	die('No direct access...');
 }
 
-require_once SMF\Config::$sourcedir . '/Subs-Compat.php';
+require_once SMF\Config::$sourcedir . DIRECTORY_SEPARATOR . 'Subs-Compat.php';

--- a/Sources/Subs-Auth.php
+++ b/Sources/Subs-Auth.php
@@ -17,4 +17,4 @@ if (!defined('SMF')) {
 	die('No direct access...');
 }
 
-require_once SMF\Config::$sourcedir . '/Subs-Compat.php';
+require_once SMF\Config::$sourcedir . DIRECTORY_SEPARATOR . 'Subs-Compat.php';

--- a/Sources/Subs-BoardIndex.php
+++ b/Sources/Subs-BoardIndex.php
@@ -17,4 +17,4 @@ if (!defined('SMF')) {
 	die('No direct access...');
 }
 
-require_once SMF\Config::$sourcedir . '/Subs-Compat.php';
+require_once SMF\Config::$sourcedir . DIRECTORY_SEPARATOR . 'Subs-Compat.php';

--- a/Sources/Subs-Boards.php
+++ b/Sources/Subs-Boards.php
@@ -17,4 +17,4 @@ if (!defined('SMF')) {
 	die('No direct access...');
 }
 
-require_once SMF\Config::$sourcedir . '/Subs-Compat.php';
+require_once SMF\Config::$sourcedir . DIRECTORY_SEPARATOR . 'Subs-Compat.php';

--- a/Sources/Subs-Calendar.php
+++ b/Sources/Subs-Calendar.php
@@ -17,4 +17,4 @@ if (!defined('SMF')) {
 	die('No direct access...');
 }
 
-require_once SMF\Config::$sourcedir . '/Subs-Compat.php';
+require_once SMF\Config::$sourcedir . DIRECTORY_SEPARATOR . 'Subs-Compat.php';

--- a/Sources/Subs-Categories.php
+++ b/Sources/Subs-Categories.php
@@ -17,4 +17,4 @@ if (!defined('SMF')) {
 	die('No direct access...');
 }
 
-require_once SMF\Config::$sourcedir . '/Subs-Compat.php';
+require_once SMF\Config::$sourcedir . DIRECTORY_SEPARATOR . 'Subs-Compat.php';

--- a/Sources/Subs-Charset.php
+++ b/Sources/Subs-Charset.php
@@ -17,4 +17,4 @@ if (!defined('SMF')) {
 	die('No direct access...');
 }
 
-require_once SMF\Config::$sourcedir . '/Subs-Compat.php';
+require_once SMF\Config::$sourcedir . DIRECTORY_SEPARATOR . 'Subs-Compat.php';

--- a/Sources/Subs-Editor.php
+++ b/Sources/Subs-Editor.php
@@ -17,4 +17,4 @@ if (!defined('SMF')) {
 	die('No direct access...');
 }
 
-require_once SMF\Config::$sourcedir . '/Subs-Compat.php';
+require_once SMF\Config::$sourcedir . DIRECTORY_SEPARATOR . 'Subs-Compat.php';

--- a/Sources/Subs-Graphics.php
+++ b/Sources/Subs-Graphics.php
@@ -17,4 +17,4 @@ if (!defined('SMF')) {
 	die('No direct access...');
 }
 
-require_once SMF\Config::$sourcedir . '/Subs-Compat.php';
+require_once SMF\Config::$sourcedir . DIRECTORY_SEPARATOR . 'Subs-Compat.php';

--- a/Sources/Subs-List.php
+++ b/Sources/Subs-List.php
@@ -17,4 +17,4 @@ if (!defined('SMF')) {
 	die('No direct access...');
 }
 
-require_once SMF\Config::$sourcedir . '/Subs-Compat.php';
+require_once SMF\Config::$sourcedir . DIRECTORY_SEPARATOR . 'Subs-Compat.php';

--- a/Sources/Subs-Membergroups.php
+++ b/Sources/Subs-Membergroups.php
@@ -17,4 +17,4 @@ if (!defined('SMF')) {
 	die('No direct access...');
 }
 
-require_once SMF\Config::$sourcedir . '/Subs-Compat.php';
+require_once SMF\Config::$sourcedir . DIRECTORY_SEPARATOR . 'Subs-Compat.php';

--- a/Sources/Subs-Members.php
+++ b/Sources/Subs-Members.php
@@ -17,4 +17,4 @@ if (!defined('SMF')) {
 	die('No direct access...');
 }
 
-require_once SMF\Config::$sourcedir . '/Subs-Compat.php';
+require_once SMF\Config::$sourcedir . DIRECTORY_SEPARATOR . 'Subs-Compat.php';

--- a/Sources/Subs-MembersOnline.php
+++ b/Sources/Subs-MembersOnline.php
@@ -17,4 +17,4 @@ if (!defined('SMF')) {
 	die('No direct access...');
 }
 
-require_once SMF\Config::$sourcedir . '/Subs-Compat.php';
+require_once SMF\Config::$sourcedir . DIRECTORY_SEPARATOR . 'Subs-Compat.php';

--- a/Sources/Subs-MessageIndex.php
+++ b/Sources/Subs-MessageIndex.php
@@ -17,4 +17,4 @@ if (!defined('SMF')) {
 	die('No direct access...');
 }
 
-require_once SMF\Config::$sourcedir . '/Subs-Compat.php';
+require_once SMF\Config::$sourcedir . DIRECTORY_SEPARATOR . 'Subs-Compat.php';

--- a/Sources/Subs-Package.php
+++ b/Sources/Subs-Package.php
@@ -17,4 +17,4 @@ if (!defined('SMF')) {
 	die('No direct access...');
 }
 
-require_once SMF\Config::$sourcedir . '/Subs-Compat.php';
+require_once SMF\Config::$sourcedir . DIRECTORY_SEPARATOR . 'Subs-Compat.php';

--- a/Sources/Subs-ReportedContent.php
+++ b/Sources/Subs-ReportedContent.php
@@ -17,4 +17,4 @@ if (!defined('SMF')) {
 	die('No direct access...');
 }
 
-require_once SMF\Config::$sourcedir . '/Subs-Compat.php';
+require_once SMF\Config::$sourcedir . DIRECTORY_SEPARATOR . 'Subs-Compat.php';

--- a/Sources/Subs-Sound.php
+++ b/Sources/Subs-Sound.php
@@ -17,4 +17,4 @@ if (!defined('SMF')) {
 	die('No direct access...');
 }
 
-require_once SMF\Config::$sourcedir . '/Subs-Compat.php';
+require_once SMF\Config::$sourcedir . DIRECTORY_SEPARATOR . 'Subs-Compat.php';

--- a/Sources/Subs-Timezones.php
+++ b/Sources/Subs-Timezones.php
@@ -17,4 +17,4 @@ if (!defined('SMF')) {
 	die('No direct access...');
 }
 
-require_once SMF\Config::$sourcedir . '/Subs-Compat.php';
+require_once SMF\Config::$sourcedir . DIRECTORY_SEPARATOR . 'Subs-Compat.php';

--- a/Sources/Subscriptions/PayPal/index.php
+++ b/Sources/Subscriptions/PayPal/index.php
@@ -1,8 +1,8 @@
 <?php
 
 // Try to handle it with the upper level index.php. (it should know what to do.)
-if (file_exists(dirname(__DIR__) . '/index.php')) {
-	include dirname(__DIR__) . '/index.php';
+if (file_exists(dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php')) {
+	include dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php';
 } else {
 	exit;
 }

--- a/Sources/Subscriptions/index.php
+++ b/Sources/Subscriptions/index.php
@@ -1,8 +1,8 @@
 <?php
 
 // Try to handle it with the upper level index.php. (it should know what to do.)
-if (file_exists(dirname(__DIR__) . '/index.php')) {
-	include dirname(__DIR__) . '/index.php';
+if (file_exists(dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php')) {
+	include dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php';
 } else {
 	exit;
 }

--- a/Sources/TOTP/index.php
+++ b/Sources/TOTP/index.php
@@ -1,8 +1,8 @@
 <?php
 
 // Try to handle it with the upper level index.php. (it should know what to do.)
-if (file_exists(dirname(__DIR__) . '/index.php')) {
-	include dirname(__DIR__) . '/index.php';
+if (file_exists(dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php')) {
+	include dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php';
 } else {
 	exit;
 }

--- a/Sources/TaskRunner.php
+++ b/Sources/TaskRunner.php
@@ -552,7 +552,7 @@ class TaskRunner
 			$include = strtr(trim($task_details['task_file']), ['$boarddir' => Config::$boarddir, '$sourcedir' => Config::$sourcedir]);
 
 			if (file_exists($include)) {
-				require_once $include;
+				require_once Config::canonicalPath($include);
 			}
 		}
 

--- a/Sources/Tasks/ExportProfileData.php
+++ b/Sources/Tasks/ExportProfileData.php
@@ -1919,31 +1919,6 @@ class ExportProfileData extends BackgroundTask
 				}
 			}
 		}
-		// Autoloading is unavailable for background tasks, so we have to do things the hard way...
-		else {
-			if (!empty(Config::$modSettings['minimize_files']) && (!class_exists('MatthiasMullie\\Minify\\CSS') || !class_exists('MatthiasMullie\\Minify\\JS'))) {
-				// Include, not require, because minimization is nice to have but not vital here.
-				include_once implode(DIRECTORY_SEPARATOR, [Config::$sourcedir, 'minify', 'src', 'Exception.php']);
-
-				include_once implode(DIRECTORY_SEPARATOR, [Config::$sourcedir, 'minify', 'src', 'Exceptions', 'BasicException.php']);
-
-				include_once implode(DIRECTORY_SEPARATOR, [Config::$sourcedir, 'minify', 'src', 'Exceptions', 'FileImportException.php']);
-
-				include_once implode(DIRECTORY_SEPARATOR, [Config::$sourcedir, 'minify', 'src', 'Exceptions', 'IOException.php']);
-
-				include_once implode(DIRECTORY_SEPARATOR, [Config::$sourcedir, 'minify', 'src', 'Minify.php']);
-
-				include_once implode(DIRECTORY_SEPARATOR, [Config::$sourcedir, 'minify', 'path-converter', 'src', 'Converter.php']);
-
-				include_once implode(DIRECTORY_SEPARATOR, [Config::$sourcedir, 'minify', 'src', 'CSS.php']);
-
-				include_once implode(DIRECTORY_SEPARATOR, [Config::$sourcedir, 'minify', 'src', 'JS.php']);
-
-				if (!class_exists('MatthiasMullie\\Minify\\CSS') || !class_exists('MatthiasMullie\\Minify\\JS')) {
-					Config::$modSettings['minimize_files'] = false;
-				}
-			}
-		}
 
 		// Load our standard CSS files.
 		Theme::loadCSSFile('index.css', ['minimize' => true, 'order_pos' => 1], 'smf_index');

--- a/Sources/Tasks/ExportProfileData.php
+++ b/Sources/Tasks/ExportProfileData.php
@@ -1647,7 +1647,7 @@ class ExportProfileData extends BackgroundTask
 				$this->_details['format'] = 'XML_XSLT';
 			}
 
-			require_once Config::$sourcedir . '/Actions/Profile/Export.php';
+			require_once Config::canonicalPath(Config::$sourcedir . '/Actions/Profile/Export.php');
 			$export_formats = Export::getFormats();
 
 			/* Notes:

--- a/Sources/Tasks/index.php
+++ b/Sources/Tasks/index.php
@@ -1,8 +1,8 @@
 <?php
 
 // Try to handle it with the upper level index.php. (it should know what to do.)
-if (file_exists(dirname(__DIR__) . '/index.php')) {
-	include dirname(__DIR__) . '/index.php';
+if (file_exists(dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php')) {
+	include dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php';
 } else {
 	exit;
 }

--- a/Sources/Theme.php
+++ b/Sources/Theme.php
@@ -236,7 +236,7 @@ class Theme
 				$include = strtr(trim($include), ['$boarddir' => Config::$boarddir, '$sourcedir' => Config::$sourcedir, '$themedir' => $this->settings['theme_dir']]);
 
 				if (file_exists($include)) {
-					require_once $include;
+					require_once Config::canonicalPath($include);
 				}
 			}
 		}
@@ -2346,9 +2346,9 @@ class Theme
 		$file_found = file_exists($filename);
 
 		if ($once && $file_found) {
-			require_once $filename;
+			require_once Config::canonicalPath($filename);
 		} elseif ($file_found) {
-			require $filename;
+			require Config::canonicalPath($filename);
 		}
 
 		if ($file_found !== true) {

--- a/Sources/Topic.php
+++ b/Sources/Topic.php
@@ -1548,7 +1548,7 @@ class Topic implements \ArrayAccess, Routable
 				self::move($recycleTopics, (int) Config::$modSettings['recycle_board']);
 
 				// Close reports that are being recycled.
-				require_once Config::$sourcedir . '/Actions/Moderation/Main.php';
+				require_once Config::canonicalPath(Config::$sourcedir . '/Actions/Moderation/Main.php');
 
 				Db::$db->query(
 					'UPDATE {db_prefix}log_reported

--- a/Sources/Unicode/SpoofDetector.php
+++ b/Sources/Unicode/SpoofDetector.php
@@ -50,7 +50,7 @@ class SpoofDetector
 		$chars = Utf8String::decompose($chars, false);
 
 		// 2. Replace confusable characters with their prototypes.
-		require_once __DIR__ . '/Confusables.php';
+		require_once __DIR__ . DIRECTORY_SEPARATOR . 'Confusables.php';
 		$substitutions = utf8_confusables();
 
 		foreach ($chars as &$char) {
@@ -79,7 +79,7 @@ class SpoofDetector
 			return [];
 		}
 
-		require_once __DIR__ . '/Confusables.php';
+		require_once __DIR__ . DIRECTORY_SEPARATOR . 'Confusables.php';
 
 		$scripts_data = utf8_character_scripts();
 
@@ -434,7 +434,7 @@ class SpoofDetector
 				return true;
 			}
 
-			require_once __DIR__ . '/Confusables.php';
+			require_once __DIR__ . DIRECTORY_SEPARATOR . 'Confusables.php';
 			$regexes = utf8_regex_identifier_status();
 
 			// If either string contains Identifier_Status=Restricted characters, reject.

--- a/Sources/Unicode/Utf8String.php
+++ b/Sources/Unicode/Utf8String.php
@@ -1033,10 +1033,6 @@ class Utf8String implements \Stringable
 			// Hangul characters.
 			// See "Hangul Syllable Decomposition" in the Unicode standard, ch. 3.12.
 			if ($chars[$i] >= "\xEA\xB0\x80" && $chars[$i] <= "\xED\x9E\xA3") {
-				if (!\function_exists('mb_ord')) {
-					require_once Config::$sourcedir . '/Subs-Compat.php';
-				}
-
 				$s = mb_ord($chars[$i]);
 				$sindex = $s - 0xAC00;
 				$l = (int) (0x1100 + $sindex / (21 * 28));
@@ -1099,10 +1095,6 @@ class Utf8String implements \Stringable
 			// Hangul characters.
 			// See "Hangul Syllable Composition" in the Unicode standard, ch. 3.12.
 			if ($chars[$c] >= "\xE1\x84\x80" && $chars[$c] <= "\xE1\x84\x92" && isset($chars[$c + 1]) && $chars[$c + 1] >= "\xE1\x85\xA1" && $chars[$c + 1] <= "\xE1\x85\xB5") {
-				if (!\function_exists('mb_ord')) {
-					require_once Config::$sourcedir . '/Subs-Compat.php';
-				}
-
 				$l_part = $chars[$c];
 				$v_part = $chars[$c + 1];
 				$t_part = null;

--- a/Sources/Unicode/Utf8String.php
+++ b/Sources/Unicode/Utf8String.php
@@ -80,7 +80,7 @@ class Utf8String implements \Stringable
 
 		// Can we use the intl extension's Normalizer class?
 		if (!isset(self::$use_intl_normalizer)) {
-			require_once __DIR__ . '/Metadata.php';
+			require_once __DIR__ . DIRECTORY_SEPARATOR . 'Metadata.php';
 
 			self::$use_intl_normalizer = \extension_loaded('intl') && version_compare(implode('.', \IntlChar::getUnicodeVersion()), SMF_UNICODE_VERSION, '>=');
 		}
@@ -146,7 +146,7 @@ class Utf8String implements \Stringable
 
 			switch ($case) {
 				case 'upper':
-					require_once __DIR__ . '/CaseUpper.php';
+					require_once __DIR__ . DIRECTORY_SEPARATOR . 'CaseUpper.php';
 					$substitutions = $simple ? utf8_strtoupper_simple_maps() : utf8_strtoupper_maps();
 
 					// Turkish & Azeri conditional casing, part 1.
@@ -157,7 +157,7 @@ class Utf8String implements \Stringable
 					break;
 
 				case 'lower':
-					require_once __DIR__ . '/CaseLower.php';
+					require_once __DIR__ . DIRECTORY_SEPARATOR . 'CaseLower.php';
 					$substitutions = $simple ? utf8_strtolower_simple_maps() : utf8_strtolower_maps();
 
 					// Turkish & Azeri conditional casing, part 1.
@@ -170,7 +170,7 @@ class Utf8String implements \Stringable
 					break;
 
 				case 'fold':
-					require_once __DIR__ . '/CaseFold.php';
+					require_once __DIR__ . DIRECTORY_SEPARATOR . 'CaseFold.php';
 					$substitutions = $simple ? utf8_casefold_simple_maps() : utf8_casefold_maps();
 					break;
 			}
@@ -181,11 +181,11 @@ class Utf8String implements \Stringable
 
 			$this->string = implode('', $chars);
 		} elseif (\in_array($case, ['title', 'ucfirst', 'ucwords'])) {
-			require_once __DIR__ . '/RegularExpressions.php';
+			require_once __DIR__ . DIRECTORY_SEPARATOR . 'RegularExpressions.php';
 
-			require_once __DIR__ . '/CaseUpper.php';
+			require_once __DIR__ . DIRECTORY_SEPARATOR . 'CaseUpper.php';
 
-			require_once __DIR__ . '/CaseTitle.php';
+			require_once __DIR__ . DIRECTORY_SEPARATOR . 'CaseTitle.php';
 
 			$prop_classes = utf8_regex_properties();
 
@@ -240,7 +240,7 @@ class Utf8String implements \Stringable
 		// Greek conditional casing, part 1: Fix lowercase sigma.
 		// Note that this rule doesn't depend on $txt['lang_locale'].
 		if ($case !== 'upper' && str_contains($this->string, 'ς') || str_contains($this->string, 'σ')) {
-			require_once Config::$sourcedir . '/Unicode/RegularExpressions.php';
+			require_once __DIR__ . DIRECTORY_SEPARATOR . 'RegularExpressions.php';
 
 			$prop_classes = utf8_regex_properties();
 
@@ -434,7 +434,7 @@ class Utf8String implements \Stringable
 				return false;
 		}
 
-		require_once __DIR__ . '/QuickCheck.php';
+		require_once __DIR__ . DIRECTORY_SEPARATOR . 'QuickCheck.php';
 		$qc = utf8_regex_quick_check();
 
 		if (preg_match('/[' . $qc[$prop] . ']/u', $this->string)) {
@@ -448,7 +448,7 @@ class Utf8String implements \Stringable
 		// strings that don't need them, but building and running a perfect regex
 		// would be more expensive in the vast majority of cases, so meh.
 		if (preg_match_all('/([\p{M}\p{Cn}])/u', $this->string, $matches, PREG_OFFSET_CAPTURE)) {
-			require_once __DIR__ . '/CombiningClasses.php';
+			require_once __DIR__ . DIRECTORY_SEPARATOR . 'CombiningClasses.php';
 
 			$combining_classes = utf8_combining_classes();
 
@@ -499,7 +499,7 @@ class Utf8String implements \Stringable
 		$level = min(max((int) $level, 0), 2);
 		$substitute = (string) $substitute;
 
-		require_once __DIR__ . '/RegularExpressions.php';
+		require_once __DIR__ . DIRECTORY_SEPARATOR . 'RegularExpressions.php';
 		$prop_classes = utf8_regex_properties();
 
 		// We never want non-whitespace control characters
@@ -670,7 +670,7 @@ class Utf8String implements \Stringable
 		// Normalize the whitespace.
 		$this->string = Utils::normalizeSpaces($this->string, true, true, ['replace_tabs' => true, 'collapse_hspace' => true]);
 
-		require_once __DIR__ . '/RegularExpressions.php';
+		require_once __DIR__ . DIRECTORY_SEPARATOR . 'RegularExpressions.php';
 		$prop_classes = utf8_regex_properties();
 
 		// Split into words, with Unicode awareness.
@@ -724,7 +724,7 @@ class Utf8String implements \Stringable
 				];
 			}
 
-			require_once __DIR__ . '/RegularExpressions.php';
+			require_once __DIR__ . DIRECTORY_SEPARATOR . 'RegularExpressions.php';
 			$prop_classes = utf8_regex_properties();
 
 			for ($i = 0; $i < \count($chars); $i++) {
@@ -1012,7 +1012,7 @@ class Utf8String implements \Stringable
 	public static function decompose(array $chars, bool $compatibility = false): array
 	{
 		if (!empty($compatibility)) {
-			require_once __DIR__ . '/DecompositionCompatibility.php';
+			require_once __DIR__ . DIRECTORY_SEPARATOR . 'DecompositionCompatibility.php';
 
 			$substitutions = utf8_normalize_kd_maps();
 
@@ -1021,9 +1021,9 @@ class Utf8String implements \Stringable
 			}
 		}
 
-		require_once __DIR__ . '/DecompositionCanonical.php';
+		require_once __DIR__ . DIRECTORY_SEPARATOR . 'DecompositionCanonical.php';
 
-		require_once __DIR__ . '/CombiningClasses.php';
+		require_once __DIR__ . DIRECTORY_SEPARATOR . 'CombiningClasses.php';
 
 		$substitutions = utf8_normalize_d_maps();
 		$combining_classes = utf8_combining_classes();
@@ -1079,9 +1079,9 @@ class Utf8String implements \Stringable
 	 */
 	public static function compose(array $chars): array
 	{
-		require_once __DIR__ . '/Composition.php';
+		require_once __DIR__ . DIRECTORY_SEPARATOR . 'Composition.php';
 
-		require_once __DIR__ . '/CombiningClasses.php';
+		require_once __DIR__ . DIRECTORY_SEPARATOR . 'CombiningClasses.php';
 
 		$substitutions = utf8_compose_maps();
 		$combining_classes = utf8_combining_classes();
@@ -1156,7 +1156,7 @@ class Utf8String implements \Stringable
 	 */
 	public static function emojiRegex(): string
 	{
-		require_once __DIR__ . '/RegularExpressions.php';
+		require_once __DIR__ . DIRECTORY_SEPARATOR . 'RegularExpressions.php';
 
 		$prop_classes = utf8_regex_properties();
 
@@ -1369,9 +1369,9 @@ class Utf8String implements \Stringable
 
 		$chars = self::decompose($chars, true);
 
-		require_once __DIR__ . '/CaseFold.php';
+		require_once __DIR__ . DIRECTORY_SEPARATOR . 'CaseFold.php';
 
-		require_once __DIR__ . '/DefaultIgnorables.php';
+		require_once __DIR__ . DIRECTORY_SEPARATOR . 'DefaultIgnorables.php';
 
 		$substitutions = utf8_casefold_maps();
 		$ignorables = array_flip(utf8_default_ignorables());
@@ -1400,7 +1400,7 @@ class Utf8String implements \Stringable
 	 */
 	protected function preserveEmoji(array &$placeholders): void
 	{
-		require_once __DIR__ . '/RegularExpressions.php';
+		require_once __DIR__ . DIRECTORY_SEPARATOR . 'RegularExpressions.php';
 		$prop_classes = utf8_regex_properties();
 
 		$this->string  = preg_replace_callback(
@@ -1430,7 +1430,7 @@ class Utf8String implements \Stringable
 	 */
 	protected function sanitizeVariationSelectors(array &$placeholders, string $substitute): void
 	{
-		require_once __DIR__ . '/RegularExpressions.php';
+		require_once __DIR__ . DIRECTORY_SEPARATOR . 'RegularExpressions.php';
 		$prop_classes = utf8_regex_properties();
 
 		$patterns = ['/[' . $prop_classes['Ideographic'] . '][\x{E0100}-\x{E01EF}]/u'];
@@ -1469,7 +1469,7 @@ class Utf8String implements \Stringable
 	 */
 	protected function sanitizeJoinControls(array &$placeholders, int $level, string $substitute): void
 	{
-		require_once __DIR__ . '/RegularExpressions.php';
+		require_once __DIR__ . DIRECTORY_SEPARATOR . 'RegularExpressions.php';
 
 		// Zero Width Non-Joiner (U+200C)
 		$zwnj = "\xE2\x80\x8C";

--- a/Sources/Unicode/index.php
+++ b/Sources/Unicode/index.php
@@ -1,8 +1,8 @@
 <?php
 
 // Try to handle it with the upper level index.php. (it should know what to do.)
-if (file_exists(dirname(__DIR__) . '/index.php')) {
-	include dirname(__DIR__) . '/index.php';
+if (file_exists(dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php')) {
+	include dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php';
 } else {
 	exit;
 }

--- a/Sources/Url.php
+++ b/Sources/Url.php
@@ -223,7 +223,7 @@ class Url implements \Stringable
 
 		if (!empty($this->host)) {
 			if (!\function_exists('idn_to_ascii')) {
-				require_once Config::$sourcedir . '/Subs-Compat.php';
+				require_once Config::canonicalPath(Config::$sourcedir . '/Subs-Compat.php');
 			}
 
 			// Convert the host using the Punycode algorithm
@@ -275,7 +275,7 @@ class Url implements \Stringable
 
 		if (!empty($this->host)) {
 			if (!\function_exists('idn_to_utf8')) {
-				require_once Config::$sourcedir . '/Subs-Compat.php';
+				require_once Config::canonicalPath(Config::$sourcedir . '/Subs-Compat.php');
 			}
 
 			// Decode the domain from Punycode.
@@ -713,7 +713,7 @@ class Url implements \Stringable
 
 			// Convert Punycode to Unicode
 			if (!\function_exists('idn_to_utf8')) {
-				require_once Config::$sourcedir . '/Subs-Compat.php';
+				require_once Config::canonicalPath(Config::$sourcedir . '/Subs-Compat.php');
 			}
 
 			foreach ($tlds as &$tld) {

--- a/Sources/Utils.php
+++ b/Sources/Utils.php
@@ -2549,14 +2549,14 @@ class Utils
 
 			// Load the file if it can be loaded.
 			if (is_file($path)) {
-				require_once $path;
+				require_once Config::canonicalPath($path);
 			}
 			// No? Try a fallback to Config::$sourcedir.
 			else {
 				$path = Config::$sourcedir . '/' . $file;
 
 				if (is_file($path)) {
-					require_once $path;
+					require_once Config::canonicalPath($path);
 				}
 				// Sorry, can't do much for you at this point.
 				elseif (empty(Utils::$context['uninstalling'])) {

--- a/Sources/WebFetch/APIs/index.php
+++ b/Sources/WebFetch/APIs/index.php
@@ -1,8 +1,8 @@
 <?php
 
 // Try to handle it with the upper level index.php. (it should know what to do.)
-if (file_exists(dirname(__DIR__) . '/index.php')) {
-	include dirname(__DIR__) . '/index.php';
+if (file_exists(dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php')) {
+	include dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php';
 } else {
 	exit;
 }

--- a/Sources/WebFetch/index.php
+++ b/Sources/WebFetch/index.php
@@ -1,8 +1,8 @@
 <?php
 
 // Try to handle it with the upper level index.php. (it should know what to do.)
-if (file_exists(dirname(__DIR__) . '/index.php')) {
-	include dirname(__DIR__) . '/index.php';
+if (file_exists(dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php')) {
+	include dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php';
 } else {
 	exit;
 }

--- a/Sources/ZxcvbnPhp/Matchers/index.php
+++ b/Sources/ZxcvbnPhp/Matchers/index.php
@@ -1,8 +1,8 @@
 <?php
 
 // Try to handle it with the upper level index.php. (it should know what to do.)
-if (file_exists(dirname(__DIR__) . '/index.php')) {
-	include dirname(__DIR__) . '/index.php';
+if (file_exists(dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php')) {
+	include dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php';
 } else {
 	exit;
 }

--- a/Sources/ZxcvbnPhp/Math/Impl/index.php
+++ b/Sources/ZxcvbnPhp/Math/Impl/index.php
@@ -1,8 +1,8 @@
 <?php
 
 // Try to handle it with the upper level index.php. (it should know what to do.)
-if (file_exists(dirname(__DIR__) . '/index.php')) {
-	include dirname(__DIR__) . '/index.php';
+if (file_exists(dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php')) {
+	include dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php';
 } else {
 	exit;
 }

--- a/Sources/ZxcvbnPhp/Math/index.php
+++ b/Sources/ZxcvbnPhp/Math/index.php
@@ -1,8 +1,8 @@
 <?php
 
 // Try to handle it with the upper level index.php. (it should know what to do.)
-if (file_exists(dirname(__DIR__) . '/index.php')) {
-	include dirname(__DIR__) . '/index.php';
+if (file_exists(dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php')) {
+	include dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php';
 } else {
 	exit;
 }

--- a/Sources/ZxcvbnPhp/index.php
+++ b/Sources/ZxcvbnPhp/index.php
@@ -1,8 +1,8 @@
 <?php
 
 // Try to handle it with the upper level index.php. (it should know what to do.)
-if (file_exists(dirname(__DIR__) . '/index.php')) {
-	include dirname(__DIR__) . '/index.php';
+if (file_exists(dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php')) {
+	include dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php';
 } else {
 	exit;
 }

--- a/Sources/index.php
+++ b/Sources/index.php
@@ -1,8 +1,8 @@
 <?php
 
 // Try to handle it with the upper level index.php. (it should know what to do.)
-if (file_exists(dirname(__DIR__) . '/index.php')) {
-	include dirname(__DIR__) . '/index.php';
+if (file_exists(dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php')) {
+	include dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php';
 } else {
 	exit;
 }

--- a/Sources/minify/data/index.php
+++ b/Sources/minify/data/index.php
@@ -1,8 +1,8 @@
 <?php
 
 // Try to handle it with the upper level index.php. (it should know what to do.)
-if (file_exists(dirname(__DIR__) . '/index.php')) {
-	include dirname(__DIR__) . '/index.php';
+if (file_exists(dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php')) {
+	include dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php';
 } else {
 	exit;
 }

--- a/Sources/minify/data/js/index.php
+++ b/Sources/minify/data/js/index.php
@@ -1,8 +1,8 @@
 <?php
 
 // Try to handle it with the upper level index.php. (it should know what to do.)
-if (file_exists(dirname(__DIR__) . '/index.php')) {
-	include dirname(__DIR__) . '/index.php';
+if (file_exists(dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php')) {
+	include dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php';
 } else {
 	exit;
 }

--- a/Sources/minify/index.php
+++ b/Sources/minify/index.php
@@ -1,8 +1,8 @@
 <?php
 
 // Try to handle it with the upper level index.php. (it should know what to do.)
-if (file_exists(dirname(__DIR__) . '/index.php')) {
-	include dirname(__DIR__) . '/index.php';
+if (file_exists(dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php')) {
+	include dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php';
 } else {
 	exit;
 }

--- a/Sources/minify/path-converter/index.php
+++ b/Sources/minify/path-converter/index.php
@@ -1,8 +1,8 @@
 <?php
 
 // Try to handle it with the upper level index.php. (it should know what to do.)
-if (file_exists(dirname(__DIR__) . '/index.php')) {
-	include dirname(__DIR__) . '/index.php';
+if (file_exists(dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php')) {
+	include dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php';
 } else {
 	exit;
 }

--- a/Sources/minify/path-converter/src/index.php
+++ b/Sources/minify/path-converter/src/index.php
@@ -1,8 +1,8 @@
 <?php
 
 // Try to handle it with the upper level index.php. (it should know what to do.)
-if (file_exists(dirname(__DIR__) . '/index.php')) {
-	include dirname(__DIR__) . '/index.php';
+if (file_exists(dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php')) {
+	include dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php';
 } else {
 	exit;
 }

--- a/Sources/minify/src/Exceptions/index.php
+++ b/Sources/minify/src/Exceptions/index.php
@@ -1,8 +1,8 @@
 <?php
 
 // Try to handle it with the upper level index.php. (it should know what to do.)
-if (file_exists(dirname(__DIR__) . '/index.php')) {
-	include dirname(__DIR__) . '/index.php';
+if (file_exists(dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php')) {
+	include dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php';
 } else {
 	exit;
 }

--- a/Sources/minify/src/index.php
+++ b/Sources/minify/src/index.php
@@ -1,8 +1,8 @@
 <?php
 
 // Try to handle it with the upper level index.php. (it should know what to do.)
-if (file_exists(dirname(__DIR__) . '/index.php')) {
-	include dirname(__DIR__) . '/index.php';
+if (file_exists(dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php')) {
+	include dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php';
 } else {
 	exit;
 }

--- a/Themes/default/css/index.php
+++ b/Themes/default/css/index.php
@@ -1,8 +1,8 @@
 <?php
 
 // Try to handle it with the upper level index.php. (it should know what to do.)
-if (file_exists(dirname(__DIR__) . '/index.php')) {
-	include dirname(__DIR__) . '/index.php';
+if (file_exists(dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php')) {
+	include dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php';
 } else {
 	exit;
 }

--- a/Themes/default/fonts/AnonymousPro/index.php
+++ b/Themes/default/fonts/AnonymousPro/index.php
@@ -1,8 +1,8 @@
 <?php
 
 // Try to handle it with the upper level index.php. (it should know what to do.)
-if (file_exists(dirname(__DIR__) . '/index.php')) {
-	include dirname(__DIR__) . '/index.php';
+if (file_exists(dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php')) {
+	include dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php';
 } else {
 	exit;
 }

--- a/Themes/default/fonts/ConsolaMono/index.php
+++ b/Themes/default/fonts/ConsolaMono/index.php
@@ -1,8 +1,8 @@
 <?php
 
 // Try to handle it with the upper level index.php. (it should know what to do.)
-if (file_exists(dirname(__DIR__) . '/index.php')) {
-	include dirname(__DIR__) . '/index.php';
+if (file_exists(dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php')) {
+	include dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php';
 } else {
 	exit;
 }

--- a/Themes/default/fonts/index.php
+++ b/Themes/default/fonts/index.php
@@ -1,8 +1,8 @@
 <?php
 
 // Try to handle it with the upper level index.php. (it should know what to do.)
-if (file_exists(dirname(__DIR__) . '/index.php')) {
-	include dirname(__DIR__) . '/index.php';
+if (file_exists(dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php')) {
+	include dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php';
 } else {
 	exit;
 }

--- a/Themes/default/fonts/sound/index.php
+++ b/Themes/default/fonts/sound/index.php
@@ -1,8 +1,8 @@
 <?php
 
 // Try to handle it with the upper level index.php. (it should know what to do.)
-if (file_exists(dirname(__DIR__) . '/index.php')) {
-	include dirname(__DIR__) . '/index.php';
+if (file_exists(dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php')) {
+	include dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php';
 } else {
 	exit;
 }

--- a/Themes/default/images/bbc/index.php
+++ b/Themes/default/images/bbc/index.php
@@ -1,8 +1,8 @@
 <?php
 
 // Try to handle it with the upper level index.php. (it should know what to do.)
-if (file_exists(dirname(__DIR__) . '/index.php')) {
-	include dirname(__DIR__) . '/index.php';
+if (file_exists(dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php')) {
+	include dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php';
 } else {
 	exit;
 }

--- a/Themes/default/images/icons/index.php
+++ b/Themes/default/images/icons/index.php
@@ -1,8 +1,8 @@
 <?php
 
 // Try to handle it with the upper level index.php. (it should know what to do.)
-if (file_exists(dirname(__DIR__) . '/index.php')) {
-	include dirname(__DIR__) . '/index.php';
+if (file_exists(dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php')) {
+	include dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php';
 } else {
 	exit;
 }

--- a/Themes/default/images/index.php
+++ b/Themes/default/images/index.php
@@ -1,8 +1,8 @@
 <?php
 
 // Try to handle it with the upper level index.php. (it should know what to do.)
-if (file_exists(dirname(__DIR__) . '/index.php')) {
-	include dirname(__DIR__) . '/index.php';
+if (file_exists(dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php')) {
+	include dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php';
 } else {
 	exit;
 }

--- a/Themes/default/images/membericons/index.php
+++ b/Themes/default/images/membericons/index.php
@@ -1,8 +1,8 @@
 <?php
 
 // Try to handle it with the upper level index.php. (it should know what to do.)
-if (file_exists(dirname(__DIR__) . '/index.php')) {
-	include dirname(__DIR__) . '/index.php';
+if (file_exists(dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php')) {
+	include dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php';
 } else {
 	exit;
 }

--- a/Themes/default/images/post/index.php
+++ b/Themes/default/images/post/index.php
@@ -1,8 +1,8 @@
 <?php
 
 // Try to handle it with the upper level index.php. (it should know what to do.)
-if (file_exists(dirname(__DIR__) . '/index.php')) {
-	include dirname(__DIR__) . '/index.php';
+if (file_exists(dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php')) {
+	include dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php';
 } else {
 	exit;
 }

--- a/Themes/default/images/topic/index.php
+++ b/Themes/default/images/topic/index.php
@@ -1,8 +1,8 @@
 <?php
 
 // Try to handle it with the upper level index.php. (it should know what to do.)
-if (file_exists(dirname(__DIR__) . '/index.php')) {
-	include dirname(__DIR__) . '/index.php';
+if (file_exists(dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php')) {
+	include dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php';
 } else {
 	exit;
 }

--- a/Themes/default/index.php
+++ b/Themes/default/index.php
@@ -1,8 +1,8 @@
 <?php
 
 // Try to handle it with the upper level index.php. (it should know what to do.)
-if (file_exists(dirname(__DIR__) . '/index.php')) {
-	include dirname(__DIR__) . '/index.php';
+if (file_exists(dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php')) {
+	include dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php';
 } else {
 	exit;
 }

--- a/Themes/default/languages/en_US/index.php
+++ b/Themes/default/languages/en_US/index.php
@@ -1,8 +1,8 @@
 <?php
 
 // Try to handle it with the upper level index.php. (it should know what to do.)
-if (file_exists(dirname(__DIR__) . '/index.php')) {
-	include dirname(__DIR__) . '/index.php';
+if (file_exists(dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php')) {
+	include dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php';
 } else {
 	exit;
 }

--- a/Themes/default/languages/index.php
+++ b/Themes/default/languages/index.php
@@ -1,8 +1,8 @@
 <?php
 
 // Try to handle it with the upper level index.php. (it should know what to do.)
-if (file_exists(dirname(__DIR__) . '/index.php')) {
-	include dirname(__DIR__) . '/index.php';
+if (file_exists(dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php')) {
+	include dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php';
 } else {
 	exit;
 }

--- a/Themes/default/scripts/index.php
+++ b/Themes/default/scripts/index.php
@@ -1,8 +1,8 @@
 <?php
 
 // Try to handle it with the upper level index.php. (it should know what to do.)
-if (file_exists(dirname(__DIR__) . '/index.php')) {
-	include dirname(__DIR__) . '/index.php';
+if (file_exists(dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php')) {
+	include dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php';
 } else {
 	exit;
 }

--- a/Themes/index.php
+++ b/Themes/index.php
@@ -1,8 +1,8 @@
 <?php
 
 // Try to handle it with the upper level index.php. (it should know what to do.)
-if (file_exists(dirname(__DIR__) . '/index.php')) {
-	include dirname(__DIR__) . '/index.php';
+if (file_exists(dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php')) {
+	include dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php';
 } else {
 	exit;
 }

--- a/attachments/index.php
+++ b/attachments/index.php
@@ -1,8 +1,8 @@
 <?php
 
 // Try to handle it with the upper level index.php. (it should know what to do.)
-if (file_exists(dirname(__DIR__) . '/index.php')) {
-	include dirname(__DIR__) . '/index.php';
+if (file_exists(dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php')) {
+	include dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php';
 } else {
 	exit;
 }

--- a/avatars/Oxygen/index.php
+++ b/avatars/Oxygen/index.php
@@ -1,8 +1,8 @@
 <?php
 
 // Try to handle it with the upper level index.php. (it should know what to do.)
-if (file_exists(dirname(__DIR__) . '/index.php')) {
-	include dirname(__DIR__) . '/index.php';
+if (file_exists(dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php')) {
+	include dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php';
 } else {
 	exit;
 }

--- a/avatars/index.php
+++ b/avatars/index.php
@@ -1,8 +1,8 @@
 <?php
 
 // Try to handle it with the upper level index.php. (it should know what to do.)
-if (file_exists(dirname(__DIR__) . '/index.php')) {
-	include dirname(__DIR__) . '/index.php';
+if (file_exists(dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php')) {
+	include dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php';
 } else {
 	exit;
 }

--- a/cache/images/index.php
+++ b/cache/images/index.php
@@ -1,8 +1,8 @@
 <?php
 
 // Try to handle it with the upper level index.php. (it should know what to do.)
-if (file_exists(dirname(__DIR__) . '/index.php')) {
-	include dirname(__DIR__) . '/index.php';
+if (file_exists(dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php')) {
+	include dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php';
 } else {
 	exit;
 }

--- a/cache/index.php
+++ b/cache/index.php
@@ -1,8 +1,8 @@
 <?php
 
 // Try to handle it with the upper level index.php. (it should know what to do.)
-if (file_exists(dirname(__DIR__) . '/index.php')) {
-	include dirname(__DIR__) . '/index.php';
+if (file_exists(dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php')) {
+	include dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php';
 } else {
 	exit;
 }

--- a/composer.lock
+++ b/composer.lock
@@ -669,12 +669,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/SimpleMachines/BuildTools.git",
-                "reference": "4ecd9b09871a71e110fa3561e1bd8ab588f48461"
+                "reference": "e6dfbbb08149d1c82e497f0270fc9685361e94be"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/SimpleMachines/BuildTools/zipball/4ecd9b09871a71e110fa3561e1bd8ab588f48461",
-                "reference": "4ecd9b09871a71e110fa3561e1bd8ab588f48461",
+                "url": "https://api.github.com/repos/SimpleMachines/BuildTools/zipball/e6dfbbb08149d1c82e497f0270fc9685361e94be",
+                "reference": "e6dfbbb08149d1c82e497f0270fc9685361e94be",
                 "shasum": ""
             },
             "require": {
@@ -687,7 +687,7 @@
                 "source": "https://github.com/SimpleMachines/BuildTools/tree/release-3.0",
                 "issues": "https://github.com/SimpleMachines/BuildTools/issues"
             },
-            "time": "2024-02-21T21:39:32+00:00"
+            "time": "2025-09-05T00:26:29+00:00"
         },
         {
             "name": "symfony/cache",

--- a/cron.php
+++ b/cron.php
@@ -26,7 +26,7 @@ if (defined('SMF')) {
 define('SMF', 'BACKGROUND');
 
 // Initialize.
-require_once __DIR__ . '/index.php';
+require_once __DIR__ . DIRECTORY_SEPARATOR . 'index.php';
 
 $task_runner = new SMF\TaskRunner();
 $task_runner->execute();

--- a/custom_avatar/index.php
+++ b/custom_avatar/index.php
@@ -1,8 +1,8 @@
 <?php
 
 // Try to handle it with the upper level index.php. (it should know what to do.)
-if (file_exists(dirname(__DIR__) . '/index.php')) {
-	include dirname(__DIR__) . '/index.php';
+if (file_exists(dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php')) {
+	include dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php';
 } else {
 	exit;
 }

--- a/index.php
+++ b/index.php
@@ -68,11 +68,11 @@ if (!defined('TIME_START')) {
 }
 
 if (!defined('SMF_SETTINGS_FILE')) {
-	define('SMF_SETTINGS_FILE', __DIR__ . '/Settings.php');
+	define('SMF_SETTINGS_FILE', __DIR__ . DIRECTORY_SEPARATOR . 'Settings.php');
 }
 
 if (!defined('SMF_SETTINGS_BACKUP_FILE')) {
-	define('SMF_SETTINGS_BACKUP_FILE', dirname(SMF_SETTINGS_FILE) . '/' . pathinfo(SMF_SETTINGS_FILE, PATHINFO_FILENAME) . '_bak.php');
+	define('SMF_SETTINGS_BACKUP_FILE', dirname(SMF_SETTINGS_FILE) . DIRECTORY_SEPARATOR . pathinfo(SMF_SETTINGS_FILE, PATHINFO_FILENAME) . '_bak.php');
 }
 
 /*
@@ -108,18 +108,18 @@ call_user_func(function () {
 			$boarddir = __DIR__;
 		}
 
-		if (is_dir($boarddir . '/Sources')) {
-			$sourcedir = $boarddir . '/Sources';
+		if (is_dir($boarddir . DIRECTORY_SEPARATOR . 'Sources')) {
+			$sourcedir = $boarddir . DIRECTORY_SEPARATOR . 'Sources';
 		}
 	}
 
 	// We need this class, or nothing works.
-	if (!is_file($sourcedir . '/Config.php') || !is_readable($sourcedir . '/Config.php')) {
+	if (!is_file($sourcedir . DIRECTORY_SEPARATOR . 'Config.php') || !is_readable($sourcedir . DIRECTORY_SEPARATOR . 'Config.php')) {
 		die('File not readable: (Sources)/Config.php');
 	}
 
 	// Pass all the settings to SMF\Config.
-	require_once $sourcedir . '/Config.php';
+	require_once $sourcedir . DIRECTORY_SEPARATOR . 'Config.php';
 	SMF\Config::set(get_defined_vars());
 
 	// Ensure $db_last_error is set, too.
@@ -135,10 +135,10 @@ if (SMF === 1) {
  * 3. Load some other essential includes.
  */
 
-require_once SMF\Config::$sourcedir . '/Autoloader.php';
+require_once SMF\Config::$sourcedir . DIRECTORY_SEPARATOR . 'Autoloader.php';
 
 // Ensure we don't trip over disabled internal functions
-require_once SMF\Config::$sourcedir . '/Subs-Compat.php';
+require_once SMF\Config::$sourcedir . DIRECTORY_SEPARATOR . 'Subs-Compat.php';
 
 
 /*********************************************************************

--- a/other/install.php
+++ b/other/install.php
@@ -18,7 +18,7 @@ declare(strict_types=1);
 
 define('SMF', 'INSTALL');
 define('SMF_INSTALLING', 1);
-define('SMF_SETTINGS_FILE', __DIR__ . '/Settings.php');
+define('SMF_SETTINGS_FILE', __DIR__ . DIRECTORY_SEPARATOR . 'Settings.php');
 
 // Ensure Settings.php exists. We can recover if it is blank, but it must exist.
 if (!file_exists(SMF_SETTINGS_FILE)) {
@@ -26,6 +26,6 @@ if (!file_exists(SMF_SETTINGS_FILE)) {
 }
 
 // Initialize.
-require_once __DIR__ . '/index.php';
+require_once __DIR__ . DIRECTORY_SEPARATOR . 'index.php';
 
 (new SMF\Maintenance\Maintenance())->execute(SMF\Maintenance\Maintenance::INSTALL);

--- a/other/upgrade.php
+++ b/other/upgrade.php
@@ -17,7 +17,7 @@ define('SMF', 'UPGRADE');
 define('SMF_INSTALLING', 1);
 
 // Initialize.
-require_once __DIR__ . '/index.php';
+require_once __DIR__ . DIRECTORY_SEPARATOR . 'index.php';
 
 SMF\Maintenance\Maintenance::$disable_security = false;
 

--- a/proxy.php
+++ b/proxy.php
@@ -21,7 +21,7 @@ if (!defined('SMF')) {
 
 if (SMF == 'PROXY') {
 	// Initialize.
-	require_once __DIR__ . '/index.php';
+	require_once __DIR__ . DIRECTORY_SEPARATOR . 'index.php';
 
 	$proxy = new SMF\ProxyServer();
 	$proxy->serve();

--- a/subscriptions.php
+++ b/subscriptions.php
@@ -31,14 +31,11 @@ $paid_debug = false;
 // Start things rolling by getting SMF alive...
 $ssi_guest_access = true;
 
-if (!file_exists(__DIR__ . '/SSI.php')) {
+if (!file_exists(__DIR__ . DIRECTORY_SEPARATOR . 'SSI.php')) {
 	die('Cannot find SSI.php');
 }
 
-require_once __DIR__ . '/SSI.php';
-
-// Ensure we don't trip over disabled internal functions
-require_once Config::$sourcedir . '/Subs-Compat.php';
+require_once __DIR__ . DIRECTORY_SEPARATOR . 'SSI.php';
 
 // If there's literally nothing coming in, let's take flight!
 if (empty($_POST)) {


### PR DESCRIPTION
On Windows servers, the paths that were used to include files often contained a mix of backslashes and forward slashes, because our code typically uses forward slashes as per Unix/Linux conventions, but saved paths like `Config::$sourcedir` typically used backslashes as per Windows conventions.

This has been known to cause issues in situations where the path of an included file has to be checked for whatever reason. For example, #8293 documents a case where Settings.php is included over and over due to this issue. 

This PR fixes the problem by always using the correct directory separator character in our paths when including files:
- In cases where the path to be included was a hard-coded string, this could be achieved most efficiently by simply replacing literal `/` characters in paths with the `DIRECTORY_SEPARATOR` constant. 7b9a16d implements this.
- In cases where the path to be included was determined programmatically, it was easier to implement a function to canonicalize the path just before including the file. b3be59d implements this.

The new `Config::canonicalpath()` method added in b3be59d is a wrapper for `realpath()` that is also able to handle paths that don't exist.

Fixes #8293.