### PR TITLE
[2.1] Don't log guests if disallowed

### DIFF
--- a/Sources/Security.php
+++ b/Sources/Security.php
@@ -103,6 +103,7 @@ function is_not_guest($message = '')
 	if (!$user_info['is_guest'])
 		return;
 
+	// Log what they were trying to do didn't work)
 	writeLog(true);
 
 	// Just die.

--- a/Sources/Security.php
+++ b/Sources/Security.php
@@ -103,11 +103,6 @@ function is_not_guest($message = '')
 	if (!$user_info['is_guest'])
 		return;
 
-	// Log what they were trying to do didn't work)
-	if (!empty($modSettings['who_enabled']))
-		$_GET['error'] = 'guest_login';
-	writeLog(true);
-
 	// Just die.
 	if (isset($_REQUEST['xml']))
 		obExit(false);

--- a/Sources/Security.php
+++ b/Sources/Security.php
@@ -103,6 +103,8 @@ function is_not_guest($message = '')
 	if (!$user_info['is_guest'])
 		return;
 
+	writeLog(true);
+
 	// Just die.
 	if (isset($_REQUEST['xml']))
 		obExit(false);

--- a/Sources/Who.php
+++ b/Sources/Who.php
@@ -448,8 +448,6 @@ function determineActions($urls, $preferred_prefix = false)
 
 			if (isset($txt[$actions['error']]))
 				$error_message = str_replace('"', '&quot;', empty($actions['error_params']) ? $txt[$actions['error']] : vsprintf($txt[$actions['error']], (array) $actions['error_params']));
-			elseif ($actions['error'] == 'guest_login')
-				$error_message = str_replace('"', '&quot;', $txt['who_guest_login']);
 			else
 				$error_message = str_replace('"', '&quot;', $actions['error']);
 

--- a/Themes/default/languages/Who.english.php
+++ b/Themes/default/languages/Who.english.php
@@ -19,7 +19,6 @@ $txt['who_show_all'] = 'Everyone';
 $txt['who_no_online_spiders'] = 'There are currently no spiders online.';
 $txt['who_no_online_guests'] = 'There are currently no guests online.';
 $txt['who_no_online_members'] = 'There are currently no members online.';
-$txt['who_guest_login'] = 'User has been taken to the login page.';
 
 $txt['whospider_login'] = 'Viewing the login page.';
 $txt['whospider_register'] = 'Viewing the registration page.';

--- a/index.php
+++ b/index.php
@@ -240,6 +240,30 @@ function smf_main()
 	if (!empty($topic) && empty($board_info['cur_topic_approved']) && !allowedTo('approve_posts') && ($user_info['id'] != $board_info['cur_topic_starter'] || $user_info['is_guest']))
 		fatal_lang_error('not_a_topic', false);
 
+	// Do some logging, unless this is an attachment, avatar, toggle of editor buttons, theme option, XML feed, popup, etc.
+	$no_stat_actions = array(
+		'about:unknown' => true,
+		'clock' => true,
+		'dlattach' => true,
+		'findmember' => true,
+		'helpadmin' => true,
+		'jsoption' => true,
+		'likes' => true,
+		'modifycat' => true,
+		'pm' => array('sa' => array('popup')),
+		'profile' => array('area' => array('popup', 'alerts_popup', 'download', 'dlattach')),
+		'requestmembers' => true,
+		'smstats' => true,
+		'suggest' => true,
+		'uploadAttach' => true,
+		'verificationcode' => true,
+		'viewquery' => true,
+		'viewsmfile' => true,
+		'xmlhttp' => true,
+		'.xml' => true,
+	);
+	call_integration_hook('integrate_pre_log_stats', array(&$no_stat_actions));
+
 	// Make sure that our scheduled tasks have been running as intended
 	check_cron();
 
@@ -300,30 +324,6 @@ function smf_main()
 			return 'Display';
 		}
 	}
-
-	// Do some logging, unless this is an attachment, avatar, toggle of editor buttons, theme option, XML feed, popup, etc.
-	$no_stat_actions = array(
-		'about:unknown' => true,
-		'clock' => true,
-		'dlattach' => true,
-		'findmember' => true,
-		'helpadmin' => true,
-		'jsoption' => true,
-		'likes' => true,
-		'modifycat' => true,
-		'pm' => array('sa' => array('popup')),
-		'profile' => array('area' => array('popup', 'alerts_popup', 'download', 'dlattach')),
-		'requestmembers' => true,
-		'smstats' => true,
-		'suggest' => true,
-		'uploadAttach' => true,
-		'verificationcode' => true,
-		'viewquery' => true,
-		'viewsmfile' => true,
-		'xmlhttp' => true,
-		'.xml' => true,
-	);
-	call_integration_hook('integrate_pre_log_stats', array(&$no_stat_actions));
 
 	$should_log = !is_filtered_request($no_stat_actions, 'action');
 	if ($should_log)

--- a/index.php
+++ b/index.php
@@ -240,42 +240,6 @@ function smf_main()
 	if (!empty($topic) && empty($board_info['cur_topic_approved']) && !allowedTo('approve_posts') && ($user_info['id'] != $board_info['cur_topic_starter'] || $user_info['is_guest']))
 		fatal_lang_error('not_a_topic', false);
 
-	// Do some logging, unless this is an attachment, avatar, toggle of editor buttons, theme option, XML feed, popup, etc.
-	$no_stat_actions = array(
-		'about:unknown' => true,
-		'clock' => true,
-		'dlattach' => true,
-		'findmember' => true,
-		'helpadmin' => true,
-		'jsoption' => true,
-		'likes' => true,
-		'modifycat' => true,
-		'pm' => array('sa' => array('popup')),
-		'profile' => array('area' => array('popup', 'alerts_popup', 'download', 'dlattach')),
-		'requestmembers' => true,
-		'smstats' => true,
-		'suggest' => true,
-		'uploadAttach' => true,
-		'verificationcode' => true,
-		'viewquery' => true,
-		'viewsmfile' => true,
-		'xmlhttp' => true,
-		'.xml' => true,
-	);
-	call_integration_hook('integrate_pre_log_stats', array(&$no_stat_actions));
-
-	$should_log = !is_filtered_request($no_stat_actions, 'action');
-	if ($should_log)
-	{
-		// Log this user as online.
-		writeLog();
-
-		// Track forum statistics and hits...?
-		if (!empty($modSettings['hitStats']))
-			trackStats(array('hits' => '+'));
-	}
-	unset($no_stat_actions);
-
 	// Make sure that our scheduled tasks have been running as intended
 	check_cron();
 
@@ -336,6 +300,42 @@ function smf_main()
 			return 'Display';
 		}
 	}
+
+	// Do some logging, unless this is an attachment, avatar, toggle of editor buttons, theme option, XML feed, popup, etc.
+	$no_stat_actions = array(
+		'about:unknown' => true,
+		'clock' => true,
+		'dlattach' => true,
+		'findmember' => true,
+		'helpadmin' => true,
+		'jsoption' => true,
+		'likes' => true,
+		'modifycat' => true,
+		'pm' => array('sa' => array('popup')),
+		'profile' => array('area' => array('popup', 'alerts_popup', 'download', 'dlattach')),
+		'requestmembers' => true,
+		'smstats' => true,
+		'suggest' => true,
+		'uploadAttach' => true,
+		'verificationcode' => true,
+		'viewquery' => true,
+		'viewsmfile' => true,
+		'xmlhttp' => true,
+		'.xml' => true,
+	);
+	call_integration_hook('integrate_pre_log_stats', array(&$no_stat_actions));
+
+	$should_log = !is_filtered_request($no_stat_actions, 'action');
+	if ($should_log)
+	{
+		// Log this user as online.
+		writeLog();
+
+		// Track forum statistics and hits...?
+		if (!empty($modSettings['hitStats']))
+			trackStats(array('hits' => '+'));
+	}
+	unset($no_stat_actions);
 
 	// Here's the monstrous $_REQUEST['action'] array - $_REQUEST['action'] => array($file, $function).
 	$actionArray = array(


### PR DESCRIPTION
Partial for #9136 
Fixes #7453

Do any guest logging AFTER checking if guests should be kicked...

This will relieve I/O during bot attacks - no need to log folks who aren't doing anything.

Also, the logging was confusing - it made it look like they were doing something in Who's Online.