### PR TITLE
[3.0] Fixed a typo in the MySQL database class

### DIFF
--- a/Sources/Db/APIs/MySQL.php
+++ b/Sources/Db/APIs/MySQL.php
@@ -2897,7 +2897,7 @@ class MySQL extends DatabaseApi implements DatabaseApiInterface
 		// These types cannot have a default value.
 		if (
 			\in_array(
-				$column_info['type'],
+				$column['type'],
 				[
 					'text',
 					'tinytext',


### PR DESCRIPTION
This PR fixes a typo in the MySQL database class.