### PR TITLE
[3.0] Sync PostgreSQL sequences with the rows the installer inserts

### DIFF
--- a/Sources/Db/Schema/Table.php
+++ b/Sources/Db/Schema/Table.php
@@ -592,6 +592,10 @@ abstract class Table
 
 		$num_inserts = \count($ids ?? $this->initial_data);
 
+		if (isset($auto_col)) {
+			$this->resyncAutoIncrement($auto_col);
+		}
+
 		return $num_inserts;
 	}
 
@@ -696,5 +700,47 @@ abstract class Table
 		}
 
 		return [];
+	}
+
+	/******************
+	 * Internal methods
+	 ******************/
+
+	/**
+	 * Points the table's ID generator past the rows that were just inserted.
+	 *
+	 * The initial data carries its own IDs — the default board is board 1, and
+	 * plenty of other rows are referred to by number elsewhere in it — so they
+	 * are supplied rather than generated.
+	 *
+	 * MySQL notices that and moves AUTO_INCREMENT along by itself. PostgreSQL
+	 * does not: a sequence only advances when something calls nextval() on it,
+	 * and nothing has, so it still sits at 1 and hands 1 to the next insert.
+	 * That collides with the row already there, and the insert fails on the
+	 * primary key. The first topic anybody starts on a new forum is the usual
+	 * way to meet this, and it fails once and then works, because the failed
+	 * attempt consumed the 1 and the retry gets 2.
+	 *
+	 * The 2.1 upgrade path has had this fix for years, in the PostgreSqlSequences
+	 * migration. This is the same thing for a fresh install.
+	 *
+	 * @param string $auto_col Name of the auto-incrementing column.
+	 */
+	private function resyncAutoIncrement(string $auto_col): void
+	{
+		if (Db::$db->title !== POSTGRE_TITLE) {
+			return;
+		}
+
+		// COALESCE for the table that ended up empty after an 'ignore' insert:
+		// setval() will not accept NULL, and 1 is where the sequence began.
+		Db::$db->query(
+			'SELECT setval(\'{raw:sequence}\', COALESCE((SELECT MAX({raw:column}) FROM {db_prefix}{raw:table}), 1))',
+			[
+				'sequence' => Db::$db->prefix . $this->name . '_seq',
+				'column' => $auto_col,
+				'table' => $this->name,
+			],
+		);
 	}
 }


### PR DESCRIPTION
#### Description

On a freshly installed PostgreSQL forum, the first topic anybody starts is silently not created.

The table schemas carry initial data with explicit IDs — the default board is board 1, and other seeded rows refer to each other by number — so those values are supplied to the `INSERT` rather than generated. MySQL notices a value above its `AUTO_INCREMENT` counter and moves the counter along by itself. PostgreSQL does not: a sequence only advances when something calls `nextval()` on it, nothing has, so it still sits at 1 and hands 1 to the next insert. That collides with the row already there:

```
ERROR:  duplicate key value violates unique constraint "smf_topics_pkey"
ERROR:  duplicate key value violates unique constraint "smf_messages_pkey"
```

**28 sequences** are in that state on a new install — `boards`, `categories`, `membergroups`, `smileys`, `attachments`, `polls`, `personal_messages`, `scheduled_tasks` and more.

What makes it easy to miss rather than easy to report:

- **It does not look like a database problem.** `Post2` runs on to its normal redirect, the browser lands on the board, and the topic simply is not there. Nothing is shown to the user and nothing reaches `log_errors`.
- **It fixes itself after one attempt.** The insert that failed still consumed the `1`, so the retry gets `2` and succeeds. Anyone who tries again concludes it was a fluke, and the forum behaves correctly from then on.

Because of that second point it only reproduces on a forum that has just been installed, which is why it has survived this long.

#### The fix

`Table::populate()` already works out which column auto-increments, in order to decide its insert mode. After the insert it now points the generator past what it just wrote. On MySQL this returns immediately.

This is not a new idea in the codebase: the 2.1 upgrade path has carried the same `setval()` for years, as `Sources/Maintenance/Migration/v2_1/PostgreSqlSequences.php`. Installs never got the equivalent.

#### Testing

The unit suite cannot reach this — it needs a database, and the state only exists on a forum that has just been installed.

Verified by hand on both engines, installing from scratch each time:

- **PostgreSQL, before:** starting the first topic returns 302 to the board and creates nothing; the PostgreSQL log shows the duplicate key errors above; `pg_sequences.last_value` is `NULL` for 28 sequences.
- **PostgreSQL, after:** no seeded table's sequence is left uncalled, and the first topic and its first reply post normally.
- **MySQL:** reinstalled and exercised as well, since `populate()` is shared. Unchanged, as expected.

### Issues References (Fixes|Related|Closes)

Found while running HTTP tests against a freshly installed forum in #9347. Not otherwise reported that I can find.
