### PR TITLE
[2.1] Language must be a string, no arrays etc.

### DIFF
--- a/Sources/Load.php
+++ b/Sources/Load.php
@@ -938,7 +938,7 @@ function loadUserSettings()
 		$languages = getLanguages();
 
 		// Is it valid?
-		if (!empty($_GET['language']) && isset($languages[strtr($_GET['language'], './\\:', '____')]))
+		if (!empty($_GET['language']) && is_string($_GET['language']) && isset($languages[strtr($_GET['language'], './\\:', '____')]))
 		{
 			$user_info['language'] = strtr($_GET['language'], './\\:', '____');
 


### PR DESCRIPTION
Partial for #9173

This let bots flood the logs.  Simple fix.

Note that in 2.1 I sometimes saw MANY errors, 9 per request, for each of these.  But this was due to the language string being passed elsewhere, e.g., to mods, etc.  This one simple fix dealt with all of that.