### PR TITLE
[3.0] Fixes type guessing for 16 byte strings in Db::getTypeIndicators()

### DIFF
--- a/Sources/Db/DatabaseApi.php
+++ b/Sources/Db/DatabaseApi.php
@@ -441,9 +441,9 @@ abstract class DatabaseApi
 				default:
 					$test = \is_array($value) ? reset($value) : $value;
 
-					if (IP::create((string) $test)->isValid()) {
+					if ((string) IP::create((string) $test) === $test) {
 						$type = 'inet';
-					} elseif ($test instanceof Uuid || (string) (@Uuid::createFromString((string) $test)) !== Uuid::NIL_UUID) {
+					} elseif ($test instanceof Uuid || (string) @Uuid::createFromString((string) $test) === $test) {
 						$type = 'uuid';
 					} else {
 						$type = 'string';


### PR DESCRIPTION
Previously, the code to check for an IPv6 or a UUID would both always match for any 16 byte string.

Fixes #8933 