### PR TITLE
[3.0] Miscellaneous fixes

### DIFF
--- a/SSI.php
+++ b/SSI.php
@@ -38,5 +38,4 @@ if (!defined('SMF')) {
 // Initialize.
 require_once __DIR__ . DIRECTORY_SEPARATOR . 'index.php';
 
-$ssi = new SMF\ServerSideIncludes();
-$ssi->execute();
+(new SMF\ServerSideIncludes())->execute();

--- a/Sources/Permissions/UserPermissionSet.php
+++ b/Sources/Permissions/UserPermissionSet.php
@@ -291,8 +291,19 @@ class UserPermissionSet
 		}
 
 		if (!empty($boards)) {
+			$boards = array_map('intval', $boards);
+
+			// We need to temporarily load the boards, but we don't want to keep
+			// any that weren't already loaded.
+			$boards_to_unload = array_diff($boards, array_keys(Board::$loaded));
+
 			foreach (Board::load($boards) as $board) {
 				$loaded[$board->profile] = self::$loaded[$user->id][$board->profile] ?? new self($user, $board);
+			}
+
+			// Unload any boards that weren't already loaded.
+			foreach ($boards_to_unload as $id) {
+				unset(Board::$loaded[$id]);
 			}
 		}
 

--- a/Sources/TaskRunner.php
+++ b/Sources/TaskRunner.php
@@ -140,7 +140,11 @@ class TaskRunner
 			}
 
 			// Do nothing if we are in the middle of an install or upgrade.
-			if (!empty(Config::$package_installing) || !empty(Config::$upgradeData)) {
+			if (
+				\defined('SMF_INSTALLING')
+				|| !empty(Config::$custom['package_installing'])
+				|| !empty(Config::$custom['maintenance_tool_progress'])
+			) {
 				$this->obExit();
 			}
 

--- a/Themes/default/InstallTemplate.php
+++ b/Themes/default/InstallTemplate.php
@@ -161,16 +161,16 @@ class InstallTemplate extends MaintenanceTemplate
 					<dd>
 						<div class="floatright">
 							<label for="ftp_port" class="textbox"><strong>', Lang::$txt['ftp_port'], ':&nbsp;</strong></label>
-							<input type="text" size="3" name="ftp_port" id="ftp_port" value="', Maintenance::$context['ftp']['port'], '">
+							<input type="text" size="3" name="ftp_port" id="ftp_port" value="', Maintenance::$context['chmod']['port'] ?? '', '">
 						</div>
-						<input type="text" size="30" name="ftp_server" id="ftp_server" value="', Maintenance::$context['ftp']['server'], '">
+						<input type="text" size="30" name="ftp_server" id="ftp_server" value="', Maintenance::$context['chmod']['server'] ?? '', '">
 						<div class="smalltext block">', Lang::$txt['ftp_server_info'], '</div>
 					</dd>
 					<dt>
 						<label for="ftp_username">', Lang::$txt['ftp_username'], ':</label>
 					</dt>
 					<dd>
-						<input type="text" size="30" name="ftp_username" id="ftp_username" value="', Maintenance::$context['ftp']['username'], '">
+						<input type="text" size="30" name="ftp_username" id="ftp_username" value="', Maintenance::$context['chmod']['username'] ?? '', '">
 						<div class="smalltext block">', Lang::$txt['ftp_username_info'], '</div>
 					</dd>
 					<dt>
@@ -184,8 +184,8 @@ class InstallTemplate extends MaintenanceTemplate
 						<label for="ftp_path">', Lang::$txt['ftp_path'], ':</label>
 					</dt>
 					<dd>
-						<input type="text" size="30" name="ftp_path" id="ftp_path" value="', Maintenance::$context['ftp']['path'], '">
-						<div class="smalltext block">', Maintenance::$context['ftp']['path_msg'], '</div>
+						<input type="text" size="30" name="ftp_path" id="ftp_path" value="', Maintenance::$context['chmod']['path'] ?? '', '">
+						<div class="smalltext block">', Maintenance::$context['chmod']['path_msg'] ?? '', '</div>
 					</dd>
 				</dl>
 				<div class="righttext buttons">

--- a/cron.php
+++ b/cron.php
@@ -28,5 +28,4 @@ define('SMF', 'BACKGROUND');
 // Initialize.
 require_once __DIR__ . DIRECTORY_SEPARATOR . 'index.php';
 
-$task_runner = new SMF\TaskRunner();
-$task_runner->execute();
+(new SMF\TaskRunner())->execute();

--- a/proxy.php
+++ b/proxy.php
@@ -23,8 +23,7 @@ if (SMF == 'PROXY') {
 	// Initialize.
 	require_once __DIR__ . DIRECTORY_SEPARATOR . 'index.php';
 
-	$proxy = new SMF\ProxyServer();
-	$proxy->serve();
+	(new SMF\ProxyServer())->serve();
 }
 // In case an old mod included this file in order to load the ProxyServer class.
 else {


### PR DESCRIPTION
- [Avoid polluting the global namespace](https://github.com/SimpleMachines/SMF/commit/113e6a4a510a2857accd69c5b7c0b64e77eb09bb) in SSI.php, cron.php, and proxy.php.
- [Fixes undefined array key errors in installer's FTP template](https://github.com/SimpleMachines/SMF/commit/f34cf21c904c72af15d808332b7088d7e23d51a0)
- [Fixes checks for installing state in SMF\TaskRunner::__construct()](https://github.com/SimpleMachines/SMF/commit/ed26920d6f7ec43ed5a5d990eae9856172228a21). This will ensure that background tasks are never executed while packages or SMF itself are being installed or upgraded.
- [Don't load boards as a side effect of loading user permissions sets](https://github.com/SimpleMachines/SMF/commit/312815777172a80a434bf426fe2f8f52a78602f0). Fixes an issue where calling `User::boardsAllowedTo()` could result in boards being unexpectedly added to `Board::$loaded`.