### PR TITLE
[3.0] Count the posts a board is holding for approval

### DIFF
--- a/Sources/Actions/MessageIndex.php
+++ b/Sources/Actions/MessageIndex.php
@@ -947,15 +947,14 @@ class MessageIndex implements ActionInterface, Routable
 	{
 		// If we can view unapproved messages and there are some build up a list.
 		if (User::$me->allowedTo('approve_posts') && (Board::$info->unapproved_topics || Board::$info->unapproved_posts)) {
-			$untopics = Board::$info->unapproved_topics ? '<a href="' . Config::$scripturl . '?action=moderate;area=postmod;sa=topics;brd=' . Board::$info->id . '">' . Board::$info->unapproved_topics . '</a>' : 0;
-
-			$unposts = Board::$info->unapproved_posts ? '<a href="' . Config::$scripturl . '?action=moderate;area=postmod;sa=posts;brd=' . Board::$info->id . '">' . (Board::$info->unapproved_posts - Board::$info->unapproved_topics) . '</a>' : 0;
-
+			// Both of these are plural arguments in the string, so they have to
+			// arrive as numbers. Wrapping them in a link first gets them read as
+			// zero, and the string already carries a link of its own.
 			Utils::$context['unapproved_posts_message'] = Lang::getTxt(
 				'there_are_unapproved_topics',
 				[
-					'topics' => $untopics,
-					'posts' => $unposts,
+					'topics' => Board::$info->unapproved_topics,
+					'posts' => Board::$info->unapproved_posts - Board::$info->unapproved_topics,
 					'url' => Config::$scripturl . '?action=moderate;area=postmod;sa=' . (Board::$info->unapproved_topics ? 'topics' : 'posts') . ';brd=' . Board::$info->id,
 				],
 				file: 'General',


### PR DESCRIPTION
#### Description

A board with posts waiting for approval always said it had none:

> There are **0** topics and **0** posts awaiting approval in this board. Click [here](#) to view them all.

`$txt['there_are_unapproved_topics']` puts both counts through ICU plural arguments, and carries its own link to the moderation queue:

```
There are {topics, plural, one {# topic} other {# topics}} and {posts, plural,
one {# post} other {# posts}} awaiting approval in this board.
Click <a href="{url}">here</a> to view them all.
```

`MessageIndex::buildUnapprovedPostsMessage()` wrapped each count in a link of its own before handing it over. ICU wants a number for a plural argument, gets a string, reads it as zero, and drops the markup on the floor — so the counts read zero and the extra links never appeared anyway.

Straight off the running forum, on a board carrying three unapproved topics and five unapproved posts:

```
before  There are 0 topics and 0 posts awaiting approval in this board. Click <a href="…">here</a> …
after   There are 3 topics and 2 posts awaiting approval in this board. Click <a href="…">here</a> …
```

Three topics and two posts, the two being the replies — `unapproved_posts` counts the topic starters as well, which is why the existing code subtracts.

Reduced to the pattern on its own, so the coercion is easy to see:

```
$args = ['topics' => '<a href="…">3</a>', 'posts' => '<a href="…">2</a>', 'url' => …]
  → There are 0 topics and 0 posts awaiting approval …

$args = ['topics' => 3, 'posts' => 2, 'url' => …]
  → There are 3 topics and 2 posts awaiting approval …

$args = ['topics' => 1, 'posts' => 1, 'url' => …]
  → There are 1 topic and 1 post awaiting approval …
```

The `url` argument is already built for whichever queue is the more useful one, so nothing is lost by letting the string place the single link itself.

This is one of the fixes carried on the #7933 branch. It touches no theme template, so per the grouping asked for on that PR it comes over on its own, straight to `release-3.0`.

### Issues References (Fixes|Related|Closes)

Related to #7933