### PR TITLE
[3.0] Theme split (wave 4, part 6) — use logical properties in the direction-branching inline styles

### DIFF
--- a/Themes/default/ManageBoards.template.php
+++ b/Themes/default/ManageBoards.template.php
@@ -70,7 +70,7 @@ function template_main()
 		// List through every board in the category, printing its name and link to modify the board.
 		foreach ($category['boards'] as $board) {
 			echo '
-					<li', !empty(Config::$modSettings['recycle_board']) && !empty(Config::$modSettings['recycle_enable']) && Config::$modSettings['recycle_board'] == $board['id'] ? ' id="recycle_board"' : ' ', ' class="windowbg', $board['is_redirect'] ? ' redirect_board' : '', '" style="padding-' . (Utils::$context['right_to_left'] ? 'right' : 'left') . ': ', 5 + 30 * $board['child_level'], 'px;">
+					<li', !empty(Config::$modSettings['recycle_board']) && !empty(Config::$modSettings['recycle_enable']) && Config::$modSettings['recycle_board'] == $board['id'] ? ' id="recycle_board"' : ' ', ' class="windowbg', $board['is_redirect'] ? ' redirect_board' : '', '" style="padding-inline-start: ', 5 + 30 * $board['child_level'], 'px;">
 						<span class="floatleft"><a', $board['move'] ? ' class="red"' : '', ' href="', Config::$scripturl, '?board=', $board['id'], '.0">', $board['name'], '</a>', !empty(Config::$modSettings['recycle_board']) && !empty(Config::$modSettings['recycle_enable']) && Config::$modSettings['recycle_board'] == $board['id'] ? $recycle_board : '', $board['is_redirect'] ? $redirect_board : '', '</span>
 						<span class="floatright">
 							', Utils::$context['can_manage_permissions'] ? '<a href="' . Config::$scripturl . '?action=admin;area=permissions;sa=index;pid=' . $board['permission_profile'] . ';' . Utils::$context['session_var'] . '=' . Utils::$context['session_id'] . '" class="button">' . Lang::getTxt('mboards_permissions', file: 'ManageBoards') . '</a>' : '', '
@@ -81,7 +81,7 @@ function template_main()
 
 			if (!empty($board['move_links'])) {
 				echo '
-					<li class="windowbg" style="padding-', Utils::$context['right_to_left'] ? 'right' : 'left', ': ', 5 + 30 * $board['move_links'][0]['child_level'], 'px;">';
+					<li class="windowbg" style="padding-inline-start: ', 5 + 30 * $board['move_links'][0]['child_level'], 'px;">';
 
 				foreach ($board['move_links'] as $link) {
 					echo '

--- a/Themes/default/ManageMaintenance.template.php
+++ b/Themes/default/ManageMaintenance.template.php
@@ -330,7 +330,7 @@ function template_maintain_topics()
 		// Display a checkbox with every board.
 		foreach ($category['boards'] as $board) {
 			echo '
-									<li style="margin-', Utils::$context['right_to_left'] ? 'right' : 'left', ': ', $board['child_level'] * 1.5, 'em;">
+									<li style="margin-inline-start: ', $board['child_level'] * 1.5, 'em;">
 										<label for="boards_', $board['id'], '"><input type="checkbox" name="boards[', $board['id'], ']" id="boards_', $board['id'], '" checked>', $board['name'], '</label>
 									</li>';
 		}

--- a/Themes/default/ManageMembergroups.template.php
+++ b/Themes/default/ManageMembergroups.template.php
@@ -488,13 +488,13 @@ function template_add_edit_group_boards_list($collapse = true, $form_id = 'new_g
 		foreach ($category['boards'] as $board) {
 			if (empty(Config::$modSettings['deny_boards_access'])) {
 				echo '
-											<li class="board" style="margin-', Utils::$context['right_to_left'] ? 'right' : 'left', ' ', $board['child_level'], 'em;">
+											<li class="board" style="margin-inline-start: ', $board['child_level'], 'em;">
 												<input type="checkbox" name="boardaccess[', $board['id'], ']" id="brd', $board['id'], '" value="allow"', $board['allow'] ? ' checked' : '', '> <label for="brd', $board['id'], '">', $board['name'], '</label>
 											</li>';
 			} else {
 			echo '
 											<li class="board clear">
-												<span style="margin-', Utils::$context['right_to_left'] ? 'right' : 'left', ': ', $board['child_level'], 'em;">', $board['name'], ': </span>
+												<span style="margin-inline-start: ', $board['child_level'], 'em;">', $board['name'], ': </span>
 												<span class="floatright">
 													<input type="radio" name="boardaccess[', $board['id'], ']" id="allow_brd', $board['id'], '" value="allow"', $board['allow'] ? ' checked' : '', '> <label for="allow_brd', $board['id'], '">', Lang::getTxt('permissions_option_on', file: 'ManagePermissions'), '</label>
 													<input type="radio" name="boardaccess[', $board['id'], ']" id="ignore_brd', $board['id'], '" value="ignore"', !$board['allow'] && !$board['deny'] ? ' checked' : '', '> <label for="ignore_brd', $board['id'], '">', Lang::getTxt('permissions_option_off', file: 'ManagePermissions'), '</label>

--- a/Themes/default/Profile.template.php
+++ b/Themes/default/Profile.template.php
@@ -2301,7 +2301,7 @@ function template_ignoreboards()
 
 			if ($next_child_level > $curr_child_level) {
 				echo '
-								<ul style="margin-', Utils::$context['right_to_left'] ? 'right' : 'left', ': 2.5ch;">';
+								<ul style="margin-inline-start: 2.5ch;">';
 			} else {
 				// Close child board lists until we reach a common level
 				// with the next board.

--- a/Themes/default/Search.template.php
+++ b/Themes/default/Search.template.php
@@ -188,7 +188,7 @@ function template_main()
 
 				if ($next_child_level > $curr_child_level) {
 					echo '
-									<ul style="margin-', Utils::$context['right_to_left'] ? 'right' : 'left', ': 2.5ch;">';
+									<ul style="margin-inline-start: 2.5ch;">';
 				} else {
 					// Close child board lists until we reach a common level
 					// with the next board.


### PR DESCRIPTION
#### Description

Part of the split of #7933, wave 4 part 6.

Seven inline styles pick their side by hand:

```php
style="margin-', Utils::$context['right_to_left'] ? 'right' : 'left', ': ', …
```

which is what `margin-inline-start` and `padding-inline-start` already mean. The
values are unchanged; only the branch goes. Six templates: `ManageBoards`,
`ManageMaintenance`, `ManageMembergroups`, `Profile`, `Search`.

#### One of the seven never worked

The board list on the membergroup editor writes the declaration with a space where
the colon should be:

```php
<li class="board" style="margin-', … ? 'right' : 'left', ' ', $board['child_level'], 'em;">
```

so the browser drops it and boards nested under a parent are not indented at all.
On `release-3.0`, with a child and a grandchild board:

| board | style attribute | computed |
|---|---|---|
| General Discussion | `margin-left 0em;` | `0px` |
| Child board A | `margin-left 1em;` | `0px` |
| Grandchild B | `margin-left 2em;` | `0px` |

After:

| board | style attribute | computed |
|---|---|---|
| General Discussion | `margin-inline-start: 0em;` | `0px` |
| Child board A | `margin-inline-start: 1em;` | `13.33px` |
| Grandchild B | `margin-inline-start: 2em;` | `26.67px` |

#### Testing

On a clean install with a child board and a grandchild board added.

Board manager, `?action=admin;area=manageboards` — the indentation is byte for
byte what the ternary produced, and now flips without it:

| | LTR | RTL |
|---|---|---|
| General Discussion | `padding-left: 5px` | `padding-right: 5px` |
| Child board A | `padding-left: 35px` | `padding-right: 35px` |
| Grandchild B | `padding-left: 65px` | `padding-right: 65px` |

Membergroup editor as above. `composer lint` is clean on all five files.

I have deliberately not taken the theme branch's other change to the same line,
which moves the board manager's base indent from 5px to 10px. That is a visual
tweak and does not belong in a change that is otherwise value-for-value.

### Issues References (Fixes|Related|Closes)

Related to #7933
