### PR TITLE
[3.0] Give the agreement page its heading back

### DIFF
--- a/Themes/default/Agreement.template.php
+++ b/Themes/default/Agreement.template.php
@@ -27,7 +27,7 @@ function template_main()
 	if (!empty(Utils::$context['agreement'])) {
 		echo '
 		<div class="cat_bar">
-			<h3 class="catbg">', Lang::getTxt('agreement' . (!empty(Utils::$context['can_accept_agreement']) ? '_updated' : ''), file: 'General+Agreement'), '</h3>
+			<h3 class="catbg">', Lang::getTxt(!empty(Utils::$context['can_accept_agreement']) ? 'agreement_updated' : 'registration_agreement', file: 'General+Agreement'), '</h3>
 		</div>';
 
 		if (!empty(Utils::$context['can_accept_agreement'])) {


### PR DESCRIPTION
#### Description

`?action=agreement` renders its heading as `<h3 class="catbg"></h3>` — an empty bar above the agreement text.

The template builds the key by concatenation:

```php
Lang::getTxt('agreement' . (!empty(Utils::$context['can_accept_agreement']) ? '_updated' : ''), file: 'General+Agreement')
```

so it wants either `agreement_updated` or `agreement`. Only the first of those exists. 2.1 had both in `Agreement.english.php`:

```php
$txt['agreement'] = 'Registration Agreement';
$txt['agreement_updated'] = 'Updated Registration Agreement';
```

3.0's `Languages/en_US/Agreement.php` kept `agreement_updated` and dropped `agreement`; the string under that name now lives in `General.php` as `registration_agreement`, which is what `Actions/Agreement.php` uses for the page title. `Lang::getTxt()` returns `''` for a key it cannot find, so nothing is drawn and nothing is logged.

Naming both keys rather than assembling one is also easier to grep for, which is how this stayed hidden.

I went with `registration_agreement` rather than adding `$txt['agreement']` back, so the heading and the page title come from the same string.

Before, on a fresh install:

```html
<div class="cat_bar">
    <h3 class="catbg"></h3>
</div>
```

After:

```html
<div class="cat_bar">
    <h3 class="catbg">Registration Agreement</h3>
</div>
```

which now matches `<title>Registration Agreement</title>`.

Found by listing every `getTxt()` key literal that no language file defines.

### Issues References (Fixes|Related|Closes)

Part of the groundwork for #7933; not a theme change itself.
