### PR TITLE
[3.0] Import SMF\Time in Display, so a topic with a reply can be read

### DIFF
--- a/Sources/Actions/Display.php
+++ b/Sources/Actions/Display.php
@@ -35,6 +35,7 @@ use SMF\Poll;
 use SMF\Routable;
 use SMF\Security;
 use SMF\Theme;
+use SMF\Time;
 use SMF\Topic;
 use SMF\User;
 use SMF\Utils;


### PR DESCRIPTION
#### Description

**Any topic that has been replied to returns a 500.**

`Display::loadMessages()` measures the gap between consecutive posts to decide
whether to warn about replying to an old topic:

```php
$since = Time::create('@' . $prev_timestamp)->diff(Time::create('@' . $message->poster_time));
```

`SMF\Time` is not imported, so inside `namespace SMF\Actions` that name resolves
to `SMF\Actions\Time`, which does not exist:

```
Class "SMF\Actions\Time" not found  —  Sources/Actions/Display.php:335
```

The surrounding block is guarded by:

```php
if (
	!empty(Config::$modSettings['oldTopicDays'])
	&& (
		empty(Theme::$current->options['view_newest_first'])
			? $message->id > Topic::$info->id_first_msg
			: $message->id < Topic::$info->id_last_msg
	)
) {
```

`oldTopicDays` defaults to 120, so the only thing standing between a forum and
this is having no post after the first one in any topic.

#### Testing

Clean install of `release-3.0` (`a7ac468b1`), MySQL, default settings. The
shipped "Welcome to SMF!" topic reads fine with its single post. Add one reply to
it and:

| | `?topic=1.0` | `smf_log_errors` |
|---|---|---|
| before | HTTP 500, "An error has occurred" | `Class "SMF\Actions\Time" not found` at `Display.php:335` |
| after | HTTP 200, both posts rendered | nothing new |

`composer lint` is clean.

#### How it was found

By sweeping `Sources/` for class names used unqualified inside a sub-namespace
that are neither imported nor declared there — the same shape as the
`ThemeChooser` bug in #9387. Two of the five candidates that survived filtering
were real; this is the more serious one. The other is a migration and is in a
separate PR.

If it would be useful I am happy to tidy the script up and propose it as a CI
step, since neither `phplint` nor `php-cs-fixer` catches this class of mistake and
it fails only at runtime.

### Issues References (Fixes|Related|Closes)

Related to #7933
