### PR TITLE
[2.1] Fix string literal detection

### DIFF
--- a/Sources/Subs-Db-mysql.php
+++ b/Sources/Subs-Db-mysql.php
@@ -368,7 +368,7 @@ function smf_db_query($identifier, $db_string, $db_values = array(), $connection
 
 	// Comments that are allowed in a query are preg_removed.
 	static $allowed_comments_from = array(
-		'~(?<![\'\\\\])\'\X*?(?<![\'\\\\])\'~',
+		'~\'\X*?\'~s',
 		'~\s+~s',
 		'~/\*!40001 SQL_NO_CACHE \*/~',
 		'~/\*!40000 USE INDEX \([A-Za-z\_]+?\) \*/~',
@@ -417,7 +417,9 @@ function smf_db_query($identifier, $db_string, $db_values = array(), $connection
 	// First, we clean strings out of the query, reduce whitespace, lowercase, and trim - so we can check it over.
 	if (empty($modSettings['disableQueryCheck']))
 	{
-		$clean = trim(strtolower(preg_replace($allowed_comments_from, $allowed_comments_to, $db_string)));
+		// Clear out escaped backslashes & single quotes first, to make it simpler to ID & remove string literals
+		$clean = str_replace(array('\\\\', '\\\''), array('', ''), $db_string);
+		$clean = trim(strtolower(preg_replace($allowed_comments_from, $allowed_comments_to, $clean)));
 
 		// Comments?  We don't use comments in our queries, we leave 'em outside!
 		if (strpos($clean, '/*') > 2 || strpos($clean, '--') !== false || strpos($clean, ';') !== false)

--- a/Sources/Subs-Db-postgresql.php
+++ b/Sources/Subs-Db-postgresql.php
@@ -379,7 +379,7 @@ function smf_db_query($identifier, $db_string, $db_values = array(), $connection
 
 	// Comments that are allowed in a query are preg_removed.
 	static $allowed_comments_from = array(
-		'~(?<![\'\\\\])\'\X*?(?<![\'\\\\])\'~',
+		'~\'\X*?\'~s',
 		'~\s+~s',
 		'~/\*!40001 SQL_NO_CACHE \*/~',
 		'~/\*!40000 USE INDEX \([A-Za-z\_]+?\) \*/~',
@@ -415,7 +415,9 @@ function smf_db_query($identifier, $db_string, $db_values = array(), $connection
 	// First, we clean strings out of the query, reduce whitespace, lowercase, and trim - so we can check it over.
 	if (empty($modSettings['disableQueryCheck']))
 	{
-		$clean = trim(strtolower(preg_replace($allowed_comments_from, $allowed_comments_to, $db_string)));
+		// Clear out escaped single quotes first, to make it simpler to ID & remove string literals
+		$clean = str_replace('\'\'', '', $db_string);
+		$clean = trim(strtolower(preg_replace($allowed_comments_from, $allowed_comments_to, $clean)));
 
 		// Comments?  We don't use comments in our queries, we leave 'em outside!
 		if (strpos($clean, '/*') > 2 || strpos($clean, '--') !== false || strpos($clean, ';') !== false)


### PR DESCRIPTION
Fixes #8980

pg & mysql escape literals a bit differently.  The rules that work for one won't work for the other.  pg will escape single quotes by doubling them, `''`, mysql will escape them with a backslash, `\'`.  Also, mysql escapes backslashes, `\\`, where pg doesn't.

So you cannot identify & clean the literals with the same logic.

The 'query check' logic makes a fully fleshed out copy of the current query, inserting values & smf substitutions, in order to do some syntax checks for behavior that SMF forbids.  It wants to focus on the sql syntax itself, not anything that might only look like syntax, so it strips all string literals.  Then it can easily check for forbidden syntax - internal comments, stacked sql commands, sleep() & benchmark() functions.  The cleaned copy is discarded after this check.

Here are two properly escaped strings in pg:
`'Hello world \'`
`'subject: ''SMF 2.0.17 has been released'','`

And here are the same strings in mysql:
`'Hello world \\'`
`'subject: \'SMF 2.0.17 has been released\','`

So...  The solution here was to remove the respective escapes first, making removing the string literals more straightforward.  For mysql, this was a two step process - had to get rid of escaped backslashes first, in order to make the distinction between an escaped backslash with a valid end-of-string single quote (`\\'`) and an escaped mid-string single quote (`\'`).

An aside: during A/B testing, I ran across one of those elusive 'mysql result expected false given' errors.  This may have been a (the?) source of them.

Another benefit of these fixes: Performance.  On very large inserts, with lots of literals, the strpos() calls in the old method were insanely inefficient.  (I have a mod that loads large files, and disabling the query check improves load time ~10x...  Viewing the execution profile in WinCacheGrind, virtually all the time was spent executing strpos()...  MUCH faster now.)
