### PR TITLE
[3.0] Imports the UserDataset enum that PM.php has been using without it

### DIFF
--- a/Sources/PersonalMessage/PM.php
+++ b/Sources/PersonalMessage/PM.php
@@ -34,6 +34,7 @@ use SMF\Security;
 use SMF\Theme;
 use SMF\Time;
 use SMF\User;
+use SMF\UserDataset;
 use SMF\Utils;
 use SMF\Verifier;
 


### PR DESCRIPTION
#### Description

Sending a personal message fails outright on current `release-3.0`:

```
Class "SMF\PersonalMessage\UserDataset" not found
```

`Sources/PersonalMessage/PM.php` uses `UserDataset::Minimal` and `UserDataset::None` at lines 1607, 1670 and 1917, but the file never imports the enum. Its own namespace is `SMF\PersonalMessage`, so an unqualified name resolves there rather than to `SMF\UserDataset`.

`PM::send()` gets as far as `User::load($all_to, dataset: UserDataset::Minimal)` when it goes to load the recipients, and dies. The message is not stored and the sender lands on an error page. Nothing in the class is guarded against it, so it happens every time, on both databases and on every theme.

One line: `use SMF\UserDataset;`.

#### Testing

Docker environment, PostgreSQL 17. Before: composing a PM and pressing "Send message" produced the "Class not found" error page, `smf_personal_messages` unchanged, and a `general` row in `log_errors`. After: the PM is delivered, the sender is redirected to the inbox with `done=sent`, the row is in `smf_personal_messages`, and the error log stays empty.

`vendor/bin/phpunit` — 108 tests, 157 assertions, OK.

Found while checking what the PostgreSQL error reporting in #9341 exposed. This one is not a query failure and is unrelated to that change; it just turned up on the way past.

The report in #9308 also mentions that the recipient autocomplete does not complete the way 2.1 does. That part does not reproduce here: on the same tree, typing into the To field returns an `auto_suggest_div` populated from `action=suggest` as expected. Whatever is behind that half of the report is separate from this fix.

### Issues References (Fixes|Related|Closes)

Fixes #9308
Related to #9341
