### PR TITLE
[3.0] Composer and PHP-CS-Fixer updates

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -35,7 +35,7 @@ return (new PhpCsFixer\Config())
         new SMF\Fixer\ClassNotation\SectionComments(),
     ])
 	->setRules([
-		'@PER-CS2.0' => true,
+		'@PER-CS2x0' => true,
 
 		// PSR12 overrides.
 		'no_break_comment' => false,  // A bit buggy with comments.

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
 		"friendsofphp/php-cs-fixer": "^3.40"
 	},
 	"scripts": {
-		"lint": "php-cs-fixer --quiet check --config .php-cs-fixer.dist.php --path-mode=intersection $(git diff --name-only \"*.php\") || php-cs-fixer check --diff --config .php-cs-fixer.dist.php --path-mode=intersection $(git diff --name-only \"*.php\") --allow-risky=yes",
+		"lint": "php-cs-fixer --quiet check --config .php-cs-fixer.dist.php --path-mode=intersection $(git diff --name-only \"*.php\") --allow-risky=yes || php-cs-fixer check --diff --config .php-cs-fixer.dist.php --path-mode=intersection $(git diff --name-only \"*.php\") --allow-risky=yes",
 		"lint-fix": "php-cs-fixer fix -v --config .php-cs-fixer.dist.php --path-mode=intersection $(git diff --name-only \"*.php\") --allow-risky=yes"
 	},
 	"config": {

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,9 @@
 	},
 	"scripts": {
 		"lint": "php-cs-fixer --quiet check --config .php-cs-fixer.dist.php --path-mode=intersection $(git diff --name-only \"*.php\") --allow-risky=yes || php-cs-fixer check --diff --config .php-cs-fixer.dist.php --path-mode=intersection $(git diff --name-only \"*.php\") --allow-risky=yes",
-		"lint-fix": "php-cs-fixer fix -v --config .php-cs-fixer.dist.php --path-mode=intersection $(git diff --name-only \"*.php\") --allow-risky=yes"
+		"lint-fix": "php-cs-fixer fix -v --config .php-cs-fixer.dist.php --path-mode=intersection $(git diff --name-only \"*.php\") --allow-risky=yes",
+		"post-install-cmd": "php ./vendor/simplemachines/build-tools/secure-vendor-dir.php",
+		"post-update-cmd": "php ./vendor/simplemachines/build-tools/secure-vendor-dir.php"
 	},
 	"config": {
 		"platform": {

--- a/composer.lock
+++ b/composer.lock
@@ -1699,12 +1699,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/SimpleMachines/BuildTools.git",
-                "reference": "d75973c86bea740fabc920cb6d35d65fa29bb2a9"
+                "reference": "803472386a47076dd0ede0e964f5e87e11ad8925"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/SimpleMachines/BuildTools/zipball/d75973c86bea740fabc920cb6d35d65fa29bb2a9",
-                "reference": "d75973c86bea740fabc920cb6d35d65fa29bb2a9",
+                "url": "https://api.github.com/repos/SimpleMachines/BuildTools/zipball/803472386a47076dd0ede0e964f5e87e11ad8925",
+                "reference": "803472386a47076dd0ede0e964f5e87e11ad8925",
                 "shasum": ""
             },
             "require": {
@@ -1717,7 +1717,7 @@
                 "source": "https://github.com/SimpleMachines/BuildTools/tree/release-3.0",
                 "issues": "https://github.com/SimpleMachines/BuildTools/issues"
             },
-            "time": "2025-09-21T00:49:06+00:00"
+            "time": "2025-11-07T23:20:34+00:00"
         },
         {
             "name": "symfony/cache",


### PR DESCRIPTION
The main thing here is that composer will now automatically secure the contents of the vendor directory and subdirectories by adding the standard index.php that we use to secure all our other directories.

This does mean that running `composer status` will show that the libraries have been changed locally, but since the only actual change is that the index.php files have been added, that doesn't actually make a difference.