### PR TITLE
[2.1] Bots - view likes attacks

### DIFF
--- a/Themes/default/Display.template.php
+++ b/Themes/default/Display.template.php
@@ -462,7 +462,7 @@ function template_main()
  */
 function template_single_post($message)
 {
-	global $context, $settings, $options, $txt, $scripturl, $modSettings;
+	global $context, $settings, $options, $txt, $scripturl, $modSettings, $user_info;
 
 	$ignoring = false;
 
@@ -847,7 +847,8 @@ function template_single_post($message)
 			$base .= (isset($txt[$base . $count])) ? $count : 'n';
 
 			// Remove link if no cookies; session reference won't work
-			if (empty($_COOKIE))
+			// Also, don't show link to guests
+			if (empty($_COOKIE) || !empty($user_info['is_guest']))
 				$txt[$base] = preg_replace('~</?a\b[^>]*>~', '', $txt[$base]);
 
 			echo '


### PR DESCRIPTION
This PR removes the link allowing users to drill down to see who liked a post.  Only guests & bots are affected.

This link is a bot magnet during botnet attacks.  During some attacks, these are the ONLY requests made - in the tens of thousands.  Note that the request includes the session var & value in the URL.  (I believe this is the only guest link that does so...???)  When bots pass this bogus session info, the existing session is destroyed and a new one is created, ultimately causing TWO session writes for each bot request.  I.e., double the impact.  

I believe this should be removed from guests/bots altogether.  If that user wants to drill down, they can register.

Fixes #9112

I've been running this code on my prod forum with no issues.

If this is approved, I can submit a 3.0 version.  

For more discussion see:
https://www.simplemachines.org/community/index.php?topic=592442.0
https://www.simplemachines.org/community/index.php?topic=590069.0

Feedback welcome.
