### PR TITLE
[3.0] Stop the search weights page locking itself out at zero

### DIFF
--- a/Sources/Actions/Admin/Search.php
+++ b/Sources/Actions/Admin/Search.php
@@ -179,7 +179,9 @@ class Search implements ActionInterface
 			$changes = [];
 
 			foreach ($factors as $factor) {
-				$changes[$factor] = (int) $_POST[$factor];
+				// A factor added by a mod through the hook above may well have
+				// no field of its own on the form.
+				$changes[$factor] = (int) ($_POST[$factor] ?? 0);
 			}
 
 			Config::updateModSettings($changes);
@@ -192,7 +194,9 @@ class Search implements ActionInterface
 		}
 
 		foreach ($factors as $factor) {
-			Utils::$context['relative_weights'][$factor] = round(100 * (Config::$modSettings[$factor] ?? 0) / Utils::$context['relative_weights']['total'], 1);
+			// Nothing stops every weight being set to zero, and the page has to
+			// keep working afterwards or there is no way back in to undo it.
+			Utils::$context['relative_weights'][$factor] = empty(Utils::$context['relative_weights']['total']) ? 0 : round(100 * (Config::$modSettings[$factor] ?? 0) / Utils::$context['relative_weights']['total'], 1);
 		}
 
 		SecurityToken::create('admin-msw');


### PR DESCRIPTION
#### Description

`?action=admin;area=managesearch;sa=weights` lets an admin set six search weight factors. Setting all six to zero makes the page a 500 that cannot be undone from the UI.

The page works out each factor's share of the total:

```php
Utils::$context['relative_weights'] = ['total' => 0];

foreach ($factors as $factor) {
    Utils::$context['relative_weights']['total'] += Config::$modSettings[$factor] ?? 0;
}

foreach ($factors as $factor) {
    Utils::$context['relative_weights'][$factor] = round(100 * (Config::$modSettings[$factor] ?? 0) / Utils::$context['relative_weights']['total'], 1);
}
```

With every weight at zero the total is zero and this raises `DivisionByZeroError`, which nothing catches — an HTTP 500 rather than an error page.

The part that makes it worth fixing rather than shrugging at is that the calculation runs on the plain page load, not only on save. So once the zeros are stored, the weights page is the only place to change them and it will not open. The admin has to go into the database.

Zero is a value the form accepts: the fields are plain number inputs with no minimum, and zero for a factor means "ignore this factor", which is a reasonable thing to want for five of the six.

Showing `0%` for each is the honest answer when there is nothing to be a share of.

I also gave the save loop a default. `$factors` comes out of `integrate_modify_search_weights`, so a mod can add one; if it does not also add a field to the template, `(int) $_POST[$factor]` is an undefined key notice on every save.

Verified on a local 3.0 install.

Before — every weight zero:

```
$ curl -s -o /dev/null -w '%{http_code}' '…?action=admin;area=managesearch;sa=weights'
500
```

and the error log holds `Division by zero` at `Search.php:195`.

After, same stored values:

```
200
```

with all six inputs rendered and each showing `0%`, total `100%`. Saving normal values again (30/25/20/15/10/20) gives `25% / 20.8% / 16.7% / 12.5% / 8.3% / 16.7%`, as before.

Found by submitting each admin settings form in turn and reading `smf_log_errors`.

### Issues References (Fixes|Related|Closes)

Part of the groundwork for #7933; not a theme change itself.
