### PR TITLE
[2.1] Replaces backticks with shell_exec()

### DIFF
--- a/Sources/Load.php
+++ b/Sources/Load.php
@@ -376,7 +376,7 @@ function reloadSettings()
 			$modSettings['load_average'] = @file_get_contents('/proc/loadavg');
 			if (!empty($modSettings['load_average']) && preg_match('~^([^ ]+?) ([^ ]+?) ([^ ]+)~', $modSettings['load_average'], $matches) != 0)
 				$modSettings['load_average'] = (float) $matches[1];
-			elseif (($modSettings['load_average'] = @`uptime`) != null && preg_match('~load average[s]?: (\d+\.\d+), (\d+\.\d+), (\d+\.\d+)~i', $modSettings['load_average'], $matches) != 0)
+			elseif (($modSettings['load_average'] = @shell_exec('uptime')) != null && preg_match('~load average[s]?: (\d+\.\d+), (\d+\.\d+), (\d+\.\d+)~i', $modSettings['load_average'], $matches) != 0)
 				$modSettings['load_average'] = (float) $matches[1];
 			else
 				unset($modSettings['load_average']);

--- a/Sources/ManageServer.php
+++ b/Sources/ManageServer.php
@@ -939,7 +939,7 @@ function ModifyLoadBalancingSettings($return_config = false)
 		$modSettings['load_average'] = @file_get_contents('/proc/loadavg');
 		if (!empty($modSettings['load_average']) && preg_match('~^([^ ]+?) ([^ ]+?) ([^ ]+)~', $modSettings['load_average'], $matches) !== 0)
 			$modSettings['load_average'] = (float) $matches[1];
-		elseif (($modSettings['load_average'] = @`uptime`) !== null && preg_match('~load averages?: (\d+\.\d+), (\d+\.\d+), (\d+\.\d+)~i', $modSettings['load_average'], $matches) !== 0)
+		elseif (($modSettings['load_average'] = @shell_exec('uptime')) !== null && preg_match('~load averages?: (\d+\.\d+), (\d+\.\d+), (\d+\.\d+)~i', $modSettings['load_average'], $matches) !== 0)
 			$modSettings['load_average'] = (float) $matches[1];
 		else
 			unset($modSettings['load_average']);


### PR DESCRIPTION
The backtick operator as an alias for shell_exec() has been deprecated in PHP 8.5.