### PR TITLE
[2.1] Upgrader - Performance

### DIFF
--- a/Themes/default/css/install.css
+++ b/Themes/default/css/install.css
@@ -91,7 +91,7 @@ ul.steps_list .stepcurrent ~ li {
 	color: #d05800;
 }
 .panel form div {
-	max-height: 560px;
+	height: auto;
 }
 .panel p, .panel h3, .panel ul {
 	margin: 0 0 1em 0;

--- a/Themes/default/languages/Install.english.php
+++ b/Themes/default/languages/Install.english.php
@@ -293,7 +293,6 @@ $txt['upgrade_run'] = 'You can choose to either run the upgrade again from the b
 
 $txt['upgrade_completed_table'] = 'Completed Table:';
 $txt['upgrade_current_table'] = 'Current Table:';
-$txt['upgrade_fulltext'] = 'Please note that your fulltext index was dropped to facilitate the conversion and will need to be recreated in the admin area after the upgrade is complete.';
 $txt['upgrade_conversion_proceed'] = 'Conversion Complete! Click Continue to Proceed.';
 $txt['upgrade_convert_datajson'] = 'Converting data from serialize to JSON...';
 $txt['upgrade_json_completed'] = 'Convert to JSON Complete! Click Continue to Proceed.';

--- a/other/upgrade.php
+++ b/other/upgrade.php
@@ -3052,51 +3052,6 @@ function ConvertUtf8()
 		list($upcontext['database_charset']) = explode('_', $column_info['Collation']);
 		$upcontext['database_charset'] = in_array($upcontext['database_charset'], $charsets) ? array_search($upcontext['database_charset'], $charsets) : $upcontext['database_charset'];
 
-		// Detect whether a fulltext index is set.
-		$request = $smcFunc['db_query']('', '
-			SHOW INDEX
-			FROM {db_prefix}messages',
-			array(
-			)
-		);
-
-		$upcontext['dropping_index'] = false;
-
-		// If there's a fulltext index, we need to drop it first...
-		if ($request !== false || $smcFunc['db_num_rows']($request) != 0)
-		{
-			while ($row = $smcFunc['db_fetch_assoc']($request))
-				if ($row['Column_name'] == 'body' && (isset($row['Index_type']) && $row['Index_type'] == 'FULLTEXT' || isset($row['Comment']) && $row['Comment'] == 'FULLTEXT'))
-					$upcontext['fulltext_index'][] = $row['Key_name'];
-			$smcFunc['db_free_result']($request);
-
-			if (isset($upcontext['fulltext_index']))
-				$upcontext['fulltext_index'] = array_unique($upcontext['fulltext_index']);
-		}
-
-		// Drop it and make a note...
-		if (!empty($upcontext['fulltext_index']))
-		{
-			$upcontext['dropping_index'] = true;
-
-			$smcFunc['db_query']('', '
-				ALTER TABLE {db_prefix}messages
-				DROP INDEX ' . implode(',
-				DROP INDEX ', $upcontext['fulltext_index']),
-				array(
-					'db_error_skip' => true,
-				)
-			);
-
-			// Update the settings table
-			$smcFunc['db_insert']('replace',
-				'{db_prefix}settings',
-				array('variable' => 'string', 'value' => 'string'),
-				array('db_search_index', ''),
-				array('variable')
-			);
-		}
-
 		// Figure out what charset we should be converting from...
 		$lang_charsets = array(
 			'arabic' => 'windows-1256',
@@ -3470,7 +3425,7 @@ function ConvertUtf8()
 		}
 		$smcFunc['db_free_result']($request);
 
-		if ($upcontext['dropping_index'] && $command_line)
+		if (!empty($_SESSION['dropping_index']) && $command_line)
 		{
 			echo "\n" . '', $txt['upgrade_fulltext_error'], '';
 			flush();
@@ -4905,11 +4860,6 @@ function template_convert_utf8()
 						', $txt['upgrade_current_table'], ' &quot;<span id="current_table">', $upcontext['cur_table_name'], '</span>&quot;
 					</h3>';
 
-	// If we dropped their index, let's let them know
-	if ($upcontext['dropping_index'])
-		echo '
-					<p id="indexmsg" class="', $upcontext['cur_table_num'] == $upcontext['table_count'] ? 'inline_block' : 'hidden', '>', $txt['upgrade_fulltext'], '</p>';
-
 	// Completion notification
 	echo '
 					<p id="commess" class="', $upcontext['cur_table_num'] == $upcontext['table_count'] ? 'inline_block' : 'hidden', '">', $txt['upgrade_conversion_proceed'], '</p>';
@@ -4957,9 +4907,6 @@ function template_convert_utf8()
 						if (iTableNum == ', $upcontext['table_count'], ')
 						{
 							document.getElementById(\'commess\').classList.remove(\'hidden\');
-							if (document.getElementById(\'indexmsg\') != null) {
-								document.getElementById(\'indexmsg\').classList.remove(\'hidden\');
-							}
 							document.getElementById(\'current_tab\').classList.add(\'hidden\');
 							document.getElementById(\'contbutt\').disabled = 0;
 							document.getElementById(\'utf8_done\').value = 1;
@@ -5123,6 +5070,11 @@ function template_upgrade_complete()
 						', $txt['upgrade_luck'], '<br>
 						Simple Machines
 					</p>';
+
+	// If we dropped their index, let's let them know
+	if (!empty($_SESSION['dropping_index']))
+		echo '
+					<p id="indexmsg">', $txt['upgrade_fulltext_error'], '</p>';
 }
 
 /**

--- a/other/upgrade.php
+++ b/other/upgrade.php
@@ -5089,7 +5089,7 @@ function template_upgrade_complete()
  * @param int $setSize The amount of entries after which to update the database.
  * @return bool
  */
-function MySQLConvertOldIp($targetTable, $oldCol, $newCol, $limit = 50000, $setSize = 100)
+function MySQLConvertOldIp($targetTable, $oldCol, $newCol, $limit = 10000, $setSize = 100)
 {
 	global $smcFunc, $step_progress;
 

--- a/other/upgrade_2-1_mysql.sql
+++ b/other/upgrade_2-1_mysql.sql
@@ -1710,11 +1710,6 @@ CREATE TABLE IF NOT EXISTS {$db_prefix}user_likes (
 ) ENGINE=MyISAM;
 ---#
 
----# Adding likes column to the messages table. (May take a while)
-ALTER TABLE {$db_prefix}messages
-ADD COLUMN likes SMALLINT UNSIGNED NOT NULL DEFAULT '0';
----#
-
 /******************************************************************************/
 --- Adding support for mentions
 /******************************************************************************/
@@ -2362,14 +2357,6 @@ ADD COLUMN in_inbox TINYINT NOT NULL DEFAULT '1';
 ---#
 
 /******************************************************************************/
---- Adding support for edit reasons (May take a while)
-/******************************************************************************/
----# Adding "modified_reason" column to messages (May take a while)
-ALTER TABLE {$db_prefix}messages
-ADD COLUMN modified_reason VARCHAR(255) NOT NULL DEFAULT '';
----#
-
-/******************************************************************************/
 --- Cleaning up guest permissions
 /******************************************************************************/
 ---# Removing permissions guests can no longer have...
@@ -2597,10 +2584,6 @@ ADD COLUMN tfa_required TINYINT NOT NULL DEFAULT '0';
 /******************************************************************************/
 --- Remove redundant indexes
 /******************************************************************************/
----# Duplicates to messages_current_topic
-DROP INDEX idx_id_topic on {$db_prefix}messages;
-DROP INDEX idx_topic on {$db_prefix}messages;
----#
 
 ---# Duplicate to topics_last_message_sticky and topics_board_news
 DROP INDEX idx_id_board on {$db_prefix}topics;
@@ -2774,69 +2757,6 @@ DROP INDEX temp_old_ip2 on {$db_prefix}members;
 ---# Remove the old member columns
 ALTER TABLE {$db_prefix}members DROP COLUMN member_ip_old;
 ALTER TABLE {$db_prefix}members DROP COLUMN member_ip2_old;
----#
-
-/******************************************************************************/
---- Update messages poster_ip with ipv6 support (May take a while)
-/******************************************************************************/
----# Rename old ip column on messages
----{
-$doChange = true;
-$column_info = upgradeGetColumnInfo('{db_prefix}messages', 'poster_ip');
-if (stripos($column_info['type'], 'varbinary') !== false)
-	$doChange = false;
-
-if ($doChange)
-	upgrade_query("ALTER TABLE {$db_prefix}messages CHANGE poster_ip poster_ip_old varchar(255);");
----}
----#
-
----# Add the new ip column to messages
-ALTER TABLE {$db_prefix}messages ADD COLUMN poster_ip VARBINARY(16);
----#
-
----# Create an ip index for old ips
----{
-$doChange = true;
-$results = $smcFunc['db_list_columns']('{db_prefix}messages');
-if (!in_array('poster_ip_old', $results))
-	$doChange = false;
-
-if ($doChange)
-	upgrade_query("CREATE INDEX {$db_prefix}temp_old_poster_ip ON {$db_prefix}messages (poster_ip_old);");
----}
----#
-
----# Initialize new ip column
----{
-$results = $smcFunc['db_list_columns']('{db_prefix}messages');
-if (in_array('poster_ip_old', $results))
-{
-	upgrade_query("UPDATE {$db_prefix}messages SET poster_ip = '';");
-}
----}
----#
-
----# Convert ips on messages
----{
-MySQLConvertOldIp('messages','poster_ip_old','poster_ip');
----}
----#
-
----# Remove the temporary ip indexes
-DROP INDEX temp_old_poster_ip on {$db_prefix}messages;
----#
-
----# Drop old column to messages
-ALTER TABLE {$db_prefix}messages DROP COLUMN poster_ip_old;
----#
-
----# Add the index again to messages poster ip topic
-CREATE INDEX idx_ip_index ON {$db_prefix}messages (poster_ip, id_topic);
----#
-
----# Add the index again to messages poster ip msg
-CREATE INDEX idx_related_ip ON {$db_prefix}messages (id_member, poster_ip, id_msg);
 ---#
 
 /******************************************************************************/
@@ -3077,14 +2997,6 @@ SET lngfile = REPLACE(lngfile, '-utf8', '');
 ---#
 
 /******************************************************************************/
---- Create index for messages likes
-/******************************************************************************/
----# Add Index for messages likes
-DROP INDEX idx_likes ON {$db_prefix}messages;
-CREATE INDEX idx_likes ON {$db_prefix}messages (likes);
----#
-
-/******************************************************************************/
 --- Aligning legacy column data
 /******************************************************************************/
 ---# Updating board_permissions
@@ -3203,56 +3115,6 @@ DROP INDEX idx_active_real_name;
 ---# Updating members active_real_name (add)
 ALTER TABLE {$db_prefix}members
 ADD INDEX idx_active_real_name (is_activated, real_name);
----#
-
----# Updating messages drop old ipIndex
-ALTER TABLE {$db_prefix}messages
-DROP INDEX ipIndex;
----#
-
----# Updating messages drop old ip_index
-ALTER TABLE {$db_prefix}messages
-DROP INDEX ip_index;
----#
-
----# Updating messages drop old related_ip
-ALTER TABLE {$db_prefix}messages
-DROP INDEX related_ip;
----#
-
----# Updating messages drop old topic ix
-ALTER TABLE {$db_prefix}messages
-DROP INDEX topic;
----#
-
----# Updating messages drop another old topic ix
-ALTER TABLE {$db_prefix}messages
-DROP INDEX id_topic;
----#
-
----# Updating messages drop approved ix
-ALTER TABLE {$db_prefix}messages
-DROP INDEX approved;
----#
-
----# Updating messages drop approved ix alt name
-ALTER TABLE {$db_prefix}messages
-DROP INDEX idx_approved;
----#
-
----# Updating messages drop id_board ix
-ALTER TABLE {$db_prefix}messages
-DROP INDEX id_board;
----#
-
----# Updating messages drop id_board ix alt name
-ALTER TABLE {$db_prefix}messages
-DROP INDEX idx_id_board;
----#
-
----# Updating messages add new id_board ix
-ALTER TABLE {$db_prefix}messages
-ADD UNIQUE INDEX idx_id_board (id_board, id_msg, approved);
 ---#
 
 ---# Updating topics drop old id_board ix
@@ -3911,4 +3773,239 @@ foreach($files AS $filename)
 ---# Updating primary key for log_search_results table
 ALTER TABLE {$db_prefix}log_search_results DROP PRIMARY KEY;
 ALTER TABLE {$db_prefix}log_search_results ADD PRIMARY KEY (id_search, id_topic, id_msg);
+---#
+
+/******************************************************************************/
+---  Restructure Messages
+/******************************************************************************/
+
+---# If messages_21upgr_copy doesn't exist, create it
+---{
+$column_info = upgradeGetColumnInfo('{db_prefix}messages', 'poster_ip');
+if (stripos($column_info['type'], 'varbinary') === false)
+{
+	$request = $smcFunc['db_query']('',
+		'SHOW TABLES LIKE {string:table_copy}',
+		array(
+			'table_copy' => $db_prefix . 'messages_21upgr_copy',
+		),
+	);
+	if ($smcFunc['db_num_rows']($request) == 0)
+	{
+		$smcFunc['db_query']('',
+			'RENAME TABLE {db_prefix}messages to {db_prefix}messages_21upgr_copy',
+			array(),
+		);
+		$smcFunc['db_query']('',
+			'CREATE TABLE {db_prefix}messages LIKE {db_prefix}messages_21upgr_copy',
+			array(),
+		);
+	}
+}
+---}
+---#
+
+/* We want all structural changes to the messages table done here, prior to repopulating. */
+/* Many of these operations result in a full table copy & rebuild under the covers... */
+/* Doing these operations on an empty table saves a LOT of time. */
+
+---# Adding likes column to the messages table
+ALTER TABLE {$db_prefix}messages
+ADD COLUMN likes SMALLINT UNSIGNED NOT NULL DEFAULT '0';
+---#
+
+---# Adding "modified_reason" column to messages
+ALTER TABLE {$db_prefix}messages
+ADD COLUMN modified_reason VARCHAR(255) NOT NULL DEFAULT '';
+---#
+
+---# Duplicates to messages_current_topic
+DROP INDEX idx_id_topic on {$db_prefix}messages;
+DROP INDEX idx_topic on {$db_prefix}messages;
+---#
+
+---# Redefine Index for messages likes
+DROP INDEX idx_likes ON {$db_prefix}messages;
+CREATE INDEX idx_likes ON {$db_prefix}messages (likes);
+---#
+
+---# Updating messages drop old ipIndex
+ALTER TABLE {$db_prefix}messages
+DROP INDEX ipIndex;
+---#
+
+---# Updating messages drop old ip_index
+ALTER TABLE {$db_prefix}messages
+DROP INDEX ip_index;
+---#
+
+---# Updating messages drop old related_ip
+ALTER TABLE {$db_prefix}messages
+DROP INDEX related_ip;
+---#
+
+---# Updating messages drop old topic ix
+ALTER TABLE {$db_prefix}messages
+DROP INDEX topic;
+---#
+
+---# Updating messages drop another old topic ix
+ALTER TABLE {$db_prefix}messages
+DROP INDEX id_topic;
+---#
+
+---# Updating messages drop approved ix
+ALTER TABLE {$db_prefix}messages
+DROP INDEX approved;
+---#
+
+---# Updating messages drop approved ix alt name
+ALTER TABLE {$db_prefix}messages
+DROP INDEX idx_approved;
+---#
+
+---# Updating messages drop id_board ix
+ALTER TABLE {$db_prefix}messages
+DROP INDEX id_board;
+---#
+
+---# Updating messages drop id_board ix alt name
+ALTER TABLE {$db_prefix}messages
+DROP INDEX idx_id_board;
+---#
+
+---# Updating messages add new id_board ix
+ALTER TABLE {$db_prefix}messages
+ADD UNIQUE INDEX idx_id_board (id_board, id_msg, approved);
+---#
+
+---# Rename old ip column on messages
+---{
+$doChange = true;
+$column_info = upgradeGetColumnInfo('{db_prefix}messages', 'poster_ip');
+if (stripos($column_info['type'], 'varbinary') !== false)
+	$doChange = false;
+
+if ($doChange)
+	upgrade_query("ALTER TABLE {$db_prefix}messages CHANGE poster_ip poster_ip_old varchar(255);");
+---}
+---#
+
+---# Add the new ip column to messages
+ALTER TABLE {$db_prefix}messages ADD COLUMN poster_ip VARBINARY(16);
+---#
+
+---# Create an ip index for old ips
+---{
+$doChange = true;
+$results = $smcFunc['db_list_columns']('{db_prefix}messages');
+if (!in_array('poster_ip_old', $results))
+	$doChange = false;
+
+// Move to end for faster deletion later
+if ($doChange)
+	upgrade_query("ALTER TABLE {$db_prefix}messages CHANGE COLUMN poster_ip_old poster_ip_old varchar(255) AFTER poster_ip;");
+
+if ($doChange)
+	upgrade_query("CREATE INDEX {$db_prefix}temp_old_poster_ip ON {$db_prefix}messages (poster_ip_old);");
+---}
+---#
+
+---# Repopulate messages table
+---{
+$request = $smcFunc['db_query']('',
+	'SHOW TABLES LIKE {string:table_copy}',
+	array(
+		'table_copy' => $db_prefix . 'messages_21upgr_copy',
+	),
+);
+if ($smcFunc['db_num_rows']($request) > 0)
+{
+	$chunksize = 50000;
+	$records = 0;
+	$chunks = 1;
+	$request = $smcFunc['db_query']('',
+		'SELECT COUNT(*) FROM {db_prefix}messages_21upgr_copy',
+		array(),
+	);
+	list ($records) = $smcFunc['db_fetch_row']($request);
+	$chunks = ceil($records/$chunksize);
+
+	$_GET['a'] = isset($_GET['a']) ? (int) $_GET['a'] : 0;
+	$step_progress['name'] = 'Repopulating messages table';
+	$step_progress['current'] = $_GET['a'];
+	$step_progress['total'] = $chunks;
+
+	// Just in case of restart...
+	if ($_GET['a'] == 0)
+	{
+		$request = $smcFunc['db_query']('',
+			'TRUNCATE TABLE {db_prefix}messages',
+			array(),
+		);
+	}
+
+	// Need column lists...  map old poster_ip to poster_ip_old, and '' to the new poster_ip
+	// Other new cols have defaults, we are OK not mapping them
+	$msg_columns = $smcFunc['db_list_columns']('{db_prefix}messages_21upgr_copy');
+	$old_ip_key = array_search('poster_ip', $msg_columns, true);
+	unset($msg_columns[$old_ip_key]);
+	$from_cols = implode(',', $msg_columns) . ',\'\',poster_ip';
+	$to_cols = implode(',', $msg_columns) . ',poster_ip,poster_ip_old';
+
+	$is_done = false;
+	while (!$is_done)
+	{
+		nextSubstep($substep);
+
+		$request = $smcFunc['db_query']('',
+			'INSERT INTO {db_prefix}messages ({raw:to_cols}) SELECT {raw:from_cols} FROM {db_prefix}messages_21upgr_copy WHERE id_msg BETWEEN {int:chunk_start} AND {int:chunk_end}',
+			array(
+				'to_cols' => $to_cols,
+				'from_cols' => $from_cols,
+				'chunk_start' => ($_GET['a'] * $chunksize) + 1,
+				'chunk_end' => (($_GET['a'] + 1) * $chunksize),
+			),
+		);
+
+		$_GET['a']++;
+		$step_progress['current'] = $_GET['a'];
+		if ($_GET['a'] >= $chunks)
+			$is_done = true;
+	}
+	// Done with this now...
+	$request = $smcFunc['db_query']('',
+		'DROP TABLE {db_prefix}messages_21upgr_copy',
+		array(),
+	);
+}
+$step_progress = array();
+unset($_GET['a']);
+---}
+---#
+
+/******************************************************************************/
+--- IPv6 Conversion
+/******************************************************************************/
+
+---# Convert ips on messages
+---{
+MySQLConvertOldIp('messages','poster_ip_old','poster_ip');
+---}
+---#
+
+---# Remove the temporary ip indexes
+DROP INDEX temp_old_poster_ip on {$db_prefix}messages;
+---#
+
+---# Drop old column to messages
+ALTER TABLE {$db_prefix}messages DROP COLUMN poster_ip_old;
+---#
+
+---# Add the index again to messages poster ip topic
+CREATE INDEX idx_ip_index ON {$db_prefix}messages (poster_ip, id_topic);
+---#
+
+---# Add the index again to messages poster ip msg
+CREATE INDEX idx_related_ip ON {$db_prefix}messages (id_member, poster_ip, id_msg);
 ---#

--- a/other/upgrade_2-1_mysql.sql
+++ b/other/upgrade_2-1_mysql.sql
@@ -378,6 +378,7 @@ INSERT INTO {$db_prefix}settings (variable, value) VALUES ('defaultMaxListItems'
 		array('variable')
 	);
 ---}
+---#
 
 ---# Disable Moderation Center Security if it doesn't exist
 ---{
@@ -876,7 +877,7 @@ VALUES
 ---#
 
 /******************************************************************************/
----- Adding background tasks support
+--- Adding background tasks support
 /******************************************************************************/
 ---# Adding the new table
 CREATE TABLE IF NOT EXISTS {$db_prefix}background_tasks (
@@ -3321,6 +3322,7 @@ CREATE TABLE IF NOT EXISTS {$db_prefix}board_permissions_view
 	deny smallint NOT NULL,
 	PRIMARY KEY (id_group, id_board, deny)
 ) ENGINE=MyISAM;
+---#
 
 ---# upgrade check
 ---{
@@ -3331,7 +3333,7 @@ $upcontext['skip_db_substeps'] = !in_array('id_group', $table_columns) || !in_ar
 ---}
 ---#
 
----#
+---# Truncate board_permissions view
 TRUNCATE {$db_prefix}board_permissions_view;
 ---#
 

--- a/other/upgrade_2-1_mysql.sql
+++ b/other/upgrade_2-1_mysql.sql
@@ -106,6 +106,59 @@ if (!empty($upcontext['empty_error']))
 ---#
 
 /******************************************************************************/
+--- Checking for fulltext index
+/******************************************************************************/
+
+---# If index exists drop it and make a note
+---{
+// Detect whether a fulltext index is set.
+$request = $smcFunc['db_query']('', '
+	SHOW INDEX
+	FROM {db_prefix}messages',
+	array(
+	)
+);
+
+$_SESSION['dropping_index'] = false;
+
+// If there's a fulltext index, we need to drop it first...
+if ($request !== false || $smcFunc['db_num_rows']($request) != 0)
+{
+	while ($row = $smcFunc['db_fetch_assoc']($request))
+		if ($row['Column_name'] == 'body' && (isset($row['Index_type']) && $row['Index_type'] == 'FULLTEXT' || isset($row['Comment']) && $row['Comment'] == 'FULLTEXT'))
+			$upgrtmp['fulltext_index'][] = $row['Key_name'];
+	$smcFunc['db_free_result']($request);
+
+	if (isset($upgrtmp['fulltext_index']))
+		$upgrtmp['fulltext_index'] = array_unique($upgrtmp['fulltext_index']);
+}
+
+// Drop it and make a note...
+if (!empty($upgrtmp['fulltext_index']))
+{
+	$_SESSION['dropping_index'] = true;
+
+	$smcFunc['db_query']('', '
+		ALTER TABLE {db_prefix}messages
+		DROP INDEX ' . implode(',
+		DROP INDEX ', $upgrtmp['fulltext_index']),
+		array(
+			'db_error_skip' => true,
+		)
+	);
+
+	// Update the settings table
+	$smcFunc['db_insert']('replace',
+		'{db_prefix}settings',
+		array('variable' => 'string', 'value' => 'string'),
+		array('db_search_index', ''),
+		array('variable')
+	);
+}
+---}
+---#
+
+/******************************************************************************/
 --- Adding new settings...
 /******************************************************************************/
 ---# Adding login history...

--- a/other/upgrade_2-1_postgresql.sql
+++ b/other/upgrade_2-1_postgresql.sql
@@ -71,6 +71,59 @@ if (!empty($upcontext['empty_error']))
 ---#
 
 /******************************************************************************/
+--- Checking for fulltext index
+/******************************************************************************/
+
+---# If index exists drop it and make a note
+---{
+// Detect whether a fulltext index is set.
+$request = $smcFunc['db_query']('', '
+	SHOW INDEX
+	FROM {db_prefix}messages',
+	array(
+	)
+);
+
+$_SESSION['dropping_index'] = false;
+
+// If there's a fulltext index, we need to drop it first...
+if ($request !== false || $smcFunc['db_num_rows']($request) != 0)
+{
+	while ($row = $smcFunc['db_fetch_assoc']($request))
+		if ($row['Column_name'] == 'body' && (isset($row['Index_type']) && $row['Index_type'] == 'FULLTEXT' || isset($row['Comment']) && $row['Comment'] == 'FULLTEXT'))
+			$upgrtmp['fulltext_index'][] = $row['Key_name'];
+	$smcFunc['db_free_result']($request);
+
+	if (isset($upgrtmp['fulltext_index']))
+		$upgrtmp['fulltext_index'] = array_unique($upgrtmp['fulltext_index']);
+}
+
+// Drop it and make a note...
+if (!empty($upgrtmp['fulltext_index']))
+{
+	$_SESSION['dropping_index'] = true;
+
+	$smcFunc['db_query']('', '
+		ALTER TABLE {db_prefix}messages
+		DROP INDEX ' . implode(',
+		DROP INDEX ', $upgrtmp['fulltext_index']),
+		array(
+			'db_error_skip' => true,
+		)
+	);
+
+	// Update the settings table
+	$smcFunc['db_insert']('replace',
+		'{db_prefix}settings',
+		array('variable' => 'string', 'value' => 'string'),
+		array('db_search_index', ''),
+		array('variable')
+	);
+}
+---}
+---#
+
+/******************************************************************************/
 --- Fixing sequences
 /******************************************************************************/
 

--- a/other/upgrade_2-1_postgresql.sql
+++ b/other/upgrade_2-1_postgresql.sql
@@ -1061,7 +1061,7 @@ VALUES
 ---#
 
 /******************************************************************************/
----- Adding background tasks support
+--- Adding background tasks support
 /******************************************************************************/
 ---# Adding the sequence
 CREATE SEQUENCE IF NOT EXISTS {$db_prefix}background_tasks_seq;
@@ -2010,7 +2010,7 @@ CREATE TABLE IF NOT EXISTS {$db_prefix}moderator_groups (
 /******************************************************************************/
 --- Cleaning up integration hooks
 /******************************************************************************/
----#
+---# Deleting integration hooks
 DELETE FROM {$db_prefix}settings
 WHERE variable LIKE 'integrate_%';
 ---#
@@ -2150,6 +2150,7 @@ WHERE variable IN ('show_board_desc', 'display_quick_reply', 'show_mark_read', '
 		array('variable')
 	);
 ---}
+---#
 
 /******************************************************************************/
 --- Updating files that fetched from simplemachines.org
@@ -3098,7 +3099,7 @@ ALTER TABLE {$db_prefix}log_errors
 ---#
 
 /******************************************************************************/
---- update log_errors members ip with ipv6 support
+--- update members ip with ipv6 support
 /******************************************************************************/
 ---# upgrade check
 ---{
@@ -3108,7 +3109,7 @@ if (stripos($column_info['type'], 'inet') !== false)
 ---}
 ---#
 
----#
+---# update old columns on members
 ALTER TABLE {$db_prefix}members
 	ALTER member_ip DROP not null,
 	ALTER member_ip DROP default,
@@ -3594,6 +3595,7 @@ CREATE TABLE IF NOT EXISTS {$db_prefix}board_permissions_view
 	deny smallint NOT NULL,
 	PRIMARY KEY (id_group, id_board, deny)
 );
+---#
 
 ---# upgrade check
 ---{
@@ -3604,7 +3606,7 @@ $upcontext['skip_db_substeps'] = !in_array('id_group', $table_columns) || !in_ar
 ---}
 ---#
 
----#
+---# Truncate board_permissions view
 TRUNCATE {$db_prefix}board_permissions_view;
 ---#
 


### PR DESCRIPTION
See #9259 for other issues with large DB upgrades

The upgrader has several extremely expensive database operations, all to the messages table:
 - Adding likes column
 - Adding modified_reason column
 - Renaming poster_ip to poster_ip_old
 - Adding column poster_ip
 - Dropping column poster_ip_old

For ***each*** of the above operations, under the covers, ALTER TABLE makes a copy of the table then rebuilds it from scratch.  
 - Everything gets rebuilt, even fulltext indexes when present
 - MySQL implicit table rebuilds can be VERY costly; I've seen them take as long as 10 hours ***each*** on a table with 3.3M records

It doesn't makes sense for it to take many hours to do a simple operation, even on 3.3M messages...  ALTER TABLE clearly has issues with these implicit table rebuilds; it is much faster to rebuild the table explicitly yourself.

MariaDB handles this much better than MySQL, I believe due to a better implementation of ALGORITHM=INPLACE & ALGORITHM=INSTANT.  MySQL has more constraints on these timesavers.  HOWEVER...  If you restructure the activity a bit, to account for such constraints (e.g., only dropping columns at the end of the column list) MySQL is almost as quick as MariaDB.

This PR:
 - Reduces message table rebuilds by making an empty copy of messages, then doing most DB changes to the empty copy.
 - The table is then repopulated explicitly, which is far faster than ALTER TABLE's implicit copy.
 - Removes the fulltext index prior to any DB activity.  This had been part of the utf8 conversion; this PR moves it prior to the DB changes.  This cleans up many warnings & errors in the MySQL/MariaDB logs when FTS is present.  _More importantly, the upgrader isn't rebuilding the fulltext index over & over & over..._  
 - Where necessary (because the operation requires populated data), moved column to be dropped to the end of the column list.

The IPv6 & UTF8 conversions remain time-consuming.  No way around that.

Still, the time savings are significant.  My "before" executions on MySQL were in the ~60 hour range, and varied on a number of factors, e.g., InnoDB vs MyISAM & environment/debug settings.  MariaDB "before" executions varied from 5-18 hours.  Tests were 2.0 => 2.1 upgrades, DB has 3.3M rows, no attachments.  

With this change, MySQL now takes ~1 hour, & MariaDB takes ~45 mins.

If necessary, we could do the same to members.  I've never seen members updates go near as long though.

I'm still doing tests on this.

If approved, I'll work on the 3.0 version.

