### PR TITLE
fix base32 encode/decode

### DIFF
--- a/Sources/Uuid.php
+++ b/Sources/Uuid.php
@@ -1058,18 +1058,42 @@ class Uuid implements \Stringable
 	 * that PHP's base_convert() produces. This is different from basic base32,
 	 * which is specified in RFC 4648, section 6.
 	 *
+	 * This implementation is optimized specifically for UUIDs:
+	 *
 	 * @param string $hex A hexadecimal string.
 	 * @return string A base32hex string.
 	 */
 	protected static function encodeBase32Hex(string $hex): string
 	{
-		$b32 = '';
+		$bin = hex2bin($hex);
+		$alphabet = self::BASE32_HEX;
+		$buffer = 0;
+		$bits = 0;
+		$pos = 0;
 
-		foreach (str_split(strrev($hex), 10) as $chunk) {
-			$b32 = str_pad(base_convert(strrev($chunk), 16, 32), 8, '0', STR_PAD_LEFT) . $b32;
+		// UUID Base32 is always 26 chars
+		$out = str_repeat('0', 26);
+
+		// UUIDs are always exactly 128 bits (16 bytes).
+		for ($i = 0; $i < 16; $i++) {
+			// Each input byte contributes 8 bits to a buffer.
+			$buffer = ($buffer << 8) | \ord($bin[$i]);
+			$bits += 8;
+
+			// Output characters consume 5 bits at a time.  Remaining bits are carried forward between iterations.
+			while ($bits >= 5) {
+				$bits -= 5;
+
+				$out[$pos++] = $alphabet[($buffer >> $bits) & 31];
+			}
 		}
 
-		return ltrim($b32, '0');
+		// UUID Base32 encoding always leaves remaining bits.
+		if ($bits > 0) {
+			$out[$pos] = $alphabet[($buffer << (5 - $bits)) & 31];
+		}
+
+		return $out;
 	}
 
 	/**
@@ -1079,17 +1103,38 @@ class Uuid implements \Stringable
 	 * that PHP's base_convert() produces. This is different from basic base32,
 	 * which is specified in RFC 4648, section 6.
 	 *
+	 * This implementation is optimized specifically for UUIDs:
+	 *
 	 * @param string $b32 A base32hex string.
 	 * @return string A hexadecimal string.
 	 */
 	protected static function decodeBase32Hex(string $b32): string
 	{
-		$hex = '';
+		$buffer = 0;
+		$bits = 0;
+		$pos = 0;
 
-		foreach (str_split(strrev($b32), 8) as $chunk) {
-			$hex = str_pad(base_convert(strrev($chunk), 32, 16), 10, '0', STR_PAD_LEFT) . $hex;
+		// Decoded UUIDs are always exactly 16 bytes.
+		$out = str_repeat("\0", 16);
+
+		// UUID Base32 strings are always exactly 26 chars.
+		for ($i = 0; $i < 26; $i++) {
+			$c = \ord($b32[$i]);
+
+			// Convert ASCII to base32 (0-9 => 0-9, a-v => 10-31).
+			$buffer = ($buffer << 5) | ($c <= 57 ? $c - 48 : $c - 87);
+
+			// Each Base32 character contributes 5 bits to a buffer.
+			$bits += 5;
+
+			// Consume output bytes 8 bits at a time.
+			if ($bits >= 8) {
+				$bits -= 8;
+
+				$out[$pos++] = \chr(($buffer >> $bits) & 0xFF);
+			}
 		}
 
-		return ltrim($hex, '0');
+		return bin2hex($out);
 	}
 }


### PR DESCRIPTION
test script

```php
<?php

declare(strict_types=1);

use SMF\Uuid;

require_once __DIR__ . '/Uuid.php';

/**
 * Verify equality.
 */
function assertEqual(
	mixed $expected,
	mixed $actual,
	string $message
): void {
	if ($expected !== $actual) {
		throw new RuntimeException(
			$message .
			PHP_EOL .
			'Expected: ' . var_export($expected, true) .
			PHP_EOL .
			'Actual:   ' . var_export($actual, true)
		);
	}
}

/******************************************************************************
 * Base32 encode/decode correctness tests
 *****************************************************************************/

echo PHP_EOL;
echo "Running Base32 correctness tests..." . PHP_EOL;

/**
 * Test vectors.
 */
$vectors = [

	/******************************************************************************
	 * Nil UUID
	 *****************************************************************************/

	'00000000-0000-0000-0000-000000000000',

	/******************************************************************************
	 * Max UUID
	 *****************************************************************************/

	'ffffffff-ffff-ffff-ffff-ffffffffffff',

	/******************************************************************************
	 * RFC example UUIDs
	 *****************************************************************************/

	'6ba7b810-9dad-11d1-80b4-00c04fd430c8',
	'6ba7b811-9dad-11d1-80b4-00c04fd430c8',
	'6ba7b812-9dad-11d1-80b4-00c04fd430c8',

	/******************************************************************************
	 * Random fixed UUIDs
	 *****************************************************************************/

	'019e0e2e-4a3a-7fb1-8754-29d817add942',
	'12345678-1234-5678-9abc-def012345678',
	'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
	'deadbeef-cafe-babe-face-0123456789ab',

	/******************************************************************************
	 * Leading zero stress
	 *****************************************************************************/

	'00000001-0000-0000-0000-000000000000',
	'00000000-0000-0000-0000-000000000001',
	'00000000-0000-0000-0000-ffffffffffff',

	/******************************************************************************
	 * Trailing bit stress
	 *****************************************************************************/

	'ffffffff-ffff-ffff-ffff-fffffffffffe',
	'ffffffff-ffff-ffff-ffff-ffffffffffff',
];

/******************************************************************************
 * Test both implementations
 *****************************************************************************/

echo PHP_EOL;
echo "Testing {Uuid}" . PHP_EOL;

foreach ($vectors as $uuid) {

	/******************************************************************************
	 * Encode
	 *****************************************************************************/

	$b32 = Uuid::compress(
		$uuid,
		Uuid::COMPRESS_BASE32
	);

	/******************************************************************************
	 * Length check
	 *****************************************************************************/

	assertEqual(
		26,
		strlen($b32),
		"Base32 length mismatch for {$uuid}"
	);

	/******************************************************************************
	 * Character set check
	 *****************************************************************************/

	if (
		strspn(
			$b32,
			Uuid::BASE32_ALT
		) !== 26
	) {
		throw new RuntimeException(
			"Invalid Base32 chars for {$uuid}: {$b32}"
		);
	}

	/******************************************************************************
	 * Decode
	 *****************************************************************************/

	$expanded = Uuid::expand($b32);

	/******************************************************************************
	 * Roundtrip check
	 *****************************************************************************/

	assertEqual(
		strtolower($uuid),
		strtolower($expanded),
		"Base32 roundtrip failed"
	);

	/******************************************************************************
	 * Stability check
	 *****************************************************************************/

	$b32_2 = Uuid::compress(
		$expanded,
		Uuid::COMPRESS_BASE32
	);

	assertEqual(
		$b32,
		$b32_2,
		"Base32 stability failed"
	);
}

echo "  OK" . PHP_EOL;

/******************************************************************************
 * Random fuzz tests
 *****************************************************************************/

echo PHP_EOL;
echo "Running Base32 fuzz tests..." . PHP_EOL;

for ($i = 0; $i < 10000; $i++) {

	/******************************************************************************
	 * Generate UUID
	 *****************************************************************************/

	$uuid = (string) new Uuid(7);

	/******************************************************************************
	 * Encode/decode
	 *****************************************************************************/

	$b32 = Uuid::compress(
		$uuid,
		Uuid::COMPRESS_BASE32
	);

	$expanded = Uuid::expand($b32);

	/******************************************************************************
	 * Verify exact roundtrip
	 *****************************************************************************/

	assertEqual(
		strtolower($uuid),
		strtolower($expanded),
		"Fuzz roundtrip failed at iteration {$i}"
	);
}

echo "Fuzz tests passed." . PHP_EOL;
```