### PR TITLE
[3.0] Theme split (wave 4, part 3) — fix the auto-submitting continue buttons

### DIFF
--- a/Themes/default/MaintenanceTemplate.php
+++ b/Themes/default/MaintenanceTemplate.php
@@ -443,7 +443,9 @@ abstract class MaintenanceTemplate
 									document.getElementById("contbutt").disabled = 0;
 									document.getElementById("' . $done_param . '").value = 1;
 
-									setTimeout("doAutoSubmit();", 1000);
+									setTimeout(function() {
+										doAutoSubmit(0, "", "' . Maintenance::$tool->form_id . '", "contbutt");
+									}, 1000);
 								} else {
 									getNextSubstep();
 								}

--- a/Themes/default/ManageNews.template.php
+++ b/Themes/default/ManageNews.template.php
@@ -392,7 +392,7 @@ function template_email_members_send()
 					<div class="bar" style="width: ', Utils::$context['percentage_done'], '%;"></div>
 				</div>
 				<hr>
-				<input type="submit" name="b" value="', Lang::getTxt('email_continue', file: 'Admin'), '" class="button">
+				<input type="submit" name="cont" value="', Lang::getTxt('email_continue', file: 'Admin'), '" class="button">
 				<input type="hidden" name="', Utils::$context['session_var'], '" value="', Utils::$context['session_id'], '">
 				<input type="hidden" name="subject" value="', Utils::$context['subject'], '">
 				<input type="hidden" name="message" value="', Utils::$context['message'], '">
@@ -413,9 +413,9 @@ function template_email_members_send()
 			</div><!-- .windowbg -->
 		</form>
 
-	<script>
-			doAutoSubmit(2, ', Utils::escapeJavaScript(Lang::getTxt('email_continue', file: 'Admin')), ', "autoSubmit", "b");
-	</script>';
+		<script>
+			doAutoSubmit(2, ', Utils::escapeJavaScript(Lang::getTxt('email_continue', file: 'Admin')), ');
+		</script>';
 }
 
 /**

--- a/Themes/default/ManageSearch.template.php
+++ b/Themes/default/ManageSearch.template.php
@@ -323,7 +323,7 @@ function template_create_index_progress()
 				</div>
 			</div>
 			<hr>
-			<input type="submit" name="b" value="', Lang::getTxt('search_create_index_continue', file: 'Search'), '" class="button">
+			<input type="submit" name="cont" value="', Lang::getTxt('search_create_index_continue', file: 'Search'), '" class="button">
 		</div>
 		<input type="hidden" name="step" value="', Utils::$context['step'], '">
 		<input type="hidden" name="start" value="', Utils::$context['start'], '">
@@ -331,9 +331,8 @@ function template_create_index_progress()
 		<input type="hidden" name="', Utils::$context['session_var'], '" value="', Utils::$context['session_id'], '">
 	</form>
 	<script>
-		doAutoSubmit(10, ', Utils::escapeJavaScript(Lang::getTxt('search_create_index_continue', file: 'Search')), ', "autoSubmit", "b");
+		doAutoSubmit(10, ', Utils::escapeJavaScript(Lang::getTxt('search_create_index_continue', file: 'Search')), ');
 	</script>';
-
 }
 
 /**

--- a/Themes/default/Post.template.php
+++ b/Themes/default/Post.template.php
@@ -857,7 +857,7 @@ function template_announcement_send()
 				</div>
 				<hr>
 				<div id="confirm_buttons">
-					<input type="submit" name="b" value="', Lang::getTxt('announce_continue', file: 'Post'), '" class="button">
+					<input type="submit" name="cont" value="', Lang::getTxt('announce_continue', file: 'Post'), '" class="button">
 					<input type="hidden" name="', Utils::$context['session_var'], '" value="', Utils::$context['session_id'], '">
 					<input type="hidden" name="topic" value="', Utils::$context['current_topic'], '">
 					<input type="hidden" name="move" value="', Utils::$context['move'], '">
@@ -871,7 +871,7 @@ function template_announcement_send()
 	</div><!-- #announcement -->
 	<br>
 	<script>
-		doAutoSubmit(2, ', Utils::escapeJavaScript(Lang::getTxt('announce_continue', file: 'Post')), ', "autoSubmit", "b");
+		doAutoSubmit(2, ', Utils::escapeJavaScript(Lang::getTxt('announce_continue', file: 'Post')), ');
 	</script>';
 }
 


### PR DESCRIPTION
#### Description

Part of the split of #7933, wave 4 part 3.

`doAutoSubmit()` finds the countdown button by name, defaulting to `cont`:

```js
function doAutoSubmit(countdown, txtMessage, formName = 'autoSubmit', fieldName = 'cont') {
	const form = document.forms[formName];
	...
	const contField = form.elements[fieldName];
```

`template_not_done()` names its button `cont` and calls it with the defaults. Three
other progress pages — the newsletter, the search index and the announcement —
name theirs `b` and pass `"autoSubmit", "b"` to compensate. They work, but only
because every one of them remembers to repeat the argument.

This renames those three to `cont` and drops the redundant arguments, so all four
agree with the default.

It is worth doing deliberately rather than leaving alone, because the theme branch
renames all three buttons and leaves the `"b"` argument in place. I measured what
that combination does:

| markup | call | countdown field after `doAutoSubmit(3, 'Continue')` |
|---|---|---|
| `name="cont"` | defaults (this PR) | `Continue (3)` |
| `name="cont"` | `"autoSubmit", "b"` (the branch) | `Continue` — countdown lost |
| `name="b"` | `"autoSubmit", "b"` (today) | `Continue (3)` |

The middle row takes the `console.warn('Field "b" not found…')` path. The form still
submits when the count runs out, so nothing breaks loudly; the countdown just stops
appearing.

#### The maintenance template had already drifted the other way

`MaintenanceTemplate.php` calls it with no arguments at all:

```js
setTimeout("doAutoSubmit();", 1000);
```

so it looks for a form named `autoSubmit`. There isn't one. The installer and the
upgrader name their form from `Maintenance::$tool->form_id`, which is `install_form`
or `upgrade_form` — I checked the served page, and `<form id="install_form" …>` is
the only form on it. `doAutoSubmit()` hits `console.error('Form with name
"autoSubmit" not found.')` and returns, so **the step that should continue by itself
once its substeps finish just waits for the user to click Continue.**

It now names the form it is actually on. Also passes a function to `setTimeout()`
rather than a string for it to eval.

#### Testing

The table above is real output: `doAutoSubmit()` run against each markup/call
combination in the browser on this build.

For the maintenance template, the fix is against the rendered installer — its only
form is `install_form`, so the old lookup could never have matched. I have not
driven a full install or upgrade to watch the countdown; the substep loop it sits
in needs one, and this is the kind of change where saying what was and was not
exercised seems more useful than implying otherwise.

### Issues References (Fixes|Related|Closes)

Related to #7933
