### PR TITLE
[3.0] Don't treat a new topic as an unapproved topic

### DIFF
--- a/Sources/Actions/Post2.php
+++ b/Sources/Actions/Post2.php
@@ -180,7 +180,9 @@ class Post2 extends Post
 		$this->submitAttachments();
 
 		// Replies to unapproved topics are unapproved by default (but not for moderators)
-		if (empty(Topic::$info->is_approved) && !$this->can_approve) {
+		// There is no topic yet when starting a new one, so Topic::$info is null
+		// in that case and must not be mistaken for an unapproved topic.
+		if ($this->intent !== self::INTENT_NEW_TOPIC && empty(Topic::$info->is_approved) && !$this->can_approve) {
 			$this->becomes_approved = false;
 
 			// Set a nice session var...


### PR DESCRIPTION
> [!NOTE]
> **This change was produced by an LLM.** The code, the commit message and this
> description were all written by Claude (Anthropic), driven by @albertlast. It has
> not yet had human code review.
>
> Everything stated below was verified by actually running it against a PostgreSQL
> install of this branch, rather than only reasoned about. Even so, please review it
> as untrusted work: the diagnosis may be right while the fix is not what SMF would
> prefer stylistically or architecturally.

#### Description

An ordinary member who starts a new topic is told, on the page they land on
afterwards:

> Your message was not approved because it was posted in an unapproved topic. Once
> the topic is approved your message will be approved too.

The topic is in fact approved. `Post2::submit()` decides this before it knows which
kind of post it is dealing with:

```php
// Replies to unapproved topics are unapproved by default (but not for moderators)
if (empty(Topic::$info->is_approved) && !$this->can_approve) {
    $this->becomes_approved = false;

    // Set a nice session var...
    $_SESSION['becomesUnapproved'] = true;
}
```

When a new topic is being started there is no topic yet. `Post2::execute()` only
loads one when there is something to load:

```php
// If there is an existing topic, load it.
if ($this->intent !== self::INTENT_NEW_TOPIC) {
    $this->loadTopic();
}
```

So `Topic::$info` is `null`, `empty(null->is_approved)` is `true` under `empty()`'s
isset semantics, and every non-approver who starts a topic gets
`$_SESSION['becomesUnapproved']` set. `MessageIndex` and `Display` pick that up on
the next page and show the notice.

The post itself is unaffected — `prepareNewTopic()` runs immediately afterwards and
sets `$becomes_approved = true` again — so this is purely a bogus message. It also
fires with post moderation switched off entirely, since the check never consults
`postmod_active`.

In 2.1 the whole block sat inside `if (!empty($topic))` (`Sources/Post.php`, ~1789),
so it only ever applied to replies. That guard was lost when the code moved into
`Post2`. This restores it in the form `Post2` uses to express the same thing, which
is `$this->intent !== self::INTENT_NEW_TOPIC`.

#### How this was verified

PostgreSQL 17 / PHP 8.4.23, as an ordinary member with no moderation permissions.

Worth noting up front: the test install has post moderation entirely off —
`postmod_active` is not even present in `smf_settings` — which is what shows the
check is misfiring rather than doing its job.

- Before: member starts a new topic, is redirected to the board index, and the
  "posted in an unapproved topic" notice is **shown**. Meanwhile the database has
  `topics.approved = 1` and `messages.approved = 1` for what was just posted, so the
  message contradicts what actually happened.
- After: same steps, notice **not shown**, post still stored approved.
- Regression check on the case the code is actually for: marked a topic unapproved,
  then replied to it as the same member. The notice is **still shown** and the reply
  is stored with `approved = 0`, so genuine replies to unapproved topics behave
  exactly as before.

`php -l` clean.

#### Relationship to other PRs

`Sources/Actions/Post2.php` is not touched by any of the other open PRs
(#9310–#9317), so this one stands alone.

### Issues References (Fixes|Related|Closes)
1. No existing issue found for this.
