### PR TITLE
[3.0] Look language strings up under the name they are stored with

### DIFF
--- a/Sources/Actions/Admin/Themes.php
+++ b/Sources/Actions/Admin/Themes.php
@@ -621,7 +621,7 @@ class Themes implements ActionInterface
 					$available_variants[$variant] = Lang::getTxt('variant_' . $variant, file: 'Themes') ?? $variant;
 				}
 
-				Utils::$context['options'][] = Lang::getTxt('theme_opt_variant', file: 'Themes');
+				Utils::$context['options'][] = Lang::getTxt('theme_opt_variant', file: 'Profile');
 				Utils::$context['options'][] = [
 					'id' => 'theme_variant',
 					'label' => Lang::getTxt('theme_pick_variant', file: 'Themes'),
@@ -639,7 +639,7 @@ class Themes implements ActionInterface
 					$available_modes[$mode] = Lang::getTxt('colormode_' . $mode, file: 'Themes') ?? $mode;
 				}
 
-				Utils::$context['options'][] = Lang::getTxt('theme_opt_colormode', file: 'Themes');
+				Utils::$context['options'][] = Lang::getTxt('theme_opt_colormode', file: 'Profile');
 				Utils::$context['options'][] = [
 					'id' => 'theme_colormode',
 					'label' => Lang::getTxt('theme_pick_colormode', file: 'Themes'),

--- a/Sources/Actions/Login2.php
+++ b/Sources/Actions/Login2.php
@@ -289,7 +289,7 @@ class Login2 implements ActionInterface, Routable
 				true,
 			)
 		) {
-			Utils::$context['login_errors'] = [Lang::getTxt('invalid_credentials', file: 'Login')];
+			Utils::$context['login_errors'] = [Lang::getTxt('invalid_credentials', file: 'General')];
 
 			return;
 		}
@@ -648,7 +648,7 @@ class Login2 implements ActionInterface, Routable
 				// Log an error so we know that it didn't go well in the error log.
 				ErrorHandler::log(Lang::getTxt('incorrect_password', file: 'Login') . ' - <span class="remove">' . $this->member->username . '</span>', 'user');
 
-				Utils::$context['login_errors'] = [Lang::getTxt('invalid_credentials', file: 'Login')];
+				Utils::$context['login_errors'] = [Lang::getTxt('invalid_credentials', file: 'General')];
 
 				return false;
 			}

--- a/Sources/Actions/Profile/ThemeOptions.php
+++ b/Sources/Actions/Profile/ThemeOptions.php
@@ -60,7 +60,7 @@ class ThemeOptions implements ActionInterface
 				Utils::$context['additional_options'][] = Lang::getTxt('theme_opt_variant', file: 'Profile');
 				Utils::$context['additional_options'][] = [
 					'id' => 'theme_variant',
-					'label' => Lang::getTxt('theme_pick_variant', file: 'THemes'),
+					'label' => Lang::getTxt('theme_pick_variant', file: 'Themes'),
 					'options' => $available_variants,
 					'default' => isset(Theme::$current->settings['default_variant']) && !empty(Theme::$current->settings['default_variant']) ? Theme::$current->settings['default_variant'] : Theme::$current->settings['theme_variants'][0],
 					'enabled' => !empty(Theme::$current->settings['theme_variants']),

--- a/Sources/Actions/Search.php
+++ b/Sources/Actions/Search.php
@@ -166,7 +166,7 @@ class Search implements ActionInterface, Routable
 				if ($search_error == 'string_too_long') {
 					Lang::setTxt(
 						'error_string_too_long',
-						Lang::getTxt('error_string_too_long', [SearchApi::MAX_LENGTH], file: 'Errors'),
+						Lang::getTxt('error_string_too_long', [SearchApi::MAX_LENGTH], file: 'Search'),
 					);
 				}
 

--- a/Sources/Maintenance/Tools/Upgrade.php
+++ b/Sources/Maintenance/Tools/Upgrade.php
@@ -795,7 +795,7 @@ class Upgrade extends ToolsBase implements ToolsInterface
 			)
 		) {
 			if (!SecurityToken::validate('login', 'post', false)) {
-				Maintenance::$errors[] = Lang::getTxt('token_verify_fail', file: 'Maintenance');
+				Maintenance::$errors[] = Lang::getTxt('token_verify_fail', file: 'Errors');
 				Maintenance::$context += SecurityToken::create('login');
 
 				return false;

--- a/Sources/Parsers/MarkdownParser.php
+++ b/Sources/Parsers/MarkdownParser.php
@@ -3131,7 +3131,7 @@ class MarkdownParser extends Parser
 						'{txt_code}' => Lang::getTxt('code', file: 'General'),
 						'{txt_code_select}' => Lang::getTxt('code_select', file: 'General'),
 						'{txt_code_shrink}' => Lang::getTxt('code_shrink', file: 'General'),
-						'{txt_code_expand}' => Lang::getTxt('quote_expand', file: 'General'),
+						'{txt_code_expand}' => Lang::getTxt('code_expand', file: 'General'),
 						'$2' => htmlspecialchars($element['properties']['info_string'] ?? ''),
 					],
 				);

--- a/Themes/default/ManageLanguages.template.php
+++ b/Themes/default/ManageLanguages.template.php
@@ -295,7 +295,7 @@ function template_modify_language_entries()
 			if (!empty(Utils::$context['can_add_lang_entry'][$group])) {
 				echo '
 				<span class="add_lang_entry_button" style="display: none;">
-					<a class="button" href="javascript:void(0);" onclick="add_lang_entry(\'', $group, '\'); return false;">' . Lang::getTxt('edit_language_entries_add', file: 'Admin') . '</a>
+					<a class="button" href="javascript:void(0);" onclick="add_lang_entry(\'', $group, '\'); return false;">' . Lang::getTxt('edit_language_entries_add', file: 'ManageSettings') . '</a>
 				</span>
 				<script>
 					entry_num = ', $entry_num, ';

--- a/Themes/default/Register.template.php
+++ b/Themes/default/Register.template.php
@@ -663,7 +663,7 @@ function template_edit_agreement()
 						<a href="" onclick="return false;" class="modified">', Utils::$context['agreement_info'], '</a>
 						<div id="edit_history_list_' . Utils::$context['current_agreement'] . '" class="edit_history_list">
 							<div class="edit_history_count">
-								' . Lang::getTxt('edit_history_count', [count(Utils::$context['agreement_history'])], file: 'Agreement') . '
+								' . Lang::getTxt('edit_history_count', [count(Utils::$context['agreement_history'])], file: 'General') . '
 							</div>
 							<ol>';
 
@@ -806,7 +806,7 @@ function template_edit_privacy_policy()
 					<a href="" onclick="return false;" class="modified">', Utils::$context['privacy_policy_info'], '</a>
 					<div id="edit_history_list_' . Utils::$context['current_policy_lang'] . '" class="edit_history_list">
 						<div class="edit_history_count">
-							' . Lang::getTxt('edit_history_count', [count(Utils::$context['privacy_policy_history'])], file: 'Agreement') . '
+							' . Lang::getTxt('edit_history_count', [count(Utils::$context['privacy_policy_history'])], file: 'General') . '
 						</div>
 						<ol>';
 


### PR DESCRIPTION
#### Description

`Lang::getTxt()` takes a `file:` argument naming the language file a string lives in. It loads that file, then looks the key up in the flat `Lang::$txt` array, and returns `''` when it is not there.

Nine calls name a file that does not define the key they ask for. I found them by sweeping every `getTxt('key', …, file: 'Name')` call against what `Languages/en_US/*.php` actually defines.

Where the right file happens to be loaded by something else on the same page, the lookup survives by luck. Where it is not, the string comes back empty. Two of these are certainly empty:

- **`Sources/Parsers/MarkdownParser.php`** asked for `quote_expand`. That is the *admin setting* label "Minimum quote height to add an expand link on large quotes", and it lives in `Admin`, not `General`. The label wanted is `code_expand`. The value is substituted into `data-expand-txt`, and `attachBbCodeEvents()` in `script.js` only builds the button when that attribute has a value — so **a fenced code block in Markdown never got its Expand button**.
- **`Sources/Actions/Profile/ThemeOptions.php`** asked for `file: 'THemes'`, with a capital H. On a case sensitive filesystem no file is loaded at all.

The rest name a real file that simply does not hold the string:

| Call site | Key | Named | Actually in |
|---|---|---|---|
| `Actions/Admin/Themes.php` | `theme_opt_variant` | Themes | Profile |
| `Actions/Admin/Themes.php` | `theme_opt_colormode` | Themes | Profile |
| `Actions/Login2.php` (×2) | `invalid_credentials` | Login | General |
| `Actions/Search.php` | `error_string_too_long` | Errors | Search |
| `Maintenance/Tools/Upgrade.php` | `token_verify_fail` | Maintenance | Errors |
| `Themes/default/ManageLanguages.template.php` | `edit_history_count`… `edit_language_entries_add` | Admin | ManageSettings |
| `Themes/default/Register.template.php` (×2) | `edit_history_count` | Agreement | General |

The two theme option headings are worth pointing out: the same two strings are fetched in `Actions/Profile/ThemeOptions.php`, and those calls already say `file: 'Profile'`. The admin side just disagrees with the profile side.

##### What I checked, and what I did not

- The `edit_language_entries_add` button does render today ("Add another item" on *Admin → Languages → Edit → Modifications*), because the admin area loads `ManageSettings` for its own reasons. It is still naming the wrong file — it works by accident.
- `invalid_credentials`, `edit_history_count` and `error_string_too_long` are the same shape: `General` is always loaded, and `Search` is loaded on the search page.
- The two theme option headings sit behind `theme_variants` / `has_dark_mode`, and the default theme sets neither, so that branch does not run on a stock install and I could not exercise it. The evidence is the language files themselves plus the disagreeing sibling calls.
- `token_verify_fail` needs a failed token in the upgrader; I did not stage that.

The sweep script is 60 lines and finds this class of mistake with no false positives once concatenated keys (`getTxt('icon_' . $x, …)`) are excluded. Happy to contribute it as a CI step alongside the unimported-class check offered in #9395 if that is wanted — neither `phplint` nor `php-cs-fixer` can see this, and the failure is silent rather than loud.

Found while splitting #7933; this is not part of the theme itself, so it goes straight to `release-3.0`.

### Issues References (Fixes|Related|Closes)

Related to #7933