### PR TITLE
[3.0] Theme split (wave 3, part 1) — Add the primary and secondary colour ramps

### DIFF
--- a/Themes/default/css/variables.css
+++ b/Themes/default/css/variables.css
@@ -6,6 +6,44 @@
 /* Every value here is the one the theme already used before the token existed.
 /* Adding a token is not meant to change what the forum looks like. */
 :root {
+	/* The two colour ramps the theme is built from. Each is nine steps derived
+	/* from one hue, so a forum can be re-tinted by changing the hue alone. The
+	/* 700 step is the base colour itself; lower numbers are lighter, higher are
+	/* darker.
+	/*
+	/* Nothing references these yet. They are here for the parts of the theme
+	/* that are still to come, so that the tokens those parts add can be written
+	/* in terms of the ramp instead of another hard-coded colour. The tokens
+	/* below still hold their own literal values and are unchanged. */
+
+	/** Primary Color **/
+	--primary-color-hex:                              #38546B;
+	--primary-color-hue:                              207;
+	--primary-color-50:                               hsl(var(--primary-color-hue), 93%, 95%);
+	--primary-color-100:                              hsl(var(--primary-color-hue), 43%, 84%);
+	--primary-color-200:                              hsl(var(--primary-color-hue), 30%, 73%);
+	--primary-color-300:                              hsl(var(--primary-color-hue), 26%, 62%);
+	--primary-color-400:                              hsl(var(--primary-color-hue), 23%, 54%);
+	--primary-color-500:                              hsl(var(--primary-color-hue), 27%, 45%);
+	--primary-color-600:                              hsl(var(--primary-color-hue), 29%, 39%);
+	--primary-color-700:                              var(--primary-color-hex);
+	--primary-color-800:                              hsl(var(--primary-color-hue), 34%, 25%);
+	--primary-color-900:                              hsl(var(--primary-color-hue), 44%, 17%);
+
+	/** Secondary Color **/
+	--secondary-color-hex:                            #ff9400;
+	--secondary-color-hue:                            35;
+	--secondary-color-50:                             hsl(var(--secondary-color-hue), 100%, 94%);
+	--secondary-color-100:                            hsl(var(--secondary-color-hue), 100%, 85%);
+	--secondary-color-200:                            hsl(var(--secondary-color-hue), 100%, 75%);
+	--secondary-color-300:                            hsl(var(--secondary-color-hue), 100%, 65%);
+	--secondary-color-400:                            hsl(var(--secondary-color-hue), 100%, 57%);
+	--secondary-color-500:                            var(--secondary-color-hex);
+	--secondary-color-600:                            hsl(var(--secondary-color-hue), 99%, 49%);
+	--secondary-color-700:                            hsl(var(--secondary-color-hue), 98%, 48%);
+	--secondary-color-800:                            hsl(var(--secondary-color-hue), 98%, 47%);
+	--secondary-color-900:                            hsl(var(--secondary-color-hue), 97%, 46%);
+
 	/** HTML **/
 	--html-bg:                                        #3e5a78;
 


### PR DESCRIPTION
#### Description

Part 1 of wave 3 of the #7933 split. Adds the two colour ramps the rest of the theme is built on.

The theme branch does not pick its colours one at a time. It derives them from two nine-step ramps, each generated from a single hue, so that a forum can be re-tinted by changing one number. `release-3.0` has no equivalent, because wave 2 deliberately kept every token at the literal value the rule already used.

```css
--primary-color-hex:   #38546B;
--primary-color-hue:   207;
--primary-color-500:   hsl(var(--primary-color-hue), 27%, 45%);
--primary-color-700:   var(--primary-color-hex);
--primary-color-800:   hsl(var(--primary-color-hue), 34%, 25%);
```

The ramps are internally consistent, which is worth checking rather than assuming:

- `#38546B` is `hsl(207, 31%, 32%)`, so hue 207 is right, and step 700 sits correctly between step 600 at 39% lightness and step 800 at 25%.
- `#ff9400` is `hsl(35, 100%, 50%)`, so hue 35 is right, and step 500 sits between step 400 at 57% and step 600 at 49%.

#### What this does not do

Nothing references the ramps, and no existing token is repointed at one. `--html-bg` is still `#3e5a78` rather than `var(--primary-color-900)`, and the same goes for every other token already in the file. **Nothing rendered changes.**

Repointing the existing tokens at the ramp is a real visual change and deserves its own review, so it is not in here. This only puts the ramp in place so that the chrome parts that follow can express the tokens they add in terms of it instead of adding more hard-coded colours.

### Issues References (Fixes|Related|Closes)

Related to #7933.
