### PR TITLE
[3.0] Misc improvements to SMF\Localization\MessageFormatter

### DIFF
--- a/Sources/Localization/MessageFormatter.php
+++ b/Sources/Localization/MessageFormatter.php
@@ -128,7 +128,9 @@ class MessageFormatter
 
 			$fmt = self::$message_formatters[Lang::getTxt('lang_locale', file: 'General')][$message]->format(array_filter($args, 'is_scalar'));
 
-			return $fmt == false ? '' : strtr($fmt, array_flip($placeholders));
+			if ($fmt !== false) {
+				return strtr($fmt, array_flip($placeholders));
+			}
 		}
 
 		// Parse $message and build the finalized string.

--- a/Sources/Localization/MessageFormatter.php
+++ b/Sources/Localization/MessageFormatter.php
@@ -22,6 +22,7 @@ use SMF\Time;
 use SMF\User;
 use SMF\Utils;
 
+use function SMF\Unicode\country_currencies;
 use function SMF\Unicode\currencies;
 
 /**
@@ -40,28 +41,139 @@ class MessageFormatter
 	 * Note that not all currencies have long-form symbols. For currencies that
 	 * do not have long-form symbols, the raw currency code is used instead.
 	 */
-	public const CURRENCY_SYMBOLS = [
+	public const CURRENCY_SYMBOLS_LONG = [
 		'AUD' => 'A$',
 		'BRL' => 'R$',
 		'CAD' => 'CA$',
-		'CNY' => 'CN¥',
-		'EUR' => '€',
-		'GBP' => '£',
+		'CNY' => "CN\u{A5}",
+		'DEFAULT' => '¤',
+		'EUR' => "\u{20AC}",
+		'GBP' => "\u{A3}",
 		'HKD' => 'HK$',
-		'ILS' => '₪',
-		'INR' => '₹',
-		'JPY' => '¥',
-		'KRW' => '₩',
+		'ILS' => "\u{20AA}",
+		'INR' => "\u{20B9}",
+		'JPY' => "\u{A5}",
+		'KRW' => "\u{20A9}",
 		'MXN' => 'MX$',
 		'NZD' => 'NZ$',
-		'PHP' => '₱',
+		'PHP' => "\u{20B1}",
 		'TWD' => 'NT$',
 		'USD' => 'US$',
-		'VND' => '₫',
-		'XAF' => 'FCFA',
+		'VND' => "\u{20AB}",
+		'XAF' => "FCFA\u{A0}",
 		'XCD' => 'EC$',
-		'XOF' => "F\u{202F}CFA",
-		'XPF' => 'CFPF',
+		'XCG' => "Cg.\u{A0}",
+		'XOF' => "F\u{202F}CFA\u{A0}",
+		'XPF' => "CFPF\u{A0}",
+	];
+
+	/**
+	 * Short-form (and often ambiguous) symbols for certain currencies.
+	 *
+	 * Note that not all currencies have short-form symbols. For currencies that
+	 * do not have short-form symbols, the raw currency code is used instead.
+	 */
+	public const CURRENCY_SYMBOLS_SHORT = [
+		'AFN' => "\u{60B}",
+		'AMD' => "\u{58F}",
+		'AOA' => "Kz\u{A0}",
+		'ARS' => '$',
+		'AUD' => '$',
+		'AZN' => "\u{20BC}",
+		'BAM' => "KM\u{A0}",
+		'BBD' => '$',
+		'BDT' => "\u{9F3}",
+		'BMD' => '$',
+		'BND' => '$',
+		'BOB' => "Bs\u{A0}",
+		'BRL' => 'R$',
+		'BSD' => '$',
+		'BWP' => "P\u{A0}",
+		'BZD' => '$',
+		'CAD' => '$',
+		'CLP' => '$',
+		'CNY' => "\u{A5}",
+		'COP' => '$',
+		'CRC' => "\u{20A1}",
+		'CUP' => '$',
+		'CZK' => "K\u{10D}\u{A0}",
+		'DEFAULT' => '¤',
+		'DKK' => "kr\u{A0}",
+		'DOP' => '$',
+		'EGP' => "E\u{A3}",
+		'EUR' => "\u{20AC}",
+		'FJD' => '$',
+		'FKP' => "\u{A3}",
+		'GBP' => "\u{A3}",
+		'GEL' => "\u{20BE}",
+		'GHS' => "GH\u{20B5}",
+		'GIP' => "\u{A3}",
+		'GNF' => "FG\u{A0}",
+		'GTQ' => "Q\u{A0}",
+		'GYD' => '$',
+		'HKD' => '$',
+		'HNL' => "L\u{A0}",
+		'HUF' => "Ft\u{A0}",
+		'IDR' => "Rp\u{A0}",
+		'ILS' => "\u{20AA}",
+		'INR' => "\u{20B9}",
+		'ISK' => "kr\u{A0}",
+		'JMD' => '$',
+		'JPY' => "\u{A5}",
+		'KGS' => "\u{20C0}",
+		'KHR' => "\u{17DB}",
+		'KMF' => "CF\u{A0}",
+		'KPW' => "\u{20A9}",
+		'KRW' => "\u{20A9}",
+		'KYD' => '$',
+		'KZT' => "\u{20B8}",
+		'LAK' => "\u{20AD}",
+		'LBP' => "L\u{A3}",
+		'LKR' => "Rs\u{A0}",
+		'LRD' => '$',
+		'MGA' => "Ar\u{A0}",
+		'MMK' => "K\u{A0}",
+		'MNT' => "\u{20AE}",
+		'MUR' => "Rs\u{A0}",
+		'MXN' => '$',
+		'MYR' => "RM\u{A0}",
+		'NAD' => '$',
+		'NGN' => "\u{20A6}",
+		'NIO' => 'C$',
+		'NOK' => "kr\u{A0}",
+		'NPR' => "Rs\u{A0}",
+		'NZD' => '$',
+		'PHP' => "\u{20B1}",
+		'PKR' => "Rs\u{A0}",
+		'PLN' => "z\u{142}\u{A0}",
+		'PYG' => "\u{20B2}",
+		'RON' => "lei\u{A0}",
+		'RUB' => "\u{20BD}",
+		'RWF' => "RF\u{A0}",
+		'SBD' => '$',
+		'SEK' => "kr\u{A0}",
+		'SGD' => '$',
+		'SHP' => "\u{A3}",
+		'SRD' => '$',
+		'SSP' => "\u{A3}",
+		'STN' => "Db\u{A0}",
+		'SYP' => "\u{A3}",
+		'THB' => "\u{E3F}",
+		'TOP' => 'T$',
+		'TRY' => "\u{20BA}",
+		'TTD' => '$',
+		'TWD' => '$',
+		'UAH' => "\u{20B4}",
+		'USD' => '$',
+		'UYU' => '$',
+		'VND' => "\u{20AB}",
+		'XAF' => "FCFA\u{A0}",
+		'XCD' => '$',
+		'XCG' => "Cg.\u{A0}",
+		'XOF' => "F\u{202F}CFA\u{A0}",
+		'XPF' => "CFPF\u{A0}",
+		'ZAR' => "R\u{A0}",
+		'ZMW' => "ZK\u{A0}",
 	];
 
 	/**************************
@@ -187,7 +299,7 @@ class MessageFormatter
 								else {
 									require_once Sapi::canonicalPath(Config::$sourcedir . '/Unicode/Currencies.php');
 
-									$country_currencies = \function_exists('country_currencies') ? country_currencies() : [];
+									$country_currencies = country_currencies();
 
 									// If the admin wants to prioritize a certain country, use that.
 									if (!empty(Config::$modSettings['timezone_priority_countries'])) {
@@ -620,6 +732,8 @@ class MessageFormatter
 			'sign-always',
 			'sign-never',
 			'sign-except-zero',
+			'precision-currency-standard',
+			'precision-currency-cash',
 
 			// Tokens that manipulate the number.
 			'scale',
@@ -637,22 +751,20 @@ class MessageFormatter
 			'group-thousands',
 			'decimal-auto',
 			'decimal-always',
-			'percent',
-			'permille',
-			'currency',
-
-			// Unsupported.
-			'precision-currency-standard',
-			'precision-currency-cash',
-			'base-unit',
-			'measure-unit',
-			'unit',
-			'per-measure-unit',
 			'unit-width-narrow',
 			'unit-width-short',
 			'unit-width-full-name',
 			'unit-width-iso-code',
 			'unit-width-hidden',
+			'percent',
+			'permille',
+			'currency',
+
+			// Unsupported.
+			'base-unit',
+			'measure-unit',
+			'unit',
+			'per-measure-unit',
 			'latin',
 			'numbering-system',
 			'sign-negative',
@@ -668,6 +780,7 @@ class MessageFormatter
 		$round = fn(int|float|string $number, int $precision = 0) => round($number + 0, $precision, \RoundingMode::HalfEven);
 		$group = 'thousands';
 		$flags = '0';
+		$currency_symbols = self::CURRENCY_SYMBOLS_LONG;
 
 		// Work through the tokens.
 		foreach ($tokens as $token) {
@@ -755,7 +868,7 @@ class MessageFormatter
 					if ($precision >= 0) {
 						$number = \sprintf("%{$flags}.{$precision}F", $round($number, $precision));
 					} else {
-						$number = (string) $round($number, $precision);
+						$number = self::strval($round($number, $precision));
 					}
 				} else {
 					$precision = min(max($significant_decimals, \strlen($matches[1]) - $significant_integers), \strlen($matches[1]) - $significant_integers);
@@ -914,13 +1027,102 @@ class MessageFormatter
 
 						$currency = $currencies[$options[0]];
 
-						if ($currency['digits'] === 0) {
-							$number = \strval(\intval($number));
-						} else {
-							$number = \sprintf('%0.' . $currency['digits'] . 'F', $number);
+						$number = self::strval($round($number, $currency['digits']));
+
+						if (str_contains($skeleton, 'precision-currency-standard')) {
+							$number = self::applyNumberSkeleton(
+								$number,
+								'precision-increment/' . \sprintf('%0.' . $currency['digits'] . 'F', $currency['rounding'] * (10 ** -$currency['digits'])),
+							);
+						} elseif (str_contains($skeleton, 'precision-currency-cash')) {
+							$cash_digits = $currency['cashDigits'] ?? $currency['digits'];
+							$cash_rounding = $currency['cashRounding'] ?? $currency['rounding'];
+
+							$number = self::applyNumberSkeleton(
+								$number,
+								'precision-increment/' . \sprintf(
+									'%0.' . $cash_digits . 'F',
+									$cash_rounding * (10 ** -$cash_digits),
+								),
+							);
 						}
 
-						$post_processing[] = fn($number) => (\in_array(substr($number, 0, 1), ['-', '+']) ? substr($number, 0, 1) : '') . strtr(Lang::getTxt('currency_format', file: 'General'), ['{0}' => \in_array(substr($number, 0, 1), ['-', '+']) ? substr($number, 1) : $number, '¤' => self::CURRENCY_SYMBOLS[$options[0]] ?? ($options[0] === 'DEFAULT' ? '¤' : $options[0] . "\u{A0}")]);
+						$post_processing[] = function ($number) use ($currency_symbols, $options) {
+							// If this currency has no defined symbol, use the raw currency code.
+							$symbol = $currency_symbols[$options[0]] ?? $options[0] . "\u{A0}";
+
+							// Get this language's currency format.
+							$currency_format = Lang::getTxt('currency_format', file: 'General');
+
+							// Gather info about the format.
+							$symbol_after = (bool) preg_match('/\{0\}\s*¤/u', $currency_format, $matches);
+
+							$space_between = (bool) preg_match('/\s+¤|¤\s+/u', $currency_format, $matches);
+
+							// Do we need to force a space separator in there?
+							if ($space_between) {
+								$symbol = match ($symbol_after) {
+									false => match (str_ends_with($symbol, "\u{A0}")) {
+										false => $symbol . "\u{A0}",
+										true => $symbol,
+									},
+									true => match (str_starts_with($symbol, "\u{A0}")) {
+										false => "\u{A0}" . $symbol,
+										true => $symbol,
+									},
+								};
+							}
+
+							// Do we need to swap where the space separator occurs?
+							if ($symbol_after) {
+								$symbol = preg_replace('/(.*?)(\s+)$/', '$2$1', $symbol);
+							}
+
+							// Now that we've pushed any space separators into the symbols,
+							// remove the space separators from the format string.
+							$currency_format = preg_replace('/\s*¤\s*/', '¤', $currency_format);
+
+							// Deal with postive and negative signs.
+							if (!$symbol_after && \in_array(substr($number, 0, 1), ['-', '+'])) {
+								$sign = substr($number, 0, 1);
+								$number = substr($number, 1);
+							} else {
+								$sign = '';
+							}
+
+							// Do the job.
+							return $sign . strtr($currency_format, ['{0}' => $number, '¤' => $currency_symbol]);
+						};
+
+						break;
+
+					case 'precision-currency-standard':
+					case 'precision-currency-cash':
+						// These tokens are only meant to be used in conjuction
+						// with currency/XXX. If they occur alone, treat them
+						// like '.00'. Otherwise, they are handled elsewhere.
+						if (\count($tokens) === 1) {
+							$number = \sprintf("%{$flags}.2F", $round($number, 2));
+						}
+
+						break;
+
+					case 'unit-width-narrow':
+						$currency_symbols = self::CURRENCY_SYMBOLS_SHORT;
+						break;
+
+					case 'unit-width-short':
+					case 'unit-width-full-name':
+					case 'unit-width-iso-code':
+						$currency_symbols = self::CURRENCY_SYMBOLS_LONG;
+						break;
+
+					case 'unit-width-hidden':
+						require_once Sapi::canonicalPath(Config::$sourcedir . '/Unicode/Currencies.php');
+
+						foreach (currencies() as $currency_code => $currency_info) {
+							$currency_symbols[$currency_code] = '';
+						}
 
 						break;
 

--- a/Sources/Localization/MessageFormatter.php
+++ b/Sources/Localization/MessageFormatter.php
@@ -677,13 +677,13 @@ class MessageFormatter
 			// Float precision format.
 			if (str_starts_with($stem, '.')) {
 				// Special handling if $number is in scientific notation.
-				if (stripos(\strval($number), 'E') !== false) {
-					list($base, $exponent) = explode('E', strtoupper(\strval($number)));
+				if (strpos(var_export($number, true), 'E') !== false) {
+					list($base, $exponent) = explode('E', var_export($number, true));
 					$significant_integers = max(1, (int) $exponent);
 					$significant_decimals = (\strlen($base) - 2) + max(-$exponent, 0);
 				} else {
-					$significant_integers = \strlen(\strval(\intval($number + 0)));
-					$significant_decimals = (int) strpos(strrev(\strval($number)), '.');
+					$significant_integers = (int) strpos(self::strval($number), '.');
+					$significant_decimals = (int) strpos(strrev(self::strval($number)), '.');
 				}
 
 				preg_match('/\.(0*)(#*)(\*?)/', $stem, $matches);
@@ -728,20 +728,20 @@ class MessageFormatter
 
 				$number = \sprintf("%{$flags}.{$precision}F", $round($number, $precision));
 
-				if (!empty($options) && \in_array('w', $options) && $number == (int) $number) {
-					$number = \strval(\intval($number));
+				if (\in_array('w', $options ?? [])) {
+					$number = preg_replace('/\.0*$/', '', $number);
 				}
 			}
 			// Significant digits format.
 			elseif (str_starts_with($stem, '@')) {
 				// Special handling if $number is in scientific notation.
-				if (stripos(\strval($number), 'E') !== false) {
-					list($base, $exponent) = explode('E', strtoupper(\strval($number)));
+				if (strpos(var_export($number, true), 'E') !== false) {
+					list($base, $exponent) = explode('E', var_export($number, true));
 					$significant_integers = max(1, (int) $exponent);
 					$significant_decimals = (\strlen($base) - 2) + max(-$exponent, 0);
 				} else {
-					$significant_integers = \strlen(\strval(\intval($number + 0)));
-					$significant_decimals = (int) strpos(strrev(\strval($number)), '.');
+					$significant_integers = (int) strpos(self::strval($number), '.');
+					$significant_decimals = (int) strpos(strrev(self::strval($number)), '.');
 				}
 
 				preg_match('/(@+)(#*)(\*?)/', $stem, $matches);
@@ -763,8 +763,8 @@ class MessageFormatter
 					$number = \sprintf("%{$flags}.{$precision}F", $round($number, $precision));
 				}
 
-				if (!empty($options) && \in_array('w', $options) && $number == (int) $number) {
-					$number = \strval(\intval($number));
+				if (\in_array('w', $options ?? [])) {
+					$number = preg_replace('/\.0*$/', '', $number);
 				}
 			} else {
 				switch ($stem) {
@@ -859,14 +859,21 @@ class MessageFormatter
 						break;
 
 					case 'precision-increment':
-						$number /= $options[0];
-						$number = $round($number);
-						$number *= $options[0];
+						// Do we need to do any complicated rounding?
+						if (!empty($options[0] + 0) && trim($options[0], '0.') !== '1') {
+							$number = $round($number / $options[0]) * $options[0];
+						}
 
-						if (\is_float($number)) {
-							$precision = \is_float($options[0] + 0) ? \strlen($options[0]) - \strlen(\strval(\intval($options[0] + 0))) - 1 : 0;
+						$precision = str_contains($options[0], '.') ? strpos(strrev($options[0]), '.') : -(\strlen($options[0]) - 1);
 
-							$number = \sprintf("%0.{$precision}F", $number);
+						$number = self::strval($number);
+
+						if (!ctype_digit($number)) {
+							$number = \sprintf($precision <= 0 ? '%d' : '%.' . min($precision, strpos(strrev($number), '.')) . 'F', $round($number, $precision)) . str_repeat('0', max(0, $precision - strpos(strrev($number), '.')));
+						} elseif ($precision > 0) {
+							$number .= '.' . str_repeat('0', $precision);
+						} else {
+							$number = substr($number, 0, -(\strlen($options[0]))) . $round(substr($number, -(\strlen($options[0]))), $precision);
 						}
 
 						break;
@@ -972,11 +979,8 @@ class MessageFormatter
 		}
 
 		// Ensure $number is a string.
-		if (\is_float($number)) {
-			$precision = (int) strpos(strrev(\strval($number)), '.');
-			$number = \sprintf("%{$flags}.{$precision}F", $number);
-		} elseif (\is_int($number)) {
-			$number = \sprintf("%{$flags}d", $number);
+		if (!\is_string($number)) {
+			$number = self::strval($number, $flags);
 		}
 
 		// Apply the relevant grouping to the number.
@@ -1018,5 +1022,77 @@ class MessageFormatter
 		}
 
 		return $number;
+	}
+
+	/**
+	 * A wrapper for strval() with special handling to address the specific
+	 * needs of this class.
+	 *
+	 * @param mixed $input The value to be converted to a string.
+	 * @param string $flags Optional sprintf() flags.
+	 * @return string The new string.
+	 */
+	protected static function strval(mixed $input, string $flags = ''): string
+	{
+		// Convert floats to strings.
+		// Use var_export() for highest possible fidelity.
+		if (\is_float($input)) {
+			$input = var_export($input, true);
+		}
+
+		// For non-strings, just use normal strval().
+		if (!\is_string($input)) {
+			return $flags === '' ? @\strval($input) : \sprintf("%{$flags}s", @\strval($input));
+		}
+
+		// Non-numeric strings and integer strings need no further work.
+		if (!is_numeric($input) || ctype_digit($input)) {
+			return $input;
+		}
+
+		// A simple float.
+		if (stripos($input, 'E') === false) {
+			// Before returning, check whether sprintf() formats it with
+			// scientific notation.
+			$temp = \sprintf('%.17H', $input);
+
+			if (strpos($temp, 'E') === false) {
+				return \sprintf("%{$flags}.17H", $input);
+			}
+
+			$input = $temp;
+		}
+
+		// Scientific notation takes more work.
+		list($significand, $e) = explode('E', strtoupper($input));
+
+		$e = (int) $e;
+
+		// In case the decimal point is in a weird place.
+		if (strpos($significand, '.') !== 1) {
+			$e += strpos($significand, '.') - 1;
+			$significand = str_replace('.', '', $significand);
+			$significand = substr($significand, 0, 1) . '.' . substr($significand, 1);
+		}
+
+		// Shorten overly long significands.
+		if (\strlen($significand) > 18) {
+			// Do the rounding manually to avoid floating point errors.
+			$significand = substr($significand, 0, 17) . substr((string) round((int) substr($significand, 17, 2), -1), 0, 1);
+
+			$input = $significand . 'E' . \sprintf('%+d', $e);
+		}
+
+		// Negative exponents still aren't too difficult.
+		if ($e < 0) {
+			return \sprintf("%{$flags}." . (abs($e) + \strlen($significand) - 2) . 'F', $input);
+		}
+
+		// Postive exponents can get tricky for large values.
+		@list($int, $frac) = explode('.', $significand);
+
+		$frac = str_pad($frac ?? '', $e, '0');
+
+		return \sprintf("%{$flags}d", $int) . substr($frac, 0, $e) . rtrim('.' . substr($frac, $e), '.0');
 	}
 }

--- a/Sources/Localization/MessageFormatter.php
+++ b/Sources/Localization/MessageFormatter.php
@@ -607,9 +607,12 @@ class MessageFormatter
 			// Tokens that affect how to manipulate the number.
 			'rounding-mode-ceiling',
 			'rounding-mode-floor',
-			'rounding-mode-down',
 			'rounding-mode-up',
+			'rounding-mode-down',
 			'rounding-mode-half-even',
+			'rounding-mode-half-odd',
+			'rounding-mode-half-ceiling',
+			'rounding-mode-half-floor',
 			'rounding-mode-half-down',
 			'rounding-mode-half-up',
 			'rounding-mode-unnecessary',
@@ -662,7 +665,7 @@ class MessageFormatter
 		usort($tokens, fn($a, $b) => array_search(str_starts_with($a[0], '.') || str_starts_with($a[0], '@') ? substr($a[0], 0, 1) : $a[0], $preferred_order) <=> array_search(str_starts_with($b[0], '.') || str_starts_with($b[0], '@') ? substr($b[0], 0, 1) : $b[0], $preferred_order));
 
 		// A few variables that will affect how we manipulate and format numbers below.
-		$round = fn(int|float|string $number, int $precision = 0) => round($number + 0, $precision, PHP_ROUND_HALF_EVEN);
+		$round = fn(int|float|string $number, int $precision = 0) => round($number + 0, $precision, \RoundingMode::HalfEven);
 		$group = 'thousands';
 		$flags = '0';
 
@@ -766,44 +769,87 @@ class MessageFormatter
 			} else {
 				switch ($stem) {
 					case 'rounding-mode-ceiling':
-						$round = fn(int|float|string $number, int $precision = 0) => ceil($number * (10 ** $precision)) / (10 ** $precision);
+						$round = fn(int|float|string $number, int $precision = 0) => round(
+							$number + 0,
+							$precision,
+							\RoundingMode::PositiveInfinity,
+						);
 						break;
 
 					case 'rounding-mode-floor':
-						$round = fn(int|float|string $number, int $precision = 0) => floor($number * (10 ** $precision)) / (10 ** $precision);
+						$round = fn(int|float|string $number, int $precision = 0) => round(
+							$number + 0,
+							$precision,
+							\RoundingMode::NegativeInfinity,
+						);
 						break;
 
 					case 'rounding-mode-up':
-						$round = fn(int|float|string $number, int $precision = 0) => ($number >= 0 ? ceil($number * (10 ** $precision)) : floor($number * (10 ** $precision))) / (10 ** $precision);
+						$round = fn(int|float|string $number, int $precision = 0) => round(
+							$number + 0,
+							$precision,
+							\RoundingMode::AwayFromZero,
+						);
 						break;
 
 					case 'rounding-mode-down':
-						$round = fn(int|float|string $number, int $precision = 0) => ($number < 0 ? ceil($number * (10 ** $precision)) : floor($number * (10 ** $precision))) / (10 ** $precision);
+						$round = fn(int|float|string $number, int $precision = 0) => round(
+							$number + 0,
+							$precision,
+							\RoundingMode::TowardsZero,
+						);
 						break;
 
 					case 'rounding-mode-half-even':
-						$round = fn(int|float|string $number, int $precision = 0) => round($number + 0, $precision, PHP_ROUND_HALF_EVEN);
+						$round = fn(int|float|string $number, int $precision = 0) => round(
+							$number + 0,
+							$precision,
+							\RoundingMode::HalfEven,
+						);
 						break;
 
 					case 'rounding-mode-half-odd':
-						$round = fn(int|float|string $number, int $precision = 0) => round($number + 0, $precision, PHP_ROUND_HALF_ODD);
+						$round = fn(int|float|string $number, int $precision = 0) => round(
+							$number + 0,
+							$precision,
+							\RoundingMode::HalfOdd,
+						);
 						break;
 
 					case 'rounding-mode-half-ceiling':
-						$round = fn(int|float|string $number, int $precision = 0) => round($number + 0, $precision, $number >= 0 ? PHP_ROUND_HALF_UP : PHP_ROUND_HALF_DOWN);
+						$round = fn(int|float|string $number, int $precision = 0) => round(
+							$number + 0,
+							$precision,
+							$number >= 0 ? \RoundingMode::HalfAwayFromZero : \RoundingMode::HalfTowardsZero,
+						);
 						break;
 
 					case 'rounding-mode-half-floor':
-						$rounding_mode = $number < 0 ? PHP_ROUND_HALF_UP : PHP_ROUND_HALF_DOWN;
-						$round = fn(int|float|string $number, int $precision = 0) => round($number + 0, $precision, $number < 0 ? PHP_ROUND_HALF_UP : PHP_ROUND_HALF_DOWN);
+						$round = fn(int|float|string $number, int $precision = 0) => round(
+							$number + 0,
+							$precision,
+							$number < 0 ? \RoundingMode::HalfAwayFromZero : \RoundingMode::HalfTowardsZero,
+						);
 						break;
 
 					case 'rounding-mode-half-down':
-						$round = fn(int|float|string $number, int $precision = 0) => round($number + 0, $precision, PHP_ROUND_HALF_DOWN);
+						$round = fn(int|float|string $number, int $precision = 0) => round(
+							$number + 0,
+							$precision,
+							\RoundingMode::HalfTowardsZero,
+						);
 						break;
 
 					case 'rounding-mode-half-up':
-						$round = fn(int|float|string $number, int $precision = 0) => round($number + 0, $precision, PHP_ROUND_HALF_UP);
+						$round = fn(int|float|string $number, int $precision = 0) => round(
+							$number + 0,
+							$precision,
+							\RoundingMode::HalfAwayFromZero,
+						);
+						break;
+
+					case 'rounding-mode-unnecessary':
+						$round = fn(int|float|string $number, int $precision = 0) => (float) $number;
 						break;
 
 					case 'scale':

--- a/Sources/Localization/MessageFormatter.php
+++ b/Sources/Localization/MessageFormatter.php
@@ -199,6 +199,16 @@ class MessageFormatter
 	 */
 	private static $message_formatters = [];
 
+	/**
+	 * @var bool
+	 *
+	 * Whether to use the intl extension's \MessageFormatter class.
+	 *
+	 * This only exists for internal purposes and should be regarded as an
+	 * implementation detail.
+	 */
+	private static $use_intl;
+
 	/***********************
 	 * Public static methods
 	 ***********************/
@@ -214,6 +224,23 @@ class MessageFormatter
 	{
 		if ($args === [] || !str_contains($message, '{') || !str_contains($message, '}')) {
 			return $message;
+		}
+
+		self::$use_intl ??= class_exists('\MessageFormatter');
+
+		// Workaround for cases where ICU loses precision on some manipulations
+		// of very large numbers.
+		if (self::$use_intl && preg_match_all('/^{\s*([^\s,]+)\s*,\s*number(?:,[^,}]+)?}$/', $message, $matches, PREG_SET_ORDER)) {
+			foreach ($matches as $match) {
+				if (
+					is_numeric($args[$match[1]] ?? null)
+					&& ($args[$match[1]] >= (2 ** 53) || $args[$match[1]] < -(2 ** 53))
+				) {
+					self::$use_intl = false;
+					$message = str_replace($match[0], self::formatMessage($match[0], [$match[1] => $args[$match[1]]]), $message);
+					self::$use_intl = true;
+				}
+			}
 		}
 
 		// Avoid issues with MessageFormat syntax characters in $args.
@@ -233,7 +260,7 @@ class MessageFormatter
 		}
 
 		// Use the intl extension's MessageFormatter class if available.
-		if (class_exists('\MessageFormatter')) {
+		if (self::$use_intl) {
 			if (!isset(self::$message_formatters[Lang::getTxt('lang_locale', file: 'General')][$message])) {
 				self::$message_formatters[Lang::getTxt('lang_locale', file: 'General')][$message] = new \MessageFormatter(Lang::getTxt('lang_locale', file: 'General'), $message);
 			}

--- a/Sources/Localization/MessageFormatter.php
+++ b/Sources/Localization/MessageFormatter.php
@@ -304,6 +304,11 @@ class MessageFormatter
 				// @todo Implement 'spellout' properly.
 				case 'spellout':
 				case 'number':
+					if (!is_numeric($args[$arg_name] ?? null)) {
+						$final .= $part;
+						break;
+					}
+
 					if (str_starts_with($rest, '::')) {
 						$final .= self::applyNumberSkeleton($args[$arg_name] ?? 0, ltrim(substr($rest, 2)));
 					} else {
@@ -382,10 +387,20 @@ class MessageFormatter
 					break;
 
 				case 'ordinal':
+					if (!isset($args[$arg_name])) {
+						$final .= $part;
+						break;
+					}
+
 					$final .= self::formatMessage(Lang::getTxt('ordinal', file: 'General'), [$args[$arg_name]]);
 					break;
 
 				case 'date':
+					if (!isset($args[$arg_name])) {
+						$final .= $part;
+						break;
+					}
+
 					if ($args[$arg_name] instanceof \DateTimeInterface) {
 						$args[$arg_name] = Time::createFromInterface($args[$arg_name]);
 					} elseif (is_numeric($args[$arg_name])) {
@@ -427,6 +442,11 @@ class MessageFormatter
 					break;
 
 				case 'time':
+					if (!isset($args[$arg_name])) {
+						$final .= $part;
+						break;
+					}
+
 					if ($args[$arg_name] instanceof \DateTimeInterface) {
 						$args[$arg_name] = Time::createFromInterface($args[$arg_name]);
 					} elseif (is_numeric($args[$arg_name])) {
@@ -463,6 +483,11 @@ class MessageFormatter
 					break;
 
 				case 'duration':
+					if (!is_numeric($args[$arg_name] ?? null)) {
+						$final .= $part;
+						break;
+					}
+
 					// Input is a number of seconds.
 					$args[$arg_name] = (int) $args[$arg_name];
 
@@ -479,6 +504,11 @@ class MessageFormatter
 					break;
 
 				case 'plural':
+					if (!is_numeric($args[$arg_name] ?? null)) {
+						$final .= $part;
+						break;
+					}
+
 					if (str_starts_with($rest, 'offset:')) {
 						preg_match('/^offset:(\d+)/', $rest, $offset_matches);
 						$offset = $offset_matches[1];
@@ -509,6 +539,11 @@ class MessageFormatter
 					break;
 
 				case 'selectordinal':
+					if (!is_numeric($args[$arg_name] ?? null)) {
+						$final .= $part;
+						break;
+					}
+
 					if (str_starts_with($rest, 'offset:')) {
 						preg_match('/^offset:(\d+)/', $rest, $offset_matches);
 						$offset = $offset_matches[1];
@@ -539,6 +574,11 @@ class MessageFormatter
 					break;
 
 				case 'select':
+					if (!isset($args[$arg_name])) {
+						$final .= $part;
+						break;
+					}
+
 					preg_match_all('/\b(?P<rule>\w+)\b\s*(?P<sel>{(?' . '>[^{}]|(?2))*})/', $rest, $cases, PREG_SET_ORDER);
 
 					foreach ($cases as $case) {
@@ -553,7 +593,7 @@ class MessageFormatter
 					break;
 
 				default:
-					if (\is_scalar($args[$arg_name]) || $args[$arg_name] instanceof \Stringable) {
+					if (isset($args[$arg_name]) && (\is_scalar($args[$arg_name]) || $args[$arg_name] instanceof \Stringable)) {
 						$final .= (string) $args[$arg_name];
 					} else {
 						$final .= $part;

--- a/Sources/Localization/MessageFormatter.php
+++ b/Sources/Localization/MessageFormatter.php
@@ -546,26 +546,6 @@ class MessageFormatter
 	protected static function applyNumberSkeleton(int|float|string $number, string $skeleton): string
 	{
 		// For simplicity, standardize alternative notations to a single form.
-		$skeleton = strtr($skeleton, [
-			'%x100' => 'percent scale/100',
-			',_' => 'group-off',
-			',?' => 'group-min2',
-			',!' => 'group-on-aligned',
-			'+!' => 'sign-always',
-			'+_' => 'sign-never',
-			'+?' => 'sign-except-zero',
-			'+-' => 'sign-negative',
-			'()' => 'sign-accounting',
-			'()!' => 'sign-accounting-always',
-			'()?' => 'sign-accounting-except-zero',
-			'()-' => 'sign-accounting-negative',
-			'KK' => 'compact-long',
-			'K' => 'compact-short',
-			'precision-integer' => '.',
-			'precision-unlimited' => '.*',
-			'sign-auto' => '',
-		]);
-
 		$skeleton = preg_replace_callback_array(
 			[
 				'/(?<=\s|^)(EE?)((?:\+[!?])?)(0+)(?=\s|$)/' => function ($matches) {
@@ -588,6 +568,24 @@ class MessageFormatter
 					return $long_form;
 				},
 				'/(?<=\s|^)0+(?=\s|$)/' => fn($matches) => 'integer-width/*' . $matches[0],
+				'/(?<=\s|^)(KK?)(?=\s|$)/' => fn($matches) => 'compact-' . ($matches[1] === 'KK' ? 'long' : 'short'),
+				'/(?<=\s|^)%x(\d+)(?=\s|$)/' => fn($matches) => 'percent scale/' . $matches[1],
+				'/(?<=\s|^)(?>\(\)[!?\-]?|\+[!?\-_]|,[!?_])(?=\s|$)/' => fn($matches) => match ($matches[0]) {
+					',_' => 'group-off',
+					',?' => 'group-min2',
+					',!' => 'group-on-aligned',
+					'+!' => 'sign-always',
+					'+_' => 'sign-never',
+					'+?' => 'sign-except-zero',
+					'+-' => 'sign-negative',
+					'()' => 'sign-accounting',
+					'()!' => 'sign-accounting-always',
+					'()?' => 'sign-accounting-except-zero',
+					'()-' => 'sign-accounting-negative',
+				},
+				'/(?<=\s|^)precision-integer(?=\s|$)/' => fn($matches) => '.',
+				'/(?<=\s|^)precision-unlimited(?=\s|$)/' => fn($matches) => '.*',
+				'/(?<=\s|^)sign-auto(?=\s|$)/' => fn($matches) => '',
 			],
 			$skeleton,
 		);

--- a/Sources/ServerSideIncludes.php
+++ b/Sources/ServerSideIncludes.php
@@ -505,7 +505,7 @@ class ServerSideIncludes
 				echo Lang::getTxt('hello_member', file: 'General'), ' <strong>', User::$me->name, '</strong>';
 
 				if (User::$me->allowedTo('pm_read')) {
-					echo ', ', Lang::getTxt('msg_alert', ['total' => User::$me->messages, 'unread' => User::$me->unread_messages], file: 'General');
+					echo ', ', Lang::getTxt('msg_alert', ['total' => User::$me->messages, 'unread' => User::$me->unread_messages, 'url' => Config::$scripturl . '?action=pm;f=inbox'], file: 'General');
 				}
 			}
 


### PR DESCRIPTION
1. Fixes some bugs.
2. Improves formatting of floating point numbers.
3. Improves currency support.
4. If the intl extension's \MessageFormatter fails to format a message for some reason, tries again using our fallback code before giving up.