### PR TITLE
[3.0] Remove stray variable causing undefined variable warning which slipped in by a merge

### DIFF
--- a/Sources/ErrorHandler.php
+++ b/Sources/ErrorHandler.php
@@ -280,7 +280,6 @@ class ErrorHandler
 			time(),
 			User::$me->ip ?? IP::getUserIP(),
 			$request_url,
-			$query_string,
 			$error_message,
 			(string) (User::$sc ?? ''),
 			$error_type,


### PR DESCRIPTION
This PR removes a variable that slipped in by the following merge:

<img width="1561" height="371" alt="image" src="https://github.com/user-attachments/assets/ca622dcd-af8a-4869-8add-3882268018f2" />

The variable is highlighted in red. The commit highlighted in green originally removed the variable.