### PR TITLE
[3.0] Bots - reduce permissions queries

### DIFF
--- a/Sources/User.php
+++ b/Sources/User.php
@@ -1411,7 +1411,11 @@ class User implements \ArrayAccess
 		}
 
 		// What groups can they moderate?
-		$group_query = $this->allowedTo('manage_membergroups') ? '1=1' : '0=1';
+		if ($this->is_guest) {
+			$group_query = $this->allowedTo('manage_membergroups') ? '1=1' : '0=1';
+		} else {
+			$group_query = '0=1';
+		}
 
 		if ($group_query == '0=1' && !$this->is_guest) {
 			$groups = [];
@@ -1438,7 +1442,11 @@ class User implements \ArrayAccess
 		}
 
 		// Then, same again, just the boards this time!
-		$board_query = $this->allowedTo('moderate_forum') ? '1=1' : '0=1';
+		if ($this->is_guest) {
+			$board_query = $this->allowedTo('moderate_forum') ? '1=1' : '0=1';
+		} else {
+			$board_query = '0=1';
+		}
 
 		if ($board_query == '0=1' && !$this->is_guest) {
 			$boards = $this->boardsAllowedTo('moderate_board', true);
@@ -1496,7 +1504,7 @@ class User implements \ArrayAccess
 			// If you change the format of 'gq' and/or 'bq' make sure to adjust 'can_mod' in SMF\User.
 			'gq' => $group_query,
 			'bq' => $board_query,
-			'ap' => $this->boardsAllowedTo('approve_posts'),
+			'ap' => !$this->is_guest ? $this->boardsAllowedTo('approve_posts') : [],
 			'mb' => $boards_mod,
 			'mq' => $mod_query,
 		];


### PR DESCRIPTION
3.0 version of #9124 - More discussion may be found there.

This PR aims to minimize unnecessary I/O by not doing moderator permissions lookups for guests and bots, who we already know will not have any moderator or admin privileges... This can add a lot of unnecessary permissions queries during normal operation, but especially during bot attacks.

I've been running this code on my prod forum with no issues.

For more discussion see:
https://www.simplemachines.org/community/index.php?topic=592442.0

NOTE I cannot test this due to #9146 , but it looks simple enough...

NOTE2 I cannot run php fixer due to errors, e.g., 

> 	The rules contain risky fixers ("native_function_invocation"), but they are not allowed to run. Perhaps you forget to use --allow-risky=yes option?

I hope I did the new syntax correctly.  

Feedback welcome.
