### PR TITLE
[2.1] Fix string literal cleanup - take 3

### DIFF
--- a/Sources/Subs-Db-mysql.php
+++ b/Sources/Subs-Db-mysql.php
@@ -368,12 +368,14 @@ function smf_db_query($identifier, $db_string, $db_values = array(), $connection
 
 	// Comments that are allowed in a query are preg_removed.
 	static $allowed_comments_from = array(
+		'~\'\X*?\'~s',
 		'~\s+~s',
 		'~/\*!40001 SQL_NO_CACHE \*/~',
 		'~/\*!40000 USE INDEX \([A-Za-z\_]+?\) \*/~',
 		'~/\*!40100 ON DUPLICATE KEY UPDATE id_msg = \d+ \*/~',
 	);
 	static $allowed_comments_to = array(
+		' %s ',
 		' ',
 		'',
 		'',
@@ -415,19 +417,9 @@ function smf_db_query($identifier, $db_string, $db_values = array(), $connection
 	// First, we clean strings out of the query, reduce whitespace, lowercase, and trim - so we can check it over.
 	if (empty($modSettings['disableQueryCheck']))
 	{
-		$clean = preg_split('/(?:\\\\{2})*\K(?<![\'\\\\])\'(?![\'])/', $db_string);
-
-		for ($i = 0; $i < count($clean); $i++)
-		{
-			if ($i % 2 === 1)
-				$clean[$i] = ' %s ';
-		}
-
-		$clean = trim(strtolower(preg_replace(
-			$allowed_comments_from,
-			$allowed_comments_to,
-			implode('', $clean)
-		)));
+		// Clear out escaped backslashes & single quotes first, to make it simpler to ID & remove string literals
+		$clean = str_replace(array('\\\\', '\\\'', '\'\''), array('', '', ''), $db_string);
+		$clean = trim(strtolower(preg_replace($allowed_comments_from, $allowed_comments_to, $clean)));
 
 		// Comments?  We don't use comments in our queries, we leave 'em outside!
 		if (strpos($clean, '/*') > 2 || strpos($clean, '--') !== false || strpos($clean, ';') !== false)


### PR DESCRIPTION
Fixes #9031 

Third attempt!  I believe this one addresses concerns raised by @Sesquipedalian in the discussion on #8996 .

The only quirk in this version is that it will strip empty strings from the query prior to the search for forbidden syntax, which isn't a problem given what it's looking for.

Spent time testing with:
 - The primary test case in the bug reports (subject `Hello World \`, body `I'm`), as a PM and as a new topic
 - The smileys test
 - Fetching SMF files (the original, original bug...)
 - Several attempts to break it with content with repeating quotes & slashes & apostrophes & entities of various lengths, etc.
 - Observing a few dozen cleaned misc queries just browsing around the forum
 - An install; running all scheduled tasks; several admin functions
