### PR TITLE
[3.0] More improvements to SMF\IP

### DIFF
--- a/Sources/IP.php
+++ b/Sources/IP.php
@@ -171,6 +171,20 @@ class IP implements \Stringable
 	}
 
 	/**
+	 * Check whether this is an IPv6 containing an IPv4.
+	 *
+	 * Returns true for IPs matching one of the following patterns:
+	 *  - ::ffff:123.123.123.123
+	 *  = 64:ff9b::123.123.123.123
+	 *
+	 * @return bool
+	 */
+	public function is4in6(): bool
+	{
+		return $this->isValid(FILTER_FLAG_IPV6) && (str_starts_with($this->ip, '::ffff:') || str_starts_with($this->ip, '64:ff9b::'));
+	}
+
+	/**
 	 * Tries to finds the name of the host that corresponds to this IP address.
 	 *
 	 * @param int $timeout Milliseconds until timeout. Set to 0 for no timeout.
@@ -522,6 +536,8 @@ class IP implements \Stringable
 			return '';
 		}
 
+		$remote_addr = new self($_SERVER['REMOTE_ADDR']);
+
 		// If we haven't specified how to handle Reverse Proxy IP headers, lets do what we always used to do.
 		if (!isset(Config::$modSettings['proxy_ip_header'])) {
 			Config::$modSettings['proxy_ip_header'] = 'autodetect';
@@ -549,7 +565,7 @@ class IP implements \Stringable
 				foreach (explode(',', Config::$modSettings['proxy_ip_servers']) as $proxy) {
 					if (
 						$proxy == $_SERVER['REMOTE_ADDR']
-						|| (new IP($_SERVER['REMOTE_ADDR']))->matchToCIDR($proxy)
+						|| $remote_addr->matchToCIDR($proxy)
 					) {
 						$valid_sender = true;
 						break;
@@ -561,31 +577,30 @@ class IP implements \Stringable
 				}
 			}
 
-			// If there are commas, get the last one.. probably.
-			if (str_contains($_SERVER[$proxyIPheader], ',')) {
-				$ips = array_reverse(explode(', ', $_SERVER[$proxyIPheader]));
+			$ips = array_map(
+				fn($ip) => new self($ip),
+				array_map(
+					'trim',
+					array_reverse(explode(',', $_SERVER[$proxyIPheader])),
+				),
+			);
 
-				// Go through each IP...
-				foreach ($ips as $i => $ip) {
-					// Make sure it's in a valid range...
-					if (self::isLocal($ip) && !self::isLocal($_SERVER['REMOTE_ADDR'])) {
-						continue;
-					}
-
-					// Otherwise, we've got an IP!
-					return static::$user_ip = trim($ip);
+			foreach ($ips as $ip) {
+				if ($ip->isValid(FILTER_FLAG_GLOBAL_RANGE)) {
+					static::$user_ip = $ip->is4in6() ? preg_replace('/^.*:(\d+\.\d+\.\d+\.\d+)$/', '$1', (string) $ip) : (string) $ip;
 				}
 			}
-			// Otherwise just use the only one.
-			elseif (!self::isLocal($_SERVER[$proxyIPheader]) && self::isLocal($_SERVER['REMOTE_ADDR'])) {
-				return static::$user_ip = $_SERVER[$proxyIPheader];
-			} elseif (self::is4in6($_SERVER[$proxyIPheader])) {
-				// @ TODO: Convert to IPv6.
-				continue;
+
+			// If both IPs are private, then I guess that's all we've got.
+			if (!isset(static::$user_ip) && !$remote_addr->isValid(FILTER_FLAG_GLOBAL_RANGE)) {
+				static::$user_ip = $ips[0]->is4in6() ? preg_replace('/^.*:(\d+\.\d+\.\d+\.\d+)$/', '$1', (string) $ips[0]) : (string) $ips[0];
 			}
 		}
 
-		return static::$user_ip = $_SERVER['REMOTE_ADDR'];
+		// If checking proxy headers gave us nothing, use the plain remote address.
+		static::$user_ip ??= $_SERVER['REMOTE_ADDR'];
+
+		return static::$user_ip;
 	}
 
 	/**
@@ -764,40 +779,5 @@ class IP implements \Stringable
 		$query .= "\0\0\x0C\0\1";
 
 		return $query;
-	}
-
-	/*************************
-	 * Internal static methods
-	 *************************/
-
-	/**
-	 * Check whether this is a local area network address or not.
-	 *
-	 * @param string $ip
-	 * @return bool
-	 */
-	private static function isLocal(string $ip): bool
-	{
-		return preg_match('~^((0|10|172\.(1[6-9]|2[0-9]|3[01])|192\.168|255|127)\.|unknown|::1|fe80::|fc00::)~', $ip) === 1;
-	}
-
-	/**
-	 * Check whether this is a IPv4 inside of a IPv6.
-	 *
-	 * @param string $ip
-	 * @return bool
-	 */
-	private static function is4in6(string $ip): bool
-	{
-		if (!self::create($ip)->isValid(FILTER_FLAG_IPV6) || preg_match('~::ffff:\d+\.\d+\.\d+\.\d+~', $ip) !== 0) {
-			$ipv4_in_v6 = preg_replace('~^::ffff:(\d+\.\d+\.\d+\.\d+)~', '$1', $ip);
-
-			// Just incase we have a legacy IPv4 address.
-			if (preg_match('~^(((1?\d)?\d|2[0-4]\d|25[0-5])\.){3}(([1]?\d)?\d|2[0-4]\d|25[0-5])$~', $ipv4_in_v6) === 0) {
-				return true;
-			}
-		}
-
-		return false;
 	}
 }

--- a/Sources/WebFetch/WebFetchApi.php
+++ b/Sources/WebFetch/WebFetchApi.php
@@ -15,9 +15,9 @@ declare(strict_types=1);
 
 namespace SMF\WebFetch;
 
+use SMF\IP;
 use SMF\Lang;
 use SMF\Url;
-use SMF\IP;
 
 /**
  * Class SearchApi
@@ -257,7 +257,7 @@ abstract class WebFetchApi implements WebFetchApiInterface
 			// Couldn't resolve to anything: refuse rather than guess.
 			$ips === []
 			// EVERY resolved address must be a global, public, unicast IP.
-			|| $ips !== array_filter($ips, fn($ip) => IP::create($ip)->isValid(FILTER_FLAG_GLOBAL_RANGE)),
+			|| $ips !== array_filter($ips, fn($ip) => IP::create($ip)->isValid(FILTER_FLAG_GLOBAL_RANGE))
 		) {
 			self::$safe_hosts[$url->host] = false;
 		}


### PR DESCRIPTION
1. Fixes a typo I made in ce59add.
2. [Improves logic to detect current user's IP address](https://github.com/SimpleMachines/SMF/commit/a41ab6c83aa24dbf99c6fafc860c79125eade029)
    - There was a spot where `&&` had been incorrectly changed to `||`. That logic error has been fixed.
    - More generally, the nasty procedural spaghetti logic in `SMF\IP::getUserIP()` that was inherited from previous versions of SMF has been replaced with cleaner and simpler code.