### PR TITLE
[3.0] Passes fatalLang() its arguments in the right order

### DIFF
--- a/Sources/Actions/Admin/Themes.php
+++ b/Sources/Actions/Admin/Themes.php
@@ -2036,7 +2036,7 @@ class Themes implements ActionInterface
 				}
 				// Nope, sorry, couldn't find any theme already installed.
 				else {
-					ErrorHandler::fatalLang('package_get_error_theme_no_based_on_found', false, Utils::$context['to_install']['based_on']);
+					ErrorHandler::fatalLang('package_get_error_theme_no_based_on_found', false, [Utils::$context['to_install']['based_on']]);
 				}
 			}
 

--- a/Sources/Actions/Calendar.php
+++ b/Sources/Actions/Calendar.php
@@ -113,7 +113,7 @@ class Calendar implements ActionInterface, Routable
 	{
 		// You can't do anything if the calendar is off.
 		if (empty(Config::$modSettings['cal_enabled'])) {
-			ErrorHandler::fatalLang('calendar_off', false, 403);
+			ErrorHandler::fatalLang('calendar_off', false, [], 403);
 		}
 
 		// This is gonna be needed...
@@ -240,11 +240,11 @@ class Calendar implements ActionInterface, Routable
 
 		// Make sure the year and month are in valid ranges.
 		if ($curPage['month'] < 1 || $curPage['month'] > 12) {
-			ErrorHandler::fatalLang('invalid_month', false, 400);
+			ErrorHandler::fatalLang('invalid_month', false, [], 400);
 		}
 
 		if ($curPage['year'] < Config::$modSettings['cal_minyear'] || $curPage['year'] > Config::$modSettings['cal_maxyear']) {
-			ErrorHandler::fatalLang('invalid_year', false, 400);
+			ErrorHandler::fatalLang('invalid_year', false, [], 400);
 		}
 
 		// If we have a day clean that too.
@@ -252,7 +252,7 @@ class Calendar implements ActionInterface, Routable
 			$isValid = checkdate((int) $curPage['month'], (int) $curPage['day'], (int) $curPage['year']);
 
 			if (!$isValid) {
-				ErrorHandler::fatalLang('invalid_day', false, 400);
+				ErrorHandler::fatalLang('invalid_day', false, [], 400);
 			}
 		}
 
@@ -524,7 +524,7 @@ class Calendar implements ActionInterface, Routable
 			list(Utils::$context['event']) = Event::load($_REQUEST['eventid']);
 
 			if (empty(Utils::$context['event'])) {
-				ErrorHandler::fatalLang('no_access', false, 403);
+				ErrorHandler::fatalLang('no_access', false, [], 403);
 			}
 
 			// If it has a board, then they should be editing it within the topic.
@@ -608,7 +608,7 @@ class Calendar implements ActionInterface, Routable
 	{
 		// You can't export if the calendar export feature is off.
 		if (empty(Config::$modSettings['cal_export'])) {
-			ErrorHandler::fatalLang('calendar_export_off', false, 403);
+			ErrorHandler::fatalLang('calendar_export_off', false, [], 403);
 		}
 
 		$file = [
@@ -632,7 +632,7 @@ class Calendar implements ActionInterface, Routable
 			$event = current(Event::load((int) $_REQUEST['eventid']));
 
 			if (!($event instanceof Event)) {
-				ErrorHandler::fatalLang('no_access', false, 403);
+				ErrorHandler::fatalLang('no_access', false, [], 403);
 			}
 
 			// Was a specific occurrence requested, or the event in general?
@@ -657,7 +657,7 @@ class Calendar implements ActionInterface, Routable
 				try {
 					$low_date = new Time($_REQUEST['start_date']);
 				} catch (\Throwable $e) {
-					ErrorHandler::fatalLang('invalid_date', false, 400);
+					ErrorHandler::fatalLang('invalid_date', false, [], 400);
 				}
 			}
 
@@ -670,7 +670,7 @@ class Calendar implements ActionInterface, Routable
 				try {
 					$duration = new TimeInterval($_REQUEST['duration']);
 				} catch (\Throwable $e) {
-					ErrorHandler::fatalLang('invalid_days_numb', false, 400);
+					ErrorHandler::fatalLang('invalid_days_numb', false, [], 400);
 				}
 			}
 
@@ -941,7 +941,7 @@ class Calendar implements ActionInterface, Routable
 		// Is the calendar enabled?
 		if (empty(Config::$modSettings['cal_enabled'])) {
 			if ($trigger_error) {
-				ErrorHandler::fatalLang('calendar_off', false, 403);
+				ErrorHandler::fatalLang('calendar_off', false, [], 403);
 			}
 
 			return false;
@@ -961,7 +961,7 @@ class Calendar implements ActionInterface, Routable
 		// Are we in a topic?
 		if (empty(Topic::$topic_id)) {
 			if ($trigger_error) {
-				ErrorHandler::fatalLang('missing_topic_id', false, 400);
+				ErrorHandler::fatalLang('missing_topic_id', false, [], 400);
 			}
 
 			return false;
@@ -970,7 +970,7 @@ class Calendar implements ActionInterface, Routable
 		// Don't let guests edit the posts of other guests.
 		if (User::$me->is_guest) {
 			if ($trigger_error) {
-				ErrorHandler::fatalLang('not_your_topic', false, 403);
+				ErrorHandler::fatalLang('not_your_topic', false, [], 403);
 			}
 
 			return false;
@@ -1558,49 +1558,49 @@ class Calendar implements ActionInterface, Routable
 				$d = date_parse(str_replace(',', '', Time::convertToEnglish($_POST['start_date'])));
 
 				if (!empty($d['error_count']) || !empty($d['warning_count'])) {
-					ErrorHandler::fatalLang('invalid_date', false, 400);
+					ErrorHandler::fatalLang('invalid_date', false, [], 400);
 				}
 
 				if (empty($d['year'])) {
-					ErrorHandler::fatalLang('event_year_missing', false, 400);
+					ErrorHandler::fatalLang('event_year_missing', false, [], 400);
 				}
 
 				if (empty($d['month'])) {
-					ErrorHandler::fatalLang('event_month_missing', false, 400);
+					ErrorHandler::fatalLang('event_month_missing', false, [], 400);
 				}
 			} elseif (isset($_POST['start_datetime'])) {
 				$d = date_parse(str_replace(',', '', Time::convertToEnglish($_POST['start_datetime'])));
 
 				if (!empty($d['error_count']) || !empty($d['warning_count'])) {
-					ErrorHandler::fatalLang('invalid_date', false, 400);
+					ErrorHandler::fatalLang('invalid_date', false, [], 400);
 				}
 
 				if (empty($d['year'])) {
-					ErrorHandler::fatalLang('event_year_missing', false, 400);
+					ErrorHandler::fatalLang('event_year_missing', false, [], 400);
 				}
 
 				if (empty($d['month'])) {
-					ErrorHandler::fatalLang('event_month_missing', false, 400);
+					ErrorHandler::fatalLang('event_month_missing', false, [], 400);
 				}
 			}
 			// The 2.0 way
 			else {
 				// No month?  No year?
 				if (!isset($_POST['month'])) {
-					ErrorHandler::fatalLang('event_month_missing', false, 400);
+					ErrorHandler::fatalLang('event_month_missing', false, [], 400);
 				}
 
 				if (!isset($_POST['year'])) {
-					ErrorHandler::fatalLang('event_year_missing', false, 400);
+					ErrorHandler::fatalLang('event_year_missing', false, [], 400);
 				}
 
 				// Check the month and year...
 				if ($_POST['month'] < 1 || $_POST['month'] > 12) {
-					ErrorHandler::fatalLang('invalid_month', false, 400);
+					ErrorHandler::fatalLang('invalid_month', false, [], 400);
 				}
 
 				if ($_POST['year'] < Config::$modSettings['cal_minyear'] || $_POST['year'] > Config::$modSettings['cal_maxyear']) {
-					ErrorHandler::fatalLang('invalid_year', false, 400);
+					ErrorHandler::fatalLang('invalid_year', false, [], 400);
 				}
 			}
 		}
@@ -1610,7 +1610,7 @@ class Calendar implements ActionInterface, Routable
 
 		// If they want to us to calculate an end date, make sure it will fit in an acceptable range.
 		if (isset($_POST['span']) && (($_POST['span'] < 1) || (!empty(Config::$modSettings['cal_maxspan']) && $_POST['span'] > Config::$modSettings['cal_maxspan']))) {
-			ErrorHandler::fatalLang('invalid_days_numb', false, 400);
+			ErrorHandler::fatalLang('invalid_days_numb', false, [], 400);
 		}
 
 		// There is no need to validate the following values if we are just deleting the event.
@@ -1619,18 +1619,18 @@ class Calendar implements ActionInterface, Routable
 			if (empty($_POST['start_date']) && empty($_POST['start_datetime'])) {
 				// No day?
 				if (!isset($_POST['day'])) {
-					ErrorHandler::fatalLang('event_day_missing', false, 400);
+					ErrorHandler::fatalLang('event_day_missing', false, [], 400);
 				}
 
 				// Bad day?
 				if (!checkdate($_POST['month'], $_POST['day'], $_POST['year'])) {
-					ErrorHandler::fatalLang('invalid_date', false, 400);
+					ErrorHandler::fatalLang('invalid_date', false, [], 400);
 				}
 			}
 
 			if (!isset($_POST['evtitle'])) {
 				if (!isset($_POST['subject'])) {
-					ErrorHandler::fatalLang('event_title_missing', false, 400);
+					ErrorHandler::fatalLang('event_title_missing', false, [], 400);
 				}
 
 				$_POST['evtitle'] = $_POST['subject'];
@@ -1638,7 +1638,7 @@ class Calendar implements ActionInterface, Routable
 
 			// No title?
 			if (Utils::htmlTrim($_POST['evtitle']) === '') {
-				ErrorHandler::fatalLang('event_title_missing', false, 400);
+				ErrorHandler::fatalLang('event_title_missing', false, [], 400);
 			}
 
 			if (Utils::entityStrlen($_POST['evtitle']) > 100) {


### PR DESCRIPTION
#### Description

```php
public static function fatalLang(string $error, string|bool $log = 'general', array $sprintf = [], int $status = 403, string $file = 'Errors'): void
```

`Sources/Actions/Calendar.php` puts the HTTP status in the third slot in **all 27** of its calls:

```php
ErrorHandler::fatalLang('calendar_off', false, 403);
ErrorHandler::fatalLang('invalid_month', false, 400);
ErrorHandler::fatalLang('event_title_missing', false, 400);
```

Under `strict_types` every one of those is a TypeError, so the calendar never delivers a single one of the messages it means to deliver. It reports this instead:

```
SMF\ErrorHandler::fatalLang(): Argument #3 ($sprintf) must be of type array,
int given, called in /var/www/html/Sources/Actions/Calendar.php on line 116
```

Which covers the calendar being switched off, an invalid month, year, day or date, a missing event title, a topic that is not yours, a missing topic ID, an out-of-range number of days, and the iCal export being disabled. All of them end in a 500 and the generic "An error has occurred" instead of the written explanation and the right status code.

`Sources/Actions/Admin/Themes.php` has the same mistake in a different shape: it hands `$sprintf` a bare string where `package_get_error_theme_no_based_on_found` wants `{0}` filled in, so installing a theme that depends on a missing base theme fails with a TypeError rather than naming the theme you need.

The status codes involved were either the default 403 or a plain 400, so nothing is lost by moving them into the parameter they belong in. `Sources/Forum.php`, `Sources/Topic.php` and `Sources/Actions/HelpAdmin.php` already show the intended shape:

```php
ErrorHandler::fatalLang('not_found', false, [], 404);
```

#### Testing

Docker environment, PostgreSQL 17, calendar toggled on and off.

| | before | after |
|---|---|---|
| `?action=calendar`, calendar off | 500, "Argument #3 ($sprintf) must be of type array" | **403**, "You cannot access the calendar right now because it is disabled." |
| `?action=calendar;month=5;year=1800` | 500, TypeError | **400**, "Invalid year value." |
| `?action=calendar;sa=ical`, export off | 500, TypeError | **403**, the export-disabled message |
| `?action=calendar;sa=post` without permission | 500, TypeError | **403** |
| `?action=calendar` normally | 200 | 200, unchanged |

Error log empty across the run. `vendor/bin/phpunit` — 108 tests, 157 assertions, OK.

Found while checking what the PostgreSQL error reporting in #9341 exposed. Not a query failure, and unrelated to that change.

### Issues References (Fixes|Related|Closes)

Related to #9341
