### PR TITLE
[2.1] Remove deprecated moz feature

### DIFF
--- a/Themes/default/css/index.css
+++ b/Themes/default/css/index.css
@@ -75,10 +75,6 @@ input[type="file"] {
 	padding: 2px;
 	height: auto;
 }
-/* Remove default mozilla dotted borders */
-input[type="submit"]::-moz-focus-inner, button::-moz-focus-inner {
-	border: 0;
-}
 /* Prevent inputs and images overflowing */
 img, input, select, textarea {
 	max-width: 100%;


### PR DESCRIPTION
Related to #8809

In case you reconsider...  I know you weren't planning on addressing for 2.1, but it's simple & safe enough to remove. 

And gets rid of that pesky console warning.  Which is literally the only console warning/error produced by SMF...  So it's driving me nuts.

