### PR TITLE
[3.0] Misc fixes affecting pg install

### DIFF
--- a/Sources/Db/APIs/PostgreSQL.php
+++ b/Sources/Db/APIs/PostgreSQL.php
@@ -1810,7 +1810,11 @@ class PostgreSQL extends DatabaseApi implements DatabaseApiInterface
 				}
 				$default = 'default nextval(\'' . $short_table_name . '_seq\')';
 			} elseif (isset($column['default']) && $column['default'] !== null) {
-				$default = 'default \'' . $this->escape_string($column['default']) . '\'';
+				// Numbers don't need quotes.
+				if (is_numeric($column['default']))
+					$default = 'default ' . $column['default'];
+				else
+					$default = 'default \'' . $this->escape_string($column['default']) . '\'';
 			} else {
 				$default = '';
 			}

--- a/Sources/Db/APIs/PostgreSQL.php
+++ b/Sources/Db/APIs/PostgreSQL.php
@@ -680,7 +680,7 @@ class PostgreSQL extends DatabaseApi implements DatabaseApiInterface
 	/**
 	 *
 	 */
-	public function error(object $connection): string
+	public function error(?object $connection = null): string
 	{
 		if ($connection === null && $this->connection === null) {
 			return '';


### PR DESCRIPTION
Fixes #8995

Various errors installing pg:

SMF\Db\APIs\PostgreSQL::escape_string(): Argument # 1 ($string) must be of type string, int given, called in D:\wamp64\www\pgvan30\Sources\Db\APIs\PostgreSQL.php on line 1813

Too few arguments to SMF\Db\APIs\PostgreSQL::error() 0 passed in ... Tools\Install.php on line 800 ... 1 expected

**_I will take this out of draft mode & submit the other issues separately.  No need to wait._**