### PR TITLE
build first class callables for hooks

### DIFF
--- a/Sources/IntegrationHook.php
+++ b/Sources/IntegrationHook.php
@@ -118,7 +118,7 @@ class IntegrationHook
 		foreach ($this->callables as $func_string => $callable) {
 			// Is it valid?
 			if (\is_callable($callable)) {
-				$this->results[$func_string] = \call_user_func_array($callable, $parameters);
+				$this->results[$func_string] = $callable(...$parameters);
 			}
 			// This failed, but we want to do so silently.
 			elseif ($this->ignore_errors) {

--- a/Sources/IntegrationHook.php
+++ b/Sources/IntegrationHook.php
@@ -116,39 +116,7 @@ class IntegrationHook
 
 		// Loop through each callable.
 		foreach ($this->callables as $func_string => $callable) {
-			// Is it valid?
-			if (\is_callable($callable)) {
-				$this->results[$func_string] = $callable(...$parameters);
-			}
-			// This failed, but we want to do so silently.
-			elseif ($this->ignore_errors) {
-				// return $this->results;
-				continue;
-			}
-			// Whatever it was supposed to call, it failed :(
-			else {
-				// Get a full path to show on error.
-				if (str_contains($func_string, '|')) {
-					list($file, $func) = explode('|', $func_string);
-
-					$path = strtr($file, [
-						'$boarddir' => Config::$boarddir,
-						'$sourcedir' => Config::$sourcedir,
-					]);
-
-					if (str_contains($path, '$themedir') && class_exists('SMF\\Theme', false) && !empty(Theme::$current->settings['theme_dir'])) {
-						$path = strtr($path, [
-							'$themedir' => Theme::$current->settings['theme_dir'],
-						]);
-					}
-
-					ErrorHandler::log(Lang::getTxt('hook_fail_call_to', [$func, $path], file: 'Errors'), 'general');
-				}
-				// Assume the file resides on Config::$boarddir somewhere...
-				else {
-					ErrorHandler::log(Lang::getTxt('hook_fail_call_to', [$func_string, Config::$boarddir], file: 'Errors'), 'general');
-				}
-			}
+			$this->results[$func_string] = $callable(...1$parameters);
 		}
 
 		return $this->results;

--- a/Sources/IntegrationHook.php
+++ b/Sources/IntegrationHook.php
@@ -116,7 +116,7 @@ class IntegrationHook
 
 		// Loop through each callable.
 		foreach ($this->callables as $func_string => $callable) {
-			$this->results[$func_string] = $callable(...1$parameters);
+			$this->results[$func_string] = $callable(...$parameters);
 		}
 
 		return $this->results;

--- a/Sources/Utils.php
+++ b/Sources/Utils.php
@@ -2428,8 +2428,11 @@ class Utils
 		}
 
 		// Process static or instance method callables.
-		if (str_contains($input, '::')) {
-			list($class, $method) = explode('::', $input);
+		$pos = strpos($input, '::');
+
+		if ($pos !== false) {
+			$class = substr($input, 0, $pos);
+			$method = substr($input, $pos + 2);
 
 			// Handle instance creation for methods with "#".
 			if (str_contains($method, '#')) {

--- a/Sources/Utils.php
+++ b/Sources/Utils.php
@@ -2440,11 +2440,12 @@ class Utils
 					Utils::$context['instances'] = [];
 				}
 
+				$instances = &Utils::$context['instances'];
 				// Remove the "#" and ensure an instance exists.
 				$method = str_replace('#', '', $method);
 
-				if (empty(Utils::$context['instances'][$class]) || !(Utils::$context['instances'][$class] instanceof $class)) {
-					Utils::$context['instances'][$class] = new $class();
+				if (empty($instances[$class]) || !($instances[$class] instanceof $class)) {
+					$instances[$class] = new $class();
 
 					// Optionally track instance creation for debugging.
 					if (DebugUtils::isDebugEnabled()) {
@@ -2456,14 +2457,14 @@ class Utils
 					}
 				}
 
-				$callable = [Utils::$context['instances'][$class], $method];
+				$callable = $instances[$class]->$method(...);
 			} else {
 				// Static method reference.
-				$callable = [$class, $method];
+				$callable = $class::$method(...);
 			}
 		} else {
 			// Treat as a plain function.
-			$callable = $input;
+			$callable = $input(...);
 		}
 
 		// Validate the callable.

--- a/Sources/Utils.php
+++ b/Sources/Utils.php
@@ -2419,9 +2419,6 @@ class Utils
 			return \is_callable($input) ? $input : false;
 		}
 
-		// Sanitize and trim the input.
-		$input = Utils::htmlspecialchars(Utils::htmlTrim($input));
-
 		// Attempt to load a file, if applicable.
 		$input = self::loadFile($input);
 


### PR DESCRIPTION
This is the first of a series of pull requests that will convert string callables to first-class callables. Each branch will focus on a single related unit. For example, this one addresses hooks, while another one focuses on menus, and so on.

Fully backward compatible. I have compiled a script testing all the various callable types that I can think of:

[https://github.com/live627/benchmark-tests/blob/main/callables.php](https://github.com/live627/benchmark-tests/blob/main/callables.php)

It’s quite interesting how the static `class::method` syntax lost the horse race. Any string method will be slower because it is internally converted to a callable, and the first-class syntax can be used directly:

[https://github.com/live627/benchmark-tests/blob/main/callables.txt](https://github.com/live627/benchmark-tests/blob/main/callables.txt)
