### PR TITLE
[3.0] Theme split (wave 3, part 6) — Make the main menu a band across the page

### DIFF
--- a/Sources/Tasks/ExportProfileData.php
+++ b/Sources/Tasks/ExportProfileData.php
@@ -146,20 +146,16 @@ class ExportProfileData extends BackgroundTask
 									</h1>
 								</div>
 								<div id="wrapper" class="content_wrapper">
-									<div id="upper_section">
-										<div id="inner_section">
-											<div id="inner_wrap">
-												<div class="user">
-													<time>
-														<xsl:attribute name="datetime">
-															<xsl:value-of select="@generated-date-UTC"/>
-														</xsl:attribute>
-														<xsl:value-of select="@generated-date-localized"/>
-													</time>
-												</div>
-												<hr class="clear"/>
-											</div>
+									<div id="inner_wrap">
+										<div class="user">
+											<time>
+												<xsl:attribute name="datetime">
+													<xsl:value-of select="@generated-date-UTC"/>
+												</xsl:attribute>
+												<xsl:value-of select="@generated-date-localized"/>
+											</time>
 										</div>
+										<hr class="clear"/>
 									</div>
 
 									<xsl:call-template name="content_section"/>

--- a/Themes/default/MaintenanceTemplate.php
+++ b/Themes/default/MaintenanceTemplate.php
@@ -61,28 +61,24 @@ abstract class MaintenanceTemplate
 		// Have we got a language drop down - if so do it on the first step only.
 		if (!empty(Maintenance::$languages) && \count(Maintenance::$languages) > 1 && Maintenance::getCurrentStep() == 0) {
 			echo '
-			<div id="upper_section">
-				<div id="inner_section">
-					<div id="inner_wrap">
-						<div class="news">
-							<form action="', Maintenance::getSelf(), '" method="get">
-								<label for="maintenance_language">', Lang::getTxt('maintenance_language', file: 'Maintenance'), ':</label>
-								<select id="maintenance_language" name="lang_file" onchange="location.href = \'', Maintenance::getSelf(), '?lang_file=\' + this.options[this.selectedIndex].value;">';
+			<div id="inner_wrap">
+				<div class="news">
+					<form action="', Maintenance::getSelf(), '" method="get">
+						<label for="maintenance_language">', Lang::getTxt('maintenance_language', file: 'Maintenance'), ':</label>
+						<select id="maintenance_language" name="lang_file" onchange="location.href = \'', Maintenance::getSelf(), '?lang_file=\' + this.options[this.selectedIndex].value;">';
 
 			foreach (Maintenance::$languages as $lang => $name) {
 				echo '
-									<option', isset($_SESSION['lang_file']) && $_SESSION['lang_file'] == $lang ? ' selected' : '', ' value="', $lang, '">', $name, '</option>';
+							<option', isset($_SESSION['lang_file']) && $_SESSION['lang_file'] == $lang ? ' selected' : '', ' value="', $lang, '">', $name, '</option>';
 			}
 
 			echo '
-								</select>
-								<noscript><input type="submit" value="', Lang::getTxt('action_set', file: 'Maintenance'), '" class="button"></noscript>
-							</form>
-						</div><!-- .news -->
-						<hr class="clear">
-					</div><!-- #inner_wrap -->
-				</div><!-- #inner_section -->
-			</div><!-- #upper_section -->';
+						</select>
+						<noscript><input type="submit" value="', Lang::getTxt('action_set', file: 'Maintenance'), '" class="button"></noscript>
+					</form>
+				</div><!-- .news -->
+				<hr class="clear">
+			</div><!-- #inner_wrap -->';
 		}
 
 		echo '

--- a/Themes/default/css/index.css
+++ b/Themes/default/css/index.css
@@ -1217,18 +1217,6 @@ html[lang="el-GR"] .inline_mod_check {
 }
 
 /* The framing graphics */
-/* The top bar. */
-#top_section {
-	border-bottom: 1px solid #bbb;
-	box-shadow: 0 1px 4px rgba(0, 0, 0, 0.16);
-	background: #fff;
-	clear: both;
-}
-#top_section::after {
-	content: "";
-	display: block;
-	clear: both;
-}
 #top_info {
 	padding: 5px 0;
 	line-height: 1.3em;
@@ -1259,16 +1247,38 @@ html[lang="el-GR"] .inline_mod_check {
 #languages_form {
 	margin: 0 0 0 10px;
 }
-/* The logo and slogan. */
+/* The header. Full width, with its contents lined up with the rest of the
+/* page by the wrapper inside it. */
 #header {
-	padding: 2px 2px 12px 2px;
+	background: var(--header-bg);
+	border-color: var(--header-border-color);
+	border-radius: var(--header-border-radius);
+	border-style: var(--header-border-style);
+	border-width: var(--header-border-width);
+	box-shadow: var(--header-box-shadow);
+	margin: 0;
+	min-height: var(--header-height);
+	padding: .5em .2em;
+}
+#header .content_wrapper {
+	align-items: center;
 	display: flex;
-	align-items: flex-end;
+	gap: .5em;
+	justify-content: space-between;
+	min-height: var(--header-height);
 }
 #header::after {
 	content: "";
 	display: block;
 	clear: both;
+}
+/* Everything about the current user sits at the end of the header, stacked. */
+.user_panel {
+	align-content: space-between;
+	display: inline-grid;
+	flex: 1;
+	gap: .5em;
+	justify-content: flex-end;
 }
 /* The main title. */
 h1.forumtitle {
@@ -4159,7 +4169,7 @@ h3.profile_hd::before,
 /* Background of buttons */
 .dropmenu li ul, .top_menu, .dropmenu li li:hover, .button,
 .dropmenu li li:hover > a, .dropmenu li li a:focus, .dropmenu li li a:hover,
-#top_section, .quickbuttons > li,
+.quickbuttons > li,
 .quickbuttons li ul, .quickbuttons li ul li a:hover, .quickbuttons ul li a:focus,
 .inline_mod_check, .popup_window, #inner_section, .post_options ul,
 .post_options ul a:hover, .post_options ul a:focus, .dropmenu .viewport .overview a:hover, .dropmenu .viewport .overview a:focus {

--- a/Themes/default/css/index.css
+++ b/Themes/default/css/index.css
@@ -1222,10 +1222,12 @@ html[lang="el-GR"] .inline_mod_check {
 	line-height: 1.3em;
 	max-width: 100%;
 }
+/* These hang off #top_info, which is positioned. It sits at the end of the
+/* header, so they have to open towards the start or they run off the edge
+/* of the screen on a narrow window. */
 #pm_menu, #alerts_menu, #profile_menu {
-	left: 0;
-	right: 0;
-	padding-right: 10px;
+	inset-inline: auto 0;
+	padding-inline-end: 10px;
 }
 #profile_menu_top > img.avatar {
 	height: 18px;

--- a/Themes/default/css/index.css
+++ b/Themes/default/css/index.css
@@ -909,7 +909,13 @@ a[class^="mobile_generic_menu_"] {
 	display: none;
 }
 
+/* A band of its own across the page, under the header. */
 #main_menu {
+	background: var(--mainmenu-bg);
+	border-color: var(--mainmenu-border-color);
+	border-style: var(--mainmenu-border-style);
+	border-width: var(--mainmenu-border-width);
+	box-shadow: var(--mainmenu-box-shadow);
 	margin: 0 0 4px 0;
 }
 
@@ -1310,25 +1316,15 @@ img#smflogo {
 }
 /*
 /* The user info, news, etc.*/
-#upper_section {
-	padding: 2px 2px 0 2px;
-}
-#inner_section {
-	padding: 12px 10px 2px 10px;
-	border-radius: 6px 6px 0 0;
-}
-#inner_section::after {
-	content: "";
-	display: block;
-	clear: both;
-}
-/* The upper_section, float the two each way */
+/* The clock and the news line, one at each end. The padding was on the
+/* section that used to wrap this. */
 #inner_wrap {
 	display: flex;
 	justify-content: space-between;
 	align-items: center;
 	border-bottom: 1px solid #bbb;
 	margin-bottom: 12px;
+	padding: 12px 10px 2px 10px;
 }
 .user {
 	padding: 0 4px 8px 4px;
@@ -1385,7 +1381,7 @@ ul li.greeting {
 	border-width: var(--navigatesection-border-width);
 	box-shadow: var(--navigatesection-box-shadow);
 	margin-block: .5em .75em;
-	margin-inline: 0;
+	margin-inline: 10px;
 	padding: 0;
 }
 .navigate_section ol {
@@ -4173,7 +4169,7 @@ h3.profile_hd::before,
 .dropmenu li li:hover > a, .dropmenu li li a:focus, .dropmenu li li a:hover,
 .quickbuttons > li,
 .quickbuttons li ul, .quickbuttons li ul li a:hover, .quickbuttons ul li a:focus,
-.inline_mod_check, .popup_window, #inner_section, .post_options ul,
+.inline_mod_check, .popup_window, .post_options ul,
 .post_options ul a:hover, .post_options ul a:focus, .dropmenu .viewport .overview a:hover, .dropmenu .viewport .overview a:focus {
 	background: #fff; /* fallback for some browsers */
 	background-image: linear-gradient(#e2e9f3 0%, #fff 70%);

--- a/Themes/default/css/responsive.css
+++ b/Themes/default/css/responsive.css
@@ -159,7 +159,7 @@
 	.content_wrapper {
 		width: 100%;
 	}
-	#upper_section, #inner_section, #content_section {
+	#content_section {
 		border-radius: 0;
 	}
 	#boardindex_table .stats {

--- a/Themes/default/css/rtl.css
+++ b/Themes/default/css/rtl.css
@@ -103,12 +103,6 @@ img#smflogo {
 	padding-left: 0;
 	text-align: left;
 }
-#upper_section .news {
-	float: right;
-}
-.navigate_section .unread_links {
-	float: left;
-}
 
 /* Profile drop it needs reverse on RTL */
 #profile_menu_top > img.avatar {

--- a/Themes/default/css/variables.css
+++ b/Themes/default/css/variables.css
@@ -47,6 +47,13 @@
 	/** Layout **/
 	--wrapper-width:                                  1200px;
 
+	/** Main Menu **/
+	--mainmenu-bg:                                    linear-gradient(#e2e9f3 0%, #fff 70%);
+	--mainmenu-border-color:                          #bbb;
+	--mainmenu-border-style:                          solid;
+	--mainmenu-border-width:                          0 0 1px 0;
+	--mainmenu-box-shadow:                            none;
+
 	/** Header **/
 	--header-bg:                                      #fff;
 	--header-border-color:                            transparent;

--- a/Themes/default/css/variables.css
+++ b/Themes/default/css/variables.css
@@ -47,6 +47,15 @@
 	/** Layout **/
 	--wrapper-width:                                  1200px;
 
+	/** Header **/
+	--header-bg:                                      #fff;
+	--header-border-color:                            transparent;
+	--header-border-radius:                           0;
+	--header-border-style:                            solid;
+	--header-border-width:                            0;
+	--header-box-shadow:                              none;
+	--header-height:                                  80px;
+
 	/** HTML **/
 	--html-bg:                                        #3e5a78;
 

--- a/Themes/default/index.template.php
+++ b/Themes/default/index.template.php
@@ -422,64 +422,60 @@ function template_body_above()
 	echo '
 			</div><!-- .user_panel -->
 		</div><!-- .content_wrapper -->
-	</header>
+	</header>';
+
+	// The menu is a band of its own across the page, with its contents lined up
+	// with everything else by the wrapper inside it.
+	echo '
+	<nav id="main_menu" aria-label="', Lang::getTxt('mobile_user_menu', file: 'General'), '">
+		<div class="content_wrapper">
+			<a class="mobile_user_menu">
+				<span class="menu_icon"></span>
+				<span class="text_menu">', Lang::getTxt('mobile_user_menu', file: 'General'), '</span>
+			</a>
+			<div id="mobile_user_menu" class="popup_container">
+				<div class="popup_window description">
+					<div class="popup_heading">', Lang::getTxt('mobile_user_menu', file: 'General'), '
+						<a href="javascript:void(0);" class="main_icons hide_popup"></a>
+					</div>
+					', template_menu(), '
+				</div>
+			</div>
+		</div>
+	</nav>
 	<div id="wrapper" class="content_wrapper">
-		<div id="upper_section">
-			<div id="inner_section">
-				<div id="inner_wrap"', User::$me->is_guest ? ' class="hide_720"' : '', '>
-					<div class="user">
-						<time datetime="', Time::gmstrftime('%FT%TZ'), '">', Utils::$context['current_time'], '</time>';
+		<div id="inner_wrap"', User::$me->is_guest ? ' class="hide_720"' : '', '>
+			<div class="user">
+				<time datetime="', Time::gmstrftime('%FT%TZ'), '">', Utils::$context['current_time'], '</time>';
 
 	if (!User::$me->is_guest) {
 		echo '
-						<ul class="unread_links">
-							<li>
-								<a href="', Config::$scripturl, '?action=unread" title="', Lang::getTxt('unread_since_visit', file: 'General'), '">', Lang::getTxt('view_unread_category', file: 'General'), '</a>
-							</li>
-							<li>
-								<a href="', Config::$scripturl, '?action=unreadreplies" title="', Lang::getTxt('show_unread_replies', file: 'General'), '">', Lang::getTxt('unread_replies', file: 'General'), '</a>
-							</li>
-						</ul>';
+				<ul class="unread_links">
+					<li>
+						<a href="', Config::$scripturl, '?action=unread" title="', Lang::getTxt('unread_since_visit', file: 'General'), '">', Lang::getTxt('view_unread_category', file: 'General'), '</a>
+					</li>
+					<li>
+						<a href="', Config::$scripturl, '?action=unreadreplies" title="', Lang::getTxt('show_unread_replies', file: 'General'), '">', Lang::getTxt('unread_replies', file: 'General'), '</a>
+					</li>
+				</ul>';
 	}
 
 	echo '
-					</div>';
+			</div>';
 
 	// Show a random news item? (or you could pick one from news_lines...)
 	if (!empty(Theme::$current->settings['enable_news']) && !empty(Utils::$context['random_news_line'])) {
 		echo '
-					<div class="news">
-						<h2>', Lang::getTxt('news', file: 'General'), ': </h2>
-						<p>', Utils::$context['random_news_line'], '</p>
-					</div>';
+			<div class="news">
+				<h2>', Lang::getTxt('news', file: 'General'), ': </h2>
+				<p>', Utils::$context['random_news_line'], '</p>
+			</div>';
 	}
 
 	echo '
-				</div>';
-
-	// Show the menu here, according to the menu sub template, followed by the navigation tree.
-	// Load mobile menu here
-	echo '
-				<a class="mobile_user_menu">
-					<span class="menu_icon"></span>
-					<span class="text_menu">', Lang::getTxt('mobile_user_menu', file: 'General'), '</span>
-				</a>
-				<nav id="main_menu" aria-label="', Lang::getTxt('mobile_user_menu', file: 'General'), '">
-					<div id="mobile_user_menu" class="popup_container">
-						<div class="popup_window description">
-							<div class="popup_heading">', Lang::getTxt('mobile_user_menu', file: 'General'), '
-								<a href="javascript:void(0);" class="main_icons hide_popup"></a>
-							</div>
-							', template_menu(), '
-						</div>
-					</div>
-				</nav>';
+		</div><!-- #inner_wrap -->';
 
 	theme_linktree();
-
-	echo '
-			</div><!-- #inner_section -->
-		</div><!-- #upper_section -->';
 
 	// The main content should go here.
 	echo '

--- a/Themes/default/index.template.php
+++ b/Themes/default/index.template.php
@@ -228,16 +228,22 @@ function template_html_above()
  */
 function template_body_above()
 {
-	// Wrapper div now echoes permanently for better layout options. h1 a is now target for "Go up" links.
+	// The header holds the forum title on one side and everything to do with
+	// the current user on the other. h1 a is the target for "Go up" links.
 	echo '
-	<div id="top_section">
-		<div class="inner_wrap content_wrapper">';
+	<header id="header">
+		<div class="content_wrapper">
+			<h1 class="forumtitle">
+				<a id="top" href="', Config::$scripturl, '">', empty(Utils::$context['header_logo_url_html_safe']) ? Utils::$context['forum_name_html_safe'] : '<img src="' . Utils::$context['header_logo_url_html_safe'] . '" alt="' . Utils::$context['forum_name_html_safe'] . '">', '</a>
+			</h1>
+			', empty(Theme::$current->settings['site_slogan']) ? '<img id="smflogo" src="' . Theme::$current->settings['images_url'] . '/smflogo.svg" alt="Simple Machines Forum" title="Simple Machines Forum">' : '<div id="siteslogan">' . Theme::$current->settings['site_slogan'] . '</div>', '
+			<div class="user_panel">';
 
 	// If the user is logged in, display some things that might be useful.
 	if (!User::$me->is_guest) {
 		// Firstly, the user's menu
 		echo '
-			<ul class="floatleft" id="top_info">
+			<ul id="top_info">
 				<li>
 					<a href="', Config::$scripturl, '?action=profile"', !empty(Utils::$context['self_profile']) ? ' class="active"' : '', ' id="profile_menu_top">';
 
@@ -291,7 +297,7 @@ function template_body_above()
 		// Some people like to do things the old-fashioned way.
 		if (!empty(Theme::$current->settings['login_main_menu'])) {
 			echo '
-			<ul class="floatleft">
+			<ul id="top_info">
 				<li class="welcome">', Lang::getTxt(
 				Utils::$context['can_register'] ? 'welcome_guest_register' : 'welcome_guest',
 				[
@@ -305,7 +311,7 @@ function template_body_above()
 			</ul>';
 		} else {
 			echo '
-			<ul class="floatleft" id="top_info">
+			<ul id="top_info">
 				<li class="welcome">
 					', Lang::getTxt('welcome_to_forum', ['forum_name' => Utils::$context['forum_name_html_safe']], file: 'General'), '
 				</li>
@@ -331,7 +337,7 @@ function template_body_above()
 		}
 	} else { // In maintenance mode, only login is allowed and don't show OverlayDiv
 		echo '
-			<ul class="floatleft welcome">
+			<ul id="top_info" class="welcome">
 				<li>', Lang::getTxt(
 			'welcome_guest',
 			[
@@ -346,7 +352,7 @@ function template_body_above()
 
 	if (!empty(Config::$modSettings['userLanguage']) && !empty(Utils::$context['languages']) && count(Utils::$context['languages']) > 1) {
 		echo '
-			<form id="languages_form" method="get" class="floatright">
+			<form id="languages_form" method="get">
 				<select id="language_select" name="language" onchange="this.form.submit()">';
 
 		foreach (Utils::$context['languages'] as $language) {
@@ -364,7 +370,7 @@ function template_body_above()
 
 	if (Utils::$context['allow_search']) {
 		echo '
-			<form id="search_form" class="floatright" action="', Config::$scripturl, '?action=search2" method="post" accept-charset="UTF-8">
+			<form id="search_form" action="', Config::$scripturl, '?action=search2" method="post" accept-charset="UTF-8">
 				<input type="search" name="search" value="">&nbsp;';
 
 		// Using the quick search dropdown?
@@ -414,19 +420,8 @@ function template_body_above()
 	}
 
 	echo '
-		</div><!-- .inner_wrap -->
-	</div><!-- #top_section -->';
-
-	echo '
-	<header id="header" class="content_wrapper">
-		<h1 class="forumtitle">
-			<a id="top" href="', Config::$scripturl, '">', empty(Utils::$context['header_logo_url_html_safe']) ? Utils::$context['forum_name_html_safe'] : '<img src="' . Utils::$context['header_logo_url_html_safe'] . '" alt="' . Utils::$context['forum_name_html_safe'] . '">', '</a>
-		</h1>';
-
-	echo '
-		', empty(Theme::$current->settings['site_slogan']) ? '<img id="smflogo" src="' . Theme::$current->settings['images_url'] . '/smflogo.svg" alt="Simple Machines Forum" title="Simple Machines Forum">' : '<div id="siteslogan">' . Theme::$current->settings['site_slogan'] . '</div>', '';
-
-	echo '
+			</div><!-- .user_panel -->
+		</div><!-- .content_wrapper -->
 	</header>
 	<div id="wrapper" class="content_wrapper">
 		<div id="upper_section">
@@ -511,7 +506,7 @@ function template_body_below()
 	// There is now a global "Go to top" link at the right.
 	echo '
 		<ul>
-			<li class="floatright"><a href="', Config::$scripturl, '?action=help">', Lang::getTxt('help', file: 'General'), '</a> ', (!empty(Config::$modSettings['requireAgreement'])) ? '| <a href="' . Config::$scripturl . '?action=agreement">' . Lang::getTxt('terms_and_rules', file: 'General') . '</a>' : '', ' | <a href="#top_section">', Lang::getTxt('go_up', file: 'General'), ' &#9650;</a></li>
+			<li class="floatright"><a href="', Config::$scripturl, '?action=help">', Lang::getTxt('help', file: 'General'), '</a> ', (!empty(Config::$modSettings['requireAgreement'])) ? '| <a href="' . Config::$scripturl . '?action=agreement">' . Lang::getTxt('terms_and_rules', file: 'General') . '</a>' : '', ' | <a href="#header">', Lang::getTxt('go_up', file: 'General'), ' &#9650;</a></li>
 			<li class="copyright">', Theme::copyright(), '</li>
 		</ul>';
 


### PR DESCRIPTION
#### Description

Part 6 of wave 3 of the #7933 split. Stacked on #9373 and the parts below it — the diff of this one is its last commit.

The main menu was buried inside `#upper_section > #inner_section`, two nested wrappers whose only job was some padding and a rounded top corner. It becomes a band of its own across the page, directly under the header, with a `.content-wrapper` inside it lining its contents up with everything else:

```html
<header id="header">…</header>
<nav id="main_menu">
	<div class="content-wrapper">…</div>
</nav>
<div id="wrapper" class="content-wrapper">
	<div id="inner_wrap">…clock and news…</div>
	<nav class="navigate_section">…</nav>
	<div id="content_section">…</div>
</div>
```

Both section wrappers go, and the clock, the news line and the breadcrumb move up a level. The padding `#inner_section` was providing moves onto `#inner_wrap` and the breadcrumb, which is what they actually needed it for. The light gradient that `#inner_section` was picking up from the shared background rule becomes `--mainmenu-bg` on the band, so the strip under the header still reads the same way.

#### Three copies of this markup, not one

`Themes/default/MaintenanceTemplate.php` and the XSLT in `Sources/Tasks/ExportProfileData.php` both build their own `#upper_section > #inner_section > #inner_wrap` and load this same `index.css`, so they lose those wrappers too. `maintenance.css` already carries a `/* Add the gradient here if there is no upper_section */` rule for exactly this case.

#### Two dead RTL rules removed

- `#upper_section .news { float: right }` — `.news` is a flex item of `#inner_wrap`, and float does nothing to a flex item.
- `.navigate_section .unread_links { float: left }` — `.unread_links` is inside `.user`, never inside `.navigate_section`, so this has never matched anything.

Both were already dead before this change; they are removed here because this is the part that touches the markup around them.

#### Verification

Logged in, board index and a board page, at 1401px and 701px.

Structure, read back from the DOM rather than from the template, since unbalanced tags in a template that echoes strings are easy to write and invisible until something reflows:

```
#upper_section present: no          #inner_section present: no
#main_menu is a sibling of #wrapper and comes before it: yes
#main_menu has a .content-wrapper directly inside it:    yes
#inner_wrap, .navigate_section, #content_section all directly in #wrapper: yes
#main_content_section still inside #content_section:     yes
```

Widths and overflow:

```
1401px: band 1401 wide, contents 1200 wide, no horizontal scrollbar
 701px: band  701 wide, contents  701 wide, no horizontal scrollbar
```

Every `var()` in `index.css` still resolves against `variables.css`.

### Issues References (Fixes|Related|Closes)

Related to #7933.
