### PR TITLE
[3.0] Bots - view likes attacks

### DIFF
--- a/Themes/default/Display.template.php
+++ b/Themes/default/Display.template.php
@@ -836,7 +836,8 @@ function template_single_post($message)
 			$like_text = Lang::getTxt($base, ['url' => Config::$scripturl . '?action=likes;sa=view;ltype=msg;like=' . $message['id'] . ';' . Utils::$context['session_var'] . '=' . Utils::$context['session_id'], 'num' => $count], file: 'General');
 
 			// Remove link if no cookies; session reference won't work
-			if (empty($_COOKIE)) {
+			// Also, don't show link to guests
+			if (empty($_COOKIE) || User::$me->is_guest) {
 				$like_text = preg_replace('~</?a\b[^>]*>~', '', $like_text);
 			}
 


### PR DESCRIPTION
Fixes #9112 

3.0 version of #9127 - More discussion may be found there.

This PR removes the link allowing users to drill down to see who liked a post. Only guests & bots are affected.

This link is a bot magnet during botnet attacks. During some attacks, these are the ONLY requests made - in the tens of thousands. Note that the request includes the session var & value in the URL. (I believe this is the only guest link that does so...???) When bots pass this bogus session info, the existing session is destroyed and a new one is created, ultimately causing TWO session writes for each bot request. I.e., double the impact.

I believe this should be removed from guests/bots altogether. If that user wants to drill down, they can register.

For more discussion see:
https://www.simplemachines.org/community/index.php?topic=592442.0
https://www.simplemachines.org/community/index.php?topic=590069.0

NOTE I cannot test this due to #9146 , but it looks simple enough...