### PR TITLE
[3.0] Theme split (wave 1, part 6) — Repair the post preview

### DIFF
--- a/Themes/default/Display.template.php
+++ b/Themes/default/Display.template.php
@@ -1041,6 +1041,5 @@ function template_quickreply()
 				});
 			});
 			var oEditorID = "', Utils::$context['post_box_name'], '";
-			var oEditorObject = oEditorHandle_', Utils::$context['post_box_name'], ';
 		</script>';
 }

--- a/Themes/default/Post.template.php
+++ b/Themes/default/Post.template.php
@@ -573,7 +573,6 @@ function template_main()
 
 	echo '
 			var oEditorID = "', Utils::$context['post_box_name'], '";
-			var oEditorObject = oEditorHandle_', Utils::$context['post_box_name'], ';
 		</script>';
 
 	// If the user is replying to a topic show the previous posts.

--- a/Themes/default/scripts/quotedText.js
+++ b/Themes/default/scripts/quotedText.js
@@ -54,7 +54,7 @@ function quotedTextClick(oOptions)
 
 		// Do a call to make sure this is a valid message.
 		$.ajax({
-			url: smf_prepareScriptUrl(smf_scripturl) + 'action=quotefast;quote=' + oOptions.msgID + ';xml;pb='+ oEditorID + ';mode=' + (oEditorObject?.bRichTextEnabled ? 1 : 0),
+			url: smf_prepareScriptUrl(smf_scripturl) + 'action=quotefast;quote=' + oOptions.msgID + ';xml;pb='+ oEditorID + ';mode=' + (sceditor.instance(document.getElementById(oEditorID))?.inSourceMode() ? 0 : 1),
 			type: 'GET',
 			headers: {
 				"X-SMF-AJAX": 1

--- a/Themes/default/scripts/script.js
+++ b/Themes/default/scripts/script.js
@@ -1604,13 +1604,14 @@ smc_preview_post.prototype.doPreviewPost = function (event)
 			if (textFields[i] in document.forms.postmodify)
 			{
 				// Handle the WYSIWYG editor.
-				var e = $('#' + this.opts.sPostBoxContainerID).get(0);
+				var e = document.getElementById(this.opts.sPostBoxContainerID);
+				var oEditor = e ? sceditor.instance(e) : undefined;
 
 				// After moving this from Post template, html() stopped working in all cases.
-				if (textFields[i] == this.opts.sPostBoxContainerID && sceditor.instance(e) != undefined && typeof sceditor.instance(e).getText().html !== 'undefined')
-					x[x.length] = textFields[i] + '=' + sceditor.instance(e).getText().html().php_to8bit().php_urlencode();
-				else if (textFields[i] == this.opts.sPostBoxContainerID && sceditor.instance(e) != undefined)
-					x[x.length] = textFields[i] + '=' + sceditor.instance(e).getText().php_to8bit().php_urlencode();
+				if (textFields[i] == this.opts.sPostBoxContainerID && oEditor != undefined && typeof oEditor.val().html !== 'undefined')
+					x[x.length] = textFields[i] + '=' + oEditor.val().html().php_to8bit().php_urlencode();
+				else if (textFields[i] == this.opts.sPostBoxContainerID && oEditor != undefined)
+					x[x.length] = textFields[i] + '=' + oEditor.val().php_to8bit().php_urlencode();
 				else if (typeof document.forms.postmodify[textFields[i]].value.html !== 'undefined')
 					x[x.length] = textFields[i] + '=' + document.forms.postmodify[textFields[i]].value.html().php_to8bit().php_urlencode();
 				else

--- a/Themes/default/scripts/spellcheck.js
+++ b/Themes/default/scripts/spellcheck.js
@@ -19,7 +19,7 @@ function spellCheck(formName, fieldName)
 
 	var aWords = new Array(), aResult = new Array();
 	var e = $('#' + fieldName).get(0);
-	var sText = sceditor.instance(e).getText(false);
+	var sText = sceditor.instance(e).val();
 	var bInCode = false;
 	var iOffset1, iOffset2;
 
@@ -296,7 +296,7 @@ function openSpellWin(width, height)
 function spellCheckGetText(editorID)
 {
 	var e = $('#' + editorID).get(0);
-	return sceditor.instance(e).getText(false);
+	return sceditor.instance(e).val();
 }
 function spellCheckSetText(text, editorID)
 {


### PR DESCRIPTION
Wave 1, part 6 of breaking up #7933.

## The preview does not work

On `release-3.0`, pressing Preview on a post does nothing at all — the preview section never appears — and the console shows two errors:

```
Uncaught ReferenceError: oEditorHandle_message is not defined
Uncaught TypeError: sceditor.instance(...).getText is not a function
```

Both are leftovers from the SCEditor upgrade.

**`oEditorHandle_<id>`** has not existed for a long time, but `Post.template.php` and `Display.template.php` still do

```php
var oEditorObject = oEditorHandle_', Utils::$context['post_box_name'], ';
```

which throws, and takes the rest of that inline `<script>` block with it. `quotedText.js` was the only reader, using it to decide whether the editor was in rich text mode, so it now asks SCEditor directly. `oEditorID` is kept — `quotedText.js` and `smf_fileUpload.js` both still use it.

**`getText()`** is gone from the bundled SCEditor, so `smc_preview_post.doPreviewPost()` died on the first field it tried to collect. `val()` replaces it. `spellcheck.js` called it in two places as well, so those go the same way.

## Why not the plugin from #7933

#7933 replaces this with an `xmlPreview` SCEditor plugin. I did not port it, because it takes its form data once and keeps it:

```js
this.signalReady = function () {
	opts.oSendData ??= new FormData(editor.opts.original.form);
	...
};
var preview = function (event) {
	sendXMLDocument(opts.sUrl, opts.oSendData, response);
```

`oSendData` is captured when the editor becomes ready and reused for every click after that, so the preview would show whatever the form held at page load rather than what was typed. Repairing the existing code is a much smaller change and keeps the behaviour people expect.

I also left the `quoteFast` plugin from that branch alone. Quoting works today, and that plugin finds the quote link by walking to `el.children[iChildNum].firstElementChild` — a fixed position in the quick-buttons list, which moves as soon as a button is hidden by permissions — and calls `insertQuoteFast` unconditionally, dropping the case where the quick reply is collapsed and the click should take you to the full post page instead. I confirmed that path still works on `release-3.0` and did not want to regress it.

## Testing

- Post page: Preview now opens the section and shows the subject and the parsed body. Previewed twice in a row with different text each time, to be sure it sends the current content and not a snapshot — `Body typed <strong>after</strong> page load.` then `Completely different second body.`
- Personal messages: preview renders the typed subject and body, markup included.
- Topic page: no console errors, `oEditorID` still resolves, and the rich-text mode flag `quotedText.js` sends computes correctly.
- Quoting from a topic still navigates to the full post page with the quote pre-filled when the quick reply is collapsed.
- 108/108 unit tests pass.

Three `getText(false)` calls remain in `ManageNews.template.php` and `PersonalMessage.template.php`. They sit inside `'oEditorHandle_x' in window` guards that are always false, so they are unreachable; they belong to the parts that cover those templates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
