### PR TITLE
[3.0] Theme split (wave 3, part 2) — Rebuild the linktree as a breadcrumb landmark

### DIFF
--- a/Languages/en_US/General.php
+++ b/Languages/en_US/General.php
@@ -1229,6 +1229,9 @@ $txt['mobile_moderation'] = 'Moderation';
 $txt['mobile_user_menu'] = 'Main Menu';
 $txt['mobile_generic_menu'] = '{label} Menu';
 
+// Names the breadcrumb trail for screen readers. Not shown on screen.
+$txt['breadcrumb'] = 'Breadcrumb';
+
 // Punctuation mark that is normally used to separate list items in a sentence.
 $txt['sentence_list_separator'] = ',';
 

--- a/Themes/default/css/index.css
+++ b/Themes/default/css/index.css
@@ -1364,50 +1364,91 @@ ul li.greeting {
 
 /* The navigation list (i.e. linktree) */
 .navigate_section {
-	padding: 3px 0 0 0;
-	float: left;
-	width: 100%;
-}
-#main_content_section .navigate_section {
-	margin: 4px 0 0 0;
+	background: var(--navigatesection-bg);
+	border-color: var(--navigatesection-border-color);
+	border-radius: var(--navigatesection-border-radius);
+	border-style: var(--navigatesection-border-style);
+	border-width: var(--navigatesection-border-width);
+	box-shadow: var(--navigatesection-box-shadow);
+	margin-block: .5em .75em;
+	margin-inline: 0;
 	padding: 0;
 }
-.navigate_section ul {
-	margin: 4px 0 0 0;
-	padding: 0 10px;
+.navigate_section ol {
+	align-items: center;
+	background: var(--breadcrumb-bg);
+	border-color: var(--breadcrumb-border-color);
+	border-radius: var(--breadcrumb-border-radius);
+	border-style: var(--breadcrumb-border-style);
+	border-width: var(--breadcrumb-border-width);
+	box-shadow: var(--breadcrumb-box-shadow);
+	color: var(--breadcrumb-color);
+	display: flex;
+	flex-wrap: wrap;
+	font-family: var(--breadcrumb-font-family);
+	font-size: var(--breadcrumb-font-size);
+	margin: 0;
+	padding: .75em;
+}
+.navigate_section li {
+	align-items: center;
+	display: inline-flex;
+	flex-wrap: wrap;
+	gap: .25em .15em;
+}
+.navigate_section a {
+	color: var(--breadcrumb-link-color);
+}
+.navigate_section a:hover {
+	color: var(--breadcrumb-link-color_hover);
+}
+.navigate_section a:focus {
+	color: var(--breadcrumb-link-color_focus);
+}
+.navigate_section li > a {
+	align-items: center;
+	display: inline-flex;
+	font-weight: var(--breadcrumb-link-font-weight);
+	gap: 0 .25em;
+	line-height: var(--breadcrumb-link-line-height);
+	padding: .2em;
+	text-decoration: var(--breadcrumb-link-text-decoration);
+	text-shadow: var(--breadcrumb-link-text-shadow);
+}
+.navigate_section li > a:hover {
+	font-weight: var(--breadcrumb-link-font-weight_hover);
+	text-decoration: var(--breadcrumb-link-text-decoration_hover);
+	text-shadow: var(--breadcrumb-link-text-shadow_hover);
+}
+.navigate_section li > a:focus {
+	font-weight: var(--breadcrumb-link-font-weight_focus);
+	text-decoration: var(--breadcrumb-link-text-decoration_focus);
+	text-shadow: var(--breadcrumb-link-text-shadow_focus);
+}
+/* The page you are on, which is the last crumb unless it is the only one. */
+.navigate_section li:last-child:not(:first-child) > a {
+	color: var(--breadcrumb-link-color_active);
+	font-weight: var(--breadcrumb-link-font-weight_active);
+	text-decoration: var(--breadcrumb-link-text-decoration_active);
+	text-shadow: var(--breadcrumb-link-text-shadow_active);
+}
+.navigate_section li > a + span {
 	font-size: 0.9em;
-	overflow: hidden;
-	border: 1px solid #ddd;
-	border-radius: 2px;
-	box-shadow: 0 -2px 2px rgba(0, 0, 0, 0.08);
 }
-.navigate_section ul li {
-	float: left;
-	padding-bottom: 3px;
-	line-height: 1.1em;
-	color: #444;
-	text-shadow: 1px 1px 0 #fff;
+.navigate_section span.board_moderators {
+	align-items: center;
+	display: inline-flex;
 }
-.navigate_section ul li a, .navigate_section ul li em {
-	padding: 4px 0 4px;
-	margin-top: -4px;
-	display: inline-block;
+.navigate_section span.board_moderators a {
+	padding-inline-start: 0.25em;
 }
-.navigate_section ul li span {
-	display: inline-block;
-	margin-top: 8px;
-}
-.navigate_section ul li .dividers {
-	color: #3f6b8c;
-	font: 83.33%/150% Arial, sans-serif;
-	padding: 0 2px 0 6px;
-}
-.navigate_section ul li .board_moderators a {
-	padding: 4px 0;
-}
-
-.navigate_section a:hover span {
-	text-decoration: underline;
+.navigate_section ol li .dividers {
+	color: var(--breadcrumb-divider-color);
+	font-family: var(--breadcrumb-divider-font-family);
+	font-size: var(--breadcrumb-divider-font-size);
+	line-height: var(--breadcrumb-divider-line-height);
+	margin: 0;
+	padding: 0 .4em;
 }
 
 /* The content section */

--- a/Themes/default/css/rtl.css
+++ b/Themes/default/css/rtl.css
@@ -131,15 +131,6 @@ img#smflogo {
 	text-align: left;
 }
 
-/* The navigation list (i.e. linktree) */
-.navigate_section ul li {
-	float: right;
-}
-
-.navigate_section ul li .dividers {
-	padding: 0 6px 0 2px;
-}
-
 /* the posting icons */
 #postbuttons_upper ul li a span {
 	line-height: 19px;

--- a/Themes/default/css/variables.css
+++ b/Themes/default/css/variables.css
@@ -6,6 +6,44 @@
 /* Every value here is the one the theme already used before the token existed.
 /* Adding a token is not meant to change what the forum looks like. */
 :root {
+	/* The two colour ramps the theme is built from. Each is nine steps derived
+	/* from one hue, so a forum can be re-tinted by changing the hue alone. The
+	/* 700 step is the base colour itself; lower numbers are lighter, higher are
+	/* darker.
+	/*
+	/* Nothing references these yet. They are here for the parts of the theme
+	/* that are still to come, so that the tokens those parts add can be written
+	/* in terms of the ramp instead of another hard-coded colour. The tokens
+	/* below still hold their own literal values and are unchanged. */
+
+	/** Primary Color **/
+	--primary-color-hex:                              #38546B;
+	--primary-color-hue:                              207;
+	--primary-color-50:                               hsl(var(--primary-color-hue), 93%, 95%);
+	--primary-color-100:                              hsl(var(--primary-color-hue), 43%, 84%);
+	--primary-color-200:                              hsl(var(--primary-color-hue), 30%, 73%);
+	--primary-color-300:                              hsl(var(--primary-color-hue), 26%, 62%);
+	--primary-color-400:                              hsl(var(--primary-color-hue), 23%, 54%);
+	--primary-color-500:                              hsl(var(--primary-color-hue), 27%, 45%);
+	--primary-color-600:                              hsl(var(--primary-color-hue), 29%, 39%);
+	--primary-color-700:                              var(--primary-color-hex);
+	--primary-color-800:                              hsl(var(--primary-color-hue), 34%, 25%);
+	--primary-color-900:                              hsl(var(--primary-color-hue), 44%, 17%);
+
+	/** Secondary Color **/
+	--secondary-color-hex:                            #ff9400;
+	--secondary-color-hue:                            35;
+	--secondary-color-50:                             hsl(var(--secondary-color-hue), 100%, 94%);
+	--secondary-color-100:                            hsl(var(--secondary-color-hue), 100%, 85%);
+	--secondary-color-200:                            hsl(var(--secondary-color-hue), 100%, 75%);
+	--secondary-color-300:                            hsl(var(--secondary-color-hue), 100%, 65%);
+	--secondary-color-400:                            hsl(var(--secondary-color-hue), 100%, 57%);
+	--secondary-color-500:                            var(--secondary-color-hex);
+	--secondary-color-600:                            hsl(var(--secondary-color-hue), 99%, 49%);
+	--secondary-color-700:                            hsl(var(--secondary-color-hue), 98%, 48%);
+	--secondary-color-800:                            hsl(var(--secondary-color-hue), 98%, 47%);
+	--secondary-color-900:                            hsl(var(--secondary-color-hue), 97%, 46%);
+
 	/** HTML **/
 	--html-bg:                                        #3e5a78;
 

--- a/Themes/default/css/variables.css
+++ b/Themes/default/css/variables.css
@@ -293,4 +293,48 @@
 	/** Moderation Link **/
 	--moderationlink-bg:                              #f59e00;
 	--moderationlink-font-weight:                     bold;
+
+	/** Navigate Section **/
+	--navigatesection-bg:                             hsl(0, 0%, 97%);
+	--navigatesection-border-color:                   hsl(0, 0%, 87%);
+	--navigatesection-border-radius:                  5px;
+	--navigatesection-border-style:                   solid;
+	--navigatesection-border-width:                   1px;
+	--navigatesection-box-shadow:                     0 0 1px 1px rgb(255, 255, 255) inset;
+
+	/** Breadcrumb **/
+	--breadcrumb-bg:                                  var(--navigatesection-bg);
+	--breadcrumb-border-color:                        transparent;
+	--breadcrumb-border-radius:                       var(--navigatesection-border-radius);
+	--breadcrumb-border-style:                        solid;
+	--breadcrumb-border-width:                        0;
+	--breadcrumb-box-shadow:                          0 6px 10px -5px rgba(0, 0, 0, 0.1);
+	--breadcrumb-color:                               hsl(0, 0%, 27%);
+	--breadcrumb-font-family:                         inherit;
+	--breadcrumb-font-size:                           0.9em;
+
+	/** Breadcrumb Divider **/
+	--breadcrumb-divider-color:                       hsl(206, 38%, 40%);
+	--breadcrumb-divider-font-family:                 Arial, sans-serif;
+	--breadcrumb-divider-font-size:                   0.8em;
+	--breadcrumb-divider-line-height:                 150%;
+
+	/** Breadcrumb Links **/
+	--breadcrumb-link-color:                          var(--primary-color-800);
+	--breadcrumb-link-color_active:                   hsl(213, 58%, 37%);
+	--breadcrumb-link-color_focus:                    var(--breadcrumb-link-color_hover);
+	--breadcrumb-link-color_hover:                    var(--primary-color-500);
+	--breadcrumb-link-font-weight:                    400;
+	--breadcrumb-link-font-weight_active:             700;
+	--breadcrumb-link-font-weight_focus:              var(--breadcrumb-link-font-weight_hover);
+	--breadcrumb-link-font-weight_hover:              var(--breadcrumb-link-font-weight);
+	--breadcrumb-link-line-height:                    1;
+	--breadcrumb-link-text-decoration:                none;
+	--breadcrumb-link-text-decoration_active:         none;
+	--breadcrumb-link-text-decoration_focus:          none;
+	--breadcrumb-link-text-decoration_hover:          none;
+	--breadcrumb-link-text-shadow:                    none;
+	--breadcrumb-link-text-shadow_active:             none;
+	--breadcrumb-link-text-shadow_focus:              none;
+	--breadcrumb-link-text-shadow_hover:              none;
 }

--- a/Themes/default/index.template.php
+++ b/Themes/default/index.template.php
@@ -561,14 +561,16 @@ function theme_linktree($force_show = false)
 		return;
 	}
 
+	// A breadcrumb trail is a landmark, and it is an ordered list rather than an
+	// unordered one - "General Category" comes before "General Discussion".
 	echo '
-				<div class="navigate_section">
-					<ul>';
+				<nav class="navigate_section" aria-label="', Lang::getTxt('breadcrumb', file: 'General'), '">
+					<ol itemscope itemtype="https://schema.org/BreadcrumbList">';
 
 	// Each tree item has a URL and name. Some may have extra_before and extra_after.
 	foreach (Utils::$context['linktree'] as $link_num => $tree) {
 		echo '
-						<li', ($link_num == count(Utils::$context['linktree']) - 1) ? ' class="last"' : '', '>';
+						<li itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem"', ($link_num == count(Utils::$context['linktree']) - 1) ? ' class="last"' : '', '>';
 
 		// Don't show a separator for the first one.
 		// Better here. Always points to the next level when the linktree breaks to a second line.
@@ -583,14 +585,19 @@ function theme_linktree($force_show = false)
 			echo $tree['extra_before'], ' ';
 		}
 
-		// Show the link, including a URL if it should have one.
+		// Show the link, including a URL if it should have one. The itemprop
+		// attributes let a search engine read the trail as a breadcrumb.
 		if (isset($tree['url'])) {
 			echo '
-							<a href="' . $tree['url'] . '"><span>' . $tree['name'] . '</span></a>';
+							<a itemprop="item" href="' . $tree['url'] . '"><span itemprop="name">' . $tree['name'] . '</span></a>';
 		} else {
-		echo '
-							<span>' . $tree['name'] . '</span>';
+			echo '
+							<span itemprop="name">' . $tree['name'] . '</span>';
 		}
+
+		// Where this one sits in the trail. Positions are 1 based.
+		echo '
+							<meta itemprop="position" content="', $link_num + 1, '">';
 
 		// Show something after the link...?
 		if (isset($tree['extra_after'])) {
@@ -602,8 +609,8 @@ function theme_linktree($force_show = false)
 	}
 
 	echo '
-					</ul>
-				</div><!-- .navigate_section -->';
+					</ol>
+				</nav><!-- .navigate_section -->';
 
 	$shown_linktree = true;
 }


### PR DESCRIPTION
#### Description

Part 2 of wave 3 of the #7933 split. Stacked on #9369 — the first commit here is that one, and this diff is the second commit.

Rebuilds the linktree as a proper breadcrumb.

- It becomes a `<nav>` landmark with an accessible name, wrapping an `<ol>` rather than a `<ul>`. The trail is ordered: "General Category" comes before "General Discussion".
- It carries [schema.org BreadcrumbList](https://schema.org/BreadcrumbList) microdata, so a search engine can read the trail.
- Layout moves from floats to flexbox, and the colours, spacing and dividers move to tokens.

Because it is flexbox rather than floats, it flips for RTL on its own. That makes the two `rtl.css` rules for it dead, so they go, continuing what parts 7 and 8 of wave 2 started.

#### Two things taken deliberately differently from the theme branch

**The dividers stay as HTML entities.** The theme branch replaces `&#9658;` with `<i class="fa-solid fa-angle-right">`. Nothing in the default theme uses Font Awesome today, and the bundled local copy of it has no `@font-face` rule at all, so a forum with `fontawesome_source` set to `local` would get no divider rather than a different one. The same applies to the house icon the branch puts before the trail. Both are easy to add once the local Font Awesome source is fixed, which is worth doing separately.

**`.last` is still emitted.** The branch drops the class in favour of `:last-child`, but its own CSS still matches `:is(.last, :last-child)`, and mods and custom themes may well style it. Keeping it costs nothing.

#### Two fixes to what is on the branch

- The markup there opens `<ul itemscope>` and closes `</ol>`. The stylesheet targets `ol`, and an ordered list is what a breadcrumb should be, so this opens `<ol>`.
- The stylesheet there asks for `var(--breadcrumb_divider_font_family)` with underscores, while `variables.css` defines `--breadcrumb-divider-font-family` with hyphens. As an undefined token with no fallback it is invalid at computed-value time, so it does not fall back to the previous rule — it unsets `font-family` on the divider entirely. Spelled correctly here, and confirmed in the browser: the divider computes to `Arial, sans-serif`, which is what tells you it resolved.

#### Verification

Board page in the running forum, computed styles and geometry rather than eyeballing:

- `nav` / `ol` / `aria-label="Breadcrumb"` all as intended, 3 crumbs, `position` metas 1 to 3.
- Every token resolves. The first crumb computes to `rgb(42, 66, 85)`, which is `hsl(207, 34%, 25%)` — that is `--primary-color-800` from #9369 arriving through `--breadcrumb-link-color`. The current page computes to `rgb(40, 89, 149)` at weight 700.
- Crumbs sit on one line, left to right, at x = 73, 124, 240.
- Setting `dir="rtl"` on the document reverses them to x = 598, 483, 353 with no `rtl.css` involved, which is what shows the two deleted rules really were redundant.
- A control element confirmed a 1px border computes to 0.571429px in that browser, so the border width reads correctly rather than looking wrong.
- `index.css` references 221 tokens, `variables.css` defines 245, and nothing is referenced without being defined.

### Issues References (Fixes|Related|Closes)

Related to #7933.
