### PR TITLE
[3.0] Adds missing use statement in SMF\Actions\Login

### DIFF
--- a/Sources/Actions/Login.php
+++ b/Sources/Actions/Login.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 namespace SMF\Actions;
 
 use SMF\Config;
+use SMF\Cookie;
 use SMF\Lang;
 use SMF\SecurityToken;
 use SMF\Theme;


### PR DESCRIPTION
Adds a `use SMF\Cookie;` statement that should have been included in #9178.