### PR TITLE
[3.0] Theme split (wave 4, part 2) — name the board index's sub templates instead of wrapping them

### DIFF
--- a/Sources/Actions/BoardIndex.php
+++ b/Sources/Actions/BoardIndex.php
@@ -36,7 +36,8 @@ use SMF\Utils;
 /**
  * This class shows the board index.
  *
- * It uses the BoardIndex template, and main sub template.
+ * It uses the BoardIndex template, and the newsfader, boardindex and
+ * info_center sub templates.
  * It updates most of the online statistics.
  *
  * Although this class is not accessed using an ?action=... URL query, it
@@ -57,7 +58,15 @@ class BoardIndex implements ActionInterface, Routable
 	public function execute(): void
 	{
 		Theme::loadTemplate('BoardIndex');
-		Utils::$context['template_layers'][] = 'boardindex_outer';
+
+		// The three parts of this page are siblings, not a wrapper around a
+		// middle. Naming them is clearer than a layer whose _above and _below
+		// halves each call one of them.
+		Utils::$context['sub_templates'] = [
+			'newsfader',
+			'boardindex',
+			'info_center',
+		];
 
 		Utils::$context['page_title'] = Lang::getTxt('forum_index', ['forum_name' => Utils::$context['forum_name']], file: 'General');
 

--- a/Themes/default/BoardIndex.template.php
+++ b/Themes/default/BoardIndex.template.php
@@ -19,14 +19,6 @@ use SMF\User;
 use SMF\Utils;
 
 /**
- * The top part of the outer layer of the boardindex
- */
-function template_boardindex_outer_above()
-{
-	template_newsfader();
-}
-
-/**
  * This shows the newsfader
  */
 function template_newsfader()
@@ -57,7 +49,7 @@ function template_newsfader()
 /**
  * This actually displays the board index
  */
-function template_main()
+function template_boardindex()
 {
 	echo '
 	<div id="boardindex_table" class="boardindex_table">';
@@ -278,14 +270,6 @@ function template_bi_board_children($board)
 				'</p>
 			</div>';
 	}
-}
-
-/**
- * The lower part of the outer layer of the board index
- */
-function template_boardindex_outer_below()
-{
-	template_info_center();
 }
 
 /**


### PR DESCRIPTION
#### Description

Part of the split of #7933, wave 4 part 2.

The board index is drawn by a template layer whose two halves each call exactly
one function:

```php
function template_boardindex_outer_above()
{
	template_newsfader();
}

function template_boardindex_outer_below()
{
	template_info_center();
}
```

A layer says that something wraps around the middle of the page. Nothing here
does: the news fader, the board list and the info centre are three things one
after another. `Theme::loadSubTemplates()` already walks a `sub_templates` array,
so they can be named directly:

```php
Utils::$context['sub_templates'] = [
	'newsfader',
	'boardindex',
	'info_center',
];
```

and the layer, along with both forwarding functions, goes.

#### Testing

The rendered page is byte-for-byte identical, as a guest and as an admin.
`index.php` fetched on `release-3.0` and on this branch, normalised for the
session variable, the security tokens, the cache-busting query strings, the
`<time>` values and the cron timestamp:

| | lines | result |
|---|---|---|
| guest | 270 | identical |
| admin | 378 | identical |

The admin capture is a real logged-in session — it contains the logout link, the
mark-all-as-read button and the user menus — so both branches of
`template_boardindex()` are covered.

#### Notes for the reviewer

- **`template_main()` becomes `template_boardindex()`.** It has to have a name to
  be listed. A custom theme that overrides `BoardIndex.template.php` and provides
  only `template_main()` will stop being called, so this is worth a line in the
  upgrade notes whenever those get written. Nothing in the repository refers to
  the old name — I checked `Sources/`, `Themes/` and `SSI.php` — and
  `boardindex_outer` has no other references either.
- The class docblock said "and main sub template", which is no longer true, so it
  now names the three.
- This is deliberately only the structural change. The theme branch also rewrites
  the markup of all three (`board_container`, `board_info`, the info centre's
  `info_block` / `info_block_icon` split, an avatar in the last-post column) and
  those need their `index.css` slice with them, so they follow separately.

### Issues References (Fixes|Related|Closes)

Related to #7933
