### PR TITLE
[3.0] Stop the buddy and ignore lists erroring when they are empty

### DIFF
--- a/Sources/Actions/Profile/BuddyIgnoreLists.php
+++ b/Sources/Actions/Profile/BuddyIgnoreLists.php
@@ -222,7 +222,10 @@ class BuddyIgnoreLists implements ActionInterface
 		Db::$db->free_result($request);
 
 		// Get all the user's "buddies"...
-		$buddies = User::loadCustom(
+		// Only ask if there are any. {array_int:} with an empty array is a
+		// database error rather than a query that matches nothing, so a member
+		// who has never added a buddy would get an error page instead of a list.
+		$buddies = Profile::$member->buddies === [] ? [] : User::loadCustom(
 			[
 				'where' => ['mem.id_member IN ({array_int:buddy_list})'],
 				'order' => ['mem.real_name'],
@@ -375,7 +378,8 @@ class BuddyIgnoreLists implements ActionInterface
 		}
 
 		// Initialise the list of members we're ignoring.
-		$ignored = User::loadCustom(
+		// Same as the buddy list above: an empty array cannot go into the query.
+		$ignored = Profile::$member->ignoreusers === [] ? [] : User::loadCustom(
 			[
 				'where' => ['mem.id_member IN ({array_int:ignore_list})'],
 				'order' => ['mem.real_name'],

--- a/Sources/Actions/Profile/BuddyIgnoreLists.php
+++ b/Sources/Actions/Profile/BuddyIgnoreLists.php
@@ -222,9 +222,6 @@ class BuddyIgnoreLists implements ActionInterface
 		Db::$db->free_result($request);
 
 		// Get all the user's "buddies"...
-		// Only ask if there are any. {array_int:} with an empty array is a
-		// database error rather than a query that matches nothing, so a member
-		// who has never added a buddy would get an error page instead of a list.
 		$buddies = Profile::$member->buddies === [] ? [] : User::loadCustom(
 			[
 				'where' => ['mem.id_member IN ({array_int:buddy_list})'],
@@ -378,7 +375,6 @@ class BuddyIgnoreLists implements ActionInterface
 		}
 
 		// Initialise the list of members we're ignoring.
-		// Same as the buddy list above: an empty array cannot go into the query.
 		$ignored = Profile::$member->ignoreusers === [] ? [] : User::loadCustom(
 			[
 				'where' => ['mem.id_member IN ({array_int:ignore_list})'],


### PR DESCRIPTION
#### Description

*Profile → Buddies and Ignore List* is an error page for any member who has not added a buddy — which is every member on a new forum:

```
Database error, given array of integer values is empty. (buddy_list)
Function: retrieveUserData
```

`BuddyIgnoreLists::buddies()` runs its query unconditionally:

```php
$buddies = User::loadCustom(
	[
		'where' => ['mem.id_member IN ({array_int:buddy_list})'],
		'limit' => \count(Profile::$member->buddies),
		'params' => ['buddy_list' => Profile::$member->buddies],
	],
	UserDataset::Profile,
);
```

An empty array in `{array_int:}` is a hard database error in SMF's query layer, not a query that matches nothing. `ignore()` has the same shape and the same problem.

2.1 had the guard — `Sources/Profile-Modify.php`:

```php
if (!empty($buddiesArray))
{
	$result = $smcFunc['db_query']('', '
		SELECT id_member
		FROM {db_prefix}members
		WHERE id_member IN ({array_int:buddy_list})
	…
```

It was lost when this moved to `User::loadCustom()`. Both lists now skip the query when there is nothing to look up, which leaves `$buddies` / `$ignored` as the empty arrays the rest of each method already copes with — `count()` for `buddy_count`, then a `foreach` that does not run.

##### Checked

On the running forum, as an admin with no buddies and nobody ignored. Before: both pages render the error, and `smf_log_errors` gains a row per visit. After: both render their "Add to buddy list" / "Add to ignore list" forms, and nothing is logged.

Found while sweeping every page of a stock forum for fatals, alongside #9405.

### Issues References (Fixes|Related|Closes)

Related to #7933