### PR TITLE
[3.0] Fix sqlite connect logic

### DIFF
--- a/Sources/Cache/APIs/Sqlite.php
+++ b/Sources/Cache/APIs/Sqlite.php
@@ -79,7 +79,7 @@ class Sqlite extends CacheApi implements CacheApiInterface
 	{
 		$database = $this->cachedir . '/' . 'SQLite3Cache.db3';
 
-		if (!is_writable($database) || !is_writeable($this->cachedir)) {
+		if ((file_exists($database) && !is_writable($database)) || !is_writeable($this->cachedir)) {
 			return false;
 		}
 


### PR DESCRIPTION
Fixes #9029 

is_writable() fails if the file doesn't exist.