### PR TITLE
[3.0] Theme split (wave 3, part 5) — Move the top bar into the header as a user panel

### DIFF
--- a/Themes/default/css/index.css
+++ b/Themes/default/css/index.css
@@ -1217,18 +1217,6 @@ html[lang="el-GR"] .inline_mod_check {
 }
 
 /* The framing graphics */
-/* The top bar. */
-#top_section {
-	border-bottom: 1px solid #bbb;
-	box-shadow: 0 1px 4px rgba(0, 0, 0, 0.16);
-	background: #fff;
-	clear: both;
-}
-#top_section::after {
-	content: "";
-	display: block;
-	clear: both;
-}
 #top_info {
 	padding: 5px 0;
 	line-height: 1.3em;
@@ -1259,16 +1247,38 @@ html[lang="el-GR"] .inline_mod_check {
 #languages_form {
 	margin: 0 0 0 10px;
 }
-/* The logo and slogan. */
+/* The header. Full width, with its contents lined up with the rest of the
+/* page by the wrapper inside it. */
 #header {
-	padding: 2px 2px 12px 2px;
+	background: var(--header-bg);
+	border-color: var(--header-border-color);
+	border-radius: var(--header-border-radius);
+	border-style: var(--header-border-style);
+	border-width: var(--header-border-width);
+	box-shadow: var(--header-box-shadow);
+	margin: 0;
+	min-height: var(--header-height);
+	padding: .5em .2em;
+}
+#header .content_wrapper {
+	align-items: center;
 	display: flex;
-	align-items: flex-end;
+	gap: .5em;
+	justify-content: space-between;
+	min-height: var(--header-height);
 }
 #header::after {
 	content: "";
 	display: block;
 	clear: both;
+}
+/* Everything about the current user sits at the end of the header, stacked. */
+.user_panel {
+	align-content: space-between;
+	display: inline-grid;
+	flex: 1;
+	gap: .5em;
+	justify-content: flex-end;
 }
 /* The main title. */
 h1.forumtitle {
@@ -4159,7 +4169,7 @@ h3.profile_hd::before,
 /* Background of buttons */
 .dropmenu li ul, .top_menu, .dropmenu li li:hover, .button,
 .dropmenu li li:hover > a, .dropmenu li li a:focus, .dropmenu li li a:hover,
-#top_section, .quickbuttons > li,
+.quickbuttons > li,
 .quickbuttons li ul, .quickbuttons li ul li a:hover, .quickbuttons ul li a:focus,
 .inline_mod_check, .popup_window, #inner_section, .post_options ul,
 .post_options ul a:hover, .post_options ul a:focus, .dropmenu .viewport .overview a:hover, .dropmenu .viewport .overview a:focus {

--- a/Themes/default/css/index.css
+++ b/Themes/default/css/index.css
@@ -1222,10 +1222,12 @@ html[lang="el-GR"] .inline_mod_check {
 	line-height: 1.3em;
 	max-width: 100%;
 }
+/* These hang off #top_info, which is positioned. It sits at the end of the
+/* header, so they have to open towards the start or they run off the edge
+/* of the screen on a narrow window. */
 #pm_menu, #alerts_menu, #profile_menu {
-	left: 0;
-	right: 0;
-	padding-right: 10px;
+	inset-inline: auto 0;
+	padding-inline-end: 10px;
 }
 #profile_menu_top > img.avatar {
 	height: 18px;

--- a/Themes/default/css/variables.css
+++ b/Themes/default/css/variables.css
@@ -47,6 +47,15 @@
 	/** Layout **/
 	--wrapper-width:                                  1200px;
 
+	/** Header **/
+	--header-bg:                                      #fff;
+	--header-border-color:                            transparent;
+	--header-border-radius:                           0;
+	--header-border-style:                            solid;
+	--header-border-width:                            0;
+	--header-box-shadow:                              none;
+	--header-height:                                  80px;
+
 	/** HTML **/
 	--html-bg:                                        #3e5a78;
 

--- a/Themes/default/index.template.php
+++ b/Themes/default/index.template.php
@@ -228,16 +228,22 @@ function template_html_above()
  */
 function template_body_above()
 {
-	// Wrapper div now echoes permanently for better layout options. h1 a is now target for "Go up" links.
+	// The header holds the forum title on one side and everything to do with
+	// the current user on the other. h1 a is the target for "Go up" links.
 	echo '
-	<div id="top_section">
-		<div class="inner_wrap content_wrapper">';
+	<header id="header">
+		<div class="content_wrapper">
+			<h1 class="forumtitle">
+				<a id="top" href="', Config::$scripturl, '">', empty(Utils::$context['header_logo_url_html_safe']) ? Utils::$context['forum_name_html_safe'] : '<img src="' . Utils::$context['header_logo_url_html_safe'] . '" alt="' . Utils::$context['forum_name_html_safe'] . '">', '</a>
+			</h1>
+			', empty(Theme::$current->settings['site_slogan']) ? '<img id="smflogo" src="' . Theme::$current->settings['images_url'] . '/smflogo.svg" alt="Simple Machines Forum" title="Simple Machines Forum">' : '<div id="siteslogan">' . Theme::$current->settings['site_slogan'] . '</div>', '
+			<div class="user_panel">';
 
 	// If the user is logged in, display some things that might be useful.
 	if (!User::$me->is_guest) {
 		// Firstly, the user's menu
 		echo '
-			<ul class="floatleft" id="top_info">
+			<ul id="top_info">
 				<li>
 					<a href="', Config::$scripturl, '?action=profile"', !empty(Utils::$context['self_profile']) ? ' class="active"' : '', ' id="profile_menu_top">';
 
@@ -291,7 +297,7 @@ function template_body_above()
 		// Some people like to do things the old-fashioned way.
 		if (!empty(Theme::$current->settings['login_main_menu'])) {
 			echo '
-			<ul class="floatleft">
+			<ul id="top_info">
 				<li class="welcome">', Lang::getTxt(
 				Utils::$context['can_register'] ? 'welcome_guest_register' : 'welcome_guest',
 				[
@@ -305,7 +311,7 @@ function template_body_above()
 			</ul>';
 		} else {
 			echo '
-			<ul class="floatleft" id="top_info">
+			<ul id="top_info">
 				<li class="welcome">
 					', Lang::getTxt('welcome_to_forum', ['forum_name' => Utils::$context['forum_name_html_safe']], file: 'General'), '
 				</li>
@@ -331,7 +337,7 @@ function template_body_above()
 		}
 	} else { // In maintenance mode, only login is allowed and don't show OverlayDiv
 		echo '
-			<ul class="floatleft welcome">
+			<ul id="top_info" class="welcome">
 				<li>', Lang::getTxt(
 			'welcome_guest',
 			[
@@ -346,7 +352,7 @@ function template_body_above()
 
 	if (!empty(Config::$modSettings['userLanguage']) && !empty(Utils::$context['languages']) && count(Utils::$context['languages']) > 1) {
 		echo '
-			<form id="languages_form" method="get" class="floatright">
+			<form id="languages_form" method="get">
 				<select id="language_select" name="language" onchange="this.form.submit()">';
 
 		foreach (Utils::$context['languages'] as $language) {
@@ -364,7 +370,7 @@ function template_body_above()
 
 	if (Utils::$context['allow_search']) {
 		echo '
-			<form id="search_form" class="floatright" action="', Config::$scripturl, '?action=search2" method="post" accept-charset="UTF-8">
+			<form id="search_form" action="', Config::$scripturl, '?action=search2" method="post" accept-charset="UTF-8">
 				<input type="search" name="search" value="">&nbsp;';
 
 		// Using the quick search dropdown?
@@ -414,19 +420,8 @@ function template_body_above()
 	}
 
 	echo '
-		</div><!-- .inner_wrap -->
-	</div><!-- #top_section -->';
-
-	echo '
-	<header id="header" class="content_wrapper">
-		<h1 class="forumtitle">
-			<a id="top" href="', Config::$scripturl, '">', empty(Utils::$context['header_logo_url_html_safe']) ? Utils::$context['forum_name_html_safe'] : '<img src="' . Utils::$context['header_logo_url_html_safe'] . '" alt="' . Utils::$context['forum_name_html_safe'] . '">', '</a>
-		</h1>';
-
-	echo '
-		', empty(Theme::$current->settings['site_slogan']) ? '<img id="smflogo" src="' . Theme::$current->settings['images_url'] . '/smflogo.svg" alt="Simple Machines Forum" title="Simple Machines Forum">' : '<div id="siteslogan">' . Theme::$current->settings['site_slogan'] . '</div>', '';
-
-	echo '
+			</div><!-- .user_panel -->
+		</div><!-- .content_wrapper -->
 	</header>
 	<div id="wrapper" class="content_wrapper">
 		<div id="upper_section">
@@ -511,7 +506,7 @@ function template_body_below()
 	// There is now a global "Go to top" link at the right.
 	echo '
 		<ul>
-			<li class="floatright"><a href="', Config::$scripturl, '?action=help">', Lang::getTxt('help', file: 'General'), '</a> ', (!empty(Config::$modSettings['requireAgreement'])) ? '| <a href="' . Config::$scripturl . '?action=agreement">' . Lang::getTxt('terms_and_rules', file: 'General') . '</a>' : '', ' | <a href="#top_section">', Lang::getTxt('go_up', file: 'General'), ' &#9650;</a></li>
+			<li class="floatright"><a href="', Config::$scripturl, '?action=help">', Lang::getTxt('help', file: 'General'), '</a> ', (!empty(Config::$modSettings['requireAgreement'])) ? '| <a href="' . Config::$scripturl . '?action=agreement">' . Lang::getTxt('terms_and_rules', file: 'General') . '</a>' : '', ' | <a href="#header">', Lang::getTxt('go_up', file: 'General'), ' &#9650;</a></li>
 			<li class="copyright">', Theme::copyright(), '</li>
 		</ul>';
 


### PR DESCRIPTION
#### Description

Part 5 of wave 3 of the #7933 split. Stacked on #9372, #9371, #9370 and #9369 — the diff of this one is its last two commits.

This is the first part of wave 3 that changes how the forum looks.

The top bar was a separate white band above the header holding the user links, the language picker and the search box, which left the header itself holding nothing but the forum title and the logo. They merge. `#top_section` goes, and the header becomes:

```html
<header id="header">
	<div class="content-wrapper">
		<h1 class="forumtitle">...</h1>
		<img id="smflogo"> or <div id="siteslogan">
		<div class="user_panel">
			<ul id="top_info">...</ul>
			<form id="languages_form">...</form>
			<form id="search_form">...</form>
		</div>
	</div>
</header>
```

The panel is a grid, so the float classes those three carried are gone. `#header` is now full width with the wrapper inside it lining its contents up with the rest of the page.

#### Two things kept that the theme branch loses

Its `index.template.php` no longer emits the **search box** or the **clock**, while `index.css`, `responsive.css` and `rtl.css` on that same branch still carry `#search_form` rules. Leftover CSS for markup that no longer exists is usually the sign of something dropped by accident rather than on purpose, so both are kept here. The clock stays where it is for now and moves with the part that deals with the section below the header.

#### A regression this introduced, and the fix

Moving `#top_info` from the left of the page to the end of the header broke the profile, PM and alerts dropdowns.

`.dropmenu, #top_info { position: relative }` has always been there, so those menus are positioned against `#top_info`, and they were anchored to its **start** edge with `left: 0`. While `#top_info` was on the left that put them at the left of the page. With `#top_info` at the end of the header, `left: 0` plus their `min-width: 25em` sent them off the right of the screen — 163px past the edge at a 701px viewport, with a horizontal scrollbar to go with it.

They are anchored to the end edge instead, using logical properties so that right to left behaves too:

```css
#pm_menu, #alerts_menu, #profile_menu {
	inset-inline: auto 0;
	padding-inline-end: 10px;
}
```

The footer's "Go up" link also pointed at `#top_section`, so it now points at `#header`.

#### Verification

Logged in as an admin in the running forum, since the interesting parts of the header only exist for a logged-in user.

Each of the three dropdowns opened and measured, at a 701px viewport:

```
profile_menu   left 381  right 698   within viewport: yes
pm_menu        left 381  right 698   within viewport: yes
alerts_menu    left 381  right 698   within viewport: yes
horizontal scrollbar: no
```

Before the fix, at that same width: `left 547, right 864`, 163px past the edge, horizontal scrollbar present. On the parent branch: `left 0, right 317`, no scrollbar — which is what identified this as mine rather than something already broken.

At 1401px, the menu's end edge lines up with `#top_info`'s end edge, in both directions:

```
ltr:  menu right 1301, #top_info right 1301   aligned
rtl:  menu left   101, #top_info left   101   aligned
```

Every `var()` in `index.css` still resolves against `variables.css`, with nothing referenced but undefined.

### Issues References (Fixes|Related|Closes)

Related to #7933.
