### PR TITLE
[2.1] Upgrader - Set db_character_set

### DIFF
--- a/other/upgrade.php
+++ b/other/upgrade.php
@@ -807,6 +807,35 @@ function loadEssentialData()
 			die($txt['error_db_connect_settings'] . '<br><br>' . $db_error);
 		}
 
+		// Many old 2.0 DBs don't have $db_character_set defined in Settings.php.
+		// We need to set it explicitly here so SET NAMES can do its job.
+		// Set it based on the charset for smf_messages.body.
+		if ($db_type == 'mysql' && !isset($db_character_set))
+		{
+			$body_charset = '';
+			$request = $smcFunc['db_query']('', '
+				SELECT CHARACTER_SET_NAME
+				FROM INFORMATION_SCHEMA.COLUMNS
+				WHERE TABLE_SCHEMA = {string:schema}
+				AND TABLE_NAME = {string:table}
+				AND COLUMN_NAME = {string:column}',
+				array(
+					'schema' => $db_name,
+					'table' => $db_prefix . 'messages',
+					'column' => 'body',
+				)
+			);
+			list ($body_charset) = $smcFunc['db_fetch_row']($request);
+			if (!empty($body_charset))
+			{
+				$db_character_set = $body_charset;
+				$changes = array();
+				$changes['db_character_set'] = $db_character_set;
+				require_once($sourcedir . '/Subs-Admin.php');
+				updateSettingsFile($changes);
+			}
+		}
+
 		if ($db_type == 'mysql' && isset($db_character_set) && preg_match('~^\w+$~', $db_character_set) === 1)
 			$smcFunc['db_query']('', '
 				SET NAMES {string:db_character_set}',


### PR DESCRIPTION
Spun off from #9271 

Mid-upgrade, $db_character_set was getting erroneously set to 'utf8' in step 2 under some circumstances.  So, if there were non-utf8 characters, updates to that data could mangle or delete the data.  This is mostly visible during the json conversion, where lots of latin1 characters may be encountered.  Both MySQL & MariaDB are affected.

In 2.0, $db_character_set was not set by the SMF installer.   So it's blank for a lot of forums.  The 2.1 upgrader, when the 'Migrate to new Settings.php' box is checked, detects the blank $db_character_set and defaults it to 'utf8'.  This causes the upgrader to issue a SET NAMES for 'utf8'.  Database updates prior to the utf8 conversion could cause issues.

So, this PR detects what $db_character_set should be, then sets it in Settings.php.  That way the Settings.php migration leaves it alone.  It is then properly set to 'utf8' in a later step, after the utf8 conversion completes.

If approved, I'll work on a 3.0 version.

Note there is still one odd wrinkle related to charsets/collations I haven't figured out...  During the utf8 conversion, MariaDB is setting all the tables to utf8mb3_uca1400_ai_ci instead of utf8mb3_general_ci, the SMF 2.1 default.  They are not synonymous.  Haven't figured out why yet.  