### PR TITLE
[3.0][Testing] Install the forum from the command line

### DIFF
--- a/.docker/README.md
+++ b/.docker/README.md
@@ -71,6 +71,14 @@ though it succeeded — it pauses so a human can read its "N duplicate tables
 ignored" report, and the form's `pop_done` field is the short-circuit past it.
 Passing `pop_done` on the first pass would skip building the schema entirely.
 
+It then deletes `install.php`, which the installer asks for but cannot do
+itself — its `?delete` link is a GET, and command line arguments only ever reach
+`$_POST`. That matters more than it sounds: while the file is there
+`Settings.php` redirects every request back into the installer, and SMF puts a
+"MAJOR SECURITY RISK" box on every page it shows an administrator. Reinstalling
+still works, because `reset.sh` runs first and does not return until the
+entrypoint has staged a fresh copy.
+
 Two flags worth knowing:
 
 - `--force` reinstalls even when a forum is already there. Without it the

--- a/.docker/README.md
+++ b/.docker/README.md
@@ -110,6 +110,35 @@ are gitignored.
 installer, discarding that forum. `use-engine.sh` switches between forums,
 `reset.sh` throws one away.
 
+## Accounts and passwords
+
+Two forums, each with its own administrator, and a password chosen months ago is
+a recipe for an afternoon of hand written SQL. `user.sh` is there so it is not:
+
+```sh
+.docker/user.sh list
+.docker/user.sh check admin 'password'
+.docker/user.sh reset admin 'a new password'
+```
+
+`check` exits 0 when SMF would accept the password and 1 when it would not, so
+it works in a conditional as well as by eye. It also points out an account that
+is not activated, which fails to log in with a correct password and looks
+exactly like a wrong one.
+
+`--engine mysql|postgresql` reads the settings `use-engine.sh` saved for that
+engine, so the *other* forum can be inspected without switching to it:
+
+```sh
+.docker/user.sh check admin 'password' --engine mysql
+```
+
+The hashing goes through SMF's own `Security` class rather than being written
+here, so what `reset` puts in the table is by construction what `Login2` expects
+to find. It clears `passwd_flood` at the same time: SMF locks an account out for
+a while after enough wrong guesses, and a fresh password behind a lockout looks
+exactly like a password that did not take.
+
 ### Installing in a browser instead
 
 On first boot the entrypoint writes a `Settings.php` pre-filled for the chosen
@@ -307,6 +336,12 @@ compose.yaml                     the stack
 .docker/mysql/init/10-smf.sh     runs once on first mysql database creation
 .docker/postgres/init/10-smf.sh  runs once on first postgres database creation
 .docker/env.example              optional overrides
+.docker/lib.sh                   paths, credentials and engine names, shared
+.docker/install-forum.sh         install a forum with no browser involved
+.docker/reset.sh                 empty one engine and restage the installer
+.docker/use-engine.sh            switch which installed forum is live
+.docker/user.sh                  inspect accounts, check and reset passwords
+
 .docker/upgrade-readings.sh      shared: driving upgrade.php, reading a database
 .docker/rerun-upgrade.sh         upgrade twice, report what the second run changed
 .docker/interrupt-upgrade.sh     kill an upgrade part way, report what recovery left

--- a/.docker/install-forum.sh
+++ b/.docker/install-forum.sh
@@ -96,6 +96,13 @@ install_one() {
 		--password2="$SMF_ADMIN_PASS"
 	)
 
+	# reset.sh does not return until the entrypoint has staged this, so its
+	# absence means something went wrong there rather than here. Worth saying so:
+	# without it php reports "Could not open input file: install.php", which reads
+	# like a broken script rather than a forum that was never made installable.
+	docker compose exec -T web test -f install.php \
+		|| die "${smf_type}: install.php is not staged, so there is nothing to run (docker compose logs web)"
+
 	log "${smf_type}: building the schema"
 	docker compose exec -T web php install.php "${args[@]}" >/dev/null
 
@@ -106,6 +113,17 @@ install_one() {
 	version=$(installed_version "$smf_type" || true)
 
 	[ -n "$version" ] || die "${smf_type}: the installer finished but the forum is not installed"
+
+	# The installer tells you to delete this and cannot do it itself: its ?delete
+	# link is a GET, and command line arguments only ever reach $_POST. Leaving it
+	# is not cosmetic - Settings.php redirects every request back into the
+	# installer while it is there, and SMF puts a "MAJOR SECURITY RISK: you have
+	# not removed install.php" box on every page it shows an administrator.
+	#
+	# Safe to delete even though a reinstall needs it again: install_one() always
+	# calls reset.sh first, and reset.sh clears Settings.php and waits for the
+	# entrypoint to put a fresh copy back before returning.
+	rm -f install.php
 
 	log "${smf_type}: installed SMF ${version}"
 

--- a/.docker/user.sh
+++ b/.docker/user.sh
@@ -1,0 +1,204 @@
+#!/usr/bin/env bash
+# Looks at forum accounts and fixes their passwords, so "which password did this
+# forum end up with?" does not turn into a session of hand written SQL.
+#
+#   .docker/user.sh list
+#   .docker/user.sh check admin 'password'
+#   .docker/user.sh reset admin 'a new password'
+#   .docker/user.sh check admin 'password' --engine postgresql
+#
+# check exits 0 when SMF would accept the password and 1 when it would not, so
+# it is usable in a conditional as well as by eye.
+#
+# Everything goes through SMF's own Security class rather than writing a hash
+# from here: what this puts in the table is by construction what Login2 expects
+# to find there. Nothing is ever printed that would reveal an existing password;
+# hashes are one way and this does not try to be clever about that.
+#
+# Without --engine it acts on the forum Settings.php currently points at. With
+# it, it reads the copy use-engine.sh saved for that engine instead, which means
+# the other forum can be inspected without switching to it.
+#
+# Runs on the host.
+set -euo pipefail
+
+. "$(dirname -- "${BASH_SOURCE[0]}")/lib.sh"
+
+ENGINE=''
+ACTION=''
+NAME=''
+PASSWORD=''
+POSITIONAL=()
+
+while [ $# -gt 0 ]; do
+	case "$1" in
+		--engine) ENGINE="$2"; shift 2 ;;
+		--engine=*) ENGINE="${1#*=}"; shift ;;
+		-h|--help) sed -n '2,22p' "${BASH_SOURCE[0]}"; exit 0 ;;
+		-*) die "unknown argument: $1" ;;
+		*) POSITIONAL+=("$1"); shift ;;
+	esac
+done
+
+[ "${#POSITIONAL[@]}" -gt 0 ] || die "need an action: list, check or reset (see --help)"
+
+ACTION="${POSITIONAL[0]}"
+NAME="${POSITIONAL[1]:-}"
+PASSWORD="${POSITIONAL[2]:-}"
+
+case "$ACTION" in
+	list) ;;
+	check|reset)
+		[ -n "$NAME" ] || die "${ACTION}: need a member name"
+		[ -n "$PASSWORD" ] || die "${ACTION}: need a password"
+		;;
+	*) die "unknown action: ${ACTION} (expected list, check or reset)" ;;
+esac
+
+# The settings file to read, as the container sees it. Empty means "whichever
+# forum is live", which is the common case and needs no explanation in the log.
+SETTINGS='/var/www/html/Settings.php'
+
+if [ -n "$ENGINE" ]; then
+	SMF_TYPE=$(engine_smf_type "$ENGINE") || die "unknown engine: $ENGINE"
+	SAVED="$DOCKER_DIR/settings/Settings.${SMF_TYPE}.php"
+
+	[ -f "$SAVED" ] || die "no saved settings for ${SMF_TYPE}; install it first with install-forum.sh --engine ${SMF_TYPE}"
+
+	SETTINGS="/var/www/html/.docker/settings/Settings.${SMF_TYPE}.php"
+fi
+
+cd "$BOARD_DIR"
+
+# The password goes through the environment rather than the argument list:
+# arguments are visible to anything that can read the process table, and a
+# password typed at a shell is quite enough exposure already.
+docker compose exec -T \
+	-e SMF_USER_ACTION="$ACTION" \
+	-e SMF_USER_NAME="$NAME" \
+	-e SMF_USER_PASSWORD="$PASSWORD" \
+	-e SMF_USER_SETTINGS="$SETTINGS" \
+	web php <<-'PHP'
+	<?php
+
+	/*
+	 * Runs inside the web container against the installed forum. Kept to the
+	 * constants Config::load() and Db::load() actually read, because anything
+	 * more would be pretending this is a request.
+	 */
+
+	define('SMF', 1);
+	define('SMF_SETTINGS_FILE', getenv('SMF_USER_SETTINGS'));
+	define('SMF_SETTINGS_BACKUP_FILE', str_replace('Settings.php', 'Settings_bak.php', SMF_SETTINGS_FILE));
+
+	// Config::getSettingsDefs() reads both of these while working out what a
+	// Settings.php should contain. Taken from index.php rather than written out
+	// here, so this cannot disagree with the version it is running against.
+	$index = (string) file_get_contents('/var/www/html/index.php');
+
+	preg_match("~define\('SMF_VERSION', '([^']+)'\);~", $index, $version);
+	preg_match("~define\('SMF_SOFTWARE_YEAR', '(\d{4})'\);~", $index, $year);
+
+	define('SMF_VERSION', $version[1] ?? '3.0');
+	define('SMF_SOFTWARE_YEAR', $year[1] ?? date('Y'));
+
+	define('SMF_FULL_VERSION', 'SMF ' . SMF_VERSION);
+	define('SMF_USER_AGENT', 'SMF dev tools');
+	define('TIME_START', microtime(true));
+
+	// DatabaseApi::getClass() names the engine with these when it cannot find
+	// one, so they have to exist before the connection is made.
+	define('POSTGRE_TITLE', 'PostgreSQL');
+	define('MYSQL_TITLE', 'MySQL');
+
+	require '/var/www/html/vendor/autoload.php';
+
+	SMF\Config::load();
+	SMF\Db\DatabaseApi::load();
+	SMF\Config::reloadModSettings();
+
+	$db = SMF\Db\DatabaseApi::$db;
+	$action = (string) getenv('SMF_USER_ACTION');
+	$name = (string) getenv('SMF_USER_NAME');
+	$password = (string) getenv('SMF_USER_PASSWORD');
+
+	fwrite(STDERR, '[smf-dev] ' . SMF\Config::$db_type . ' forum at ' . SMF\Config::$boardurl . "\n");
+
+	if ($action === 'list') {
+		$request = $db->query(
+			'SELECT id_member, member_name, real_name, email_address, id_group, is_activated
+			FROM {db_prefix}members
+			ORDER BY id_member',
+			[],
+		);
+
+		printf("%-5s %-20s %-28s %-7s %s\n", 'id', 'member_name', 'email', 'group', 'activated');
+
+		while ($row = $db->fetch_assoc($request)) {
+			printf(
+				"%-5d %-20s %-28s %-7d %s\n",
+				$row['id_member'],
+				$row['member_name'],
+				$row['email_address'],
+				$row['id_group'],
+				// 1 is the only value that can log in; the rest are awaiting
+				// activation, awaiting approval, banned or deleted.
+				$row['is_activated'] == 1 ? 'yes' : 'no (' . $row['is_activated'] . ')',
+			);
+		}
+
+		$db->free_result($request);
+
+		exit(0);
+	}
+
+	$request = $db->query(
+		'SELECT id_member, member_name, passwd, is_activated
+		FROM {db_prefix}members
+		WHERE member_name = {string:name} OR email_address = {string:name}
+		LIMIT 1',
+		[
+			'name' => $name,
+		],
+	);
+
+	$member = $db->fetch_assoc($request);
+	$db->free_result($request);
+
+	if (!is_array($member)) {
+		fwrite(STDERR, 'error: no member called "' . $name . '" (try: user.sh list)' . "\n");
+
+		exit(1);
+	}
+
+	if ($action === 'check') {
+		$ok = SMF\Security::hashVerifyPassword($password, $member['passwd']);
+
+		echo $member['member_name'], ': ', $ok ? 'password is correct' : 'password is WRONG', "\n";
+
+		// Being right about the password is not the same as being able to log
+		// in, and the difference is worth saying out loud before someone spends
+		// an afternoon on it.
+		if ($ok && $member['is_activated'] != 1) {
+			echo '  note: the account is not active (is_activated = ', $member['is_activated'], '), so it cannot log in', "\n";
+		}
+
+		exit($ok ? 0 : 1);
+	}
+
+	$db->query(
+		'UPDATE {db_prefix}members
+		SET passwd = {string:passwd}, passwd_flood = {string:empty}
+		WHERE id_member = {int:id}',
+		[
+			'passwd' => SMF\Security::hashPassword($password),
+			// Cleared as well: SMF locks an account out for a while after
+			// enough wrong guesses, and resetting the password while leaving
+			// the lockout in place looks exactly like the password not working.
+			'empty' => '',
+			'id' => (int) $member['id_member'],
+		],
+	);
+
+	echo $member['member_name'], ': password changed', "\n";
+	PHP


### PR DESCRIPTION
#### Description

The dev environment from #9317 stops at a generated `Settings.php` and a staged
`install.php`, leaving the install itself to a human clicking through a browser.
That is the one step between a fresh clone and a running forum that could not be
scripted, and everything that wants to test against a real install has to start
by doing it.

This makes it one command:

```sh
.docker/install-forum.sh --engine mysql
.docker/install-forum.sh --engine both
```

Four scripts under `.docker/`: `install-forum.sh`, `use-engine.sh`, `reset.sh`,
and a sourced `lib.sh`. Nothing ships with the forum — `.docker/` is already
skipped by `check-smf-index.php` and `check-smf-license.php`.

The installer turned out to be almost there already: `parseCliArguments()` turns
`--name=value` into `$_POST` and `execute()` runs every step in one process. So
this needs two passes rather than the five curl requests 2.1 needs. The second
carries `pop_done`, which is the short-circuit past the population report;
passing it on the first pass would skip building the schema entirely.

`--engine both` installs MySQL and then PostgreSQL, sequentially — `Settings.php`
pins one `$db_type` and `Db::load()` hands back the connection it already made,
so only one engine is ever live in a process. Both installs are kept, and
`use-engine.sh` switches between them without reinstalling.

##### The five installer fixes this needed

Each of these only bites without a browser, so none could be worked around from
outside. Four are CLI-only; the last one is wrong in the browser too.

1. **Nothing was ever reported.** `Maintenance::exit()` renders the tool's
   templates, and those are the only place errors are shown. On the command line
   it takes the fallthrough path straight to `die()`, so a scripted install that
   died on step three looked exactly like one that finished — no message, exit
   status 0. `ToolsBase::updateSettingsFile()` made the same assumption more
   directly, calling `die()` outright rather than recording the error.
2. **`forumSettings()` was fatal.** It built a suggested board URL with
   `substr($self, 0, strrpos($self, '/'))`. `getSelf()` is `$_SERVER['PHP_SELF']`,
   which on the command line is usually a bare `install.php` with no directory in
   it, so `strrpos()` returns false and `substr()` throws on PHP 8.
3. **`defaultHost()`** read `$_SERVER['SERVER_NAME']` and `['SERVER_PORT']`
   unguarded, so every run opened with an undefined index warning.
4. **`finalize()` signed a browser in**, setting a login cookie and recording a
   session against the user agent that asked for it. With no browser that is four
   warnings — headers sent after output started, a session that could not start,
   an id that could not be regenerated — and a `sessions` row built from an
   undefined `HTTP_USER_AGENT`.
5. **An unrecognised database type reported nothing.** It used
   `Lang::getTxt('upgrade_unknown_error')`, which is not a string that exists, so
   the fatal error was blank in the browser as well. Now names the type that was
   rejected and the ones that would have been accepted — which matters most on
   the command line, where the type is typed by hand rather than picked from a
   list of exactly those keys. (They are capitalised: `MySQL`, `PostgreSQL`.)

##### Verified

Installed from scratch on both engines, from the tree in this branch:

- `.docker/install-forum.sh --engine both --pin-secrets --force` completes clean,
  no warnings, exit 0.
- Both forums serve 200 on the board index, login, help, recent, stats and
  credits.
- `check-signed-off.php`, `check-smf-index.php`, `check-smf-license.php` and
  `check-smf-languages.php` all pass; `shellcheck` is clean on all four scripts.

Not addressed here, because it is not CLI-specific: a fresh install logs five
`undefined_vars` errors for `latestMember` / `latestRealName`, because
`finalize()` loads the theme before `Logging::updateStats('member')` runs. The
values are correct once installed, and browsing afterwards is clean.

#### Merge order

**Merge #9317 and #9316 before this one.** Both are contained in this branch, so the
diff shown here is theirs as well as its own; once they land and this is rebased on
`release-3.0`, what is left is the install script and the installer fixes it needed.

### Issues References (Fixes|Related|Closes)
1. Depends on #9317 — this builds on `.docker/` and `compose.yaml`.
2. Depends on #9316 — merged in here, or the install dies on its last step.

