### PR TITLE
[3.0] Fix `<create-file>`, `<move-file>` and `<move-dir>` in `package-info.xml`

### DIFF
--- a/Sources/PackageManager/PackageManager.php
+++ b/Sources/PackageManager/PackageManager.php
@@ -746,7 +746,7 @@ class PackageManager
 			}
 
 			// Don't fail if a file/directory we're trying to create doesn't exist...
-			if (isset($action['filename']) && !file_exists($file) && !\in_array($action['type'], ['create-dir', 'create-file']) && $action['error'] != 'ignore') {
+			if (isset($action['filename']) && !file_exists($file) && !\in_array($action['type'], ['create-dir', 'create-file', 'move-dir', 'move-file']) && $action['error'] != 'ignore') {
 				Utils::$context['has_failure'] = true;
 
 				$thisAction += [

--- a/Sources/PackageManager/PackageUtils.php
+++ b/Sources/PackageManager/PackageUtils.php
@@ -1454,7 +1454,7 @@ class PackageUtils
 				}
 
 				// Create an empty file.
-				self::packagePutContents($action['destination'], self::packageGetContents($action['source']), $testing_only);
+				self::packagePutContents($action['destination'], '', $testing_only);
 
 				if (!file_exists($action['destination'])) {
 					$failure = true;


### PR DESCRIPTION
3.0 version of #8987 

Fixes #8970 
Fixes #8986