### PR TITLE
[3.0] Bots - reduce topic view updates

### DIFF
--- a/Languages/en_US/Help.php
+++ b/Languages/en_US/Help.php
@@ -437,6 +437,8 @@ $helptxt['deny_boards_access'] = 'Checking this setting will allow you to deny a
 // argument(s): scripturl
 $helptxt['who_enabled'] = 'This setting allows you to turn on or off the <a href="{scripturl}?action=who" target="_blank" rel="noopener">Who’s Online</a> page, which shows who is browsing the forum and what they are doing.';
 
+$helptxt['no_guest_views'] = 'This setting disables incrementing views for guests as well as bots.  Bot activity can cause excessive IO, and is often disguised as guest activity, so this may help during a bot attack.';
+
 $helptxt['recycle_enable'] = '&quot;Recycles&quot; deleted topics and posts to the specified board.';
 
 $helptxt['enableReportPM'] = 'This setting allows your users to report personal messages they receive to the administration team. This may be useful in helping to track down any abuse of the personal messaging system.';

--- a/Languages/en_US/ManageSettings.php
+++ b/Languages/en_US/ManageSettings.php
@@ -109,6 +109,7 @@ $txt['defaultMaxMembers'] = 'Members per page in member list';
 $txt['timeLoadPageEnable'] = 'Display time taken to create every page';
 $txt['disableHostnameLookup'] = 'Disable hostname lookups';
 $txt['who_enabled'] = 'Enable who’s online list';
+$txt['no_guest_views'] = 'Disable counting views for guests and bots';
 $txt['settings_error'] = 'Warning: Updating of Settings.php failed, the settings cannot be saved.';
 $txt['image_proxy_enabled'] = 'Enable Image Proxy';
 $txt['image_proxy_secret'] = 'Image Proxy Secret';

--- a/Sources/Actions/Admin/Features.php
+++ b/Sources/Actions/Admin/Features.php
@@ -1650,6 +1650,10 @@ class Features implements ActionInterface
 			['check', 'hitStats'],
 			'',
 
+			// Guest stats.
+			['check', 'no_guest_views'],
+			'',
+
 			// Option-ish things... miscellaneous sorta.
 			['check', 'disallow_sendBody'],
 			'',

--- a/Sources/Actions/Display.php
+++ b/Sources/Actions/Display.php
@@ -523,7 +523,14 @@ class Display implements ActionInterface, Routable
 	 */
 	protected function incrementNumViews(): void
 	{
-		if (!User::$me->possibly_robot && (empty($_SESSION['last_read_topic']) || $_SESSION['last_read_topic'] != Topic::$info->id)) {
+		// No_guest_views is stricter, & won't log bots or guests.
+		if (empty(Config::$modSettings['no_guest_views'])) {
+			$check = !User::$me->possibly_robot;
+		} else {
+			$check = !User::$me->is_guest;
+		}
+
+		if ($check && (empty($_SESSION['last_read_topic']) || $_SESSION['last_read_topic'] != Topic::$info->id)) {
 			Db::$db->query(
 				'UPDATE {db_prefix}topics
 				SET num_views = num_views + 1


### PR DESCRIPTION
3.0 version of #9128 - More discussion may be found there.

This PR aims to minimize I/O during a bot attack by eliminating the tracking of guest & bot views in the smf_topics record. Note this counter is incremented under all circumstances, and causes yet another I/O during bot attacks.

An option is added, allowing the user to turn this behavior on or off. Users may wish to disable this only during high-CPU bot attacks.

I've been running this code on my prod forum with no issues.

For more discussion see:
https://www.simplemachines.org/community/index.php?topic=592442.0
