### PR TITLE
[3.0] Dont let bots flood logs

### DIFF
--- a/Sources/User.php
+++ b/Sources/User.php
@@ -2106,7 +2106,6 @@ class User implements \ArrayAccess
 				&& strtolower($referrer['host']) != strtolower($real_host)
 			) {
 				$error = 'verify_url_fail';
-				$log_error = true;
 			}
 		}
 


### PR DESCRIPTION
Fixes #9142 

3.0 version of #9144 .  More discussion may be found there.

Just don't log "Unable to verify referring URL" errors. This gives a handle for bots to flood your logs. Plus, I'm not sure the info is usable or actionable. Note also that the other similar session errors throughout this logic are not logged.

I kept the one a few lines below this as logged - that condition appears to be more of a trap for an internal issue. So it's kept, for now...