### PR TITLE
[3.0] Prevent infinite loop while building regexes

### DIFF
--- a/Sources/Utils.php
+++ b/Sources/Utils.php
@@ -1053,7 +1053,7 @@ class Utils
 		$trailing = '';
 		$i = -1;
 
-		while ($strings[0] !== '') {
+		while ($strings[0] !== '' && strlen($strings[0]) < $i * -1) {
 			$last_char = mb_substr($strings[0], $i, null, $encoding);
 
 			foreach ($strings as $string) {


### PR DESCRIPTION
A simple word "test" can break this because the condition inside the foreach is never satisfied. Ensure that if $i reaches the length of the string, we give up We can't use a equals comparison because it breaks highlighting