### PR TITLE
[3.0] Give these strings the named arguments they ask for

### DIFF
--- a/Sources/Actions/Admin/Boards.php
+++ b/Sources/Actions/Admin/Boards.php
@@ -194,7 +194,7 @@ class Boards implements ActionInterface
 					if (!isset(Utils::$context['categories'][$catid]['move_link'])) {
 						Utils::$context['categories'][$catid]['move_link'] = [
 							'child_level' => 0,
-							'label' => Lang::getTxt('mboards_order_before', [Utils::htmlspecialchars(Board::$loaded[$boardid]->name)], file: 'ManageBoards'),
+							'label' => Lang::getTxt('mboards_order_before', ['name' => Utils::htmlspecialchars(Board::$loaded[$boardid]->name)], file: 'ManageBoards'),
 							'href' => Config::$scripturl . '?action=admin;area=manageboards;sa=move;src_board=' . Utils::$context['move_board'] . ';target_board=' . $boardid . ';move_to=before;' . $security,
 						];
 					}
@@ -203,13 +203,13 @@ class Boards implements ActionInterface
 						Utils::$context['categories'][$catid]['boards'][$boardid]['move_links'] = [
 							[
 								'child_level' => Board::$loaded[$boardid]->child_level,
-								'label' => Lang::getTxt('mboards_order_after', [Utils::htmlspecialchars(Board::$loaded[$boardid]->name)], file: 'ManageBoards'),
+								'label' => Lang::getTxt('mboards_order_after', ['name' => Utils::htmlspecialchars(Board::$loaded[$boardid]->name)], file: 'ManageBoards'),
 								'href' => Config::$scripturl . '?action=admin;area=manageboards;sa=move;src_board=' . Utils::$context['move_board'] . ';target_board=' . $boardid . ';move_to=after;' . $security,
 								'class' => Board::$loaded[$boardid]->child_level > 0 ? 'above' : 'below',
 							],
 							[
 								'child_level' => Board::$loaded[$boardid]->child_level + 1,
-								'label' => Lang::getTxt('mboards_order_child_of', [Utils::htmlspecialchars(Board::$loaded[$boardid]->name)], file: 'ManageBoards'),
+								'label' => Lang::getTxt('mboards_order_child_of', ['name' => Utils::htmlspecialchars(Board::$loaded[$boardid]->name)], file: 'ManageBoards'),
 								'href' => Config::$scripturl . '?action=admin;area=manageboards;sa=move;src_board=' . Utils::$context['move_board'] . ';target_board=' . $boardid . ';move_to=child;' . $security,
 								'class' => 'here',
 							],
@@ -245,7 +245,7 @@ class Boards implements ActionInterface
 				if (empty(Category::$boardList[$catid])) {
 					Utils::$context['categories'][$catid]['move_link'] = [
 						'child_level' => 0,
-						'label' => Lang::getTxt('mboards_order_before', [Utils::htmlspecialchars($tree->name)], file: 'ManageBoards'),
+						'label' => Lang::getTxt('mboards_order_before', ['name' => Utils::htmlspecialchars($tree->name)], file: 'ManageBoards'),
 						'href' => Config::$scripturl . '?action=admin;area=manageboards;sa=move;src_board=' . Utils::$context['move_board'] . ';target_cat=' . $catid . ';move_to=top;' . $security,
 					];
 				}

--- a/Sources/Actions/Admin/Logs.php
+++ b/Sources/Actions/Admin/Logs.php
@@ -131,7 +131,7 @@ class Logs implements ActionInterface
 			'tabs' => [
 				'errorlog' => [
 					'url' => Config::$scripturl . '?action=admin;area=logs;sa=errorlog;desc',
-					'description' => Lang::getTxt('errorlog_desc', [Lang::getTxt('remove', file: 'General')], file: 'Admin'),
+					'description' => Lang::getTxt('errorlog_desc', ['remove' => Lang::getTxt('remove', file: 'General')], file: 'Admin'),
 				],
 				'adminlog' => [
 					'description' => Lang::getTxt('admin_log_desc', file: 'Admin'),

--- a/Sources/User.php
+++ b/Sources/User.php
@@ -2215,7 +2215,7 @@ class User implements \ArrayAccess
 				} else {
 					$message .= '<br>' . Lang::getTxt(
 						'your_ban_expires',
-						[Time::create('@' . $bans['expire_time'])->format(null, false)],
+						['datetime' => Time::create('@' . $bans['expire_time'])->format(null, false)],
 						file: 'General',
 					);
 				}


### PR DESCRIPTION
#### Description

A `Lang::getTxt()` call passes either a positional list or a named map, and the string decides which is right: `{0}` wants a list, `{name}` wants a map. Five calls pass a list to a string with named placeholders, so nothing is substituted and the placeholder is printed as written.

##### Moving a board is the worst of them

Every destination in the list reads the same, so there is no way to tell them apart. *Admin → Boards → Move*, before and after:

```
Before {name}         →   Before General Discussion
After {name}          →   After General Discussion
Sub-board of {name}   →   Sub-board of General Discussion
```

Four calls in `Actions/Admin/Boards.php` are affected. The same file already gets it right about a hundred lines further down, for the board order drop-down:

```php
'name' => Lang::getTxt('mboards_order_after', ['name' => $tree->name], file: 'ManageBoards'),
```

##### The other two

- `Actions/Admin/Logs.php` — the error log's own description tells you to *"click the **{remove}** button at the bottom of the page"*. `Languages/en_US/Admin.php` even carries a translator note above the string: *"Do not translate '{remove}'. It will be automatically replaced with the value of $txt['remove']."* It was not being replaced. Now reads "click the Remove button".
- `Sources/User.php` — the ban notice says *"This ban is set to expire **{datetime}**."* By inspection; I did not stage a ban with an expiry to watch it.

##### How these were found

A sweep matching each `getTxt('key', [ … ])` call against the placeholders in the string it names, and comparing the shape of the literal array — top-level `=>` or not — against whether the string wants named or positional arguments. Eight hits, three of them false: `ordinal_spellout` and `guest_plural` (twice) are ICU `selectordinal` / `plural` patterns whose branch bodies (`=1 {first}`, `one {guest}`) look like placeholders to a regex but are not.

This is the same family as #9400, where an ICU *plural* argument was given HTML and read as zero. If the unimported-class sweep offered in #9395 is of interest as a CI step, this one and the language-file sweep in #9397 belong with it — none of the three is visible to `phplint` or `php-cs-fixer`, and all three fail silently.

### Issues References (Fixes|Related|Closes)

Related to #7933