### PR TITLE
[3.0] Theme split (wave 4, part 8) — use the shared confirmation handler instead of inline onclick

### DIFF
--- a/Themes/default/ManageLanguages.template.php
+++ b/Themes/default/ManageLanguages.template.php
@@ -185,7 +185,7 @@ function template_modify_language_entries()
 	// Allow deleting entries. English can't be deleted though.
 	if (Utils::$context['lang_id'] != 'english') {
 		echo '
-				<input type="submit" name="delete_main" value="', Lang::getTxt('delete', file: 'General'), '"', !empty(Utils::$context['lang_file_not_writable_message']) ? ' disabled' : '', ' onclick="return confirm(\'', Lang::getTxt('languages_delete_confirm', file: 'ManageSettings'), '\');" class="button">';
+				<input type="submit" name="delete_main" value="', Lang::getTxt('delete', file: 'General'), '"', !empty(Utils::$context['lang_file_not_writable_message']) ? ' disabled' : '', ' data-confirm="', Lang::getTxt('languages_delete_confirm', file: 'ManageSettings'), '" class="button you_sure">';
 	}
 
 	echo '

--- a/Themes/default/PersonalMessage.template.php
+++ b/Themes/default/PersonalMessage.template.php
@@ -233,7 +233,7 @@ function template_folder()
 			<div class="pagesection">
 				<div class="pagelinks">', Utils::$context['page_index'], '</div>
 				<div class="floatright">
-					<input type="submit" name="del_selected" value="', Lang::getTxt('quickmod_delete_selected', file: 'General'), '" onclick="if (!confirm(\'', Lang::getTxt('delete_selected_confirm', file: 'PersonalMessage'), '\')) return false;" class="button">
+					<input type="submit" name="del_selected" value="', Lang::getTxt('quickmod_delete_selected', file: 'General'), '" data-confirm="', Lang::getTxt('delete_selected_confirm', file: 'PersonalMessage'), '" class="button you_sure">
 				</div>
 			</div>';
 		}
@@ -735,7 +735,7 @@ function template_subject_list()
 		}
 
 		echo '
-			<input type="submit" name="del_selected" value="', Lang::getTxt('quickmod_delete_selected', file: 'General'), '" onclick="if (!confirm(\'', Lang::getTxt('delete_selected_confirm', file: 'PersonalMessage'), '\')) return false;" class="button">';
+			<input type="submit" name="del_selected" value="', Lang::getTxt('quickmod_delete_selected', file: 'General'), '" data-confirm="', Lang::getTxt('delete_selected_confirm', file: 'PersonalMessage'), '" class="button you_sure">';
 	}
 
 	echo '
@@ -1599,7 +1599,7 @@ function template_rules()
 
 	if (!empty(Utils::$context['rules'])) {
 		echo '
-			<a href="', Config::$scripturl, '?action=pm;sa=manrules;apply;', Utils::$context['session_var'], '=', Utils::$context['session_id'], '" onclick="return confirm(\'', Lang::getTxt('pm_js_apply_rules_confirm', file: 'PersonalMessage'), '\');" class="button">', Lang::getTxt('pm_apply_rules', file: 'PersonalMessage'), '</a>';
+			<a href="', Config::$scripturl, '?action=pm;sa=manrules;apply;', Utils::$context['session_var'], '=', Utils::$context['session_id'], '" data-confirm="', Lang::getTxt('pm_js_apply_rules_confirm', file: 'PersonalMessage'), '" class="button you_sure">', Lang::getTxt('pm_apply_rules', file: 'PersonalMessage'), '</a>';
 	}
 
 	echo '


### PR DESCRIPTION
#### Description

Part of the split of #7933, wave 4 part 8.

Four buttons still ask for confirmation with an inline handler, in two spellings:

```php
onclick="return confirm(\'…\');"
onclick="if (!confirm(\'…\')) return false;"
```

`script.js` has carried a delegated `.you_sure` handler for exactly this, and most
of the forum already uses it — the error log, the calendar, the custom profile
field editor, the mark-all-as-read button. This moves the last four over, with the
message in `data-confirm` as everywhere else.

The shared handler also does something the inline calls do not:

```js
// Check if the browser disabled the alert
if (!result && (timeAfter - timeBefore) < 10)
	return true;
```

If `confirm()` comes back false in under ten milliseconds it assumes the dialog
was suppressed by the browser and lets the action through, rather than the button
silently doing nothing. The inline versions have no such fallback.

| file | button |
|---|---|
| `PersonalMessage.template.php` | delete selected, on the message index and on a conversation |
| `PersonalMessage.template.php` | apply rules |
| `ManageLanguages.template.php` | delete a language |

#### Testing

Dispatched a real click at each button with `window.confirm` stubbed, and read
`event.defaultPrevented` after the delegated handler had run:

| button | declined | accepted |
|---|---|---|
| PM → delete selected | click blocked | click proceeds |
| PM → apply rules | click blocked | navigates to `…sa=manrules;apply` |

Both come out with `class="button you_sure"`, the string in `data-confirm`, and no
`onclick` left.

Worth noting how that had to be measured: a stub that returns instantly is treated
by the handler as a suppressed dialog and the click goes through anyway. My first
attempt therefore "showed" that declining did nothing. The stub has to take longer
than the ten millisecond threshold before the result means anything.

The language delete button I have not exercised — it only appears once a second
language is installed, and I have one. It is the same one-line swap as the three
above.

### Issues References (Fixes|Related|Closes)

Related to #7933
