### PR TITLE
[3.0] Improves PHP-CS-Fixer workflow

### DIFF
--- a/.github/workflows/php-cs-fixer.yml
+++ b/.github/workflows/php-cs-fixer.yml
@@ -8,14 +8,14 @@ on:
 
 jobs:
   php-cs-fixer:
-    name: PHP-CS-Fixer
+    name: Code standard compliance check
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #4.2.2
 
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@v46
+        uses: tj-actions/changed-files@8cba46e29c11878d930bca7870bb54394d3e8b21
 
       - name: Get extra arguments for PHP-CS-Fixer
         id: phpcs-intersection
@@ -29,4 +29,4 @@ jobs:
       - name: PHP-CS-Fixer
         uses: docker://oskarstark/php-cs-fixer-ga
         with:
-          args: --config=.php-cs-fixer.dist.php -v --dry-run --stop-on-violation --using-cache=no --quiet --allow-risky=yes ${{ env.PHPCS_EXTRA_ARGS }}
+          args: --config=.php-cs-fixer.dist.php -v --dry-run --diff --no-ansi --show-progress=none --using-cache=no --allow-risky=yes ${{ env.PHPCS_EXTRA_ARGS }}


### PR DESCRIPTION
1. As requested by @jdarwood007, now pegs the call to tj-actions/changed-files to a specific hash rather than a version. Note that when I tried reverting to the raw shell code that was used prior to #9110, the action stopped working, which strongly suggests that said shell code was the cause of the problem that #9110 fixed.
2. To address an issue raised by @Oldiesmann, the error message in the action output now shows the changes that need to be made in order to comply with our code standard.