### PR TITLE
[3.0] Raises minimum PHP version to 8.4.1

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: [ 8.0, 8.1, 8.2, 8.3, 8.4, 8.5 ]
+        php: [ 8.4, 8.5 ]
 
     name: PHP ${{ matrix.php }} Syntax Check
     steps:

--- a/Sources/Maintenance/Maintenance.php
+++ b/Sources/Maintenance/Maintenance.php
@@ -36,7 +36,7 @@ class Maintenance
 	/**
 	 * The lowest PHP version we support.
 	 */
-	public const PHP_MIN_VERSION = '8.0.1';
+	public const PHP_MIN_VERSION = '8.4.1';
 
 	/**
 	 * Tool Types.

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
 	},
 	"config": {
 		"platform": {
-			"php": "8.0.0"
+			"php": "8.4.1"
 		}
 	},
 	"require": {


### PR DESCRIPTION
Up until now, we have pegged SMF 3.0's minimum required PHP version at PHP 8.0. The main reason for doing so was to try to ease the transition for admins running SMF 2.0. The thinking was that, since PHP 8.0 is the highest version supported by SMF 2.0, having SMF 3.0 support PHP 8.0 and higher would ensure an overlap in their respective ranges of supported PHP versions. Back in 2023, when SMF 3.0 first began public development, PHP 8.0 had not yet reached End of Life status, and so supporting it seemed quite reasonable.

However, we have lately been reconsidering whether that's really worthwhile.

First, there's the growing development burden that comes with chaining ourselves to PHP versions that are already obsolete. Today, not only has PHP 8.0 reached EOL, but so has PHP 8.1, and even PHP 8.2 will by the end of this year. By holding onto support for these old PHP versions, we have to perform a wide series of tests in order to make sure that changes that seem to work on a developer's local machine will in fact work on all our supported PHP versions. This has already been a problem a few times, and it is likely to continue to be. Even our continuous integration scripts, such as PHP-CS-Fixer, have begun complaining about trying to support 8.0.

Second, it doesn't seem like upgrading PHP versions is actually much of a barrier for people anymore. These days, even cheap shared hosting usually allows the customer to choose between PHP versions using a simple dropdown menu. Moreover, we've had an increasing number of support topics lately in which admins tell us that their hosts have forced them to upgrade to a new PHP version and now they are scrambling to upgrade their forums to match. Getting people onto a recent version of PHP doesn't seem to be the problem we need to worry about.

In light of these two realities, we have decided to drop support for PHP 8.0 and raise SMF 3.0's minimum PHP version to PHP 8.4.

Moving forward between now and whenever we hit SMF 3.0 RC1, the minimum PHP version will be the lowest PHP version that has [active support](https://www.php.net/supported-versions.php) from the PHP devs. Today that means PHP 8.4. If we haven't reached SMF 3.0 RC1 by Jan 1, 2027—when PHP 8.4 moves into security support only—then on that day our minimum PHP version will become PHP 8.5. 

Once we reach SMF 3.0 RC1, things will change a little. Whatever the minimum supported PHP version is at that time will remain the minimum version for as long as it is receiving security fixes from the PHP devs. Then the minimum PHP version will be bumped up to the next PHP version that is still receiving security fixes. This approach will continue forward through the release of 3.0.0, 3.0.1, and onward indefinitely.