### PR TITLE
[3.0] Read cached bans from the right place in the session

### DIFF
--- a/Sources/Security.php
+++ b/Sources/Security.php
@@ -393,7 +393,14 @@ class Security
 			&& ($_SESSION['ban']['email'] ?? NAN) == ($user->email ?? NAN)
 		) {
 			foreach ($restrictions as $restriction) {
-				$bans[$restriction] = $_SESSION[$restriction];
+				// Only the restrictions that actually applied were stored.
+				if (isset($_SESSION['ban'][$restriction])) {
+					$bans[$restriction] = $_SESSION['ban'][$restriction];
+				}
+			}
+
+			if (isset($_SESSION['ban']['expire_time'])) {
+				$bans['expire_time'] = $_SESSION['ban']['expire_time'];
 			}
 
 			return $bans;


### PR DESCRIPTION
> [!NOTE]
> **This change was produced by an LLM.** The code, the commit message and this
> description were all written by Claude (Anthropic), driven by @albertlast. It has
> not yet had human code review.
>
> Everything stated below was verified by actually running it against a fresh
> PostgreSQL install of this branch, rather than only reasoned about. Even so,
> please review it as untrusted work: the diagnosis may be right while the fix is
> not what SMF would prefer stylistically or architecturally.

#### Description

`Security::checkBans()` stores the restrictions that applied under `$_SESSION['ban']`,
by merging them in alongside the metadata:

```php
$_SESSION['ban'] = array_merge(
    ['last_checked' => time(), 'id_member' => ..., 'ip' => ..., 'ip2' => ..., 'email' => ...],
    $bans,
);
```

The cached path read them back from `$_SESSION` directly, one level too high, so it
never found them:

```php
$bans[$restriction] = $_SESSION[$restriction];
```

That is four warnings on every request that takes the cached path:

```
Undefined array key "cannot_access" in Sources/Security.php:396
Undefined array key "cannot_login" in Sources/Security.php:396
Undefined array key "cannot_post" in Sources/Security.php:396
Undefined array key "cannot_register" in Sources/Security.php:396
```

and an array of `null`s returned to the caller, so a banned member stops being
recognised as banned until the ban is rechecked against the database.

This reads from `$_SESSION['ban']`, and only copies restrictions that are actually
present, since `checkBans()` only stores the ones that applied. It also restores
`expire_time`, which the cached path dropped even though `User::enforceBans()` uses
it to tell the member when the ban ends.

#### How this was verified

PostgreSQL 17 / PHP 8.4. Before: four warnings logged per request taking the cached
path. After: eight consecutive guest requests, **0 errors logged**, all HTTP 200.
Re-checked with a real ban in place to confirm the cached path still returns the ban.

#### Relationship to other PRs

Same subsystem as #9310, #9311 and #9312, but an independent mechanism — this one is
observable without any ban existing, as log spam on ordinary requests. Merges cleanly
alongside them.

Also merges cleanly onto #9302, which touches `Sources/Security.php` at lines 24, 676
and 1037; this change is at ~396.

#### Relationship to issue #9307

#9307, "[3.0] Guest access broken", quotes this exact warning:

```
Warning: Undefined array key "cannot_access" in /Sources/Security.php on line 396
```

Recorded as *related* rather than as a fix. #9307 also reports
`Typed static property SMF\Profile::$member must not be accessed before initialization`
and a `TypeError: rej is not a function`, neither of which this change touches, so
merging it should not close the issue.

### Issues References (Fixes|Related|Closes)
1. Related: #9307 (partially; see above. Not a fix, do not close on merge.)
2. Related: #9310, #9311, #9312

