### PR TITLE
[3.0] Stop fractional durations throwing in SMF\TimeInterval

### DIFF
--- a/Sources/TimeInterval.php
+++ b/Sources/TimeInterval.php
@@ -257,6 +257,14 @@ class TimeInterval extends \DateInterval implements \Stringable
 
 			$duration = rtrim($duration, 'PT');
 
+			// The fractional unit was the only one given, so taking it out has
+			// left nothing behind. 'P' and 'PT' are not durations \DateInterval
+			// will accept, but the zero duration is, and the fractional part is
+			// added to it immediately below.
+			if ($duration === '') {
+				$duration = 'PT0S';
+			}
+
 			// Create the base object.
 			$this->base = new parent($duration);
 


### PR DESCRIPTION
#### Description

`SMF\TimeInterval::__construct()` documents that it takes a fractional value for
the smallest unit in the duration — that is the thing that makes the class cover
the whole ISO 8601 duration spec instead of the subset `\DateInterval` handles:

> Accepts fractional values for whatever the smallest unit in `$duration` is. In
> other words, this class supports the complete spec for ISO 8601 durations, not
> just a subset of the spec.

Every duration that actually uses one throws:

```php
new SMF\TimeInterval('P0.5M');
// DateMalformedIntervalStringException: Unknown or bad format ()
```

`P0.5M`, `P0.99M`, `P0.5D`, `PT0.5H`, `PT1.5M`, `PT0.5S`, `P1.5Y` — all of them,
including the `'P0.5M'` the code's own comment uses as its worked example.

#### Cause

The fractional part is lifted out into `$frac` and the unit it came from is
truncated to an integer, then the duration is rebuilt from what is left. When the
fractional unit was the only one given, that leaves nothing: the loop emits `P`,
the `T` separator, and no units at all, so after the `rtrim($duration, 'PT')` the
string is empty. `new \DateInterval('')` then throws.

The zero duration is used instead. The line straight after adds the fractional
part to the base object, so no value changes — this only affects durations that
threw before.

#### Testing

Round-tripped through `(string)` on PHP 8.4, before and after:

| duration | before | after |
|---|---|---|
| `P0.5M` | throws | `P15D` |
| `P0.99M` | throws | `P27D` |
| `P0.5D` | throws | `P0DT12H` |
| `PT0.5H` | throws | `P0DT30M` |
| `PT1.5M` | throws | `P0DT1M30S` |
| `PT0.5S` | throws | `P0DT0.5S` |
| `P1.5Y` | throws | `P1Y6M` |
| `P1DT1.5H` | throws | `P1DT1H30M` |
| `P1Y` | `P1Y` | `P1Y` |
| `P1D` | `P1D` | `P1D` |
| `P1W` | `P7D` | `P7D` |
| `PT1H30M` | `P0DT1H30M` | `P0DT1H30M` |
| `P1Y2M3DT4H5M6S` | `P1Y2M3DT4H5M6S` | `P1Y2M3DT4H5M6S` |
| `P0000-00-01T02:00:00` | `P1DT2H` | `P1DT2H` |

Nothing that worked before moved.

#### One thing this does not fix

`P0.99M` gives `P27D`, where the comment on the multiplier says it is calibrated
so that it means `P28D`. The multiplier works out at `32 - (4 * 0.99) = 28.04`,
and `0.99 * 28.04 = 27.76` days, which truncates to 27. That is the existing
arithmetic and I have left it alone rather than change a value silently, but it
looks like it is a rounding short of what was intended.

Found while testing the calendar for the #7933 split.

### Issues References (Fixes|Related|Closes)

Related to #7933
