### PR TITLE
[3.0] Fixes password reminders never validating

### DIFF
--- a/Sources/Actions/Reminder.php
+++ b/Sources/Actions/Reminder.php
@@ -246,7 +246,9 @@ class Reminder implements ActionInterface, Routable
 			}
 		}
 
-		list($real_code, $issue_time) = $this->member->validation_code;
+		// The code is stored as 'code|time'. Older codes have no time attached,
+		// so pad the result rather than assuming both halves are there.
+		list($real_code, $issue_time) = array_pad(explode('|', $this->member->validation_code), 2, '');
 		$issue_time = empty($issue_time) ? 0 : (int) $issue_time;
 
 		// Quit if this code is not right.

--- a/Sources/Actions/Reminder.php
+++ b/Sources/Actions/Reminder.php
@@ -246,8 +246,11 @@ class Reminder implements ActionInterface, Routable
 			}
 		}
 
-		// The code is stored as 'code|time'. Older codes have no time attached,
-		// so pad the result rather than assuming both halves are there.
+		// Codes are stored as 'code|time'. One without a timestamp was issued
+		// before they expired at all, and is deliberately not honoured: padding
+		// leaves it with no issue time, which reads as expired below. That costs
+		// anyone mid-reminder when the forum upgrades a second attempt, which
+		// beats letting a pre-expiry code stand forever.
 		list($real_code, $issue_time) = array_pad(explode('|', $this->member->validation_code), 2, '');
 		$issue_time = empty($issue_time) ? 0 : (int) $issue_time;
 

--- a/Sources/Db/Schema/v3_0/Members.php
+++ b/Sources/Db/Schema/v3_0/Members.php
@@ -250,7 +250,7 @@ class Members extends Table
 			'validation_code' => new Column(
 				name: 'validation_code',
 				type: 'varchar',
-				size: 10,
+				size: 32,
 				not_null: true,
 				default: '',
 			),

--- a/Sources/Maintenance/Migration/v3_0/ValidationCodeLength.php
+++ b/Sources/Maintenance/Migration/v3_0/ValidationCodeLength.php
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2026 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 4
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v3_0;
+
+use SMF\Db\Schema;
+use SMF\Maintenance\Migration\MigrationBase;
+
+class ValidationCodeLength extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Widening validation_code to fit the code and its issue time';
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		$table = new Schema\v3_0\Members();
+
+		foreach ($table->columns as $column) {
+			if ($column->name === 'validation_code') {
+				$table->alterColumn($column);
+			}
+		}
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Tools/Upgrade.php
+++ b/Sources/Maintenance/Tools/Upgrade.php
@@ -181,6 +181,7 @@ class Upgrade extends ToolsBase implements ToolsInterface
 			Migration\v3_0\RemoveCookieTime::class,
 			Migration\v3_0\PermissionChanges::class,
 			Migration\v3_0\BoardPostsCount::class,
+			Migration\v3_0\ValidationCodeLength::class,
 		],
 	];
 


### PR DESCRIPTION
#### Description

Password reset by emailed link is broken on `release-3.0`. On MySQL's strict mode it fails
before the mail is even queued, with `Data too long for column 'validation_code' at row 1`
and a "Database Error" page; if it gets past that, the code is refused anyway.

Both faults come from `ec7a781d2` "Expire validation codes", which changed the stored value
to `code|time`:

1. **The value is never parsed.** `Reminder::setPassword2()` does
   `list($real_code, $issue_time) = $this->member->validation_code;`, but `validation_code`
   is a `string` (`User::$validation_code`), not an array. `list()` on a string yields
   `null`s, so `$real_code` is never the submitted code and `$issue_time` falls back to `0`
   — which makes `$issue_time + 3600 < time()` true on every attempt. Each refusal also
   burns a `validatePasswordFlood()` strike. The same commit's change to `Login2` is fine;
   only `Reminder` is affected.
2. **The column is too small.** `members.validation_code` is `varchar(10)`, and
   `code|time` is 21 characters (10 hex + separator + 10 digits).

Nothing else is affected: `Security::generateValidationCode()` returns exactly 10 chars, and
`Activate`, `Register2` and `Admin\Members` all store the bare code, which still fits.

The fix splits on the separator (padded, so a code stored before this change still parses
rather than warning) and widens the column to 32.

**On the migration.** Fresh installs pick the width up from the schema class, but existing
forums need help: `Table::normalize()` opens with `if (!$this->exists())`, and
`Table::exists()` compares `Db::$db->prefix . $name` against `Db::$db->list_tables()`. The
prefix is database-qualified (`` `smf`.smf_ ``) while `list_tables()` returns bare
`smf_members`, so it never matches and `normalize()` returns early without altering
anything. Hence the explicit migration rather than relying on normalize.

**Testing.** Verified on both engines in the Docker environment — fresh install, request a
reminder, follow the real emailed link, set a new password, and log in with it. Also
confirmed a wrong code is refused, a code backdated past an hour is refused (so the expiry
the original commit wanted now actually works), and that the migration takes an existing
install from `varchar(10)` to `varchar(32)` on MySQL and PostgreSQL.

### Issues References (Fixes|Related|Closes)
1. Regression from ec7a781d2 ("Expire validation codes")
2. 
