### PR TITLE
[3.0] Parse memory settings that carry no unit designator

### DIFF
--- a/Sources/Sapi.php
+++ b/Sources/Sapi.php
@@ -334,19 +334,28 @@ class Sapi
 	/**
 	 * Helper function to convert memory string settings to bytes
 	 *
-	 * @param string $val The byte string, like '256M' or '1G'.
+	 * The shorthand notation PHP accepts for these settings is optional, so the
+	 * value may be a plain byte count with no designator at all.
+	 *
+	 * A negative value means there is no limit, which is reported as PHP_INT_MAX
+	 * so that callers comparing it against an amount of memory they need do not
+	 * have to special case it.
+	 *
+	 * @param string $val The byte string, like '256M', '1G' or '2097152'.
 	 * @return int The string converted to a proper integer in bytes.
 	 */
 	public static function memoryReturnBytes(string $val): int
 	{
-		if (\is_integer($val)) {
-			return (int) $val;
+		$val = trim($val);
+
+		// No limit at all.
+		if ((int) $val < 0) {
+			return PHP_INT_MAX;
 		}
 
-		// Separate the number from the designator.
-		$val = trim($val);
-		$num = \intval(substr($val, 0, \strlen($val) - 1));
+		// Separate the number from the designator, if there is one.
 		$last = strtolower(substr($val, -1));
+		$num = \in_array($last, ['g', 'm', 'k'], true) ? (int) substr($val, 0, -1) : (int) $val;
 
 		// Convert to bytes.
 		switch ($last) {


### PR DESCRIPTION
> [!NOTE]
> **This change was produced by an LLM.** The code, the commit message and this
> description were all written by Claude (Anthropic), driven by @albertlast. It has
> not yet had human code review.
>
> Everything stated below was verified by actually running it, rather than only
> reasoned about. Even so, please review it as untrusted work: the diagnosis may be
> right while the fix is not what SMF would prefer stylistically or architecturally.

#### Description

`Sapi::memoryReturnBytes()` removes the last character of the value before parsing
the number, on the assumption that it is always a unit designator:

```php
$num = \intval(substr($val, 0, \strlen($val) - 1));
$last = strtolower(substr($val, -1));
```

PHP's shorthand notation is optional, so a setting may be a plain byte count. When it
is, the last digit is eaten: `'128'` reads as `12`, and `'2097152'` reads as `209715`.

`Sources/Graphics/Image.php` does exactly that. It works out how much memory an image
needs and passes the raw byte count with no designator:

```php
return Sapi::setMemoryLimit((string) $needed_memory, true);
```

so image resizing asks for a tenth of what it just calculated.

The other value carrying no designator is `-1`, which is how PHP spells "no limit".
`substr('-1', 0, 1)` is `'-'`, and `intval('-')` is `0`, so an unlimited server reports
zero bytes available. `setMemoryLimit()` then finds the current limit smaller than
anything at all and imposes one.

This strips the last character only when it is a designator PHP actually accepts, and
reports "no limit" as `PHP_INT_MAX` so that the four call sites comparing it against an
amount they need do not each have to special case it. The dead `is_integer()` check at
the top went with it; the parameter is typed `string`, so it never fired.

#### How this was verified

PHP 8.4.23. Same script before and after the change.

Parsing:

| value | before | after |
| --- | --- | --- |
| `'256M'` | 268435456 | 268435456 |
| `'1G'` | 1073741824 | 1073741824 |
| `'512K'` | 524288 | 524288 |
| `'128'` | **12** | 128 |
| `'2097152'` | **209715** | 2097152 |
| `'-1'` | **0** | PHP_INT_MAX |
| `' 64M '` | 67108864 | 67108864 |

Then through the caller, with `memory_limit` set to `-1`:

```
before:  setMemoryLimit('128M') -> memory_limit is now 128M
after:   setMemoryLimit('128M') -> memory_limit is still -1
```

Nothing that already worked changes: every value with a designator parses to the same
number as before.

`php -l` and PHP-CS-Fixer clean.

#### Relationship to other PRs

`Sources/Sapi.php` is not touched by any other open PR.

Found while writing unit tests for the stateless parts of the codebase (#9326). That
branch carries the regression tests for this fix, and reverting this file alone fails
exactly those tests. This PR is deliberately independent of it, so it can be merged on
its own.

### Issues References (Fixes|Related|Closes)
1. No existing issue found for this.
2. Related: #9326
