### PR TITLE
[3.0] Add logException to ErrorHandler

### DIFF
--- a/Sources/Cache/APIs/Sqlite.php
+++ b/Sources/Cache/APIs/Sqlite.php
@@ -107,7 +107,7 @@ class Sqlite extends CacheApi implements CacheApiInterface
 		} catch (\Exception $ex) {
 			if (!$this->logOnce) {
 				$this->logOnce = true;
-				ErrorHandler::log(self::class . ':' . $ex->getMessage());
+				ErrorHandler::logException($ex, null);
 			}
 
 			return false;
@@ -140,7 +140,7 @@ class Sqlite extends CacheApi implements CacheApiInterface
 		} catch (\Exception $ex) {
 			if (!$this->logOnce) {
 				$this->logOnce = true;
-				ErrorHandler::log(self::class . ':' . $ex->getMessage());
+				ErrorHandler::logException($ex, null);
 			}
 
 			return null;
@@ -173,7 +173,7 @@ class Sqlite extends CacheApi implements CacheApiInterface
 		} catch (\Exception $ex) {
 			if (!$this->logOnce) {
 				$this->logOnce = true;
-				ErrorHandler::log(self::class . ':' . $ex->getMessage());
+				ErrorHandler::logException($ex);
 			}
 
 			return false;
@@ -201,7 +201,7 @@ class Sqlite extends CacheApi implements CacheApiInterface
 		} catch (\Exception $ex) {
 			if (!$this->logOnce) {
 				$this->logOnce = true;
-				ErrorHandler::log(self::class . ':' . $ex->getMessage());
+				ErrorHandler::logException($ex, null);
 			}
 
 			$result = false;

--- a/Sources/ErrorHandler.php
+++ b/Sources/ErrorHandler.php
@@ -124,6 +124,22 @@ class ErrorHandler
 	}
 
 	/**
+	 * Log an exception, if the error logging is enabled.
+	 *
+	 * $file and $line should be __FILE__ and __LINE__, respectively.
+	 *
+	 * Example use:
+	 *  die(ErrorHandler::log($msg));
+	 *
+	 * @param \Exception $ex The message to log.
+	 * @param string|bool|null $error_type The type of error.
+	 */
+	public static function logException(\Exception $ex, string|bool|null $error_type = null): string
+	{
+		return self::getService()->log($ex->getMessage(), $error_type ?? \get_class($ex), $ex->getFile(), $ex->getLine(), $ex->getTrace());
+	}
+
+	/**
 	 * An unrecoverable error.
 	 *
 	 * This function stops execution and displays an error message.

--- a/Sources/MailAgent/APIs/SendMail.php
+++ b/Sources/MailAgent/APIs/SendMail.php
@@ -85,8 +85,8 @@ class SendMail extends MailAgent implements MailAgentInterface
 				ErrorHandler::log(Lang::getTxt('mail_send_unable', [$to], file: 'General'));
 				$mail_result = false;
 			}
-		} catch (\ErrorException $e) {
-			ErrorHandler::log($e->getMessage(), 'general', $e->getFile(), $e->getLine());
+		} catch (\ErrorException $ex) {
+			ErrorHandler::logException($ex);
 			ErrorHandler::log(Lang::getTxt('mail_send_unable', [$to], file: 'General'));
 			$mail_result = false;
 		}

--- a/Sources/PackageManager/PackageUtils.php
+++ b/Sources/PackageManager/PackageUtils.php
@@ -3525,8 +3525,8 @@ class PackageUtils
 					$files[] = $file_info;
 				}
 			}
-		} catch (\Exception $e) {
-			ErrorHandler::log($e->getMessage(), 'backup');
+		} catch (\Exception $ex) {
+			ErrorHandler::logException($ex, 'backup');
 
 			return false;
 		}

--- a/Sources/Services/ErrorHandlerService.php
+++ b/Sources/Services/ErrorHandlerService.php
@@ -264,7 +264,6 @@ class ErrorHandlerService
 		// Exceptions may get mapped back into our common error types.
 		if (isset($this->known_exception_types[$error_type])) {
 			$error_type = $this->known_exception_types[$error_type];
-
 		}
 
 		if (empty($tried_hook)) {

--- a/Sources/Services/ErrorHandlerService.php
+++ b/Sources/Services/ErrorHandlerService.php
@@ -36,6 +36,7 @@ class ErrorHandlerService
 		'general',
 		'critical',
 		'database',
+		'cache',
 		'undefined_vars',
 		'user',
 		'ban',
@@ -45,6 +46,15 @@ class ErrorHandlerService
 		'paidsubs',
 		'backup',
 		'login',
+	];
+
+	/**
+	 * @var array
+	 *
+	 * Map of exceptions to the categories we have.
+	 */
+	public array $known_exception_types = [
+		\SQLite3Exception::class => 'cache',
 	];
 
 	/****************
@@ -250,6 +260,12 @@ class ErrorHandlerService
 
 		// This prevents us from infinite looping if the hook or call produces an error.
 		$other_error_types = [];
+
+		// Exceptions may get mapped back into our common error types.
+		if (isset($this->known_exception_types[$error_type])) {
+			$error_type = $this->known_exception_types[$error_type];
+
+		}
 
 		if (empty($tried_hook)) {
 			$tried_hook = true;


### PR DESCRIPTION
We can now call errorHandler::LogException(\Exception) and have SMF handle the work of putting the pieces together to log the data.

Additionally a new known_exception_types map is added to allow us to natively map some known or excepted types to the known_error_types.  This wasn't passed into our hooks as we want to carefully add to this list since a generalization of a exception class to a error type may lead to false categorization.