### PR TITLE
[2.1] Dont let bots flood logs

### DIFF
--- a/Sources/Security.php
+++ b/Sources/Security.php
@@ -680,7 +680,6 @@ function checkSession($type = 'post', $from_action = '', $is_fatal = true)
 		if (isset($parsed_url['host']) && strtolower($referrer['host']) != strtolower($parsed_url['host']) && strtolower($referrer['host']) != strtolower($real_host))
 		{
 			$error = 'verify_url_fail';
-			$log_error = true;
 		}
 	}
 


### PR DESCRIPTION
Partial for #9142 

2.1 portion only.  Just don't log "Unable to verify referring URL" errors.  This gives a handle for bots to flood your logs.  Plus, I'm not sure the info is usable or actionable.  Note also that the other similar session errors throughout this logic are not logged.  

I kept the one a few lines below this as logged (line 691) - that condition appears to be more of a trap for an internal issue.  So it's kept, for now...

If approved, I'll submit the 3.0 equivalent.

