### PR TITLE
[3.0] Bots - reduce log_online updates

### DIFF
--- a/Languages/en_US/Help.php
+++ b/Languages/en_US/Help.php
@@ -437,6 +437,7 @@ $helptxt['deny_boards_access'] = 'Checking this setting will allow you to deny a
 // argument(s): scripturl
 $helptxt['who_enabled'] = 'This setting allows you to turn on or off the <a href="{scripturl}?action=who" target="_blank" rel="noopener">Who’s Online</a> page, which shows who is browsing the forum and what they are doing.';
 
+$helptxt['no_guest_logging'] = 'This setting prevents guests from being included in the Users Online counts. Guest and bot activity can cause excessive IO, so this may help during a bot attack.';
 $helptxt['no_guest_views'] = 'This setting disables incrementing views for guests as well as bots.  Bot activity can cause excessive IO, and is often disguised as guest activity, so this may help during a bot attack.';
 
 $helptxt['recycle_enable'] = '&quot;Recycles&quot; deleted topics and posts to the specified board.';

--- a/Languages/en_US/ManageSettings.php
+++ b/Languages/en_US/ManageSettings.php
@@ -109,6 +109,7 @@ $txt['defaultMaxMembers'] = 'Members per page in member list';
 $txt['timeLoadPageEnable'] = 'Display time taken to create every page';
 $txt['disableHostnameLookup'] = 'Disable hostname lookups';
 $txt['who_enabled'] = 'Enable who’s online list';
+$txt['no_guest_logging'] = 'Do not include guests or bots in Users Online stats';
 $txt['no_guest_views'] = 'Disable counting views for guests and bots';
 $txt['settings_error'] = 'Warning: Updating of Settings.php failed, the settings cannot be saved.';
 $txt['image_proxy_enabled'] = 'Enable Image Proxy';

--- a/Sources/Actions/Admin/Features.php
+++ b/Sources/Actions/Admin/Features.php
@@ -1651,6 +1651,7 @@ class Features implements ActionInterface
 			'',
 
 			// Guest stats.
+			['check', 'no_guest_logging'],
 			['check', 'no_guest_views'],
 			'',
 

--- a/Sources/User.php
+++ b/Sources/User.php
@@ -1204,6 +1204,10 @@ class User implements \ArrayAccess
 			self::logSpider();
 		}
 
+		// Don't log guests anymore - helps during bot attacks.
+		if (!empty(Config::$modSettings['no_guest_logging']) && !empty(User::$me->is_guest))
+			return;
+
 		// Don't mark them as online more than every so often.
 		if (!empty($_SESSION['log_time']) && $_SESSION['log_time'] >= (time() - 8) && !$force) {
 			return;

--- a/Sources/User.php
+++ b/Sources/User.php
@@ -1205,8 +1205,9 @@ class User implements \ArrayAccess
 		}
 
 		// Don't log guests anymore - helps during bot attacks.
-		if (!empty(Config::$modSettings['no_guest_logging']) && !empty(User::$me->is_guest))
+		if (!empty(Config::$modSettings['no_guest_logging']) && !empty(User::$me->is_guest)) {
 			return;
+		}
 
 		// Don't mark them as online more than every so often.
 		if (!empty($_SESSION['log_time']) && $_SESSION['log_time'] >= (time() - 8) && !$force) {

--- a/Themes/default/BoardIndex.template.php
+++ b/Themes/default/BoardIndex.template.php
@@ -499,7 +499,7 @@ function template_ic_block_online()
 				</h4>
 			</div>
 			<p class="inline">
-				', Utils::$context['show_who'] ? '<a href="' . Config::$scripturl . '?action=who">' : '', '<strong>', Lang::getTxt('online', file: 'General'), ': </strong>', Lang::getTxt('number_of_guests', [Utils::$context['num_guests']], file: 'General'), ', ', Lang::getTxt('number_of_members', [Utils::$context['num_users_online']], file: 'General');
+				', Utils::$context['show_who'] ? '<a href="' . Config::$scripturl . '?action=who">' : '', '<strong>', Lang::getTxt('online', file: 'General'), ': </strong>', empty(Config::$modSettings['no_guest_logging']) ? Lang::getTxt('number_of_guests', [Utils::$context['num_guests']], file: 'General') . ', ' : '', Lang::getTxt('number_of_members', [Utils::$context['num_users_online']], file: 'General');
 
 	// Handle hidden users and buddies.
 	$bracketList = [];


### PR DESCRIPTION
3.0 version of #9125 - More discussion may be found there.

This PR aims to minimize I/O during a bot attack by eliminating the logging of guests & bots in log_online. The problem is that the really troublesome bots are indistinguishable from guests via normal means, e.g., useragent.

An option is added, allowing the user to turn this behavior on or off. Users may wish to disable this only during high-CPU bot attacks.

Note that some of these bot attacks are what I call 'long tail' attacks, in which many IPs are used once and only once. This was a trademark of the 2025 Q3 Brazil/Vietnam attack; on some days, I would have 150,000+ IPs with only one request each... The problem being that each would get its own unique session & log_online record, causing a flood of writes & log activity. And then, of course, they would all need to be deleted during garbage collection.

With this change, they wouldn't be written at all.

I've been running this code on my prod forum with no issues. Though, I must admit, forum members asked this one to be removed, as they liked following those stats. Spikes usually indicated cross-forum discussions with other gear forums. Somehow they gleaned that thru all the bot noise (tbh, I dunno how...). Still, having the option to disable during a botnet attack with high CPU is an important option.

For more discussion see:
https://www.simplemachines.org/community/index.php?topic=592442.0
https://www.simplemachines.org/community/index.php?topic=592345.0
