### PR TITLE
[3.0] Handles enum case in ordered_class_elements rule of coding standard

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -67,6 +67,7 @@ return (new PhpCsFixer\Config())
 		'ordered_class_elements' => [
 			'order' => [
 				'use_trait',
+				'case',
 				'constant_public',
 				'constant_protected',
 				'constant_private',


### PR DESCRIPTION
This was supposed to be included in #9189.