### PR TITLE
[3.0] Stop the package browser dying without a cached version list

### DIFF
--- a/Sources/PackageManager/PackageManager.php
+++ b/Sources/PackageManager/PackageManager.php
@@ -1704,9 +1704,13 @@ class PackageManager
 		Db::$db->free_result($get_versions);
 
 		// Decode the data.
-		$items = Utils::jsonDecode($data['data'], true);
+		// This list is fetched from simplemachines.org and cached in the
+		// database. A forum that has never managed to reach it — a fresh
+		// install, or one with no outbound access — has nothing stored, and
+		// jsonDecode() hands back null rather than a list of versions.
+		$items = Utils::jsonDecode($data['data'] ?? '', true);
 
-		Utils::$context['emulation_versions'] = preg_replace('~^SMF ~', '', $items);
+		Utils::$context['emulation_versions'] = \is_array($items) ? preg_replace('~^SMF ~', '', $items) : [];
 
 		// Current SMF version, which is selected by default
 		Utils::$context['default_version'] = SMF_VERSION;


### PR DESCRIPTION
#### Description

`PackageManager::browse()` cannot render on a forum that has never fetched the
version list from simplemachines.org:

```
in_array(): Argument #2 ($haystack) must be of type array, string given
```

The whole Package Manager → Browse Packages page is replaced by that error.

The emulation version list is fetched from simplemachines.org and cached in
`admin_info_files`. `browse()` reads it and passes it straight on:

```php
$items = Utils::jsonDecode($data['data'], true);

Utils::$context['emulation_versions'] = preg_replace('~^SMF ~', '', $items);
```

`Utils::jsonDecode()` opens with `if (empty($json)) { return null; }`, so with
nothing cached `$items` is null, `preg_replace()` returns null rather than an
array, and `in_array()` on the next line rejects it.

Every fresh install is in that state until the first successful fetch, and any
forum without outbound access is in it permanently. On mine all four rows of
`admin_info_files` are zero-length:

```
filename              len
current-version.js    0
detailed-version.js   0
latest-news.js        0
latest-versions.txt   0
```

Falls back to an empty list. The three lines below already cope with that — they
add the running version to the list if it is not in it — so the dropdown offers
the current version rather than nothing.

`$data` also gets a `?? ''`, since `fetch_assoc()` returns false when there is no
row at all rather than a row with an empty column.

#### Testing

On a clean install of `release-3.0` (`a7ac468b1`), MySQL, with no outbound access:

- Before: `?action=admin;area=packages;sa=browse` shows the error above, and the
  page has only the "Package Manager" heading.
- After: the page renders in full — "Obtaining Packages" and "Emulation Support"
  sections, the advanced panel, and the emulation dropdown offering
  `3.0 Alpha 4`, selected.

`composer lint` is clean.

Found while testing the package browser for the #7933 split.

### Issues References (Fixes|Related|Closes)

Related to #7933
