### PR TITLE
[3.0] Point the recent profile reports block at the profile reports

### DIFF
--- a/Sources/Actions/Moderation/Home.php
+++ b/Sources/Actions/Moderation/Home.php
@@ -510,7 +510,7 @@ class Home implements ActionInterface
 		foreach ($reported_users as $i => $row) {
 			Utils::$context['reported_users'][] = [
 				'id' => $row['id_report'],
-				'report_href' => Config::$scripturl . '?action=moderate;area=reportedmembers;report=' . $row['id_report'],
+				'report_href' => Config::$scripturl . '?action=moderate;area=reportedmembers;sa=details;rid=' . $row['id_report'],
 				'user' => [
 					'id' => $row['id_user'],
 					'name' => $row['user_name'],

--- a/Themes/default/ModerationCenter.template.php
+++ b/Themes/default/ModerationCenter.template.php
@@ -209,7 +209,7 @@ function template_reported_posts_block()
 		</div><!-- #reported_posts_panel -->
 
 		<script>
-			var oWatchedUsersToggle = new smc_Toggle({
+			var oReportedPostsToggle = new smc_Toggle({
 				bToggleEnabled: true,
 				bCurrentlyCollapsed: ', !empty(Utils::$context['admin_prefs']['mcrp']) ? 'true' : 'false', ',
 				aSwappableContainers: [
@@ -249,7 +249,7 @@ function template_reported_users_block()
 	echo '
 		<div class="cat_bar">
 			<h3 class="catbg">
-				<a href="', Config::$scripturl, '?action=moderate;area=userwatch" id="reported_users_link">', Lang::getTxt('mc_recent_user_reports', file: 'ModerationCenter'), '</a>
+				<a href="', Config::$scripturl, '?action=moderate;area=reportedmembers" id="reported_users_link">', Lang::getTxt('mc_recent_user_reports', file: 'ModerationCenter'), '</a>
 			</h3>
 			<span id="reported_users_toggle" class="', !empty(Utils::$context['admin_prefs']['mcur']) ? 'toggle_down' : 'toggle_up', '" title="', Lang::getTxt(empty(Utils::$context['admin_prefs']['mcur']) ? 'hide' : 'show', file: 'General'), '" style="display: none;"></span>
 		</div>
@@ -276,7 +276,7 @@ function template_reported_users_block()
 		</div><!-- #reported_users_panel -->
 
 		<script>
-			var oWatchedUsersToggle = new smc_Toggle({
+			var oReportedUsersToggle = new smc_Toggle({
 				bToggleEnabled: true,
 				bCurrentlyCollapsed: ', !empty(Utils::$context['admin_prefs']['mcur']) ? 'true' : 'false', ',
 				aSwappableContainers: [


### PR DESCRIPTION
#### Description

The moderation home draws four blocks. Two of them link to the same page.

```
?action=groups;sa=requests           Membergroup Requests
?action=moderate;area=reportedposts  Recent Topic Reports
?action=moderate;area=userwatch      Recent Watched Members
?action=moderate;area=userwatch      Recent Profile Reports   <-- Watched Users again
```

"Recent Profile Reports" should go to `area=reportedmembers`. As it stands the block lists the reported members but there is no way to get from it to the reports; a moderator has to find the area in the menu instead. `area=reportedmembers` is what `Moderation\Main.php` registers and what `Moderation\Logs.php` links to elsewhere.

Two smaller things in the same blocks:

- `Home::reportedMembers()` builds `'report_href' => …;area=reportedmembers;report=' . $row['id_report']`. `ReportedContent` reads `rid`, not `report`, and needs `sa=details` to show one, so that url lands on the report list. The sibling `reportedPosts()` two functions above has it right: `…;area=reportedposts;sa=details;rid=…`. Nothing renders `report_href` today, so this is not visible — it is fixed because it is wrong, and because it is the obvious thing to reach for if the block ever grows a link.
- Three of the four blocks declare their toggle as `var oWatchedUsersToggle`. They are separate `smc_Toggle` objects on the same page and each still works, since only the last binding survives and nothing reads the variable, but it makes the page hard to read. Renamed each to match its panel.

These are all inherited from 2.1 rather than new in 3.0.

Verified on a local 3.0 install — the rendered ids and hrefs on `?action=moderate;area=index`:

```
<a href="?action=moderate;area=reportedposts"   id="reported_posts_link">Recent Topic Reports
<a href="?action=moderate;area=userwatch"       id="watched_users_link">Recent Watched Members
<a href="?action=moderate;area=reportedmembers" id="reported_users_link">Recent Profile Reports

var oGroupRequestsPanelToggle
var oReportedPostsToggle
var oReportedUsersToggle
var oWatchedUsersToggle
```

and `?action=moderate;area=reportedmembers` renders without error.

### Issues References (Fixes|Related|Closes)

Part of the groundwork for #7933; not a theme change itself.
