### PR TITLE
[3.0] Label a spoiler that was given no summary of its own

### DIFF
--- a/Sources/BBCode/Spoiler1.php
+++ b/Sources/BBCode/Spoiler1.php
@@ -123,7 +123,9 @@ class Spoiler1 extends BBCode
 			$bbc->before = Lang::formatText(
 				BBCodeParser::insertTxt($details->before),
 				[
-					'summary' => $params['{text}'] ?? Lang::getTxt('spoiler', var: 'editortxt'),
+					// An optional parameter that was not given arrives as an
+					// empty string rather than null, so ?? never falls back.
+					'summary' => $params['{text}'] ?: Lang::getTxt('spoiler', var: 'editortxt', file: 'Editor'),
 				],
 			);
 

--- a/Sources/BBCode/Spoiler1.php
+++ b/Sources/BBCode/Spoiler1.php
@@ -123,8 +123,6 @@ class Spoiler1 extends BBCode
 			$bbc->before = Lang::formatText(
 				BBCodeParser::insertTxt($details->before),
 				[
-					// An optional parameter that was not given arrives as an
-					// empty string rather than null, so ?? never falls back.
 					'summary' => $params['{text}'] ?: Lang::getTxt('spoiler', var: 'editortxt', file: 'Editor'),
 				],
 			);

--- a/Sources/BBCode/Spoiler2.php
+++ b/Sources/BBCode/Spoiler2.php
@@ -84,7 +84,7 @@ class Spoiler2 extends BBCode
 	public function validate(BBCodeInterface &$bbc, array|string &$data, array $disabled, array $params): void
 	{
 		if (\strlen((string) $data) === 0) {
-			$data = Lang::getTxt('summary_default', var: 'editortxt');
+			$data = Lang::getTxt('spoiler', var: 'editortxt', file: 'Editor');
 		}
 	}
 }


### PR DESCRIPTION
#### Description

A spoiler with no summary of its own renders `<summary class="bbc_summary"></summary>` — a details element with nothing in the part you are meant to click.

There are two fallbacks and neither works.

`Spoiler2` (the `[spoiler="…"]` form) asks for a string that does not exist:

```php
$data = Lang::getTxt('summary_default', var: 'editortxt');
```

No language file defines `summary_default`, and `Lang::getTxt()` returns `''` for a key it cannot find, so nothing is logged and nothing is drawn.

`Spoiler1` (the `[spoiler]` form, which becomes a details element when the content has more than one paragraph) has the right key but the wrong test:

```php
'summary' => $params['{text}'] ?? Lang::getTxt('spoiler', var: 'editortxt'),
```

The parser fills every optional parameter in, as an empty string rather than leaving it unset, so `??` never falls back. Dumping `$params` for a plain `[spoiler]`:

```
array (
  '{guests}' => '', '{hide}' => '', '{log}' => '', '{log_id}' => '',
  '{quote}' => '', '{show}' => '', '{text}' => '',
)
```

The branch is only entered when `!empty($params['{text}'])` is false or the content has paragraphs, so in the paragraph case `{text}` is known to be empty by the time `??` is asked — it could never have fired.

`Details::validate()` a few files over gets both parts right, and its `$editortxt['details']` is the model for this, so `$editortxt['spoiler']` is what I used rather than adding a `summary_default` string.

I also named the language file on both calls. `Editor.php` happens to be loaded on a topic view already, so this is not what was breaking them, but neither call said where its string lives.

Verified on a local 3.0 install, three posts:

| BBCode | before | after |
|---|---|---|
| `[spoiler=""]hidden[/spoiler]` | `<summary class="bbc_summary"></summary>` | `<summary class="bbc_summary">Spoiler</summary>` |
| `[spoiler]` with two paragraphs | `<summary class="bbc_summary"></summary>` | `<summary class="bbc_summary">Spoiler</summary>` |
| `[details]plain[/details]` | `<summary class="bbc_summary">Details</summary>` | unchanged |

One thing I noticed while testing and did not touch: a multi-paragraph `[spoiler]` leaves its closing tag in the output as literal text (`second paragraph[/spoiler]`) while still emitting `</div></details>` at the end. That happens on `release-3.0` too and is unrelated to the label — filed separately as #9421.

### Issues References (Fixes|Related|Closes)

Related: #9421
