### PR TITLE
[3.0] Theme split (wave 4, part 7) — make the admin and moderation menu a nav landmark

### DIFF
--- a/Themes/default/GenericMenu.template.php
+++ b/Themes/default/GenericMenu.template.php
@@ -29,11 +29,11 @@ function template_generic_menu_dropdown_above()
 	// Load the menu
 	// Add mobile menu as well
 	echo '
-	<a class="mobile_generic_menu_', Utils::$context['cur_menu_id'], '">
-		<span class="menu_icon"></span>
-		<span class="text_menu">', Lang::getTxt('mobile_generic_menu', ['label' => $menu_label], file: 'General'), '</span>
-	</a>
-	<div id="genericmenu">
+	<nav id="genericmenu" aria-label="', Lang::getTxt('mobile_generic_menu', ['label' => $menu_label], file: 'General'), '">
+		<a class="mobile_generic_menu_', Utils::$context['cur_menu_id'], '">
+			<span class="menu_icon"></span>
+			<span class="text_menu">', Lang::getTxt('mobile_generic_menu', ['label' => $menu_label], file: 'General'), '</span>
+		</a>
 		<div id="mobile_generic_menu_', Utils::$context['cur_menu_id'], '" class="popup_container">
 			<div class="popup_window description">
 				<div class="popup_heading">
@@ -43,7 +43,7 @@ function template_generic_menu_dropdown_above()
 				', template_generic_menu($menu_context), '
 			</div>
 		</div>
-	</div>
+	</nav>
 	<script>
 		$( ".mobile_generic_menu_', Utils::$context['cur_menu_id'], '" ).click(function() {
 			$( "#mobile_generic_menu_', Utils::$context['cur_menu_id'], '" ).show();


### PR DESCRIPTION
#### Description

Part of the split of #7933, wave 4 part 7. This is the piece deferred out of wave
3 — `GenericMenu.template.php` — taken as the landmark change only.

#9371 turned the main menu and the breadcrumb into `<nav>` landmarks. The menu
down the side of the administration and moderation centres was left as it was, so
the one navigation block those pages are built around is still an anonymous `div`
to a screen reader.

It is now a `<nav>`, labelled after the centre it belongs to. The label is the
string the mobile popup heading already uses, so nothing new is needed in
`Languages/`.

The mobile toggle moves inside it as well — a control whose only job is to open
the menu belongs to the menu rather than sitting beside it.

#### Testing

Geometry is identical. `?action=admin` at 1280px, on both branches:

| | `release-3.0` | this branch |
|---|---|---|
| `#genericmenu` | 76, 233, 1115×24 | 76, 233, 1115×24 |
| `ul.dropmenu` | 76, 233, 1115×24 | 76, 233, 1115×24 |
| `#admin_content` | 76, 262, 1115×938 | 76, 262, 1115×938 |

Landmarks on the page go from `Main Menu`, `Breadcrumb` to `Main Menu`,
`Breadcrumb`, `Administration Center Menu`; on `?action=moderate` the third is
`Moderation Center Menu`.

The mobile menu still works. Below the 560px breakpoint the toggle is
`display: flex` with its icon drawn, the popup starts hidden, and clicking the
toggle opens it with all five sections. Above it the toggle is `display: none`, as
before. The CSS reaches the toggle through `a[class^="mobile_generic_menu_"]`,
which is an attribute selector and does not care that it moved.

#### Not done here

The theme branch makes four other changes to this file that are not landmark
work and want reading rather than copying:

- `template_generic_menu()` loses `&$menu_context` and gains a `$menu_label`
  parameter.
- The `.generic_menu` wrapper div goes, which `responsive.css` still selects
  through `div[id^="mobile_generic_menu_"] .generic_menu`.
- `Utils::$context['tabs']` stops being populated as a side effect of drawing the
  menu. That is the tab resolution change, and `template_generic_menu_tabs()`
  reads what it sets, so the two have to move together.
- Several `Lang::getTxt()` calls lose their `file:` argument, which would be a
  regression against `release-3.0`.

### Issues References (Fixes|Related|Closes)

Related to #7933
