### PR TITLE
[3.0] Revert "Preserve ignored boards in User properties even if feature is disabled"

### DIFF
--- a/Sources/Actions/BoardIndex.php
+++ b/Sources/Actions/BoardIndex.php
@@ -436,7 +436,7 @@ class BoardIndex implements ActionInterface, Routable
 			$parent = Board::$loaded[$row_board['id_parent']] ?? null;
 
 			// Perhaps we are ignoring this board?
-			$ignoreThisBoard = !empty(Config::$modSettings['allow_ignore_boards']) && \in_array($row_board['id_board'], User::$me->ignoreboards);
+			$ignoreThisBoard = \in_array($row_board['id_board'], User::$me->ignoreboards);
 			$row_board['is_read'] = !empty($row_board['is_read']) || $ignoreThisBoard ? '1' : '0';
 
 			if ($board_index_options['include_categories']) {

--- a/Sources/Actions/Calendar.php
+++ b/Sources/Actions/Calendar.php
@@ -1511,10 +1511,7 @@ class Calendar implements ActionInterface, Routable
 		foreach ($cache_block['data']['calendar_events'] as $k => $event) {
 			// Remove events that the user may not see or wants to ignore.
 			if (
-				(
-					!empty(Config::$modSettings['allow_ignore_boards'])
-					&& \in_array($event->id_board, User::$me->ignoreboards)
-				)
+				\in_array($event->id_board, User::$me->ignoreboards)
 				|| (
 					\count(array_intersect(User::$me->groups, $event->allowed_groups)) === 0
 					&& !User::$me->allowedTo('admin_forum')

--- a/Sources/Actions/Search.php
+++ b/Sources/Actions/Search.php
@@ -209,7 +209,7 @@ class Search implements ActionInterface, Routable
 				}
 				// User didn't select any boards, so select all except ignored and recycle boards.
 				else {
-					$board->selected = !$board->recycle && (empty(Config::$modSettings['allow_ignore_boards']) || !\in_array($board->id, User::$me->ignoreboards));
+					$board->selected = !$board->recycle && !\in_array($board->id, User::$me->ignoreboards);
 				}
 
 				if (!$board->selected && !$board->recycle) {

--- a/Sources/User.php
+++ b/Sources/User.php
@@ -2724,7 +2724,7 @@ class User implements \ArrayAccess
 		// This will take the place of query_see_boards in certain spots, so it better include the boards they can see also
 
 		// If they aren't ignoring any boards then they want to see all the boards they can see
-		if (empty(Config::$modSettings['allow_ignore_boards']) || empty($this->ignoreboards)) {
+		if (empty($ignoreboards)) {
 			$query_part['query_wanna_see_board'] = $query_part['query_see_board'];
 			$query_part['query_wanna_see_message_board'] = $query_part['query_see_message_board'];
 			$query_part['query_wanna_see_topic_board'] = $query_part['query_see_topic_board'];


### PR DESCRIPTION
Whoops! That commit wasn't supposed to be included in #9260.

This reverts commit 33b1d95f4aa1de7ad229b062a063c581b3c2755b.