### PR TITLE
[3.0] Extend template system with callable support

### DIFF
--- a/Sources/Theme.php
+++ b/Sources/Theme.php
@@ -536,7 +536,7 @@ class Theme
 			}
 		}
 
-		if (! $template_loaded) {
+		if (!$template_loaded) {
 			$theme_function = 'template_' . $template_name;
 
 			$callable = Utils::getCallable($theme_function);
@@ -548,7 +548,7 @@ class Theme
 			}
 		}
 
-		if (! $template_loaded) {
+		if (!$template_loaded) {
 			// Handle errors based on the $fatal parameter.
 			if ($fatal === false) {
 				ErrorHandler::fatalLang(

--- a/Sources/Theme.php
+++ b/Sources/Theme.php
@@ -517,35 +517,21 @@ class Theme
 		$template_loaded = false;
 
 		if (\is_string($template_name) && \str_contains($template_name, '::')) {
-			$template_name = preg_replace_callback(
+			$template_name = \preg_replace_callback(
 				'/(#?)_(above|below)$/i',
-				fn($m) => ucfirst($m[2]) . $m[1],
+				fn($m) => \ucfirst($m[2]) . $m[1],
 				$template_name
 			);
 
-			$callable = Utils::getCallable($template_name);
-
-			if ($callable !== false) {
-				if (empty($function_params)) {
-					\call_user_func($callable);
-				} else {
-					\call_user_func_array($callable, $function_params);
-				}
-
+			if ($callable = Utils::getCallable($template_name, true)) {
+				\call_user_func_array($callable, $function_params);
 				$template_loaded = true;
 			}
 		}
 
-		if (!$template_loaded) {
-			$theme_function = 'template_' . $template_name;
-
-			$callable = Utils::getCallable($theme_function);
-
-			if ($callable !== false) {
-				\call_user_func_array($theme_function, $function_params);
-
-				$template_loaded = true;
-			}
+		if (!$template_loaded && ($callable = Utils::getCallable('template_' . $template_name, true))) {
+			\call_user_func_array($callable, $function_params);
+			$template_loaded = true;
 		}
 
 		if (!$template_loaded) {

--- a/Sources/Theme.php
+++ b/Sources/Theme.php
@@ -517,6 +517,12 @@ class Theme
 		$template_loaded = false;
 
 		if (\is_string($template_name) && \str_contains($template_name, '::')) {
+			$template_name = preg_replace_callback(
+				'/(#?)_(above|below)$/i',
+				fn($m) => ucfirst($m[2]) . $m[1],
+				$template_name
+			);
+
 			$callable = Utils::getCallable($template_name);
 
 			if ($callable !== false) {

--- a/Sources/Theme.php
+++ b/Sources/Theme.php
@@ -507,25 +507,42 @@ class Theme
 	public static function loadSubTemplate(string|array $sub_template_name, bool|string $fatal = false): void
 	{
 		$template_name = \is_array($sub_template_name) ? $sub_template_name[0] : $sub_template_name;
+		$function_params = \is_array($sub_template_name) ? ($sub_template_name[1] ?? []) : [];
 
 		// Add the sub-template to the debug context if debugging is enabled.
 		if (DebugUtils::isDebugEnabled()) {
 			DebugUtils::addDebugSource('sub_templates', $template_name);
 		}
 
-		// Determine the template function name and any associated parameters.
-		if (\is_array($sub_template_name)) {
-			$theme_function = 'template_' . $sub_template_name[0];
-			$function_params = $sub_template_name[1] ?? [];
-		} else {
-			$theme_function = 'template_' . $sub_template_name;
-			$function_params = [];
+		$template_loaded = false;
+
+		if (\is_string($template_name) && \str_contains($template_name, '::')) {
+			$callable = Utils::getCallable($template_name);
+
+			if ($callable !== false) {
+				if (empty($function_params)) {
+					\call_user_func($callable);
+				} else {
+					\call_user_func_array($callable, $function_params);
+				}
+
+				$template_loaded = true;
+			}
 		}
 
-		// Attempt to call the sub-template function.
-		if (\is_callable($theme_function)) {
-			\call_user_func_array($theme_function, $function_params);
-		} else {
+		if (! $template_loaded) {
+			$theme_function = 'template_' . $template_name;
+
+			$callable = Utils::getCallable($theme_function);
+
+			if ($callable !== false) {
+				\call_user_func_array($theme_function, $function_params);
+
+				$template_loaded = true;
+			}
+		}
+
+		if (! $template_loaded) {
 			// Handle errors based on the $fatal parameter.
 			if ($fatal === false) {
 				ErrorHandler::fatalLang(

--- a/Sources/Utils.php
+++ b/Sources/Utils.php
@@ -2477,6 +2477,28 @@ class Utils
 		return $callable;
 	}
 
+	/**
+	 * Universal template callback invoker following the logic of the "first file".
+	 *
+	 * @param string $name   Callback name (without prefix)
+	 * @param string $prefix Function name prefix (e.g. 'template_callback_' or 'template_profile_')
+	 * @return mixed Result of the callback execution or null if not found
+	 */
+	public static function callTemplateCallback(string $name, string $prefix = 'template_callback_'): mixed
+	{
+		if (function_exists($prefix . $name)) {
+			$name = $prefix . $name;
+		}
+
+		$callable = Utils::getCallable($name);
+
+		if ($callable) {
+			return call_user_func($callable);
+		}
+
+		return null;
+	}
+
 	/*************************
 	 * Internal static methods
 	 *************************/

--- a/Themes/default/Admin.template.php
+++ b/Themes/default/Admin.template.php
@@ -872,13 +872,7 @@ function template_show_settings()
 		// Hang about? Are you pulling my leg - a callback?!
 		if (is_array($config_var) && $config_var['type'] == 'callback')
 		{
-			$callbackName = $config_var['name'];
-			if (function_exists('template_callback_' . $callbackName)) {
-				$callbackName = 'template_callback_' . $callbackName;
-			}
-
-			$callable = Utils::getCallable($callbackName);
-			$callable && call_user_func($callable);
+			Utils::callTemplateCallback($config_var['name']);
 
 			continue;
 		}

--- a/Themes/default/Admin.template.php
+++ b/Themes/default/Admin.template.php
@@ -872,8 +872,13 @@ function template_show_settings()
 		// Hang about? Are you pulling my leg - a callback?!
 		if (is_array($config_var) && $config_var['type'] == 'callback')
 		{
-			if (function_exists('template_callback_' . $config_var['name']))
-				call_user_func('template_callback_' . $config_var['name']);
+			$callbackName = $config_var['name'];
+			if (function_exists('template_callback_' . $callbackName)) {
+				$callbackName = 'template_callback_' . $callbackName;
+			}
+
+			$callable = Utils::getCallable($callbackName);
+			$callable && call_user_func($callable);
 
 			continue;
 		}

--- a/Themes/default/Profile.template.php
+++ b/Themes/default/Profile.template.php
@@ -1505,10 +1505,8 @@ function template_edit_options()
 
 		elseif ($field['type'] == 'callback')
 		{
-			if (isset($field['callback_func']) && function_exists('template_profile_' . $field['callback_func']))
-			{
-				$callback_func = 'template_profile_' . $field['callback_func'];
-				$callback_func();
+			if (!empty($field['callback_func'])) {
+				Utils::callTemplateCallback($field['callback_func'], 'template_profile_');
 			}
 		}
 		else

--- a/Themes/default/Register.template.php
+++ b/Themes/default/Register.template.php
@@ -198,10 +198,8 @@ function template_registration_form()
 		{
 			if ($field['type'] == 'callback')
 			{
-				if (isset($field['callback_func']) && function_exists('template_profile_' . $field['callback_func']))
-				{
-					$callback_func = 'template_profile_' . $field['callback_func'];
-					$callback_func();
+				if (!empty($field['callback_func'])) {
+					Utils::callTemplateCallback($field['callback_func'], 'template_profile_');
 				}
 			}
 			else


### PR DESCRIPTION
Adds support for callable strings (e.g., `Class::method#`) in the `loadSubTemplate` method, allowing both static methods and instance method calls with object caching. Adds the same support for the callback option in `Admin.template.php`

**Example with callback functions:**

```php
<?php

namespace SMF;

class SomeClass
{
	public static function getConfigVars(): array
	{
		return [
			['callback', 'legacy_callback_name'], // looking for `template_callback_legacy_callback_name` function
			['callback', __CLASS__ . '::test#'], // looking for `test` method in the current class
			['callback', TestClass::class . '::test#'], // looking for `test` method in other class
			['callback', TestClass::class . '::test2'], // looking for `test2` static method in other class
		];
	}

	public function test(): void
	{
		echo __METHOD__;
	}
}

class TestClass
{
	public function test(): void
	{
		echo __METHOD__;
	}

	public static function test2(): void
	{
		echo __METHOD__;
	}
}
```

**Example with subaction:**

```php
Utils::$context['sub_template'] = 'show_settings'; // current (legacy)
Utils::$context['sub_template'] = TestClass::class . '::test#'; // new
```

**Example with layers:**

```php
Utils::$context['template_layers'][] = TestClass::class . '::test#';
```

```php
<?php

namespace SMF;

class TestClass
{
	public function testAbove(): void
	{
		echo 'above';
	}

	public function testBelow(): void
	{
		echo 'below';
	}
}
```
