### PR TITLE
[3.0] Let SMF\Time do arithmetic with an SMF\TimeInterval

### DIFF
--- a/Sources/Calendar/RecurrenceIterator.php
+++ b/Sources/Calendar/RecurrenceIterator.php
@@ -339,7 +339,12 @@ class RecurrenceIterator implements \Iterator
 
 		// We were given a view duration.
 		if (isset($view)) {
-			$this->view_end = (clone $this->view_start)->add($view);
+			// $view_start is a plain \DateTime or \DateTimeImmutable here, so
+			// unlike everywhere else in the calendar it cannot unwrap an
+			// SMF\TimeInterval for itself.
+			$this->view_end = (clone $this->view_start)->add(
+				$view instanceof TimeInterval ? $view->toDateInterval() : $view,
+			);
 		}
 		// Rule contained an UNTIL value, so use that as our view end.
 		elseif (isset($this->rrule->until)) {

--- a/Sources/Time.php
+++ b/Sources/Time.php
@@ -740,6 +740,37 @@ class Time extends \DateTime implements \ArrayAccess
 	}
 
 	/**
+	 * Like \DateTime::add(), except that it also accepts the SMF\TimeInterval
+	 * instances that SMF\Time::diff() and the calendar hand around.
+	 *
+	 * Those are not usable by PHP's date arithmetic on their own, so they are
+	 * unwrapped first. See SMF\TimeInterval::toDateInterval().
+	 *
+	 * @param \DateInterval $interval The interval to add.
+	 * @return static reference to this object.
+	 */
+	public function add(\DateInterval $interval): static
+	{
+		parent::add($interval instanceof TimeInterval ? $interval->toDateInterval() : $interval);
+
+		return $this;
+	}
+
+	/**
+	 * Like \DateTime::sub(), except that it also accepts SMF\TimeInterval
+	 * instances. See self::add().
+	 *
+	 * @param \DateInterval $interval The interval to subtract.
+	 * @return static reference to this object.
+	 */
+	public function sub(\DateInterval $interval): static
+	{
+		parent::sub($interval instanceof TimeInterval ? $interval->toDateInterval() : $interval);
+
+		return $this;
+	}
+
+	/**
 	 * Like \DateTimeInterface::diff(), except it returns SMF\TimeInterval
 	 * instances instead of \DateInterval instances.
 	 *

--- a/Sources/TimeInterval.php
+++ b/Sources/TimeInterval.php
@@ -291,6 +291,23 @@ class TimeInterval extends \DateInterval implements \Stringable
 	}
 
 	/**
+	 * Returns the underlying \DateInterval instance.
+	 *
+	 * PHP's date arithmetic reads a \DateInterval's internal state directly
+	 * rather than going through the property hooks above, and this class never
+	 * calls parent::__construct(), so it cannot be handed to
+	 * \DateTimeInterface::add() or ::sub() itself. Anything doing date
+	 * arithmetic wants this instead. SMF\Time::add() and ::sub() call it for
+	 * you.
+	 *
+	 * @return \DateInterval The underlying \DateInterval.
+	 */
+	public function toDateInterval(): \DateInterval
+	{
+		return clone $this->base;
+	}
+
+	/**
 	 * Formats the object as a string so it can be reconstructed later.
 	 *
 	 * @return string A ISO 8601 duration string suitable for reconstructing


### PR DESCRIPTION
#### Description

**The calendar is a fatal error on a stock install.** Not on a forum that has had an event added to it — on every forum, because the installer seeds 28 holidays, and drawing any of them goes through `Calendar\Event::__set()`:

```php
$end = (clone $this->start)->add($this->duration);   // Event.php:1125
```

`$this->duration` is an `SMF\TimeInterval`, and PHP refuses it:

```
Object of type SMF\TimeInterval (inheriting DateInterval) has not been correctly
initialized by calling parent::__construct() in its constructor
```

This is the bug reported in #9384. It has been sitting there since, so here is a fix that does not require settling the design question first.

##### Why the constructor is not simply restored

PHP's date arithmetic reads a `\DateInterval`'s internal state directly, not the property hooks. `TimeInterval` keeps its values in a private `\DateInterval` and serves them through hooks precisely so that `$days` can work — as its own docblock says, that is the only reliable way to get a usable `$days` in a subclass.

Calling `parent::__construct()` fixes the arithmetic and breaks that, because PHP then serves **every** hooked property from the internal state and ignores the hooks. Confirmed on the image's PHP 8.4.24:

```php
class TI extends DateInterval {
	public mixed $days { get => $this->base->days; }   // base->days === 45
	private DateInterval $base;
	public function __construct(string $d) { …; parent::__construct($d); }
}

$ti = new TI('P45D');
// y=0 m=0 d=45 days=false      ← the hook is declared, and never consulted
// $dt->add($ti) → works
```

Assigning `$this->days` afterwards does not help either — it creates a deprecated dynamic property that shadows nothing, and reads still return `false`. `Calendar\Holiday.php:214` reads `->days` off a `Time::diff()` result, so losing it is not free.

##### What this does instead

`TimeInterval::toDateInterval()` hands out the instance it is wrapping, and `SMF\Time::add()` / `::sub()` unwrap before calling PHP:

```php
public function add(\DateInterval $interval): static
{
	parent::add($interval instanceof TimeInterval ? $interval->toDateInterval() : $interval);

	return $this;
}
```

Every caller that passes a `TimeInterval` — `Event.php` ×2, `EventOccurrence.php` ×3, `Actions/Calendar.php` — has an `SMF\Time` on the left-hand side, so they are all covered. A plain `\DateInterval` takes exactly the path it took before. `TimeInterval`'s public API is unchanged, and `$days` still works.

It is a fix at the boundary rather than in the type, and I would rather you had the choice: the alternative is to make `TimeInterval` a genuine `\DateInterval` and give up the hooked `$days`, which changes a public property's behaviour and is your call, not mine. This unblocks the calendar either way.

##### Checked

On the running forum, before: `action=calendar` returns the fatal error page, `Event.php:1125` in `smf_log_errors`. After: renders, and December 2026 marks the 21st and the 25th as `class="days windowbg holidays"`, November the 11th and the 26th. Nothing new in the error log.

Rebased on the merged #9383 — the fractional duration fix — which this needs to construct the seeded holidays in the first place.

### Issues References (Fixes|Related|Closes)

Fixes #9384
Related to #7933