### PR TITLE
[3.0] Deprecate hooks without standard prefixes

### DIFF
--- a/Sources/Actions/Who.php
+++ b/Sources/Actions/Who.php
@@ -376,6 +376,9 @@ class Who implements ActionInterface, Routable
 			return [];
 		}
 
+		IntegrationHook::call('integrate_who_allowed', [&self::$allowedActions]);
+
+		// This hook is depreated because it is missing the corerct prefix.
 		IntegrationHook::call('who_allowed', [&self::$allowedActions]);
 
 		if (!\is_array($urls)) {
@@ -642,6 +645,9 @@ class Who implements ActionInterface, Routable
 			Db::$db->free_result($result);
 		}
 
+		IntegrationHook::call('integrate_whos_online_after', [&$url_list, &$data]);
+
+		// This hook is depreated because it is missing the corerct prefix.
 		IntegrationHook::call('whos_online_after', [&$urls, &$data]);
 
 		if (!\is_array($urls)) {


### PR DESCRIPTION
### Summary

This pull request adds new integration hooks to the Who's Online action processing flow while preserving backward compatibility with existing hooks.

### Changes

* Added a new `integrate_who_allowed` hook before action determination begins, allowing integrations to modify the list of allowed actions used by `Who::determineActions()`.
* Added a new `integrate_whos_online_after` hook after Who's Online data has been processed, allowing integrations to inspect or modify the generated URL list and user activity data.
* Retained the existing `who_allowed` and `whos_online_after` hooks for backward compatibility.
* Added comments marking the legacy hooks as deprecated because they do not follow the standard `integrate_` hook naming convention.

### Why

The existing hooks were created without the standard `integrate_` prefix used throughout SMF's integration system. Adding correctly named hooks provides a consistent API for new integrations while ensuring older modifications continue to function unchanged.

### Compatibility

* No breaking changes.
* Existing integrations using `who_allowed` or `whos_online_after` will continue to work.
* New integrations should use `integrate_who_allowed` and `integrate_whos_online_after` instead.