### PR TITLE
[3.0] Sqlite caching didn't always create a table

### DIFF
--- a/Sources/Cache/APIs/Sqlite.php
+++ b/Sources/Cache/APIs/Sqlite.php
@@ -98,9 +98,9 @@ class Sqlite extends CacheApi implements CacheApiInterface
 				$this->cacheDB->exec('PRAGMA journal_mode = wal;');
 			}
 
-			if (filesize($database) == 0) {
-				$this->cacheDB->exec('CREATE TABLE cache (key text unique, value blob, ttl int);');
-				$this->cacheDB->exec('CREATE INDEX ttls ON cache(ttl);');
+			if (filesize($database) <= 4096) {
+				$this->cacheDB->exec('CREATE TABLE IF NOT EXISTS cache (key text unique, value blob, ttl int);');
+				$this->cacheDB->exec('CREATE INDEX IF NOT EXISTS ttls ON cache(ttl);');
 			}
 
 			return true;


### PR DESCRIPTION
Due to the journal mode changes, it seems that the table doesn't always get created because the file size can be larger than 0.  But it still seems to be exactly 4096. Changed the check and added an exists to trying to create the table/index.