### PR TITLE
[3.0] Admin info files data should be medium text

### DIFF
--- a/Sources/Db/Schema/v3_0/AdminInfoFiles.php
+++ b/Sources/Db/Schema/v3_0/AdminInfoFiles.php
@@ -110,7 +110,7 @@ class AdminInfoFiles extends Table
 			),
 			'data' => new Column(
 				name: 'data',
-				type: 'text',
+				type: 'mediumtext',
 				not_null: true,
 			),
 			'filetype' => new Column(


### PR DESCRIPTION
Fixes #8952

@Oldiesmann and @MisterVector ,
Can you test this?  You can test either a fresh install or, after pulling in this change, run upgrade.php.