### PR TITLE
[3.0][Testing] Add an integration test suite that runs against a real forum

### DIFF
--- a/.docker/README.md
+++ b/.docker/README.md
@@ -165,6 +165,27 @@ compose network.
 When the installer finishes, delete `install.php` from the repo root — while it
 exists, `Settings.php` redirects every request back into the installer.
 
+## Running the tests
+
+```sh
+.docker/test.sh                          # both engines
+.docker/test.sh --engine postgresql
+.docker/test.sh --engine both --filter ModSettings
+```
+
+Anything it does not recognise is passed on to PHPUnit. It installs a forum for
+an engine that has not got one, and puts the previously active engine back when
+it finishes.
+
+Running on both is the point rather than a thoroughness exercise. The counter
+regression in `tests/Integration/ModSettingsTest.php` **passes on MySQL with the
+bug still in place** and only fails on PostgreSQL, because MySQL coerces text to
+a number where PostgreSQL refuses. A suite that only ever sees one engine proves
+considerably less than it looks like it does.
+
+The unit suite needs none of this — `composer test` runs everything, and the
+integration tests skip themselves when there is no forum to talk to.
+
 ## Running CI locally
 
 ```sh
@@ -402,6 +423,7 @@ compose.yaml                     the stack
 .docker/reset.sh                 empty one engine and restage the installer
 .docker/use-engine.sh            switch which installed forum is live
 .docker/user.sh                  inspect accounts, check and reset passwords
+.docker/test.sh                  run the test suites against an installed forum
 
 .docker/upgrade-readings.sh      shared: driving upgrade.php, reading a database
 .docker/rerun-upgrade.sh         upgrade twice, report what the second run changed

--- a/.docker/test.sh
+++ b/.docker/test.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Runs the test suite against a real forum, on one engine or on both.
+#
+#   .docker/test.sh                          both engines, whole suite
+#   .docker/test.sh --engine postgresql
+#   .docker/test.sh --engine both --filter ModSettings
+#
+# Anything after the recognised options is handed straight to PHPUnit, so
+# --filter, --testsuite and friends work as usual.
+#
+# Installs a forum for an engine that has not got one yet. Use
+# .docker/install-forum.sh --force to start any of them over.
+#
+# Running on both engines is the point rather than a thoroughness exercise: the
+# two disagree often enough that a suite which only ever sees one of them
+# proves considerably less than it appears to. The counter regression in
+# tests/Integration/ModSettingsTest.php passes on MySQL with the bug still in
+# place, and fails on PostgreSQL.
+#
+# Runs on the host.
+set -euo pipefail
+
+. "$(dirname -- "${BASH_SOURCE[0]}")/lib.sh"
+
+ENGINE='both'
+PHPUNIT_ARGS=()
+
+while [ $# -gt 0 ]; do
+	case "$1" in
+		--engine) ENGINE="$2"; shift 2 ;;
+		--engine=*) ENGINE="${1#*=}"; shift ;;
+		-h|--help) sed -n '2,19p' "${BASH_SOURCE[0]}"; exit 0 ;;
+		*) PHPUNIT_ARGS+=("$1"); shift ;;
+	esac
+done
+
+ENGINES=$(engine_list "$ENGINE") || die "unknown engine: $ENGINE"
+
+cd "$BOARD_DIR"
+
+# Remember what was active, and put it back afterwards however this ends. A test
+# run should not silently leave the forum pointed somewhere else.
+ORIGINAL=''
+
+if [ -f Settings.php ]; then
+	ORIGINAL=$(sed -n "s|^\$db_type = '\([^']*\)';.*|\1|p" Settings.php | head -n 1 | tr '[:upper:]' '[:lower:]')
+fi
+
+restore_engine() {
+	if [ -n "$ORIGINAL" ] && [ -f "$SETTINGS_DIR/Settings.$(engine_smf_type "$ORIGINAL").php" ]; then
+		"$DOCKER_DIR/use-engine.sh" "$ORIGINAL" >/dev/null 2>&1 || true
+	fi
+}
+
+trap restore_engine EXIT
+
+FAILED=''
+
+for smf_type in $ENGINES; do
+	if [ -z "$(installed_version "$smf_type" || true)" ]; then
+		log "${smf_type}: no forum yet, installing one"
+		"$DOCKER_DIR/install-forum.sh" --engine "$smf_type" >/dev/null
+	fi
+
+	"$DOCKER_DIR/use-engine.sh" "$smf_type" >/dev/null
+
+	log "${smf_type}: running the tests"
+
+	if docker compose exec -T web vendor/bin/phpunit --no-coverage --colors=always "${PHPUNIT_ARGS[@]+"${PHPUNIT_ARGS[@]}"}"; then
+		log "${smf_type}: passed"
+	else
+		warn "${smf_type}: FAILED"
+		FAILED="${FAILED} ${smf_type}"
+	fi
+done
+
+if [ -n "$FAILED" ]; then
+	die "failed on:${FAILED}"
+fi
+
+log "passed on: ${ENGINES}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -156,6 +156,7 @@ worked example in `tests/Unit/`:
 #### When it is not
 
 - Anything calling `Db::$db` — there is no connection, and faking one is not worth it.
+  This belongs in the integration suite below.
 - Anything reading `User::$me`, the session, `$_GET`/`$_POST`/`$_SERVER`, or expecting a
   loaded theme or `Utils::$context`.
 - Anything that emits output or sends headers. `beStrictAboutOutputDuringTests` is on, so
@@ -163,6 +164,44 @@ worked example in `tests/Unit/`:
 
 `failOnRisky` and `failOnWarning` are on as well: a test that asserts nothing is a
 failure, not a pass.
+
+### The integration suite
+
+`tests/Integration/` runs against a forum that is actually installed, so it reaches the
+things above: `Db::$db`, `Config::$modSettings` as the database holds it, and `User::$me`.
+
+```bash
+.docker/test.sh                     # both engines
+.docker/test.sh --engine postgresql
+```
+
+`composer test` still runs everything. When there is no forum to talk to the integration
+tests **skip** rather than fail, so it stays useful on a machine with no Docker. To get
+one: `.docker/install-forum.sh --engine mysql`.
+
+Extend `SMF\Tests\Integration\IntegrationTestCase`, which gives you:
+
+- a transaction per test, rolled back afterwards, so tests do not have to order
+  themselves around each other;
+- `actingAs($id)` and `adminId()` for a current user, via `User::setMe()` — the same seam
+  `Login2::DoLogin()` uses;
+- `hook($name, $function)`, registered in `$modSettings` only, so it disappears with the
+  rollback;
+- `assertNoErrorsLogged()`, which is usually the most valuable line in the test: SMF
+  records most of what goes wrong in `log_errors` rather than showing it, so a page that
+  returned the right thing while quietly logging an undefined index has still regressed;
+- `queryRow()` and `rawSetting()`, which read past `$modSettings` and its cache and fail
+  with a readable message instead of a `TypeError` when a query fails.
+
+Two things the rollback does not cover: **DDL**, since MySQL commits implicitly on
+`CREATE`/`ALTER`/`DROP`; and anything happening in another process, such as a request made
+over HTTP, which runs on its own connection.
+
+**Run both engines.** This is not thoroughness for its own sake — the two disagree often
+enough to matter. `ModSettingsTest` pins a bug that *passes on MySQL with the bug still
+in place*, because MySQL silently coerces text to a number where PostgreSQL refuses.
+On PostgreSQL a failed query also poisons the rest of the transaction, so one swallowed
+error turns every later query in the test into `false`.
 
 #### Writing one
 

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,8 @@
 	},
 	"scripts": {
 		"test": "phpunit --no-coverage",
+		"test-unit": "phpunit --no-coverage --testsuite unit",
+		"test-integration": "phpunit --no-coverage --testsuite integration",
 		"lint": "php-cs-fixer --quiet check --config .php-cs-fixer.dist.php --path-mode=intersection $(git diff --name-only \"*.php\") --allow-risky=yes || php-cs-fixer check --diff --config .php-cs-fixer.dist.php --path-mode=intersection $(git diff --name-only \"*.php\") --allow-risky=yes",
 		"lint-fix": "php-cs-fixer fix -v --config .php-cs-fixer.dist.php --path-mode=intersection $(git diff --name-only \"*.php\") --allow-risky=yes",
 		"post-install-cmd": "php ./vendor/simplemachines/build-tools/secure-vendor-dir.php",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -11,6 +11,14 @@
 		<testsuite name="unit">
 			<directory>tests/Unit</directory>
 		</testsuite>
+		<!--
+			Needs an installed forum, and skips itself when there is not one, so
+			running the whole file is safe with or without a database. See
+			tests/Integration/Installation.php.
+		-->
+		<testsuite name="integration">
+			<directory>tests/Integration</directory>
+		</testsuite>
 	</testsuites>
 	<source>
 		<include>

--- a/tests/Integration/HarnessTest.php
+++ b/tests/Integration/HarnessTest.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SMF\Tests\Integration;
+
+use PHPUnit\Framework\AssertionFailedError;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Depends;
+use SMF\Config;
+use SMF\Db\DatabaseApi as Db;
+
+/**
+ * Checks the integration harness itself.
+ *
+ * A suite whose isolation quietly stopped working would not fail; it would start
+ * passing things it should not, or failing things depending on the order they
+ * ran in. These tests are here so that breaks loudly instead.
+ */
+#[CoversNothing]
+class HarnessTest extends IntegrationTestCase
+{
+	/**
+	 * The variable the rollback tests write. Named so that finding it left
+	 * behind in a real forum points straight back here.
+	 */
+	private const LEFTOVER = 'smf_tests_rollback_canary';
+
+	public function testTheForumIsInstalled(): void
+	{
+		$this->assertNotEmpty(Config::$modSettings['smfVersion']);
+		$this->assertSame(SMF_VERSION, Config::$modSettings['smfVersion']);
+	}
+
+	public function testTheEngineIsOneSmfSupports(): void
+	{
+		$this->assertContains(
+			strtolower(Config::$db_type),
+			['mysql', 'postgresql'],
+			'Settings.php names an engine this suite does not know about',
+		);
+	}
+
+	/**
+	 * Writes a row the next test then looks for. Together with the test below,
+	 * this is what proves the rollback in tearDown() is real.
+	 */
+	public function testAWriteIsVisibleInsideTheTestThatMadeIt(): void
+	{
+		Db::$db->insert(
+			'replace',
+			'{db_prefix}settings',
+			['variable' => 'string', 'value' => 'string'],
+			[[self::LEFTOVER, 'written']],
+			['variable'],
+		);
+
+		$this->assertSame('written', $this->rawSetting(self::LEFTOVER));
+	}
+
+	#[Depends('testAWriteIsVisibleInsideTheTestThatMadeIt')]
+	public function testThatWriteIsGoneByTheNextTest(): void
+	{
+		$this->assertNull(
+			$this->rawSetting(self::LEFTOVER),
+			'the previous test\'s write survived, so tests are not isolated',
+		);
+	}
+
+	public function testModSettingsIsRestoredEvenThoughItIsAStaticArray(): void
+	{
+		// The rollback returns the table, not the copy in memory. tearDown() has
+		// to put that back by hand, and this is the check that it does.
+		Config::$modSettings['smf_tests_in_memory_only'] = 'x';
+
+		$this->assertArrayHasKey('smf_tests_in_memory_only', Config::$modSettings);
+	}
+
+	#[Depends('testModSettingsIsRestoredEvenThoughItIsAStaticArray')]
+	public function testModSettingsHasNoLeftoversFromTheLastTest(): void
+	{
+		$this->assertArrayNotHasKey('smf_tests_in_memory_only', Config::$modSettings);
+	}
+
+	public function testAdminIdFindsAnAdministrator(): void
+	{
+		$id = $this->adminId();
+
+		$this->assertGreaterThan(0, $id);
+
+		$this->actingAs($id);
+
+		$this->assertSame($id, \SMF\User::$me->id);
+		$this->assertTrue(\SMF\User::$me->is_admin, 'actingAs() did not produce an administrator');
+	}
+
+	public function testNothingIsLoggedByAnEmptyTest(): void
+	{
+		$this->assertNoErrorsLogged();
+	}
+
+	/**
+	 * The assertion is only worth anything if it can fail, and it reads the log
+	 * through a watermark taken in setUp() rather than a count, so an empty log
+	 * is not what makes it pass.
+	 */
+	public function testAssertNoErrorsLoggedNoticesALoggedError(): void
+	{
+		Db::$db->insert(
+			'insert',
+			'{db_prefix}log_errors',
+			[
+				'log_time' => 'int',
+				'id_member' => 'int',
+				'ip' => 'inet',
+				'url' => 'string',
+				'message' => 'string',
+				'session' => 'string',
+				'error_type' => 'string',
+				'file' => 'string',
+				'line' => 'int',
+				'backtrace' => 'string',
+			],
+			[[time(), 0, '', '', 'canary', '', 'general', __FILE__, __LINE__, '[]']],
+			['id_error'],
+		);
+
+		$this->expectException(AssertionFailedError::class);
+
+		$this->assertNoErrorsLogged();
+	}
+}

--- a/tests/Integration/HarnessTest.php
+++ b/tests/Integration/HarnessTest.php
@@ -20,11 +20,19 @@ use SMF\Db\DatabaseApi as Db;
 #[CoversNothing]
 class HarnessTest extends IntegrationTestCase
 {
+	/*****************
+	 * Class constants
+	 *****************/
+
 	/**
 	 * The variable the rollback tests write. Named so that finding it left
 	 * behind in a real forum points straight back here.
 	 */
 	private const LEFTOVER = 'smf_tests_rollback_canary';
+
+	/****************
+	 * Public methods
+	 ****************/
 
 	public function testTheForumIsInstalled(): void
 	{

--- a/tests/Integration/Installation.php
+++ b/tests/Integration/Installation.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SMF\Tests\Integration;
+
+use SMF\Config;
+use SMF\Db\DatabaseApi as Db;
+use SMF\Infrastructure\Container;
+
+/**
+ * Finds the forum the integration suite runs against.
+ *
+ * The unit bootstrap deliberately stops short of a database. This carries on
+ * from where it left off - reads Settings.php, connects, loads $modSettings -
+ * but only when an integration test actually asks, so `composer test` on a
+ * machine with no forum still costs nothing.
+ *
+ * It never throws. When there is nothing to test against it says why, and
+ * IntegrationTestCase turns that into a skip rather than a failure.
+ *
+ * To get a forum: .docker/install-forum.sh --engine mysql
+ */
+final class Installation
+{
+	/****************************
+	 * Internal static properties
+	 ****************************/
+
+	/**
+	 * @var string|null Why the forum is unusable, '' when it is fine, null
+	 *     before anything has looked.
+	 */
+	private static ?string $unavailable = null;
+
+	/***********************
+	 * Public static methods
+	 ***********************/
+
+	/**
+	 * Connects, once per process.
+	 *
+	 * @return string Empty when there is a forum to test against, otherwise the
+	 *     reason there is not.
+	 */
+	public static function unavailableReason(): string
+	{
+		// Db::load() hands back the connection it already made and there is no
+		// way to drop it, so this can only usefully run once anyway.
+		if (self::$unavailable === null) {
+			self::$unavailable = self::connect();
+		}
+
+		return self::$unavailable;
+	}
+
+	/*************************
+	 * Internal static methods
+	 *************************/
+
+	/**
+	 * Does the actual work of unavailableReason().
+	 *
+	 * @return string Empty on success, otherwise the reason.
+	 */
+	private static function connect(): string
+	{
+		if (!is_file(SMF_SETTINGS_FILE) || filesize(SMF_SETTINGS_FILE) === 0) {
+			return 'there is no Settings.php';
+		}
+
+		try {
+			Config::load();
+		} catch (\Throwable $e) {
+			return 'Settings.php could not be loaded: ' . $e->getMessage();
+		}
+
+		if (empty(Config::$db_type) || empty(Config::$db_name)) {
+			return 'Settings.php names no database';
+		}
+
+		// index.php builds this before anything can ask for a service.
+		Container::init();
+
+		try {
+			// non_fatal, or a refused connection ends the process with SMF's own
+			// database error page instead of letting us report it here.
+			Db::load(['non_fatal' => true]);
+		} catch (\Throwable $e) {
+			return 'could not connect to ' . Config::$db_type . ': ' . $e->getMessage();
+		}
+
+		if (!isset(Db::$db->connection)) {
+			return 'could not connect to ' . Config::$db_type . ' as ' . Config::$db_user;
+		}
+
+		// Connecting is not the same as finding a forum: the dev environment
+		// writes a Settings.php long before anything is installed behind it.
+		try {
+			Config::reloadModSettings();
+		} catch (\Throwable $e) {
+			return 'the database holds no forum: ' . $e->getMessage();
+		}
+
+		if (empty(Config::$modSettings['smfVersion'])) {
+			return 'the database holds no forum (no smfVersion in ' . Config::$db_prefix . 'settings)';
+		}
+
+		return '';
+	}
+}

--- a/tests/Integration/IntegrationTestCase.php
+++ b/tests/Integration/IntegrationTestCase.php
@@ -1,0 +1,270 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SMF\Tests\Integration;
+
+use PHPUnit\Framework\TestCase;
+use SMF\Config;
+use SMF\Db\DatabaseApi as Db;
+use SMF\IntegrationHook;
+use SMF\User;
+
+/**
+ * Base class for tests that need a real, installed forum.
+ *
+ * Everything here exists because the unit suite cannot have it: a database
+ * connection, $modSettings as the forum actually stores it, and a current user.
+ *
+ * Each test runs inside a transaction that is rolled back afterwards, so tests
+ * can write freely without ordering themselves around each other. Two things
+ * that does not cover:
+ *
+ *  - DDL. MySQL commits implicitly on CREATE, ALTER and DROP, so a test that
+ *    changes the schema has to put it back itself.
+ *  - Anything a test causes to happen in another process, such as a request made
+ *    over HTTP. That runs on its own connection and will not see the open
+ *    transaction, nor be undone by the rollback.
+ */
+abstract class IntegrationTestCase extends TestCase
+{
+	/*******************
+	 * Internal properties
+	 *******************/
+
+	/**
+	 * @var array Copy of Config::$modSettings taken before the test ran.
+	 */
+	private array $mod_settings_backup = [];
+
+	/**
+	 * @var int Highest id_error before the test ran.
+	 */
+	private int $error_watermark = 0;
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	public static function setUpBeforeClass(): void
+	{
+		$reason = Installation::unavailableReason();
+
+		if ($reason !== '') {
+			self::markTestSkipped(
+				'no forum to test against: ' . $reason
+				. '. Run .docker/install-forum.sh --engine mysql',
+			);
+		}
+	}
+
+	/*******************
+	 * Internal methods
+	 *******************/
+
+	protected function setUp(): void
+	{
+		parent::setUp();
+
+		Db::$db->transaction('begin');
+
+		// $modSettings is a plain static array, so a test that calls
+		// updateModSettings() changes it for everything that runs after it. The
+		// rollback puts the table back, not the copy in memory.
+		$this->mod_settings_backup = Config::$modSettings;
+
+		$this->error_watermark = $this->lastErrorId();
+	}
+
+	protected function tearDown(): void
+	{
+		Db::$db->transaction('rollback');
+
+		Config::$modSettings = $this->mod_settings_backup;
+
+		// Hooks added with permanent: false live in $modSettings, so restoring it
+		// above has already removed them. This only puts the switch back.
+		IntegrationHook::$enabled = true;
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Becomes the given member for the rest of the test.
+	 *
+	 * This is the seam Login2::DoLogin() itself uses once it has checked the
+	 * password, so everything downstream - permissions, bans, logging - behaves
+	 * as it would for a real login, with no cookie and no request involved.
+	 *
+	 * Note that User::$me is a typed static and cannot be unset once assigned,
+	 * so this outlives the test. Say who you are rather than assuming.
+	 *
+	 * @param int $id The member to become.
+	 */
+	protected function actingAs(int $id): void
+	{
+		User::setMe($id);
+	}
+
+	/**
+	 * The id of an administrator, for actingAs().
+	 *
+	 * @return int The lowest member id in group 1.
+	 */
+	protected function adminId(): int
+	{
+		$request = Db::$db->query(
+			'SELECT id_member
+			FROM {db_prefix}members
+			WHERE id_group = {int:admin_group}
+			ORDER BY id_member
+			LIMIT 1',
+			[
+				'admin_group' => 1,
+			],
+		);
+
+		$row = Db::$db->fetch_assoc($request);
+		Db::$db->free_result($request);
+
+		$this->assertNotEmpty($row, 'the forum has no administrator');
+
+		return (int) $row['id_member'];
+	}
+
+	/**
+	 * Registers a hook for the duration of the test.
+	 *
+	 * permanent: false keeps it in Config::$modSettings and out of the database,
+	 * so tearDown() removes it by restoring that array.
+	 *
+	 * @param string $name The hook to add to, e.g. 'integrate_verify_user'.
+	 * @param string $function The callable, in any form Utils::getCallable() takes.
+	 */
+	protected function hook(string $name, string $function): void
+	{
+		IntegrationHook::add($name, $function, false);
+	}
+
+	/**
+	 * Asserts the forum logged nothing since the test started.
+	 *
+	 * Most of what goes wrong in SMF is recorded here rather than shown, so a
+	 * page that returned the right thing while quietly logging an undefined index
+	 * has still regressed.
+	 *
+	 * @param string $message Optional context for the failure.
+	 */
+	protected function assertNoErrorsLogged(string $message = ''): void
+	{
+		$request = Db::$db->query(
+			'SELECT error_type, message, file, line
+			FROM {db_prefix}log_errors
+			WHERE id_error > {int:watermark}
+			ORDER BY id_error',
+			[
+				'watermark' => $this->error_watermark,
+			],
+		);
+
+		$this->assertNotFalse(
+			$request,
+			rtrim($message . "\n") . 'could not read the error log, so this proves nothing',
+		);
+
+		$errors = [];
+
+		while ($row = Db::$db->fetch_assoc($request)) {
+			$errors[] = sprintf(
+				'  [%s] %s (%s:%d)',
+				$row['error_type'],
+				html_entity_decode((string) $row['message'], ENT_QUOTES | ENT_HTML5, 'UTF-8'),
+				$row['file'],
+				$row['line'],
+			);
+		}
+
+		Db::$db->free_result($request);
+
+		$this->assertSame(
+			[],
+			$errors,
+			rtrim($message . "\n") . "the forum logged " . \count($errors) . " error(s):\n" . implode("\n", $errors),
+		);
+	}
+
+	/**
+	 * Runs a query and returns its first row.
+	 *
+	 * Exists because a failed query is not an exception here. MySQL returns
+	 * false and carries on; PostgreSQL returns false and additionally puts the
+	 * surrounding transaction into a failed state, so every later query in the
+	 * same test returns false too. Handing that false to fetch_assoc() produces
+	 * a TypeError about argument #1, which says nothing about what went wrong.
+	 *
+	 * @param string $sql The query, in SMF's dialect.
+	 * @param array $params Its parameters.
+	 * @return array|null The first row, or null when there were none.
+	 */
+	protected function queryRow(string $sql, array $params = []): ?array
+	{
+		$request = Db::$db->query($sql, $params);
+
+		$this->assertNotFalse(
+			$request,
+			"the query failed:\n" . trim($sql)
+			. "\non PostgreSQL this also aborts the transaction, so every query after it fails too",
+		);
+
+		$row = Db::$db->fetch_assoc($request);
+		Db::$db->free_result($request);
+
+		return \is_array($row) ? $row : null;
+	}
+
+	/**
+	 * Reads a setting straight out of the table.
+	 *
+	 * Bypasses Config::$modSettings and its cache, so what comes back is what
+	 * the database actually holds rather than what the process believes.
+	 *
+	 * @param string $variable The setting to read.
+	 * @return string|null The value, or null when there is no such row.
+	 */
+	protected function rawSetting(string $variable): ?string
+	{
+		$row = $this->queryRow(
+			'SELECT value
+			FROM {db_prefix}settings
+			WHERE variable = {string:variable}',
+			[
+				'variable' => $variable,
+			],
+		);
+
+		return $row === null ? null : (string) $row['value'];
+	}
+
+	/**
+	 * The highest id_error currently in the log.
+	 *
+	 * @return int The id, or 0 when nothing has ever been logged.
+	 */
+	private function lastErrorId(): int
+	{
+		$request = Db::$db->query(
+			'SELECT COALESCE(MAX(id_error), 0) AS id_error
+			FROM {db_prefix}log_errors',
+			[],
+		);
+
+		if ($request === false) {
+			return 0;
+		}
+
+		$row = Db::$db->fetch_assoc($request);
+		Db::$db->free_result($request);
+
+		return (int) ($row['id_error'] ?? 0);
+	}
+}

--- a/tests/Integration/IntegrationTestCase.php
+++ b/tests/Integration/IntegrationTestCase.php
@@ -28,9 +28,9 @@ use SMF\User;
  */
 abstract class IntegrationTestCase extends TestCase
 {
-	/*******************
+	/*********************
 	 * Internal properties
-	 *******************/
+	 *********************/
 
 	/**
 	 * @var array Copy of Config::$modSettings taken before the test ran.
@@ -42,9 +42,9 @@ abstract class IntegrationTestCase extends TestCase
 	 */
 	private int $error_watermark = 0;
 
-	/****************
-	 * Public methods
-	 ****************/
+	/***********************
+	 * Public static methods
+	 ***********************/
 
 	public static function setUpBeforeClass(): void
 	{
@@ -58,9 +58,9 @@ abstract class IntegrationTestCase extends TestCase
 		}
 	}
 
-	/*******************
+	/******************
 	 * Internal methods
-	 *******************/
+	 ******************/
 
 	protected function setUp(): void
 	{
@@ -175,7 +175,7 @@ abstract class IntegrationTestCase extends TestCase
 		$errors = [];
 
 		while ($row = Db::$db->fetch_assoc($request)) {
-			$errors[] = sprintf(
+			$errors[] = \sprintf(
 				'  [%s] %s (%s:%d)',
 				$row['error_type'],
 				html_entity_decode((string) $row['message'], ENT_QUOTES | ENT_HTML5, 'UTF-8'),
@@ -189,7 +189,7 @@ abstract class IntegrationTestCase extends TestCase
 		$this->assertSame(
 			[],
 			$errors,
-			rtrim($message . "\n") . "the forum logged " . \count($errors) . " error(s):\n" . implode("\n", $errors),
+			rtrim($message . "\n") . 'the forum logged ' . \count($errors) . " error(s):\n" . implode("\n", $errors),
 		);
 	}
 

--- a/tests/Integration/ModSettingsTest.php
+++ b/tests/Integration/ModSettingsTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SMF\Tests\Integration;
+
+use PHPUnit\Framework\Attributes\CoversMethod;
+use SMF\Config;
+use SMF\Db\DatabaseApi as Db;
+
+/**
+ * Config::updateModSettings() against a real database, on whichever engine is
+ * configured.
+ *
+ * The counter case is a regression test. Passing true or false as a value means
+ * "add one" or "take one away", and that was emitted as SET value = value + 1
+ * against settings.value, which is a text column. MySQL coerces that silently;
+ * PostgreSQL rejects it outright, and because the PostgreSQL API discarded
+ * failed queries without a word, the statement simply did nothing. Every counter
+ * that goes through this path - totalMessages, totalTopics, totalMembers,
+ * unapprovedMembers - stayed frozen at whatever the last full recount produced.
+ *
+ * Nothing about that is reachable without a database, and it only shows up on
+ * one of the two engines, which is exactly the gap this suite exists to close.
+ */
+#[CoversMethod(Config::class, 'updateModSettings')]
+class ModSettingsTest extends IntegrationTestCase
+{
+	private const COUNTER = 'smf_tests_counter';
+
+	public function testWritesAValue(): void
+	{
+		Config::updateModSettings([self::COUNTER => '41']);
+
+		$this->assertSame('41', $this->rawSetting(self::COUNTER));
+		$this->assertSame('41', Config::$modSettings[self::COUNTER]);
+	}
+
+	public function testIncrementsACounter(): void
+	{
+		Config::updateModSettings([self::COUNTER => '41']);
+		Config::updateModSettings([self::COUNTER => true], true);
+
+		$this->assertSame(
+			42,
+			(int) $this->rawSetting(self::COUNTER),
+			'the counter did not increment - on PostgreSQL this means the '
+			. 'arithmetic was rejected and the failure swallowed',
+		);
+	}
+
+	public function testDecrementsACounter(): void
+	{
+		Config::updateModSettings([self::COUNTER => '41']);
+		Config::updateModSettings([self::COUNTER => false], true);
+
+		$this->assertSame(40, (int) $this->rawSetting(self::COUNTER));
+	}
+
+	/**
+	 * The value has to stay something the next increment can read back, so a
+	 * cast that leaves '42.0000' behind is not good enough.
+	 */
+	public function testAnIncrementedCounterStaysAPlainInteger(): void
+	{
+		Config::updateModSettings([self::COUNTER => '41']);
+		Config::updateModSettings([self::COUNTER => true], true);
+
+		$this->assertMatchesRegularExpression(
+			'~^\d+$~',
+			(string) $this->rawSetting(self::COUNTER),
+			'the incremented value is not a plain integer, so it will not survive a round trip',
+		);
+	}
+
+	public function testCountersCanBeIncrementedRepeatedly(): void
+	{
+		// Starts at 10 rather than 0 on purpose: see the test below for why a
+		// brand new setting cannot be created holding a falsy value.
+		Config::updateModSettings([self::COUNTER => '10']);
+
+		for ($i = 0; $i < 3; $i++) {
+			Config::updateModSettings([self::COUNTER => true], true);
+		}
+
+		$this->assertSame(13, (int) $this->rawSetting(self::COUNTER));
+	}
+
+	/**
+	 * A setting that does not exist yet and would only be set to nothingness is
+	 * skipped rather than written. That is deliberate, and it is a sharp edge:
+	 * seeding a counter at zero looks like it worked and leaves no row, so the
+	 * first increment then has nothing to increment.
+	 */
+	public function testDoesNotCreateANewSettingHoldingAFalsyValue(): void
+	{
+		Config::updateModSettings([self::COUNTER => '0']);
+
+		$this->assertNull($this->rawSetting(self::COUNTER));
+
+		// An existing one can be set to zero perfectly well.
+		Config::updateModSettings([self::COUNTER => '7']);
+		Config::updateModSettings([self::COUNTER => '0']);
+
+		$this->assertSame('0', $this->rawSetting(self::COUNTER));
+	}
+
+	public function testUpdatingSettingsLogsNoErrors(): void
+	{
+		Config::updateModSettings([self::COUNTER => '1']);
+		Config::updateModSettings([self::COUNTER => true], true);
+		Config::updateModSettings([self::COUNTER => false], true);
+
+		$this->assertNoErrorsLogged('updating a counter should be silent');
+	}
+}

--- a/tests/Integration/ModSettingsTest.php
+++ b/tests/Integration/ModSettingsTest.php
@@ -6,7 +6,6 @@ namespace SMF\Tests\Integration;
 
 use PHPUnit\Framework\Attributes\CoversMethod;
 use SMF\Config;
-use SMF\Db\DatabaseApi as Db;
 
 /**
  * Config::updateModSettings() against a real database, on whichever engine is
@@ -26,7 +25,15 @@ use SMF\Db\DatabaseApi as Db;
 #[CoversMethod(Config::class, 'updateModSettings')]
 class ModSettingsTest extends IntegrationTestCase
 {
+	/*****************
+	 * Class constants
+	 *****************/
+
 	private const COUNTER = 'smf_tests_counter';
+
+	/****************
+	 * Public methods
+	 ****************/
 
 	public function testWritesAValue(): void
 	{

--- a/tests/Integration/SchemaTest.php
+++ b/tests/Integration/SchemaTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SMF\Tests\Integration;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use SMF\Db\DatabaseApi as Db;
+use SMF\Db\Schema\Table;
+
+/**
+ * Compares the schema SMF declares in PHP against the one it actually built.
+ *
+ * The schema for 3.0 lives in Sources/Db/Schema/v3_0/ as 70-odd classes, and the
+ * installer creates the database from them. Nothing checks afterwards that the
+ * two still agree, and a query naming a column that is no longer there fails at
+ * runtime only - inside a background task, it retries forever and takes down
+ * unrelated page loads.
+ *
+ * Both engines get their own DDL out of the same declarations, so this is worth
+ * running twice.
+ */
+#[CoversNothing]
+class SchemaTest extends IntegrationTestCase
+{
+	public function testTheSchemaDeclaresTables(): void
+	{
+		// Guards the two tests below: if getAll() ever returns nothing they
+		// would both pass by iterating over an empty list.
+		$this->assertNotEmpty(Table::getAll('v3_0'), 'the v3_0 schema declares no tables at all');
+	}
+
+	public function testEveryDeclaredTableExists(): void
+	{
+		$existing = array_map(
+			static fn($table): string => strtolower($table),
+			Db::$db->list_tables(),
+		);
+
+		$missing = [];
+
+		foreach (Table::getAll('v3_0') as $table) {
+			if (!\in_array(strtolower(Db::$db->prefix . $table->name), $existing, true)) {
+				$missing[] = $table->name;
+			}
+		}
+
+		$this->assertSame([], $missing, 'tables the schema declares but the database does not have');
+	}
+
+	public function testEveryDeclaredColumnExists(): void
+	{
+		$missing = [];
+
+		foreach (Table::getAll('v3_0') as $table) {
+			$columns = array_map(
+				static fn($column): string => strtolower($column),
+				Db::$db->list_columns('{db_prefix}' . $table->name),
+			);
+
+			// A table that is missing entirely is the other test's business.
+			if ($columns === []) {
+				continue;
+			}
+
+			foreach ($table->columns as $column) {
+				if (!\in_array(strtolower($column->name), $columns, true)) {
+					$missing[] = $table->name . '.' . $column->name;
+				}
+			}
+		}
+
+		$this->assertSame([], $missing, 'columns the schema declares but the database does not have');
+	}
+
+	/**
+	 * The reverse direction, which is the one that catches a migration that
+	 * dropped a column in the schema but not in the database, or a table left
+	 * behind by an older version.
+	 */
+	public function testTheDatabaseHasNoColumnsTheSchemaDoesNotDeclare(): void
+	{
+		$unexpected = [];
+
+		foreach (Table::getAll('v3_0') as $table) {
+			$declared = array_map(
+				static fn($column): string => strtolower($column->name),
+				$table->columns,
+			);
+
+			foreach (Db::$db->list_columns('{db_prefix}' . $table->name) as $column) {
+				if (!\in_array(strtolower($column), $declared, true)) {
+					$unexpected[] = $table->name . '.' . $column;
+				}
+			}
+		}
+
+		$this->assertSame([], $unexpected, 'columns the database has that the schema does not declare');
+	}
+}

--- a/tests/Integration/SchemaTest.php
+++ b/tests/Integration/SchemaTest.php
@@ -23,6 +23,10 @@ use SMF\Db\Schema\Table;
 #[CoversNothing]
 class SchemaTest extends IntegrationTestCase
 {
+	/****************
+	 * Public methods
+	 ****************/
+
 	public function testTheSchemaDeclaresTables(): void
 	{
 		// Guards the two tests below: if getAll() ever returns nothing they

--- a/tests/Integration/index.php
+++ b/tests/Integration/index.php
@@ -1,0 +1,8 @@
+<?php
+
+// Try to handle it with the upper level index.php. (it should know what to do.)
+if (file_exists(dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php')) {
+	include dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php';
+} else {
+	exit;
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -52,6 +52,12 @@ $loader = require TESTS_BOARDDIR . '/vendor/autoload.php';
 $loader->setPsr4('SMF\\', TESTS_BOARDDIR . '/Sources');
 $loader->setPsr4('SMF\\Themes\\', TESTS_BOARDDIR . '/Themes');
 
+// The unit tests are each self-contained, so nothing had to autoload them.
+// Anything sharing a base class or a helper does, and registering it here keeps
+// it beside the other two rather than adding an autoload-dev section that only
+// the test suite would ever use.
+$loader->setPsr4('SMF\\Tests\\', TESTS_BOARDDIR . '/tests');
+
 /*
  * Paths and the default language, which the Unicode and entity helpers need in
  * order to locate their data files. These are the only pieces of Config the suite


### PR DESCRIPTION
#### Description

The unit suite from #9326 is deliberately database-free, and its own bootstrap
says what is missing: anything reaching `Config::$modSettings`, `User::$me` or
`Db::$db` "belongs in an integration suite running against a real install".
There was not one, so most of the forum had no automated proof of anything.

This adds it. `tests/Integration/` is a second PHPUnit testsuite that runs
against a forum installed by #9344, on either engine:

```sh
.docker/test.sh                     # both engines
.docker/test.sh --engine postgresql
```

`composer test` still runs everything. **When there is no forum to talk to the
integration tests skip rather than fail**, so it stays useful on a machine with
no Docker — 108 unit tests pass, 20 integration tests skip, exit 0.

##### What the base class provides

`IntegrationTestCase` gives each test:

- a transaction, rolled back in `tearDown()`, so tests need not order themselves
  around each other. `$modSettings` is restored separately, because the rollback
  returns the table and not the static array;
- `actingAs($id)` / `adminId()`, via `User::setMe()` — the same seam
  `Login2::DoLogin()` uses once it has checked the password;
- `hook($name, $function)` with `permanent: false`, so it lives in `$modSettings`
  and disappears with the rollback;
- `assertNoErrorsLogged()`, usually the point of the test. SMF records most of
  what goes wrong in `log_errors` rather than showing it, so a page that returned
  the right thing while quietly logging an undefined index has still regressed;
- `queryRow()` / `rawSetting()`, which read past `$modSettings` and its cache.

Two things the rollback does not cover, both documented in the class: DDL, since
MySQL commits implicitly on `CREATE`/`ALTER`/`DROP`; and anything happening in
another process, such as a request made over HTTP.

##### The three tests

- **`HarnessTest`** checks the harness itself — that the rollback really happens
  (one test writes, the next asserts it is gone), that `$modSettings` is
  restored, and that `assertNoErrorsLogged()` is capable of failing. A suite
  whose isolation quietly broke would not fail; it would start passing things it
  should not.
- **`ModSettingsTest`** pins the counter regression fixed in #9340.
  `updateModSettings($x, true)` emitted `SET value = value + 1` against
  `settings.value`, a text column.
- **`SchemaTest`** compares `Sources/Db/Schema/v3_0/` against the live database
  **in both directions** — declared tables and columns that are missing, and
  columns present that nothing declares. This is the drift AGENTS.md warns about,
  where a query naming a removed column fails at runtime only, and inside a
  background task retries forever.

##### Why both engines, concretely

Not thoroughness for its own sake. I reverted #9340's fix and re-ran:

| | MySQL | PostgreSQL |
| --- | --- | --- |
| with the fix | 9 pass | 9 pass |
| fix reverted | **9 pass** | **5 fail** |

MySQL coerces text to a number and hides the bug completely. A suite that only
ever saw one engine would have proved nothing here. Worth knowing too: on
PostgreSQL a failed query poisons the rest of the transaction, so one swallowed
error turns every later query in that test into `false` — `queryRow()` reports
that as a readable assertion failure rather than a `TypeError` about argument #1.

##### Notes

- `tests/bootstrap.php` gains one line registering `SMF\Tests\` for autoloading.
  The unit tests are each self-contained so nothing needed it before; anything
  sharing a base class does. Kept beside the two `setPsr4()` calls already there
  rather than adding an `autoload-dev` section only the suite would use.
- `composer.json` gains `test-unit` and `test-integration` alongside `test`.
- `AGENTS.md` is updated: it previously told contributors that `Db::$db` was
  simply out of scope.

##### Verified

- `.docker/test.sh` — 128 tests, 196 assertions, green on **both** engines.
- With `Settings.php` removed — 108 pass, 20 skip, exit 0.
- Regression proven in both directions, as above.
- `check-signed-off.php`, `check-smf-index.php`, `check-smf-license.php`,
  `check-smf-languages.php` and `phplint` all pass; `shellcheck` clean on all
  five `.docker` scripts.

##### Two commits that are not about testing

- **`Lets the section comment fixer place its own banners`** — I wrote the section
  banners by hand with the wrong asterisk count, so `SMF/section_comments` did not
  recognise them and added its own alongside. AGENTS.md already says not to
  hand-write these; this takes what the fixer produces.
- **`Removes the trailing tabs from a blank line in PM search`** — one character in
  `Sources/PersonalMessage/Search.php`, which I have otherwise not touched.
  `c344b5c23` left a line holding nothing but three tabs. It has not turned CI red
  so far because the style workflow normally only checks the files a PR changes;
  it checks **everything** when `composer.lock` is in the diff, which this PR's
  does. Any other branch touching a dependency will hit the same thing, so it
  seemed better to fix than to work around. Happy to split it out if preferred.

#### Merge order

**Merge #9326 and #9344 before this one.** Both are contained in this branch, so the
diff shown here is theirs as well as its own; once they land and this is rebased on
`release-3.0`, what is left is `tests/Integration/` and its bootstrap.

### Issues References (Fixes|Related|Closes)
1. Depends on #9344 — needs `.docker/install-forum.sh` to have a forum to test.
2. Depends on #9326 — builds on the PHPUnit suite and its bootstrap.
3. Related to #9317, #9340.


