### PR TITLE
[3.0] Get member selected smiley set on create post notification task

### DIFF
--- a/Sources/Tasks/CreatePost_Notify.php
+++ b/Sources/Tasks/CreatePost_Notify.php
@@ -177,7 +177,7 @@ class CreatePost_Notify extends BackgroundTask
 				ln.id_member, ln.id_board, ln.id_topic, ln.sent,
 				mem.email_address, mem.lngfile, mem.pm_ignore_list,
 				mem.id_group, mem.id_post_group, mem.additional_groups,
-				mem.time_format, mem.time_offset, mem.timezone,
+				mem.smiley_set, mem.time_format, mem.time_offset, mem.timezone,
 				t.id_member_started, t.id_member_updated
 			FROM {db_prefix}log_notify AS ln
 				INNER JOIN {db_prefix}members AS mem ON (ln.id_member = mem.id_member)
@@ -575,7 +575,7 @@ class CreatePost_Notify extends BackgroundTask
 				// Use the target member's localization settings.
 				Parser::$time_offset = (int) $member_data['time_offset'];
 				Parser::$time_format = $member_data['time_format'];
-				Parser::$smiley_set = $member_data['smiley_set'] ?? '';
+				Parser::$smiley_set = $member_data['smiley_set'];
 				Parser::$locale = Lang::getLocaleFromLanguageName($member_data['lngfile']) ?? Lang::getTxt('lang_locale', file: 'General', lang: $member_data['lngfile']);
 
 				$parsed_message[$localization]['subject'] = $msgOptions['subject'];


### PR DESCRIPTION
```
Fatal error: Uncaught TypeError: Cannot assign null to property SMF\Parser::$smiley_set of type string in C:\wamp64\www\smf-dev\Sources\Tasks\CreatePost_Notify.php:579
Stack trace:
#0 C:\wamp64\www\smf-dev\Sources\Tasks\CreatePost_Notify.php(310): SMF\Tasks\CreatePost_Notify->handleWatchedNotifications()
#1 C:\wamp64\www\smf-dev\Sources\TaskRunner.php(599): SMF\Tasks\CreatePost_Notify->execute()
#2 C:\wamp64\www\smf-dev\Sources\TaskRunner.php(238): SMF\TaskRunner->performTask(Array)
#3 C:\wamp64\www\smf-dev\Sources\Theme.php(2275): SMF\TaskRunner->runOneTask()
#4 C:\wamp64\www\smf-dev\Sources\Theme.php(227): SMF\Theme->loadJavaScript()
#5 C:\wamp64\www\smf-dev\Sources\Theme.php(328): SMF\Theme->initialize()
#6 C:\wamp64\www\smf-dev\Sources\ServerSideIncludes.php(283): SMF\Theme::load(1)
#7 C:\wamp64\www\smf-dev\SSI.php(42): SMF\ServerSideIncludes->__construct()
#8 C:\wamp64\www\smf-dev\install.php(4): require_once('C:\\wamp64\\www\\s...')
#9 {main}
  thrown in C:\wamp64\www\smf-dev\Sources\Tasks\CreatePost_Notify.php on line 579
```

Perhaps another problem could be that the database value is empty string. So is the column default.