### PR TITLE
[3.0] Improves handling of entities and non-ASCII characters in names of file downloads

### DIFF
--- a/Sources/Localization/AsciiTransliterator.php
+++ b/Sources/Localization/AsciiTransliterator.php
@@ -118,9 +118,11 @@ class AsciiTransliterator
 	 * that the returned string contains nothing but ASCII.
 	 *
 	 * @param string $string A UTF-8 string.
+	 * @param string $substitute Substitute to use for characters that have no
+	 *    ASCII approximation. Default: '[?]'
 	 * @return string An ASCII string.
 	 */
-	public static function toAscii(string $string): string
+	public static function toAscii(string $string, string $substitute = '[?]'): string
 	{
 		$string = class_exists('\Transliterator') ? self::intl($string) : self::manual($string);
 
@@ -137,10 +139,18 @@ class AsciiTransliterator
 			$string,
 		);
 
-		// Replace any remaining non-ASCII characters with '[?]'.
+		// Replace any remaining non-ASCII graphemes with $substitute.
+		// Explanation: \X in the regex matches a grapheme cluster, which can
+		// contain one base character and any number of combining marks. Then
+		// in mb_ord($m[0]) we pass the entire grapheme cluster to mb_ord(),
+		// but mb_ord() only ever returns the ord for the base character. If
+		// the base character is not ASCII, we replace the grapheme with our
+		// substitute. If the base character is ASCII, then we replace the
+		// grapheme with the first byte of the grapheme (i.e. $m[0][0]), which
+		// will be just the ASCII character itself without any combining marks.
 		$string = preg_replace_callback(
 			'/\X/u',
-			fn($m) => mb_ord($m[0]) > 0x7f ? '[?]' : $m[0],
+			fn($m) => mb_ord($m[0]) > 0x7f ? $substitute : $m[0][0],
 			$string,
 		);
 

--- a/Sources/Utils.php
+++ b/Sources/Utils.php
@@ -2008,7 +2008,9 @@ class Utils
 		}
 
 		// Provide a plain ASCII name for the sake of old browsers.
-		$file['asciiname'] = preg_replace('/[\x{80}-\x{10FFFF}]+/u', '?', Utils::entityDecode($file['filename']));
+		if (preg_match('/[\x{80}-\x{10FFFF}]/u', $file['filename'])) {
+			$file['asciiname'] = Localization\AsciiTransliterator::toAscii($file['filename'], '?');
+		}
 
 		// Replace ASCII names like ??????.jpg with something more unique.
 		if (strspn($file['asciiname'], '?') === strpos($file['asciiname'], '.')) {

--- a/Sources/Utils.php
+++ b/Sources/Utils.php
@@ -2007,6 +2007,9 @@ class Utils
 			$file['filename'] = hash_hmac('md5', var_export($file, true), Config::$image_proxy_secret) . '.' . ltrim($file['fileext'] ?? 'dat', '.');
 		}
 
+		// Decode any entities in the name.
+		$file['filename'] = Utils::entityDecode($file['filename']);
+
 		// Provide a plain ASCII name for the sake of old browsers.
 		if (preg_match('/[\x{80}-\x{10FFFF}]/u', $file['filename'])) {
 			$file['asciiname'] = Localization\AsciiTransliterator::toAscii($file['filename'], '?');


### PR DESCRIPTION
- Decodes entities in filenames of files downloaded from SMF (e.g. downloaded attachments). Thus fixes #7785.
- Improves handling of non-ASCII characters in filenames when creating the pure ASCII fallback name that is needed for clients that don't support UTF-8 filenames.