### PR TITLE
[3.0] Fix explosion of smileys

### DIFF
--- a/Sources/Db/Schema/v3_0/Settings.php
+++ b/Sources/Db/Schema/v3_0/Settings.php
@@ -724,7 +724,7 @@ class Settings extends Table
 		],
 		[
 			'variable' => 'smiley_sets_names',
-			'value' => '{$default_fugue_smileyset_name}\n{$default_alienine_smileyset_name}',
+			'value' => '{$default_fugue_smileyset_name}' . "\n" . '{$default_alienine_smileyset_name}',
 		],
 		[
 			'variable' => 'smileys_dir',


### PR DESCRIPTION
Fixes #9058 

Note that there are two places where we use a plain '\n' instead of an "\n" in the install, smiley sets & reserveNames.

reserveNames seems to work as-is, so I left it alone.

<img width="571" height="105" alt="image" src="https://github.com/user-attachments/assets/f312e105-4bca-4ac3-8778-ab6ed7c2a2a0" />

<img width="568" height="80" alt="image" src="https://github.com/user-attachments/assets/2ecc49d7-fddf-4abc-ac1f-7ed6a3e4af00" />
