### PR TITLE
[3.0] Add AGENTS.md instructions for AI coding agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,22 +83,33 @@ param, throws, return.
 CI only proves that the code parses (`phplint` on 8.4 and 8.5) and is formatted
 correctly. It never executes SMF. Do not assume green checks mean a change works.
 
-So verify by running the forum. The repository ships a Docker environment:
+So verify by running the forum. The repository ships a Docker environment, documented
+in full in `.docker/README.md`:
 
 ```bash
 docker compose up -d --build
 # http://localhost:8080          the forum (install.php on first run)
 # http://localhost:8081          Adminer
 # http://localhost:8025          Mailpit, catches all outgoing mail
+# localhost:3307                 MySQL 8.4
 # localhost:5433                 PostgreSQL 17
 ```
+
+Both database services always start. `SMF_DB_TYPE` decides which one the generated
+`Settings.php` points at, and it defaults to `mysql`. Because raw SQL has to work on
+both engines, verify anything touching SQL on the other one as well: delete
+`Settings.php` and `Settings_bak.php`, restart `web` with `SMF_DB_TYPE` set the other
+way, then reinstall.
 
 The checkout is bind-mounted into the web container, so edits are live with no rebuild.
 Useful while working:
 
 ```bash
-docker exec smf-dev-web-1 php -l /var/www/html/Sources/Whatever.php
-docker exec smf-dev-db-1 psql -U smf -d smf -c 'SELECT * FROM smf_log_errors ORDER BY id_error DESC LIMIT 5;'
+docker compose exec web php -l /var/www/html/Sources/Whatever.php
+
+# Whichever engine the forum is installed on:
+docker compose exec mysql mysql -usmf -psmf smf -e 'SELECT * FROM smf_log_errors ORDER BY id_error DESC LIMIT 5;'
+docker compose exec postgres psql -U smf -d smf -c 'SELECT * FROM smf_log_errors ORDER BY id_error DESC LIMIT 5;'
 ```
 
 `smf_log_errors` is the first place to look. Many failures are recorded there rather

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,143 @@
+# AGENTS.md
+
+Instructions for coding agents working on Simple Machines Forum (SMF).
+Read by GitHub Copilot, Codex, Cursor, Gemini CLI and others directly; Claude Code
+reads it through the `CLAUDE.md` in this directory.
+
+Everything below is derived from the config files in this repository. When they
+disagree with this document, the config files win.
+
+## The project
+
+- SMF 3.0 Alpha, PHP 8.4+ (`composer.json` pins the platform to 8.4.1; CI lints on 8.4 and 8.5).
+- PSR-4: `SMF\` maps to `Sources/`, `SMF\Themes\` maps to `Themes/`.
+- Entry points are `index.php`, `cron.php`, `SSI.php`, `proxy.php`, `subscriptions.php`.
+- Database schema is defined in PHP, not SQL: `Sources/Db/Schema/v3_0/` (74 table classes),
+  with migrations in `Sources/Maintenance/Migration/`.
+- Both MySQL and PostgreSQL are supported. Any raw SQL must work on both.
+
+## Branching and pull requests
+
+- Branch from `release-3.0`. It is the main branch; `release-2.1` is maintenance only.
+- One logical change per branch. The reviewers here prefer small, focused diffs.
+- PR titles start with the target version: `[3.0] Short description in the imperative`.
+- The PR body follows `.github/PULL_REQUEST_TEMPLATE/standard_pr.md`: a `#### Description`
+  section and an `### Issues References (Fixes|Related|Closes)` section.
+
+### Sign off every commit
+
+SMF requires a Developer Certificate of Origin sign-off (`DCO.txt`). Commit with:
+
+```bash
+git commit -s
+```
+
+This appends `Signed-off-by: Name <email>`, which `check-signed-off.php` looks for on the
+**last line** of the commit message. Two things to know:
+
+- A trailer such as `Co-Authored-By:` after it will push the sign-off off the last line
+  and the check will not find it. Keep `Signed-off-by:` last.
+- The CI job can pass even when your commits are unsigned, because on a pull request it
+  inspects a merge commit and walks up to the parents, where `release-3.0` is signed off.
+  Verify locally instead:
+
+```bash
+php ./vendor/simplemachines/build-tools/check-signed-off.php; echo $?
+```
+
+## Code style
+
+Run this before every commit; it is what CI checks:
+
+```bash
+composer lint       # check only, on files you changed
+composer lint-fix   # apply the fixes
+```
+
+CI runs the same rules over changed files via `.github/workflows/php-cs-fixer.yml`.
+The configuration is `.php-cs-fixer.dist.php`, based on `@PER-CS2x0`. The parts that
+most often catch people out:
+
+- **Tabs, not spaces**, width 4, LF line endings, final newline, no trailing whitespace
+  (`.editorconfig`, and `.gitattributes` forces `eol=lf` even on Windows).
+  YAML uses 2 spaces; `*.lock` uses spaces.
+- **Short array syntax**, single quotes, `!=` rather than `<>`, no unused imports,
+  imports ordered alphabetically (class, then function, then const).
+- **Class members are ordered by the fixer**, via `ordered_class_elements`. Statics come
+  *after* non-statics within each visibility, so the order for methods is
+  `method_public`, `method_public_static`, `method_protected`, `method_private`,
+  `method_protected_static`, `method_private_static`. Adding a protected *static* method
+  next to the protected methods is a common way to fail the check.
+- **Section banner comments are generated** by the custom `SMF/section_comments` fixer in
+  `.github/phpcs/SectionComments.php`. Each group gets its own banner, for example
+  `Public methods`, `Public static methods`, `Internal methods`,
+  `Internal static methods`, `Class constants`, `Public properties`. Do not hand-write or
+  reposition them; let `composer lint-fix` place them.
+
+Docblocks are expected on classes, properties and methods, with tags ordered
+param, throws, return.
+
+## Verifying a change
+
+**There is no test suite.** No PHPUnit, no `tests/` directory, nothing in the history.
+CI only proves that the code parses (`phplint` on 8.4 and 8.5) and is formatted
+correctly. It never executes SMF. Do not assume green checks mean a change works.
+
+So verify by running the forum. The repository ships a Docker environment:
+
+```bash
+docker compose up -d --build
+# http://localhost:8080          the forum (install.php on first run)
+# http://localhost:8081          Adminer
+# http://localhost:8025          Mailpit, catches all outgoing mail
+# localhost:5433                 PostgreSQL 17
+```
+
+The checkout is bind-mounted into the web container, so edits are live with no rebuild.
+Useful while working:
+
+```bash
+docker exec smf-dev-web-1 php -l /var/www/html/Sources/Whatever.php
+docker exec smf-dev-db-1 psql -U smf -d smf -c 'SELECT * FROM smf_log_errors ORDER BY id_error DESC LIMIT 5;'
+```
+
+`smf_log_errors` is the first place to look. Many failures are recorded there rather
+than shown, especially anything in a background task.
+
+Some code is reachable with only the autoloader plus the constants that `index.php`
+defines, which is enough to exercise pure helpers without a database. Anything that
+touches `User::$me` or `Db::$db` needs a real request or fixtures.
+
+## Things that bite in this codebase
+
+- **Typed properties with no default throw when read before assignment.** Several are
+  populated by a separate load step rather than a constructor, so an object obtained
+  outside the usual request flow may not have them yet. Guard with `isset()` before
+  reading, and do not "fix" it by adding a default: other code uses the uninitialised
+  state as the signal to load.
+- **Late static binding and shared statics.** A `static` property declared in a trait or
+  parent class is shared with every descendant that does not redeclare it. Check
+  `static::class` when the value is expected to be class-specific.
+- **`empty()` and `isset()` hide errors.** `empty($obj->prop)` on a null `$obj` returns
+  true silently, so a missing object reads as an empty value rather than failing. Check
+  that the object exists before testing its properties.
+- **Global state is everywhere**: `Config::$modSettings`, `User::$me`, `Db::$db`,
+  `Utils::$context`, `Lang::$txt`, `Board::$info`, `Topic::$info`. Static properties such
+  as `Topic::$info` are null when there is no current topic, which is not the same as an
+  unapproved one.
+- **Columns get dropped between versions.** Check the query you are editing against
+  `Sources/Db/Schema/v3_0/` before trusting a column name. A query naming a removed column
+  fails at runtime only, and inside a background task it retries forever and takes down
+  unrelated page loads.
+- **Deprecated compatibility layer**: `Sources/Subs-Compat.php` holds the old procedural
+  API. It often shows the guard clauses the modern class methods should have; useful when
+  tracking down a missing check.
+
+## Conventions to follow
+
+- Match the surrounding code. Comment density here is high and conversational.
+- Commit messages use the imperative-with-s form used upstream, for example
+  "Ensures trailing chars are correctly quoted", "Only enforces bans that actually exist".
+- Language strings live in `Languages/en_US/`; never hard-code user-facing text.
+- Do not edit `vendor/`, `Packages/`, `Smileys/`, `cache/`, or `other/`.
+- `Settings.php` is local configuration and is not committed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,12 @@
+@AGENTS.md
+
+## Claude Code
+
+Claude Code does not read `AGENTS.md` on its own, so the import above pulls it in. Keep
+the shared instructions there and only Claude-specific notes here.
+
+- The Bash tool runs Git Bash on Windows, which rewrites `/var/www/html/...` arguments
+  into Windows paths. Use the PowerShell tool for `docker exec ... php /var/www/html/...`,
+  or the call will fail with "Could not open input file".
+- Prefer `Grep`/`Glob` over shelling out to `rg`/`find`, and read `Sources/Db/Schema/v3_0/`
+  before trusting any column name in a query.


### PR DESCRIPTION
> [!NOTE]
> **This change was produced by an LLM.** The file, the commit message and this
> description were all written by Claude (Anthropic), driven by @albertlast. It has
> not yet had human code review.
>
> Unlike the bug fixes in #9319–#9322, there is no runtime behaviour to verify here.
> What was checked is that every claim in the file was read out of this repository's
> own configuration rather than written from habit, and that the two new files do not
> disturb the existing checks. Please review it as untrusted work, and in particular
> as a proposal rather than a fix: whether SMF wants agent instructions in-tree at all
> is a project decision, not a defect.

#### Description

`AGENTS.md` is the cross-tool convention for giving AI coding agents project context.
GitHub Copilot reads it natively, as do Codex, Cursor, Gemini CLI, Aider, Windsurf and
Zed. Claude Code reads only `CLAUDE.md`, so that file is a two-line import:

```markdown
@AGENTS.md

## Claude Code
...
```

A symlink is the other documented option, but it needs Developer Mode or Administrator
on Windows, and `.gitattributes` already goes out of its way to keep Windows checkouts
working, so the import is the portable choice. The result is one file to maintain and
no duplicated instructions.

The contents are derived from this repository rather than from assumption:

| Source | What it contributes |
| --- | --- |
| `.editorconfig`, `.gitattributes` | tabs at width 4, LF, final newline; 2 spaces for YAML |
| `.php-cs-fixer.dist.php` | `@PER-CS2x0`, the `ordered_class_elements` order, `composer lint` / `lint-fix` |
| `.github/phpcs/SectionComments.php` | that the section banners are generated, and their names |
| `.github/workflows/*.yml` | what CI does and does not check |
| `composer.json` | PHP 8.4 platform, PSR-4 mapping, lint scripts |
| `DCO.txt`, `check-signed-off.php` | sign-off requirements |
| `.github/PULL_REQUEST_TEMPLATE/standard_pr.md` | PR body shape |
| `compose.yaml` | how to run the forum to check a change |
| `Sources/Db/Schema/v3_0/` | where to confirm a column still exists |

Two things are stated explicitly because a tool cannot infer them, and both were learned
the hard way while working on #9319–#9322:

- **There is no test suite.** CI proves the code parses and is formatted; it never
  executes SMF. An agent that treats four green checks as "this works" will be wrong,
  and all four of those bugs were runtime failures in code that parsed perfectly.
- **The sign-off check can pass on a pull request even when the commits are unsigned.**
  `check-signed-off.php` looks for `Signed-off-by:` on the last line, and when it does
  not find one it walks up to the parent commits — where `release-3.0` is signed off. Run
  against a feature branch directly it exits 1; run against `release-3.0` it exits 0. The
  file tells agents to verify locally rather than trust the badge.

The remaining sections cover the codebase traps that produced the recent run of bugs,
generalised rather than listed: typed properties that throw when read before their load
step, static properties shared with descendant classes, `empty()` hiding a null object,
and columns that migrations removed while a query still names them.

#### What was checked

- All four integrity scripts the `build` job runs pass with the files added:
  `check-smf-license`, `check-smf-index`, `check-smf-languages`, `check-version`.
- PHP-CS-Fixer over the whole tree: `Found 0 of 1725 files that can be fixed`. Markdown
  is outside the finder, so the new files are not linted, but nothing else shifted.
- Both files are LF with a final newline, matching `.editorconfig`, and together come to
  155 lines, within the 200-line guidance for instruction files.
- The only `@` in `AGENTS.md` is `` `@PER-CS2x0` `` inside a code span, so it is not
  mistaken for an import when Claude Code expands the file.

#### Relationship to other PRs

**Depends on #9317.** The "Verifying a change" section documents `docker compose up`,
the service ports and the two `docker exec` helpers, all of which come from the Docker
environment added there. If #9317 is not merged, that section describes something that
does not exist and should be dropped or rewritten before this lands. Merging #9317 first
is the natural order.

Related to #9319, #9320, #9321 and #9322 by origin rather than by content: the "Things
that bite in this codebase" section is a generalisation of those four root causes, and
the "no test suite" note is the reason each of them had to be verified by hand against a
running forum. No file overlap with any of them.

This PR touches only new files, so it conflicts with nothing.

### Issues References (Fixes|Related|Closes)
1. Depends on: #9317
2. Related: #9319, #9320, #9321, #9322

