### PR TITLE
[3.0] Guests could not always see boards

### DIFF
--- a/Sources/Actions/BoardIndex.php
+++ b/Sources/Actions/BoardIndex.php
@@ -458,7 +458,12 @@ class BoardIndex implements ActionInterface, Routable
 
 					$category->parseDescription();
 				} else {
-					$category = Category::$loaded[$row_board['id_cat']];
+					$category = Category::init((int) $row_board['id_cat'], [
+						'is_collapsed' => !empty($row_board['can_collapse']) && !empty(Theme::$current->options['collapse_category_' . $row_board['id_cat']]),
+						'new' => false,
+						'link' => '<a id="c' . $row_board['id_cat'] . '"></a>' . (!User::$me->is_guest ?
+							'<a href="' . Config::$scripturl . '?action=unread;c=' . $row_board['id_cat'] . '" title="' . Lang::getTxt('new_posts_in_category', $row_board, file: 'General') . '">' . $row_board['cat_name'] . '</a>' : $row_board['cat_name']),
+					]);
 				}
 
 				// If this board has new posts in it (and isn't the recycle bin!) then the category is new.

--- a/Sources/Board.php
+++ b/Sources/Board.php
@@ -72,12 +72,12 @@ class Board implements \ArrayAccess, Routable
 	public int $id;
 
 	/**
-	 * @var object
+	 * @var Category
 	 *
 	 * This board's category.
 	 * An instance of SMF\Category.
 	 */
-	public object $cat;
+	public Category $cat;
 
 	/**
 	 * @var string
@@ -193,7 +193,7 @@ class Board implements \ArrayAccess, Routable
 	public int $prev_board = 0;
 
 	/**
-	 * @var array
+	 * @var Board[]
 	 *
 	 * Boards that are children of this board.
 	 */
@@ -349,7 +349,7 @@ class Board implements \ArrayAccess, Routable
 	public static ?self $info;
 
 	/**
-	 * @var array
+	 * @var Board[]
 	 *
 	 * All loaded instances of this class.
 	 */
@@ -2087,11 +2087,12 @@ class Board implements \ArrayAccess, Routable
 						'id' => $id,
 					],
 				);
-				$props = Db::$db->fetch_all($request);
+				$props = Db::$db->fetch_assoc($request);
 				Db::$db->free_result($request);
 			}
 
 			$this->id = $id;
+
 			$this->set($props);
 			self::$loaded[$this->id] = $this;
 		}
@@ -2102,6 +2103,10 @@ class Board implements \ArrayAccess, Routable
 		}
 
 		// Plug this board into its category.
+		if ($id > 0 && empty($this->cat) && !empty($props['id_cat'])) {
+			$this->cat = Category::init((int) $props['id_cat']);
+		}
+
 		if (!empty($this->cat) && $this->child_level == 0) {
 			$this->cat->children[$this->id] = $this;
 		}

--- a/Sources/Category.php
+++ b/Sources/Category.php
@@ -70,7 +70,7 @@ class Category implements \ArrayAccess
 	 *
 	 * Whether the current user has collapsed this category.
 	 */
-	public bool $is_collapsed;
+	public bool $is_collapsed = false;
 
 	/**
 	 * @var int
@@ -87,7 +87,7 @@ class Category implements \ArrayAccess
 	public int $last_board_order;
 
 	/**
-	 * @var array
+	 * @var Board[]
 	 *
 	 * Boards that are children of this category.
 	 */
@@ -105,7 +105,7 @@ class Category implements \ArrayAccess
 	 *
 	 * HTML anchor link for this category.
 	 */
-	public string $link;
+	public string $link = '';
 
 	/**
 	 * @var string
@@ -127,7 +127,7 @@ class Category implements \ArrayAccess
 	 *
 	 * Whether this category contains posts that the current user hasn't read.
 	 */
-	public bool $new;
+	public bool $new = false;
 
 	/**
 	 * @var bool
@@ -141,14 +141,14 @@ class Category implements \ArrayAccess
 	 **************************/
 
 	/**
-	 * @var array
+	 * @var Category[]
 	 *
 	 * All loaded instances of this class.
 	 */
 	public static array $loaded = [];
 
 	/**
-	 * @var array
+	 * @var Board[]
 	 *
 	 * A list of boards grouped by category ID.
 	 */
@@ -816,7 +816,7 @@ class Category implements \ArrayAccess
 			);
 
 			if (Db::$db->num_rows($request) > 0) {
-				$props = Db::$db->fetch_all($request);
+				$props = Db::$db->fetch_assoc($request);
 			}
 			Db::$db->free_result($request);
 		}


### PR DESCRIPTION
Fixes #8624

This fixes it by
- Using fetch_assoc instead of fetch_all, which ensures $props is not a multi-dimensional array which otherwise causes our useful data to be put into `$prop[0]` and then stored as "custom" properties.  This same issue is present on both Boards and Categories objects.
- Ensure if we end up finding a id_cat and we didn't build the category, to attempt to load it.
- When initializing a category on the board index, ensure we pass properties that are dynamic per user into the creation.