### PR TITLE
Further improves SectionComments

### DIFF
--- a/.github/phpcs/SectionComments.php
+++ b/.github/phpcs/SectionComments.php
@@ -99,10 +99,10 @@ final class SectionComments extends AbstractFixer
 		];
 
 		foreach ($this->comments as $type => $string) {
-			$regexes[$type] = preg_replace('/\s+/', '\s+', preg_quote($string, '/'));
+			$words[] = trim($string, "/* \n\t");
 		}
 
-		$this->comment_regex = implode('|', $regexes);
+		$this->comment_regex = '/^\/[*\s]+(?:' . implode('|', $words) . ')[*\s]+\/$/';
 	}
 
 	public function getName(): string
@@ -207,31 +207,15 @@ final class SectionComments extends AbstractFixer
 
 	protected function applyFix(\SplFileInfo $file, Tokens $tokens): void
 	{
-		// First remove any existing section comments.
-		foreach ($tokens as $key => $token) {
-			if ($token->getName() === 'T_COMMENT') {
-				if (preg_match('/^' . $this->comment_regex . '$/', $token->getContent())) {
-					$tokens->clearAt($key);
+		$existing = [];
 
-					if ($tokens[$key + 1]->isWhitespace()) {
-						$tokens[$key + 1] = new Token([
-							T_WHITESPACE,
-							"\n\n\t",
-						]);
-					} else {
-						$tokens->insertAt(
-							$key + 1,
-							new Token([
-								T_WHITESPACE,
-								"\n\n\t",
-							]),
-						);
-					}
+		foreach ($tokens as $key => $token) {
+			if ($token->getId() === T_COMMENT) {
+				if (preg_match($this->comment_regex, $token->getContent())) {
+					$existing[$key] = true;
 				}
 			}
 		}
-
-		$tokens->clearEmptyTokens();
 
 		// Does this file contain an enumeration?
 		$is_enum = $tokens->isAnyTokenKindsFound([T_ENUM]);
@@ -254,57 +238,58 @@ final class SectionComments extends AbstractFixer
 		$in = [];
 
 		foreach ($tokens as $key => $token) {
-			$name = $token->getName();
+			$id = $token->getId();
 
 			// Build up the list of token types so that we can figure out
 			// which comment type we will want.
 			if (\in_array(
-				$name,
-				empty($in) ? [
-					'T_PUBLIC',
-					'T_PROTECTED',
-					'T_PRIVATE',
-					$is_enum && !$exists['case'] ? 'T_CASE' : NAN,
+				$id,
+				$in === [] ? [
+					T_PUBLIC,
+					T_PROTECTED,
+					T_PRIVATE,
+					$is_enum && !$exists['case'] ? T_CASE : -1,
 				] : [
-					'T_CONST',
-					'T_STATIC',
-					'T_VARIABLE',
-					'T_FUNCTION',
+					T_CONST,
+					T_STATIC,
+					T_VARIABLE,
+					T_FUNCTION,
 				],
+				true,
 			)) {
-				$in[$name] = $key;
+				$in[$id] = $key;
 			}
 
 			// Which comment type do we want to insert?
-			if (\array_key_exists('T_CONST', $in)) {
+			if (isset($in[T_CONST])) {
 				$insert_type = 'const';
-			} elseif ($is_enum && !$exists['case'] && \array_key_exists('T_CASE', $in)) {
+			} elseif ($is_enum && !$exists['case'] && isset($in[T_CASE])) {
 				$insert_type = 'case';
-			} elseif (\array_key_exists('T_VARIABLE', $in)) {
-				if (\array_key_exists('T_STATIC', $in)) {
-					if (\array_key_exists('T_PUBLIC', $in)) {
+			} elseif (isset($in[T_VARIABLE])) {
+				if (isset($in[T_STATIC])) {
+					if (isset($in[T_PUBLIC])) {
 						$insert_type = 'public_static_property';
-					} elseif (\array_key_exists('T_PROTECTED', $in) || \array_key_exists('T_PRIVATE', $in)) {
+					} elseif (isset($in[T_PROTECTED]) || isset($in[T_PRIVATE])) {
 						$insert_type = 'internal_static_property';
 					}
 				} else {
-					if (\array_key_exists('T_PUBLIC', $in)) {
+					if (isset($in[T_PUBLIC])) {
 						$insert_type = 'public_property';
-					} elseif (\array_key_exists('T_PROTECTED', $in) || \array_key_exists('T_PRIVATE', $in)) {
+					} elseif (isset($in[T_PROTECTED]) || isset($in[T_PRIVATE])) {
 						$insert_type = 'internal_property';
 					}
 				}
-			} elseif (\array_key_exists('T_FUNCTION', $in)) {
-				if (\array_key_exists('T_STATIC', $in)) {
-					if (\array_key_exists('T_PUBLIC', $in)) {
+			} elseif (isset($in[T_FUNCTION])) {
+				if (isset($in[T_STATIC])) {
+					if (isset($in[T_PUBLIC])) {
 						$insert_type = 'public_static_method';
-					} elseif (\array_key_exists('T_PROTECTED', $in) || \array_key_exists('T_PRIVATE', $in)) {
+					} elseif (isset($in[T_PROTECTED]) || isset($in[T_PRIVATE])) {
 						$insert_type = 'internal_static_method';
 					}
 				} else {
-					if (\array_key_exists('T_PUBLIC', $in)) {
+					if (isset($in[T_PUBLIC])) {
 						$insert_type = 'public_method';
-					} elseif (\array_key_exists('T_PROTECTED', $in) || \array_key_exists('T_PRIVATE', $in)) {
+					} elseif (isset($in[T_PROTECTED]) || isset($in[T_PRIVATE])) {
 						$insert_type = 'internal_method';
 					}
 				}
@@ -332,31 +317,58 @@ final class SectionComments extends AbstractFixer
 					// Now we need to take one step forward again.
 					$insert_at++;
 
-					// Create the comment to insert.
-					$to_insert = [
-						new Token([
-							T_COMMENT,
-							$this->comments[$insert_type],
-						]),
-					];
+					if ($tokens[$insert_at]->getContent() !== $this->comments[$insert_type]) {
+						// Create the comment to insert.
+						$to_insert = [
+							new Token([
+								T_COMMENT,
+								$this->comments[$insert_type],
+							]),
+						];
 
-					// If necessary, also insert some whitespace.
-					if (!$tokens[$insert_at]->isWhitespace()) {
-						$to_insert[] = new Token([
-							T_WHITESPACE,
-							"\n\n\t",
-						]);
+						// If necessary, also insert some whitespace.
+						if (!$tokens[$insert_at]->isWhitespace()) {
+							$to_insert[] = new Token([
+								T_WHITESPACE,
+								"\n\n\t",
+							]);
+						}
+
+						// Insert our comment.
+						$slices[$insert_at] = $to_insert;
+
+						// This comment type has now been done.
+						$exists[$insert_type] = true;
+					} else {
+						// Normalize whitespace.
+						if ($tokens[$insert_at + 1]->isWhitespace()) {
+							$tokens[$insert_at + 1] = new Token([
+								T_WHITESPACE,
+								"\n\n\t",
+							]);
+						}
+
+						$exists[$insert_type] = true;
+
+						// Do not remove this token.
+						if (isset($existing[$insert_at])) {
+							unset($existing[$insert_at]);
+						}
 					}
-
-					// Insert our comment.
-					$slices[$insert_at] = $to_insert;
-
-					// This comment type has now been done.
-					$exists[$insert_type] = true;
 				}
 
 				$in = [];
 				unset($insert_type);
+			}
+		}
+
+		// Any existing tokens to empty out?
+		foreach ($existing as $key => $_) {
+			$tokens->clearAt($key);
+
+			// If necessary, also delete whitespace.
+			if ($tokens[$key + 1]->isWhitespace()) {
+				$tokens->clearAt($key + 1);
 			}
 		}
 

--- a/.github/phpcs/SectionComments.php
+++ b/.github/phpcs/SectionComments.php
@@ -341,6 +341,15 @@ final class SectionComments extends AbstractFixer
 						$exists[$insert_type] = true;
 					} else {
 						// Normalize whitespace.
+						if ($tokens[$insert_at - 1]->isWhitespace()) {
+							$prev = $tokens->getPrevMeaningfulToken($insert_at);
+
+							$tokens[$insert_at - 1] = new Token([
+								T_WHITESPACE,
+								$tokens[$prev]->equals('{') ? "\n\t" : "\n\n\t",
+							]);
+						}
+
 						if ($tokens[$insert_at + 1]->isWhitespace()) {
 							$tokens[$insert_at + 1] = new Token([
 								T_WHITESPACE,

--- a/.github/phpcs/SectionComments.php
+++ b/.github/phpcs/SectionComments.php
@@ -100,7 +100,7 @@ final class SectionComments extends AbstractFixer
 		];
 
 		foreach ($this->comments as $type => $string) {
-			$words[] = trim($string, "/* \n\t");
+			$words[] = preg_replace('/\s+/', '\s+', preg_quote(trim($string, "/* \n\t"), '/'));
 		}
 
 		$this->comment_regex = '/^\/[*\s]+(?:' . implode('|', $words) . ')[*\s]+\/$/';

--- a/.github/phpcs/SectionComments.php
+++ b/.github/phpcs/SectionComments.php
@@ -19,6 +19,7 @@ use PhpCsFixer\AbstractFixer;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
 use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
+use PhpCsFixer\Tokenizer\CT;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 
@@ -316,6 +317,21 @@ final class SectionComments extends AbstractFixer
 
 					// Now we need to take one step forward again.
 					$insert_at++;
+
+					// Rewind to the first attribute in an attribute group.
+					while ($tokens[$prev_index = $tokens->getPrevMeaningfulToken($insert_at)]->isGivenKind(CT::T_ATTRIBUTE_CLOSE)) {
+						$insert_at = $tokens->findBlockStart(Tokens::BLOCK_TYPE_ATTRIBUTE, $prev_index);
+
+						while (
+							isset($tokens[$insert_at - 1])
+							&& ($tokens[$insert_at - 1]->isWhitespace() || $tokens[$insert_at - 1]->isComment())
+						) {
+							$insert_at--;
+						}
+
+						// Now we need to take one step forward again.
+						$insert_at++;
+					}
 
 					if ($tokens[$insert_at]->getContent() !== $this->comments[$insert_type]) {
 						// Create the comment to insert.

--- a/.github/phpcs/SectionComments.php
+++ b/.github/phpcs/SectionComments.php
@@ -286,7 +286,7 @@ final class SectionComments extends AbstractFixer
 			if (isset($insert_type)) {
 				$elements[] = [
 					'type' => $insert_type,
-					'start' => array_first($in),
+					'start' => $in[array_key_first($in)];,
 				];
 
 				$in = [];

--- a/.github/phpcs/SectionComments.php
+++ b/.github/phpcs/SectionComments.php
@@ -208,38 +208,24 @@ final class SectionComments extends AbstractFixer
 
 	protected function applyFix(\SplFileInfo $file, Tokens $tokens): void
 	{
+		// Does this file contain an enumeration?
+		$is_enum = $tokens->isTokenKindFound(T_ENUM);
+
+		// Now insert fresh copies of the section comments.
+		$elements = [];
+		$slices = [];
+		$found_case = false;
+		$in = [];
 		$existing = [];
 
 		foreach ($tokens as $key => $token) {
-			if ($token->getId() === T_COMMENT) {
+			$id = $token->getId();
+
+			if ($id === T_COMMENT) {
 				if (preg_match($this->comment_regex, $token->getContent())) {
 					$existing[$key] = true;
 				}
 			}
-		}
-
-		// Does this file contain an enumeration?
-		$is_enum = $tokens->isAnyTokenKindsFound([T_ENUM]);
-
-		// Now insert fresh copies of the section comments.
-		$slices = [];
-		$exists = [
-			'case' => false,
-			'const' => false,
-			'public_property' => false,
-			'public_static_property' => false,
-			'internal_property' => false,
-			'internal_static_property' => false,
-			'public_method' => false,
-			'public_static_method' => false,
-			'internal_method' => false,
-			'internal_static_method' => false,
-		];
-
-		$in = [];
-
-		foreach ($tokens as $key => $token) {
-			$id = $token->getId();
 
 			// Build up the list of token types so that we can figure out
 			// which comment type we will want.
@@ -249,7 +235,7 @@ final class SectionComments extends AbstractFixer
 					T_PUBLIC,
 					T_PROTECTED,
 					T_PRIVATE,
-					$is_enum && !$exists['case'] ? T_CASE : NAN,
+					$is_enum && !$found_case ? T_CASE : NAN,
 				] : [
 					T_CONST,
 					T_STATIC,
@@ -264,8 +250,9 @@ final class SectionComments extends AbstractFixer
 			// Which comment type do we want to insert?
 			if (isset($in[T_CONST])) {
 				$insert_type = 'const';
-			} elseif ($is_enum && !$exists['case'] && isset($in[T_CASE])) {
+			} elseif ($is_enum && !$found_case && isset($in[T_CASE])) {
 				$insert_type = 'case';
+				$found_case = true;
 			} elseif (isset($in[T_VARIABLE])) {
 				if (isset($in[T_STATIC])) {
 					if (isset($in[T_PUBLIC])) {
@@ -297,93 +284,108 @@ final class SectionComments extends AbstractFixer
 			}
 
 			if (isset($insert_type)) {
-				if (!$exists[$insert_type]) {
-					// Start by assuming we want to insert right before the
-					// 'public', 'protected', or 'private' keyword.
-					$insert_at = array_first($in);
-
-					// Walk back to include any preceding 'final' or 'readonly'
-					// keywords, as well as any comments or whitespace.
-					while (
-						isset($tokens[$insert_at - 1])
-						&& (
-							$tokens[$insert_at - 1]->isGivenKind([T_FINAL, T_READONLY, T_ABSTRACT])
-							|| $tokens[$insert_at - 1]->isWhitespace()
-							|| $tokens[$insert_at - 1]->isComment()
-						)
-					) {
-						$insert_at--;
-					}
-
-					// Now we need to take one step forward again.
-					$insert_at++;
-
-					// Rewind to the first attribute in an attribute group.
-					while ($tokens[$prev_index = $tokens->getPrevMeaningfulToken($insert_at)]->isGivenKind(CT::T_ATTRIBUTE_CLOSE)) {
-						$insert_at = $tokens->findBlockStart(Tokens::BLOCK_TYPE_ATTRIBUTE, $prev_index);
-
-						while (
-							isset($tokens[$insert_at - 1])
-							&& ($tokens[$insert_at - 1]->isWhitespace() || $tokens[$insert_at - 1]->isComment())
-						) {
-							$insert_at--;
-						}
-
-						// Now we need to take one step forward again.
-						$insert_at++;
-					}
-
-					if ($tokens[$insert_at]->getContent() !== $this->comments[$insert_type]) {
-						// Create the comment to insert.
-						$to_insert = [
-							new Token([
-								T_COMMENT,
-								$this->comments[$insert_type],
-							]),
-						];
-
-						// If necessary, also insert some whitespace.
-						if (!$tokens[$insert_at]->isWhitespace()) {
-							$to_insert[] = new Token([
-								T_WHITESPACE,
-								"\n\n\t",
-							]);
-						}
-
-						// Insert our comment.
-						$slices[$insert_at] = $to_insert;
-
-						// This comment type has now been done.
-						$exists[$insert_type] = true;
-					} else {
-						// Normalize whitespace.
-						if ($tokens[$insert_at - 1]->isWhitespace()) {
-							$prev = $tokens->getPrevMeaningfulToken($insert_at);
-
-							$tokens[$insert_at - 1] = new Token([
-								T_WHITESPACE,
-								$tokens[$prev]->equals('{') ? "\n\t" : "\n\n\t",
-							]);
-						}
-
-						if ($tokens[$insert_at + 1]->isWhitespace()) {
-							$tokens[$insert_at + 1] = new Token([
-								T_WHITESPACE,
-								"\n\n\t",
-							]);
-						}
-
-						$exists[$insert_type] = true;
-
-						// Do not remove this token.
-						if (isset($existing[$insert_at])) {
-							unset($existing[$insert_at]);
-						}
-					}
-				}
+				$elements[] = [
+					'type' => $insert_type,
+					'start' => array_first($in),
+				];
 
 				$in = [];
 				unset($insert_type);
+			}
+		}
+
+		$seen = [];
+
+		foreach ($elements as $element) {
+			if (isset($seen[$element['type']])) {
+				continue;
+			}
+
+			$seen[$element['type']] = true;
+
+			// Start by assuming we want to insert right before the
+			// 'public', 'protected', or 'private' keyword.
+			$insert_at = $element['start'];
+			$insert_type = $element['type'];
+
+			// Walk back to include any preceding 'final' or 'readonly'
+			// keywords, as well as any comments or whitespace.
+			while (isset($tokens[$insert_at - 1])) {
+				$prev = $tokens[$insert_at - 1];
+				$id = $prev->getId();
+
+				if (
+					$id !== T_FINAL
+					&& $id !== T_READONLY
+					&& $id !== T_ABSTRACT
+					&& !$prev->isWhitespace()
+					&& !$prev->isComment()
+				) {
+					break;
+				}
+
+				--$insert_at;
+			}
+
+			// Now we need to take one step forward again.
+			$insert_at++;
+
+			// Rewind to the first attribute in an attribute group.
+			while ($tokens[$prev_index = $tokens->getPrevMeaningfulToken($insert_at)]->getId() === CT::T_ATTRIBUTE_CLOSE) {
+				$insert_at = $tokens->findBlockStart(Tokens::BLOCK_TYPE_ATTRIBUTE, $prev_index);
+
+				while (
+					isset($tokens[$insert_at - 1])
+					&& ($tokens[$insert_at - 1]->isWhitespace() || $tokens[$insert_at - 1]->isComment())
+				) {
+					$insert_at--;
+				}
+
+				// Now we need to take one step forward again.
+				$insert_at++;
+			}
+
+			if ($tokens[$insert_at]->getContent() !== $this->comments[$insert_type]) {
+				// Create the comment to insert.
+				$to_insert = [
+					new Token([
+						T_COMMENT,
+						$this->comments[$insert_type],
+					]),
+				];
+
+				// If necessary, also insert some whitespace.
+				if (!$tokens[$insert_at]->isWhitespace()) {
+					$to_insert[] = new Token([
+						T_WHITESPACE,
+						"\n\n\t",
+					]);
+				}
+
+				// Insert our comment.
+				$slices[$insert_at] = $to_insert;
+			} else {
+				// Normalize whitespace.
+				if ($tokens[$insert_at - 1]->isWhitespace()) {
+					$prev = $tokens->getPrevMeaningfulToken($insert_at);
+
+					$tokens[$insert_at - 1] = new Token([
+						T_WHITESPACE,
+						$tokens[$prev]->equals('{') ? "\n\t" : "\n\n\t",
+					]);
+				}
+
+				if ($tokens[$insert_at + 1]->isWhitespace()) {
+					$tokens[$insert_at + 1] = new Token([
+						T_WHITESPACE,
+						"\n\n\t",
+					]);
+				}
+
+				// Do not remove this token.
+				if (isset($existing[$insert_at])) {
+					unset($existing[$insert_at]);
+				}
 			}
 		}
 

--- a/.github/phpcs/SectionComments.php
+++ b/.github/phpcs/SectionComments.php
@@ -249,7 +249,7 @@ final class SectionComments extends AbstractFixer
 					T_PUBLIC,
 					T_PROTECTED,
 					T_PRIVATE,
-					$is_enum && !$exists['case'] ? T_CASE : -1,
+					$is_enum && !$exists['case'] ? T_CASE : NAN,
 				] : [
 					T_CONST,
 					T_STATIC,

--- a/.github/phpcs/SectionComments.php
+++ b/.github/phpcs/SectionComments.php
@@ -286,7 +286,7 @@ final class SectionComments extends AbstractFixer
 			if (isset($insert_type)) {
 				$elements[] = [
 					'type' => $insert_type,
-					'start' => $in[array_key_first($in)];,
+					'start' => $in[array_key_first($in)],
 				];
 
 				$in = [];


### PR DESCRIPTION
* Use a more forgiving regex to detect slightly malformed section comments. Idea for further improvement: Use `Utils::buildRegex()` if available, because each comment is stripped to the bare words before building the final regex.
* Avoids removing and reinserting section comments that are already correct and in the proper location. This is explicitly checked for in the vendor-provided test suite. 
* Defers removal of obsolete section comments until after analysis, reducing token stream mutations during processing. This improves fixer idempotency by avoiding unnecessary token modifications when no changes are required.
* Correctly preserves valid section comments while removing duplicates and misplaced comments.

My tests https://github.com/live627/php-cs-fixer-custom-fixers/blob/main/tests/SectionCommentsFixerTest.php