### PR TITLE
[3.0] Fix key identification to address data population

### DIFF
--- a/Sources/Db/APIs/PostgreSQL.php
+++ b/Sources/Db/APIs/PostgreSQL.php
@@ -413,17 +413,11 @@ class PostgreSQL extends DatabaseApi implements DatabaseApiInterface
 		if ($method == 'replace' || $method == 'ignore') {
 			$key_str = implode(',', $keys);
 			$col_str = '';
-
 			$count = 0;
-			$count_pk = 0;
 
+			// Make a list of the non-pk fields.
 			foreach ($columns as $columnName => $type) {
-				// Check pk field.
-				if (\in_array($columnName, $keys)) {
-					$count_pk++;
-				}
-				// Normal field.
-				elseif ($method == 'replace') {
+				if (!\in_array($columnName, $keys) && ($method == 'replace')) {
 					$col_str .= ($count > 0 ? ',' : '');
 					$col_str .= $columnName . ' = EXCLUDED.' . $columnName;
 					$count++;

--- a/Sources/Db/APIs/PostgreSQL.php
+++ b/Sources/Db/APIs/PostgreSQL.php
@@ -411,7 +411,7 @@ class PostgreSQL extends DatabaseApi implements DatabaseApiInterface
 
 		// PostgreSQL doesn't support replace: we implement a MySQL-compatible behavior instead
 		if ($method == 'replace' || $method == 'ignore') {
-			$key_str = '';
+			$key_str = implode(',', $keys);
 			$col_str = '';
 
 			$count = 0;
@@ -420,8 +420,6 @@ class PostgreSQL extends DatabaseApi implements DatabaseApiInterface
 			foreach ($columns as $columnName => $type) {
 				// Check pk field.
 				if (\in_array($columnName, $keys)) {
-					$key_str .= ($count_pk > 0 ? ',' : '');
-					$key_str .= $columnName;
 					$count_pk++;
 				}
 				// Normal field.

--- a/Sources/Db/Schema/Table.php
+++ b/Sources/Db/Schema/Table.php
@@ -547,7 +547,7 @@ class Table
 			table: '{db_prefix}' . $this->name,
 			columns: Db::$db->getTypeIndicators('{db_prefix}' . $this->name, reset($this->initial_data)),
 			data: array_map(fn($row) => array_values($row), $this->initial_data),
-			keys: isset($auto_col) ? [$auto_col] : [],
+			keys: isset($auto_col) ? [$auto_col] : array_column($this->indexes['primary']->columns, 'name'),
 			returnmode: $returnmode,
 		);
 


### PR DESCRIPTION
Fixes #9012 

Note that it was important to pass the whole key, not just an auto inc column, to address the query issues.  Not all keys are just auto incs.

Further, the old logic wouldn't add a key unless it was a passed column in the query, but pg didn't like that because it wasn't always the complete unique/primary key (e.g., auto incs usually excluded).  So had to ensure it passed all pk elements, all the time.

Another possible solution would have been to remove the conflict target (key list in parens) entirely.  This solution felt a little more holistic, however, as it addressed the broader issue with Table.php as well.

Tests great; no more hidden errors.  Freshly installed pg 3.0 database is fully populated.