### PR TITLE
[3.0] Import the classes the theme actions actually use

### DIFF
--- a/Sources/Actions/ThemeChooser.php
+++ b/Sources/Actions/ThemeChooser.php
@@ -18,7 +18,7 @@ namespace SMF\Actions;
 use SMF\ActionInterface;
 use SMF\ActionRouter;
 use SMF\ActionTrait;
-use SMF\CacheApi;
+use SMF\Cache\CacheApi;
 use SMF\Config;
 use SMF\Db\DatabaseApi as Db;
 use SMF\Lang;
@@ -26,6 +26,7 @@ use SMF\Routable;
 use SMF\SecurityToken;
 use SMF\Theme;
 use SMF\User;
+use SMF\UserDataset;
 use SMF\Utils;
 
 /**

--- a/Sources/Actions/ThemeSetOption.php
+++ b/Sources/Actions/ThemeSetOption.php
@@ -18,7 +18,7 @@ namespace SMF\Actions;
 use SMF\ActionInterface;
 use SMF\ActionRouter;
 use SMF\ActionTrait;
-use SMF\CacheApi;
+use SMF\Cache\CacheApi;
 use SMF\Db\DatabaseApi as Db;
 use SMF\Routable;
 use SMF\Theme;


### PR DESCRIPTION
#### Description

`SMF\Actions\ThemeChooser` uses `UserDataset` without importing it, so choosing a
theme for a member fatals:

```
Class "SMF\Actions\UserDataset" not found
```

I hit this from the UI: Admin → Themes → *Choose a theme*, pick one, submit. The
member's theme is never saved and the page is replaced by the error. It is logged
in `smf_log_errors` against `?action=themechooser`.

The same file, and `SMF\Actions\ThemeSetOption`, also import `SMF\CacheApi`. There
is no such class — it is `SMF\Cache\CacheApi`; `Sources/CacheApi.php` does not
exist and nothing aliases the short name. `BackwardCompatibility::exportStatic()`
returns immediately when `$backward_compatibility` is empty, which it is by
default in both `Settings.php` and the shipped `other/Settings.php`.

`ThemeChooser` reaches its `CacheApi::put()` only when a theme variant was chosen,
and the bundled theme ships no variants, which is presumably why this has gone
unnoticed. `ThemeSetOption` calls it on both of its paths.

#### Testing

Before, on `release-3.0` (`a7ac468b1`): submitting the theme picker gives the
error above and `smf_members.id_theme` is unchanged.

After: the same submission redirects to `?action=profile;area=theme;u=1`, which is
the success path, and nothing new appears in `smf_log_errors`.

`composer lint` is clean on both files.

Found while testing the theme picker for the #7933 split.

### Issues References (Fixes|Related|Closes)

Related to #7933
