### PR TITLE
[3.0] Bring back the last edit note on the posting form

### DIFF
--- a/Sources/Actions/Post.php
+++ b/Sources/Actions/Post.php
@@ -1199,7 +1199,10 @@ class Post implements ActionInterface, Routable
 			Utils::$context['last_modified_reason'] = Lang::censorText($row['modified_reason']);
 			Utils::$context['last_modified_reason_raw'] = $row['modified_reason'];
 			Utils::$context['last_modified_name'] = $row['modified_name'];
-			Utils::$context['last_modified_text'] = Lang::getTxt('last_edit_by', ['time' => Utils::$context['last_modified'], 'member' => $row['modified_name']], file: 'General') . empty($row['modified_reason']) ? '' : ' ' . Lang::getTxt('last_edit_reason', ['reason' => $row['modified_reason']], file: 'General');
+			// The reason is optional, so it needs brackets of its own here.
+			// Concatenation binds tighter than the ternary, so without them the
+			// whole thing is the condition and the note is always empty.
+			Utils::$context['last_modified_text'] = Lang::getTxt('last_edit_by', ['time' => Utils::$context['last_modified'], 'member' => $row['modified_name']], file: 'General') . (empty($row['modified_reason']) ? '' : ' ' . Lang::getTxt('last_edit_reason', ['reason' => $row['modified_reason']], file: 'General'));
 		}
 
 		// Get the stuff ready for the form.


### PR DESCRIPTION
#### Description

Editing a post that has been edited before is supposed to show a "Last Edit: … by …" note above the editor. It never does.

`Post.php` builds that note as:

```php
Utils::$context['last_modified_text'] = Lang::getTxt('last_edit_by', [...]) . empty($row['modified_reason']) ? '' : ' ' . Lang::getTxt('last_edit_reason', [...]);
```

The reason half is optional, but `.` binds tighter than `?:`, so PHP reads the whole left-hand side as the condition:

```php
(Lang::getTxt('last_edit_by', ...) . empty($row['modified_reason'])) ? '' : (' ' . Lang::getTxt('last_edit_reason', ...))
```

`last_edit_by` always resolves to a non-empty string, so the condition is always true and the result is always `''`. `Post.php` then only renders the note when it is non-empty, so nothing is shown either way — with a reason or without one.

2.1 had the brackets (`Sources/Post.php`, `sprintf($txt['last_edit_by'], …) . (empty($row['modified_reason']) ? '' : …)`); they were dropped in the move to `Lang::getTxt()`.

Adding them back is the whole fix.

Verified on a local 3.0 install. Message 1 was given an edit history so that the generated `modified_*` columns are populated, then `?action=post;msg=1;topic=1.0` was loaded.

Before — no note anywhere in the page:

```
$ grep -c 'Last Edit' edit.html
0
```

After:

```html
<div class="smalltext em"><span class="lastedit">Last Edit</span>: Aug 07, 2025, 08:53 PM by Admin <span class="lastedit reason">Reason</span>: Fixing a typo</div>
```

Found while sweeping `messages` column references against `Sources/Db/Schema/v3_0/`.

### Issues References (Fixes|Related|Closes)

Part of the groundwork for #7933; not a theme change itself.
