### PR TITLE
[3.0] Removes call to deprecated and useless curl_close() function

### DIFF
--- a/Sources/WebFetch/APIs/CurlFetcher.php
+++ b/Sources/WebFetch/APIs/CurlFetcher.php
@@ -354,9 +354,6 @@ class CurlFetcher extends WebFetchApi
 		$body = (!curl_error($cr)) ? substr($curl_content, $curl_info['header_size']) : false;
 		$error = (curl_error($cr)) ? curl_error($cr) : false;
 
-		// Close this request.
-		curl_close($cr);
-
 		// Store this loop's data, someone may want all of these. :O
 		$this->response[] = [
 			'url' => $url,


### PR DESCRIPTION
Avoids triggering the following warning: "Function curl_close() is deprecated since 8.5, as it has no effect since PHP 8.0"