### PR TITLE
[3.0] Theme split (wave 2, part 4) — Move the message box and bar values into variables.css

### DIFF
--- a/Themes/default/css/index.css
+++ b/Themes/default/css/index.css
@@ -3029,30 +3029,30 @@ dl.addrules dt.floatleft {
 }
 
 .generic_list_wrapper, .windowbg, .approvebg, .approvebg2 {
-	background: #f0f4f7;
+	background: var(--window-bg);
 	margin: 12px 0 0 0;
 	padding: 12px 16px;
-	border: 1px solid #ddd;
-	border-radius: 6px;
-	box-shadow: 0 -2px 2px rgba(0, 0, 0, 0.1);
+	border: var(--window-border-width) var(--window-border-style) var(--window-border-color);
+	border-radius: var(--window-border-radius);
+	box-shadow: var(--window-box-shadow);
 	overflow: auto;
 }
 /* Here comes the glory... */
 .windowbg:nth-of-type(even), .bg.even {
-	background: #f0f4f7;
+	background: var(--window-bg);
 }
 .windowbg:nth-of-type(odd), .bg.odd {
-	background: #fdfdfd;
+	background: var(--window-odd-bg);
 }
 
 /* Highlight the target item */
 .windowbg:target {
-	background: #ffffe0;
+	background: var(--window-target-bg);
 }
 
 /* Add some hover on table rows */
 tr.windowbg:hover {
-	background: #e2eef8;
+	background: var(--window-bg_hover);
 }
 
 /* Special treatment for #forumposts area */
@@ -3061,23 +3061,23 @@ tr.windowbg:hover {
 }
 /* Nobody wants locked topics to stand out much. */
 .windowbg.locked {
-	background: #e7eaef;
+	background: var(--window-locked-bg);
 }
 /* Sticky topics get a different background */
 .windowbg.sticky {
-	background: #cfdce8;
+	background: var(--window-sticky-bg);
 }
 /* Locked AND sticky are a bit more technical */
 .windowbg.sticky.locked {
-	background: #e8d8cf;
+	background: var(--window-stickylocked-bg);
 }
 /* Awaiting approval is a bit special, topics first */
 .windowbg.approvetopic {
-	background: #e4a17c;
+	background: var(--window-approvetopic-bg);
 }
 /* Unapproved posts in approved topics */
 .windowbg.approvepost {
-	background: #ffcbcb;
+	background: var(--window-approvepost-bg);
 }
 .generic_list_wrapper .additional_row {
 	margin: 0;
@@ -3856,12 +3856,12 @@ ul.post_options li {
 /* General Classes */
 /* Cat_bar / catbg */
 div.cat_bar {
-	background: #557ea0;
-	border-bottom: 1px solid #777;
+	background: var(--catbar-bg);
+	border-bottom: var(--catbar-border-width) var(--catbar-border-style) var(--catbar-border-color);
 	padding: 0;
-	border-radius: 6px 6px 0 0;
-	box-shadow: 0 16px 20px rgba(255, 255, 255, 0.15) inset;
-	text-shadow: -1px -1px 1px rgba(0, 0, 0, 0.2);
+	border-radius: var(--catbar-border-radius);
+	box-shadow: var(--catbar-box-shadow);
+	text-shadow: var(--catbar-text-shadow);
 }
 .cat_bar.collapsed,
 .cat_bar.cat_bar_round {
@@ -3872,26 +3872,26 @@ div.cat_bar {
 }
 /* Styles for rounded headers. */
 .cat_bar .desc {
-	color: #fff;
+	color: var(--catbar-color);
 	font-size: 12px;
 	line-height: 1.5em;
 	font-weight: normal;
 	margin: -8px 0 4px 8px;
 }
 .cat_bar .desc a {
-	color: #fff;
+	color: var(--catbar-color);
 	font-weight: 600;
 }
 h3.catbg {
 	overflow: hidden;
-	font-size: 1.1em;
-	font-family: "Tahoma", sans-serif;
+	font-size: var(--catbar-font-size);
+	font-family: var(--catbar-font-family);
 }
 h3.catbg, h3.catbg a, h3.catbg a:hover {
-	color: #fff;
+	color: var(--catbar-color);
 }
 h3.catbg a:hover {
-	text-shadow: -1px -1px 0 rgba(0, 0, 0, 0.4);
+	text-shadow: var(--catbar-text-shadow_hover);
 	text-decoration: none;
 }
 h3.catbg .main_icons::before, h3.catbg .icon {
@@ -3909,27 +3909,27 @@ h3.catbg .main_icons::before, h3.catbg .icon {
 .roundframe {
 	margin: 10px 0 0 0;
 	padding: 12px 16px;
-	background: #f8f8f8;
-	border: 1px solid #c5c5c5;
-	border-radius: 7px;
-	box-shadow: 0 -2px 2px rgba(0, 0, 0, 0.1);
+	background: var(--roundframe-bg);
+	border: var(--roundframe-border-width) var(--roundframe-border-style) var(--roundframe-border-color);
+	border-radius: var(--roundframe-border-radius);
+	box-shadow: var(--roundframe-box-shadow);
 	overflow: auto;
 }
 /* TitleBar & SubBar */
 .title_bar {
-	border: 1px solid #ddd;
-	border-top: 2px solid #ff9400;
-	border-bottom: 2px solid #bf6900;
-	background: #fff;
-	color: #666;
-	border-radius: 2px 2px 0 0;
+	border-color: var(--titlebar-border-color);
+	border-style: var(--titlebar-border-style);
+	border-width: var(--titlebar-border-width);
+	background: var(--titlebar-bg);
+	color: var(--titlebar-color);
+	border-radius: var(--titlebar-border-radius);
 	margin: 5px 0 0 0;
 }
 .sub_bar {
-	border-bottom: 1px solid #ddd;
-	text-shadow: none;
-	background: none;
-	box-shadow: 0 -1px 0 #999 inset;
+	border-bottom: var(--subbar-border-width) var(--subbar-border-style) var(--subbar-border-color);
+	text-shadow: var(--subbar-text-shadow);
+	background: var(--subbar-bg);
+	box-shadow: var(--subbar-box-shadow);
 	clear: both;
 }
 h3.titlebg, h4.titlebg, .titlebg, h3.subbg, h4.subbg, .subbg {
@@ -3955,12 +3955,12 @@ h3.titlebg, h4.titlebg, .titlebg, h3.subbg, h4.subbg, .subbg {
 /* Other */
 /* Information */
 .information {
-	background: #f8f8f8;
+	background: var(--information-bg);
 	overflow: auto;
 	padding-bottom: .5em;
-	border: 1px solid #ddd;
+	border: var(--information-border-width) var(--information-border-style) var(--information-border-color);
 	border-top: none;
-	border-radius: 0 0 7px 7px;
+	border-radius: var(--information-border-radius);
 	margin: 0 0 10px 0;
 	padding: 12px 9px 8px 9px;
 }

--- a/Themes/default/css/index.css
+++ b/Themes/default/css/index.css
@@ -1114,16 +1114,16 @@ a[class^="mobile_generic_menu_"] {
 .button, .quickbuttons > li > a, .inline_mod_check {
 	display: inline-block;
 	padding: 0 8px;
-	color: #444;
-	font-size: 0.7rem;
+	color: var(--button-color);
+	font-size: var(--button-font-size);
 	line-height: 2em;
-	text-transform: uppercase;
-	cursor: pointer;
+	text-transform: var(--button-text-transform);
+	cursor: var(--button-cursor);
 	min-height: calc(2em + 2em * (0.9 - 0.85)); /* "input" font size minus ".button" font size */
-	border: 1px solid;
-	border-color: #ddd #bbb #aaa #ddd;
-	border-radius: 3px;
-	box-shadow: 1px 1px 1px rgba(221, 221, 221, 0.57);
+	border: var(--button-border-width) var(--button-border-style);
+	border-color: var(--button-border-color);
+	border-radius: var(--button-border-radius);
+	box-shadow: var(--button-box-shadow);
 	box-sizing: border-box;
 	vertical-align: middle;
 }
@@ -1138,25 +1138,25 @@ html[lang="el-GR"] .inline_mod_check {
 .button:hover, .button:focus,
 .quickbuttons > li:hover > a, .quickbuttons > li > a:focus {
 	color: #222;
-	border-color: #aaa #ddd #ddd #bbb;
-	box-shadow: -1px -1px 2px rgba(221, 221, 221, 0.7), -1px -2px 4px #ddd inset;
+	border-color: var(--button-border-color_hover);
+	box-shadow: var(--button-box-shadow_hover);
 	text-decoration: none;
 }
 .button:hover, .button:focus {
-	color: #af6700;
+	color: var(--button-color_hover);
 }
 /* the active one */
 .button.active {
-	background: #557ea0;
-	color: #fff;
-	font-weight: bold;
-	border: 1px solid #558080;
-	text-shadow: 0 0 1px #000;
+	background: var(--button-bg_active);
+	color: var(--button-color_active);
+	font-weight: var(--button-font-weight_active);
+	border: var(--button-border-width) var(--button-border-style) var(--button-border-color_active);
+	text-shadow: var(--button-text-shadow_active);
 }
 .button.active:hover, .button.active:focus {
-	color: #ffc187;
-	background: #557ea0;
-	box-shadow: none;
+	color: var(--button-color_active_hover);
+	background: var(--button-bg_active);
+	box-shadow: var(--button-box-shadow_active);
 }
 .cat_bar .button {
 	box-shadow: none;

--- a/Themes/default/css/index.css
+++ b/Themes/default/css/index.css
@@ -1,13 +1,13 @@
 /* You can find detailed information at https://wiki.simplemachines.org/smf/Curve2_CSS
 /* Index */
 html {
-	background: #3e5a78;
+	background: var(--html-bg);
 	scroll-padding-top: 3rem;
 }
 body {
-	background: #e9eef2;
-	font: 83.33%/150% "Segoe UI", "Helvetica Neue", "Nimbus Sans L", Arial, "Liberation Sans", sans-serif;
-	color: #4d4d4d;
+	background: var(--body-bg);
+	font: var(--body-font-size)/150% var(--body-font-family);
+	color: var(--body-color);
 	display: flex;
 	flex-direction: column;
 	min-height: 100vh;
@@ -15,8 +15,8 @@ body {
 }
 ::selection {
 	text-shadow: none;
-	background: #99d4ff;
-	color: rgba(0, 0, 0, 0.6);
+	background: var(--selection-bg);
+	color: var(--selection-color);
 }
 /* General reset */
 * {
@@ -38,27 +38,27 @@ abbr {
 	border-bottom: 0.1em dotted;
 }
 input, button, select, textarea {
-	color: #222;
-	font: 83.33%/150% "Segoe UI", "Helvetica Neue", "Nimbus Sans L", Arial, "Liberation Sans", sans-serif;
-	background: #fff;
+	color: var(--input-color);
+	font: var(--body-font-size)/150% var(--body-font-family);
+	background: var(--input-bg);
 	outline: none;
-	border: 1px solid #bbb;
+	border: var(--input-border-width) var(--input-border-style) var(--input-border-color);
 	vertical-align: middle;
-	border-radius: 3px;
-	box-shadow: 1px 2px 1px rgba(160, 187, 221, 0.2) inset;
+	border-radius: var(--input-border-radius);
+	box-shadow: var(--input-box-shadow);
 	padding: 0.3em 0.4em;
 }
 input:hover, textarea:hover, button:hover, select:hover {
 	outline: none;
-	border-color: #82a2bc;
+	border-color: var(--input-border-color_hover);
 }
 textarea:hover {
-	background: #fbfbfb;
+	background: var(--input-bg_hover);
 }
 input:focus, textarea:focus, button:focus, select:focus {
 	outline: none;
-	border-color: #7fb0d8;
-	background: #fff;
+	border-color: var(--input-border-color_focus);
+	background: var(--input-bg_focus);
 }
 input, button, select {
 	padding: 0 0.4em;
@@ -126,12 +126,12 @@ select option {
 fieldset {
 	padding: 18px;
 	margin: 0 0 6px 0;
-	border: 1px solid #ddd;
-	border-radius: 3px;
+	border: var(--fieldset-border-width) var(--fieldset-border-style) var(--fieldset-border-color);
+	border-radius: var(--fieldset-border-radius);
 }
 fieldset legend {
 	font-weight: bold;
-	color: #555;
+	color: var(--fieldset-legend-color);
 	box-shadow: none;
 	border: none;
 }
@@ -147,7 +147,7 @@ summary {
 /* This gives a better effect for those areas, and will default to bold for fonts which do not support numerical font-weight */
 strong, .strong {
 	font-weight: bold;
-	color: #444;
+	color: var(--strong-color);
 }
 .cat_bar strong {
 	color: #fff;
@@ -157,8 +157,8 @@ em, .em {
 }
 /* Default <strong> color on these tags */
 h1, h2, h3, h4, h5, h6 {
-	font-size: 1em;
-	color: #444;
+	font-size: var(--heading-font-size);
+	color: var(--heading-color);
 }
 /* All input elements that are checkboxes or radio buttons shouldn't have a border around them */
 input[type="checkbox"], input[type="radio"] {
@@ -173,9 +173,9 @@ input[type="checkbox"], input[type="radio"] {
 }
 /* Give disabled input elements a different style */
 input[disabled], textarea[disabled], select[disabled], .button.disabled, .button[disabled]:hover {
-	background: #eee;
-	color: #999;
-	border-color: #b6b6b6;
+	background: var(--input-bg_disabled);
+	color: var(--input-color_disabled);
+	border-color: var(--input-border-color_disabled);
 	opacity: 0.8;
 	cursor: default;
 }
@@ -183,13 +183,13 @@ input[disabled], textarea[disabled], select[disabled], .button.disabled, .button
 hr {
 	border: none;
 	margin: 12px 0;
-	height: 2px;
-	background: #fff;
-	box-shadow: 0 1px 0 #bbb inset;
+	height: var(--horizontalrule-height);
+	background: var(--horizontalrule-bg);
+	box-shadow: var(--horizontalrule-box-shadow);
 }
 /* This is about links */
 a, a:visited, .reset.link {
-	color: #346;
+	color: var(--body-link-color);
 	text-decoration: none;
 }
 a:hover, .reset.link:hover {

--- a/Themes/default/css/index.css
+++ b/Themes/default/css/index.css
@@ -2271,9 +2271,9 @@ a.main_icons.feed::before {
 	position: relative;
 }
 .errorbox {
-	background-color: #fee;
-	border-top: 2px solid #c34;
-	border-bottom: 2px solid #c34;
+	background-color: var(--errorbox-bg);
+	border-top: var(--errorbox-border-width) var(--errorbox-border-style) var(--errorbox-border-color);
+	border-bottom: var(--errorbox-border-width) var(--errorbox-border-style) var(--errorbox-border-color);
 }
 .errorbox h3 {
 	padding: 0;
@@ -2305,20 +2305,20 @@ a.main_icons.feed::before {
 	background-position: -161px -83px;
 }
 .noticebox {
-	color: #666;
-	background: #fff6ca;
-	border-top: 1px solid #ffd324;
-	border-bottom: 1px solid #ffd324;
+	color: var(--noticebox-color);
+	background: var(--noticebox-bg);
+	border-top: var(--noticebox-border-width) var(--noticebox-border-style) var(--noticebox-border-color);
+	border-bottom: var(--noticebox-border-width) var(--noticebox-border-style) var(--noticebox-border-color);
 }
 .infobox {
-	color: #222;
-	background: #cfc;
-	border-top: 1px solid green;
-	border-bottom: 1px solid green;
+	color: var(--infobox-color);
+	background: var(--infobox-bg);
+	border-top: var(--infobox-border-width) var(--infobox-border-style) var(--infobox-border-color);
+	border-bottom: var(--infobox-border-width) var(--infobox-border-style) var(--infobox-border-color);
 }
 .descbox {
 	padding: 7px 10px 7px 10px;
-	border: 1px solid #c5c5c5;
+	border: var(--descbox-border-width) var(--descbox-border-style) var(--descbox-border-color);
 	margin: 6px 0;
 }
 
@@ -2326,19 +2326,19 @@ a.main_icons.feed::before {
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
 
 .generic_bar, .progress_bar {
-	border: 1px solid #cecaca;
-	background: #fff;
-	min-height: 16px;
-	line-height: 1.4em;
-	border-radius: 2px;
+	border: var(--genericbar-border-width) var(--genericbar-border-style) var(--genericbar-border-color);
+	background: var(--genericbar-bg);
+	min-height: var(--genericbar-height);
+	line-height: var(--genericbar-line-height);
+	border-radius: var(--genericbar-border-radius);
 	position: relative;
 	overflow: hidden;
-	color: rgba(0, 0, 0, 0.6);
+	color: var(--genericbar-color);
 }
 .generic_bar span, .progress_bar span {
 	position: relative;
 	z-index: 2;
-	text-shadow: 1px 1px rgba(255, 255, 255, .4);
+	text-shadow: var(--genericbar-text-shadow);
 	display: inline-block;
 	padding: 0 5px;
 }
@@ -2348,50 +2348,47 @@ a.main_icons.feed::before {
 	top: 0;
 	left: 0;
 	bottom: 0;
-	background: orange;
+	background: var(--genericbar-inner-bg);
 	transition: width .3s;
-	border-radius: 1px;
-	box-shadow: 4px -4px 8px rgba(0, 0, 0, 0.1) inset,
-		4px 4px 8px rgba(255,255,255,0.3) inset;
+	border-radius: var(--genericbar-inner-border-radius);
+	box-shadow: var(--genericbar-inner-box-shadow);
 	display: block;
 }
 .generic_bar.vertical {
-	width: 15px;
+	width: var(--genericbar-width);
 }
 .generic_bar.vertical .bar {
 	right: 0;
 	top: auto;
-	box-shadow: 4px -4px 4px rgba(0, 0, 0, 0.1) inset,
-		4px 4px 4px rgba(255,255,255,0.3) inset;
+	box-shadow: var(--genericbar-inner-box-shadow_vertical);
 }
 
 .progress_bar {
-	border-radius: 4px;
+	border-radius: var(--progressbar-border-radius);
 	text-align: center;
-	font-weight: bold;
-	color: rgba(0, 0, 0, 0.8);
+	font-weight: var(--progressbar-font-weight);
+	color: var(--progressbar-color);
 }
 .progress_bar .bar {
-	box-shadow: -1px 1px 0 rgba(255, 255, 255, 0.25) inset,
-		1px -1px 0 rgba(0,0,0,0.1) inset;
-	background-color: #75da41;
+	box-shadow: var(--progressbar-inner-box-shadow);
+	background-color: var(--progressbar-inner-bg);
 	background-size: 30px 30px;
 	background-image: linear-gradient(135deg, rgba(255, 255, 255, .15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, .15) 50%, rgba(255, 255, 255, .15) 75%, transparent 75%, transparent);
 }
 .progress_yellow .bar {
-	background-color: #f6c51c;
+	background-color: var(--progressbar-inner-bg_yellow);
 }
 
 .progress_green .bar {
-	background-color: #75da41;
+	background-color: var(--progressbar-inner-bg_green);
 }
 
 .progress_red .bar {
-	background-color: #f45d4c;
+	background-color: var(--progressbar-inner-bg_red);
 }
 
 .progress_blue .bar {
-	background-color: #34c2e3;
+	background-color: var(--progressbar-inner-bg_blue);
 }
 
 /* Styles for the profile section.

--- a/Themes/default/css/variables.css
+++ b/Themes/default/css/variables.css
@@ -56,4 +56,25 @@
 	--fieldset-border-style:                          solid;
 	--fieldset-border-width:                          1px;
 	--fieldset-legend-color:                          #555;
+
+	/** Buttons **/
+	--button-bg_active:                               #557ea0;
+	--button-border-color:                            #ddd #bbb #aaa #ddd;
+	--button-border-color_active:                     #558080;
+	--button-border-color_hover:                      #aaa #ddd #ddd #bbb;
+	--button-border-radius:                           3px;
+	--button-border-style:                            solid;
+	--button-border-width:                            1px;
+	--button-box-shadow:                              1px 1px 1px rgba(221, 221, 221, 0.57);
+	--button-box-shadow_active:                       none;
+	--button-box-shadow_hover:                        -1px -1px 2px rgba(221, 221, 221, 0.7), -1px -2px 4px #ddd inset;
+	--button-color:                                   #444;
+	--button-color_active:                            #fff;
+	--button-color_active_hover:                      #ffc187;
+	--button-color_hover:                             #af6700;
+	--button-cursor:                                  pointer;
+	--button-font-size:                               0.7rem;
+	--button-font-weight_active:                      bold;
+	--button-text-shadow_active:                      0 0 1px #000;
+	--button-text-transform:                          uppercase;
 }

--- a/Themes/default/css/variables.css
+++ b/Themes/default/css/variables.css
@@ -137,4 +137,58 @@
 	--window-stickylocked-bg:                         #e8d8cf;
 	--window-approvetopic-bg:                         #e4a17c;
 	--window-approvepost-bg:                          #ffcbcb;
+
+	/** Error Box **/
+	--errorbox-bg:                                    #fee;
+	--errorbox-border-color:                          #c34;
+	--errorbox-border-style:                          solid;
+	--errorbox-border-width:                          2px;
+
+	/** Notice Box **/
+	--noticebox-bg:                                   #fff6ca;
+	--noticebox-border-color:                         #ffd324;
+	--noticebox-border-style:                         solid;
+	--noticebox-border-width:                         1px;
+	--noticebox-color:                                #666;
+
+	/** Info Box **/
+	--infobox-bg:                                     #cfc;
+	--infobox-border-color:                           green;
+	--infobox-border-style:                           solid;
+	--infobox-border-width:                           1px;
+	--infobox-color:                                  #222;
+
+	/** Desc Box **/
+	--descbox-border-color:                           #c5c5c5;
+	--descbox-border-style:                           solid;
+	--descbox-border-width:                           1px;
+
+	/** Generic Bar **/
+	--genericbar-bg:                                  #fff;
+	--genericbar-border-color:                        #cecaca;
+	--genericbar-border-radius:                       2px;
+	--genericbar-border-style:                        solid;
+	--genericbar-border-width:                        1px;
+	--genericbar-color:                               rgba(0, 0, 0, 0.6);
+	--genericbar-height:                              16px;
+	--genericbar-line-height:                         1.4em;
+	--genericbar-text-shadow:                         1px 1px rgba(255, 255, 255, .4);
+	--genericbar-width:                               15px;
+
+	--genericbar-inner-bg:                            orange;
+	--genericbar-inner-border-radius:                 1px;
+	--genericbar-inner-box-shadow:                    4px -4px 8px rgba(0, 0, 0, 0.1) inset, 4px 4px 8px rgba(255, 255, 255, 0.3) inset;
+	--genericbar-inner-box-shadow_vertical:           4px -4px 4px rgba(0, 0, 0, 0.1) inset, 4px 4px 4px rgba(255, 255, 255, 0.3) inset;
+
+	/** Progress Bar **/
+	--progressbar-border-radius:                      4px;
+	--progressbar-color:                              rgba(0, 0, 0, 0.8);
+	--progressbar-font-weight:                        bold;
+
+	--progressbar-inner-bg:                           #75da41;
+	--progressbar-inner-bg_blue:                      #34c2e3;
+	--progressbar-inner-bg_green:                     #75da41;
+	--progressbar-inner-bg_red:                       #f45d4c;
+	--progressbar-inner-bg_yellow:                    #f6c51c;
+	--progressbar-inner-box-shadow:                   -1px 1px 0 rgba(255, 255, 255, 0.25) inset, 1px -1px 0 rgba(0, 0, 0, 0.1) inset;
 }

--- a/Themes/default/css/variables.css
+++ b/Themes/default/css/variables.css
@@ -77,4 +77,64 @@
 	--button-font-weight_active:                      bold;
 	--button-text-shadow_active:                      0 0 1px #000;
 	--button-text-transform:                          uppercase;
+
+	/** Cat Bar **/
+	--catbar-bg:                                      #557ea0;
+	--catbar-border-color:                            #777;
+	--catbar-border-radius:                           6px 6px 0 0;
+	--catbar-border-style:                            solid;
+	--catbar-border-width:                            1px;
+	--catbar-box-shadow:                              0 16px 20px rgba(255, 255, 255, 0.15) inset;
+	--catbar-color:                                   #fff;
+	--catbar-font-family:                             "Tahoma", sans-serif;
+	--catbar-font-size:                               1.1em;
+	--catbar-text-shadow:                             -1px -1px 1px rgba(0, 0, 0, 0.2);
+	--catbar-text-shadow_hover:                       -1px -1px 0 rgba(0, 0, 0, 0.4);
+
+	/** Title Bar **/
+	--titlebar-bg:                                    #fff;
+	--titlebar-border-color:                          #ff9400 #ddd #bf6900 #ddd;
+	--titlebar-border-radius:                         2px 2px 0 0;
+	--titlebar-border-style:                          solid;
+	--titlebar-border-width:                          2px 1px;
+	--titlebar-color:                                 #666;
+
+	/** Sub Bar **/
+	--subbar-bg:                                      none;
+	--subbar-border-color:                            #ddd;
+	--subbar-border-style:                            solid;
+	--subbar-border-width:                            1px;
+	--subbar-box-shadow:                              0 -1px 0 #999 inset;
+	--subbar-text-shadow:                             none;
+
+	/** Round Frame **/
+	--roundframe-bg:                                  #f8f8f8;
+	--roundframe-border-color:                        #c5c5c5;
+	--roundframe-border-radius:                       7px;
+	--roundframe-border-style:                        solid;
+	--roundframe-border-width:                        1px;
+	--roundframe-box-shadow:                          0 -2px 2px rgba(0, 0, 0, 0.1);
+
+	/** Information **/
+	--information-bg:                                 #f8f8f8;
+	--information-border-color:                       #ddd;
+	--information-border-radius:                      0 0 7px 7px;
+	--information-border-style:                       solid;
+	--information-border-width:                       1px;
+
+	/** Windowbg **/
+	--window-bg:                                      #f0f4f7;
+	--window-bg_hover:                                #e2eef8;
+	--window-border-color:                            #ddd;
+	--window-border-radius:                           6px;
+	--window-border-style:                            solid;
+	--window-border-width:                            1px;
+	--window-box-shadow:                              0 -2px 2px rgba(0, 0, 0, 0.1);
+	--window-odd-bg:                                  #fdfdfd;
+	--window-target-bg:                               #ffffe0;
+	--window-locked-bg:                               #e7eaef;
+	--window-sticky-bg:                               #cfdce8;
+	--window-stickylocked-bg:                         #e8d8cf;
+	--window-approvetopic-bg:                         #e4a17c;
+	--window-approvepost-bg:                          #ffcbcb;
 }

--- a/Themes/default/css/variables.css
+++ b/Themes/default/css/variables.css
@@ -1,0 +1,59 @@
+/* Design tokens for the default theme.
+/* Loaded ahead of index.css, so anything declared here can be overridden by a
+/* variant, by dark.css, or by a rule further down that sets the property on a
+/* narrower selector.
+/*
+/* Every value here is the one the theme already used before the token existed.
+/* Adding a token is not meant to change what the forum looks like. */
+:root {
+	/** HTML **/
+	--html-bg:                                        #3e5a78;
+
+	/** Body **/
+	--body-bg:                                        #e9eef2;
+	--body-color:                                     #4d4d4d;
+	--body-font-family:                               "Segoe UI", "Helvetica Neue", "Nimbus Sans L", Arial, "Liberation Sans", sans-serif;
+	--body-font-size:                                 83.33%;
+
+	/** Body Links **/
+	--body-link-color:                                #346;
+
+	/** Strong **/
+	--strong-color:                                   #444;
+
+	/** Headings **/
+	--heading-color:                                  #444;
+	--heading-font-size:                              1em;
+
+	/** Selection **/
+	--selection-bg:                                   #99d4ff;
+	--selection-color:                                rgba(0, 0, 0, 0.6);
+
+	/** Horizontal Rule **/
+	--horizontalrule-bg:                              #fff;
+	--horizontalrule-box-shadow:                      0 1px 0 #bbb inset;
+	--horizontalrule-height:                          2px;
+
+	/** Inputs **/
+	--input-bg:                                       #fff;
+	--input-bg_disabled:                              #eee;
+	--input-bg_focus:                                 #fff;
+	--input-bg_hover:                                 #fbfbfb;
+	--input-border-color:                             #bbb;
+	--input-border-color_disabled:                    #b6b6b6;
+	--input-border-color_focus:                       #7fb0d8;
+	--input-border-color_hover:                       #82a2bc;
+	--input-border-radius:                            3px;
+	--input-border-style:                             solid;
+	--input-border-width:                             1px;
+	--input-box-shadow:                               1px 2px 1px rgba(160, 187, 221, 0.2) inset;
+	--input-color:                                    #222;
+	--input-color_disabled:                           #999;
+
+	/** Fieldsets **/
+	--fieldset-border-color:                          #ddd;
+	--fieldset-border-radius:                         3px;
+	--fieldset-border-style:                          solid;
+	--fieldset-border-width:                          1px;
+	--fieldset-legend-color:                          #555;
+}


### PR DESCRIPTION
#### Description

Part of the #7933 split, wave 2 part 4. **Stacked on #9350, #9351 and #9352**, in that merge order — they all add to `variables.css`, so each branches from the one before and shows the earlier commits until they land.

The boxes SMF talks to people through, and the two bars:

| Rule | Tokens |
| --- | --- |
| `.errorbox` | `--errorbox-bg`, `--errorbox-border-*` |
| `.noticebox` | `--noticebox-bg`, `--noticebox-border-*`, `--noticebox-color` |
| `.infobox` | `--infobox-bg`, `--infobox-border-*`, `--infobox-color` |
| `.descbox` | `--descbox-border-*` |
| `.generic_bar`, its span, its inner `.bar`, the vertical variant | `--genericbar-*`, `--genericbar-inner-*` |
| `.progress_bar` and the yellow, green, red and blue variants | `--progressbar-*`, `--progressbar-inner-bg*` |

Every value is the one the rule already had. Nothing changes on screen.

#### Notes

- The error, notice and info boxes each carry a border on the **top and bottom only**, so they keep their two single-side shorthands, for the reason #9352 ran into: writing them as the `border-color` / `border-style` / `border-width` triple leaves a style and a colour on the left and right sides, where today there is none, and a later rule giving those sides a width would then paint a border that could not have appeared before.
- `.errorbox` sets no colour of its own — it inherits. So there is no `--errorbox-color` here. Better to leave that visible than to invent a value for it.

#### Testing

Fresh install on MySQL, Docker environment. The same two passes as the earlier parts:

1. **All 40 tokens resolve to the literal they replaced**, read back from `:root`. No mismatches.
2. **Computed styles before and after** for 23 elements — each box, the error box's heading, its alert paragraph and its span, both bars, their inner `.bar`, the vertical variant and the four progress colours — across 27 properties, with every border side read separately. **621 comparisons, no differences.**

Error log clean. The unit suite does not reach CSS, so there is no test to add here.

### Issues References (Fixes|Related|Closes)

Related to #7933, #9350, #9351, #9352
