### PR TITLE
feat(utils): support character classes in regex builder

### DIFF
--- a/Sources/Utils.php
+++ b/Sources/Utils.php
@@ -1083,8 +1083,6 @@ class Utils
 
 				$node = &$node[$char];
 			}
-
-			$node[''] = '';
 		}
 
 		// This recursive closure turns the trie into a regular expression.
@@ -1097,6 +1095,7 @@ class Utils
 
 			$regex = [];
 			$length = 0;
+			$single_chars = [];
 
 			foreach ($trie as $key => $value) {
 				$key_regex = preg_quote((string) $key, $delim);
@@ -1107,24 +1106,34 @@ class Utils
 				} else {
 					$sub_regex = $trie_to_regex($value, $delim);
 
-					if (\count(array_keys($value)) == 1) {
-						$new_key_array = explode('(?' . '>', $sub_regex);
+					if (\count($value) == 1) {
+						$new_key_array = explode('(?>', $sub_regex);
 						$new_key .= $new_key_array[0];
-					} else {
-						$sub_regex = '(?' . '>' . $sub_regex . ')';
+					} elseif (!str_starts_with($sub_regex, '[') && !str_ends_with($sub_regex, ']')) {
+						$sub_regex = '(?>' . $sub_regex . ')';
 					}
 				}
+				$str = $key_regex . $sub_regex;
 
 				if ($depth > 1) {
-					$regex[$new_key] = $key_regex . $sub_regex;
+					// Collect single-char leaves for character class
+					if (empty($value) && mb_strlen($str, $encoding) === 1 && \count($trie) !== 1) {
+						$single_chars[] = $str;
+					} else {
+						$regex[$new_key] = $str;
+					}
 				} else {
-					if (($length += \strlen($key_regex . $sub_regex) + 1) < $max_length || empty($regex)) {
-						$regex[$new_key] = $key_regex . $sub_regex;
+					if (($length += \strlen($str) + 1) < $max_length || empty($regex)) {
+						$regex[$new_key] = $str;
 						unset($trie[$key]);
 					} else {
 						break;
 					}
 				}
+			}
+
+			if ($single_chars !== [] && $regex === []) {
+				return '[' . implode('',  $single_chars) . ']';
 			}
 
 			// Sort by key length and then alphabetically


### PR DESCRIPTION
- Remove phantom leaf nodes from trie construction
- Collapse single-character alternations into `[...]` character classes
- Avoid redundant `(?> … )` wrapping for character classes

### Before
```
(?>HAVING|GROUP|JOIN|KEY|PR(?>OCEDURE|IMARY)|SE(?>LECT|T)|A(?>DD|L(?>TER|L)|N(?>D|Y)|S(?>C|))|B(?>ETWEEN|ACKUP|Y)|C(?>URRENT_(?>DATE|TIME(?>STAMP|))|HECK|ASE|O(?>NSTRAINT|LUMN)|R(?>EATE|OSS))|D(?>ATABASE|ISTINCT|ROP|E(?>FAULT|LETE|SC))|E(?>LSE|ND|X(?>CEPT|ISTS))|F(?>OREIGN|ROM|ULL)|I(?>F|N(?>SERT|DEX|NER|T(?>ERSECT|O)|)|S)|L(?>EFT|I(?>MIT|KE))|N(?>ULL|OT)|O(?>UTER|N|R(?>DER|))|R(?>EFERENCES|IGHT|O(?>LLBACK|WNUM))|T(?>RUNCATE|ABLE|OP)|U(?>PDATE|NI(?>QUE|ON))|V(?>ALUES|IEW)|W(?>HERE|ITH))
```
###  After

```
(?>HAVING|GROUP|JOIN|KEY|PR(?>OCEDURE|IMARY)|SE(?>LECT)|ADD|SC|L(?>TER)|N[DY]|B(?>ETWEEN|ACKUP)|C(?>URRENT_(?>TIMESTAMP|DATE)|HECK|ASE|O(?>NSTRAINT|LUMN)|R(?>EATE|OSS))|D(?>ATABASE|ISTINCT|ROP|E(?>FAULT|LETE|SC))|E(?>LSE|ND|X(?>CEPT|ISTS))|F(?>OREIGN|ROM|ULL)|I(?>N(?>SERT|DEX|NER|T(?>ERSECT)))|L(?>EFT|I(?>MIT|KE))|N(?>ULL|OT)|O(?>RDER|UTER)|R(?>EFERENCES|IGHT|O(?>LLBACK|WNUM))|T(?>RUNCATE|ABLE|OP)|U(?>PDATE|NI(?>QUE|ON))|V(?>ALUES|IEW)|W(?>HERE|ITH))
```

Observe the character class `/*...*/ ADD|SC|L(?>TER)|N[DY]|B(?>ETWEEN  /*...*/`