### PR TITLE
[3.0] Use the keys these language lookups meant

### DIFF
--- a/Sources/Actions/Admin/Themes.php
+++ b/Sources/Actions/Admin/Themes.php
@@ -2233,9 +2233,9 @@ class Themes implements ActionInterface
 				$size = filesize($path . '/' . $entry);
 
 				if ($size > 2048 || $size == 1024) {
-					$size = Lang::getTxt('size_kilobytes', [Lang::numberFormat($size / 1024, 2)], file: 'General');
+					$size = Lang::getTxt('size_kilobyte', [round($size / 1024, 2)], file: 'General');
 				} else {
-					$size = Lang::getTxt('size_bytes', [Lang::numberFormat($size)], file: 'General');
+					$size = Lang::getTxt('size_byte', [$size], file: 'General');
 				}
 
 				$list2[] = [

--- a/Sources/Maintenance/Tools/ToolsBase.php
+++ b/Sources/Maintenance/Tools/ToolsBase.php
@@ -503,9 +503,9 @@ abstract class ToolsBase
 
 				if (is_writable($file)) {
 					unset($files[$k]);
-					$this->logProgress(Lang::getTxt('done', file: 'Maintenance'));
+					$this->logProgress(Lang::getTxt('log_done', file: 'Maintenance'));
 				} else {
-					$this->logProgress(Lang::getTxt('failed', file: 'Maintenance'));
+					$this->logProgress(Lang::getTxt('log_failed', file: 'Maintenance'));
 				}
 			}
 


### PR DESCRIPTION
#### Description

Four lookups name a key that no language file defines, so `Lang::getTxt()` returns an empty string.

##### The theme file browser has no size column

`Sources/Actions/Admin/Themes.php` asks for `size_kilobytes` and `size_bytes`. Everywhere else in SMF — `Attachment.php`, `Feed.php`, `Actions/Admin/Search.php`, `ManageAttachments.template.php`, and about a dozen more — the keys are singular: `size_kilobyte` and `size_byte`. So *Admin → Themes → Modify → browse files* showed nothing in the size column, for every file. Straight off the running forum:

```
before                                       after
<td class="righttext"></td>                  <td class="righttext">242 B</td>
<td class="righttext"></td>                  <td class="righttext">32.76 KB</td>
```

The arguments needed a second look too. Both went through `Lang::numberFormat()` first, which hands an already formatted string like `32.76` to a `{0, number}` placeholder. The other callers pass the number and let the string format it, so that is what these do now.

##### The installer's FTP log says nothing

`Sources/Maintenance/Tools/ToolsBase.php` reports whether a `chmod` through FTP worked with `getTxt('done')` and `getTxt('failed')`. `Languages/en_US/Maintenance.php` calls those `log_done` (`'done.'`) and `log_failed` (`'failed.'`), and has since the file was written. I have not staged a failing FTP chmod to watch it, so this one is by inspection.

##### One I left alone

`Themes/default/ReportedContent.template.php` asks for `mc_recent_member_reports`, which is also undefined, in `template_reported_members_block()`. That function is dead: the moderation home registers `reported_users_block`, which `ModerationCenter.template.php` provides, and `ReportedContent.template.php` also carries a second `template_reported_posts_block()` that duplicates the one in `ModerationCenter.template.php`. Deleting dead template functions is a bigger call than this PR, so it is only flagged here.

Found while splitting #7933, with the same sweep as #9397 (which fixes calls that name the wrong language *file*) and #9398 (which fixes fallbacks that cannot fire). Not part of the theme, so it goes straight to `release-3.0`.

### Issues References (Fixes|Related|Closes)

Related to #7933