### PR TITLE
[3.0] Adds migration and cleanup steps for upgrading from old versions

### DIFF
--- a/Sources/Db/Schema/v1_0/Attachments.php
+++ b/Sources/Db/Schema/v1_0/Attachments.php
@@ -1,0 +1,122 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v1_0;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class Attachments extends Table
+{
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'attachments';
+
+		$this->columns = [
+			'ID_ATTACH' => new Column(
+				name: 'ID_ATTACH',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				auto: true,
+			),
+			'ID_MSG' => new Column(
+				name: 'ID_MSG',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'ID_MEMBER' => new Column(
+				name: 'ID_MEMBER',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'filename' => new Column(
+				name: 'filename',
+				type: 'tinytext',
+				not_null: true,
+				default: '',
+			),
+			'file_hash' => new Column(
+				name: 'file_hash',
+				type: 'varchar',
+				size: 40,
+				not_null: true,
+				default: '',
+			),
+			'size' => new Column(
+				name: 'size',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'downloads' => new Column(
+				name: 'downloads',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'ID_ATTACH',
+					],
+				],
+			),
+			'ID_MEMBER' => new DbIndex(
+				type: 'unique',
+				name: 'ID_MEMBER',
+				columns: [
+					[
+						'name' => 'ID_MEMBER',
+					],
+					[
+						'name' => 'ID_ATTACH',
+					],
+				],
+			),
+			'ID_MSG' => new DbIndex(
+				name: 'ID_MSG',
+				columns: [
+					[
+						'name' => 'ID_MSG',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v1_0/Banned.php
+++ b/Sources/Db/Schema/v1_0/Banned.php
@@ -1,0 +1,174 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v1_0;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class Banned extends Table
+{
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'banned';
+
+		$this->columns = [
+			'ID_BAN' => new Column(
+				name: 'ID_BAN',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				auto: true,
+			),
+			'ban_type' => new Column(
+				name: 'ban_type',
+				type: 'varchar',
+				size: 30,
+				not_null: true,
+				default: '',
+			),
+			'ip_low1' => new Column(
+				name: 'ip_low1',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'ip_high1' => new Column(
+				name: 'ip_high1',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'ip_low2' => new Column(
+				name: 'ip_low2',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'ip_high2' => new Column(
+				name: 'ip_high2',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'ip_low3' => new Column(
+				name: 'ip_low3',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'ip_high3' => new Column(
+				name: 'ip_high3',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'ip_low4' => new Column(
+				name: 'ip_low4',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'ip_high4' => new Column(
+				name: 'ip_high4',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'hostname' => new Column(
+				name: 'hostname',
+				type: 'tinytext',
+				not_null: true,
+				default: '',
+			),
+			'email_address' => new Column(
+				name: 'email_address',
+				type: 'tinytext',
+				not_null: true,
+				default: '',
+			),
+			'ID_MEMBER' => new Column(
+				name: 'ID_MEMBER',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'ban_time' => new Column(
+				name: 'ban_time',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'expire_time' => new Column(
+				name: 'expire_time',
+				type: 'int',
+				unsigned: true,
+			),
+			'restriction_type' => new Column(
+				name: 'restriction_type',
+				type: 'varchar',
+				size: 30,
+				not_null: true,
+				default: '',
+			),
+			'reason' => new Column(
+				name: 'reason',
+				type: 'tinytext',
+				not_null: true,
+				default: '',
+			),
+			'notes' => new Column(
+				name: 'notes',
+				type: 'text',
+				not_null: true,
+				default: '',
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'ID_BAN',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v1_0/BoardPermissions.php
+++ b/Sources/Db/Schema/v1_0/BoardPermissions.php
@@ -1,0 +1,443 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v1_0;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class BoardPermissions extends Table
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 * @var array
+	 *
+	 * Data used to populate the table during install.
+	 */
+	public array $initial_data = [
+		[
+			'ID_GROUP' => -1,
+			'ID_BOARD' => 0,
+			'permission' => 'poll_view',
+		],
+		[
+			'ID_GROUP' => 0,
+			'ID_BOARD' => 0,
+			'permission' => 'delete_own',
+		],
+		[
+			'ID_GROUP' => 0,
+			'ID_BOARD' => 0,
+			'permission' => 'lock_own',
+		],
+		[
+			'ID_GROUP' => 0,
+			'ID_BOARD' => 0,
+			'permission' => 'mark_any_notify',
+		],
+		[
+			'ID_GROUP' => 0,
+			'ID_BOARD' => 0,
+			'permission' => 'mark_notify',
+		],
+		[
+			'ID_GROUP' => 0,
+			'ID_BOARD' => 0,
+			'permission' => 'modify_own',
+		],
+		[
+			'ID_GROUP' => 0,
+			'ID_BOARD' => 0,
+			'permission' => 'poll_add_own',
+		],
+		[
+			'ID_GROUP' => 0,
+			'ID_BOARD' => 0,
+			'permission' => 'poll_edit_own',
+		],
+		[
+			'ID_GROUP' => 0,
+			'ID_BOARD' => 0,
+			'permission' => 'poll_lock_own',
+		],
+		[
+			'ID_GROUP' => 0,
+			'ID_BOARD' => 0,
+			'permission' => 'poll_post',
+		],
+		[
+			'ID_GROUP' => 0,
+			'ID_BOARD' => 0,
+			'permission' => 'poll_view',
+		],
+		[
+			'ID_GROUP' => 0,
+			'ID_BOARD' => 0,
+			'permission' => 'poll_vote',
+		],
+		[
+			'ID_GROUP' => 0,
+			'ID_BOARD' => 0,
+			'permission' => 'post_attachment',
+		],
+		[
+			'ID_GROUP' => 0,
+			'ID_BOARD' => 0,
+			'permission' => 'post_new',
+		],
+		[
+			'ID_GROUP' => 0,
+			'ID_BOARD' => 0,
+			'permission' => 'post_reply_any',
+		],
+		[
+			'ID_GROUP' => 0,
+			'ID_BOARD' => 0,
+			'permission' => 'post_reply_own',
+		],
+		[
+			'ID_GROUP' => 0,
+			'ID_BOARD' => 0,
+			'permission' => 'remove_own',
+		],
+		[
+			'ID_GROUP' => 0,
+			'ID_BOARD' => 0,
+			'permission' => 'report_any',
+		],
+		[
+			'ID_GROUP' => 0,
+			'ID_BOARD' => 0,
+			'permission' => 'send_topic',
+		],
+		[
+			'ID_GROUP' => 0,
+			'ID_BOARD' => 0,
+			'permission' => 'view_attachments',
+		],
+		[
+			'ID_GROUP' => 2,
+			'ID_BOARD' => 0,
+			'permission' => 'moderate_board',
+		],
+		[
+			'ID_GROUP' => 2,
+			'ID_BOARD' => 0,
+			'permission' => 'post_new',
+		],
+		[
+			'ID_GROUP' => 2,
+			'ID_BOARD' => 0,
+			'permission' => 'post_reply_own',
+		],
+		[
+			'ID_GROUP' => 2,
+			'ID_BOARD' => 0,
+			'permission' => 'post_reply_any',
+		],
+		[
+			'ID_GROUP' => 2,
+			'ID_BOARD' => 0,
+			'permission' => 'poll_post',
+		],
+		[
+			'ID_GROUP' => 2,
+			'ID_BOARD' => 0,
+			'permission' => 'poll_add_any',
+		],
+		[
+			'ID_GROUP' => 2,
+			'ID_BOARD' => 0,
+			'permission' => 'poll_remove_any',
+		],
+		[
+			'ID_GROUP' => 2,
+			'ID_BOARD' => 0,
+			'permission' => 'poll_view',
+		],
+		[
+			'ID_GROUP' => 2,
+			'ID_BOARD' => 0,
+			'permission' => 'poll_vote',
+		],
+		[
+			'ID_GROUP' => 2,
+			'ID_BOARD' => 0,
+			'permission' => 'poll_edit_any',
+		],
+		[
+			'ID_GROUP' => 2,
+			'ID_BOARD' => 0,
+			'permission' => 'report_any',
+		],
+		[
+			'ID_GROUP' => 2,
+			'ID_BOARD' => 0,
+			'permission' => 'lock_own',
+		],
+		[
+			'ID_GROUP' => 2,
+			'ID_BOARD' => 0,
+			'permission' => 'send_topic',
+		],
+		[
+			'ID_GROUP' => 2,
+			'ID_BOARD' => 0,
+			'permission' => 'mark_any_notify',
+		],
+		[
+			'ID_GROUP' => 2,
+			'ID_BOARD' => 0,
+			'permission' => 'mark_notify',
+		],
+		[
+			'ID_GROUP' => 2,
+			'ID_BOARD' => 0,
+			'permission' => 'remove_own',
+		],
+		[
+			'ID_GROUP' => 2,
+			'ID_BOARD' => 0,
+			'permission' => 'modify_own',
+		],
+		[
+			'ID_GROUP' => 2,
+			'ID_BOARD' => 0,
+			'permission' => 'make_sticky',
+		],
+		[
+			'ID_GROUP' => 2,
+			'ID_BOARD' => 0,
+			'permission' => 'lock_any',
+		],
+		[
+			'ID_GROUP' => 2,
+			'ID_BOARD' => 0,
+			'permission' => 'delete_any',
+		],
+		[
+			'ID_GROUP' => 2,
+			'ID_BOARD' => 0,
+			'permission' => 'move_any',
+		],
+		[
+			'ID_GROUP' => 2,
+			'ID_BOARD' => 0,
+			'permission' => 'merge_any',
+		],
+		[
+			'ID_GROUP' => 2,
+			'ID_BOARD' => 0,
+			'permission' => 'split_any',
+		],
+		[
+			'ID_GROUP' => 2,
+			'ID_BOARD' => 0,
+			'permission' => 'remove_any',
+		],
+		[
+			'ID_GROUP' => 2,
+			'ID_BOARD' => 0,
+			'permission' => 'modify_any',
+		],
+		[
+			'ID_GROUP' => 3,
+			'ID_BOARD' => 0,
+			'permission' => 'moderate_board',
+		],
+		[
+			'ID_GROUP' => 3,
+			'ID_BOARD' => 0,
+			'permission' => 'post_new',
+		],
+		[
+			'ID_GROUP' => 3,
+			'ID_BOARD' => 0,
+			'permission' => 'post_reply_own',
+		],
+		[
+			'ID_GROUP' => 3,
+			'ID_BOARD' => 0,
+			'permission' => 'post_reply_any',
+		],
+		[
+			'ID_GROUP' => 3,
+			'ID_BOARD' => 0,
+			'permission' => 'poll_post',
+		],
+		[
+			'ID_GROUP' => 3,
+			'ID_BOARD' => 0,
+			'permission' => 'poll_add_own',
+		],
+		[
+			'ID_GROUP' => 3,
+			'ID_BOARD' => 0,
+			'permission' => 'poll_remove_any',
+		],
+		[
+			'ID_GROUP' => 3,
+			'ID_BOARD' => 0,
+			'permission' => 'poll_view',
+		],
+		[
+			'ID_GROUP' => 3,
+			'ID_BOARD' => 0,
+			'permission' => 'poll_vote',
+		],
+		[
+			'ID_GROUP' => 3,
+			'ID_BOARD' => 0,
+			'permission' => 'report_any',
+		],
+		[
+			'ID_GROUP' => 3,
+			'ID_BOARD' => 0,
+			'permission' => 'lock_own',
+		],
+		[
+			'ID_GROUP' => 3,
+			'ID_BOARD' => 0,
+			'permission' => 'send_topic',
+		],
+		[
+			'ID_GROUP' => 3,
+			'ID_BOARD' => 0,
+			'permission' => 'mark_any_notify',
+		],
+		[
+			'ID_GROUP' => 3,
+			'ID_BOARD' => 0,
+			'permission' => 'mark_notify',
+		],
+		[
+			'ID_GROUP' => 3,
+			'ID_BOARD' => 0,
+			'permission' => 'remove_own',
+		],
+		[
+			'ID_GROUP' => 3,
+			'ID_BOARD' => 0,
+			'permission' => 'modify_own',
+		],
+		[
+			'ID_GROUP' => 3,
+			'ID_BOARD' => 0,
+			'permission' => 'make_sticky',
+		],
+		[
+			'ID_GROUP' => 3,
+			'ID_BOARD' => 0,
+			'permission' => 'lock_any',
+		],
+		[
+			'ID_GROUP' => 3,
+			'ID_BOARD' => 0,
+			'permission' => 'delete_any',
+		],
+		[
+			'ID_GROUP' => 3,
+			'ID_BOARD' => 0,
+			'permission' => 'move_any',
+		],
+		[
+			'ID_GROUP' => 3,
+			'ID_BOARD' => 0,
+			'permission' => 'merge_any',
+		],
+		[
+			'ID_GROUP' => 3,
+			'ID_BOARD' => 0,
+			'permission' => 'split_any',
+		],
+		[
+			'ID_GROUP' => 3,
+			'ID_BOARD' => 0,
+			'permission' => 'remove_any',
+		],
+		[
+			'ID_GROUP' => 3,
+			'ID_BOARD' => 0,
+			'permission' => 'modify_any',
+		],
+	];
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'board_permissions';
+
+		$this->columns = [
+			'ID_GROUP' => new Column(
+				name: 'ID_GROUP',
+				type: 'smallint',
+				not_null: true,
+				default: 0,
+			),
+			'ID_BOARD' => new Column(
+				name: 'ID_BOARD',
+				type: 'smallint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'permission' => new Column(
+				name: 'permission',
+				type: 'varchar',
+				size: 30,
+				not_null: true,
+				default: '',
+			),
+			'addDeny' => new Column(
+				name: 'addDeny',
+				type: 'tinyint',
+				not_null: true,
+				default: 1,
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'ID_GROUP',
+					],
+					[
+						'name' => 'ID_BOARD',
+					],
+					[
+						'name' => 'permission',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v1_0/Boards.php
+++ b/Sources/Db/Schema/v1_0/Boards.php
@@ -1,0 +1,240 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v1_0;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class Boards extends Table
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 * @var array
+	 *
+	 * Data used to populate the table during install.
+	 */
+	public array $initial_data = [
+		[
+			'ID_BOARD' => 1,
+			'ID_CAT' => 1,
+			'boardOrder' => 1,
+			'ID_LAST_MSG' => 1,
+			'lastUpdated' => '{$current_time}',
+			'name' => '{$default_board_name}',
+			'description' => '{$default_board_description}',
+			'numTopics' => 1,
+			'numPosts' => 1,
+		],
+	];
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'boards';
+
+		$this->columns = [
+			'ID_BOARD' => new Column(
+				name: 'ID_BOARD',
+				type: 'smallint',
+				unsigned: true,
+				not_null: true,
+				auto: true,
+			),
+			'ID_CAT' => new Column(
+				name: 'ID_CAT',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'childLevel' => new Column(
+				name: 'childLevel',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'ID_PARENT' => new Column(
+				name: 'ID_PARENT',
+				type: 'smallint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'boardOrder' => new Column(
+				name: 'boardOrder',
+				type: 'smallint',
+				not_null: true,
+				default: 0,
+			),
+			'ID_LAST_MSG' => new Column(
+				name: 'ID_LAST_MSG',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'lastUpdated' => new Column(
+				name: 'lastUpdated',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'memberGroups' => new Column(
+				name: 'memberGroups',
+				type: 'varchar',
+				size: 128,
+				not_null: true,
+				default: '-1,0',
+			),
+			'name' => new Column(
+				name: 'name',
+				type: 'tinytext',
+				not_null: true,
+				default: '',
+			),
+			'description' => new Column(
+				name: 'description',
+				type: 'text',
+				not_null: true,
+				default: '',
+			),
+			'numTopics' => new Column(
+				name: 'numTopics',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'numPosts' => new Column(
+				name: 'numPosts',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'countPosts' => new Column(
+				name: 'countPosts',
+				type: 'tinyint',
+				not_null: true,
+				default: 0,
+			),
+			'ID_THEME' => new Column(
+				name: 'ID_THEME',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'use_local_permissions' => new Column(
+				name: 'use_local_permissions',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'override_theme' => new Column(
+				name: 'override_theme',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'ID_BOARD',
+					],
+				],
+			),
+			'categories' => new DbIndex(
+				type: 'unique',
+				name: 'categories',
+				columns: [
+					[
+						'name' => 'ID_CAT',
+					],
+					[
+						'name' => 'ID_BOARD',
+					],
+				],
+			),
+			'children' => new DbIndex(
+				type: 'unique',
+				name: 'children',
+				columns: [
+					[
+						'name' => 'childLevel',
+					],
+					[
+						'name' => 'ID_PARENT',
+					],
+					[
+						'name' => 'boardOrder',
+					],
+					[
+						'name' => 'ID_BOARD',
+					],
+				],
+			),
+			'boardOrder' => new DbIndex(
+				name: 'boardOrder',
+				columns: [
+					[
+						'name' => 'boardOrder',
+					],
+				],
+			),
+			'lastUpdated' => new DbIndex(
+				name: 'lastUpdated',
+				columns: [
+					[
+						'name' => 'lastUpdated',
+					],
+				],
+			),
+			'memberGroups' => new DbIndex(
+				name: 'memberGroups',
+				columns: [
+					[
+						'name' => 'memberGroups',
+						'size' => 48,
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v1_0/Calendar.php
+++ b/Sources/Db/Schema/v1_0/Calendar.php
@@ -1,0 +1,105 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v1_0;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class Calendar extends Table
+{
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'calendar';
+
+		$this->columns = [
+			'ID_EVENT' => new Column(
+				name: 'ID_EVENT',
+				type: 'smallint',
+				unsigned: true,
+				not_null: true,
+				auto: true,
+			),
+			'eventDate' => new Column(
+				name: 'eventDate',
+				type: 'date',
+				not_null: true,
+				// SMF 1.0 actually used '0000-00-00', but modern versions
+				// of MySQL don't like that.
+				default: '1004-01-01',
+			),
+			'ID_BOARD' => new Column(
+				name: 'ID_BOARD',
+				type: 'smallint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'ID_TOPIC' => new Column(
+				name: 'ID_TOPIC',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'title' => new Column(
+				name: 'title',
+				type: 'varchar',
+				size: 48,
+				not_null: true,
+				default: '',
+			),
+			'ID_MEMBER' => new Column(
+				name: 'ID_MEMBER',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'ID_EVENT',
+					],
+				],
+			),
+			'eventDate' => new DbIndex(
+				name: 'eventDate',
+				columns: [
+					[
+						'name' => 'eventDate',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v1_0/CalendarHolidays.php
+++ b/Sources/Db/Schema/v1_0/CalendarHolidays.php
@@ -1,0 +1,474 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v1_0;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class CalendarHolidays extends Table
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 * @var array
+	 *
+	 * Data used to populate the table during install.
+	 */
+	public array $initial_data = [
+		[
+			'title' => 'New Year\'s',
+			'eventDate' => '1004-01-01',
+		],
+		[
+			'title' => 'Christmas',
+			'eventDate' => '1004-12-25',
+		],
+		[
+			'title' => 'Valentine\'s Day',
+			'eventDate' => '1004-02-14',
+		],
+		[
+			'title' => 'St. Patrick\'s Day',
+			'eventDate' => '1004-03-17',
+		],
+		[
+			'title' => 'April Fools',
+			'eventDate' => '1004-04-01',
+		],
+		[
+			'title' => 'Earth Day',
+			'eventDate' => '1004-04-22',
+		],
+		[
+			'title' => 'United Nations Day',
+			'eventDate' => '1004-10-24',
+		],
+		[
+			'title' => 'Halloween',
+			'eventDate' => '1004-10-31',
+		],
+		[
+			'title' => 'Mother\'s Day',
+			'eventDate' => '2002-05-12',
+		],
+		[
+			'title' => 'Mother\'s Day',
+			'eventDate' => '2003-05-11',
+		],
+		[
+			'title' => 'Mother\'s Day',
+			'eventDate' => '2004-05-09',
+		],
+		[
+			'title' => 'Mother\'s Day',
+			'eventDate' => '2005-05-08',
+		],
+		[
+			'title' => 'Mother\'s Day',
+			'eventDate' => '2006-05-14',
+		],
+		[
+			'title' => 'Mother\'s Day',
+			'eventDate' => '2007-05-13',
+		],
+		[
+			'title' => 'Mother\'s Day',
+			'eventDate' => '2008-05-11',
+		],
+		[
+			'title' => 'Mother\'s Day',
+			'eventDate' => '2009-05-10',
+		],
+		[
+			'title' => 'Mother\'s Day',
+			'eventDate' => '2010-05-09',
+		],
+		[
+			'title' => 'Father\'s Day',
+			'eventDate' => '2002-06-16',
+		],
+		[
+			'title' => 'Father\'s Day',
+			'eventDate' => '2003-06-15',
+		],
+		[
+			'title' => 'Father\'s Day',
+			'eventDate' => '2004-06-20',
+		],
+		[
+			'title' => 'Father\'s Day',
+			'eventDate' => '2005-06-19',
+		],
+		[
+			'title' => 'Father\'s Day',
+			'eventDate' => '2006-06-18',
+		],
+		[
+			'title' => 'Father\'s Day',
+			'eventDate' => '2007-06-17',
+		],
+		[
+			'title' => 'Father\'s Day',
+			'eventDate' => '2008-06-15',
+		],
+		[
+			'title' => 'Father\'s Day',
+			'eventDate' => '2009-06-21',
+		],
+		[
+			'title' => 'Father\'s Day',
+			'eventDate' => '2010-06-20',
+		],
+		[
+			'title' => 'Summer Solstice',
+			'eventDate' => '2002-06-21',
+		],
+		[
+			'title' => 'Summer Solstice',
+			'eventDate' => '2003-06-21',
+		],
+		[
+			'title' => 'Summer Solstice',
+			'eventDate' => '2004-06-20',
+		],
+		[
+			'title' => 'Summer Solstice',
+			'eventDate' => '2005-06-20',
+		],
+		[
+			'title' => 'Summer Solstice',
+			'eventDate' => '2006-06-21',
+		],
+		[
+			'title' => 'Summer Solstice',
+			'eventDate' => '2007-06-21',
+		],
+		[
+			'title' => 'Summer Solstice',
+			'eventDate' => '2008-06-20',
+		],
+		[
+			'title' => 'Summer Solstice',
+			'eventDate' => '2009-06-20',
+		],
+		[
+			'title' => 'Summer Solstice',
+			'eventDate' => '2010-06-21',
+		],
+		[
+			'title' => 'Vernal Equinox',
+			'eventDate' => '2002-03-20',
+		],
+		[
+			'title' => 'Vernal Equinox',
+			'eventDate' => '2003-03-20',
+		],
+		[
+			'title' => 'Vernal Equinox',
+			'eventDate' => '2004-03-19',
+		],
+		[
+			'title' => 'Vernal Equinox',
+			'eventDate' => '2005-03-20',
+		],
+		[
+			'title' => 'Vernal Equinox',
+			'eventDate' => '2006-03-20',
+		],
+		[
+			'title' => 'Vernal Equinox',
+			'eventDate' => '2007-03-20',
+		],
+		[
+			'title' => 'Vernal Equinox',
+			'eventDate' => '2008-03-19',
+		],
+		[
+			'title' => 'Vernal Equinox',
+			'eventDate' => '2009-03-20',
+		],
+		[
+			'title' => 'Vernal Equinox',
+			'eventDate' => '2010-03-20',
+		],
+		[
+			'title' => 'Winter Solstice',
+			'eventDate' => '2002-12-21',
+		],
+		[
+			'title' => 'Winter Solstice',
+			'eventDate' => '2003-12-22',
+		],
+		[
+			'title' => 'Winter Solstice',
+			'eventDate' => '2004-12-21',
+		],
+		[
+			'title' => 'Winter Solstice',
+			'eventDate' => '2005-12-21',
+		],
+		[
+			'title' => 'Winter Solstice',
+			'eventDate' => '2006-12-22',
+		],
+		[
+			'title' => 'Winter Solstice',
+			'eventDate' => '2007-12-22',
+		],
+		[
+			'title' => 'Winter Solstice',
+			'eventDate' => '2008-12-21',
+		],
+		[
+			'title' => 'Winter Solstice',
+			'eventDate' => '2009-12-21',
+		],
+		[
+			'title' => 'Winter Solstice',
+			'eventDate' => '2010-12-21',
+		],
+		[
+			'title' => 'Autumnal Equinox',
+			'eventDate' => '2002-09-22',
+		],
+		[
+			'title' => 'Autumnal Equinox',
+			'eventDate' => '2003-09-23',
+		],
+		[
+			'title' => 'Autumnal Equinox',
+			'eventDate' => '2004-09-22',
+		],
+		[
+			'title' => 'Autumnal Equinox',
+			'eventDate' => '2005-09-22',
+		],
+		[
+			'title' => 'Autumnal Equinox',
+			'eventDate' => '2006-09-22',
+		],
+		[
+			'title' => 'Autumnal Equinox',
+			'eventDate' => '2007-09-23',
+		],
+		[
+			'title' => 'Autumnal Equinox',
+			'eventDate' => '2008-09-22',
+		],
+		[
+			'title' => 'Autumnal Equinox',
+			'eventDate' => '2009-09-22',
+		],
+		[
+			'title' => 'Autumnal Equinox',
+			'eventDate' => '2010-09-22',
+		],
+		[
+			'title' => 'Independence Day',
+			'eventDate' => '1004-07-04',
+		],
+		[
+			'title' => 'Cinco de Mayo',
+			'eventDate' => '1004-05-05',
+		],
+		[
+			'title' => 'Flag Day',
+			'eventDate' => '1004-06-14',
+		],
+		[
+			'title' => 'Veterans Day',
+			'eventDate' => '1004-11-11',
+		],
+		[
+			'title' => 'Groundhog Day',
+			'eventDate' => '1004-02-02',
+		],
+		[
+			'title' => 'Thanksgiving',
+			'eventDate' => '2002-11-28',
+		],
+		[
+			'title' => 'Thanksgiving',
+			'eventDate' => '2003-11-27',
+		],
+		[
+			'title' => 'Thanksgiving',
+			'eventDate' => '2004-11-25',
+		],
+		[
+			'title' => 'Thanksgiving',
+			'eventDate' => '2005-11-24',
+		],
+		[
+			'title' => 'Thanksgiving',
+			'eventDate' => '2006-11-23',
+		],
+		[
+			'title' => 'Thanksgiving',
+			'eventDate' => '2007-11-22',
+		],
+		[
+			'title' => 'Thanksgiving',
+			'eventDate' => '2008-11-27',
+		],
+		[
+			'title' => 'Thanksgiving',
+			'eventDate' => '2009-11-26',
+		],
+		[
+			'title' => 'Thanksgiving',
+			'eventDate' => '2010-11-25',
+		],
+		[
+			'title' => 'Memorial Day',
+			'eventDate' => '2002-05-27',
+		],
+		[
+			'title' => 'Memorial Day',
+			'eventDate' => '2003-05-26',
+		],
+		[
+			'title' => 'Memorial Day',
+			'eventDate' => '2004-05-31',
+		],
+		[
+			'title' => 'Memorial Day',
+			'eventDate' => '2005-05-30',
+		],
+		[
+			'title' => 'Memorial Day',
+			'eventDate' => '2006-05-29',
+		],
+		[
+			'title' => 'Memorial Day',
+			'eventDate' => '2007-05-28',
+		],
+		[
+			'title' => 'Memorial Day',
+			'eventDate' => '2008-05-26',
+		],
+		[
+			'title' => 'Memorial Day',
+			'eventDate' => '2009-05-25',
+		],
+		[
+			'title' => 'Memorial Day',
+			'eventDate' => '2010-05-31',
+		],
+		[
+			'title' => 'Labor Day',
+			'eventDate' => '2002-09-02',
+		],
+		[
+			'title' => 'Labor Day',
+			'eventDate' => '2003-09-01',
+		],
+		[
+			'title' => 'Labor Day',
+			'eventDate' => '2004-09-06',
+		],
+		[
+			'title' => 'Labor Day',
+			'eventDate' => '2005-09-05',
+		],
+		[
+			'title' => 'Labor Day',
+			'eventDate' => '2006-09-04',
+		],
+		[
+			'title' => 'Labor Day',
+			'eventDate' => '2007-09-03',
+		],
+		[
+			'title' => 'Labor Day',
+			'eventDate' => '2008-09-01',
+		],
+		[
+			'title' => 'Labor Day',
+			'eventDate' => '2009-09-07',
+		],
+		[
+			'title' => 'Labor Day',
+			'eventDate' => '2010-09-06',
+		],
+		[
+			'title' => 'D-Day',
+			'eventDate' => '1004-06-06',
+		],
+	];
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'calendar_holidays';
+
+		$this->columns = [
+			'ID_HOLIDAY' => new Column(
+				name: 'ID_HOLIDAY',
+				type: 'smallint',
+				unsigned: true,
+				not_null: true,
+				auto: true,
+			),
+			'eventDate' => new Column(
+				name: 'eventDate',
+				type: 'date',
+				not_null: true,
+				default: '1004-01-01',
+			),
+			'title' => new Column(
+				name: 'title',
+				type: 'varchar',
+				size: 30,
+				not_null: true,
+				default: '',
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'ID_HOLIDAY',
+					],
+				],
+			),
+			'eventDate' => new DbIndex(
+				name: 'eventDate',
+				columns: [
+					[
+						'name' => 'eventDate',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v1_0/Categories.php
+++ b/Sources/Db/Schema/v1_0/Categories.php
@@ -1,0 +1,87 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v1_0;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class Categories extends Table
+{
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'categories';
+
+		$this->columns = [
+			'ID_CAT' => new Column(
+				name: 'ID_CAT',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				auto: true,
+			),
+			'catOrder' => new Column(
+				name: 'catOrder',
+				type: 'tinyint',
+				not_null: true,
+				default: 0,
+			),
+			'name' => new Column(
+				name: 'name',
+				type: 'tinytext',
+				not_null: true,
+				default: '',
+			),
+			'canCollapse' => new Column(
+				name: 'canCollapse',
+				type: 'tinyint',
+				not_null: true,
+				default: 1,
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'ID_CAT',
+					],
+				],
+			),
+			'catOrder' => new DbIndex(
+				name: 'catOrder',
+				columns: [
+					[
+						'name' => 'catOrder',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v1_0/CollapsedCategories.php
+++ b/Sources/Db/Schema/v1_0/CollapsedCategories.php
@@ -1,0 +1,71 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v1_0;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class CollapsedCategories extends Table
+{
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'collapsed_categories';
+
+		$this->columns = [
+			'ID_CAT' => new Column(
+				name: 'ID_CAT',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'ID_MEMBER' => new Column(
+				name: 'ID_MEMBER',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'ID_CAT',
+					],
+					[
+						'name' => 'ID_MEMBER',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v1_0/ImRecipients.php
+++ b/Sources/Db/Schema/v1_0/ImRecipients.php
@@ -1,0 +1,103 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v1_0;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class ImRecipients extends Table
+{
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'im_recipients';
+
+		$this->columns = [
+			'ID_PM' => new Column(
+				name: 'ID_PM',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'ID_MEMBER' => new Column(
+				name: 'ID_MEMBER',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'bcc' => new Column(
+				name: 'bcc',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'is_read' => new Column(
+				name: 'is_read',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'deleted' => new Column(
+				name: 'deleted',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'ID_PM',
+					],
+					[
+						'name' => 'ID_MEMBER',
+					],
+				],
+			),
+			'ID_MEMBER' => new DbIndex(
+				name: 'ID_MEMBER',
+				columns: [
+					[
+						'name' => 'ID_MEMBER',
+					],
+					[
+						'name' => 'deleted',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v1_0/InstantMessages.php
+++ b/Sources/Db/Schema/v1_0/InstantMessages.php
@@ -1,0 +1,115 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v1_0;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class InstantMessages extends Table
+{
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'instant_messages';
+
+		$this->columns = [
+			'ID_PM' => new Column(
+				name: 'ID_PM',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				auto: true,
+			),
+			'ID_MEMBER_FROM' => new Column(
+				name: 'ID_MEMBER_FROM',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'deletedBySender' => new Column(
+				name: 'deletedBySender',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'fromName' => new Column(
+				name: 'fromName',
+				type: 'tinytext',
+				not_null: true,
+			),
+			'msgtime' => new Column(
+				name: 'msgtime',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'subject' => new Column(
+				name: 'subject',
+				type: 'tinytext',
+				not_null: true,
+			),
+			'body' => new Column(
+				name: 'body',
+				type: 'text',
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'ID_PM',
+					],
+				],
+			),
+			'ID_MEMBER' => new DbIndex(
+				name: 'ID_MEMBER',
+				columns: [
+					[
+						'name' => 'ID_MEMBER_FROM',
+					],
+					[
+						'name' => 'deletedBySender',
+					],
+				],
+			),
+			'msgtime' => new DbIndex(
+				name: 'msgtime',
+				columns: [
+					[
+						'name' => 'msgtime',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v1_0/LogActions.php
+++ b/Sources/Db/Schema/v1_0/LogActions.php
@@ -1,0 +1,110 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v1_0;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class LogActions extends Table
+{
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'log_actions';
+
+		$this->columns = [
+			'ID_ACTION' => new Column(
+				name: 'ID_ACTION',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				auto: true,
+			),
+			'logTime' => new Column(
+				name: 'logTime',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'ID_MEMBER' => new Column(
+				name: 'ID_MEMBER',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'IP' => new Column(
+				name: 'IP',
+				type: 'tinytext',
+				not_null: true,
+				default: '',
+			),
+			'action' => new Column(
+				name: 'action',
+				type: 'varchar',
+				size: 30,
+				not_null: true,
+				default: '',
+			),
+			'extra' => new Column(
+				name: 'extra',
+				type: 'text',
+				not_null: true,
+				default: '',
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'ID_ACTION',
+					],
+				],
+			),
+			'logTime' => new DbIndex(
+				name: 'logTime',
+				columns: [
+					[
+						'name' => 'logTime',
+					],
+				],
+			),
+			'ID_MEMBER' => new DbIndex(
+				name: 'ID_MEMBER',
+				columns: [
+					[
+						'name' => 'ID_MEMBER',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v1_0/LogActivity.php
+++ b/Sources/Db/Schema/v1_0/LogActivity.php
@@ -1,0 +1,111 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v1_0;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class LogActivity extends Table
+{
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'log_activity';
+
+		$this->columns = [
+			'date' => new Column(
+				name: 'date',
+				type: 'date',
+				not_null: true,
+				default: '0000-00-00',
+			),
+			'hits' => new Column(
+				name: 'hits',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'topics' => new Column(
+				name: 'topics',
+				type: 'smallint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'posts' => new Column(
+				name: 'posts',
+				type: 'smallint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'registers' => new Column(
+				name: 'registers',
+				type: 'smallint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'mostOn' => new Column(
+				name: 'mostOn',
+				type: 'smallint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'date',
+					],
+				],
+			),
+			'hits' => new DbIndex(
+				name: 'hits',
+				columns: [
+					[
+						'name' => 'hits',
+					],
+				],
+			),
+			'mostOn' => new DbIndex(
+				name: 'mostOn',
+				columns: [
+					[
+						'name' => 'mostOn',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v1_0/LogBanned.php
+++ b/Sources/Db/Schema/v1_0/LogBanned.php
@@ -1,0 +1,91 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v1_0;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class LogBanned extends Table
+{
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'log_banned';
+
+		$this->columns = [
+			'ID_BAN_LOG' => new Column(
+				name: 'ID_BAN_LOG',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				auto: true,
+			),
+			'ID_MEMBER' => new Column(
+				name: 'ID_MEMBER',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'ip' => new Column(
+				name: 'ip',
+				type: 'tinytext',
+			),
+			'email' => new Column(
+				name: 'email',
+				type: 'tinytext',
+			),
+			'logTime' => new Column(
+				name: 'logTime',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'ID_BAN_LOG',
+					],
+				],
+			),
+			'logTime' => new DbIndex(
+				name: 'logTime',
+				columns: [
+					[
+						'name' => 'logTime',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v1_0/LogBoards.php
+++ b/Sources/Db/Schema/v1_0/LogBoards.php
@@ -1,0 +1,78 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v1_0;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class LogBoards extends Table
+{
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'log_boards';
+
+		$this->columns = [
+			'ID_BOARD' => new Column(
+				name: 'ID_BOARD',
+				type: 'smallint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'ID_MEMBER' => new Column(
+				name: 'ID_MEMBER',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'logTime' => new Column(
+				name: 'logTime',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'ID_BOARD',
+					],
+					[
+						'name' => 'ID_MEMBER',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v1_0/LogErrors.php
+++ b/Sources/Db/Schema/v1_0/LogErrors.php
@@ -1,0 +1,108 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v1_0;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class LogErrors extends Table
+{
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'log_errors';
+
+		$this->columns = [
+			'ID_ERROR' => new Column(
+				name: 'ID_ERROR',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				auto: true,
+			),
+			'logTime' => new Column(
+				name: 'logTime',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'ID_MEMBER' => new Column(
+				name: 'ID_MEMBER',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'IP' => new Column(
+				name: 'IP',
+				type: 'tinytext',
+				not_null: true,
+				default: '',
+			),
+			'url' => new Column(
+				name: 'url',
+				type: 'text',
+				not_null: true,
+				default: '',
+			),
+			'message' => new Column(
+				name: 'message',
+				type: 'text',
+				not_null: true,
+				default: '',
+			),
+			'session' => new Column(
+				name: 'session',
+				type: 'char',
+				size: 32,
+				not_null: true,
+				default: '                                ',
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'ID_ERROR',
+					],
+				],
+			),
+			'logTime' => new DbIndex(
+				name: 'logTime',
+				columns: [
+					[
+						'name' => 'logTime',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v1_0/LogFloodcontrol.php
+++ b/Sources/Db/Schema/v1_0/LogFloodcontrol.php
@@ -1,0 +1,76 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v1_0;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class LogFloodcontrol extends Table
+{
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'log_floodcontrol';
+
+		$this->columns = [
+			'ip' => new Column(
+				name: 'ip',
+				type: 'tinytext',
+				not_null: true,
+				default: '',
+			),
+			'logTime' => new Column(
+				name: 'logTime',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'ip',
+						'size' => 16,
+					],
+				],
+			),
+			'logTime' => new DbIndex(
+				name: 'logTime',
+				columns: [
+					[
+						'name' => 'logTime',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v1_0/LogKarma.php
+++ b/Sources/Db/Schema/v1_0/LogKarma.php
@@ -1,0 +1,92 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v1_0;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class LogKarma extends Table
+{
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'log_karma';
+
+		$this->columns = [
+			'ID_TARGET' => new Column(
+				name: 'ID_TARGET',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'ID_EXECUTOR' => new Column(
+				name: 'ID_EXECUTOR',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'logTime' => new Column(
+				name: 'logTime',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'action' => new Column(
+				name: 'action',
+				type: 'tinyint',
+				not_null: true,
+				default: 0,
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'ID_TARGET',
+					],
+					[
+						'name' => 'ID_EXECUTOR',
+					],
+				],
+			),
+			'logTime' => new DbIndex(
+				name: 'logTime',
+				columns: [
+					[
+						'name' => 'logTime',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v1_0/LogMarkRead.php
+++ b/Sources/Db/Schema/v1_0/LogMarkRead.php
@@ -1,0 +1,78 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v1_0;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class LogMarkRead extends Table
+{
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'log_mark_read';
+
+		$this->columns = [
+			'ID_BOARD' => new Column(
+				name: 'ID_BOARD',
+				type: 'smallint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'ID_MEMBER' => new Column(
+				name: 'ID_MEMBER',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'logTime' => new Column(
+				name: 'logTime',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'ID_BOARD',
+					],
+					[
+						'name' => 'ID_MEMBER',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v1_0/LogNotify.php
+++ b/Sources/Db/Schema/v1_0/LogNotify.php
@@ -1,0 +1,88 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v1_0;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class LogNotify extends Table
+{
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'log_notify';
+
+		$this->columns = [
+			'ID_MEMBER' => new Column(
+				name: 'ID_MEMBER',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'ID_TOPIC' => new Column(
+				name: 'ID_TOPIC',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'ID_BOARD' => new Column(
+				name: 'ID_BOARD',
+				type: 'smallint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'sent' => new Column(
+				name: 'sent',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'ID_MEMBER',
+					],
+					[
+						'name' => 'ID_TOPIC',
+					],
+					[
+						'name' => 'ID_BOARD',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v1_0/LogOnline.php
+++ b/Sources/Db/Schema/v1_0/LogOnline.php
@@ -1,0 +1,104 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v1_0;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class LogOnline extends Table
+{
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'log_online';
+
+		$this->columns = [
+			'session' => new Column(
+				name: 'session',
+				type: 'char',
+				size: 32,
+				not_null: true,
+				default: '                                ',
+			),
+			'logTime' => new Column(
+				name: 'logTime',
+				type: 'timestamp',
+			),
+			'ID_MEMBER' => new Column(
+				name: 'ID_MEMBER',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'ip' => new Column(
+				name: 'ip',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'url' => new Column(
+				name: 'url',
+				type: 'text',
+				not_null: true,
+				default: '',
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'session',
+					],
+				],
+			),
+			'online' => new DbIndex(
+				name: 'online',
+				columns: [
+					[
+						'name' => 'logTime',
+					],
+					[
+						'name' => 'ID_MEMBER',
+					],
+				],
+			),
+			'ID_MEMBER' => new DbIndex(
+				name: 'ID_MEMBER',
+				columns: [
+					[
+						'name' => 'ID_MEMBER',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v1_0/LogPolls.php
+++ b/Sources/Db/Schema/v1_0/LogPolls.php
@@ -1,0 +1,81 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v1_0;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class LogPolls extends Table
+{
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'log_polls';
+
+		$this->columns = [
+			'ID_POLL' => new Column(
+				name: 'ID_POLL',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'ID_MEMBER' => new Column(
+				name: 'ID_MEMBER',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'ID_CHOICE' => new Column(
+				name: 'ID_CHOICE',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'ID_POLL',
+					],
+					[
+						'name' => 'ID_MEMBER',
+					],
+					[
+						'name' => 'ID_CHOICE',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v1_0/LogSearch.php
+++ b/Sources/Db/Schema/v1_0/LogSearch.php
@@ -1,0 +1,92 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v1_0;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class LogSearch extends Table
+{
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'log_search';
+
+		$this->columns = [
+			'ID_SEARCH' => new Column(
+				name: 'ID_SEARCH',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'ID_TOPIC' => new Column(
+				name: 'ID_TOPIC',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'ID_MSG' => new Column(
+				name: 'ID_MSG',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'relevance' => new Column(
+				name: 'relevance',
+				type: 'smallint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'num_matches' => new Column(
+				name: 'num_matches',
+				type: 'smallint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'ID_SEARCH',
+					],
+					[
+						'name' => 'ID_TOPIC',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v1_0/LogTopics.php
+++ b/Sources/Db/Schema/v1_0/LogTopics.php
@@ -1,0 +1,78 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v1_0;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class LogTopics extends Table
+{
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'log_topics';
+
+		$this->columns = [
+			'ID_TOPIC' => new Column(
+				name: 'ID_TOPIC',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'ID_MEMBER' => new Column(
+				name: 'ID_MEMBER',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'logTime' => new Column(
+				name: 'logTime',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'ID_TOPIC',
+					],
+					[
+						'name' => 'ID_MEMBER',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v1_0/Membergroups.php
+++ b/Sources/Db/Schema/v1_0/Membergroups.php
@@ -1,0 +1,170 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v1_0;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class Membergroups extends Table
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 * @var array
+	 *
+	 * Data used to populate the table during install.
+	 */
+	public array $initial_data = [
+		[
+			'ID_GROUP' => 1,
+			'groupName' => 'Administrator',
+			'onlineColor' => '#FF0000',
+			'minPosts' => -1,
+			'stars' => '5#staradmin.gif',
+		],
+		[
+			'ID_GROUP' => 2,
+			'groupName' => 'Global Moderator',
+			'onlineColor' => '#0000FF',
+			'minPosts' => -1,
+			'stars' => '5#stargmod.gif',
+		],
+		[
+			'ID_GROUP' => 3,
+			'groupName' => 'Moderator',
+			'onlineColor' => '',
+			'minPosts' => -1,
+			'stars' => '5#starmod.gif',
+		],
+		[
+			'ID_GROUP' => 4,
+			'groupName' => 'Newbie',
+			'onlineColor' => '',
+			'minPosts' => 0,
+			'stars' => '1#star.gif',
+		],
+		[
+			'ID_GROUP' => 5,
+			'groupName' => 'Jr. Member',
+			'onlineColor' => '',
+			'minPosts' => 50,
+			'stars' => '2#star.gif',
+		],
+		[
+			'ID_GROUP' => 6,
+			'groupName' => 'Full Member',
+			'onlineColor' => '',
+			'minPosts' => 100,
+			'stars' => '3#star.gif',
+		],
+		[
+			'ID_GROUP' => 7,
+			'groupName' => 'Sr. Member',
+			'onlineColor' => '',
+			'minPosts' => 250,
+			'stars' => '4#star.gif',
+		],
+		[
+			'ID_GROUP' => 8,
+			'groupName' => 'Hero Member',
+			'onlineColor' => '',
+			'minPosts' => 500,
+			'stars' => '5#star.gif',
+		],
+	];
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'membergroups';
+
+		$this->columns = [
+			'ID_GROUP' => new Column(
+				name: 'ID_GROUP',
+				type: 'smallint',
+				unsigned: true,
+				not_null: true,
+				auto: true,
+			),
+			'groupName' => new Column(
+				name: 'groupName',
+				type: 'varchar',
+				size: 80,
+				not_null: true,
+				default: '',
+			),
+			'onlineColor' => new Column(
+				name: 'onlineColor',
+				type: 'varchar',
+				size: 20,
+				not_null: true,
+				default: '',
+			),
+			'minPosts' => new Column(
+				name: 'minPosts',
+				type: 'mediumint',
+				not_null: true,
+				default: -1,
+			),
+			'maxMessages' => new Column(
+				name: 'maxMessages',
+				type: 'smallint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'stars' => new Column(
+				name: 'stars',
+				type: 'tinytext',
+				not_null: true,
+				default: '',
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'ID_GROUP',
+					],
+				],
+			),
+			'minPosts' => new DbIndex(
+				name: 'minPosts',
+				columns: [
+					[
+						'name' => 'minPosts',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v1_0/Members.php
+++ b/Sources/Db/Schema/v1_0/Members.php
@@ -1,0 +1,420 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v1_0;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class Members extends Table
+{
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'members';
+
+		$this->columns = [
+			'ID_MEMBER' => new Column(
+				name: 'ID_MEMBER',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				auto: true,
+			),
+			'memberName' => new Column(
+				name: 'memberName',
+				type: 'varchar',
+				size: 80,
+				not_null: true,
+				default: '',
+			),
+			'dateRegistered' => new Column(
+				name: 'dateRegistered',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'posts' => new Column(
+				name: 'posts',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'ID_GROUP' => new Column(
+				name: 'ID_GROUP',
+				type: 'smallint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'lngfile' => new Column(
+				name: 'lngfile',
+				type: 'tinytext',
+				not_null: true,
+				default: '',
+			),
+			'lastLogin' => new Column(
+				name: 'lastLogin',
+				type: 'int',
+				not_null: true,
+				default: 0,
+			),
+			'realName' => new Column(
+				name: 'realName',
+				type: 'tinytext',
+				not_null: true,
+				default: '',
+			),
+			'instantMessages' => new Column(
+				name: 'instantMessages',
+				type: 'smallint',
+				not_null: true,
+				default: 0,
+			),
+			'unreadMessages' => new Column(
+				name: 'unreadMessages',
+				type: 'smallint',
+				not_null: true,
+				default: 0,
+			),
+			'im_ignore_list' => new Column(
+				name: 'im_ignore_list',
+				type: 'tinytext',
+				not_null: true,
+				default: '',
+			),
+			'passwd' => new Column(
+				name: 'passwd',
+				type: 'varchar',
+				size: 64,
+				not_null: true,
+				default: '',
+			),
+			'emailAddress' => new Column(
+				name: 'emailAddress',
+				type: 'tinytext',
+				not_null: true,
+				default: '',
+			),
+			'personalText' => new Column(
+				name: 'personalText',
+				type: 'tinytext',
+				not_null: true,
+				default: '',
+			),
+			'gender' => new Column(
+				name: 'gender',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'birthdate' => new Column(
+				name: 'birthdate',
+				type: 'date',
+				not_null: true,
+				default: '0000-00-00',
+			),
+			'websiteTitle' => new Column(
+				name: 'websiteTitle',
+				type: 'tinytext',
+				not_null: true,
+				default: '',
+			),
+			'websiteUrl' => new Column(
+				name: 'websiteUrl',
+				type: 'tinytext',
+				not_null: true,
+				default: '',
+			),
+			'location' => new Column(
+				name: 'location',
+				type: 'tinytext',
+				not_null: true,
+				default: '',
+			),
+			'ICQ' => new Column(
+				name: 'ICQ',
+				type: 'tinytext',
+				not_null: true,
+				default: '',
+			),
+			'AIM' => new Column(
+				name: 'AIM',
+				type: 'varchar',
+				size: 16,
+				not_null: true,
+				default: '',
+			),
+			'YIM' => new Column(
+				name: 'YIM',
+				type: 'varchar',
+				size: 32,
+				not_null: true,
+				default: '',
+			),
+			'MSN' => new Column(
+				name: 'MSN',
+				type: 'tinytext',
+				not_null: true,
+				default: '',
+			),
+			'hideEmail' => new Column(
+				name: 'hideEmail',
+				type: 'tinyint',
+				not_null: true,
+				default: 0,
+			),
+			'showOnline' => new Column(
+				name: 'showOnline',
+				type: 'tinyint',
+				not_null: true,
+				default: 1,
+			),
+			'timeFormat' => new Column(
+				name: 'timeFormat',
+				type: 'varchar',
+				size: 80,
+				not_null: true,
+				default: '',
+			),
+			'signature' => new Column(
+				name: 'signature',
+				type: 'text',
+			),
+			'timeOffset' => new Column(
+				name: 'timeOffset',
+				type: 'float',
+				not_null: true,
+				default: 0,
+			),
+			'avatar' => new Column(
+				name: 'avatar',
+				type: 'tinytext',
+				not_null: true,
+				default: '',
+			),
+			'im_email_notify' => new Column(
+				name: 'im_email_notify',
+				type: 'tinyint',
+				not_null: true,
+				default: 0,
+			),
+			'karmaBad' => new Column(
+				name: 'karmaBad',
+				type: 'smallint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'karmaGood' => new Column(
+				name: 'karmaGood',
+				type: 'smallint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'usertitle' => new Column(
+				name: 'usertitle',
+				type: 'tinytext',
+				not_null: true,
+				default: '',
+			),
+			'notifyAnnouncements' => new Column(
+				name: 'notifyAnnouncements',
+				type: 'tinyint',
+				not_null: true,
+				default: 1,
+			),
+			'notifyOnce' => new Column(
+				name: 'notifyOnce',
+				type: 'tinyint',
+				not_null: true,
+				default: 1,
+			),
+			'memberIP' => new Column(
+				name: 'memberIP',
+				type: 'tinytext',
+				not_null: true,
+				default: '',
+			),
+			'secretQuestion' => new Column(
+				name: 'secretQuestion',
+				type: 'tinytext',
+				not_null: true,
+				default: '',
+			),
+			'secretAnswer' => new Column(
+				name: 'secretAnswer',
+				type: 'tinytext',
+				not_null: true,
+				default: '',
+			),
+			'ID_THEME' => new Column(
+				name: 'ID_THEME',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'is_activated' => new Column(
+				name: 'is_activated',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				default: 1,
+			),
+			'validation_code' => new Column(
+				name: 'validation_code',
+				type: 'varchar',
+				size: 10,
+				not_null: true,
+				default: '',
+			),
+			'ID_MSG_LAST_VISIT' => new Column(
+				name: 'ID_MSG_LAST_VISIT',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'additionalGroups' => new Column(
+				name: 'additionalGroups',
+				type: 'tinytext',
+				not_null: true,
+				default: '',
+			),
+			'smileySet' => new Column(
+				name: 'smileySet',
+				type: 'varchar',
+				size: 48,
+				not_null: true,
+				default: '',
+			),
+			'ID_POST_GROUP' => new Column(
+				name: 'ID_POST_GROUP',
+				type: 'smallint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'totalTimeLoggedIn' => new Column(
+				name: 'totalTimeLoggedIn',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'passwordSalt' => new Column(
+				name: 'passwordSalt',
+				type: 'varchar',
+				size: 5,
+				not_null: true,
+				default: '',
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'ID_MEMBER',
+					],
+				],
+			),
+			'memberName' => new DbIndex(
+				name: 'memberName',
+				columns: [
+					[
+						'name' => 'memberName',
+						'size' => 30,
+					],
+				],
+			),
+			'dateRegistered' => new DbIndex(
+				name: 'dateRegistered',
+				columns: [
+					[
+						'name' => 'dateRegistered',
+					],
+				],
+			),
+			'ID_GROUP' => new DbIndex(
+				name: 'ID_GROUP',
+				columns: [
+					[
+						'name' => 'ID_GROUP',
+					],
+				],
+			),
+			'birthdate' => new DbIndex(
+				name: 'birthdate',
+				columns: [
+					[
+						'name' => 'birthdate',
+					],
+				],
+			),
+			'posts' => new DbIndex(
+				name: 'posts',
+				columns: [
+					[
+						'name' => 'posts',
+					],
+				],
+			),
+			'lastLogin' => new DbIndex(
+				name: 'lastLogin',
+				columns: [
+					[
+						'name' => 'lastLogin',
+					],
+				],
+			),
+			'lngfile' => new DbIndex(
+				name: 'lngfile',
+				columns: [
+					[
+						'name' => 'lngfile',
+						'size' => 30,
+					],
+				],
+			),
+			'ID_POST_GROUP' => new DbIndex(
+				name: 'ID_POST_GROUP',
+				columns: [
+					[
+						'name' => 'ID_POST_GROUP',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v1_0/Messages.php
+++ b/Sources/Db/Schema/v1_0/Messages.php
@@ -1,0 +1,231 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v1_0;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class Messages extends Table
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 * @var array
+	 *
+	 * Data used to populate the table during install.
+	 */
+	public array $initial_data = [
+		[
+			'ID_MSG' => 1,
+			'ID_TOPIC' => 1,
+			'ID_BOARD' => 1,
+			'posterTime' => '{$current_time}',
+			'subject' => '{$default_topic_subject}',
+			'posterName' => 'Simple Machines',
+			'posterEmail' => 'info@simplemachines.org',
+			'posterIP' => '127.0.0.1',
+			'body' => '{$default_topic_message}',
+		],
+	];
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'messages';
+
+		$this->columns = [
+			'ID_MSG' => new Column(
+				name: 'ID_MSG',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				auto: true,
+			),
+			'ID_TOPIC' => new Column(
+				name: 'ID_TOPIC',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'ID_BOARD' => new Column(
+				name: 'ID_BOARD',
+				type: 'smallint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'posterTime' => new Column(
+				name: 'posterTime',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'ID_MEMBER' => new Column(
+				name: 'ID_MEMBER',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'subject' => new Column(
+				name: 'subject',
+				type: 'tinytext',
+				not_null: true,
+				default: '',
+			),
+			'posterName' => new Column(
+				name: 'posterName',
+				type: 'tinytext',
+				not_null: true,
+				default: '',
+			),
+			'posterEmail' => new Column(
+				name: 'posterEmail',
+				type: 'tinytext',
+				not_null: true,
+				default: '',
+			),
+			'posterIP' => new Column(
+				name: 'posterIP',
+				type: 'tinytext',
+				not_null: true,
+				default: '',
+			),
+			'smileysEnabled' => new Column(
+				name: 'smileysEnabled',
+				type: 'tinyint',
+				not_null: true,
+				default: 1,
+			),
+			'modifiedTime' => new Column(
+				name: 'modifiedTime',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'modifiedName' => new Column(
+				name: 'modifiedName',
+				type: 'tinytext',
+			),
+			'body' => new Column(
+				name: 'body',
+				type: 'text',
+			),
+			'icon' => new Column(
+				name: 'icon',
+				type: 'varchar',
+				size: 16,
+				not_null: true,
+				default: 'xx',
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'ID_MSG',
+					],
+				],
+			),
+			'topic' => new DbIndex(
+				type: 'unique',
+				name: 'topic',
+				columns: [
+					[
+						'name' => 'ID_TOPIC',
+					],
+					[
+						'name' => 'ID_MSG',
+					],
+				],
+			),
+			'ID_TOPIC' => new DbIndex(
+				name: 'ID_TOPIC',
+				columns: [
+					[
+						'name' => 'ID_TOPIC',
+					],
+				],
+			),
+			'ID_BOARD' => new DbIndex(
+				name: 'ID_BOARD',
+				columns: [
+					[
+						'name' => 'ID_BOARD',
+					],
+				],
+			),
+			'ID_MEMBER' => new DbIndex(
+				name: 'ID_MEMBER',
+				columns: [
+					[
+						'name' => 'ID_MEMBER',
+					],
+				],
+			),
+			'posterTime' => new DbIndex(
+				name: 'posterTime',
+				columns: [
+					[
+						'name' => 'posterTime',
+					],
+				],
+			),
+			'ipIndex' => new DbIndex(
+				name: 'ipIndex',
+				columns: [
+					[
+						'name' => 'posterIP',
+						'size' => 15,
+					],
+					[
+						'name' => 'ID_TOPIC',
+					],
+				],
+			),
+			'participation' => new DbIndex(
+				name: 'participation',
+				columns: [
+					[
+						'name' => 'ID_MEMBER',
+					],
+					[
+						'name' => 'ID_TOPIC',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v1_0/Moderators.php
+++ b/Sources/Db/Schema/v1_0/Moderators.php
@@ -1,0 +1,71 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v1_0;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class Moderators extends Table
+{
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'moderators';
+
+		$this->columns = [
+			'ID_BOARD' => new Column(
+				name: 'ID_BOARD',
+				type: 'smallint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'ID_MEMBER' => new Column(
+				name: 'ID_MEMBER',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'ID_BOARD',
+					],
+					[
+						'name' => 'ID_MEMBER',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v1_0/Permissions.php
+++ b/Sources/Db/Schema/v1_0/Permissions.php
@@ -1,0 +1,236 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v1_0;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class Permissions extends Table
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 * @var array
+	 *
+	 * Data used to populate the table during install.
+	 */
+	public array $initial_data = [
+		[
+			'ID_GROUP' => -1,
+			'permission' => 'search_posts',
+		],
+		[
+			'ID_GROUP' => -1,
+			'permission' => 'calendar_view',
+		],
+		[
+			'ID_GROUP' => -1,
+			'permission' => 'view_stats',
+		],
+		[
+			'ID_GROUP' => -1,
+			'permission' => 'profile_view_any',
+		],
+		[
+			'ID_GROUP' => 0,
+			'permission' => 'view_mlist',
+		],
+		[
+			'ID_GROUP' => 0,
+			'permission' => 'search_posts',
+		],
+		[
+			'ID_GROUP' => 0,
+			'permission' => 'profile_view_own',
+		],
+		[
+			'ID_GROUP' => 0,
+			'permission' => 'profile_view_any',
+		],
+		[
+			'ID_GROUP' => 0,
+			'permission' => 'pm_read',
+		],
+		[
+			'ID_GROUP' => 0,
+			'permission' => 'pm_send',
+		],
+		[
+			'ID_GROUP' => 0,
+			'permission' => 'calendar_view',
+		],
+		[
+			'ID_GROUP' => 0,
+			'permission' => 'view_stats',
+		],
+		[
+			'ID_GROUP' => 0,
+			'permission' => 'who_view',
+		],
+		[
+			'ID_GROUP' => 0,
+			'permission' => 'profile_edit_own',
+		],
+		[
+			'ID_GROUP' => 0,
+			'permission' => 'profile_identity_own',
+		],
+		[
+			'ID_GROUP' => 0,
+			'permission' => 'profile_extra_own',
+		],
+		[
+			'ID_GROUP' => 0,
+			'permission' => 'profile_remove_own',
+		],
+		[
+			'ID_GROUP' => 0,
+			'permission' => 'profile_remote_avatar',
+		],
+		[
+			'ID_GROUP' => 0,
+			'permission' => 'karma_edit',
+		],
+		[
+			'ID_GROUP' => 2,
+			'permission' => 'view_mlist',
+		],
+		[
+			'ID_GROUP' => 2,
+			'permission' => 'search_posts',
+		],
+		[
+			'ID_GROUP' => 2,
+			'permission' => 'profile_view_own',
+		],
+		[
+			'ID_GROUP' => 2,
+			'permission' => 'profile_view_any',
+		],
+		[
+			'ID_GROUP' => 2,
+			'permission' => 'pm_read',
+		],
+		[
+			'ID_GROUP' => 2,
+			'permission' => 'pm_send',
+		],
+		[
+			'ID_GROUP' => 2,
+			'permission' => 'calendar_view',
+		],
+		[
+			'ID_GROUP' => 2,
+			'permission' => 'view_stats',
+		],
+		[
+			'ID_GROUP' => 2,
+			'permission' => 'who_view',
+		],
+		[
+			'ID_GROUP' => 2,
+			'permission' => 'profile_edit_own',
+		],
+		[
+			'ID_GROUP' => 2,
+			'permission' => 'profile_identity_own',
+		],
+		[
+			'ID_GROUP' => 2,
+			'permission' => 'profile_extra_own',
+		],
+		[
+			'ID_GROUP' => 2,
+			'permission' => 'profile_remove_own',
+		],
+		[
+			'ID_GROUP' => 2,
+			'permission' => 'profile_remote_avatar',
+		],
+		[
+			'ID_GROUP' => 2,
+			'permission' => 'profile_title_own',
+		],
+		[
+			'ID_GROUP' => 2,
+			'permission' => 'calendar_post',
+		],
+		[
+			'ID_GROUP' => 2,
+			'permission' => 'calendar_edit_any',
+		],
+		[
+			'ID_GROUP' => 2,
+			'permission' => 'karma_edit',
+		],
+	];
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'permissions';
+
+		$this->columns = [
+			'ID_GROUP' => new Column(
+				name: 'ID_GROUP',
+				type: 'smallint',
+				not_null: true,
+				default: 0,
+			),
+			'permission' => new Column(
+				name: 'permission',
+				type: 'varchar',
+				size: 30,
+				not_null: true,
+				default: '',
+			),
+			'addDeny' => new Column(
+				name: 'addDeny',
+				type: 'tinyint',
+				not_null: true,
+				default: 1,
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'ID_GROUP',
+					],
+					[
+						'name' => 'permission',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v1_0/PollChoices.php
+++ b/Sources/Db/Schema/v1_0/PollChoices.php
@@ -1,0 +1,84 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v1_0;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class PollChoices extends Table
+{
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'poll_choices';
+
+		$this->columns = [
+			'ID_POLL' => new Column(
+				name: 'ID_POLL',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'ID_CHOICE' => new Column(
+				name: 'ID_CHOICE',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'label' => new Column(
+				name: 'label',
+				type: 'tinytext',
+				not_null: true,
+				default: '',
+			),
+			'votes' => new Column(
+				name: 'votes',
+				type: 'smallint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'ID_POLL',
+					],
+					[
+						'name' => 'ID_CHOICE',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v1_0/Polls.php
+++ b/Sources/Db/Schema/v1_0/Polls.php
@@ -1,0 +1,114 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v1_0;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class Polls extends Table
+{
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'polls';
+
+		$this->columns = [
+			'ID_POLL' => new Column(
+				name: 'ID_POLL',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				auto: true,
+			),
+			'question' => new Column(
+				name: 'question',
+				type: 'tinytext',
+				not_null: true,
+				default: '',
+			),
+			'votingLocked' => new Column(
+				name: 'votingLocked',
+				type: 'tinyint',
+				not_null: true,
+				default: 0,
+			),
+			'maxVotes' => new Column(
+				name: 'maxVotes',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				default: 1,
+			),
+			'expireTime' => new Column(
+				name: 'expireTime',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'hideResults' => new Column(
+				name: 'hideResults',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'changeVote' => new Column(
+				name: 'changeVote',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'ID_MEMBER' => new Column(
+				name: 'ID_MEMBER',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'posterName' => new Column(
+				name: 'posterName',
+				type: 'tinytext',
+				not_null: true,
+				default: '',
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'ID_POLL',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v1_0/Sessions.php
+++ b/Sources/Db/Schema/v1_0/Sessions.php
@@ -1,0 +1,71 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v1_0;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class Sessions extends Table
+{
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'sessions';
+
+		$this->columns = [
+			'session_id' => new Column(
+				name: 'session_id',
+				type: 'char',
+				size: 32,
+				not_null: true,
+			),
+			'last_update' => new Column(
+				name: 'last_update',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+			),
+			'data' => new Column(
+				name: 'data',
+				type: 'text',
+				not_null: true,
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'session_id',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v1_0/Settings.php
+++ b/Sources/Db/Schema/v1_0/Settings.php
@@ -1,0 +1,731 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v1_0;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class Settings extends Table
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 * @var array
+	 *
+	 * Data used to populate the table during install.
+	 */
+	public array $initial_data = [
+		[
+			'variable' => 'allow_editDisplayName',
+			'value' => 1,
+		],
+		[
+			'variable' => 'allow_guestAccess',
+			'value' => 1,
+		],
+		[
+			'variable' => 'allow_hideEmail',
+			'value' => 1,
+		],
+		[
+			'variable' => 'allow_hideOnline',
+			'value' => 1,
+		],
+		[
+			'variable' => 'attachmentCheckExtensions',
+			'value' => 1,
+		],
+		[
+			'variable' => 'attachmentDirSizeLimit',
+			'value' => 10240,
+		],
+		[
+			'variable' => 'attachmentEnable',
+			'value' => 1,
+		],
+		[
+			'variable' => 'attachmentEncryptFilenames',
+			'value' => 1,
+		],
+		[
+			'variable' => 'attachmentExtensions',
+			'value' => 'txt,doc,pdf,jpg,gif,mpg,png',
+		],
+		[
+			'variable' => 'attachmentNumPerPostLimit',
+			'value' => 4,
+		],
+		[
+			'variable' => 'attachmentPostLimit',
+			'value' => 192,
+		],
+		[
+			'variable' => 'attachmentShowImages',
+			'value' => 1,
+		],
+		[
+			'variable' => 'attachmentSizeLimit',
+			'value' => 128,
+		],
+		[
+			'variable' => 'attachmentUploadDir',
+			'value' => '{$boarddir}/attachments',
+		],
+		[
+			'variable' => 'autoFixDatabase',
+			'value' => 1,
+		],
+		[
+			'variable' => 'autoLinkUrls',
+			'value' => 1,
+		],
+		[
+			'variable' => 'autoOptDatabase',
+			'value' => 7,
+		],
+		[
+			'variable' => 'autoOptLastOpt',
+			'value' => 0,
+		],
+		[
+			'variable' => 'autoOptMaxOnline',
+			'value' => 0,
+		],
+		[
+			'variable' => 'avatar_action_too_large',
+			'value' => 'option_html_resize',
+		],
+		[
+			'variable' => 'avatar_allow_external_url',
+			'value' => 1,
+		],
+		[
+			'variable' => 'avatar_allow_server_stored',
+			'value' => 1,
+		],
+		[
+			'variable' => 'avatar_allow_upload',
+			'value' => 0,
+		],
+		[
+			'variable' => 'avatar_check_size',
+			'value' => 0,
+		],
+		[
+			'variable' => 'avatar_directory',
+			'value' => '{$boarddir}/avatars',
+		],
+		[
+			'variable' => 'avatar_download_png',
+			'value' => 1,
+		],
+		[
+			'variable' => 'avatar_max_height_external',
+			'value' => 65,
+		],
+		[
+			'variable' => 'avatar_max_height_upload',
+			'value' => 65,
+		],
+		[
+			'variable' => 'avatar_max_width_external',
+			'value' => 65,
+		],
+		[
+			'variable' => 'avatar_max_width_upload',
+			'value' => 65,
+		],
+		[
+			'variable' => 'avatar_resize_upload',
+			'value' => 1,
+		],
+		[
+			'variable' => 'avatar_url',
+			'value' => '{$boardurl}/avatars',
+		],
+		[
+			'variable' => 'banLastUpdated',
+			'value' => 0,
+		],
+		[
+			'variable' => 'cal_allowspan',
+			'value' => 0,
+		],
+		[
+			'variable' => 'cal_bdaycolor',
+			'value' => '920AC4',
+		],
+		[
+			'variable' => 'cal_days_for_index',
+			'value' => 7,
+		],
+		[
+			'variable' => 'cal_daysaslink',
+			'value' => 0,
+		],
+		[
+			'variable' => 'cal_defaultboard',
+			'value' => '',
+		],
+		[
+			'variable' => 'cal_enabled',
+			'value' => 0,
+		],
+		[
+			'variable' => 'cal_eventcolor',
+			'value' => '078907',
+		],
+		[
+			'variable' => 'cal_holidaycolor',
+			'value' => '000080',
+		],
+		[
+			'variable' => 'cal_maxspan',
+			'value' => 7,
+		],
+		[
+			'variable' => 'cal_maxyear',
+			'value' => 2010,
+		],
+		[
+			'variable' => 'cal_minyear',
+			'value' => 2002,
+		],
+		[
+			'variable' => 'cal_showbdaysonindex',
+			'value' => 0,
+		],
+		[
+			'variable' => 'cal_showeventsonindex',
+			'value' => 0,
+		],
+		[
+			'variable' => 'cal_showholidaysonindex',
+			'value' => 0,
+		],
+		[
+			'variable' => 'cal_showweeknum',
+			'value' => 0,
+		],
+		[
+			'variable' => 'censorIgnoreCase',
+			'value' => 1,
+		],
+		[
+			'variable' => 'censorWholeWord',
+			'value' => 0,
+		],
+		[
+			'variable' => 'censor_proper',
+			'value' => '',
+		],
+		[
+			'variable' => 'censor_vulgar',
+			'value' => '',
+		],
+		[
+			'variable' => 'compactTopicPagesContiguous',
+			'value' => 5,
+		],
+		[
+			'variable' => 'compactTopicPagesEnable',
+			'value' => 1,
+		],
+		[
+			'variable' => 'cookieTime',
+			'value' => 60,
+		],
+		[
+			'variable' => 'databaseSession_enable',
+			'value' => '{$databaseSession_enable}',
+		],
+		[
+			'variable' => 'databaseSession_lifetime',
+			'value' => 2880,
+		],
+		[
+			'variable' => 'databaseSession_loose',
+			'value' => 1,
+		],
+		[
+			'variable' => 'defaultMaxMembers',
+			'value' => 30,
+		],
+		[
+			'variable' => 'defaultMaxMessages',
+			'value' => 15,
+		],
+		[
+			'variable' => 'defaultMaxTopics',
+			'value' => 20,
+		],
+		[
+			'variable' => 'default_personalText',
+			'value' => '',
+		],
+		[
+			'variable' => 'disableTemporaryTables',
+			'value' => 0,
+		],
+		[
+			'variable' => 'edit_wait_time',
+			'value' => 90,
+		],
+		[
+			'variable' => 'enableAllMessages',
+			'value' => 0,
+		],
+		[
+			'variable' => 'enableBBC',
+			'value' => 1,
+		],
+		[
+			'variable' => 'enableCompressedOutput',
+			'value' => '{$enableCompressedOutput}',
+		],
+		[
+			'variable' => 'enableEmbeddedFlash',
+			'value' => 0,
+		],
+		[
+			'variable' => 'enableErrorLogging',
+			'value' => 1,
+		],
+		[
+			'variable' => 'enableNewReplyWarning',
+			'value' => 1,
+		],
+		[
+			'variable' => 'enableParticipation',
+			'value' => 1,
+		],
+		[
+			'variable' => 'enablePostHTML',
+			'value' => 0,
+		],
+		[
+			'variable' => 'enablePreviousNext',
+			'value' => 1,
+		],
+		[
+			'variable' => 'enableReportToMod',
+			'value' => 1,
+		],
+		[
+			'variable' => 'enableSpellChecking',
+			'value' => 1,
+		],
+		[
+			'variable' => 'enableStickyTopics',
+			'value' => 1,
+		],
+		[
+			'variable' => 'enableVBStyleLogin',
+			'value' => 1,
+		],
+		[
+			'variable' => 'failed_login_threshold',
+			'value' => 3,
+		],
+		[
+			'variable' => 'fixLongWords',
+			'value' => 0,
+		],
+		[
+			'variable' => 'globalCookies',
+			'value' => 0,
+		],
+		[
+			'variable' => 'guest_hideContacts',
+			'value' => 0,
+		],
+		[
+			'variable' => 'hitStats',
+			'value' => 0,
+		],
+		[
+			'variable' => 'hotTopicPosts',
+			'value' => 15,
+		],
+		[
+			'variable' => 'hotTopicVeryPosts',
+			'value' => 25,
+		],
+		[
+			'variable' => 'karmaApplaudLabel',
+			'value' => '[applaud]',
+		],
+		[
+			'variable' => 'karmaLabel',
+			'value' => 'Karma:',
+		],
+		[
+			'variable' => 'karmaMinPosts',
+			'value' => 0,
+		],
+		[
+			'variable' => 'karmaMode',
+			'value' => 0,
+		],
+		[
+			'variable' => 'karmaSmiteLabel',
+			'value' => '[smite]',
+		],
+		[
+			'variable' => 'karmaTimeRestrictAdmins',
+			'value' => 1,
+		],
+		[
+			'variable' => 'karmaWaitTime',
+			'value' => 1,
+		],
+		[
+			'variable' => 'knownThemes',
+			'value' => '1,2',
+		],
+		[
+			'variable' => 'lastActive',
+			'value' => 15,
+		],
+		[
+			'variable' => 'localCookies',
+			'value' => 0,
+		],
+		[
+			'variable' => 'mail_type',
+			'value' => 'sendmail',
+		],
+		[
+			'variable' => 'maxMsgID',
+			'value' => 1,
+		],
+		[
+			'variable' => 'max_messageLength',
+			'value' => 20000,
+		],
+		[
+			'variable' => 'max_signatureLength',
+			'value' => 300,
+		],
+		[
+			'variable' => 'maxheight',
+			'value' => 0,
+		],
+		[
+			'variable' => 'maxwidth',
+			'value' => 0,
+		],
+		[
+			'variable' => 'modlog_enabled',
+			'value' => 0,
+		],
+		[
+			'variable' => 'mostDate',
+			'value' => '{$current_time}',
+		],
+		[
+			'variable' => 'mostOnline',
+			'value' => 1,
+		],
+		[
+			'variable' => 'mostOnlineToday',
+			'value' => 1,
+		],
+		[
+			'variable' => 'news',
+			'value' => 'SMF - Just Installed',
+		],
+		[
+			'variable' => 'notifyAnncmnts_UserDisable',
+			'value' => 1,
+		],
+		[
+			'variable' => 'number_format',
+			'value' => '1234.00',
+		],
+		[
+			'variable' => 'onlineEnable',
+			'value' => 0,
+		],
+		[
+			'variable' => 'package_make_backups',
+			'value' => 1,
+		],
+		[
+			'variable' => 'pollMode',
+			'value' => 1,
+		],
+		[
+			'variable' => 'queryless_urls',
+			'value' => 0,
+		],
+		[
+			'variable' => 'recycle_board',
+			'value' => 0,
+		],
+		[
+			'variable' => 'recycle_enable',
+			'value' => 0,
+		],
+		[
+			'variable' => 'registration_method',
+			'value' => 0,
+		],
+		[
+			'variable' => 'removeNestedQuotes',
+			'value' => 0,
+		],
+		[
+			'variable' => 'requireAgreement',
+			'value' => 1,
+		],
+		[
+			'variable' => 'reserveCase',
+			'value' => 1,
+		],
+		[
+			'variable' => 'reserveName',
+			'value' => 1,
+		],
+		[
+			'variable' => 'reserveNames',
+			'value' => 'Admin' . "\n" . 'Webmaster' . "\n" . 'Guest',
+		],
+		[
+			'variable' => 'reserveUser',
+			'value' => 1,
+		],
+		[
+			'variable' => 'reserveWord',
+			'value' => 0,
+		],
+		[
+			'variable' => 'search_cache_size',
+			'value' => 50,
+		],
+		[
+			'variable' => 'search_match_complete_words',
+			'value' => 0,
+		],
+		[
+			'variable' => 'search_results_per_page',
+			'value' => 30,
+		],
+		[
+			'variable' => 'search_weight_age',
+			'value' => 25,
+		],
+		[
+			'variable' => 'search_weight_first_message',
+			'value' => 10,
+		],
+		[
+			'variable' => 'search_weight_frequency',
+			'value' => 30,
+		],
+		[
+			'variable' => 'search_weight_length',
+			'value' => 20,
+		],
+		[
+			'variable' => 'search_weight_subject',
+			'value' => 15,
+		],
+		[
+			'variable' => 'send_validation_onChange',
+			'value' => 0,
+		],
+		[
+			'variable' => 'send_welcomeEmail',
+			'value' => 1,
+		],
+		[
+			'variable' => 'simpleSearch',
+			'value' => 0,
+		],
+		[
+			'variable' => 'smfVersion',
+			'value' => '1.0.17',
+		],
+		[
+			'variable' => 'smiley_enable',
+			'value' => 1,
+		],
+		[
+			'variable' => 'smiley_sets_default',
+			'value' => 'default',
+		],
+		[
+			'variable' => 'smiley_sets_enable',
+			'value' => 0,
+		],
+		[
+			'variable' => 'smiley_sets_known',
+			'value' => 'default,classic',
+		],
+		[
+			'variable' => 'smiley_sets_names',
+			'value' => 'Default' . "\n" . 'Classic',
+		],
+		[
+			'variable' => 'smileys_dir',
+			'value' => '{$boarddir}/Smileys',
+		],
+		[
+			'variable' => 'smileys_url',
+			'value' => '{$boardurl}/Smileys',
+		],
+		[
+			'variable' => 'smtp_host',
+			'value' => '',
+		],
+		[
+			'variable' => 'smtp_password',
+			'value' => '',
+		],
+		[
+			'variable' => 'smtp_port',
+			'value' => 25,
+		],
+		[
+			'variable' => 'smtp_username',
+			'value' => '',
+		],
+		[
+			'variable' => 'spamWaitTime',
+			'value' => 5,
+		],
+		[
+			'variable' => 'theme_allow',
+			'value' => 1,
+		],
+		[
+			'variable' => 'theme_default',
+			'value' => 1,
+		],
+		[
+			'variable' => 'theme_guests',
+			'value' => 1,
+		],
+		[
+			'variable' => 'timeLoadPageEnable',
+			'value' => 0,
+		],
+		[
+			'variable' => 'time_format',
+			'value' => '{$default_time_format}',
+		],
+		[
+			'variable' => 'time_offset',
+			'value' => 0,
+		],
+		[
+			'variable' => 'titlesEnable',
+			'value' => 1,
+		],
+		[
+			'variable' => 'todayMod',
+			'value' => 1,
+		],
+		[
+			'variable' => 'topbottomEnable',
+			'value' => 0,
+		],
+		[
+			'variable' => 'topicSummaryPosts',
+			'value' => 15,
+		],
+		[
+			'variable' => 'totalMessages',
+			'value' => 1,
+		],
+		[
+			'variable' => 'totalTopics',
+			'value' => 1,
+		],
+		[
+			'variable' => 'trackStats',
+			'value' => 1,
+		],
+		[
+			'variable' => 'unapprovedMembers',
+			'value' => 0,
+		],
+		[
+			'variable' => 'userLanguage',
+			'value' => 1,
+		],
+		[
+			'variable' => 'who_enabled',
+			'value' => 1,
+		],
+		[
+			'variable' => 'xmlnews_enable',
+			'value' => 1,
+		],
+		[
+			'variable' => 'xmlnews_maxlen',
+			'value' => 255,
+		],
+	];
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'settings';
+
+		$this->columns = [
+			'variable' => new Column(
+				name: 'variable',
+				type: 'tinytext',
+				not_null: true,
+				default: '',
+			),
+			'value' => new Column(
+				name: 'value',
+				type: 'text',
+				not_null: true,
+				default: '',
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'variable',
+						'size' => 30,
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v1_0/Smileys.php
+++ b/Sources/Db/Schema/v1_0/Smileys.php
@@ -1,0 +1,256 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v1_0;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class Smileys extends Table
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 * @var array
+	 *
+	 * Data used to populate the table during install.
+	 */
+	public array $initial_data = [
+		[
+			'code' => ':)',
+			'filename' => 'smiley.gif',
+			'description' => 'Smiley',
+			'smileyOrder' => 0,
+			'hidden' => 0,
+		],
+		[
+			'code' => ';)',
+			'filename' => 'wink.gif',
+			'description' => 'Wink',
+			'smileyOrder' => 1,
+			'hidden' => 0,
+		],
+		[
+			'code' => ':D',
+			'filename' => 'cheesy.gif',
+			'description' => 'Cheesy',
+			'smileyOrder' => 2,
+			'hidden' => 0,
+		],
+		[
+			'code' => ';D',
+			'filename' => 'grin.gif',
+			'description' => 'Grin',
+			'smileyOrder' => 3,
+			'hidden' => 0,
+		],
+		[
+			'code' => '>:(',
+			'filename' => 'angry.gif',
+			'description' => 'Angry',
+			'smileyOrder' => 4,
+			'hidden' => 0,
+		],
+		[
+			'code' => ':(',
+			'filename' => 'sad.gif',
+			'description' => 'Sad',
+			'smileyOrder' => 5,
+			'hidden' => 0,
+		],
+		[
+			'code' => ':o',
+			'filename' => 'shocked.gif',
+			'description' => 'Shocked',
+			'smileyOrder' => 6,
+			'hidden' => 0,
+		],
+		[
+			'code' => '8)',
+			'filename' => 'cool.gif',
+			'description' => 'Cool',
+			'smileyOrder' => 7,
+			'hidden' => 0,
+		],
+		[
+			'code' => '???',
+			'filename' => 'huh.gif',
+			'description' => 'Huh',
+			'smileyOrder' => 8,
+			'hidden' => 0,
+		],
+		[
+			'code' => '::)',
+			'filename' => 'rolleyes.gif',
+			'description' => 'Roll Eyes',
+			'smileyOrder' => 9,
+			'hidden' => 0,
+		],
+		[
+			'code' => ':P',
+			'filename' => 'tongue.gif',
+			'description' => 'Tongue',
+			'smileyOrder' => 10,
+			'hidden' => 0,
+		],
+		[
+			'code' => ':-[',
+			'filename' => 'embarassed.gif',
+			'description' => 'Embarrassed',
+			'smileyOrder' => 11,
+			'hidden' => 0,
+		],
+		[
+			'code' => ':-X',
+			'filename' => 'lipsrsealed.gif',
+			'description' => 'Lips Sealed',
+			'smileyOrder' => 12,
+			'hidden' => 0,
+		],
+		[
+			'code' => ':-\\',
+			'filename' => 'undecided.gif',
+			'description' => 'Undecided',
+			'smileyOrder' => 13,
+			'hidden' => 0,
+		],
+		[
+			'code' => ':-*',
+			'filename' => 'kiss.gif',
+			'description' => 'Kiss',
+			'smileyOrder' => 14,
+			'hidden' => 0,
+		],
+		[
+			'code' => ':\'(',
+			'filename' => 'cry.gif',
+			'description' => 'Cry',
+			'smileyOrder' => 15,
+			'hidden' => 0,
+		],
+		[
+			'code' => '>:D',
+			'filename' => 'evil.gif',
+			'description' => 'Evil',
+			'smileyOrder' => 16,
+			'hidden' => 1,
+		],
+		[
+			'code' => '^-^',
+			'filename' => 'azn.gif',
+			'description' => 'Azn',
+			'smileyOrder' => 17,
+			'hidden' => 1,
+		],
+		[
+			'code' => 'O0',
+			'filename' => 'afro.gif',
+			'description' => 'Afro',
+			'smileyOrder' => 18,
+			'hidden' => 1,
+		],
+	];
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'smileys';
+
+		$this->columns = [
+			'ID_SMILEY' => new Column(
+				name: 'ID_SMILEY',
+				type: 'smallint',
+				unsigned: true,
+				not_null: true,
+				auto: true,
+			),
+			'code' => new Column(
+				name: 'code',
+				type: 'varchar',
+				size: 30,
+				not_null: true,
+				default: '',
+			),
+			'filename' => new Column(
+				name: 'filename',
+				type: 'varchar',
+				size: 48,
+				not_null: true,
+				default: '',
+			),
+			'description' => new Column(
+				name: 'description',
+				type: 'varchar',
+				size: 80,
+				not_null: true,
+				default: '',
+			),
+			'smileyRow' => new Column(
+				name: 'smileyRow',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'smileyOrder' => new Column(
+				name: 'smileyOrder',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'hidden' => new Column(
+				name: 'hidden',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'ID_SMILEY',
+					],
+				],
+			),
+			'smileyOrder' => new DbIndex(
+				name: 'smileyOrder',
+				columns: [
+					[
+						'name' => 'smileyOrder',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v1_0/Themes.php
+++ b/Sources/Db/Schema/v1_0/Themes.php
@@ -1,0 +1,238 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v1_0;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class Themes extends Table
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 * @var array
+	 *
+	 * Data used to populate the table during install.
+	 */
+	public array $initial_data = [
+		[
+			'ID_THEME' => 1,
+			'variable' => 'name',
+			'value' => 'SMF Default Theme',
+		],
+		[
+			'ID_THEME' => 1,
+			'variable' => 'theme_url',
+			'value' => '{$boardurl}/Themes/default',
+		],
+		[
+			'ID_THEME' => 1,
+			'variable' => 'images_url',
+			'value' => '{$boardurl}/Themes/default/images',
+		],
+		[
+			'ID_THEME' => 1,
+			'variable' => 'theme_dir',
+			'value' => '{$boarddir}/Themes/default',
+		],
+		[
+			'ID_THEME' => 1,
+			'variable' => 'show_bbc',
+			'value' => 1,
+		],
+		[
+			'ID_THEME' => 1,
+			'variable' => 'show_latest_member',
+			'value' => 1,
+		],
+		[
+			'ID_THEME' => 1,
+			'variable' => 'show_modify',
+			'value' => 1,
+		],
+		[
+			'ID_THEME' => 1,
+			'variable' => 'show_user_images',
+			'value' => 1,
+		],
+		[
+			'ID_THEME' => 1,
+			'variable' => 'show_blurb',
+			'value' => 1,
+		],
+		[
+			'ID_THEME' => 1,
+			'variable' => 'show_gender',
+			'value' => 0,
+		],
+		[
+			'ID_THEME' => 1,
+			'variable' => 'show_newsfader',
+			'value' => 0,
+		],
+		[
+			'ID_THEME' => 1,
+			'variable' => 'number_recent_posts',
+			'value' => 0,
+		],
+		[
+			'ID_THEME' => 1,
+			'variable' => 'show_member_bar',
+			'value' => 1,
+		],
+		[
+			'ID_THEME' => 1,
+			'variable' => 'linktree_link',
+			'value' => 1,
+		],
+		[
+			'ID_THEME' => 1,
+			'variable' => 'show_profile_buttons',
+			'value' => 1,
+		],
+		[
+			'ID_THEME' => 1,
+			'variable' => 'show_mark_read',
+			'value' => 1,
+		],
+		[
+			'ID_THEME' => 1,
+			'variable' => 'show_sp1_info',
+			'value' => 1,
+		],
+		[
+			'ID_THEME' => 1,
+			'variable' => 'linktree_inline',
+			'value' => 0,
+		],
+		[
+			'ID_THEME' => 1,
+			'variable' => 'show_board_desc',
+			'value' => 1,
+		],
+		[
+			'ID_THEME' => 1,
+			'variable' => 'newsfader_time',
+			'value' => 5000,
+		],
+		[
+			'ID_THEME' => 1,
+			'variable' => 'allow_no_censored',
+			'value' => 0,
+		],
+		[
+			'ID_THEME' => 1,
+			'variable' => 'additional_options_collapsable',
+			'value' => 1,
+		],
+		[
+			'ID_THEME' => 1,
+			'variable' => 'use_image_buttons',
+			'value' => 1,
+		],
+		[
+			'ID_THEME' => 1,
+			'variable' => 'enable_news',
+			'value' => 1,
+		],
+		[
+			'ID_THEME' => 2,
+			'variable' => 'name',
+			'value' => 'Classic YaBB SE Theme',
+		],
+		[
+			'ID_THEME' => 2,
+			'variable' => 'theme_url',
+			'value' => '{$boardurl}/Themes/classic',
+		],
+		[
+			'ID_THEME' => 2,
+			'variable' => 'images_url',
+			'value' => '{$boardurl}/Themes/classic/images',
+		],
+		[
+			'ID_THEME' => 2,
+			'variable' => 'theme_dir',
+			'value' => '{$boarddir}/Themes/classic',
+		],
+	];
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'themes';
+
+		$this->columns = [
+			'ID_MEMBER' => new Column(
+				name: 'ID_MEMBER',
+				type: 'mediumint',
+				not_null: true,
+				default: 0,
+			),
+			'ID_THEME' => new Column(
+				name: 'ID_THEME',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				default: 1,
+			),
+			'variable' => new Column(
+				name: 'variable',
+				type: 'tinytext',
+				not_null: true,
+				default: '',
+			),
+			'value' => new Column(
+				name: 'value',
+				type: 'text',
+				not_null: true,
+				default: '',
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'ID_MEMBER',
+					],
+					[
+						'name' => 'ID_THEME',
+					],
+					[
+						'name' => 'variable',
+						'size' => 30,
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v1_0/Topics.php
+++ b/Sources/Db/Schema/v1_0/Topics.php
@@ -1,0 +1,179 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v1_0;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class Topics extends Table
+{
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'topics';
+
+		$this->columns = [
+			'ID_TOPIC' => new Column(
+				name: 'ID_TOPIC',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				auto: true,
+			),
+			'isSticky' => new Column(
+				name: 'isSticky',
+				type: 'tinyint',
+				not_null: true,
+				default: 0,
+			),
+			'ID_BOARD' => new Column(
+				name: 'ID_BOARD',
+				type: 'smallint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'ID_FIRST_MSG' => new Column(
+				name: 'ID_FIRST_MSG',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'ID_LAST_MSG' => new Column(
+				name: 'ID_LAST_MSG',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'ID_MEMBER_STARTED' => new Column(
+				name: 'ID_MEMBER_STARTED',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'ID_MEMBER_UPDATED' => new Column(
+				name: 'ID_MEMBER_UPDATED',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'ID_POLL' => new Column(
+				name: 'ID_POLL',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'numReplies' => new Column(
+				name: 'numReplies',
+				type: 'int',
+				not_null: true,
+				default: 0,
+			),
+			'numViews' => new Column(
+				name: 'numViews',
+				type: 'int',
+				not_null: true,
+				default: 0,
+			),
+			'locked' => new Column(
+				name: 'locked',
+				type: 'tinyint',
+				not_null: true,
+				default: 0,
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'ID_TOPIC',
+					],
+				],
+			),
+			'lastMessage' => new DbIndex(
+				type: 'unique',
+				name: 'lastMessage',
+				columns: [
+					[
+						'name' => 'ID_LAST_MSG',
+					],
+					[
+						'name' => 'ID_BOARD',
+					],
+				],
+			),
+			'firstMessage' => new DbIndex(
+				type: 'unique',
+				name: 'firstMessage',
+				columns: [
+					[
+						'name' => 'ID_FIRST_MSG',
+					],
+					[
+						'name' => 'ID_BOARD',
+					],
+				],
+			),
+			'poll' => new DbIndex(
+				type: 'unique',
+				name: 'poll',
+				columns: [
+					[
+						'name' => 'ID_POLL',
+					],
+					[
+						'name' => 'ID_TOPIC',
+					],
+				],
+			),
+			'isSticky' => new DbIndex(
+				name: 'isSticky',
+				columns: [
+					[
+						'name' => 'isSticky',
+					],
+				],
+			),
+			'ID_BOARD' => new DbIndex(
+				name: 'ID_BOARD',
+				columns: [
+					[
+						'name' => 'ID_BOARD',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v1_0/index.php
+++ b/Sources/Db/Schema/v1_0/index.php
@@ -1,0 +1,8 @@
+<?php
+
+// Try to handle it with the upper level index.php. (it should know what to do.)
+if (file_exists(dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php')) {
+	include dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php';
+} else {
+	exit;
+}

--- a/Sources/Db/Schema/v1_1/Attachments.php
+++ b/Sources/Db/Schema/v1_1/Attachments.php
@@ -1,0 +1,149 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v1_1;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class Attachments extends Table
+{
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'attachments';
+
+		$this->columns = [
+			'ID_ATTACH' => new Column(
+				name: 'ID_ATTACH',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				auto: true,
+			),
+			'ID_THUMB' => new Column(
+				name: 'ID_THUMB',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'ID_MSG' => new Column(
+				name: 'ID_MSG',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'ID_MEMBER' => new Column(
+				name: 'ID_MEMBER',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'attachmentType' => new Column(
+				name: 'attachmentType',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'filename' => new Column(
+				name: 'filename',
+				type: 'tinytext',
+				not_null: true,
+			),
+			'file_hash' => new Column(
+				name: 'file_hash',
+				type: 'varchar',
+				size: 40,
+				not_null: true,
+				default: '',
+			),
+			'size' => new Column(
+				name: 'size',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'downloads' => new Column(
+				name: 'downloads',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'width' => new Column(
+				name: 'width',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'height' => new Column(
+				name: 'height',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'ID_ATTACH',
+					],
+				],
+			),
+			'ID_MEMBER' => new DbIndex(
+				type: 'unique',
+				name: 'ID_MEMBER',
+				columns: [
+					[
+						'name' => 'ID_MEMBER',
+					],
+					[
+						'name' => 'ID_ATTACH',
+					],
+				],
+			),
+			'ID_MSG' => new DbIndex(
+				name: 'ID_MSG',
+				columns: [
+					[
+						'name' => 'ID_MSG',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v1_1/BanGroups.php
+++ b/Sources/Db/Schema/v1_1/BanGroups.php
@@ -1,0 +1,118 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v1_1;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class BanGroups extends Table
+{
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'ban_groups';
+
+		$this->columns = [
+			'ID_BAN_GROUP' => new Column(
+				name: 'ID_BAN_GROUP',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				auto: true,
+			),
+			'name' => new Column(
+				name: 'name',
+				type: 'varchar',
+				size: 20,
+				not_null: true,
+				default: '',
+			),
+			'ban_time' => new Column(
+				name: 'ban_time',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'expire_time' => new Column(
+				name: 'expire_time',
+				type: 'int',
+				unsigned: true,
+			),
+			'cannot_access' => new Column(
+				name: 'cannot_access',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'cannot_register' => new Column(
+				name: 'cannot_register',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'cannot_post' => new Column(
+				name: 'cannot_post',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'cannot_login' => new Column(
+				name: 'cannot_login',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'reason' => new Column(
+				name: 'reason',
+				type: 'tinytext',
+				not_null: true,
+			),
+			'notes' => new Column(
+				name: 'notes',
+				type: 'text',
+				not_null: true,
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'ID_BAN_GROUP',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v1_1/BanItems.php
+++ b/Sources/Db/Schema/v1_1/BanItems.php
@@ -1,0 +1,156 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v1_1;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class BanItems extends Table
+{
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'ban_items';
+
+		$this->columns = [
+			'ID_BAN' => new Column(
+				name: 'ID_BAN',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				auto: true,
+			),
+			'ID_BAN_GROUP' => new Column(
+				name: 'ID_BAN_GROUP',
+				type: 'smallint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'ip_low1' => new Column(
+				name: 'ip_low1',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'ip_high1' => new Column(
+				name: 'ip_high1',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'ip_low2' => new Column(
+				name: 'ip_low2',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'ip_high2' => new Column(
+				name: 'ip_high2',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'ip_low3' => new Column(
+				name: 'ip_low3',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'ip_high3' => new Column(
+				name: 'ip_high3',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'ip_low4' => new Column(
+				name: 'ip_low4',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'ip_high4' => new Column(
+				name: 'ip_high4',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'hostname' => new Column(
+				name: 'hostname',
+				type: 'tinytext',
+				not_null: true,
+			),
+			'email_address' => new Column(
+				name: 'email_address',
+				type: 'tinytext',
+				not_null: true,
+			),
+			'ID_MEMBER' => new Column(
+				name: 'ID_MEMBER',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'hits' => new Column(
+				name: 'hits',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'ID_BAN',
+					],
+				],
+			),
+			'ID_BAN_GROUP' => new DbIndex(
+				name: 'ID_BAN_GROUP',
+				columns: [
+					[
+						'name' => 'ID_BAN_GROUP',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v1_1/BoardPermissions.php
+++ b/Sources/Db/Schema/v1_1/BoardPermissions.php
@@ -1,0 +1,443 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v1_1;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class BoardPermissions extends Table
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 * @var array
+	 *
+	 * Data used to populate the table during install.
+	 */
+	public array $initial_data = [
+		[
+			'ID_GROUP' => -1,
+			'ID_BOARD' => 0,
+			'permission' => 'poll_view',
+		],
+		[
+			'ID_GROUP' => 0,
+			'ID_BOARD' => 0,
+			'permission' => 'remove_own',
+		],
+		[
+			'ID_GROUP' => 0,
+			'ID_BOARD' => 0,
+			'permission' => 'lock_own',
+		],
+		[
+			'ID_GROUP' => 0,
+			'ID_BOARD' => 0,
+			'permission' => 'mark_any_notify',
+		],
+		[
+			'ID_GROUP' => 0,
+			'ID_BOARD' => 0,
+			'permission' => 'mark_notify',
+		],
+		[
+			'ID_GROUP' => 0,
+			'ID_BOARD' => 0,
+			'permission' => 'modify_own',
+		],
+		[
+			'ID_GROUP' => 0,
+			'ID_BOARD' => 0,
+			'permission' => 'poll_add_own',
+		],
+		[
+			'ID_GROUP' => 0,
+			'ID_BOARD' => 0,
+			'permission' => 'poll_edit_own',
+		],
+		[
+			'ID_GROUP' => 0,
+			'ID_BOARD' => 0,
+			'permission' => 'poll_lock_own',
+		],
+		[
+			'ID_GROUP' => 0,
+			'ID_BOARD' => 0,
+			'permission' => 'poll_post',
+		],
+		[
+			'ID_GROUP' => 0,
+			'ID_BOARD' => 0,
+			'permission' => 'poll_view',
+		],
+		[
+			'ID_GROUP' => 0,
+			'ID_BOARD' => 0,
+			'permission' => 'poll_vote',
+		],
+		[
+			'ID_GROUP' => 0,
+			'ID_BOARD' => 0,
+			'permission' => 'post_attachment',
+		],
+		[
+			'ID_GROUP' => 0,
+			'ID_BOARD' => 0,
+			'permission' => 'post_new',
+		],
+		[
+			'ID_GROUP' => 0,
+			'ID_BOARD' => 0,
+			'permission' => 'post_reply_any',
+		],
+		[
+			'ID_GROUP' => 0,
+			'ID_BOARD' => 0,
+			'permission' => 'post_reply_own',
+		],
+		[
+			'ID_GROUP' => 0,
+			'ID_BOARD' => 0,
+			'permission' => 'delete_own',
+		],
+		[
+			'ID_GROUP' => 0,
+			'ID_BOARD' => 0,
+			'permission' => 'report_any',
+		],
+		[
+			'ID_GROUP' => 0,
+			'ID_BOARD' => 0,
+			'permission' => 'send_topic',
+		],
+		[
+			'ID_GROUP' => 0,
+			'ID_BOARD' => 0,
+			'permission' => 'view_attachments',
+		],
+		[
+			'ID_GROUP' => 2,
+			'ID_BOARD' => 0,
+			'permission' => 'moderate_board',
+		],
+		[
+			'ID_GROUP' => 2,
+			'ID_BOARD' => 0,
+			'permission' => 'post_new',
+		],
+		[
+			'ID_GROUP' => 2,
+			'ID_BOARD' => 0,
+			'permission' => 'post_reply_own',
+		],
+		[
+			'ID_GROUP' => 2,
+			'ID_BOARD' => 0,
+			'permission' => 'post_reply_any',
+		],
+		[
+			'ID_GROUP' => 2,
+			'ID_BOARD' => 0,
+			'permission' => 'poll_post',
+		],
+		[
+			'ID_GROUP' => 2,
+			'ID_BOARD' => 0,
+			'permission' => 'poll_add_any',
+		],
+		[
+			'ID_GROUP' => 2,
+			'ID_BOARD' => 0,
+			'permission' => 'poll_remove_any',
+		],
+		[
+			'ID_GROUP' => 2,
+			'ID_BOARD' => 0,
+			'permission' => 'poll_view',
+		],
+		[
+			'ID_GROUP' => 2,
+			'ID_BOARD' => 0,
+			'permission' => 'poll_vote',
+		],
+		[
+			'ID_GROUP' => 2,
+			'ID_BOARD' => 0,
+			'permission' => 'poll_edit_any',
+		],
+		[
+			'ID_GROUP' => 2,
+			'ID_BOARD' => 0,
+			'permission' => 'report_any',
+		],
+		[
+			'ID_GROUP' => 2,
+			'ID_BOARD' => 0,
+			'permission' => 'lock_own',
+		],
+		[
+			'ID_GROUP' => 2,
+			'ID_BOARD' => 0,
+			'permission' => 'send_topic',
+		],
+		[
+			'ID_GROUP' => 2,
+			'ID_BOARD' => 0,
+			'permission' => 'mark_any_notify',
+		],
+		[
+			'ID_GROUP' => 2,
+			'ID_BOARD' => 0,
+			'permission' => 'mark_notify',
+		],
+		[
+			'ID_GROUP' => 2,
+			'ID_BOARD' => 0,
+			'permission' => 'delete_own',
+		],
+		[
+			'ID_GROUP' => 2,
+			'ID_BOARD' => 0,
+			'permission' => 'modify_own',
+		],
+		[
+			'ID_GROUP' => 2,
+			'ID_BOARD' => 0,
+			'permission' => 'make_sticky',
+		],
+		[
+			'ID_GROUP' => 2,
+			'ID_BOARD' => 0,
+			'permission' => 'lock_any',
+		],
+		[
+			'ID_GROUP' => 2,
+			'ID_BOARD' => 0,
+			'permission' => 'remove_any',
+		],
+		[
+			'ID_GROUP' => 2,
+			'ID_BOARD' => 0,
+			'permission' => 'move_any',
+		],
+		[
+			'ID_GROUP' => 2,
+			'ID_BOARD' => 0,
+			'permission' => 'merge_any',
+		],
+		[
+			'ID_GROUP' => 2,
+			'ID_BOARD' => 0,
+			'permission' => 'split_any',
+		],
+		[
+			'ID_GROUP' => 2,
+			'ID_BOARD' => 0,
+			'permission' => 'delete_any',
+		],
+		[
+			'ID_GROUP' => 2,
+			'ID_BOARD' => 0,
+			'permission' => 'modify_any',
+		],
+		[
+			'ID_GROUP' => 3,
+			'ID_BOARD' => 0,
+			'permission' => 'moderate_board',
+		],
+		[
+			'ID_GROUP' => 3,
+			'ID_BOARD' => 0,
+			'permission' => 'post_new',
+		],
+		[
+			'ID_GROUP' => 3,
+			'ID_BOARD' => 0,
+			'permission' => 'post_reply_own',
+		],
+		[
+			'ID_GROUP' => 3,
+			'ID_BOARD' => 0,
+			'permission' => 'post_reply_any',
+		],
+		[
+			'ID_GROUP' => 3,
+			'ID_BOARD' => 0,
+			'permission' => 'poll_post',
+		],
+		[
+			'ID_GROUP' => 3,
+			'ID_BOARD' => 0,
+			'permission' => 'poll_add_own',
+		],
+		[
+			'ID_GROUP' => 3,
+			'ID_BOARD' => 0,
+			'permission' => 'poll_remove_any',
+		],
+		[
+			'ID_GROUP' => 3,
+			'ID_BOARD' => 0,
+			'permission' => 'poll_view',
+		],
+		[
+			'ID_GROUP' => 3,
+			'ID_BOARD' => 0,
+			'permission' => 'poll_vote',
+		],
+		[
+			'ID_GROUP' => 3,
+			'ID_BOARD' => 0,
+			'permission' => 'report_any',
+		],
+		[
+			'ID_GROUP' => 3,
+			'ID_BOARD' => 0,
+			'permission' => 'lock_own',
+		],
+		[
+			'ID_GROUP' => 3,
+			'ID_BOARD' => 0,
+			'permission' => 'send_topic',
+		],
+		[
+			'ID_GROUP' => 3,
+			'ID_BOARD' => 0,
+			'permission' => 'mark_any_notify',
+		],
+		[
+			'ID_GROUP' => 3,
+			'ID_BOARD' => 0,
+			'permission' => 'mark_notify',
+		],
+		[
+			'ID_GROUP' => 3,
+			'ID_BOARD' => 0,
+			'permission' => 'delete_own',
+		],
+		[
+			'ID_GROUP' => 3,
+			'ID_BOARD' => 0,
+			'permission' => 'modify_own',
+		],
+		[
+			'ID_GROUP' => 3,
+			'ID_BOARD' => 0,
+			'permission' => 'make_sticky',
+		],
+		[
+			'ID_GROUP' => 3,
+			'ID_BOARD' => 0,
+			'permission' => 'lock_any',
+		],
+		[
+			'ID_GROUP' => 3,
+			'ID_BOARD' => 0,
+			'permission' => 'remove_any',
+		],
+		[
+			'ID_GROUP' => 3,
+			'ID_BOARD' => 0,
+			'permission' => 'move_any',
+		],
+		[
+			'ID_GROUP' => 3,
+			'ID_BOARD' => 0,
+			'permission' => 'merge_any',
+		],
+		[
+			'ID_GROUP' => 3,
+			'ID_BOARD' => 0,
+			'permission' => 'split_any',
+		],
+		[
+			'ID_GROUP' => 3,
+			'ID_BOARD' => 0,
+			'permission' => 'delete_any',
+		],
+		[
+			'ID_GROUP' => 3,
+			'ID_BOARD' => 0,
+			'permission' => 'modify_any',
+		],
+	];
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'board_permissions';
+
+		$this->columns = [
+			'ID_GROUP' => new Column(
+				name: 'ID_GROUP',
+				type: 'smallint',
+				not_null: true,
+				default: 0,
+			),
+			'ID_BOARD' => new Column(
+				name: 'ID_BOARD',
+				type: 'smallint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'permission' => new Column(
+				name: 'permission',
+				type: 'varchar',
+				size: 30,
+				not_null: true,
+				default: '',
+			),
+			'addDeny' => new Column(
+				name: 'addDeny',
+				type: 'tinyint',
+				not_null: true,
+				default: 1,
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'ID_GROUP',
+					],
+					[
+						'name' => 'ID_BOARD',
+					],
+					[
+						'name' => 'permission',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v1_1/Boards.php
+++ b/Sources/Db/Schema/v1_1/Boards.php
@@ -1,0 +1,221 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v1_1;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class Boards extends Table
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 * @var array
+	 *
+	 * Data used to populate the table during install.
+	 */
+	public array $initial_data = [
+		[
+			'ID_BOARD' => 1,
+			'ID_CAT' => 1,
+			'boardOrder' => 1,
+			'ID_LAST_MSG' => 1,
+			'ID_MSG_UPDATED' => 1,
+			'name' => '{$default_board_name}',
+			'description' => '{$default_board_description}',
+			'numTopics' => 1,
+			'numPosts' => 1,
+			'memberGroups' => '-1,0',
+		],
+	];
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'boards';
+
+		$this->columns = [
+			'ID_BOARD' => new Column(
+				name: 'ID_BOARD',
+				type: 'smallint',
+				unsigned: true,
+				not_null: true,
+				auto: true,
+			),
+			'ID_CAT' => new Column(
+				name: 'ID_CAT',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'childLevel' => new Column(
+				name: 'childLevel',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'ID_PARENT' => new Column(
+				name: 'ID_PARENT',
+				type: 'smallint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'boardOrder' => new Column(
+				name: 'boardOrder',
+				type: 'smallint',
+				not_null: true,
+				default: 0,
+			),
+			'ID_LAST_MSG' => new Column(
+				name: 'ID_LAST_MSG',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'ID_MSG_UPDATED' => new Column(
+				name: 'ID_MSG_UPDATED',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'memberGroups' => new Column(
+				name: 'memberGroups',
+				type: 'varchar',
+				size: 255,
+				not_null: true,
+				default: '-1,0',
+			),
+			'name' => new Column(
+				name: 'name',
+				type: 'tinytext',
+				not_null: true,
+			),
+			'description' => new Column(
+				name: 'description',
+				type: 'text',
+				not_null: true,
+			),
+			'numTopics' => new Column(
+				name: 'numTopics',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'numPosts' => new Column(
+				name: 'numPosts',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'countPosts' => new Column(
+				name: 'countPosts',
+				type: 'tinyint',
+				not_null: true,
+				default: 0,
+			),
+			'ID_THEME' => new Column(
+				name: 'ID_THEME',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'permission_mode' => new Column(
+				name: 'permission_mode',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'override_theme' => new Column(
+				name: 'override_theme',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'ID_BOARD',
+					],
+				],
+			),
+			'categories' => new DbIndex(
+				type: 'unique',
+				name: 'categories',
+				columns: [
+					[
+						'name' => 'ID_CAT',
+					],
+					[
+						'name' => 'ID_BOARD',
+					],
+				],
+			),
+			'ID_PARENT' => new DbIndex(
+				name: 'ID_PARENT',
+				columns: [
+					[
+						'name' => 'ID_PARENT',
+					],
+				],
+			),
+			'ID_MSG_UPDATED' => new DbIndex(
+				name: 'ID_MSG_UPDATED',
+				columns: [
+					[
+						'name' => 'ID_MSG_UPDATED',
+					],
+				],
+			),
+			'memberGroups' => new DbIndex(
+				name: 'memberGroups',
+				columns: [
+					[
+						'name' => 'memberGroups',
+						'size' => 48,
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v1_1/Calendar.php
+++ b/Sources/Db/Schema/v1_1/Calendar.php
@@ -1,0 +1,132 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v1_1;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class Calendar extends Table
+{
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'calendar';
+
+		$this->columns = [
+			'ID_EVENT' => new Column(
+				name: 'ID_EVENT',
+				type: 'smallint',
+				unsigned: true,
+				not_null: true,
+				auto: true,
+			),
+			'startDate' => new Column(
+				name: 'startDate',
+				type: 'date',
+				not_null: true,
+				// SMF 1.1 actually used '0001-01-01', but modern versions
+				// of MySQL don't like that.
+				default: '1004-01-01',
+			),
+			'endDate' => new Column(
+				name: 'endDate',
+				type: 'date',
+				not_null: true,
+				// SMF 1.1 actually used '0001-01-01', but modern versions
+				// of MySQL don't like that.
+				default: '1004-01-01',
+			),
+			'ID_BOARD' => new Column(
+				name: 'ID_BOARD',
+				type: 'smallint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'ID_TOPIC' => new Column(
+				name: 'ID_TOPIC',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'title' => new Column(
+				name: 'title',
+				type: 'varchar',
+				size: 48,
+				not_null: true,
+				default: '',
+			),
+			'ID_MEMBER' => new Column(
+				name: 'ID_MEMBER',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'ID_EVENT',
+					],
+				],
+			),
+			'startDate' => new DbIndex(
+				name: 'startDate',
+				columns: [
+					[
+						'name' => 'startDate',
+					],
+				],
+			),
+			'endDate' => new DbIndex(
+				name: 'endDate',
+				columns: [
+					[
+						'name' => 'endDate',
+					],
+				],
+			),
+			'topic' => new DbIndex(
+				name: 'topic',
+				columns: [
+					[
+						'name' => 'ID_TOPIC',
+					],
+					[
+						'name' => 'ID_MEMBER',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v1_1/CalendarHolidays.php
+++ b/Sources/Db/Schema/v1_1/CalendarHolidays.php
@@ -1,0 +1,762 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v1_1;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class CalendarHolidays extends Table
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 * @var array
+	 *
+	 * Data used to populate the table during install.
+	 */
+	public array $initial_data = [
+		[
+			'title' => 'New Year\'s',
+			'eventDate' => '0004-01-01',
+		],
+		[
+			'title' => 'Christmas',
+			'eventDate' => '0004-12-25',
+		],
+		[
+			'title' => 'Valentine\'s Day',
+			'eventDate' => '0004-02-14',
+		],
+		[
+			'title' => 'St. Patrick\'s Day',
+			'eventDate' => '0004-03-17',
+		],
+		[
+			'title' => 'April Fools',
+			'eventDate' => '0004-04-01',
+		],
+		[
+			'title' => 'Earth Day',
+			'eventDate' => '0004-04-22',
+		],
+		[
+			'title' => 'United Nations Day',
+			'eventDate' => '0004-10-24',
+		],
+		[
+			'title' => 'Halloween',
+			'eventDate' => '0004-10-31',
+		],
+		[
+			'title' => 'Mother\'s Day',
+			'eventDate' => '2004-05-09',
+		],
+		[
+			'title' => 'Mother\'s Day',
+			'eventDate' => '2005-05-08',
+		],
+		[
+			'title' => 'Mother\'s Day',
+			'eventDate' => '2006-05-14',
+		],
+		[
+			'title' => 'Mother\'s Day',
+			'eventDate' => '2007-05-13',
+		],
+		[
+			'title' => 'Mother\'s Day',
+			'eventDate' => '2008-05-11',
+		],
+		[
+			'title' => 'Mother\'s Day',
+			'eventDate' => '2009-05-10',
+		],
+		[
+			'title' => 'Mother\'s Day',
+			'eventDate' => '2010-05-09',
+		],
+		[
+			'title' => 'Mother\'s Day',
+			'eventDate' => '2011-05-08',
+		],
+		[
+			'title' => 'Mother\'s Day',
+			'eventDate' => '2012-05-13',
+		],
+		[
+			'title' => 'Mother\'s Day',
+			'eventDate' => '2013-05-12',
+		],
+		[
+			'title' => 'Mother\'s Day',
+			'eventDate' => '2014-05-11',
+		],
+		[
+			'title' => 'Mother\'s Day',
+			'eventDate' => '2015-05-10',
+		],
+		[
+			'title' => 'Mother\'s Day',
+			'eventDate' => '2016-05-08',
+		],
+		[
+			'title' => 'Mother\'s Day',
+			'eventDate' => '2017-05-14',
+		],
+		[
+			'title' => 'Mother\'s Day',
+			'eventDate' => '2018-05-13',
+		],
+		[
+			'title' => 'Mother\'s Day',
+			'eventDate' => '2019-05-12',
+		],
+		[
+			'title' => 'Mother\'s Day',
+			'eventDate' => '2020-05-10',
+		],
+		[
+			'title' => 'Father\'s Day',
+			'eventDate' => '2004-06-20',
+		],
+		[
+			'title' => 'Father\'s Day',
+			'eventDate' => '2005-06-19',
+		],
+		[
+			'title' => 'Father\'s Day',
+			'eventDate' => '2006-06-18',
+		],
+		[
+			'title' => 'Father\'s Day',
+			'eventDate' => '2007-06-17',
+		],
+		[
+			'title' => 'Father\'s Day',
+			'eventDate' => '2008-06-15',
+		],
+		[
+			'title' => 'Father\'s Day',
+			'eventDate' => '2009-06-21',
+		],
+		[
+			'title' => 'Father\'s Day',
+			'eventDate' => '2010-06-20',
+		],
+		[
+			'title' => 'Father\'s Day',
+			'eventDate' => '2011-06-19',
+		],
+		[
+			'title' => 'Father\'s Day',
+			'eventDate' => '2012-06-17',
+		],
+		[
+			'title' => 'Father\'s Day',
+			'eventDate' => '2013-06-16',
+		],
+		[
+			'title' => 'Father\'s Day',
+			'eventDate' => '2014-06-15',
+		],
+		[
+			'title' => 'Father\'s Day',
+			'eventDate' => '2015-06-21',
+		],
+		[
+			'title' => 'Father\'s Day',
+			'eventDate' => '2016-06-19',
+		],
+		[
+			'title' => 'Father\'s Day',
+			'eventDate' => '2017-06-18',
+		],
+		[
+			'title' => 'Father\'s Day',
+			'eventDate' => '2018-06-17',
+		],
+		[
+			'title' => 'Father\'s Day',
+			'eventDate' => '2019-06-16',
+		],
+		[
+			'title' => 'Father\'s Day',
+			'eventDate' => '2020-06-21',
+		],
+		[
+			'title' => 'Summer Solstice',
+			'eventDate' => '2004-06-20',
+		],
+		[
+			'title' => 'Summer Solstice',
+			'eventDate' => '2005-06-20',
+		],
+		[
+			'title' => 'Summer Solstice',
+			'eventDate' => '2006-06-21',
+		],
+		[
+			'title' => 'Summer Solstice',
+			'eventDate' => '2007-06-21',
+		],
+		[
+			'title' => 'Summer Solstice',
+			'eventDate' => '2008-06-20',
+		],
+		[
+			'title' => 'Summer Solstice',
+			'eventDate' => '2009-06-20',
+		],
+		[
+			'title' => 'Summer Solstice',
+			'eventDate' => '2010-06-21',
+		],
+		[
+			'title' => 'Summer Solstice',
+			'eventDate' => '2011-06-21',
+		],
+		[
+			'title' => 'Summer Solstice',
+			'eventDate' => '2012-06-20',
+		],
+		[
+			'title' => 'Summer Solstice',
+			'eventDate' => '2013-06-21',
+		],
+		[
+			'title' => 'Summer Solstice',
+			'eventDate' => '2014-06-21',
+		],
+		[
+			'title' => 'Summer Solstice',
+			'eventDate' => '2015-06-21',
+		],
+		[
+			'title' => 'Summer Solstice',
+			'eventDate' => '2016-06-20',
+		],
+		[
+			'title' => 'Summer Solstice',
+			'eventDate' => '2017-06-20',
+		],
+		[
+			'title' => 'Summer Solstice',
+			'eventDate' => '2018-06-21',
+		],
+		[
+			'title' => 'Summer Solstice',
+			'eventDate' => '2019-06-21',
+		],
+		[
+			'title' => 'Summer Solstice',
+			'eventDate' => '2020-06-20',
+		],
+		[
+			'title' => 'Vernal Equinox',
+			'eventDate' => '2004-03-19',
+		],
+		[
+			'title' => 'Vernal Equinox',
+			'eventDate' => '2005-03-20',
+		],
+		[
+			'title' => 'Vernal Equinox',
+			'eventDate' => '2006-03-20',
+		],
+		[
+			'title' => 'Vernal Equinox',
+			'eventDate' => '2007-03-20',
+		],
+		[
+			'title' => 'Vernal Equinox',
+			'eventDate' => '2008-03-19',
+		],
+		[
+			'title' => 'Vernal Equinox',
+			'eventDate' => '2009-03-20',
+		],
+		[
+			'title' => 'Vernal Equinox',
+			'eventDate' => '2010-03-20',
+		],
+		[
+			'title' => 'Vernal Equinox',
+			'eventDate' => '2011-03-20',
+		],
+		[
+			'title' => 'Vernal Equinox',
+			'eventDate' => '2012-03-20',
+		],
+		[
+			'title' => 'Vernal Equinox',
+			'eventDate' => '2013-03-20',
+		],
+		[
+			'title' => 'Vernal Equinox',
+			'eventDate' => '2014-03-20',
+		],
+		[
+			'title' => 'Vernal Equinox',
+			'eventDate' => '2015-03-20',
+		],
+		[
+			'title' => 'Vernal Equinox',
+			'eventDate' => '2016-03-19',
+		],
+		[
+			'title' => 'Vernal Equinox',
+			'eventDate' => '2017-03-20',
+		],
+		[
+			'title' => 'Vernal Equinox',
+			'eventDate' => '2018-03-20',
+		],
+		[
+			'title' => 'Vernal Equinox',
+			'eventDate' => '2019-03-20',
+		],
+		[
+			'title' => 'Vernal Equinox',
+			'eventDate' => '2020-03-19',
+		],
+		[
+			'title' => 'Winter Solstice',
+			'eventDate' => '2004-12-21',
+		],
+		[
+			'title' => 'Winter Solstice',
+			'eventDate' => '2005-12-21',
+		],
+		[
+			'title' => 'Winter Solstice',
+			'eventDate' => '2006-12-22',
+		],
+		[
+			'title' => 'Winter Solstice',
+			'eventDate' => '2007-12-22',
+		],
+		[
+			'title' => 'Winter Solstice',
+			'eventDate' => '2008-12-21',
+		],
+		[
+			'title' => 'Winter Solstice',
+			'eventDate' => '2009-12-21',
+		],
+		[
+			'title' => 'Winter Solstice',
+			'eventDate' => '2010-12-21',
+		],
+		[
+			'title' => 'Winter Solstice',
+			'eventDate' => '2011-12-22',
+		],
+		[
+			'title' => 'Winter Solstice',
+			'eventDate' => '2012-12-21',
+		],
+		[
+			'title' => 'Winter Solstice',
+			'eventDate' => '2013-12-21',
+		],
+		[
+			'title' => 'Winter Solstice',
+			'eventDate' => '2014-12-21',
+		],
+		[
+			'title' => 'Winter Solstice',
+			'eventDate' => '2015-12-21',
+		],
+		[
+			'title' => 'Winter Solstice',
+			'eventDate' => '2016-12-21',
+		],
+		[
+			'title' => 'Winter Solstice',
+			'eventDate' => '2017-12-21',
+		],
+		[
+			'title' => 'Winter Solstice',
+			'eventDate' => '2018-12-21',
+		],
+		[
+			'title' => 'Winter Solstice',
+			'eventDate' => '2019-12-21',
+		],
+		[
+			'title' => 'Winter Solstice',
+			'eventDate' => '2020-12-21',
+		],
+		[
+			'title' => 'Autumnal Equinox',
+			'eventDate' => '2004-09-22',
+		],
+		[
+			'title' => 'Autumnal Equinox',
+			'eventDate' => '2005-09-22',
+		],
+		[
+			'title' => 'Autumnal Equinox',
+			'eventDate' => '2006-09-22',
+		],
+		[
+			'title' => 'Autumnal Equinox',
+			'eventDate' => '2007-09-23',
+		],
+		[
+			'title' => 'Autumnal Equinox',
+			'eventDate' => '2008-09-22',
+		],
+		[
+			'title' => 'Autumnal Equinox',
+			'eventDate' => '2009-09-22',
+		],
+		[
+			'title' => 'Autumnal Equinox',
+			'eventDate' => '2010-09-22',
+		],
+		[
+			'title' => 'Autumnal Equinox',
+			'eventDate' => '2011-09-23',
+		],
+		[
+			'title' => 'Autumnal Equinox',
+			'eventDate' => '2012-09-22',
+		],
+		[
+			'title' => 'Autumnal Equinox',
+			'eventDate' => '2013-09-22',
+		],
+		[
+			'title' => 'Autumnal Equinox',
+			'eventDate' => '2014-09-22',
+		],
+		[
+			'title' => 'Autumnal Equinox',
+			'eventDate' => '2015-09-23',
+		],
+		[
+			'title' => 'Autumnal Equinox',
+			'eventDate' => '2016-09-22',
+		],
+		[
+			'title' => 'Autumnal Equinox',
+			'eventDate' => '2017-09-22',
+		],
+		[
+			'title' => 'Autumnal Equinox',
+			'eventDate' => '2018-09-22',
+		],
+		[
+			'title' => 'Autumnal Equinox',
+			'eventDate' => '2019-09-23',
+		],
+		[
+			'title' => 'Autumnal Equinox',
+			'eventDate' => '2020-09-22',
+		],
+		[
+			'title' => 'Independence Day',
+			'eventDate' => '0004-07-04',
+		],
+		[
+			'title' => 'Cinco de Mayo',
+			'eventDate' => '0004-05-05',
+		],
+		[
+			'title' => 'Flag Day',
+			'eventDate' => '0004-06-14',
+		],
+		[
+			'title' => 'Veterans Day',
+			'eventDate' => '0004-11-11',
+		],
+		[
+			'title' => 'Groundhog Day',
+			'eventDate' => '0004-02-02',
+		],
+		[
+			'title' => 'Thanksgiving',
+			'eventDate' => '2004-11-25',
+		],
+		[
+			'title' => 'Thanksgiving',
+			'eventDate' => '2005-11-24',
+		],
+		[
+			'title' => 'Thanksgiving',
+			'eventDate' => '2006-11-23',
+		],
+		[
+			'title' => 'Thanksgiving',
+			'eventDate' => '2007-11-22',
+		],
+		[
+			'title' => 'Thanksgiving',
+			'eventDate' => '2008-11-27',
+		],
+		[
+			'title' => 'Thanksgiving',
+			'eventDate' => '2009-11-26',
+		],
+		[
+			'title' => 'Thanksgiving',
+			'eventDate' => '2010-11-25',
+		],
+		[
+			'title' => 'Thanksgiving',
+			'eventDate' => '2011-11-24',
+		],
+		[
+			'title' => 'Thanksgiving',
+			'eventDate' => '2012-11-22',
+		],
+		[
+			'title' => 'Thanksgiving',
+			'eventDate' => '2013-11-21',
+		],
+		[
+			'title' => 'Thanksgiving',
+			'eventDate' => '2014-11-20',
+		],
+		[
+			'title' => 'Thanksgiving',
+			'eventDate' => '2015-11-26',
+		],
+		[
+			'title' => 'Thanksgiving',
+			'eventDate' => '2016-11-24',
+		],
+		[
+			'title' => 'Thanksgiving',
+			'eventDate' => '2017-11-23',
+		],
+		[
+			'title' => 'Thanksgiving',
+			'eventDate' => '2018-11-22',
+		],
+		[
+			'title' => 'Thanksgiving',
+			'eventDate' => '2019-11-21',
+		],
+		[
+			'title' => 'Thanksgiving',
+			'eventDate' => '2020-11-26',
+		],
+		[
+			'title' => 'Memorial Day',
+			'eventDate' => '2004-05-31',
+		],
+		[
+			'title' => 'Memorial Day',
+			'eventDate' => '2005-05-30',
+		],
+		[
+			'title' => 'Memorial Day',
+			'eventDate' => '2006-05-29',
+		],
+		[
+			'title' => 'Memorial Day',
+			'eventDate' => '2007-05-28',
+		],
+		[
+			'title' => 'Memorial Day',
+			'eventDate' => '2008-05-26',
+		],
+		[
+			'title' => 'Memorial Day',
+			'eventDate' => '2009-05-25',
+		],
+		[
+			'title' => 'Memorial Day',
+			'eventDate' => '2010-05-31',
+		],
+		[
+			'title' => 'Memorial Day',
+			'eventDate' => '2011-05-30',
+		],
+		[
+			'title' => 'Memorial Day',
+			'eventDate' => '2012-05-28',
+		],
+		[
+			'title' => 'Memorial Day',
+			'eventDate' => '2013-05-27',
+		],
+		[
+			'title' => 'Memorial Day',
+			'eventDate' => '2014-05-26',
+		],
+		[
+			'title' => 'Memorial Day',
+			'eventDate' => '2015-05-25',
+		],
+		[
+			'title' => 'Memorial Day',
+			'eventDate' => '2016-05-30',
+		],
+		[
+			'title' => 'Memorial Day',
+			'eventDate' => '2017-05-29',
+		],
+		[
+			'title' => 'Memorial Day',
+			'eventDate' => '2018-05-28',
+		],
+		[
+			'title' => 'Memorial Day',
+			'eventDate' => '2019-05-27',
+		],
+		[
+			'title' => 'Memorial Day',
+			'eventDate' => '2020-05-25',
+		],
+		[
+			'title' => 'Labor Day',
+			'eventDate' => '2004-09-06',
+		],
+		[
+			'title' => 'Labor Day',
+			'eventDate' => '2005-09-05',
+		],
+		[
+			'title' => 'Labor Day',
+			'eventDate' => '2006-09-04',
+		],
+		[
+			'title' => 'Labor Day',
+			'eventDate' => '2007-09-03',
+		],
+		[
+			'title' => 'Labor Day',
+			'eventDate' => '2008-09-01',
+		],
+		[
+			'title' => 'Labor Day',
+			'eventDate' => '2009-09-07',
+		],
+		[
+			'title' => 'Labor Day',
+			'eventDate' => '2010-09-06',
+		],
+		[
+			'title' => 'Labor Day',
+			'eventDate' => '2011-09-05',
+		],
+		[
+			'title' => 'Labor Day',
+			'eventDate' => '2012-09-03',
+		],
+		[
+			'title' => 'Labor Day',
+			'eventDate' => '2013-09-09',
+		],
+		[
+			'title' => 'Labor Day',
+			'eventDate' => '2014-09-08',
+		],
+		[
+			'title' => 'Labor Day',
+			'eventDate' => '2015-09-07',
+		],
+		[
+			'title' => 'Labor Day',
+			'eventDate' => '2016-09-05',
+		],
+		[
+			'title' => 'Labor Day',
+			'eventDate' => '2017-09-04',
+		],
+		[
+			'title' => 'Labor Day',
+			'eventDate' => '2018-09-03',
+		],
+		[
+			'title' => 'Labor Day',
+			'eventDate' => '2019-09-09',
+		],
+		[
+			'title' => 'Labor Day',
+			'eventDate' => '2020-09-07',
+		],
+		[
+			'title' => 'D-Day',
+			'eventDate' => '0004-06-06',
+		],
+	];
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'calendar_holidays';
+
+		$this->columns = [
+			'ID_HOLIDAY' => new Column(
+				name: 'ID_HOLIDAY',
+				type: 'smallint',
+				unsigned: true,
+				not_null: true,
+				auto: true,
+			),
+			'eventDate' => new Column(
+				name: 'eventDate',
+				type: 'date',
+				not_null: true,
+				default: '0001-01-01',
+			),
+			'title' => new Column(
+				name: 'title',
+				type: 'varchar',
+				size: 30,
+				not_null: true,
+				default: '',
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'ID_HOLIDAY',
+					],
+				],
+			),
+			'eventDate' => new DbIndex(
+				name: 'eventDate',
+				columns: [
+					[
+						'name' => 'eventDate',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v1_1/Categories.php
+++ b/Sources/Db/Schema/v1_1/Categories.php
@@ -1,0 +1,78 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v1_1;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class Categories extends Table
+{
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'categories';
+
+		$this->columns = [
+			'ID_CAT' => new Column(
+				name: 'ID_CAT',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				auto: true,
+			),
+			'catOrder' => new Column(
+				name: 'catOrder',
+				type: 'tinyint',
+				not_null: true,
+				default: 0,
+			),
+			'name' => new Column(
+				name: 'name',
+				type: 'tinytext',
+				not_null: true,
+			),
+			'canCollapse' => new Column(
+				name: 'canCollapse',
+				type: 'tinyint',
+				not_null: true,
+				default: 1,
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'ID_CAT',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v1_1/CollapsedCategories.php
+++ b/Sources/Db/Schema/v1_1/CollapsedCategories.php
@@ -1,0 +1,71 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v1_1;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class CollapsedCategories extends Table
+{
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'collapsed_categories';
+
+		$this->columns = [
+			'ID_CAT' => new Column(
+				name: 'ID_CAT',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'ID_MEMBER' => new Column(
+				name: 'ID_MEMBER',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'ID_CAT',
+					],
+					[
+						'name' => 'ID_MEMBER',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v1_1/LogActions.php
+++ b/Sources/Db/Schema/v1_1/LogActions.php
@@ -1,0 +1,110 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v1_1;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class LogActions extends Table
+{
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'log_actions';
+
+		$this->columns = [
+			'ID_ACTION' => new Column(
+				name: 'ID_ACTION',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				auto: true,
+			),
+			'logTime' => new Column(
+				name: 'logTime',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'ID_MEMBER' => new Column(
+				name: 'ID_MEMBER',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'ip' => new Column(
+				name: 'ip',
+				type: 'char',
+				size: 16,
+				not_null: true,
+				default: '                ',
+			),
+			'action' => new Column(
+				name: 'action',
+				type: 'varchar',
+				size: 30,
+				not_null: true,
+				default: '',
+			),
+			'extra' => new Column(
+				name: 'extra',
+				type: 'text',
+				not_null: true,
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'ID_ACTION',
+					],
+				],
+			),
+			'logTime' => new DbIndex(
+				name: 'logTime',
+				columns: [
+					[
+						'name' => 'logTime',
+					],
+				],
+			),
+			'ID_MEMBER' => new DbIndex(
+				name: 'ID_MEMBER',
+				columns: [
+					[
+						'name' => 'ID_MEMBER',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v1_1/LogActivity.php
+++ b/Sources/Db/Schema/v1_1/LogActivity.php
@@ -1,0 +1,111 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v1_1;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class LogActivity extends Table
+{
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'log_activity';
+
+		$this->columns = [
+			'date' => new Column(
+				name: 'date',
+				type: 'date',
+				not_null: true,
+				default: '0001-01-01',
+			),
+			'hits' => new Column(
+				name: 'hits',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'topics' => new Column(
+				name: 'topics',
+				type: 'smallint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'posts' => new Column(
+				name: 'posts',
+				type: 'smallint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'registers' => new Column(
+				name: 'registers',
+				type: 'smallint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'mostOn' => new Column(
+				name: 'mostOn',
+				type: 'smallint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'date',
+					],
+				],
+			),
+			'hits' => new DbIndex(
+				name: 'hits',
+				columns: [
+					[
+						'name' => 'hits',
+					],
+				],
+			),
+			'mostOn' => new DbIndex(
+				name: 'mostOn',
+				columns: [
+					[
+						'name' => 'mostOn',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v1_1/LogBanned.php
+++ b/Sources/Db/Schema/v1_1/LogBanned.php
@@ -1,0 +1,95 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v1_1;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class LogBanned extends Table
+{
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'log_banned';
+
+		$this->columns = [
+			'ID_BAN_LOG' => new Column(
+				name: 'ID_BAN_LOG',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				auto: true,
+			),
+			'ID_MEMBER' => new Column(
+				name: 'ID_MEMBER',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'ip' => new Column(
+				name: 'ip',
+				type: 'char',
+				size: 16,
+				not_null: true,
+				default: '                ',
+			),
+			'email' => new Column(
+				name: 'email',
+				type: 'tinytext',
+				not_null: true,
+			),
+			'logTime' => new Column(
+				name: 'logTime',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'ID_BAN_LOG',
+					],
+				],
+			),
+			'logTime' => new DbIndex(
+				name: 'logTime',
+				columns: [
+					[
+						'name' => 'logTime',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v1_1/LogBoards.php
+++ b/Sources/Db/Schema/v1_1/LogBoards.php
@@ -1,0 +1,78 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v1_1;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class LogBoards extends Table
+{
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'log_boards';
+
+		$this->columns = [
+			'ID_MEMBER' => new Column(
+				name: 'ID_MEMBER',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'ID_BOARD' => new Column(
+				name: 'ID_BOARD',
+				type: 'smallint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'ID_MSG' => new Column(
+				name: 'ID_MSG',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'ID_MEMBER',
+					],
+					[
+						'name' => 'ID_BOARD',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v1_1/LogErrors.php
+++ b/Sources/Db/Schema/v1_1/LogErrors.php
@@ -1,0 +1,124 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v1_1;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class LogErrors extends Table
+{
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'log_errors';
+
+		$this->columns = [
+			'ID_ERROR' => new Column(
+				name: 'ID_ERROR',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				auto: true,
+			),
+			'logTime' => new Column(
+				name: 'logTime',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'ID_MEMBER' => new Column(
+				name: 'ID_MEMBER',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'ip' => new Column(
+				name: 'ip',
+				type: 'char',
+				size: 16,
+				not_null: true,
+				default: '                ',
+			),
+			'url' => new Column(
+				name: 'url',
+				type: 'text',
+				not_null: true,
+			),
+			'message' => new Column(
+				name: 'message',
+				type: 'text',
+				not_null: true,
+			),
+			'session' => new Column(
+				name: 'session',
+				type: 'char',
+				size: 32,
+				not_null: true,
+				default: '                                ',
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'ID_ERROR',
+					],
+				],
+			),
+			'logTime' => new DbIndex(
+				name: 'logTime',
+				columns: [
+					[
+						'name' => 'logTime',
+					],
+				],
+			),
+			'ID_MEMBER' => new DbIndex(
+				name: 'ID_MEMBER',
+				columns: [
+					[
+						'name' => 'ID_MEMBER',
+					],
+				],
+			),
+			'ip' => new DbIndex(
+				name: 'ip',
+				columns: [
+					[
+						'name' => 'ip',
+						'size' => 16,
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v1_1/LogFloodcontrol.php
+++ b/Sources/Db/Schema/v1_1/LogFloodcontrol.php
@@ -1,0 +1,69 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v1_1;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class LogFloodcontrol extends Table
+{
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'log_floodcontrol';
+
+		$this->columns = [
+			'ip' => new Column(
+				name: 'ip',
+				type: 'char',
+				size: 16,
+				not_null: true,
+				default: '                ',
+			),
+			'logTime' => new Column(
+				name: 'logTime',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'ip',
+						'size' => 16,
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v1_1/LogKarma.php
+++ b/Sources/Db/Schema/v1_1/LogKarma.php
@@ -1,0 +1,92 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v1_1;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class LogKarma extends Table
+{
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'log_karma';
+
+		$this->columns = [
+			'ID_TARGET' => new Column(
+				name: 'ID_TARGET',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'ID_EXECUTOR' => new Column(
+				name: 'ID_EXECUTOR',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'logTime' => new Column(
+				name: 'logTime',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'action' => new Column(
+				name: 'action',
+				type: 'tinyint',
+				not_null: true,
+				default: 0,
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'ID_TARGET',
+					],
+					[
+						'name' => 'ID_EXECUTOR',
+					],
+				],
+			),
+			'logTime' => new DbIndex(
+				name: 'logTime',
+				columns: [
+					[
+						'name' => 'logTime',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v1_1/LogMarkRead.php
+++ b/Sources/Db/Schema/v1_1/LogMarkRead.php
@@ -1,0 +1,78 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v1_1;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class LogMarkRead extends Table
+{
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'log_mark_read';
+
+		$this->columns = [
+			'ID_MEMBER' => new Column(
+				name: 'ID_MEMBER',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'ID_BOARD' => new Column(
+				name: 'ID_BOARD',
+				type: 'smallint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'ID_MSG' => new Column(
+				name: 'ID_MSG',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'ID_MEMBER',
+					],
+					[
+						'name' => 'ID_BOARD',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v1_1/LogNotify.php
+++ b/Sources/Db/Schema/v1_1/LogNotify.php
@@ -1,0 +1,88 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v1_1;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class LogNotify extends Table
+{
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'log_notify';
+
+		$this->columns = [
+			'ID_MEMBER' => new Column(
+				name: 'ID_MEMBER',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'ID_TOPIC' => new Column(
+				name: 'ID_TOPIC',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'ID_BOARD' => new Column(
+				name: 'ID_BOARD',
+				type: 'smallint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'sent' => new Column(
+				name: 'sent',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'ID_MEMBER',
+					],
+					[
+						'name' => 'ID_TOPIC',
+					],
+					[
+						'name' => 'ID_BOARD',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v1_1/LogOnline.php
+++ b/Sources/Db/Schema/v1_1/LogOnline.php
@@ -1,0 +1,101 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v1_1;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class LogOnline extends Table
+{
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'log_online';
+
+		$this->columns = [
+			'session' => new Column(
+				name: 'session',
+				type: 'varchar',
+				size: 32,
+				not_null: true,
+				default: '',
+			),
+			'logTime' => new Column(
+				name: 'logTime',
+				type: 'timestamp',
+				not_null: true,
+			),
+			'ID_MEMBER' => new Column(
+				name: 'ID_MEMBER',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'ip' => new Column(
+				name: 'ip',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'url' => new Column(
+				name: 'url',
+				type: 'text',
+				not_null: true,
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'session',
+					],
+				],
+			),
+			'logTime' => new DbIndex(
+				name: 'logTime',
+				columns: [
+					[
+						'name' => 'logTime',
+					],
+				],
+			),
+			'ID_MEMBER' => new DbIndex(
+				name: 'ID_MEMBER',
+				columns: [
+					[
+						'name' => 'ID_MEMBER',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v1_1/LogPolls.php
+++ b/Sources/Db/Schema/v1_1/LogPolls.php
@@ -1,0 +1,81 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v1_1;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class LogPolls extends Table
+{
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'log_polls';
+
+		$this->columns = [
+			'ID_POLL' => new Column(
+				name: 'ID_POLL',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'ID_MEMBER' => new Column(
+				name: 'ID_MEMBER',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'ID_CHOICE' => new Column(
+				name: 'ID_CHOICE',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'ID_POLL',
+					],
+					[
+						'name' => 'ID_MEMBER',
+					],
+					[
+						'name' => 'ID_CHOICE',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v1_1/LogSearchMessages.php
+++ b/Sources/Db/Schema/v1_1/LogSearchMessages.php
@@ -1,0 +1,71 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v1_1;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class LogSearchMessages extends Table
+{
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'log_search_messages';
+
+		$this->columns = [
+			'ID_SEARCH' => new Column(
+				name: 'ID_SEARCH',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'ID_MSG' => new Column(
+				name: 'ID_MSG',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'ID_SEARCH',
+					],
+					[
+						'name' => 'ID_MSG',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v1_1/LogSearchResults.php
+++ b/Sources/Db/Schema/v1_1/LogSearchResults.php
@@ -1,0 +1,92 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v1_1;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class LogSearchResults extends Table
+{
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'log_search_results';
+
+		$this->columns = [
+			'ID_SEARCH' => new Column(
+				name: 'ID_SEARCH',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'ID_TOPIC' => new Column(
+				name: 'ID_TOPIC',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'ID_MSG' => new Column(
+				name: 'ID_MSG',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'relevance' => new Column(
+				name: 'relevance',
+				type: 'smallint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'num_matches' => new Column(
+				name: 'num_matches',
+				type: 'smallint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'ID_SEARCH',
+					],
+					[
+						'name' => 'ID_TOPIC',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v1_1/LogSearchSubjects.php
+++ b/Sources/Db/Schema/v1_1/LogSearchSubjects.php
@@ -1,0 +1,79 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v1_1;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class LogSearchSubjects extends Table
+{
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'log_search_subjects';
+
+		$this->columns = [
+			'word' => new Column(
+				name: 'word',
+				type: 'varchar',
+				size: 20,
+				not_null: true,
+				default: '',
+			),
+			'ID_TOPIC' => new Column(
+				name: 'ID_TOPIC',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'word',
+					],
+					[
+						'name' => 'ID_TOPIC',
+					],
+				],
+			),
+			'ID_TOPIC' => new DbIndex(
+				name: 'ID_TOPIC',
+				columns: [
+					[
+						'name' => 'ID_TOPIC',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v1_1/LogSearchTopics.php
+++ b/Sources/Db/Schema/v1_1/LogSearchTopics.php
@@ -1,0 +1,70 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v1_1;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class LogSearchTopics extends Table
+{
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'log_search_topics';
+
+		$this->columns = [
+			'ID_SEARCH' => new Column(
+				name: 'ID_SEARCH',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'ID_TOPIC' => new Column(
+				name: 'ID_TOPIC',
+				type: 'mediumint',
+				not_null: true,
+				default: 0,
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'ID_SEARCH',
+					],
+					[
+						'name' => 'ID_TOPIC',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v1_1/LogTopics.php
+++ b/Sources/Db/Schema/v1_1/LogTopics.php
@@ -1,0 +1,86 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v1_1;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class LogTopics extends Table
+{
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'log_topics';
+
+		$this->columns = [
+			'ID_MEMBER' => new Column(
+				name: 'ID_MEMBER',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'ID_TOPIC' => new Column(
+				name: 'ID_TOPIC',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'ID_MSG' => new Column(
+				name: 'ID_MSG',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'ID_MEMBER',
+					],
+					[
+						'name' => 'ID_TOPIC',
+					],
+				],
+			),
+			'ID_TOPIC' => new DbIndex(
+				name: 'ID_TOPIC',
+				columns: [
+					[
+						'name' => 'ID_TOPIC',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v1_1/Membergroups.php
+++ b/Sources/Db/Schema/v1_1/Membergroups.php
@@ -1,0 +1,169 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v1_1;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class Membergroups extends Table
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 * @var array
+	 *
+	 * Data used to populate the table during install.
+	 */
+	public array $initial_data = [
+		[
+			'ID_GROUP' => 1,
+			'groupName' => '{$default_administrator_group}',
+			'onlineColor' => '#FF0000',
+			'minPosts' => -1,
+			'stars' => '5#staradmin.gif',
+		],
+		[
+			'ID_GROUP' => 2,
+			'groupName' => '{$default_global_moderator_group}',
+			'onlineColor' => '#0000FF',
+			'minPosts' => -1,
+			'stars' => '5#stargmod.gif',
+		],
+		[
+			'ID_GROUP' => 3,
+			'groupName' => '{$default_moderator_group}',
+			'onlineColor' => '',
+			'minPosts' => -1,
+			'stars' => '5#starmod.gif',
+		],
+		[
+			'ID_GROUP' => 4,
+			'groupName' => '{$default_newbie_group}',
+			'onlineColor' => '',
+			'minPosts' => 0,
+			'stars' => '1#star.gif',
+		],
+		[
+			'ID_GROUP' => 5,
+			'groupName' => '{$default_junior_group}',
+			'onlineColor' => '',
+			'minPosts' => 50,
+			'stars' => '2#star.gif',
+		],
+		[
+			'ID_GROUP' => 6,
+			'groupName' => '{$default_full_group}',
+			'onlineColor' => '',
+			'minPosts' => 100,
+			'stars' => '3#star.gif',
+		],
+		[
+			'ID_GROUP' => 7,
+			'groupName' => '{$default_senior_group}',
+			'onlineColor' => '',
+			'minPosts' => 250,
+			'stars' => '4#star.gif',
+		],
+		[
+			'ID_GROUP' => 8,
+			'groupName' => '{$default_hero_group}',
+			'onlineColor' => '',
+			'minPosts' => 500,
+			'stars' => '5#star.gif',
+		],
+	];
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'membergroups';
+
+		$this->columns = [
+			'ID_GROUP' => new Column(
+				name: 'ID_GROUP',
+				type: 'smallint',
+				unsigned: true,
+				not_null: true,
+				auto: true,
+			),
+			'groupName' => new Column(
+				name: 'groupName',
+				type: 'varchar',
+				size: 80,
+				not_null: true,
+				default: '',
+			),
+			'onlineColor' => new Column(
+				name: 'onlineColor',
+				type: 'varchar',
+				size: 20,
+				not_null: true,
+				default: '',
+			),
+			'minPosts' => new Column(
+				name: 'minPosts',
+				type: 'mediumint',
+				not_null: true,
+				default: -1,
+			),
+			'maxMessages' => new Column(
+				name: 'maxMessages',
+				type: 'smallint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'stars' => new Column(
+				name: 'stars',
+				type: 'tinytext',
+				not_null: true,
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'ID_GROUP',
+					],
+				],
+			),
+			'minPosts' => new DbIndex(
+				name: 'minPosts',
+				columns: [
+					[
+						'name' => 'minPosts',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v1_1/Members.php
+++ b/Sources/Db/Schema/v1_1/Members.php
@@ -1,0 +1,435 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v1_1;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class Members extends Table
+{
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'members';
+
+		$this->columns = [
+			'ID_MEMBER' => new Column(
+				name: 'ID_MEMBER',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				auto: true,
+			),
+			'memberName' => new Column(
+				name: 'memberName',
+				type: 'varchar',
+				size: 80,
+				not_null: true,
+				default: '',
+			),
+			'dateRegistered' => new Column(
+				name: 'dateRegistered',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'posts' => new Column(
+				name: 'posts',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'ID_GROUP' => new Column(
+				name: 'ID_GROUP',
+				type: 'smallint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'lngfile' => new Column(
+				name: 'lngfile',
+				type: 'tinytext',
+				not_null: true,
+			),
+			'lastLogin' => new Column(
+				name: 'lastLogin',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'realName' => new Column(
+				name: 'realName',
+				type: 'tinytext',
+				not_null: true,
+			),
+			'instantMessages' => new Column(
+				name: 'instantMessages',
+				type: 'smallint',
+				not_null: true,
+				default: 0,
+			),
+			'unreadMessages' => new Column(
+				name: 'unreadMessages',
+				type: 'smallint',
+				not_null: true,
+				default: 0,
+			),
+			'buddy_list' => new Column(
+				name: 'buddy_list',
+				type: 'text',
+				not_null: true,
+			),
+			'pm_ignore_list' => new Column(
+				name: 'pm_ignore_list',
+				type: 'tinytext',
+				not_null: true,
+			),
+			'messageLabels' => new Column(
+				name: 'messageLabels',
+				type: 'text',
+				not_null: true,
+			),
+			'passwd' => new Column(
+				name: 'passwd',
+				type: 'varchar',
+				size: 64,
+				not_null: true,
+				default: '',
+			),
+			'emailAddress' => new Column(
+				name: 'emailAddress',
+				type: 'tinytext',
+				not_null: true,
+			),
+			'personalText' => new Column(
+				name: 'personalText',
+				type: 'tinytext',
+				not_null: true,
+			),
+			'gender' => new Column(
+				name: 'gender',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'birthdate' => new Column(
+				name: 'birthdate',
+				type: 'date',
+				not_null: true,
+				default: '0001-01-01',
+			),
+			'websiteTitle' => new Column(
+				name: 'websiteTitle',
+				type: 'tinytext',
+				not_null: true,
+			),
+			'websiteUrl' => new Column(
+				name: 'websiteUrl',
+				type: 'tinytext',
+				not_null: true,
+			),
+			'location' => new Column(
+				name: 'location',
+				type: 'tinytext',
+				not_null: true,
+			),
+			'ICQ' => new Column(
+				name: 'ICQ',
+				type: 'tinytext',
+				not_null: true,
+			),
+			'AIM' => new Column(
+				name: 'AIM',
+				type: 'varchar',
+				size: 16,
+				not_null: true,
+				default: '',
+			),
+			'YIM' => new Column(
+				name: 'YIM',
+				type: 'varchar',
+				size: 32,
+				not_null: true,
+				default: '',
+			),
+			'MSN' => new Column(
+				name: 'MSN',
+				type: 'tinytext',
+				not_null: true,
+			),
+			'hideEmail' => new Column(
+				name: 'hideEmail',
+				type: 'tinyint',
+				not_null: true,
+				default: 0,
+			),
+			'showOnline' => new Column(
+				name: 'showOnline',
+				type: 'tinyint',
+				not_null: true,
+				default: 1,
+			),
+			'timeFormat' => new Column(
+				name: 'timeFormat',
+				type: 'varchar',
+				size: 80,
+				not_null: true,
+				default: '',
+			),
+			'signature' => new Column(
+				name: 'signature',
+				type: 'text',
+				not_null: true,
+			),
+			'timeOffset' => new Column(
+				name: 'timeOffset',
+				type: 'float',
+				not_null: true,
+				default: 0,
+			),
+			'avatar' => new Column(
+				name: 'avatar',
+				type: 'tinytext',
+				not_null: true,
+			),
+			'pm_email_notify' => new Column(
+				name: 'pm_email_notify',
+				type: 'tinyint',
+				not_null: true,
+				default: 0,
+			),
+			'karmaBad' => new Column(
+				name: 'karmaBad',
+				type: 'smallint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'karmaGood' => new Column(
+				name: 'karmaGood',
+				type: 'smallint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'usertitle' => new Column(
+				name: 'usertitle',
+				type: 'tinytext',
+				not_null: true,
+			),
+			'notifyAnnouncements' => new Column(
+				name: 'notifyAnnouncements',
+				type: 'tinyint',
+				not_null: true,
+				default: 1,
+			),
+			'notifyOnce' => new Column(
+				name: 'notifyOnce',
+				type: 'tinyint',
+				not_null: true,
+				default: 1,
+			),
+			'notifySendBody' => new Column(
+				name: 'notifySendBody',
+				type: 'tinyint',
+				not_null: true,
+				default: 0,
+			),
+			'notifyTypes' => new Column(
+				name: 'notifyTypes',
+				type: 'tinyint',
+				not_null: true,
+				default: 2,
+			),
+			'memberIP' => new Column(
+				name: 'memberIP',
+				type: 'tinytext',
+				not_null: true,
+			),
+			'memberIP2' => new Column(
+				name: 'memberIP2',
+				type: 'tinytext',
+				not_null: true,
+			),
+			'secretQuestion' => new Column(
+				name: 'secretQuestion',
+				type: 'tinytext',
+				not_null: true,
+			),
+			'secretAnswer' => new Column(
+				name: 'secretAnswer',
+				type: 'varchar',
+				size: 64,
+				not_null: true,
+				default: '',
+			),
+			'ID_THEME' => new Column(
+				name: 'ID_THEME',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'is_activated' => new Column(
+				name: 'is_activated',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				default: 1,
+			),
+			'validation_code' => new Column(
+				name: 'validation_code',
+				type: 'varchar',
+				size: 10,
+				not_null: true,
+				default: '',
+			),
+			'ID_MSG_LAST_VISIT' => new Column(
+				name: 'ID_MSG_LAST_VISIT',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'additionalGroups' => new Column(
+				name: 'additionalGroups',
+				type: 'tinytext',
+				not_null: true,
+			),
+			'smileySet' => new Column(
+				name: 'smileySet',
+				type: 'varchar',
+				size: 48,
+				not_null: true,
+				default: '',
+			),
+			'ID_POST_GROUP' => new Column(
+				name: 'ID_POST_GROUP',
+				type: 'smallint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'totalTimeLoggedIn' => new Column(
+				name: 'totalTimeLoggedIn',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'passwordSalt' => new Column(
+				name: 'passwordSalt',
+				type: 'varchar',
+				size: 5,
+				not_null: true,
+				default: '',
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'ID_MEMBER',
+					],
+				],
+			),
+			'memberName' => new DbIndex(
+				name: 'memberName',
+				columns: [
+					[
+						'name' => 'memberName',
+						'size' => 30,
+					],
+				],
+			),
+			'dateRegistered' => new DbIndex(
+				name: 'dateRegistered',
+				columns: [
+					[
+						'name' => 'dateRegistered',
+					],
+				],
+			),
+			'ID_GROUP' => new DbIndex(
+				name: 'ID_GROUP',
+				columns: [
+					[
+						'name' => 'ID_GROUP',
+					],
+				],
+			),
+			'birthdate' => new DbIndex(
+				name: 'birthdate',
+				columns: [
+					[
+						'name' => 'birthdate',
+					],
+				],
+			),
+			'posts' => new DbIndex(
+				name: 'posts',
+				columns: [
+					[
+						'name' => 'posts',
+					],
+				],
+			),
+			'lastLogin' => new DbIndex(
+				name: 'lastLogin',
+				columns: [
+					[
+						'name' => 'lastLogin',
+					],
+				],
+			),
+			'lngfile' => new DbIndex(
+				name: 'lngfile',
+				columns: [
+					[
+						'name' => 'lngfile',
+						'size' => 30,
+					],
+				],
+			),
+			'ID_POST_GROUP' => new DbIndex(
+				name: 'ID_POST_GROUP',
+				columns: [
+					[
+						'name' => 'ID_POST_GROUP',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v1_1/MessageIcons.php
+++ b/Sources/Db/Schema/v1_1/MessageIcons.php
@@ -1,0 +1,169 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v1_1;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class MessageIcons extends Table
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 * @var array
+	 *
+	 * Data used to populate the table during install.
+	 */
+	public array $initial_data = [
+		[
+			'filename' => 'xx',
+			'title' => 'Standard',
+			'iconOrder' => 0,
+		],
+		[
+			'filename' => 'thumbup',
+			'title' => 'Thumb Up',
+			'iconOrder' => 1,
+		],
+		[
+			'filename' => 'thumbdown',
+			'title' => 'Thumb Down',
+			'iconOrder' => 2,
+		],
+		[
+			'filename' => 'exclamation',
+			'title' => 'Exclamation point',
+			'iconOrder' => 3,
+		],
+		[
+			'filename' => 'question',
+			'title' => 'Question mark',
+			'iconOrder' => 4,
+		],
+		[
+			'filename' => 'lamp',
+			'title' => 'Lamp',
+			'iconOrder' => 5,
+		],
+		[
+			'filename' => 'smiley',
+			'title' => 'Smiley',
+			'iconOrder' => 6,
+		],
+		[
+			'filename' => 'angry',
+			'title' => 'Angry',
+			'iconOrder' => 7,
+		],
+		[
+			'filename' => 'cheesy',
+			'title' => 'Cheesy',
+			'iconOrder' => 8,
+		],
+		[
+			'filename' => 'grin',
+			'title' => 'Grin',
+			'iconOrder' => 9,
+		],
+		[
+			'filename' => 'sad',
+			'title' => 'Sad',
+			'iconOrder' => 10,
+		],
+		[
+			'filename' => 'wink',
+			'title' => 'Wink',
+			'iconOrder' => 11,
+		],
+	];
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'message_icons';
+
+		$this->columns = [
+			'ID_ICON' => new Column(
+				name: 'ID_ICON',
+				type: 'smallint',
+				unsigned: true,
+				not_null: true,
+				auto: true,
+			),
+			'title' => new Column(
+				name: 'title',
+				type: 'varchar',
+				size: 80,
+				not_null: true,
+				default: '',
+			),
+			'filename' => new Column(
+				name: 'filename',
+				type: 'varchar',
+				size: 80,
+				not_null: true,
+				default: '',
+			),
+			'ID_BOARD' => new Column(
+				name: 'ID_BOARD',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'iconOrder' => new Column(
+				name: 'iconOrder',
+				type: 'smallint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'ID_ICON',
+					],
+				],
+			),
+			'ID_BOARD' => new DbIndex(
+				name: 'ID_BOARD',
+				columns: [
+					[
+						'name' => 'ID_BOARD',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v1_1/Messages.php
+++ b/Sources/Db/Schema/v1_1/Messages.php
@@ -1,0 +1,250 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v1_1;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class Messages extends Table
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 * @var array
+	 *
+	 * Data used to populate the table during install.
+	 */
+	public array $initial_data = [
+		[
+			'ID_MSG' => 1,
+			'ID_MSG_MODIFIED' => 1,
+			'ID_TOPIC' => 1,
+			'ID_BOARD' => 1,
+			'posterTime' => '{$current_time}',
+			'subject' => '{$default_topic_subject}',
+			'posterName' => 'Simple Machines',
+			'posterEmail' => 'info@simplemachines.org',
+			'posterIP' => '127.0.0.1',
+			'modifiedName' => '',
+			'body' => '{$default_topic_message}',
+			'icon' => 'xx',
+		],
+	];
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'messages';
+
+		$this->columns = [
+			'ID_MSG' => new Column(
+				name: 'ID_MSG',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				auto: true,
+			),
+			'ID_TOPIC' => new Column(
+				name: 'ID_TOPIC',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'ID_BOARD' => new Column(
+				name: 'ID_BOARD',
+				type: 'smallint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'posterTime' => new Column(
+				name: 'posterTime',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'ID_MEMBER' => new Column(
+				name: 'ID_MEMBER',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'ID_MSG_MODIFIED' => new Column(
+				name: 'ID_MSG_MODIFIED',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'subject' => new Column(
+				name: 'subject',
+				type: 'tinytext',
+				not_null: true,
+			),
+			'posterName' => new Column(
+				name: 'posterName',
+				type: 'tinytext',
+				not_null: true,
+			),
+			'posterEmail' => new Column(
+				name: 'posterEmail',
+				type: 'tinytext',
+				not_null: true,
+			),
+			'posterIP' => new Column(
+				name: 'posterIP',
+				type: 'tinytext',
+				not_null: true,
+			),
+			'smileysEnabled' => new Column(
+				name: 'smileysEnabled',
+				type: 'tinyint',
+				not_null: true,
+				default: 1,
+			),
+			'modifiedTime' => new Column(
+				name: 'modifiedTime',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'modifiedName' => new Column(
+				name: 'modifiedName',
+				type: 'tinytext',
+				not_null: true,
+			),
+			'body' => new Column(
+				name: 'body',
+				type: 'text',
+				not_null: true,
+			),
+			'icon' => new Column(
+				name: 'icon',
+				type: 'varchar',
+				size: 16,
+				not_null: true,
+				default: 'xx',
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'ID_MSG',
+					],
+				],
+			),
+			'topic' => new DbIndex(
+				type: 'unique',
+				name: 'topic',
+				columns: [
+					[
+						'name' => 'ID_TOPIC',
+					],
+					[
+						'name' => 'ID_MSG',
+					],
+				],
+			),
+			'ID_BOARD' => new DbIndex(
+				type: 'unique',
+				name: 'ID_BOARD',
+				columns: [
+					[
+						'name' => 'ID_BOARD',
+					],
+					[
+						'name' => 'ID_MSG',
+					],
+				],
+			),
+			'ID_MEMBER' => new DbIndex(
+				type: 'unique',
+				name: 'ID_MEMBER',
+				columns: [
+					[
+						'name' => 'ID_MEMBER',
+					],
+					[
+						'name' => 'ID_MSG',
+					],
+				],
+			),
+			'ipIndex' => new DbIndex(
+				name: 'ipIndex',
+				columns: [
+					[
+						'name' => 'posterIP',
+						'size' => 15,
+					],
+					[
+						'name' => 'ID_TOPIC',
+					],
+				],
+			),
+			'participation' => new DbIndex(
+				name: 'participation',
+				columns: [
+					[
+						'name' => 'ID_MEMBER',
+					],
+					[
+						'name' => 'ID_TOPIC',
+					],
+				],
+			),
+			'showPosts' => new DbIndex(
+				name: 'showPosts',
+				columns: [
+					[
+						'name' => 'ID_MEMBER',
+					],
+					[
+						'name' => 'ID_BOARD',
+					],
+				],
+			),
+			'ID_TOPIC' => new DbIndex(
+				name: 'ID_TOPIC',
+				columns: [
+					[
+						'name' => 'ID_TOPIC',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v1_1/Moderators.php
+++ b/Sources/Db/Schema/v1_1/Moderators.php
@@ -1,0 +1,71 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v1_1;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class Moderators extends Table
+{
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'moderators';
+
+		$this->columns = [
+			'ID_BOARD' => new Column(
+				name: 'ID_BOARD',
+				type: 'smallint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'ID_MEMBER' => new Column(
+				name: 'ID_MEMBER',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'ID_BOARD',
+					],
+					[
+						'name' => 'ID_MEMBER',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v1_1/PackageServers.php
+++ b/Sources/Db/Schema/v1_1/PackageServers.php
@@ -1,0 +1,87 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v1_1;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class PackageServers extends Table
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 * @var array
+	 *
+	 * Data used to populate the table during install.
+	 */
+	public array $initial_data = [
+		[
+			'name' => 'Simple Machines Third-party Mod Site',
+			'url' => 'http://mods.simplemachines.org',
+		],
+	];
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'package_servers';
+
+		$this->columns = [
+			'ID_SERVER' => new Column(
+				name: 'ID_SERVER',
+				type: 'smallint',
+				unsigned: true,
+				not_null: true,
+				auto: true,
+			),
+			'name' => new Column(
+				name: 'name',
+				type: 'tinytext',
+				not_null: true,
+			),
+			'url' => new Column(
+				name: 'url',
+				type: 'tinytext',
+				not_null: true,
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'ID_SERVER',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v1_1/Permissions.php
+++ b/Sources/Db/Schema/v1_1/Permissions.php
@@ -1,0 +1,244 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v1_1;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class Permissions extends Table
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 * @var array
+	 *
+	 * Data used to populate the table during install.
+	 */
+	public array $initial_data = [
+		[
+			'ID_GROUP' => -1,
+			'permission' => 'search_posts',
+		],
+		[
+			'ID_GROUP' => -1,
+			'permission' => 'calendar_view',
+		],
+		[
+			'ID_GROUP' => -1,
+			'permission' => 'view_stats',
+		],
+		[
+			'ID_GROUP' => -1,
+			'permission' => 'profile_view_any',
+		],
+		[
+			'ID_GROUP' => 0,
+			'permission' => 'view_mlist',
+		],
+		[
+			'ID_GROUP' => 0,
+			'permission' => 'search_posts',
+		],
+		[
+			'ID_GROUP' => 0,
+			'permission' => 'profile_view_own',
+		],
+		[
+			'ID_GROUP' => 0,
+			'permission' => 'profile_view_any',
+		],
+		[
+			'ID_GROUP' => 0,
+			'permission' => 'pm_read',
+		],
+		[
+			'ID_GROUP' => 0,
+			'permission' => 'pm_send',
+		],
+		[
+			'ID_GROUP' => 0,
+			'permission' => 'calendar_view',
+		],
+		[
+			'ID_GROUP' => 0,
+			'permission' => 'view_stats',
+		],
+		[
+			'ID_GROUP' => 0,
+			'permission' => 'who_view',
+		],
+		[
+			'ID_GROUP' => 0,
+			'permission' => 'profile_identity_own',
+		],
+		[
+			'ID_GROUP' => 0,
+			'permission' => 'profile_extra_own',
+		],
+		[
+			'ID_GROUP' => 0,
+			'permission' => 'profile_remove_own',
+		],
+		[
+			'ID_GROUP' => 0,
+			'permission' => 'profile_server_avatar',
+		],
+		[
+			'ID_GROUP' => 0,
+			'permission' => 'profile_upload_avatar',
+		],
+		[
+			'ID_GROUP' => 0,
+			'permission' => 'profile_remote_avatar',
+		],
+		[
+			'ID_GROUP' => 0,
+			'permission' => 'karma_edit',
+		],
+		[
+			'ID_GROUP' => 2,
+			'permission' => 'view_mlist',
+		],
+		[
+			'ID_GROUP' => 2,
+			'permission' => 'search_posts',
+		],
+		[
+			'ID_GROUP' => 2,
+			'permission' => 'profile_view_own',
+		],
+		[
+			'ID_GROUP' => 2,
+			'permission' => 'profile_view_any',
+		],
+		[
+			'ID_GROUP' => 2,
+			'permission' => 'pm_read',
+		],
+		[
+			'ID_GROUP' => 2,
+			'permission' => 'pm_send',
+		],
+		[
+			'ID_GROUP' => 2,
+			'permission' => 'calendar_view',
+		],
+		[
+			'ID_GROUP' => 2,
+			'permission' => 'view_stats',
+		],
+		[
+			'ID_GROUP' => 2,
+			'permission' => 'who_view',
+		],
+		[
+			'ID_GROUP' => 2,
+			'permission' => 'profile_identity_own',
+		],
+		[
+			'ID_GROUP' => 2,
+			'permission' => 'profile_extra_own',
+		],
+		[
+			'ID_GROUP' => 2,
+			'permission' => 'profile_remove_own',
+		],
+		[
+			'ID_GROUP' => 2,
+			'permission' => 'profile_server_avatar',
+		],
+		[
+			'ID_GROUP' => 2,
+			'permission' => 'profile_upload_avatar',
+		],
+		[
+			'ID_GROUP' => 2,
+			'permission' => 'profile_remote_avatar',
+		],
+		[
+			'ID_GROUP' => 2,
+			'permission' => 'profile_title_own',
+		],
+		[
+			'ID_GROUP' => 2,
+			'permission' => 'calendar_post',
+		],
+		[
+			'ID_GROUP' => 2,
+			'permission' => 'calendar_edit_any',
+		],
+		[
+			'ID_GROUP' => 2,
+			'permission' => 'karma_edit',
+		],
+	];
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'permissions';
+
+		$this->columns = [
+			'ID_GROUP' => new Column(
+				name: 'ID_GROUP',
+				type: 'smallint',
+				not_null: true,
+				default: 0,
+			),
+			'permission' => new Column(
+				name: 'permission',
+				type: 'varchar',
+				size: 30,
+				not_null: true,
+				default: '',
+			),
+			'addDeny' => new Column(
+				name: 'addDeny',
+				type: 'tinyint',
+				not_null: true,
+				default: 1,
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'ID_GROUP',
+					],
+					[
+						'name' => 'permission',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v1_1/PersonalMessages.php
+++ b/Sources/Db/Schema/v1_1/PersonalMessages.php
@@ -1,0 +1,116 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v1_1;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class PersonalMessages extends Table
+{
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'personal_messages';
+
+		$this->columns = [
+			'ID_PM' => new Column(
+				name: 'ID_PM',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				auto: true,
+			),
+			'ID_MEMBER_FROM' => new Column(
+				name: 'ID_MEMBER_FROM',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'deletedBySender' => new Column(
+				name: 'deletedBySender',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'fromName' => new Column(
+				name: 'fromName',
+				type: 'tinytext',
+				not_null: true,
+			),
+			'msgtime' => new Column(
+				name: 'msgtime',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'subject' => new Column(
+				name: 'subject',
+				type: 'tinytext',
+				not_null: true,
+			),
+			'body' => new Column(
+				name: 'body',
+				type: 'text',
+				not_null: true,
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'ID_PM',
+					],
+				],
+			),
+			'ID_MEMBER' => new DbIndex(
+				name: 'ID_MEMBER',
+				columns: [
+					[
+						'name' => 'ID_MEMBER_FROM',
+					],
+					[
+						'name' => 'deletedBySender',
+					],
+				],
+			),
+			'msgtime' => new DbIndex(
+				name: 'msgtime',
+				columns: [
+					[
+						'name' => 'msgtime',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v1_1/PmRecipients.php
+++ b/Sources/Db/Schema/v1_1/PmRecipients.php
@@ -1,0 +1,114 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v1_1;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class PmRecipients extends Table
+{
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'pm_recipients';
+
+		$this->columns = [
+			'ID_PM' => new Column(
+				name: 'ID_PM',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'ID_MEMBER' => new Column(
+				name: 'ID_MEMBER',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'labels' => new Column(
+				name: 'labels',
+				type: 'varchar',
+				size: 60,
+				not_null: true,
+				default: '-1',
+			),
+			'bcc' => new Column(
+				name: 'bcc',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'is_read' => new Column(
+				name: 'is_read',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'deleted' => new Column(
+				name: 'deleted',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'ID_PM',
+					],
+					[
+						'name' => 'ID_MEMBER',
+					],
+				],
+			),
+			'ID_MEMBER' => new DbIndex(
+				type: 'unique',
+				name: 'ID_MEMBER',
+				columns: [
+					[
+						'name' => 'ID_MEMBER',
+					],
+					[
+						'name' => 'deleted',
+					],
+					[
+						'name' => 'ID_PM',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v1_1/PollChoices.php
+++ b/Sources/Db/Schema/v1_1/PollChoices.php
@@ -1,0 +1,83 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v1_1;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class PollChoices extends Table
+{
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'poll_choices';
+
+		$this->columns = [
+			'ID_POLL' => new Column(
+				name: 'ID_POLL',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'ID_CHOICE' => new Column(
+				name: 'ID_CHOICE',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'label' => new Column(
+				name: 'label',
+				type: 'tinytext',
+				not_null: true,
+			),
+			'votes' => new Column(
+				name: 'votes',
+				type: 'smallint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'ID_POLL',
+					],
+					[
+						'name' => 'ID_CHOICE',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v1_1/Polls.php
+++ b/Sources/Db/Schema/v1_1/Polls.php
@@ -1,0 +1,112 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v1_1;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class Polls extends Table
+{
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'polls';
+
+		$this->columns = [
+			'ID_POLL' => new Column(
+				name: 'ID_POLL',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				auto: true,
+			),
+			'question' => new Column(
+				name: 'question',
+				type: 'tinytext',
+				not_null: true,
+			),
+			'votingLocked' => new Column(
+				name: 'votingLocked',
+				type: 'tinyint',
+				not_null: true,
+				default: 0,
+			),
+			'maxVotes' => new Column(
+				name: 'maxVotes',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				default: 1,
+			),
+			'expireTime' => new Column(
+				name: 'expireTime',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'hideResults' => new Column(
+				name: 'hideResults',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'changeVote' => new Column(
+				name: 'changeVote',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'ID_MEMBER' => new Column(
+				name: 'ID_MEMBER',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'posterName' => new Column(
+				name: 'posterName',
+				type: 'tinytext',
+				not_null: true,
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'ID_POLL',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v1_1/Sessions.php
+++ b/Sources/Db/Schema/v1_1/Sessions.php
@@ -1,0 +1,71 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v1_1;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class Sessions extends Table
+{
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'sessions';
+
+		$this->columns = [
+			'session_id' => new Column(
+				name: 'session_id',
+				type: 'char',
+				size: 32,
+				not_null: true,
+			),
+			'last_update' => new Column(
+				name: 'last_update',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+			),
+			'data' => new Column(
+				name: 'data',
+				type: 'text',
+				not_null: true,
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'session_id',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v1_1/Settings.php
+++ b/Sources/Db/Schema/v1_1/Settings.php
@@ -1,0 +1,701 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v1_1;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class Settings extends Table
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 * @var array
+	 *
+	 * Data used to populate the table during install.
+	 */
+	public array $initial_data = [
+		[
+			'variable' => 'allow_disableAnnounce',
+			'value' => 1,
+		],
+		[
+			'variable' => 'allow_editDisplayName',
+			'value' => 1,
+		],
+		[
+			'variable' => 'allow_guestAccess',
+			'value' => 1,
+		],
+		[
+			'variable' => 'allow_hideEmail',
+			'value' => 1,
+		],
+		[
+			'variable' => 'allow_hideOnline',
+			'value' => 1,
+		],
+		[
+			'variable' => 'attachmentCheckExtensions',
+			'value' => 0,
+		],
+		[
+			'variable' => 'attachmentDirSizeLimit',
+			'value' => 10240,
+		],
+		[
+			'variable' => 'attachmentEnable',
+			'value' => 1,
+		],
+		[
+			'variable' => 'attachmentEncryptFilenames',
+			'value' => 1,
+		],
+		[
+			'variable' => 'attachmentExtensions',
+			'value' => 'doc,gif,jpg,mpg,pdf,png,txt,zip',
+		],
+		[
+			'variable' => 'attachmentNumPerPostLimit',
+			'value' => 4,
+		],
+		[
+			'variable' => 'attachmentPostLimit',
+			'value' => 192,
+		],
+		[
+			'variable' => 'attachmentShowImages',
+			'value' => 1,
+		],
+		[
+			'variable' => 'attachmentSizeLimit',
+			'value' => 128,
+		],
+		[
+			'variable' => 'attachmentThumbHeight',
+			'value' => 150,
+		],
+		[
+			'variable' => 'attachmentThumbWidth',
+			'value' => 150,
+		],
+		[
+			'variable' => 'attachmentThumbnails',
+			'value' => 1,
+		],
+		[
+			'variable' => 'attachmentUploadDir',
+			'value' => '{$boarddir}/attachments',
+		],
+		[
+			'variable' => 'autoFixDatabase',
+			'value' => 1,
+		],
+		[
+			'variable' => 'autoLinkUrls',
+			'value' => 1,
+		],
+		[
+			'variable' => 'autoOptDatabase',
+			'value' => 7,
+		],
+		[
+			'variable' => 'autoOptLastOpt',
+			'value' => 0,
+		],
+		[
+			'variable' => 'autoOptMaxOnline',
+			'value' => 0,
+		],
+		[
+			'variable' => 'avatar_action_too_large',
+			'value' => 'option_html_resize',
+		],
+		[
+			'variable' => 'avatar_directory',
+			'value' => '{$boarddir}/avatars',
+		],
+		[
+			'variable' => 'avatar_download_png',
+			'value' => 1,
+		],
+		[
+			'variable' => 'avatar_max_height_external',
+			'value' => 65,
+		],
+		[
+			'variable' => 'avatar_max_height_upload',
+			'value' => 65,
+		],
+		[
+			'variable' => 'avatar_max_width_external',
+			'value' => 65,
+		],
+		[
+			'variable' => 'avatar_max_width_upload',
+			'value' => 65,
+		],
+		[
+			'variable' => 'avatar_resize_upload',
+			'value' => 1,
+		],
+		[
+			'variable' => 'avatar_url',
+			'value' => '{$boardurl}/avatars',
+		],
+		[
+			'variable' => 'banLastUpdated',
+			'value' => 0,
+		],
+		[
+			'variable' => 'cal_bdaycolor',
+			'value' => '920AC4',
+		],
+		[
+			'variable' => 'cal_days_for_index',
+			'value' => 7,
+		],
+		[
+			'variable' => 'cal_daysaslink',
+			'value' => 0,
+		],
+		[
+			'variable' => 'cal_defaultboard',
+			'value' => '',
+		],
+		[
+			'variable' => 'cal_enabled',
+			'value' => 0,
+		],
+		[
+			'variable' => 'cal_eventcolor',
+			'value' => '078907',
+		],
+		[
+			'variable' => 'cal_holidaycolor',
+			'value' => '000080',
+		],
+		[
+			'variable' => 'cal_maxspan',
+			'value' => 7,
+		],
+		[
+			'variable' => 'cal_maxyear',
+			'value' => 2010,
+		],
+		[
+			'variable' => 'cal_minyear',
+			'value' => 2004,
+		],
+		[
+			'variable' => 'cal_showbdaysoncalendar',
+			'value' => 1,
+		],
+		[
+			'variable' => 'cal_showbdaysonindex',
+			'value' => 0,
+		],
+		[
+			'variable' => 'cal_showeventsoncalendar',
+			'value' => 1,
+		],
+		[
+			'variable' => 'cal_showeventsonindex',
+			'value' => 0,
+		],
+		[
+			'variable' => 'cal_showholidaysoncalendar',
+			'value' => 1,
+		],
+		[
+			'variable' => 'cal_showholidaysonindex',
+			'value' => 0,
+		],
+		[
+			'variable' => 'cal_showweeknum',
+			'value' => 0,
+		],
+		[
+			'variable' => 'censorIgnoreCase',
+			'value' => 1,
+		],
+		[
+			'variable' => 'censor_proper',
+			'value' => '',
+		],
+		[
+			'variable' => 'censor_vulgar',
+			'value' => '',
+		],
+		[
+			'variable' => 'compactTopicPagesContiguous',
+			'value' => 5,
+		],
+		[
+			'variable' => 'compactTopicPagesEnable',
+			'value' => 1,
+		],
+		[
+			'variable' => 'cookieTime',
+			'value' => 60,
+		],
+		[
+			'variable' => 'databaseSession_enable',
+			'value' => '{$databaseSession_enable}',
+		],
+		[
+			'variable' => 'databaseSession_lifetime',
+			'value' => 2880,
+		],
+		[
+			'variable' => 'databaseSession_loose',
+			'value' => 1,
+		],
+		[
+			'variable' => 'defaultMaxMembers',
+			'value' => 30,
+		],
+		[
+			'variable' => 'defaultMaxMessages',
+			'value' => 15,
+		],
+		[
+			'variable' => 'defaultMaxTopics',
+			'value' => 20,
+		],
+		[
+			'variable' => 'default_personalText',
+			'value' => '',
+		],
+		[
+			'variable' => 'edit_disable_time',
+			'value' => 0,
+		],
+		[
+			'variable' => 'edit_wait_time',
+			'value' => 90,
+		],
+		[
+			'variable' => 'enableAllMessages',
+			'value' => 0,
+		],
+		[
+			'variable' => 'enableBBC',
+			'value' => 1,
+		],
+		[
+			'variable' => 'enableCompressedOutput',
+			'value' => '{$enableCompressedOutput}',
+		],
+		[
+			'variable' => 'enableEmbeddedFlash',
+			'value' => 0,
+		],
+		[
+			'variable' => 'enableErrorLogging',
+			'value' => 1,
+		],
+		[
+			'variable' => 'enableParticipation',
+			'value' => 1,
+		],
+		[
+			'variable' => 'enablePostHTML',
+			'value' => 0,
+		],
+		[
+			'variable' => 'enablePreviousNext',
+			'value' => 1,
+		],
+		[
+			'variable' => 'enableStickyTopics',
+			'value' => 1,
+		],
+		[
+			'variable' => 'enableVBStyleLogin',
+			'value' => 1,
+		],
+		[
+			'variable' => 'failed_login_threshold',
+			'value' => 3,
+		],
+		[
+			'variable' => 'fixLongWords',
+			'value' => 0,
+		],
+		[
+			'variable' => 'guest_hideContacts',
+			'value' => 0,
+		],
+		[
+			'variable' => 'hotTopicPosts',
+			'value' => 15,
+		],
+		[
+			'variable' => 'hotTopicVeryPosts',
+			'value' => 25,
+		],
+		[
+			'variable' => 'karmaApplaudLabel',
+			'value' => '{$default_karmaApplaudLabel}',
+		],
+		[
+			'variable' => 'karmaLabel',
+			'value' => '{$default_karmaLabel}',
+		],
+		[
+			'variable' => 'karmaMinPosts',
+			'value' => 0,
+		],
+		[
+			'variable' => 'karmaMode',
+			'value' => 0,
+		],
+		[
+			'variable' => 'karmaSmiteLabel',
+			'value' => '{$default_karmaSmiteLabel}',
+		],
+		[
+			'variable' => 'karmaTimeRestrictAdmins',
+			'value' => 1,
+		],
+		[
+			'variable' => 'karmaWaitTime',
+			'value' => 1,
+		],
+		[
+			'variable' => 'knownThemes',
+			'value' => '1,2,3',
+		],
+		[
+			'variable' => 'lastActive',
+			'value' => 15,
+		],
+		[
+			'variable' => 'mail_type',
+			'value' => 0,
+		],
+		[
+			'variable' => 'maxMsgID',
+			'value' => 1,
+		],
+		[
+			'variable' => 'max_image_height',
+			'value' => 0,
+		],
+		[
+			'variable' => 'max_image_width',
+			'value' => 0,
+		],
+		[
+			'variable' => 'max_messageLength',
+			'value' => 20000,
+		],
+		[
+			'variable' => 'max_signatureLength',
+			'value' => 300,
+		],
+		[
+			'variable' => 'mostDate',
+			'value' => '{$current_time}',
+		],
+		[
+			'variable' => 'mostOnline',
+			'value' => 1,
+		],
+		[
+			'variable' => 'mostOnlineToday',
+			'value' => 1,
+		],
+		[
+			'variable' => 'news',
+			'value' => '{$default_news}',
+		],
+		[
+			'variable' => 'number_format',
+			'value' => '1234.00',
+		],
+		[
+			'variable' => 'oldTopicDays',
+			'value' => 120,
+		],
+		[
+			'variable' => 'onlineEnable',
+			'value' => 0,
+		],
+		[
+			'variable' => 'package_make_backups',
+			'value' => 1,
+		],
+		[
+			'variable' => 'permission_enable_by_board',
+			'value' => 0,
+		],
+		[
+			'variable' => 'permission_enable_deny',
+			'value' => 0,
+		],
+		[
+			'variable' => 'permission_enable_postgroups',
+			'value' => 0,
+		],
+		[
+			'variable' => 'pm_spam_settings',
+			'value' => '10,5,20',
+		],
+		[
+			'variable' => 'pollMode',
+			'value' => 1,
+		],
+		[
+			'variable' => 'recycle_board',
+			'value' => 0,
+		],
+		[
+			'variable' => 'recycle_enable',
+			'value' => 0,
+		],
+		[
+			'variable' => 'registration_method',
+			'value' => 0,
+		],
+		[
+			'variable' => 'requireAgreement',
+			'value' => 1,
+		],
+		[
+			'variable' => 'reserveCase',
+			'value' => 1,
+		],
+		[
+			'variable' => 'reserveName',
+			'value' => 1,
+		],
+		[
+			'variable' => 'reserveNames',
+			'value' => '{$default_reserved_names}',
+		],
+		[
+			'variable' => 'reserveUser',
+			'value' => 1,
+		],
+		[
+			'variable' => 'reserveWord',
+			'value' => 0,
+		],
+		[
+			'variable' => 'search_cache_size',
+			'value' => 50,
+		],
+		[
+			'variable' => 'search_max_results',
+			'value' => 1200,
+		],
+		[
+			'variable' => 'search_results_per_page',
+			'value' => 30,
+		],
+		[
+			'variable' => 'search_weight_age',
+			'value' => 25,
+		],
+		[
+			'variable' => 'search_weight_first_message',
+			'value' => 10,
+		],
+		[
+			'variable' => 'search_weight_frequency',
+			'value' => 30,
+		],
+		[
+			'variable' => 'search_weight_length',
+			'value' => 20,
+		],
+		[
+			'variable' => 'search_weight_subject',
+			'value' => 15,
+		],
+		[
+			'variable' => 'send_validation_onChange',
+			'value' => 0,
+		],
+		[
+			'variable' => 'send_welcomeEmail',
+			'value' => 1,
+		],
+		[
+			'variable' => 'simpleSearch',
+			'value' => 0,
+		],
+		[
+			'variable' => 'smfVersion',
+			'value' => '{$smf_version}',
+		],
+		[
+			'variable' => 'smiley_sets_default',
+			'value' => 'default',
+		],
+		[
+			'variable' => 'smiley_sets_known',
+			'value' => 'default,classic',
+		],
+		[
+			'variable' => 'smiley_sets_names',
+			'value' => '{$default_smileyset_name}' . "\n" . '{$default_classic_smileyset_name}',
+		],
+		[
+			'variable' => 'smileys_dir',
+			'value' => '{$boarddir}/Smileys',
+		],
+		[
+			'variable' => 'smileys_url',
+			'value' => '{$boardurl}/Smileys',
+		],
+		[
+			'variable' => 'smtp_host',
+			'value' => '',
+		],
+		[
+			'variable' => 'smtp_password',
+			'value' => '',
+		],
+		[
+			'variable' => 'smtp_port',
+			'value' => 25,
+		],
+		[
+			'variable' => 'smtp_username',
+			'value' => '',
+		],
+		[
+			'variable' => 'spamWaitTime',
+			'value' => 5,
+		],
+		[
+			'variable' => 'theme_allow',
+			'value' => 1,
+		],
+		[
+			'variable' => 'theme_default',
+			'value' => 1,
+		],
+		[
+			'variable' => 'theme_guests',
+			'value' => 1,
+		],
+		[
+			'variable' => 'timeLoadPageEnable',
+			'value' => 0,
+		],
+		[
+			'variable' => 'time_format',
+			'value' => '{$default_time_format}',
+		],
+		[
+			'variable' => 'time_offset',
+			'value' => 0,
+		],
+		[
+			'variable' => 'titlesEnable',
+			'value' => 1,
+		],
+		[
+			'variable' => 'todayMod',
+			'value' => 1,
+		],
+		[
+			'variable' => 'topicSummaryPosts',
+			'value' => 15,
+		],
+		[
+			'variable' => 'totalMessages',
+			'value' => 1,
+		],
+		[
+			'variable' => 'totalTopics',
+			'value' => 1,
+		],
+		[
+			'variable' => 'trackStats',
+			'value' => 1,
+		],
+		[
+			'variable' => 'unapprovedMembers',
+			'value' => 0,
+		],
+		[
+			'variable' => 'userLanguage',
+			'value' => 1,
+		],
+		[
+			'variable' => 'who_enabled',
+			'value' => 1,
+		],
+		[
+			'variable' => 'xmlnews_enable',
+			'value' => 1,
+		],
+		[
+			'variable' => 'xmlnews_maxlen',
+			'value' => 255,
+		],
+	];
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'settings';
+
+		$this->columns = [
+			'variable' => new Column(
+				name: 'variable',
+				type: 'tinytext',
+				not_null: true,
+			),
+			'value' => new Column(
+				name: 'value',
+				type: 'text',
+				not_null: true,
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'variable',
+						'size' => 30,
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v1_1/Smileys.php
+++ b/Sources/Db/Schema/v1_1/Smileys.php
@@ -1,0 +1,248 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v1_1;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class Smileys extends Table
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 * @var array
+	 *
+	 * Data used to populate the table during install.
+	 */
+	public array $initial_data = [
+		[
+			'code' => ':)',
+			'filename' => 'smiley.gif',
+			'description' => '{$default_smiley_smiley}',
+			'smileyOrder' => 0,
+			'hidden' => 0,
+		],
+		[
+			'code' => ';)',
+			'filename' => 'wink.gif',
+			'description' => '{$default_wink_smiley}',
+			'smileyOrder' => 1,
+			'hidden' => 0,
+		],
+		[
+			'code' => ':D',
+			'filename' => 'cheesy.gif',
+			'description' => '{$default_cheesy_smiley}',
+			'smileyOrder' => 2,
+			'hidden' => 0,
+		],
+		[
+			'code' => ';D',
+			'filename' => 'grin.gif',
+			'description' => '{$default_grin_smiley}',
+			'smileyOrder' => 3,
+			'hidden' => 0,
+		],
+		[
+			'code' => '>:(',
+			'filename' => 'angry.gif',
+			'description' => '{$default_angry_smiley}',
+			'smileyOrder' => 4,
+			'hidden' => 0,
+		],
+		[
+			'code' => ':(',
+			'filename' => 'sad.gif',
+			'description' => '{$default_sad_smiley}',
+			'smileyOrder' => 5,
+			'hidden' => 0,
+		],
+		[
+			'code' => ':o',
+			'filename' => 'shocked.gif',
+			'description' => '{$default_shocked_smiley}',
+			'smileyOrder' => 6,
+			'hidden' => 0,
+		],
+		[
+			'code' => '8)',
+			'filename' => 'cool.gif',
+			'description' => '{$default_cool_smiley}',
+			'smileyOrder' => 7,
+			'hidden' => 0,
+		],
+		[
+			'code' => '???',
+			'filename' => 'huh.gif',
+			'description' => '{$default_huh_smiley}',
+			'smileyOrder' => 8,
+			'hidden' => 0,
+		],
+		[
+			'code' => '::)',
+			'filename' => 'rolleyes.gif',
+			'description' => '{$default_roll_eyes_smiley}',
+			'smileyOrder' => 9,
+			'hidden' => 0,
+		],
+		[
+			'code' => ':P',
+			'filename' => 'tongue.gif',
+			'description' => '{$default_tongue_smiley}',
+			'smileyOrder' => 10,
+			'hidden' => 0,
+		],
+		[
+			'code' => ':-[',
+			'filename' => 'embarrassed.gif',
+			'description' => '{$default_embarrassed_smiley}',
+			'smileyOrder' => 11,
+			'hidden' => 0,
+		],
+		[
+			'code' => ':-X',
+			'filename' => 'lipsrsealed.gif',
+			'description' => '{$default_lips_sealed_smiley}',
+			'smileyOrder' => 12,
+			'hidden' => 0,
+		],
+		[
+			'code' => ':-\\',
+			'filename' => 'undecided.gif',
+			'description' => '{$default_undecided_smiley}',
+			'smileyOrder' => 13,
+			'hidden' => 0,
+		],
+		[
+			'code' => ':-*',
+			'filename' => 'kiss.gif',
+			'description' => '{$default_kiss_smiley}',
+			'smileyOrder' => 14,
+			'hidden' => 0,
+		],
+		[
+			'code' => ':\'(',
+			'filename' => 'cry.gif',
+			'description' => '{$default_cry_smiley}',
+			'smileyOrder' => 15,
+			'hidden' => 0,
+		],
+		[
+			'code' => '>:D',
+			'filename' => 'evil.gif',
+			'description' => '{$default_evil_smiley}',
+			'smileyOrder' => 16,
+			'hidden' => 1,
+		],
+		[
+			'code' => '^-^',
+			'filename' => 'azn.gif',
+			'description' => '{$default_azn_smiley}',
+			'smileyOrder' => 17,
+			'hidden' => 1,
+		],
+		[
+			'code' => 'O0',
+			'filename' => 'afro.gif',
+			'description' => '{$default_afro_smiley}',
+			'smileyOrder' => 18,
+			'hidden' => 1,
+		],
+	];
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'smileys';
+
+		$this->columns = [
+			'ID_SMILEY' => new Column(
+				name: 'ID_SMILEY',
+				type: 'smallint',
+				unsigned: true,
+				not_null: true,
+				auto: true,
+			),
+			'code' => new Column(
+				name: 'code',
+				type: 'varchar',
+				size: 30,
+				not_null: true,
+				default: '',
+			),
+			'filename' => new Column(
+				name: 'filename',
+				type: 'varchar',
+				size: 48,
+				not_null: true,
+				default: '',
+			),
+			'description' => new Column(
+				name: 'description',
+				type: 'varchar',
+				size: 80,
+				not_null: true,
+				default: '',
+			),
+			'smileyRow' => new Column(
+				name: 'smileyRow',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'smileyOrder' => new Column(
+				name: 'smileyOrder',
+				type: 'smallint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'hidden' => new Column(
+				name: 'hidden',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'ID_SMILEY',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v1_1/Themes.php
+++ b/Sources/Db/Schema/v1_1/Themes.php
@@ -1,0 +1,264 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v1_1;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class Themes extends Table
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 * @var array
+	 *
+	 * Data used to populate the table during install.
+	 */
+	public array $initial_data = [
+		[
+			'ID_THEME' => 1,
+			'variable' => 'name',
+			'value' => '{$default_theme_name}',
+		],
+		[
+			'ID_THEME' => 1,
+			'variable' => 'theme_url',
+			'value' => '{$boardurl}/Themes/default',
+		],
+		[
+			'ID_THEME' => 1,
+			'variable' => 'images_url',
+			'value' => '{$boardurl}/Themes/default/images',
+		],
+		[
+			'ID_THEME' => 1,
+			'variable' => 'theme_dir',
+			'value' => '{$boarddir}/Themes/default',
+		],
+		[
+			'ID_THEME' => 1,
+			'variable' => 'show_bbc',
+			'value' => 1,
+		],
+		[
+			'ID_THEME' => 1,
+			'variable' => 'show_latest_member',
+			'value' => 1,
+		],
+		[
+			'ID_THEME' => 1,
+			'variable' => 'show_modify',
+			'value' => 1,
+		],
+		[
+			'ID_THEME' => 1,
+			'variable' => 'show_user_images',
+			'value' => 1,
+		],
+		[
+			'ID_THEME' => 1,
+			'variable' => 'show_blurb',
+			'value' => 1,
+		],
+		[
+			'ID_THEME' => 1,
+			'variable' => 'show_gender',
+			'value' => 0,
+		],
+		[
+			'ID_THEME' => 1,
+			'variable' => 'show_newsfader',
+			'value' => 0,
+		],
+		[
+			'ID_THEME' => 1,
+			'variable' => 'number_recent_posts',
+			'value' => 0,
+		],
+		[
+			'ID_THEME' => 1,
+			'variable' => 'show_member_bar',
+			'value' => 1,
+		],
+		[
+			'ID_THEME' => 1,
+			'variable' => 'linktree_link',
+			'value' => 1,
+		],
+		[
+			'ID_THEME' => 1,
+			'variable' => 'show_profile_buttons',
+			'value' => 1,
+		],
+		[
+			'ID_THEME' => 1,
+			'variable' => 'show_mark_read',
+			'value' => 1,
+		],
+		[
+			'ID_THEME' => 1,
+			'variable' => 'show_sp1_info',
+			'value' => 1,
+		],
+		[
+			'ID_THEME' => 1,
+			'variable' => 'linktree_inline',
+			'value' => 0,
+		],
+		[
+			'ID_THEME' => 1,
+			'variable' => 'show_board_desc',
+			'value' => 1,
+		],
+		[
+			'ID_THEME' => 1,
+			'variable' => 'newsfader_time',
+			'value' => 5000,
+		],
+		[
+			'ID_THEME' => 1,
+			'variable' => 'allow_no_censored',
+			'value' => 0,
+		],
+		[
+			'ID_THEME' => 1,
+			'variable' => 'additional_options_collapsable',
+			'value' => 1,
+		],
+		[
+			'ID_THEME' => 1,
+			'variable' => 'use_image_buttons',
+			'value' => 1,
+		],
+		[
+			'ID_THEME' => 1,
+			'variable' => 'enable_news',
+			'value' => 1,
+		],
+		[
+			'ID_THEME' => 2,
+			'variable' => 'name',
+			'value' => '{$default_classic_theme_name}',
+		],
+		[
+			'ID_THEME' => 2,
+			'variable' => 'theme_url',
+			'value' => '{$boardurl}/Themes/classic',
+		],
+		[
+			'ID_THEME' => 2,
+			'variable' => 'images_url',
+			'value' => '{$boardurl}/Themes/classic/images',
+		],
+		[
+			'ID_THEME' => 2,
+			'variable' => 'theme_dir',
+			'value' => '{$boarddir}/Themes/classic',
+		],
+		[
+			'ID_THEME' => 3,
+			'variable' => 'name',
+			'value' => '{$default_babylon_theme_name}',
+		],
+		[
+			'ID_THEME' => 3,
+			'variable' => 'theme_url',
+			'value' => '{$boardurl}/Themes/babylon',
+		],
+		[
+			'ID_THEME' => 3,
+			'variable' => 'images_url',
+			'value' => '{$boardurl}/Themes/babylon/images',
+		],
+		[
+			'ID_THEME' => 3,
+			'variable' => 'theme_dir',
+			'value' => '{$boarddir}/Themes/babylon',
+		],
+	];
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'themes';
+
+		$this->columns = [
+			'ID_MEMBER' => new Column(
+				name: 'ID_MEMBER',
+				type: 'mediumint',
+				not_null: true,
+				default: 0,
+			),
+			'ID_THEME' => new Column(
+				name: 'ID_THEME',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				default: 1,
+			),
+			'variable' => new Column(
+				name: 'variable',
+				type: 'tinytext',
+				not_null: true,
+			),
+			'value' => new Column(
+				name: 'value',
+				type: 'text',
+				not_null: true,
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'ID_THEME',
+					],
+					[
+						'name' => 'ID_MEMBER',
+					],
+					[
+						'name' => 'variable',
+						'size' => 30,
+					],
+				],
+			),
+			'ID_MEMBER' => new DbIndex(
+				name: 'ID_MEMBER',
+				columns: [
+					[
+						'name' => 'ID_MEMBER',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v1_1/Topics.php
+++ b/Sources/Db/Schema/v1_1/Topics.php
@@ -1,0 +1,201 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v1_1;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class Topics extends Table
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 * @var array
+	 *
+	 * Data used to populate the table during install.
+	 */
+	public array $initial_data = [
+		[
+			'ID_TOPIC' => 1,
+			'ID_BOARD' => 1,
+			'ID_FIRST_MSG' => 1,
+			'ID_LAST_MSG' => 1,
+			'ID_MEMBER_STARTED' => 0,
+			'ID_MEMBER_UPDATED' => 0,
+		],
+	];
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'topics';
+
+		$this->columns = [
+			'ID_TOPIC' => new Column(
+				name: 'ID_TOPIC',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				auto: true,
+			),
+			'isSticky' => new Column(
+				name: 'isSticky',
+				type: 'tinyint',
+				not_null: true,
+				default: 0,
+			),
+			'ID_BOARD' => new Column(
+				name: 'ID_BOARD',
+				type: 'smallint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'ID_FIRST_MSG' => new Column(
+				name: 'ID_FIRST_MSG',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'ID_LAST_MSG' => new Column(
+				name: 'ID_LAST_MSG',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'ID_MEMBER_STARTED' => new Column(
+				name: 'ID_MEMBER_STARTED',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'ID_MEMBER_UPDATED' => new Column(
+				name: 'ID_MEMBER_UPDATED',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'ID_POLL' => new Column(
+				name: 'ID_POLL',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'numReplies' => new Column(
+				name: 'numReplies',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'numViews' => new Column(
+				name: 'numViews',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'locked' => new Column(
+				name: 'locked',
+				type: 'tinyint',
+				not_null: true,
+				default: 0,
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'ID_TOPIC',
+					],
+				],
+			),
+			'lastMessage' => new DbIndex(
+				type: 'unique',
+				name: 'lastMessage',
+				columns: [
+					[
+						'name' => 'ID_LAST_MSG',
+					],
+					[
+						'name' => 'ID_BOARD',
+					],
+				],
+			),
+			'firstMessage' => new DbIndex(
+				type: 'unique',
+				name: 'firstMessage',
+				columns: [
+					[
+						'name' => 'ID_FIRST_MSG',
+					],
+					[
+						'name' => 'ID_BOARD',
+					],
+				],
+			),
+			'poll' => new DbIndex(
+				type: 'unique',
+				name: 'poll',
+				columns: [
+					[
+						'name' => 'ID_POLL',
+					],
+					[
+						'name' => 'ID_TOPIC',
+					],
+				],
+			),
+			'isSticky' => new DbIndex(
+				name: 'isSticky',
+				columns: [
+					[
+						'name' => 'isSticky',
+					],
+				],
+			),
+			'ID_BOARD' => new DbIndex(
+				name: 'ID_BOARD',
+				columns: [
+					[
+						'name' => 'ID_BOARD',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v1_1/index.php
+++ b/Sources/Db/Schema/v1_1/index.php
@@ -1,0 +1,8 @@
+<?php
+
+// Try to handle it with the upper level index.php. (it should know what to do.)
+if (file_exists(dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php')) {
+	include dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php';
+} else {
+	exit;
+}

--- a/Sources/Db/Schema/v2_0/AdminInfoFiles.php
+++ b/Sources/Db/Schema/v2_0/AdminInfoFiles.php
@@ -1,0 +1,171 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v2_0;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class AdminInfoFiles extends Table
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 * @var array
+	 *
+	 * Data used to populate the table during install.
+	 */
+	public array $initial_data = [
+		[
+			'id_file' => 1,
+			'filename' => 'current-version.js',
+			'path' => '/smf/',
+			'parameters' => 'version=%3$s',
+			'data' => '',
+			'filetype' => 'text/javascript',
+		],
+		[
+			'id_file' => 2,
+			'filename' => 'detailed-version.js',
+			'path' => '/smf/',
+			'parameters' => 'language=%1$s&version=%3$s',
+			'data' => '',
+			'filetype' => 'text/javascript',
+		],
+		[
+			'id_file' => 3,
+			'filename' => 'latest-news.js',
+			'path' => '/smf/',
+			'parameters' => 'language=%1$s&format=%2$s',
+			'data' => '',
+			'filetype' => 'text/javascript',
+		],
+		[
+			'id_file' => 4,
+			'filename' => 'latest-packages.js',
+			'path' => '/smf/',
+			'parameters' => 'language=%1$s&version=%3$s',
+			'data' => '',
+			'filetype' => 'text/javascript',
+		],
+		[
+			'id_file' => 5,
+			'filename' => 'latest-smileys.js',
+			'path' => '/smf/',
+			'parameters' => 'language=%1$s&version=%3$s',
+			'data' => '',
+			'filetype' => 'text/javascript',
+		],
+		[
+			'id_file' => 6,
+			'filename' => 'latest-support.js',
+			'path' => '/smf/',
+			'parameters' => 'language=%1$s&version=%3$s',
+			'data' => '',
+			'filetype' => 'text/javascript',
+		],
+		[
+			'id_file' => 7,
+			'filename' => 'latest-themes.js',
+			'path' => '/smf/',
+			'parameters' => 'language=%1$s&version=%3$s',
+			'data' => '',
+			'filetype' => 'text/javascript',
+		],
+	];
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'admin_info_files';
+
+		$this->columns = [
+			'id_file' => new Column(
+				name: 'id_file',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				auto: true,
+			),
+			'filename' => new Column(
+				name: 'filename',
+				type: 'varchar',
+				size: 255,
+				not_null: true,
+				default: '',
+			),
+			'path' => new Column(
+				name: 'path',
+				type: 'varchar',
+				size: 255,
+				not_null: true,
+				default: '',
+			),
+			'parameters' => new Column(
+				name: 'parameters',
+				type: 'varchar',
+				size: 255,
+				not_null: true,
+				default: '',
+			),
+			'data' => new Column(
+				name: 'data',
+				type: 'text',
+				not_null: true,
+			),
+			'filetype' => new Column(
+				name: 'filetype',
+				type: 'varchar',
+				size: 255,
+				not_null: true,
+				default: '',
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'id_file',
+					],
+				],
+			),
+			'filename' => new DbIndex(
+				name: 'filename',
+				columns: [
+					[
+						'name' => 'filename',
+						'size' => 30,
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v2_0/ApprovalQueue.php
+++ b/Sources/Db/Schema/v2_0/ApprovalQueue.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v2_0;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class ApprovalQueue extends Table
+{
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'approval_queue';
+
+		$this->columns = [
+			'id_msg' => new Column(
+				name: 'id_msg',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'id_attach' => new Column(
+				name: 'id_attach',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'id_event' => new Column(
+				name: 'id_event',
+				type: 'smallint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v2_0/Attachments.php
+++ b/Sources/Db/Schema/v2_0/Attachments.php
@@ -1,0 +1,185 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v2_0;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class Attachments extends Table
+{
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'attachments';
+
+		$this->columns = [
+			'id_attach' => new Column(
+				name: 'id_attach',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				auto: true,
+			),
+			'id_thumb' => new Column(
+				name: 'id_thumb',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'id_msg' => new Column(
+				name: 'id_msg',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'id_member' => new Column(
+				name: 'id_member',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'id_folder' => new Column(
+				name: 'id_folder',
+				type: 'tinyint',
+				not_null: true,
+				default: 1,
+			),
+			'attachment_type' => new Column(
+				name: 'attachment_type',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'filename' => new Column(
+				name: 'filename',
+				type: 'varchar',
+				size: 255,
+				not_null: true,
+				default: '',
+			),
+			'file_hash' => new Column(
+				name: 'file_hash',
+				type: 'varchar',
+				size: 40,
+				not_null: true,
+				default: '',
+			),
+			'fileext' => new Column(
+				name: 'fileext',
+				type: 'varchar',
+				size: 8,
+				not_null: true,
+				default: '',
+			),
+			'size' => new Column(
+				name: 'size',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'downloads' => new Column(
+				name: 'downloads',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'width' => new Column(
+				name: 'width',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'height' => new Column(
+				name: 'height',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'mime_type' => new Column(
+				name: 'mime_type',
+				type: 'varchar',
+				size: 20,
+				not_null: true,
+				default: '',
+			),
+			'approved' => new Column(
+				name: 'approved',
+				type: 'tinyint',
+				not_null: true,
+				default: 1,
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'id_attach',
+					],
+				],
+			),
+			'id_member' => new DbIndex(
+				type: 'unique',
+				name: 'id_member',
+				columns: [
+					[
+						'name' => 'id_member',
+					],
+					[
+						'name' => 'id_attach',
+					],
+				],
+			),
+			'id_msg' => new DbIndex(
+				name: 'id_msg',
+				columns: [
+					[
+						'name' => 'id_msg',
+					],
+				],
+			),
+			'attachment_type' => new DbIndex(
+				name: 'attachment_type',
+				columns: [
+					[
+						'name' => 'attachment_type',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v2_0/BanGroups.php
+++ b/Sources/Db/Schema/v2_0/BanGroups.php
@@ -1,0 +1,120 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v2_0;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class BanGroups extends Table
+{
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'ban_groups';
+
+		$this->columns = [
+			'id_ban_group' => new Column(
+				name: 'id_ban_group',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				auto: true,
+			),
+			'name' => new Column(
+				name: 'name',
+				type: 'varchar',
+				size: 20,
+				not_null: true,
+				default: '',
+			),
+			'ban_time' => new Column(
+				name: 'ban_time',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'expire_time' => new Column(
+				name: 'expire_time',
+				type: 'int',
+				unsigned: true,
+			),
+			'cannot_access' => new Column(
+				name: 'cannot_access',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'cannot_register' => new Column(
+				name: 'cannot_register',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'cannot_post' => new Column(
+				name: 'cannot_post',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'cannot_login' => new Column(
+				name: 'cannot_login',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'reason' => new Column(
+				name: 'reason',
+				type: 'varchar',
+				size: 255,
+				not_null: true,
+				default: '',
+			),
+			'notes' => new Column(
+				name: 'notes',
+				type: 'text',
+				not_null: true,
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'id_ban_group',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v2_0/BanItems.php
+++ b/Sources/Db/Schema/v2_0/BanItems.php
@@ -1,0 +1,160 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v2_0;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class BanItems extends Table
+{
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'ban_items';
+
+		$this->columns = [
+			'id_ban' => new Column(
+				name: 'id_ban',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				auto: true,
+			),
+			'id_ban_group' => new Column(
+				name: 'id_ban_group',
+				type: 'smallint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'ip_low1' => new Column(
+				name: 'ip_low1',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'ip_high1' => new Column(
+				name: 'ip_high1',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'ip_low2' => new Column(
+				name: 'ip_low2',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'ip_high2' => new Column(
+				name: 'ip_high2',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'ip_low3' => new Column(
+				name: 'ip_low3',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'ip_high3' => new Column(
+				name: 'ip_high3',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'ip_low4' => new Column(
+				name: 'ip_low4',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'ip_high4' => new Column(
+				name: 'ip_high4',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'hostname' => new Column(
+				name: 'hostname',
+				type: 'varchar',
+				size: 255,
+				not_null: true,
+				default: '',
+			),
+			'email_address' => new Column(
+				name: 'email_address',
+				type: 'varchar',
+				size: 255,
+				not_null: true,
+				default: '',
+			),
+			'id_member' => new Column(
+				name: 'id_member',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'hits' => new Column(
+				name: 'hits',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'id_ban',
+					],
+				],
+			),
+			'id_ban_group' => new DbIndex(
+				name: 'id_ban_group',
+				columns: [
+					[
+						'name' => 'id_ban_group',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v2_0/BoardPermissions.php
+++ b/Sources/Db/Schema/v2_0/BoardPermissions.php
@@ -1,0 +1,1768 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v2_0;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class BoardPermissions extends Table
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 * @var array
+	 *
+	 * Data used to populate the table during install.
+	 */
+	public array $initial_data = [
+		[
+			'id_group' => -1,
+			'id_profile' => 1,
+			'permission' => 'poll_view',
+		],
+		[
+			'id_group' => 0,
+			'id_profile' => 1,
+			'permission' => 'remove_own',
+		],
+		[
+			'id_group' => 0,
+			'id_profile' => 1,
+			'permission' => 'lock_own',
+		],
+		[
+			'id_group' => 0,
+			'id_profile' => 1,
+			'permission' => 'mark_any_notify',
+		],
+		[
+			'id_group' => 0,
+			'id_profile' => 1,
+			'permission' => 'mark_notify',
+		],
+		[
+			'id_group' => 0,
+			'id_profile' => 1,
+			'permission' => 'modify_own',
+		],
+		[
+			'id_group' => 0,
+			'id_profile' => 1,
+			'permission' => 'poll_add_own',
+		],
+		[
+			'id_group' => 0,
+			'id_profile' => 1,
+			'permission' => 'poll_edit_own',
+		],
+		[
+			'id_group' => 0,
+			'id_profile' => 1,
+			'permission' => 'poll_lock_own',
+		],
+		[
+			'id_group' => 0,
+			'id_profile' => 1,
+			'permission' => 'poll_post',
+		],
+		[
+			'id_group' => 0,
+			'id_profile' => 1,
+			'permission' => 'poll_view',
+		],
+		[
+			'id_group' => 0,
+			'id_profile' => 1,
+			'permission' => 'poll_vote',
+		],
+		[
+			'id_group' => 0,
+			'id_profile' => 1,
+			'permission' => 'post_attachment',
+		],
+		[
+			'id_group' => 0,
+			'id_profile' => 1,
+			'permission' => 'post_new',
+		],
+		[
+			'id_group' => 0,
+			'id_profile' => 1,
+			'permission' => 'post_reply_any',
+		],
+		[
+			'id_group' => 0,
+			'id_profile' => 1,
+			'permission' => 'post_reply_own',
+		],
+		[
+			'id_group' => 0,
+			'id_profile' => 1,
+			'permission' => 'post_unapproved_topics',
+		],
+		[
+			'id_group' => 0,
+			'id_profile' => 1,
+			'permission' => 'post_unapproved_replies_any',
+		],
+		[
+			'id_group' => 0,
+			'id_profile' => 1,
+			'permission' => 'post_unapproved_replies_own',
+		],
+		[
+			'id_group' => 0,
+			'id_profile' => 1,
+			'permission' => 'post_unapproved_attachments',
+		],
+		[
+			'id_group' => 0,
+			'id_profile' => 1,
+			'permission' => 'delete_own',
+		],
+		[
+			'id_group' => 0,
+			'id_profile' => 1,
+			'permission' => 'report_any',
+		],
+		[
+			'id_group' => 0,
+			'id_profile' => 1,
+			'permission' => 'send_topic',
+		],
+		[
+			'id_group' => 0,
+			'id_profile' => 1,
+			'permission' => 'view_attachments',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 1,
+			'permission' => 'moderate_board',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 1,
+			'permission' => 'post_new',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 1,
+			'permission' => 'post_reply_own',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 1,
+			'permission' => 'post_reply_any',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 1,
+			'permission' => 'post_unapproved_topics',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 1,
+			'permission' => 'post_unapproved_replies_any',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 1,
+			'permission' => 'post_unapproved_replies_own',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 1,
+			'permission' => 'post_unapproved_attachments',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 1,
+			'permission' => 'poll_post',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 1,
+			'permission' => 'poll_add_any',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 1,
+			'permission' => 'poll_remove_any',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 1,
+			'permission' => 'poll_view',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 1,
+			'permission' => 'poll_vote',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 1,
+			'permission' => 'poll_lock_any',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 1,
+			'permission' => 'poll_edit_any',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 1,
+			'permission' => 'report_any',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 1,
+			'permission' => 'lock_own',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 1,
+			'permission' => 'send_topic',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 1,
+			'permission' => 'mark_any_notify',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 1,
+			'permission' => 'mark_notify',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 1,
+			'permission' => 'delete_own',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 1,
+			'permission' => 'modify_own',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 1,
+			'permission' => 'make_sticky',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 1,
+			'permission' => 'lock_any',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 1,
+			'permission' => 'remove_any',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 1,
+			'permission' => 'move_any',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 1,
+			'permission' => 'merge_any',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 1,
+			'permission' => 'split_any',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 1,
+			'permission' => 'delete_any',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 1,
+			'permission' => 'modify_any',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 1,
+			'permission' => 'approve_posts',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 1,
+			'permission' => 'post_attachment',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 1,
+			'permission' => 'view_attachments',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 1,
+			'permission' => 'moderate_board',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 1,
+			'permission' => 'post_new',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 1,
+			'permission' => 'post_reply_own',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 1,
+			'permission' => 'post_reply_any',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 1,
+			'permission' => 'post_unapproved_topics',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 1,
+			'permission' => 'post_unapproved_replies_any',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 1,
+			'permission' => 'post_unapproved_replies_own',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 1,
+			'permission' => 'post_unapproved_attachments',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 1,
+			'permission' => 'poll_post',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 1,
+			'permission' => 'poll_add_any',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 1,
+			'permission' => 'poll_remove_any',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 1,
+			'permission' => 'poll_view',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 1,
+			'permission' => 'poll_vote',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 1,
+			'permission' => 'poll_lock_any',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 1,
+			'permission' => 'poll_edit_any',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 1,
+			'permission' => 'report_any',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 1,
+			'permission' => 'lock_own',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 1,
+			'permission' => 'send_topic',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 1,
+			'permission' => 'mark_any_notify',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 1,
+			'permission' => 'mark_notify',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 1,
+			'permission' => 'delete_own',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 1,
+			'permission' => 'modify_own',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 1,
+			'permission' => 'make_sticky',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 1,
+			'permission' => 'lock_any',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 1,
+			'permission' => 'remove_any',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 1,
+			'permission' => 'move_any',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 1,
+			'permission' => 'merge_any',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 1,
+			'permission' => 'split_any',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 1,
+			'permission' => 'delete_any',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 1,
+			'permission' => 'modify_any',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 1,
+			'permission' => 'approve_posts',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 1,
+			'permission' => 'post_attachment',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 1,
+			'permission' => 'view_attachments',
+		],
+		[
+			'id_group' => -1,
+			'id_profile' => 2,
+			'permission' => 'poll_view',
+		],
+		[
+			'id_group' => 0,
+			'id_profile' => 2,
+			'permission' => 'remove_own',
+		],
+		[
+			'id_group' => 0,
+			'id_profile' => 2,
+			'permission' => 'lock_own',
+		],
+		[
+			'id_group' => 0,
+			'id_profile' => 2,
+			'permission' => 'mark_any_notify',
+		],
+		[
+			'id_group' => 0,
+			'id_profile' => 2,
+			'permission' => 'mark_notify',
+		],
+		[
+			'id_group' => 0,
+			'id_profile' => 2,
+			'permission' => 'modify_own',
+		],
+		[
+			'id_group' => 0,
+			'id_profile' => 2,
+			'permission' => 'poll_view',
+		],
+		[
+			'id_group' => 0,
+			'id_profile' => 2,
+			'permission' => 'poll_vote',
+		],
+		[
+			'id_group' => 0,
+			'id_profile' => 2,
+			'permission' => 'post_attachment',
+		],
+		[
+			'id_group' => 0,
+			'id_profile' => 2,
+			'permission' => 'post_new',
+		],
+		[
+			'id_group' => 0,
+			'id_profile' => 2,
+			'permission' => 'post_reply_any',
+		],
+		[
+			'id_group' => 0,
+			'id_profile' => 2,
+			'permission' => 'post_reply_own',
+		],
+		[
+			'id_group' => 0,
+			'id_profile' => 2,
+			'permission' => 'post_unapproved_topics',
+		],
+		[
+			'id_group' => 0,
+			'id_profile' => 2,
+			'permission' => 'post_unapproved_replies_any',
+		],
+		[
+			'id_group' => 0,
+			'id_profile' => 2,
+			'permission' => 'post_unapproved_replies_own',
+		],
+		[
+			'id_group' => 0,
+			'id_profile' => 2,
+			'permission' => 'post_unapproved_attachments',
+		],
+		[
+			'id_group' => 0,
+			'id_profile' => 2,
+			'permission' => 'delete_own',
+		],
+		[
+			'id_group' => 0,
+			'id_profile' => 2,
+			'permission' => 'report_any',
+		],
+		[
+			'id_group' => 0,
+			'id_profile' => 2,
+			'permission' => 'send_topic',
+		],
+		[
+			'id_group' => 0,
+			'id_profile' => 2,
+			'permission' => 'view_attachments',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 2,
+			'permission' => 'moderate_board',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 2,
+			'permission' => 'post_new',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 2,
+			'permission' => 'post_reply_own',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 2,
+			'permission' => 'post_reply_any',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 2,
+			'permission' => 'post_unapproved_topics',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 2,
+			'permission' => 'post_unapproved_replies_any',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 2,
+			'permission' => 'post_unapproved_replies_own',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 2,
+			'permission' => 'post_unapproved_attachments',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 2,
+			'permission' => 'poll_post',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 2,
+			'permission' => 'poll_add_any',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 2,
+			'permission' => 'poll_remove_any',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 2,
+			'permission' => 'poll_view',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 2,
+			'permission' => 'poll_vote',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 2,
+			'permission' => 'poll_lock_any',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 2,
+			'permission' => 'poll_edit_any',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 2,
+			'permission' => 'report_any',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 2,
+			'permission' => 'lock_own',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 2,
+			'permission' => 'send_topic',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 2,
+			'permission' => 'mark_any_notify',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 2,
+			'permission' => 'mark_notify',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 2,
+			'permission' => 'delete_own',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 2,
+			'permission' => 'modify_own',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 2,
+			'permission' => 'make_sticky',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 2,
+			'permission' => 'lock_any',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 2,
+			'permission' => 'remove_any',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 2,
+			'permission' => 'move_any',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 2,
+			'permission' => 'merge_any',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 2,
+			'permission' => 'split_any',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 2,
+			'permission' => 'delete_any',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 2,
+			'permission' => 'modify_any',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 2,
+			'permission' => 'approve_posts',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 2,
+			'permission' => 'post_attachment',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 2,
+			'permission' => 'view_attachments',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 2,
+			'permission' => 'moderate_board',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 2,
+			'permission' => 'post_new',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 2,
+			'permission' => 'post_reply_own',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 2,
+			'permission' => 'post_reply_any',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 2,
+			'permission' => 'post_unapproved_topics',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 2,
+			'permission' => 'post_unapproved_replies_any',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 2,
+			'permission' => 'post_unapproved_replies_own',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 2,
+			'permission' => 'post_unapproved_attachments',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 2,
+			'permission' => 'poll_post',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 2,
+			'permission' => 'poll_add_any',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 2,
+			'permission' => 'poll_remove_any',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 2,
+			'permission' => 'poll_view',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 2,
+			'permission' => 'poll_vote',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 2,
+			'permission' => 'poll_lock_any',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 2,
+			'permission' => 'poll_edit_any',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 2,
+			'permission' => 'report_any',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 2,
+			'permission' => 'lock_own',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 2,
+			'permission' => 'send_topic',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 2,
+			'permission' => 'mark_any_notify',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 2,
+			'permission' => 'mark_notify',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 2,
+			'permission' => 'delete_own',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 2,
+			'permission' => 'modify_own',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 2,
+			'permission' => 'make_sticky',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 2,
+			'permission' => 'lock_any',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 2,
+			'permission' => 'remove_any',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 2,
+			'permission' => 'move_any',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 2,
+			'permission' => 'merge_any',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 2,
+			'permission' => 'split_any',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 2,
+			'permission' => 'delete_any',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 2,
+			'permission' => 'modify_any',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 2,
+			'permission' => 'approve_posts',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 2,
+			'permission' => 'post_attachment',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 2,
+			'permission' => 'view_attachments',
+		],
+		[
+			'id_group' => -1,
+			'id_profile' => 3,
+			'permission' => 'poll_view',
+		],
+		[
+			'id_group' => 0,
+			'id_profile' => 3,
+			'permission' => 'remove_own',
+		],
+		[
+			'id_group' => 0,
+			'id_profile' => 3,
+			'permission' => 'lock_own',
+		],
+		[
+			'id_group' => 0,
+			'id_profile' => 3,
+			'permission' => 'mark_any_notify',
+		],
+		[
+			'id_group' => 0,
+			'id_profile' => 3,
+			'permission' => 'mark_notify',
+		],
+		[
+			'id_group' => 0,
+			'id_profile' => 3,
+			'permission' => 'modify_own',
+		],
+		[
+			'id_group' => 0,
+			'id_profile' => 3,
+			'permission' => 'poll_view',
+		],
+		[
+			'id_group' => 0,
+			'id_profile' => 3,
+			'permission' => 'poll_vote',
+		],
+		[
+			'id_group' => 0,
+			'id_profile' => 3,
+			'permission' => 'post_attachment',
+		],
+		[
+			'id_group' => 0,
+			'id_profile' => 3,
+			'permission' => 'post_reply_any',
+		],
+		[
+			'id_group' => 0,
+			'id_profile' => 3,
+			'permission' => 'post_reply_own',
+		],
+		[
+			'id_group' => 0,
+			'id_profile' => 3,
+			'permission' => 'post_unapproved_replies_any',
+		],
+		[
+			'id_group' => 0,
+			'id_profile' => 3,
+			'permission' => 'post_unapproved_replies_own',
+		],
+		[
+			'id_group' => 0,
+			'id_profile' => 3,
+			'permission' => 'post_unapproved_attachments',
+		],
+		[
+			'id_group' => 0,
+			'id_profile' => 3,
+			'permission' => 'delete_own',
+		],
+		[
+			'id_group' => 0,
+			'id_profile' => 3,
+			'permission' => 'report_any',
+		],
+		[
+			'id_group' => 0,
+			'id_profile' => 3,
+			'permission' => 'send_topic',
+		],
+		[
+			'id_group' => 0,
+			'id_profile' => 3,
+			'permission' => 'view_attachments',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 3,
+			'permission' => 'moderate_board',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 3,
+			'permission' => 'post_new',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 3,
+			'permission' => 'post_reply_own',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 3,
+			'permission' => 'post_reply_any',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 3,
+			'permission' => 'post_unapproved_topics',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 3,
+			'permission' => 'post_unapproved_replies_any',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 3,
+			'permission' => 'post_unapproved_replies_own',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 3,
+			'permission' => 'post_unapproved_attachments',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 3,
+			'permission' => 'poll_post',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 3,
+			'permission' => 'poll_add_any',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 3,
+			'permission' => 'poll_remove_any',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 3,
+			'permission' => 'poll_view',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 3,
+			'permission' => 'poll_vote',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 3,
+			'permission' => 'poll_lock_any',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 3,
+			'permission' => 'poll_edit_any',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 3,
+			'permission' => 'report_any',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 3,
+			'permission' => 'lock_own',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 3,
+			'permission' => 'send_topic',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 3,
+			'permission' => 'mark_any_notify',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 3,
+			'permission' => 'mark_notify',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 3,
+			'permission' => 'delete_own',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 3,
+			'permission' => 'modify_own',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 3,
+			'permission' => 'make_sticky',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 3,
+			'permission' => 'lock_any',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 3,
+			'permission' => 'remove_any',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 3,
+			'permission' => 'move_any',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 3,
+			'permission' => 'merge_any',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 3,
+			'permission' => 'split_any',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 3,
+			'permission' => 'delete_any',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 3,
+			'permission' => 'modify_any',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 3,
+			'permission' => 'approve_posts',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 3,
+			'permission' => 'post_attachment',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 3,
+			'permission' => 'view_attachments',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 3,
+			'permission' => 'moderate_board',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 3,
+			'permission' => 'post_new',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 3,
+			'permission' => 'post_reply_own',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 3,
+			'permission' => 'post_reply_any',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 3,
+			'permission' => 'post_unapproved_topics',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 3,
+			'permission' => 'post_unapproved_replies_any',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 3,
+			'permission' => 'post_unapproved_replies_own',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 3,
+			'permission' => 'post_unapproved_attachments',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 3,
+			'permission' => 'poll_post',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 3,
+			'permission' => 'poll_add_any',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 3,
+			'permission' => 'poll_remove_any',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 3,
+			'permission' => 'poll_view',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 3,
+			'permission' => 'poll_vote',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 3,
+			'permission' => 'poll_lock_any',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 3,
+			'permission' => 'poll_edit_any',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 3,
+			'permission' => 'report_any',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 3,
+			'permission' => 'lock_own',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 3,
+			'permission' => 'send_topic',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 3,
+			'permission' => 'mark_any_notify',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 3,
+			'permission' => 'mark_notify',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 3,
+			'permission' => 'delete_own',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 3,
+			'permission' => 'modify_own',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 3,
+			'permission' => 'make_sticky',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 3,
+			'permission' => 'lock_any',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 3,
+			'permission' => 'remove_any',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 3,
+			'permission' => 'move_any',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 3,
+			'permission' => 'merge_any',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 3,
+			'permission' => 'split_any',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 3,
+			'permission' => 'delete_any',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 3,
+			'permission' => 'modify_any',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 3,
+			'permission' => 'approve_posts',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 3,
+			'permission' => 'post_attachment',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 3,
+			'permission' => 'view_attachments',
+		],
+		[
+			'id_group' => -1,
+			'id_profile' => 4,
+			'permission' => 'poll_view',
+		],
+		[
+			'id_group' => 0,
+			'id_profile' => 4,
+			'permission' => 'mark_any_notify',
+		],
+		[
+			'id_group' => 0,
+			'id_profile' => 4,
+			'permission' => 'mark_notify',
+		],
+		[
+			'id_group' => 0,
+			'id_profile' => 4,
+			'permission' => 'poll_view',
+		],
+		[
+			'id_group' => 0,
+			'id_profile' => 4,
+			'permission' => 'poll_vote',
+		],
+		[
+			'id_group' => 0,
+			'id_profile' => 4,
+			'permission' => 'report_any',
+		],
+		[
+			'id_group' => 0,
+			'id_profile' => 4,
+			'permission' => 'send_topic',
+		],
+		[
+			'id_group' => 0,
+			'id_profile' => 4,
+			'permission' => 'view_attachments',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 4,
+			'permission' => 'moderate_board',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 4,
+			'permission' => 'post_new',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 4,
+			'permission' => 'post_reply_own',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 4,
+			'permission' => 'post_reply_any',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 4,
+			'permission' => 'post_unapproved_topics',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 4,
+			'permission' => 'post_unapproved_replies_any',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 4,
+			'permission' => 'post_unapproved_replies_own',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 4,
+			'permission' => 'post_unapproved_attachments',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 4,
+			'permission' => 'poll_post',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 4,
+			'permission' => 'poll_add_any',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 4,
+			'permission' => 'poll_remove_any',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 4,
+			'permission' => 'poll_view',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 4,
+			'permission' => 'poll_vote',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 4,
+			'permission' => 'poll_lock_any',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 4,
+			'permission' => 'poll_edit_any',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 4,
+			'permission' => 'report_any',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 4,
+			'permission' => 'lock_own',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 4,
+			'permission' => 'send_topic',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 4,
+			'permission' => 'mark_any_notify',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 4,
+			'permission' => 'mark_notify',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 4,
+			'permission' => 'delete_own',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 4,
+			'permission' => 'modify_own',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 4,
+			'permission' => 'make_sticky',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 4,
+			'permission' => 'lock_any',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 4,
+			'permission' => 'remove_any',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 4,
+			'permission' => 'move_any',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 4,
+			'permission' => 'merge_any',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 4,
+			'permission' => 'split_any',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 4,
+			'permission' => 'delete_any',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 4,
+			'permission' => 'modify_any',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 4,
+			'permission' => 'approve_posts',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 4,
+			'permission' => 'post_attachment',
+		],
+		[
+			'id_group' => 2,
+			'id_profile' => 4,
+			'permission' => 'view_attachments',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 4,
+			'permission' => 'moderate_board',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 4,
+			'permission' => 'post_new',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 4,
+			'permission' => 'post_reply_own',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 4,
+			'permission' => 'post_reply_any',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 4,
+			'permission' => 'post_unapproved_topics',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 4,
+			'permission' => 'post_unapproved_replies_any',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 4,
+			'permission' => 'post_unapproved_replies_own',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 4,
+			'permission' => 'post_unapproved_attachments',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 4,
+			'permission' => 'poll_post',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 4,
+			'permission' => 'poll_add_any',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 4,
+			'permission' => 'poll_remove_any',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 4,
+			'permission' => 'poll_view',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 4,
+			'permission' => 'poll_vote',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 4,
+			'permission' => 'poll_lock_any',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 4,
+			'permission' => 'poll_edit_any',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 4,
+			'permission' => 'report_any',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 4,
+			'permission' => 'lock_own',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 4,
+			'permission' => 'send_topic',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 4,
+			'permission' => 'mark_any_notify',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 4,
+			'permission' => 'mark_notify',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 4,
+			'permission' => 'delete_own',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 4,
+			'permission' => 'modify_own',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 4,
+			'permission' => 'make_sticky',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 4,
+			'permission' => 'lock_any',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 4,
+			'permission' => 'remove_any',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 4,
+			'permission' => 'move_any',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 4,
+			'permission' => 'merge_any',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 4,
+			'permission' => 'split_any',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 4,
+			'permission' => 'delete_any',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 4,
+			'permission' => 'modify_any',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 4,
+			'permission' => 'approve_posts',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 4,
+			'permission' => 'post_attachment',
+		],
+		[
+			'id_group' => 3,
+			'id_profile' => 4,
+			'permission' => 'view_attachments',
+		],
+	];
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'board_permissions';
+
+		$this->columns = [
+			'id_group' => new Column(
+				name: 'id_group',
+				type: 'smallint',
+				not_null: true,
+				default: 0,
+			),
+			'id_profile' => new Column(
+				name: 'id_profile',
+				type: 'smallint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'permission' => new Column(
+				name: 'permission',
+				type: 'varchar',
+				size: 30,
+				not_null: true,
+				default: '',
+			),
+			'add_deny' => new Column(
+				name: 'add_deny',
+				type: 'tinyint',
+				not_null: true,
+				default: 1,
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'id_group',
+					],
+					[
+						'name' => 'id_profile',
+					],
+					[
+						'name' => 'permission',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v2_0/Boards.php
+++ b/Sources/Db/Schema/v2_0/Boards.php
@@ -1,0 +1,242 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v2_0;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class Boards extends Table
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 * @var array
+	 *
+	 * Data used to populate the table during install.
+	 */
+	public array $initial_data = [
+		[
+			'id_board' => 1,
+			'id_cat' => 1,
+			'board_order' => 1,
+			'id_last_msg' => 1,
+			'id_msg_updated' => 1,
+			'name' => '{$default_board_name}',
+			'description' => '{$default_board_description}',
+			'num_topics' => 1,
+			'num_posts' => 1,
+			'member_groups' => '-1,0,2',
+		],
+	];
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'boards';
+
+		$this->columns = [
+			'id_board' => new Column(
+				name: 'id_board',
+				type: 'smallint',
+				unsigned: true,
+				not_null: true,
+				auto: true,
+			),
+			'id_cat' => new Column(
+				name: 'id_cat',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'child_level' => new Column(
+				name: 'child_level',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'id_parent' => new Column(
+				name: 'id_parent',
+				type: 'smallint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'board_order' => new Column(
+				name: 'board_order',
+				type: 'smallint',
+				not_null: true,
+				default: 0,
+			),
+			'id_last_msg' => new Column(
+				name: 'id_last_msg',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'id_msg_updated' => new Column(
+				name: 'id_msg_updated',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'member_groups' => new Column(
+				name: 'member_groups',
+				type: 'varchar',
+				size: 255,
+				not_null: true,
+				default: '-1,0',
+			),
+			'id_profile' => new Column(
+				name: 'id_profile',
+				type: 'smallint',
+				unsigned: true,
+				not_null: true,
+				default: 1,
+			),
+			'name' => new Column(
+				name: 'name',
+				type: 'varchar',
+				size: 255,
+				not_null: true,
+				default: '',
+			),
+			'description' => new Column(
+				name: 'description',
+				type: 'text',
+				not_null: true,
+			),
+			'num_topics' => new Column(
+				name: 'num_topics',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'num_posts' => new Column(
+				name: 'num_posts',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'count_posts' => new Column(
+				name: 'count_posts',
+				type: 'tinyint',
+				not_null: true,
+				default: 0,
+			),
+			'id_theme' => new Column(
+				name: 'id_theme',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'override_theme' => new Column(
+				name: 'override_theme',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'unapproved_posts' => new Column(
+				name: 'unapproved_posts',
+				type: 'smallint',
+				not_null: true,
+				default: 0,
+			),
+			'unapproved_topics' => new Column(
+				name: 'unapproved_topics',
+				type: 'smallint',
+				not_null: true,
+				default: 0,
+			),
+			'redirect' => new Column(
+				name: 'redirect',
+				type: 'varchar',
+				size: 255,
+				not_null: true,
+				default: '',
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'id_board',
+					],
+				],
+			),
+			'categories' => new DbIndex(
+				type: 'unique',
+				name: 'categories',
+				columns: [
+					[
+						'name' => 'id_cat',
+					],
+					[
+						'name' => 'id_board',
+					],
+				],
+			),
+			'id_parent' => new DbIndex(
+				name: 'id_parent',
+				columns: [
+					[
+						'name' => 'id_parent',
+					],
+				],
+			),
+			'id_msg_updated' => new DbIndex(
+				name: 'id_msg_updated',
+				columns: [
+					[
+						'name' => 'id_msg_updated',
+					],
+				],
+			),
+			'member_groups' => new DbIndex(
+				name: 'member_groups',
+				columns: [
+					[
+						'name' => 'member_groups',
+						'size' => 48,
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v2_0/Calendar.php
+++ b/Sources/Db/Schema/v2_0/Calendar.php
@@ -1,0 +1,132 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v2_0;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class Calendar extends Table
+{
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'calendar';
+
+		$this->columns = [
+			'id_event' => new Column(
+				name: 'id_event',
+				type: 'smallint',
+				unsigned: true,
+				not_null: true,
+				auto: true,
+			),
+			'start_date' => new Column(
+				name: 'start_date',
+				type: 'date',
+				not_null: true,
+				// SMF 2.0 actually used '0001-01-01', but modern versions
+				// of MySQL don't like that.
+				default: '1004-01-01',
+			),
+			'end_date' => new Column(
+				name: 'end_date',
+				type: 'date',
+				not_null: true,
+				// SMF 2.0 actually used '0001-01-01', but modern versions
+				// of MySQL don't like that.
+				default: '1004-01-01',
+			),
+			'id_board' => new Column(
+				name: 'id_board',
+				type: 'smallint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'id_topic' => new Column(
+				name: 'id_topic',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'title' => new Column(
+				name: 'title',
+				type: 'varchar',
+				size: 255,
+				not_null: true,
+				default: '',
+			),
+			'id_member' => new Column(
+				name: 'id_member',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'id_event',
+					],
+				],
+			),
+			'start_date' => new DbIndex(
+				name: 'start_date',
+				columns: [
+					[
+						'name' => 'start_date',
+					],
+				],
+			),
+			'end_date' => new DbIndex(
+				name: 'end_date',
+				columns: [
+					[
+						'name' => 'end_date',
+					],
+				],
+			),
+			'topic' => new DbIndex(
+				name: 'topic',
+				columns: [
+					[
+						'name' => 'id_topic',
+					],
+					[
+						'name' => 'id_member',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v2_0/CalendarHolidays.php
+++ b/Sources/Db/Schema/v2_0/CalendarHolidays.php
@@ -1,0 +1,554 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v2_0;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class CalendarHolidays extends Table
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 * @var array
+	 *
+	 * Data used to populate the table during install.
+	 */
+	public array $initial_data = [
+		[
+			'title' => 'New Year\'s',
+			'event_date' => '0004-01-01',
+		],
+		[
+			'title' => 'Christmas',
+			'event_date' => '0004-12-25',
+		],
+		[
+			'title' => 'Valentine\'s Day',
+			'event_date' => '0004-02-14',
+		],
+		[
+			'title' => 'St. Patrick\'s Day',
+			'event_date' => '0004-03-17',
+		],
+		[
+			'title' => 'April Fools',
+			'event_date' => '0004-04-01',
+		],
+		[
+			'title' => 'Earth Day',
+			'event_date' => '0004-04-22',
+		],
+		[
+			'title' => 'United Nations Day',
+			'event_date' => '0004-10-24',
+		],
+		[
+			'title' => 'Halloween',
+			'event_date' => '0004-10-31',
+		],
+		[
+			'title' => 'Mother\'s Day',
+			'event_date' => '2010-05-09',
+		],
+		[
+			'title' => 'Mother\'s Day',
+			'event_date' => '2011-05-08',
+		],
+		[
+			'title' => 'Mother\'s Day',
+			'event_date' => '2012-05-13',
+		],
+		[
+			'title' => 'Mother\'s Day',
+			'event_date' => '2013-05-12',
+		],
+		[
+			'title' => 'Mother\'s Day',
+			'event_date' => '2014-05-11',
+		],
+		[
+			'title' => 'Mother\'s Day',
+			'event_date' => '2015-05-10',
+		],
+		[
+			'title' => 'Mother\'s Day',
+			'event_date' => '2016-05-08',
+		],
+		[
+			'title' => 'Mother\'s Day',
+			'event_date' => '2017-05-14',
+		],
+		[
+			'title' => 'Mother\'s Day',
+			'event_date' => '2018-05-13',
+		],
+		[
+			'title' => 'Mother\'s Day',
+			'event_date' => '2019-05-12',
+		],
+		[
+			'title' => 'Mother\'s Day',
+			'event_date' => '2020-05-10',
+		],
+		[
+			'title' => 'Father\'s Day',
+			'event_date' => '2008-06-15',
+		],
+		[
+			'title' => 'Father\'s Day',
+			'event_date' => '2009-06-21',
+		],
+		[
+			'title' => 'Father\'s Day',
+			'event_date' => '2010-06-20',
+		],
+		[
+			'title' => 'Father\'s Day',
+			'event_date' => '2011-06-19',
+		],
+		[
+			'title' => 'Father\'s Day',
+			'event_date' => '2012-06-17',
+		],
+		[
+			'title' => 'Father\'s Day',
+			'event_date' => '2013-06-16',
+		],
+		[
+			'title' => 'Father\'s Day',
+			'event_date' => '2014-06-15',
+		],
+		[
+			'title' => 'Father\'s Day',
+			'event_date' => '2015-06-21',
+		],
+		[
+			'title' => 'Father\'s Day',
+			'event_date' => '2016-06-19',
+		],
+		[
+			'title' => 'Father\'s Day',
+			'event_date' => '2017-06-18',
+		],
+		[
+			'title' => 'Father\'s Day',
+			'event_date' => '2018-06-17',
+		],
+		[
+			'title' => 'Father\'s Day',
+			'event_date' => '2019-06-16',
+		],
+		[
+			'title' => 'Father\'s Day',
+			'event_date' => '2020-06-21',
+		],
+		[
+			'title' => 'Summer Solstice',
+			'event_date' => '2010-06-21',
+		],
+		[
+			'title' => 'Summer Solstice',
+			'event_date' => '2011-06-21',
+		],
+		[
+			'title' => 'Summer Solstice',
+			'event_date' => '2012-06-20',
+		],
+		[
+			'title' => 'Summer Solstice',
+			'event_date' => '2013-06-21',
+		],
+		[
+			'title' => 'Summer Solstice',
+			'event_date' => '2014-06-21',
+		],
+		[
+			'title' => 'Summer Solstice',
+			'event_date' => '2015-06-21',
+		],
+		[
+			'title' => 'Summer Solstice',
+			'event_date' => '2016-06-20',
+		],
+		[
+			'title' => 'Summer Solstice',
+			'event_date' => '2017-06-20',
+		],
+		[
+			'title' => 'Summer Solstice',
+			'event_date' => '2018-06-21',
+		],
+		[
+			'title' => 'Summer Solstice',
+			'event_date' => '2019-06-21',
+		],
+		[
+			'title' => 'Summer Solstice',
+			'event_date' => '2020-06-20',
+		],
+		[
+			'title' => 'Vernal Equinox',
+			'event_date' => '2010-03-20',
+		],
+		[
+			'title' => 'Vernal Equinox',
+			'event_date' => '2011-03-20',
+		],
+		[
+			'title' => 'Vernal Equinox',
+			'event_date' => '2012-03-20',
+		],
+		[
+			'title' => 'Vernal Equinox',
+			'event_date' => '2013-03-20',
+		],
+		[
+			'title' => 'Vernal Equinox',
+			'event_date' => '2014-03-20',
+		],
+		[
+			'title' => 'Vernal Equinox',
+			'event_date' => '2015-03-20',
+		],
+		[
+			'title' => 'Vernal Equinox',
+			'event_date' => '2016-03-19',
+		],
+		[
+			'title' => 'Vernal Equinox',
+			'event_date' => '2017-03-20',
+		],
+		[
+			'title' => 'Vernal Equinox',
+			'event_date' => '2018-03-20',
+		],
+		[
+			'title' => 'Vernal Equinox',
+			'event_date' => '2019-03-20',
+		],
+		[
+			'title' => 'Vernal Equinox',
+			'event_date' => '2020-03-19',
+		],
+		[
+			'title' => 'Winter Solstice',
+			'event_date' => '2010-12-21',
+		],
+		[
+			'title' => 'Winter Solstice',
+			'event_date' => '2011-12-22',
+		],
+		[
+			'title' => 'Winter Solstice',
+			'event_date' => '2012-12-21',
+		],
+		[
+			'title' => 'Winter Solstice',
+			'event_date' => '2013-12-21',
+		],
+		[
+			'title' => 'Winter Solstice',
+			'event_date' => '2014-12-21',
+		],
+		[
+			'title' => 'Winter Solstice',
+			'event_date' => '2015-12-21',
+		],
+		[
+			'title' => 'Winter Solstice',
+			'event_date' => '2016-12-21',
+		],
+		[
+			'title' => 'Winter Solstice',
+			'event_date' => '2017-12-21',
+		],
+		[
+			'title' => 'Winter Solstice',
+			'event_date' => '2018-12-21',
+		],
+		[
+			'title' => 'Winter Solstice',
+			'event_date' => '2019-12-21',
+		],
+		[
+			'title' => 'Winter Solstice',
+			'event_date' => '2020-12-21',
+		],
+		[
+			'title' => 'Autumnal Equinox',
+			'event_date' => '2010-09-22',
+		],
+		[
+			'title' => 'Autumnal Equinox',
+			'event_date' => '2011-09-23',
+		],
+		[
+			'title' => 'Autumnal Equinox',
+			'event_date' => '2012-09-22',
+		],
+		[
+			'title' => 'Autumnal Equinox',
+			'event_date' => '2013-09-22',
+		],
+		[
+			'title' => 'Autumnal Equinox',
+			'event_date' => '2014-09-22',
+		],
+		[
+			'title' => 'Autumnal Equinox',
+			'event_date' => '2015-09-23',
+		],
+		[
+			'title' => 'Autumnal Equinox',
+			'event_date' => '2016-09-22',
+		],
+		[
+			'title' => 'Autumnal Equinox',
+			'event_date' => '2017-09-22',
+		],
+		[
+			'title' => 'Autumnal Equinox',
+			'event_date' => '2018-09-22',
+		],
+		[
+			'title' => 'Autumnal Equinox',
+			'event_date' => '2019-09-23',
+		],
+		[
+			'title' => 'Autumnal Equinox',
+			'event_date' => '2020-09-22',
+		],
+		[
+			'title' => 'Independence Day',
+			'event_date' => '0004-07-04',
+		],
+		[
+			'title' => 'Cinco de Mayo',
+			'event_date' => '0004-05-05',
+		],
+		[
+			'title' => 'Flag Day',
+			'event_date' => '0004-06-14',
+		],
+		[
+			'title' => 'Veterans Day',
+			'event_date' => '0004-11-11',
+		],
+		[
+			'title' => 'Groundhog Day',
+			'event_date' => '0004-02-02',
+		],
+		[
+			'title' => 'Thanksgiving',
+			'event_date' => '2010-11-25',
+		],
+		[
+			'title' => 'Thanksgiving',
+			'event_date' => '2011-11-24',
+		],
+		[
+			'title' => 'Thanksgiving',
+			'event_date' => '2012-11-22',
+		],
+		[
+			'title' => 'Thanksgiving',
+			'event_date' => '2013-11-28',
+		],
+		[
+			'title' => 'Thanksgiving',
+			'event_date' => '2014-11-27',
+		],
+		[
+			'title' => 'Thanksgiving',
+			'event_date' => '2015-11-26',
+		],
+		[
+			'title' => 'Thanksgiving',
+			'event_date' => '2016-11-24',
+		],
+		[
+			'title' => 'Thanksgiving',
+			'event_date' => '2017-11-23',
+		],
+		[
+			'title' => 'Thanksgiving',
+			'event_date' => '2018-11-22',
+		],
+		[
+			'title' => 'Thanksgiving',
+			'event_date' => '2019-11-28',
+		],
+		[
+			'title' => 'Thanksgiving',
+			'event_date' => '2020-11-26',
+		],
+		[
+			'title' => 'Memorial Day',
+			'event_date' => '2010-05-31',
+		],
+		[
+			'title' => 'Memorial Day',
+			'event_date' => '2011-05-30',
+		],
+		[
+			'title' => 'Memorial Day',
+			'event_date' => '2012-05-28',
+		],
+		[
+			'title' => 'Memorial Day',
+			'event_date' => '2013-05-27',
+		],
+		[
+			'title' => 'Memorial Day',
+			'event_date' => '2014-05-26',
+		],
+		[
+			'title' => 'Memorial Day',
+			'event_date' => '2015-05-25',
+		],
+		[
+			'title' => 'Memorial Day',
+			'event_date' => '2016-05-30',
+		],
+		[
+			'title' => 'Memorial Day',
+			'event_date' => '2017-05-29',
+		],
+		[
+			'title' => 'Memorial Day',
+			'event_date' => '2018-05-28',
+		],
+		[
+			'title' => 'Memorial Day',
+			'event_date' => '2019-05-27',
+		],
+		[
+			'title' => 'Memorial Day',
+			'event_date' => '2020-05-25',
+		],
+		[
+			'title' => 'Labor Day',
+			'event_date' => '2010-09-06',
+		],
+		[
+			'title' => 'Labor Day',
+			'event_date' => '2011-09-05',
+		],
+		[
+			'title' => 'Labor Day',
+			'event_date' => '2012-09-03',
+		],
+		[
+			'title' => 'Labor Day',
+			'event_date' => '2013-09-02',
+		],
+		[
+			'title' => 'Labor Day',
+			'event_date' => '2014-09-01',
+		],
+		[
+			'title' => 'Labor Day',
+			'event_date' => '2015-09-07',
+		],
+		[
+			'title' => 'Labor Day',
+			'event_date' => '2016-09-05',
+		],
+		[
+			'title' => 'Labor Day',
+			'event_date' => '2017-09-04',
+		],
+		[
+			'title' => 'Labor Day',
+			'event_date' => '2018-09-03',
+		],
+		[
+			'title' => 'Labor Day',
+			'event_date' => '2019-09-02',
+		],
+		[
+			'title' => 'Labor Day',
+			'event_date' => '2020-09-07',
+		],
+		[
+			'title' => 'D-Day',
+			'event_date' => '0004-06-06',
+		],
+	];
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'calendar_holidays';
+
+		$this->columns = [
+			'id_holiday' => new Column(
+				name: 'id_holiday',
+				type: 'smallint',
+				unsigned: true,
+				not_null: true,
+				auto: true,
+			),
+			'event_date' => new Column(
+				name: 'event_date',
+				type: 'date',
+				not_null: true,
+				default: '0001-01-01',
+			),
+			'title' => new Column(
+				name: 'title',
+				type: 'varchar',
+				size: 255,
+				not_null: true,
+				default: '',
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'id_holiday',
+					],
+				],
+			),
+			'event_date' => new DbIndex(
+				name: 'event_date',
+				columns: [
+					[
+						'name' => 'event_date',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v2_0/Categories.php
+++ b/Sources/Db/Schema/v2_0/Categories.php
@@ -1,0 +1,80 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v2_0;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class Categories extends Table
+{
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'categories';
+
+		$this->columns = [
+			'id_cat' => new Column(
+				name: 'id_cat',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				auto: true,
+			),
+			'cat_order' => new Column(
+				name: 'cat_order',
+				type: 'tinyint',
+				not_null: true,
+				default: 0,
+			),
+			'name' => new Column(
+				name: 'name',
+				type: 'varchar',
+				size: 255,
+				not_null: true,
+				default: '',
+			),
+			'can_collapse' => new Column(
+				name: 'can_collapse',
+				type: 'tinyint',
+				not_null: true,
+				default: 1,
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'id_cat',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v2_0/CollapsedCategories.php
+++ b/Sources/Db/Schema/v2_0/CollapsedCategories.php
@@ -1,0 +1,71 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v2_0;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class CollapsedCategories extends Table
+{
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'collapsed_categories';
+
+		$this->columns = [
+			'id_cat' => new Column(
+				name: 'id_cat',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'id_member' => new Column(
+				name: 'id_member',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'id_cat',
+					],
+					[
+						'name' => 'id_member',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v2_0/CustomFields.php
+++ b/Sources/Db/Schema/v2_0/CustomFields.php
@@ -1,0 +1,176 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v2_0;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class CustomFields extends Table
+{
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'custom_fields';
+
+		$this->columns = [
+			'id_field' => new Column(
+				name: 'id_field',
+				type: 'smallint',
+				not_null: true,
+				auto: true,
+			),
+			'col_name' => new Column(
+				name: 'col_name',
+				type: 'varchar',
+				size: 12,
+				not_null: true,
+				default: '',
+			),
+			'field_name' => new Column(
+				name: 'field_name',
+				type: 'varchar',
+				size: 40,
+				not_null: true,
+				default: '',
+			),
+			'field_desc' => new Column(
+				name: 'field_desc',
+				type: 'varchar',
+				size: 255,
+				not_null: true,
+				default: '',
+			),
+			'field_type' => new Column(
+				name: 'field_type',
+				type: 'varchar',
+				size: 8,
+				not_null: true,
+				default: 'text',
+			),
+			'field_length' => new Column(
+				name: 'field_length',
+				type: 'smallint',
+				not_null: true,
+				default: 255,
+			),
+			'field_options' => new Column(
+				name: 'field_options',
+				type: 'text',
+				not_null: true,
+			),
+			'mask' => new Column(
+				name: 'mask',
+				type: 'varchar',
+				size: 255,
+				not_null: true,
+				default: '',
+			),
+			'show_reg' => new Column(
+				name: 'show_reg',
+				type: 'tinyint',
+				not_null: true,
+				default: 0,
+			),
+			'show_display' => new Column(
+				name: 'show_display',
+				type: 'tinyint',
+				not_null: true,
+				default: 0,
+			),
+			'show_profile' => new Column(
+				name: 'show_profile',
+				type: 'varchar',
+				size: 20,
+				not_null: true,
+				default: 'forumprofile',
+			),
+			'private' => new Column(
+				name: 'private',
+				type: 'tinyint',
+				not_null: true,
+				default: 0,
+			),
+			'active' => new Column(
+				name: 'active',
+				type: 'tinyint',
+				not_null: true,
+				default: 1,
+			),
+			'bbc' => new Column(
+				name: 'bbc',
+				type: 'tinyint',
+				not_null: true,
+				default: 0,
+			),
+			'can_search' => new Column(
+				name: 'can_search',
+				type: 'tinyint',
+				not_null: true,
+				default: 0,
+			),
+			'default_value' => new Column(
+				name: 'default_value',
+				type: 'varchar',
+				size: 255,
+				not_null: true,
+				default: '',
+			),
+			'enclose' => new Column(
+				name: 'enclose',
+				type: 'text',
+				not_null: true,
+			),
+			'placement' => new Column(
+				name: 'placement',
+				type: 'tinyint',
+				not_null: true,
+				default: 0,
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'id_field',
+					],
+				],
+			),
+			'col_name' => new DbIndex(
+				type: 'unique',
+				name: 'col_name',
+				columns: [
+					[
+						'name' => 'col_name',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v2_0/GroupModerators.php
+++ b/Sources/Db/Schema/v2_0/GroupModerators.php
@@ -1,0 +1,71 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v2_0;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class GroupModerators extends Table
+{
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'group_moderators';
+
+		$this->columns = [
+			'id_group' => new Column(
+				name: 'id_group',
+				type: 'smallint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'id_member' => new Column(
+				name: 'id_member',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'id_group',
+					],
+					[
+						'name' => 'id_member',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v2_0/LogActions.php
+++ b/Sources/Db/Schema/v2_0/LogActions.php
@@ -1,0 +1,162 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v2_0;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class LogActions extends Table
+{
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'log_actions';
+
+		$this->columns = [
+			'id_action' => new Column(
+				name: 'id_action',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				auto: true,
+			),
+			'id_log' => new Column(
+				name: 'id_log',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				default: 1,
+			),
+			'log_time' => new Column(
+				name: 'log_time',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'id_member' => new Column(
+				name: 'id_member',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'ip' => new Column(
+				name: 'ip',
+				type: 'char',
+				size: 16,
+				not_null: true,
+				default: '                ',
+			),
+			'action' => new Column(
+				name: 'action',
+				type: 'varchar',
+				size: 30,
+				not_null: true,
+				default: '',
+			),
+			'id_board' => new Column(
+				name: 'id_board',
+				type: 'smallint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'id_topic' => new Column(
+				name: 'id_topic',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'id_msg' => new Column(
+				name: 'id_msg',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'extra' => new Column(
+				name: 'extra',
+				type: 'text',
+				not_null: true,
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'id_action',
+					],
+				],
+			),
+			'id_log' => new DbIndex(
+				name: 'id_log',
+				columns: [
+					[
+						'name' => 'id_log',
+					],
+				],
+			),
+			'log_time' => new DbIndex(
+				name: 'log_time',
+				columns: [
+					[
+						'name' => 'log_time',
+					],
+				],
+			),
+			'id_member' => new DbIndex(
+				name: 'id_member',
+				columns: [
+					[
+						'name' => 'id_member',
+					],
+				],
+			),
+			'id_board' => new DbIndex(
+				name: 'id_board',
+				columns: [
+					[
+						'name' => 'id_board',
+					],
+				],
+			),
+			'id_msg' => new DbIndex(
+				name: 'id_msg',
+				columns: [
+					[
+						'name' => 'id_msg',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v2_0/LogActivity.php
+++ b/Sources/Db/Schema/v2_0/LogActivity.php
@@ -1,0 +1,103 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v2_0;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class LogActivity extends Table
+{
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'log_activity';
+
+		$this->columns = [
+			'date' => new Column(
+				name: 'date',
+				type: 'date',
+				not_null: true,
+				default: '0001-01-01',
+			),
+			'hits' => new Column(
+				name: 'hits',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'topics' => new Column(
+				name: 'topics',
+				type: 'smallint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'posts' => new Column(
+				name: 'posts',
+				type: 'smallint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'registers' => new Column(
+				name: 'registers',
+				type: 'smallint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'most_on' => new Column(
+				name: 'most_on',
+				type: 'smallint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'date',
+					],
+				],
+			),
+			'most_on' => new DbIndex(
+				name: 'most_on',
+				columns: [
+					[
+						'name' => 'most_on',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v2_0/LogBanned.php
+++ b/Sources/Db/Schema/v2_0/LogBanned.php
@@ -1,0 +1,97 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v2_0;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class LogBanned extends Table
+{
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'log_banned';
+
+		$this->columns = [
+			'id_ban_log' => new Column(
+				name: 'id_ban_log',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				auto: true,
+			),
+			'id_member' => new Column(
+				name: 'id_member',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'ip' => new Column(
+				name: 'ip',
+				type: 'char',
+				size: 16,
+				not_null: true,
+				default: '                ',
+			),
+			'email' => new Column(
+				name: 'email',
+				type: 'varchar',
+				size: 255,
+				not_null: true,
+				default: '',
+			),
+			'log_time' => new Column(
+				name: 'log_time',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'id_ban_log',
+					],
+				],
+			),
+			'log_time' => new DbIndex(
+				name: 'log_time',
+				columns: [
+					[
+						'name' => 'log_time',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v2_0/LogBoards.php
+++ b/Sources/Db/Schema/v2_0/LogBoards.php
@@ -1,0 +1,78 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v2_0;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class LogBoards extends Table
+{
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'log_boards';
+
+		$this->columns = [
+			'id_member' => new Column(
+				name: 'id_member',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'id_board' => new Column(
+				name: 'id_board',
+				type: 'smallint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'id_msg' => new Column(
+				name: 'id_msg',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'id_member',
+					],
+					[
+						'name' => 'id_board',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v2_0/LogComments.php
+++ b/Sources/Db/Schema/v2_0/LogComments.php
@@ -1,0 +1,145 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v2_0;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class LogComments extends Table
+{
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'log_comments';
+
+		$this->columns = [
+			'id_comment' => new Column(
+				name: 'id_comment',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				auto: true,
+			),
+			'id_member' => new Column(
+				name: 'id_member',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'member_name' => new Column(
+				name: 'member_name',
+				type: 'varchar',
+				size: 80,
+				not_null: true,
+				default: '',
+			),
+			'comment_type' => new Column(
+				name: 'comment_type',
+				type: 'varchar',
+				size: 8,
+				not_null: true,
+				default: 'warning',
+			),
+			'id_recipient' => new Column(
+				name: 'id_recipient',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'recipient_name' => new Column(
+				name: 'recipient_name',
+				type: 'varchar',
+				size: 255,
+				not_null: true,
+				default: '',
+			),
+			'log_time' => new Column(
+				name: 'log_time',
+				type: 'int',
+				not_null: true,
+				default: 0,
+			),
+			'id_notice' => new Column(
+				name: 'id_notice',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'counter' => new Column(
+				name: 'counter',
+				type: 'tinyint',
+				not_null: true,
+				default: 0,
+			),
+			'body' => new Column(
+				name: 'body',
+				type: 'text',
+				not_null: true,
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'id_comment',
+					],
+				],
+			),
+			'id_recipient' => new DbIndex(
+				name: 'id_recipient',
+				columns: [
+					[
+						'name' => 'id_recipient',
+					],
+				],
+			),
+			'log_time' => new DbIndex(
+				name: 'log_time',
+				columns: [
+					[
+						'name' => 'log_time',
+					],
+				],
+			),
+			'comment_type' => new DbIndex(
+				name: 'comment_type',
+				columns: [
+					[
+						'name' => 'comment_type',
+						'size' => 8,
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v2_0/LogDigest.php
+++ b/Sources/Db/Schema/v2_0/LogDigest.php
@@ -1,0 +1,75 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v2_0;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class LogDigest extends Table
+{
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'log_digest';
+
+		$this->columns = [
+			'id_topic' => new Column(
+				name: 'id_topic',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+			),
+			'id_msg' => new Column(
+				name: 'id_msg',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+			),
+			'note_type' => new Column(
+				name: 'note_type',
+				type: 'varchar',
+				size: 10,
+				not_null: true,
+				default: 'post',
+			),
+			'daily' => new Column(
+				name: 'daily',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'exclude' => new Column(
+				name: 'exclude',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v2_0/LogErrors.php
+++ b/Sources/Db/Schema/v2_0/LogErrors.php
@@ -1,0 +1,145 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v2_0;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class LogErrors extends Table
+{
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'log_errors';
+
+		$this->columns = [
+			'id_error' => new Column(
+				name: 'id_error',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				auto: true,
+			),
+			'log_time' => new Column(
+				name: 'log_time',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'id_member' => new Column(
+				name: 'id_member',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'ip' => new Column(
+				name: 'ip',
+				type: 'char',
+				size: 16,
+				not_null: true,
+				default: '                ',
+			),
+			'url' => new Column(
+				name: 'url',
+				type: 'text',
+				not_null: true,
+			),
+			'message' => new Column(
+				name: 'message',
+				type: 'text',
+				not_null: true,
+			),
+			'session' => new Column(
+				name: 'session',
+				type: 'char',
+				size: 32,
+				not_null: true,
+				default: '                                ',
+			),
+			'error_type' => new Column(
+				name: 'error_type',
+				type: 'char',
+				size: 15,
+				not_null: true,
+				default: 'general',
+			),
+			'file' => new Column(
+				name: 'file',
+				type: 'varchar',
+				size: 255,
+				not_null: true,
+				default: '',
+			),
+			'line' => new Column(
+				name: 'line',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'id_error',
+					],
+				],
+			),
+			'log_time' => new DbIndex(
+				name: 'log_time',
+				columns: [
+					[
+						'name' => 'log_time',
+					],
+				],
+			),
+			'id_member' => new DbIndex(
+				name: 'id_member',
+				columns: [
+					[
+						'name' => 'id_member',
+					],
+				],
+			),
+			'ip' => new DbIndex(
+				name: 'ip',
+				columns: [
+					[
+						'name' => 'ip',
+						'size' => 16,
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v2_0/LogFloodcontrol.php
+++ b/Sources/Db/Schema/v2_0/LogFloodcontrol.php
@@ -1,0 +1,80 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v2_0;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class LogFloodcontrol extends Table
+{
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'log_floodcontrol';
+
+		$this->columns = [
+			'ip' => new Column(
+				name: 'ip',
+				type: 'char',
+				size: 16,
+				not_null: true,
+				default: '                ',
+			),
+			'log_time' => new Column(
+				name: 'log_time',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'log_type' => new Column(
+				name: 'log_type',
+				type: 'varchar',
+				size: 8,
+				not_null: true,
+				default: 'post',
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'ip',
+						'size' => 16,
+					],
+					[
+						'name' => 'log_type',
+						'size' => 8,
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v2_0/LogGroupRequests.php
+++ b/Sources/Db/Schema/v2_0/LogGroupRequests.php
@@ -1,0 +1,99 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v2_0;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class LogGroupRequests extends Table
+{
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'log_group_requests';
+
+		$this->columns = [
+			'id_request' => new Column(
+				name: 'id_request',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				auto: true,
+			),
+			'id_member' => new Column(
+				name: 'id_member',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'id_group' => new Column(
+				name: 'id_group',
+				type: 'smallint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'time_applied' => new Column(
+				name: 'time_applied',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'reason' => new Column(
+				name: 'reason',
+				type: 'text',
+				not_null: true,
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'id_request',
+					],
+				],
+			),
+			'id_member' => new DbIndex(
+				type: 'unique',
+				name: 'id_member',
+				columns: [
+					[
+						'name' => 'id_member',
+					],
+					[
+						'name' => 'id_group',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v2_0/LogKarma.php
+++ b/Sources/Db/Schema/v2_0/LogKarma.php
@@ -1,0 +1,92 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v2_0;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class LogKarma extends Table
+{
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'log_karma';
+
+		$this->columns = [
+			'id_target' => new Column(
+				name: 'id_target',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'id_executor' => new Column(
+				name: 'id_executor',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'log_time' => new Column(
+				name: 'log_time',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'action' => new Column(
+				name: 'action',
+				type: 'tinyint',
+				not_null: true,
+				default: 0,
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'id_target',
+					],
+					[
+						'name' => 'id_executor',
+					],
+				],
+			),
+			'log_time' => new DbIndex(
+				name: 'log_time',
+				columns: [
+					[
+						'name' => 'log_time',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v2_0/LogMarkRead.php
+++ b/Sources/Db/Schema/v2_0/LogMarkRead.php
@@ -1,0 +1,78 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v2_0;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class LogMarkRead extends Table
+{
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'log_mark_read';
+
+		$this->columns = [
+			'id_member' => new Column(
+				name: 'id_member',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'id_board' => new Column(
+				name: 'id_board',
+				type: 'smallint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'id_msg' => new Column(
+				name: 'id_msg',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'id_member',
+					],
+					[
+						'name' => 'id_board',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v2_0/LogMemberNotices.php
+++ b/Sources/Db/Schema/v2_0/LogMemberNotices.php
@@ -1,0 +1,73 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v2_0;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class LogMemberNotices extends Table
+{
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'log_member_notices';
+
+		$this->columns = [
+			'id_notice' => new Column(
+				name: 'id_notice',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				auto: true,
+			),
+			'subject' => new Column(
+				name: 'subject',
+				type: 'varchar',
+				size: 255,
+				not_null: true,
+				default: '',
+			),
+			'body' => new Column(
+				name: 'body',
+				type: 'text',
+				not_null: true,
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'id_notice',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v2_0/LogNotify.php
+++ b/Sources/Db/Schema/v2_0/LogNotify.php
@@ -1,0 +1,99 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v2_0;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class LogNotify extends Table
+{
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'log_notify';
+
+		$this->columns = [
+			'id_member' => new Column(
+				name: 'id_member',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'id_topic' => new Column(
+				name: 'id_topic',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'id_board' => new Column(
+				name: 'id_board',
+				type: 'smallint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'sent' => new Column(
+				name: 'sent',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'id_member',
+					],
+					[
+						'name' => 'id_topic',
+					],
+					[
+						'name' => 'id_board',
+					],
+				],
+			),
+			'id_topic' => new DbIndex(
+				name: 'id_topic',
+				columns: [
+					[
+						'name' => 'id_topic',
+					],
+					[
+						'name' => 'id_member',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v2_0/LogOnline.php
+++ b/Sources/Db/Schema/v2_0/LogOnline.php
@@ -1,0 +1,109 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v2_0;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class LogOnline extends Table
+{
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'log_online';
+
+		$this->columns = [
+			'session' => new Column(
+				name: 'session',
+				type: 'varchar',
+				size: 32,
+				not_null: true,
+				default: '',
+			),
+			'log_time' => new Column(
+				name: 'log_time',
+				type: 'int',
+				not_null: true,
+				default: 0,
+			),
+			'id_member' => new Column(
+				name: 'id_member',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'id_spider' => new Column(
+				name: 'id_spider',
+				type: 'smallint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'ip' => new Column(
+				name: 'ip',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'url' => new Column(
+				name: 'url',
+				type: 'text',
+				not_null: true,
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'session',
+					],
+				],
+			),
+			'log_time' => new DbIndex(
+				name: 'log_time',
+				columns: [
+					[
+						'name' => 'log_time',
+					],
+				],
+			),
+			'id_member' => new DbIndex(
+				name: 'id_member',
+				columns: [
+					[
+						'name' => 'id_member',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v2_0/LogPackages.php
+++ b/Sources/Db/Schema/v2_0/LogPackages.php
@@ -1,0 +1,158 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v2_0;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class LogPackages extends Table
+{
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'log_packages';
+
+		$this->columns = [
+			'id_install' => new Column(
+				name: 'id_install',
+				type: 'int',
+				not_null: true,
+				auto: true,
+			),
+			'filename' => new Column(
+				name: 'filename',
+				type: 'varchar',
+				size: 255,
+				not_null: true,
+				default: '',
+			),
+			'package_id' => new Column(
+				name: 'package_id',
+				type: 'varchar',
+				size: 255,
+				not_null: true,
+				default: '',
+			),
+			'name' => new Column(
+				name: 'name',
+				type: 'varchar',
+				size: 255,
+				not_null: true,
+				default: '',
+			),
+			'version' => new Column(
+				name: 'version',
+				type: 'varchar',
+				size: 255,
+				not_null: true,
+				default: '',
+			),
+			'id_member_installed' => new Column(
+				name: 'id_member_installed',
+				type: 'mediumint',
+				not_null: true,
+				default: 0,
+			),
+			'member_installed' => new Column(
+				name: 'member_installed',
+				type: 'varchar',
+				size: 255,
+				not_null: true,
+				default: '',
+			),
+			'time_installed' => new Column(
+				name: 'time_installed',
+				type: 'int',
+				not_null: true,
+				default: 0,
+			),
+			'id_member_removed' => new Column(
+				name: 'id_member_removed',
+				type: 'mediumint',
+				not_null: true,
+				default: 0,
+			),
+			'member_removed' => new Column(
+				name: 'member_removed',
+				type: 'varchar',
+				size: 255,
+				not_null: true,
+				default: '',
+			),
+			'time_removed' => new Column(
+				name: 'time_removed',
+				type: 'int',
+				not_null: true,
+				default: 0,
+			),
+			'install_state' => new Column(
+				name: 'install_state',
+				type: 'tinyint',
+				not_null: true,
+				default: 1,
+			),
+			'failed_steps' => new Column(
+				name: 'failed_steps',
+				type: 'text',
+				not_null: true,
+			),
+			'themes_installed' => new Column(
+				name: 'themes_installed',
+				type: 'varchar',
+				size: 255,
+				not_null: true,
+				default: '',
+			),
+			'db_changes' => new Column(
+				name: 'db_changes',
+				type: 'text',
+				not_null: true,
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'id_install',
+					],
+				],
+			),
+			'filename' => new DbIndex(
+				name: 'filename',
+				columns: [
+					[
+						'name' => 'filename',
+						'size' => 15,
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v2_0/LogPolls.php
+++ b/Sources/Db/Schema/v2_0/LogPolls.php
@@ -1,0 +1,81 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v2_0;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class LogPolls extends Table
+{
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'log_polls';
+
+		$this->columns = [
+			'id_poll' => new Column(
+				name: 'id_poll',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'id_member' => new Column(
+				name: 'id_member',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'id_choice' => new Column(
+				name: 'id_choice',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+		];
+
+		$this->indexes = [
+			'id_poll' => new DbIndex(
+				name: 'id_poll',
+				columns: [
+					[
+						'name' => 'id_poll',
+					],
+					[
+						'name' => 'id_member',
+					],
+					[
+						'name' => 'id_choice',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v2_0/LogReported.php
+++ b/Sources/Db/Schema/v2_0/LogReported.php
@@ -1,0 +1,178 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v2_0;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class LogReported extends Table
+{
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'log_reported';
+
+		$this->columns = [
+			'id_report' => new Column(
+				name: 'id_report',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				auto: true,
+			),
+			'id_msg' => new Column(
+				name: 'id_msg',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'id_topic' => new Column(
+				name: 'id_topic',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'id_board' => new Column(
+				name: 'id_board',
+				type: 'smallint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'id_member' => new Column(
+				name: 'id_member',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'membername' => new Column(
+				name: 'membername',
+				type: 'varchar',
+				size: 255,
+				not_null: true,
+				default: '',
+			),
+			'subject' => new Column(
+				name: 'subject',
+				type: 'varchar',
+				size: 255,
+				not_null: true,
+				default: '',
+			),
+			'body' => new Column(
+				name: 'body',
+				type: 'text',
+				not_null: true,
+			),
+			'time_started' => new Column(
+				name: 'time_started',
+				type: 'int',
+				not_null: true,
+				default: 0,
+			),
+			'time_updated' => new Column(
+				name: 'time_updated',
+				type: 'int',
+				not_null: true,
+				default: 0,
+			),
+			'num_reports' => new Column(
+				name: 'num_reports',
+				type: 'mediumint',
+				not_null: true,
+				default: 0,
+			),
+			'closed' => new Column(
+				name: 'closed',
+				type: 'tinyint',
+				not_null: true,
+				default: 0,
+			),
+			'ignore_all' => new Column(
+				name: 'ignore_all',
+				type: 'tinyint',
+				not_null: true,
+				default: 0,
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'id_report',
+					],
+				],
+			),
+			'id_member' => new DbIndex(
+				name: 'id_member',
+				columns: [
+					[
+						'name' => 'id_member',
+					],
+				],
+			),
+			'id_topic' => new DbIndex(
+				name: 'id_topic',
+				columns: [
+					[
+						'name' => 'id_topic',
+					],
+				],
+			),
+			'closed' => new DbIndex(
+				name: 'closed',
+				columns: [
+					[
+						'name' => 'closed',
+					],
+				],
+			),
+			'time_started' => new DbIndex(
+				name: 'time_started',
+				columns: [
+					[
+						'name' => 'time_started',
+					],
+				],
+			),
+			'id_msg' => new DbIndex(
+				name: 'id_msg',
+				columns: [
+					[
+						'name' => 'id_msg',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v2_0/LogReportedComments.php
+++ b/Sources/Db/Schema/v2_0/LogReportedComments.php
@@ -1,0 +1,129 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v2_0;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class LogReportedComments extends Table
+{
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'log_reported_comments';
+
+		$this->columns = [
+			'id_comment' => new Column(
+				name: 'id_comment',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				auto: true,
+			),
+			'id_report' => new Column(
+				name: 'id_report',
+				type: 'mediumint',
+				not_null: true,
+				default: 0,
+			),
+			'id_member' => new Column(
+				name: 'id_member',
+				type: 'mediumint',
+				not_null: true,
+			),
+			'membername' => new Column(
+				name: 'membername',
+				type: 'varchar',
+				size: 255,
+				not_null: true,
+				default: '',
+			),
+			'email_address' => new Column(
+				name: 'email_address',
+				type: 'varchar',
+				size: 255,
+				not_null: true,
+				default: '',
+			),
+			'member_ip' => new Column(
+				name: 'member_ip',
+				type: 'varchar',
+				size: 255,
+				not_null: true,
+				default: '',
+			),
+			'comment' => new Column(
+				name: 'comment',
+				type: 'varchar',
+				size: 255,
+				not_null: true,
+				default: '',
+			),
+			'time_sent' => new Column(
+				name: 'time_sent',
+				type: 'int',
+				not_null: true,
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'id_comment',
+					],
+				],
+			),
+			'id_report' => new DbIndex(
+				name: 'id_report',
+				columns: [
+					[
+						'name' => 'id_report',
+					],
+				],
+			),
+			'id_member' => new DbIndex(
+				name: 'id_member',
+				columns: [
+					[
+						'name' => 'id_member',
+					],
+				],
+			),
+			'time_sent' => new DbIndex(
+				name: 'time_sent',
+				columns: [
+					[
+						'name' => 'time_sent',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v2_0/LogScheduledTasks.php
+++ b/Sources/Db/Schema/v2_0/LogScheduledTasks.php
@@ -1,0 +1,78 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v2_0;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class LogScheduledTasks extends Table
+{
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'log_scheduled_tasks';
+
+		$this->columns = [
+			'id_log' => new Column(
+				name: 'id_log',
+				type: 'mediumint',
+				not_null: true,
+				auto: true,
+			),
+			'id_task' => new Column(
+				name: 'id_task',
+				type: 'smallint',
+				not_null: true,
+				default: 0,
+			),
+			'time_run' => new Column(
+				name: 'time_run',
+				type: 'int',
+				not_null: true,
+				default: 0,
+			),
+			'time_taken' => new Column(
+				name: 'time_taken',
+				type: 'float',
+				not_null: true,
+				default: 0,
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'id_log',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v2_0/LogSearchMessages.php
+++ b/Sources/Db/Schema/v2_0/LogSearchMessages.php
@@ -1,0 +1,71 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v2_0;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class LogSearchMessages extends Table
+{
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'log_search_messages';
+
+		$this->columns = [
+			'id_search' => new Column(
+				name: 'id_search',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'id_msg' => new Column(
+				name: 'id_msg',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'id_search',
+					],
+					[
+						'name' => 'id_msg',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v2_0/LogSearchResults.php
+++ b/Sources/Db/Schema/v2_0/LogSearchResults.php
@@ -1,0 +1,92 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v2_0;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class LogSearchResults extends Table
+{
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'log_search_results';
+
+		$this->columns = [
+			'id_search' => new Column(
+				name: 'id_search',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'id_topic' => new Column(
+				name: 'id_topic',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'id_msg' => new Column(
+				name: 'id_msg',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'relevance' => new Column(
+				name: 'relevance',
+				type: 'smallint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'num_matches' => new Column(
+				name: 'num_matches',
+				type: 'smallint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'id_search',
+					],
+					[
+						'name' => 'id_topic',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v2_0/LogSearchSubjects.php
+++ b/Sources/Db/Schema/v2_0/LogSearchSubjects.php
@@ -1,0 +1,79 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v2_0;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class LogSearchSubjects extends Table
+{
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'log_search_subjects';
+
+		$this->columns = [
+			'word' => new Column(
+				name: 'word',
+				type: 'varchar',
+				size: 20,
+				not_null: true,
+				default: '',
+			),
+			'id_topic' => new Column(
+				name: 'id_topic',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'word',
+					],
+					[
+						'name' => 'id_topic',
+					],
+				],
+			),
+			'id_topic' => new DbIndex(
+				name: 'id_topic',
+				columns: [
+					[
+						'name' => 'id_topic',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v2_0/LogSearchTopics.php
+++ b/Sources/Db/Schema/v2_0/LogSearchTopics.php
@@ -1,0 +1,71 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v2_0;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class LogSearchTopics extends Table
+{
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'log_search_topics';
+
+		$this->columns = [
+			'id_search' => new Column(
+				name: 'id_search',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'id_topic' => new Column(
+				name: 'id_topic',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'id_search',
+					],
+					[
+						'name' => 'id_topic',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v2_0/LogSpiderHits.php
+++ b/Sources/Db/Schema/v2_0/LogSpiderHits.php
@@ -1,0 +1,112 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v2_0;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class LogSpiderHits extends Table
+{
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'log_spider_hits';
+
+		$this->columns = [
+			'id_hit' => new Column(
+				name: 'id_hit',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				auto: true,
+			),
+			'id_spider' => new Column(
+				name: 'id_spider',
+				type: 'smallint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'log_time' => new Column(
+				name: 'log_time',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'url' => new Column(
+				name: 'url',
+				type: 'varchar',
+				size: 255,
+				not_null: true,
+				default: '',
+			),
+			'processed' => new Column(
+				name: 'processed',
+				type: 'tinyint',
+				not_null: true,
+				default: 0,
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'id_hit',
+					],
+				],
+			),
+			'id_spider' => new DbIndex(
+				name: 'id_spider',
+				columns: [
+					[
+						'name' => 'id_spider',
+					],
+				],
+			),
+			'log_time' => new DbIndex(
+				name: 'log_time',
+				columns: [
+					[
+						'name' => 'log_time',
+					],
+				],
+			),
+			'processed' => new DbIndex(
+				name: 'processed',
+				columns: [
+					[
+						'name' => 'processed',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v2_0/LogSpiderStats.php
+++ b/Sources/Db/Schema/v2_0/LogSpiderStats.php
@@ -1,0 +1,84 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v2_0;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class LogSpiderStats extends Table
+{
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'log_spider_stats';
+
+		$this->columns = [
+			'id_spider' => new Column(
+				name: 'id_spider',
+				type: 'smallint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'page_hits' => new Column(
+				name: 'page_hits',
+				type: 'smallint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'last_seen' => new Column(
+				name: 'last_seen',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'stat_date' => new Column(
+				name: 'stat_date',
+				type: 'date',
+				not_null: true,
+				default: '0001-01-01',
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'stat_date',
+					],
+					[
+						'name' => 'id_spider',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v2_0/LogSubscribed.php
+++ b/Sources/Db/Schema/v2_0/LogSubscribed.php
@@ -1,0 +1,174 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v2_0;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class LogSubscribed extends Table
+{
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'log_subscribed';
+
+		$this->columns = [
+			'id_sublog' => new Column(
+				name: 'id_sublog',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				auto: true,
+			),
+			'id_subscribe' => new Column(
+				name: 'id_subscribe',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'id_member' => new Column(
+				name: 'id_member',
+				type: 'int',
+				not_null: true,
+				default: 0,
+			),
+			'old_id_group' => new Column(
+				name: 'old_id_group',
+				type: 'smallint',
+				not_null: true,
+				default: 0,
+			),
+			'start_time' => new Column(
+				name: 'start_time',
+				type: 'int',
+				not_null: true,
+				default: 0,
+			),
+			'end_time' => new Column(
+				name: 'end_time',
+				type: 'int',
+				not_null: true,
+				default: 0,
+			),
+			'status' => new Column(
+				name: 'status',
+				type: 'tinyint',
+				not_null: true,
+				default: 0,
+			),
+			'payments_pending' => new Column(
+				name: 'payments_pending',
+				type: 'tinyint',
+				not_null: true,
+				default: 0,
+			),
+			'pending_details' => new Column(
+				name: 'pending_details',
+				type: 'text',
+				not_null: true,
+			),
+			'reminder_sent' => new Column(
+				name: 'reminder_sent',
+				type: 'tinyint',
+				not_null: true,
+				default: 0,
+			),
+			'vendor_ref' => new Column(
+				name: 'vendor_ref',
+				type: 'varchar',
+				size: 255,
+				not_null: true,
+				default: '',
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'id_sublog',
+					],
+				],
+			),
+			'id_subscribe' => new DbIndex(
+				type: 'unique',
+				name: 'id_subscribe',
+				columns: [
+					[
+						'name' => 'id_subscribe',
+					],
+					[
+						'name' => 'id_member',
+					],
+				],
+			),
+			'end_time' => new DbIndex(
+				name: 'end_time',
+				columns: [
+					[
+						'name' => 'end_time',
+					],
+				],
+			),
+			'reminder_sent' => new DbIndex(
+				name: 'reminder_sent',
+				columns: [
+					[
+						'name' => 'reminder_sent',
+					],
+				],
+			),
+			'payments_pending' => new DbIndex(
+				name: 'payments_pending',
+				columns: [
+					[
+						'name' => 'payments_pending',
+					],
+				],
+			),
+			'status' => new DbIndex(
+				name: 'status',
+				columns: [
+					[
+						'name' => 'status',
+					],
+				],
+			),
+			'id_member' => new DbIndex(
+				name: 'id_member',
+				columns: [
+					[
+						'name' => 'id_member',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v2_0/LogTopics.php
+++ b/Sources/Db/Schema/v2_0/LogTopics.php
@@ -1,0 +1,86 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v2_0;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class LogTopics extends Table
+{
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'log_topics';
+
+		$this->columns = [
+			'id_member' => new Column(
+				name: 'id_member',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'id_topic' => new Column(
+				name: 'id_topic',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'id_msg' => new Column(
+				name: 'id_msg',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'id_member',
+					],
+					[
+						'name' => 'id_topic',
+					],
+				],
+			),
+			'id_topic' => new DbIndex(
+				name: 'id_topic',
+				columns: [
+					[
+						'name' => 'id_topic',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v2_0/MailQueue.php
+++ b/Sources/Db/Schema/v2_0/MailQueue.php
@@ -1,0 +1,128 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v2_0;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class MailQueue extends Table
+{
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'mail_queue';
+
+		$this->columns = [
+			'id_mail' => new Column(
+				name: 'id_mail',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				auto: true,
+			),
+			'time_sent' => new Column(
+				name: 'time_sent',
+				type: 'int',
+				not_null: true,
+				default: 0,
+			),
+			'recipient' => new Column(
+				name: 'recipient',
+				type: 'varchar',
+				size: 255,
+				not_null: true,
+				default: '',
+			),
+			'body' => new Column(
+				name: 'body',
+				type: 'text',
+				not_null: true,
+			),
+			'subject' => new Column(
+				name: 'subject',
+				type: 'varchar',
+				size: 255,
+				not_null: true,
+				default: '',
+			),
+			'headers' => new Column(
+				name: 'headers',
+				type: 'text',
+				not_null: true,
+			),
+			'send_html' => new Column(
+				name: 'send_html',
+				type: 'tinyint',
+				not_null: true,
+				default: 0,
+			),
+			'priority' => new Column(
+				name: 'priority',
+				type: 'tinyint',
+				not_null: true,
+				default: 1,
+			),
+			'private' => new Column(
+				name: 'private',
+				type: 'tinyint',
+				not_null: true,
+				default: 0,
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'id_mail',
+					],
+				],
+			),
+			'time_sent' => new DbIndex(
+				name: 'time_sent',
+				columns: [
+					[
+						'name' => 'time_sent',
+					],
+				],
+			),
+			'mail_priority' => new DbIndex(
+				name: 'mail_priority',
+				columns: [
+					[
+						'name' => 'priority',
+					],
+					[
+						'name' => 'id_mail',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v2_0/Membergroups.php
+++ b/Sources/Db/Schema/v2_0/Membergroups.php
@@ -1,0 +1,210 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v2_0;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class Membergroups extends Table
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 * @var array
+	 *
+	 * Data used to populate the table during install.
+	 */
+	public array $initial_data = [
+		[
+			'id_group' => 1,
+			'group_name' => '{$default_administrator_group}',
+			'description' => '',
+			'online_color' => '#FF0000',
+			'min_posts' => -1,
+			'stars' => '5#staradmin.gif',
+			'group_type' => 1,
+		],
+		[
+			'id_group' => 2,
+			'group_name' => '{$default_global_moderator_group}',
+			'description' => '',
+			'online_color' => '#0000FF',
+			'min_posts' => -1,
+			'stars' => '5#stargmod.gif',
+			'group_type' => 0,
+		],
+		[
+			'id_group' => 3,
+			'group_name' => '{$default_moderator_group}',
+			'description' => '',
+			'online_color' => '',
+			'min_posts' => -1,
+			'stars' => '5#starmod.gif',
+			'group_type' => 0,
+		],
+		[
+			'id_group' => 4,
+			'group_name' => '{$default_newbie_group}',
+			'description' => '',
+			'online_color' => '',
+			'min_posts' => 0,
+			'stars' => '1#star.gif',
+			'group_type' => 0,
+		],
+		[
+			'id_group' => 5,
+			'group_name' => '{$default_junior_group}',
+			'description' => '',
+			'online_color' => '',
+			'min_posts' => 50,
+			'stars' => '2#star.gif',
+			'group_type' => 0,
+		],
+		[
+			'id_group' => 6,
+			'group_name' => '{$default_full_group}',
+			'description' => '',
+			'online_color' => '',
+			'min_posts' => 100,
+			'stars' => '3#star.gif',
+			'group_type' => 0,
+		],
+		[
+			'id_group' => 7,
+			'group_name' => '{$default_senior_group}',
+			'description' => '',
+			'online_color' => '',
+			'min_posts' => 250,
+			'stars' => '4#star.gif',
+			'group_type' => 0,
+		],
+		[
+			'id_group' => 8,
+			'group_name' => '{$default_hero_group}',
+			'description' => '',
+			'online_color' => '',
+			'min_posts' => 500,
+			'stars' => '5#star.gif',
+			'group_type' => 0,
+		],
+	];
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'membergroups';
+
+		$this->columns = [
+			'id_group' => new Column(
+				name: 'id_group',
+				type: 'smallint',
+				unsigned: true,
+				not_null: true,
+				auto: true,
+			),
+			'group_name' => new Column(
+				name: 'group_name',
+				type: 'varchar',
+				size: 80,
+				not_null: true,
+				default: '',
+			),
+			'description' => new Column(
+				name: 'description',
+				type: 'text',
+				not_null: true,
+			),
+			'online_color' => new Column(
+				name: 'online_color',
+				type: 'varchar',
+				size: 20,
+				not_null: true,
+				default: '',
+			),
+			'min_posts' => new Column(
+				name: 'min_posts',
+				type: 'mediumint',
+				not_null: true,
+				default: -1,
+			),
+			'max_messages' => new Column(
+				name: 'max_messages',
+				type: 'smallint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'stars' => new Column(
+				name: 'stars',
+				type: 'varchar',
+				size: 255,
+				not_null: true,
+				default: '',
+			),
+			'group_type' => new Column(
+				name: 'group_type',
+				type: 'tinyint',
+				not_null: true,
+				default: 0,
+			),
+			'hidden' => new Column(
+				name: 'hidden',
+				type: 'tinyint',
+				not_null: true,
+				default: 0,
+			),
+			'id_parent' => new Column(
+				name: 'id_parent',
+				type: 'smallint',
+				not_null: true,
+				default: -2,
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'id_group',
+					],
+				],
+			),
+			'min_posts' => new DbIndex(
+				name: 'min_posts',
+				columns: [
+					[
+						'name' => 'min_posts',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v2_0/Members.php
+++ b/Sources/Db/Schema/v2_0/Members.php
@@ -1,0 +1,548 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v2_0;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class Members extends Table
+{
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'members';
+
+		$this->columns = [
+			'id_member' => new Column(
+				name: 'id_member',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				auto: true,
+			),
+			'member_name' => new Column(
+				name: 'member_name',
+				type: 'varchar',
+				size: 80,
+				not_null: true,
+				default: '',
+			),
+			'date_registered' => new Column(
+				name: 'date_registered',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'posts' => new Column(
+				name: 'posts',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'id_group' => new Column(
+				name: 'id_group',
+				type: 'smallint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'lngfile' => new Column(
+				name: 'lngfile',
+				type: 'varchar',
+				size: 255,
+				not_null: true,
+				default: '',
+			),
+			'last_login' => new Column(
+				name: 'last_login',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'real_name' => new Column(
+				name: 'real_name',
+				type: 'varchar',
+				size: 255,
+				not_null: true,
+				default: '',
+			),
+			'instant_messages' => new Column(
+				name: 'instant_messages',
+				type: 'smallint',
+				not_null: true,
+				default: 0,
+			),
+			'unread_messages' => new Column(
+				name: 'unread_messages',
+				type: 'smallint',
+				not_null: true,
+				default: 0,
+			),
+			'new_pm' => new Column(
+				name: 'new_pm',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'buddy_list' => new Column(
+				name: 'buddy_list',
+				type: 'text',
+				not_null: true,
+			),
+			'pm_ignore_list' => new Column(
+				name: 'pm_ignore_list',
+				type: 'varchar',
+				size: 255,
+				not_null: true,
+				default: '',
+			),
+			'pm_prefs' => new Column(
+				name: 'pm_prefs',
+				type: 'mediumint',
+				not_null: true,
+				default: 0,
+			),
+			'mod_prefs' => new Column(
+				name: 'mod_prefs',
+				type: 'varchar',
+				size: 20,
+				not_null: true,
+				default: '',
+			),
+			'message_labels' => new Column(
+				name: 'message_labels',
+				type: 'text',
+				not_null: true,
+			),
+			'passwd' => new Column(
+				name: 'passwd',
+				type: 'varchar',
+				size: 64,
+				not_null: true,
+				default: '',
+			),
+			'openid_uri' => new Column(
+				name: 'openid_uri',
+				type: 'text',
+				not_null: true,
+			),
+			'email_address' => new Column(
+				name: 'email_address',
+				type: 'varchar',
+				size: 255,
+				not_null: true,
+				default: '',
+			),
+			'personal_text' => new Column(
+				name: 'personal_text',
+				type: 'varchar',
+				size: 255,
+				not_null: true,
+				default: '',
+			),
+			'gender' => new Column(
+				name: 'gender',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'birthdate' => new Column(
+				name: 'birthdate',
+				type: 'date',
+				not_null: true,
+				default: '0001-01-01',
+			),
+			'website_title' => new Column(
+				name: 'website_title',
+				type: 'varchar',
+				size: 255,
+				not_null: true,
+				default: '',
+			),
+			'website_url' => new Column(
+				name: 'website_url',
+				type: 'varchar',
+				size: 255,
+				not_null: true,
+				default: '',
+			),
+			'location' => new Column(
+				name: 'location',
+				type: 'varchar',
+				size: 255,
+				not_null: true,
+				default: '',
+			),
+			'icq' => new Column(
+				name: 'icq',
+				type: 'varchar',
+				size: 255,
+				not_null: true,
+				default: '',
+			),
+			'aim' => new Column(
+				name: 'aim',
+				type: 'varchar',
+				size: 255,
+				not_null: true,
+				default: '',
+			),
+			'yim' => new Column(
+				name: 'yim',
+				type: 'varchar',
+				size: 32,
+				not_null: true,
+				default: '',
+			),
+			'msn' => new Column(
+				name: 'msn',
+				type: 'varchar',
+				size: 255,
+				not_null: true,
+				default: '',
+			),
+			'hide_email' => new Column(
+				name: 'hide_email',
+				type: 'tinyint',
+				not_null: true,
+				default: 0,
+			),
+			'show_online' => new Column(
+				name: 'show_online',
+				type: 'tinyint',
+				not_null: true,
+				default: 1,
+			),
+			'time_format' => new Column(
+				name: 'time_format',
+				type: 'varchar',
+				size: 80,
+				not_null: true,
+				default: '',
+			),
+			'signature' => new Column(
+				name: 'signature',
+				type: 'text',
+				not_null: true,
+			),
+			'time_offset' => new Column(
+				name: 'time_offset',
+				type: 'float',
+				not_null: true,
+				default: 0,
+			),
+			'avatar' => new Column(
+				name: 'avatar',
+				type: 'varchar',
+				size: 255,
+				not_null: true,
+				default: '',
+			),
+			'pm_email_notify' => new Column(
+				name: 'pm_email_notify',
+				type: 'tinyint',
+				not_null: true,
+				default: 0,
+			),
+			'karma_bad' => new Column(
+				name: 'karma_bad',
+				type: 'smallint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'karma_good' => new Column(
+				name: 'karma_good',
+				type: 'smallint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'usertitle' => new Column(
+				name: 'usertitle',
+				type: 'varchar',
+				size: 255,
+				not_null: true,
+				default: '',
+			),
+			'notify_announcements' => new Column(
+				name: 'notify_announcements',
+				type: 'tinyint',
+				not_null: true,
+				default: 1,
+			),
+			'notify_regularity' => new Column(
+				name: 'notify_regularity',
+				type: 'tinyint',
+				not_null: true,
+				default: 1,
+			),
+			'notify_send_body' => new Column(
+				name: 'notify_send_body',
+				type: 'tinyint',
+				not_null: true,
+				default: 0,
+			),
+			'notify_types' => new Column(
+				name: 'notify_types',
+				type: 'tinyint',
+				not_null: true,
+				default: 2,
+			),
+			'member_ip' => new Column(
+				name: 'member_ip',
+				type: 'varchar',
+				size: 255,
+				not_null: true,
+				default: '',
+			),
+			'member_ip2' => new Column(
+				name: 'member_ip2',
+				type: 'varchar',
+				size: 255,
+				not_null: true,
+				default: '',
+			),
+			'secret_question' => new Column(
+				name: 'secret_question',
+				type: 'varchar',
+				size: 255,
+				not_null: true,
+				default: '',
+			),
+			'secret_answer' => new Column(
+				name: 'secret_answer',
+				type: 'varchar',
+				size: 64,
+				not_null: true,
+				default: '',
+			),
+			'id_theme' => new Column(
+				name: 'id_theme',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'is_activated' => new Column(
+				name: 'is_activated',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				default: 1,
+			),
+			'validation_code' => new Column(
+				name: 'validation_code',
+				type: 'varchar',
+				size: 10,
+				not_null: true,
+				default: '',
+			),
+			'id_msg_last_visit' => new Column(
+				name: 'id_msg_last_visit',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'additional_groups' => new Column(
+				name: 'additional_groups',
+				type: 'varchar',
+				size: 255,
+				not_null: true,
+				default: '',
+			),
+			'smiley_set' => new Column(
+				name: 'smiley_set',
+				type: 'varchar',
+				size: 48,
+				not_null: true,
+				default: '',
+			),
+			'id_post_group' => new Column(
+				name: 'id_post_group',
+				type: 'smallint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'total_time_logged_in' => new Column(
+				name: 'total_time_logged_in',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'password_salt' => new Column(
+				name: 'password_salt',
+				type: 'varchar',
+				size: 255,
+				not_null: true,
+				default: '',
+			),
+			'ignore_boards' => new Column(
+				name: 'ignore_boards',
+				type: 'text',
+				not_null: true,
+			),
+			'warning' => new Column(
+				name: 'warning',
+				type: 'tinyint',
+				not_null: true,
+				default: 0,
+			),
+			'passwd_flood' => new Column(
+				name: 'passwd_flood',
+				type: 'varchar',
+				size: 12,
+				not_null: true,
+				default: '',
+			),
+			'pm_receive_from' => new Column(
+				name: 'pm_receive_from',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				default: 1,
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'id_member',
+					],
+				],
+			),
+			'member_name' => new DbIndex(
+				name: 'member_name',
+				columns: [
+					[
+						'name' => 'member_name',
+					],
+				],
+			),
+			'real_name' => new DbIndex(
+				name: 'real_name',
+				columns: [
+					[
+						'name' => 'real_name',
+					],
+				],
+			),
+			'date_registered' => new DbIndex(
+				name: 'date_registered',
+				columns: [
+					[
+						'name' => 'date_registered',
+					],
+				],
+			),
+			'id_group' => new DbIndex(
+				name: 'id_group',
+				columns: [
+					[
+						'name' => 'id_group',
+					],
+				],
+			),
+			'birthdate' => new DbIndex(
+				name: 'birthdate',
+				columns: [
+					[
+						'name' => 'birthdate',
+					],
+				],
+			),
+			'posts' => new DbIndex(
+				name: 'posts',
+				columns: [
+					[
+						'name' => 'posts',
+					],
+				],
+			),
+			'last_login' => new DbIndex(
+				name: 'last_login',
+				columns: [
+					[
+						'name' => 'last_login',
+					],
+				],
+			),
+			'lngfile' => new DbIndex(
+				name: 'lngfile',
+				columns: [
+					[
+						'name' => 'lngfile',
+						'size' => 30,
+					],
+				],
+			),
+			'id_post_group' => new DbIndex(
+				name: 'id_post_group',
+				columns: [
+					[
+						'name' => 'id_post_group',
+					],
+				],
+			),
+			'warning' => new DbIndex(
+				name: 'warning',
+				columns: [
+					[
+						'name' => 'warning',
+					],
+				],
+			),
+			'total_time_logged_in' => new DbIndex(
+				name: 'total_time_logged_in',
+				columns: [
+					[
+						'name' => 'total_time_logged_in',
+					],
+				],
+			),
+			'id_theme' => new DbIndex(
+				name: 'id_theme',
+				columns: [
+					[
+						'name' => 'id_theme',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v2_0/MessageIcons.php
+++ b/Sources/Db/Schema/v2_0/MessageIcons.php
@@ -1,0 +1,169 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v2_0;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class MessageIcons extends Table
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 * @var array
+	 *
+	 * Data used to populate the table during install.
+	 */
+	public array $initial_data = [
+		[
+			'filename' => 'xx',
+			'title' => 'Standard',
+			'icon_order' => 0,
+		],
+		[
+			'filename' => 'thumbup',
+			'title' => 'Thumb Up',
+			'icon_order' => 1,
+		],
+		[
+			'filename' => 'thumbdown',
+			'title' => 'Thumb Down',
+			'icon_order' => 2,
+		],
+		[
+			'filename' => 'exclamation',
+			'title' => 'Exclamation point',
+			'icon_order' => 3,
+		],
+		[
+			'filename' => 'question',
+			'title' => 'Question mark',
+			'icon_order' => 4,
+		],
+		[
+			'filename' => 'lamp',
+			'title' => 'Lamp',
+			'icon_order' => 5,
+		],
+		[
+			'filename' => 'smiley',
+			'title' => 'Smiley',
+			'icon_order' => 6,
+		],
+		[
+			'filename' => 'angry',
+			'title' => 'Angry',
+			'icon_order' => 7,
+		],
+		[
+			'filename' => 'cheesy',
+			'title' => 'Cheesy',
+			'icon_order' => 8,
+		],
+		[
+			'filename' => 'grin',
+			'title' => 'Grin',
+			'icon_order' => 9,
+		],
+		[
+			'filename' => 'sad',
+			'title' => 'Sad',
+			'icon_order' => 10,
+		],
+		[
+			'filename' => 'wink',
+			'title' => 'Wink',
+			'icon_order' => 11,
+		],
+	];
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'message_icons';
+
+		$this->columns = [
+			'id_icon' => new Column(
+				name: 'id_icon',
+				type: 'smallint',
+				unsigned: true,
+				not_null: true,
+				auto: true,
+			),
+			'title' => new Column(
+				name: 'title',
+				type: 'varchar',
+				size: 80,
+				not_null: true,
+				default: '',
+			),
+			'filename' => new Column(
+				name: 'filename',
+				type: 'varchar',
+				size: 80,
+				not_null: true,
+				default: '',
+			),
+			'id_board' => new Column(
+				name: 'id_board',
+				type: 'smallint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'icon_order' => new Column(
+				name: 'icon_order',
+				type: 'smallint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'id_icon',
+					],
+				],
+			),
+			'id_board' => new DbIndex(
+				name: 'id_board',
+				columns: [
+					[
+						'name' => 'id_board',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v2_0/Messages.php
+++ b/Sources/Db/Schema/v2_0/Messages.php
@@ -1,0 +1,319 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v2_0;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class Messages extends Table
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 * @var array
+	 *
+	 * Data used to populate the table during install.
+	 */
+	public array $initial_data = [
+		[
+			'id_msg' => 1,
+			'id_msg_modified' => 1,
+			'id_topic' => 1,
+			'id_board' => 1,
+			'poster_time' => '{$current_time}',
+			'subject' => '{$default_topic_subject}',
+			'poster_name' => 'Simple Machines',
+			'poster_email' => 'info@simplemachines.org',
+			'poster_ip' => '127.0.0.1',
+			'modified_name' => '',
+			'body' => '{$default_topic_message}',
+			'icon' => 'xx',
+		],
+	];
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'messages';
+
+		$this->columns = [
+			'id_msg' => new Column(
+				name: 'id_msg',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				auto: true,
+			),
+			'id_topic' => new Column(
+				name: 'id_topic',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'id_board' => new Column(
+				name: 'id_board',
+				type: 'smallint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'poster_time' => new Column(
+				name: 'poster_time',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'id_member' => new Column(
+				name: 'id_member',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'id_msg_modified' => new Column(
+				name: 'id_msg_modified',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'subject' => new Column(
+				name: 'subject',
+				type: 'varchar',
+				size: 255,
+				not_null: true,
+				default: '',
+			),
+			'poster_name' => new Column(
+				name: 'poster_name',
+				type: 'varchar',
+				size: 255,
+				not_null: true,
+				default: '',
+			),
+			'poster_email' => new Column(
+				name: 'poster_email',
+				type: 'varchar',
+				size: 255,
+				not_null: true,
+				default: '',
+			),
+			'poster_ip' => new Column(
+				name: 'poster_ip',
+				type: 'varchar',
+				size: 255,
+				not_null: true,
+				default: '',
+			),
+			'smileys_enabled' => new Column(
+				name: 'smileys_enabled',
+				type: 'tinyint',
+				not_null: true,
+				default: 1,
+			),
+			'modified_time' => new Column(
+				name: 'modified_time',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'modified_name' => new Column(
+				name: 'modified_name',
+				type: 'varchar',
+				size: 255,
+				not_null: true,
+				default: '',
+			),
+			'body' => new Column(
+				name: 'body',
+				type: 'text',
+				not_null: true,
+			),
+			'icon' => new Column(
+				name: 'icon',
+				type: 'varchar',
+				size: 16,
+				not_null: true,
+				default: 'xx',
+			),
+			'approved' => new Column(
+				name: 'approved',
+				type: 'tinyint',
+				not_null: true,
+				default: 1,
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'id_msg',
+					],
+				],
+			),
+			'topic' => new DbIndex(
+				type: 'unique',
+				name: 'topic',
+				columns: [
+					[
+						'name' => 'id_topic',
+					],
+					[
+						'name' => 'id_msg',
+					],
+				],
+			),
+			'id_board' => new DbIndex(
+				type: 'unique',
+				name: 'id_board',
+				columns: [
+					[
+						'name' => 'id_board',
+					],
+					[
+						'name' => 'id_msg',
+					],
+				],
+			),
+			'id_member' => new DbIndex(
+				type: 'unique',
+				name: 'id_member',
+				columns: [
+					[
+						'name' => 'id_member',
+					],
+					[
+						'name' => 'id_msg',
+					],
+				],
+			),
+			'approved' => new DbIndex(
+				name: 'approved',
+				columns: [
+					[
+						'name' => 'approved',
+					],
+				],
+			),
+			'ip_index' => new DbIndex(
+				name: 'ip_index',
+				columns: [
+					[
+						'name' => 'poster_ip',
+						'size' => 15,
+					],
+					[
+						'name' => 'id_topic',
+					],
+				],
+			),
+			'participation' => new DbIndex(
+				name: 'participation',
+				columns: [
+					[
+						'name' => 'id_member',
+					],
+					[
+						'name' => 'id_topic',
+					],
+				],
+			),
+			'show_posts' => new DbIndex(
+				name: 'show_posts',
+				columns: [
+					[
+						'name' => 'id_member',
+					],
+					[
+						'name' => 'id_board',
+					],
+				],
+			),
+			'id_topic' => new DbIndex(
+				name: 'id_topic',
+				columns: [
+					[
+						'name' => 'id_topic',
+					],
+				],
+			),
+			'id_member_msg' => new DbIndex(
+				name: 'id_member_msg',
+				columns: [
+					[
+						'name' => 'id_member',
+					],
+					[
+						'name' => 'approved',
+					],
+					[
+						'name' => 'id_msg',
+					],
+				],
+			),
+			'current_topic' => new DbIndex(
+				name: 'current_topic',
+				columns: [
+					[
+						'name' => 'id_topic',
+					],
+					[
+						'name' => 'id_msg',
+					],
+					[
+						'name' => 'id_member',
+					],
+					[
+						'name' => 'approved',
+					],
+				],
+			),
+			'related_ip' => new DbIndex(
+				name: 'related_ip',
+				columns: [
+					[
+						'name' => 'id_member',
+					],
+					[
+						'name' => 'poster_ip',
+					],
+					[
+						'name' => 'id_msg',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v2_0/Moderators.php
+++ b/Sources/Db/Schema/v2_0/Moderators.php
@@ -1,0 +1,71 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v2_0;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class Moderators extends Table
+{
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'moderators';
+
+		$this->columns = [
+			'id_board' => new Column(
+				name: 'id_board',
+				type: 'smallint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'id_member' => new Column(
+				name: 'id_member',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'id_board',
+					],
+					[
+						'name' => 'id_member',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v2_0/OpenIdAssoc.php
+++ b/Sources/Db/Schema/v2_0/OpenIdAssoc.php
@@ -1,0 +1,102 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v2_0;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class OpenIdAssoc extends Table
+{
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'openid_assoc';
+
+		$this->columns = [
+			'server_url' => new Column(
+				name: 'server_url',
+				type: 'text',
+				not_null: true,
+			),
+			'handle' => new Column(
+				name: 'handle',
+				type: 'varchar',
+				size: 255,
+				not_null: true,
+				default: '',
+			),
+			'secret' => new Column(
+				name: 'secret',
+				type: 'text',
+				not_null: true,
+			),
+			'issued' => new Column(
+				name: 'issued',
+				type: 'int',
+				not_null: true,
+				default: 0,
+			),
+			'expires' => new Column(
+				name: 'expires',
+				type: 'int',
+				not_null: true,
+				default: 0,
+			),
+			'assoc_type' => new Column(
+				name: 'assoc_type',
+				type: 'varchar',
+				size: 64,
+				not_null: true,
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'server_url',
+						'size' => 125,
+					],
+					[
+						'name' => 'handle',
+						'size' => 125,
+					],
+				],
+			),
+			'expires' => new DbIndex(
+				name: 'expires',
+				columns: [
+					[
+						'name' => 'expires',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v2_0/PackageServers.php
+++ b/Sources/Db/Schema/v2_0/PackageServers.php
@@ -1,0 +1,91 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v2_0;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class PackageServers extends Table
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 * @var array
+	 *
+	 * Data used to populate the table during install.
+	 */
+	public array $initial_data = [
+		[
+			'name' => 'Simple Machines Third-party Mod Site',
+			'url' => 'http://custom.simplemachines.org/packages/mods',
+		],
+	];
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'package_servers';
+
+		$this->columns = [
+			'id_server' => new Column(
+				name: 'id_server',
+				type: 'smallint',
+				unsigned: true,
+				not_null: true,
+				auto: true,
+			),
+			'name' => new Column(
+				name: 'name',
+				type: 'varchar',
+				size: 255,
+				not_null: true,
+				default: '',
+			),
+			'url' => new Column(
+				name: 'url',
+				type: 'varchar',
+				size: 255,
+				not_null: true,
+				default: '',
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'id_server',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v2_0/PermissionProfiles.php
+++ b/Sources/Db/Schema/v2_0/PermissionProfiles.php
@@ -1,0 +1,95 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v2_0;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class PermissionProfiles extends Table
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 * @var array
+	 *
+	 * Data used to populate the table during install.
+	 */
+	public array $initial_data = [
+		[
+			'id_profile' => 1,
+			'profile_name' => 'default',
+		],
+		[
+			'id_profile' => 2,
+			'profile_name' => 'no_polls',
+		],
+		[
+			'id_profile' => 3,
+			'profile_name' => 'reply_only',
+		],
+		[
+			'id_profile' => 4,
+			'profile_name' => 'read_only',
+		],
+	];
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'permission_profiles';
+
+		$this->columns = [
+			'id_profile' => new Column(
+				name: 'id_profile',
+				type: 'smallint',
+				not_null: true,
+				auto: true,
+			),
+			'profile_name' => new Column(
+				name: 'profile_name',
+				type: 'varchar',
+				size: 255,
+				not_null: true,
+				default: '',
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'id_profile',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v2_0/Permissions.php
+++ b/Sources/Db/Schema/v2_0/Permissions.php
@@ -1,0 +1,248 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v2_0;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class Permissions extends Table
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 * @var array
+	 *
+	 * Data used to populate the table during install.
+	 */
+	public array $initial_data = [
+		[
+			'id_group' => -1,
+			'permission' => 'search_posts',
+		],
+		[
+			'id_group' => -1,
+			'permission' => 'calendar_view',
+		],
+		[
+			'id_group' => -1,
+			'permission' => 'view_stats',
+		],
+		[
+			'id_group' => -1,
+			'permission' => 'profile_view_any',
+		],
+		[
+			'id_group' => 0,
+			'permission' => 'view_mlist',
+		],
+		[
+			'id_group' => 0,
+			'permission' => 'search_posts',
+		],
+		[
+			'id_group' => 0,
+			'permission' => 'profile_view_own',
+		],
+		[
+			'id_group' => 0,
+			'permission' => 'profile_view_any',
+		],
+		[
+			'id_group' => 0,
+			'permission' => 'pm_read',
+		],
+		[
+			'id_group' => 0,
+			'permission' => 'pm_send',
+		],
+		[
+			'id_group' => 0,
+			'permission' => 'calendar_view',
+		],
+		[
+			'id_group' => 0,
+			'permission' => 'view_stats',
+		],
+		[
+			'id_group' => 0,
+			'permission' => 'who_view',
+		],
+		[
+			'id_group' => 0,
+			'permission' => 'profile_identity_own',
+		],
+		[
+			'id_group' => 0,
+			'permission' => 'profile_extra_own',
+		],
+		[
+			'id_group' => 0,
+			'permission' => 'profile_remove_own',
+		],
+		[
+			'id_group' => 0,
+			'permission' => 'profile_server_avatar',
+		],
+		[
+			'id_group' => 0,
+			'permission' => 'profile_upload_avatar',
+		],
+		[
+			'id_group' => 0,
+			'permission' => 'profile_remote_avatar',
+		],
+		[
+			'id_group' => 0,
+			'permission' => 'karma_edit',
+		],
+		[
+			'id_group' => 2,
+			'permission' => 'view_mlist',
+		],
+		[
+			'id_group' => 2,
+			'permission' => 'search_posts',
+		],
+		[
+			'id_group' => 2,
+			'permission' => 'profile_view_own',
+		],
+		[
+			'id_group' => 2,
+			'permission' => 'profile_view_any',
+		],
+		[
+			'id_group' => 2,
+			'permission' => 'pm_read',
+		],
+		[
+			'id_group' => 2,
+			'permission' => 'pm_send',
+		],
+		[
+			'id_group' => 2,
+			'permission' => 'calendar_view',
+		],
+		[
+			'id_group' => 2,
+			'permission' => 'view_stats',
+		],
+		[
+			'id_group' => 2,
+			'permission' => 'who_view',
+		],
+		[
+			'id_group' => 2,
+			'permission' => 'profile_identity_own',
+		],
+		[
+			'id_group' => 2,
+			'permission' => 'profile_extra_own',
+		],
+		[
+			'id_group' => 2,
+			'permission' => 'profile_remove_own',
+		],
+		[
+			'id_group' => 2,
+			'permission' => 'profile_server_avatar',
+		],
+		[
+			'id_group' => 2,
+			'permission' => 'profile_upload_avatar',
+		],
+		[
+			'id_group' => 2,
+			'permission' => 'profile_remote_avatar',
+		],
+		[
+			'id_group' => 2,
+			'permission' => 'profile_title_own',
+		],
+		[
+			'id_group' => 2,
+			'permission' => 'calendar_post',
+		],
+		[
+			'id_group' => 2,
+			'permission' => 'calendar_edit_any',
+		],
+		[
+			'id_group' => 2,
+			'permission' => 'karma_edit',
+		],
+		[
+			'id_group' => 2,
+			'permission' => 'access_mod_center',
+		],
+	];
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'permissions';
+
+		$this->columns = [
+			'id_group' => new Column(
+				name: 'id_group',
+				type: 'smallint',
+				not_null: true,
+				default: 0,
+			),
+			'permission' => new Column(
+				name: 'permission',
+				type: 'varchar',
+				size: 30,
+				not_null: true,
+				default: '',
+			),
+			'add_deny' => new Column(
+				name: 'add_deny',
+				type: 'tinyint',
+				not_null: true,
+				default: 1,
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'id_group',
+					],
+					[
+						'name' => 'permission',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v2_0/PersonalMessages.php
+++ b/Sources/Db/Schema/v2_0/PersonalMessages.php
@@ -1,0 +1,135 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v2_0;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class PersonalMessages extends Table
+{
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'personal_messages';
+
+		$this->columns = [
+			'id_pm' => new Column(
+				name: 'id_pm',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				auto: true,
+			),
+			'id_pm_head' => new Column(
+				name: 'id_pm_head',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'id_member_from' => new Column(
+				name: 'id_member_from',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'deleted_by_sender' => new Column(
+				name: 'deleted_by_sender',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'from_name' => new Column(
+				name: 'from_name',
+				type: 'varchar',
+				size: 255,
+				not_null: true,
+				default: '',
+			),
+			'msgtime' => new Column(
+				name: 'msgtime',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'subject' => new Column(
+				name: 'subject',
+				type: 'varchar',
+				size: 255,
+				not_null: true,
+				default: '',
+			),
+			'body' => new Column(
+				name: 'body',
+				type: 'text',
+				not_null: true,
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'id_pm',
+					],
+				],
+			),
+			'id_member' => new DbIndex(
+				name: 'id_member',
+				columns: [
+					[
+						'name' => 'id_member_from',
+					],
+					[
+						'name' => 'deleted_by_sender',
+					],
+				],
+			),
+			'msgtime' => new DbIndex(
+				name: 'msgtime',
+				columns: [
+					[
+						'name' => 'msgtime',
+					],
+				],
+			),
+			'id_pm_head' => new DbIndex(
+				name: 'id_pm_head',
+				columns: [
+					[
+						'name' => 'id_pm_head',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v2_0/PmRecipients.php
+++ b/Sources/Db/Schema/v2_0/PmRecipients.php
@@ -1,0 +1,121 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v2_0;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class PmRecipients extends Table
+{
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'pm_recipients';
+
+		$this->columns = [
+			'id_pm' => new Column(
+				name: 'id_pm',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'id_member' => new Column(
+				name: 'id_member',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'labels' => new Column(
+				name: 'labels',
+				type: 'varchar',
+				size: 60,
+				not_null: true,
+				default: '-1',
+			),
+			'bcc' => new Column(
+				name: 'bcc',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'is_read' => new Column(
+				name: 'is_read',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'is_new' => new Column(
+				name: 'is_new',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'deleted' => new Column(
+				name: 'deleted',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'id_pm',
+					],
+					[
+						'name' => 'id_member',
+					],
+				],
+			),
+			'id_member' => new DbIndex(
+				type: 'unique',
+				name: 'id_member',
+				columns: [
+					[
+						'name' => 'id_member',
+					],
+					[
+						'name' => 'deleted',
+					],
+					[
+						'name' => 'id_pm',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v2_0/PmRules.php
+++ b/Sources/Db/Schema/v2_0/PmRules.php
@@ -1,0 +1,114 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v2_0;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class PmRules extends Table
+{
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'pm_rules';
+
+		$this->columns = [
+			'id_rule' => new Column(
+				name: 'id_rule',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				auto: true,
+			),
+			'id_member' => new Column(
+				name: 'id_member',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'rule_name' => new Column(
+				name: 'rule_name',
+				type: 'varchar',
+				size: 60,
+				not_null: true,
+			),
+			'criteria' => new Column(
+				name: 'criteria',
+				type: 'text',
+				not_null: true,
+			),
+			'actions' => new Column(
+				name: 'actions',
+				type: 'text',
+				not_null: true,
+			),
+			'delete_pm' => new Column(
+				name: 'delete_pm',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'is_or' => new Column(
+				name: 'is_or',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'id_rule',
+					],
+				],
+			),
+			'id_member' => new DbIndex(
+				name: 'id_member',
+				columns: [
+					[
+						'name' => 'id_member',
+					],
+				],
+			),
+			'delete_pm' => new DbIndex(
+				name: 'delete_pm',
+				columns: [
+					[
+						'name' => 'delete_pm',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v2_0/PollChoices.php
+++ b/Sources/Db/Schema/v2_0/PollChoices.php
@@ -1,0 +1,85 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v2_0;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class PollChoices extends Table
+{
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'poll_choices';
+
+		$this->columns = [
+			'id_poll' => new Column(
+				name: 'id_poll',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'id_choice' => new Column(
+				name: 'id_choice',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'label' => new Column(
+				name: 'label',
+				type: 'varchar',
+				size: 255,
+				not_null: true,
+				default: '',
+			),
+			'votes' => new Column(
+				name: 'votes',
+				type: 'smallint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'id_poll',
+					],
+					[
+						'name' => 'id_choice',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v2_0/Polls.php
+++ b/Sources/Db/Schema/v2_0/Polls.php
@@ -1,0 +1,136 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v2_0;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class Polls extends Table
+{
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'polls';
+
+		$this->columns = [
+			'id_poll' => new Column(
+				name: 'id_poll',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				auto: true,
+			),
+			'question' => new Column(
+				name: 'question',
+				type: 'varchar',
+				size: 255,
+				not_null: true,
+				default: '',
+			),
+			'voting_locked' => new Column(
+				name: 'voting_locked',
+				type: 'tinyint',
+				not_null: true,
+				default: 0,
+			),
+			'max_votes' => new Column(
+				name: 'max_votes',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				default: 1,
+			),
+			'expire_time' => new Column(
+				name: 'expire_time',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'hide_results' => new Column(
+				name: 'hide_results',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'change_vote' => new Column(
+				name: 'change_vote',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'guest_vote' => new Column(
+				name: 'guest_vote',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'num_guest_voters' => new Column(
+				name: 'num_guest_voters',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'reset_poll' => new Column(
+				name: 'reset_poll',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'id_member' => new Column(
+				name: 'id_member',
+				type: 'mediumint',
+				not_null: true,
+				default: 0,
+			),
+			'poster_name' => new Column(
+				name: 'poster_name',
+				type: 'varchar',
+				size: 255,
+				not_null: true,
+				default: '',
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'id_poll',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v2_0/ScheduledTasks.php
+++ b/Sources/Db/Schema/v2_0/ScheduledTasks.php
@@ -1,0 +1,216 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v2_0;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class ScheduledTasks extends Table
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 * @var array
+	 *
+	 * Data used to populate the table during install.
+	 */
+	public array $initial_data = [
+		[
+			'id_task' => 1,
+			'next_time' => 0,
+			'time_offset' => 0,
+			'time_regularity' => 2,
+			'time_unit' => 'h',
+			'disabled' => 0,
+			'task' => 'approval_notification',
+		],
+		[
+			'id_task' => 2,
+			'next_time' => 0,
+			'time_offset' => 0,
+			'time_regularity' => 7,
+			'time_unit' => 'd',
+			'disabled' => 0,
+			'task' => 'auto_optimize',
+		],
+		[
+			'id_task' => 3,
+			'next_time' => 0,
+			'time_offset' => 60,
+			'time_regularity' => 1,
+			'time_unit' => 'd',
+			'disabled' => 0,
+			'task' => 'daily_maintenance',
+		],
+		[
+			'id_task' => 5,
+			'next_time' => 0,
+			'time_offset' => 0,
+			'time_regularity' => 1,
+			'time_unit' => 'd',
+			'disabled' => 0,
+			'task' => 'daily_digest',
+		],
+		[
+			'id_task' => 6,
+			'next_time' => 0,
+			'time_offset' => 0,
+			'time_regularity' => 1,
+			'time_unit' => 'w',
+			'disabled' => 0,
+			'task' => 'weekly_digest',
+		],
+		[
+			'id_task' => 7,
+			'next_time' => 0,
+			'time_offset' => '{$sched_task_offset}',
+			'time_regularity' => 1,
+			'time_unit' => 'd',
+			'disabled' => 0,
+			'task' => 'fetchSMfiles',
+		],
+		[
+			'id_task' => 8,
+			'next_time' => 0,
+			'time_offset' => 0,
+			'time_regularity' => 1,
+			'time_unit' => 'd',
+			'disabled' => 1,
+			'task' => 'birthdayemails',
+		],
+		[
+			'id_task' => 9,
+			'next_time' => 0,
+			'time_offset' => 0,
+			'time_regularity' => 1,
+			'time_unit' => 'w',
+			'disabled' => 0,
+			'task' => 'weekly_maintenance',
+		],
+		[
+			'id_task' => 10,
+			'next_time' => 0,
+			'time_offset' => 120,
+			'time_regularity' => 1,
+			'time_unit' => 'd',
+			'disabled' => 1,
+			'task' => 'paid_subscriptions',
+		],
+	];
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'scheduled_tasks';
+
+		$this->columns = [
+			'id_task' => new Column(
+				name: 'id_task',
+				type: 'smallint',
+				not_null: true,
+				auto: true,
+			),
+			'next_time' => new Column(
+				name: 'next_time',
+				type: 'int',
+				not_null: true,
+				default: 0,
+			),
+			'time_offset' => new Column(
+				name: 'time_offset',
+				type: 'int',
+				not_null: true,
+				default: 0,
+			),
+			'time_regularity' => new Column(
+				name: 'time_regularity',
+				type: 'smallint',
+				not_null: true,
+				default: 0,
+			),
+			'time_unit' => new Column(
+				name: 'time_unit',
+				type: 'varchar',
+				size: 1,
+				not_null: true,
+				default: 'h',
+			),
+			'disabled' => new Column(
+				name: 'disabled',
+				type: 'tinyint',
+				not_null: true,
+				default: 0,
+			),
+			'task' => new Column(
+				name: 'task',
+				type: 'varchar',
+				size: 24,
+				not_null: true,
+				default: '',
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'id_task',
+					],
+				],
+			),
+			'next_time' => new DbIndex(
+				name: 'next_time',
+				columns: [
+					[
+						'name' => 'next_time',
+					],
+				],
+			),
+			'disabled' => new DbIndex(
+				name: 'disabled',
+				columns: [
+					[
+						'name' => 'disabled',
+					],
+				],
+			),
+			'task' => new DbIndex(
+				type: 'unique',
+				name: 'task',
+				columns: [
+					[
+						'name' => 'task',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v2_0/Sessions.php
+++ b/Sources/Db/Schema/v2_0/Sessions.php
@@ -1,0 +1,71 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v2_0;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class Sessions extends Table
+{
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'sessions';
+
+		$this->columns = [
+			'session_id' => new Column(
+				name: 'session_id',
+				type: 'char',
+				size: 32,
+				not_null: true,
+			),
+			'last_update' => new Column(
+				name: 'last_update',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+			),
+			'data' => new Column(
+				name: 'data',
+				type: 'text',
+				not_null: true,
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'session_id',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v2_0/Settings.php
+++ b/Sources/Db/Schema/v2_0/Settings.php
@@ -1,0 +1,771 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v2_0;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class Settings extends Table
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 * @var array
+	 *
+	 * Data used to populate the table during install.
+	 */
+	public array $initial_data = [
+		[
+			'variable' => 'admin_features',
+			'value' => '',
+		],
+		[
+			'variable' => 'allow_disableAnnounce',
+			'value' => 1,
+		],
+		[
+			'variable' => 'allow_editDisplayName',
+			'value' => 1,
+		],
+		[
+			'variable' => 'allow_guestAccess',
+			'value' => 1,
+		],
+		[
+			'variable' => 'allow_hideOnline',
+			'value' => 1,
+		],
+		[
+			'variable' => 'attachmentCheckExtensions',
+			'value' => 0,
+		],
+		[
+			'variable' => 'attachmentDirSizeLimit',
+			'value' => 10240,
+		],
+		[
+			'variable' => 'attachmentEnable',
+			'value' => 1,
+		],
+		[
+			'variable' => 'attachmentEncryptFilenames',
+			'value' => 1,
+		],
+		[
+			'variable' => 'attachmentExtensions',
+			'value' => 'doc,gif,jpg,mpg,pdf,png,txt,zip',
+		],
+		[
+			'variable' => 'attachmentNumPerPostLimit',
+			'value' => 4,
+		],
+		[
+			'variable' => 'attachmentPostLimit',
+			'value' => 192,
+		],
+		[
+			'variable' => 'attachmentShowImages',
+			'value' => 1,
+		],
+		[
+			'variable' => 'attachmentSizeLimit',
+			'value' => 128,
+		],
+		[
+			'variable' => 'attachmentThumbHeight',
+			'value' => 150,
+		],
+		[
+			'variable' => 'attachmentThumbWidth',
+			'value' => 150,
+		],
+		[
+			'variable' => 'attachmentThumbnails',
+			'value' => 1,
+		],
+		[
+			'variable' => 'attachmentUploadDir',
+			'value' => '{$boarddir}/attachments',
+		],
+		[
+			'variable' => 'attachment_image_paranoid',
+			'value' => 0,
+		],
+		[
+			'variable' => 'attachment_image_reencode',
+			'value' => 1,
+		],
+		[
+			'variable' => 'attachment_thumb_png',
+			'value' => 1,
+		],
+		[
+			'variable' => 'autoFixDatabase',
+			'value' => 1,
+		],
+		[
+			'variable' => 'autoLinkUrls',
+			'value' => 1,
+		],
+		[
+			'variable' => 'autoOptMaxOnline',
+			'value' => 0,
+		],
+		[
+			'variable' => 'avatar_action_too_large',
+			'value' => 'option_html_resize',
+		],
+		[
+			'variable' => 'avatar_directory',
+			'value' => '{$boarddir}/avatars',
+		],
+		[
+			'variable' => 'avatar_download_png',
+			'value' => 1,
+		],
+		[
+			'variable' => 'avatar_max_height_external',
+			'value' => 65,
+		],
+		[
+			'variable' => 'avatar_max_height_upload',
+			'value' => 65,
+		],
+		[
+			'variable' => 'avatar_max_width_external',
+			'value' => 65,
+		],
+		[
+			'variable' => 'avatar_max_width_upload',
+			'value' => 65,
+		],
+		[
+			'variable' => 'avatar_paranoid',
+			'value' => 0,
+		],
+		[
+			'variable' => 'avatar_reencode',
+			'value' => 1,
+		],
+		[
+			'variable' => 'avatar_resize_upload',
+			'value' => 1,
+		],
+		[
+			'variable' => 'avatar_url',
+			'value' => '{$boardurl}/avatars',
+		],
+		[
+			'variable' => 'banLastUpdated',
+			'value' => 0,
+		],
+		[
+			'variable' => 'birthday_email',
+			'value' => 'happy_birthday',
+		],
+		[
+			'variable' => 'cache_enable',
+			'value' => 1,
+		],
+		[
+			'variable' => 'cal_days_for_index',
+			'value' => 7,
+		],
+		[
+			'variable' => 'cal_daysaslink',
+			'value' => 0,
+		],
+		[
+			'variable' => 'cal_defaultboard',
+			'value' => '',
+		],
+		[
+			'variable' => 'cal_enabled',
+			'value' => 0,
+		],
+		[
+			'variable' => 'cal_maxspan',
+			'value' => 7,
+		],
+		[
+			'variable' => 'cal_maxyear',
+			'value' => 2030,
+		],
+		[
+			'variable' => 'cal_minyear',
+			'value' => 2008,
+		],
+		[
+			'variable' => 'cal_showbdays',
+			'value' => 1,
+		],
+		[
+			'variable' => 'cal_showevents',
+			'value' => 1,
+		],
+		[
+			'variable' => 'cal_showholidays',
+			'value' => 1,
+		],
+		[
+			'variable' => 'cal_showweeknum',
+			'value' => 0,
+		],
+		[
+			'variable' => 'censorIgnoreCase',
+			'value' => 1,
+		],
+		[
+			'variable' => 'censor_proper',
+			'value' => '',
+		],
+		[
+			'variable' => 'censor_vulgar',
+			'value' => '',
+		],
+		[
+			'variable' => 'compactTopicPagesContiguous',
+			'value' => 5,
+		],
+		[
+			'variable' => 'compactTopicPagesEnable',
+			'value' => 1,
+		],
+		[
+			'variable' => 'cookieTime',
+			'value' => 60,
+		],
+		[
+			'variable' => 'databaseSession_enable',
+			'value' => '{$databaseSession_enable}',
+		],
+		[
+			'variable' => 'databaseSession_lifetime',
+			'value' => 2880,
+		],
+		[
+			'variable' => 'databaseSession_loose',
+			'value' => 1,
+		],
+		[
+			'variable' => 'defaultMaxMembers',
+			'value' => 30,
+		],
+		[
+			'variable' => 'defaultMaxMessages',
+			'value' => 15,
+		],
+		[
+			'variable' => 'defaultMaxTopics',
+			'value' => 20,
+		],
+		[
+			'variable' => 'default_personal_text',
+			'value' => '',
+		],
+		[
+			'variable' => 'dont_repeat_buddylists',
+			'value' => 1,
+		],
+		[
+			'variable' => 'dont_repeat_smileys_20',
+			'value' => 1,
+		],
+		[
+			'variable' => 'dont_repeat_theme_core',
+			'value' => 1,
+		],
+		[
+			'variable' => 'edit_disable_time',
+			'value' => 0,
+		],
+		[
+			'variable' => 'edit_wait_time',
+			'value' => 90,
+		],
+		[
+			'variable' => 'enableAllMessages',
+			'value' => 0,
+		],
+		[
+			'variable' => 'enableBBC',
+			'value' => 1,
+		],
+		[
+			'variable' => 'enableCompressedOutput',
+			'value' => '{$enableCompressedOutput}',
+		],
+		[
+			'variable' => 'enableEmbeddedFlash',
+			'value' => 0,
+		],
+		[
+			'variable' => 'enableErrorLogging',
+			'value' => 1,
+		],
+		[
+			'variable' => 'enableParticipation',
+			'value' => 1,
+		],
+		[
+			'variable' => 'enablePostHTML',
+			'value' => 0,
+		],
+		[
+			'variable' => 'enablePreviousNext',
+			'value' => 1,
+		],
+		[
+			'variable' => 'enableStickyTopics',
+			'value' => 1,
+		],
+		[
+			'variable' => 'enableVBStyleLogin',
+			'value' => 1,
+		],
+		[
+			'variable' => 'enable_buddylist',
+			'value' => 1,
+		],
+		[
+			'variable' => 'failed_login_threshold',
+			'value' => 3,
+		],
+		[
+			'variable' => 'fixLongWords',
+			'value' => 0,
+		],
+		[
+			'variable' => 'guest_hideContacts',
+			'value' => 1,
+		],
+		[
+			'variable' => 'hotTopicPosts',
+			'value' => 15,
+		],
+		[
+			'variable' => 'hotTopicVeryPosts',
+			'value' => 25,
+		],
+		[
+			'variable' => 'karmaApplaudLabel',
+			'value' => '{$default_karmaApplaudLabel}',
+		],
+		[
+			'variable' => 'karmaLabel',
+			'value' => '{$default_karmaLabel}',
+		],
+		[
+			'variable' => 'karmaMinPosts',
+			'value' => 0,
+		],
+		[
+			'variable' => 'karmaMode',
+			'value' => 0,
+		],
+		[
+			'variable' => 'karmaSmiteLabel',
+			'value' => '{$default_karmaSmiteLabel}',
+		],
+		[
+			'variable' => 'karmaTimeRestrictAdmins',
+			'value' => 1,
+		],
+		[
+			'variable' => 'karmaWaitTime',
+			'value' => 1,
+		],
+		[
+			'variable' => 'knownThemes',
+			'value' => '1,2,3',
+		],
+		[
+			'variable' => 'lastActive',
+			'value' => 15,
+		],
+		[
+			'variable' => 'last_mod_report_action',
+			'value' => 0,
+		],
+		[
+			'variable' => 'mail_next_send',
+			'value' => 0,
+		],
+		[
+			'variable' => 'mail_recent',
+			'value' => '0000000000|0',
+		],
+		[
+			'variable' => 'mail_type',
+			'value' => 0,
+		],
+		[
+			'variable' => 'maxMsgID',
+			'value' => 1,
+		],
+		[
+			'variable' => 'max_image_height',
+			'value' => 0,
+		],
+		[
+			'variable' => 'max_image_width',
+			'value' => 0,
+		],
+		[
+			'variable' => 'max_messageLength',
+			'value' => 20000,
+		],
+		[
+			'variable' => 'mostDate',
+			'value' => '{$current_time}',
+		],
+		[
+			'variable' => 'mostOnline',
+			'value' => 1,
+		],
+		[
+			'variable' => 'mostOnlineToday',
+			'value' => 1,
+		],
+		[
+			'variable' => 'news',
+			'value' => '{$default_news}',
+		],
+		[
+			'variable' => 'next_task_time',
+			'value' => 1,
+		],
+		[
+			'variable' => 'number_format',
+			'value' => '1234.00',
+		],
+		[
+			'variable' => 'oldTopicDays',
+			'value' => 120,
+		],
+		[
+			'variable' => 'onlineEnable',
+			'value' => 0,
+		],
+		[
+			'variable' => 'package_make_backups',
+			'value' => 1,
+		],
+		[
+			'variable' => 'permission_enable_deny',
+			'value' => 0,
+		],
+		[
+			'variable' => 'permission_enable_postgroups',
+			'value' => 0,
+		],
+		[
+			'variable' => 'pm_spam_settings',
+			'value' => '10,5,20',
+		],
+		[
+			'variable' => 'pollMode',
+			'value' => 1,
+		],
+		[
+			'variable' => 'pruningOptions',
+			'value' => '30,180,180,180,30,0',
+		],
+		[
+			'variable' => 'recycle_board',
+			'value' => 0,
+		],
+		[
+			'variable' => 'recycle_enable',
+			'value' => 0,
+		],
+		[
+			'variable' => 'reg_verification',
+			'value' => 1,
+		],
+		[
+			'variable' => 'registration_method',
+			'value' => 0,
+		],
+		[
+			'variable' => 'requireAgreement',
+			'value' => 1,
+		],
+		[
+			'variable' => 'requirePolicyAgreement',
+			'value' => 0,
+		],
+		[
+			'variable' => 'reserveCase',
+			'value' => 1,
+		],
+		[
+			'variable' => 'reserveName',
+			'value' => 1,
+		],
+		[
+			'variable' => 'reserveNames',
+			'value' => '{$default_reserved_names}',
+		],
+		[
+			'variable' => 'reserveUser',
+			'value' => 1,
+		],
+		[
+			'variable' => 'reserveWord',
+			'value' => 0,
+		],
+		[
+			'variable' => 'search_cache_size',
+			'value' => 50,
+		],
+		[
+			'variable' => 'search_floodcontrol_time',
+			'value' => 5,
+		],
+		[
+			'variable' => 'search_max_results',
+			'value' => 1200,
+		],
+		[
+			'variable' => 'search_results_per_page',
+			'value' => 30,
+		],
+		[
+			'variable' => 'search_weight_age',
+			'value' => 25,
+		],
+		[
+			'variable' => 'search_weight_first_message',
+			'value' => 10,
+		],
+		[
+			'variable' => 'search_weight_frequency',
+			'value' => 30,
+		],
+		[
+			'variable' => 'search_weight_length',
+			'value' => 20,
+		],
+		[
+			'variable' => 'search_weight_subject',
+			'value' => 15,
+		],
+		[
+			'variable' => 'send_validation_onChange',
+			'value' => 0,
+		],
+		[
+			'variable' => 'send_welcomeEmail',
+			'value' => 1,
+		],
+		[
+			'variable' => 'settings_updated',
+			'value' => 0,
+		],
+		[
+			'variable' => 'signature_settings',
+			'value' => '1,300,0,0,0,0,0,0:',
+		],
+		[
+			'variable' => 'simpleSearch',
+			'value' => 0,
+		],
+		[
+			'variable' => 'smfVersion',
+			'value' => '{$smf_version}',
+		],
+		[
+			'variable' => 'smiley_sets_default',
+			'value' => 'default',
+		],
+		[
+			'variable' => 'smiley_sets_known',
+			'value' => 'default,aaron,akyhne',
+		],
+		[
+			'variable' => 'smiley_sets_names',
+			'value' => '{$default_smileyset_name}' . "\n" . '{$default_aaron_smileyset_name}' . "\n" . '{$default_akyhne_smileyset_name}',
+		],
+		[
+			'variable' => 'smileys_dir',
+			'value' => '{$boarddir}/Smileys',
+		],
+		[
+			'variable' => 'smileys_url',
+			'value' => '{$boardurl}/Smileys',
+		],
+		[
+			'variable' => 'smtp_host',
+			'value' => '',
+		],
+		[
+			'variable' => 'smtp_password',
+			'value' => '',
+		],
+		[
+			'variable' => 'smtp_port',
+			'value' => 25,
+		],
+		[
+			'variable' => 'smtp_username',
+			'value' => '',
+		],
+		[
+			'variable' => 'spamWaitTime',
+			'value' => 5,
+		],
+		[
+			'variable' => 'theme_allow',
+			'value' => 1,
+		],
+		[
+			'variable' => 'theme_default',
+			'value' => 1,
+		],
+		[
+			'variable' => 'theme_guests',
+			'value' => 1,
+		],
+		[
+			'variable' => 'timeLoadPageEnable',
+			'value' => 0,
+		],
+		[
+			'variable' => 'time_format',
+			'value' => '{$default_time_format}',
+		],
+		[
+			'variable' => 'time_offset',
+			'value' => 0,
+		],
+		[
+			'variable' => 'titlesEnable',
+			'value' => 1,
+		],
+		[
+			'variable' => 'todayMod',
+			'value' => 1,
+		],
+		[
+			'variable' => 'topicSummaryPosts',
+			'value' => 15,
+		],
+		[
+			'variable' => 'totalMembers',
+			'value' => 0,
+		],
+		[
+			'variable' => 'totalMessages',
+			'value' => 1,
+		],
+		[
+			'variable' => 'totalTopics',
+			'value' => 1,
+		],
+		[
+			'variable' => 'trackStats',
+			'value' => 1,
+		],
+		[
+			'variable' => 'unapprovedMembers',
+			'value' => 0,
+		],
+		[
+			'variable' => 'userLanguage',
+			'value' => 1,
+		],
+		[
+			'variable' => 'visual_verification_type',
+			'value' => 3,
+		],
+		[
+			'variable' => 'warning_moderate',
+			'value' => 35,
+		],
+		[
+			'variable' => 'warning_mute',
+			'value' => 60,
+		],
+		[
+			'variable' => 'warning_settings',
+			'value' => '1,20,0',
+		],
+		[
+			'variable' => 'warning_watch',
+			'value' => 10,
+		],
+		[
+			'variable' => 'who_enabled',
+			'value' => 1,
+		],
+		[
+			'variable' => 'xmlnews_enable',
+			'value' => 1,
+		],
+		[
+			'variable' => 'xmlnews_maxlen',
+			'value' => 255,
+		],
+	];
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'settings';
+
+		$this->columns = [
+			'variable' => new Column(
+				name: 'variable',
+				type: 'varchar',
+				size: 255,
+				not_null: true,
+				default: '',
+			),
+			'value' => new Column(
+				name: 'value',
+				type: 'text',
+				not_null: true,
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'variable',
+						'size' => 30,
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v2_0/Smileys.php
+++ b/Sources/Db/Schema/v2_0/Smileys.php
@@ -1,0 +1,103 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v2_0;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class Smileys extends Table
+{
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'smileys';
+
+		$this->columns = [
+			'id_smiley' => new Column(
+				name: 'id_smiley',
+				type: 'smallint',
+				unsigned: true,
+				not_null: true,
+				auto: true,
+			),
+			'code' => new Column(
+				name: 'code',
+				type: 'varchar',
+				size: 30,
+				not_null: true,
+				default: '',
+			),
+			'filename' => new Column(
+				name: 'filename',
+				type: 'varchar',
+				size: 48,
+				not_null: true,
+				default: '',
+			),
+			'description' => new Column(
+				name: 'description',
+				type: 'varchar',
+				size: 80,
+				not_null: true,
+				default: '',
+			),
+			'smiley_row' => new Column(
+				name: 'smiley_row',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'smiley_order' => new Column(
+				name: 'smiley_order',
+				type: 'smallint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'hidden' => new Column(
+				name: 'hidden',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'id_smiley',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v2_0/Spiders.php
+++ b/Sources/Db/Schema/v2_0/Spiders.php
@@ -1,0 +1,208 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v2_0;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class Spiders extends Table
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 * @var array
+	 *
+	 * Data used to populate the table during install.
+	 */
+	public array $initial_data = [
+		[
+			'id_spider' => 1,
+			'spider_name' => 'Google',
+			'user_agent' => 'googlebot',
+			'ip_info' => '',
+		],
+		[
+			'id_spider' => 2,
+			'spider_name' => 'Yahoo!',
+			'user_agent' => 'slurp',
+			'ip_info' => '',
+		],
+		[
+			'id_spider' => 3,
+			'spider_name' => 'MSN',
+			'user_agent' => 'msnbot',
+			'ip_info' => '',
+		],
+		[
+			'id_spider' => 4,
+			'spider_name' => 'Google (Mobile)',
+			'user_agent' => 'Googlebot-Mobile',
+			'ip_info' => '',
+		],
+		[
+			'id_spider' => 5,
+			'spider_name' => 'Google (Image)',
+			'user_agent' => 'Googlebot-Image',
+			'ip_info' => '',
+		],
+		[
+			'id_spider' => 6,
+			'spider_name' => 'Google (AdSense)',
+			'user_agent' => 'Mediapartners-Google',
+			'ip_info' => '',
+		],
+		[
+			'id_spider' => 7,
+			'spider_name' => 'Google (Adwords)',
+			'user_agent' => 'AdsBot-Google',
+			'ip_info' => '',
+		],
+		[
+			'id_spider' => 8,
+			'spider_name' => 'Yahoo! (Mobile)',
+			'user_agent' => 'YahooSeeker/M1A1-R2D2',
+			'ip_info' => '',
+		],
+		[
+			'id_spider' => 9,
+			'spider_name' => 'Yahoo! (Image)',
+			'user_agent' => 'Yahoo-MMCrawler',
+			'ip_info' => '',
+		],
+		[
+			'id_spider' => 10,
+			'spider_name' => 'MSN (Mobile)',
+			'user_agent' => 'MSNBOT_Mobile',
+			'ip_info' => '',
+		],
+		[
+			'id_spider' => 11,
+			'spider_name' => 'MSN (Media)',
+			'user_agent' => 'msnbot-media',
+			'ip_info' => '',
+		],
+		[
+			'id_spider' => 12,
+			'spider_name' => 'Cuil',
+			'user_agent' => 'twiceler',
+			'ip_info' => '',
+		],
+		[
+			'id_spider' => 13,
+			'spider_name' => 'Ask',
+			'user_agent' => 'Teoma',
+			'ip_info' => '',
+		],
+		[
+			'id_spider' => 14,
+			'spider_name' => 'Baidu',
+			'user_agent' => 'Baiduspider',
+			'ip_info' => '',
+		],
+		[
+			'id_spider' => 15,
+			'spider_name' => 'Gigablast',
+			'user_agent' => 'Gigabot',
+			'ip_info' => '',
+		],
+		[
+			'id_spider' => 16,
+			'spider_name' => 'InternetArchive',
+			'user_agent' => 'ia_archiver-web.archive.org',
+			'ip_info' => '',
+		],
+		[
+			'id_spider' => 17,
+			'spider_name' => 'Alexa',
+			'user_agent' => 'ia_archiver',
+			'ip_info' => '',
+		],
+		[
+			'id_spider' => 18,
+			'spider_name' => 'Omgili',
+			'user_agent' => 'omgilibot',
+			'ip_info' => '',
+		],
+		[
+			'id_spider' => 19,
+			'spider_name' => 'EntireWeb',
+			'user_agent' => 'Speedy Spider',
+			'ip_info' => '',
+		],
+	];
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'spiders';
+
+		$this->columns = [
+			'id_spider' => new Column(
+				name: 'id_spider',
+				type: 'smallint',
+				unsigned: true,
+				not_null: true,
+				auto: true,
+			),
+			'spider_name' => new Column(
+				name: 'spider_name',
+				type: 'varchar',
+				size: 255,
+				not_null: true,
+				default: '',
+			),
+			'user_agent' => new Column(
+				name: 'user_agent',
+				type: 'varchar',
+				size: 255,
+				not_null: true,
+				default: '',
+			),
+			'ip_info' => new Column(
+				name: 'ip_info',
+				type: 'varchar',
+				size: 255,
+				not_null: true,
+				default: '',
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'id_spider',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v2_0/Subscriptions.php
+++ b/Sources/Db/Schema/v2_0/Subscriptions.php
@@ -1,0 +1,137 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v2_0;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class Subscriptions extends Table
+{
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'subscriptions';
+
+		$this->columns = [
+			'id_subscribe' => new Column(
+				name: 'id_subscribe',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				auto: true,
+			),
+			'name' => new Column(
+				name: 'name',
+				type: 'varchar',
+				size: 60,
+				not_null: true,
+				default: '',
+			),
+			'description' => new Column(
+				name: 'description',
+				type: 'varchar',
+				size: 255,
+				not_null: true,
+				default: '',
+			),
+			'cost' => new Column(
+				name: 'cost',
+				type: 'text',
+				not_null: true,
+			),
+			'length' => new Column(
+				name: 'length',
+				type: 'varchar',
+				size: 6,
+				not_null: true,
+				default: '',
+			),
+			'id_group' => new Column(
+				name: 'id_group',
+				type: 'smallint',
+				not_null: true,
+				default: 0,
+			),
+			'add_groups' => new Column(
+				name: 'add_groups',
+				type: 'varchar',
+				size: 40,
+				not_null: true,
+				default: '',
+			),
+			'active' => new Column(
+				name: 'active',
+				type: 'tinyint',
+				not_null: true,
+				default: 1,
+			),
+			'repeatable' => new Column(
+				name: 'repeatable',
+				type: 'tinyint',
+				not_null: true,
+				default: 0,
+			),
+			'allow_partial' => new Column(
+				name: 'allow_partial',
+				type: 'tinyint',
+				not_null: true,
+				default: 0,
+			),
+			'reminder' => new Column(
+				name: 'reminder',
+				type: 'tinyint',
+				not_null: true,
+				default: 0,
+			),
+			'email_complete' => new Column(
+				name: 'email_complete',
+				type: 'text',
+				not_null: true,
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'id_subscribe',
+					],
+				],
+			),
+			'active' => new DbIndex(
+				name: 'active',
+				columns: [
+					[
+						'name' => 'active',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v2_0/Themes.php
+++ b/Sources/Db/Schema/v2_0/Themes.php
@@ -1,0 +1,263 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v2_0;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class Themes extends Table
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 * @var array
+	 *
+	 * Data used to populate the table during install.
+	 */
+	public array $initial_data = [
+		[
+			'id_theme' => 1,
+			'variable' => 'name',
+			'value' => '{$default_theme_name}',
+		],
+		[
+			'id_theme' => 1,
+			'variable' => 'theme_url',
+			'value' => '{$boardurl}/Themes/default',
+		],
+		[
+			'id_theme' => 1,
+			'variable' => 'images_url',
+			'value' => '{$boardurl}/Themes/default/images',
+		],
+		[
+			'id_theme' => 1,
+			'variable' => 'theme_dir',
+			'value' => '{$boarddir}/Themes/default',
+		],
+		[
+			'id_theme' => 1,
+			'variable' => 'show_bbc',
+			'value' => 1,
+		],
+		[
+			'id_theme' => 1,
+			'variable' => 'show_latest_member',
+			'value' => 1,
+		],
+		[
+			'id_theme' => 1,
+			'variable' => 'show_modify',
+			'value' => 1,
+		],
+		[
+			'id_theme' => 1,
+			'variable' => 'show_user_images',
+			'value' => 1,
+		],
+		[
+			'id_theme' => 1,
+			'variable' => 'show_blurb',
+			'value' => 1,
+		],
+		[
+			'id_theme' => 1,
+			'variable' => 'show_gender',
+			'value' => 0,
+		],
+		[
+			'id_theme' => 1,
+			'variable' => 'show_newsfader',
+			'value' => 0,
+		],
+		[
+			'id_theme' => 1,
+			'variable' => 'number_recent_posts',
+			'value' => 0,
+		],
+		[
+			'id_theme' => 1,
+			'variable' => 'show_member_bar',
+			'value' => 1,
+		],
+		[
+			'id_theme' => 1,
+			'variable' => 'linktree_link',
+			'value' => 1,
+		],
+		[
+			'id_theme' => 1,
+			'variable' => 'show_profile_buttons',
+			'value' => 1,
+		],
+		[
+			'id_theme' => 1,
+			'variable' => 'show_mark_read',
+			'value' => 1,
+		],
+		[
+			'id_theme' => 1,
+			'variable' => 'show_stats_index',
+			'value' => 1,
+		],
+		[
+			'id_theme' => 1,
+			'variable' => 'linktree_inline',
+			'value' => 0,
+		],
+		[
+			'id_theme' => 1,
+			'variable' => 'show_board_desc',
+			'value' => 1,
+		],
+		[
+			'id_theme' => 1,
+			'variable' => 'newsfader_time',
+			'value' => 5000,
+		],
+		[
+			'id_theme' => 1,
+			'variable' => 'allow_no_censored',
+			'value' => 0,
+		],
+		[
+			'id_theme' => 1,
+			'variable' => 'additional_options_collapsable',
+			'value' => 1,
+		],
+		[
+			'id_theme' => 1,
+			'variable' => 'use_image_buttons',
+			'value' => 1,
+		],
+		[
+			'id_theme' => 1,
+			'variable' => 'enable_news',
+			'value' => 1,
+		],
+		[
+			'id_theme' => 1,
+			'variable' => 'forum_width',
+			'value' => '90%',
+		],
+		[
+			'id_theme' => 2,
+			'variable' => 'name',
+			'value' => '{$default_core_theme_name}',
+		],
+		[
+			'id_theme' => 2,
+			'variable' => 'theme_url',
+			'value' => '{$boardurl}/Themes/core',
+		],
+		[
+			'id_theme' => 2,
+			'variable' => 'images_url',
+			'value' => '{$boardurl}/Themes/core/images',
+		],
+		[
+			'id_theme' => 2,
+			'variable' => 'theme_dir',
+			'value' => '{$boarddir}/Themes/core',
+		],
+		[
+			'id_member' => -1,
+			'id_theme' => 1,
+			'variable' => 'display_quick_reply',
+			'value' => 1,
+		],
+		[
+			'id_member' => -1,
+			'id_theme' => 1,
+			'variable' => 'posts_apply_ignore_list',
+			'value' => 1,
+		],
+	];
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'themes';
+
+		$this->columns = [
+			'id_member' => new Column(
+				name: 'id_member',
+				type: 'mediumint',
+				not_null: true,
+				default: 0,
+			),
+			'id_theme' => new Column(
+				name: 'id_theme',
+				type: 'tinyint',
+				unsigned: true,
+				not_null: true,
+				default: 1,
+			),
+			'variable' => new Column(
+				name: 'variable',
+				type: 'varchar',
+				size: 255,
+				not_null: true,
+				default: '',
+			),
+			'value' => new Column(
+				name: 'value',
+				type: 'text',
+				not_null: true,
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'id_theme',
+					],
+					[
+						'name' => 'id_member',
+					],
+					[
+						'name' => 'variable',
+						'size' => 30,
+					],
+				],
+			),
+			'id_member' => new DbIndex(
+				name: 'id_member',
+				columns: [
+					[
+						'name' => 'id_member',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v2_0/Topics.php
+++ b/Sources/Db/Schema/v2_0/Topics.php
@@ -1,0 +1,269 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2023 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v2_0;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class Topics extends Table
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 * @var array
+	 *
+	 * Data used to populate the table during install.
+	 */
+	public array $initial_data = [
+		[
+			'id_topic' => 1,
+			'id_board' => 1,
+			'id_first_msg' => 1,
+			'id_last_msg' => 1,
+			'id_member_started' => 0,
+			'id_member_updated' => 0,
+		],
+	];
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'topics';
+
+		$this->columns = [
+			'id_topic' => new Column(
+				name: 'id_topic',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				auto: true,
+			),
+			'is_sticky' => new Column(
+				name: 'is_sticky',
+				type: 'tinyint',
+				not_null: true,
+				default: 0,
+			),
+			'id_board' => new Column(
+				name: 'id_board',
+				type: 'smallint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'id_first_msg' => new Column(
+				name: 'id_first_msg',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'id_last_msg' => new Column(
+				name: 'id_last_msg',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'id_member_started' => new Column(
+				name: 'id_member_started',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'id_member_updated' => new Column(
+				name: 'id_member_updated',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'id_poll' => new Column(
+				name: 'id_poll',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'id_previous_board' => new Column(
+				name: 'id_previous_board',
+				type: 'smallint',
+				not_null: true,
+				default: 0,
+			),
+			'id_previous_topic' => new Column(
+				name: 'id_previous_topic',
+				type: 'mediumint',
+				not_null: true,
+				default: 0,
+			),
+			'num_replies' => new Column(
+				name: 'num_replies',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'num_views' => new Column(
+				name: 'num_views',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'locked' => new Column(
+				name: 'locked',
+				type: 'tinyint',
+				not_null: true,
+				default: 0,
+			),
+			'unapproved_posts' => new Column(
+				name: 'unapproved_posts',
+				type: 'smallint',
+				not_null: true,
+				default: 0,
+			),
+			'approved' => new Column(
+				name: 'approved',
+				type: 'tinyint',
+				not_null: true,
+				default: 1,
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'id_topic',
+					],
+				],
+			),
+			'last_message' => new DbIndex(
+				type: 'unique',
+				name: 'last_message',
+				columns: [
+					[
+						'name' => 'id_last_msg',
+					],
+					[
+						'name' => 'id_board',
+					],
+				],
+			),
+			'first_message' => new DbIndex(
+				type: 'unique',
+				name: 'first_message',
+				columns: [
+					[
+						'name' => 'id_first_msg',
+					],
+					[
+						'name' => 'id_board',
+					],
+				],
+			),
+			'poll' => new DbIndex(
+				type: 'unique',
+				name: 'poll',
+				columns: [
+					[
+						'name' => 'id_poll',
+					],
+					[
+						'name' => 'id_topic',
+					],
+				],
+			),
+			'is_sticky' => new DbIndex(
+				name: 'is_sticky',
+				columns: [
+					[
+						'name' => 'is_sticky',
+					],
+				],
+			),
+			'approved' => new DbIndex(
+				name: 'approved',
+				columns: [
+					[
+						'name' => 'approved',
+					],
+				],
+			),
+			'id_board' => new DbIndex(
+				name: 'id_board',
+				columns: [
+					[
+						'name' => 'id_board',
+					],
+				],
+			),
+			'member_started' => new DbIndex(
+				name: 'member_started',
+				columns: [
+					[
+						'name' => 'id_member_started',
+					],
+					[
+						'name' => 'id_board',
+					],
+				],
+			),
+			'last_message_sticky' => new DbIndex(
+				name: 'last_message_sticky',
+				columns: [
+					[
+						'name' => 'id_board',
+					],
+					[
+						'name' => 'is_sticky',
+					],
+					[
+						'name' => 'id_last_msg',
+					],
+				],
+			),
+			'board_news' => new DbIndex(
+				name: 'board_news',
+				columns: [
+					[
+						'name' => 'id_board',
+					],
+					[
+						'name' => 'id_first_msg',
+					],
+				],
+			),
+		];
+
+		parent::__construct();
+	}
+}

--- a/Sources/Db/Schema/v2_0/index.php
+++ b/Sources/Db/Schema/v2_0/index.php
@@ -1,0 +1,8 @@
+<?php
+
+// Try to handle it with the upper level index.php. (it should know what to do.)
+if (file_exists(dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php')) {
+	include dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php';
+} else {
+	exit;
+}

--- a/Sources/Maintenance/Cleanup/CleanupBase.php
+++ b/Sources/Maintenance/Cleanup/CleanupBase.php
@@ -38,9 +38,7 @@ abstract class CleanupBase implements SubStepInterface
 	 ****************/
 
 	/**
-	 * Check if the task should be performed or not.
 	 *
-	 * @return bool True if this task needs to be run, false otherwise.
 	 */
 	public function isCandidate(): bool
 	{

--- a/Sources/Maintenance/Cleanup/OldFilesBase.php
+++ b/Sources/Maintenance/Cleanup/OldFilesBase.php
@@ -13,13 +13,16 @@
 
 declare(strict_types=1);
 
-namespace SMF\Maintenance\Cleanup\v3_0;
+namespace SMF\Maintenance\Cleanup;
 
 use SMF\Config;
-use SMF\Maintenance\Cleanup\CleanupBase;
 use SMF\Utils;
 
-class OldFiles extends CleanupBase
+/**
+ * Base class for cleanup tasks that delete files that have been removed in a
+ * new version of SMF.
+ */
+abstract class OldFilesBase extends CleanupBase
 {
 	/*******************
 	 * Public properties
@@ -37,7 +40,7 @@ class OldFiles extends CleanupBase
 	/**
 	 * @var array
 	 *
-	 * List of files removed in SMF 3.0.
+	 * List of files removed in the relevant version of SMF.
 	 */
 	protected array $removed = [
 		// Files in the Themes directory.
@@ -57,9 +60,7 @@ class OldFiles extends CleanupBase
 	 ****************/
 
 	/**
-	 * Check if the task should be performed or not.
 	 *
-	 * @return bool True if this task needs to be run, false otherwise.
 	 */
 	public function isCandidate(): bool
 	{

--- a/Sources/Maintenance/Cleanup/v1_0/RemoveObsoleteSettings.php
+++ b/Sources/Maintenance/Cleanup/v1_0/RemoveObsoleteSettings.php
@@ -1,0 +1,387 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Cleanup\v1_0;
+
+use SMF\IntegrationHook;
+use SMF\Maintenance\Cleanup\CleanupBase;
+use SMF\Utils;
+
+class RemoveObsoleteSettings extends CleanupBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 * @var string
+	 *
+	 * Name of the cleanup task.
+	 */
+	public string $name = 'Removing obsolete settings';
+
+	/**
+	 * @var array
+	 *
+	 * Settings to delete.
+	 */
+	public array $obsolete_settings_defs = [
+		'guestaccess' => [
+			'default' => 0,
+			'auto_delete' => 3,
+			'type' => 'integer',
+		],
+		'yyForceIIS' => [
+			'default' => 0,
+			'auto_delete' => 3,
+			'type' => 'integer',
+		],
+		'yyblankpageIIS' => [
+			'default' => 0,
+			'auto_delete' => 3,
+			'type' => 'integer',
+		],
+		'Cookie_Length' => [
+			'default' => 0,
+			'auto_delete' => 3,
+			'type' => 'integer',
+		],
+		'RegAgree' => [
+			'default' => 0,
+			'auto_delete' => 3,
+			'type' => 'integer',
+		],
+		'emailpassword' => [
+			'default' => 0,
+			'auto_delete' => 3,
+			'type' => 'integer',
+		],
+		'emailnewpass' => [
+			'default' => 0,
+			'auto_delete' => 3,
+			'type' => 'integer',
+		],
+		'emailwelcome' => [
+			'default' => 0,
+			'auto_delete' => 3,
+			'type' => 'integer',
+		],
+		'mailprog' => [
+			'default' => '',
+			'auto_delete' => 3,
+			'type' => 'string',
+		],
+		'smtp_server' => [
+			'default' => '',
+			'auto_delete' => 3,
+			'type' => 'string',
+		],
+		'mailtype' => [
+			'default' => 0,
+			'auto_delete' => 3,
+			'type' => 'integer',
+		],
+		'facesdir' => [
+			'default' => '',
+			'auto_delete' => 3,
+			'type' => 'string',
+		],
+		'facesurl' => [
+			'default' => '',
+			'auto_delete' => 3,
+			'type' => 'string',
+		],
+		'imagesdir' => [
+			'default' => '',
+			'auto_delete' => 3,
+			'type' => 'string',
+		],
+		'ubbcjspath' => [
+			'default' => '',
+			'auto_delete' => 3,
+			'type' => 'string',
+		],
+		'faderpath' => [
+			'default' => '',
+			'auto_delete' => 3,
+			'type' => 'string',
+		],
+		'helpfile' => [
+			'default' => '',
+			'auto_delete' => 3,
+			'type' => 'string',
+		],
+		'MenuType' => [
+			'default' => 0,
+			'auto_delete' => 3,
+			'type' => 'integer',
+		],
+		'curposlinks' => [
+			'default' => 0,
+			'auto_delete' => 3,
+			'type' => 'integer',
+		],
+		'profilebutton' => [
+			'default' => 0,
+			'auto_delete' => 3,
+			'type' => 'integer',
+		],
+		'timeformatstring' => [
+			'default' => '',
+			'auto_delete' => 3,
+			'type' => 'string',
+		],
+		'allow_hide_email' => [
+			'default' => 0,
+			'auto_delete' => 3,
+			'type' => 'integer',
+		],
+		'showlatestmember' => [
+			'default' => 0,
+			'auto_delete' => 3,
+			'type' => 'integer',
+		],
+		'shownewsfader' => [
+			'default' => 0,
+			'auto_delete' => 3,
+			'type' => 'integer',
+		],
+		'Show_RecentBar' => [
+			'default' => 0,
+			'auto_delete' => 3,
+			'type' => 'integer',
+		],
+		'Show_MemberBar' => [
+			'default' => 0,
+			'auto_delete' => 3,
+			'type' => 'integer',
+		],
+		'showmarkread' => [
+			'default' => 0,
+			'auto_delete' => 3,
+			'type' => 'integer',
+		],
+		'showmodify' => [
+			'default' => 0,
+			'auto_delete' => 3,
+			'type' => 'integer',
+		],
+		'ShowBDescrip' => [
+			'default' => 0,
+			'auto_delete' => 3,
+			'type' => 'integer',
+		],
+		'showuserpic' => [
+			'default' => 0,
+			'auto_delete' => 3,
+			'type' => 'integer',
+		],
+		'showusertext' => [
+			'default' => 0,
+			'auto_delete' => 3,
+			'type' => 'integer',
+		],
+		'showgenderimage' => [
+			'default' => 0,
+			'auto_delete' => 3,
+			'type' => 'integer',
+		],
+		'showyabbcbutt' => [
+			'default' => 0,
+			'auto_delete' => 3,
+			'type' => 'integer',
+		],
+		'enable_ubbc' => [
+			'default' => 0,
+			'auto_delete' => 3,
+			'type' => 'integer',
+		],
+		'enable_news' => [
+			'default' => 0,
+			'auto_delete' => 3,
+			'type' => 'integer',
+		],
+		'allowpics' => [
+			'default' => 0,
+			'auto_delete' => 3,
+			'type' => 'integer',
+		],
+		'enable_guestposting' => [
+			'default' => 0,
+			'auto_delete' => 3,
+			'type' => 'integer',
+		],
+		'enable_notification' => [
+			'default' => 0,
+			'auto_delete' => 3,
+			'type' => 'integer',
+		],
+		'autolinkurls' => [
+			'default' => 0,
+			'auto_delete' => 3,
+			'type' => 'integer',
+		],
+		'timeoffset' => [
+			'default' => 0,
+			'auto_delete' => 3,
+			'type' => 'integer',
+		],
+		'TopAmmount' => [
+			'default' => 0,
+			'auto_delete' => 3,
+			'type' => 'integer',
+		],
+		'MembersPerPage' => [
+			'default' => 0,
+			'auto_delete' => 3,
+			'type' => 'integer',
+		],
+		'maxdisplay' => [
+			'default' => 0,
+			'auto_delete' => 3,
+			'type' => 'integer',
+		],
+		'maxmessagedisplay' => [
+			'default' => 0,
+			'auto_delete' => 3,
+			'type' => 'integer',
+		],
+		'MaxMessLen' => [
+			'default' => 0,
+			'auto_delete' => 3,
+			'type' => 'integer',
+		],
+		'MaxSigLen' => [
+			'default' => 0,
+			'auto_delete' => 3,
+			'type' => 'integer',
+		],
+		'ClickLogTime' => [
+			'default' => 0,
+			'auto_delete' => 3,
+			'type' => 'integer',
+		],
+		'max_log_days_old' => [
+			'default' => 0,
+			'auto_delete' => 3,
+			'type' => 'integer',
+		],
+		'fadertime' => [
+			'default' => 0,
+			'auto_delete' => 3,
+			'type' => 'integer',
+		],
+		'timeout' => [
+			'default' => 0,
+			'auto_delete' => 3,
+			'type' => 'integer',
+		],
+		'JrPostNum' => [
+			'default' => 0,
+			'auto_delete' => 3,
+			'type' => 'integer',
+		],
+		'FullPostNum' => [
+			'default' => 0,
+			'auto_delete' => 3,
+			'type' => 'integer',
+		],
+		'SrPostNum' => [
+			'default' => 0,
+			'auto_delete' => 3,
+			'type' => 'integer',
+		],
+		'GodPostNum' => [
+			'default' => 0,
+			'auto_delete' => 3,
+			'type' => 'integer',
+		],
+		'userpic_width' => [
+			'default' => 0,
+			'auto_delete' => 3,
+			'type' => 'integer',
+		],
+		'userpic_height' => [
+			'default' => 0,
+			'auto_delete' => 3,
+			'type' => 'integer',
+		],
+		'userpic_limits' => [
+			'default' => '',
+			'auto_delete' => 3,
+			'type' => 'string',
+		],
+		'color' => [
+			'default' => null,
+			'auto_delete' => 3,
+			'type' => ['NULL', 'array'],
+			// Special search pattern needed because YaBB's settings file used a
+			// separate statement for each element of this array.
+			'search_pattern' => '/^\$color(\s*=\s*array\s*(?P<parentheses_a>\((?' . '>[^()]|(?P>parentheses_a))*\))|(?P<brackets>\[(?' . '>[^\[\]]|(?P>brackets))*\])|\[(?P<quote_k>["\'])\w+(?P>quote_k)\]\s*=\s*(?P<quote_v>["\'])(?:.(?!(?P>quote_v))|\\\(?=(?P>quote_v)))*.?(?P>quote_v))\s*;\h*$/m',
+		],
+	];
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function isCandidate(): bool
+	{
+		return (bool) preg_match(
+			'/\$' . Utils::buildRegex(array_keys(self::$obsolete_settings_defs), '/') . '\b/',
+			file_get_contents(SMF_SETTINGS_FILE),
+		);
+	}
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		// Add the obsolete settings to the list of defined settings.
+		IntegrationHook::add('integrate_update_settings_file', __CLASS__ . '::addSettingsDefs', false);
+
+		// Delete all the obsolete settings and rebuild the file.
+		Maintenance::$tool->updateSettingsFile(
+			config_vars: array_combine(
+				array_keys(self::$obsolete_settings_defs),
+				array_map(fn($def) => $def['default'], self::$obsolete_settings_defs),
+			),
+			rebuild: true,
+		);
+
+		// Remove the obsolete settings from the list of defined settings.
+		IntegrationHook::remove('integrate_update_settings_file', __CLASS__ . '::addSettingsDefs', false);
+
+		return true;
+	}
+
+	/***********************
+	 * Public static methods
+	 ***********************/
+
+	/**
+	 * Adds the obsolete YaBB SE settings to the list of defined settings.
+	 *
+	 * @param array &$settings_defs A reference to Config::$settings_defs.
+	 */
+	public static function addSettingsDefs(array &$settings_defs): void
+	{
+		$settings_defs += self::$obsolete_settings_defs;
+	}
+}

--- a/Sources/Maintenance/Cleanup/v1_0/index.php
+++ b/Sources/Maintenance/Cleanup/v1_0/index.php
@@ -1,0 +1,8 @@
+<?php
+
+// Try to handle it with the upper level index.php. (it should know what to do.)
+if (file_exists(dirname(__DIR__) . '/index.php')) {
+	include dirname(__DIR__) . '/index.php';
+} else {
+	exit;
+}

--- a/Sources/Maintenance/Cleanup/v1_1/OldFiles.php
+++ b/Sources/Maintenance/Cleanup/v1_1/OldFiles.php
@@ -13,12 +13,12 @@
 
 declare(strict_types=1);
 
-namespace SMF\Maintenance\Cleanup\v2_0;
+namespace SMF\Maintenance\Cleanup\v1_1;
 
 use SMF\Maintenance\Cleanup\OldFilesBase;
 
 /**
- * Deletes files that were present in SMF 1.1 but not in SMF 2.0.
+ * Deletes files that were present in SMF 1.0 but not in SMF 1.1.
  */
 class OldFiles extends OldFilesBase
 {
@@ -29,17 +29,21 @@ class OldFiles extends OldFilesBase
 	/**
 	 * @var array
 	 *
-	 * List of files removed in SMF 2.0.
+	 * List of files removed in SMF 1.1.
 	 */
 	protected array $removed = [
 		// Files in the Themes directory.
 		'themedir' => [
-			'babylon',
+			'default/Combat.template.php',
+			'default/Modlog.template.php',
+			'default/fader.js',
+			'default/script.js',
+			'default/spellcheck.js',
+			'default/xml_board.js',
+			'default/xml_topic.js',
 		],
 		// Files in the Sources directory.
-		'sourcedir' => [
-			'ModSettings.php',
-		],
+		'sourcedir' => [],
 		// Files in the Smileys directory.
 		'smileysdir' => [],
 		// Files in the avatars directory.

--- a/Sources/Maintenance/Cleanup/v1_1/RemoveTempSettings.php
+++ b/Sources/Maintenance/Cleanup/v1_1/RemoveTempSettings.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Cleanup\v1_1;
+
+use SMF\Config;
+use SMF\Maintenance\Cleanup\CleanupBase;
+
+class RemoveTempSettings extends CleanupBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 * @var string
+	 *
+	 * Name of the cleanup task.
+	 */
+	public string $name = 'Removing temporary settings';
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		Config::updateModSettings([
+			'dont_repeat_smtp' => null,
+			'dont_repeat_theme' => null,
+		]);
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Cleanup/v1_1/index.php
+++ b/Sources/Maintenance/Cleanup/v1_1/index.php
@@ -1,0 +1,8 @@
+<?php
+
+// Try to handle it with the upper level index.php. (it should know what to do.)
+if (file_exists(dirname(__DIR__) . '/index.php')) {
+	include dirname(__DIR__) . '/index.php';
+} else {
+	exit;
+}

--- a/Sources/Maintenance/Cleanup/v2_0/OldFiles.php
+++ b/Sources/Maintenance/Cleanup/v2_0/OldFiles.php
@@ -5,20 +5,20 @@
  *
  * @package SMF
  * @author Simple Machines https://www.simplemachines.org
- * @copyright 2026 Simple Machines and individual contributors
+ * @copyright 2024 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 3
  */
 
 declare(strict_types=1);
 
-namespace SMF\Maintenance\Cleanup\v2_1;
+namespace SMF\Maintenance\Cleanup\v2_0;
 
 use SMF\Maintenance\Cleanup\OldFilesBase;
 
 /**
- * Deletes files that were present in SMF 2.0 but not in SMF 2.1.
+ * Deletes files that were present in SMF 1.1 but not in SMF 2.0.
  */
 class OldFiles extends OldFilesBase
 {
@@ -29,17 +29,24 @@ class OldFiles extends OldFilesBase
 	/**
 	 * @var array
 	 *
-	 * List of files removed in SMF 2.1.
+	 * List of files removed in SMF 2.0 (and earlier).
 	 */
 	protected array $removed = [
 		// Files in the Themes directory.
 		'themedir' => [
-			'core',
+			'babylon',
+			// Removed in 1.1.
+			'default/Combat.template.php',
+			'default/Modlog.template.php',
+			'default/fader.js',
+			'default/script.js',
+			'default/spellcheck.js',
+			'default/xml_board.js',
+			'default/xml_topic.js',
 		],
 		// Files in the Sources directory.
 		'sourcedir' => [
-			'DumpDatabase.php',
-			'LockTopic.php',
+			'ModSettings.php',
 		],
 		// Files in the Smileys directory.
 		'smileysdir' => [],

--- a/Sources/Maintenance/Cleanup/v2_0/index.php
+++ b/Sources/Maintenance/Cleanup/v2_0/index.php
@@ -1,0 +1,8 @@
+<?php
+
+// Try to handle it with the upper level index.php. (it should know what to do.)
+if (file_exists(dirname(__DIR__) . '/index.php')) {
+	include dirname(__DIR__) . '/index.php';
+} else {
+	exit;
+}

--- a/Sources/Maintenance/Cleanup/v2_1/OldFiles.php
+++ b/Sources/Maintenance/Cleanup/v2_1/OldFiles.php
@@ -15,10 +15,10 @@ declare(strict_types=1);
 
 namespace SMF\Maintenance\Cleanup\v2_1;
 
-use SMF\Maintenance\Cleanup\v3_0\OldFiles as OldFilesBase;
+use SMF\Maintenance\Cleanup\OldFilesBase;
 
 /**
- * Just like the v3_0 version of OldFiles, but with a different list of files.
+ * Deletes files that were present in SMF 2.0 but not in SMF 2.1.
  */
 class OldFiles extends OldFilesBase
 {

--- a/Sources/Maintenance/Cleanup/v3_0/TasksDirCase.php
+++ b/Sources/Maintenance/Cleanup/v3_0/TasksDirCase.php
@@ -35,9 +35,7 @@ class TasksDirCase extends CleanupBase
 	 ****************/
 
 	/**
-	 * Check if the task should be performed or not.
 	 *
-	 * @return bool True if this task needs to be run, false otherwise.
 	 */
 	public function isCandidate(): bool
 	{

--- a/Sources/Maintenance/Migration/v1_0/AnnouncementPermissions.php
+++ b/Sources/Maintenance/Migration/v1_0/AnnouncementPermissions.php
@@ -1,0 +1,145 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v1_0;
+
+use SMF\Db\DatabaseApi as Db;
+use SMF\Db\Schema;
+use SMF\Maintenance\Migration\MigrationBase;
+
+class AnnouncementPermissions extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Converting announcement permissions';
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function isCandidate(): bool
+	{
+		$table = new Schema\v1_0\Boards();
+		$structure = $table->getCurrentStructure();
+
+		return array_filter($structure['columns'], fn($c) => $c['name'] === 'notifyAnnouncements') !== [];
+	}
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		$conversions = [
+			'moderate_forum' => ['manage_membergroups', 'manage_bans'],
+			'admin_forum' => ['manage_permissions'],
+			'edit_forum' => ['manage_boards', 'manage_smileys', 'manage_attachments'],
+		];
+
+		foreach ($conversions as $original_permission => $new_permissions) {
+			$inserts = [];
+
+			$result = $this->query(
+				'SELECT ID_GROUP, addDeny
+				FROM {db_prefix}permissions
+				WHERE permission = {string:perm}',
+				[
+					'perm' => $original_permission,
+				],
+			);
+
+			while ($row = Db::$db->fetch_assoc($result)) {
+				foreach ($new_permissions as $new_perm) {
+					$inserts[] = [
+						$new_perm,
+						$row['ID_GROUP'],
+						$row['addDeny'],
+					];
+				}
+			}
+
+			Db::$db->free_result($result);
+
+			if (!empty($inserts)) {
+				Db::$db->insert(
+					method: 'ignore',
+					table: '{db_prefix}permissions',
+					columns: [
+						'permission' => 'string',
+						'ID_GROUP' => 'int',
+						'addDeny' => 'int',
+					],
+					data: $inserts,
+					keys: [],
+				);
+			}
+		}
+
+		$this->query(
+			'DELETE FROM {db_prefix}permissions
+			WHERE permission = {string:perm}',
+			[
+				'perm' => 'edit_forum',
+			],
+		);
+
+		$table = new Schema\v1_0\Boards();
+		$table->dropColumn('notifyAnnouncements');
+
+		$this->handleTimeout();
+
+		return true;
+	}
+
+	/******************
+	 * Internal methods
+	 ******************/
+
+	/**
+	 *
+	 */
+	private function getMemberGroups(): array
+	{
+		$request = $this->query(
+			'SELECT groupName, ID_GROUP
+			FROM {db_prefix}membergroups
+			WHERE ID_GROUP = 1 OR ID_GROUP > 7',
+		);
+
+		if (!$request || Db::$db->num_rows($request) === 0) {
+			$request = $this->query(
+				'SELECT membergroup, ID_GROUP
+				FROM {db_prefix}membergroups
+				WHERE ID_GROUP = 1 OR ID_GROUP > 7',
+			);
+		}
+
+		while ($row = Db::$db->fetch_row($request)) {
+			$member_groups[trim($row[0])] = (int) $row[1];
+		}
+
+		Db::$db->free_result($request);
+
+		return $member_groups;
+	}
+}

--- a/Sources/Maintenance/Migration/v1_0/Attachments.php
+++ b/Sources/Maintenance/Migration/v1_0/Attachments.php
@@ -1,0 +1,70 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v1_0;
+
+use SMF\Maintenance\Migration\MigrationBase;
+
+class Attachments extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Converting attachments';
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		$this->query(
+			'INSERT INTO {db_prefix}attachments
+				(ID_MSG, filename, size)
+			SELECT ID_MSG, SUBSTRING(attachmentFilename, 1, 255), attachmentSize
+			FROM {db_prefix}messages
+			WHERE attachmentFilename IS NOT NULL
+				AND attachmentFilename != {empty}',
+		);
+
+		$this->query(
+			'ALTER TABLE {db_prefix}messages
+			DROP attachmentSize,
+			DROP attachmentFilename',
+		);
+
+		$this->query(
+			'ALTER TABLE {db_prefix}attachments
+			DROP INDEX ID_MEMBER,
+			ADD UNIQUE ID_MEMBER (ID_MEMBER, ID_ATTACH)',
+		);
+
+		$this->query(
+			'ALTER TABLE {db_prefix}attachments
+			CHANGE COLUMN size size int(10) unsigned NOT NULL default {literal:0}',
+		);
+
+		$this->handleTimeout();
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v1_0/Banned.php
+++ b/Sources/Maintenance/Migration/v1_0/Banned.php
@@ -1,0 +1,197 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v1_0;
+
+use SMF\Db\DatabaseApi as Db;
+use SMF\Db\Schema;
+use SMF\IP;
+use SMF\Maintenance\Migration\MigrationBase;
+
+class Banned extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Converting bans';
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function isCandidate(): bool
+	{
+		$table = new Schema\v1_0\Topics();
+		$structure = $table->getCurrentStructure();
+
+		return array_filter($structure['columns'], fn($c) => $c['name'] === 'ip_low1') === [];
+	}
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		$inserts = [];
+
+		// IP bans.
+		$request = $this->query(
+			'SELECT type, value
+			FROM {db_prefix}banned
+			WHERE type = {literal:ip}',
+		);
+
+		while ($row = Db::$db->fetch_assoc($request)) {
+			if (!preg_match('~^\d{1,3}\.(\d{1,3}|\*)\.(\d{1,3}|\*)\.(\d{1,3}|\*)$~', $row['value'])) {
+				continue;
+			}
+
+			$ip_parts = [
+				0 => ['low' => 0, 'high' => 0],
+				1 => ['low' => 0, 'high' => 0],
+				2 => ['low' => 0, 'high' => 0],
+				3 => ['low' => 0, 'high' => 0],
+			];
+
+			foreach (IP::ip2range($row['value']) as $low_or_high => $ip) {
+				foreach (explode('.', (string) $ip) as $octet_num => $octet) {
+					$ip_parts[$octet_num][$low_or_high] = $octet;
+				}
+			}
+
+			$inserts[] = [
+				'ip_ban',
+				$ip_parts[0]['low'],
+				$ip_parts[0]['high'],
+				$ip_parts[1]['low'],
+				$ip_parts[1]['high'],
+				$ip_parts[2]['low'],
+				$ip_parts[2]['high'],
+				$ip_parts[3]['low'],
+				$ip_parts[3]['high'],
+				'',
+				'',
+				0,
+				time(),
+				null,
+				'full_ban',
+				'',
+				'Imported from YaBB SE',
+			];
+		}
+
+		Db::$db->free_result($request);
+
+		// Email bans.
+		$request = $this->query(
+			'SELECT type, value
+			FROM {db_prefix}banned
+			WHERE type = {literal:email}',
+		);
+
+		while ($row = Db::$db->fetch_assoc($request)) {
+			$inserts[] = [
+				'email_ban',
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				'',
+				$row['value'],
+				0,
+				time(),
+				null,
+				'full_ban',
+				'',
+				'Imported from YaBB SE',
+			];
+		}
+
+		Db::$db->free_result($request);
+
+		// Member bans.
+		$request = $this->query(
+			'SELECT b.type, b.value, m.ID_MEMBER
+			FROM {db_prefix}banned AS b
+				INNER JOIN {db_prefix}members AS m ON (b.value = m.memberName)
+			WHERE b.type = {literal:username}',
+		);
+
+		while ($row = Db::$db->fetch_assoc($request)) {
+			$inserts[] = [
+				'user_ban',
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				'',
+				'',
+				$row['ID_MEMBER'],
+				time(),
+				null,
+				'full_ban',
+				'',
+				'Imported from YaBB SE',
+			];
+		}
+
+		Db::$db->free_result($request);
+
+		// Drop the old table.
+		Db::$db->drop_table(Config::$db_prefix . 'banned');
+
+		// Create the new table.
+		$table = new Schema\v1_0\Banned();
+		$table->create();
+
+		// Insert the data.
+		if (!empty($inserts)) {
+			$columns = [];
+
+			foreach ($table->columns as $column) {
+				if ($column->name === 'ID_BAN') {
+					continue;
+				}
+
+				$columns[$column->name] = str_contains($column->type, 'char') || str_contains($column->type, 'text') ? 'string' : 'int';
+			}
+
+			Db::$db->insert(
+				method: '',
+				table: '{db_prefix}banned',
+				columns: $columns,
+				data: $inserts,
+				keys: [],
+			);
+		}
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v1_0/BoardAccess1.php
+++ b/Sources/Maintenance/Migration/v1_0/BoardAccess1.php
@@ -1,0 +1,96 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v1_0;
+
+use SMF\Db\DatabaseApi as Db;
+use SMF\Maintenance\Migration\MigrationBase;
+
+class BoardAccess1 extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Fixing possible issues with board access, part 1';
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function isCandidate(): bool
+	{
+		return version_compare(
+			str_replace(' ', '.', strtolower(Config::$modSettings['smfVersion'] ?? '0.0.dev.0')),
+			'1.0.beta.5',
+			'<=',
+		);
+	}
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		$all_groups = [];
+
+		$result = $this->query(
+			'SELECT ID_GROUP
+			FROM {db_prefix}membergroups',
+		);
+
+		while ($row = Db::$db->fetch_assoc($result)) {
+			$all_groups[] = $row['ID_GROUP'];
+		}
+
+		Db::$db->free_result($result);
+
+		$result = $this->query(
+			'SELECT ID_BOARD, memberGroups
+			FROM {db_prefix}boards
+			WHERE FIND_IN_SET(0, memberGroups)',
+		);
+
+		while ($row = Db::$db->fetch_assoc($result)) {
+			$this->query(
+				'UPDATE {db_prefix}boards
+				SET memberGroups = {string:groups}
+				WHERE ID_BOARD = {int:id}
+				LIMIT 1',
+				[
+					'groups' => implode(',', array_unique(
+						array_merge(
+							array_map('trim', explode(',', $row['memberGroups'])),
+							$all_groups,
+						),
+					)),
+					'id' => $row['ID_BOARD'],
+				],
+			);
+		}
+
+		Db::$db->free_result($result);
+
+		$this->handleTimeout();
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v1_0/BoardAccess2.php
+++ b/Sources/Maintenance/Migration/v1_0/BoardAccess2.php
@@ -1,0 +1,72 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v1_0;
+
+use SMF\Maintenance\Migration\MigrationBase;
+
+class BoardAccess2 extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Fixing possible issues with board access, part 2';
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		$this->query(
+			'UPDATE {db_prefix}boards
+			SET memberGroups = SUBSTRING(memberGroups, 2)
+			WHERE SUBSTRING(memberGroups, 1, 1) = {string:comma}',
+			[
+				'comma' => ',',
+			],
+		);
+
+		$this->query(
+			'UPDATE {db_prefix}boards
+			SET memberGroups = SUBSTRING(memberGroups, 1, LENGTH(memberGroups) - 1)
+			WHERE SUBSTRING(memberGroups, LENGTH(memberGroups)) = {string:comma}',
+			[
+				'comma' => ',',
+			],
+		);
+
+		$this->query(
+			'UPDATE {db_prefix}boards
+			SET memberGroups = REPLACE({string:two_comma}, {string:one_comma}, REPLACE({string:two_comma}, {string:one_comma}, memberGroups))
+			WHERE LOCATE({string:two_comma}, memberGroups)',
+			[
+				'one_comma' => ',',
+				'two_comma' => ',',
+			],
+		);
+
+		$this->handleTimeout();
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v1_0/BoardOrder.php
+++ b/Sources/Maintenance/Migration/v1_0/BoardOrder.php
@@ -1,0 +1,90 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v1_0;
+
+use SMF\Db\DatabaseApi as Db;
+use SMF\Maintenance\Migration\MigrationBase;
+
+class BoardOrder extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Updating board order';
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		$catOrder = -1;
+		$boardOrder = -1;
+		$curCat = -1;
+
+		$request = Db::$db->query(
+			'SELECT c.ID_CAT, c.catOrder, b.ID_BOARD, b.boardOrder
+			FROM {db_prefix}categories AS c
+				LEFT JOIN {db_prefix}boards AS b ON (b.ID_CAT = c.ID_CAT)
+			ORDER BY c.catOrder, b.childLevel, b.boardOrder, b.ID_BOARD',
+		);
+
+		while ($row = Db::$db->fetch_assoc($request)) {
+			if ($curCat != $row['ID_CAT']) {
+				$curCat = $row['ID_CAT'];
+
+				if (++$catOrder != $row['catOrder']) {
+					Db::$db->query(
+						'UPDATE {db_prefix}categories
+						SET catOrder = {int:order}
+						WHERE ID_CAT = {int:id}
+						LIMIT 1',
+						[
+							'order' => $catOrder,
+							'id' => $row['ID_CAT'],
+						],
+					);
+				}
+			}
+
+			if (!empty($row['ID_BOARD']) && ++$boardOrder != $row['boardOrder']) {
+				Db::$db->query(
+					'UPDATE {db_prefix}boards
+					SET boardOrder = {int:order}
+					WHERE ID_BOARD = {int:id}
+					LIMIT 1',
+					[
+						'order' => $boardOrder,
+						'id' => $row['ID_BOARD'],
+					],
+				);
+			}
+		}
+
+		Db::$db->free_result($request);
+
+		$this->handleTimeout();
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v1_0/BoardStats.php
+++ b/Sources/Maintenance/Migration/v1_0/BoardStats.php
@@ -1,0 +1,88 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v1_0;
+
+use SMF\Db\DatabaseApi as Db;
+use SMF\Maintenance\Migration\MigrationBase;
+
+class BoardStats extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Converting board statistics';
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		$result = $this->query(
+			'SELECT MAX(m.ID_MSG) AS ID_LAST_MSG, t.ID_BOARD
+			FROM {db_prefix}messages AS m
+				INNER JOIN {db_prefix}topics AS t ON (m.ID_MSG = t.ID_LAST_MSG)
+			GROUP BY t.ID_BOARD',
+		);
+
+		$last_msgs = [];
+
+		while ($row = Db::$db->fetch_assoc($result)) {
+			$last_msgs[] = $row['ID_LAST_MSG'];
+		}
+
+		Db::$db->free_result($result);
+
+		if (!empty($last_msgs)) {
+			$result = $this->query(
+				'SELECT m.ID_MSG, m.posterTime, t.ID_BOARD
+				FROM {db_prefix}messages AS m
+					INNER JOIN {db_prefix}topics AS t ON (
+						m.ID_MSG = t.ID_LAST_MSG
+						AND m.ID_MSG IN ({array_int:last_msgs})
+					)
+				LIMIT {int:limit}',
+				[
+					'last_msgs' => $last_msgs,
+					'limit' => \count($last_msgs),
+				],
+			);
+
+			while ($row = Db::$db->fetch_assoc($result)) {
+				$this->query(
+					'UPDATE {db_prefix}boards
+					SET ID_LAST_MSG = {int:ID_MSG}, lastUpdated = {int:posterTime}
+					WHERE ID_BOARD = {int:ID_BOARD}
+					LIMIT 1',
+					$row,
+				);
+			}
+
+			Db::$db->free_result($result);
+		}
+
+		$this->handleTimeout();
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v1_0/BoardsAndCategories.php
+++ b/Sources/Maintenance/Migration/v1_0/BoardsAndCategories.php
@@ -1,0 +1,147 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v1_0;
+
+use SMF\Db\DatabaseApi as Db;
+use SMF\Db\Schema;
+use SMF\Maintenance\Migration\MigrationBase;
+
+class BoardsAndCategories extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Converting boards and categories';
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		// Updating the structure of the boards table.
+		$boards_table = new Schema\v1_0\Boards();
+		$boards_table->alterColumn($boards_table->columns['countPosts'], 'count');
+		$boards_table->dropColumn('isAnnouncement');
+		$boards_table->dropColumn('ID_LAST_TOPIC');
+		$boards_table->dropIndex('ID_CAT');
+		$boards_table->dropIndex('memberGroups');
+		$boards_table->normalize();
+
+		// Updating access permissions.
+		$categories_table = new Schema\v1_0\Categories();
+		$cat_structure = $categories_table->getCurrectStructure();
+
+		if (array_filter($cat_structure['columns'], fn($c) => $c['name'] === 'memberGroups') !== []) {
+			$member_groups = $this->getMemberGroups();
+
+			$request = $this->query(
+				'SELECT memberGroups, ID_CAT
+				FROM {db_prefix}categories',
+			);
+
+			while ($row = Db::$db->fetch_assoc($request)) {
+				if (trim($row['memberGroups']) == '') {
+					$groups = '-1,0,2';
+				} else {
+					$memberGroups = array_unique(explode(',', $row['memberGroups']));
+
+					$groups = [2];
+
+					foreach ($memberGroups as $k => $check) {
+						$memberGroups[$k] = trim($memberGroups[$k]);
+
+						if (
+							$memberGroups[$k] == ''
+							|| !isset($member_groups[$memberGroups[$k]])
+							|| $member_groups[$memberGroups[$k]] == 8
+						) {
+							continue;
+						}
+
+						$groups[] = $member_groups[$memberGroups[$k]];
+					}
+
+					$groups = array_unique($groups);
+
+					sort($groups);
+
+					$groups = implode(',', $groups);
+				}
+
+				$this->query(
+					'UPDATE {db_prefix}boards
+					SET memberGroups = {string:groups}, lastUpdated = {int:now}
+					WHERE ID_CAT = {int:cat}',
+					[
+						'groups' => $groups,
+						'now' => time(),
+						'cat' => $row['ID_CAT'],
+					],
+				);
+			}
+
+			Db::$db->free_result($request);
+		}
+
+		// Converting categories table.
+		$categories_table->dropColumn('memberGroups');
+		$categories_table->normalize();
+
+		$this->handleTimeout();
+
+		return true;
+	}
+
+	/******************
+	 * Internal methods
+	 ******************/
+
+	/**
+	 *
+	 */
+	private function getMemberGroups(): array
+	{
+		$request = $this->query(
+			'SELECT groupName, ID_GROUP
+			FROM {db_prefix}membergroups
+			WHERE ID_GROUP = 1 OR ID_GROUP > 7',
+		);
+
+		if (!$request || Db::$db->num_rows($request) === 0) {
+			$request = $this->query(
+				'SELECT membergroup, ID_GROUP
+				FROM {db_prefix}membergroups
+				WHERE ID_GROUP = 1 OR ID_GROUP > 7',
+			);
+		}
+
+		while ($row = Db::$db->fetch_row($request)) {
+			$member_groups[trim($row[0])] = (int) $row[1];
+		}
+
+		Db::$db->free_result($request);
+
+		return $member_groups;
+	}
+}

--- a/Sources/Maintenance/Migration/v1_0/Calendar.php
+++ b/Sources/Maintenance/Migration/v1_0/Calendar.php
@@ -1,0 +1,102 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v1_0;
+
+use SMF\Db\Schema;
+use SMF\Maintenance\Migration\MigrationBase;
+
+class Calendar extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Converting calendar';
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function isCandidate(): bool
+	{
+		$table = new Schema\v1_0\Calendar();
+		$structure = $table->getCurrentStructure();
+
+		return array_filter($structure['columns'], fn($c) => $c['name'] === 'eventDate') === [];
+	}
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		$this->query(
+			'ALTER TABLE {db_prefix}calendar
+			DROP PRIMARY KEY,
+			CHANGE COLUMN id ID_EVENT smallint(5) unsigned NOT NULL auto_increment PRIMARY KEY,
+			CHANGE COLUMN id_board ID_BOARD smallint(5) unsigned NOT NULL default 0,
+			CHANGE COLUMN id_topic ID_TOPIC mediumint(8) unsigned NOT NULL default 0,
+			CHANGE COLUMN id_member ID_MEMBER mediumint(8) unsigned NOT NULL default 0,
+			CHANGE COLUMN title title varchar(48) NOT NULL default {empty}',
+		);
+
+		$this->query(
+			'ALTER TABLE {db_prefix}calendar
+			ADD eventDate date NOT NULL default {string:date}',
+			[
+				// SMF 1.0 actually used '0000-00-00', but modern versions
+				// of MySQL don't like that.
+				'date' => '1004-01-01',
+			],
+		);
+
+		$this->query(
+			'ALTER TABLE {db_prefix}calendar
+			DROP INDEX idx_year_month',
+		);
+
+		$this->query(
+			'ALTER TABLE {db_prefix}calendar
+			DROP INDEX year',
+		);
+
+		$this->query(
+			'UPDATE IGNORE {db_prefix}calendar
+			SET eventDate = CONCAT(year, {string:hyphen}, month + 1, {string:hyphen}, day)',
+			[
+				'hyphen' => '-',
+			],
+		);
+
+		$this->query(
+			'ALTER TABLE {db_prefix}calendar
+			DROP year,
+			DROP month,
+			DROP day,
+			ADD INDEX eventDate (eventDate)',
+		);
+
+		$this->handleTimeout();
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v1_0/CensoredWords.php
+++ b/Sources/Maintenance/Migration/v1_0/CensoredWords.php
@@ -1,0 +1,88 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v1_0;
+
+use SMF\Config;
+use SMF\Db\DatabaseApi as Db;
+use SMF\Maintenance\Migration\MigrationBase;
+
+class CensoredWords extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Converting censored words';
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function isCandidate(): bool
+	{
+		return !isset(Config::$modSettings['censor_vulgar']) || !isset(Config::$modSettings['censor_proper']);
+	}
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		// Can't make changes without the table.
+		if (\count(Db::$db->list_tables(false, Config::$db_prefix . 'censor')) === 0) {
+			Config::updateModSettings([
+				'censor_vulgar' => Config::$modSettings['censor_vulgar'] ?? '',
+				'censor_proper' => Config::$modSettings['censor_proper'] ?? '',
+			]);
+
+			$this->handleTimeout();
+
+			return true;
+		}
+
+		$request = $this->query(
+			'SELECT vulgar, proper
+			FROM {db_prefix}censor',
+		);
+
+		$censor_vulgar = [];
+		$censor_proper = [];
+
+		while ($row = Db::$db->fetch_row($request)) {
+			$censor_vulgar[] = trim($row[0]);
+			$censor_proper[] = trim($row[1]);
+		}
+
+		Db::$db->free_result($request);
+
+		Config::updateModSettings([
+			'censor_vulgar' => implode("\n", $censor_vulgar),
+			'censor_proper' => implode("\n", $censor_proper),
+		]);
+
+		Db::$db->drop_table('{db_prefix}censor');
+
+		$this->handleTimeout();
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v1_0/Holidays.php
+++ b/Sources/Maintenance/Migration/v1_0/Holidays.php
@@ -1,0 +1,101 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v1_0;
+
+use SMF\Db\DatabaseApi as Db;
+use SMF\Db\Schema;
+use SMF\Maintenance\Migration\MigrationBase;
+
+class Holidays extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Converting calendar holidays';
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function isCandidate(): bool
+	{
+		return \count(Db::$db->list_tables(false, Config::$db_prefix . 'calendar_holiday')) > 0;
+	}
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		$table = new Schema\v1_0\CalendarHolidays();
+		$table->create();
+
+		$request = $this->query(
+			'SELECT COUNT(*)
+			FROM {db_prefix}calendar_holidays',
+		);
+
+		list($num_rows) = Db::$db->fetch_row($request);
+		Db::$db->free_result($request);
+
+		if (empty($num_rows)) {
+			$inserts = [];
+
+			$request = $this->query(
+				'SELECT id, title, month, day, year
+				FROM {db_prefix}calendar_holiday',
+			);
+
+			while ($row = Db::$db->fetch_assoc($request)) {
+				$inserts[] = [
+					\sprintf('%04d-%02d-%02d', min('1004', (int) $row['year']), (int) $row['month'], (int) $row['day']),
+					strtolower($row['title']) === 'new years' ? 'New Year\'s' : $row['title'],
+				];
+			}
+
+			Db::$db->free_result($request);
+
+			$inserts[] = [
+				'1004-06-06',
+				'D-Day',
+			];
+
+			Db::$db->insert(
+				method: '',
+				table: '{db_prefix}banned',
+				columns: [
+					'eventDate' => 'date',
+					'title' => 'string-30',
+				],
+				data: $inserts,
+				keys: [],
+			);
+		}
+
+		Db::$db->drop_table('{db_prefix}calendar_holiday');
+
+		$this->handleTimeout();
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v1_0/InstantMessages1.php
+++ b/Sources/Maintenance/Migration/v1_0/InstantMessages1.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v1_0;
+
+use SMF\Maintenance\Migration\MigrationBase;
+
+class InstantMessages1 extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Converting instant messages, part 1';
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		$this->query(
+			'ALTER TABLE {db_prefix}instant_messages
+			ADD COLUMN deletedBySender tinyint(3) unsigned NOT NULL default {literal:0} AFTER ID_MEMBER_FROM',
+		);
+
+		$this->handleTimeout();
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v1_0/InstantMessages2.php
+++ b/Sources/Maintenance/Migration/v1_0/InstantMessages2.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v1_0;
+
+use SMF\Maintenance\Migration\MigrationBase;
+
+class InstantMessages2 extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Converting instant messages, part 2';
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		$this->query(
+			'ALTER TABLE {db_prefix}instant_messages
+			CHANGE COLUMN ID_MEMBER_FROM ID_MEMBER_FROM mediumint(8) unsigned NOT NULL default {int:zero},
+			CHANGE COLUMN msgtime msgtime int(10) unsigned NOT NULL default {string:zero},
+			CHANGE COLUMN subject subject tinytext NOT NULL',
+			[
+				'zero' => 0,
+			],
+		);
+
+		$this->query(
+			'ALTER TABLE {db_prefix}instant_messages
+			DROP INDEX fromName,
+			DROP INDEX ID_MEMBER_FROM',
+		);
+
+		$this->handleTimeout();
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v1_0/InstantMessages3.php
+++ b/Sources/Maintenance/Migration/v1_0/InstantMessages3.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v1_0;
+
+use SMF\Maintenance\Migration\MigrationBase;
+
+class InstantMessages3 extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Converting instant messages, part 3';
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		$this->query(
+			'ALTER TABLE {db_prefix}instant_messages
+			DROP PRIMARY KEY,
+			CHANGE COLUMN ID_IM ID_PM int(10) unsigned NOT NULL auto_increment PRIMARY KEY',
+		);
+
+		$this->query(
+			'ALTER TABLE {db_prefix}instant_messages
+			ADD INDEX msgtime (msgtime)',
+		);
+
+		$this->handleTimeout();
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v1_0/InstantMessages4.php
+++ b/Sources/Maintenance/Migration/v1_0/InstantMessages4.php
@@ -1,0 +1,104 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v1_0;
+
+use SMF\Maintenance\Migration\MigrationBase;
+
+class InstantMessages4 extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Converting instant messages, part 4';
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		$this->query(
+			'ALTER TABLE {db_prefix}instant_messages
+			DROP INDEX ID_MEMBER_FROM_2',
+		);
+
+		$this->query(
+			'ALTER TABLE {db_prefix}instant_messages
+			DROP INDEX ID_MEMBER_FROM_3',
+		);
+
+		$this->query(
+			'ALTER TABLE {db_prefix}instant_messages
+			DROP INDEX ID_MEMBER_FROM_4',
+		);
+
+		$this->query(
+			'ALTER TABLE {db_prefix}instant_messages
+			DROP INDEX ID_MEMBER_FROM_5',
+		);
+
+		$this->query(
+			'ALTER TABLE {db_prefix}instant_messages
+			DROP INDEX ID_MEMBER_TO_2',
+		);
+
+		$this->query(
+			'ALTER TABLE {db_prefix}instant_messages
+			DROP INDEX ID_MEMBER_TO_3',
+		);
+
+		$this->query(
+			'ALTER TABLE {db_prefix}instant_messages
+			DROP INDEX ID_MEMBER_TO_4',
+		);
+
+		$this->query(
+			'ALTER TABLE {db_prefix}instant_messages
+			DROP INDEX ID_MEMBER_TO_5',
+		);
+
+		$this->query(
+			'ALTER TABLE {db_prefix}instant_messages
+			DROP INDEX deletedBy_2',
+		);
+
+		$this->query(
+			'ALTER TABLE {db_prefix}instant_messages
+			DROP INDEX deletedBy_3',
+		);
+
+		$this->query(
+			'ALTER TABLE {db_prefix}instant_messages
+			DROP INDEX deletedBy_4',
+		);
+
+		$this->query(
+			'ALTER TABLE {db_prefix}instant_messages
+			DROP INDEX deletedBy_5',
+		);
+
+		$this->handleTimeout();
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v1_0/InstantMessages5.php
+++ b/Sources/Maintenance/Migration/v1_0/InstantMessages5.php
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v1_0;
+
+use SMF\Maintenance\Migration\MigrationBase;
+
+class InstantMessages5 extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Converting instant messages, part 5';
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		$this->query(
+			'ALTER TABLE {db_prefix}im_recipients
+			DROP PRIMARY KEY,
+			CHANGE COLUMN ID_IM ID_PM int(10) unsigned NOT NULL default {literal:0},
+			ADD PRIMARY KEY (ID_PM, ID_MEMBER)',
+		);
+
+		$this->handleTimeout();
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v1_0/InstantMessages6.php
+++ b/Sources/Maintenance/Migration/v1_0/InstantMessages6.php
@@ -1,0 +1,74 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v1_0;
+
+use SMF\Db\DatabaseApi as Db;
+use SMF\Maintenance\Migration\MigrationBase;
+
+class InstantMessages6 extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Converting instant messages, part 6';
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		$request = $this->query(
+			'SHOW COLUMNS
+			FROM {db_prefix}instant_messages
+			LIKE {literal:readBy}',
+		);
+
+		$do_it = $request !== false;
+
+		if ($do_it) {
+			$adv_im = Db::$db->num_rows($request) == 0;
+			Db::$db->free_result($request);
+
+			$this->query(
+				'INSERT IGNORE INTO {db_prefix}im_recipients
+					(ID_PM, ID_MEMBER, bcc, is_read, deleted)
+				SELECT ID_PM, ID_MEMBER_TO, 0, IF({raw:col} != 0, 1, 0), IF(deletedBy = {literal:1}, 1, 0)
+				FROM {db_prefix}instant_messages',
+				[
+					'col' => !$adv_im ? 'readBy' : 'alerted',
+				],
+			);
+		}
+
+		$this->query(
+			'UPDATE IGNORE {db_prefix}instant_messages
+			SET deletedBySender = 1
+			WHERE deletedBy = 0',
+		);
+
+		$this->handleTimeout();
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v1_0/InstantMessages7.php
+++ b/Sources/Maintenance/Migration/v1_0/InstantMessages7.php
@@ -1,0 +1,72 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v1_0;
+
+use SMF\Maintenance\Migration\MigrationBase;
+
+class InstantMessages7 extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Converting instant messages, part 7';
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		$this->query(
+			'ALTER TABLE {db_prefix}instant_messages
+			DROP INDEX ID_MEMBER_TO',
+		);
+
+		$this->query(
+			'ALTER TABLE {db_prefix}instant_messages
+			DROP INDEX deletedBy',
+		);
+
+		$this->query(
+			'ALTER TABLE {db_prefix}instant_messages
+			DROP INDEX readBy',
+		);
+
+		$this->query(
+			'ALTER TABLE {db_prefix}instant_messages
+			DROP COLUMN ID_MEMBER_TO,
+			DROP COLUMN deletedBy,
+			DROP COLUMN toName,
+			DROP COLUMN readBy',
+		);
+
+		$this->query(
+			'ALTER TABLE {db_prefix}instant_messages
+			ADD INDEX ID_MEMBER (ID_MEMBER_FROM, deletedBySender)',
+		);
+
+		$this->handleTimeout();
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v1_0/InstantMessages8.php
+++ b/Sources/Maintenance/Migration/v1_0/InstantMessages8.php
@@ -1,0 +1,107 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v1_0;
+
+use SMF\Db\DatabaseApi as Db;
+use SMF\Maintenance\Migration\MigrationBase;
+
+class InstantMessages8 extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Recounting instant messages';
+
+	/*********************
+	 * Internal properties
+	 *********************/
+
+	/**
+	 * @var int
+	 *
+	 * Maximum number of items to process at once.
+	 */
+	private int $limit = 512;
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function isCandidate(): bool
+	{
+		return \count(Db::$db->list_tables(false, Config::$db_prefix . 'instant_messages')) > 0;
+	}
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		$request = $this->query(
+			'SELECT MAX(ID_MEMBER)
+			FROM {db_prefix}members',
+		);
+
+		list($max) = Db::$db->fetch_row($request);
+		Maintenance::$total_items = (int) $max;
+
+		Db::$db->free_result($request);
+
+		do {
+			$start = Maintenance::getCurrentStart();
+			$this->handleTimeout($start);
+
+			Db::$db->update_from(
+				table: [
+					'name' => '{db_prefix}members',
+					'alias' => 'mem',
+				],
+				from_tables: [
+					[
+						// Using a subquery as the table name is a bit cheeky, but it works!
+						'name' => '(
+							SELECT ID_MEMBER, COUNT(ID_PM) AS num_messages
+							FROM {db_prefix}im_recipients
+							WHERE deleted = 0
+								AND id_member > {int:min}
+								AND id_member <= {int:max}
+							GROUP BY id_member
+						)',
+						'alias' => 'pmr',
+						'condition' => 'mem.ID_MEMBER = pmr.ID_MEMBER',
+					],
+				],
+				set: 'mem.instantMessages = COALESCE(pmr.num_messages, mem.instantMessages)',
+				where: '',
+				db_values: [
+					'min' => Maintenance::getCurrentStart(),
+					'max' => Maintenance::getCurrentStart() + $this->limit,
+				],
+			);
+
+			Maintenance::setCurrentStart($start + $this->limit);
+		} while (Maintenance::getCurrentStart() < Maintenance::$total_items);
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v1_0/InstantMessages9.php
+++ b/Sources/Maintenance/Migration/v1_0/InstantMessages9.php
@@ -1,0 +1,108 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v1_0;
+
+use SMF\Db\DatabaseApi as Db;
+use SMF\Maintenance\Migration\MigrationBase;
+
+class InstantMessages9 extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Recounting unread instant messages';
+
+	/*********************
+	 * Internal properties
+	 *********************/
+
+	/**
+	 * @var int
+	 *
+	 * Maximum number of items to process at once.
+	 */
+	private int $limit = 512;
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function isCandidate(): bool
+	{
+		return \count(Db::$db->list_tables(false, Config::$db_prefix . 'instant_messages')) > 0;
+	}
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		$request = $this->query(
+			'SELECT MAX(ID_MEMBER)
+			FROM {db_prefix}members',
+		);
+
+		list($max) = Db::$db->fetch_row($request);
+		Maintenance::$total_items = (int) $max;
+
+		Db::$db->free_result($request);
+
+		do {
+			$start = Maintenance::getCurrentStart();
+			$this->handleTimeout($start);
+
+			Db::$db->update_from(
+				table: [
+					'name' => '{db_prefix}members',
+					'alias' => 'mem',
+				],
+				from_tables: [
+					[
+						// Using a subquery as the table name is a bit cheeky, but it works!
+						'name' => '(
+							SELECT ID_MEMBER, COUNT(ID_PM) AS num_messages
+							FROM {db_prefix}im_recipients
+							WHERE deleted = 0
+								AND is_read = 0
+								AND id_member > {int:min}
+								AND id_member <= {int:max}
+							GROUP BY id_member
+						)',
+						'alias' => 'pmr',
+						'condition' => 'mem.ID_MEMBER = pmr.ID_MEMBER',
+					],
+				],
+				set: 'mem.unreadMessages = COALESCE(pmr.num_messages, mem.unreadMessages)',
+				where: '',
+				db_values: [
+					'min' => Maintenance::getCurrentStart(),
+					'max' => Maintenance::getCurrentStart() + $this->limit,
+				],
+			);
+
+			Maintenance::setCurrentStart($start + $this->limit);
+		} while (Maintenance::getCurrentStart() < Maintenance::$total_items);
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v1_0/LogPolls.php
+++ b/Sources/Maintenance/Migration/v1_0/LogPolls.php
@@ -1,0 +1,99 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v1_0;
+
+use SMF\Db\DatabaseApi as Db;
+use SMF\Maintenance\Migration\MigrationBase;
+
+class LogPolls extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Converting poll voter logs';
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function isCandidate(): bool
+	{
+		$request = $this->query(
+			'SELECT COUNT(*)
+			FROM {db_prefix}log_polls',
+		);
+
+		list($num_rows) = Db::$db->fetch_row($request);
+
+		Db::$db->free_result($request);
+
+		return empty($num_rows);
+	}
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		$inserts = [];
+
+		$request = $this->query(
+			'SELECT ID_POLL, votedMemberIDs
+			FROM {db_prefix}polls',
+		);
+
+		while ($row = Db::$db->fetch_assoc($query)) {
+			$members = explode(',', $row['votedMemberIDs']);
+
+			foreach ($members as $member) {
+				if (is_numeric($member) && !empty($member)) {
+					$inserts[] = [
+						(int) $row['ID_POLL'],
+						(int) $member,
+						0,
+					];
+				}
+			}
+		}
+
+		Db::$db->free_result($request);
+
+		if (!empty($inserts)) {
+			Db::$db->insert(
+				method: 'ignore',
+				table: '{db_prefix}log_polls',
+				columns: [
+					'ID_POLL' => 'int',
+					'ID_MEMBER' => 'int',
+					'ID_CHOICE' => 'int',
+				],
+				data: $inserts,
+				keys: [],
+			);
+		}
+
+		$this->handleTimeout();
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v1_0/Logs.php
+++ b/Sources/Maintenance/Migration/v1_0/Logs.php
@@ -1,0 +1,144 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v1_0;
+
+use SMF\Db\DatabaseApi as Db;
+use SMF\Db\Schema;
+use SMF\Maintenance\Migration\MigrationBase;
+
+class Logs extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Converting activity logs';
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		// Converting "log_online"
+		$table = new Schema\v1_0\LogOnline();
+		$table->drop();
+		$table->create();
+
+		// Converting "log_floodcontrol"
+		$table = new Schema\v1_0\LogFloodcontrol();
+		$table->drop();
+		$table->create();
+
+		// Converting "log_karma"
+		$table = new Schema\v1_0\LogKarma();
+		$table->drop();
+		$table->create();
+
+		// Retiring "log_clicks"
+		Db::$db->drop_table('{db_prefix}log_clicks');
+
+		// Converting "log_notify"
+		$inserts = [];
+
+		$request = $this->query(
+			'SELECT ID_MEMBER, ID_TOPIC, 0, notificationSent
+			FROM {db_prefix}log_topics
+			WHERE notificationSent != 0',
+		);
+
+		while ($row = Db::$db->fetch_row($request)) {
+			$inserts[] = $row;
+		}
+
+		Db::$db->free_result($request);
+
+		Db::$db->insert(
+			method: '',
+			table: '{db_prefix}log_notify',
+			columns: [
+				'ID_MEMBER' => 'int',
+				'ID_TOPIC' => 'int',
+				'ID_BOARD' => 'int',
+				'sent' => 'int',
+			],
+			data: $inserts,
+			keys: [],
+		);
+
+		$table = new Schema\v1_0\LogTopics();
+		$table->dropColumn('notificationSent');
+
+		// Converting "log_errors"
+		$table = new Schema\v1_0\LogErrors();
+		$table->normalize();
+
+		// Converting "log_boards"
+		$request = $this->query(
+			'SELECT lmr.ID_BOARD, lmr.ID_MEMBER, lmr.logTime
+			FROM {db_prefix}log_mark_read AS lmr
+				LEFT JOIN {db_prefix}log_boards AS lb ON (lb.ID_BOARD = lmr.ID_BOARD AND lb.ID_MEMBER = lmr.ID_MEMBER)
+			WHERE lb.logTime < lmr.logTime',
+		);
+
+		$inserts = Db::$db->fetch_all($request);
+
+		Db::$db->free_result($request);
+
+		if (!empty($inserts)) {
+			Db::$db->insert(
+				method: '',
+				table: '{db_prefix}log_boards',
+				columns: [
+					'ID_BOARD' => 'int',
+					'ID_MEMBER' => 'int',
+					'logTime' => 'int',
+				],
+				data: $inserts,
+				keys: [],
+			);
+		}
+
+		// Converting "log_activity"
+		$table = new Schema\v1_0\LogActivity();
+		$structure = $table->getCurrentStructure();
+
+		if (!isset($structure['columns']['date'])) {
+			$table->addColumn($table->columns['date']);
+		}
+
+		$this->query(
+			'UPDATE IGNORE {db_prefix}log_activity
+			SET date = year * 10000 + month * 100 + day',
+		);
+
+		$table->dropIndex('primary');
+		$table->dropColumn('day');
+		$table->dropColumn('month');
+		$table->dropColumn('year');
+		$table->normalize();
+
+		$this->handleTimeout();
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v1_0/MemberStats.php
+++ b/Sources/Maintenance/Migration/v1_0/MemberStats.php
@@ -1,0 +1,83 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v1_0;
+
+use SMF\Maintenance\Migration\MigrationBase;
+
+class MemberStats extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Converting member statistics';
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		$this->query(
+			'REPLACE INTO {db_prefix}settings
+				(variable, value)
+			SELECT {string:var}, ID_MEMBER
+			FROM {db_prefix}members
+			ORDER BY ID_MEMBER DESC
+			LIMIT {int:limit}',
+			[
+				'var' => 'latestMember',
+				'limit' => 1,
+			],
+		);
+
+		$this->query(
+			'REPLACE INTO {db_prefix}settings
+				(variable, value)
+			SELECT {string:var}, IFNULL(realName, memberName)
+			FROM {db_prefix}members
+			ORDER BY ID_MEMBER DESC
+			LIMIT {int:limit}',
+			[
+				'var' => 'latestRealName',
+				'limit' => 1,
+			],
+		);
+
+		$this->query(
+			'REPLACE INTO {db_prefix}settings
+				(variable, value)
+			SELECT {string:var}, ID_MSG
+			FROM {db_prefix}messages
+			ORDER BY ID_MSG DESC
+			LIMIT {int:limit}',
+			[
+				'var' => 'maxMsgID',
+				'limit' => 1,
+			],
+		);
+
+		$this->handleTimeout();
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v1_0/Membergroups1.php
+++ b/Sources/Maintenance/Migration/v1_0/Membergroups1.php
@@ -1,0 +1,221 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v1_0;
+
+use SMF\Db\DatabaseApi as Db;
+use SMF\Db\Schema;
+use SMF\Maintenance\Migration\MigrationBase;
+
+class Membergroups1 extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Converting membergroups, part 1';
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function isCandidate(): bool
+	{
+		$table = new Schema\v1_0\Membergroups();
+		$structure = $table->getCurrentStructure();
+
+		return array_filter($structure['columns'], fn($c) => $c['name'] === 'minPosts') === [];
+	}
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		Db::$db->rename_table('{db_prefix}membergroups', '{db_prefix}old_membergroups');
+
+		$table = new Schema\v1_0\Membergroups();
+		$table->create();
+
+		// Migrate the administrator group.
+		Db::$db->query(
+			'INSERT INTO {db_prefix}membergroups
+				(ID_GROUP, groupName, onlineColor, minPosts, stars)
+			SELECT {int:new_id}, membergroup, {string:color}, -1, {string:icons}
+			FROM {db_prefix}old_membergroups
+			WHERE ID_GROUP = {int:old_id}',
+			[
+				'old_id' => 1,
+				'new_id' => 1,
+				'color' => '#FF0000',
+				'icons' => '5#staradmin.gif',
+			],
+		);
+
+		// Migrate the global moderator group.
+		Db::$db->query(
+			'INSERT INTO {db_prefix}membergroups
+				(ID_GROUP, groupName, onlineColor, minPosts, stars)
+			SELECT {int:new_id}, membergroup, {string:color}, -1, {string:icons}
+			FROM {db_prefix}old_membergroups
+			WHERE ID_GROUP = {int:old_id}',
+			[
+				'old_id' => 8,
+				'new_id' => 2,
+				'color' => '#0000FF',
+				'icons' => '5#stargmod.gif',
+			],
+		);
+
+		// Migrate the local moderator group.
+		Db::$db->query(
+			'INSERT INTO {db_prefix}membergroups
+				(ID_GROUP, groupName, onlineColor, minPosts, stars)
+			SELECT {int:new_id}, membergroup, {string:color}, -1, {string:icons}
+			FROM {db_prefix}old_membergroups
+			WHERE ID_GROUP = {int:old_id}',
+			[
+				'old_id' => 2,
+				'new_id' => 3,
+				'color' => '',
+				'icons' => '5#starmod.gif',
+			],
+		);
+
+		// Migrate the post-count groups.
+		// In YaBB SE, the minimum post values for post-count groups were stored
+		// as global variables in Settings.php.
+		Db::$db->query(
+			'INSERT INTO {db_prefix}membergroups
+				(ID_GROUP, groupName, onlineColor, minPosts, stars)
+			SELECT
+				ID_GROUP + 1,
+				membergroup,
+				{string:color},
+				CASE ID_GROUP
+					WHEN 3 THEN 0
+					WHEN 4 THEN {int:JrPostNum}
+					WHEN 5 THEN {int:FullPostNum}
+					WHEN 6 THEN {int:SrPostNum}
+					WHEN 7 THEN {int:GodPostNum}
+				END,
+				CONCAT(ID_GROUP - 2, "#star.gif")
+			FROM {db_prefix}old_membergroups
+			WHERE ID_GROUP IN {array_int:old_groups}',
+			[
+				'color' => '',
+				'JrPostNum' => (int) ($GLOBALS['JrPostNum'] ?? 50),
+				'FullPostNum' => (int) ($GLOBALS['FullPostNum'] ?? 100),
+				'SrPostNum' => (int) ($GLOBALS['SrPostNum'] ?? 250),
+				'GodPostNum' => (int) ($GLOBALS['GodPostNum'] ?? 500),
+				'old_groups' => [3, 4, 5, 6, 7],
+			],
+		);
+
+		// Migrate any custom groups.
+		Db::$db->query(
+			'INSERT INTO {db_prefix}membergroups
+				(ID_GROUP, groupName, onlineColor, minPosts, stars)
+			SELECT ID_GROUP, membergroup, {string:color}, -1, {string:icons}
+			FROM {db_prefix}old_membergroups
+			WHERE ID_GROUP > {int:eight}',
+			[
+				'eight' => 8,
+				'color' => '',
+				'icons' => '',
+			],
+		);
+
+		// Drop the old table.
+		Db::$db->drop_table('{db_prefix}old_membergroups');
+
+		// Add new permissions for the membergroups.
+		$permissions = [
+			'view_mlist',
+			'search_posts',
+			'profile_view_own',
+			'profile_view_any',
+			'pm_read',
+			'pm_send',
+			'calendar_view',
+			'view_stats',
+			'who_view',
+			'profile_identity_own',
+			'profile_extra_own',
+			'profile_remote_avatar',
+			'profile_remove_own',
+		];
+
+		foreach ($permissions as $perm) {
+			$this->query(
+				'INSERT INTO {db_prefix}permissions
+					(ID_GROUP, permission)
+				SELECT IF(ID_GROUP = 1, 0, ID_GROUP), {string:perm}
+				FROM {db_prefix}membergroups
+				WHERE ID_GROUP != 3
+					AND minPosts = -1',
+				[
+					'perm' => $perm,
+				],
+			);
+		}
+
+		$board_permissions = [
+			'remove_own',
+			'lock_own',
+			'mark_any_notify',
+			'mark_notify',
+			'modify_own',
+			'poll_add_own',
+			'poll_edit_own',
+			'poll_lock_own',
+			'poll_post',
+			'poll_view',
+			'poll_vote',
+			'post_attachment',
+			'post_new',
+			'post_reply_any',
+			'post_reply_own',
+			'delete_own',
+			'report_any',
+			'send_topic',
+			'view_attachments',
+		];
+
+		foreach ($board_permissions as $perm) {
+			$this->query(
+				'INSERT INTO {db_prefix}board_permissions
+					(ID_GROUP, permission)
+				SELECT IF(ID_GROUP = 1, 0, ID_GROUP), {string:perm}
+				FROM {db_prefix}membergroups
+				WHERE minPosts = -1',
+				[
+					'perm' => $perm,
+				],
+			);
+		}
+
+		// Done.
+		$this->handleTimeout();
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v1_0/Membergroups2.php
+++ b/Sources/Maintenance/Migration/v1_0/Membergroups2.php
@@ -1,0 +1,136 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v1_0;
+
+use SMF\Db\DatabaseApi as Db;
+use SMF\Db\Schema;
+use SMF\Maintenance\Migration\MigrationBase;
+
+class Membergroups2 extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Converting membergroups, part 2';
+
+	/*********************
+	 * Internal properties
+	 *********************/
+
+	/**
+	 * @var int
+	 *
+	 * Maximum number of items to process at once.
+	 */
+	private int $limit = 512;
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		// Ensure members table has the necessary column and index.
+		$table = new Schema\v1_0\Members();
+		$table->addColumn($table->columns['ID_POST_GROUP'], if_exists: 'update');
+		$table->addIndex($table->indexes['ID_POST_GROUP'], if_exists: 'update');
+
+		// Get the minimum number of posts for each post-count group.
+		$request = $this->query(
+			'SELECT ID_GROUP, minPosts
+			FROM {db_prefix}membergroups
+			WHERE minPosts != -1
+			ORDER BY minPosts DESC',
+		);
+
+		$post_groups = [];
+
+		while ($row = Db::$db->fetch_assoc($request)) {
+			$post_groups[$row['minPosts']] = $row['ID_GROUP'];
+		}
+
+		Db::$db->free_result($request);
+
+		// Get the maximum member ID.
+		$request = $this->query(
+			'SELECT MAX(ID_MEMBER)
+			FROM {db_prefix}members',
+		);
+
+		list($max) = Db::$db->fetch_row($request);
+		Maintenance::$total_items = (int) $max;
+
+		Db::$db->free_result($request);
+
+		// Update the members table.
+		do {
+			$start = Maintenance::getCurrentStart();
+			$this->handleTimeout($start);
+
+			$request = $this->query(
+				'SELECT ID_MEMBER, posts
+				FROM {db_prefix}members
+				WHERE ID_MEMBER > {int:min}
+					AND ID_MEMBER <= {int:max}',
+				[
+					'min' => $start,
+					'max' => $start + $this->limit,
+				],
+			);
+
+			$updates = [];
+
+			while ($row = Db::$db->fetch_assoc($request)) {
+				$group = 4;
+
+				foreach ($post_groups as $min_posts => $group_id) {
+					if ($row['posts'] > $min_posts) {
+						$group = $group_id;
+						break;
+					}
+				}
+
+				$updates[$group][] = $row['ID_MEMBER'];
+			}
+
+			Db::$db->free_result($request);
+
+			foreach ($updates as $group_to => $update_members) {
+				$this->query(
+					'UPDATE {db_prefix}members
+					SET ID_POST_GROUP = {string:group}
+					WHERE ID_MEMBER IN ({array_int:members})',
+					[
+						'group' => $group_to,
+						'members' => $update_members,
+						'limit' => \count($update_members),
+					],
+				);
+			}
+
+			Maintenance::setCurrentStart($start + $this->limit);
+		} while (Maintenance::getCurrentStart() < Maintenance::$total_items);
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v1_0/Members1.php
+++ b/Sources/Maintenance/Migration/v1_0/Members1.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v1_0;
+
+use SMF\Maintenance\Migration\MigrationBase;
+
+class Members1 extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Converting members, part 1';
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		$this->query(
+			'UPDATE IGNORE {db_prefix}members
+			SET im_ignore_list = {string:star)
+			WHERE im_ignore_list RLIKE {string:regex}',
+			[
+				'star' => '*',
+				'regex' => '([\n,]|^)[*]([\n,]|$)',
+			],
+		);
+
+		$this->handleTimeout();
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v1_0/Members10.php
+++ b/Sources/Maintenance/Migration/v1_0/Members10.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v1_0;
+
+use SMF\Maintenance\Migration\MigrationBase;
+
+class Members10 extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Converting members, part 10';
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		$this->query(
+			'ALTER TABLE {db_prefix}members
+			CHANGE COLUMN timeOffset timeOffset float NOT NULL default {literal:0},
+			CHANGE COLUMN posts posts mediumint(8) unsigned NOT NULL default {literal:0},
+			CHANGE COLUMN timeFormat timeFormat varchar(80) NOT NULL default {empty},
+			CHANGE COLUMN lastLogin lastLogin int(11) NOT NULL default {literal:0},
+			CHANGE COLUMN karmaBad karmaBad smallint(5) unsigned NOT NULL default {literal:0},
+			CHANGE COLUMN karmaGood karmaGood smallint(5) unsigned NOT NULL default {literal:0},
+			CHANGE COLUMN gender gender tinyint(4) unsigned NOT NULL default {literal:0},
+			CHANGE COLUMN hideEmail hideEmail tinyint(4) NOT NULL default {literal:0}',
+		);
+
+		$this->handleTimeout();
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v1_0/Members11.php
+++ b/Sources/Maintenance/Migration/v1_0/Members11.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v1_0;
+
+use SMF\Maintenance\Migration\MigrationBase;
+
+class Members11 extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Converting members, part 11';
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		$this->query(
+			'ALTER TABLE {db_prefix}members
+			DROP INDEX realName',
+		);
+
+		$this->query(
+			'ALTER TABLE {db_prefix}members
+			CHANGE COLUMN AIM AIM varchar(16) NOT NULL default {empty},
+			CHANGE COLUMN YIM YIM varchar(32) NOT NULL default {empty},
+			CHANGE COLUMN ICQ ICQ tinytext NOT NULL default {empty},
+			CHANGE COLUMN realName realName tinytext NOT NULL default {empty},
+			CHANGE COLUMN emailAddress emailAddress tinytext NOT NULL default {empty},
+			CHANGE COLUMN dateRegistered dateRegistered int(10) unsigned NOT NULL default {literal:0},
+			CHANGE COLUMN passwd passwd varchar(64) NOT NULL default {empty},
+			CHANGE COLUMN personalText personalText tinytext NOT NULL default {empty},
+			CHANGE COLUMN websiteTitle websiteTitle tinytext NOT NULL default {empty}',
+		);
+
+		$this->handleTimeout();
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v1_0/Members12.php
+++ b/Sources/Maintenance/Migration/v1_0/Members12.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v1_0;
+
+use SMF\Maintenance\Migration\MigrationBase;
+
+class Members12 extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Converting members, part 12';
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		$this->query(
+			'ALTER TABLE {db_prefix}members
+			DROP INDEX lngfile',
+		);
+
+		$this->query(
+			'ALTER TABLE {db_prefix}members
+			CHANGE COLUMN websiteUrl websiteUrl tinytext NOT NULL default {empty},
+			CHANGE COLUMN location location tinytext NOT NULL default {empty},
+			CHANGE COLUMN avatar avatar tinytext NOT NULL default {empty},
+			CHANGE COLUMN im_ignore_list im_ignore_list tinytext NOT NULL default {empty},
+			CHANGE COLUMN usertitle usertitle tinytext NOT NULL default {empty},
+			CHANGE COLUMN lngfile lngfile tinytext NOT NULL default {empty},
+			CHANGE COLUMN MSN MSN tinytext NOT NULL default {empty},
+			CHANGE COLUMN memberIP memberIP tinytext NOT NULL default {empty},
+			ADD INDEX lngfile (lngfile(24))',
+		);
+
+		$this->handleTimeout();
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v1_0/Members13.php
+++ b/Sources/Maintenance/Migration/v1_0/Members13.php
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v1_0;
+
+use SMF\Maintenance\Migration\MigrationBase;
+
+class Members13 extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Converting members, part 13';
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		$this->query(
+			'ALTER TABLE {db_prefix}members
+			ADD INDEX ID_GROUP (ID_GROUP),
+			ADD INDEX birthdate (birthdate),
+			ADD INDEX lngfile (lngfile(30))',
+		);
+
+		$this->handleTimeout();
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v1_0/Members2.php
+++ b/Sources/Maintenance/Migration/v1_0/Members2.php
@@ -1,0 +1,118 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v1_0;
+
+use SMF\Db\DatabaseApi as Db;
+use SMF\Maintenance\Migration\MigrationBase;
+
+class Members2 extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Converting members, part 2';
+
+	/*********************
+	 * Internal properties
+	 *********************/
+
+	/**
+	 * @var int
+	 *
+	 * Maximum number of items to process at once.
+	 */
+	private int $limit = 512;
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		$request = $this->query(
+			'SHOW COLUMNS
+			FROM {db_prefix}members
+			LIKE {literal:im_ignore_list}',
+		);
+
+		$do_it = Db::$db->num_rows($request) != 0;
+
+		Db::$db->free_result($request);
+
+		while ($do_it) {
+			$this->handleTimeout();
+
+			$request = $this->query(
+				'SELECT ID_MEMBER, im_ignore_list
+				FROM {db_prefix}members
+				WHERE im_ignore_list RLIKE {string:regex}
+				LIMIT {int:limit}',
+				[
+					'regex' => '[a-z]',
+					'limit' => $this->limit,
+				],
+			);
+
+			while ($row = Db::$db->fetch_assoc($request)) {
+				$request2 = $this->query(
+					'SELECT ID_MEMBER
+					FROM {db_prefix}members
+					WHERE FIND_IN_SET(memberName, {string:im_ignore_list})',
+					[
+						'im_ignore_list' => $row['im_ignore_list'],
+					],
+				);
+
+				$im_ignore_list = '';
+
+				while ($row2 = Db::$db->fetch_assoc($request2)) {
+					$im_ignore_list .= ',' . $row2['ID_MEMBER'];
+				}
+
+				Db::$db->free_result($request2);
+
+				$this->query(
+					'UPDATE {db_prefix}members
+					SET im_ignore_list = {string:im_ignore_list}
+					WHERE ID_MEMBER = {int:id_member}
+					LIMIT 1',
+					[
+						'im_ignore_list' => substr($im_ignore_list, 1),
+						'id_member' => $row['ID_MEMBER'],
+						'limit' => 1,
+					],
+				);
+			}
+
+			$num_rows = Db::$db->num_rows($request);
+
+			Db::$db->free_result($request);
+
+			if ($num_rows < $this->limit) {
+				break;
+			}
+		}
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v1_0/Members3.php
+++ b/Sources/Maintenance/Migration/v1_0/Members3.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v1_0;
+
+use SMF\Maintenance\Migration\MigrationBase;
+
+class Members3 extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Converting members, part 3';
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		$this->query(
+			'UPDATE {db_prefix}members
+			SET realName = memberName
+			WHERE IFNULL(realName, {empty}) = {empty}',
+		);
+
+		$this->handleTimeout();
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v1_0/Members4.php
+++ b/Sources/Maintenance/Migration/v1_0/Members4.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v1_0;
+
+use SMF\Maintenance\Migration\MigrationBase;
+
+class Members4 extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Converting members, part 4';
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		$this->query(
+			'UPDATE {db_prefix}members
+			SET lngfile = REPLACE(lngfile, {string:suffix}, {empty})
+			WHERE lngfile LIKE {string:pattern}',
+			[
+				'suffix' => '.lng',
+				'pattern' => '%.lng',
+			],
+		);
+
+		$this->handleTimeout();
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v1_0/Members5.php
+++ b/Sources/Maintenance/Migration/v1_0/Members5.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v1_0;
+
+use SMF\Maintenance\Migration\MigrationBase;
+
+class Members5 extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Converting members, part 5';
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		$this->query(
+			'ALTER TABLE {db_prefix}members
+			DROP INDEX memberID',
+		);
+
+		$this->query(
+			'ALTER TABLE {db_prefix}members
+			DROP INDEX memberID_2',
+		);
+
+		$this->handleTimeout();
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v1_0/Members6.php
+++ b/Sources/Maintenance/Migration/v1_0/Members6.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v1_0;
+
+use SMF\Maintenance\Migration\MigrationBase;
+
+class Members6 extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Converting members, part 6';
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		$this->query(
+			'ALTER TABLE {db_prefix}members
+			DROP PRIMARY KEY,
+			CHANGE COLUMN ID_MEMBER ID_MEMBER mediumint(8) unsigned NOT NULL auto_increment PRIMARY KEY,
+			ADD instantMessages smallint(5) NOT NULL default 0,
+			ADD unreadMessages smallint(5) NOT NULL default 0,
+			ADD ID_THEME tinyint(4) unsigned NOT NULL default 0,
+			ADD ID_GROUP smallint(5) unsigned NOT NULL default 0,
+			ADD is_activated tinyint(3) unsigned NOT NULL default {literal:1},
+			ADD validation_code varchar(10) NOT NULL default {empty},
+			ADD ID_MSG_LAST_VISIT int(10) unsigned NOT NULL default {literal:0},
+			ADD additionalGroups tinytext NOT NULL default {empty}',
+		);
+
+		$this->handleTimeout();
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v1_0/Members7.php
+++ b/Sources/Maintenance/Migration/v1_0/Members7.php
@@ -1,0 +1,69 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v1_0;
+
+use SMF\Maintenance\Migration\MigrationBase;
+
+class Members7 extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Converting members, part 7';
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		$this->query(
+			'ALTER TABLE {db_prefix}members
+			CHANGE COLUMN ID_THEME ID_THEME tinyint(4) unsigned NOT NULL default 0',
+		);
+
+		$this->query(
+			'ALTER TABLE {db_prefix}members
+			ADD showOnline tinyint(4) NOT NULL default {literal:1}',
+		);
+
+		$this->query(
+			'ALTER TABLE {db_prefix}members
+			ADD smileySet varchar(48) NOT NULL default {empty}',
+		);
+
+		$this->query(
+			'ALTER TABLE {db_prefix}members
+			ADD totalTimeLoggedIn int(10) unsigned NOT NULL default {literal:0}',
+		);
+
+		$this->query(
+			'ALTER TABLE {db_prefix}members
+			ADD passwordSalt varchar(5) NOT NULL default {empty}',
+		);
+
+		$this->handleTimeout();
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v1_0/Members8.php
+++ b/Sources/Maintenance/Migration/v1_0/Members8.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v1_0;
+
+use SMF\Maintenance\Migration\MigrationBase;
+
+class Members8 extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Converting members, part 8';
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		$this->query(
+			'UPDATE {db_prefix}members
+			SET gender = CASE gender
+				WHEN {literal:0} THEN 0
+				WHEN {literal:Male} THEN 1
+				WHEN {literal:Female} THEN 2
+				ELSE 0 END, secretAnswer = IF(secretAnswer = {empty}, {empty}, MD5(secretAnswer))
+			WHERE gender NOT IN ({literal:0}, {literal:1}, {literal:2})',
+		);
+
+		$this->handleTimeout();
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v1_0/Members9.php
+++ b/Sources/Maintenance/Migration/v1_0/Members9.php
@@ -1,0 +1,155 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v1_0;
+
+use SMF\Db\DatabaseApi as Db;
+use SMF\Maintenance\Migration\MigrationBase;
+
+class Members9 extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Converting members, part 9';
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		$member_groups = $this->getMemberGroups();
+
+		$result = $this->query(
+			'ALTER TABLE {db_prefix}boards
+			ADD memberGroups varchar(128) NOT NULL default {string:default}',
+			[
+				'default' => '-1,0',
+			],
+		);
+
+		if ($result !== false) {
+			$result = $this->query(
+				'SELECT TRIM(memberGroups) AS memberGroups, ID_CAT
+				FROM {db_prefix}categories',
+			);
+
+			while ($row = smf_mysql_fetch_assoc($result)) {
+				if (trim($row['memberGroups']) == '') {
+					$groups = '-1,0,2';
+				} else {
+					$memberGroups = array_unique(explode(',', $row['memberGroups']));
+					$groups = [2];
+
+					foreach ($memberGroups as $k => $check) {
+						$memberGroups[$k] = trim($memberGroups[$k]);
+
+						if (
+							$memberGroups[$k] == ''
+							|| !isset($member_groups[$memberGroups[$k]])
+							|| $member_groups[$memberGroups[$k]] == 8
+						) {
+							continue;
+						}
+
+						$groups[] = $member_groups[$memberGroups[$k]];
+					}
+
+					$groups = implode(',', array_unique($groups));
+				}
+
+				$this->query(
+					'UPDATE {db_prefix}boards
+					SET memberGroups = {string:groups}, lastUpdated = {int:now}
+					WHERE ID_CAT = {int:id_cat}',
+					[
+						'groups' => $groups,
+						'now' => time(),
+						'id_cat' => $row['ID_CAT'],
+					],
+				);
+			}
+		}
+
+		$this->query(
+			'UPDATE IGNORE {db_prefix}members
+			SET ID_GROUP = {int:id}
+			WHERE memberGroup = {string:name}',
+			[
+				'name' => 'Administrator',
+				'id' => 1,
+			],
+		);
+
+		$this->query(
+			'UPDATE IGNORE {db_prefix}members
+			SET ID_GROUP = {int:id}
+			WHERE memberGroup = {string:name}',
+			[
+				'name' => 'Global Moderator',
+				'id' => 2,
+			],
+		);
+
+		$this->query(
+			'ALTER TABLE {db_prefix}members
+			DROP memberGroup',
+		);
+
+		$this->handleTimeout();
+
+		return true;
+	}
+
+	/******************
+	 * Internal methods
+	 ******************/
+
+	/**
+	 *
+	 */
+	private function getMemberGroups(): array
+	{
+		$request = $this->query(
+			'SELECT groupName, ID_GROUP
+			FROM {db_prefix}membergroups
+			WHERE ID_GROUP = 1 OR ID_GROUP > 7',
+		);
+
+		if (!$request || Db::$db->num_rows($request) === 0) {
+			$request = $this->query(
+				'SELECT membergroup, ID_GROUP
+				FROM {db_prefix}membergroups
+				WHERE ID_GROUP = 1 OR ID_GROUP > 7',
+			);
+		}
+
+		while ($row = Db::$db->fetch_row($request)) {
+			$member_groups[trim($row[0])] = (int) $row[1];
+		}
+
+		Db::$db->free_result($request);
+
+		return $member_groups;
+	}
+}

--- a/Sources/Maintenance/Migration/v1_0/Messages1.php
+++ b/Sources/Maintenance/Migration/v1_0/Messages1.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v1_0;
+
+use SMF\Maintenance\Migration\MigrationBase;
+
+class Messages1 extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Converting messages, part 1';
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		$this->query(
+			'ALTER TABLE {db_prefix}messages
+			DROP PRIMARY KEY,
+			CHANGE COLUMN ID_MSG ID_MSG int(10) unsigned NOT NULL auto_increment PRIMARY KEY',
+		);
+
+		$this->handleTimeout();
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v1_0/Messages2.php
+++ b/Sources/Maintenance/Migration/v1_0/Messages2.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v1_0;
+
+use SMF\Maintenance\Migration\MigrationBase;
+
+class Messages2 extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Converting messages, part 2';
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		$this->query(
+			'ALTER TABLE {db_prefix}messages
+			CHANGE COLUMN ID_TOPIC ID_TOPIC mediumint(8) unsigned NOT NULL default {literal:0}',
+		);
+
+		$this->query(
+			'ALTER TABLE {db_prefix}messages
+			CHANGE COLUMN smiliesEnabled smileysEnabled tinyint(4) NOT NULL default {literal:1}',
+		);
+
+		$this->handleTimeout();
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v1_0/Messages3.php
+++ b/Sources/Maintenance/Migration/v1_0/Messages3.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v1_0;
+
+use SMF\Maintenance\Migration\MigrationBase;
+
+class Messages3 extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Converting messages, part 3';
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		$this->query(
+			'ALTER TABLE {db_prefix}messages
+			CHANGE COLUMN posterTime posterTime int(10) unsigned NOT NULL default {literal:0},
+			CHANGE COLUMN modifiedTime modifiedTime int(10) unsigned NOT NULL default {literal:0}',
+		);
+
+		$this->query(
+			'ALTER TABLE {db_prefix}messages
+			ADD INDEX participation (ID_MEMBER, ID_TOPIC)',
+		);
+
+		$this->query(
+			'ALTER TABLE {db_prefix}messages
+			ADD INDEX ipIndex (posterIP(15), ID_TOPIC)',
+		);
+
+		$this->handleTimeout();
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v1_0/Messages4.php
+++ b/Sources/Maintenance/Migration/v1_0/Messages4.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v1_0;
+
+use SMF\Maintenance\Migration\MigrationBase;
+
+class Messages4 extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Converting messages, part 4';
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		$this->query(
+			'ALTER TABLE {db_prefix}messages
+			CHANGE COLUMN ID_MEMBER ID_MEMBER mediumint(8) unsigned NOT NULL default {literal:0},
+			CHANGE COLUMN icon icon varchar(16) NOT NULL default {literal:xx}',
+		);
+
+		$this->query(
+			'ALTER TABLE {db_prefix}messages
+			ADD INDEX ID_MEMBER (ID_MEMBER)',
+		);
+
+		$this->query(
+			'ALTER TABLE {db_prefix}messages
+			ADD UNIQUE INDEX topic (ID_TOPIC, ID_MSG)',
+		);
+
+		$this->handleTimeout();
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v1_0/Messages5.php
+++ b/Sources/Maintenance/Migration/v1_0/Messages5.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v1_0;
+
+use SMF\Maintenance\Migration\MigrationBase;
+
+class Messages5 extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Converting messages, part 5';
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		$this->query(
+			'ALTER TABLE {db_prefix}messages
+			ADD COLUMN ID_BOARD smallint(5) unsigned NOT NULL default {literal:0}',
+		);
+
+		$this->handleTimeout();
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v1_0/Messages6.php
+++ b/Sources/Maintenance/Migration/v1_0/Messages6.php
@@ -1,0 +1,96 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v1_0;
+
+use SMF\Db\DatabaseApi as Db;
+use SMF\Maintenance\Migration\MigrationBase;
+
+class Messages6 extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Converting messages, part 6';
+
+	/*********************
+	 * Internal properties
+	 *********************/
+
+	/**
+	 * @var int
+	 *
+	 * Maximum number of items to process at once.
+	 */
+	private int $limit = 1400;
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		while (true) {
+			$this->handleTimeout();
+
+			$request = $this->query(
+				'SELECT DISTINCT t.ID_BOARD, t.ID_TOPIC
+				FROM ({db_prefix}messages AS m, {db_prefix}topics AS t)
+				WHERE t.ID_TOPIC = m.ID_TOPIC
+					AND m.ID_BOARD = {int:zero}
+				LIMIT {int:limit}',
+				[
+					'zero' => 0,
+					'limit' => $this->limit,
+				],
+			);
+
+			$boards = [];
+
+			while ($row = Db::$db->fetch_assoc($request)) {
+				$boards[$row['ID_BOARD']][] = $row['ID_TOPIC'];
+			}
+
+			foreach ($boards as $board => $topics) {
+				$this->query(
+					'UPDATE {db_prefix}messages
+					SET ID_BOARD = {int:board}
+					WHERE ID_TOPIC IN ({array_int:topics})',
+					[
+						'board' => $board,
+						'topics' => $topics,
+					],
+				);
+			}
+
+			$num_rows = Db::$db->num_rows($request);
+
+			Db::$db->free_result($request);
+
+			if ($num_rows < $this->limit) {
+				break;
+			}
+		}
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v1_0/Messages7.php
+++ b/Sources/Maintenance/Migration/v1_0/Messages7.php
@@ -1,0 +1,69 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v1_0;
+
+use SMF\Maintenance\Migration\MigrationBase;
+
+class Messages7 extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Converting messages, part 7';
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		$this->query(
+			'ALTER TABLE {db_prefix}messages
+			ADD INDEX ID_BOARD (ID_BOARD)',
+		);
+
+		$this->query(
+			'ALTER TABLE {db_prefix}messages
+			DROP INDEX posterTime_2',
+		);
+
+		$this->query(
+			'ALTER TABLE {db_prefix}messages
+			DROP INDEX posterTime_3',
+		);
+
+		$this->query(
+			'ALTER TABLE {db_prefix}messages
+			DROP INDEX ID_MEMBER_2',
+		);
+
+		$this->query(
+			'ALTER TABLE {db_prefix}messages
+			DROP INDEX ID_MEMBER_3',
+		);
+
+		$this->handleTimeout();
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v1_0/Moderators.php
+++ b/Sources/Maintenance/Migration/v1_0/Moderators.php
@@ -1,0 +1,110 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v1_0;
+
+use SMF\Db\DatabaseApi as Db;
+use SMF\Db\Schema;
+use SMF\Maintenance\Migration\MigrationBase;
+
+class Moderators extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Converting moderators';
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function isCandidate(): bool
+	{
+		$table = new Schema\v1_0\Boards();
+		$structure = $table->getCurrentStructure();
+
+		return array_filter($structure['columns'], fn($c) => $c['name'] === 'moderators') !== [];
+	}
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		$result = $this->query(
+			'SELECT moderators, ID_BOARD
+			FROM {db_prefix}boards
+			WHERE TRIM(moderators) != {string:empty}',
+			[
+				'empty' => '',
+			],
+		);
+
+		while ($row = Db::$db->fetch_assoc($result)) {
+			$names = array_filter(
+				array_unique(array_map('trim', explode(',', $row['moderators']))),
+				'strlen',
+			);
+
+			if (!empty($names)) {
+				$inserts = [];
+
+				$request2 = $this->query(
+					'SELECT ID_MEMBER
+					FROM {db_prefix}members
+					WHERE memberName IN ({array_string:names})
+					LIMIT {int:limit}',
+					[
+						'names' => $names,
+						'limit' => \count($names),
+					],
+				);
+
+				while ($row = Db::$db->fetch_row($request2)) {
+					$inserts[] = [$row['ID_BOARD'], $row[0]];
+				}
+
+				Db::$db->free_result($request2);
+
+				Db::$db->insert(
+					method: 'ignore',
+					table: '{db_prefix}moderators',
+					columns: [
+						'ID_BOARD' => 'int',
+						'ID_MEMBER' => 'int',
+					],
+					data: $inserts,
+					keys: [],
+				);
+			}
+		}
+
+		Db::$db->free_result($request);
+
+		$table = new Schema\v1_0\Boards();
+		$table->dropColumn('moderators');
+
+		$this->handleTimeout();
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v1_0/NewSettings.php
+++ b/Sources/Maintenance/Migration/v1_0/NewSettings.php
@@ -1,0 +1,209 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v1_0;
+
+use SMF\Config;
+use SMF\Db\Schema;
+use SMF\Maintenance\Migration\MigrationBase;
+use SMF\Sapi;
+
+class NewSettings extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Adding new settings';
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		$table = new Schema\v1_0\Settings();
+		$table->dropIndex('variable');
+
+		// Renamed setting.
+		if (isset(Config::$modSettings['guest_hideEmail'])) {
+			Config::updateModSettings([
+				'guest_hideContacts' => Config::$modSettings['guest_hideEmail'],
+				'guest_hideEmail' => null,
+			]);
+		}
+
+		// New settings.
+		Config::updateModSettings([
+			'news' => Config::$modSettings['news'] ?? '',
+			'compactTopicPagesContiguous' => Config::$modSettings['compactTopicPagesContiguous'] ?? 5,
+			'compactTopicPagesEnable' => Config::$modSettings['compactTopicPagesEnable'] ?? 1,
+			'enableStickyTopics' => Config::$modSettings['enableStickyTopics'] ?? 1,
+			'todayMod' => Config::$modSettings['todayMod'] ?? 1,
+			'karmaMode' => Config::$modSettings['karmaMode'] ?? 0,
+			'karmaTimeRestrictAdmins' => Config::$modSettings['karmaTimeRestrictAdmins'] ?? 1,
+			'enablePreviousNext' => Config::$modSettings['enablePreviousNext'] ?? 1,
+			'pollMode' => Config::$modSettings['pollMode'] ?? 1,
+			'enableVBStyleLogin' => Config::$modSettings['enableVBStyleLogin'] ?? 1,
+			'enableCompressedOutput' => Config::$modSettings['enableCompressedOutput'] ?? 1,
+			'karmaWaitTime' => Config::$modSettings['karmaWaitTime'] ?? 1,
+			'karmaMinPosts' => Config::$modSettings['karmaMinPosts'] ?? 0,
+			'karmaLabel' => Config::$modSettings['karmaLabel'] ?? 'Karma:',
+			'karmaSmiteLabel' => Config::$modSettings['karmaSmiteLabel'] ?? '[smite]',
+			'karmaApplaudLabel' => Config::$modSettings['karmaApplaudLabel'] ?? '[applaud]',
+			'attachmentSizeLimit' => Config::$modSettings['attachmentSizeLimit'] ?? 128,
+			'attachmentPostLimit' => Config::$modSettings['attachmentPostLimit'] ?? 192,
+			'attachmentNumPerPostLimit' => Config::$modSettings['attachmentNumPerPostLimit'] ?? 4,
+			'attachmentDirSizeLimit' => Config::$modSettings['attachmentDirSizeLimit'] ?? 10240,
+			'attachmentUploadDir' => Config::$modSettings['attachmentUploadDir'] ?? Config::$boarddir . DIRECTORY_SEPARATOR . 'attachments',
+			'attachmentExtensions' => Config::$modSettings['attachmentExtensions'] ?? 'txt,doc,pdf,jpg,gif,mpg,png',
+			'attachmentCheckExtensions' => Config::$modSettings['attachmentCheckExtensions'] ?? 1,
+			'attachmentShowImages' => Config::$modSettings['attachmentShowImages'] ?? 1,
+			'attachmentEnable' => Config::$modSettings['attachmentEnable'] ?? 1,
+			'attachmentEncryptFilenames' => Config::$modSettings['attachmentEncryptFilenames'] ?? 1,
+			'censorIgnoreCase' => Config::$modSettings['censorIgnoreCase'] ?? 1,
+			'mostOnline' => Config::$modSettings['mostOnline'] ?? 1,
+			'mostOnlineToday' => Config::$modSettings['mostOnlineToday'] ?? 1,
+			'mostDate' => Config::$modSettings['mostDate'] ?? time(),
+			'trackStats' => Config::$modSettings['trackStats'] ?? 1,
+			'userLanguage' => Config::$modSettings['userLanguage'] ?? 1,
+			'titlesEnable' => Config::$modSettings['titlesEnable'] ?? 1,
+			'topicSummaryPosts' => Config::$modSettings['topicSummaryPosts'] ?? 15,
+			'enableErrorLogging' => Config::$modSettings['enableErrorLogging'] ?? 1,
+			'onlineEnable' => Config::$modSettings['onlineEnable'] ?? 0,
+			'cal_holidaycolor' => Config::$modSettings['cal_holidaycolor'] ?? '000080',
+			'cal_bdaycolor' => Config::$modSettings['cal_bdaycolor'] ?? '920AC4',
+			'cal_eventcolor' => Config::$modSettings['cal_eventcolor'] ?? '078907',
+			'cal_enabled' => Config::$modSettings['cal_enabled'] ?? 0,
+			'cal_maxyear' => Config::$modSettings['cal_maxyear'] ?? 2010,
+			'cal_minyear' => Config::$modSettings['cal_minyear'] ?? 2002,
+			'cal_daysaslink' => Config::$modSettings['cal_daysaslink'] ?? 0,
+			'cal_defaultboard' => Config::$modSettings['cal_defaultboard'] ?? '',
+			'cal_showeventsonindex' => Config::$modSettings['cal_showeventsonindex'] ?? 0,
+			'cal_showbdaysonindex' => Config::$modSettings['cal_showbdaysonindex'] ?? 0,
+			'cal_showholidaysonindex' => Config::$modSettings['cal_showholidaysonindex'] ?? 0,
+			'cal_showweeknum' => Config::$modSettings['cal_showweeknum'] ?? 0,
+			'cal_maxspan' => Config::$modSettings['cal_maxspan'] ?? 7,
+			'smtp_host' => Config::$modSettings['smtp_host'] ?? '',
+			'smtp_username' => Config::$modSettings['smtp_username'] ?? '',
+			'smtp_password' => Config::$modSettings['smtp_password'] ?? '',
+			'mail_type' => Config::$modSettings['mail_type'] ?? 0,
+			'timeLoadPageEnable' => Config::$modSettings['timeLoadPageEnable'] ?? 0,
+			'totalTopics' => Config::$modSettings['totalTopics'] ?? 1,
+			'totalMessages' => Config::$modSettings['totalMessages'] ?? 1,
+			'simpleSearch' => Config::$modSettings['simpleSearch'] ?? 0,
+			'censor_vulgar' => Config::$modSettings['censor_vulgar'] ?? '',
+			'censor_proper' => Config::$modSettings['censor_proper'] ?? '',
+			'mostOnlineToday' => Config::$modSettings['mostOnlineToday'] ?? 1,
+			'enablePostHTML' => Config::$modSettings['enablePostHTML'] ?? 0,
+			'theme_allow' => Config::$modSettings['theme_allow'] ?? 1,
+			'theme_default' => Config::$modSettings['theme_default'] ?? 1,
+			'theme_guests' => Config::$modSettings['theme_guests'] ?? 1,
+			'xmlnews_enable' => Config::$modSettings['xmlnews_enable'] ?? 1,
+			'xmlnews_maxlen' => Config::$modSettings['xmlnews_maxlen'] ?? 255,
+			'hotTopicPosts' => Config::$modSettings['hotTopicPosts'] ?? 15,
+			'hotTopicVeryPosts' => Config::$modSettings['hotTopicVeryPosts'] ?? 25,
+			'allow_editDisplayName' => Config::$modSettings['allow_editDisplayName'] ?? 1,
+			'number_format' => Config::$modSettings['number_format'] ?? '1234.00',
+			'attachmentEncryptFilenames' => Config::$modSettings['attachmentEncryptFilenames'] ?? 1,
+			'autoLinkUrls' => Config::$modSettings['autoLinkUrls'] ?? 1,
+			'avatar_allow_server_stored' => Config::$modSettings['avatar_allow_server_stored'] ?? 1,
+			'avatar_check_size' => Config::$modSettings['avatar_check_size'] ?? 0,
+			'avatar_action_too_large' => Config::$modSettings['avatar_action_too_large'] ?? 'option_user_resize',
+			'avatar_resize_upload' => Config::$modSettings['avatar_resize_upload'] ?? 1,
+			'avatar_download_png' => Config::$modSettings['avatar_download_png'] ?? 1,
+			'failed_login_threshold' => Config::$modSettings['failed_login_threshold'] ?? 3,
+			'edit_wait_time' => Config::$modSettings['edit_wait_time'] ?? 90,
+			'autoFixDatabase' => Config::$modSettings['autoFixDatabase'] ?? 1,
+			'autoOptDatabase' => Config::$modSettings['autoOptDatabase'] ?? 7,
+			'autoOptMaxOnline' => Config::$modSettings['autoOptMaxOnline'] ?? 0,
+			'autoOptLastOpt' => Config::$modSettings['autoOptLastOpt'] ?? 0,
+			'enableParticipation' => Config::$modSettings['enableParticipation'] ?? 1,
+			'recycle_enable' => Config::$modSettings['recycle_enable'] ?? 0,
+			'recycle_board' => Config::$modSettings['recycle_board'] ?? 0,
+			'banLastUpdated' => Config::$modSettings['banLastUpdated'] ?? 0,
+			'enableAllMessages' => Config::$modSettings['enableAllMessages'] ?? 0,
+			'fixLongWords' => Config::$modSettings['fixLongWords'] ?? 0,
+			'knownThemes' => Config::$modSettings['knownThemes'] ?? '1,2',
+			'who_enabled' => Config::$modSettings['who_enabled'] ?? 1,
+			'lastActive' => Config::$modSettings['lastActive'] ?? 15,
+			'allow_hideOnline' => Config::$modSettings['allow_hideOnline'] ?? 1,
+			'guest_hideContacts' => Config::$modSettings['guest_hideContacts'] ?? 0,
+			'registration_method' => match (true) {
+				!empty(Config::$modSettings['registration_disabled']) => 3,
+				!empty(Config::$modSettings['approve_registration']) => 2,
+				!empty($GLOBALS['emailpassword']) => 1,
+				!empty(Config::$modSettings['send_validation']) => 1,
+				default => 0,
+			},
+			'send_validation_onChange' => $GLOBALS['emailnewpass'] ?? 0,
+			'send_welcomeEmail' => $GLOBALS['emailwelcome'] ?? 1,
+			'allow_hideEmail' => $GLOBALS['allow_hide_email'] ?? 1,
+			'allow_guestAccess' => $GLOBALS['guestaccess'] ?? 1,
+			'time_format' => !empty($GLOBALS['timeformatstring']) ? $GLOBALS['timeformatstring'] : '%B %d, %Y, %I:%M:%S %p',
+			'enableBBC' => $GLOBALS['enable_ubbc'] ?? 1,
+			'max_messageLength' => $GLOBALS['MaxMessLen'] ?? 20000,
+			'max_signatureLength' => $GLOBALS['MaxSigLen'] ?? 300,
+			'spamWaitTime' => $GLOBALS['timeout'] ?? 5,
+			'avatar_directory' => Sapi::canonicalPath($GLOBALS['facesdir'] ?? './avatars', Config::$boarddir),
+			'avatar_url' => $GLOBALS['facesurl'] ?? Config::$boardurl . '/avatars',
+			'avatar_max_height_external' => $GLOBALS['userpic_height'] ?? 65,
+			'avatar_max_width_external' => $GLOBALS['userpic_width'] ?? 65,
+			'avatar_max_height_upload' => $GLOBALS['userpic_height'] ?? 65,
+			'avatar_max_width_upload' => $GLOBALS['userpic_width'] ?? 65,
+			'defaultMaxMessages' => $GLOBALS['maxmessagedisplay'] ?? 15,
+			'defaultMaxTopics' => $GLOBALS['maxdisplay'] ?? 20,
+			'defaultMaxMembers' => $GLOBALS['MembersPerPage'] ?? 30,
+			'time_offset' => $GLOBALS['timeoffset'] ?? 0,
+			'cookieTime' => $GLOBALS['Cookie_Length'] ?? 60,
+			'requireAgreement' => $GLOBALS['RegAgree'] ?? 1,
+			'smileys_dir' => Config::$boarddir . DIRECTORY_SEPARATOR . 'Smileys',
+			'smileys_url' => Config::$boardurl . '/Smileys',
+			'smiley_sets_known' => 'default,classic',
+			'smiley_sets_names' => 'Default' . "\n" . 'Classic',
+			'smiley_sets_default' => 'default',
+			'censorIgnoreCase' => 1,
+			'cal_days_for_index' => 7,
+			'unapprovedMembers' => 0,
+			'default_personalText' => '',
+			'attachmentPostLimit' => 192,
+			'attachmentNumPerPostLimit' => 4,
+			'package_make_backups' => 1,
+			'databaseSession_loose' => 1,
+			'databaseSession_lifetime' => 2880,
+			'smtp_port' => 25,
+			'search_cache_size' => 50,
+			'search_results_per_page' => 30,
+			'search_weight_frequency' => 30,
+			'search_weight_age' => 25,
+			'search_weight_length' => 20,
+			'search_weight_subject' => 15,
+			'search_weight_first_message' => 10,
+			'agreement' => null,
+			'cal_today_updated' => '00000000',
+			'enable_password_conversion' => 1,
+		]);
+
+		$this->handleTimeout();
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v1_0/NewTables.php
+++ b/Sources/Maintenance/Migration/v1_0/NewTables.php
@@ -1,0 +1,220 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v1_0;
+
+use SMF\Db\DatabaseApi as Db;
+use SMF\Db\Schema;
+use SMF\Maintenance\Migration\MigrationBase;
+
+class NewTables extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Creating new tables and inserting default data';
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		// Themes table.
+		$table = new Schema\v1_0\Themes();
+
+		if (!$table->create(if_exists: 'false')) {
+			$table->alterColumn($table->columns['ID_MEMBER']);
+			$table->alterColumn($table->columns['value']);
+		}
+
+		Db::$db->insert(
+			method: 'ignore',
+			table: '{db_prefix}' . $table->name,
+			columns: [
+				'ID_MEMBER' => 'int',
+				'ID_THEME' => 'int',
+				'variable' => 'string',
+				'value' => 'string',
+			],
+			data: [
+				[0, 1, 'name', 'SMF Default Theme'],
+				[0, 1, 'theme_url', Config::$boardurl . '/Themes/default'],
+				[0, 1, 'images_url', Config::$boardurl . '/Themes/default/images'],
+				[0, 1, 'theme_dir', Config::$boarddir . '/Themes/default'],
+				[0, 1, 'allow_no_censored', 0],
+				[0, 1, 'additional_options_collapsable', 1],
+				[0, 2, 'name', 'Classic YaBB SE Theme'],
+				[0, 2, 'theme_url', Config::$boardurl . '/Themes/classic'],
+				[0, 2, 'images_url', Config::$boardurl . '/Themes/classic/images'],
+				[0, 2, 'theme_dir', Config::$boarddir . '/Themes/classic'],
+			],
+			keys: [],
+		);
+
+		$this->handleTimeout();
+
+		// Permissions table.
+		$table = new Schema\v1_0\Permissions();
+
+		if (!$table->create(if_exists: 'false')) {
+			$table->addColumn($table->columns['addDeny']);
+			$table->alterColumn($table->columns['permission']);
+		}
+
+		$this->query(
+			'UPDATE IGNORE {db_prefix}permissions
+			SET
+				permission = REPLACE(permission, "profile_own_identity", "profile_identity_own"),
+				permission = REPLACE(permission, "profile_any_identity", "profile_identity_any"),
+				permission = REPLACE(permission, "profile_own_extra", "profile_extra_own"),
+				permission = REPLACE(permission, "profile_any_extra", "profile_extra_any"),
+				permission = REPLACE(permission, "profile_own_title", "profile_title_own"),
+				permission = REPLACE(permission, "profile_any_title", "profile_title_any"),
+				permission = REPLACE(permission, "im_read", "pm_read"),
+				permission = REPLACE(permission, "im_send", "pm_send")',
+		);
+
+		Db::$db->insert(
+			method: 'ignore',
+			table: '{db_prefix}' . $table->name,
+			columns: [
+				'ID_GROUP' => 'int',
+				'permission' => 'string-30',
+			],
+			data: [
+				[-1, 'search_posts'],
+				[-1, 'calendar_view'],
+				[-1, 'view_stats'],
+				[-1, 'profile_view_any'],
+				[2, 'calendar_post'],
+				[2, 'calendar_edit_any'],
+				[2, 'calendar_edit_own'],
+			],
+			keys: [],
+		);
+
+		$this->handleTimeout();
+
+		// Board permissions table.
+		$table = new Schema\v1_0\BoardPermissions();
+
+		if (!$table->create(if_exists: 'false')) {
+			$table->addColumn($table->columns['addDeny']);
+			$table->alterColumn($table->columns['permission']);
+		}
+
+		Db::$db->insert(
+			method: '',
+			table: '{db_prefix}' . $table->name,
+			columns: [
+				'ID_GROUP' => 'int',
+				'ID_BOARD' => 'int',
+				'permission' => 'string-30',
+			],
+			data: [
+				[-1, 0, 'poll_view'],
+				[3, 0, 'make_sticky'],
+				[3, 0, 'lock_any'],
+				[3, 0, 'remove_any'],
+				[3, 0, 'move_any'],
+				[3, 0, 'merge_any'],
+				[3, 0, 'split_any'],
+				[3, 0, 'delete_any'],
+				[3, 0, 'modify_any'],
+				[2, 0, 'make_sticky'],
+				[2, 0, 'lock_any'],
+				[2, 0, 'remove_any'],
+				[2, 0, 'move_any'],
+				[2, 0, 'merge_any'],
+				[2, 0, 'split_any'],
+				[2, 0, 'delete_any'],
+				[2, 0, 'modify_any'],
+				[2, 0, 'poll_lock_any'],
+				[2, 0, 'poll_lock_any'],
+				[2, 0, 'poll_add_any'],
+				[2, 0, 'poll_remove_any'],
+				[2, 0, 'poll_remove_any'],
+			],
+			keys: [],
+		);
+
+		Db::$db->insert(
+			method: 'ignore',
+			table: '{db_prefix}' . $table->name,
+			columns: [
+				'ID_GROUP' => 'int',
+				'ID_BOARD' => 'int',
+				'permission' => 'string-30',
+			],
+			data: [
+				[3, 0, 'moderate_board'],
+				[2, 0, 'moderate_board'],
+			],
+			keys: [],
+		);
+
+		$this->handleTimeout();
+
+		// Other tables.
+		$table = new Schema\v1_0\Moderators();
+		$table->create();
+
+		$table = new Schema\v1_0\Attachments();
+		$table->create();
+
+		$table = new Schema\v1_0\LogNotify();
+		$table->create();
+
+		$table = new Schema\v1_0\LogPolls();
+		$table->create();
+
+		$table = new Schema\v1_0\LogActions();
+		$table->create();
+
+		$table = new Schema\v1_0\PollChoices();
+		$table->create();
+
+		$table = new Schema\v1_0\Smileys();
+		$table->create();
+		$table->populate();
+
+		$table = new Schema\v1_0\LogSearch();
+		$table->drop();
+		$table->create();
+
+		$table = new Schema\v1_0\Sessions();
+		$table->drop();
+		$table->create();
+
+		$table = new Schema\v1_0\Settings();
+		$table->dropIndex($this->indexes['primary']);
+		$table->addIndex($this->indexes['primary']);
+
+		$table = new Schema\v1_0\ImRecipients();
+		$table->create();
+
+		$this->handleTimeout();
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v1_0/News.php
+++ b/Sources/Maintenance/Migration/v1_0/News.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v1_0;
+
+use SMF\Config;
+use SMF\Maintenance\Migration\MigrationBase;
+use SMF\Utils;
+
+class News extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Converting news';
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		Config::updateModSettings([
+			'news' => Utils::htmlspecialchars(
+				Utils::entityDecode(
+					stripslashes(Config::$modSettings['news']),
+					nbsp_to_space: true,
+				),
+				ENT_QUOTES,
+			),
+		]);
+
+		$this->handleTimeout();
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v1_0/Options.php
+++ b/Sources/Maintenance/Migration/v1_0/Options.php
@@ -1,0 +1,82 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v1_0;
+
+use SMF\Config;
+use SMF\Db\DatabaseApi as Db;
+use SMF\Maintenance\Migration\MigrationBase;
+
+class Options extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Converting settings to options';
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		// Format: new_setting -> old_setting_name.
+		$values = [
+			'calendar_start_day' => 'cal_startmonday',
+			'view_newest_first' => 'viewNewestFirst',
+			'view_newest_pm_first' => 'viewNewestFirst',
+		];
+
+		foreach ($values as $variable => $value) {
+			if (empty(Config::$modSettings[$value[0]])) {
+				continue;
+			}
+
+			Db::$db->query(
+				'INSERT IGNORE INTO {db_prefix}themes
+					(id_member, id_theme, variable, value)
+				SELECT id_member, 1, {string:variable}, {string:value}
+				FROM {db_prefix}members',
+				[
+					'variable' => $variable,
+					'value' => Config::$modSettings[$value[0]],
+					'db_error_skip' => true,
+				],
+			);
+
+			Db::$db->query(
+				'INSERT IGNORE INTO {db_prefix}themes
+					(id_member, id_theme, variable, value)
+				VALUES (-1, 1, {string:variable}, {string:value})',
+				[
+					'variable' => $variable,
+					'value' => Config::$modSettings[$value[0]],
+					'db_error_skip' => true,
+				],
+			);
+		}
+
+		$this->handleTimeout();
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v1_0/PollChoices.php
+++ b/Sources/Maintenance/Migration/v1_0/PollChoices.php
@@ -1,0 +1,77 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v1_0;
+
+use SMF\Db\DatabaseApi as Db;
+use SMF\Maintenance\Migration\MigrationBase;
+
+class PollChoices extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Converting poll choices';
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function isCandidate(): bool
+	{
+		$request = $this->query(
+			'SELECT COUNT(*)
+			FROM {db_prefix}poll_choices',
+		);
+
+		list($num_rows) = Db::$db->fetch_row($request);
+
+		Db::$db->free_result($request);
+
+		return empty($num_rows);
+	}
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		for ($i = 0; $i < 8; $i++) {
+			$this->query(
+				'INSERT INTO {db_prefix}poll_choices
+					(ID_POLL, ID_CHOICE, label, votes)
+				SELECT ID_POLL, {int:id_choice}, {raw:option}, {raw:votes}
+				FROM {db_prefix}polls',
+				[
+					'id_choice' => $i,
+					'option' => 'option' . ($i + 1),
+					'votes' => 'votes' . ($i + 1),
+				],
+			);
+
+		}
+
+		$this->handleTimeout();
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v1_0/Polls.php
+++ b/Sources/Maintenance/Migration/v1_0/Polls.php
@@ -1,0 +1,88 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v1_0;
+
+use SMF\Db\DatabaseApi as Db;
+use SMF\Db\Schema;
+use SMF\Maintenance\Migration\MigrationBase;
+
+class Polls extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Converting polls';
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function isCandidate(): bool
+	{
+		$table = new Schema\v1_0\Polls();
+		$structure = $table->getCurrentStructure();
+
+		return array_filter($structure['columns'], fn($c) => $c['name'] === 'option1') !== [];
+	}
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		// Normalize the table structure.
+		$table = new Schema\v1_0\Polls();
+
+		for ($i = 1; $i <= 8; $i++) {
+			$table->dropColumn('option' . $i);
+			$table->dropColumn('votes' . $i);
+		}
+
+		$table->dropColumn('votedMemberIDs');
+		$table->dropIndex($table->indexes['primary']);
+		$table->normalize();
+
+		// Update data about who created each poll.
+		Db::$db->update_from(
+			table: [
+				'name' => '{db_prefix}polls',
+				'alias' => 'p',
+			],
+			from_tables: [
+				[
+					'name' => '{db_prefix}topics',
+					'alias' => 't',
+					'condition' => 'p.ID_POLL = t.ID_POLL',
+				],
+			],
+			set: 'p.ID_MEMBER = t.ID_MEMBER_STARTED',
+			where: 'p.ID_MEMBER = 0 AND t.ID_MEMBER_STARTED != 0',
+			db_values: [],
+		);
+
+		// Done.
+		$this->handleTimeout();
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v1_0/ReservedNames.php
+++ b/Sources/Maintenance/Migration/v1_0/ReservedNames.php
@@ -1,0 +1,87 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v1_0;
+
+use SMF\Config;
+use SMF\Db\DatabaseApi as Db;
+use SMF\Maintenance\Migration\MigrationBase;
+
+class ReservedNames extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Converting "reserved_names"';
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function isCandidate(): bool
+	{
+		return \count(Db::$db->list_tables(false, Config::$db_prefix . 'reserved_names')) > 0;
+	}
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		$request = $this->query(
+			'SELECT setting, value
+			FROM {db_prefix}reserved_names',
+		);
+
+		$words = [];
+		$match_settings = [
+			'matchword' => 0,
+			'matchcase' => 0,
+			'matchuser' => 0,
+			'matchname' => 0,
+		];
+
+		while ($row = Db::$db->fetch_assoc($request)) {
+			if (substr($row['setting'], 0, 5) == 'match') {
+				$match_settings[$row['setting']] = (int) $row['value'];
+			} else {
+				$words[] = $row['value'];
+			}
+		}
+
+		Db::$db->free_result($request);
+
+		Config::updateModSettings([
+			'reserveWord' => $match_settings['matchword'],
+			'reserveCase' => $match_settings['matchcase'],
+			'reserveUser' => $match_settings['matchuser'],
+			'reserveName' => $match_settings['matchname'],
+			'reserveNames' => implode("\n", $words),
+		]);
+
+		Db::$db->drop_table('{db_prefix}reserved_names');
+
+		$this->handleTimeout();
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v1_0/Statistics.php
+++ b/Sources/Maintenance/Migration/v1_0/Statistics.php
@@ -1,0 +1,101 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v1_0;
+
+use SMF\Maintenance\Migration\MigrationBase;
+
+class Statistics extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Updating statistics';
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		$this->query(
+			'REPLACE INTO {db_prefix}settings
+				(variable, value)
+			SELECT {literal:latestMember}, ID_MEMBER
+			FROM {db_prefix}members
+			ORDER BY ID_MEMBER DESC
+			LIMIT 1',
+		);
+
+		$this->query(
+			'REPLACE INTO {db_prefix}settings
+				(variable, value)
+			SELECT {literal:latestRealName}, COALESCE(realName, memberName)
+			FROM {db_prefix}members
+			ORDER BY ID_MEMBER DESC
+			LIMIT 1',
+		);
+
+		$this->query(
+			'REPLACE INTO {db_prefix}settings
+				(variable, value)
+			SELECT {literal:maxMsgID}, ID_MSG
+			FROM {db_prefix}messages
+			ORDER BY ID_MSG DESC
+			LIMIT 1',
+		);
+
+		$this->query(
+			'REPLACE INTO {db_prefix}settings
+				(variable, value)
+			SELECT {literal:totalMembers}, COUNT(*)
+			FROM {db_prefix}members',
+		);
+
+		$this->query(
+			'REPLACE INTO {db_prefix}settings
+				(variable, value)
+			SELECT {literal:unapprovedMembers}, COUNT(*)
+			FROM {db_prefix}members
+			WHERE is_activated = 0
+				AND validation_code = {empty}',
+		);
+
+		$this->query(
+			'REPLACE INTO {db_prefix}settings
+				(variable, value)
+			SELECT {literal:totalMessages}, COUNT(*)
+			FROM {db_prefix}messages',
+		);
+
+		$this->query(
+			'REPLACE INTO {db_prefix}settings
+				(variable, value)
+			SELECT {literal:totalTopics}, COUNT(*)
+			FROM {db_prefix}topics',
+		);
+
+		$this->handleTimeout();
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v1_0/Themes.php
+++ b/Sources/Maintenance/Migration/v1_0/Themes.php
@@ -1,0 +1,117 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v1_0;
+
+use SMF\Config;
+use SMF\Db\DatabaseApi as Db;
+use SMF\Maintenance\Migration\MigrationBase;
+
+class Themes extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Converting theme settings';
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		// A bunch of theme settings that were global settings in YaBB SE.
+		Db::$db->insert(
+			method: 'ignore',
+			table: '{db_prefix}themes',
+			columns: [
+				'id_member' => 'int',
+				'id_theme' => 'int',
+				'variable' => 'string',
+				'value' => 'string',
+			],
+			data: [
+				[0, 1, 'show_latest_member',  $GLOBALS['showlatestmember'] ?? 0],
+				[0, 1, 'show_bbc',  $GLOBALS['showyabbcbutt'] ?? $GLOBALS['showbbcbutt'] ?? 0],
+				[0, 1, 'show_modify',  $GLOBALS['showmodify'] ?? 0],
+				[0, 1, 'show_user_images',  $GLOBALS['showuserpic'] ?? 0],
+				[0, 1, 'show_blurb',  $GLOBALS['showusertext'] ?? 0],
+				[0, 1, 'show_gender',  $GLOBALS['showgenderimage'] ?? 0],
+				[0, 1, 'show_newsfader',  $GLOBALS['shownewsfader'] ?? 0],
+				[0, 1, 'display_recent_bar',  $GLOBALS['Show_RecentBar'] ?? 0],
+				[0, 1, 'show_member_bar',  $GLOBALS['Show_MemberBar'] ?? 0],
+				[0, 1, 'linktree_link',  $GLOBALS['curposlinks'] ?? 0],
+				[0, 1, 'show_profile_buttons',  $GLOBALS['profilebutton'] ?? 0],
+				[0, 1, 'show_mark_read',  $GLOBALS['showmarkread'] ?? 0],
+				[0, 1, 'show_board_desc',  $GLOBALS['ShowBDescrip'] ?? 0],
+				[0, 1, 'newsfader_time',  $GLOBALS['fadertime'] ?? 0],
+				[0, 1, 'use_image_buttons',  empty($GLOBALS['MenuType']) ? 1 : 0],
+				[0, 1, 'enable_news',  $GLOBALS['enable_news'] ?? 0],
+				[0, 1, 'linktree_inline',  Config::$modSettings['enableInlineLinks'] ?? 0],
+				[0, 1, 'return_to_post',  Config::$modSettings['returnToPost'] ?? 0],
+			],
+			keys: ['id_member', 'id_theme', 'variable'],
+		);
+
+		// This theme setting changed both its name and the meaning of its values.
+		$request = $this->query(
+			'SELECT ID_THEME, IF(value = {literal:2}, 5, value) AS value
+			FROM {db_prefix}themes
+			WHERE variable = {string:var}',
+			[
+				'var' => 'display_recent_bar',
+			],
+		);
+
+		while ($row = Db::$db->fetch_assoc($request)) {
+			$inserts[] = [$row['ID_THEME'], 'number_recent_posts', $row['value']];
+		}
+
+		Db::$db->free_result($request);
+
+		if (!empty($inserts)) {
+			Db::$db->insert(
+				method: 'ignore',
+				table: '{db_prefix}themes',
+				columns: [
+					'id_theme' => 'int',
+					'variable' => 'string',
+					'value' => 'string',
+				],
+				data: $inserts,
+				keys: ['id_member', 'id_theme', 'variable'],
+			);
+		}
+
+		$this->query(
+			'DELETE FROM {db_prefix}themes
+			WHERE variable = {string:var}',
+			[
+				'var' => 'display_recent_bar',
+			],
+		);
+
+		$this->handleTimeout();
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v1_0/TopicNotifications.php
+++ b/Sources/Maintenance/Migration/v1_0/TopicNotifications.php
@@ -1,0 +1,103 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v1_0;
+
+use SMF\Db\DatabaseApi as Db;
+use SMF\Db\Schema;
+use SMF\Maintenance\Migration\MigrationBase;
+
+class TopicNotifications extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Converting topic notifications';
+
+	/*********************
+	 * Internal properties
+	 *********************/
+
+	/**
+	 * @var int
+	 *
+	 * Maximum number of items to process at once.
+	 */
+	private int $limit = 512;
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function isCandidate(): bool
+	{
+		$table = new Schema\v1_0\Topics();
+		$structure = $table->getCurrentStructure();
+
+		return array_filter($structure['columns'], fn($c) => $c['name'] === 'notifies') !== [];
+	}
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		$request = $this->query(
+			'SELECT COUNT(*)
+			FROM {db_prefix}topics
+			WHERE notifies != {empty}',
+		);
+
+		list($num_notifies) = Db::$db->fetch_row($request);
+		Maintenance::$total_items = (int) $num_notifies;
+
+		Db::$db->free_result($request);
+
+		do {
+			$start = Maintenance::getCurrentStart();
+			$this->handleTimeout($start);
+
+			$this->query(
+				'INSERT IGNORE INTO {db_prefix}log_notify
+					(ID_MEMBER, ID_TOPIC)
+				SELECT mem.ID_MEMBER, t.ID_TOPIC
+				FROM ({db_prefix}topics AS t, {db_prefix}members AS mem)
+				WHERE t.notifies != {empty}
+					AND FIND_IN_SET(mem.ID_MEMBER, t.notifies)
+				LIMIT {int:limit}
+				OFFSET {int:start}',
+				[
+					'start' => $start,
+					'limit' => $this->limit,
+				],
+			);
+
+			Maintenance::setCurrentStart($start + $this->limit);
+		} while (Maintenance::getCurrentStart() < Maintenance::$total_items);
+
+		// Drop the obsolete column.
+		$table = new Schema\v1_0\Topics();
+		$table->dropColumn('notifies');
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v1_0/Topics1.php
+++ b/Sources/Maintenance/Migration/v1_0/Topics1.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v1_0;
+
+use SMF\Maintenance\Migration\MigrationBase;
+
+class Topics1 extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Converting topics, part 1';
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		$this->query(
+			'ALTER TABLE {db_prefix}topics
+			DROP INDEX ID_FIRST_MSG',
+		);
+
+		$this->query(
+			'ALTER TABLE {db_prefix}topics
+			DROP INDEX ID_LAST_MSG',
+		);
+
+		$this->query(
+			'ALTER TABLE {db_prefix}topics
+			ADD INDEX isSticky (isSticky)',
+		);
+
+		$this->handleTimeout();
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v1_0/Topics2.php
+++ b/Sources/Maintenance/Migration/v1_0/Topics2.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v1_0;
+
+use SMF\Maintenance\Migration\MigrationBase;
+
+class Topics2 extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Converting topics, part 2';
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		$this->query(
+			'ALTER TABLE {db_prefix}topics
+			ADD UNIQUE INDEX lastMessage (ID_LAST_MSG, ID_BOARD)',
+		);
+
+		$this->query(
+			'ALTER TABLE {db_prefix}topics
+			ADD UNIQUE INDEX firstMessage (ID_FIRST_MSG, ID_BOARD)',
+		);
+
+		$this->query(
+			'ALTER TABLE {db_prefix}topics
+			ADD UNIQUE INDEX poll (ID_POLL, ID_TOPIC)',
+		);
+
+		$this->handleTimeout();
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v1_0/Topics3.php
+++ b/Sources/Maintenance/Migration/v1_0/Topics3.php
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v1_0;
+
+use SMF\Maintenance\Migration\MigrationBase;
+
+class Topics3 extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Converting topics, part 3';
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		$this->query(
+			'ALTER TABLE {db_prefix}topics
+			DROP PRIMARY KEY,
+			CHANGE COLUMN ID_TOPIC ID_TOPIC mediumint(8) unsigned NOT NULL auto_increment PRIMARY KEY,
+			CHANGE COLUMN ID_BOARD ID_BOARD smallint(5) unsigned NOT NULL default {literal:0}',
+		);
+
+		$this->handleTimeout();
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v1_0/Topics4.php
+++ b/Sources/Maintenance/Migration/v1_0/Topics4.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v1_0;
+
+use SMF\Maintenance\Migration\MigrationBase;
+
+class Topics4 extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Converting topics, part 4';
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		$this->query(
+			'ALTER TABLE {db_prefix}topics
+			CHANGE COLUMN ID_MEMBER_STARTED ID_MEMBER_STARTED mediumint(8) unsigned NOT NULL default {literal:0},
+			CHANGE COLUMN ID_MEMBER_UPDATED ID_MEMBER_UPDATED mediumint(8) unsigned NOT NULL default {literal:0}',
+		);
+
+		$this->handleTimeout();
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v1_0/Topics5.php
+++ b/Sources/Maintenance/Migration/v1_0/Topics5.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v1_0;
+
+use SMF\Maintenance\Migration\MigrationBase;
+
+class Topics5 extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Converting topics, part 5';
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		$this->query(
+			'ALTER TABLE {db_prefix}topics
+			CHANGE COLUMN ID_FIRST_MSG ID_FIRST_MSG int(10) unsigned NOT NULL default {literal:0},
+			CHANGE COLUMN ID_LAST_MSG ID_LAST_MSG int(10) unsigned NOT NULL default {literal:0}',
+		);
+
+		$this->handleTimeout();
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v1_0/Topics6.php
+++ b/Sources/Maintenance/Migration/v1_0/Topics6.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v1_0;
+
+use SMF\Maintenance\Migration\MigrationBase;
+
+class Topics6 extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Converting topics, part 6';
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		$this->query(
+			'ALTER TABLE {db_prefix}topics
+			CHANGE COLUMN ID_POLL ID_POLL mediumint(8) unsigned NOT NULL default {literal:0}',
+		);
+
+		$this->handleTimeout();
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v1_0/index.php
+++ b/Sources/Maintenance/Migration/v1_0/index.php
@@ -1,0 +1,8 @@
+<?php
+
+// Try to handle it with the upper level index.php. (it should know what to do.)
+if (file_exists(dirname(__DIR__) . '/index.php')) {
+	include dirname(__DIR__) . '/index.php';
+} else {
+	exit;
+}

--- a/Sources/Maintenance/Migration/v1_1/AvatarPermissions.php
+++ b/Sources/Maintenance/Migration/v1_1/AvatarPermissions.php
@@ -1,0 +1,90 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v1_1;
+
+use SMF\Config;
+use SMF\Db\DatabaseApi as Db;
+use SMF\Maintenance\Migration\MigrationBase;
+
+class AvatarPermissions extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Converting avatar permissions and settings';
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		// Converting avatar permissions.
+		if (
+			!empty(Config::$modSettings['avatar_allow_server_stored'])
+			|| !empty(Config::$modSettings['avatar_allow_upload'])
+		) {
+			$request = $this->query(
+				'SELECT IF(ID_GROUP = 1, 0, ID_GROUP)
+				FROM {db_prefix}membergroups
+				WHERE ID_GROUP != 3
+					AND minPosts = -1',
+			);
+
+			while ($row = Db::$db->fetch_row($request)) {
+				if (!empty(Config::$modSettings['avatar_allow_server_stored'])) {
+					$data[] = [$row[0], 'profile_server_avatar'];
+				}
+
+				if (!empty(Config::$modSettings['avatar_allow_upload'])) {
+					$data[] = [$row[0], 'profile_upload_avatar'];
+				}
+			}
+
+			Db::$db->free_result($request);
+
+			Db::$db->insert(
+				method: '',
+				table: '{db_prefix}permissions',
+				columns: [
+					'ID_GROUP' => 'int',
+					'permission' => 'string-30',
+				],
+				data: $data,
+				keys: [],
+			);
+		}
+
+		// Removing obsolete avatar settings.
+		Config::updateModSettings([
+			'avatar_allow_external_url' => null,
+			'avatar_check_size' => null,
+			'avatar_allow_upload' => null,
+			'avatar_allow_server_stored' => null,
+		]);
+
+		$this->handleTimeout();
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v1_1/BanStats.php
+++ b/Sources/Maintenance/Migration/v1_1/BanStats.php
@@ -1,0 +1,116 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v1_1;
+
+use SMF\Db\DatabaseApi as Db;
+use SMF\Maintenance\Migration\MigrationBase;
+
+class BanStats extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Updating ban statistics';
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		$request = $this->query(
+			'SELECT mem.ID_MEMBER, mem.is_activated + 10 AS new_value
+			FROM {db_prefix}ban_items AS bi
+				INNER JOIN {db_prefix}ban_groups AS bg ON (
+					bg.id_ban_group = bi.id_ban_group
+				)
+				INNER JOIN {db_prefix}members AS mem ON (
+					mem.ID_MEMBER = bi.ID_MEMBER
+					OR mem.emailAddress LIKE bi.email_address
+				)
+			WHERE bg.cannot_access = 1
+				AND (bg.expire_time IS NULL OR bg.expire_time > {int:now})
+				AND mem.is_activated < 10',
+			[
+				'now' => time(),
+			],
+		);
+
+		$updates = [];
+
+		while ($row = Db::$db->fetch_assoc($request)) {
+			$updates[$row['new_value']][] = $row['ID_MEMBER'];
+		}
+
+		Db::$db->free_result($request);
+
+		// Find members that are wrongfully marked as banned.
+		$request = $this->query(
+			'SELECT mem.ID_MEMBER, mem.is_activated - 10 AS new_value
+			FROM {db_prefix}members AS mem
+				LEFT JOIN {db_prefix}ban_items AS bi ON (
+					bi.ID_MEMBER = mem.ID_MEMBER
+					OR mem.emailAddress LIKE bi.email_address
+				)
+				LEFT JOIN {db_prefix}ban_groups AS bg ON (
+					bg.id_ban_group = bi.id_ban_group
+					AND bg.cannot_access = 1
+					AND (
+						bg.expire_time IS NULL
+						OR bg.expire_time > {int:now}
+					)
+				)
+			WHERE (bi.id_ban IS NULL OR bg.id_ban_group IS NULL)
+				AND mem.is_activated >= 10',
+			[
+				'now' => time(),
+			],
+		);
+
+		while ($row = Db::$db->fetch_assoc($request)) {
+			$updates[$row['new_value']][] = $row['ID_MEMBER'];
+		}
+
+		Db::$db->free_result($request);
+
+		if (!empty($updates)) {
+			foreach ($updates as $new_status => $members) {
+				$this->query(
+					'UPDATE {db_prefix}members
+					SET is_activated = {string:status}
+					WHERE ID_MEMBER IN ({array_int:members})
+					LIMIT {int:limit}',
+					[
+						'status' => $new_status,
+						'members' => $members,
+						'limit' => \count($members),
+					],
+				);
+			}
+		}
+
+		$this->handleTimeout();
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v1_1/Bans.php
+++ b/Sources/Maintenance/Migration/v1_1/Bans.php
@@ -1,0 +1,170 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v1_1;
+
+use SMF\Config;
+use SMF\Db\DatabaseApi as Db;
+use SMF\Db\Schema;
+use SMF\Maintenance\Migration\MigrationBase;
+
+class Bans extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Updating ban system';
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function isCandidate(): bool
+	{
+		return Db::$db->list_tables(false, Config::$db_prefix . 'banned') !== [];
+	}
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		// Splitting ban table.
+		$this->query(
+			'RENAME TABLE {db_prefix}banned
+			TO {db_prefix}ban_groups',
+		);
+
+		$bg_table = new Schema\v1_1\BanGroups();
+		$bg_table->normalize();
+
+		$bi_table = new Schema\v1_1\BanItems();
+		$bi_table->create();
+
+		$request = $this->query(
+			'SELECT id_ban_group, ip_low1, ip_high1, ip_low2, ip_high2, ip_low3, ip_high3, ip_low4, ip_high4, hostname, email_address, ID_MEMBER
+			FROM {db_prefix}ban_groups',
+		);
+
+		while ($row = Db::$db->fetch_row($request)) {
+			Db::$db->insert(
+				method: '',
+				table: '{db_prefix}ban_items',
+				columns: [
+					'ID_BAN_GROUP' => 'int',
+					'ip_low1' => 'int',
+					'ip_high1' => 'int',
+					'ip_low2' => 'int',
+					'ip_high2' => 'int',
+					'ip_low3' => 'int',
+					'ip_high3' => 'int',
+					'ip_low4' => 'int',
+					'ip_high4' => 'int',
+					'hostname' => 'string-255',
+					'email_address' => 'string-255',
+					'ID_MEMBER' => 'int',
+				],
+				data: [$row],
+				keys: ['ID_BAN'],
+			);
+		}
+
+		Db::$db->free_result($request);
+
+		$bg_table->dropColumn('ban_type');
+		$bg_table->dropColumn('ip_low1');
+		$bg_table->dropColumn('ip_high1');
+		$bg_table->dropColumn('ip_low2');
+		$bg_table->dropColumn('ip_high2');
+		$bg_table->dropColumn('ip_low3');
+		$bg_table->dropColumn('ip_high3');
+		$bg_table->dropColumn('ip_low4');
+		$bg_table->dropColumn('ip_high4');
+		$bg_table->dropColumn('hostname');
+		$bg_table->dropColumn('email_address');
+		$bg_table->dropColumn('ID_MEMBER');
+
+		$this->handleTimeout();
+
+		// Generate names for existing bans.
+		$request = $this->query(
+			'SELECT id_ban_group, restriction_type
+			FROM {db_prefix}ban_groups
+			ORDER BY ban_time ASC',
+		);
+
+		$ban_names = [
+			'full_ban' => 1,
+			'cannot_register' => 1,
+			'cannot_post' => 1,
+		];
+
+		if ($request != false) {
+			while ($row = Db::$db->fetch_assoc($request)) {
+				$this->query(
+					'UPDATE {db_prefix}ban_groups
+					SET name = {string:ban_name}
+					WHERE id_ban_group = {int:id}',
+					[
+						'ban_name' => $row['restriction_type'] . '_' . str_pad($ban_names[$row['restriction_type']]++, 3, '0', STR_PAD_LEFT),
+						'id' => $row['id_ban_group'],
+					],
+				);
+			}
+
+			Db::$db->free_result($request);
+		}
+
+		$this->handleTimeout();
+
+		// Move each restriction type to its own column.
+		$this->query(
+			'UPDATE {db_prefix}ban_groups
+			SET
+				cannot_access = IF(restriction_type = {string:full_ban}, 1, 0),
+				cannot_register = IF(restriction_type = {string:cannot_register}, 1, 0),
+				cannot_post = IF(restriction_type = {string:cannot_post}, 1, 0)',
+			[
+				'full_ban' => 'full_ban',
+				'cannot_register' => 'cannot_register',
+				'cannot_post' => 'cannot_post',
+			],
+		);
+
+		$bg_table->dropColumn('restriction_type');
+
+		// Make sure everybody's ban situation is re-evaluated.
+		$this->query(
+			'UPDATE {db_prefix}settings
+			SET value = {int:now}
+			WHERE variable = {string:var}',
+			[
+				'now' => time(),
+				'var' => 'banLastUpdated',
+			],
+		);
+
+		$this->handleTimeout();
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v1_1/BoardPermissions.php
+++ b/Sources/Maintenance/Migration/v1_1/BoardPermissions.php
@@ -1,0 +1,110 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v1_1;
+
+use SMF\Config;
+use SMF\Maintenance\Migration\MigrationBase;
+
+class BoardPermissions extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Renaming board permissions';
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function isCandidate(): bool
+	{
+		return version_compare(
+			str_replace(' ', '.', strtolower(Config::$modSettings['smfVersion'] ?? '0.0.dev.0')),
+			'1.1',
+			'<',
+		);
+	}
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		// Step 1
+		$this->query(
+			'UPDATE {db_prefix}board_permissions
+			SET
+				permission = REPLACE(
+					permission,
+					{literal:remove_replies},
+					{literal:delete_replies},
+				),
+				permission = REPLACE(
+					permission,
+					{literal:remove_own},
+					{literal:delete2_own},
+				),
+				permission = REPLACE(
+					permission,
+					{literal:remove_any},
+					{literal:delete2_any},
+				)',
+		);
+
+		// Step 2
+		$this->query(
+			'UPDATE {db_prefix}board_permissions
+			SET
+				permission = REPLACE(
+					permission,
+					{literal:delete_own},
+					{literal:remove_own},
+				),
+				permission = REPLACE(
+					permission,
+					{literal:delete_any},
+					{literal:remove_any},
+				)',
+		);
+
+		// Step 3
+		$this->query(
+			'UPDATE {db_prefix}board_permissions
+			SET
+				permission = REPLACE(
+					permission,
+					{literal:delete2_own},
+					{literal:delete_own},
+				),
+				permission = REPLACE(
+					permission,
+					{literal:delete2_any},
+					{literal:delete_any},
+				)',
+		);
+
+		$this->handleTimeout();
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v1_1/Calendar.php
+++ b/Sources/Maintenance/Migration/v1_1/Calendar.php
@@ -1,0 +1,88 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v1_1;
+
+use SMF\Db\Schema;
+use SMF\Maintenance\Migration\MigrationBase;
+
+class Calendar extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Updating calendar tables and data';
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		// Ensure the tables are structured correctly.
+		$table = new Schema\v1_1\Calendar();
+		$table->alterColumn($table->columns['startDate'], 'eventDate');
+		$table->dropIndex('ID_TOPIC');
+		$table->normalize();
+
+		$table = new Schema\v1_1\CalendarHolidays();
+		$table->normalize();
+
+		// Data updates.
+		$this->query(
+			'UPDATE {db_prefix}calendar
+			SET endDate = startDate
+			WHERE endDate = {string:date_zero}
+				OR endDate = {string:date_one}',
+			[
+				'date_zero' => '0000-00-00',
+				'date_one' => '0001-01-01',
+			],
+		);
+
+		$this->query(
+			'UPDATE {db_prefix}calendar_holidays
+			SET eventDate = {string:date_one}
+			WHERE eventDate = {string:date_zero}',
+			[
+				'date_zero' => '0000-00-00',
+				'date_one' => '0001-01-01',
+			],
+		);
+
+		// This only works on MySQL, but that's fine because SMF 1.0 never
+		// supported other databases anyway.
+		$this->query(
+			'UPDATE {db_prefix}calendar_holidays
+			SET eventDate = CONCAT_WS({string:hyphen}, {string:year_four}, MONTH(eventDate), DAYOFMONTH(eventDate))
+			WHERE YEAR(eventDate) = 0',
+			[
+				'year_four' => '0004',
+				'hyphen' => '-',
+			],
+		);
+
+		$this->handleTimeout();
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v1_1/Dates.php
+++ b/Sources/Maintenance/Migration/v1_1/Dates.php
@@ -1,0 +1,86 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v1_1;
+
+use SMF\Db\Schema;
+use SMF\Maintenance\Migration\MigrationBase;
+
+class Dates extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Converting other date columns';
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		// Ensure the tables are structured correctly.
+		$table = new Schema\v1_1\LogActivity();
+		$table->alterColumn($table->columns['date'], 'startDate');
+		$table->normalize();
+
+		$table = new Schema\v1_1\Members();
+		$table->normalize();
+
+		// Data updates.
+		$this->query(
+			'UPDATE {db_prefix}log_activity
+			SET date = {string:date_one}
+			WHERE date = {string:date_zero}',
+			[
+				'date_zero' => '0000-00-00',
+				'date_one' => '0001-01-01',
+			],
+		);
+
+		$this->query(
+			'UPDATE {db_prefix}members
+			SET birthdate = {string:date_one}
+			WHERE birthdate = {string:date_zero}',
+			[
+				'date_zero' => '0000-00-00',
+				'date_one' => '0001-01-01',
+			],
+		);
+
+		// This only works on MySQL, but that's fine because SMF 1.0 never
+		// supported other databases anyway.
+		$this->query(
+			'UPDATE {db_prefix}members
+			SET birthdate = CONCAT_WS({string:hyphen}, {string:year_four}, MONTH(birthdate), DAYOFMONTH(birthdate))
+			WHERE YEAR(birthdate) = 0',
+			[
+				'year_four' => '0004',
+				'hyphen' => '-',
+			],
+		);
+
+		$this->handleTimeout();
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v1_1/DenyPermissions.php
+++ b/Sources/Maintenance/Migration/v1_1/DenyPermissions.php
@@ -1,0 +1,85 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v1_1;
+
+use SMF\Config;
+use SMF\Db\DatabaseApi as Db;
+use SMF\Maintenance\Migration\MigrationBase;
+
+class DenyPermissions extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Upgrading "deny" permissions.';
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function isCandidate(): bool
+	{
+		return !isset(Config::$modSettings['permission_enable_deny']);
+	}
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		// Only disable if no deny permissions are used.
+		$request = $this->query(
+			'SELECT permission
+			FROM {db_prefix}permissions
+			WHERE addDeny = 0
+			LIMIT 1',
+		);
+
+		$disable_deny_permissions = Db::$db->num_rows($request) == 0;
+
+		Db::$db->free_result($request);
+
+		// Still wanna disable deny permissions? Check board permissions.
+		if ($disable_deny_permissions) {
+			$request = $this->query(
+				'SELECT permission
+				FROM {db_prefix}board_permissions
+				WHERE addDeny = 0
+				LIMIT 1',
+			);
+
+			$disable_deny_permissions &= Db::$db->num_rows($request) == 0;
+
+			Db::$db->free_result($request);
+		}
+
+		// Update the setting.
+		Config::updatedModSettings([
+			'permission_enable_postgroups' => $disable_deny_permissions ? 0 : 1,
+		]);
+
+		$this->handleTimeout();
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v1_1/GuestPermissions.php
+++ b/Sources/Maintenance/Migration/v1_1/GuestPermissions.php
@@ -1,0 +1,76 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v1_1;
+
+use SMF\Maintenance\Migration\MigrationBase;
+
+class GuestPermissions extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Removing illegal guest permissions';
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		// Removing all guest deny permissions.
+		$this->query(
+			'DELETE FROM {db_prefix}permissions
+			WHERE ID_GROUP = -1
+				AND addDeny = 0',
+		);
+
+		$this->query(
+			'DELETE FROM {db_prefix}board_permissions
+			WHERE ID_GROUP = -1
+				AND addDeny = 0',
+		);
+
+		// Removing guest admin permissions (if any).
+		$this->query(
+			'DELETE FROM {db_prefix}permissions
+			WHERE ID_GROUP = -1
+				AND permission IN ({array_string:perms})',
+			[
+				'perms' => ['admin_forum', 'manage_boards', 'manage_attachments', 'manage_smileys', 'edit_news', 'moderate_forum', 'manage_membergroups', 'manage_permissions', 'manage_bans', 'send_mail'],
+			],
+		);
+
+		$this->query(
+			'DELETE FROM {db_prefix}board_permissions
+			WHERE ID_GROUP = -1
+				AND permission IN ({array_string:perms})',
+			[
+				'perms' => ['admin_forum', 'manage_boards', 'manage_attachments', 'manage_smileys', 'edit_news', 'moderate_forum', 'manage_membergroups', 'manage_permissions', 'manage_bans', 'send_mail'],
+			],
+		);
+
+		$this->handleTimeout();
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v1_1/ImageAttachments.php
+++ b/Sources/Maintenance/Migration/v1_1/ImageAttachments.php
@@ -1,0 +1,154 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v1_1;
+
+use SMF\Config;
+use SMF\Db\DatabaseApi as Db;
+use SMF\Graphics\Image;
+use SMF\Maintenance\Migration\MigrationBase;
+
+class ImageAttachments extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Adding image dimensions';
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		$request = $this->query(
+			'SELECT ID_ATTACH, filename, attachmentType
+			FROM {db_prefix}attachments
+			WHERE id_thumb = 0
+				AND (
+					RIGHT(filename, 4) IN ({array_string:ext4})
+					OR RIGHT(filename, 5) IN ({array_string:ext5})
+				)
+				AND width = 0
+				AND height = 0',
+			[
+				'ext4' => ['.gif', '.jpg', '.png', '.bmp'],
+				'ext5' => ['.jpeg'],
+			],
+		);
+
+		while ($row = Db::$db->fetch_assoc($request)) {
+			if ($row['attachmentType'] == 1) {
+				$filename = Config::$modSettings['custom_avatar_dir'] . '/' . $row['filename'];
+			} else {
+				$filename = $this->getAttachmentFilePath($row['filename'], (int) $row['ID_ATTACH']);
+			}
+
+			if (!file_exists($filename) || \strlen(basename($filename)) > 249) {
+				continue;
+			}
+
+			$image = new Image($filename);
+
+			if (!empty($image->width) && !empty($image->height)) {
+				$this->query(
+					'UPDATE {db_prefix}attachments
+					SET
+						width = {int:width},
+						height = {int:height}
+					WHERE ID_ATTACH = {int:id}
+					LIMIT 1',
+					[
+						'id' => $row['ID_ATTACH'],
+						'width' -> $image->width,
+						'height' -> $image->height,
+					],
+				);
+			}
+		}
+
+		Db::$db->free_result($request);
+
+		$this->handleTimeout();
+
+		return true;
+	}
+
+	/******************
+	 * Internal methods
+	 ******************/
+
+	/**
+	 * Get the file path that would have been used to save to disk.
+	 *
+	 * @param string $filename
+	 * @param int $attachment_id
+	 * @return string
+	 */
+	private function getAttachmentFilePath(string $filename, int $attachment_id): array
+	{
+		// This is not a modern or robust way to deal with non-ASCII characters,
+		// but it's how things were done in the early days of SMF, so we need
+		// to reproduce it here.
+		$clean_name = strtr(
+			$filename,
+			"\x8a\x8e\x9a\x9e\x9f\xc0\xc1\xc2\xc3\xc4\xc5\xc7\xc8\xc9\xca\xcb\xcc\xcd\xce\xcf\xd1\xd2\xd3\xd4\xd5\xd6\xd8\xd9\xda\xdb\xdc\xdd\xe0\xe1\xe2\xe3\xe4\xe5\xe7\xe8\xe9\xea\xeb\xec\xed\xee\xef\xf1\xf2\xf3\xf4\xf5\xf6\xf8\xf9\xfa\xfb\xfc\xfd\xff",
+			'SZszYAAAAAACEEEEIIIINOOOOOOUUUUYaaaaaaceeeeiiiinoooooouuuuyy',
+		);
+
+		$clean_name = strtr(
+			$clean_name,
+			[
+				'Þ' => 'TH',
+				'þ' => 'th',
+				'Ð' => 'DH',
+				'ð' => 'dh',
+				'ß' => 'ss',
+				'Œ' => 'OE',
+				'œ' => 'oe',
+				'Æ' => 'AE',
+				'æ' => 'ae',
+				'µ' => 'u',
+			],
+		);
+
+		$clean_name = preg_replace(
+			['/\s/', '/[^\w_\.\-]/'],
+			['_', ''],
+			$clean_name,
+		);
+
+		$enc_name = $attachment_id . '_' . strtr($clean_name, '.', '_') . md5($clean_name);
+
+		$clean_name = preg_replace('~\.[\.]+~', '.', $clean_name);
+
+		if (file_exists(Config::$modSettings['attachmentUploadDir'] . '/' . $enc_name)) {
+			$filename = Config::$modSettings['attachmentUploadDir'] . '/' . $enc_name;
+		} elseif (file_exists(Config::$modSettings['attachmentUploadDir'] . '/' . $clean_name)) {
+			$filename = Config::$modSettings['attachmentUploadDir'] . '/' . $clean_name;
+		} else {
+			$filename = Config::$modSettings['attachmentUploadDir'] . '/' . $row['filename'];
+		}
+
+		return $filename;
+	}
+}

--- a/Sources/Maintenance/Migration/v1_1/LocalPermissions.php
+++ b/Sources/Maintenance/Migration/v1_1/LocalPermissions.php
@@ -1,0 +1,68 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v1_1;
+
+use SMF\Config;
+use SMF\Db\DatabaseApi as Db;
+use SMF\Db\Schema;
+use SMF\Maintenance\Migration\MigrationBase;
+
+class LocalPermissions extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Upgrading by-board permissions';
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		$table = new Schema\v1_1\Boards();
+		$table->alterColumn($table->columns['permission_mode'], 'use_local_permissions');
+
+		if (!isset(Config::$modSettings['permission_enable_by_board'])) {
+			// Enable by-board permissions if there's >= 1 local permission board.
+			$request = $this->query(
+				'SELECT ID_BOARD
+				FROM {db_prefix}boards
+				WHERE permission_mode = 1
+				LIMIT 1',
+			);
+
+			$enable_by_board = Db::$db->num_rows($request);
+
+			Db::$db->free_result($request);
+
+			Config::updateModSettings([
+				'permission_enable_by_board' => $enable_by_board,
+			]);
+		}
+
+		$this->handleTimeout();
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v1_1/Logs1.php
+++ b/Sources/Maintenance/Migration/v1_1/Logs1.php
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v1_1;
+
+use SMF\Db\Schema;
+use SMF\Maintenance\Migration\MigrationBase;
+
+class Logs1 extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Upgrading log tables, part 1';
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		// Updating flood control log.
+		$table = new Schema\v1_1\LogFloodcontrol();
+		$table->dropIndex('logTime');
+
+		// Updating ip address storage.
+		$table = new Schema\v1_1\LogActions();
+		$table->alterColumn($table->columns['ip'], 'IP');
+
+		$table = new Schema\v1_1\LogBanned();
+		$table->alterColumn($table->columns['ip'], 'IP');
+		$table->dropColumn('ban_ids');
+
+		$table = new Schema\v1_1\LogErrors();
+		$table->dropIndex('IP');
+		$table->alterColumn($table->columns['ip'], 'IP');
+
+		// Converting "log_online".
+		$table = new Schema\v1_1\LogOnline();
+		$table->drop();
+		$table->create();
+
+		$this->handleTimeout();
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v1_1/Logs2.php
+++ b/Sources/Maintenance/Migration/v1_1/Logs2.php
@@ -1,0 +1,90 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v1_1;
+
+use SMF\Db\Schema;
+use SMF\Maintenance\Maintenance;
+use SMF\Maintenance\Migration\MigrationBase;
+
+class Logs2 extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Upgrading log tables, part 2';
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function isCandidate(): bool
+	{
+		$table = new Schema\v1_1\LogTopics();
+		$structure = $table->getCurrentStructure();
+
+		return array_filter($structure['columns'], fn($c) => $c['name'] === 'logTime') !== [];
+	}
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		// Add temporary indexes to these tables.
+		while (true) {
+			switch (Maintenance::getCurrentStart()) {
+				case 0:
+					$table = new Schema\v1_1\LogBoards();
+					$table->addIndex(new Schema\DbIndex(
+						name: 'logTime',
+						columns: ['logTime'],
+					));
+					break;
+
+				case 1:
+					$table = new Schema\v1_1\LogMarkRead();
+					$table->addIndex(new Schema\DbIndex(
+						name: 'logTime',
+						columns: ['logTime'],
+					));
+					break;
+
+				case 2:
+					$table = new Schema\v1_1\Messages();
+					$table->addIndex(new Schema\DbIndex(
+						name: 'modifiedTime',
+						columns: ['modifiedTime'],
+					));
+					break;
+
+				default:
+					break 2;
+			}
+
+			Maintenance::setCurrentStart();
+			$this->handleTimeout();
+		}
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v1_1/Logs3.php
+++ b/Sources/Maintenance/Migration/v1_1/Logs3.php
@@ -1,0 +1,114 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v1_1;
+
+use SMF\Db\Schema;
+use SMF\Maintenance\Maintenance;
+use SMF\Maintenance\Migration\MigrationBase;
+
+class Logs3 extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Upgrading log tables, part 3';
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function isCandidate(): bool
+	{
+		$table = new Schema\v1_1\LogTopics();
+		$structure = $table->getCurrentStructure();
+
+		return array_filter($structure['columns'], fn($c) => $c['name'] === 'logTime') !== [];
+	}
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		while (true) {
+			switch (Maintenance::getCurrentStart()) {
+				case 0:
+					$table = new Schema\v1_1\LogTopics();
+					$table->dropIndex('ID_MEMBER');
+					break;
+
+				case 1:
+					$table = new Schema\v1_1\LogTopics();
+					$table->dropIndex('primary');
+					$table->addIndex($table->indexes['primary']);
+					break;
+
+				case 2:
+					$table = new Schema\v1_1\LogTopics();
+					$table->addIndex(new Schema\DbIndex(
+						name: 'logTime',
+						columns: ['logTime'],
+					));
+					break;
+
+				case 3:
+					$table = new Schema\v1_1\LogBoards();
+					$table->addColumn($table->columns['ID_MSG']);
+					break;
+
+				case 4:
+					$table = new Schema\v1_1\LogMarkRead();
+					$table->addColumn($table->columns['ID_MSG']);
+					break;
+
+				case 5:
+					$table = new Schema\v1_1\LogTopics();
+					$table->addColumn($table->columns['ID_MSG']);
+					break;
+
+				case 6:
+					$table = new Schema\v1_1\Messages();
+					$table->addColumn($table->columns['ID_MSG_MODIFIED']);
+					break;
+
+				case 7:
+					$table = new Schema\v1_1\Boards();
+					$table->addColumn($table->columns['ID_MSG_UPDATED']);
+					break;
+
+				case 8:
+					$table = new Schema\v1_1\Boards();
+					$table->addIndex($table->indexes['ID_MSG_UPDATED']);
+					break;
+
+				default:
+					break 2;
+			}
+
+			Maintenance::setCurrentStart();
+			$this->handleTimeout();
+		}
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v1_1/Logs4.php
+++ b/Sources/Maintenance/Migration/v1_1/Logs4.php
@@ -1,0 +1,241 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v1_1;
+
+use SMF\Db\DatabaseApi as Db;
+use SMF\Db\Schema;
+use SMF\Maintenance\Maintenance;
+use SMF\Maintenance\Migration\MigrationBase;
+
+class Logs4 extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Upgrading log tables, part 4';
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function isCandidate(): bool
+	{
+		$table = new Schema\v1_1\LogTopics();
+		$structure = $table->getCurrentStructure();
+
+		return array_filter($structure['columns'], fn($c) => $c['name'] === 'logTime') !== [];
+	}
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		$request = $this->query(
+			'SELECT MAX(ID_MSG)
+			FROM {db_prefix}messages',
+		);
+		list($max_msg) = Db::$db->fetch_row($request);
+		Db::$db->free_result($request);
+
+		if (empty($max_msg)) {
+			$max_msg = 0;
+		}
+
+		if (Maintenance::getCurrentStart() == 0) {
+			// By default a message is modified when it was written.
+			$this->query(
+				'UPDATE {db_prefix}messages
+				SET ID_MSG_MODIFIED = ID_MSG',
+			);
+
+			$request = $this->query(
+				'SELECT posterTime
+				FROM {db_prefix}messages
+				WHERE ID_MSG = {int:max_msg}',
+				[
+					'max_msg' => $max_msg,
+				],
+			);
+			list($max_poster_time) = Db::$db->fetch_row($request);
+			Db::$db->free_result($request);
+
+			if (empty($max_poster_time)) {
+				$max_poster_time = 0;
+			}
+
+			$this->query(
+				'UPDATE {db_prefix}log_boards
+				SET ID_MSG = {int:max_msg}
+				WHERE logTime >= {int:max_poster_time}',
+				[
+					'max_msg' => $max_msg,
+					'max_poster_time' => $max_poster_time,
+				],
+			);
+
+			$this->query(
+				'UPDATE {db_prefix}log_mark_read
+				SET ID_MSG = {int:max_msg}
+				WHERE logTime >= {int:max_poster_time}',
+				[
+					'max_msg' => $max_msg,
+					'max_poster_time' => $max_poster_time,
+				],
+			);
+
+			$this->query(
+				'UPDATE {db_prefix}log_topics
+				SET ID_MSG = {int:max_msg}
+				WHERE logTime >= {int:max_poster_time}',
+				[
+					'max_msg' => $max_msg,
+					'max_poster_time' => $max_poster_time,
+				],
+			);
+
+			$this->query(
+				'UPDATE {db_prefix}messages
+				SET ID_MSG_MODIFIED = {int:max_msg}
+				WHERE modifiedTime >= {int:max_poster_time}',
+				[
+					'max_msg' => $max_msg,
+					'max_poster_time' => $max_poster_time,
+				],
+			);
+
+			// Timestamp 1 is where it all starts.
+			$lower_limit = 1;
+		} else {
+			// Determine the lower limit.
+			$request = $this->query(
+				'SELECT MAX(posterTime) + 1
+				FROM {db_prefix}messages
+				WHERE ID_MSG < {int:start}',
+				[
+					'start' => Maintenance::getCurrentStart(),
+				],
+			);
+			list($lower_limit) = Db::$db->fetch_row($request);
+			Db::$db->free_result($request);
+
+			if (empty($lower_limit)) {
+				$lower_limit = 1;
+			}
+
+			if (empty($max_poster_time)) {
+				$max_poster_time = 1;
+			}
+		}
+
+		while (Maintenance::getCurrentStart() <= $max_msg) {
+			$start = Maintenance::getCurrentStart();
+
+			$condition = '';
+			$lowest_limit = $lower_limit;
+
+			$request = $this->query(
+				'SELECT MAX(ID_MSG) AS ID_MSG, posterTime
+				FROM {db_prefix}messages
+				WHERE ID_MSG BETWEEN {int:start} AND {int:end}
+				GROUP BY posterTime
+				ORDER BY posterTime
+				LIMIT 300',
+				[
+					'start' => $start,
+					'end' => $start + 300,
+				],
+			);
+
+			while ($row = Db::$db->fetch_assoc($request)) {
+				if ($condition === '') {
+					$condition = "IF(logTime BETWEEN {$lower_limit} AND {$row['posterTime']}, {$row['ID_MSG']}, %else%)";
+				} else {
+					$condition = strtr($condition, ['%else%' => "IF(logTime <= {$row['posterTime']}, {$row['ID_MSG']}, %else%)"]);
+				}
+
+				$lower_limit = $row['posterTime'] + 1;
+			}
+
+			Db::$db->free_result($request);
+
+			if ($condition !== '') {
+				$condition = strtr($condition, ['%else%' => '0']);
+				$highest_limit = $lower_limit;
+
+				$this->query(
+					'UPDATE {db_prefix}log_boards
+					SET ID_MSG = {raw:condition}
+					WHERE logTime BETWEEN {int:lowest_limit} AND {int:highest_limit}
+						AND ID_MSG = 0',
+					[
+						'condition' => $condition,
+						'lowest_limit' => $lowest_limit,
+						'highest_limit' => $highest_limit,
+					],
+				);
+
+				$this->query(
+					'UPDATE {db_prefix}log_mark_read
+					SET ID_MSG = {raw:condition}
+					WHERE logTime BETWEEN {int:lowest_limit} AND {int:highest_limit}
+						AND ID_MSG = 0',
+					[
+						'condition' => $condition,
+						'lowest_limit' => $lowest_limit,
+						'highest_limit' => $highest_limit,
+					],
+				);
+
+				$this->query(
+					'UPDATE {db_prefix}log_topics
+					SET ID_MSG = {raw:condition}
+					WHERE logTime BETWEEN {int:lowest_limit} AND {int:highest_limit}
+						AND ID_MSG = 0',
+					[
+						'condition' => $condition,
+						'lowest_limit' => $lowest_limit,
+						'highest_limit' => $highest_limit,
+					],
+				);
+
+				$this->query(
+					'UPDATE {db_prefix}messages
+					SET ID_MSG_MODIFIED = {raw:condition}
+					WHERE modifiedTime BETWEEN {int:lowest_limit} AND {int:highest_limit}
+						AND modifiedTime > 0',
+					[
+						'condition' => strtr($condition, ['logTime' => 'modifiedTime']),
+						'lowest_limit' => $lowest_limit,
+						'highest_limit' => $highest_limit,
+					],
+				);
+			}
+
+			Maintenance::setCurrentStart($start + 300);
+			$this->handleTimeout();
+		}
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v1_1/Logs5.php
+++ b/Sources/Maintenance/Migration/v1_1/Logs5.php
@@ -1,0 +1,113 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v1_1;
+
+use SMF\Db\DatabaseApi as Db;
+use SMF\Db\Schema;
+use SMF\Maintenance\Maintenance;
+use SMF\Maintenance\Migration\MigrationBase;
+
+class Logs5 extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Upgrading log tables, part 5';
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function isCandidate(): bool
+	{
+		$table = new Schema\v1_1\Boards();
+		$structure = $table->getCurrentStructure();
+
+		return array_filter($structure['columns'], fn($c) => $c['name'] === 'lastUpdated') !== [];
+	}
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		$request = $this->query(
+			'SELECT MAX(ID_BOARD)
+			FROM {db_prefix}boards',
+		);
+		list($max_board) = Db::$db->fetch_row($request);
+		Db::$db->free_result($request);
+
+		// We need to get the last updated message.
+		$request = $this->query(
+			'SELECT ID_BOARD, lastUpdated
+			FROM {db_prefix}boards',
+		);
+
+		while ($row = Db::$db->fetch_assoc($request)) {
+			// Done this?
+			if ($row['ID_BOARD'] < Maintenance::getCurrentStart()) {
+				continue;
+			}
+
+			// Maybe we don't have any?
+			if ($row['lastUpdated'] == 0) {
+				$ID_MSG = 0;
+			}
+			// Otherwise need to query it?
+			else {
+				$request2 = $this->query(
+					'SELECT MIN(ID_MSG)
+					FROM {db_prefix}messages
+					WHERE posterTime >= {int:lastUpdated}',
+					[
+						'lastUpdated' => $row['lastUpdated'],
+					],
+				);
+				list($ID_MSG) = Db::$db->fetch_row($request2);
+				Db::$db->free_result($request2);
+
+				if (empty($ID_MSG)) {
+					$ID_MSG = 0;
+				}
+			}
+
+			$this->query(
+				'UPDATE {db_prefix}boards
+				SET ID_MSG_UPDATED = {int:id_msg}
+				WHERE ID_BOARD = {int:id_board}',
+				[
+					'id_msg' => $ID_MSG,
+					'id_board' => $row['ID_BOARD'],
+				],
+			);
+
+			Maintenance::setCurrentStart();
+			$this->handleTimeout();
+		}
+
+		Db::$db->free_result($request);
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v1_1/Logs6.php
+++ b/Sources/Maintenance/Migration/v1_1/Logs6.php
@@ -1,0 +1,100 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v1_1;
+
+use SMF\Db\Schema;
+use SMF\Maintenance\Maintenance;
+use SMF\Maintenance\Migration\MigrationBase;
+
+class Logs6 extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Upgrading log tables, part 6';
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function isCandidate(): bool
+	{
+		$table = new Schema\v1_1\LogTopics();
+		$structure = $table->getCurrentStructure();
+
+		return array_filter($structure['columns'], fn($c) => $c['name'] === 'logTime') !== [];
+	}
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		// Here we remove all the unused indexes.
+		while (true) {
+			switch (Maintenance::getCurrentStart()) {
+				case 0:
+					$table = new Schema\v1_1\Boards();
+					$table->dropIndex('lastUpdated');
+					$table->dropColumn('lastUpdated');
+					break;
+
+				case 1:
+					$table = new Schema\v1_1\Messages();
+					$table->dropIndex('posterTime');
+					break;
+
+				case 2:
+					$table = new Schema\v1_1\Messages();
+					$table->dropIndex('modifiedTime');
+					break;
+
+				case 3:
+					$table = new Schema\v1_1\LogTopics();
+					$table->dropIndex('logTime');
+					$table->dropColumn('logTime');
+					break;
+
+				case 4:
+					$table = new Schema\v1_1\LogBoards();
+					$table->dropIndex('logTime');
+					$table->dropColumn('logTime');
+					break;
+
+				case 5:
+					$table = new Schema\v1_1\LogMarkRead();
+					$table->dropIndex('logTime');
+					$table->dropColumn('logTime');
+					break;
+
+				default:
+					break 2;
+			}
+
+			Maintenance::setCurrentStart();
+			$this->handleTimeout();
+		}
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v1_1/MemberApproval.php
+++ b/Sources/Maintenance/Migration/v1_1/MemberApproval.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v1_1;
+
+use SMF\Config;
+use SMF\Maintenance\Migration\MigrationBase;
+
+class MemberApproval extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Updating member approval';
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function isCandidate(): bool
+	{
+		return version_compare(
+			str_replace(' ', '.', strtolower(Config::$modSettings['smfVersion'] ?? '0.0.dev.0')),
+			'1.1',
+			'<',
+		);
+	}
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		$this->query(
+			'UPDATE {db_prefix}members
+			SET is_activated = 3
+			WHERE validation_code = {string:empty}
+				AND is_activated = 0',
+			[
+				'empty' => '',
+			],
+		);
+
+		$this->handleTimeout();
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v1_1/MessageIcons.php
+++ b/Sources/Maintenance/Migration/v1_1/MessageIcons.php
@@ -1,0 +1,94 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v1_1;
+
+use SMF\Config;
+use SMF\Db\DatabaseApi as Db;
+use SMF\Db\Schema;
+use SMF\Maintenance\Migration\MigrationBase;
+
+class MessageIcons extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Adding custom message icons';
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		// Update columns and indexes on pm_recipients table.
+		$table = new Schema\v1_1\MessageIcons();
+		$existing_structure = $table->getCurrentStructure();
+
+		if (isset($existing_structure['columns']['Name'])) {
+			$table->alterColumn($table->columns['filename'], 'Name');
+			$table->alterColumn($table->columns['title'], 'Description');
+			$table->dropIndex('id_icon');
+			$table->normalize();
+		} else {
+			$table->normalize();
+		}
+
+		// We do not want to do this twice!
+		if (
+			version_compare(
+				str_replace(' ', '.', strtolower(Config::$modSettings['smfVersion'] ?? '0.0.dev.0')),
+				'1.1',
+				'<',
+			)
+		) {
+			Db::$db->insert(
+				method: '',
+				table: '{db_prefix}message_icons',
+				columns: [
+					'filename' => 'string-80',
+					'title' => 'string-80',
+					'iconOrder' => 'int',
+				],
+				data: [
+					['xx', 'Standard', 0],
+					['thumbup', 'Thumb Up', 1],
+					['thumbdown', 'Thumb Down', 2],
+					['exclamation', 'Exclamation point', 3],
+					['question', 'Question mark', 4],
+					['lamp', 'Lamp', 5],
+					['smiley', 'Smiley', 6],
+					['angry', 'Angry', 7],
+					['cheesy', 'Cheesy', 8],
+					['grin', 'Grin', 9],
+					['sad', 'Sad', 10],
+					['wink', 'Wink', 11],
+				],
+				keys: ['ID_ICON'],
+			);
+		}
+
+		$this->handleTimeout();
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v1_1/NewSettings.php
+++ b/Sources/Maintenance/Migration/v1_1/NewSettings.php
@@ -1,0 +1,223 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v1_1;
+
+use SMF\Config;
+use SMF\Db\DatabaseApi as Db;
+use SMF\Maintenance\Migration\MigrationBase;
+
+class NewSettings extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Reorganizing configuration settings';
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		$smf_version = str_replace(' ', '.', strtolower(Config::$modSettings['smfVersion'] ?? '0.0.dev.0'));
+
+		$request = $this->query(
+			'SELECT COUNT(*)
+			FROM {db_prefix}members',
+		);
+		list($total_members) = Db::$db->fetch_row($request);
+		Db::$db->free_result($request);
+
+		Config::updateModSettings([
+			'totalMembers' => $total_members,
+		]);
+
+		// Renaming a bunch of settings.
+		if (isset(Config::$modSettings['notify_on_new_registration'])) {
+			Config::updateModSettings([
+				'notify_new_registration' => Config::$modSettings['notify_on_new_registration'],
+				'notify_on_new_registration' => null,
+			]);
+		}
+
+		if (isset(Config::$modSettings['maxwidth'])) {
+			Config::updateModSettings([
+				'max_image_width' => Config::$modSettings['maxwidth'],
+				'maxwidth' => null,
+			]);
+		}
+
+		if (isset(Config::$modSettings['maxheight'])) {
+			Config::updateModSettings([
+				'max_image_height' => Config::$modSettings['maxheight'],
+				'maxheight' => null,
+			]);
+		}
+
+		if (isset(Config::$modSettings['search_match_complete_words'])) {
+			Config::updateModSettings([
+				'search_method' => Config::$modSettings['search_match_complete_words'],
+				'search_match_complete_words' => null,
+			]);
+		}
+
+		if (isset(Config::$modSettings['notifyAnncmnts_UserDisable'])) {
+			Config::updateModSettings([
+				'allow_disableAnnounce' => Config::$modSettings['notifyAnncmnts_UserDisable'],
+				'notifyAnncmnts_UserDisable' => null,
+			]);
+		}
+
+		// Replacing various values.
+		Config::updateModSettings([
+			'mail_type' => \in_array(Config::$modSettings['mail_type'] ?? 0, ['sendmail', 0]) ? 0 : 1,
+		]);
+
+		// Adding new settings.
+		Config::updateModSettings([
+			'oldTopicDays' => '120',
+			'cal_showeventsoncalendar' => '1',
+			'cal_showbdaysoncalendar' => '1',
+			'cal_showholidaysoncalendar' => '1',
+			'allow_disableAnnounce' => '1',
+			'attachmentThumbnails' => '1',
+			'attachmentThumbWidth' => '150',
+			'attachmentThumbHeight' => '150',
+			'max_pm_recipients' => '10',
+		]);
+
+		// Hopefully 90 days is enough?
+		if (version_compare($smf_version, '1.1', '<')) {
+			Config::updateModSettings([
+				'disableHashTime' => time() + 7776000,
+			]);
+		}
+
+		// Enable the buddy list for those used to it.
+		if (version_compare($smf_version, '1.1.beta.4', '<=')) {
+			Config::updateModSettings([
+				'enable_buddylist' => 1,
+			]);
+		}
+
+		// Adding PM spam protection settings.
+		if (empty(Config::$modSettings['pm_spam_settings'])) {
+			if (isset(Config::$modSettings['max_pm_recipients'])) {
+				$pm_spam_settings = (int) Config::$modSettings['max_pm_recipients'] . ',5,20';
+			} else {
+				$pm_spam_settings = '10,5,20';
+			}
+
+			Config::updateModSettings([
+				'pm_spam_settings' => $pm_spam_settings,
+			]);
+		}
+
+		// Converting search settings.
+		if (!empty(Config::$modSettings['search_method'])) {
+			$search_settings['search_match_words'] = 1;
+
+			if (Config::$modSettings['search_method'] > 1) {
+				$search_settings['search_index'] = 'fulltext';
+			}
+
+			if (Config::$modSettings['search_method'] == 3) {
+				$search_settings['search_force_index'] = 1;
+			}
+		}
+
+		// Removing obsolete settings.
+		$to_delete = [
+			'max_pm_recipients' => null,
+			'totalMessag' => null,
+			'redirectMetaRefresh' => null,
+			'memberCount' => null,
+			'cal_today_u' => null,
+			'approve_registration' => null,
+			'registration_disabled' => null,
+			'requireRegistrationVerification' => null,
+			'returnToPost' => null,
+			'send_validation' => null,
+			'search_max_cached_results' => null,
+			'disableTemporaryTables' => null,
+			'search_cache_size' => null,
+			'enableReportToMod' => null,
+			'search_method' => null,
+		];
+
+		foreach (
+			[
+				'modlog_enabled',
+				'localCookies',
+				'globalCookies',
+				'send_welcomeEmail',
+				'notify_new_registration',
+				'removeNestedQuotes',
+				'smiley_enable',
+				'smiley_sets_enable',
+				'allow_guestAccess',
+				'userLanguage',
+				'allow_editDisplayName',
+				'allow_hideOnline',
+				'allow_hideEmail',
+				'guest_hideContacts',
+				'titlesEnable',
+				'search_match_complete_words',
+				'cal_allowspan',
+				'hitStats',
+				'queryless_urls',
+				'disableHostnameLookup',
+				'messageIcons_enable',
+				'disallow_sendBody',
+				'censorWholeWord',
+			] as $var
+		) {
+			if (empty(Config::$modSettings[$var])) {
+				$to_delete[$var] = null;
+			}
+		}
+
+		Config::updateModSettings($to_delete);
+
+		// Encoding SMTP password.
+		if (
+			version_compare($smf_version, '1.1.rc.1', '<=')
+			&& empty(Config::$modSettings['dont_repeat_smtp'])
+		) {
+			if (!empty(Config::$modSettings['smtp_password'])) {
+				Config::updateModSettings([
+					'smtp_password' => base64_encode(Config::$modSettings['smtp_password']),
+				]);
+			}
+
+			// Don't let this run twice!
+			Config::updateModSettings([
+				'dont_repeat_smtp' => 1,
+			]);
+		}
+
+		$this->handleTimeout();
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v1_1/OldBoardPermissions.php
+++ b/Sources/Maintenance/Migration/v1_1/OldBoardPermissions.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v1_1;
+
+use SMF\Maintenance\Migration\MigrationBase;
+
+class OldBoardPermissions extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Removing obsolete board permissions';
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		// Deleting some very old permissions.
+		$request = $this->query(
+			'DELETE FROM {db_prefix}board_permissions
+			WHERE permission IN ({array_string:old_perms})',
+			[
+				'old_perms' => ['view_threads', 'poll_delete_own', 'poll_delete_any', 'profile_edit_own', 'profile_edit_any'],
+			],
+		);
+
+		$this->handleTimeout();
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v1_1/OldThemes.php
+++ b/Sources/Maintenance/Migration/v1_1/OldThemes.php
@@ -1,0 +1,129 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v1_1;
+
+use SMF\Config;
+use SMF\Db\DatabaseApi as Db;
+use SMF\Maintenance\Migration\MigrationBase;
+
+class OldThemes extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Cleaning up after old themes';
+
+	/*********************
+	 * Internal properties
+	 *********************/
+
+	/**
+	 * @var int
+	 *
+	 * ID of the classic theme.
+	 */
+	private int $id_theme;
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function isCandidate(): bool
+	{
+		$request = $this->query(
+			'SELECT id_theme
+			FROM {db_prefix}themes
+			WHERE variable = {string:themedir}
+				AND value = {string:classicdir}',
+			[
+				'themedir' => 'theme_dir',
+				'classicdir' => Config::$boarddir . '/Themes/classic',
+			],
+		);
+
+		if (Db::$db->num_rows($request) == 1) {
+			list($this->id_theme) = array_map('intval', Db::$db->fetch_row($request));
+		}
+
+		Db::$db->free_result($request);
+
+		return isset($this->id_theme);
+	}
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		$known_themes = explode(',', Config::$modSettings['knownThemes']);
+
+		// Remove this value...
+		$known_themes = array_diff($known_themes, [$this->id_theme]);
+
+		// Change back to a string...
+		$known_themes = implode(',', $known_themes);
+
+		// Update the database.
+		Config::updateModSettings([
+			'knownThemes' => $known_themes,
+		]);
+
+		// Delete any info about this theme
+		$this->query(
+			'DELETE FROM {db_prefix}themes
+			WHERE ID_THEME = {int:id}',
+			[
+				'id' => $this->id_theme,
+			],
+		);
+
+		// Set any members or boards using this theme to the default
+		$this->query(
+			'UPDATE {db_prefix}members
+			SET ID_THEME = 0
+			WHERE ID_THEME = {int:id}',
+			[
+				'id' => $this->id_theme,
+			],
+		);
+
+		$this->query(
+			'UPDATE {db_prefix}boards
+			SET ID_THEME = 0
+			WHERE ID_THEME = {int:id}',
+			[
+				'id' => $this->id_theme,
+			],
+		);
+
+		if (Config::$modSettings['theme_guests'] == $this->id_theme) {
+			Config::updateModSettings([
+				'theme_guests' => 0,
+			]);
+		}
+
+		$this->handleTimeout();
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v1_1/PackageServers.php
+++ b/Sources/Maintenance/Migration/v1_1/PackageServers.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v1_1;
+
+use SMF\Db\DatabaseApi as Db;
+use SMF\Db\Schema;
+use SMF\Maintenance\Migration\MigrationBase;
+
+class PackageServers extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Adding package servers';
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		$table = new Schema\v1_1\PackageServers();
+		$table->normalize();
+
+		Db::$db->insert(
+			method: 'ignore',
+			table: '{db_prefix}package_servers',
+			columns: [
+				'id_server' => 'int',
+				'name' => 'string-255',
+				'url' => 'string-255',
+			],
+			data: [
+				[
+					1,
+					'Simple Machines Third-party Mod Site',
+					'http://mods.simplemachines.org',
+				],
+			],
+			keys: ['id_server'],
+		);
+
+		$this->handleTimeout();
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v1_1/PersonalMessages.php
+++ b/Sources/Maintenance/Migration/v1_1/PersonalMessages.php
@@ -1,0 +1,94 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v1_1;
+
+use SMF\Config;
+use SMF\Db\DatabaseApi as Db;
+use SMF\Db\Schema;
+use SMF\Maintenance\Migration\MigrationBase;
+
+class PersonalMessages extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Updating personal message functionality';
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		$existing_tables = Db::$db->list_tables();
+
+		// Rename the existing tables.
+		if (\in_array(Config::$db_prefix . 'instant_messages', $existing_tables)) {
+			$this->query(
+				'RENAME TABLE {db_prefix}instant_messages
+				TO {db_prefix}personal_messages',
+			);
+		}
+
+		if (\in_array(Config::$db_prefix . 'im_recipients', $existing_tables)) {
+			$this->query(
+				'RENAME TABLE {db_prefix}im_recipients
+				TO {db_prefix}pm_recipients',
+			);
+		}
+
+		// Update columns and indexes on pm_recipients table.
+		$table = new Schema\v1_1\PmRecipients();
+		$table->normalize();
+
+		// Data updates.
+		$this->query(
+			'UPDATE {db_prefix}pm_recipients
+			SET labels = {string:neg_one}
+			WHERE labels NOT RLIKE {string:regex} OR labels = {string:empty}',
+			[
+				'neg_one' => '-1',
+				'regex' => '[0-9,\-]',
+				'empty' => '',
+			],
+		);
+
+		// Rename columns in members table
+		$table = new Schema\v1_1\Members();
+		$existing_structure = $table->getCurrentStructure();
+
+		if (isset($existing_structure['columns']['im_ignore_list'])) {
+			$table->alterColumn($table->columns['pm_ignore_list'], 'im_ignore_list');
+		}
+
+		if (isset($existing_structure['columns']['im_email_notify'])) {
+			$table->alterColumn($table->columns['pm_email_notify'], 'im_email_notify');
+		}
+
+		$table->normalize();
+
+		$this->handleTimeout();
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v1_1/PostGroupPermissions.php
+++ b/Sources/Maintenance/Migration/v1_1/PostGroupPermissions.php
@@ -1,0 +1,106 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v1_1;
+
+use SMF\Config;
+use SMF\Db\DatabaseApi as Db;
+use SMF\Maintenance\Migration\MigrationBase;
+
+class PostGroupPermissions extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Upgrading post based group permissions';
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function isCandidate(): bool
+	{
+		return !isset(Config::$modSettings['permission_enable_postgroups']);
+	}
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		$request = $this->query(
+			'SELECT ID_GROUP
+			FROM {db_prefix}membergroups
+			WHERE minPosts != -1',
+		);
+
+		list($groups) = array_map(
+			fn($row) => $row['ID_GROUP'],
+			Db::$db->fetch_all($request),
+		);
+
+		Db::$db->free_result($request);
+
+		// Only disable if no post group permissions are used.
+		$disable_postgroup_permissions = true;
+
+		$request = $this->query(
+			'SELECT p.permission
+			FROM {db_prefix}permissions AS p
+			WHERE p.ID_GROUP IN ({array_int:groups})
+			LIMIT 1',
+			[
+				'groups' => $groups,
+			],
+		);
+
+		$disable_postgroup_permissions &= Db::$db->num_rows($request) == 0;
+
+		Db::$db->free_result($request);
+
+		// Still wanna disable postgroup permissions? Check board permissions.
+		if ($disable_postgroup_permissions) {
+			$request = $this->query(
+				'SELECT bp.permission
+				FROM {db_prefix}board_permissions AS bp
+				WHERE bp.ID_GROUP IN ({array_int:groups})
+				LIMIT 1',
+				[
+					'groups' => $groups,
+				],
+			);
+
+			$disable_postgroup_permissions &= Db::$db->num_rows($request) == 0;
+
+			Db::$db->free_result($request);
+		}
+
+		// Update the setting.
+		Config::updatedModSettings([
+			'permission_enable_postgroups' => $disable_postgroup_permissions ? 0 : 1,
+		]);
+
+		$this->handleTimeout();
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v1_1/RecountPMs1.php
+++ b/Sources/Maintenance/Migration/v1_1/RecountPMs1.php
@@ -1,0 +1,100 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v1_1;
+
+use SMF\Db\DatabaseApi as Db;
+use SMF\Maintenance\Maintenance;
+use SMF\Maintenance\Migration\MigrationBase;
+
+class RecountPMs1 extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Recounting personal messages, part 1';
+
+	/*********************
+	 * Internal properties
+	 *********************/
+
+	/**
+	 * @var int
+	 *
+	 * Maximum number of items to process at once.
+	 */
+	private int $limit = 512;
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		$request = $this->query(
+			'SELECT COUNT(*)
+			FROM {db_prefix}members',
+		);
+
+		list($maxMembers) = Db::$db->fetch_row($request);
+		Maintenance::$total_items = (int) $maxMembers;
+
+		Db::$db->free_result($request);
+
+		do {
+			$start = Maintenance::getCurrentStart();
+			$this->handleTimeout($start);
+
+			Db::$db->update_from(
+				table: [
+					'name' => '{db_prefix}members',
+					'alias' => 'mem',
+				],
+				from_tables: [
+					[
+						// Using a subquery as the table name is a bit cheeky, but it works!
+						'name' => '(
+							SELECT ID_MEMBER, COUNT(ID_PM) AS num_messages
+							FROM {db_prefix}pm_recipients
+							WHERE deleted = 0
+								AND id_member > {int:min_id}
+								AND id_member <= {int:max_id}
+							GROUP BY id_member
+						)',
+						'alias' => 'pmr',
+						'condition' => 'mem.ID_MEMBER = pmr.ID_MEMBER',
+					],
+				],
+				set: 'mem.instantMessages = COALESCE(pmr.num_messages, mem.instantMessages)',
+				where: '',
+				db_values: [
+					'min_id' => Maintenance::getCurrentStart(),
+					'max_id' => Maintenance::getCurrentStart() + $this->limit,
+				],
+			);
+
+			Maintenance::setCurrentStart($start + $this->limit);
+		} while (Maintenance::getCurrentStart() < Maintenance::$total_items);
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v1_1/RecountPMs2.php
+++ b/Sources/Maintenance/Migration/v1_1/RecountPMs2.php
@@ -1,0 +1,101 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v1_1;
+
+use SMF\Db\DatabaseApi as Db;
+use SMF\Maintenance\Maintenance;
+use SMF\Maintenance\Migration\MigrationBase;
+
+class RecountPMs2 extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Recounting personal messages, part 2';
+
+		/*********************
+	 * Internal properties
+	 *********************/
+
+	/**
+		 * @var int
+		 *
+		 * Maximum number of items to process at once.
+		 */
+		private int $limit = 512;
+
+		/****************
+	 * Public methods
+	 ****************/
+
+	/**
+		 *
+		 */
+		public function execute(): bool
+		{
+			$request = $this->query(
+				'SELECT COUNT(*)
+				FROM {db_prefix}members',
+			);
+
+			list($maxMembers) = Db::$db->fetch_row($request);
+			Maintenance::$total_items = (int) $maxMembers;
+
+			Db::$db->free_result($request);
+
+			do {
+				$start = Maintenance::getCurrentStart();
+				$this->handleTimeout($start);
+
+				Db::$db->update_from(
+					table: [
+						'name' => '{db_prefix}members',
+						'alias' => 'mem',
+					],
+					from_tables: [
+						[
+							// Using a subquery as the table name is a bit cheeky, but it works!
+							'name' => '(
+								SELECT ID_MEMBER, COUNT(ID_PM) AS num_messages
+								FROM {db_prefix}pm_recipients
+								WHERE deleted = 0
+									AND is_read = 0
+									AND id_member > {int:min_id}
+									AND id_member <= {int:max_id}
+								GROUP BY id_member
+							)',
+							'alias' => 'pmr',
+							'condition' => 'mem.ID_MEMBER = pmr.ID_MEMBER',
+						],
+					],
+					set: 'mem.instantMessages = COALESCE(pmr.num_messages, mem.instantMessages)',
+					where: '',
+					db_values: [
+						'min_id' => Maintenance::getCurrentStart(),
+						'max_id' => Maintenance::getCurrentStart() + $this->limit,
+					],
+				);
+
+				Maintenance::setCurrentStart($start + $this->limit);
+			} while (Maintenance::getCurrentStart() < Maintenance::$total_items);
+
+			return true;
+		}
+	}

--- a/Sources/Maintenance/Migration/v1_1/RemoveIndexes.php
+++ b/Sources/Maintenance/Migration/v1_1/RemoveIndexes.php
@@ -1,0 +1,80 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v1_1;
+
+use SMF\Db\Schema;
+use SMF\Maintenance\Migration\MigrationBase;
+
+class RemoveIndexes extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Removing obsolete table indexes';
+
+	/*********************
+	 * Internal properties
+	 *********************/
+
+	/**
+	 *
+	 */
+	private array $to_drop = [
+		Schema\v1_1\Boards::class => [
+			'catOrder',
+		],
+		Schema\v1_1\Categories::class => [
+			'boardOrder',
+			'children',
+		],
+		Schema\v1_1\LogOnline::class => [
+			'online',
+		],
+		Schema\v1_1\Messages::class => [
+			'ID_MEMBER',
+		],
+		Schema\v1_1\Smileys::class => [
+			'smileyOrder',
+		],
+	];
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		// Drop the ones we no longer want.
+		foreach ($this->to_drop as $table_class => $indexes) {
+			$table = new $table_class();
+
+			foreach ($indexes as $index) {
+				$table->dropIndex($index);
+			}
+		}
+
+		$this->handleTimeout();
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v1_1/ReorderBoards.php
+++ b/Sources/Maintenance/Migration/v1_1/ReorderBoards.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v1_1;
+
+use SMF\Maintenance\Migration\MigrationBase;
+
+class ReorderBoards extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Reordering boards';
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		$this->query(
+			'ALTER TABLE {db_prefix}boards
+			ORDER BY boardOrder',
+			[],
+		);
+
+		$this->handleTimeout();
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v1_1/ReorderCategories.php
+++ b/Sources/Maintenance/Migration/v1_1/ReorderCategories.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v1_1;
+
+use SMF\Maintenance\Migration\MigrationBase;
+
+class ReorderCategories extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Reordering categories';
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		$this->query(
+			'ALTER TABLE {db_prefix}categories
+			ORDER BY catOrder',
+			[],
+		);
+
+		$this->handleTimeout();
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v1_1/SearchCache.php
+++ b/Sources/Maintenance/Migration/v1_1/SearchCache.php
@@ -1,0 +1,64 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v1_1;
+
+use SMF\Db\DatabaseApi as Db;
+use SMF\Db\Schema;
+use SMF\Maintenance\Migration\MigrationBase;
+
+class SearchCache extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Updating search cache';
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		Db::$db->drop_table('{db_prefix}log_search_fulltext');
+		Db::$db->drop_table('{db_prefix}log_search_messages');
+		Db::$db->drop_table('{db_prefix}log_search_topics');
+		Db::$db->drop_table('{db_prefix}log_search');
+
+		$table = new Schema\v1_1\LogSearchMessages();
+		$table->create();
+
+		$table = new Schema\v1_1\LogSearchTopics();
+		$table->create();
+
+		$table = new Schema\v1_1\LogSearchResults();
+		$table->create();
+
+		$table = new Schema\v1_1\LogSearchSubjects();
+		$table->create();
+
+
+		$this->handleTimeout();
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v1_1/SearchFullText.php
+++ b/Sources/Maintenance/Migration/v1_1/SearchFullText.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v1_1;
+
+use SMF\Db\DatabaseApi as Db;
+use SMF\Db\Schema;
+use SMF\Maintenance\Migration\MigrationBase;
+
+class SearchFullText extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Rebuilding fulltext index';
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function isCandidate(): bool
+	{
+		foreach (Db::$db->list_indexes('{db_prefix}messages', true) as $index) {
+			if ($index['name'] === 'subject' && \in_array('subject', $index['columns'])) {
+				return true;
+			}
+		}
+	}
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		$table = new Schema\v1_1\Messages();
+		$table->dropIndex('subject');
+		$table->dropIndex('body');
+
+		$this->query(
+			'ALTER TABLE {db_prefix}messages
+			ADD FULLTEXT body (body)',
+		);
+
+		$this->handleTimeout();
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v1_1/SearchSubjects.php
+++ b/Sources/Maintenance/Migration/v1_1/SearchSubjects.php
@@ -1,0 +1,116 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v1_1;
+
+use SMF\Db\DatabaseApi as Db;
+use SMF\Db\Schema;
+use SMF\Maintenance\Maintenance;
+use SMF\Maintenance\Migration\MigrationBase;
+use SMF\Utils;
+
+class SearchSubjects extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Indexing topic subjects';
+
+	/*********************
+	 * Internal properties
+	 *********************/
+
+	/**
+	 * @var int
+	 *
+	 * Maximum number of items to process at once.
+	 */
+	private int $limit = 250;
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		$table = new Schema\v1_1\LogSearchSubjects();
+		$table->normalize();
+
+		$request = $this->query(
+			'SELECT COUNT(*)
+			FROM {db_prefix}topics',
+			[],
+		);
+
+		list($max) = Db::$db->fetch_row($request);
+
+		Db::$db->free_result($request);
+
+		$is_done = false;
+
+		while (!$is_done) {
+			$this->handleTimeout();
+
+			$inserts = [];
+
+			$request = $this->query(
+				'SELECT t.ID_TOPIC, m.subject
+				FROM {db_prefix}topics AS t
+					INNER JOIN {db_prefix}messages AS m ON (m.ID_MSG = t.ID_FIRST_MSG)
+		 		ORDER BY t.ID_TOPIC
+		 		LIMIT {int:limit}
+		 		OFFSET {int:start}',
+				[
+					'start' => Maintenance::getCurrentStart(),
+					'limit' => $this->limit,
+				],
+			);
+
+			while ($row = Db::$db->fetch_assoc($request)) {
+				Maintenance::setCurrentStart();
+				$is_done = Maintenance::getCurrentStart() >= $max;
+
+				foreach (Utils::extractWords($row['subject'], 2) as $word) {
+					$word = Db::$db->escape_string($word);
+					$inserts[$word . ' ' . $row['ID_TOPIC']] = [$word, $row['ID_TOPIC']];
+				}
+			}
+
+			Db::$db->free_result($request);
+
+			if (!empty($inserts)) {
+				Db::$db->insert(
+					method: '',
+					table: '{db_prefix}log_search_subjects',
+					columns: [
+						'word' => 'string',
+						'ID_TOPIC' => 'int',
+					],
+					data: $inserts,
+					keys: [],
+				);
+			}
+		}
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v1_1/SmileyFix.php
+++ b/Sources/Maintenance/Migration/v1_1/SmileyFix.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v1_1;
+
+use SMF\Maintenance\Migration\MigrationBase;
+
+class SmileyFix extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Updating data in smileys table';
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		$this->query(
+			'UPDATE {db_prefix}smileys
+			SET filename = {string:new}
+			WHERE filename = {string:old}',
+			[
+				'old' => 'embarassed.gif',
+				'new' => 'embarrassed.gif',
+			],
+		);
+
+		$this->handleTimeout();
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v1_1/Thumbnails.php
+++ b/Sources/Maintenance/Migration/v1_1/Thumbnails.php
@@ -1,0 +1,230 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v1_1;
+
+use SMF\Config;
+use SMF\Db\DatabaseApi as Db;
+use SMF\Db\Schema;
+use SMF\Graphics\Image;
+use SMF\Maintenance\Migration\MigrationBase;
+
+class Thumbnails extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Updating thumbnails';
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		$table = new Schema\v1_1\Attachments();
+		$structure = $table->getCurrentStructure();
+
+		// Post SMF 1.1 Beta 1.
+		if (isset($structure['columns']['customAvatarDir'])) {
+			$table->alterColumn($table->columns['attachmentType'], 'customAvatarDir');
+		}
+
+		$table->normalize();
+
+		// Pre SMF 1.1.
+		if (!isset($structure['columns']['attachmentType'])) {
+			// Get a list of attachments currently stored in the database.
+			$filenames = [];
+			$encrypted_filenames = [];
+			$ID_MSG = [];
+
+			$request = $this->query(
+				'SELECT ID_ATTACH, ID_MSG, filename
+				FROM {db_prefix}attachments',
+			);
+
+			while ($row = Db::$db->fetch_assoc($request)) {
+				list($filename, $clean_name) = $this->getAttachmentFilePathAndName($row['filename'], (int) $row['ID_ATTACH']);
+
+				$filenames[$row['ID_ATTACH']] = $clean_name;
+				$encrypted_filenames[$row['ID_ATTACH']] = $filename;
+				$ID_MSG[$row['ID_ATTACH']] = $row['ID_MSG'];
+			}
+
+			Db::$db->free_result($request);
+
+			// Let's loop through the attachments
+			if (
+				is_dir(Config::$modSettings['attachmentUploadDir'])
+				&& $dir = @opendir(Config::$modSettings['attachmentUploadDir'])
+			) {
+				while ($file = readdir($dir)) {
+					if (substr($file, -6) == '_thumb') {
+						// We found a thumbnail, now find the attachment it represents.
+						$attach_realFilename = substr($file, 0, -6);
+
+						if (\in_array($attach_realFilename, $filenames)) {
+							$attach_id = array_search($attach_realFilename, $filenames);
+							$attach_filename = $attach_realFilename;
+						} elseif (\in_array($attach_realFilename, $encrypted_filenames)) {
+							$attach_id = array_search($attach_realFilename, $encrypted_filenames);
+							$attach_filename = $filenames[$attach_id];
+						} else {
+							continue;
+						}
+
+						// No need to register thumbs of non-existent attachments.
+						if (
+							!file_exists(Config::$modSettings['attachmentUploadDir'] . '/' . $attach_realFilename)
+							|| \strlen($attach_filename) > 249
+						) {
+							continue;
+						}
+
+						// Determine the dimensions of the thumb.
+						$thumbnail_image = new Image(Config::$modSettings['attachmentUploadDir'] . '/' . $file);
+
+						$thumb_filename = $attach_filename . '_thumb';
+
+						// Insert the thumbnail in the attachment database.
+						$thumb_attach_id = Db::$db->insert(
+							method: '',
+							table: '{db_prefix}attachments',
+							columns: [
+								'ID_MSG' => 'int',
+								'attachmentType' => 'int',
+								'filename' => 'string-255',
+								'size' => 'int',
+								'width' => 'int',
+								'height' => 'int',
+							],
+							data: [
+								[
+									$ID_MSG[$attach_id],
+									3,
+									$thumb_filename,
+									$thumbnail_image->filesize,
+									$thumbnail_image->width,
+									$thumbnail_image->height,
+								],
+							],
+							keys: ['ID_ICON'],
+						);
+
+						// Determine the dimensions of the original attachment.
+						$orig_image = new Image(Config::$modSettings['attachmentUploadDir'] . '/' . $attach_realFilename);
+
+						// Link the original attachment to its thumb.
+						if (\is_int($orig_image->width) && \is_int($orig_image->height)) {
+							$this->query(
+								'UPDATE {db_prefix}attachments
+								SET
+									id_thumb = {int:thumb_id},
+									width = {int:width},
+									height = {int:height}
+								WHERE ID_ATTACH = {int:attach_id}
+								LIMIT 1',
+								[
+									'attach_id' => $attach_id,
+									'thumb_id' => $thumb_attach_id,
+									'width' => $orig_image->width,
+									'height' => $orig_image->height,
+								],
+							);
+						}
+
+						// Since it's an attachment now, we might as well encrypt it.
+						if (!empty(Config::$modSettings['attachmentEncryptFilenames'])) {
+							@rename(
+								Config::$modSettings['attachmentUploadDir'] . '/' . $file,
+								Config::$modSettings['attachmentUploadDir'] . '/' . $thumb_attach_id . '_' . strtr($thumb_filename, '.', '_') . md5($thumb_filename),
+							);
+						}
+					}
+				}
+				closedir($dir);
+			}
+		}
+
+		$this->handleTimeout();
+
+		return true;
+	}
+
+	/******************
+	 * Internal methods
+	 ******************/
+
+	/**
+	 * Get the file path that would have been used to save to disk.
+	 *
+	 * @param string $filename
+	 * @param int $attachment_id
+	 * @return array
+	 */
+	private function getAttachmentFilePathAndName(string $filename, int $attachment_id): array
+	{
+		// This is not a modern or robust way to deal with non-ASCII characters,
+		// but it's how things were done in the early days of SMF, so we need
+		// to reproduce it here.
+		$clean_name = strtr(
+			$filename,
+			"\x8a\x8e\x9a\x9e\x9f\xc0\xc1\xc2\xc3\xc4\xc5\xc7\xc8\xc9\xca\xcb\xcc\xcd\xce\xcf\xd1\xd2\xd3\xd4\xd5\xd6\xd8\xd9\xda\xdb\xdc\xdd\xe0\xe1\xe2\xe3\xe4\xe5\xe7\xe8\xe9\xea\xeb\xec\xed\xee\xef\xf1\xf2\xf3\xf4\xf5\xf6\xf8\xf9\xfa\xfb\xfc\xfd\xff",
+			'SZszYAAAAAACEEEEIIIINOOOOOOUUUUYaaaaaaceeeeiiiinoooooouuuuyy',
+		);
+
+		$clean_name = strtr(
+			$clean_name,
+			[
+				'Þ' => 'TH',
+				'þ' => 'th',
+				'Ð' => 'DH',
+				'ð' => 'dh',
+				'ß' => 'ss',
+				'Œ' => 'OE',
+				'œ' => 'oe',
+				'Æ' => 'AE',
+				'æ' => 'ae',
+				'µ' => 'u',
+			],
+		);
+
+		$clean_name = preg_replace(
+			['/\s/', '/[^\w_\.\-]/'],
+			['_', ''],
+			$clean_name,
+		);
+
+		$enc_name = $attachment_id . '_' . strtr($clean_name, '.', '_') . md5($clean_name);
+
+		$clean_name = preg_replace('~\.[\.]+~', '.', $clean_name);
+
+		if (file_exists(Config::$modSettings['attachmentUploadDir'] . '/' . $enc_name)) {
+			$filename = Config::$modSettings['attachmentUploadDir'] . '/' . $enc_name;
+		} else {
+			$filename = Config::$modSettings['attachmentUploadDir'] . '/' . $clean_name;
+		}
+
+		return [$filename, $clean_name];
+	}
+}

--- a/Sources/Maintenance/Migration/v1_1/index.php
+++ b/Sources/Maintenance/Migration/v1_1/index.php
@@ -1,0 +1,8 @@
+<?php
+
+// Try to handle it with the upper level index.php. (it should know what to do.)
+if (file_exists(dirname(__DIR__) . '/index.php')) {
+	include dirname(__DIR__) . '/index.php';
+} else {
+	exit;
+}

--- a/Sources/Maintenance/Migration/v2_0/AdminFeatureToggles.php
+++ b/Sources/Maintenance/Migration/v2_0/AdminFeatureToggles.php
@@ -1,0 +1,76 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v2_0;
+
+use SMF\Config;
+use SMF\Maintenance\Migration\MigrationBase;
+
+class AdminFeatureToggles extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Implementing admin feature toggles';
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function isCandidate(): bool
+	{
+		return !isset(Config::$modSettings['admin_features']);
+	}
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		// Work out what they used to have enabled.
+		$enabled_features = ['rg'];
+
+		if (!empty(Config::$modSettings['cal_enabled'])) {
+			$enabled_features[] = 'cd';
+		}
+
+		if (!empty(Config::$modSettings['karmaMode'])) {
+			$enabled_features[] = 'k';
+		}
+
+		if (!empty(Config::$modSettings['modlog_enabled'])) {
+			$enabled_features[] = 'ml';
+		}
+
+		if (!empty(Config::$modSettings['paid_enabled'])) {
+			$enabled_features[] = 'ps';
+		}
+
+		Config::updateModSettings([
+			'admin_features' => implode(',', $enabled_features),
+		]);
+
+		$this->handleTimeout();
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v2_0/AdminInfoFiles.php
+++ b/Sources/Maintenance/Migration/v2_0/AdminInfoFiles.php
@@ -1,0 +1,74 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v2_0;
+
+use SMF\Db\Schema;
+use SMF\Maintenance\Migration\MigrationBase;
+
+class AdminInfoFiles extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Create a repository for the JavaScript files from Simple Machines';
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		// Ensure the table is structured correctly.
+		$table = new Schema\v2_0\AdminInfoFiles();
+		$table->normalize();
+
+		// Add in the files to get from Simple Machines.
+		$table->populate();
+
+		// Set the filetype for the files.
+		$this->query(
+			'UPDATE {db_prefix}admin_info_files
+			SET filetype = {string:type}
+			WHERE id_file IN ({array_int:ids})',
+			[
+				'type' => 'text/javascript',
+				'ids' => [1, 2, 3, 4, 5, 6, 7],
+			],
+		);
+
+		// Ensure that the files from Simple Machines get updated.
+		$this->query(
+			'UPDATE {db_prefix}scheduled_tasks
+			SET next_time = {int:now}
+			WHERE task = {string:task}',
+			[
+				'now' => time(),
+				'task' => 'fetchSMfiles',
+			],
+		);
+
+		$this->handleTimeout();
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v2_0/Attachments1.php
+++ b/Sources/Maintenance/Migration/v2_0/Attachments1.php
@@ -1,0 +1,91 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v2_0;
+
+use SMF\Db\Schema;
+use SMF\Maintenance\Migration\MigrationBase;
+
+class Attachments1 extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Updating attachment data';
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		// Ensure the table exists and is structured correctly.
+		$table = new Schema\v2_0\Attachments();
+		$table->normalize();
+
+		// Populate the attachment extension.
+		$this->query(
+			'UPDATE {db_prefix}attachments
+			SET fileext = LOWER(SUBSTRING(filename, 1 - (INSTR(REVERSE(filename), ' . '))))
+			WHERE fileext = {string:empty}
+				AND INSTR(filename, {string:dot})
+				AND INSTR(REVERSE(filename), {string:dot}) < 10
+				AND attachment_type != 3',
+			[
+				'empty' => '',
+				'dot' => '.',
+			],
+		);
+
+		// Updating thumbnail attachments JPG.
+		$this->query(
+			'UPDATE {db_prefix}attachments
+			SET fileext = {string:ext}
+			WHERE attachment_type = 3
+				AND fileext = {string:empty}
+				AND RIGHT(filename, 9) = {string:old}',
+			[
+				'empty' => '',
+				'ext' => 'jpg',
+				'old' => 'JPG_thumb',
+			],
+		);
+
+		// Updating thumbnail attachments PNG.
+		$this->query(
+			'UPDATE {db_prefix}attachments
+			SET fileext = {string:ext}
+			WHERE attachment_type = 3
+				AND fileext = {string:empty}
+				AND RIGHT(filename, 9) = {string:old}',
+			[
+				'empty' => '',
+				'ext' => 'png',
+				'old' => 'PNG_thumb',
+			],
+		);
+
+		$this->handleTimeout();
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v2_0/Attachments2.php
+++ b/Sources/Maintenance/Migration/v2_0/Attachments2.php
@@ -1,0 +1,195 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v2_0;
+
+use SMF\Config;
+use SMF\Db\DatabaseApi as Db;
+use SMF\Maintenance\Maintenance;
+use SMF\Maintenance\Migration\MigrationBase;
+use SMF\Utils;
+
+class Attachments2 extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Calculating attachment MIME Types';
+
+	/*********************
+	 * Internal properties
+	 *********************/
+
+	/**
+	 * @var int
+	 *
+	 * Maximum number of items to process at once.
+	 */
+	private int $limit = 100;
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function isCandidate(): bool
+	{
+		return version_compare(
+			str_replace(' ', '.', strtolower(Config::$modSettings['smfVersion'] ?? '0.0.dev.0')),
+			'2.0',
+			'<',
+		);
+	}
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		$request = $this->query(
+			'SELECT MAX(id_attach)
+			FROM {db_prefix}attachments',
+			[],
+		);
+
+		list($max) = Db::$db->fetch_row($request);
+
+		Db::$db->free_result($request);
+
+		$is_done = false;
+
+		while (!$is_done) {
+			$start = Maintenance::getCurrentStart();
+			$this->handleTimeout();
+
+			$request = $this->query(
+				'SELECT id_attach, filename, fileext
+				FROM {db_prefix}attachments
+		 		WHERE fileext != {string:empty}
+		 			AND mime_type = {string:empty}
+		 			AND id_attach >= {int:start}
+		 		ORDER BY id_attach
+		 		LIMIT {int:limit}',
+				[
+					'empty' => '',
+					'start' => $start,
+					'limit' => $this->limit,
+				],
+			);
+
+			while ($row = Db::$db->fetch_assoc($request)) {
+				$is_done = $row['id_attach'] == $max;
+				Maintenance::setCurrentStart($row['id_attach'] + 1);
+
+				$filepath = $this->getAttachmentFilePath($row['filename'], (int) $row['id_attach']);
+
+				if (!file_exists($filepath)) {
+					continue;
+				}
+
+				$mime_type = Utils::getMimeType($filepath, true);
+
+				if (!empty($mime_type)) {
+					$updates[$mime_type][] = $row['id_attach'];
+				}
+			}
+
+			Db::$db->free_result($request);
+
+			if (!empty($updates)) {
+				foreach ($updates as $mime_type => $ids) {
+					$this->query(
+						'UPDATE {db_prefix}attachments
+						SET mime_type = {string:mime_type}
+						WHERE id_attach IN ({array_int:ids})',
+						[
+							'mime_type' => $mime_type,
+							'ids' => $ids,
+						],
+					);
+				}
+			}
+		}
+
+		return true;
+	}
+
+	/******************
+	 * Internal methods
+	 ******************/
+
+	/**
+	 * Get the file path that would have been used to save to disk.
+	 *
+	 * @param string $filename
+	 * @param int $attachment_id
+	 * @return string Path to the attachment file on disk.
+	 */
+	private function getAttachmentFilePath(string $filename, int $attachment_id): string
+	{
+		// This is not a modern or robust way to deal with non-ASCII characters,
+		// but it's how things were done in the early days of SMF, so we need
+		// to reproduce it here.
+		$clean_name = strtr(
+			$filename,
+			"\x8a\x8e\x9a\x9e\x9f\xc0\xc1\xc2\xc3\xc4\xc5\xc7\xc8\xc9\xca\xcb\xcc\xcd\xce\xcf\xd1\xd2\xd3\xd4\xd5\xd6\xd8\xd9\xda\xdb\xdc\xdd\xe0\xe1\xe2\xe3\xe4\xe5\xe7\xe8\xe9\xea\xeb\xec\xed\xee\xef\xf1\xf2\xf3\xf4\xf5\xf6\xf8\xf9\xfa\xfb\xfc\xfd\xff",
+			'SZszYAAAAAACEEEEIIIINOOOOOOUUUUYaaaaaaceeeeiiiinoooooouuuuyy',
+		);
+
+		$clean_name = strtr(
+			$clean_name,
+			[
+				'Þ' => 'TH',
+				'þ' => 'th',
+				'Ð' => 'DH',
+				'ð' => 'dh',
+				'ß' => 'ss',
+				'Œ' => 'OE',
+				'œ' => 'oe',
+				'Æ' => 'AE',
+				'æ' => 'ae',
+				'µ' => 'u',
+			],
+		);
+
+		$clean_name = preg_replace(
+			['/\s/', '/[^\w_\.\-]/'],
+			['_', ''],
+			$clean_name,
+		);
+
+		$enc_name = $attachment_id . '_' . strtr($clean_name, '.', '_') . md5($clean_name);
+
+		$clean_name = preg_replace('~\.[\.]+~', '.', $clean_name);
+
+		if ($attachment_id == false) {
+			return $clean_name;
+		}
+
+		if (file_exists(Config::$modSettings['attachmentUploadDir'] . '/' . $enc_name)) {
+			$filename = Config::$modSettings['attachmentUploadDir'] . '/' . $enc_name;
+		} else {
+			$filename = Config::$modSettings['attachmentUploadDir'] . '/' . $clean_name;
+		}
+
+		return $filename;
+	}
+}

--- a/Sources/Maintenance/Migration/v2_0/CustomFields.php
+++ b/Sources/Maintenance/Migration/v2_0/CustomFields.php
@@ -1,0 +1,104 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v2_0;
+
+use SMF\Config;
+use SMF\Db\DatabaseApi as Db;
+use SMF\Db\Schema;
+use SMF\Maintenance\Migration\MigrationBase;
+
+class CustomFields extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Adding custom profile fields';
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		// Ensure the table exists and is structured correctly.
+		$table = new Schema\v2_0\CustomFields();
+		$table->normalize();
+
+		if (isset(Config::$modSettings['smfVersion'])) {
+			$smfVersion = str_replace(' ', '.', strtolower(Config::$modSettings['smfVersion']));
+
+			// Enhance the privacy settings for custom fields.
+			if (version_compare($smfVersion, '2.0.beta.1', '<=')) {
+				$this->query(
+					'UPDATE {db_prefix}custom_fields
+					SET private = 2
+					WHERE private = 1',
+					[],
+				);
+			} elseif (version_compare($smfVersion, '2.0.beta.4', '<')) {
+				$this->query(
+					'UPDATE {db_prefix}custom_fields
+					SET private = 3
+					WHERE private = 2',
+					[],
+				);
+			}
+
+			// Ensure that the display fields are set up correctly.
+			if (
+				version_compare($smfVersion, '2.0.beta.1', '<=')
+				&& isset(Config::$modSettings['displayFields'])
+				&& @unserialize(Config::$modSettings['displayFields']) == false
+			) {
+				$request = $this->query(
+					'SELECT col_name, field_name, bbc
+					FROM {db_prefix}custom_fields
+					WHERE show_display = 1
+						AND active = 1
+						AND private != 2',
+					[],
+				);
+
+				$fields = [];
+
+				while ($row = Db::$db->fetch_assoc($request)) {
+					$fields[] = [
+						'c' => strtr($row['col_name'], ['|' => '', ';' => '']),
+						'f' => strtr($row['field_name'], ['|' => '', ';' => '']),
+						'b' => ($row['bbc'] ? '1' : '0'),
+					];
+				}
+
+				Db::$db->free_result($request);
+
+				Config::updateModSettings([
+					'displayFields' => Db::$db->escape_string(serialize($fields)),
+				]);
+			}
+		}
+
+		$this->handleTimeout();
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v2_0/EmailDigests.php
+++ b/Sources/Maintenance/Migration/v2_0/EmailDigests.php
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v2_0;
+
+use SMF\Db\Schema;
+use SMF\Maintenance\Migration\MigrationBase;
+
+class EmailDigests extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Adding email digest functionality';
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		// Note: there is also a table that needs to be created, but the table
+		// normalization substeps will take care of that part.
+
+		// Change the old 'notifyOnce' column to handle digest options.
+		$table = new Schema\v2_0\Members();
+		$table->alterColumn($table->columns['notify_regularity'], 'notifyOnce');
+
+		$this->handleTimeout();
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v2_0/ErrorLog.php
+++ b/Sources/Maintenance/Migration/v2_0/ErrorLog.php
@@ -1,0 +1,108 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v2_0;
+
+use SMF\Db\DatabaseApi as Db;
+use SMF\Maintenance\Maintenance;
+use SMF\Maintenance\Migration\MigrationBase;
+
+class ErrorLog extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Upgrading the error log';
+
+	/*********************
+	 * Internal properties
+	 *********************/
+
+	/**
+	 * @var int
+	 *
+	 * Maximum number of items to process at once.
+	 */
+	private int $limit = 500;
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		$request = $this->query(
+			'SELECT MAX(*)
+			FROM {db_prefix}log_errors',
+			[],
+		);
+
+		list($max) = Db::$db->fetch_row($request);
+
+		Db::$db->free_result($request);
+
+		$is_done = false;
+
+		while (!$is_done) {
+			$start = Maintenance::getCurrentStart();
+			$this->handleTimeout();
+
+			$request = $this->query(
+				'SELECT id_error, message, file, line
+				FROM {db_prefix}log_errors
+				WHERE id_error >= {int:start}
+		 		ORDER BY id_error
+		 		LIMIT {int:limit}',
+				[
+					'start' => $start,
+					'limit' => $this->limit,
+				],
+			);
+
+			while ($row = Db::$db->fetch_assoc($request)) {
+				$is_done = $row['id_error'] == $max;
+				Maintenance::setCurrentStart($row['id_attach'] + 1);
+
+				preg_match('~<br />(%1\$s: )?([\w\. \\\\/\-_:]+)<br />(%2\$s: )?([\d]+)~', $row['message'], $matches);
+
+				if (!empty($matches[2]) && !empty($matches[4]) && empty($row['file']) && empty($row['line'])) {
+					$row['file'] = Db::$db->escape_string(str_replace('\\', '/', $matches[2]));
+					$row['line'] = (int) $matches[4];
+					$row['message'] = Db::$db->escape_string(str_replace($matches[0], '', $row['message']));
+
+					$this->query(
+						'UPDATE {db_prefix}log_errors
+						SET file = SUBSTRING({string:file}, 1, 255),
+							line = {string:line},
+							message = SUBSTRING({string:message}, 1, 65535)
+						WHERE id_error = {int:id_error}',
+						$row,
+					);
+				}
+			}
+
+			Db::$db->free_result($request);
+		}
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v2_0/GuestVoting.php
+++ b/Sources/Maintenance/Migration/v2_0/GuestVoting.php
@@ -1,0 +1,90 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v2_0;
+
+use SMF\Config;
+use SMF\Db\DatabaseApi as Db;
+use SMF\Db\Schema;
+use SMF\Maintenance\Migration\MigrationBase;
+
+class GuestVoting extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Adding guest voting';
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function isCandidate(): bool
+	{
+		return !\in_array('guest_vote', Db::$db->list_columns(Config::$db_prefix . 'log_polls'));
+	}
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		// Ensure the tables are structured correctly.
+		$table = new Schema\v2_0\Polls();
+		$table->normalize();
+
+		$table = new Schema\v2_0\LogPolls();
+		$table->normalize();
+
+		$this->query(
+			'DELETE FROM {db_prefix}log_polls
+			WHERE id_member < 0',
+			[],
+		);
+
+		$request = $this->query(
+			'SELECT p.id_poll, count(lp.id_member) as guest_voters
+			FROM {db_prefix}polls AS p
+				LEFT JOIN {db_prefix}log_polls AS lp ON (lp.id_poll = p.id_poll AND lp.id_member = 0)
+			WHERE lp.id_member = 0
+				AND p.num_guest_voters = 0
+			GROUP BY p.id_poll',
+			[],
+		);
+
+		while ($row = Db::$db->fetch_assoc($request)) {
+			$this->query(
+				'UPDATE {db_prefix}polls
+				SET num_guest_voters = {int:guest_voters}
+				WHERE id_poll = {int:id_poll}
+					AND num_guest_voters = 0',
+				$row,
+			);
+		}
+
+		Db::$db->free_result($request);
+
+		$this->handleTimeout();
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v2_0/LogActivity.php
+++ b/Sources/Maintenance/Migration/v2_0/LogActivity.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v2_0;
+
+use SMF\Db\Schema;
+use SMF\Maintenance\Migration\MigrationBase;
+
+class LogActivity extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Removing index on hits in log_activity table';
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		// Ensure this obsolete index has been deleted.
+		$table = new Schema\v2_0\LogActivity();
+		$table->dropIndex('hits');
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v2_0/MailQueue.php
+++ b/Sources/Maintenance/Migration/v2_0/MailQueue.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v2_0;
+
+use SMF\Config;
+use SMF\Db\Schema;
+use SMF\Maintenance\Migration\MigrationBase;
+
+class MailQueue extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Creating mail queue functionality';
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		// Ensure this obsolete index has been deleted.
+		$table = new Schema\v2_0\MailQueue();
+		$table->dropIndex('priority');
+
+		// Add new mail queue settings.
+		if (!isset(Config::$modSettings['mail_next_send'])) {
+			Config::updateModSettings([
+				'mail_next_send' => 0,
+				'mail_recent' => '0000000000|0',
+			]);
+		}
+
+		$this->handleTimeout();
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v2_0/MembergroupTypes.php
+++ b/Sources/Maintenance/Migration/v2_0/MembergroupTypes.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v2_0;
+
+use SMF\Maintenance\Migration\MigrationBase;
+
+class MembergroupTypes extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Adjusting group types';
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		$this->query(
+			'UPDATE {db_prefix}membergroups
+			SET group_type = 1
+			WHERE id_group = 1',
+			[],
+		);
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v2_0/ModCenter.php
+++ b/Sources/Maintenance/Migration/v2_0/ModCenter.php
@@ -1,0 +1,95 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v2_0;
+
+use SMF\Config;
+use SMF\Db\DatabaseApi as Db;
+use SMF\Maintenance\Migration\MigrationBase;
+
+class ModCenter extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Creating moderation center';
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function isCandidate(): bool
+	{
+		return version_compare(
+			str_replace(' ', '.', strtolower(Config::$modSettings['smfVersion'] ?? '0.0.dev.0')),
+			'2.0',
+			'<',
+		);
+	}
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		// Note: there are some tables that need to be created, and a column
+		// that needs to be added to the members table, but the table
+		// normalization substeps will take care of that part.
+
+		// Try to find people who probably should see the moderation center.
+		$request = $this->query(
+			'SELECT id_group, add_deny
+			FROM {db_prefix}permissions
+			WHERE permission = {string:perm}',
+			[
+				'perm' => 'calendar_edit_any',
+			],
+		);
+
+		$inserts = [];
+
+		while ($row = Db::$db->fetch_assoc($request)) {
+			$inserts[] = [$row['id_group'], 'access_mod_center', $row['add_deny']];
+		}
+
+		Db::$db->free_result($request);
+
+		// Add moderation center permissions.
+		if (!empty($inserts)) {
+			Db::$db->insert(
+				method: 'ignore',
+				table: '{db_prefix}permissions',
+				columns: [
+					'id_group' => 'int',
+					'permission' => 'string-30',
+					'add_deny' => 'int',
+				],
+				data: $inserts,
+				keys: [],
+			);
+		}
+
+		$this->handleTimeout();
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v2_0/ModLog.php
+++ b/Sources/Maintenance/Migration/v2_0/ModLog.php
@@ -1,0 +1,204 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v2_0;
+
+use SMF\Db\DatabaseApi as Db;
+use SMF\Db\Schema;
+use SMF\Maintenance\Maintenance;
+use SMF\Maintenance\Migration\MigrationBase;
+
+class ModLog extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Upgrading the moderation log';
+
+	/*********************
+	 * Internal properties
+	 *********************/
+
+	/**
+	 * @var int
+	 *
+	 * How many rows there are in the log_actions table.
+	 */
+	private int $num_actions = 0;
+
+	/**
+	 * @var int
+	 *
+	 * Maximum number of items to process at once.
+	 */
+	private int $limit = 500;
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function isCandidate(): bool
+	{
+		$request = $this->query(
+			'SELECT COUNT(*)
+			FROM {db_prefix}log_actions',
+			[],
+		);
+
+		list($this->num_actions) = array_map('intval', Db::$db->fetch_row($request));
+
+		Db::$db->free_result($request);
+
+		return $this->num_actions > 0;
+	}
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		// Ensure the table is structured correctly.
+		$table = new Schema\v2_0\LogActions();
+		$table->normalize();
+
+		$is_done = false;
+
+		while (!$is_done) {
+			$start = Maintenance::getCurrentStart();
+			$this->handleTimeout();
+
+			$mrequest = $this->query(
+				'SELECT id_action, extra, id_board, id_topic, id_msg
+				FROM {db_prefix}log_actions
+				LIMIT {int:limit}
+				OFFSET {int:start}',
+				[
+					'limit' => $this->limit,
+					'start' => $start,
+				],
+			);
+
+			while ($row = Db::$db->fetch_assoc($mrequest)) {
+				Maintenance::setCurrentStart();
+
+				if (
+					!empty($row['id_board'])
+					|| !empty($row['id_topic'])
+					|| !empty($row['id_msg'])
+				) {
+					continue;
+				}
+
+				$row['extra'] = @unserialize($row['extra']);
+
+				// Corrupt?
+				$row['extra'] = \is_array($row['extra']) ? $row['extra'] : [];
+
+				if (!empty($row['extra']['board'])) {
+					$board_id = (int) $row['extra']['board'];
+					unset($row['extra']['board']);
+				} else {
+					$board_id = 0;
+				}
+
+				if (!empty($row['extra']['board_to']) && empty($board_id)) {
+					$board_id = (int) $row['extra']['board_to'];
+					unset($row['extra']['board_to']);
+				}
+
+				if (!empty($row['extra']['topic'])) {
+					$topic_id = (int) $row['extra']['topic'];
+
+					unset($row['extra']['topic']);
+
+					if (empty($board_id)) {
+						$trequest = $this->query(
+							'SELECT id_board
+							FROM {db_prefix}topics
+							WHERE id_topic = {int:id}',
+							[
+								'id' => $topic_id,
+							],
+						);
+
+						if (Db::$db->num_rows($trequest) > 0) {
+							list($board_id) = Db::$db->fetch_row($trequest);
+						}
+
+						Db::$db->free_result($trequest);
+					}
+				} else {
+					$topic_id = 0;
+				}
+
+				if (!empty($row['extra']['message'])) {
+					$msg_id = (int) $row['extra']['message'];
+
+					unset($row['extra']['message']);
+
+					if (empty($topic_id) || empty($board_id)) {
+						$trequest = $this->query(
+							'SELECT id_board, id_topic
+							FROM {db_prefix}messages
+							WHERE id_msg = {int:id}
+							LIMIT 1',
+							[
+								'id' => $msg_id,
+							],
+						);
+
+						if (Db::$db->num_rows($trequest)) {
+							list($board_id, $topic_id) = Db::$db->fetch_row($trequest);
+						}
+
+						Db::$db->free_result($trequest);
+					}
+				} else {
+					$msg_id = 0;
+				}
+
+				$row['extra'] = Db::$db->escape_string(serialize($row['extra']));
+
+				$this->query(
+					'UPDATE {db_prefix}log_actions
+					SET
+						id_board = {int:board_id},
+						id_topic = {int:topic_id},
+						id_msg = {int:msg_id},
+						extra = {string:extra}
+					WHERE id_action = {int:id_action}',
+					[
+						'board_id' => $board_id,
+						'topic_id' => $topic_id,
+						'msg_id' => $msg_id,
+						'extra' => $row['extra'],
+						'id_action' => $row['id_action'],
+					],
+				);
+
+				$is_done = Maintenance::getCurrentStart() >= $this->num_actions;
+			}
+		}
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v2_0/NewSettings.php
+++ b/Sources/Maintenance/Migration/v2_0/NewSettings.php
@@ -1,0 +1,341 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v2_0;
+
+use SMF\Config;
+use SMF\Db\DatabaseApi as Db;
+use SMF\Maintenance\Migration\MigrationBase;
+
+class NewSettings extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Adding new forum settings';
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		// Don't call Config::reloadModSettings(), because we only want the
+		// plain values without any other stuff happening.
+		$request = $this->query(
+			'SELECT variable, value
+			FROM {db_prefix}settings',
+			[],
+		);
+
+		foreach (Db::$db->fetch_all($request) as $row) {
+			Config::$modSettings[$row['variable']] = $row['value'];
+		}
+
+		Db::$db->free_result($request);
+
+		// Resetting settings_updated.
+		Config::updateModSettings([
+			'settings_updated' => '0',
+			'last_mod_report_action' => '0',
+			'search_floodcontrol_time' => '5',
+			'next_task_time' => time(),
+		]);
+
+		// Changing stats settings.
+		$request = $this->query(
+			'SELECT value
+			FROM {db_prefix}themes
+			WHERE variable = {string:var}',
+			[
+				'var' => 'show_sp1_info',
+			],
+		);
+
+		if (Db::$db->num_rows($request) != 0) {
+			$this->query(
+				'DELETE FROM {db_prefix}themes
+				WHERE variable = {string:var}',
+				[
+					'var' => 'show_stats_index',
+				],
+			);
+
+			$this->query(
+				'UPDATE {db_prefix}themes
+				SET variable = {string:new}
+				WHERE variable = {string:old}',
+				[
+					'new' => 'show_stats_index',
+					'old' => 'show_sp1_info',
+				],
+			);
+		}
+
+		Db::$db->free_result($request);
+
+		$this->query(
+			'DELETE FROM {db_prefix}themes
+			WHERE variable = {string:var}',
+			[
+				'var' => 'show_sp1_info',
+			],
+		);
+
+		// Enable cache if upgrading from 2.0 Beta 1 and lower.
+		if (
+			version_compare(
+				str_replace(' ', '.', strtolower(Config::$modSettings['smfVersion'] ?? '0.0.dev.0')),
+				'2.0.beta.1',
+				'<=',
+			)
+		) {
+			Config::updateModSettings([
+				'cache_enable' => '1',
+			]);
+		}
+
+		// Changing visual verification setting.
+		if (isset(Config::$modSettings['disable_visual_verification'])) {
+			$vv_type = Config::$modSettings['disable_visual_verification'] == 4 ? 5 : Config::$modSettings['disable_visual_verification'];
+
+			Config::updateModSettings([
+				'visual_verification_type' => $vv_type,
+				'disable_visual_verification' => null,
+			]);
+		}
+
+		// Changing visual verification setting, again.
+		if (!isset(Config::$modSettings['reg_verification'])) {
+			$vv_type = !isset(Config::$modSettings['visual_verification_type']) ? 3 : (!empty(Config::$modSettings['visual_verification_type']) ? Config::$modSettings['visual_verification_type'] - 1 : Config::$modSettings['visual_verification_type']);
+
+			Config::updateModSettings([
+				'visual_verification_type' => $vv_type,
+				'reg_verification' => !empty($vv_type) ? 1 : 0,
+			]);
+		}
+
+		Config::updateModSettings([
+			// Changing default personal text setting.
+			'default_personal_text' => Config::$modSettings['default_personalText'] ?? '',
+			'default_personalText' => null,
+			// Removing allow hide email setting.
+			'allow_hideEmail' => null,
+			'allow_hide_email' => null,
+		]);
+
+		Db::$db->insert(
+			method: 'ignore',
+			table: '{db_prefix}themes',
+			columns: [
+				'id_theme' => 'int',
+				'variable' => 'string-255',
+				'value' => 'string-65535',
+			],
+			data: [
+				// Ensuring stats index setting present...
+				[1, 'show_stats_index', '0'],
+				// Ensuring forum width setting present...
+				[1, 'forum_width', '90%'],
+			],
+			keys: [],
+		);
+
+		// Replacing old calendar settings.
+		// Only try it if one of the "new" settings doesn't yet exist.
+		if (
+			!isset(Config::$modSettings['cal_showholidays'])
+			|| !isset(Config::$modSettings['cal_showbdays'])
+			|| !isset(Config::$modSettings['cal_showevents'])
+		) {
+			// Default to just the calendar setting.
+			Config::updateModSettings([
+				'cal_showholidays' => (int) !empty(Config::$modSettings['cal_showholidaysoncalendar']),
+				'cal_showbdays' => (int) !empty(Config::$modSettings['cal_showbdaysoncalendar']),
+				'cal_showevents' => (int) !empty(Config::$modSettings['cal_showeventsoncalendar']),
+			]);
+
+			// Then take into account board index.
+			if (!empty(Config::$modSettings['cal_showholidaysonindex'])) {
+				Config::updateModSettings([
+					'cal_showholidays' => Config::$modSettings['cal_showholidays'] === 1 ? 2 : 3,
+				]);
+			}
+
+			if (!empty(Config::$modSettings['cal_showbdaysonindex'])) {
+				Config::updateModSettings([
+					'cal_showbdays' => Config::$modSettings['cal_showbdays'] === 1 ? 2 : 3,
+				]);
+			}
+
+			if (!empty(Config::$modSettings['cal_showeventsonindex'])) {
+				Config::updateModSettings([
+					'cal_showevents' => Config::$modSettings['cal_showevents'] === 1 ? 2 : 3,
+				]);
+			}
+
+			// We no longer need these.
+			Config::updateModSettings([
+				'cal_showholidaysoncalendar' => null,
+				'cal_showbdaysoncalendar' => null,
+				'cal_showeventsoncalendar' => null,
+				'cal_showholidaysonindex' => null,
+				'cal_showbdaysonindex' => null,
+				'cal_showeventsonindex' => null,
+			]);
+		}
+
+		// Adjusting calendar maximum year.
+		Config::updateModSettings([
+			'cal_maxyear' => 2030,
+		]);
+
+		// Adding advanced signature settings...
+		if (empty(Config::$modSettings['signature_settings'])) {
+			Config::updateModSettings([
+				'signature_settings' => '1,' . (Config::$modSettings['max_signatureLength'] ?? '300') . ',0,0,0,0,0,0:',
+				'max_signatureLength' => null,
+			]);
+		}
+
+		// Updating spam protection settings.
+		if (empty(Config::$modSettings['pm_spam_settings'])) {
+			Config::updateModSettings([
+				'pm_spam_settings' => (Config::$modSettings['max_pm_recipients'] ?? '10') . ',5,20',
+				'max_pm_recipients' => null,
+			]);
+		} elseif (substr_count(Config::$modSettings['pm_spam_settings'], ',') == 1) {
+			Config::updateModSettings([
+				'pm_spam_settings' => Config::$modSettings['pm_spam_settings'] . ',20',
+				'max_pm_recipients' => null,
+			]);
+		}
+
+		// Checking theme layers are correct for default themes.
+		$request = $this->query(
+			'SELECT id_theme, value, variable
+			FROM {db_prefix}themes
+			WHERE variable = {literal:theme_layers}
+				OR variable = {literal:theme_dir}',
+		);
+
+		$theme_layer_changes = [];
+
+		while ($row = Db::$db->fetch_assoc($request)) {
+			$theme_layer_changes[$row['id_theme']][$row['variable']] = $row['value'];
+		}
+
+		Db::$db->free_result($request);
+
+		foreach ($theme_layer_changes as $id_theme => $data) {
+			// Has to be a SMF provided theme and have custom layers defined.
+			if (
+				!isset($data['theme_layers'])
+				|| !isset($data['theme_dir'])
+				|| !\in_array(
+					substr($data['theme_dir'], -7),
+					['default', 'babylon', 'classic'],
+				)
+			) {
+				continue;
+			}
+
+			$layers = explode(',', $data['theme_layers']);
+
+			foreach ($layers as $k => $v) {
+				if ($v == 'main') {
+					$layers[$k] = 'html,body';
+
+					$this->query(
+						'UPDATE {db_prefix}themes
+						SET value = {string:layers}
+						WHERE id_theme = {int:id}
+							AND variable = {string:var}',
+						[
+							'layers' => implode(',', $layers),
+							'id' => $id_theme,
+							'var' => 'theme_layers',
+						],
+					);
+
+					break;
+				}
+			}
+		}
+
+		// Adding index to log_notify table.
+		Db::$db->add_index(
+			table_name: '{db_prefix}log_notify',
+			index_info: [
+				'name' => 'id_topic',
+				'columns' => ['id_topic', 'id_member'],
+			],
+			if_exists: 'ignore',
+		);
+
+		// GDPR compliance settings.
+		if (!isset(Config::$modSettings['requirePolicyAgreement'])) {
+			Config::updateModSettings([
+				'requirePolicyAgreement' => 0,
+			]);
+		}
+
+		// Adding weekly maintenance task.
+		Db::$db->insert(
+			method: 'ignore',
+			table: '{db_prefix}scheduled_tasks',
+			columns: [
+				'next_time' => 'int',
+				'time_offset' => 'int',
+				'time_regularity' => 'int',
+				'time_unit' => 'string-1',
+				'disabled' => 'int',
+				'task' => 'string-24',
+			],
+			data: [
+				[0, 0, 1, 'w', 0, 'weekly_maintenance'],
+			],
+			keys: [],
+		);
+
+		// Adding pruning option.
+		Config::updateModSettings([
+			'pruningOptions' => '30,180,180,180,30,0',
+		]);
+
+		// Adding settings for attachments and avatars.
+		Config::updateModSettings([
+			// Enable image re-encoding by default.
+			'attachment_image_reencode' => Config::$modSettings['attachment_image_reencode'] ?? 1,
+			'avatar_reencode' => Config::$modSettings['avatar_reencode'] ?? 1,
+			// Disable draconic checks by default.
+			'attachment_image_paranoid' => Config::$modSettings['attachment_image_paranoid'] ?? 0,
+			'avatar_paranoid' => Config::$modSettings['avatar_paranoid'] ?? 0,
+			// Make image attachment thumbnail as PNG by default.
+			'attachment_thumb_png' => Config::$modSettings['attachment_thumb_png'] ?? 1,
+		]);
+
+		$this->handleTimeout();
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v2_0/OldThemes.php
+++ b/Sources/Maintenance/Migration/v2_0/OldThemes.php
@@ -1,0 +1,129 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v2_0;
+
+use SMF\Config;
+use SMF\Db\DatabaseApi as Db;
+use SMF\Maintenance\Migration\MigrationBase;
+
+class OldThemes extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Cleaning up after old themes';
+
+	/*********************
+	 * Internal properties
+	 *********************/
+
+	/**
+	 * @var int
+	 *
+	 * ID of the Babylon theme.
+	 */
+	private int $id_theme;
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function isCandidate(): bool
+	{
+		$request = $this->query(
+			'SELECT id_theme
+			FROM {db_prefix}themes
+			WHERE variable = {string:themedir}
+				AND value = {string:babylondir}',
+			[
+				'themedir' => 'theme_dir',
+				'babylondir' => Config::$boarddir . '/Themes/babylon',
+			],
+		);
+
+		if (Db::$db->num_rows($request) == 1) {
+			list($this->id_theme) = array_map('intval', Db::$db->fetch_row($request));
+		}
+
+		Db::$db->free_result($request);
+
+		return isset($this->id_theme);
+	}
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		$known_themes = explode(',', Config::$modSettings['knownThemes']);
+
+		// Remove this value...
+		$known_themes = array_diff($known_themes, [$this->id_theme]);
+
+		// Change back to a string...
+		$known_themes = implode(',', $known_themes);
+
+		// Update the database.
+		Config::updateModSettings([
+			'knownThemes' => $known_themes,
+		]);
+
+		// Delete any info about this theme
+		$this->query(
+			'DELETE FROM {db_prefix}themes
+			WHERE id_theme = {int:id}',
+			[
+				'id' => $this->id_theme,
+			],
+		);
+
+		// Set any members or boards using this theme to the default
+		$this->query(
+			'UPDATE {db_prefix}members
+			SET id_theme = 0
+			WHERE id_theme = {int:id}',
+			[
+				'id' => $this->id_theme,
+			],
+		);
+
+		$this->query(
+			'UPDATE {db_prefix}boards
+			SET id_theme = 0
+			WHERE id_theme = {int:id}',
+			[
+				'id' => $this->id_theme,
+			],
+		);
+
+		if (Config::$modSettings['theme_guests'] == $this->id_theme) {
+			Config::updateModSettings([
+				'theme_guests' => 0,
+			]);
+		}
+
+		$this->handleTimeout();
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v2_0/PackageManager.php
+++ b/Sources/Maintenance/Migration/v2_0/PackageManager.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v2_0;
+
+use SMF\Maintenance\Migration\MigrationBase;
+
+class PackageManager extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Making changes to the package manager';
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		// Note: there is also a table that needs to be created, but the table
+		// normalization substeps will take care of that part.
+
+		// Change the URL of the SMF package server.
+		$this->query(
+			'UPDATE {db_prefix}package_servers
+			SET url = {string:new}
+			WHERE url = {string:old}',
+			[
+				'new' => 'http://custom.simplemachines.org/packages/mods',
+				'old' => 'http://mods.simplemachines.org',
+			],
+		);
+
+		$this->handleTimeout();
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v2_0/PaidSubs.php
+++ b/Sources/Maintenance/Migration/v2_0/PaidSubs.php
@@ -1,0 +1,75 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v2_0;
+
+use SMF\Config;
+use SMF\Db\Schema;
+use SMF\Maintenance\Migration\MigrationBase;
+
+class PaidSubs extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Adding paid subscriptions';
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		// Ensure the tables are structured correctly.
+		$table = new Schema\v2_0\Subscriptions();
+		$table->normalize();
+
+		$table = new Schema\v2_0\LogSubscribed();
+		$table->normalize();
+
+		// Clean up any pre-2.0 mod settings.
+		Config::updateModSettings([
+			'paid_currency_code' => Config::$modSettings['currency_code'] ?? null,
+			'paid_currency_symbol' => Config::$modSettings['currency_symbol'] ?? null,
+			'currency_code' => null,
+			'currency_symbol' => null,
+		]);
+
+		$this->query(
+			'UPDATE {db_prefix}log_subscribed
+			SET status = 0
+			WHERE status = 1',
+			[],
+		);
+
+		$this->query(
+			'UPDATE {db_prefix}log_subscribed
+			SET status = 1
+			WHERE status = 2',
+			[],
+		);
+
+		$this->handleTimeout();
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v2_0/PermissionProfiles1.php
+++ b/Sources/Maintenance/Migration/v2_0/PermissionProfiles1.php
@@ -1,0 +1,118 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v2_0;
+
+use SMF\Config;
+use SMF\Db\DatabaseApi as Db;
+use SMF\Db\Schema;
+use SMF\Maintenance\Migration\MigrationBase;
+
+class PermissionProfiles1 extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Adding permission profiles for boards';
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function isCandidate(): bool
+	{
+		// Don't need to clean up a non-existent table.
+		if (empty(Db::$db->list_tables(false, Config::$db_prefix . 'permission_profiles'))) {
+			return false;
+		}
+
+		$smfVersion = str_replace(' ', '.', strtolower(Config::$modSettings['smfVersion'] ?? '0.0.dev.0'));
+
+		return (
+			version_compare($smfVersion, '2.0', '<')
+			&& version_compare($smfVersion, '1.1.99', '>')
+		);
+	}
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		// Ensure the table is structured correctly.
+		$table = new Schema\v2_0\PermissionProfiles();
+		$table->normalize();
+
+		$request = $this->query(
+			'SELECT id_profile
+			FROM {db_prefix}permission_profiles
+			WHERE profile_name = {string:empty}',
+			[
+				'empty' => '',
+			],
+		);
+
+		$profiles = [];
+
+		while ($row = Db::$db->fetch_assoc($request)) {
+			$profiles[] = $row['id_profile'];
+		}
+
+		Db::$db->free_result($request);
+
+		if (!empty($profiles)) {
+			$request = $this->query(
+				'SELECT id_profile, name
+				FROM {db_prefix}boards
+				WHERE id_profile IN ({array_int:profiles})',
+				[
+					'profiles' => $profiles,
+				],
+			);
+
+			$done_ids = [];
+
+			while ($row = Db::$db->fetch_assoc($request)) {
+				if (isset($done_ids[$row['id_profile']])) {
+					continue;
+				}
+
+				$done_ids[$row['id_profile']] = true;
+
+				$row['name'] = Db::$db->escape_string($row['name']);
+
+				$this->query(
+					'UPDATE {db_prefix}permission_profiles
+					SET profile_name = {string:name}
+					WHERE id_profile = {int:id_profile}',
+					$row,
+				);
+			}
+
+			Db::$db->free_result($request);
+		}
+
+		$this->handleTimeout();
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v2_0/PermissionProfiles2.php
+++ b/Sources/Maintenance/Migration/v2_0/PermissionProfiles2.php
@@ -1,0 +1,211 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v2_0;
+
+use SMF\Config;
+use SMF\Db\DatabaseApi as Db;
+use SMF\Db\Schema;
+use SMF\Maintenance\Migration\MigrationBase;
+
+class PermissionProfiles2 extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Migrating old board profiles to profile system';
+
+	/*********************
+	 * Internal properties
+	 *********************/
+
+	/**
+	 *
+	 */
+	private int $num_profiles = 0;
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function isCandidate(): bool
+	{
+		if (!empty(Db::$db->list_tables(false, Config::$db_prefix . 'permission_profiles'))) {
+			$request = $this->query(
+				'SELECT COUNT(*)
+				FROM {db_prefix}permission_profiles',
+				[],
+			);
+
+			list($this->num_profiles) = Db::$db->fetch_row($request);
+
+			Db::$db->free_result($request);
+		}
+
+		return empty($this->num_profiles);
+	}
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		// Ensure the tables are structured correctly.
+		$table = new Schema\v2_0\PermissionProfiles();
+		$table->normalize();
+
+		$table = new Schema\v2_0\BoardPermissions();
+		$table->normalize();
+
+		// Everything starts off invalid.
+		$this->query(
+			'UPDATE {db_prefix}board_permissions
+			SET id_profile = 0',
+			[],
+		);
+
+		// Insert the default profile permissions.
+		Db::$db->insert(
+			method: '',
+			table: '{db_prefix}permission_profiles',
+			columns: [
+				'id_profile' => 'int',
+				'profile_name' => 'string-255',
+			],
+			data: [
+				[1, 'default'],
+				[2, 'no_polls'],
+				[3, 'reply_only'],
+				[4, 'read_only'],
+			],
+			keys: ['id_profile'],
+		);
+
+		// Update the default permissions, this is easy!
+		$this->query(
+			'UPDATE {db_prefix}board_permissions
+			SET id_profile = 1
+			WHERE id_board = 0',
+			[],
+		);
+
+		// Load all the other permissions
+		$request = $this->query(
+			'SELECT id_board, id_group, permission, add_deny
+			FROM {db_prefix}board_permissions
+			WHERE id_profile = 0',
+			[],
+		);
+
+		$all_perms = [];
+
+		while ($row = Db::$db->fetch_assoc($request)) {
+			$all_perms[$row['id_board']][$row['id_group']][$row['permission']] = $row['add_deny'];
+		}
+
+		Db::$db->free_result($request);
+
+		// Now we have the profile profiles for this installation. We now need to go through each board and work out what the permission profile should be!
+		$request = $this->query(
+			'SELECT id_board, name, permission_mode
+			FROM {db_prefix}boards',
+			[],
+		);
+
+		$board_updates = [];
+
+		while ($row = Db::$db->fetch_assoc($request)) {
+			$row['name'] = addslashes($row['name']);
+
+			// Is it a truly local permission board? If so this is a new profile!
+			if ($row['permission_mode'] == 1) {
+				Db::$db->insert(
+					method: '',
+					table: '{db_prefix}permission_profiles',
+					columns: [
+						'profile_name' => 'string-255',
+					],
+					data: [
+						[$row['name']],
+					],
+					keys: ['id_profile'],
+				);
+
+				$board_updates[Db::$db->insert_id()][] = $row['id_board'];
+			}
+			// Otherwise, dear god, this is an old school "simple" permission...
+			elseif ($row['permission_mode'] > 1 && $row['permission_mode'] < 5) {
+				$board_updates[$row['permission_mode']][] = $row['id_board'];
+			}
+			// Otherwise this is easy. It becomes default.
+			else {
+			$board_updates[1][] = $row['id_board'];
+			}
+		}
+
+		Db::$db->free_result($request);
+
+		// Update the board tables.
+		foreach ($board_updates as $profile => $boards) {
+			if (empty($boards) || empty($profile)) {
+				continue;
+			}
+
+			$boards = implode(',', $boards);
+
+			$this->query(
+				'UPDATE {db_prefix}boards
+				SET id_profile = {int:profile}
+				WHERE id_board IN ({array_int:boards})',
+				[
+					'profile' => $profile,
+					'boards' => $boards,
+				],
+			);
+
+			// If it's a custom profile then update this too.
+			if ($profile > 4) {
+				$this->query(
+					'UPDATE {db_prefix}board_permissions
+					SET id_profile = {int:profile}
+					WHERE id_board IN ({array_int:boards})
+						AND id_profile = 0',
+					[
+						'profile' => $profile,
+						'boards' => $boards,
+					],
+				);
+			}
+		}
+
+		// Just in case we have any random permissions that didn't have boards.
+		$this->query(
+			'DELETE FROM {db_prefix}board_permissions
+			WHERE id_profile = 0',
+			[],
+		);
+
+		$this->handleTimeout();
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v2_0/PermissionProfiles3.php
+++ b/Sources/Maintenance/Migration/v2_0/PermissionProfiles3.php
@@ -1,0 +1,231 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v2_0;
+
+use SMF\Config;
+use SMF\Db\DatabaseApi as Db;
+use SMF\Db\Schema;
+use SMF\Maintenance\Migration\MigrationBase;
+
+class PermissionProfiles3 extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Migrating old board profiles to profile system';
+
+	/*********************
+	 * Internal properties
+	 *********************/
+
+	/**
+	 *
+	 */
+	private array $mod_permissions = [
+		'moderate_board',
+		'post_new',
+		'post_reply_own',
+		'post_reply_any',
+		'poll_post',
+		'poll_add_any',
+		'poll_remove_any',
+		'poll_view',
+		'poll_vote',
+		'poll_lock_any',
+		'poll_edit_any',
+		'report_any',
+		'lock_own',
+		'send_topic',
+		'mark_any_notify',
+		'mark_notify',
+		'delete_own',
+		'modify_own',
+		'make_sticky',
+		'lock_any',
+		'remove_any',
+		'move_any',
+		'merge_any',
+		'split_any',
+		'delete_any',
+		'modify_any',
+		'approve_posts',
+		'post_attachment',
+		'view_attachments',
+		'post_unapproved_replies_any',
+		'post_unapproved_replies_own',
+		'post_unapproved_attachments',
+		'post_unapproved_topics',
+	];
+
+	/**
+	 *
+	 */
+	private array $no_poll_reg = [
+		'post_new',
+		'post_reply_own',
+		'post_reply_any',
+		'poll_view',
+		'poll_vote',
+		'report_any',
+		'lock_own',
+		'send_topic',
+		'mark_any_notify',
+		'mark_notify',
+		'delete_own',
+		'modify_own',
+		'post_attachment',
+		'view_attachments',
+		'remove_own',
+		'post_unapproved_replies_any',
+		'post_unapproved_replies_own',
+		'post_unapproved_attachments',
+		'post_unapproved_topics',
+	];
+
+	/**
+	 *
+	 */
+	private array $reply_only_reg = [
+		'post_reply_own',
+		'post_reply_any',
+		'poll_view',
+		'poll_vote',
+		'report_any',
+		'lock_own',
+		'send_topic',
+		'mark_any_notify',
+		'mark_notify',
+		'delete_own',
+		'modify_own',
+		'post_attachment',
+		'view_attachments',
+		'remove_own',
+		'post_unapproved_replies_any',
+		'post_unapproved_replies_own',
+		'post_unapproved_attachments',
+	];
+
+	/**
+	 *
+	 */
+	private array $read_only_reg = [
+		'poll_view',
+		'poll_vote',
+		'report_any',
+		'send_topic',
+		'mark_any_notify',
+		'mark_notify',
+		'view_attachments',
+	];
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		// Ensure the table is structured correctly.
+		$table = new Schema\v2_0\BoardPermissions();
+		$table->normalize();
+
+		// Clear all the current predefined profiles.
+		$this->query(
+			'DELETE FROM {db_prefix}board_permissions
+			WHERE id_profile IN (2,3,4)',
+			[],
+		);
+
+		// Get all the membergroups - cheating to use the fact id_group = 1 exists to get a group of 0.
+		$request = $this->query(
+			'SELECT IF(id_group = 1, 0, id_group) AS id_group
+			FROM {db_prefix}membergroups
+			WHERE id_group != 0
+				AND min_posts = -1',
+			[],
+		);
+
+		$inserts = [
+			[-1, 2, 'poll_view'],
+			[-1, 3, 'poll_view'],
+			[-1, 4, 'poll_view'],
+		];
+
+		while ($row = Db::$db->fetch_assoc($request)) {
+			if ($row['id_group'] == 2 || $row['id_group'] == 3) {
+				foreach ($this->mod_permissions as $permission) {
+					$inserts[] = [$row['id_group'], 2, $permission];
+					$inserts[] = [$row['id_group'], 3, $permission];
+					$inserts[] = [$row['id_group'], 4, $permission];
+				}
+			} else {
+				foreach ($this->no_poll_reg as $permission) {
+					$inserts[] = [$row['id_group'], 2, $permission];
+				}
+
+				foreach ($reply_only_reg as $permission) {
+					$inserts[] = [$row['id_group'], 3, $permission];
+				}
+
+				foreach ($read_only_reg as $permission) {
+					$inserts[] = [$row['id_group'], 4, $permission];
+				}
+			}
+		}
+
+		Db::$db->free_result($request);
+
+		Db::$db->insert(
+			method: '',
+			table: '{db_prefix}board_permissions',
+			columns: [
+				'id_group' => 'int',
+				'id_profile' => 'int',
+				'permission' => 'string-30',
+			],
+			data: $inserts,
+			keys: ['id_profile'],
+		);
+
+		// Make sure admins and moderators don't inherit.
+		$table = new Schema\v2_0\Membergroups();
+		$table->normalize();
+
+		$this->query(
+			'UPDATE {db_prefix}membergroups
+			SET id_parent = -2
+			WHERE id_group IN ({array_int:groups})',
+			[
+				'groups' => [1, 3],
+			],
+		);
+
+		// Delete old permission settings.
+		Config::updateModSettings([
+			'permission_enable_by_board' => null,
+		]);
+
+		$this->handleTimeout();
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v2_0/PersonalMessages1.php
+++ b/Sources/Maintenance/Migration/v2_0/PersonalMessages1.php
@@ -1,0 +1,92 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v2_0;
+
+use SMF\Config;
+use SMF\Db\Schema;
+use SMF\Maintenance\Migration\MigrationBase;
+
+class PersonalMessages1 extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Adding new personal messaging functionality';
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function isCandidate(): bool
+	{
+		return version_compare(
+			str_replace(' ', '.', strtolower(Config::$modSettings['smfVersion'] ?? '0.0.dev.0')),
+			'2.0',
+			'<',
+		);
+	}
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		// Ensure the tables are structured correctly.
+		$table = new Schema\v2_0\PersonalMessages();
+		$table->normalize();
+
+		$table = new Schema\v2_0\Members();
+		$table->normalize();
+
+		$table = new Schema\v2_0\PmRecipients();
+		$table->normalize();
+
+		// Set all unread messages as new.
+		$this->query(
+			'UPDATE {db_prefix}pm_recipients
+			SET is_new = 1
+			WHERE is_read = 0',
+			[],
+		);
+
+		// Also set members to have a new pm if they have any unread.
+		$this->query(
+			'UPDATE {db_prefix}members
+			SET new_pm = 1
+			WHERE unread_messages > 0',
+			[],
+		);
+
+		// Set the correct value of id_pm_head.
+		$this->query(
+			'UPDATE {db_prefix}personal_messages
+			SET id_pm_head = id_pm
+			WHERE id_pm_head = 0',
+			[],
+		);
+
+		$this->handleTimeout();
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v2_0/PersonalMessages2.php
+++ b/Sources/Maintenance/Migration/v2_0/PersonalMessages2.php
@@ -1,0 +1,100 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v2_0;
+
+use SMF\Config;
+use SMF\Db\DatabaseApi as Db;
+use SMF\Db\Schema;
+use SMF\Maintenance\Migration\MigrationBase;
+
+class PersonalMessages2 extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Adding new personal message settings';
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		// Ensure the table is structured correctly.
+		$table = new Schema\v2_0\Members();
+		$table->normalize();
+
+		// Don't do this if we've done this already.
+		if (empty(Config::$modSettings['dont_repeat_buddylists'])) {
+			// Update previous ignore lists if they're set to ignore all.
+			$this->query(
+				"UPDATE {db_prefix}members
+				SET pm_receive_from = 3, pm_ignore_list = ''
+				WHERE pm_ignore_list = '*'",
+				[],
+			);
+
+			// Ignore posts made by ignored users by default.
+			Db::$db->insert(
+				method: 'replace',
+				table: '{db_prefix}themes',
+				columns: [
+					'id_member' => 'int',
+					'id_theme' => 'int',
+					'variable' => 'string-255',
+					'value' => 'string-65535',
+				],
+				data: [
+					[-1, 1, 'posts_apply_ignore_list', '1'],
+				],
+				keys: [],
+			);
+
+			// Enable buddy and ignore lists, and make sure not to skip this step next time we run this.
+			Config::updateModSettings([
+				'enable_buddylist' => 1,
+				'dont_repeat_buddylists' => 1,
+			]);
+		}
+
+		// And yet, and yet... We might have a small hiccup here...
+		if (!empty(Config::$modSettings['dont_repeat_buddylists']) && !isset(Config::$modSettings['enable_buddylist'])) {
+			// Correct RC3 adopters' setting here...
+			if (isset(Config::$modSettings['enable_buddylists'])) {
+				Config::updateModSettings([
+					'enable_buddylist' => Config::$modSettings['enable_buddylists'],
+					'enable_buddylists' => null,
+				]);
+			} else {
+				// This should never happen :)
+				Config::updateModSettings([
+					'enable_buddylist' => 1,
+				]);
+			}
+		}
+
+		$this->handleTimeout();
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v2_0/PostModeration.php
+++ b/Sources/Maintenance/Migration/v2_0/PostModeration.php
@@ -1,0 +1,101 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v2_0;
+
+use SMF\Config;
+use SMF\Db\DatabaseApi as Db;
+use SMF\Maintenance\Migration\MigrationBase;
+
+class PostModeration extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Adding post moderation';
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function isCandidate(): bool
+	{
+		return version_compare(
+			str_replace(' ', '.', strtolower(Config::$modSettings['smfVersion'] ?? '0.0.dev.0')),
+			'2.0',
+			'<',
+		);
+	}
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		// Note: there are some tables that need to be created, and some changes
+		// that need to be made to other tables, but the table normalization
+		// substeps will take care of that part.
+
+		// Anyone who can currently edit posts we assume can approve them...
+		$request = $this->query(
+			'SELECT id_group, id_board, add_deny, permission
+			FROM {db_prefix}board_permissions
+			WHERE permission = {string:perm}',
+			[
+				'perm' => 'modify_any',
+			],
+		);
+
+		$inserts = [];
+
+		while ($row = Db::$db->fetch_assoc($request)) {
+			$inserts[] = [
+				$row['id_group'],
+				$row['id_board'],
+				'approve_posts',
+				$row['add_deny'],
+			];
+		}
+
+		Db::$db->free_result($request);
+
+		// Add moderation center permissions.
+		if (!empty($inserts)) {
+			Db::$db->insert(
+				method: 'ignore',
+				table: '{db_prefix}board_permissions',
+				columns: [
+					'id_group' => 'int',
+					'id_board' => 'int',
+					'permission' => 'string-30',
+					'add_deny' => 'int',
+				],
+				data: $inserts,
+				keys: [],
+			);
+		}
+
+		$this->handleTimeout();
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v2_0/PostgreSQLFunctions.php
+++ b/Sources/Maintenance/Migration/v2_0/PostgreSQLFunctions.php
@@ -1,0 +1,283 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v2_0;
+
+use SMF\Db\DatabaseApi as Db;
+use SMF\Maintenance\Migration\MigrationBase;
+
+class PostgreSQLFunctions extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Updating PostgreSQL functions';
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function isCandidate(): bool
+	{
+		return Db::$db->title === POSTGRE_TITLE;
+	}
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		// Changing inet_aton function to use bigint instead of int...
+		$this->query(
+			'CREATE OR REPLACE FUNCTION INET_ATON(text) RETURNS bigint AS
+				{string:func_text}
+			LANGUAGE {string:lang}',
+			[
+				'func_text' => Db::$db->quote(
+					'SELECT
+					CASE WHEN
+						$1 !~ {string:regex} THEN 0
+					ELSE
+						split_part($1, {string:dot}, 1)::int8 * (256 * 256 * 256) +
+						split_part($1, {string:dot}, 2)::int8 * (256 * 256) +
+						split_part($1, {string:dot}, 3)::int8 * 256 +
+						split_part($1, {string:dot}, 4)::int8
+					END AS result',
+					[
+						'regex' => '^[0-9]?[0-9]?[0-9]?\.[0-9]?[0-9]?[0-9]?\.[0-9]?[0-9]?[0-9]?\.[0-9]?[0-9]?[0-9]?$',
+						'dot' => '.',
+					],
+				),
+				'lang' => 'sql',
+			],
+		);
+
+		// Adding an IFNULL to handle 8-bit integers returned by inet_aton
+		$this->query(
+			'CREATE OR REPLACE FUNCTION IFNULL(int8, int8) RETURNS int8 AS
+				{string:func_text}
+			LANGUAGE  {string:lang}',
+			[
+				'func_text' => Db::$db->quote(
+					'SELECT COALESCE($1, $2) AS result',
+					[],
+				),
+				'lang' => 'sql',
+			],
+		);
+
+		// Adding instr()
+		$this->query(
+			'DROP FUNCTION IF EXISTS INSTR(text, text)',
+			[],
+		);
+
+		$this->query(
+			'CREATE OR REPLACE FUNCTION INSTR(text, text) RETURNS integer AS
+				{string:func_text}
+			LANGUAGE  {string:lang}',
+			[
+				'func_text' => Db::$db->quote(
+					'SELECT POSITION($2 IN $1) AS result',
+					[],
+				),
+				'lang' => 'sql',
+			],
+		);
+
+		// Adding date_format()
+		$this->query(
+			'CREATE OR REPLACE FUNCTION DATE_FORMAT(timestamp, text) RETURNS text AS
+				{string:func_text}
+			LANGUAGE  {string:lang}',
+			[
+				'func_text' => Db::$db->quote(
+					'SELECT REPLACE(REPLACE($2, {string:m}, to_char($1, {string:mm})), {string:d}, to_char($1, {string:dd})) AS result',
+					[
+						'm' => '%m',
+						'mm' => 'MM',
+						'd' => '%d',
+						'dd' => 'DD',
+					],
+				),
+				'lang' => 'sql',
+			],
+		);
+
+		// Adding day()
+		$this->query(
+			'CREATE OR REPLACE FUNCTION day(date) RETURNS integer AS
+				{string:func_text}
+			LANGUAGE  {string:lang}',
+			[
+				'func_text' => Db::$db->quote(
+					'SELECT EXTRACT(DAY FROM DATE($1))::integer AS result',
+					[],
+				),
+				'lang' => 'sql',
+			],
+		);
+
+		// Adding IFNULL(varying, varying)
+		$this->query(
+			'CREATE OR REPLACE FUNCTION IFNULL (character varying, character varying) RETURNS character varying AS
+				{string:func_text}
+			LANGUAGE  {string:lang}',
+			[
+				'func_text' => Db::$db->quote(
+					'SELECT COALESCE($1, $2) AS result',
+					[],
+				),
+				'lang' => 'sql',
+			],
+		);
+
+		// Adding IFNULL(varying, bool)
+		$this->query(
+			'CREATE OR REPLACE FUNCTION IFNULL(character varying, boolean) RETURNS character varying AS
+				{string:func_text}
+			LANGUAGE  {string:lang}',
+			[
+				'func_text' => Db::$db->quote(
+					'SELECT COALESCE($1, CAST(CAST($2 AS int) AS varchar)) AS result',
+					[],
+				),
+				'lang' => 'sql',
+			],
+		);
+
+		// Adding IFNULL(int, bool)
+		$this->query(
+			'CREATE OR REPLACE FUNCTION IFNULL(int, boolean) RETURNS int AS
+				{string:func_text}
+			LANGUAGE  {string:lang}',
+			[
+				'func_text' => Db::$db->quote(
+					'SELECT COALESCE($1, CAST($2 AS int)) AS result',
+					[],
+				),
+				'lang' => 'sql',
+			],
+		);
+
+		// Adding bool_not_eq_int()
+		$this->query(
+			'CREATE OR REPLACE FUNCTION bool_not_eq_int (boolean, integer) RETURNS boolean AS
+				{string:func_text}
+			LANGUAGE  {string:lang}',
+			[
+				'func_text' => Db::$db->quote(
+					'SELECT CAST($1 AS integer) != $2 AS result',
+					[],
+				),
+				'lang' => 'sql',
+			],
+		);
+
+		// Creating operator bool_not_eq_int()
+		$result = $this->query(
+			'SELECT oprname
+			FROM pg_operator
+			WHERE oprcode = {string:code}::regproc',
+			[
+				'code' => 'bool_not_eq_int',
+			],
+		);
+
+		if (Db::$db->num_rows($result) == 0) {
+			$this->query(
+				'CREATE OPERATOR != (PROCEDURE = bool_not_eq_int, LEFTARG = boolean, RIGHTARG = integer)',
+				[],
+			);
+		}
+
+		// Recreating function FIND_IN_SET()
+		$this->query(
+			'DROP FUNCTION IF EXISTS FIND_IN_SET(text, text)',
+			[],
+		);
+
+		$this->query(
+			'DROP FUNCTION IF EXISTS FIND_IN_SET(integer, character varying)',
+			[],
+		);
+
+		$this->query(
+			'CREATE OR REPLACE FUNCTION FIND_IN_SET(needle text, haystack text) RETURNS integer AS
+				{string:func_text}
+			LANGUAGE  {string:lang}',
+			[
+				'func_text' => Db::$db->quote(
+					'SELECT i AS result
+					FROM generate_series(1, array_upper(string_to_array($2, {string:comma}), 1)) AS g(i)
+					WHERE (string_to_array($2, {string:comma}))[i] = $1
+						UNION ALL
+					SELECT 0
+					LIMIT 1',
+					[
+						'comma' => ',',
+					],
+				),
+				'lang' => 'sql',
+			],
+		);
+
+		$this->query(
+			'CREATE OR REPLACE FUNCTION FIND_IN_SET(needle integer, haystack text) RETURNS integer AS
+				{string:func_text}
+			LANGUAGE  {string:lang}',
+			[
+				'func_text' => Db::$db->quote(
+					'SELECT i AS result
+					FROM generate_series(1, array_upper(string_to_array($2, {string:comma}), 1)) AS g(i)
+					WHERE (string_to_array($2, {string:comma}))[i] = CAST($1 AS text)
+						UNION ALL
+					SELECT 0
+					LIMIT 1',
+					[
+						'comma' => ',',
+					],
+				),
+				'lang' => 'sql',
+			],
+		);
+
+		// Updating TO_DAYS()
+		$this->query(
+			'CREATE OR REPLACE FUNCTION TO_DAYS (timestamp) RETURNS integer AS
+				{string:func_text}
+			LANGUAGE  {string:lang}',
+			[
+				'func_text' => Db::$db->quote(
+					'SELECT DATE_PART({string:day}, $1 - {string:day_zero})::integer AS result',
+					[
+						'day' => 'DAY',
+						'day_zero' => '0001-01-01bc',
+					],
+				),
+				'lang' => 'sql',
+			],
+		);
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v2_0/PurgeFloodcontrol.php
+++ b/Sources/Maintenance/Migration/v2_0/PurgeFloodcontrol.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v2_0;
+
+use SMF\Maintenance\Migration\MigrationBase;
+
+class PurgeFloodcontrol extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Purging the log_floodcontrol table';
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		// Purge flood control.
+		$this->query(
+			'DELETE FROM {db_prefix}log_floodcontrol',
+			[],
+		);
+
+		$this->handleTimeout();
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v2_0/RenameColumns.php
+++ b/Sources/Maintenance/Migration/v2_0/RenameColumns.php
@@ -1,0 +1,415 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v2_0;
+
+use SMF\Db\Schema;
+use SMF\Maintenance\Migration\MigrationBase;
+
+class RenameColumns extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Changing column names';
+
+	/*********************
+	 * Internal properties
+	 *********************/
+
+	/**
+	 *
+	 */
+	private array $name_changes = [
+		Schema\v2_0\AdminInfoFiles::class => [
+			'ID_FILE' => 'id_file',
+		],
+		Schema\v2_0\ApprovalQueue::class => [
+			'ID_MSG' => 'id_msg',
+			'ID_ATTACH' => 'id_attach',
+			'ID_EVENT' => 'id_event',
+			'attachmentType' => 'attachment_type',
+		],
+		Schema\v2_0\Attachments::class => [
+			'ID_ATTACH' => 'id_attach',
+			'ID_THUMB' => 'id_thumb',
+			'ID_MSG' => 'id_msg',
+			'ID_MEMBER' => 'id_member',
+			'attachmentType' => 'attachment_type',
+		],
+		Schema\v2_0\BanGroups::class => [
+			'ID_BAN_GROUP' => 'id_ban_group',
+		],
+		Schema\v2_0\BanItems::class => [
+			'ID_BAN' => 'id_ban',
+			'ID_BAN_GROUP' => 'id_ban_group',
+			'ID_MEMBER' => 'id_member',
+		],
+		Schema\v2_0\BoardPermissions::class => [
+			'ID_GROUP' => 'id_group',
+			'ID_PROFILE' => 'id_profile',
+			'addDeny' => 'add_deny',
+		],
+		Schema\v2_0\Boards::class => [
+			'ID_BOARD' => 'id_board',
+			'ID_CAT' => 'id_cat',
+			'childLevel' => 'child_level',
+			'ID_PARENT' => 'id_parent',
+			'boardOrder' => 'board_order',
+			'ID_LAST_MSG' => 'id_last_msg',
+			'ID_MSG_UPDATED' => 'id_msg_updated',
+			'memberGroups' => 'member_groups',
+			'ID_PROFILE' => 'id_profile',
+			'numTopics' => 'num_topics',
+			'numPosts' => 'num_posts',
+			'countPosts' => 'count_posts',
+			'ID_THEME' => 'id_theme',
+			'unapprovedPosts' => 'unapproved_posts',
+			'unapprovedTopics' => 'unapproved_topics',
+		],
+		Schema\v2_0\Calendar::class => [
+			'ID_EVENT' => 'id_event',
+			'ID_MEMBER' => 'id_member',
+			'ID_BOARD' => 'id_board',
+			'ID_TOPIC' => 'id_topic',
+			'startDate' => 'start_date',
+			'endDate' => 'end_date',
+		],
+		Schema\v2_0\CalendarHolidays::class => [
+			'ID_HOLIDAY' => 'id_holiday',
+			'eventDate' => 'event_date',
+		],
+		Schema\v2_0\Categories::class => [
+			'ID_CAT' => 'id_cat',
+			'catOrder' => 'cat_order',
+			'canCollapse' => 'can_collapse',
+		],
+		Schema\v2_0\CustomFields::class => [
+			'ID_FIELD' => 'id_field',
+			'colName' => 'col_name',
+			'fieldName' => 'field_name',
+			'fieldDesc' => 'field_desc',
+			'fieldType' => 'field_type',
+			'fieldLength' => 'field_length',
+			'fieldOptions' => 'field_options',
+			'showReg' => 'show_reg',
+			'showDisplay' => 'show_display',
+			'showProfile' => 'show_profile',
+			'defaultValue' => 'default_value',
+		],
+		Schema\v2_0\GroupModerators::class => [
+			'ID_MEMBER' => 'id_member',
+			'ID_GROUP' => 'id_group',
+		],
+		Schema\v2_0\LogActions::class => [
+			'ID_ACTION' => 'id_action',
+			'ID_MEMBER' => 'id_member',
+			'logTime' => 'log_time',
+			'ID_MSG' => 'id_msg',
+			'ID_TOPIC' => 'id_topic',
+			'ID_BOARD' => 'id_board',
+		],
+		Schema\v2_0\LogActivity::class => [
+			'mostOn' => 'most_on',
+		],
+		Schema\v2_0\LogBanned::class => [
+			'ID_BAN_LOG' => 'id_ban_log',
+			'ID_MEMBER' => 'id_member',
+			'logTime' => 'log_time',
+		],
+		Schema\v2_0\LogBoards::class => [
+			'ID_MEMBER' => 'id_member',
+			'ID_MSG' => 'id_msg',
+			'ID_BOARD' => 'id_board',
+		],
+		Schema\v2_0\LogDigest::class => [
+			'ID_TOPIC' => 'id_topic',
+			'ID_MSG' => 'id_msg',
+		],
+		Schema\v2_0\LogErrors::class => [
+			'ID_ERROR' => 'id_error',
+			'logTime' => 'log_time',
+			'ID_MEMBER' => 'id_member',
+			'errorType' => 'error_type',
+		],
+		Schema\v2_0\LogFloodcontrol::class => [
+			'logTime' => 'log_time',
+		],
+		Schema\v2_0\LogGroupRequests::class => [
+			'ID_REQUEST' => 'id_request',
+			'ID_MEMBER' => 'id_member',
+			'ID_GROUP' => 'id_group',
+		],
+		Schema\v2_0\LogKarma::class => [
+			'ID_TARGET' => 'id_target',
+			'ID_EXECUTOR' => 'id_executor',
+			'logTime' => 'log_time',
+		],
+		Schema\v2_0\LogMarkRead::class => [
+			'ID_MEMBER' => 'id_member',
+			'ID_MSG' => 'id_msg',
+			'ID_BOARD' => 'id_board',
+		],
+		Schema\v2_0\LogNotify::class => [
+			'ID_MEMBER' => 'id_member',
+			'ID_TOPIC' => 'id_topic',
+			'ID_BOARD' => 'id_board',
+		],
+		Schema\v2_0\LogPackages::class => [
+			'ID_INSTALL' => 'id_install',
+			'ID_MEMBER_INSTALLED' => 'id_member_installed',
+			'ID_MEMBER_REMOVED' => 'id_member_removed',
+		],
+		Schema\v2_0\LogPolls::class => [
+			'ID_MEMBER' => 'id_member',
+			'ID_CHOICE' => 'id_choice',
+			'ID_POLL' => 'id_poll',
+		],
+		Schema\v2_0\LogReported::class => [
+			'ID_REPORT' => 'id_report',
+			'ID_MEMBER' => 'id_member',
+			'ID_MSG' => 'id_msg',
+			'ID_TOPIC' => 'id_topic',
+			'ID_BOARD' => 'id_board',
+		],
+		Schema\v2_0\LogReportedComments::class => [
+			'ID_COMMENT' => 'id_comment',
+			'ID_REPORT' => 'id_report',
+			'ID_MEMBER' => 'id_member',
+		],
+		Schema\v2_0\LogScheduledTasks::class => [
+			'ID_LOG' => 'id_log',
+			'ID_TASK' => 'id_task',
+			'timeRun' => 'time_run',
+			'timeTaken' => 'time_taken',
+		],
+		Schema\v2_0\LogSearchMessages::class => [
+			'ID_SEARCH' => 'id_search',
+			'ID_MSG' => 'id_msg',
+		],
+		Schema\v2_0\LogSearchResults::class => [
+			'ID_TOPIC' => 'id_topic',
+			'ID_MSG' => 'id_msg',
+			'ID_SEARCH' => 'id_search',
+		],
+		Schema\v2_0\LogSearchSubjects::class => [
+			'ID_TOPIC' => 'id_topic',
+		],
+		Schema\v2_0\LogSearchTopics::class => [
+			'ID_SEARCH' => 'id_search',
+			'ID_TOPIC' => 'id_topic',
+		],
+		Schema\v2_0\LogSubscribed::class => [
+			'ID_SUBLOG' => 'id_sublog',
+			'ID_SUBSCRIBE' => 'id_subscribe',
+			'OLD_ID_GROUP' => 'old_id_group',
+			'startTime' => 'start_time',
+			'endTime' => 'end_time',
+		],
+		Schema\v2_0\LogTopics::class => [
+			'ID_MEMBER' => 'id_member',
+			'ID_MSG' => 'id_msg',
+			'ID_TOPIC' => 'id_topic',
+		],
+		Schema\v2_0\MailQueue::class => [
+			'ID_MAIL' => 'id_mail',
+		],
+		Schema\v2_0\Members::class => [
+			'ID_MEMBER' => 'id_member',
+			'memberName' => 'member_name',
+			'dateRegistered' => 'date_registered',
+			'ID_GROUP' => 'id_group',
+			'lastLogin' => 'last_login',
+			'realName' => 'real_name',
+			'instantMessages' => 'instant_messages',
+			'unreadMessages' => 'unread_messages',
+			'messageLabels' => 'message_labels',
+			'emailAddress' => 'email_address',
+			'personalText' => 'personal_text',
+			'websiteTitle' => 'website_title',
+			'websiteUrl' => 'website_url',
+			'ICQ' => 'icq',
+			'AIM' => 'aim',
+			'YIM' => 'yim',
+			'MSN' => 'msn',
+			'hideEmail' => 'hide_email',
+			'showOnline' => 'show_online',
+			'timeFormat' => 'time_format',
+			'timeOffset' => 'time_offset',
+			'karmaBad' => 'karma_bad',
+			'karmaGood' => 'karma_good',
+			'notifyAnnouncements' => 'notify_announcements',
+			'notifyRegularity' => 'notify_regularity',
+			'notifySendBody' => 'notify_send_body',
+			'notifyTypes' => 'notify_types',
+			'memberIP' => 'member_ip',
+			'secretQuestion' => 'secret_question',
+			'secretAnswer' => 'secret_answer',
+			'ID_THEME' => 'id_theme',
+			'ID_MSG_LAST_VISIT' => 'id_msg_last_visit',
+			'additionalGroups' => 'additional_groups',
+			'smileySet' => 'smiley_set',
+			'ID_POST_GROUP' => 'id_post_group',
+			'totalTimeLoggedIn' => 'total_time_logged_in',
+			'passwordSalt' => 'password_salt',
+			'ignoreBoards' => 'ignore_boards',
+			'memberIP2' => 'member_ip2',
+		],
+		Schema\v2_0\Messages::class => [
+			'ID_MSG' => 'id_msg',
+			'ID_TOPIC' => 'id_topic',
+			'ID_BOARD' => 'id_board',
+			'posterTime' => 'poster_time',
+			'ID_MEMBER' => 'id_member',
+			'ID_MSG_MODIFIED' => 'id_msg_modified',
+			'posterName' => 'poster_name',
+			'posterEmail' => 'poster_email',
+			'posterIP' => 'poster_ip',
+			'smileysEnabled' => 'smileys_enabled',
+			'modifiedTime' => 'modified_time',
+			'modifiedName' => 'modified_name',
+		],
+		Schema\v2_0\Membergroups::class => [
+			'ID_GROUP' => 'id_group',
+			'ID_PARENT' => 'id_parent',
+			'groupName' => 'group_name',
+			'onlineColor' => 'online_color',
+			'minPosts' => 'min_posts',
+			'maxMessages' => 'max_messages',
+			'groupType' => 'group_type',
+		],
+		Schema\v2_0\MessageIcons::class => [
+			'ID_ICON' => 'id_icon',
+			'iconOrder' => 'icon_order',
+			'ID_BOARD' => 'id_board',
+		],
+		Schema\v2_0\Moderators::class => [
+			'ID_MEMBER' => 'id_member',
+			'ID_BOARD' => 'id_board',
+		],
+		Schema\v2_0\PackageServers::class => [
+			'ID_SERVER' => 'id_server',
+		],
+		Schema\v2_0\PersonalMessages::class => [
+			'ID_PM' => 'id_pm',
+			'ID_MEMBER_FROM' => 'id_member_from',
+			'deletedBySender' => 'deleted_by_sender',
+			'fromName' => 'from_name',
+		],
+		Schema\v2_0\PermissionProfiles::class => [
+			'ID_PROFILE' => 'id_profile',
+		],
+		Schema\v2_0\Permissions::class => [
+			'ID_GROUP' => 'id_group',
+			'addDeny' => 'add_deny',
+		],
+		Schema\v2_0\PmRecipients::class => [
+			'ID_PM' => 'id_pm',
+			'ID_MEMBER' => 'id_member',
+		],
+		Schema\v2_0\Polls::class => [
+			'ID_POLL' => 'id_poll',
+			'ID_MEMBER' => 'id_member',
+			'votingLocked' => 'voting_locked',
+			'maxVotes' => 'max_votes',
+			'expireTime' => 'expire_time',
+			'hideResults' => 'hide_results',
+			'changeVote' => 'change_vote',
+			'posterName' => 'poster_name',
+		],
+		Schema\v2_0\PollChoices::class => [
+			'ID_CHOICE' => 'id_choice',
+			'ID_POLL' => 'id_poll',
+		],
+		Schema\v2_0\ScheduledTasks::class => [
+			'ID_TASK' => 'id_task',
+			'nextTime' => 'next_time',
+			'timeRegularity' => 'time_regularity',
+			'timeOffset' => 'time_offset',
+			'timeUnit' => 'time_unit',
+		],
+		Schema\v2_0\Smileys::class => [
+			'ID_SMILEY' => 'id_smiley',
+			'smileyRow' => 'smiley_row',
+			'smileyOrder' => 'smiley_order',
+		],
+		Schema\v2_0\Subscriptions::class => [
+			'ID_SUBSCRIBE' => 'id_subscribe',
+			'ID_GROUP' => 'id_group',
+			'addGroups' => 'add_groups',
+			'allowPartial' => 'allow_partial',
+		],
+		Schema\v2_0\Themes::class => [
+			'ID_MEMBER' => 'id_member',
+			'ID_THEME' => 'id_theme',
+		],
+		Schema\v2_0\Topics::class => [
+			'ID_TOPIC' => 'id_topic',
+			'isSticky' => 'is_sticky',
+			'ID_BOARD' => 'id_board',
+			'ID_FIRST_MSG' => 'id_first_msg',
+			'ID_LAST_MSG' => 'id_last_msg',
+			'ID_MEMBER_STARTED' => 'id_member_started',
+			'ID_MEMBER_UPDATED' => 'id_member_updated',
+			'ID_POLL' => 'id_poll',
+			'numReplies' => 'num_replies',
+			'numViews' => 'num_views',
+			'unapprovedPosts' => 'unapproved_posts',
+		],
+	];
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		// Renaming table columns
+		foreach ($this->name_changes as $table_class => $column_changes) {
+			$table = new $table_class();
+			$existing_structure = $table->getCurrentStructure();
+
+			foreach ($column_changes as $old => $new) {
+				if (
+					!isset($existing_structure['columns'][$old])
+					|| !isset($table->columns[$new])
+				) {
+					continue;
+				}
+
+				$table->alterColumn(
+					$table->columns[$new],
+					$old,
+				);
+			}
+		}
+
+		// Converting "log_online"
+		$table = new Schema\v2_0\LogOnline();
+		$table->drop();
+		$table->create();
+
+		$this->handleTimeout();
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v2_0/ScheduledTasks.php
+++ b/Sources/Maintenance/Migration/v2_0/ScheduledTasks.php
@@ -1,0 +1,110 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v2_0;
+
+use SMF\Config;
+use SMF\Db\DatabaseApi as Db;
+use SMF\Db\Schema;
+use SMF\Maintenance\Migration\MigrationBase;
+
+class ScheduledTasks extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Adding scheduled tasks data';
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		// Ensure the table exists and is structured correctly.
+		// Note: the log_scheduled_tasks table also needs to be created, but the
+		// table normalization substeps will take care of that part.
+		$table = new Schema\v2_0\ScheduledTasks();
+		$table->normalize();
+
+		// Populate scheduled task table.
+		Db::$db->insert(
+			method: 'ignore',
+			table: '{db_prefix}scheduled_tasks',
+			columns: [
+				'next_time' => 'int',
+				'time_offset' => 'int',
+				'time_regularity' => 'int',
+				'time_unit' => 'string-2',
+				'disabled' => 'int',
+				'task' => 'string-24',
+			],
+			data: [
+				[0, 0, 2, 'h', 0, 'approval_notification'],
+				[0, 60, 1, 'd', 0, 'daily_maintenance'],
+				[0, 0, 1, 'd', 0, 'daily_digest'],
+				[0, 0, 1, 'w', 0, 'weekly_digest'],
+				[0, 0, 1, 'd', 1, 'birthdayemails'],
+				[0, 120, 1, 'd', 0, 'paid_subscriptions'],
+				[0, 82800 + mt_rand(0, 86399), 1, 'd', 0, 'fetchSMfiles'],
+			],
+			keys: [],
+		);
+
+		// Moving auto optimise settings to scheduled task.
+		if (!isset(Config::$modSettings['next_task_time']) && isset(Config::$modSettings['autoOptLastOpt'])) {
+			// Try to move over the regularity...
+			if (isset(Config::$modSettings['autoOptDatabase'])) {
+				$this->query(
+					'UPDATE {db_prefix}scheduled_tasks
+					SET
+						disabled = {int:disabled},
+						time_regularity = {int:regularity},
+						next_time = {int:next_time}
+					WHERE task = {string:task}',
+					[
+						'task' => 'auto_optimize',
+						'disabled' => empty(Config::$modSettings['autoOptDatabase']) ? 1 : 0,
+						'regularity' => $disabled ? 7 : Config::$modSettings['autoOptDatabase'],
+						'next_time' => Config::$modSettings['autoOptLastOpt'] + 3600 * 24 * Config::$modSettings['autoOptDatabase'],
+					],
+				);
+			}
+
+			// Delete the old settings.
+			Config::updateModSettings([
+				'autoOptLastOpt' => null,
+				'autoOptDatabase' => null,
+			]);
+		}
+
+		// Add some new settings.
+		Config::updateModSettings([
+			'next_task_time' => Config::$modSettings['next_task_time'] ?? 0,
+			'birthday_email' => Config::$modSettings['birthday_email'] ?? 'happy_birthday',
+		]);
+
+		$this->handleTimeout();
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v2_0/SpiderTracking.php
+++ b/Sources/Maintenance/Migration/v2_0/SpiderTracking.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v2_0;
+
+use SMF\Db\Schema;
+use SMF\Maintenance\Migration\MigrationBase;
+
+class SpiderTracking extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Adding search engine tracking';
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		$table = new Schema\v2_0\Spiders();
+		$table->normalize();
+		$table->populate();
+
+		$table = new Schema\v2_0\LogSpiderHits();
+		$table->normalize();
+
+		$table = new Schema\v2_0\LogSpiderStats();
+		$table->normalize();
+
+		$this->handleTimeout();
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v2_0/Warnings.php
+++ b/Sources/Maintenance/Migration/v2_0/Warnings.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2024 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 3
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v2_0;
+
+use SMF\Config;
+use SMF\Maintenance\Migration\MigrationBase;
+
+class Warnings extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Adding user warnings';
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		// Note: there are some tables that need to be created, and some columns
+		// and indexes that need to be added to the members table, but the table
+		// normalization substeps will take care of that part.
+
+		// Ensure warning settings are present
+		if (empty(Config::$modSettings['warning_settings'])) {
+			Config::updateModSettings([
+				'warning_settings' => '1,20,0',
+				'warning_watch' => '10',
+				'warning_moderate' => '35',
+				'warning_mute' => '60',
+			]);
+		}
+
+		$this->handleTimeout();
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Migration/v2_0/index.php
+++ b/Sources/Maintenance/Migration/v2_0/index.php
@@ -1,0 +1,8 @@
+<?php
+
+// Try to handle it with the upper level index.php. (it should know what to do.)
+if (file_exists(dirname(__DIR__) . '/index.php')) {
+	include dirname(__DIR__) . '/index.php';
+} else {
+	exit;
+}

--- a/Sources/Maintenance/Tools/Upgrade.php
+++ b/Sources/Maintenance/Tools/Upgrade.php
@@ -63,6 +63,7 @@ class Upgrade extends ToolsBase implements ToolsInterface
 	 * be the highest version that the steps could apply to, not the lowest.
 	 */
 	public const VERSION_MAP = [
+		'1.0.99' => 'v1_0',
 		'1.1.99' => 'v1_1',
 		'2.0.99' => 'v2_0',
 		'2.1.99' => 'v2_1',
@@ -78,6 +79,71 @@ class Upgrade extends ToolsBase implements ToolsInterface
 	 * to ensure that all tables are structured correctly.
 	 */
 	public const MIGRATIONS = [
+		// Migration steps for YaBB SE -> SMF 1.0
+		'v1_0' => [
+			Migration\v1_0\NewTables::class,
+			Migration\v1_0\Logs::class,
+			Migration\v1_0\BoardsAndCategories::class,
+			Migration\v1_0\AnnouncementPermissions::class,
+			Migration\v1_0\BoardStats::class,
+			Migration\v1_0\Moderators::class,
+			Migration\v1_0\BoardOrder::class,
+			Migration\v1_0\BoardAccess1::class,
+			Migration\v1_0\BoardAccess2::class,
+			Migration\v1_0\Attachments::class,
+			Migration\v1_0\Messages1::class,
+			Migration\v1_0\Messages2::class,
+			Migration\v1_0\Messages3::class,
+			Migration\v1_0\Messages4::class,
+			Migration\v1_0\Messages5::class,
+			Migration\v1_0\Messages6::class,
+			Migration\v1_0\Messages7::class,
+			Migration\v1_0\Topics1::class,
+			Migration\v1_0\Topics2::class,
+			Migration\v1_0\Topics3::class,
+			Migration\v1_0\Topics4::class,
+			Migration\v1_0\Topics5::class,
+			Migration\v1_0\Topics6::class,
+			Migration\v1_0\Members1::class,
+			Migration\v1_0\Members2::class,
+			Migration\v1_0\Members3::class,
+			Migration\v1_0\Members4::class,
+			Migration\v1_0\Members5::class,
+			Migration\v1_0\Members6::class,
+			Migration\v1_0\Members7::class,
+			Migration\v1_0\Members8::class,
+			Migration\v1_0\Members9::class,
+			Migration\v1_0\Members10::class,
+			Migration\v1_0\Members11::class,
+			Migration\v1_0\Members12::class,
+			Migration\v1_0\Members13::class,
+			Migration\v1_0\MemberStats::class,
+			Migration\v1_0\InstantMessages1::class,
+			Migration\v1_0\InstantMessages2::class,
+			Migration\v1_0\InstantMessages3::class,
+			Migration\v1_0\InstantMessages4::class,
+			Migration\v1_0\InstantMessages5::class,
+			Migration\v1_0\InstantMessages6::class,
+			Migration\v1_0\InstantMessages7::class,
+			Migration\v1_0\InstantMessages8::class,
+			Migration\v1_0\InstantMessages9::class,
+			Migration\v1_0\Membergroups1::class,
+			Migration\v1_0\Membergroups2::class,
+			Migration\v1_0\ReservedNames::class,
+			Migration\v1_0\CensoredWords::class,
+			Migration\v1_0\TopicNotifications::class,
+			Migration\v1_0\Banned::class,
+			Migration\v1_0\Calendar::class,
+			Migration\v1_0\Holidays::class,
+			Migration\v1_0\PollChoices::class,
+			Migration\v1_0\LogPolls::class,
+			Migration\v1_0\Polls::class,
+			Migration\v1_0\News::class,
+			Migration\v1_0\Themes::class,
+			Migration\v1_0\NewSettings::class,
+			Migration\v1_0\Options::class,
+			Migration\v1_0\Statistics::class,
+		],
 		// Migration steps for 1.0 -> 1.1
 		'v1_1' => [
 			Migration\v1_1\RemoveIndexes::class,
@@ -257,6 +323,8 @@ class Upgrade extends ToolsBase implements ToolsInterface
 	 * Cleanups that do not require database maintenance tasks.
 	 */
 	public const CLEANUPS = [
+		// Cleanup steps for YaBB SE -> SMF 1.0
+		'v1_0' => [],
 		// Cleanup steps for 1.0 -> 1.1
 		'v1_1' => [
 			Cleanup\v1_1\RemoveTempSettings::class,

--- a/Sources/Maintenance/Tools/Upgrade.php
+++ b/Sources/Maintenance/Tools/Upgrade.php
@@ -63,6 +63,7 @@ class Upgrade extends ToolsBase implements ToolsInterface
 	 * be the highest version that the steps could apply to, not the lowest.
 	 */
 	public const VERSION_MAP = [
+		'1.1.99' => 'v1_1',
 		'2.0.99' => 'v2_0',
 		'2.1.99' => 'v2_1',
 		'3.0.99' => 'v3_0',
@@ -77,6 +78,43 @@ class Upgrade extends ToolsBase implements ToolsInterface
 	 * to ensure that all tables are structured correctly.
 	 */
 	public const MIGRATIONS = [
+		// Migration steps for 1.0 -> 1.1
+		'v1_1' => [
+			Migration\v1_1\RemoveIndexes::class,
+			Migration\v1_1\ReorderCategories::class,
+			Migration\v1_1\ReorderBoards::class,
+			Migration\v1_1\SmileyFix::class,
+			Migration\v1_1\NewSettings::class,
+			Migration\v1_1\OldThemes::class,
+			Migration\v1_1\PersonalMessages::class,
+			Migration\v1_1\MemberApproval::class,
+			Migration\v1_1\Calendar::class,
+			Migration\v1_1\Dates::class,
+			Migration\v1_1\MessageIcons::class,
+			Migration\v1_1\PackageServers::class,
+			Migration\v1_1\Logs1::class,
+			Migration\v1_1\RecountPMs1::class,
+			Migration\v1_1\RecountPMs2::class,
+			Migration\v1_1\AvatarPermissions::class,
+			Migration\v1_1\Thumbnails::class,
+			Migration\v1_1\ImageAttachments::class,
+			Migration\v1_1\Bans::class,
+			Migration\v1_1\BanStats::class,
+			Migration\v1_1\OldBoardPermissions::class,
+			Migration\v1_1\BoardPermissions::class,
+			Migration\v1_1\DenyPermissions::class,
+			Migration\v1_1\PostGroupPermissions::class,
+			Migration\v1_1\LocalPermissions::class,
+			Migration\v1_1\GuestPermissions::class,
+			Migration\v1_1\SearchCache::class,
+			Migration\v1_1\SearchFullText::class,
+			Migration\v1_1\SearchSubjects::class,
+			Migration\v1_1\Logs2::class,
+			Migration\v1_1\Logs3::class,
+			Migration\v1_1\Logs4::class,
+			Migration\v1_1\Logs5::class,
+			Migration\v1_1\Logs6::class,
+		],
 		// Migration steps for 1.1 -> 2.0
 		'v2_0' => [
 			Migration\v2_0\PostgreSQLFunctions::class,
@@ -219,6 +257,11 @@ class Upgrade extends ToolsBase implements ToolsInterface
 	 * Cleanups that do not require database maintenance tasks.
 	 */
 	public const CLEANUPS = [
+		// Cleanup steps for 1.0 -> 1.1
+		'v1_1' => [
+			Cleanup\v1_1\RemoveTempSettings::class,
+			Cleanup\v1_1\OldFiles::class,
+		],
 		// Cleanup steps for 1.1 -> 2.0
 		'v2_0' => [
 			Cleanup\v2_0\OldFiles::class,

--- a/Sources/Maintenance/Tools/Upgrade.php
+++ b/Sources/Maintenance/Tools/Upgrade.php
@@ -63,6 +63,7 @@ class Upgrade extends ToolsBase implements ToolsInterface
 	 * be the highest version that the steps could apply to, not the lowest.
 	 */
 	public const VERSION_MAP = [
+		'2.0.99' => 'v2_0',
 		'2.1.99' => 'v2_1',
 		'3.0.99' => 'v3_0',
 	];
@@ -76,6 +77,38 @@ class Upgrade extends ToolsBase implements ToolsInterface
 	 * to ensure that all tables are structured correctly.
 	 */
 	public const MIGRATIONS = [
+		// Migration steps for 1.1 -> 2.0
+		'v2_0' => [
+			Migration\v2_0\PostgreSQLFunctions::class,
+			Migration\v2_0\RenameColumns::class,
+			Migration\v2_0\SpiderTracking::class,
+			Migration\v2_0\NewSettings::class,
+			Migration\v2_0\CustomFields::class,
+			Migration\v2_0\EmailDigests::class,
+			Migration\v2_0\PackageManager::class,
+			Migration\v2_0\MailQueue::class,
+			Migration\v2_0\ModCenter::class,
+			Migration\v2_0\Warnings::class,
+			Migration\v2_0\Attachments1::class,
+			Migration\v2_0\Attachments2::class,
+			Migration\v2_0\PostModeration::class,
+			Migration\v2_0\ErrorLog::class,
+			Migration\v2_0\ScheduledTasks::class,
+			Migration\v2_0\PermissionProfiles1::class,
+			Migration\v2_0\PermissionProfiles2::class,
+			Migration\v2_0\PermissionProfiles3::class,
+			Migration\v2_0\PurgeFloodcontrol::class,
+			Migration\v2_0\GuestVoting::class,
+			Migration\v2_0\AdminFeatureToggles::class,
+			Migration\v2_0\ModLog::class,
+			Migration\v2_0\AdminInfoFiles::class,
+			Migration\v2_0\PersonalMessages1::class,
+			Migration\v2_0\PersonalMessages2::class,
+			Migration\v2_0\PaidSubs::class,
+			Migration\v2_0\OldThemes::class,
+			Migration\v2_0\LogActivity::class,
+			Migration\v2_0\MembergroupTypes::class,
+		],
 		// Migration steps for 2.0 -> 2.1
 		'v2_1' => [
 			Migration\v2_1\PostgreSqlSequences::class,
@@ -186,6 +219,10 @@ class Upgrade extends ToolsBase implements ToolsInterface
 	 * Cleanups that do not require database maintenance tasks.
 	 */
 	public const CLEANUPS = [
+		// Cleanup steps for 1.1 -> 2.0
+		'v2_0' => [
+			Cleanup\v2_0\OldFiles::class,
+		],
 		// Cleanup steps for 2.0 -> 2.1
 		'v2_1' => [
 			Cleanup\v2_1\OldFiles::class,

--- a/Sources/Maintenance/Tools/Upgrade.php
+++ b/Sources/Maintenance/Tools/Upgrade.php
@@ -193,7 +193,6 @@ class Upgrade extends ToolsBase implements ToolsInterface
 		// Cleanup steps for 2.1 -> 3.0
 		'v3_0' => [
 			Cleanup\v3_0\TasksDirCase::class,
-			Cleanup\v3_0\OldFiles::class,
 		],
 	];
 


### PR DESCRIPTION
I've had this sitting around nearly completed for months now, so I thought I'd take a few hours to finish it off and submit it.

This PR adds all the necessary table schemas, migration steps, and cleanup steps required to allow the upgrader to upgrade any version of SMF or even YaBB SE.

@jdarwood007, I know that we had previously discussed writing converters for old SMF versions rather than upgrader steps. However, when I sat down to do it, writing upgrader steps turned out to be much easier, because I could base them on the old upgrade scripts rather than trying to come up with entirely new logic. And since everything in the new SMF\Maintenance paradigm is so clearly defined and reliable, I don't think these new upgrader steps are going to be a burden to maintain the way the old upgrade scripts were.

@sbulen, is there any chance you could fire up that marvellous test suite of yours to make sure that these all work? Overall, I expect that it go well, but there are doubtless some copy-paste errors and typos hiding in there someplace.