### PR TITLE
[2.1] Ignore errors when attempting to log errors

### DIFF
--- a/Sources/Errors.php
+++ b/Sources/Errors.php
@@ -135,11 +135,18 @@ function log_error($error_message, $error_type = 'general', $file = null, $line 
 			$query = $smcFunc['db_query']('', '
 				SELECT COUNT(*)
 				FROM {db_prefix}log_errors',
-				array()
+				array(
+					'db_error_skip' => true,
+				)
 			);
 
-			list($context['num_errors']) = $smcFunc['db_fetch_row']($query);
-			$smcFunc['db_free_result']($query);
+			if ($query)
+			{
+				list($context['num_errors']) = $smcFunc['db_fetch_row']($query);
+				$smcFunc['db_free_result']($query);
+			}
+			else
+				$context['num_errors'] = 0;
 		}
 		else
 			$context['num_errors']++;
@@ -582,8 +589,13 @@ function log_error_online($error, $sprintf = array())
 		WHERE session = {string:session}',
 		array(
 			'session' => $session_id,
+			'db_error_skip' => true,
 		)
 	);
+
+	if (!$request)
+		return;
+
 	if ($smcFunc['db_num_rows']($request) != 0)
 	{
 		// If this happened very early on in SMF startup, $smcFunc may not fully be defined.

--- a/Sources/Subs-Db-mysql.php
+++ b/Sources/Subs-Db-mysql.php
@@ -787,7 +787,7 @@ function smf_db_insert($method, $table, $columns, $data, $keys, $returnmode = 0,
 				', $insertRows),
 			array(
 				'security_override' => true,
-				'db_error_skip' => $table === $db_prefix . 'log_errors',
+				'db_error_skip' => preg_match('/log_errors|sessions/', $table),
 			),
 			$connection
 		);
@@ -1002,6 +1002,9 @@ function smf_db_error_insert($error_array)
 				(id_member, log_time, ip, url, message, session, error_type, file, line, backtrace)
 			VALUES( ?, ?, unhex(?), ?, ?, ?, ?, ?, ?, ?)'
 		);
+
+	if (empty($mysql_error_data_prep))
+		return;
 
 	if (filter_var($error_array[2], FILTER_VALIDATE_IP) !== false)
 		$error_array[2] = bin2hex(inet_pton($error_array[2]));


### PR DESCRIPTION

These queries will always throw hard-to-debug errors whenever the database connection drops; for example, when a query exceeds the limit. It’s not normally an issue, but we did get these problems reported:

https://www.simplemachines.org/community/index.php?topic=590519.msg4183663#msg4183663)
https://www.simplemachines.org/community/index.php?topic=592711.msg4194037#msg4194037)
