### PR TITLE
[3.0] Removes redundant SMF\Lang::$default

### DIFF
--- a/Sources/Actions/Activate.php
+++ b/Sources/Actions/Activate.php
@@ -138,7 +138,7 @@ class Activate implements ActionInterface, Routable
 			'FORGOTPASSWORDLINK' => Config::$scripturl . '?action=reminder',
 		];
 
-		$emaildata = Mail::loadEmailTemplate('resend_activate_message', $replacements, empty($this->member->language) || empty(Config::$modSettings['userLanguage']) ? Lang::$default : $this->member->language);
+		$emaildata = Mail::loadEmailTemplate('resend_activate_message', $replacements, empty($this->member->language) || empty(Config::$modSettings['userLanguage']) ? Config::$language : $this->member->language);
 
 		Mail::send($this->member->email, $emaildata['subject'], $emaildata['body'], null, 'resendact', $emaildata['is_html'], 0);
 

--- a/Sources/Actions/Admin/ACP.php
+++ b/Sources/Actions/Admin/ACP.php
@@ -1751,7 +1751,7 @@ class ACP implements ActionInterface, Routable
 			$replacements['USERNAME'] = $row['real_name'];
 
 			// Load the data from the template.
-			$emaildata = Mail::loadEmailTemplate($template, $replacements, empty($row['lngfile']) || empty(Config::$modSettings['userLanguage']) ? Lang::$default : $row['lngfile']);
+			$emaildata = Mail::loadEmailTemplate($template, $replacements, empty($row['lngfile']) || empty(Config::$modSettings['userLanguage']) ? Config::$language : $row['lngfile']);
 
 			// Then send the actual email.
 			Mail::send($row['email_address'], $emaildata['subject'], $emaildata['body'], null, $template, $emaildata['is_html'], 1);
@@ -1773,7 +1773,7 @@ class ACP implements ActionInterface, Routable
 				$replacements['USERNAME'] = $recipient['name'];
 
 				// Load the template again.
-				$emaildata = Mail::loadEmailTemplate($template, $replacements, empty($recipient['lang']) || empty(Config::$modSettings['userLanguage']) ? Lang::$default : $recipient['lang']);
+				$emaildata = Mail::loadEmailTemplate($template, $replacements, empty($recipient['lang']) || empty(Config::$modSettings['userLanguage']) ? Config::$language : $recipient['lang']);
 
 				// Send off the email.
 				Mail::send($recipient['email'], $emaildata['subject'], $emaildata['body'], null, $template, $emaildata['is_html'], 1);

--- a/Sources/Actions/Admin/AntiSpam.php
+++ b/Sources/Actions/Admin/AntiSpam.php
@@ -82,18 +82,18 @@ class AntiSpam implements ActionInterface
 		}
 		Db::$db->free_result($request);
 
-		if (empty(Utils::$context['qa_by_lang'][strtr(Lang::$default, ['-utf8' => ''])]) && !empty(Utils::$context['question_answers'])) {
+		if (empty(Utils::$context['qa_by_lang'][strtr(Config::$language, ['-utf8' => ''])]) && !empty(Utils::$context['question_answers'])) {
 			if (empty(Utils::$context['settings_insert_above'])) {
 				Utils::$context['settings_insert_above'] = '';
 			}
 
-			Utils::$context['settings_insert_above'] .= '<div class="noticebox">' . Lang::getTxt('question_not_defined', Utils::$context['languages'][Lang::$default], file: 'ManageSettings') . '</div>';
+			Utils::$context['settings_insert_above'] .= '<div class="noticebox">' . Lang::getTxt('question_not_defined', Utils::$context['languages'][Config::$language], file: 'ManageSettings') . '</div>';
 		}
 
 		// Thirdly, push some JavaScript for the form to make it work.
 		$nextrow = !empty(Utils::$context['question_answers']) ? max(array_keys(Utils::$context['question_answers'])) + 1 : 1;
 		$setup_verification_add_answer = Utils::escapeJavaScript(Lang::getTxt('setup_verification_add_answer', file: 'ManageSettings'));
-		$default_lang = strtr(Lang::$default, ['-utf8' => '']);
+		$default_lang = strtr(Config::$language, ['-utf8' => '']);
 
 		Theme::addInlineJavaScript(<<<END
 				var nextrow = {$nextrow};

--- a/Sources/Actions/Admin/Attachments.php
+++ b/Sources/Actions/Admin/Attachments.php
@@ -597,7 +597,7 @@ class Attachments implements ActionInterface
 						WHERE id_msg IN ({array_int:messages_affected})',
 						[
 							'messages_affected' => $messages,
-							'deleted_message' => '<br><br>' . Lang::getTxt('attachment_delete_admin', file: 'Admin', lang: Lang::$default),
+							'deleted_message' => '<br><br>' . Lang::getTxt('attachment_delete_admin', file: 'Admin', lang: Config::$language),
 						],
 					);
 				}

--- a/Sources/Actions/Admin/Features.php
+++ b/Sources/Actions/Admin/Features.php
@@ -1969,7 +1969,7 @@ class Features implements ActionInterface
 	protected function init()
 	{
 		Utils::$context['page_title'] = Lang::getTxt('modSettings_title', file: 'General');
-		Utils::$context['show_privacy_policy_warning'] = empty(Config::$modSettings['policy_' . Lang::$default]);
+		Utils::$context['show_privacy_policy_warning'] = empty(Config::$modSettings['policy_' . Config::$language]);
 
 		// Load up all the tabs...
 		Menu::$loaded['admin']->tab_data = [

--- a/Sources/Actions/Admin/Languages.php
+++ b/Sources/Actions/Admin/Languages.php
@@ -474,9 +474,9 @@ class Languages implements ActionInterface
 				}
 			}
 
-			if ($_POST['def_language'] != Lang::$default && $lang_exists) {
+			if ($_POST['def_language'] != Config::$language && $lang_exists) {
 				Config::updateSettingsFile(['language' => $_POST['def_language']]);
-				Lang::$default = $_POST['def_language'];
+				Config::$language = $_POST['def_language'];
 			}
 		}
 
@@ -578,7 +578,7 @@ class Languages implements ActionInterface
 			$("tr.highlight2").removeClass("highlight2");
 			$("#" + box).addClass("highlight2");
 		}
-		highlightSelected("list_language_list_' . (Lang::$default == '' ? 'english' : Lang::$default) . '");', true);
+		highlightSelected("list_language_list_' . (Config::$language == '' ? 'english' : Config::$language) . '");', true);
 
 		// Display a warning if we cannot edit the default setting.
 		if (!is_writable(SMF_SETTINGS_FILE)) {
@@ -852,9 +852,9 @@ class Languages implements ActionInterface
 			}
 
 			// Sixth, if we deleted the default language, set us back to english?
-			if ($lang_id == Lang::$default) {
-				Lang::$default = 'en_US';
-				Config::updateSettingsFile(['language' => Lang::$default]);
+			if ($lang_id == Config::$language) {
+				Config::$language = 'en_US';
+				Config::updateSettingsFile(['language' => Config::$language]);
 			}
 
 			// Seventh, get out of here.
@@ -1574,7 +1574,7 @@ class Languages implements ActionInterface
 				'id' => $lang['filename'],
 				'count' => 0,
 				'char_set' => 'UTF-8',
-				'default' => Lang::$default == $lang['filename'] || (Lang::$default == '' && $lang['filename'] == 'en_US'),
+				'default' => Config::$language == $lang['filename'] || (Config::$language == '' && $lang['filename'] == 'en_US'),
 				'locale' => $txt['lang_locale'],
 				'name' => $lang['name'],
 			];
@@ -1592,7 +1592,7 @@ class Languages implements ActionInterface
 		while ($row = Db::$db->fetch_assoc($request)) {
 			// Default?
 			if (empty($row['lngfile']) || !isset($languages[$row['lngfile']])) {
-				$row['lngfile'] = Lang::$default;
+				$row['lngfile'] = Config::$language;
 			}
 
 			if (!isset($languages[$row['lngfile']]) && isset($languages['english'])) {

--- a/Sources/Actions/Admin/Members.php
+++ b/Sources/Actions/Admin/Members.php
@@ -1190,7 +1190,7 @@ class Members implements ActionInterface
 				'username' => $row['member_name'],
 				'name' => $row['real_name'],
 				'email' => $row['email_address'],
-				'language' => empty($row['lngfile']) || empty(Config::$modSettings['userLanguage']) ? Lang::$default : $row['lngfile'],
+				'language' => empty($row['lngfile']) || empty(Config::$modSettings['userLanguage']) ? Config::$language : $row['lngfile'],
 				'code' => $row['validation_code'],
 			];
 		}

--- a/Sources/Actions/Admin/Registration.php
+++ b/Sources/Actions/Admin/Registration.php
@@ -709,9 +709,9 @@ class Registration implements ActionInterface
 	public static function getConfigVars(): array
 	{
 		// Do we have at least default versions of the agreement and privacy policy?
-		$agreement = file_exists(Config::$languagesdir . '/' . Lang::$default . '/agreement.txt') || file_exists(Config::$languagesdir . '/agreement.txt');
+		$agreement = file_exists(Config::$languagesdir . '/' . Config::$language . '/agreement.txt') || file_exists(Config::$languagesdir . '/agreement.txt');
 
-		$policy = !empty(Config::$modSettings['policy_' . Lang::$default]);
+		$policy = !empty(Config::$modSettings['policy_' . Config::$language]);
 
 		$config_vars = [
 			[

--- a/Sources/Actions/Admin/RepairBoards.php
+++ b/Sources/Actions/Admin/RepairBoards.php
@@ -1202,7 +1202,7 @@ class RepairBoards implements ActionInterface
 			WHERE name = {string:cat_name}
 			LIMIT 1',
 			[
-				'cat_name' => Lang::getTxt('salvaged_category_name', file: 'ManageMaintenance', lang: Lang::$default),
+				'cat_name' => Lang::getTxt('salvaged_category_name', file: 'ManageMaintenance', lang: Config::$language),
 			],
 		);
 
@@ -1222,9 +1222,9 @@ class RepairBoards implements ActionInterface
 				],
 				[
 					[
-						Lang::getTxt('salvaged_category_name', file: 'ManageMaintenance', lang: Lang::$default),
+						Lang::getTxt('salvaged_category_name', file: 'ManageMaintenance', lang: Config::$language),
 						-1,
-						Lang::getTxt('salvaged_category_description', file: 'ManageMaintenance', lang: Lang::$default),
+						Lang::getTxt('salvaged_category_description', file: 'ManageMaintenance', lang: Config::$language),
 					],
 				],
 				['id_cat'],
@@ -1245,7 +1245,7 @@ class RepairBoards implements ActionInterface
 			LIMIT 1',
 			[
 				'id_cat' => $this->salvage_category,
-				'board_name' => Lang::getTxt('salvaged_board_name', file: 'ManageMaintenance', lang: Lang::$default),
+				'board_name' => Lang::getTxt('salvaged_board_name', file: 'ManageMaintenance', lang: Config::$language),
 			],
 		);
 
@@ -1268,8 +1268,8 @@ class RepairBoards implements ActionInterface
 				],
 				[
 					[
-						Lang::getTxt('salvaged_board_name', file: 'ManageMaintenance', lang: Lang::$default),
-						Lang::getTxt('salvaged_board_description', file: 'ManageMaintenance', lang: Lang::$default),
+						Lang::getTxt('salvaged_board_name', file: 'ManageMaintenance', lang: Config::$language),
+						Lang::getTxt('salvaged_board_description', file: 'ManageMaintenance', lang: Config::$language),
 						$this->salvage_category,
 						'1',
 						-1,

--- a/Sources/Actions/Agreement.php
+++ b/Sources/Actions/Agreement.php
@@ -229,7 +229,7 @@ class Agreement implements ActionInterface, Routable
 			return false;
 		}
 
-		$policy_lang = !empty(Config::$modSettings['policy_' . User::$me->language]) ? User::$me->language : Lang::$default;
+		$policy_lang = !empty(Config::$modSettings['policy_' . User::$me->language]) ? User::$me->language : Config::$language;
 
 		if (empty(Config::$modSettings['policy_updated_' . $policy_lang])) {
 			return false;
@@ -329,9 +329,9 @@ class Agreement implements ActionInterface, Routable
 					string: Config::$modSettings['policy_' . User::$me->language],
 					options: ['hard_breaks' => 0],
 				);
-			} elseif (!empty(Config::$modSettings['policy_' . Lang::$default])) {
+			} elseif (!empty(Config::$modSettings['policy_' . Config::$language])) {
 				Utils::$context['privacy_policy'] = Parser::transform(
-					string: Config::$modSettings['policy_' . Lang::$default],
+					string: Config::$modSettings['policy_' . Config::$language],
 					options: ['hard_breaks' => 0],
 				);
 			}
@@ -350,9 +350,9 @@ class Agreement implements ActionInterface, Routable
 			if (!empty(Config::$modSettings[$short . '_history_' . User::$me->language])) {
 				$text = Config::$modSettings[$short . '_' . User::$me->language] ?? '';
 				$edit_history = (array) Utils::jsonDecode(Config::$modSettings[$short . '_history_' . User::$me->language] ?? '[]', true);
-			} elseif (!empty(Config::$modSettings[$short . '_history_' . Lang::$default])) {
-				$text = Config::$modSettings[$short . '_' . Lang::$default] ?? '';
-				$edit_history = (array) Utils::jsonDecode(Config::$modSettings[$short . '_history_' . Lang::$default] ?? '[]', true);
+			} elseif (!empty(Config::$modSettings[$short . '_history_' . Config::$language])) {
+				$text = Config::$modSettings[$short . '_' . Config::$language] ?? '';
+				$edit_history = (array) Utils::jsonDecode(Config::$modSettings[$short . '_history_' . Config::$language] ?? '[]', true);
 			} else {
 				$text = '';
 				$edit_history = [];

--- a/Sources/Actions/Announce.php
+++ b/Sources/Actions/Announce.php
@@ -236,7 +236,7 @@ class Announce implements ActionInterface, Routable
 				continue;
 			}
 
-			$cur_language = empty($row['lngfile']) || empty(Config::$modSettings['userLanguage']) ? Lang::$default : $row['lngfile'];
+			$cur_language = empty($row['lngfile']) || empty(Config::$modSettings['userLanguage']) ? Config::$language : $row['lngfile'];
 
 			// If the language wasn't defined yet, load it and compose a notification message.
 			if (!isset($announcements[$cur_language])) {

--- a/Sources/Actions/Display.php
+++ b/Sources/Actions/Display.php
@@ -1060,10 +1060,10 @@ class Display implements ActionInterface, Routable
 
 		// For quick reply we need a response prefix in the default forum language.
 		if (!isset(Utils::$context['response_prefix'])) {
-			if (Lang::$default === User::$me->language) {
+			if (Config::$language === User::$me->language) {
 				Utils::$context['response_prefix'] = Lang::getTxt('response_prefix', file: 'General');
 			} elseif (!(Utils::$context['response_prefix'] = CacheApi::get('response_prefix', 600))) {
-				Utils::$context['response_prefix'] = Lang::getTxt('response_prefix', file: 'General', lang: Lang::$default);
+				Utils::$context['response_prefix'] = Lang::getTxt('response_prefix', file: 'General', lang: Config::$language);
 				CacheApi::put('response_prefix', Utils::$context['response_prefix'], 600);
 			}
 		}

--- a/Sources/Actions/JavaScriptModify.php
+++ b/Sources/Actions/JavaScriptModify.php
@@ -266,10 +266,10 @@ class JavaScriptModify implements ActionInterface, Routable
 			if (isset($_POST['subject'], $_REQUEST['change_all_subjects']) && $row['id_first_msg'] == $row['id_msg'] && !empty($row['num_replies']) && (User::$me->allowedTo('modify_any') || ($row['id_member_started'] == User::$me->id && User::$me->allowedTo('modify_replies')))) {
 				// Get the proper (default language) response prefix first.
 				if (!isset(Utils::$context['response_prefix'])) {
-					if (Lang::$default === User::$me->language) {
+					if (Config::$language === User::$me->language) {
 						Utils::$context['response_prefix'] = Lang::getTxt('response_prefix', file: 'General');
 					} elseif (!(Utils::$context['response_prefix'] = CacheApi::get('response_prefix', 600))) {
-						Utils::$context['response_prefix'] = Lang::getTxt('response_prefix', file: 'General', lang: Lang::$default);
+						Utils::$context['response_prefix'] = Lang::getTxt('response_prefix', file: 'General', lang: Config::$language);
 						CacheApi::put('response_prefix', Utils::$context['response_prefix'], 600);
 					}
 				}

--- a/Sources/Actions/PersonalMessage.php
+++ b/Sources/Actions/PersonalMessage.php
@@ -659,7 +659,7 @@ class PersonalMessage implements ActionInterface, Routable
 			// Loop through each admin, and add them to the right language pile...
 			while ($row = Db::$db->fetch_assoc($request)) {
 				// Need to send in the correct language!
-				$cur_language = empty($row['lngfile']) || empty(Config::$modSettings['userLanguage']) ? Lang::$default : $row['lngfile'];
+				$cur_language = empty($row['lngfile']) || empty(Config::$modSettings['userLanguage']) ? Config::$language : $row['lngfile'];
 
 				if (!isset($messagesToSend[$cur_language])) {
 					// Make the body.

--- a/Sources/Actions/Post.php
+++ b/Sources/Actions/Post.php
@@ -911,10 +911,10 @@ class Post implements ActionInterface, Routable
 	protected function setResponsePrefix(): void
 	{
 		if (!isset(Utils::$context['response_prefix'])) {
-			if (Lang::$default === User::$me->language) {
+			if (Config::$language === User::$me->language) {
 				Utils::$context['response_prefix'] = Lang::getTxt('response_prefix', file: 'General');
 			} elseif (!(Utils::$context['response_prefix'] = CacheApi::get('response_prefix', 600))) {
-				Utils::$context['response_prefix'] = Lang::getTxt('response_prefix', file: 'General', lang: Lang::$default);
+				Utils::$context['response_prefix'] = Lang::getTxt('response_prefix', file: 'General', lang: Config::$language);
 				CacheApi::put('response_prefix', Utils::$context['response_prefix'], 600);
 			}
 		}

--- a/Sources/Actions/Register.php
+++ b/Sources/Actions/Register.php
@@ -238,7 +238,7 @@ class Register implements ActionInterface, Routable
 		Utils::$context['notify_announcements'] = !empty($prefs[0]['announcements']);
 
 		if (!empty(Config::$modSettings['userLanguage'])) {
-			$selectedLanguage = empty($_SESSION['language']) ? Lang::$default : $_SESSION['language'];
+			$selectedLanguage = empty($_SESSION['language']) ? Config::$language : $_SESSION['language'];
 
 			// Do we have any languages?
 			if (empty(Utils::$context['languages'])) {
@@ -264,9 +264,9 @@ class Register implements ActionInterface, Routable
 					string: Config::$modSettings['policy_' . User::$me->language],
 					options: ['hard_breaks' => 0],
 				);
-			} elseif (!empty(Config::$modSettings['policy_' . Lang::$default])) {
+			} elseif (!empty(Config::$modSettings['policy_' . Config::$language])) {
 				Utils::$context['privacy_policy'] = Parser::transform(
-					string: Config::$modSettings['policy_' . Lang::$default],
+					string: Config::$modSettings['policy_' . Config::$language],
 					options: ['hard_breaks' => 0],
 				);
 			} else {

--- a/Sources/Actions/Reminder.php
+++ b/Sources/Actions/Reminder.php
@@ -154,7 +154,7 @@ class Reminder implements ActionInterface, Routable
 				'MEMBERNAME' => $this->member->username,
 			];
 
-			$emaildata = Mail::loadEmailTemplate('forgot_password', $replacements, empty($this->member->lngfile) || empty(Config::$modSettings['userLanguage']) ? Lang::$default : $this->member->lngfile);
+			$emaildata = Mail::loadEmailTemplate('forgot_password', $replacements, empty($this->member->lngfile) || empty(Config::$modSettings['userLanguage']) ? Config::$language : $this->member->lngfile);
 
 			Mail::send($this->member->email, $emaildata['subject'], $emaildata['body'], null, 'reminder', $emaildata['is_html'], 1);
 

--- a/Sources/Actions/TopicMerge.php
+++ b/Sources/Actions/TopicMerge.php
@@ -594,8 +594,8 @@ class TopicMerge implements ActionInterface, Routable
 			];
 
 			// Make sure we catch both languages in the reason.
-			if (User::$me->language != Lang::$default) {
-				$reason_replacements[Lang::getTxt('movetopic_auto_topic', file: 'General', lang: Lang::$default)] = '[iurl=$quot' . Config::$scripturl . '?topic=' . $id_topic . '.0&quot;]' . $target_subject . '[/iurl]';
+			if (User::$me->language != Config::$language) {
+				$reason_replacements[Lang::getTxt('movetopic_auto_topic', file: 'General', lang: Config::$language)] = '[iurl=$quot' . Config::$scripturl . '?topic=' . $id_topic . '.0&quot;]' . $target_subject . '[/iurl]';
 			}
 
 			$_POST['reason'] = Parser::sanitize(Utils::htmlspecialchars($_POST['reason'], ENT_QUOTES), autolink: !empty(Config::$modSettings['autoLinkUrls']));
@@ -610,7 +610,7 @@ class TopicMerge implements ActionInterface, Routable
 			$redirect_topic = isset($_POST['redirect_topic']) ? $id_topic : 0;
 
 			foreach ($deleted_topics as $this_old_topic) {
-				$redirect_subject = Lang::getTxt('merged_subject', ['subject' => $this->topic_data[$this_old_topic]['subject']], file: 'General', lang: Lang::$default);
+				$redirect_subject = Lang::getTxt('merged_subject', ['subject' => $this->topic_data[$this_old_topic]['subject']], file: 'General', lang: Config::$language);
 
 				$msgOptions = [
 					'icon' => 'moved',
@@ -640,10 +640,10 @@ class TopicMerge implements ActionInterface, Routable
 
 		// Grab the response prefix (like 'Re: ') in the default forum language.
 		if (!isset(Utils::$context['response_prefix'])) {
-			if (Lang::$default === User::$me->language) {
+			if (Config::$language === User::$me->language) {
 				Utils::$context['response_prefix'] = Lang::getTxt('response_prefix', file: 'General');
 			} elseif (!(Utils::$context['response_prefix'] = CacheApi::get('response_prefix', 600))) {
-				Utils::$context['response_prefix'] = Lang::getTxt('response_prefix', file: 'General', lang: Lang::$default);
+				Utils::$context['response_prefix'] = Lang::getTxt('response_prefix', file: 'General', lang: Config::$language);
 				CacheApi::put('response_prefix', Utils::$context['response_prefix'], 600);
 			}
 		}

--- a/Sources/Actions/TopicMove.php
+++ b/Sources/Actions/TopicMove.php
@@ -129,10 +129,10 @@ class TopicMove implements ActionInterface, Routable
 
 		Utils::$context['back_to_topic'] = isset($_REQUEST['goback']);
 
-		if (User::$me->language != Lang::$default) {
+		if (User::$me->language != Config::$language) {
 			Lang::setTxt(
 				'movetopic_default',
-				Lang::getTxt('movetopic_default', file: 'General', lang: Lang::$default),
+				Lang::getTxt('movetopic_default', file: 'General', lang: Config::$language),
 			);
 		}
 

--- a/Sources/Actions/TopicMove2.php
+++ b/Sources/Actions/TopicMove2.php
@@ -143,10 +143,10 @@ class TopicMove2 implements ActionInterface, Routable
 				if (isset($_POST['enforce_subject'])) {
 					// Get a response prefix, but in the forum's default language.
 					if (!isset(Utils::$context['response_prefix'])) {
-						if (Lang::$default === User::$me->language) {
+						if (Config::$language === User::$me->language) {
 							Utils::$context['response_prefix'] = Lang::getTxt('response_prefix', file: 'General');
 						} elseif (!(Utils::$context['response_prefix'] = CacheApi::get('response_prefix', 600))) {
-							Utils::$context['response_prefix'] = Lang::getTxt('response_prefix', file: 'General', lang: Lang::$default);
+							Utils::$context['response_prefix'] = Lang::getTxt('response_prefix', file: 'General', lang: Config::$language);
 							CacheApi::put('response_prefix', Utils::$context['response_prefix'], 600);
 						}
 					}
@@ -187,9 +187,9 @@ class TopicMove2 implements ActionInterface, Routable
 			];
 
 			// Make sure we catch both languages in the reason.
-			if (User::$me->language != Lang::$default) {
-				$reason_replacements[Lang::getTxt('movetopic_auto_board', file: 'General', lang: Lang::$default)] = '[url=&quot;' . Config::$scripturl . '?board=' . $_POST['toboard'] . '.0&quot;]' . $board_name . '[/url]';
-				$reason_replacements[Lang::getTxt('movetopic_auto_topic', file: 'General', lang: Lang::$default)] = '[iurl]' . Config::$scripturl . '?topic=' . Topic::$topic_id . '.0[/iurl]';
+			if (User::$me->language != Config::$language) {
+				$reason_replacements[Lang::getTxt('movetopic_auto_board', file: 'General', lang: Config::$language)] = '[url=&quot;' . Config::$scripturl . '?board=' . $_POST['toboard'] . '.0&quot;]' . $board_name . '[/url]';
+				$reason_replacements[Lang::getTxt('movetopic_auto_topic', file: 'General', lang: Config::$language)] = '[iurl]' . Config::$scripturl . '?topic=' . Topic::$topic_id . '.0[/iurl]';
 			}
 
 			$_POST['reason'] = Parser::sanitize(Utils::htmlspecialchars($_POST['reason'], ENT_QUOTES), autolink: !empty(Config::$modSettings['autoLinkUrls']));
@@ -204,7 +204,7 @@ class TopicMove2 implements ActionInterface, Routable
 			$redirect_topic = isset($_POST['redirect_topic']) ? Topic::$topic_id : 0;
 
 			$msgOptions = [
-				'subject' => Lang::getTxt('moved', ['subject' => $subject], file: 'General', lang: Lang::$default),
+				'subject' => Lang::getTxt('moved', ['subject' => $subject], file: 'General', lang: Config::$language),
 				'body' => $_POST['reason'],
 				'icon' => 'moved',
 				'smileys_enabled' => 1,

--- a/Sources/Lang.php
+++ b/Sources/Lang.php
@@ -100,13 +100,6 @@ class Lang
 	/**
 	 * @var string
 	 *
-	 * Local copy of SMF\Config::$language
-	 */
-	public static string $default;
-
-	/**
-	 * @var string
-	 *
 	 * MessageFormat string to show the SMF copyright.
 	 * The default value will be overwritten when a language is loaded.
 	 */
@@ -241,13 +234,9 @@ class Lang
 	 */
 	public static function load(string $filename, string $lang = '', bool $fatal = true, bool $force_reload = false): string
 	{
-		if (!isset(self::$default)) {
-			self::$default = &Config::$language;
-		}
-
 		// Default to the user's language.
 		if ($lang == '') {
-			$lang = User::$me->language ?? self::$default;
+			$lang = User::$me->language ?? Config::$language;
 		}
 
 		if (empty(self::$dirs)) {
@@ -271,14 +260,14 @@ class Lang
 			foreach (self::$dirs as $dir) {
 				$attempts[] = [$dir, $name, $lang];
 
-				if ($lang !== self::$default) {
-					$attempts[] = [$dir, $name, self::$default];
+				if ($lang !== Config::$language) {
+					$attempts[] = [$dir, $name, Config::$language];
 				}
 
 				// Fall back to English if none of the preferred languages can be found.
 				if (
 					empty(Config::$modSettings['disable_language_fallback'])
-					&& 'en_US' !== self::$default
+					&& 'en_US' !== Config::$language
 					&& 'en_US' !== $lang
 				) {
 					$attempts[] = [$dir, $name, 'en_US'];
@@ -357,7 +346,7 @@ class Lang
 					if (!empty($forum_copyright)) {
 						self::$localized_copyright[$file[2]] = $forum_copyright;
 
-						self::$forum_copyright = self::$localized_copyright[$lang] ?? (self::$localized_copyright[self::$default] ?? (self::$localized_copyright['en_US'] ?? ''));
+						self::$forum_copyright = self::$localized_copyright[$lang] ?? (self::$localized_copyright[Config::$language] ?? (self::$localized_copyright['en_US'] ?? ''));
 
 						unset($forum_copyright);
 					}
@@ -722,7 +711,7 @@ class Lang
 		$txt_key = array_values((array) $txt_key);
 
 		if ($lang == '') {
-			$lang = User::$me->language ?? self::$default;
+			$lang = User::$me->language ?? Config::$language;
 		}
 
 		self::loadFileForGetTxt($file, $var, $txt_key, $lang);

--- a/Sources/Localization/AsciiTransliterator.php
+++ b/Sources/Localization/AsciiTransliterator.php
@@ -15,8 +15,8 @@ declare(strict_types=1);
 
 namespace SMF\Localization;
 
+use SMF\Config;
 use SMF\IntegrationHook;
-use SMF\Lang;
 use SMF\Sapi;
 use SMF\Unicode\Utf8String;
 use SMF\Utils;
@@ -193,7 +193,7 @@ class AsciiTransliterator
 
 		if (!isset(self::$transliterator)) {
 			// Maybe there is a specific transliterator for the default language?
-			switch (substr(Lang::$default, 0, 2)) {
+			switch (substr(Config::$language, 0, 2)) {
 				// There's a specific transliterator for German to ASCII.
 				case 'de':
 					$locale_id = 'de-ASCII;' . self::DEFAULT_ID;
@@ -240,7 +240,7 @@ class AsciiTransliterator
 				// For anything else, guess at a specific transliterator.
 				// It might or might not work, but we'll handle that below.
 				default:
-					$locale_id = substr(Lang::$default, 0, 2) . '-Latin;' . self::DEFAULT_ID;
+					$locale_id = substr(Config::$language, 0, 2) . '-Latin;' . self::DEFAULT_ID;
 					break;
 			}
 

--- a/Sources/Mail.php
+++ b/Sources/Mail.php
@@ -364,8 +364,8 @@ class Mail
 		// Just in case we run into a problem.
 		if (empty(Lang::$txt)) {
 			Theme::loadEssential();
-			Lang::load('Errors', Lang::$default, false);
-			Lang::load('General', Lang::$default, false);
+			Lang::load('Errors', Config::$language, false);
+			Lang::load('General', Config::$language, false);
 		}
 
 		// By default send 5 at once.

--- a/Sources/PersonalMessage/PM.php
+++ b/Sources/PersonalMessage/PM.php
@@ -647,10 +647,10 @@ class PM implements \ArrayAccess
 
 			// Add 'Re: ' to it....
 			if (!isset(Utils::$context['response_prefix'])) {
-				if (Lang::$default === User::$me->language) {
+				if (Config::$language === User::$me->language) {
 					Utils::$context['response_prefix'] = Lang::getTxt('response_prefix', file: 'General');
 				} elseif (!(Utils::$context['response_prefix'] = CacheApi::get('response_prefix', 600))) {
-					Utils::$context['response_prefix'] = Lang::getTxt('response_prefix', file: 'General', lang: Lang::$default);
+					Utils::$context['response_prefix'] = Lang::getTxt('response_prefix', file: 'General', lang: Config::$language);
 					CacheApi::put('response_prefix', Utils::$context['response_prefix'], 600);
 				}
 			}
@@ -1427,7 +1427,7 @@ class PM implements \ArrayAccess
 					)
 				)
 			) {
-				$notifications[empty($row['lngfile']) || empty(Config::$modSettings['userLanguage']) ? Lang::$default : $row['lngfile']][] = $row['email_address'];
+				$notifications[empty($row['lngfile']) || empty(Config::$modSettings['userLanguage']) ? Config::$language : $row['lngfile']][] = $row['email_address'];
 			}
 
 			$log['sent'][$row['id_member']] = Lang::getTxt('pm_successfully_sent', ['member' => $row['real_name']], file: 'PersonalMessage');

--- a/Sources/Profile.php
+++ b/Sources/Profile.php
@@ -764,7 +764,7 @@ class Profile extends User implements \ArrayAccess
 						}
 						// No images at all? That's no good. Let the admin know, and quietly skip for this user.
 						else {
-							ErrorHandler::log(Lang::getTxt('smiley_set_dir_not_found', [$set_names[array_search($set, Utils::$context['smiley_sets'])]], file: 'Errors', lang: Lang::$default));
+							ErrorHandler::log(Lang::getTxt('smiley_set_dir_not_found', [$set_names[array_search($set, Utils::$context['smiley_sets'])]], file: 'Errors', lang: Config::$language));
 
 							Utils::$context['smiley_sets'] = array_filter(Utils::$context['smiley_sets'], fn($v) => $v != $set);
 						}
@@ -2923,7 +2923,7 @@ class Profile extends User implements \ArrayAccess
 		];
 
 		// Send off the email.
-		$emaildata = Mail::loadEmailTemplate('activate_reactivate', $replacements, empty(User::$profiles[$this->id]['lngfile']) || empty(Config::$modSettings['userLanguage']) ? Lang::$default : User::$profiles[$this->id]['lngfile']);
+		$emaildata = Mail::loadEmailTemplate('activate_reactivate', $replacements, empty(User::$profiles[$this->id]['lngfile']) || empty(Config::$modSettings['userLanguage']) ? Config::$language : User::$profiles[$this->id]['lngfile']);
 
 		Mail::send($this->new_data['email_address'], $emaildata['subject'], $emaildata['body'], null, 'reactivate', $emaildata['is_html'], 0);
 

--- a/Sources/Security.php
+++ b/Sources/Security.php
@@ -428,7 +428,7 @@ class Security
 			);
 			$policy_agreement = (
 				!empty(Config::$modSettings['requirePolicyAgreement'])
-				&& empty(Config::$modSettings['policy_' . Lang::$default])
+				&& empty(Config::$modSettings['policy_' . Config::$language])
 			);
 
 			// Compile warnings

--- a/Sources/Services/ErrorHandlerService.php
+++ b/Sources/Services/ErrorHandlerService.php
@@ -383,12 +383,12 @@ class ErrorHandlerService
 
 		// Log the error in the forum's language, but don't waste the time if we aren't logging
 		if ($log) {
-			$error_message = Lang::getTxt($error, $sprintf, file: $file, lang: Lang::$default);
+			$error_message = Lang::getTxt($error, $sprintf, file: $file, lang: Config::$language);
 			$this->log($error_message, $log);
 		}
 
 		// Load the language file, only if it needs to be reloaded
-		if (!$log || Lang::$default != User::$me->language) {
+		if (!$log || Config::$language != User::$me->language) {
 			$error_message = Lang::getTxt($error, $sprintf, file: $file, lang: User::$me->language);
 		}
 

--- a/Sources/Tasks/CreatePost_Notify.php
+++ b/Sources/Tasks/CreatePost_Notify.php
@@ -724,7 +724,7 @@ class CreatePost_Notify extends BackgroundTask
 					'CONTENTLINK' => Config::$scripturl . '?msg=' . $msgOptions['id'],
 				];
 
-				$emaildata = Mail::loadEmailTemplate('msg_quote', $replacements, empty($member_data['lngfile']) || empty(Config::$modSettings['userLanguage']) ? Lang::$default : $member_data['lngfile']);
+				$emaildata = Mail::loadEmailTemplate('msg_quote', $replacements, empty($member_data['lngfile']) || empty(Config::$modSettings['userLanguage']) ? Config::$language : $member_data['lngfile']);
 				$mail_result = Mail::send($member_data['email_address'], $emaildata['subject'], $emaildata['body'], null, 'msg_quote_' . $msgOptions['id'], $emaildata['is_html'], 2);
 
 				if ($mail_result !== false) {
@@ -793,7 +793,7 @@ class CreatePost_Notify extends BackgroundTask
 					'CONTENTLINK' => Config::$scripturl . '?msg=' . $msgOptions['id'],
 				];
 
-				$emaildata = Mail::loadEmailTemplate('msg_mention', $replacements, empty($member_data['lngfile']) || empty(Config::$modSettings['userLanguage']) ? Lang::$default : $member_data['lngfile']);
+				$emaildata = Mail::loadEmailTemplate('msg_mention', $replacements, empty($member_data['lngfile']) || empty(Config::$modSettings['userLanguage']) ? Config::$language : $member_data['lngfile']);
 				$mail_result = Mail::send($member_data['email_address'], $emaildata['subject'], $emaildata['body'], null, 'msg_mention_' . $msgOptions['id'], $emaildata['is_html'], 2);
 
 				if ($mail_result !== false) {

--- a/Sources/Tasks/FetchSMFiles.php
+++ b/Sources/Tasks/FetchSMFiles.php
@@ -54,7 +54,7 @@ class FetchSMFiles extends ScheduledTask
 			$js_files[$row['id_file']] = [
 				'filename' => $row['filename'],
 				'path' => $row['path'],
-				'parameters' => \sprintf($row['parameters'], Lang::$default, urlencode(Config::$modSettings['time_format']), urlencode(SMF_FULL_VERSION)),
+				'parameters' => \sprintf($row['parameters'], Config::$language, urlencode(Config::$modSettings['time_format']), urlencode(SMF_FULL_VERSION)),
 			];
 		}
 		Db::$db->free_result($request);
@@ -73,9 +73,9 @@ class FetchSMFiles extends ScheduledTask
 
 			// If we got an error - give up - the site might be down. And if we should happen to be coming from elsewhere, let's also make a note of it.
 			if ($file_data === false) {
-				Utils::$context['scheduled_errors']['fetchSMfiles'][] = Lang::getTxt('st_cannot_retrieve_file', [$url], file: 'Errors', lang: Lang::$default);
+				Utils::$context['scheduled_errors']['fetchSMfiles'][] = Lang::getTxt('st_cannot_retrieve_file', [$url], file: 'Errors', lang: Config::$language);
 
-				ErrorHandler::log(Lang::getTxt('st_cannot_retrieve_file', [$url], file: 'Errors', lang: Lang::$default));
+				ErrorHandler::log(Lang::getTxt('st_cannot_retrieve_file', [$url], file: 'Errors', lang: Config::$language));
 
 				return true;
 			}

--- a/Sources/Tasks/PaidSubs.php
+++ b/Sources/Tasks/PaidSubs.php
@@ -20,7 +20,6 @@ use SMF\Actions\Notify;
 use SMF\Alert;
 use SMF\Config;
 use SMF\Db\DatabaseApi as Db;
-use SMF\Lang;
 use SMF\Mail;
 use SMF\Theme;
 use SMF\Time;
@@ -105,7 +104,7 @@ class PaidSubs extends ScheduledTask
 				'END_DATE' => strip_tags(Time::create('@' . $row['end_time'])->format()),
 			];
 
-			$emaildata = Mail::loadEmailTemplate('paid_subscription_reminder', $replacements, empty($row['lngfile']) || empty(Config::$modSettings['userLanguage']) ? Lang::$default : $row['lngfile']);
+			$emaildata = Mail::loadEmailTemplate('paid_subscription_reminder', $replacements, empty($row['lngfile']) || empty(Config::$modSettings['userLanguage']) ? Config::$language : $row['lngfile']);
 
 			// Check notification prefs.
 			$subs_notify = $notifyPrefs[$row['id_member']]['paidsubs_expiring'] ?? 0;

--- a/Sources/Unicode/Utf8String.php
+++ b/Sources/Unicode/Utf8String.php
@@ -73,7 +73,7 @@ class Utf8String implements \Stringable
 	{
 		$this->string = $string;
 
-		$this->language = substr($language ?? User::$me->language ?? Lang::$default ?? Config::$language ?? Lang::getTxt('lang_locale', file: 'General') ?? '', 0, 2);
+		$this->language = substr($language ?? User::$me->language ?? Config::$language ?? Config::$language ?? Lang::getTxt('lang_locale', file: 'General') ?? '', 0, 2);
 
 		// Can we use the intl extension's Normalizer class?
 		if (!isset(self::$use_intl_normalizer)) {

--- a/Sources/Verifier.php
+++ b/Sources/Verifier.php
@@ -582,7 +582,7 @@ class Verifier implements \ArrayAccess
 				$possible_langs[] = User::$me->language;
 			}
 
-			$possible_langs[] = Lang::$default;
+			$possible_langs[] = Config::$language;
 
 			$this->question_ids = [];
 

--- a/other/Updaters/UpdaterBase.php
+++ b/other/Updaters/UpdaterBase.php
@@ -162,7 +162,6 @@ abstract class UpdaterBase
 				'forum_uuid' => (string) Uuid::getNamespace(),
 			];
 
-			Lang::$default = Config::$language;
 			Lang::addDirs(Config::$languagesdir);
 		}
 


### PR DESCRIPTION
SMF\Lang::$default was just a reference to SMF\Config::$language. Why bother?