### PR TITLE
[3.0] Remove deprecated moz feature

### DIFF
--- a/Themes/default/css/index.css
+++ b/Themes/default/css/index.css
@@ -76,10 +76,6 @@ input[type="file"] {
 	padding: 2px;
 	height: auto;
 }
-/* Remove default mozilla dotted borders */
-input[type="submit"]::-moz-focus-inner, button::-moz-focus-inner {
-	border: 0;
-}
 /* Prevent inputs and images overflowing */
 img, input, select, textarea {
 	max-width: 100%;


### PR DESCRIPTION
Fixes #8809 

Simple & safe enough to remove.  And gets rid of that pesky console warning.