### PR TITLE
[2.1] Fix `<create-file>`, `<move-file>` and `<move-dir>` in `package-info.xml`

### DIFF
--- a/Sources/Packages.php
+++ b/Sources/Packages.php
@@ -663,7 +663,7 @@ function PackageInstallTest()
 		}
 
 		// Don't fail if a file/directory we're trying to create doesn't exist...
-		if (isset($action['filename']) && !file_exists($file) && !in_array($action['type'], array('create-dir', 'create-file')) && $action['error'] != 'ignore')
+		if (isset($action['filename']) && !file_exists($file) && !in_array($action['type'], array('create-dir', 'create-file', 'move-dir', 'move-file')) && $action['error'] != 'ignore')
 		{
 			$context['has_failure'] = true;
 

--- a/Sources/Subs-Package.php
+++ b/Sources/Subs-Package.php
@@ -1392,7 +1392,7 @@ function parsePackageInfo(&$packageXML, $testing_only = true, $method = 'install
 				$failure |= !mktree(dirname($action['destination']), 0777);
 
 			// Create an empty file.
-			package_put_contents($action['destination'], package_get_contents($action['source']), $testing_only);
+			package_put_contents($action['destination'], '', $testing_only);
 
 			if (!file_exists($action['destination']))
 				$failure = true;


### PR DESCRIPTION
The fixes are pretty simple:

- `<create-file>` was trying to create a file with the contents of the "source" file, instead of an empty file as intended.
- For `<move-file>` and `<move-dir>`, the test was trying to confirm that the destination file existed, when it's actually supposed to not exist since we're moving something to that name.

  Turns out a similar fix was done earlier to stop the warning from showing up for `<create-dir>` and `<create-file>` (#3009), so I just extended that fix.

Fixes #8970 and #8986 for 2.1, lemme know if you'd like me to make a 3.0 PR too :)