### PR TITLE
[3.0] Stop drawing an empty tab menu with an unresolved label

### DIFF
--- a/Themes/default/GenericMenu.template.php
+++ b/Themes/default/GenericMenu.template.php
@@ -252,7 +252,16 @@ function template_generic_menu_tabs(&$menu_context)
 	// above when this menu has a title of its own. Utils::$context['tabs'] is
 	// set as a side effect of drawing the menu, so it can be full while this
 	// one is still empty, which produced an empty menu on those pages.
-	if (!empty($tab_context['tabs'])) {
+	// Labels arrive from the loop above, and it only runs over the areas the
+	// menu itself knows about, so a page that forces tabs of its own can leave
+	// some without one. Those cannot be drawn, so they do not count towards
+	// having anything to draw either. Same treatment the areas above get.
+	$drawable_tabs = array_filter(
+		$tab_context['tabs'] ?? [],
+		fn($tab) => empty($tab['disabled']) && !empty($tab['label']),
+	);
+
+	if (!empty($drawable_tabs)) {
 		// The admin tabs.
 		echo '
 					<a class="mobile_generic_menu_', Utils::$context['cur_menu_id'], '_tabs">
@@ -271,11 +280,7 @@ function template_generic_menu_tabs(&$menu_context)
 								<div class="generic_menu">
 									<ul class="dropmenu dropdown_menu_', Utils::$context['cur_menu_id'], '_tabs">';
 
-		foreach ($tab_context['tabs'] as $sa => $tab) {
-			if (!empty($tab['disabled'])) {
-				continue;
-			}
-
+		foreach ($drawable_tabs as $sa => $tab) {
 			if (!empty($tab['is_selected'])) {
 				echo '
 										<li>

--- a/Themes/default/GenericMenu.template.php
+++ b/Themes/default/GenericMenu.template.php
@@ -248,18 +248,22 @@ function template_generic_menu_tabs(&$menu_context)
 	}
 
 	// Print out all the items in this tab (if any).
-	if (!empty(Utils::$context['tabs'])) {
+	// What gets drawn below is $tab_context['tabs'], and that is only assembled
+	// above when this menu has a title of its own. Utils::$context['tabs'] is
+	// set as a side effect of drawing the menu, so it can be full while this
+	// one is still empty, which produced an empty menu on those pages.
+	if (!empty($tab_context['tabs'])) {
 		// The admin tabs.
 		echo '
 					<a class="mobile_generic_menu_', Utils::$context['cur_menu_id'], '_tabs">
 						<span class="menu_icon"></span>
-						<span class="text_menu">', Lang::getTxt('mobile_generic_menu', ['label' => $tab_context['title']], file: 'General'), '</span>
+						<span class="text_menu">', Lang::getTxt('mobile_generic_menu', ['label' => $tab_context['title'] ?? ''], file: 'General'), '</span>
 					</a>
 					<div id="adm_submenus">
 						<div id="mobile_generic_menu_', Utils::$context['cur_menu_id'], '_tabs" class="popup_container">
 							<div class="popup_window description">
 								<div class="popup_heading">
-									', Lang::getTxt('mobile_generic_menu', ['label' => $tab_context['title']], file: 'General'), '
+									', Lang::getTxt('mobile_generic_menu', ['label' => $tab_context['title'] ?? ''], file: 'General'), '
 									<a href="javascript:void(0);" class="main_icons hide_popup"></a>
 								</div>';
 


### PR DESCRIPTION
#### Description

Admin and moderation pages whose menu has no title of its own drew a mobile tab menu containing nothing, labelled with the literal text `{label} Menu`. Straight off *Admin → Scheduled Tasks*:

```html
<a class="mobile_generic_menu_1_tabs">
	<span class="menu_icon"></span>
	<span class="text_menu">{label} Menu</span>
</a>
…
		<ul class="dropmenu dropdown_menu_1_tabs">
		</ul>
```

##### Two lists with the same name

The block is guarded on `Utils::$context['tabs']` but draws `$tab_context['tabs']`:

```php
if (!empty(Utils::$context['tabs'])) {
	…
	foreach ($tab_context['tabs'] as $sa => $tab) {
```

They are not the same list. `Utils::$context['tabs']` is set as a *side effect* of drawing the menu itself, from whichever area is selected:

```php
// template_generic_menu_dropdown_above()
if (!empty($area['selected']) && empty(Utils::$context['tabs'])) {
	Utils::$context['tabs'] = $area['subsections'] ?? [];
}
```

`$tab_context['tabs']` is only assembled from it inside the `if (!empty($tab_context['title']))` branch further up. So on a page that has subsections but no tab title, the first is full and the second was never built — the guard passes, the loop finds nothing.

##### And why the label stayed raw

`$tab_context['title']` was never set either, so the call passes `['label' => null]`. `Localization\MessageFormatter::formatMessage()` filters its arguments before handing them over:

```php
->format(array_filter($args, 'is_scalar'))
```

`is_scalar(null)` is false, so the argument is dropped, and ICU leaves an unmatched placeholder in the output rather than substituting an empty string. Reproduced directly — `['label' => null]` through intl gives `" Menu"`, but with the argument filtered out it gives `"{label} Menu"`.

The guard now names the list that actually gets drawn, and the label falls back to `''` so the same thing cannot happen if a menu ever gets tabs without a title.

##### Checked

Four pages on the running forum. `{label}` no longer appears anywhere, *Scheduled Tasks* draws no `#adm_submenus` at all, and the pages that do have tabs are untouched:

```
<span class="text_menu">Reported Members Menu</span>
<span class="text_menu">Manage Members Menu</span>
<span class="text_menu">Features and Options Menu</span>
```

Found by sweeping every rendered page of a stock forum for unsubstituted `{placeholders}`. This is one of the three the sweep turned up.

`GenericMenu.template.php` is also touched by #9392, which makes this element a `nav` landmark; the two do not overlap.

### Issues References (Fixes|Related|Closes)

Related to #7933