### PR TITLE
[2.1] Respects literal `left`/`right` float direction for float BBC in RTL

### DIFF
--- a/Themes/default/css/rtl.css
+++ b/Themes/default/css/rtl.css
@@ -4,8 +4,14 @@
 .floatright {
 	float: left;
 }
+.bbc_float.floatright {
+	float: right;
+}
 .floatleft {
 	float: right;
+}
+.bbc_float.floatleft {
+	float: left;
 }
 .clear_left {
 	clear: right;


### PR DESCRIPTION
The `[float]` BBCode takes a parameter to indicate whether it should float to the left or the right (i.e. `[float=left]` or `[float=right]`). End users writing their posts generally expect that the `left`/`right` parameter value will function as described regardless of the writing direction of the text in which the BBCode is inserted. This change ensures that the float still moves to the expected side even for RTL languages.