### PR TITLE
[3.0] Say which board when merge topics is asked without one

### DIFF
--- a/Sources/Actions/TopicMerge.php
+++ b/Sources/Actions/TopicMerge.php
@@ -208,6 +208,14 @@ class TopicMerge implements ActionInterface, Routable
 			ErrorHandler::fatalLang('no_access', false);
 		}
 
+		// Everything below looks for the source topic in the current board, and
+		// pages the target list relative to it, so there has to be one.
+		// Board::$info is typed with no default, so reading it without a board
+		// is an uncaught error rather than an empty value.
+		if (!isset(Board::$info)) {
+			ErrorHandler::fatalLang('no_board', false);
+		}
+
 		$_GET['from'] = (int) $_GET['from'];
 
 		$_REQUEST['targetboard'] = isset($_REQUEST['targetboard']) ? (int) $_REQUEST['targetboard'] : Board::$info->id;


### PR DESCRIPTION
#### Description

`?action=mergetopics;from=3;targetboard=1` — no `board=` in the URL — is an HTTP 500:

```
Typed static property SMF\Board::$info must not be accessed before initialization
                                              Sources/Actions/TopicMerge.php:240
```

`index()` reads `Board::$info` three times: to default the target board, to build the page index, and to look the source topic up in the current board. The method is written around there being one. `Board::$info` is typed with no default, so without a board none of those reads work — and the first one takes the request down with an uncaught error instead of a message.

It now stops at the top with `no_board`, which is the string the same method already uses further down when the source topic turns out not to be in this board:

```
before   HTTP 500, uncaught Error, entry in smf_log_errors
after    HTTP 403, the standard "board not found" page
```

The normal flow is unaffected — `?action=mergetopics;board=1.0;from=3` still returns 200. The merge button in a topic always includes `board=` (`Actions/Display.php:1426`), so this is reached by editing the URL rather than by using the forum; it should still say what is wrong rather than fall over.

##### A note on `??`

My first attempt was `Board::$info->id ?? 0`, which does **not** work here and is worth flagging because the pattern appears elsewhere in the codebase. `??` only guards the final dereference; the static property access itself still throws. `isset(Board::$info)` is the test that works, which is what `Actions/Feed.php` uses and what #9411 does for the same problem in the news feed.

Found by walking the moderation actions on a running forum and watching for non-2xx responses.

### Issues References (Fixes|Related|Closes)

Related to #7933