### PR TITLE
[3.0] Ensures hooks are never called during maintenance scripts

### DIFF
--- a/Sources/IntegrationHook.php
+++ b/Sources/IntegrationHook.php
@@ -48,6 +48,19 @@ class IntegrationHook
 	 */
 	public array $results = [];
 
+	/**************************
+	 * Public static properties
+	 **************************/
+
+	/**
+	 * @var bool
+	 *
+	 * Whether integration hooks are currently enabled.
+	 *
+	 * Always true except in special circumstances.
+	 */
+	public static bool $enabled = true;
+
 	/*********************
 	 * Internal properties
 	 *********************/
@@ -72,7 +85,11 @@ class IntegrationHook
 	 */
 	public function __construct(string $name, ?bool $ignore_errors = null)
 	{
-		if (!class_exists('SMF\\Config', false) || !class_exists('SMF\\Utils', false)) {
+		if (
+			!self::$enabled
+			|| !class_exists('SMF\\Config', false)
+			|| !class_exists('SMF\\Utils', false)
+		) {
 			return;
 		}
 
@@ -110,7 +127,7 @@ class IntegrationHook
 	 */
 	public function execute(array $parameters = []): array
 	{
-		if (empty($this->callables)) {
+		if (!self::$enabled || empty($this->callables)) {
 			return $this->results;
 		}
 

--- a/Sources/Maintenance/Maintenance.php
+++ b/Sources/Maintenance/Maintenance.php
@@ -17,6 +17,7 @@ namespace SMF\Maintenance;
 
 use SMF\Config;
 use SMF\Db\DatabaseApi as Db;
+use SMF\IntegrationHook;
 use SMF\Lang;
 use SMF\Maintenance\Tools\ToolsInterface;
 use SMF\Sapi;
@@ -233,6 +234,9 @@ class Maintenance
 		// This might be overwritten by the tool, but we need a default value.
 		self::$context['started'] = (int) TIME_START;
 		self::$script_start = (int) TIME_START;
+
+		// No integration hooks allowed during maintenance.
+		IntegrationHook::$enabled = false;
 	}
 
 	/**


### PR DESCRIPTION
1. Implements a global switch to disable all integration hooks.
2. Uses that switch to disable all integration hooks during maintenance scripts (installer, upgrader, converters, etc.)