### PR TITLE
[3.0] Keep the script name in the url an SSI error is logged against

### DIFF
--- a/Sources/Services/ErrorHandlerService.php
+++ b/Sources/Services/ErrorHandlerService.php
@@ -246,7 +246,7 @@ class ErrorHandlerService
 
 		// Find the best path and query string we can...
 		if (SMF === 'SSI') {
-			$request_url = ($_SERVER['REQUEST_SCHEME'] ?? 'http') . '://' . ($_SERVER['SERVER_NAME'] ?? 'unknown') . '/' . ltrim($_SERVER['REQUEST_URI'] ?? (($_SERVER['DOCUMENT_URI'] ?? $_SERVER['SCRIPT_NAME']	?? 'unknown.php') . !empty($_SERVER['QUERY_STRING']) ? '?' . $_SERVER['QUERY_STRING'] : ''), '/');
+			$request_url = ($_SERVER['REQUEST_SCHEME'] ?? 'http') . '://' . ($_SERVER['SERVER_NAME'] ?? 'unknown') . '/' . ltrim($_SERVER['REQUEST_URI'] ?? (($_SERVER['DOCUMENT_URI'] ?? $_SERVER['SCRIPT_NAME'] ?? 'unknown.php') . (!empty($_SERVER['QUERY_STRING']) ? '?' . $_SERVER['QUERY_STRING'] : '')), '/');
 		} elseif (str_starts_with(($_SERVER['REQUEST_URL'] ?? ''), Config::$boardurl)) {
 			$request_url = substr($_SERVER['REQUEST_URL'], \strlen(Config::$boardurl));
 		} else {


### PR DESCRIPTION
#### Description

Same shape as #9416, in the error logger.

`ErrorHandlerService::log()` builds the url to record an error against. When SMF is running as SSI and there is no `REQUEST_URI` to use, it falls back to the script name plus the query string:

```php
ltrim($_SERVER['REQUEST_URI'] ?? (($_SERVER['DOCUMENT_URI'] ?? $_SERVER['SCRIPT_NAME'] ?? 'unknown.php') . !empty($_SERVER['QUERY_STRING']) ? '?' . $_SERVER['QUERY_STRING'] : ''), '/')
```

The query string half is optional, but `.` binds tighter than `?:`, so the script name ends up inside the condition:

```php
(($_SERVER['DOCUMENT_URI'] ?? …) . !empty($_SERVER['QUERY_STRING'])) ? ('?' . $_SERVER['QUERY_STRING']) : ''
```

A script name is never an empty string, so the condition is always true and the result is always just `'?' . QUERY_STRING` — the path is dropped. With no query string at all it is a bare `'?'`.

`QueryString.php` builds the same url and has the brackets, so that is the form to match:

```php
$_SERVER['REQUEST_URL'] = Config::$scripturl . (!empty($_SERVER['QUERY_STRING']) ? '?' . $_SERVER['QUERY_STRING'] : '');
```

Evaluating both versions with `SCRIPT_NAME = /board/ssi_examples.php` and no `REQUEST_URI`:

```
with a query string:
  before: http://example.com/?foo=bar
  after:  http://example.com/board/ssi_examples.php?foo=bar
without one:
  before: http://example.com/?
  after:  http://example.com/board/ssi_examples.php
```

Worth being straight about the reach: this branch only runs under `SMF === 'SSI'` *and* only when `REQUEST_URI` is missing, which under Apache and most SAPIs it is not. So in practice it is SSI driven from the command line. Small, but it is the error log — the one place where the recorded url is all you have to go on.

Found with a tokenizer pass over the tree looking for a concatenation running into a ternary at the same bracket depth. These two were the only hits.

### Issues References (Fixes|Related|Closes)

Related: #9416 (the same mistake in `Post.php`)
