### PR TITLE
40 files per process

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -230,5 +230,5 @@ return (new PhpCsFixer\Config())
 		],
 	])
 	->setIndent("\t")
-	->setParallelConfig(PhpCsFixer\Runner\Parallel\ParallelConfigFactory::detect())
+	->setParallelConfig(PhpCsFixer\Runner\Parallel\ParallelConfigFactory::detect(40))
 	->setFinder($finder);


### PR DESCRIPTION
Testing to see whether the overhead of creating processes in `php-cs-fixer` is greater than the time taken to run the fixers.
