### PR TITLE
[2.1] Fix IPv6 reverse hostname display on member profiles

### DIFF
--- a/Sources/Profile-View.php
+++ b/Sources/Profile-View.php
@@ -86,7 +86,7 @@ function summary($memID)
 	if (allowedTo('moderate_forum'))
 	{
 		// Make sure it's a valid ip address; otherwise, don't bother...
-		if (preg_match('/^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/', $memberContext[$memID]['ip']) == 1 && empty($modSettings['disableHostnameLookup']))
+		if (filter_var($memberContext[$memID]['ip'], FILTER_VALIDATE_IP) && empty($modSettings['disableHostnameLookup']))
 			$context['member']['hostname'] = host_from_ip($memberContext[$memID]['ip']);
 		else
 			$context['member']['hostname'] = '';


### PR DESCRIPTION
Hostnames for IPv6 addresses didn't appear on member profiles because the regex to filter invalid IP values only matched for IPv4 addresses. I changed the test to the PHP [filter_var()](https://www.php.net/manual/en/function.filter-var.php) function which should be more robust.