### PR TITLE
[3.0] Add support for Dark mode in themes

### DIFF
--- a/Languages/en_US/Profile.php
+++ b/Languages/en_US/Profile.php
@@ -644,6 +644,8 @@ $txt['theme_opt_display'] = 'Board and Topic display';
 $txt['theme_opt_posting'] = 'Posting';
 $txt['theme_opt_moderation'] = 'Moderation';
 $txt['theme_opt_personal_messages'] = 'Personal Messages';
+$txt['theme_opt_colormode'] = 'Theme Color Mode';
+$txt['theme_opt_variant'] = 'Theme Variant';
 
 $txt['export_profile_data'] = 'Download profile data';
 $txt['export_profile_data_desc'] = 'This section allows you to export a copy of your forum profile data to a downloadable file, optionally including your posts and personal messages.<br>Please note:<ul class="bbc_list">{list}</ul>';

--- a/Languages/en_US/Themes.php
+++ b/Languages/en_US/Themes.php
@@ -65,6 +65,7 @@ $txt['theme_global_description'] = 'This is the default theme, which means your 
 
 $txt['theme_url_config'] = 'Theme URLs and Configuration';
 $txt['theme_variants'] = 'Theme Variants';
+$txt['theme_colormodes'] = 'Theme Color Modes';
 $txt['theme_options'] = 'Theme Options and Preferences';
 $txt['actual_theme_name'] = 'This theme’s name: ';
 $txt['actual_theme_dir'] = 'This theme’s directory: ';
@@ -73,6 +74,7 @@ $txt['actual_images_url'] = 'This theme’s images URL: ';
 $txt['current_theme_style'] = 'This theme’s style: ';
 
 $txt['theme_variants_default'] = 'Default theme variant';
+$txt['variant_default'] = 'Default';
 $txt['theme_variants_user_disable'] = 'Disable user variant selection';
 
 $txt['site_slogan'] = 'Site slogan';
@@ -164,3 +166,11 @@ $txt['themeadmin_themelist_link'] = 'Show the list of themes';
 // Open Graph
 $txt['og_image'] = 'Open Graph image';
 $txt['og_image_desc'] = 'Suggested size: 175x175px. <a href="https://ogp.me/" target="_blank" class="bbc_link">Open Graph</a> is used for social media sharing.';
+
+// Theme Mode (dark, light, system, etc)
+$txt['theme_pick_colormode'] = 'Select Color Mode';
+$txt['theme_colormode_default'] = 'Default color mode';
+$txt['theme_colormode_user_disable'] = 'Disable user color mode selection';
+$txt['colormode_light'] = 'Light';
+$txt['colormode_dark'] = 'Dark';
+$txt['colormode_system'] = 'System Default';

--- a/Sources/Actions/Admin/Themes.php
+++ b/Sources/Actions/Admin/Themes.php
@@ -602,7 +602,51 @@ class Themes implements ActionInterface
 		Utils::$context['sub_template'] = 'set_options';
 		Utils::$context['page_title'] = Lang::getTxt('theme_settings', file: 'Admin');
 
-		Utils::$context['options'] = Utils::$context['theme_options'];
+		// Check for variants or dark mode
+		if (!empty(Theme::$current->settings['theme_variants']) || !empty(Theme::$current->settings['has_dark_mode'])) {
+			Utils::$context['options'] = [];
+
+			// Theme Variants
+			if (!empty(Theme::$current->settings['theme_variants'])) {
+				$available_variants = [];
+
+				foreach (Theme::$current->settings['theme_variants'] as $variant) {
+					$available_variants[$variant] = Lang::$txt['variant_' . $variant] ?? $variant;
+				}
+
+				Utils::$context['options'][] = Lang::$txt['theme_opt_variant'];
+				Utils::$context['options'][] = [
+					'id' => 'theme_variant',
+					'label' => Lang::$txt['theme_pick_variant'],
+					'options' => $available_variants,
+					'default' => isset(Theme::$current->settings['default_variant']) && !empty(Theme::$current->settings['default_variant']) ? Theme::$current->settings['default_variant'] : Theme::$current->settings['theme_variants'][0],
+					'enabled' => !empty(Theme::$current->settings['theme_variants']),
+				];
+			}
+
+			// Theme Color Mode
+			if (!empty(Theme::$current->settings['has_dark_mode'])) {
+				$available_modes = [];
+
+				foreach (Theme::$current->settings['theme_colormodes'] as $mode) {
+					$available_modes[$mode] = Lang::$txt['colormode_' . $mode] ?? $mode;
+				}
+
+				Utils::$context['options'][] = Lang::$txt['theme_opt_colormode'];
+				Utils::$context['options'][] = [
+					'id' => 'theme_colormode',
+					'label' => Lang::$txt['theme_pick_colormode'],
+					'options' => $available_modes,
+					'default' => isset(Theme::$current->settings['default_colormode']) && !empty(Theme::$current->settings['default_colormode']) ? Theme::$current->settings['default_colormode'] : Theme::$current->settings['theme_colormodes'][0],
+					'enabled' => !empty(Theme::$current->settings['has_dark_mode']),
+				];
+			}
+
+			Utils::$context['options'] = array_merge(Utils::$context['options'], Utils::$context['theme_options']);
+		} else {
+			Utils::$context['options'] = Utils::$context['theme_options'];
+		}
+
 		Utils::$context['theme_settings'] = Theme::$current->settings;
 
 		if (empty($_REQUEST['who'])) {

--- a/Sources/Theme.php
+++ b/Sources/Theme.php
@@ -2158,6 +2158,47 @@ class Theme
 	}
 
 	/**
+	 * Loads the theme mode, if applicable.
+	 */
+	protected function loadMode(): void
+	{
+		Utils::$context['theme_colormode'] = '';
+
+		if (!empty($this->settings['has_dark_mode'])) {
+			// Theme Modes
+			$this->settings['theme_colormodes'] = ['light', 'system', 'dark'];
+
+			// Overriding - for previews and that ilk.
+			if (!empty($_REQUEST['mode'])) {
+				$_SESSION['theme_colormode'] = $_REQUEST['mode'];
+
+				// If the user is logged, save this to their profile
+				if (User::$me->is_logged && \in_array($_SESSION['theme_colormode'], $this->settings['theme_colormodes'])) {
+					Db::$db->insert(
+						'replace',
+						'{db_prefix}themes',
+						['id_theme' => 'int', 'id_member' => 'int', 'variable' => 'string-255', 'value' => 'string-65534'],
+						[self::$current->settings['theme_id'], User::$me->id, 'theme_colormode', $_SESSION['theme_colormode']],
+						['id_theme', 'id_member', 'variable'],
+					);
+				}
+			}
+
+			// User selection?
+			if (empty($this->settings['disable_user_mode']) || User::$me->allowedTo('admin_forum')) {
+				Utils::$context['theme_colormode'] = !empty($_SESSION['theme_colormode']) && \in_array($_SESSION['theme_colormode'], $this->settings['theme_colormodes']) ? $_SESSION['theme_colormode'] : (!empty($this->options['theme_colormode']) && \in_array($this->options['theme_colormode'], $this->settings['theme_colormodes']) ? $this->options['theme_colormode'] : '');
+			}
+
+			// If no color mode, set a default
+			if (empty(Utils::$context['theme_colormode']) || !\in_array(Utils::$context['theme_colormode'], $this->settings['theme_colormodes'])) {
+				Utils::$context['theme_colormode'] = !empty($this->settings['default_colormode']) && \in_array($this->settings['default_colormode'], $this->settings['theme_colormodes']) ? $this->settings['default_colormode'] : $this->settings['theme_colormodes'][0];
+			}
+
+			self::loadCSSFile('dark.css', ['order_pos' => 2, 'attributes' => (Utils::$context['theme_colormode'] == 'system' ? ['media' => '(prefers-color-scheme: dark)'] : [])], 'smf_dark');
+		}
+	}
+
+	/**
 	 * Loads the correct theme variant, if applicable.
 	 */
 	protected function loadVariant(): void
@@ -2167,10 +2208,33 @@ class Theme
 		Utils::$context['theme_variant_url'] = '';
 
 		if (!empty($this->settings['theme_variants'])) {
+			// Add the default variant
+			$this->settings['theme_variants'] = array_unique(array_merge(['default'], $this->settings['theme_variants']));
+
 			// Overriding - for previews and that ilk.
 			if (!empty($_REQUEST['variant'])) {
 				$_SESSION['id_variant'] = $_REQUEST['variant'];
+
+				// If the user is logged, save this to their profile
+				if (User::$me->is_logged && \in_array($_SESSION['id_variant'], $this->settings['theme_variants'])) {
+					Db::$db->insert(
+						'replace',
+						'{db_prefix}themes',
+						['id_theme' => 'int', 'id_member' => 'int', 'variable' => 'string-255', 'value' => 'string-65534'],
+						[self::$current->settings['theme_id'], User::$me->id, 'theme_variant', $_SESSION['id_variant']],
+						['id_theme', 'id_member', 'variable'],
+					);
+				}
 			}
+
+			/*
+			 * Attempt to load a variants file for variable overriding
+			 * using data attribute (:root[data-variant="variant"])
+			 *
+			 * This is useful when you only want a single file for
+			 * recoloring the variants.
+			 */
+			self::loadCSSFile('variants.css', ['order_pos' => 0], 'smf_variants');
 
 			// User selection?
 			if (empty($this->settings['disable_user_variant']) || User::$me->allowedTo('admin_forum')) {
@@ -2180,18 +2244,6 @@ class Theme
 			// If not a user variant, select the default.
 			if (Utils::$context['theme_variant'] == '' || !\in_array(Utils::$context['theme_variant'], $this->settings['theme_variants'])) {
 				Utils::$context['theme_variant'] = !empty($this->settings['default_variant']) && \in_array($this->settings['default_variant'], $this->settings['theme_variants']) ? $this->settings['default_variant'] : $this->settings['theme_variants'][0];
-			}
-
-			// Do this to keep things easier in the templates.
-			Utils::$context['theme_variant'] = '_' . Utils::$context['theme_variant'];
-			Utils::$context['theme_variant_url'] = Utils::$context['theme_variant'] . '/';
-
-			if (!empty(Utils::$context['theme_variant'])) {
-				self::loadCSSFile('index' . Utils::$context['theme_variant'] . '.css', ['order_pos' => 300], 'smf_index' . Utils::$context['theme_variant']);
-
-				if (Utils::$context['right_to_left']) {
-					self::loadCSSFile('rtl' . Utils::$context['theme_variant'] . '.css', ['order_pos' => 4200], 'smf_rtl' . Utils::$context['theme_variant']);
-				}
 			}
 		}
 	}

--- a/Themes/default/Themes.template.php
+++ b/Themes/default/Themes.template.php
@@ -511,8 +511,7 @@ function template_set_settings()
 				</dl>';
 
 	// Do we allow theme variants?
-	if (!empty(Utils::$context['theme_variants']))
-	{
+	if (!empty(Utils::$context['theme_variants'])) {
 		echo '
 				<div class="title_bar">
 					<h3 class="titlebg config_hd">
@@ -542,6 +541,38 @@ function template_set_settings()
 					</dd>
 				</dl>
 				<img src="', Utils::$context['theme_variants'][Utils::$context['default_variant']]['thumbnail'], '" id="variant_preview" alt="">';
+	}
+
+	// Color modes for the theme?
+	if (!empty(Theme::$current->settings['has_dark_mode'])) {
+		echo '
+				<div class="title_bar">
+					<h3 class="titlebg config_hd">
+						', Lang::$txt['theme_colormodes'], '
+					</h3>
+				</div>
+				<dl class="settings">
+					<dt>
+						<label for="colormode">', Lang::$txt['theme_colormode_default'], '</label>
+					</dt>
+					<dd>
+						<select id="colormode" name="options[default_colormode]">';
+
+		foreach (Theme::$current->settings['theme_colormodes'] as $mode)
+			echo '
+							<option value="', $mode, '"', Theme::$current->settings['default_colormode'] == $mode ? ' selected' : '', '>', Lang::$txt['colormode_' . $mode], '</option>';
+
+		echo '
+						</select>
+					</dd>
+					<dt>
+						<label for="disable_user_mode">', Lang::$txt['theme_colormode_user_disable'], '</label>
+					</dt>
+					<dd>
+						<input type="hidden" name="options[disable_user_mode]" value="0">
+						<input type="checkbox" name="options[disable_user_mode]" id="disable_user_mode"', !empty(Utils::$context['theme_settings']['disable_user_mode']) ? ' checked' : '', ' value="1">
+					</dd>
+				</dl>';
 	}
 
 	echo '
@@ -690,65 +721,66 @@ function template_set_settings()
 function template_pick()
 {
 	echo '
-	<div id="pick_theme">
-		<form action="', Config::$scripturl, '?action=themechooser" method="post" accept-charset="UTF-8">';
+	<form action="', Config::$scripturl, '?action=themechooser" method="post" accept-charset="UTF-8">';
 
 	// Just go through each theme and show its information - thumbnail, etc.
-	foreach (Utils::$context['available_themes'] as $theme)
+	for ($i = 0; $i < 2; $i++)
 	{
 		echo '
-			<div class="cat_bar">
-				<h3 class="catbg">
+		<div class="cat_bar">
+			<h3 class="catbg">', Lang::getTxt($i == 0 ? 'current_theme' : 'theme_pick', file: 'Themes'), '</h3>
+		</div>
+		<div class="windowbg">';
+
+		// Just go through each theme and show its information - thumbnail, etc.
+		foreach (Utils::$context['available_themes'] as $theme)
+		{
+			if (($theme['selected'] && $i == 0) || (!$theme['selected'] && $i == 1))
+			{
+				echo '
+			<div class="title_bar">
+				<h3 class="titlebg">
 					', $theme['name'], '
 				</h3>
 			</div>
-			<div class="windowbg', $theme['selected'] ? ' selected' : '', '">
-				<div class="flow_hidden">
-					<div class="floatright">
-						<a href="', Config::$scripturl, '?action=themechooser;u=', Utils::$context['current_member'], ';theme=', $theme['id'], ';', Utils::$context['session_var'], '=', Utils::$context['session_id'], '" id="theme_thumb_preview_', $theme['id'], '" title="', Lang::getTxt('theme_preview', file: 'Themes'), '">
-							<img src="', $theme['thumbnail_href'], '" id="theme_thumb_', $theme['id'], '" alt="" class="padding theme_thumbnail">
-						</a>
-					</div>
-					<p>', $theme['description'], '</p>';
+			<div>
+				<small><i>', $theme['description'], '</i></small>';
 
-		if (!empty($theme['variants']))
-		{
-			echo '
-					<label for="variant', $theme['id'], '"><strong>', $theme['pick_label'], '</strong></label>:
-					<select id="variant', $theme['id'], '" name="vrt[', $theme['id'], ']" onchange="changeVariant(', $theme['id'], ', this);">';
+				if (!empty($theme['variants']))
+				{
+					echo '
+				<label><strong>', $theme['pick_label'], '</strong>
+					<select data-theme-id="', $theme['id'], '" name="vrt[', $theme['id'], ']">';
 
-			foreach ($theme['variants'] as $key => $variant)
+					foreach ($theme['variants'] as $key => $variant)
+						echo '
+						<option value="', $key, '"', $theme['selected_variant'] == $key ? ' selected' : '', ' data-url="', $variant['thumbnail'], '">', $variant['label'], '</option>';
+
+					echo '
+					</select>
+				</label>';
+				}
+
 				echo '
-						<option value="', $key, '"', $theme['selected_variant'] == $key ? ' selected' : '', '>', $variant['label'], '</option>';
-
-			echo '
-					</select>';
-		}
-
-		echo '
-					<br>
-					<p>
-						<em class="smalltext">', Lang::getTxt('theme_num_users', [$theme['num_users']], file: 'Themes'), '</em>
-					</p>
-					<br>
-					<ul>
-						<li class="lower_padding">
-							<input type="submit" name="save[', $theme['id'], ']" value="', Lang::getTxt('theme_set', file: 'Themes'), '" class="button">
-						</li>
-						<li>
-							<a class="button" href="', Config::$scripturl, '?action=themechooser;theme=', $theme['id'], '" id="theme_preview_', $theme['id'], '">', Lang::getTxt('theme_preview', file: 'Themes'), '</a>
-						</li>
-					</ul>
+				<div>
+					<input type="submit" name="save[', $theme['id'], ']" value="', Lang::getTxt('theme_set', file:'Themes'), '" class="button">
+					<a class="button" href="', Config::$scripturl, '?action=theme;sa=pick;theme=', $theme['id'], '" id="theme_preview_', $theme['id'], '">', Lang::getTxt('theme_preview', file:'Themes'), '</a>
 				</div>
+			</div>
+			<div>
+				<a href="', Config::$scripturl, '?action=theme;sa=pick;u=', Utils::$context['current_member'], ';theme=', $theme['id'], ';', Utils::$context['session_var'], '=', Utils::$context['session_id'], '" id="theme_thumb_preview_', $theme['id'], '" title="', Lang::getTxt('theme_preview', file: 'Themes'), '">
+					<img src="', $theme['thumbnail_href'], '" id="theme_thumb_', $theme['id'], '" alt="" class="padding theme_thumbnail">
+				</a>
 			</div>';
+			}
 		}
 
 		echo '
-			<input type="hidden" name="', Utils::$context['session_var'], '" value="', Utils::$context['session_id'], '">
-			<input type="hidden" name="', Utils::$context['pick-th_token_var'], '" value="', Utils::$context['pick-th_token'], '">
-			<input type="hidden" name="u" value="', Utils::$context['current_member'], '">
-		</form>
-	</div><!-- #pick_theme -->';
+		</div>
+		<input type="hidden" name="', Utils::$context['session_var'], '" value="', Utils::$context['session_id'], '">
+		<input type="hidden" name="', Utils::$context['pick-th_token_var'], '" value="', Utils::$context['pick-th_token'], '">
+		<input type="hidden" name="u" value="', Utils::$context['current_member'], '">';
+	}
 }
 
 /**

--- a/Themes/default/index.template.php
+++ b/Themes/default/index.template.php
@@ -53,6 +53,29 @@ function template_init()
 	// The version this template/theme is for. This should probably be the version of SMF it was created for.
 	Theme::$current->settings['theme_version'] = '2.1';
 
+	/*
+	 * Whether this theme supports a dark mode.
+	 *
+	 * Set this to `false` to disable.
+	 * 
+	 * A not so trivial note:
+	 * A 'dark' theme with dark mode is exactly the same as a 'light'
+	 * theme with dark mode. This means the index.css file should
+	 * always contain the light colors.
+	 */
+	Theme::$current->settings['has_dark_mode'] = false;
+
+	/*
+	 * Define the theme variants. Each variant has its own CSS file.
+	 *
+	 * Example:
+	 * - index_red.css is loaded when the user selects the `red` variant.
+	 * 
+	 * Additionally, a variants.css file is always loaded as well, in
+	 * case you'd rather keep the styles in a single file or they're minimal.
+	 */
+	Theme::$current->settings['theme_variants'] = [];
+
 	// Set the following variable to true if this theme wants to display the avatar of the user that posted the last and the first post on the message index and recent pages.
 	Theme::$current->settings['avatars_on_indexes'] = false;
 
@@ -76,7 +99,7 @@ function template_init()
 	// Allow css/js files to be disabled for this specific theme.
 	// Add the identifier as an array key. IE array('smf_script'); Some external files might not add identifiers, on those cases SMF uses its filename as reference.
 	if (!isset(Theme::$current->settings['disable_files']))
-		Theme::$current->settings['disable_files'] = array();
+		Theme::$current->settings['disable_files'] = [];
 }
 
 /**
@@ -86,7 +109,8 @@ function template_html_above()
 {
 	// Show right to left, the language code, and the character set for ease of translating.
 	echo '<!DOCTYPE html>
-<html', Utils::$context['right_to_left'] ? ' dir="rtl"' : '', !empty(Lang::getTxt('lang_locale', file: 'General')) ? ' lang="' . str_replace("_", "-", substr(Lang::getTxt('lang_locale', file: 'General'), 0, strcspn(Lang::getTxt('lang_locale', file: 'General'), "."))) . '"' : '', '>
+<html', Utils::$context['right_to_left'] ? ' dir="rtl"' : '', !empty(Lang::getTxt('lang_locale', file: 'General')) ? ' lang="' . str_replace("_", "-", substr(Lang::getTxt('lang_locale', file: 'General'), 0, strcspn(Lang::getTxt('lang_locale', file: 'General'), "."))) . '"' : '',!empty(Theme::$current->settings['theme_variants']) ? ' data-variant=' . (Utils::$context['theme_variant'] ?: 'default') . '' : '', !empty(Theme::$current->settings['has_dark_mode']) ? ' data-mode=' . (Utils::$context['theme_colormode'] ?? 'light') . '' : '', '>
+
 <head>
 	<meta charset="UTF-8">';
 


### PR DESCRIPTION
Logic pulled from #7933
Does not add a dark mode to the default theme, but enables it to support it