### PR TITLE
[3.0] Document the theme's CSS naming conventions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -152,3 +152,22 @@ touches `User::$me` or `Db::$db` needs a real request or fixtures.
 - Language strings live in `Languages/en_US/`; never hard-code user-facing text.
 - Do not edit `vendor/`, `Packages/`, `Smileys/`, `cache/`, or `other/`.
 - `Settings.php` is local configuration and is not committed.
+
+### CSS naming
+
+`php-cs-fixer` does not look at CSS, so nothing here is enforced automatically.
+Reviewers do ask for it, so get it right the first time.
+
+- **Class names are `snake_case`**, not kebab-case: `inner_wrap`, `navigate_section`,
+  `content_wrapper`. In `Themes/default/css/index.css` this holds for 389 of the 392
+  class selectors, and the three exceptions are all owned by third-party code
+  (`.sceditor-container`, `.dz-image-preview`, `.g-recaptcha`), so they are not a
+  precedent for new classes.
+- **Custom properties are `kebab-case`**: `--body-bg`, `--primary-color-500`. Do not
+  "correct" these to snake_case; the rule above is about class names only.
+- The one place an underscore belongs in a custom property is a **variant suffix**
+  appended to an otherwise kebab-case name, as `--component-property_variant`. The
+  variant is usually a state (`--input-bg_hover`, `--button-border-color_active`, also
+  `_focus` and `_disabled`), but the same slot carries other modifiers where a component
+  needs them (`--progressbar-inner-bg_green`, `--genericbar-inner-box-shadow_vertical`).
+  37 of the 246 custom properties use a suffix; the rest are plain kebab-case.


### PR DESCRIPTION
#### Description

Documents the theme's CSS naming conventions in `AGENTS.md`, so that coding agents get them right the first time instead of being corrected in review.

`php-cs-fixer` only looks at PHP, so none of this is enforced automatically and nothing in the repository stated it. This came up in #9372, where the review asked for `snake_case` class names instead of kebab-case.

The new `### CSS naming` subsection records three things, each checked against `release-3.0` rather than assumed:

- **Class names are `snake_case`.** 389 of the 392 class selectors in `Themes/default/css/index.css` follow this. The three that do not (`.sceditor-container`, `.dz-image-preview`, `.g-recaptcha`) are all owned by third-party code, so the section says explicitly that they are not a precedent for new classes — otherwise the next reader finds a kebab-case class and copies it.
- **Custom properties stay `kebab-case`** (`--body-bg`, `--primary-color-500`), with a note not to "correct" them. The class-name rule is about class names only, and there are 209 kebab-case custom properties already in the theme.
- **The underscore-suffix pattern for custom properties**, `--component-property_variant`. The variant is usually a state (`--input-bg_hover`, `--button-border-color_active`), but the same slot carries other modifiers where a component needs them (`--progressbar-inner-bg_green`, `--genericbar-inner-box-shadow_vertical`). 37 of the 246 custom properties use a suffix.

Documentation only — no code, CSS or template changes, so nothing here affects the running forum.

### Issues References (Fixes|Related|Closes)
1. Related: #9372
