### PR TITLE
[2.1] Deprecate hooks without standard prefixes

### DIFF
--- a/Sources/Who.php
+++ b/Sources/Who.php
@@ -315,6 +315,9 @@ function determineActions($urls, $preferred_prefix = false)
 		'viewerrorlog' => array('admin_forum'),
 		'viewmembers' => array('moderate_forum'),
 	);
+	call_integration_hook('integrate_who_allowed', array(&$allowedActions));
+
+	// This hook is depreated because it is missing the corerct prefix.
 	call_integration_hook('who_allowed', array(&$allowedActions));
 
 	if (!is_array($urls))
@@ -560,6 +563,9 @@ function determineActions($urls, $preferred_prefix = false)
 		$smcFunc['db_free_result']($result);
 	}
 
+	call_integration_hook('integrate_whos_online_after', array(&$url_list, &$data));
+
+	// This hook is depreated because it is missing the corerct prefix.
 	call_integration_hook('whos_online_after', array(&$urls, &$data));
 
 	if (!is_array($urls))

--- a/Sources/Who.php
+++ b/Sources/Who.php
@@ -317,7 +317,7 @@ function determineActions($urls, $preferred_prefix = false)
 	);
 	call_integration_hook('integrate_who_allowed', array(&$allowedActions));
 
-	// This hook is depreated because it is missing the corerct prefix.
+	// This hook is deprecated because it is missing the correct prefix.
 	call_integration_hook('who_allowed', array(&$allowedActions));
 
 	if (!is_array($urls))
@@ -565,7 +565,7 @@ function determineActions($urls, $preferred_prefix = false)
 
 	call_integration_hook('integrate_whos_online_after', array(&$url_list, &$data));
 
-	// This hook is depreated because it is missing the corerct prefix.
+	// This hook is deprecated because it is missing the correct prefix.
 	call_integration_hook('whos_online_after', array(&$urls, &$data));
 
 	if (!is_array($urls))


### PR DESCRIPTION
### Summary

This pull request adds new integration hooks to the Who's Online action processing flow while preserving backward compatibility with existing hooks.

### Changes

* Added a new `integrate_who_allowed` hook before action determination begins, allowing integrations to modify the list of allowed actions used by `determineActions()`.
* Added a new `integrate_whos_online_after` hook after Who's Online data has been processed, allowing integrations to inspect or modify the generated URL list and user activity data.
* Retained the existing `who_allowed` and `whos_online_after` hooks for backward compatibility.
* Added comments marking the legacy hooks as deprecated because they do not follow the standard `integrate_` hook naming convention.

### Why

The existing hooks were created without the standard `integrate_` prefix used throughout SMF's integration system. Adding correctly named hooks provides a consistent API for new integrations while ensuring older modifications continue to function unchanged.

### Compatibility

* No breaking changes.
* Existing integrations using `who_allowed` or `whos_online_after` will continue to work, but should be updated to use `integrate_who_allowed` and `integrate_whos_online_after` instead.