### PR TITLE
[3.0] Only enforces bans users on users who really are banned

### DIFF
--- a/Sources/User.php
+++ b/Sources/User.php
@@ -2105,6 +2105,10 @@ class User implements \ArrayAccess
 		foreach ($restrictions as $restriction) {
 			$ban = $bans[$restriction];
 
+			if (empty($ban['ids'])) {
+				continue;
+			}
+
 			switch ($restriction) {
 				// If you're fully banned, it's end of the story for you.
 				case 'cannot_access':


### PR DESCRIPTION
Previously, `$shouldKick` could be set to true even if there were no bans actually applicable to the current user.