### PR TITLE
[3.0] Minor upgrade fixes

### DIFF
--- a/Sources/Maintenance/Tools/ToolsBase.php
+++ b/Sources/Maintenance/Tools/ToolsBase.php
@@ -147,9 +147,15 @@ abstract class ToolsBase
 			}
 
 			$this->log_file = $dir . DIRECTORY_SEPARATOR . $name . '.log';
+
+			// Try to make the file the writable.
+			if (!is_writable($this->log_file)) {
+				chmod($this->log_file, 0664);
+			}
 		}
 
-		file_put_contents($this->log_file, $message, $reset ? 0 : FILE_APPEND);
+		// If we fail to write, be quiet about it.
+		@file_put_contents($this->log_file, $message, $reset ? 0 : FILE_APPEND);
 	}
 
 	/**
@@ -570,6 +576,11 @@ abstract class ToolsBase
 	 */
 	public function updateSettingsFile(array $config_vars, ?bool $keep_quotes = null, bool $rebuild = false): bool
 	{
+		// A whole lot of not saving anything going on.
+		if ($config_vars === []) {
+			return true;
+		}
+
 		if (array_keys($config_vars) !== ['maintenance_tool_progress']) {
 			$this->logProgress(Lang::getTxt('log_settings_file_save', ['setting_names' => Lang::sentenceList(array_keys($config_vars))], file: 'Maintenance'), true);
 		}


### PR DESCRIPTION
- If the log file is not writable, try to make it so.
- If the log file throws an error on write, ignore those.
- If we have nothing to save, don't update the settings file.