### PR TITLE
 [3.0] Bots - reduce session writes

### DIFF
--- a/Sources/Session.php
+++ b/Sources/Session.php
@@ -96,7 +96,7 @@ class Session implements \SessionHandlerInterface
 	public function write(string $session_id, string $data): bool
 	{
 		// Any action that is not dependent on data within the session may be added to this array
-		static $no_writes = array('dlattach');
+		static $no_writes = ['dlattach'];
 
 		// Don't bother writing the session if cookies are disabled
 		if (empty($_COOKIE)) {
@@ -105,7 +105,7 @@ class Session implements \SessionHandlerInterface
 
 		// Don't bother writing the session for users just browsing
 		// If verification is required, always write the session
-		if ((empty($_REQUEST['action']) || in_array($_REQUEST['action'], $no_writes, true)) && !empty(Config::$scripturl) && empty(Utils::$context['require_verification'])) {
+		if ((empty($_REQUEST['action']) || \in_array($_REQUEST['action'], $no_writes, true)) && !empty(Config::$scripturl) && empty(Utils::$context['require_verification'])) {
 			return true;
 		}
 

--- a/Sources/Session.php
+++ b/Sources/Session.php
@@ -100,6 +100,12 @@ class Session implements \SessionHandlerInterface
 			return true;
 		}
 
+		// Don't bother writing the session for users just browsing
+		// If verification is required, always write the session
+		if ((empty($_REQUEST['action']) || in_array($_REQUEST['action'], $no_writes, true)) && !empty(Config::$scripturl) && empty(Utils::$context['require_verification'])) {
+			return true;
+		}
+
 		if (preg_match('~^[A-Za-z0-9,-]{16,64}$~', $session_id) == 0) {
 			return false;
 		}

--- a/Sources/Session.php
+++ b/Sources/Session.php
@@ -95,6 +95,9 @@ class Session implements \SessionHandlerInterface
 	 */
 	public function write(string $session_id, string $data): bool
 	{
+		// Any action that is not dependent on data within the session may be added to this array
+		static $no_writes = array('dlattach');
+
 		// Don't bother writing the session if cookies are disabled
 		if (empty($_COOKIE)) {
 			return true;

--- a/Sources/Session.php
+++ b/Sources/Session.php
@@ -204,7 +204,7 @@ class Session implements \SessionHandlerInterface
 		@ini_set('session.use_cookies', '1');
 		@ini_set('url_rewriter.tags', '');
 		@ini_set('arg_separator.output', '&amp;');
-		@ini_set('session.lazy_write', true);
+		@ini_set('session.lazy_write', '1');
 		@ini_set('session.cookie_secure', !empty(Config::$modSettings['secureCookies']));
 
 		// Allows mods to change/add PHP settings

--- a/Sources/Session.php
+++ b/Sources/Session.php
@@ -204,6 +204,8 @@ class Session implements \SessionHandlerInterface
 		@ini_set('session.use_cookies', '1');
 		@ini_set('url_rewriter.tags', '');
 		@ini_set('arg_separator.output', '&amp;');
+		@ini_set('session.lazy_write', true);
+		@ini_set('session.cookie_secure', !empty(Config::$modSettings['secureCookies']));
 
 		// Allows mods to change/add PHP settings
 		IntegrationHook::call('integrate_load_session');

--- a/Sources/Session.php
+++ b/Sources/Session.php
@@ -105,7 +105,7 @@ class Session implements \SessionHandlerInterface
 
 		// Don't bother writing the session for users just browsing
 		// If verification is required, always write the session
-		if ((empty($_REQUEST['action']) || \in_array($_REQUEST['action'], $no_writes, true)) && !empty(Config::$scripturl) && empty(Utils::$context['require_verification'])) {
+		if ((empty($_REQUEST['action']) || \in_array($_REQUEST['action'], $no_writes, true)) && !empty(Config::$scripturl) && empty(Utils::$context['require_verification']) && !empty(Config::$modSettings['allow_guest_access'])) {
 			return true;
 		}
 


### PR DESCRIPTION
3.0 version of #9126 - More discussion may be found there.

This PR aims to minimize I/O during a bot attack by eliminating unnecessary duplicative session writes. Session writes spike during botnet attacks, and the database management, e.g., the undo/redo logs, can get backed up with the extremely high volume of updates.

As it is today, at least one session update occurs any time index.php is invoked. Multiple session writes can occur, e.g., during redirects, attachment loads, notification checks, verifications, keepalives, and any time a bot passes a bogus session via URL or cookie.

The approach used here is to simply not write sessions during normal browsing activity, e.g., boards, topics, & messages. Sessions will be written whenever an action is taken; this avoids any loss of functionality dependent on the session.

Note that some of these bot attacks are what I call 'long tail' attacks, in which many IPs are used once and only once. This was a trademark of the 2025 Q3 Brazil/Vietnam attack; on some days, I would have 150,000+ IPs with only one topic or message request each... The problem being that each would get its own unique session & log_online record, causing a flood of writes & log activity. And then, of course, they would all need to be deleted during garbage collection.

With this change, they wouldn't be written at all.

One of the reasons so many sessions are written is that they are timestamped by SMF during the actual write, forcing each session write to be unique. My understanding is that this thwarts PHP's normal session update checks, as they would normally only be written when real updates occur. That may be an avenue for further testing & savings. At the moment, I'm not sure what the impacts would be of removing that particular timestamp.

For more discussion see:
https://www.simplemachines.org/community/index.php?topic=592442.0
https://www.simplemachines.org/community/index.php?topic=592345.0
