### PR TITLE
[3.0] Exclude the post groups already loaded by ID, not by post count

### DIFF
--- a/Sources/Group.php
+++ b/Sources/Group.php
@@ -2165,7 +2165,9 @@ class Group implements \ArrayAccess
 				AND min_posts != {int:min_posts}',
 			[
 				'min_posts' => -1,
-				'known_post_groups' => !empty(self::$post_groups) ? self::$post_groups : [self::NONE],
+				// The keys are the group IDs; the values are post counts, which
+				// are not what id_group is being compared against.
+				'known_post_groups' => !empty(self::$post_groups) ? array_keys(self::$post_groups) : [self::NONE],
 			],
 		);
 

--- a/Sources/Group.php
+++ b/Sources/Group.php
@@ -2165,8 +2165,6 @@ class Group implements \ArrayAccess
 				AND min_posts != {int:min_posts}',
 			[
 				'min_posts' => -1,
-				// The keys are the group IDs; the values are post counts, which
-				// are not what id_group is being compared against.
 				'known_post_groups' => !empty(self::$post_groups) ? array_keys(self::$post_groups) : [self::NONE],
 			],
 		);


### PR DESCRIPTION
#### Description

`Group::getPostGroups()` collects the post groups it already has in memory:

```php
foreach (self::$loaded as $group) {
	if ($group->min_posts !== -1) {
		self::$post_groups[$group->id] = $group->min_posts;
	}
}
```

then hands that array straight to the query that fetches the rest:

```php
'SELECT id_group, min_posts
FROM {db_prefix}membergroups
WHERE id_group NOT IN ({array_int:known_post_groups})
	AND min_posts != {int:min_posts}',
[
	'min_posts' => -1,
	'known_post_groups' => !empty(self::$post_groups) ? self::$post_groups : [self::NONE],
]
```

`{array_int:}` takes the array's **values**, so `id_group` is compared against **post counts** instead of group IDs.

Two consequences. The groups that were already loaded are not excluded, so they come back from the query and get written into the list a second time — harmless. And **any post group whose ID happens to equal another post group's `min_posts` is excluded when it should not be**, so it drops out of the list entirely.

The second one costs a group. Say a forum has a custom post group at ID 9 requiring 4 posts, and it is the one already loaded. The exclusion list becomes `[4]` instead of `[9]`, so the query is asked for everything except ID 4 — and Newbie, the group for members with no posts, never arrives. Run against the two lists on a forum with that group added:

```
NOT IN (9)   ->  4,5,6,7,8      the IDs, what the query means
NOT IN (4)   ->  5,6,7,8,9      the post counts, what it passes
```

`array_keys()` is the fix.

##### What I did not verify

I have not produced a member ending up in the wrong group through the UI. It needs a specific arrangement — a post group loaded whose `min_posts` collides with another post group's ID — and I did not stage one end to end. The defect in the query is plain from the two lines that build the array, and the fix does not change behaviour in any other case: with default groups the current code excludes nothing (no group has ID 0, 50, 100, 250 or 500), so the only difference is that duplicates stop being re-fetched.

Found while chasing an unrelated 500 through `User::saveBatch()`, which is one of this method's callers.

### Issues References (Fixes|Related|Closes)

Related to #7933