### PR TITLE
[3.0] Fix board index avatar load

### DIFF
--- a/Sources/Actions/BoardIndex.php
+++ b/Sources/Actions/BoardIndex.php
@@ -773,12 +773,11 @@ class BoardIndex implements ActionInterface, Routable
 
 		unset($msg, Msg::$loaded[$row_board['id_msg']]);
 
+		// Make sure they're loaded...
+		User::load($row_board['id_member']);
+
 		if (!empty(Theme::$current->settings['avatars_on_boardIndex'])) {
-			$last_post['member']['avatar'] = User::setAvatarData([
-				'avatar' => $row_board['avatar'],
-				'email' => $row_board['email_address'],
-				'filename' => !empty($row_board['member_filename']) ? $row_board['member_filename'] : '',
-			]);
+			$last_post['member']['avatar'] = User::$loaded[$row_board['id_member']]['avatar'];
 		}
 
 		IntegrationHook::call('integrate_boardindex_last_post', [&$last_post, $row_board]);


### PR DESCRIPTION
I ran across this testing #7933 

As I run across such issues, that aren't strictly tied to the new theme, I will fix as standalone PRs like this.  No need to overload #7933 - it's big enough already.

If your theme has the setting: avatars_on_boardIndex set to true, you get a lot of undefined errors for email & avatar:
<img width="598" height="669" alt="image" src="https://github.com/user-attachments/assets/639a46bf-1a5d-49b9-8aec-b386156b3468" />

This fix addresses this.




