### PR TITLE
[3.0] Stop the forum offering to delete the language it falls back to

### DIFF
--- a/Sources/Actions/Admin/Languages.php
+++ b/Sources/Actions/Admin/Languages.php
@@ -671,6 +671,11 @@ class Languages implements ActionInterface
 
 		Utils::$context['lang_id'] = &$lang_id;
 
+		// Neither the forum's own default nor en_US can go. en_US is what
+		// Lang::load() falls back to for any string the chosen language is
+		// missing, so a forum without it has no backstop at all.
+		Utils::$context['can_delete_language'] = $lang_id !== 'en_US' && $lang_id !== Config::$language;
+
 		// Get all the theme data.
 		$themes = [
 			1 => [
@@ -792,7 +797,7 @@ class Languages implements ActionInterface
 		}
 
 		// We no longer wish to speak this language.
-		if (!empty($_POST['delete_main']) && $lang_id != 'english') {
+		if (!empty($_POST['delete_main']) && Utils::$context['can_delete_language']) {
 			User::$me->checkSession();
 			SecurityToken::validate('admin-mlang');
 

--- a/Themes/default/ManageLanguages.template.php
+++ b/Themes/default/ManageLanguages.template.php
@@ -182,8 +182,8 @@ function template_modify_language_entries()
 				<input type="submit" name="save_main" value="', Lang::getTxt('save', file: 'General'), '"', !empty(Utils::$context['lang_file_not_writable_message']) ? ' disabled' : '', ' class="button">
 				<input type="reset" id="reset_main" value="', Lang::getTxt('reset', file: 'General'), '" class="button">';
 
-	// Allow deleting entries. English can't be deleted though.
-	if (Utils::$context['lang_id'] != 'english') {
+	// Allow deleting entries. The default language and en_US can't go.
+	if (Utils::$context['can_delete_language']) {
 		echo '
 				<input type="submit" name="delete_main" value="', Lang::getTxt('delete', file: 'General'), '"', !empty(Utils::$context['lang_file_not_writable_message']) ? ' disabled' : '', ' onclick="return confirm(\'', Lang::getTxt('languages_delete_confirm', file: 'ManageSettings'), '\');" class="button">';
 	}


### PR DESCRIPTION
#### Description

The language editor offers to delete the language the forum is running on, and
goes through with it.

`template_modify_language_entries()` guards the button with:

```php
// Allow deleting entries. English can't be deleted though.
if (Utils::$context['lang_id'] != 'english') {
```

Language ids have not looked like that since 2.1 — `Sources/Lang.php` carries
`'english' => 'en_US'` in its map of old names to new ones, which is exactly why.
`$lang_id` comes from `$_GET['lid']`, so on any 3.0 install it is `en_US`,
`de_DE` and so on, and the comparison never matches. `Languages::modifyLanguage()`
spells the check the same way when it acts on the post:

```php
if (!empty($_POST['delete_main']) && $lang_id != 'english') {
```

so the button is not merely cosmetic.

Deleting `en_US` is worse than losing a translation. `Lang::load()` falls back to
it for any string the chosen language is missing:

```php
&& 'en_US' !== Config::$language
&& 'en_US' !== $lang
) {
	$attempts[] = [$dir, $name, 'en_US'];
```

A forum without it has no backstop.

The guard now covers the forum's own default language and `en_US`, decided once
where `$lang_id` is settled and read by both the action and the template rather
than written out twice.

#### Testing

On a clean install of `release-3.0` (`a7ac468b1`), one language installed,
`?action=admin;area=languages;sa=editlang;lid=en_US`:

| | delete button | other buttons |
|---|---|---|
| before | offered, with its confirmation | Save, Reset |
| after | absent | Save, Reset |

I have not exercised the positive case — a second language still being
deletable — because installing one needs to reach simplemachines.org and this box
has no outbound access. It follows from the same expression, and `en_US` is the
only value the negative case can take on a single-language install.

Found while converting this template's inline `confirm()` to the shared
`you_sure` handler in #9393.

### Issues References (Fixes|Related|Closes)

Related to #7933
