### PR TITLE
[3.0] Handles an edge case in Lang::numberFormat()

### DIFF
--- a/Sources/Lang.php
+++ b/Sources/Lang.php
@@ -952,7 +952,7 @@ class Lang
 			}
 		}
 
-		$skeleton = ':: ' . (!isset($decimals) ? '.*' : 'precision-increment/' . (10 ** -$decimals)) . ' rounding-mode-half-up';
+		$skeleton = ':: ' . (!isset($decimals) ? '.*' : 'precision-increment/' . \sprintf('%.' . max(0, $decimals) . 'F', 10 ** -$decimals)) . ' rounding-mode-half-up';
 
 		return MessageFormatter::formatMessage('{0, number, ' . $skeleton . '}', [$number]);
 	}


### PR DESCRIPTION
Always uses floating point notation in the `precision-increment/...` number format skeleton. 

Prior to this change, if $decimals was set to a high value, the number format skeleton would be set to something like `precision-increment/1.0E-10` rather than `precision-increment/0.0000000001`. The latter works, the former doesn't.