### PR TITLE
[3.0] Theme split (wave 4, part 10) — make the report picker a list of labelled choices

### DIFF
--- a/Themes/default/Reports.template.php
+++ b/Themes/default/Reports.template.php
@@ -22,31 +22,30 @@ use SMF\Utils;
 function template_report_type()
 {
 	echo '
-		<form action="', Config::$scripturl, '?action=admin;area=reports" method="post" accept-charset="UTF-8">
-			<div class="cat_bar">
-				<h3 class="catbg">', Lang::getTxt('generate_reports_type', file: 'Reports'), '</h3>
-			</div>
-			<div class="windowbg">
-				<dl class="settings">';
+		<div class="cat_bar">
+			<h3 class="catbg">', Lang::getTxt('generate_reports_type', file: 'Reports'), '</h3>
+		</div>
+		<form action="', Config::$scripturl, '?action=admin;area=reports" method="post" accept-charset="UTF-8" class="windowbg option_form">';
 
 	// Go through each type of report they can run.
 	foreach (Utils::$context['report_types'] as $type) {
+		echo '
+			<label>
+				<input type="radio" name="rt" value="', $type['id'], '"', $type['is_first'] ? ' checked' : '', '>
+				<strong>', $type['title'], '</strong>';
+
 		if (isset($type['description'])) {
 			echo '
-					<dt>', $type['description'], '</dt>';
+				<p>', $type['description'], '</p>';
 		}
 
 		echo '
-					<dd>
-						<input type="radio" id="rt_', $type['id'], '" name="rt" value="', $type['id'], '"', $type['is_first'] ? ' checked' : '', '>
-						<strong><label for="rt_', $type['id'], '">', $type['title'], '</label></strong>
-					</dd>';
+			</label>';
 	}
+
 	echo '
-				</dl>
-				<input type="submit" name="continue" value="', Lang::getTxt('generate_reports_continue', file: 'Reports'), '" class="button">
-				<input type="hidden" name="', Utils::$context['session_var'], '" value="', Utils::$context['session_id'], '">
-			</div><!-- .windowbg -->
+			<input type="submit" name="continue" value="', Lang::getTxt('generate_reports_continue', file: 'Reports'), '" class="button">
+			<input type="hidden" name="', Utils::$context['session_var'], '" value="', Utils::$context['session_id'], '">
 		</form>';
 }
 


### PR DESCRIPTION
#### Description

`template_report_type()` built the list of reports as a `dl.settings`, which is the label-and-control pattern used for settings forms. It does not fit a list of choices, and it was assembled the wrong way round:

```php
foreach (Utils::$context['report_types'] as $type) {
	if (isset($type['description'])) {
		echo '<dt>', $type['description'], '</dt>';   // the description is the term
	}

	echo '<dd>
		<input type="radio" id="rt_', $type['id'], '" …>
		<strong><label for="rt_', $type['id'], '">', $type['title'], '</label></strong>
	</dd>';                                            // the label is the definition
}
```

So the `<dt>` carried the description and the `<dd>` carried the radio together with the label that belongs to it. Read as a definition list, each report's description is the term for the report that follows, and the title — the thing that names the choice — sits inside the definition. A report with no description drops its `<dt>` and shifts everything after it.

Each report is now one `<label>` wrapping its radio, title and description:

```html
<label>
	<input type="radio" name="rt" value="board_perms">
	<strong>Board Permissions</strong>
	<p>Generate reports showing permissions each membergroup has across the different boards in your forum.</p>
</label>
```

This is the shape `template_maintain_options()` already uses for the forum maintenance picker, landed in #9333, and the `.option_form` rules that came with it lay it out with no new CSS. A missing description now just leaves the `<p>` out of that one label.

The `id="rt_…"` / `for="rt_…"` pairing goes with it — the input is inside its label, so the association no longer needs an id, and nothing else referenced those ids.

##### What I did not change

The #7933 branch also turns this into a `method="get"` form with hidden `action` and `area` fields and drops the session token. That is a separate decision about the request, not about the markup, so this keeps the POST and the token exactly as they were.

##### Checked

Rendered on the running forum, then submitted: *Admin → Reports* still produces "Reports - Boards" with the board list in it.

Part of the #7933 split. Numbering restarts each wave.

### Issues References (Fixes|Related|Closes)

Related to #7933