### PR TITLE
[3.0] Language must be a string, no arrays etc.

### DIFF
--- a/Sources/User.php
+++ b/Sources/User.php
@@ -4513,7 +4513,7 @@ class User implements \ArrayAccess
 		$languages = Lang::get();
 
 		// Change was requested in URL parameters.
-		if (!empty($_GET['language']) && is_string($_GET['language']) && isset($languages[strtr($_GET['language'], './\\:', '____')])) {
+		if (!empty($_GET['language']) && \is_string($_GET['language']) && isset($languages[strtr($_GET['language'], './\\:', '____')])) {
 			$this->language = strtr($_GET['language'], './\\:', '____');
 
 			// Make it permanent for members.

--- a/Sources/User.php
+++ b/Sources/User.php
@@ -4513,7 +4513,7 @@ class User implements \ArrayAccess
 		$languages = Lang::get();
 
 		// Change was requested in URL parameters.
-		if (!empty($_GET['language']) && isset($languages[strtr($_GET['language'], './\\:', '____')])) {
+		if (!empty($_GET['language']) && is_string($_GET['language']) && isset($languages[strtr($_GET['language'], './\\:', '____')])) {
 			$this->language = strtr($_GET['language'], './\\:', '____');
 
 			// Make it permanent for members.


### PR DESCRIPTION
Partial for #9173

This let bots flood the logs.  Simple fix.

Note that in 3.0 there was a kinda ugly ripple effect, this caused lots of errors & a WSOD.  This one simple fix dealt with all of that.