### PR TITLE
[3.0] Keep Stringable arguments instead of dropping them

### DIFF
--- a/Sources/Localization/MessageFormatter.php
+++ b/Sources/Localization/MessageFormatter.php
@@ -252,6 +252,13 @@ class MessageFormatter
 		];
 
 		foreach ($args as $arg => $value) {
+			// A Stringable is as good as a string here, but it would be thrown
+			// away by the is_scalar() filter below, and an argument that never
+			// arrives leaves its placeholder sitting in the output.
+			if ($value instanceof \Stringable) {
+				$value = $args[$arg] = (string) $value;
+			}
+
 			if (!\is_string($value)) {
 				continue;
 			}

--- a/Sources/Localization/MessageFormatter.php
+++ b/Sources/Localization/MessageFormatter.php
@@ -252,9 +252,6 @@ class MessageFormatter
 		];
 
 		foreach ($args as $arg => $value) {
-			// A Stringable is as good as a string here, but it would be thrown
-			// away by the is_scalar() filter below, and an argument that never
-			// arrives leaves its placeholder sitting in the output.
 			if ($value instanceof \Stringable) {
 				$value = $args[$arg] = (string) $value;
 			}


### PR DESCRIPTION
#### Description

*Admin → Members* prints the literal text `{member_ip}` in the IP column, inside a link to `?action=trackip;searchip={member_ip}`.

`Localization\MessageFormatter::formatMessage()` hands its arguments to intl like this:

```php
$fmt = self::$message_formatters[…][$message]->format(array_filter($args, 'is_scalar'));
```

`array_filter($args, 'is_scalar')` throws away every object. That is the right call for an array or a plain object — intl fatals on `stdClass` with *"could not be converted to string"* — but a `Stringable` converts perfectly well. Dropping it means the argument never arrives, and ICU leaves the placeholder in the output rather than substituting anything.

`Actions/Admin/Members.php::list_getMembers()` puts an `SMF\IP` object in the row:

```php
$row['member_ip'] = new IP($row['member_ip']);
```

and `SMF\IP implements \Stringable`. So the column's `format_text` never got its value.

Stringables are now converted to strings just before the MessageFormat escaping that already runs over string arguments, so one containing `{`, `}` or `'` is protected the same as any other string, and the non-intl fallback path further down gets the same value.

##### Checked

On the running forum, *Admin → Members*:

```
before   <a href="…?action=trackip;searchip={member_ip}">{member_ip}</a>
after    <a href="…?action=trackip;searchip=172.19.0.1">172.19.0.1</a>
```

Ten pages re-rendered afterwards — board index, message index, stats, member list, recent, admin home, member list, error log, moderation centre, profile — no fatals and no other change.

##### The alternative

`Members.php` could instead declare the column as `'member_ip' => true`, which makes `ItemList` do `htmlspecialchars((string) $value)` before formatting. That fixes this one column and leaves the trap in place for the next `Stringable` someone passes, so I fixed the formatter. Happy to do it the other way if you would rather keep `formatMessage()` strict.

Found by sweeping every rendered page of a stock forum for unsubstituted `{placeholders}`, alongside #9407 and #9408.

### Issues References (Fixes|Related|Closes)

Related to #7933