### PR TITLE
[3.0] Fix PM logic for groups

### DIFF
--- a/Sources/PersonalMessage/PM.php
+++ b/Sources/PersonalMessage/PM.php
@@ -1295,7 +1295,15 @@ class PM implements \ArrayAccess
 		}
 
 		// Load the groups that are allowed to read PMs.
-		$pmReadGroups = Group::getAllowedTo('pm_read');
+		$allGroups = Group::getAllWithPermissions('pm_read', null);
+
+		foreach ($allGroups as $k => $g) {
+			if ($g['pm_read'] === 1) {
+				$pmReadGroups['allowed'][] = $k;
+			} else {
+				$pmReadGroups['denied'][] = $k;
+			}
+		}
 
 		if (empty(Config::$modSettings['permission_enable_deny'])) {
 			$pmReadGroups['denied'] = [];


### PR DESCRIPTION
Fixes #8994

@Sesquipedalian
This was introduced in #8574 

The fix I did is maybe more than a patch.  But it seems that you deprecated the 'allowed'/'denied' return of the getAllowedTo and added instructions for another function, which doesn't return data the same way.
Updating the PM logic to fully use that logic would have it do much more work.