### PR TITLE
[3.0] Theme split (wave 4, part 5) — move the collapse toggles out of their headings

### DIFF
--- a/Themes/default/BoardIndex.template.php
+++ b/Themes/default/BoardIndex.template.php
@@ -75,17 +75,17 @@ function template_main()
 		echo '
 		<div class="main_container">
 			<div class="cat_bar ', $category['is_collapsed'] ? 'collapsed' : '', '" id="category_', $category['id'], '">
-				<h3 class="catbg">';
+				<h3 class="catbg">
+					', $category['link'], '
+				</h3>';
 
 		// If this category even can collapse, show a link to collapse it.
 		if ($category['can_collapse']) {
 			echo '
-					<span id="category_', $category['id'], '_upshrink" class="', $category['is_collapsed'] ? 'toggle_down' : 'toggle_up', ' floatright" data-collapsed="', (int) $category['is_collapsed'], '" title="', Lang::getTxt(!$category['is_collapsed'] ? 'hide_category' : 'show_category', file: 'General'), '" style="display: none;"></span>';
+				<span id="category_', $category['id'], '_upshrink" class="', $category['is_collapsed'] ? 'toggle_down' : 'toggle_up', '" data-collapsed="', (int) $category['is_collapsed'], '" title="', Lang::getTxt(!$category['is_collapsed'] ? 'hide_category' : 'show_category', file: 'General'), '" style="display: none;"></span>';
 		}
 
-		echo '
-					', $category['link'], '
-				</h3>', !empty($category['description']) ? '
+		echo !empty($category['description']) ? '
 				<div class="desc">' . $category['description'] . '</div>' : '', '
 			</div>
 			<div id="category_', $category['id'], '_boards" ', (!empty($category['css_class']) ? ('class="' . $category['css_class'] . '"') : ''), $category['is_collapsed'] ? ' style="display: none;"' : '', '>';
@@ -302,9 +302,9 @@ function template_info_center()
 	<div class="roundframe" id="info_center">
 		<div class="title_bar">
 			<h3 class="titlebg">
-				<span class="toggle_up floatright" id="upshrink_ic" title="', Lang::getTxt('hide_infocenter', file: 'General'), '" style="display: none;"></span>
 				<a href="#" id="upshrink_link">', Lang::getTxt('info_center_title', ['forum_name' => Utils::$context['forum_name_html_safe']], file: 'General'), '</a>
 			</h3>
+			<span class="toggle_up" id="upshrink_ic" title="', Lang::getTxt('hide_infocenter', file: 'General'), '" style="display: none;"></span>
 		</div>
 		<div id="upshrink_stats"', empty(Theme::$current->options['collapse_header_ic']) ? '' : ' style="display: none;"', '>';
 

--- a/Themes/default/ManageNews.template.php
+++ b/Themes/default/ManageNews.template.php
@@ -54,9 +54,9 @@ function template_email_members()
 				</dl>
 				<div id="advanced_panel_header" class="title_bar">
 					<h3 class="titlebg">
-						<span id="advanced_panel_toggle" class="toggle_down floatright" style="display: none;"></span>
 						<a href="#" id="advanced_panel_link">', Lang::getTxt('advanced', file: 'Admin'), '</a>
 					</h3>
+					<span id="advanced_panel_toggle" class="toggle_down" style="display: none;"></span>
 				</div>
 				<div id="advanced_panel_div" class="padding">
 					<dl class="settings">

--- a/Themes/default/ManagePermissions.template.php
+++ b/Themes/default/ManagePermissions.template.php
@@ -119,9 +119,9 @@ function template_permission_index()
 		echo '
 			<div class="cat_bar">
 				<h3 class="catbg">
-					<span id="permissions_panel_toggle" class="', empty(Utils::$context['show_advanced_options']) ? 'toggle_down' : 'toggle_up', ' floatright" style="display: none;"></span>
 					<a href="#" id="permissions_panel_link">', Lang::getTxt('permissions_advanced_options', file: 'ManagePermissions'), '</a>
 				</h3>
+				<span id="permissions_panel_toggle" class="', empty(Utils::$context['show_advanced_options']) ? 'toggle_down' : 'toggle_up', '" style="display: none;"></span>
 			</div>
 			<div id="permissions_panel_advanced" class="windowbg">
 				<fieldset>

--- a/Themes/default/ModerationCenter.template.php
+++ b/Themes/default/ModerationCenter.template.php
@@ -48,9 +48,9 @@ function template_group_requests_block()
 	echo '
 		<div class="cat_bar">
 			<h3 class="catbg">
-				<span id="group_requests_toggle" class="', !empty(Utils::$context['admin_prefs']['mcgr']) ? 'toggle_down' : 'toggle_up', ' floatright" title="', Lang::getTxt(empty(Utils::$context['admin_prefs']['mcgr']) ? 'hide' : 'show', file: 'General'), '" style="display: none;"></span>
 				<a href="', Config::$scripturl, '?action=groups;sa=requests" id="group_requests_link">', Lang::getTxt('mc_group_requests', file: 'ModerationCenter'), '</a>
 			</h3>
+			<span id="group_requests_toggle" class="', !empty(Utils::$context['admin_prefs']['mcgr']) ? 'toggle_down' : 'toggle_up', '" title="', Lang::getTxt(empty(Utils::$context['admin_prefs']['mcgr']) ? 'hide' : 'show', file: 'General'), '" style="display: none;"></span>
 		</div>
 		<div class="windowbg" id="group_requests_panel">
 			<ul>';
@@ -115,9 +115,9 @@ function template_watched_users()
 	echo '
 		<div class="cat_bar">
 			<h3 class="catbg">
-				<span id="watched_users_toggle" class="', !empty(Utils::$context['admin_prefs']['mcwu']) ? 'toggle_down' : 'toggle_up', ' floatright" title="', Lang::getTxt(empty(Utils::$context['admin_prefs']['mcwu']) ? 'hide' : 'show', file: 'General'), '" style="display: none;"></span>
 				<a href="', Config::$scripturl, '?action=moderate;area=userwatch" id="watched_users_link">', Lang::getTxt('mc_watched_users', file: 'ModerationCenter'), '</a>
 			</h3>
+			<span id="watched_users_toggle" class="', !empty(Utils::$context['admin_prefs']['mcwu']) ? 'toggle_down' : 'toggle_up', '" title="', Lang::getTxt(empty(Utils::$context['admin_prefs']['mcwu']) ? 'hide' : 'show', file: 'General'), '" style="display: none;"></span>
 		</div>
 		<div class="windowbg" id="watched_users_panel">
 			<ul>';
@@ -182,9 +182,9 @@ function template_reported_posts_block()
 	echo '
 		<div class="cat_bar">
 			<h3 class="catbg">
-				<span id="reported_posts_toggle" class="', !empty(Utils::$context['admin_prefs']['mcrp']) ? 'toggle_down' : 'toggle_up', ' floatright" title="', Lang::getTxt(empty(Utils::$context['admin_prefs']['mcrp']) ? 'hide' : 'show', file: 'General'), '" style="display: none;"></span>
 				<a href="', Config::$scripturl, '?action=moderate;area=reportedposts" id="reported_posts_link">', Lang::getTxt('mc_recent_reports', file: 'ModerationCenter'), '</a>
 			</h3>
+			<span id="reported_posts_toggle" class="', !empty(Utils::$context['admin_prefs']['mcrp']) ? 'toggle_down' : 'toggle_up', '" title="', Lang::getTxt(empty(Utils::$context['admin_prefs']['mcrp']) ? 'hide' : 'show', file: 'General'), '" style="display: none;"></span>
 		</div>
 		<div class="windowbg" id="reported_posts_panel">
 			<ul>';
@@ -249,9 +249,9 @@ function template_reported_users_block()
 	echo '
 		<div class="cat_bar">
 			<h3 class="catbg">
-				<span id="reported_users_toggle" class="', !empty(Utils::$context['admin_prefs']['mcur']) ? 'toggle_down' : 'toggle_up', ' floatright" title="', Lang::getTxt(empty(Utils::$context['admin_prefs']['mcur']) ? 'hide' : 'show', file: 'General'), '" style="display: none;"></span>
 				<a href="', Config::$scripturl, '?action=moderate;area=userwatch" id="reported_users_link">', Lang::getTxt('mc_recent_user_reports', file: 'ModerationCenter'), '</a>
 			</h3>
+			<span id="reported_users_toggle" class="', !empty(Utils::$context['admin_prefs']['mcur']) ? 'toggle_down' : 'toggle_up', '" title="', Lang::getTxt(empty(Utils::$context['admin_prefs']['mcur']) ? 'hide' : 'show', file: 'General'), '" style="display: none;"></span>
 		</div>
 		<div class="windowbg" id="reported_users_panel">
 			<ul>';

--- a/Themes/default/Packages.template.php
+++ b/Themes/default/Packages.template.php
@@ -629,9 +629,9 @@ function template_browse()
 			<div id="advanced_box">
 				<div class="cat_bar">
 					<h3 class="catbg">
-						<span id="advanced_panel_toggle" class="floatright" style="display: none;"></span>
 						<a href="#" id="advanced_panel_link">', Lang::getTxt('package_advanced_button', file: 'Packages'), '</a>
 					</h3>
+					<span id="advanced_panel_toggle" class="toggle_down" style="display: none;"></span>
 				</div>
 				<div id="advanced_panel_div" class="windowbg">
 					<p>

--- a/Themes/default/PersonalMessage.template.php
+++ b/Themes/default/PersonalMessage.template.php
@@ -839,8 +839,9 @@ function template_search()
 			<div class="roundframe alt">
 				<div class="title_bar">
 					<h3 class="titlebg">
-						<span id="advanced_panel_toggle" class="toggle_up floatright" style="display: none;"></span><a href="#" id="advanced_panel_link">', Lang::getTxt('pm_search_choose_label', file: 'PersonalMessage'), '</a>
+						<a href="#" id="advanced_panel_link">', Lang::getTxt('pm_search_choose_label', file: 'PersonalMessage'), '</a>
 					</h3>
+					<span id="advanced_panel_toggle" class="toggle_up" style="display: none;"></span>
 				</div>
 				<div id="advanced_panel_div">
 					<ul id="search_labels">';
@@ -1097,8 +1098,9 @@ function template_send()
 		echo '
 				<div id="post_draft_options_header" class="title_bar">
 					<h4 class="titlebg">
-						<span id="postDraftExpand" class="toggle_up floatright" style="display: none;"></span> <strong><a href="#" id="postDraftExpandLink">', Lang::getTxt('drafts_show', file: 'Drafts'), '</a></strong>
+						<strong><a href="#" id="postDraftExpandLink">', Lang::getTxt('drafts_show', file: 'Drafts'), '</a></strong>
 					</h4>
+					<span id="postDraftExpand" class="toggle_up" style="display: none;"></span>
 				</div>
 				<div id="post_draft_options">
 					<dl class="settings">

--- a/Themes/default/Post.template.php
+++ b/Themes/default/Post.template.php
@@ -409,8 +409,9 @@ function template_main()
 		echo '
 					<div id="post_draft_options_header" class="title_bar">
 						<h4 class="titlebg">
-							<span id="postDraftExpand" class="toggle_up floatright" style="display: none;"></span> <strong><a href="#" id="postDraftExpandLink">', Lang::getTxt('drafts_show', file: 'Drafts'), '</a></strong>
+							<strong><a href="#" id="postDraftExpandLink">', Lang::getTxt('drafts_show', file: 'Drafts'), '</a></strong>
 						</h4>
+						<span id="postDraftExpand" class="toggle_up" style="display: none;"></span>
 					</div>
 					<div id="post_draft_options">
 						<dl class="settings">

--- a/Themes/default/ReportedContent.template.php
+++ b/Themes/default/ReportedContent.template.php
@@ -115,9 +115,9 @@ function template_reported_posts_block()
 	echo '
 		<div class="cat_bar">
 			<h3 class="catbg">
-				<span id="reported_posts_toggle" class="', !empty(Utils::$context['admin_prefs']['mcrp']) ? 'toggle_down' : 'toggle_up', ' floatright" style="display: none;"></span>
 				<a href="', Config::$scripturl, '?action=moderate;area=reportedposts" id="reported_posts_link">', Lang::getTxt('mc_recent_reports', file: 'ModerationCenter'), '</a>
 			</h3>
+			<span id="reported_posts_toggle" class="', !empty(Utils::$context['admin_prefs']['mcrp']) ? 'toggle_down' : 'toggle_up', '" style="display: none;"></span>
 		</div>
 		<div class="windowbg" id="reported_posts_panel">
 			<div class="modbox">
@@ -334,9 +334,9 @@ function template_reported_members_block()
 	echo '
 		<div class="cat_bar">
 			<h3 class="catbg">
-				<span id="reported_members_toggle" class="', !empty(Utils::$context['admin_prefs']['mcru']) ? 'toggle_down' : 'toggle_up', ' floatright" style="display: none;"></span>
 				<a href="', Config::$scripturl, '?action=moderate;area=reportedmembers" id="reported_members_link">', Lang::getTxt('mc_recent_member_reports', file: 'ModerationCenter'), '</a>
 			</h3>
+			<span id="reported_members_toggle" class="', !empty(Utils::$context['admin_prefs']['mcru']) ? 'toggle_down' : 'toggle_up', '" style="display: none;"></span>
 		</div>
 		<div class="windowbg" id="reported_users_panel">
 			<div class="modbox">

--- a/Themes/default/Search.template.php
+++ b/Themes/default/Search.template.php
@@ -159,9 +159,9 @@ function template_main()
 			<div class="roundframe alt">
 				<div class="title_bar">
 					<h4 class="titlebg">
-						<span id="advanced_panel_toggle" class="toggle_down floatright" style="display: none;"></span>
 						<a href="#" id="advanced_panel_link">', Lang::getTxt('choose_board', file: 'Search'), '</a>
 					</h4>
+					<span id="advanced_panel_toggle" class="toggle_down" style="display: none;"></span>
 				</div>
 				<div class="flow_auto boardslist" id="advanced_panel_div"', !empty(Utils::$context['boards_check_all']) ? ' style="display: none;"' : '', '>
 					<ul>';

--- a/Themes/default/css/index.css
+++ b/Themes/default/css/index.css
@@ -3964,6 +3964,32 @@ div.cat_bar {
 .cat_bar h3 {
 	padding: 8px 12px 6px 12px;
 }
+/* Both bars are a row: the heading takes whatever is left, and anything sitting
+/* beside it — a collapse toggle, a link — goes at the end. Deliberately only
+/* when the bar is a div: .title_bar is also put on a <tr>, and turning that into
+/* a flex row would take the table apart. */
+div.cat_bar,
+div.title_bar {
+	align-items: center;
+	display: flex;
+	flex-wrap: wrap;
+}
+div.cat_bar > h3,
+div.title_bar > h3,
+div.title_bar > h4 {
+	flex: 1;
+}
+/* A category's description belongs under its heading rather than beside it. */
+div.cat_bar > .desc {
+	flex-basis: 100%;
+}
+/* The toggles used to sit inside the heading and take its padding with them. */
+div.cat_bar > .toggle_up,
+div.cat_bar > .toggle_down,
+div.title_bar > .toggle_up,
+div.title_bar > .toggle_down {
+	margin-inline-end: 12px;
+}
 /* Styles for rounded headers. */
 .cat_bar .desc {
 	color: var(--catbar-color);


### PR DESCRIPTION
#### Description

Part of the split of #7933, wave 4 part 5.

Every collapsible panel in the forum puts its collapse toggle *inside* the
heading and floats it right:

```php
<h3 class="catbg">
	<span id="group_requests_toggle" class="… floatright" …></span>
	<a href="…">Membergroup Requests</a>
</h3>
```

So a control that acts on the whole panel is a child of the panel's title. It
reads oddly to a screen reader, and it means the heading cannot simply be the
heading.

This makes `.cat_bar` and `.title_bar` flex rows so a sibling can sit beside the
heading, and moves the toggles out. Twelve of them, across nine templates.

**Only where the bar is a `div`.** `.title_bar` is also put on a `<tr>` — the
permissions table is one — and turning that into a flex row would take the table
apart. The selectors are `div.cat_bar` and `div.title_bar` for that reason, and I
checked: `tr.title_bar` still computes to `display: table-row`.

The category description on the board index is a sibling of its heading too, so it
gets `flex-basis: 100%` to stay under the heading rather than moving beside it.

#### One small thing fixed on the way

The package browser's advanced toggle carried no `toggle_down` or `toggle_up`
class at all — only `floatright`. Those classes are what create the `::before`
that draws the icon, so it was an empty span with nothing in it. It now starts
collapsed, like the identical toggle on the newsletter page, and draws a 17×17
icon.

(You need #9389 to see that page at all on a forum that has never fetched the
version list from simplemachines.org.)

#### Testing

The toggles land in the same place. Board index, measured on both branches:

| | `release-3.0` | this branch |
|---|---|---|
| category toggle | x 619, 28×21 | x 619, 28×21 |
| info centre toggle | x 602, 28×20 | x 602, 28×21 |
| category bar | 612×36 | 612×35 |
| category heading | 612 wide | 571 wide |

The bar is a pixel shorter and the toggle sits two pixels higher, because it is
now centred in the row rather than floated inside a padded heading. The heading is
narrower because the toggle takes its own space instead of overlapping it.

Across the affected pages, every toggle is 12–13px from the end of its bar, clear
of the heading (no overlap), on the same row, and drawing its icon:

- moderation centre — all four
- permissions → advanced options
- search → choose boards
- personal messages → choose labels
- newsletters → advanced
- package browser → advanced
- board index — category and info centre

They still work: clicking the membergroup-requests toggle collapses the panel and
flips `toggle_up` → `toggle_down`; clicking the newsletter one expands its panel
and flips the other way.

RTL is measured rather than assumed — the toggle is 13px from the right edge under
`dir="ltr"` and 13px from the left edge under `dir="rtl"`.

`composer lint` is clean on all nine templates.

#### Not done here

The theme branch's version of this block also tokenises the two bars — roughly
forty new `--catbg-*` custom properties. That is a separate change and wants its
own PR; one of them (`--catbg-border-color` where `--catbar-border-color` is
meant) is exactly the undefined-token case discussed on #7933, so it needs reading
rather than copying. Only the layout is taken here.

### Issues References (Fixes|Related|Closes)

Related to #7933
