### PR TITLE
[3.0] Theme split (wave 4, part 4) — close the theme picker's form

### DIFF
--- a/Themes/default/Themes.template.php
+++ b/Themes/default/Themes.template.php
@@ -771,11 +771,15 @@ function template_pick()
 		}
 
 		echo '
-		</div>
+		</div>';
+	}
+
+	// One set of these for the form, not one per pass of the loop above.
+	echo '
 		<input type="hidden" name="', Utils::$context['session_var'], '" value="', Utils::$context['session_id'], '">
 		<input type="hidden" name="', Utils::$context['pick-th_token_var'], '" value="', Utils::$context['pick-th_token'], '">
-		<input type="hidden" name="u" value="', Utils::$context['current_member'], '">';
-	}
+		<input type="hidden" name="u" value="', Utils::$context['current_member'], '">
+	</form>';
 }
 
 /**


### PR DESCRIPTION
#### Description

Part of the split of #7933, wave 4 part 4. The theme picker, `template_pick()` in
`Themes.template.php`.

Two things wrong with it, both visible in the served page:

**The form is never closed.** `<form action="…?action=themechooser" …>` is opened
and there is no `</form>`, so where the form ends is left to the browser's error
recovery rather than to the markup.

**The hidden fields are echoed twice.** They sit inside the `for ($i = 0; $i < 2;
$i++)` loop that draws the current theme in one pass and everything else in the
other, so the session variable, the security token and `u` are each emitted once
per pass.

#### Testing

Measured on the rendered page at `?action=themechooser;u=1`, counting the fields
of the picker form:

| | fields | duplicated |
|---|---|---|
| `release-3.0` | 8 | session var ×2, `pick-th` token ×2, `u` ×2 |
| this branch | 5 | none |

Both `save[…]` buttons and both theme sections are still inside the form
afterwards, and submitting it still saves the theme.

To submit it at all I first needed #9387 — `ThemeChooser` fatals on an unimported
class before it gets as far as saving. That one is a separate PR since it is a
`Sources/` bug rather than a template one.

The one thing I would flag: the browser does not, in practice, swallow the footer
into the unclosed form — it closes it at the enclosing element. So this is invalid
markup and duplicated fields rather than anything user-visible today.

### Issues References (Fixes|Related|Closes)

Related to #7933
