### PR TITLE
[3.0] Demotes smf_crc32() to a backward compatibility function

### DIFF
--- a/Sources/Graphics/Gif/File.php
+++ b/Sources/Graphics/Gif/File.php
@@ -23,9 +23,6 @@ declare(strict_types=1);
 
 namespace SMF\Graphics\Gif;
 
-use SMF\Config;
-use SMF\Sapi;
-
 class File
 {
 	/*******************
@@ -149,13 +146,13 @@ class File
 		// Now, we want the header...
 		$out .= "\x00\x00\x00\x0D";
 		$tmp = 'IHDR' . pack('N', (int) $this->header->m_nWidth) . pack('N', (int) $this->header->m_nHeight) . "\x08\x03\x00\x00\x00";
-		$out .= $tmp . pack('N', smf_crc32($tmp));
+		$out .= $tmp . pack('N', crc32($tmp));
 
 		// The palette, assuming we have one to speak of...
 		if ($colors > 0) {
 			$out .= pack('N', (int) $colors * 3);
 			$tmp = 'PLTE' . $pal;
-			$out .= $tmp . pack('N', smf_crc32($tmp));
+			$out .= $tmp . pack('N', crc32($tmp));
 		}
 
 		// Do we have any transparency we want to make available?
@@ -168,22 +165,17 @@ class File
 				$tmp .= $i == $this->image->m_nTrans ? "\x00" : "\xFF";
 			}
 
-			$out .= $tmp . pack('N', smf_crc32($tmp));
+			$out .= $tmp . pack('N', crc32($tmp));
 		}
 
 		// Here's the data itself!
 		$out .= pack('N', \strlen($bmp));
 		$tmp = 'IDAT' . $bmp;
-		$out .= $tmp . pack('N', smf_crc32($tmp));
+		$out .= $tmp . pack('N', crc32($tmp));
 
 		// EOF marker...
 		$out .= "\x00\x00\x00\x00" . 'IEND' . "\xAE\x42\x60\x82";
 
 		return $out;
 	}
-}
-
-// 64-bit only functions?
-if (!\function_exists('smf_crc32')) {
-	require_once Sapi::canonicalPath(Config::$sourcedir . '/Subs-Compat.php');
 }

--- a/Sources/PackageManager/PackageUtils.php
+++ b/Sources/PackageManager/PackageUtils.php
@@ -165,8 +165,9 @@ class PackageUtils
 		$crc = unpack('Vcrc32/Visize', substr($data, \strlen($data) - 8, 8));
 		$data = @gzinflate(substr($data, $offset, \strlen($data) - 8 - $offset));
 
-		// smf_crc32 and crc32 may not return the same results, so we accept either.
-		if ($crc['crc32'] != self::smf_crc32($data) && $crc['crc32'] != crc32($data)) {
+		// Compare as hex strings rather than integers in order to avoid
+		// inconsistencies between 32-bit and 64-bit systems.
+		if (hash('crc32b', $data) !== dechex($crc['crc32'])) {
 			return false;
 		}
 
@@ -3846,19 +3847,5 @@ class PackageUtils
 				}
 			}
 		}
-	}
-
-	/**
-	 * crc32 doesn't work as expected on 64-bit functions - make our own.
-	 * https://php.net/crc32#79567
-	 *
-	 * @param string $number
-	 * @return string The crc32
-	 */
-	private static function smf_crc32(string $number): string
-	{
-		require_once Sapi::canonicalPath(Config::$sourcedir . '/Subs-Compat.php');
-
-		return smf_crc32($number);
 	}
 }

--- a/Sources/Subs-Compat.php
+++ b/Sources/Subs-Compat.php
@@ -11874,6 +11874,65 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 
 		return $string;
 	}
+
+	/**
+	 * Gets the crc32 checksum of the passed string and then, if this is running
+	 * on a 64-bit system, adjusts the binary value of the checksum so that its
+	 * integer interpretion on a 64-bit system will be the same as the integer
+	 * interpretation of the true checksum would have been on a 32-bit system.
+	 *
+	 * This function was created as an attempt to give consistent cross-platform
+	 * results when trying to get a crc32 checksum. However, it is a flawed
+	 * solution and should be avoided.
+	 *
+	 * The flaw here is that when this function is called on a 64-bit system,
+	 * the integer it returns IS NOT the correct checksum value when interpreted
+	 * as binary. The integer returned by this function will be the same on all
+	 * platfroms, sure, but the underlying binary value -- which is what really
+	 * matters for a checksum -- will be different. As a result, if you run the
+	 * following on a 64-bit system:
+	 *
+	 *    `dechex(smf_crc32('derp'));`
+	 *
+	 * ... the returned hexadecimal string will be incorrect!
+	 *
+	 * In light of this, smf_crc32() should never be used except in cases where
+	 * it is necessary for backward compatibility with old mods. Instead, any
+	 * new code that needs to get a crc32 checksum for a value should always
+	 * get that checksum as a binary or hexadecimal string from the outset and
+	 * then continue to handle it as a binary or hexadecimal string and avoid
+	 * ever casting it to an integer. The safe and reliable way to obtain the
+	 * true hexadecimal representation of a crc32 checksum on all platforms is
+	 * this:
+	 *
+	 *    `hash('crc32b', $var)`
+	 *
+	 * By using hash() to get the checksum's hexadecimal representation, we can
+	 * avoid ever casting the checksum as an integer, which is what causes the
+	 * discrepancy to appear on 32-bit vs. 64-bit systems.
+	 *
+	 * @see https://php.net/crc32 for more info on the problems with crc32().
+	 * @see https://php.net/crc32#79567 for the origin of this function's code.
+	 *
+	 * @deprecated 3.0
+	 *
+	 * @param string $str
+	 * @return int The crc32 polynomial of $str
+	 */
+	function smf_crc32($str): int
+	{
+		$crc = crc32($str);
+
+		// On a 32-bit system, PHP_INT_SIZE === 4.
+		// On a 64-bit system, PHP_INT_SIZE === 8.
+		if (PHP_INT_SIZE === 8 && $crc & 0x80000000) {
+			$crc ^= 0xffffffff;
+			$crc += 1;
+			$crc = -$crc;
+		}
+
+		return $crc;
+	}
 }
 
 /***************************
@@ -11913,29 +11972,6 @@ if (version_compare(PHP_VERSION, '8.0.0', '>=')) {
 			}
 		}
 	});
-}
-
-if (!function_exists('smf_crc32')) {
-	/**
-	 * Compatibility function.
-	 * crc32 doesn't work as expected on 64-bit functions - make our own.
-	 * https://php.net/crc32#79567
-	 *
-	 * @param string $number
-	 * @return int The crc32 polynomial of $number
-	 */
-	function smf_crc32($number): int
-	{
-		$crc = crc32($number);
-
-		if ($crc & 0x80000000) {
-			$crc ^= 0xffffffff;
-			$crc += 1;
-			$crc = -$crc;
-		}
-
-		return $crc;
-	}
 }
 
 /*****************


### PR DESCRIPTION
1. [Removes unnecessary smf_crc32() calls in SMF\Graphics\Gif\File](https://github.com/SimpleMachines/SMF/pull/9123/commits/3661a5ca45dd0ceb4a4e54b90920022509910f35)
    - Although the integer value returned by crc32() can be different on 32-bit vs. 64-bit systems, `pack('N', crc32($tmp)` will always result in the same value on both 32-bit and 64-bit systems. This is because pack() only cares about the raw binary value, not the integer interpretation. Thus, there is no need to call smf_crc32() here; we can just use normal crc32() on both 32-bit and 64-bit systems.
    - Since SMF\Graphics\Gif\File is only retained for backward compatibility and is itself never used by SMF 3.0, there is no easy way to test this change within SMF itself. However, it is possible to verify that `pack('N', smf_crc32($tmp))` and `pack('N', crc32($tmp))` always produce the same results on both 32-bit and 64-bit platforms by going to [https://3v4l.org/#live](https://3v4l.org/#live) and running the following script:
	```php
	<?php
	
	echo PHP_INT_SIZE === 4 ? '32-bit' : '64-bit', PHP_EOL;
	
	$str = 'derp';
	
	$p1 = pack('N', smf_crc32($str));
	$p2 = pack('N', crc32($str));
	
	var_export($p1 === $p2);
	
	function smf_crc32($number): int
	{
		$crc = crc32($number);
	
		// On a 32-bit system, PHP_INT_SIZE === 4.
		// On a 64-bit system, PHP_INT_SIZE === 8.
		if (PHP_INT_SIZE === 8 && $crc & 0x80000000) {
			$crc ^= 0xffffffff;
			$crc += 1;
			$crc = -$crc;
		}
	
		return $crc;
	}
	```
	At least as of Feb 24, 2026, when you first go to https://3v4l.org/#live and paste in that script, the live preview will be initially executed using a 32-bit build of PHP. If you then manually click the `eval();` button, it will execute again using a 64-bit build of PHP.
2. [Removes unnecessary smf_crc32() call in PackageUtils::readTgzData()](https://github.com/SimpleMachines/SMF/pull/9123/commits/785eca45823dfbbc62ecf77126586da1d6bf5eb4)
    - To test this, simply upload any .tar.gz package via SMF's package manager and then go to the package manager's Browse Packages page. If the .tar.gz package appears in the list, then you have confirmed that this commit works.
3. [Deprecates smf_crc32()](https://github.com/SimpleMachines/SMF/pull/9123/commits/7a382b1cf12c54b573519ce509e06a4f1e25f679)
    - We no longer use it for anything in SMF itself.
    - This commit also improves the documentation for the smf_crc32() function, explaining what the function does and why it has been deprecated.