### PR TITLE
[3.0] Installer not replacing values

### DIFF
--- a/Sources/Db/Schema/Table.php
+++ b/Sources/Db/Schema/Table.php
@@ -513,6 +513,11 @@ class Table
 			'{$registration_method}' => \defined('SMF_INSTALLING') ? ((int) !empty($_POST['reg_mode'])) : (Config::$modSettings['registration_method'] ?? 0),
 		];
 
+		// Sometimes its a string, sometimes its an array, sometimes its json.
+		if (\is_array($replacements['{$attachdir}'])) {
+			$replacements['{$attachdir}'] = json_encode($replacements['{$attachdir}']);
+		}
+
 		foreach (Lang::$txt as $key => $value) {
 			if (substr($key, 0, 8) == 'default_') {
 				$replacements['{$' . $key . '}'] = Db::$db->escape_string($value);
@@ -522,11 +527,18 @@ class Table
 		$replacements['{$default_reserved_names}'] = strtr($replacements['{$default_reserved_names}'], ['\\\\n' => '\\n']);
 
 		// Replace any placeholders in the initial data.
-		foreach ($this->initial_data as $row_num => $row) {
-			$this->initial_data[$row_num] = array_map(
-				fn($v) => $replacements[$v] ?? $v,
-				$row,
-			);
+		foreach ($this->initial_data as &$row) {
+			foreach ($row as &$val) {
+				if ($val === null) {
+					continue;
+				}
+
+				if (\is_int($val)) {
+					$val = (int) strtr((string) $val, $replacements);
+				} else {
+					$val = strtr($val, $replacements);
+				}
+			}
 		}
 
 		// Insert the initial data.

--- a/Sources/Maintenance/Tools/Install.php
+++ b/Sources/Maintenance/Tools/Install.php
@@ -682,27 +682,6 @@ class Install extends ToolsBase implements ToolsInterface
 
 		Config::$modSettings['disableQueryCheck'] = true;
 
-		$replaces = [
-			'{$db_prefix}' => Db::$db->prefix,
-			'{$attachdir}' => json_encode([1 => Db::$db->escape_string(Config::$boarddir . '/attachments')]),
-			'{$boarddir}' => Db::$db->escape_string(Config::$boarddir),
-			'{$boardurl}' => Config::$boardurl,
-			'{$enableCompressedOutput}' => isset($_POST['compress']) ? '1' : '0',
-			'{$databaseSession_enable}' => isset($_POST['dbsession']) ? '1' : '0',
-			'{$smf_version}' => SMF_VERSION,
-			'{$current_time}' => time(),
-			'{$sched_task_offset}' => 82800 + mt_rand(0, 86399),
-			'{$registration_method}' => $_POST['reg_mode'] ?? 0,
-		];
-
-		foreach (Lang::$txt as $key => $value) {
-			if (substr($key, 0, 8) == 'default_') {
-				$replaces['{$' . $key . '}'] = Db::$db->escape_string($value);
-			}
-		}
-
-		$replaces['{$default_reserved_names}'] = strtr($replaces['{$default_reserved_names}'], ['\\\\n' => '\\n']);
-
 		$existing_tables = Db::$db->list_tables();
 
 		$install_tables = Table::getAll($this->schema_version);

--- a/Sources/Maintenance/Tools/ToolsBase.php
+++ b/Sources/Maintenance/Tools/ToolsBase.php
@@ -149,7 +149,7 @@ abstract class ToolsBase
 			$this->log_file = $dir . DIRECTORY_SEPARATOR . $name . '.log';
 
 			// Try to make the file the writable.
-			if (!is_writable($this->log_file)) {
+			if (file_exists($this->log_file) && !is_writable($this->log_file)) {
 				chmod($this->log_file, 0664);
 			}
 		}


### PR DESCRIPTION
Fixes #8951

We can't use just a simple array_map because we have more complexities, such as
```
			'value' => '{$boardurl}/Themes/default/images',
```

We can't just call a straight strtr, because sometimes the data is an int:
```
			'id_theme' => 1,
```

So we have to be a bit more verbose.

Additionally found some old code in the installer related to this.