### PR TITLE
[3.0] Don't log guests if disallowed

### DIFF
--- a/Languages/en_US/Who.php
+++ b/Languages/en_US/Who.php
@@ -18,7 +18,6 @@ $txt['who_show_all'] = 'Everyone';
 $txt['who_no_online_spiders'] = 'There are currently no robots online.';
 $txt['who_no_online_guests'] = 'There are currently no guests online.';
 $txt['who_no_online_members'] = 'There are currently no members online.';
-$txt['who_guest_login'] = 'User has been taken to the login page.';
 
 $txt['whospider_login'] = 'Viewing the login page.';
 $txt['whospider_register'] = 'Viewing the registration page.';

--- a/Sources/Actions/Who.php
+++ b/Sources/Actions/Who.php
@@ -523,7 +523,7 @@ class Who implements ActionInterface, Routable
 
 			if (isset($actions['error'])) {
 				$error_message = Lang::getTxt(
-					$actions['error'] == 'guest_login' ? 'who_guest_login' : $actions['error'],
+					$actions['error'],
 					(array) ($actions['error_params'] ?? []),
 					file: 'Who+Errors',
 				);

--- a/Sources/Forum.php
+++ b/Sources/Forum.php
@@ -629,32 +629,6 @@ class Forum
 			ErrorHandler::fatalLang('not_a_topic', false);
 		}
 
-		// Don't log if this is an attachment, avatar, toggle of editor buttons,
-		// theme option, XML feed, popup, etc.
-		if (
-			self::$current_action?->canBeLogged() === true
-			|| (
-				self::$current_action === null
-				&& !QueryString::isFilteredRequest(self::$unlogged_actions, 'action')
-			)
-		) {
-			// Log this user as online.
-			User::$me->logOnline();
-
-			// Track forum statistics and hits...?
-			if (!empty(Config::$modSettings['hitStats'])) {
-				Logging::trackStats(['hits' => '+']);
-			}
-
-			// Login cookies should only expire after a period of inactivity.
-			// Since doing something worthy of logging means this member is
-			// actively engaged with the forum right now, refresh their login
-			// cookie in order to reset the countdown to its expiry date.
-			if (!User::$me->is_guest) {
-				Cookie::updateLoginCookieExpiry();
-			}
-		}
-
 		// Make sure that our scheduled tasks have been running as intended.
 		Config::checkCron();
 
@@ -681,6 +655,32 @@ class Forum
 			)
 		) {
 			User::$me->kickIfGuest(null, false);
+		}
+
+		// Don't log if this is an attachment, avatar, toggle of editor buttons,
+		// theme option, XML feed, popup, etc.
+		if (
+			self::$current_action?->canBeLogged() === true
+			|| (
+				self::$current_action === null
+				&& !QueryString::isFilteredRequest(self::$unlogged_actions, 'action')
+			)
+		) {
+			// Log this user as online.
+			User::$me->logOnline();
+
+			// Track forum statistics and hits...?
+			if (!empty(Config::$modSettings['hitStats'])) {
+				Logging::trackStats(['hits' => '+']);
+			}
+
+			// Login cookies should only expire after a period of inactivity.
+			// Since doing something worthy of logging means this member is
+			// actively engaged with the forum right now, refresh their login
+			// cookie in order to reset the countdown to its expiry date.
+			if (!User::$me->is_guest) {
+				Cookie::updateLoginCookieExpiry();
+			}
 		}
 	}
 

--- a/Sources/User.php
+++ b/Sources/User.php
@@ -1545,6 +1545,11 @@ class User implements \ArrayAccess
 			return;
 		}
 
+		// Log what they were trying to do that didn't work.
+		if ($log) {
+			$this->logOnline(true);
+		}
+
 		// Just die.
 		if (isset($_REQUEST['xml'])) {
 			Utils::obExit(false);

--- a/Sources/User.php
+++ b/Sources/User.php
@@ -1545,15 +1545,6 @@ class User implements \ArrayAccess
 			return;
 		}
 
-		// Log what they were trying to do that didn't work.
-		if ($log) {
-			if (!empty(Config::$modSettings['who_enabled'])) {
-				$_GET['error'] = 'guest_login';
-			}
-
-			$this->logOnline(true);
-		}
-
 		// Just die.
 		if (isset($_REQUEST['xml'])) {
 			Utils::obExit(false);


### PR DESCRIPTION
Partial for #9136 

Do any guest logging AFTER checking if guests should be kicked...

This will relieve I/O during bot attacks - no need to log folks who aren't doing anything.

Also, the logging was confusing - it made it look like they were doing something in Who's Online.