### PR TITLE
[2.1] Bots - reduce permissions queries

### DIFF
--- a/Sources/Subs-Auth.php
+++ b/Sources/Subs-Auth.php
@@ -755,7 +755,10 @@ function rebuildModCache()
 	global $user_info, $smcFunc;
 
 	// What groups can they moderate?
-	$group_query = allowedTo('manage_membergroups') ? '1=1' : '0=1';
+	if(!$user_info['is_guest'])
+		$group_query = allowedTo('manage_membergroups') ? '1=1' : '0=1';
+	else
+		$group_query = '0=1';
 
 	if ($group_query == '0=1' && !$user_info['is_guest'])
 	{
@@ -779,7 +782,10 @@ function rebuildModCache()
 	}
 
 	// Then, same again, just the boards this time!
-	$board_query = allowedTo('moderate_forum') ? '1=1' : '0=1';
+	if(!$user_info['is_guest'])
+		$board_query = allowedTo('moderate_forum') ? '1=1' : '0=1';
+	else
+		$board_query = '0=1';
 
 	if ($board_query == '0=1' && !$user_info['is_guest'])
 	{
@@ -833,7 +839,7 @@ function rebuildModCache()
 		// If you change the format of 'gq' and/or 'bq' make sure to adjust 'can_mod' in Load.php.
 		'gq' => $group_query,
 		'bq' => $board_query,
-		'ap' => boardsAllowedTo('approve_posts'),
+		'ap' => !$user_info['is_guest'] ? boardsAllowedTo('approve_posts') : array(),
 		'mb' => $boards_mod,
 		'mq' => $mod_query,
 	);

--- a/Sources/Subs-Auth.php
+++ b/Sources/Subs-Auth.php
@@ -755,7 +755,7 @@ function rebuildModCache()
 	global $user_info, $smcFunc;
 
 	// What groups can they moderate?
-	if(!$user_info['is_guest'])
+	if (!$user_info['is_guest'])
 		$group_query = allowedTo('manage_membergroups') ? '1=1' : '0=1';
 	else
 		$group_query = '0=1';
@@ -782,7 +782,7 @@ function rebuildModCache()
 	}
 
 	// Then, same again, just the boards this time!
-	if(!$user_info['is_guest'])
+	if (!$user_info['is_guest'])
 		$board_query = allowedTo('moderate_forum') ? '1=1' : '0=1';
 	else
 		$board_query = '0=1';


### PR DESCRIPTION
This PR aims to minimize unnecessary I/O by not doing moderator permissions lookups for guests and bots, who we already know will not have any moderator or admin privileges...  This can add a lot of unnecessary permissions queries during normal operation, but especially during bot attacks.

I've been running this code on my prod forum with no issues.

If this is approved, I can submit a 3.0 version.  

For more discussion see:
https://www.simplemachines.org/community/index.php?topic=592442.0

Feedback welcome.
