### PR TITLE
[3.0] Fix a undefined query_string

### DIFF
--- a/Sources/ErrorHandler.php
+++ b/Sources/ErrorHandler.php
@@ -280,7 +280,6 @@ class ErrorHandler
 			time(),
 			User::$me->ip ?? IP::getUserIP(),
 			$request_url,
-			$query_string,
 			$error_message,
 			(string) (User::$sc ?? ''),
 			$error_type,


### PR DESCRIPTION
We can and will blame Vector