### PR TITLE
[3.0] Fix a fatal error due to numerical keys

### DIFF
--- a/Sources/Utils.php
+++ b/Sources/Utils.php
@@ -1049,7 +1049,7 @@ class Utils
 
 		// Optimizing is faster when we sort by length.
 		asort($normalized_strings);
-		$strings = array_keys($normalized_strings);
+		$strings = array_map('\strval', array_keys($normalized_strings));
 
 		// Can we trim common characters from the end?
 		$trailing = '';

--- a/Sources/Utils.php
+++ b/Sources/Utils.php
@@ -1049,7 +1049,7 @@ class Utils
 
 		// Optimizing is faster when we sort by length.
 		asort($normalized_strings);
-		$strings = array_map('\strval', array_keys($normalized_strings));
+		$strings = array_map('strval', array_keys($normalized_strings));
 
 		// Can we trim common characters from the end?
 		$trailing = '';


### PR DESCRIPTION
I was receiving the following error:
```
( ! ) Fatal error: Uncaught TypeError: mb_str_split(): Argument #1 ($string) must be of type string, int given in /Sources/Utils.php on line 1076
```

This occurred while bringing in the `$itemcodes` from the BBC parser.  After some debugging, I realized that `$normalized_strings` had a numerical index of 0 instead of a string of 0.

Some more debugging later, I found out how to reproduce it in a very simple statement: `var_dump(["0" => 1]);`

I finally discovered the reason after locating this note in the PHP documentation:
> [String](https://www.php.net/manual/en/language.types.string.php)s containing valid decimal [int](https://www.php.net/manual/en/language.types.integer.php)s, unless the number is preceded by a + sign, will be cast to the [int](https://www.php.net/manual/en/language.types.integer.php) type. E.g. the key "8" will actually be stored under 8. On the other hand "08" will not be cast, as it isn't a valid decimal integer.

https://www.php.net/manual/en/language.types.array.php#language.types.array.syntax

This is unrelated to #8937, but it may conflict with it.