### PR TITLE
[2.1] uninitialized permissions should not give error spam

### DIFF
--- a/Sources/ManagePermissions.php
+++ b/Sources/ManagePermissions.php
@@ -1822,7 +1822,8 @@ function init_inline_permissions($permissions, $excluded_groups = array())
 					'status' => 'off',
 				);
 
-		$context[$row['permission']][$row['id_group']]['status'] = empty($row['status']) ? 'deny' : ($row['status'] == 1 ? 'on' : 'off');
+		if (isset($row['permission']))
+			$context[$row['permission']][$row['id_group']]['status'] = empty($row['status']) ? 'deny' : ($row['status'] == 1 ? 'on' : 'off');
 	}
 	$smcFunc['db_free_result']($request);
 


### PR DESCRIPTION
- Install any mod that uses inline permissions
- I grabbed Message Bookmarks
- Run PHP 8.5
```
8192: Using null as an array offset is deprecated, use an empty string instead
```