### PR TITLE
[3.0] Theme split (wave 3, part 7) — Rebuild the footer as a flex row

### DIFF
--- a/Sources/Tasks/ExportProfileData.php
+++ b/Sources/Tasks/ExportProfileData.php
@@ -163,30 +163,28 @@ class ExportProfileData extends BackgroundTask
 								</div>
 							</div>
 							<div id="footer">
-								<div class="inner_wrap content_wrapper">
+								<div class="content_wrapper">
 									<ul>
-										<li class="floatright">
+										<li class="copyright">
+											<xsl:value-of select="$forum_copyright" disable-output-escaping="yes"/>
+										</li>
+										<li class="helplinks">
 											<a>
 												<xsl:attribute name="href">
 													<xsl:value-of select="concat($scripturl, '?action=help')"/>
 												</xsl:attribute>
 												<xsl:value-of select="$txt_help"/>
 											</a>
-											<xsl:text> | </xsl:text>
 											<a>
 												<xsl:attribute name="href">
 													<xsl:value-of select="concat($scripturl, '?action=help;sa=rules')"/>
 												</xsl:attribute>
 												<xsl:value-of select="$txt_terms_rules"/>
 											</a>
-											<xsl:text> | </xsl:text>
 											<a href="#top">
 												<xsl:value-of select="$txt_go_up"/>
 												<xsl:text> &#9650;</xsl:text>
 											</a>
-										</li>
-										<li class="copyright">
-											<xsl:value-of select="$forum_copyright" disable-output-escaping="yes"/>
 										</li>
 									</ul>
 								</div>

--- a/Sources/Tasks/ExportProfileData.php
+++ b/Sources/Tasks/ExportProfileData.php
@@ -146,20 +146,16 @@ class ExportProfileData extends BackgroundTask
 									</h1>
 								</div>
 								<div id="wrapper" class="content_wrapper">
-									<div id="upper_section">
-										<div id="inner_section">
-											<div id="inner_wrap">
-												<div class="user">
-													<time>
-														<xsl:attribute name="datetime">
-															<xsl:value-of select="@generated-date-UTC"/>
-														</xsl:attribute>
-														<xsl:value-of select="@generated-date-localized"/>
-													</time>
-												</div>
-												<hr class="clear"/>
-											</div>
+									<div id="inner_wrap">
+										<div class="user">
+											<time>
+												<xsl:attribute name="datetime">
+													<xsl:value-of select="@generated-date-UTC"/>
+												</xsl:attribute>
+												<xsl:value-of select="@generated-date-localized"/>
+											</time>
 										</div>
+										<hr class="clear"/>
 									</div>
 
 									<xsl:call-template name="content_section"/>

--- a/Themes/default/MaintenanceTemplate.php
+++ b/Themes/default/MaintenanceTemplate.php
@@ -61,28 +61,24 @@ abstract class MaintenanceTemplate
 		// Have we got a language drop down - if so do it on the first step only.
 		if (!empty(Maintenance::$languages) && \count(Maintenance::$languages) > 1 && Maintenance::getCurrentStep() == 0) {
 			echo '
-			<div id="upper_section">
-				<div id="inner_section">
-					<div id="inner_wrap">
-						<div class="news">
-							<form action="', Maintenance::getSelf(), '" method="get">
-								<label for="maintenance_language">', Lang::getTxt('maintenance_language', file: 'Maintenance'), ':</label>
-								<select id="maintenance_language" name="lang_file" onchange="location.href = \'', Maintenance::getSelf(), '?lang_file=\' + this.options[this.selectedIndex].value;">';
+			<div id="inner_wrap">
+				<div class="news">
+					<form action="', Maintenance::getSelf(), '" method="get">
+						<label for="maintenance_language">', Lang::getTxt('maintenance_language', file: 'Maintenance'), ':</label>
+						<select id="maintenance_language" name="lang_file" onchange="location.href = \'', Maintenance::getSelf(), '?lang_file=\' + this.options[this.selectedIndex].value;">';
 
 			foreach (Maintenance::$languages as $lang => $name) {
 				echo '
-									<option', isset($_SESSION['lang_file']) && $_SESSION['lang_file'] == $lang ? ' selected' : '', ' value="', $lang, '">', $name, '</option>';
+							<option', isset($_SESSION['lang_file']) && $_SESSION['lang_file'] == $lang ? ' selected' : '', ' value="', $lang, '">', $name, '</option>';
 			}
 
 			echo '
-								</select>
-								<noscript><input type="submit" value="', Lang::getTxt('action_set', file: 'Maintenance'), '" class="button"></noscript>
-							</form>
-						</div><!-- .news -->
-						<hr class="clear">
-					</div><!-- #inner_wrap -->
-				</div><!-- #inner_section -->
-			</div><!-- #upper_section -->';
+						</select>
+						<noscript><input type="submit" value="', Lang::getTxt('action_set', file: 'Maintenance'), '" class="button"></noscript>
+					</form>
+				</div><!-- .news -->
+				<hr class="clear">
+			</div><!-- #inner_wrap -->';
 		}
 
 		echo '

--- a/Themes/default/css/index.css
+++ b/Themes/default/css/index.css
@@ -1477,15 +1477,51 @@ ul li.greeting {
 /* Footer is now full-width by default. */
 /* The footer with copyright links etc. */
 #footer {
-	margin: 4em 0 0 0;
-	padding: 10px 0;
-	background: #3e5a78;
-	border-top: 3px solid #b2b6bd;
+	background: var(--footer-bg);
+	border-color: var(--footer-border-color);
+	border-style: var(--footer-border-style);
+	border-width: var(--footer-border-width);
+	box-shadow: var(--footer-box-shadow);
+	color: var(--footer-color);
 	flex: none;
+	font-size: var(--footer-font-size);
+	margin: 4em 0 0 0;
+	min-height: var(--footer-height);
+	padding: 10px 0;
 }
-#footer li, #footer p, #footer a {
-	font-size: 0.9em;
-	color: #fff;
+#footer li, #footer p {
+	color: var(--footer-color);
+}
+#footer a {
+	color: var(--footer-link-color);
+	font-weight: var(--footer-link-font-weight);
+	text-decoration: var(--footer-link-text-decoration);
+	text-shadow: var(--footer-link-text-shadow);
+}
+#footer a:hover {
+	color: var(--footer-link-color_hover);
+	font-weight: var(--footer-link-font-weight_hover);
+	text-decoration: var(--footer-link-text-decoration_hover);
+	text-shadow: var(--footer-link-text-shadow_hover);
+}
+#footer a:focus {
+	color: var(--footer-link-color_focus);
+	font-weight: var(--footer-link-font-weight_focus);
+	text-decoration: var(--footer-link-text-decoration_focus);
+	text-shadow: var(--footer-link-text-shadow_focus);
+}
+/* Copyright at one end, help links at the other. */
+#footer ul {
+	align-items: center;
+	display: flex;
+	flex-wrap: wrap;
+	gap: 1.25em .25em;
+	justify-content: space-between;
+}
+#footer li.helplinks {
+	display: flex;
+	flex-wrap: wrap;
+	gap: .75em;
 }
 #footer li.copyright {
 	display: block;

--- a/Themes/default/css/index.css
+++ b/Themes/default/css/index.css
@@ -1217,18 +1217,6 @@ html[lang="el-GR"] .inline_mod_check {
 }
 
 /* The framing graphics */
-/* The top bar. */
-#top_section {
-	border-bottom: 1px solid #bbb;
-	box-shadow: 0 1px 4px rgba(0, 0, 0, 0.16);
-	background: #fff;
-	clear: both;
-}
-#top_section::after {
-	content: "";
-	display: block;
-	clear: both;
-}
 #top_info {
 	padding: 5px 0;
 	line-height: 1.3em;
@@ -1259,16 +1247,38 @@ html[lang="el-GR"] .inline_mod_check {
 #languages_form {
 	margin: 0 0 0 10px;
 }
-/* The logo and slogan. */
+/* The header. Full width, with its contents lined up with the rest of the
+/* page by the wrapper inside it. */
 #header {
-	padding: 2px 2px 12px 2px;
+	background: var(--header-bg);
+	border-color: var(--header-border-color);
+	border-radius: var(--header-border-radius);
+	border-style: var(--header-border-style);
+	border-width: var(--header-border-width);
+	box-shadow: var(--header-box-shadow);
+	margin: 0;
+	min-height: var(--header-height);
+	padding: .5em .2em;
+}
+#header .content_wrapper {
+	align-items: center;
 	display: flex;
-	align-items: flex-end;
+	gap: .5em;
+	justify-content: space-between;
+	min-height: var(--header-height);
 }
 #header::after {
 	content: "";
 	display: block;
 	clear: both;
+}
+/* Everything about the current user sits at the end of the header, stacked. */
+.user_panel {
+	align-content: space-between;
+	display: inline-grid;
+	flex: 1;
+	gap: .5em;
+	justify-content: flex-end;
 }
 /* The main title. */
 h1.forumtitle {
@@ -4159,7 +4169,7 @@ h3.profile_hd::before,
 /* Background of buttons */
 .dropmenu li ul, .top_menu, .dropmenu li li:hover, .button,
 .dropmenu li li:hover > a, .dropmenu li li a:focus, .dropmenu li li a:hover,
-#top_section, .quickbuttons > li,
+.quickbuttons > li,
 .quickbuttons li ul, .quickbuttons li ul li a:hover, .quickbuttons ul li a:focus,
 .inline_mod_check, .popup_window, #inner_section, .post_options ul,
 .post_options ul a:hover, .post_options ul a:focus, .dropmenu .viewport .overview a:hover, .dropmenu .viewport .overview a:focus {

--- a/Themes/default/css/index.css
+++ b/Themes/default/css/index.css
@@ -1222,10 +1222,12 @@ html[lang="el-GR"] .inline_mod_check {
 	line-height: 1.3em;
 	max-width: 100%;
 }
+/* These hang off #top_info, which is positioned. It sits at the end of the
+/* header, so they have to open towards the start or they run off the edge
+/* of the screen on a narrow window. */
 #pm_menu, #alerts_menu, #profile_menu {
-	left: 0;
-	right: 0;
-	padding-right: 10px;
+	inset-inline: auto 0;
+	padding-inline-end: 10px;
 }
 #profile_menu_top > img.avatar {
 	height: 18px;

--- a/Themes/default/css/index.css
+++ b/Themes/default/css/index.css
@@ -909,7 +909,13 @@ a[class^="mobile_generic_menu_"] {
 	display: none;
 }
 
+/* A band of its own across the page, under the header. */
 #main_menu {
+	background: var(--mainmenu-bg);
+	border-color: var(--mainmenu-border-color);
+	border-style: var(--mainmenu-border-style);
+	border-width: var(--mainmenu-border-width);
+	box-shadow: var(--mainmenu-box-shadow);
 	margin: 0 0 4px 0;
 }
 
@@ -1310,25 +1316,15 @@ img#smflogo {
 }
 /*
 /* The user info, news, etc.*/
-#upper_section {
-	padding: 2px 2px 0 2px;
-}
-#inner_section {
-	padding: 12px 10px 2px 10px;
-	border-radius: 6px 6px 0 0;
-}
-#inner_section::after {
-	content: "";
-	display: block;
-	clear: both;
-}
-/* The upper_section, float the two each way */
+/* The clock and the news line, one at each end. The padding was on the
+/* section that used to wrap this. */
 #inner_wrap {
 	display: flex;
 	justify-content: space-between;
 	align-items: center;
 	border-bottom: 1px solid #bbb;
 	margin-bottom: 12px;
+	padding: 12px 10px 2px 10px;
 }
 .user {
 	padding: 0 4px 8px 4px;
@@ -1385,7 +1381,7 @@ ul li.greeting {
 	border-width: var(--navigatesection-border-width);
 	box-shadow: var(--navigatesection-box-shadow);
 	margin-block: .5em .75em;
-	margin-inline: 0;
+	margin-inline: 10px;
 	padding: 0;
 }
 .navigate_section ol {
@@ -4173,7 +4169,7 @@ h3.profile_hd::before,
 .dropmenu li li:hover > a, .dropmenu li li a:focus, .dropmenu li li a:hover,
 .quickbuttons > li,
 .quickbuttons li ul, .quickbuttons li ul li a:hover, .quickbuttons ul li a:focus,
-.inline_mod_check, .popup_window, #inner_section, .post_options ul,
+.inline_mod_check, .popup_window, .post_options ul,
 .post_options ul a:hover, .post_options ul a:focus, .dropmenu .viewport .overview a:hover, .dropmenu .viewport .overview a:focus {
 	background: #fff; /* fallback for some browsers */
 	background-image: linear-gradient(#e2e9f3 0%, #fff 70%);

--- a/Themes/default/css/responsive.css
+++ b/Themes/default/css/responsive.css
@@ -159,7 +159,7 @@
 	.content_wrapper {
 		width: 100%;
 	}
-	#upper_section, #inner_section, #content_section {
+	#content_section {
 		border-radius: 0;
 	}
 	#boardindex_table .stats {

--- a/Themes/default/css/rtl.css
+++ b/Themes/default/css/rtl.css
@@ -103,12 +103,6 @@ img#smflogo {
 	padding-left: 0;
 	text-align: left;
 }
-#upper_section .news {
-	float: right;
-}
-.navigate_section .unread_links {
-	float: left;
-}
 
 /* Profile drop it needs reverse on RTL */
 #profile_menu_top > img.avatar {

--- a/Themes/default/css/variables.css
+++ b/Themes/default/css/variables.css
@@ -47,6 +47,13 @@
 	/** Layout **/
 	--wrapper-width:                                  1200px;
 
+	/** Main Menu **/
+	--mainmenu-bg:                                    linear-gradient(#e2e9f3 0%, #fff 70%);
+	--mainmenu-border-color:                          #bbb;
+	--mainmenu-border-style:                          solid;
+	--mainmenu-border-width:                          0 0 1px 0;
+	--mainmenu-box-shadow:                            none;
+
 	/** Header **/
 	--header-bg:                                      #fff;
 	--header-border-color:                            transparent;

--- a/Themes/default/css/variables.css
+++ b/Themes/default/css/variables.css
@@ -47,6 +47,15 @@
 	/** Layout **/
 	--wrapper-width:                                  1200px;
 
+	/** Header **/
+	--header-bg:                                      #fff;
+	--header-border-color:                            transparent;
+	--header-border-radius:                           0;
+	--header-border-style:                            solid;
+	--header-border-width:                            0;
+	--header-box-shadow:                              none;
+	--header-height:                                  80px;
+
 	/** HTML **/
 	--html-bg:                                        #3e5a78;
 

--- a/Themes/default/css/variables.css
+++ b/Themes/default/css/variables.css
@@ -47,6 +47,30 @@
 	/** Layout **/
 	--wrapper-width:                                  1200px;
 
+	/** Footer **/
+	--footer-bg:                                      var(--primary-color-700);
+	--footer-border-color:                            transparent;
+	--footer-border-style:                            solid;
+	--footer-border-width:                            0;
+	--footer-box-shadow:                              none;
+	--footer-color:                                   hsl(0, 0%, 96%);
+	--footer-font-size:                               0.85em;
+	--footer-height:                                  35px;
+
+	/** Footer Links **/
+	--footer-link-color:                              #fff;
+	--footer-link-color_focus:                        var(--footer-link-color_hover);
+	--footer-link-color_hover:                        #f8f8f8;
+	--footer-link-font-weight:                        400;
+	--footer-link-font-weight_focus:                  var(--footer-link-font-weight_hover);
+	--footer-link-font-weight_hover:                  var(--footer-link-font-weight);
+	--footer-link-text-decoration:                    none;
+	--footer-link-text-decoration_focus:              var(--footer-link-text-decoration_hover);
+	--footer-link-text-decoration_hover:              underline;
+	--footer-link-text-shadow:                        none;
+	--footer-link-text-shadow_focus:                  none;
+	--footer-link-text-shadow_hover:                  none;
+
 	/** Main Menu **/
 	--mainmenu-bg:                                    linear-gradient(#e2e9f3 0%, #fff 70%);
 	--mainmenu-border-color:                          #bbb;

--- a/Themes/default/index.template.php
+++ b/Themes/default/index.template.php
@@ -422,64 +422,60 @@ function template_body_above()
 	echo '
 			</div><!-- .user_panel -->
 		</div><!-- .content_wrapper -->
-	</header>
+	</header>';
+
+	// The menu is a band of its own across the page, with its contents lined up
+	// with everything else by the wrapper inside it.
+	echo '
+	<nav id="main_menu" aria-label="', Lang::getTxt('mobile_user_menu', file: 'General'), '">
+		<div class="content_wrapper">
+			<a class="mobile_user_menu">
+				<span class="menu_icon"></span>
+				<span class="text_menu">', Lang::getTxt('mobile_user_menu', file: 'General'), '</span>
+			</a>
+			<div id="mobile_user_menu" class="popup_container">
+				<div class="popup_window description">
+					<div class="popup_heading">', Lang::getTxt('mobile_user_menu', file: 'General'), '
+						<a href="javascript:void(0);" class="main_icons hide_popup"></a>
+					</div>
+					', template_menu(), '
+				</div>
+			</div>
+		</div>
+	</nav>
 	<div id="wrapper" class="content_wrapper">
-		<div id="upper_section">
-			<div id="inner_section">
-				<div id="inner_wrap"', User::$me->is_guest ? ' class="hide_720"' : '', '>
-					<div class="user">
-						<time datetime="', Time::gmstrftime('%FT%TZ'), '">', Utils::$context['current_time'], '</time>';
+		<div id="inner_wrap"', User::$me->is_guest ? ' class="hide_720"' : '', '>
+			<div class="user">
+				<time datetime="', Time::gmstrftime('%FT%TZ'), '">', Utils::$context['current_time'], '</time>';
 
 	if (!User::$me->is_guest) {
 		echo '
-						<ul class="unread_links">
-							<li>
-								<a href="', Config::$scripturl, '?action=unread" title="', Lang::getTxt('unread_since_visit', file: 'General'), '">', Lang::getTxt('view_unread_category', file: 'General'), '</a>
-							</li>
-							<li>
-								<a href="', Config::$scripturl, '?action=unreadreplies" title="', Lang::getTxt('show_unread_replies', file: 'General'), '">', Lang::getTxt('unread_replies', file: 'General'), '</a>
-							</li>
-						</ul>';
+				<ul class="unread_links">
+					<li>
+						<a href="', Config::$scripturl, '?action=unread" title="', Lang::getTxt('unread_since_visit', file: 'General'), '">', Lang::getTxt('view_unread_category', file: 'General'), '</a>
+					</li>
+					<li>
+						<a href="', Config::$scripturl, '?action=unreadreplies" title="', Lang::getTxt('show_unread_replies', file: 'General'), '">', Lang::getTxt('unread_replies', file: 'General'), '</a>
+					</li>
+				</ul>';
 	}
 
 	echo '
-					</div>';
+			</div>';
 
 	// Show a random news item? (or you could pick one from news_lines...)
 	if (!empty(Theme::$current->settings['enable_news']) && !empty(Utils::$context['random_news_line'])) {
 		echo '
-					<div class="news">
-						<h2>', Lang::getTxt('news', file: 'General'), ': </h2>
-						<p>', Utils::$context['random_news_line'], '</p>
-					</div>';
+			<div class="news">
+				<h2>', Lang::getTxt('news', file: 'General'), ': </h2>
+				<p>', Utils::$context['random_news_line'], '</p>
+			</div>';
 	}
 
 	echo '
-				</div>';
-
-	// Show the menu here, according to the menu sub template, followed by the navigation tree.
-	// Load mobile menu here
-	echo '
-				<a class="mobile_user_menu">
-					<span class="menu_icon"></span>
-					<span class="text_menu">', Lang::getTxt('mobile_user_menu', file: 'General'), '</span>
-				</a>
-				<nav id="main_menu" aria-label="', Lang::getTxt('mobile_user_menu', file: 'General'), '">
-					<div id="mobile_user_menu" class="popup_container">
-						<div class="popup_window description">
-							<div class="popup_heading">', Lang::getTxt('mobile_user_menu', file: 'General'), '
-								<a href="javascript:void(0);" class="main_icons hide_popup"></a>
-							</div>
-							', template_menu(), '
-						</div>
-					</div>
-				</nav>';
+		</div><!-- #inner_wrap -->';
 
 	theme_linktree();
-
-	echo '
-			</div><!-- #inner_section -->
-		</div><!-- #upper_section -->';
 
 	// The main content should go here.
 	echo '

--- a/Themes/default/index.template.php
+++ b/Themes/default/index.template.php
@@ -497,13 +497,18 @@ function template_body_below()
 	// Show the footer with copyright, terms and help links.
 	echo '
 	<footer id="footer">
-		<div class="inner_wrap content_wrapper">';
+		<div class="content_wrapper">';
 
-	// There is now a global "Go to top" link at the right.
+	// The copyright at one end, the help links and the "Go to top" link at the
+	// other. They used to be separated by literal pipes; the gap does that now.
 	echo '
 		<ul>
-			<li class="floatright"><a href="', Config::$scripturl, '?action=help">', Lang::getTxt('help', file: 'General'), '</a> ', (!empty(Config::$modSettings['requireAgreement'])) ? '| <a href="' . Config::$scripturl . '?action=agreement">' . Lang::getTxt('terms_and_rules', file: 'General') . '</a>' : '', ' | <a href="#header">', Lang::getTxt('go_up', file: 'General'), ' &#9650;</a></li>
 			<li class="copyright">', Theme::copyright(), '</li>
+			<li class="helplinks">
+				<a href="', Config::$scripturl, '?action=help">', Lang::getTxt('help', file: 'General'), '</a>', (!empty(Config::$modSettings['requireAgreement'])) ? '
+				<a href="' . Config::$scripturl . '?action=agreement">' . Lang::getTxt('terms_and_rules', file: 'General') . '</a>' : '', '
+				<a href="#header">', Lang::getTxt('go_up', file: 'General'), ' &#9650;</a>
+			</li>
 		</ul>';
 
 	// Show the load time?

--- a/Themes/default/index.template.php
+++ b/Themes/default/index.template.php
@@ -228,16 +228,22 @@ function template_html_above()
  */
 function template_body_above()
 {
-	// Wrapper div now echoes permanently for better layout options. h1 a is now target for "Go up" links.
+	// The header holds the forum title on one side and everything to do with
+	// the current user on the other. h1 a is the target for "Go up" links.
 	echo '
-	<div id="top_section">
-		<div class="inner_wrap content_wrapper">';
+	<header id="header">
+		<div class="content_wrapper">
+			<h1 class="forumtitle">
+				<a id="top" href="', Config::$scripturl, '">', empty(Utils::$context['header_logo_url_html_safe']) ? Utils::$context['forum_name_html_safe'] : '<img src="' . Utils::$context['header_logo_url_html_safe'] . '" alt="' . Utils::$context['forum_name_html_safe'] . '">', '</a>
+			</h1>
+			', empty(Theme::$current->settings['site_slogan']) ? '<img id="smflogo" src="' . Theme::$current->settings['images_url'] . '/smflogo.svg" alt="Simple Machines Forum" title="Simple Machines Forum">' : '<div id="siteslogan">' . Theme::$current->settings['site_slogan'] . '</div>', '
+			<div class="user_panel">';
 
 	// If the user is logged in, display some things that might be useful.
 	if (!User::$me->is_guest) {
 		// Firstly, the user's menu
 		echo '
-			<ul class="floatleft" id="top_info">
+			<ul id="top_info">
 				<li>
 					<a href="', Config::$scripturl, '?action=profile"', !empty(Utils::$context['self_profile']) ? ' class="active"' : '', ' id="profile_menu_top">';
 
@@ -291,7 +297,7 @@ function template_body_above()
 		// Some people like to do things the old-fashioned way.
 		if (!empty(Theme::$current->settings['login_main_menu'])) {
 			echo '
-			<ul class="floatleft">
+			<ul id="top_info">
 				<li class="welcome">', Lang::getTxt(
 				Utils::$context['can_register'] ? 'welcome_guest_register' : 'welcome_guest',
 				[
@@ -305,7 +311,7 @@ function template_body_above()
 			</ul>';
 		} else {
 			echo '
-			<ul class="floatleft" id="top_info">
+			<ul id="top_info">
 				<li class="welcome">
 					', Lang::getTxt('welcome_to_forum', ['forum_name' => Utils::$context['forum_name_html_safe']], file: 'General'), '
 				</li>
@@ -331,7 +337,7 @@ function template_body_above()
 		}
 	} else { // In maintenance mode, only login is allowed and don't show OverlayDiv
 		echo '
-			<ul class="floatleft welcome">
+			<ul id="top_info" class="welcome">
 				<li>', Lang::getTxt(
 			'welcome_guest',
 			[
@@ -346,7 +352,7 @@ function template_body_above()
 
 	if (!empty(Config::$modSettings['userLanguage']) && !empty(Utils::$context['languages']) && count(Utils::$context['languages']) > 1) {
 		echo '
-			<form id="languages_form" method="get" class="floatright">
+			<form id="languages_form" method="get">
 				<select id="language_select" name="language" onchange="this.form.submit()">';
 
 		foreach (Utils::$context['languages'] as $language) {
@@ -364,7 +370,7 @@ function template_body_above()
 
 	if (Utils::$context['allow_search']) {
 		echo '
-			<form id="search_form" class="floatright" action="', Config::$scripturl, '?action=search2" method="post" accept-charset="UTF-8">
+			<form id="search_form" action="', Config::$scripturl, '?action=search2" method="post" accept-charset="UTF-8">
 				<input type="search" name="search" value="">&nbsp;';
 
 		// Using the quick search dropdown?
@@ -414,19 +420,8 @@ function template_body_above()
 	}
 
 	echo '
-		</div><!-- .inner_wrap -->
-	</div><!-- #top_section -->';
-
-	echo '
-	<header id="header" class="content_wrapper">
-		<h1 class="forumtitle">
-			<a id="top" href="', Config::$scripturl, '">', empty(Utils::$context['header_logo_url_html_safe']) ? Utils::$context['forum_name_html_safe'] : '<img src="' . Utils::$context['header_logo_url_html_safe'] . '" alt="' . Utils::$context['forum_name_html_safe'] . '">', '</a>
-		</h1>';
-
-	echo '
-		', empty(Theme::$current->settings['site_slogan']) ? '<img id="smflogo" src="' . Theme::$current->settings['images_url'] . '/smflogo.svg" alt="Simple Machines Forum" title="Simple Machines Forum">' : '<div id="siteslogan">' . Theme::$current->settings['site_slogan'] . '</div>', '';
-
-	echo '
+			</div><!-- .user_panel -->
+		</div><!-- .content_wrapper -->
 	</header>
 	<div id="wrapper" class="content_wrapper">
 		<div id="upper_section">
@@ -511,7 +506,7 @@ function template_body_below()
 	// There is now a global "Go to top" link at the right.
 	echo '
 		<ul>
-			<li class="floatright"><a href="', Config::$scripturl, '?action=help">', Lang::getTxt('help', file: 'General'), '</a> ', (!empty(Config::$modSettings['requireAgreement'])) ? '| <a href="' . Config::$scripturl . '?action=agreement">' . Lang::getTxt('terms_and_rules', file: 'General') . '</a>' : '', ' | <a href="#top_section">', Lang::getTxt('go_up', file: 'General'), ' &#9650;</a></li>
+			<li class="floatright"><a href="', Config::$scripturl, '?action=help">', Lang::getTxt('help', file: 'General'), '</a> ', (!empty(Config::$modSettings['requireAgreement'])) ? '| <a href="' . Config::$scripturl . '?action=agreement">' . Lang::getTxt('terms_and_rules', file: 'General') . '</a>' : '', ' | <a href="#header">', Lang::getTxt('go_up', file: 'General'), ' &#9650;</a></li>
 			<li class="copyright">', Theme::copyright(), '</li>
 		</ul>';
 


### PR DESCRIPTION
#### Description

Part 7 of wave 3 of the #7933 split. Stacked on #9374 and the parts below it — the diff of this one is its last commit.

The footer was a list with one of its two items floated, and the help links inside it were separated by pipe characters written into the markup:

```php
<li class="floatright"><a …>Help</a> | <a …>Terms and Rules</a> | <a …>Go Up ▲</a></li>
<li class="copyright">…</li>
```

It becomes a flex row: copyright at one end, links at the other, separated by a `gap` instead of punctuation. Reading order now matches visual order, and both items wrap onto their own line on a narrow window instead of colliding. Colours, size and the link states move to tokens.

`--footer-bg` is `var(--primary-color-700)`, which is `#38546B`, where the hard-coded value was `#3e5a78`. That is a deliberate change rather than an oversight: it is the same colour the ramp added in #9369 already carries, and the two were near enough identical that keeping both would have meant keeping a colour that has no reason to differ.

#### A broken selector not carried over

The theme branch has this, which is worth flagging because it looks like a working rule:

```css
#footer ul.helpitems li 
#footer li.copyright {
	display: block;
	font-family: Verdana, sans-serif;
}
```

There is no comma. It parses as one descendant selector, `#footer ul.helpitems li #footer li.copyright`, which requires a `#footer` inside a `#footer` and so can never match. The copyright loses its Verdana on that branch. The rule here is the working one `release-3.0` already had.

#### Verification

Board index, logged in.

At 1401px:

```
background   rgb(56, 84, 107)   = #38546B = --primary-color-700, so the ramp resolves
colour       rgb(245, 245, 245)
ul display   flex
copyright    x 101, right 345    first in the row
helplinks    x 1134, right 1301  aligned to the end of the row
links        Help, Terms and Rules, Go Up ▲
literal "|" characters in the footer text: none
```

At 701px both items stay inside the viewport, `x 10 → 255` and `x 525 → 691`, with no horizontal scrollbar.

Every `var()` in `index.css` still resolves against `variables.css`.

### Issues References (Fixes|Related|Closes)

Related to #7933.
