### PR TITLE
[3.0] Fixes typos in SMF\Board::loadBoardInfo()

### DIFF
--- a/Sources/Board.php
+++ b/Sources/Board.php
@@ -2338,15 +2338,15 @@ class Board implements \ArrayAccess, Routable
 
 							case 'override_theme':
 							case 'count_posts':
-								$prop[$key] = !empty($value);
+								$props[$key] = !empty($value);
 								break;
 
 							case 'member_groups':
-								$prop[$key] = $value == '' ? [] : array_filter(explode(',', $value), 'strlen');
+								$props[$key] = array_map('intval', array_filter(explode(',', $value), 'strlen'));
 								break;
 
 							case 'deny_member_groups':
-								$prop['deny_groups'] = $value == '' ? [] : array_filter(explode(',', $value), 'strlen');
+								$props['deny_groups'] = array_map('intval', array_filter(explode(',', $value), 'strlen'));
 								break;
 
 							default:


### PR DESCRIPTION
Fixes #9146 

The problem was the missing `s`.

While I was at it, I also improved type casting for the group values.