### PR TITLE
[3.0] Import SMF\Maintenance\Maintenance in the DropTimeOffset migration

### DIFF
--- a/Sources/Maintenance/Migration/v3_0/DropTimeOffset.php
+++ b/Sources/Maintenance/Migration/v3_0/DropTimeOffset.php
@@ -17,6 +17,7 @@ namespace SMF\Maintenance\Migration\v3_0;
 
 use SMF\Db\DatabaseApi as Db;
 use SMF\Db\Schema;
+use SMF\Maintenance\Maintenance;
 use SMF\Maintenance\Migration\MigrationBase;
 
 class DropTimeOffset extends MigrationBase


### PR DESCRIPTION
#### Description

`Migration\v3_0\DropTimeOffset` calls

```php
Maintenance::$tool->updateModSettings(
	['default_timezone' => $forum_tzid],
	update: true,
);
```

without importing the class. Inside `namespace SMF\Maintenance\Migration\v3_0`
that resolves relative to the namespace:

```
SMF\Maintenance\Migration\v3_0\Maintenance     what the migration asks for   MISSING
SMF\Maintenance\Maintenance                    what it means                 exists
```

Every sibling migration that touches `Maintenance::$tool` imports
`SMF\Maintenance\Maintenance` — `MigrationBase`, `v2_1\AgreementUpdate`,
`v2_1\AlertsWatchedBoards` and the rest. This one is the exception.

The call is in the branch that runs when the forum's stored `default_timezone` is
empty or is not an identifier `timezone_identifiers_list()` knows, so it is
reached while upgrading exactly the forums that need the fallback written for
them.

#### Testing

I have **not** run a 2.1 → 3.0 upgrade to see it fail. What I have checked is the
resolution itself, above: the name the file currently asks for has no file behind
it, and the one it means does. That plus the sibling migrations all importing it
is what I am going on.

Happy to drive a real upgrade if you would rather have that before it goes in —
say the word.

#### How it was found

Sweeping `Sources/` for class names used unqualified inside a sub-namespace that
are neither imported nor declared there. Two of the five surviving candidates were
real; the other is #9395, where the same mistake makes any topic with a reply
return a 500.

### Issues References (Fixes|Related|Closes)

Related to #7933
