### PR TITLE
[3.0] Misc fixes for SMF\User

### DIFF
--- a/Sources/Actions/AutoSuggest.php
+++ b/Sources/Actions/AutoSuggest.php
@@ -18,6 +18,7 @@ namespace SMF\Actions;
 use SMF\ActionInterface;
 use SMF\ActionRouter;
 use SMF\ActionTrait;
+use SMF\Config;
 use SMF\Db\DatabaseApi as Db;
 use SMF\IntegrationHook;
 use SMF\OutputTypeInterface;
@@ -135,6 +136,11 @@ class AutoSuggest implements ActionInterface, Routable
 				'children' => [],
 			],
 		];
+
+		// Can't search for buddies if that feature is disabled.
+		if (empty(Config::$modSettings['enable_buddylist'])) {
+			unset($this->search_param['buddies']);
+		}
 
 		// Find the member.
 		$request = Db::$db->query(

--- a/Sources/Actions/BoardIndex.php
+++ b/Sources/Actions/BoardIndex.php
@@ -436,7 +436,7 @@ class BoardIndex implements ActionInterface, Routable
 			$parent = Board::$loaded[$row_board['id_parent']] ?? null;
 
 			// Perhaps we are ignoring this board?
-			$ignoreThisBoard = \in_array($row_board['id_board'], User::$me->ignoreboards);
+			$ignoreThisBoard = !empty(Config::$modSettings['allow_ignore_boards']) && \in_array($row_board['id_board'], User::$me->ignoreboards);
 			$row_board['is_read'] = !empty($row_board['is_read']) || $ignoreThisBoard ? '1' : '0';
 
 			if ($board_index_options['include_categories']) {

--- a/Sources/Actions/BoardIndex.php
+++ b/Sources/Actions/BoardIndex.php
@@ -80,7 +80,7 @@ class BoardIndex implements ActionInterface, Routable
 
 		// Set a few minor things.
 		Utils::$context['show_stats'] = User::$me->allowedTo('view_stats') && !empty(Config::$modSettings['trackStats']);
-		Utils::$context['show_buddies'] = !empty(User::$me->buddies);
+		Utils::$context['show_buddies'] = !empty(User::$me->buddies) && !empty(Config::$modSettings['enable_buddylist']);
 		Utils::$context['show_who'] = User::$me->allowedTo('who_view') && !empty(Config::$modSettings['who_enabled']);
 
 		// Retrieve the categories and boards.

--- a/Sources/Actions/BuddyListToggle.php
+++ b/Sources/Actions/BuddyListToggle.php
@@ -19,6 +19,7 @@ use SMF\ActionInterface;
 use SMF\ActionRouter;
 use SMF\ActionTrait;
 use SMF\Cache\CacheApi;
+use SMF\Config;
 use SMF\Db\DatabaseApi as Db;
 use SMF\ErrorHandler;
 use SMF\Routable;
@@ -61,7 +62,7 @@ class BuddyListToggle implements ActionInterface, Routable
 		User::$me->isAllowedTo('profile_extra_own');
 		User::$me->kickIfGuest();
 
-		if (empty($this->userReceiver)) {
+		if (empty($this->userReceiver) || empty(Config::$modSettings['enable_buddylist'])) {
 			ErrorHandler::fatalLang('no_access', false);
 		}
 

--- a/Sources/Actions/Calendar.php
+++ b/Sources/Actions/Calendar.php
@@ -1511,7 +1511,10 @@ class Calendar implements ActionInterface, Routable
 		foreach ($cache_block['data']['calendar_events'] as $k => $event) {
 			// Remove events that the user may not see or wants to ignore.
 			if (
-				\in_array($event->id_board, User::$me->ignoreboards)
+				(
+					!empty(Config::$modSettings['allow_ignore_boards'])
+					&& \in_array($event->id_board, User::$me->ignoreboards)
+				)
 				|| (
 					\count(array_intersect(User::$me->groups, $event->allowed_groups)) === 0
 					&& !User::$me->allowedTo('admin_forum')

--- a/Sources/Actions/Display.php
+++ b/Sources/Actions/Display.php
@@ -861,7 +861,7 @@ class Display implements ActionInterface, Routable
 					$link = '<a href="' . Config::$scripturl . '?action=profile;u=' . $row['id_member'] . '">' . $row['real_name'] . '</a>';
 				}
 
-				$is_buddy = \in_array($row['id_member'], User::$me->buddies);
+				$is_buddy = !empty(Config::$modSettings['enable_buddylist']) && \in_array($row['id_member'], User::$me->buddies);
 
 				if ($is_buddy) {
 					$link = '<strong>' . $link . '</strong>';

--- a/Sources/Actions/MessageIndex.php
+++ b/Sources/Actions/MessageIndex.php
@@ -870,7 +870,7 @@ class MessageIndex implements ActionInterface, Routable
 					$link = '<a href="' . Config::$scripturl . '?action=profile;u=' . $row['id_member'] . '">' . $row['real_name'] . '</a>';
 				}
 
-				$is_buddy = \in_array($row['id_member'], User::$me->buddies);
+				$is_buddy = !empty(Config::$modSettings['enable_buddylist']) && \in_array($row['id_member'], User::$me->buddies);
 
 				if ($is_buddy) {
 					$link = '<strong>' . $link . '</strong>';

--- a/Sources/Actions/RequestMembers.php
+++ b/Sources/Actions/RequestMembers.php
@@ -18,6 +18,7 @@ namespace SMF\Actions;
 use SMF\ActionInterface;
 use SMF\ActionRouter;
 use SMF\ActionTrait;
+use SMF\Config;
 use SMF\Db\DatabaseApi as Db;
 use SMF\Routable;
 use SMF\User;
@@ -64,6 +65,11 @@ class RequestMembers implements ActionInterface, Routable
 		User::$me->checkSession('get');
 
 		header('content-type: text/plain; charset=UTF-8');
+
+		// Can't search for buddies if that feature is disabled.
+		if (empty(Config::$modSettings['enable_buddylist'])) {
+			unset($_REQUEST['buddies']);
+		}
 
 		$request = Db::$db->query(
 			'SELECT real_name

--- a/Sources/Actions/Search.php
+++ b/Sources/Actions/Search.php
@@ -209,7 +209,7 @@ class Search implements ActionInterface, Routable
 				}
 				// User didn't select any boards, so select all except ignored and recycle boards.
 				else {
-					$board->selected = !$board->recycle && !\in_array($board->id, User::$me->ignoreboards);
+					$board->selected = !$board->recycle && (empty(Config::$modSettings['allow_ignore_boards']) || !\in_array($board->id, User::$me->ignoreboards));
 				}
 
 				if (!$board->selected && !$board->recycle) {

--- a/Sources/Logging.php
+++ b/Sources/Logging.php
@@ -669,7 +669,7 @@ class Logging
 			}
 
 			// Buddies get counted and highlighted.
-			$is_buddy = \in_array($row['id_member'], User::$me->buddies);
+			$is_buddy = !empty(Config::$modSettings['enable_buddylist']) && \in_array($row['id_member'], User::$me->buddies);
 
 			if ($is_buddy) {
 				$membersOnlineStats['num_buddies']++;

--- a/Sources/Parser.php
+++ b/Sources/Parser.php
@@ -230,11 +230,11 @@ abstract class Parser
 	public static string $locale;
 
 	/**
-	 * @var int
+	 * @var float
 	 *
 	 * User's time offset from UTC.
 	 */
-	public static int $time_offset;
+	public static float $time_offset;
 
 	/**
 	 * @var string

--- a/Sources/ServerSideIncludes.php
+++ b/Sources/ServerSideIncludes.php
@@ -1694,7 +1694,7 @@ class ServerSideIncludes
 
 		$bracketList = [];
 
-		if (!empty(User::$me->buddies)) {
+		if (!empty(Config::$modSettings['enable_buddylist']) && !empty(User::$me->buddies)) {
 			$bracketList[] = Lang::getTxt('number_of_buddies', [$return['num_buddies']], file: 'General');
 		}
 

--- a/Sources/Subs-Compat.php
+++ b/Sources/Subs-Compat.php
@@ -10682,11 +10682,13 @@ if (!empty(SMF\Config::$backward_compatibility)) {
 	 */
 	function banPermissions(): void
 	{
-		if (!isset(SMF\User::$me->permission_set)) {
+		if (!isset(SMF\User::$me->permission_sets)) {
 			SMF\User::$me->loadPermissions();
 		}
 
-		SMF\User::$me->permission_set->applyBansAndWarnings();
+		foreach (SMF\User::$me->permission_sets as $set) {
+			$set->applyBansAndWarnings();
+		}
 	}
 
 	/**

--- a/Sources/Tasks/AnonymizeEditHistory.php
+++ b/Sources/Tasks/AnonymizeEditHistory.php
@@ -56,7 +56,6 @@ class AnonymizeEditHistory extends BackgroundTask
 
 		if (Db::$title === POSTGRE_TITLE) {
 			$request = Db::$db->query(
-				'',
 				'SELECT id_msg, edit_history
 				FROM {db_prefix}messages
 				WHERE edit_history @? {string:jsonpath}
@@ -69,7 +68,6 @@ class AnonymizeEditHistory extends BackgroundTask
 			);
 		} else {
 			$request = Db::$db->query(
-				'',
 				'SELECT id_msg, edit_history
 				FROM {db_prefix}messages
 				WHERE {int:member} MEMBER OF (edit_history->{string:path})
@@ -98,7 +96,6 @@ class AnonymizeEditHistory extends BackgroundTask
 			$row['edit_history'] = json_encode($row['edit_history']);
 
 			Db::$db->query(
-				'',
 				'UPDATE {db_prefix}messages
 				SET edit_history = {string:edit_history}
 				WHERE id_msg = {int:id_msg}',

--- a/Sources/User.php
+++ b/Sources/User.php
@@ -1039,8 +1039,8 @@ class User implements \ArrayAccess
 				'username_color' => '<span ' . (!empty($this->group_color) ? 'style="color:' . $this->group_color . ';"' : '') . '>' . $this->username . '</span>',
 				'name_color' => '<span ' . (!empty($this->group_color) ? 'style="color:' . $this->group_color . ';"' : '') . '>' . $this->name . '</span>',
 				'link_color' => '<a href="' . Config::$scripturl . '?action=profile;u=' . $this->id . '" title="' . Lang::getTxt('view_profile_of_username', ['name' => $this->name], file: 'General') . '" ' . (!empty($this->group_color) ? 'style="color:' . $this->group_color . ';"' : '') . '>' . $this->name . '</a>',
-				'is_buddy' => \in_array($this->id, self::$me->buddies),
-				'is_reverse_buddy' => \in_array(self::$me->id, $this->buddies),
+				'is_buddy' => !empty(Config::$modSettings['enable_buddylist']) && \in_array($this->id, self::$me->buddies),
+				'is_reverse_buddy' => !empty(Config::$modSettings['enable_buddylist']) && \in_array(self::$me->id, $this->buddies),
 				'buddies' => $this->buddies,
 				'title' => !empty(Config::$modSettings['titlesEnable']) ? $this->title : '',
 				'blurb' => $this->personal_text,
@@ -3620,7 +3620,7 @@ class User implements \ArrayAccess
 				AND is_activated IN ({array_int:activated})
 			LIMIT {int:limit}',
 			array_merge($where_params, [
-				'buddy_list' => self::$me->buddies,
+				'buddy_list' => !empty(Config::$modSettings['enable_buddylist']) ? self::$me->buddies : [],
 				'limit' => $max,
 				'activated' => [self::ACTIVATED, self::ACTIVATED_BANNED],
 			]),
@@ -3946,7 +3946,7 @@ class User implements \ArrayAccess
 		$this->time_offset = (int) ($profile['time_offset'] ?? 0);
 
 		// Buddies and personal messages.
-		$this->buddies = !empty(Config::$modSettings['enable_buddylist']) && !empty($profile['buddy_list']) ? explode(',', $profile['buddy_list']) : [];
+		$this->buddies = !empty($profile['buddy_list']) ? explode(',', $profile['buddy_list']) : [];
 		$this->ignoreusers = !empty($profile['pm_ignore_list']) ? explode(',', $profile['pm_ignore_list']) : [];
 		$this->pm_receive_from = (int) ($profile['pm_receive_from'] ?? 0);
 		$this->pm_prefs = (int) ($profile['pm_prefs'] ?? 0);

--- a/Sources/User.php
+++ b/Sources/User.php
@@ -1026,6 +1026,7 @@ class User implements \ArrayAccess
 				foreach (['actual_theme_dir' => 'images_url', 'default_theme_dir' => 'default_images_url'] as $dir => $url) {
 					if (file_exists(Theme::$current->settings[$dir] . '/images/membericons/' . $this->icons[1])) {
 						$group_icon_url = Theme::$current->settings[$url] . '/membericons/' . $this->icons[1];
+						break;
 					}
 				}
 			}

--- a/Sources/User.php
+++ b/Sources/User.php
@@ -3461,7 +3461,7 @@ class User implements \ArrayAccess
 		}
 
 		// Check for similar existing member names.
-		if (Unicode\SpoofDetector::checkSimilarMemberName($name, $id_member ?? 0, $fatal)) {
+		if (Unicode\SpoofDetector::checkSimilarMemberName($name, $current_id_member ?? 0, $fatal)) {
 			return true;
 		}
 

--- a/Sources/User.php
+++ b/Sources/User.php
@@ -347,11 +347,11 @@ class User implements \ArrayAccess
 	public string $timezone;
 
 	/**
-	 * @var int
+	 * @var float
 	 *
 	 * The UTC offset of the user's time zone.
 	 */
-	public int $time_offset;
+	public float $time_offset;
 
 	/**
 	 * @var int

--- a/Sources/User.php
+++ b/Sources/User.php
@@ -2724,7 +2724,7 @@ class User implements \ArrayAccess
 		// This will take the place of query_see_boards in certain spots, so it better include the boards they can see also
 
 		// If they aren't ignoring any boards then they want to see all the boards they can see
-		if (empty($ignoreboards)) {
+		if (empty(Config::$modSettings['allow_ignore_boards']) || empty($this->ignoreboards)) {
 			$query_part['query_wanna_see_board'] = $query_part['query_see_board'];
 			$query_part['query_wanna_see_message_board'] = $query_part['query_see_message_board'];
 			$query_part['query_wanna_see_topic_board'] = $query_part['query_see_topic_board'];

--- a/Sources/User.php
+++ b/Sources/User.php
@@ -2883,7 +2883,7 @@ class User implements \ArrayAccess
 					$val = max(0, $val);
 				}
 
-				User::$loaded[$member]->set([$var, $val]);
+				User::$loaded[$member]->set([$var => $val]);
 			}
 		}
 

--- a/Sources/User.php
+++ b/Sources/User.php
@@ -1861,8 +1861,8 @@ class User implements \ArrayAccess
 		}
 
 		// Fix up the banning permissions.
-		if (isset($this->permissions_set)) {
-			$this->permissions_set->applyBansAndWarnings();
+		foreach ($this->permission_sets as $set) {
+			$set->applyBansAndWarnings();
 		}
 	}
 


### PR DESCRIPTION
1. [Applies bans and warnings correctly in SMF\User::kickIfBanned()](https://github.com/SimpleMachines/SMF/commit/64f7d81dd99c9d8e78eb5febfd0d6c959bfdb76d)
    - Referred to an object property that doesn't exist rather than the property that does.
2. [Fixes bug checking spoofed names in User::isReservedName()](https://github.com/SimpleMachines/SMF/commit/cc5770097ae62774001cb726a69ed85f8727a751)
    - Fixes an incorrect variable name.
3. [Fixes queries in SMF\Tasks\AnonymizeEditHistory::execute()](https://github.com/SimpleMachines/SMF/commit/152b8c13eba0e9fca64cb4d8ecbe5fd6a2bc27b1)
    - Fixes incorrect argument order when passing arguments to Db::$db->query().
4. [Respects custom themes' membergroup icons in SMF\User::format()](https://github.com/SimpleMachines/SMF/commit/9622f9ad85451c67e01be21135cb0d48537475bb)
    - Previously, custom themes' membergroup icons would be overwritten by the default theme's.
5. [Correctly updates loaded objects in SMF\User::updateMemberData()](https://github.com/SimpleMachines/SMF/commit/56f9eb8c7f56ffc562b588519d7cecde94d3420e)
    - Previously passed `[$var, $val]` to `set()` method, but should have passed `[$var => $val]`.
6. [Fixes type of SMF\User::$time_offset](https://github.com/SimpleMachines/SMF/commit/8c00abb65ba44806087b8d2729417f35c59dd0ed)
    - Float, not int.
7. [Preserves buddy list in User properties even if feature is disabled](https://github.com/SimpleMachines/SMF/commit/2694d4b1c63209c6bf1d1ab3b1ffd3fd9f751f71)
    - Previously, this data was handled inconsistently and could be permanently lost if the related feature was disabled.
8. [Preserve ignored boards in User properties even if feature is disabled](https://github.com/SimpleMachines/SMF/commit/33b1d95f4aa1de7ad229b062a063c581b3c2755b)
    - Previously, this data was handled inconsistently and could be permanently lost if the related feature was disabled.