### PR TITLE
[3.0] External authentication (part 1 of 5) — lets something other than a password log a member in

### DIFF
--- a/Languages/en_US/Login.php
+++ b/Languages/en_US/Login.php
@@ -2,6 +2,9 @@
 
 // Version: 3.0 Alpha 4; Login
 
+// Login form.
+$txt['login_alternatives'] = 'Or sign in with:';
+
 // Registration agreement page.
 $txt['agreement_agree'] = 'I accept the terms of the agreement.';
 $txt['policy_agree'] = 'I accept the terms of the privacy policy.';

--- a/Sources/Actions/Login.php
+++ b/Sources/Actions/Login.php
@@ -76,6 +76,7 @@ class Login extends Login2
 		Utils::$context['default_username'] = Utils::htmlspecialchars($_REQUEST['u'] ?? '');
 		Utils::$context['default_password'] = '';
 		Utils::$context['never_expire'] = false;
+		Utils::$context['authentication_methods'] = parent::getAuthenticationMethods();
 
 		// Add the login chain to the link tree.
 		Utils::$context['linktree'][] = [

--- a/Sources/Actions/Login2.php
+++ b/Sources/Actions/Login2.php
@@ -178,13 +178,21 @@ class Login2 implements ActionInterface, Routable
 
 		User::$me->can_mod = User::$me->allowedTo('access_mod_center') || (!User::$me->is_guest && (User::$me->mod_cache['gq'] != '0=1' || User::$me->mod_cache['bq'] != '0=1' || (Config::$modSettings['postmod_active'] && !empty(User::$me->mod_cache['ap']))));
 
+		/*
+		 * Anything else they still have to prove before we let them all the way
+		 * in? Check tfa_mode as well as the member, because User::verifyTfa()
+		 * does, and sending them to ?action=logintfa when it won't is how you
+		 * get "You are not allowed to access this section" instead of a login.
+		 */
+		$needs_second_factor = !empty(Config::$modSettings['tfa_mode']) && User::$me->hasSecondFactor();
+
 		// Some whitelisting for login_url...
 		if (empty($_SESSION['login_url'])) {
-			Utils::redirectexit(empty(User::$me->tfa_secret) ? '' : 'action=logintfa');
+			Utils::redirectexit($needs_second_factor ? 'action=logintfa' : '');
 		} elseif (!empty($_SESSION['login_url']) && (!str_contains($_SESSION['login_url'], 'http://') && !str_contains($_SESSION['login_url'], 'https://'))) {
 			unset($_SESSION['login_url']);
-			Utils::redirectexit(empty(User::$me->tfa_secret) ? '' : 'action=logintfa');
-		} elseif (!empty(User::$me->tfa_secret)) {
+			Utils::redirectexit($needs_second_factor ? 'action=logintfa' : '');
+		} elseif ($needs_second_factor) {
 			Utils::redirectexit('action=logintfa');
 		} else {
 			// Best not to clutter the session data too much...
@@ -251,6 +259,7 @@ class Login2 implements ActionInterface, Routable
 		Utils::$context['never_expire'] = !empty($_POST['cookieneverexp']);
 		Utils::$context['login_errors'] = [Lang::getTxt('error_occured', file: 'General')];
 		Utils::$context['page_title'] = Lang::getTxt('login', file: 'General');
+		Utils::$context['authentication_methods'] = self::getAuthenticationMethods();
 
 		// Add the login chain to the link tree.
 		Utils::$context['linktree'][] = [
@@ -309,6 +318,17 @@ class Login2 implements ActionInterface, Routable
 		}
 
 		$this->member = reset($loaded);
+
+		/*
+		 * This account signs in some other way, so there is nothing here for a
+		 * password to match against. Stop before Security::checkPassword() gets
+		 * a chance to compare the submitted password to an empty hash.
+		 */
+		if (!$this->member->hasUsablePassword()) {
+			Utils::$context['login_errors'] = [Lang::getTxt('invalid_credentials', file: 'General')];
+
+			return;
+		}
 
 		// Bad password! Thought you could fool the database?!
 		if (
@@ -403,6 +423,155 @@ class Login2 implements ActionInterface, Routable
 		) {
 			Utils::$context['from_ajax'] = true;
 			Utils::$context['template_layers'] = [];
+		}
+	}
+
+	/**
+	 * Lists the ways to sign in that are offered alongside the password form.
+	 *
+	 * SMF has exactly one way to log in, so this is empty on a stock install.
+	 * It exists so that anything adding another way, such as an external
+	 * identity provider, has somewhere to say so and gets rendered in the same
+	 * place as everything else rather than each mod inventing its own spot.
+	 *
+	 * Each entry should be an array with at least:
+	 *  - 'title': what to show on the button. Already escaped for output.
+	 *  - 'url': where the button goes.
+	 * and may also carry an 'id' used as a CSS class, so a method can be styled
+	 * with its own branding.
+	 *
+	 * @return array The available alternatives, which may be empty.
+	 */
+	public static function getAuthenticationMethods(): array
+	{
+		$methods = [];
+
+		/*
+		 * MOD AUTHORS: Add your sign in method here to have it offered on the
+		 * login form. Starting the flow, and everything after it, is up to you;
+		 * finish by calling Login2::completeLogin() so that the member ends up
+		 * logged in the same way a password would have left them.
+		 */
+		IntegrationHook::call('integrate_authentication_methods', [&$methods]);
+
+		return $methods;
+	}
+
+	/**
+	 * Finishes logging a member in, once something has decided that they are who
+	 * they say they are.
+	 *
+	 * This is everything that happens *after* the credentials check: the cookie,
+	 * the session, the ban check, and the login history. The password form is
+	 * only one way to get here, so anything else that can authenticate a member
+	 * (an external identity provider, a passkey, a mod) should call this rather
+	 * than reinventing it, or it will miss a step.
+	 *
+	 * Note that this does not perform any second factor check of its own. The
+	 * redirect below goes through Login2::checkCookie(), which is what sends the
+	 * member on to the second factor when they have one.
+	 *
+	 * @param \SMF\User $member The member to log in.
+	 * @param bool $stay_logged_in Whether to use a long lived cookie.
+	 * @param bool $redirect Whether to redirect once we are done. Pass false if
+	 *    the caller needs to send its own response, e.g. because it is answering
+	 *    an AJAX request. The caller is then responsible for making sure the
+	 *    member ends up somewhere sensible.
+	 */
+	public static function completeLogin(User $member, bool $stay_logged_in = false, bool $redirect = true): void
+	{
+		// Call login integration functions.
+		IntegrationHook::call(
+			'integrate_login',
+			[
+				$member->username,
+				null,
+				// This is divided by 60 for compatibility with old mods that
+				// expected a number of minutes rather than a number of seconds.
+				($stay_logged_in ? Cookie::LENGTH_ONE_YEAR : Cookie::LENGTH_DEFAULT) / 60,
+			],
+		);
+
+		// Get ready to set the cookie...
+		User::setMe($member->id);
+		User::$me->stay_logged_in = $stay_logged_in;
+
+		// Bam!  Cookie set.  A session too, just in case.
+		Cookie::setLoginCookie(User::$me->stay_logged_in ? Cookie::LENGTH_ONE_YEAR : Cookie::LENGTH_DEFAULT, User::$me->id, Cookie::encrypt(User::$me->passwd, User::$me->password_salt));
+
+		// Reset the login threshold.
+		if (isset($_SESSION['failed_login'])) {
+			unset($_SESSION['failed_login']);
+		}
+
+		// Are you banned?
+		User::$me->enforceBans(true);
+
+		// Don't stick the language or theme after this point.
+		unset($_SESSION['language'], $_SESSION['id_theme']);
+
+		// First login?
+		if (User::$me->last_login === 0) {
+			$_SESSION['first_login'] = true;
+		} else {
+			unset($_SESSION['first_login']);
+		}
+
+		// You've logged in, haven't you?
+		User::$me->ip = IP::getUserIP();
+		User::$me->ip2 = IP::getUserIPAlternative();
+		User::$me->validation_code = '';
+
+		if (!User::$me->hasSecondFactor()) {
+			User::$me->last_login = time();
+		}
+
+		User::$me->save();
+
+		// Get rid of the online entry for that old guest....
+		Db::$db->query(
+			'DELETE FROM {db_prefix}log_online
+			WHERE session = {string:session}',
+			[
+				'session' => 'ip' . User::$me->ip,
+			],
+		);
+		$_SESSION['log_time'] = 0;
+
+		// Log this entry, only if we have it enabled.
+		if (!empty(Config::$modSettings['loginHistoryDays'])) {
+			Db::$db->insert(
+				'insert',
+				'{db_prefix}member_logins',
+				[
+					'id_member' => 'int',
+					'time' => 'int',
+					'ip' => 'inet',
+					'ip2' => 'inet',
+				],
+				[
+					[
+						User::$me->id,
+						time(),
+						User::$me->ip,
+						User::$me->ip2,
+					],
+				],
+				[
+					'id_member', 'time',
+				],
+			);
+		}
+
+		if (!$redirect) {
+			return;
+		}
+
+		// Just log you back out if it's in maintenance mode and you AREN'T an admin.
+		if (empty(Config::$maintenance) || User::$me->allowedTo('admin_forum')) {
+			Utils::redirectexit('action=login2;sa=check;member=' . User::$me->id, Sapi::needsLoginFix());
+		} else {
+			Utils::redirectexit('action=logout;' . Utils::$context['session_var'] . '=' . Utils::$context['session_id'], Sapi::needsLoginFix());
 		}
 	}
 
@@ -514,94 +683,6 @@ class Login2 implements ActionInterface, Routable
 	 */
 	protected function DoLogin(): void
 	{
-		// Call login integration functions.
-		IntegrationHook::call(
-			'integrate_login',
-			[
-				$this->member->username,
-				null,
-				// This is divided by 60 for compatibility with old mods that
-				// expected a number of minutes rather than a number of seconds.
-				(!empty(Utils::$context['never_expire']) ? Cookie::LENGTH_ONE_YEAR : Cookie::LENGTH_DEFAULT) / 60,
-			],
-		);
-
-		// Get ready to set the cookie...
-		User::setMe($this->member->id);
-		User::$me->stay_logged_in = !empty(Utils::$context['never_expire']);
-
-		// Bam!  Cookie set.  A session too, just in case.
-		Cookie::setLoginCookie(User::$me->stay_logged_in ? Cookie::LENGTH_ONE_YEAR : Cookie::LENGTH_DEFAULT, User::$me->id, Cookie::encrypt(User::$me->passwd, User::$me->password_salt));
-
-		// Reset the login threshold.
-		if (isset($_SESSION['failed_login'])) {
-			unset($_SESSION['failed_login']);
-		}
-
-		// Are you banned?
-		User::$me->enforceBans(true);
-
-		// Don't stick the language or theme after this point.
-		unset($_SESSION['language'], $_SESSION['id_theme']);
-
-		// First login?
-		if (User::$me->last_login === 0) {
-			$_SESSION['first_login'] = true;
-		} else {
-			unset($_SESSION['first_login']);
-		}
-
-		// You've logged in, haven't you?
-		User::$me->ip = IP::getUserIP();
-		User::$me->ip2 = IP::getUserIPAlternative();
-		User::$me->validation_code = '';
-
-		if (empty(User::$me->tfa_secret)) {
-			User::$me->last_login = time();
-		}
-
-		User::$me->save();
-
-		// Get rid of the online entry for that old guest....
-		Db::$db->query(
-			'DELETE FROM {db_prefix}log_online
-			WHERE session = {string:session}',
-			[
-				'session' => 'ip' . User::$me->ip,
-			],
-		);
-		$_SESSION['log_time'] = 0;
-
-		// Log this entry, only if we have it enabled.
-		if (!empty(Config::$modSettings['loginHistoryDays'])) {
-			Db::$db->insert(
-				'insert',
-				'{db_prefix}member_logins',
-				[
-					'id_member' => 'int',
-					'time' => 'int',
-					'ip' => 'inet',
-					'ip2' => 'inet',
-				],
-				[
-					[
-						User::$me->id,
-						time(),
-						User::$me->ip,
-						User::$me->ip2,
-					],
-				],
-				[
-					'id_member', 'time',
-				],
-			);
-		}
-
-		// Just log you back out if it's in maintenance mode and you AREN'T an admin.
-		if (empty(Config::$maintenance) || User::$me->allowedTo('admin_forum')) {
-			Utils::redirectexit('action=login2;sa=check;member=' . User::$me->id, Sapi::needsLoginFix());
-		} else {
-			Utils::redirectexit('action=logout;' . Utils::$context['session_var'] . '=' . Utils::$context['session_id'], Sapi::needsLoginFix());
-		}
+		self::completeLogin($this->member, !empty(Utils::$context['never_expire']));
 	}
 }

--- a/Sources/Actions/Profile/Main.php
+++ b/Sources/Actions/Profile/Main.php
@@ -693,16 +693,18 @@ class Main implements ActionInterface, Routable
 
 				$password = $_POST['oldpasswrd'] ?? '';
 
-				// You didn't even enter a password!
-				if (trim($password) == '') {
-					Profile::$member->save_errors[] = 'no_password';
-				}
-
 				// Since the password got modified due to all the $_POST cleaning, lets undo it so we can get the correct password
 				$password = Utils::htmlspecialcharsDecode($password);
 
 				// Does the integration want to check passwords?
 				$good_password = \in_array(true, IntegrationHook::call('integrate_verify_password', [Profile::$member->username, $password, false]), true);
+
+				// You didn't even enter a password! Asked after the hook, because
+				// a member who signs in without one has nothing to type here, and
+				// only the integration that signed them in can vouch for them.
+				if (!$good_password && trim($password) == '') {
+					Profile::$member->save_errors[] = 'no_password';
+				}
 
 				// Bad password!!!
 				if (!$good_password && !Security::hashVerifyPassword($password, Profile::$member->passwd)) {

--- a/Sources/Db/Schema/v3_0/MemberAuth.php
+++ b/Sources/Db/Schema/v3_0/MemberAuth.php
@@ -1,0 +1,149 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2026 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 4
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Db\Schema\v3_0;
+
+use SMF\Db\Schema\Column;
+use SMF\Db\Schema\DbIndex;
+use SMF\Db\Schema\Table;
+
+/**
+ * Defines all the properties for a database table.
+ */
+class MemberAuth extends Table
+{
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct()
+	{
+		$this->name = 'member_auth';
+
+		$this->columns = [
+			'id_auth' => new Column(
+				name: 'id_auth',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				auto: true,
+			),
+			'id_member' => new Column(
+				name: 'id_member',
+				type: 'mediumint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			// What kind of credential this is, e.g. the name of the mod that
+			// owns it. Whoever writes the row decides, and is the only thing
+			// that should read it back.
+			'type' => new Column(
+				name: 'type',
+				type: 'varchar',
+				size: 20,
+				not_null: true,
+				default: '',
+			),
+			// Which configured provider this belongs to, for credential types
+			// that can have more than one. 0 when the type has no such concept.
+			'id_provider' => new Column(
+				name: 'id_provider',
+				type: 'int',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			// Whatever identifies this credential to the thing that issued it.
+			// Unique per type and provider, so it is what a lookup matches on.
+			// Note that MySQL indexes only the first 191 characters of this, so
+			// do not store something whose meaning lives beyond that; hash it
+			// down to something shorter first if it might.
+			'identifier' => new Column(
+				name: 'identifier',
+				type: 'varchar',
+				size: 255,
+				not_null: true,
+				default: '',
+			),
+			// Anything else the owner needs to keep, as it sees fit.
+			'secret_data' => new Column(
+				name: 'secret_data',
+				type: 'text',
+				not_null: true,
+			),
+			// What the member calls this credential, when they can name it.
+			'title' => new Column(
+				name: 'title',
+				type: 'varchar',
+				size: 255,
+				not_null: true,
+				default: '',
+			),
+			'date_created' => new Column(
+				name: 'date_created',
+				type: 'bigint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+			'date_last_used' => new Column(
+				name: 'date_last_used',
+				type: 'bigint',
+				unsigned: true,
+				not_null: true,
+				default: 0,
+			),
+		];
+
+		$this->indexes = [
+			'primary' => new DbIndex(
+				type: 'primary',
+				columns: [
+					[
+						'name' => 'id_auth',
+					],
+				],
+			),
+			// One credential cannot belong to two members.
+			'idx_credential' => new DbIndex(
+				name: 'idx_credential',
+				type: 'unique',
+				columns: [
+					[
+						'name' => 'type',
+					],
+					[
+						'name' => 'id_provider',
+					],
+					[
+						'name' => 'identifier',
+					],
+				],
+			),
+			'idx_id_member' => new DbIndex(
+				name: 'idx_id_member',
+				columns: [
+					[
+						'name' => 'id_member',
+					],
+				],
+			),
+		];
+	}
+}

--- a/Sources/Maintenance/Migration/v3_0/CreateMemberAuth.php
+++ b/Sources/Maintenance/Migration/v3_0/CreateMemberAuth.php
@@ -15,6 +15,8 @@ declare(strict_types=1);
 
 namespace SMF\Maintenance\Migration\v3_0;
 
+use SMF\Config;
+use SMF\Db\DatabaseApi as Db;
 use SMF\Db\Schema;
 use SMF\Maintenance\Migration\MigrationBase;
 
@@ -32,6 +34,21 @@ class CreateMemberAuth extends MigrationBase
 	/****************
 	 * Public methods
 	 ****************/
+
+	/**
+	 * Nothing to do if the table is already there, so a re-run says "skipped".
+	 *
+	 * Note this compares against Config::$db_prefix rather than Db::$db->prefix.
+	 * The latter is database qualified, e.g. `smf`.smf_, while list_tables()
+	 * reports bare names, so it would never match. That mismatch is also why
+	 * Table::exists() cannot be used here.
+	 */
+	public function isCandidate(): bool
+	{
+		$member_auth = new Schema\v3_0\MemberAuth();
+
+		return !\in_array(Config::$db_prefix . $member_auth->name, Db::$db->list_tables());
+	}
 
 	/**
 	 *

--- a/Sources/Maintenance/Migration/v3_0/CreateMemberAuth.php
+++ b/Sources/Maintenance/Migration/v3_0/CreateMemberAuth.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2026 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 4
+ */
+
+declare(strict_types=1);
+
+namespace SMF\Maintenance\Migration\v3_0;
+
+use SMF\Db\Schema;
+use SMF\Maintenance\Migration\MigrationBase;
+
+class CreateMemberAuth extends MigrationBase
+{
+	/*******************
+	 * Public properties
+	 *******************/
+
+	/**
+	 *
+	 */
+	public string $name = 'Creating alternative authentication table';
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 *
+	 */
+	public function execute(): bool
+	{
+		$member_auth = new Schema\v3_0\MemberAuth();
+		$member_auth->create();
+
+		return true;
+	}
+}

--- a/Sources/Maintenance/Tools/Upgrade.php
+++ b/Sources/Maintenance/Tools/Upgrade.php
@@ -182,6 +182,7 @@ class Upgrade extends ToolsBase implements ToolsInterface
 			Migration\v3_0\PermissionChanges::class,
 			Migration\v3_0\BoardPostsCount::class,
 			Migration\v3_0\ValidationCodeLength::class,
+			Migration\v3_0\CreateMemberAuth::class,
 		],
 	];
 

--- a/Sources/User.php
+++ b/Sources/User.php
@@ -2241,6 +2241,39 @@ class User implements \ArrayAccess
 	}
 
 	/**
+	 * Whether this member has any second authentication factor set up.
+	 *
+	 * @return bool Whether they do.
+	 */
+	public function hasSecondFactor(): bool
+	{
+		return self::getSecondFactors($this->id) !== [];
+	}
+
+	/**
+	 * Whether this member can log in by typing a password.
+	 *
+	 * SMF has always given every account a password, so most code can assume
+	 * one exists. That stops being true as soon as something else can vouch for
+	 * a member, so anywhere that asks for a password needs to cope with the
+	 * answer being "they don't have one".
+	 *
+	 * An empty passwd is the marker. There is no separate flag column, because
+	 * password_verify() already refuses to match anything against an empty
+	 * hash; this method exists to say so out loud rather than relying on that.
+	 *
+	 * @return bool Whether asking this member for their password makes sense.
+	 */
+	public function hasUsablePassword(): bool
+	{
+		// passwd is a typed property, so it may not be populated for every
+		// dataset. Fall back to the raw profile data before giving up.
+		$passwd = $this->passwd ?? (self::$profiles[$this->id]['passwd'] ?? '');
+
+		return trim($passwd) !== '';
+	}
+
+	/**
 	 * Check if the user is who he/she says he is.
 	 *
 	 * Makes sure the user is who they claim to be by requiring a password to be
@@ -2293,6 +2326,27 @@ class User implements \ArrayAccess
 					&& $_SESSION['admin_time'] + $refreshTime >= time()
 				)
 			) {
+				return null;
+			}
+		}
+
+		/*
+		 * If this member has no password, asking them to retype it is not going
+		 * to work, and the prompt below would lock them out of the admin and
+		 * moderation areas entirely.
+		 *
+		 * MOD AUTHORS: if you let members sign in without a password, you must
+		 * implement this hook as well, and re-verify them however they signed in
+		 * originally. Return true once you are satisfied it is really them.
+		 * Nothing in SMF itself creates a member without a password, so this
+		 * hook is never reached on a stock install.
+		 */
+		if (!$this->hasUsablePassword()) {
+			if (\in_array(true, IntegrationHook::call('integrate_reauthenticate', [$type, $this->id]), true)) {
+				$_SESSION[$type . '_time'] = time();
+
+				unset($_SESSION['request_referer']);
+
 				return null;
 			}
 		}
@@ -2819,6 +2873,48 @@ class User implements \ArrayAccess
 	/***********************
 	 * Public static methods
 	 ***********************/
+
+	/**
+	 * Lists the second authentication factors a member has set up.
+	 *
+	 * Two factor authentication used to mean exactly one thing, the time based
+	 * codes in SMF\TOTP\Auth, so the rest of the code asked about it by looking
+	 * at the tfa_secret column directly. Ask here instead, so that a mod adding
+	 * another kind of factor is visible to those checks too.
+	 *
+	 * Keys are short identifiers for the factor, values describe it for display.
+	 * The built in factor uses the key 'totp'.
+	 *
+	 * Note that this reports what the member has configured, not whether the
+	 * forum currently wants a second factor from them. The tfa_mode setting is
+	 * what decides that, and callers check it separately.
+	 *
+	 * This reads the loaded profile data rather than an instance's properties,
+	 * because it has to work during self::loadMe(), where self::verifyTfa() runs
+	 * before self::setProperties() has populated anything.
+	 *
+	 * @param int $id_member The member to ask about.
+	 * @return array The factors this member has, which may be empty.
+	 */
+	public static function getSecondFactors(int $id_member): array
+	{
+		$factors = [];
+
+		if (!empty(self::$profiles[$id_member]['tfa_secret'])) {
+			$factors['totp'] = Lang::getTxt('tfa_title', file: 'Profile');
+		}
+
+		/*
+		 * MOD AUTHORS: Add your own second factor here. Doing so makes SMF treat
+		 * this member as having two factor authentication set up, which means it
+		 * will stop short of a full login and hand over to ?action=logintfa. You
+		 * are responsible for verifying your own factor there, which is what the
+		 * integrate_verify_tfa hook is for.
+		 */
+		IntegrationHook::call('integrate_second_factors', [&$factors, $id_member]);
+
+		return $factors;
+	}
 
 	/**
 	 * Loads an array of users by ID, member_name, or email_address.
@@ -3604,6 +3700,8 @@ class User implements \ArrayAccess
 			// Delete these members.
 			['table' => 'members', 'col' => 'id_member'],
 			['table' => 'member_logins', 'col' => 'id_member'],
+			// Anything else they used to sign in with goes with them.
+			['table' => 'member_auth', 'col' => 'id_member'],
 			['table' => 'user_alerts', 'col' => 'id_member'],
 			['table' => 'user_alerts', 'col' => 'id_member_started'],
 			['table' => 'user_alerts_prefs', 'col' => 'id_member'],
@@ -4542,7 +4640,7 @@ class User implements \ArrayAccess
 		}
 
 		// If they've set up Two Factor Authentication, validate it.
-		if (!empty(self::$profiles[self::$my_id]['tfa_secret'])) {
+		if (self::getSecondFactors(self::$my_id) !== []) {
 			// If they are performing the TFA login action itself, make sure
 			// to reset their ID for security, but otherwise leave it to the
 			// action to verify the TFA credentials.

--- a/Themes/default/Login.template.php
+++ b/Themes/default/Login.template.php
@@ -108,6 +108,22 @@ function template_login()
 					</script>
 				</form>';
 
+	// Anything else offering to sign them in? Nothing does out of the box.
+	if (!empty(Utils::$context['authentication_methods'])) {
+		echo '
+				<hr>
+				<div class="centertext login_alternatives">
+					<p class="smalltext">', Lang::getTxt('login_alternatives', file: 'Login'), '</p>';
+
+		foreach (Utils::$context['authentication_methods'] as $method) {
+			echo '
+					<a class="button', isset($method['id']) ? ' login_with_' . $method['id'] : '', '" href="', $method['url'], '">', $method['title'], '</a>';
+		}
+
+		echo '
+				</div><!-- .login_alternatives -->';
+	}
+
 	if (!empty(Utils::$context['can_register'])) {
 		echo '
 				<hr>


### PR DESCRIPTION
#### Description

**Feature series: external authentication, part 1 of 3.** These belong together and are
not bug fixes:

| | | |
|---|---|---|
| **part 1** | this PR | groundwork: makes login reusable by something other than the password form |
| part 2 | to come | OpenID Connect sign in (Google, Microsoft, Keycloak, …) |
| part 3 | to come | passkeys (WebAuthn), as a passwordless first factor and as a second factor |

Parts 2 and 3 are independent of each other; both sit on this one. Nothing here is user
visible on its own.

---


Groundwork so that something other than the password form can log a member in. No new
feature here, and nothing user visible on a stock install — this is the part that OpenID
Connect and passkeys would both otherwise have to work around, split out so it can be
reviewed on its own.

Three things currently assume the password form:

1. **The steps after a successful check are unreachable.** `Login2::DoLogin()` calls
   `integrate_login`, sets the cookie, resets the flood counter, enforces bans, writes
   `member_logins` and redirects — but it is `protected` and reads `$this->member`, so
   anything else authenticating a member has to reimplement it and will quietly miss a
   step. Moved to `Login2::completeLogin($member, $stay_logged_in, $redirect)`;
   `DoLogin()` is now a one line caller, so the password path is byte for byte the same.
2. **Two factor authentication is `tfa_secret`.** Every place that asks "does this member
   have a second factor" reads that column. Added `User::getSecondFactors()`, which
   reports what they have and lets a mod register its own via `integrate_second_factors`.
   It reads the loaded profile rather than object properties, because `verifyTfa()` runs
   before `setProperties()` has populated anything.
3. **Every account is assumed to have a password.** Added
   `User::hasUsablePassword()`. The login form now refuses such an account before
   `checkPasswordFallbacks()` compares the submitted password against an empty hash, and
   `validateSession()` offers `integrate_reauthenticate` so a member who signs in some
   other way is not simply locked out of the admin and moderation areas. Nothing in SMF
   creates such an account yet; this is the seam for whatever does.

Also adds a `member_auth` table for the credentials such accounts would sign in with
(deleted along with the member), and a slot on the login form that renders whatever
registers through `integrate_authentication_methods`.

**One behaviour change worth flagging.** `Login2::checkCookie()` now checks `tfa_mode` as
well as the member, which `User::verifyTfa()` already did. Previously a member with a
`tfa_secret` on a forum with TFA switched off was redirected to `?action=logintfa`, where
nothing was going to ask them for a code — they got "You are not allowed to access this
section" instead of being logged in. They now log in normally. This is not a weakening:
with `tfa_mode` off, `verifyTfa()` was not enforcing anything either way.

New hooks: `integrate_second_factors`, `integrate_authentication_methods`,
`integrate_reauthenticate`. Each is documented at its call site, since there is no central
hook list to add them to.

**Testing.** A 14 check regression run over the login paths this touches — form renders,
correct and incorrect password, remember me and its cookie lifetime, logout, the admin
password re-prompt and passing it, a member with TOTP being held at the second factor, and
an account with an empty `passwd` being refused — passes identically on this branch and on
unmodified `release-3.0`, which is the point for a change that is meant to alter nothing.
Run on both MySQL and PostgreSQL. The new table was checked on both engines, created by
the installer on a fresh install (73 tables) and by the migration on an existing one. The
two new extension points were exercised with a throwaway mod: a registered method renders
on the login form, and a registered factor holds back a member who has no `tfa_secret` at
all.

Noted while testing, **not** touched here: `?action=logintfa` is already broken on
`release-3.0` independently of this. `LoginTFA::execute()` does
`User::load(..., dataset: User::$me->dataset)`, but `verifyTfa()` has just reset the member
to a guest, whose `dataset` is null, so it dies with "Cannot assign null to property
SMF\User::$dataset". Reproduced identically with and without this branch. Worth its own PR.

### Issues References (Fixes|Related|Closes)
1. Groundwork for OpenID Connect and passkey support
2. 



---

#### Merge order (added after the series was complete)

The parts are split for review, not for merging independently. Two of them make the
forum *worse* on their own, so this is worth being explicit about:

| PR | Safe to merge alone? |
|---|---|
| #9380, #9490 | **Yes.** Plain bug fixes, no relation to this series. |
| #9381 (part 1) | **Yes.** Nothing it adds is reachable by a user: the table stays empty, no account can exist without a password, and the new hooks and the login-form slot do nothing until a mod fills them. |
| #9488 (part 2) | **No — needs #9492.** |
| #9489 (part 3) | **No — needs #9492.** |
| #9491 (part 4) | **No — needs #9492.** |
| #9492 (part 5) | Closes what 2, 3 and 4 open. |

**Why 2 and 3 are not safe alone.** Today a member who thinks their session has been
stolen has two levers that work: change the password, or log out. Changing the password
changes `passwd`, and the login cookie is an HMAC over it, so every other cookie dies;
logging out rotates `password_salt` ([Logout.php:123](../blob/release-3.0/Sources/Actions/Logout.php#L123)),
which kills them too. Parts 2 and 3 let anyone holding the session attach a passkey or
link a provider account from the profile, and **neither lever touches that** — it is a row
in `member_auth`, and the attacker signs in freshly with a credential of their own. So
those two PRs, merged without part 5, remove the forum's existing ability to evict
somebody. Part 5 is what puts a re-authentication check in front of adding one.

**Why 4 is not safe alone.** It is the first thing that creates an account with no
password, which makes the `User::validateSession()` prompt unanswerable: such a member is
shut out of the administration and moderation areas permanently. Part 5 gives that prompt
an answer.

So: part 1 can land whenever. Parts 2 to 5 want to land together, or at least part 5 must
not lag behind the others.
