### PR TITLE
[3.0] Misc fixes for SMF\Profile

### DIFF
--- a/Sources/Actions/Profile/GroupMembership.php
+++ b/Sources/Actions/Profile/GroupMembership.php
@@ -44,6 +44,17 @@ class GroupMembership implements ActionInterface
 	 */
 	public string $change_type;
 
+	/*********************
+	 * Internal properties
+	 *********************/
+
+	/**
+	 * @var array
+	 *
+	 * Info about groups that this member is part of or can become part of.
+	 */
+	protected array $current_and_assignable_groups;
+
 	/****************
 	 * Public methods
 	 ****************/
@@ -103,7 +114,7 @@ class GroupMembership implements ActionInterface
 		}, $open_requests);
 
 		// Show the assignable groups in the templates.
-		foreach (Profile::$member->current_and_assignable_groups as $id => $group) {
+		foreach ($this->current_and_assignable_groups as $id => $group) {
 			// Skip "Regular Members" for now.
 			if ($id == 0) {
 				continue;
@@ -173,12 +184,12 @@ class GroupMembership implements ActionInterface
 		// Which groups can they be assigned to?
 		$this->loadCurrentAndAssignableGroups();
 
-		if (!isset(Profile::$member->current_and_assignable_groups[$new_group_id])) {
+		if (!isset($this->current_and_assignable_groups[$new_group_id])) {
 			ErrorHandler::fatalLang('cannot_manage_membergroups', false);
 		}
 
 		// Just for improved legibility...
-		$new_group_info = Profile::$member->current_and_assignable_groups[$new_group_id];
+		$new_group_info = $this->current_and_assignable_groups[$new_group_id];
 
 		// Can't request a non-requestable group.
 		if ($this->change_type == 'request' && $new_group_info['type'] != 2) {
@@ -269,7 +280,7 @@ class GroupMembership implements ActionInterface
 	 */
 	protected function loadCurrentAndAssignableGroups(): void
 	{
-		if (isset(Profile::$member->current_and_assignable_groups)) {
+		if (isset($this->current_and_assignable_groups)) {
 			return;
 		}
 
@@ -306,7 +317,7 @@ class GroupMembership implements ActionInterface
 			},
 		);
 
-		Profile::$member->current_and_assignable_groups = $current_and_assignable_groups;
+		$this->current_and_assignable_groups = $current_and_assignable_groups;
 	}
 
 	/**
@@ -319,16 +330,16 @@ class GroupMembership implements ActionInterface
 
 		// Hidden groups cannot be primary groups.
 		if (isset($new_group_id)) {
-			$can_edit_primary = Profile::$member->current_and_assignable_groups[$new_group_id]->can_be_primary;
+			$can_edit_primary = $this->current_and_assignable_groups[$new_group_id]->can_be_primary;
 		} else {
-			$possible_primary_groups = array_filter(Profile::$member->current_and_assignable_groups, fn($group) => !empty($group->can_be_primary));
+			$possible_primary_groups = array_filter($this->current_and_assignable_groups, fn($group) => !empty($group->can_be_primary));
 
 			$can_edit_primary = !empty($possible_primary_groups);
 		}
 
 		// Changing the primary group means turning the current primary group
 		// into an additional group. So, is that possible?
-		$can_edit_primary &= Profile::$member->group_id == Group::REGULAR || Profile::$member->current_and_assignable_groups[Profile::$member->group_id]->can_be_additional;
+		$can_edit_primary &= Profile::$member->group_id == Group::REGULAR || $this->current_and_assignable_groups[Profile::$member->group_id]->can_be_additional;
 
 		return (bool) $can_edit_primary;
 	}

--- a/Sources/Profile.php
+++ b/Sources/Profile.php
@@ -1133,8 +1133,10 @@ class Profile extends User implements \ArrayAccess
 			$this->custom_fields_required = $this->custom_fields_required || $cf_def['show_reg'] == 2;
 		}
 
-		Utils::$context['custom_fields'] = &$this->custom_fields;
-		Utils::$context['custom_fields_required'] = &$this->custom_fields_required;
+		if ($this === self::$member) {
+			Utils::$context['custom_fields'] = &$this->custom_fields;
+			Utils::$context['custom_fields_required'] = &$this->custom_fields_required;
+		}
 
 		IntegrationHook::call('integrate_load_custom_profile_fields', [$this->id, $area]);
 	}
@@ -1149,6 +1151,11 @@ class Profile extends User implements \ArrayAccess
 	 */
 	public function loadThemeOptions(bool $default_only = false): void
 	{
+		// This only applies to self::$member.
+		if ($this !== self::$member) {
+			return;
+		}
+
 		// Get this member's current theme options.
 		if ($default_only && $this->theme != (Config::$modSettings['theme_guests'] ?? 1)) {
 			$temp = $this->data['options'] ?? [];
@@ -1207,6 +1214,11 @@ class Profile extends User implements \ArrayAccess
 	 */
 	public function loadSignatureData(): bool
 	{
+		// This only applies to self::$member.
+		if ($this !== self::$member) {
+			return false;
+		}
+
 		// Signature limits.
 		list($sig_limits, $sig_bbc) = explode(':', Config::$modSettings['signature_settings']);
 		$sig_limits = explode(',', $sig_limits);
@@ -1305,18 +1317,20 @@ class Profile extends User implements \ArrayAccess
 		}
 
 		// For the templates.
-		Utils::$context['member_groups'] = [
-			0 => [
-				'id' => 0,
-				'name' => Lang::getTxt('no_primary_membergroup', file: 'Profile'),
-				'is_primary' => $this->data['id_group'] == 0,
-				'can_be_additional' => false,
-				'can_be_primary' => true,
-			],
-		];
+		if ($this === self::$member) {
+			Utils::$context['member_groups'] = [
+				0 => [
+					'id' => 0,
+					'name' => Lang::getTxt('no_primary_membergroup', file: 'Profile'),
+					'is_primary' => $this->data['id_group'] == 0,
+					'can_be_additional' => false,
+					'can_be_primary' => true,
+				],
+			];
 
-		// Do not use array merge here, does not maintain key association.
-		Utils::$context['member_groups'] += $this->assignable_groups;
+			// Do not use array merge here, does not maintain key association.
+			Utils::$context['member_groups'] += $this->assignable_groups;
+		}
 
 		return true;
 	}
@@ -1326,9 +1340,15 @@ class Profile extends User implements \ArrayAccess
 	 *
 	 * @param array $fields The profile fields to display. Each item should
 	 *    correspond to an item in the $this->standard_fields array.
+	 * @throws \LogicException if called on an object that is not self::$member.
 	 */
 	public function setupContext(array $fields): void
 	{
+		if ($this !== self::$member) {
+			// Complain loudly about this programmer error.
+			throw new \LogicException('Called ' . __METHOD__ . ' for a profile that is not ' . __CLASS__ . '::$member');
+		}
+
 		// Some default bits.
 		Utils::$context['profile_prehtml'] = '';
 		Utils::$context['profile_posthtml'] = '';

--- a/Sources/Profile.php
+++ b/Sources/Profile.php
@@ -276,7 +276,7 @@ class Profile extends User implements \ArrayAccess
 	 *
 	 * @param bool $force_reload Whether to reload the data.
 	 */
-	public function loadStandardFields(bool $force_reload = false)
+	public function loadStandardFields(bool $force_reload = false): void
 	{
 		// Don't load this twice!
 		if (!empty($this->standard_fields) && !$force_reload) {
@@ -1147,7 +1147,7 @@ class Profile extends User implements \ArrayAccess
 	 *    theme, where "default theme" means whichever theme is used for guests.
 	 *    Default: false.
 	 */
-	public function loadThemeOptions(bool $default_only = false)
+	public function loadThemeOptions(bool $default_only = false): void
 	{
 		// Get this member's current theme options.
 		if ($default_only && $this->theme != (Config::$modSettings['theme_guests'] ?? 1)) {


### PR DESCRIPTION
1. [Adds some missing return types in SMF\Profile](https://github.com/SimpleMachines/SMF/commit/ded73908996e4ca10cb51dfd7082858c5e11ecf7)
2. [Avoids creating an unnecessary dynamic property for SMF\Profile](https://github.com/SimpleMachines/SMF/commit/3b607fa01c1184c6ef6629c4b3620c629318b2c5)
3. [Ensures that only Profile::$member can affect profile context data](https://github.com/SimpleMachines/SMF/commit/bae847499f3ddf2a0f558e1da74a70e6e80118f3)