### PR TITLE
[2.1] Upgrader - Disable timeouts

### DIFF
--- a/other/upgrade.php
+++ b/other/upgrade.php
@@ -692,7 +692,8 @@ function loadEssentialData()
 	if (version_compare(PHP_VERSION, '8.0.0', '>='))
 		require_once($sourcedir . '/Subs-Compat.php');
 
-	@set_time_limit(600);
+	// These are long running tasks, attempt to disable time check...
+	@set_time_limit(0);
 
 	$smcFunc['random_int'] = function($min = 0, $max = PHP_INT_MAX)
 	{
@@ -2743,7 +2744,8 @@ function nextSubstep($substep)
 		return;
 	}
 
-	@set_time_limit(300);
+	// These are long running tasks, attempt to disable time check...
+	@set_time_limit(0);
 	if (function_exists('apache_reset_timeout'))
 		@apache_reset_timeout();
 


### PR DESCRIPTION
See #9259 for other issues with large DB upgrades

In hindsight, why have timeouts at all.  Let things complete.  We know they run long.  Random timeouts hidden from sight are frustrating and add delays to the overall process.  

When run via browser, a timeout provides no visual indication that it happened.  The upgrader reports possible timeouts after 30 secs of inactivity, but most of these are bogus - many actions take longer than 30 seconds on mid-to-large sized forums.  So the user gets trained to ignore them.  So...  The user has no idea when a real timeout occurs, since the 30-second warning is normal.

The only reliable way I know of to see if the upgrader is actually running or not today is to do a SHOW PROCESSLIST at the DB console.

**_This PR makes the process much easier & more friendly.  And faster -_** no idle-time when it's not doing anything but waiting for someone to catch on & restart it...  You KNOW it's running.  And no time wasted rerunning upgrader steps over & over upon each restart.

I also think we see data loss/corruption when long-running steps get restarted repeatedly.  At some point, it skips over remaining work.

This one is ready to go.  If approved, I'll work on the 3.0 version.
