### PR TITLE
Fix number formatting issues in message formatter

### DIFF
--- a/Sources/Theme.php
+++ b/Sources/Theme.php
@@ -978,9 +978,9 @@ class Theme
 		}
 
 		Utils::$context['common_stats'] = [
-			'total_posts' => Lang::numberFormat((int) Config::$modSettings['totalMessages']),
-			'total_topics' => Lang::numberFormat((int) Config::$modSettings['totalTopics']),
-			'total_members' => Lang::numberFormat((int) Config::$modSettings['totalMembers']),
+			'total_posts' => (int) Config::$modSettings['totalMessages'],
+			'total_topics' => Config::$modSettings['totalTopics'],
+			'total_members' => (int) Config::$modSettings['totalMembers'],
 			'latest_member' => [
 				'id' => Config::$modSettings['latestMember'],
 				'name' => Config::$modSettings['latestRealName'],


### PR DESCRIPTION
The board index stats would truncate after the first thousands separator.
