### PR TITLE
[2.1] Correctly handles uppercase encoded semicolons in activation links

### DIFF
--- a/Sources/QueryString.php
+++ b/Sources/QueryString.php
@@ -243,9 +243,9 @@ function cleanRequest()
 		$_GET['action'] = (string) $_GET['action'];
 
 	// Some mail providers like to encode semicolons in activation URLs...
-	if (!empty($_REQUEST['action']) && substr($_SERVER['QUERY_STRING'], 0, 18) == 'action=activate%3b')
+	if (!empty($_REQUEST['action']) && substr(strtolower($_SERVER['QUERY_STRING']), 0, 18) == 'action=activate%3b')
 	{
-		header('location: ' . $scripturl . '?' . str_replace('%3b', ';', $_SERVER['QUERY_STRING']));
+		header('location: ' . $scripturl . '?' . str_ireplace('%3b', ';', $_SERVER['QUERY_STRING']));
 		exit;
 	}
 


### PR DESCRIPTION
Fixes #8128 for 2.1.

This is the same as #8129, but for 2.1.