### PR TITLE
[3.0] Let the news feed run without a current board

### DIFF
--- a/Sources/Actions/Feed.php
+++ b/Sources/Actions/Feed.php
@@ -724,6 +724,11 @@ class Feed implements ActionInterface, Routable
 		$done = false;
 		$loops = 0;
 
+		// A feed for the whole forum has no current board, and Board::$info is
+		// typed with no default, so it cannot be read at all until something
+		// sets it. The query only uses this when there is a board.
+		$current_board = isset(Board::$info) ? Board::$info->id : 0;
+
 		while (!$done) {
 			$optimize_msg = implode(' AND ', $this->optimize_msg);
 			$request = Db::$db->query(
@@ -745,7 +750,7 @@ class Feed implements ActionInterface, Routable
 				ORDER BY t.id_first_msg {raw:ascdesc}
 				LIMIT {int:limit}',
 				[
-					'current_board' => Board::$info->id,
+					'current_board' => $current_board,
 					'is_approved' => 1,
 					'limit' => $this->limit,
 					'optimize_msg' => $optimize_msg,

--- a/Sources/Actions/Feed.php
+++ b/Sources/Actions/Feed.php
@@ -724,11 +724,6 @@ class Feed implements ActionInterface, Routable
 		$done = false;
 		$loops = 0;
 
-		// A feed for the whole forum has no current board, and Board::$info is
-		// typed with no default, so it cannot be read at all until something
-		// sets it. The query only uses this when there is a board.
-		$current_board = isset(Board::$info) ? Board::$info->id : 0;
-
 		while (!$done) {
 			$optimize_msg = implode(' AND ', $this->optimize_msg);
 			$request = Db::$db->query(
@@ -750,7 +745,7 @@ class Feed implements ActionInterface, Routable
 				ORDER BY t.id_first_msg {raw:ascdesc}
 				LIMIT {int:limit}',
 				[
-					'current_board' => $current_board,
+					'current_board' => isset(Board::$info) ? Board::$info->id : 0,
 					'is_approved' => 1,
 					'limit' => $this->limit,
 					'optimize_msg' => $optimize_msg,


### PR DESCRIPTION
#### Description

`?action=.xml;sa=news` is an error page on every forum unless it is scoped to a board:

```
Typed static property SMF\Board::$info must not be accessed before initialization
                                                    Sources/Actions/Feed.php:748
```

`getXmlNews()` puts `Board::$info->id` straight into the query parameters:

```php
[
	'current_board' => Board::$info->id,
	'is_approved' => 1,
	…
]
```

The WHERE clause only *uses* that parameter when there is a board, and the conditions deciding it go through `empty()`, which tolerates an uninitialised typed property:

```php
(empty(Board::$info->id) ? '' : '
	AND t.id_board = {int:current_board}')
```

The parameter array does not — it reads the property outright, and a feed for the whole forum has no current board to read. So the site-wide news feed dies while the per-board one works.

`getXmlRecent()`, a few hundred lines further down in the same file, already does it the right way, and this now matches:

```php
$current_board = isset(Board::$info) ? Board::$info->id : 0;
```

##### Checked

As a guest on the running forum, before:

```
?action=.xml;sa=news             → "An error has occurred", 0 items
?action=.xml;sa=news;board=1     → 1 item
```

after:

```
?action=.xml;sa=news             → 5 <item>
?action=.xml;sa=news;board=1     → items
?action=.xml;sa=news;type=atom   → <entry>
?action=.xml;sa=recent           → items
```

This one is worth a second look precisely because `phplint` and `php-cs-fixer` both pass on it and nothing in the codebase reads the feed — it only fails when something asks for the URL. Found by sweeping a stock forum's pages **as a guest**; every earlier sweep in this series ran as an admin and never requested it.

### Issues References (Fixes|Related|Closes)

Related to #7933