### PR TITLE
[3.0] Theme split (wave 3, part 4) — Give the width-limited wrappers a shared class

### DIFF
--- a/Languages/en_US/General.php
+++ b/Languages/en_US/General.php
@@ -1229,6 +1229,9 @@ $txt['mobile_moderation'] = 'Moderation';
 $txt['mobile_user_menu'] = 'Main Menu';
 $txt['mobile_generic_menu'] = '{label} Menu';
 
+// Names the breadcrumb trail for screen readers. Not shown on screen.
+$txt['breadcrumb'] = 'Breadcrumb';
+
 // Punctuation mark that is normally used to separate list items in a sentence.
 $txt['sentence_list_separator'] = ',';
 

--- a/Sources/Tasks/ExportProfileData.php
+++ b/Sources/Tasks/ExportProfileData.php
@@ -135,7 +135,7 @@ class ExportProfileData extends BackgroundTask
 						</head>
 						<body>
 							<div id="footerfix">
-								<div id="header">
+								<div id="header" class="content-wrapper">
 									<h1 class="forumtitle">
 										<a id="top">
 											<xsl:attribute name="href">
@@ -145,7 +145,7 @@ class ExportProfileData extends BackgroundTask
 										</a>
 									</h1>
 								</div>
-								<div id="wrapper">
+								<div id="wrapper" class="content-wrapper">
 									<div id="upper_section">
 										<div id="inner_section">
 											<div id="inner_wrap">
@@ -167,7 +167,7 @@ class ExportProfileData extends BackgroundTask
 								</div>
 							</div>
 							<div id="footer">
-								<div class="inner_wrap">
+								<div class="inner_wrap content-wrapper">
 									<ul>
 										<li class="floatright">
 											<a>

--- a/Sources/Tasks/ExportProfileData.php
+++ b/Sources/Tasks/ExportProfileData.php
@@ -135,7 +135,7 @@ class ExportProfileData extends BackgroundTask
 						</head>
 						<body>
 							<div id="footerfix">
-								<div id="header" class="content-wrapper">
+								<div id="header" class="content_wrapper">
 									<h1 class="forumtitle">
 										<a id="top">
 											<xsl:attribute name="href">
@@ -145,7 +145,7 @@ class ExportProfileData extends BackgroundTask
 										</a>
 									</h1>
 								</div>
-								<div id="wrapper" class="content-wrapper">
+								<div id="wrapper" class="content_wrapper">
 									<div id="upper_section">
 										<div id="inner_section">
 											<div id="inner_wrap">
@@ -167,7 +167,7 @@ class ExportProfileData extends BackgroundTask
 								</div>
 							</div>
 							<div id="footer">
-								<div class="inner_wrap content-wrapper">
+								<div class="inner_wrap content_wrapper">
 									<ul>
 										<li class="floatright">
 											<a>

--- a/Themes/default/MaintenanceTemplate.php
+++ b/Themes/default/MaintenanceTemplate.php
@@ -52,11 +52,11 @@ abstract class MaintenanceTemplate
 	</head>
 	<body>
 		<div id="footerfix">
-		<div id="header">
+		<div id="header" class="content-wrapper">
 			<h1 class="forumtitle">', Maintenance::$tool->getScriptName(), '</h1>
 			<img id="smflogo" src="', Maintenance::$theme_url, '/images/smflogo.svg" alt="Simple Machines Forum" title="Simple Machines Forum">
 		</div>
-		<div id="wrapper">';
+		<div id="wrapper" class="content-wrapper">';
 
 		// Have we got a language drop down - if so do it on the first step only.
 		if (!empty(Maintenance::$languages) && \count(Maintenance::$languages) > 1 && Maintenance::getCurrentStep() == 0) {

--- a/Themes/default/MaintenanceTemplate.php
+++ b/Themes/default/MaintenanceTemplate.php
@@ -52,11 +52,11 @@ abstract class MaintenanceTemplate
 	</head>
 	<body>
 		<div id="footerfix">
-		<div id="header" class="content-wrapper">
+		<div id="header" class="content_wrapper">
 			<h1 class="forumtitle">', Maintenance::$tool->getScriptName(), '</h1>
 			<img id="smflogo" src="', Maintenance::$theme_url, '/images/smflogo.svg" alt="Simple Machines Forum" title="Simple Machines Forum">
 		</div>
-		<div id="wrapper" class="content-wrapper">';
+		<div id="wrapper" class="content_wrapper">';
 
 		// Have we got a language drop down - if so do it on the first step only.
 		if (!empty(Maintenance::$languages) && \count(Maintenance::$languages) > 1 && Maintenance::getCurrentStep() == 0) {

--- a/Themes/default/css/index.css
+++ b/Themes/default/css/index.css
@@ -1364,50 +1364,91 @@ ul li.greeting {
 
 /* The navigation list (i.e. linktree) */
 .navigate_section {
-	padding: 3px 0 0 0;
-	float: left;
-	width: 100%;
-}
-#main_content_section .navigate_section {
-	margin: 4px 0 0 0;
+	background: var(--navigatesection-bg);
+	border-color: var(--navigatesection-border-color);
+	border-radius: var(--navigatesection-border-radius);
+	border-style: var(--navigatesection-border-style);
+	border-width: var(--navigatesection-border-width);
+	box-shadow: var(--navigatesection-box-shadow);
+	margin-block: .5em .75em;
+	margin-inline: 0;
 	padding: 0;
 }
-.navigate_section ul {
-	margin: 4px 0 0 0;
-	padding: 0 10px;
+.navigate_section ol {
+	align-items: center;
+	background: var(--breadcrumb-bg);
+	border-color: var(--breadcrumb-border-color);
+	border-radius: var(--breadcrumb-border-radius);
+	border-style: var(--breadcrumb-border-style);
+	border-width: var(--breadcrumb-border-width);
+	box-shadow: var(--breadcrumb-box-shadow);
+	color: var(--breadcrumb-color);
+	display: flex;
+	flex-wrap: wrap;
+	font-family: var(--breadcrumb-font-family);
+	font-size: var(--breadcrumb-font-size);
+	margin: 0;
+	padding: .75em;
+}
+.navigate_section li {
+	align-items: center;
+	display: inline-flex;
+	flex-wrap: wrap;
+	gap: .25em .15em;
+}
+.navigate_section a {
+	color: var(--breadcrumb-link-color);
+}
+.navigate_section a:hover {
+	color: var(--breadcrumb-link-color_hover);
+}
+.navigate_section a:focus {
+	color: var(--breadcrumb-link-color_focus);
+}
+.navigate_section li > a {
+	align-items: center;
+	display: inline-flex;
+	font-weight: var(--breadcrumb-link-font-weight);
+	gap: 0 .25em;
+	line-height: var(--breadcrumb-link-line-height);
+	padding: .2em;
+	text-decoration: var(--breadcrumb-link-text-decoration);
+	text-shadow: var(--breadcrumb-link-text-shadow);
+}
+.navigate_section li > a:hover {
+	font-weight: var(--breadcrumb-link-font-weight_hover);
+	text-decoration: var(--breadcrumb-link-text-decoration_hover);
+	text-shadow: var(--breadcrumb-link-text-shadow_hover);
+}
+.navigate_section li > a:focus {
+	font-weight: var(--breadcrumb-link-font-weight_focus);
+	text-decoration: var(--breadcrumb-link-text-decoration_focus);
+	text-shadow: var(--breadcrumb-link-text-shadow_focus);
+}
+/* The page you are on, which is the last crumb unless it is the only one. */
+.navigate_section li:last-child:not(:first-child) > a {
+	color: var(--breadcrumb-link-color_active);
+	font-weight: var(--breadcrumb-link-font-weight_active);
+	text-decoration: var(--breadcrumb-link-text-decoration_active);
+	text-shadow: var(--breadcrumb-link-text-shadow_active);
+}
+.navigate_section li > a + span {
 	font-size: 0.9em;
-	overflow: hidden;
-	border: 1px solid #ddd;
-	border-radius: 2px;
-	box-shadow: 0 -2px 2px rgba(0, 0, 0, 0.08);
 }
-.navigate_section ul li {
-	float: left;
-	padding-bottom: 3px;
-	line-height: 1.1em;
-	color: #444;
-	text-shadow: 1px 1px 0 #fff;
+.navigate_section span.board_moderators {
+	align-items: center;
+	display: inline-flex;
 }
-.navigate_section ul li a, .navigate_section ul li em {
-	padding: 4px 0 4px;
-	margin-top: -4px;
-	display: inline-block;
+.navigate_section span.board_moderators a {
+	padding-inline-start: 0.25em;
 }
-.navigate_section ul li span {
-	display: inline-block;
-	margin-top: 8px;
-}
-.navigate_section ul li .dividers {
-	color: #3f6b8c;
-	font: 83.33%/150% Arial, sans-serif;
-	padding: 0 2px 0 6px;
-}
-.navigate_section ul li .board_moderators a {
-	padding: 4px 0;
-}
-
-.navigate_section a:hover span {
-	text-decoration: underline;
+.navigate_section ol li .dividers {
+	color: var(--breadcrumb-divider-color);
+	font-family: var(--breadcrumb-divider-font-family);
+	font-size: var(--breadcrumb-divider-font-size);
+	line-height: var(--breadcrumb-divider-line-height);
+	margin: 0;
+	padding: 0 .4em;
 }
 
 /* The content section */

--- a/Themes/default/css/index.css
+++ b/Themes/default/css/index.css
@@ -1210,7 +1210,7 @@ html[lang="el-GR"] .inline_mod_check {
 /* Set maximum width limit for content.
 /* Anything that should line up with the rest of the page gets this class,
 /* rather than each wrapper being named individually in the selector. */
-.content-wrapper {
+.content_wrapper {
 	max-width: var(--wrapper-width);
 	margin: 0 auto;
 	width: 90%;

--- a/Themes/default/css/index.css
+++ b/Themes/default/css/index.css
@@ -1207,9 +1207,11 @@ html[lang="el-GR"] .inline_mod_check {
 	box-shadow: 0 2px 3px rgba(0, 0, 0, 0.14);
 }
 
-/* Set maximum width limit for content */
-#top_section .inner_wrap, #wrapper, #header, #footer .inner_wrap {
-	max-width: 1200px;
+/* Set maximum width limit for content.
+/* Anything that should line up with the rest of the page gets this class,
+/* rather than each wrapper being named individually in the selector. */
+.content-wrapper {
+	max-width: var(--wrapper-width);
 	margin: 0 auto;
 	width: 90%;
 }

--- a/Themes/default/css/responsive.css
+++ b/Themes/default/css/responsive.css
@@ -156,7 +156,7 @@
 	#footer {
 		padding: 10px;
 	}
-	#top_section .inner_wrap, #wrapper, #header, #footer .inner_wrap {
+	.content-wrapper {
 		width: 100%;
 	}
 	#upper_section, #inner_section, #content_section {

--- a/Themes/default/css/responsive.css
+++ b/Themes/default/css/responsive.css
@@ -156,7 +156,7 @@
 	#footer {
 		padding: 10px;
 	}
-	.content-wrapper {
+	.content_wrapper {
 		width: 100%;
 	}
 	#upper_section, #inner_section, #content_section {

--- a/Themes/default/css/rtl.css
+++ b/Themes/default/css/rtl.css
@@ -131,15 +131,6 @@ img#smflogo {
 	text-align: left;
 }
 
-/* The navigation list (i.e. linktree) */
-.navigate_section ul li {
-	float: right;
-}
-
-.navigate_section ul li .dividers {
-	padding: 0 6px 0 2px;
-}
-
 /* the posting icons */
 #postbuttons_upper ul li a span {
 	line-height: 19px;

--- a/Themes/default/css/variables.css
+++ b/Themes/default/css/variables.css
@@ -6,6 +6,44 @@
 /* Every value here is the one the theme already used before the token existed.
 /* Adding a token is not meant to change what the forum looks like. */
 :root {
+	/* The two colour ramps the theme is built from. Each is nine steps derived
+	/* from one hue, so a forum can be re-tinted by changing the hue alone. The
+	/* 700 step is the base colour itself; lower numbers are lighter, higher are
+	/* darker.
+	/*
+	/* Nothing references these yet. They are here for the parts of the theme
+	/* that are still to come, so that the tokens those parts add can be written
+	/* in terms of the ramp instead of another hard-coded colour. The tokens
+	/* below still hold their own literal values and are unchanged. */
+
+	/** Primary Color **/
+	--primary-color-hex:                              #38546B;
+	--primary-color-hue:                              207;
+	--primary-color-50:                               hsl(var(--primary-color-hue), 93%, 95%);
+	--primary-color-100:                              hsl(var(--primary-color-hue), 43%, 84%);
+	--primary-color-200:                              hsl(var(--primary-color-hue), 30%, 73%);
+	--primary-color-300:                              hsl(var(--primary-color-hue), 26%, 62%);
+	--primary-color-400:                              hsl(var(--primary-color-hue), 23%, 54%);
+	--primary-color-500:                              hsl(var(--primary-color-hue), 27%, 45%);
+	--primary-color-600:                              hsl(var(--primary-color-hue), 29%, 39%);
+	--primary-color-700:                              var(--primary-color-hex);
+	--primary-color-800:                              hsl(var(--primary-color-hue), 34%, 25%);
+	--primary-color-900:                              hsl(var(--primary-color-hue), 44%, 17%);
+
+	/** Secondary Color **/
+	--secondary-color-hex:                            #ff9400;
+	--secondary-color-hue:                            35;
+	--secondary-color-50:                             hsl(var(--secondary-color-hue), 100%, 94%);
+	--secondary-color-100:                            hsl(var(--secondary-color-hue), 100%, 85%);
+	--secondary-color-200:                            hsl(var(--secondary-color-hue), 100%, 75%);
+	--secondary-color-300:                            hsl(var(--secondary-color-hue), 100%, 65%);
+	--secondary-color-400:                            hsl(var(--secondary-color-hue), 100%, 57%);
+	--secondary-color-500:                            var(--secondary-color-hex);
+	--secondary-color-600:                            hsl(var(--secondary-color-hue), 99%, 49%);
+	--secondary-color-700:                            hsl(var(--secondary-color-hue), 98%, 48%);
+	--secondary-color-800:                            hsl(var(--secondary-color-hue), 98%, 47%);
+	--secondary-color-900:                            hsl(var(--secondary-color-hue), 97%, 46%);
+
 	/** HTML **/
 	--html-bg:                                        #3e5a78;
 

--- a/Themes/default/css/variables.css
+++ b/Themes/default/css/variables.css
@@ -293,4 +293,48 @@
 	/** Moderation Link **/
 	--moderationlink-bg:                              #f59e00;
 	--moderationlink-font-weight:                     bold;
+
+	/** Navigate Section **/
+	--navigatesection-bg:                             hsl(0, 0%, 97%);
+	--navigatesection-border-color:                   hsl(0, 0%, 87%);
+	--navigatesection-border-radius:                  5px;
+	--navigatesection-border-style:                   solid;
+	--navigatesection-border-width:                   1px;
+	--navigatesection-box-shadow:                     0 0 1px 1px rgb(255, 255, 255) inset;
+
+	/** Breadcrumb **/
+	--breadcrumb-bg:                                  var(--navigatesection-bg);
+	--breadcrumb-border-color:                        transparent;
+	--breadcrumb-border-radius:                       var(--navigatesection-border-radius);
+	--breadcrumb-border-style:                        solid;
+	--breadcrumb-border-width:                        0;
+	--breadcrumb-box-shadow:                          0 6px 10px -5px rgba(0, 0, 0, 0.1);
+	--breadcrumb-color:                               hsl(0, 0%, 27%);
+	--breadcrumb-font-family:                         inherit;
+	--breadcrumb-font-size:                           0.9em;
+
+	/** Breadcrumb Divider **/
+	--breadcrumb-divider-color:                       hsl(206, 38%, 40%);
+	--breadcrumb-divider-font-family:                 Arial, sans-serif;
+	--breadcrumb-divider-font-size:                   0.8em;
+	--breadcrumb-divider-line-height:                 150%;
+
+	/** Breadcrumb Links **/
+	--breadcrumb-link-color:                          var(--primary-color-800);
+	--breadcrumb-link-color_active:                   hsl(213, 58%, 37%);
+	--breadcrumb-link-color_focus:                    var(--breadcrumb-link-color_hover);
+	--breadcrumb-link-color_hover:                    var(--primary-color-500);
+	--breadcrumb-link-font-weight:                    400;
+	--breadcrumb-link-font-weight_active:             700;
+	--breadcrumb-link-font-weight_focus:              var(--breadcrumb-link-font-weight_hover);
+	--breadcrumb-link-font-weight_hover:              var(--breadcrumb-link-font-weight);
+	--breadcrumb-link-line-height:                    1;
+	--breadcrumb-link-text-decoration:                none;
+	--breadcrumb-link-text-decoration_active:         none;
+	--breadcrumb-link-text-decoration_focus:          none;
+	--breadcrumb-link-text-decoration_hover:          none;
+	--breadcrumb-link-text-shadow:                    none;
+	--breadcrumb-link-text-shadow_active:             none;
+	--breadcrumb-link-text-shadow_focus:              none;
+	--breadcrumb-link-text-shadow_hover:              none;
 }

--- a/Themes/default/css/variables.css
+++ b/Themes/default/css/variables.css
@@ -44,6 +44,9 @@
 	--secondary-color-800:                            hsl(var(--secondary-color-hue), 98%, 47%);
 	--secondary-color-900:                            hsl(var(--secondary-color-hue), 97%, 46%);
 
+	/** Layout **/
+	--wrapper-width:                                  1200px;
+
 	/** HTML **/
 	--html-bg:                                        #3e5a78;
 

--- a/Themes/default/index.template.php
+++ b/Themes/default/index.template.php
@@ -231,7 +231,7 @@ function template_body_above()
 	// Wrapper div now echoes permanently for better layout options. h1 a is now target for "Go up" links.
 	echo '
 	<div id="top_section">
-		<div class="inner_wrap">';
+		<div class="inner_wrap content-wrapper">';
 
 	// If the user is logged in, display some things that might be useful.
 	if (!User::$me->is_guest) {
@@ -418,7 +418,7 @@ function template_body_above()
 	</div><!-- #top_section -->';
 
 	echo '
-	<header id="header">
+	<header id="header" class="content-wrapper">
 		<h1 class="forumtitle">
 			<a id="top" href="', Config::$scripturl, '">', empty(Utils::$context['header_logo_url_html_safe']) ? Utils::$context['forum_name_html_safe'] : '<img src="' . Utils::$context['header_logo_url_html_safe'] . '" alt="' . Utils::$context['forum_name_html_safe'] . '">', '</a>
 		</h1>';
@@ -428,7 +428,7 @@ function template_body_above()
 
 	echo '
 	</header>
-	<div id="wrapper">
+	<div id="wrapper" class="content-wrapper">
 		<div id="upper_section">
 			<div id="inner_section">
 				<div id="inner_wrap"', User::$me->is_guest ? ' class="hide_720"' : '', '>
@@ -506,7 +506,7 @@ function template_body_below()
 	// Show the footer with copyright, terms and help links.
 	echo '
 	<footer id="footer">
-		<div class="inner_wrap">';
+		<div class="inner_wrap content-wrapper">';
 
 	// There is now a global "Go to top" link at the right.
 	echo '

--- a/Themes/default/index.template.php
+++ b/Themes/default/index.template.php
@@ -231,7 +231,7 @@ function template_body_above()
 	// Wrapper div now echoes permanently for better layout options. h1 a is now target for "Go up" links.
 	echo '
 	<div id="top_section">
-		<div class="inner_wrap content-wrapper">';
+		<div class="inner_wrap content_wrapper">';
 
 	// If the user is logged in, display some things that might be useful.
 	if (!User::$me->is_guest) {
@@ -418,7 +418,7 @@ function template_body_above()
 	</div><!-- #top_section -->';
 
 	echo '
-	<header id="header" class="content-wrapper">
+	<header id="header" class="content_wrapper">
 		<h1 class="forumtitle">
 			<a id="top" href="', Config::$scripturl, '">', empty(Utils::$context['header_logo_url_html_safe']) ? Utils::$context['forum_name_html_safe'] : '<img src="' . Utils::$context['header_logo_url_html_safe'] . '" alt="' . Utils::$context['forum_name_html_safe'] . '">', '</a>
 		</h1>';
@@ -428,7 +428,7 @@ function template_body_above()
 
 	echo '
 	</header>
-	<div id="wrapper" class="content-wrapper">
+	<div id="wrapper" class="content_wrapper">
 		<div id="upper_section">
 			<div id="inner_section">
 				<div id="inner_wrap"', User::$me->is_guest ? ' class="hide_720"' : '', '>
@@ -506,7 +506,7 @@ function template_body_below()
 	// Show the footer with copyright, terms and help links.
 	echo '
 	<footer id="footer">
-		<div class="inner_wrap content-wrapper">';
+		<div class="inner_wrap content_wrapper">';
 
 	// There is now a global "Go to top" link at the right.
 	echo '

--- a/Themes/default/index.template.php
+++ b/Themes/default/index.template.php
@@ -418,7 +418,7 @@ function template_body_above()
 	</div><!-- #top_section -->';
 
 	echo '
-	<div id="header">
+	<header id="header">
 		<h1 class="forumtitle">
 			<a id="top" href="', Config::$scripturl, '">', empty(Utils::$context['header_logo_url_html_safe']) ? Utils::$context['forum_name_html_safe'] : '<img src="' . Utils::$context['header_logo_url_html_safe'] . '" alt="' . Utils::$context['forum_name_html_safe'] . '">', '</a>
 		</h1>';
@@ -427,7 +427,7 @@ function template_body_above()
 		', empty(Theme::$current->settings['site_slogan']) ? '<img id="smflogo" src="' . Theme::$current->settings['images_url'] . '/smflogo.svg" alt="Simple Machines Forum" title="Simple Machines Forum">' : '<div id="siteslogan">' . Theme::$current->settings['site_slogan'] . '</div>', '';
 
 	echo '
-	</div>
+	</header>
 	<div id="wrapper">
 		<div id="upper_section">
 			<div id="inner_section">
@@ -469,7 +469,7 @@ function template_body_above()
 					<span class="menu_icon"></span>
 					<span class="text_menu">', Lang::getTxt('mobile_user_menu', file: 'General'), '</span>
 				</a>
-				<div id="main_menu">
+				<nav id="main_menu" aria-label="', Lang::getTxt('mobile_user_menu', file: 'General'), '">
 					<div id="mobile_user_menu" class="popup_container">
 						<div class="popup_window description">
 							<div class="popup_heading">', Lang::getTxt('mobile_user_menu', file: 'General'), '
@@ -478,7 +478,7 @@ function template_body_above()
 							', template_menu(), '
 						</div>
 					</div>
-				</div>';
+				</nav>';
 
 	theme_linktree();
 
@@ -489,7 +489,7 @@ function template_body_above()
 	// The main content should go here.
 	echo '
 		<div id="content_section">
-			<div id="main_content_section">';
+			<main id="main_content_section">';
 }
 
 /**
@@ -498,14 +498,14 @@ function template_body_above()
 function template_body_below()
 {
 	echo '
-			</div><!-- #main_content_section -->
+			</main><!-- #main_content_section -->
 		</div><!-- #content_section -->
 	</div><!-- #wrapper -->
 </div><!-- #footerfix -->';
 
 	// Show the footer with copyright, terms and help links.
 	echo '
-	<div id="footer">
+	<footer id="footer">
 		<div class="inner_wrap">';
 
 	// There is now a global "Go to top" link at the right.
@@ -530,7 +530,7 @@ function template_body_below()
 
 	echo '
 		</div>
-	</div><!-- #footer -->';
+	</footer><!-- #footer -->';
 
 }
 

--- a/Themes/default/index.template.php
+++ b/Themes/default/index.template.php
@@ -561,14 +561,16 @@ function theme_linktree($force_show = false)
 		return;
 	}
 
+	// A breadcrumb trail is a landmark, and it is an ordered list rather than an
+	// unordered one - "General Category" comes before "General Discussion".
 	echo '
-				<div class="navigate_section">
-					<ul>';
+				<nav class="navigate_section" aria-label="', Lang::getTxt('breadcrumb', file: 'General'), '">
+					<ol itemscope itemtype="https://schema.org/BreadcrumbList">';
 
 	// Each tree item has a URL and name. Some may have extra_before and extra_after.
 	foreach (Utils::$context['linktree'] as $link_num => $tree) {
 		echo '
-						<li', ($link_num == count(Utils::$context['linktree']) - 1) ? ' class="last"' : '', '>';
+						<li itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem"', ($link_num == count(Utils::$context['linktree']) - 1) ? ' class="last"' : '', '>';
 
 		// Don't show a separator for the first one.
 		// Better here. Always points to the next level when the linktree breaks to a second line.
@@ -583,14 +585,19 @@ function theme_linktree($force_show = false)
 			echo $tree['extra_before'], ' ';
 		}
 
-		// Show the link, including a URL if it should have one.
+		// Show the link, including a URL if it should have one. The itemprop
+		// attributes let a search engine read the trail as a breadcrumb.
 		if (isset($tree['url'])) {
 			echo '
-							<a href="' . $tree['url'] . '"><span>' . $tree['name'] . '</span></a>';
+							<a itemprop="item" href="' . $tree['url'] . '"><span itemprop="name">' . $tree['name'] . '</span></a>';
 		} else {
-		echo '
-							<span>' . $tree['name'] . '</span>';
+			echo '
+							<span itemprop="name">' . $tree['name'] . '</span>';
 		}
+
+		// Where this one sits in the trail. Positions are 1 based.
+		echo '
+							<meta itemprop="position" content="', $link_num + 1, '">';
 
 		// Show something after the link...?
 		if (isset($tree['extra_after'])) {
@@ -602,8 +609,8 @@ function theme_linktree($force_show = false)
 	}
 
 	echo '
-					</ul>
-				</div><!-- .navigate_section -->';
+					</ol>
+				</nav><!-- .navigate_section -->';
 
 	$shown_linktree = true;
 }


### PR DESCRIPTION
#### Description

Part 4 of wave 3 of the #7933 split. Stacked on #9371, #9370 and #9369 — the diff of this one is its last commit.

The rule that keeps the page centred named four wrappers in a single selector:

```css
#top_section .inner_wrap, #wrapper, #header, #footer .inner_wrap {
	max-width: 1200px;
	margin: 0 auto;
	width: 90%;
}
```

Anything else wanting the same treatment had to be added to that list, and the same list is repeated in `responsive.css` for the narrow override. It becomes a `.content-wrapper` class instead, and the width becomes `--wrapper-width`. This is what the rest of the header work hangs off: once the wrappers are collapsed, the elements that need the width limit are not the ones named above.

Still no visual change. This is the second of the two structural steps, and the reparenting itself comes after it.

#### Three templates, not one

`Themes/default/MaintenanceTemplate.php` and the XSLT in `Sources/Tasks/ExportProfileData.php` each build their own markup but load this same `index.css`, so their `#header`, `#wrapper` and `.inner_wrap` elements were being centred by that selector too. They get the class as well; without it the upgrade and maintenance pages and every exported profile would lose the width limit and run the full width of the window.

The maintenance page's own `#footer` has no `.inner_wrap` and so was never centred by this rule. That is left as it is.

#### Verification

Board index captured on the parent branch and again here, at two viewport widths so that both sides of the 720px breakpoint are exercised — the wide one is where `max-width: 1200px` bites and the narrow one is where `responsive.css` overrides it to `width: 100%`. The whole DOM is walked, recording tag, `getBoundingClientRect` and 25 computed properties per element, with `max-width` among them since that is the property that would break if the class failed to apply:

```
index  (innerWidth 1401): .content-wrapper 0 -> 4    116 elements, 0 style/geometry differences
narrow (innerWidth  701): .content-wrapper 0 -> 4    116 elements, 0 style/geometry differences

compared 6960 values
style/geometry differences: 0
```

`composer lint` cannot run against the two files with classes in this environment — the custom `SMF/section_comments` fixer calls `array_first()`, which needs PHP 8.5, and the container is on 8.4. `php -l` passes on all three files and CI covers the rest.

### Issues References (Fixes|Related|Closes)

Related to #7933.
