### PR TITLE
[3.0] Keep the subscription date lists reaching the dates in use

### DIFF
--- a/Themes/default/ManagePaid.template.php
+++ b/Themes/default/ManagePaid.template.php
@@ -216,11 +216,17 @@ function template_delete_subscription()
  */
 function template_modify_user_subscription()
 {
-	// Some quickly stolen javascript from Post, could do with being more efficient :)
-	echo '
-	<script>
-		var monthLength = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
-	</script>';
+	// The year lists below have to reach whatever dates this subscription
+	// already carries, however far out they are, and leave room to pick
+	// something new either side of today.
+	$years = [
+		Utils::$context['sub']['start']['year'],
+		Utils::$context['sub']['end']['year'],
+		(int) date('Y'),
+	];
+
+	$first_year = min($years) - 10;
+	$last_year = max($years) + 10;
 
 	echo '
 	<form action="', Config::$scripturl, '?action=admin;area=paidsubscribe;sa=modifyuser;sid=', Utils::$context['sub_id'], ';lid=', Utils::$context['log_id'], '" method="post">
@@ -267,7 +273,7 @@ function template_modify_user_subscription()
 				<select name="year" id="year" onchange="generateDays();">';
 
 	// Show a list of all the years we allow...
-	for ($year = 2005; $year <= 2030; $year++) {
+	for ($year = $first_year; $year <= $last_year; $year++) {
 		echo '
 					<option value="', $year, '"', $year == Utils::$context['sub']['start']['year'] ? ' selected' : '', '>', $year, '</option>';
 	}
@@ -304,7 +310,7 @@ function template_modify_user_subscription()
 				<select name="yearend" id="yearend" onchange="generateDays(\'end\');">';
 
 	// Show a list of all the years we allow...
-	for ($year = 2005; $year <= 2030; $year++) {
+	for ($year = $first_year; $year <= $last_year; $year++) {
 		echo '
 					<option value="', $year, '"', $year == Utils::$context['sub']['end']['year'] ? ' selected' : '', '>', $year, '</option>';
 	}


### PR DESCRIPTION
#### Description

*Admin → Paid Subscriptions → modify a subscriber* builds its start and end year drop-downs from a hard coded range:

```php
for ($year = 2005; $year <= 2030; $year++) {
```

Two consequences:

- **No subscription can be given an end date past 2030.** With a one-year subscription that is four renewals away.
- **An existing subscription whose dates fall outside the range loses its own year from the list.** No `<option>` carries `selected`, so the browser shows the first one, and saving the form moves the date to 2005 without saying anything.

They now run ten years either side of today, widened where necessary to take in whatever the subscription already carries, so the stored value is always one of the options. Straight off the running forum, on 2026-08-08:

```
before   2005 … 2030
after    2016 … 2036
```

The inline `monthLength` array at the top of the function goes as well. `generateDays()` lives in `script.js` now and declares its own, so this copy — carrying the comment *"Some quickly stolen javascript from Post, could do with being more efficient"* — has not been read by anything since that function was moved out of the templates.

`Post.template.php` still declares the same dead array; I left it alone rather than widen this diff into the posting screen.

This comes out of the #7933 branch, which makes the same range calculation; per the grouping asked for there, the paid subscription templates are their own area.

### Issues References (Fixes|Related|Closes)

Related to #7933