### PR TITLE
[3.0] Always create the log_search_words table using utf8mb4

### DIFF
--- a/Sources/Db/APIs/MySQL.php
+++ b/Sources/Db/APIs/MySQL.php
@@ -1325,7 +1325,7 @@ class MySQL extends DatabaseApi implements DatabaseApiInterface
 				id_word {raw:size} unsigned NOT NULL default {string:string_zero},
 				id_msg int(10) unsigned NOT NULL default {string:string_zero},
 				PRIMARY KEY (id_word, id_msg)
-			) ENGINE=InnoDB',
+			) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci',
 			[
 				'string_zero' => '0',
 				'size' => $size,


### PR DESCRIPTION
`SMF\Search\APIs\Custom` is deprecated in 3.0 in favour of `SMF\Search\APIs\Parsed`, so the `log_search_words` table will normally not be created anymore. But if `log_search_words` somehow does get created, this PR will ensure that it is created using the correct character encoding.

Fixes #7830.