### PR TITLE
[3.0] Fix invalid timezone

### DIFF
--- a/Sources/Actions/Calendar.php
+++ b/Sources/Actions/Calendar.php
@@ -860,7 +860,7 @@ class Calendar implements ActionInterface, Routable
 		$occurrences = [];
 
 		$one_day = new \DateInterval('P1D');
-		$tz = new \DateTimeZone(User::getTimezone());
+		$tz = TimeZone::create(User::getTimezone());
 		$high_date = (new \DateTimeImmutable($high_date . ' +1 day'))->format('Y-m-d');
 
 		foreach (Event::getOccurrencesInRange($low_date, $high_date, $use_permissions) as $occurrence) {

--- a/Sources/Actions/Feed.php
+++ b/Sources/Actions/Feed.php
@@ -34,6 +34,7 @@ use SMF\QueryString;
 use SMF\Routable;
 use SMF\Theme;
 use SMF\Time;
+use SMF\TimeZone;
 use SMF\Url;
 use SMF\User;
 use SMF\Utils;
@@ -684,7 +685,7 @@ class Feed implements ActionInterface, Routable
 						[
 							'tag' => 'time',
 							'attributes' => ['label' => Lang::getTxt('date_registered', file: 'General'), 'UTC' => Time::gmstrftime('%F %T', (int) $row['date_registered'])],
-							'content' => Utils::htmlspecialchars(strip_tags(Time::create('@' . $row['date_registered'], new \DateTimeZone(Config::$modSettings['default_timezone']))->format(null, false))),
+							'content' => Utils::htmlspecialchars(strip_tags(Time::create('@' . $row['date_registered'], TimeZone::create(Config::$modSettings['default_timezone']))->format(null, false))),
 						],
 						[
 							'tag' => 'id',
@@ -1480,7 +1481,7 @@ class Feed implements ActionInterface, Routable
 						[
 							'tag' => 'time',
 							'attributes' => ['label' => Lang::getTxt('date', file: 'General'), 'UTC' => Time::gmstrftime('%F %T', (int) $row['poster_time'])],
-							'content' => Utils::htmlspecialchars(strip_tags(Time::create('@' . $row['poster_time'], new \DateTimeZone(Config::$modSettings['default_timezone']))->format(null, false))),
+							'content' => Utils::htmlspecialchars(strip_tags(Time::create('@' . $row['poster_time'], TimeZone::create(Config::$modSettings['default_timezone']))->format(null, false))),
 						],
 						[
 							'tag' => 'id',
@@ -1779,12 +1780,12 @@ class Feed implements ActionInterface, Routable
 				[
 					'tag' => 'last-login',
 					'attributes' => ['label' => Lang::getTxt('lastLoggedIn', file: 'Profile'), 'UTC' => Time::gmstrftime('%F %T', (int) $profile['last_login_timestamp'])],
-					'content' => Time::create('@' . $profile['last_login_timestamp'], new \DateTimeZone(Config::$modSettings['default_timezone']))->format(null, false),
+					'content' => Time::create('@' . $profile['last_login_timestamp'], TimeZone::create(Config::$modSettings['default_timezone']))->format(null, false),
 				],
 				[
 					'tag' => 'registered',
 					'attributes' => ['label' => Lang::getTxt('date_registered', file: 'General'), 'UTC' => Time::gmstrftime('%F %T', (int) $profile['registered_timestamp'])],
-					'content' => Time::create('@' . $profile['registered_timestamp'], new \DateTimeZone(Config::$modSettings['default_timezone']))->format(null, false),
+					'content' => Time::create('@' . $profile['registered_timestamp'], TimeZone::create(Config::$modSettings['default_timezone']))->format(null, false),
 				],
 				[
 					'tag' => 'avatar',

--- a/Sources/Logging.php
+++ b/Sources/Logging.php
@@ -509,7 +509,7 @@ class Logging
 			];
 		}
 
-		$date = (new \DateTime('now', new \DateTimeZone(Config::$modSettings['default_timezone'])))->format('Y-m-d');
+		$date = (new \DateTime('now', TimeZone::create(Config::$modSettings['default_timezone'])))->format('Y-m-d');
 
 		// No entry exists for today yet?
 		if (!isset(Config::$modSettings['mostOnlineUpdated']) || Config::$modSettings['mostOnlineUpdated'] != $date) {

--- a/Sources/Time.php
+++ b/Sources/Time.php
@@ -188,11 +188,11 @@ class Time extends \DateTime implements \ArrayAccess
 	public function __construct(string $datetime = 'now', \DateTimeZone|string|null $timezone = null)
 	{
 		if (!isset(self::$user_tz)) {
-			self::$user_tz = new \DateTimeZone(User::getTimezone());
+			self::$user_tz = TimeZone::create(User::getTimezone());
 		}
 
 		if (\is_string($timezone)) {
-			$timezone = new \DateTimeZone($timezone);
+			$timezone = TimeZone::create($timezone);
 		}
 
 		$datetime = self::sanitize($datetime);
@@ -731,7 +731,7 @@ class Time extends \DateTime implements \ArrayAccess
 		if ($timezone instanceof \DateTimeZone) {
 			date_timezone_set($this, $timezone);
 		} elseif (\in_array($timezone, \DateTimeZone::listIdentifiers(\DateTimeZone::ALL_WITH_BC))) {
-			date_timezone_set($this, new \DateTimeZone($timezone));
+			date_timezone_set($this, TimeZone::create($timezone));
 		} else {
 			throw new \ValueError();
 		}
@@ -815,7 +815,7 @@ class Time extends \DateTime implements \ArrayAccess
 		}
 
 		$date = new self('@' . $timestamp);
-		$date->setTimezone(new \DateTimeZone($tzid));
+		$date->setTimezone(TimeZone::create($tzid));
 
 		return $date->format($format, false, true);
 	}

--- a/Sources/TimeZone.php
+++ b/Sources/TimeZone.php
@@ -1836,6 +1836,21 @@ class TimeZone extends \DateTimeZone
 	 ***********************/
 
 	/**
+	 * Creates a new DateTimeZone object.
+	 *
+	 * @param string $timezone One of the supported timezone names , an offset value (+0200), or a timezone abbreviation (BST).
+	 * @return bool|\DateTimeZone Returns DateTimeZone on success. Procedural style returns `false` on failure.
+	 */
+	public static function create(string $timezone): bool|\DateTimeZone {
+		try {
+			return new \DateTimeZone($timezone);
+		}
+		catch (\Exception $ex) {
+			return new \DateTimeZone(Config::$modSettings['default_timezone']);
+		}
+	}
+
+	/**
 	 * Get a list of time zones.
 	 *
 	 * @param int|string $when The date/time for which to calculate the time

--- a/Sources/User.php
+++ b/Sources/User.php
@@ -4321,8 +4321,8 @@ class User implements \ArrayAccess
 			// Figure out the new time offset.
 			if (!empty(self::$profiles[$this->id]['timezone'])) {
 				// Get the offsets from UTC for the server, then for the user.
-				$tz_system = new \DateTimeZone(Config::$modSettings['default_timezone']);
-				$tz_user = new \DateTimeZone(self::$profiles[$this->id]['timezone']);
+				$tz_system = TimeZone::create(Config::$modSettings['default_timezone']);
+				$tz_user = TimeZone::create(self::$profiles[$this->id]['timezone']);
 				$time_system = new \DateTime('now', $tz_system);
 				$time_user = new \DateTime('now', $tz_user);
 				self::$profiles[$this->id]['time_offset'] = ($tz_user->getOffset($time_user) - $tz_system->getOffset($time_system)) / 3600;
@@ -4330,7 +4330,7 @@ class User implements \ArrayAccess
 			// We need a time zone.
 			else {
 				if (!empty(self::$profiles[$this->id]['time_offset'])) {
-					$tz_system = new \DateTimeZone(Config::$modSettings['default_timezone']);
+					$tz_system = TimeZone::create(Config::$modSettings['default_timezone']);
 					$time_system = new \DateTime('now', $tz_system);
 
 					self::$profiles[$this->id]['timezone'] = @timezone_name_from_abbr('', (int) ($tz_system->getOffset($time_system) + self::$profiles[$this->id]['time_offset'] * 3600), (int) $time_system->format('I'));


### PR DESCRIPTION
The main issue is the user has an invalid timezone in their profile.  Doing a check for an empty profile is simple, but a garbage entry is another issue.

https://www.php.net/manual/en/datetimezone.construct.php

According to the documentation an invalid timezone throws an error. Our code is assuming in many places that a valid time zone will be returned.  The exception is not being handled

Create a wrapper and attempt to fallback the forum default time zone if we fail to get a valid user time zone Anywhere we use UTC, I ignored using the wrapper.

Fixes #9037