### PR TITLE
[3.0] Centres the forum title and logo in the header

### DIFF
--- a/Themes/default/css/index.css
+++ b/Themes/default/css/index.css
@@ -1288,11 +1288,13 @@ html[lang="el-GR"] .inline_mod_check {
 	gap: .5em;
 	justify-content: flex-end;
 }
-/* The main title. */
+/* The main title. The header lines its contents up in the middle now, so the
+/* title only keeps the padding that lines it up with the page content below
+/* it. The old top-heavy padding pushed it below everything beside it. */
 h1.forumtitle {
 	font-size: 1.8em;
 	font-family: "Tahoma", sans-serif;
-	padding: 22px 12px 6px 10px;
+	padding-inline: 10px 12px;
 	font-weight: normal;
 	flex: 1 1 auto;
 }
@@ -1300,14 +1302,12 @@ h1.forumtitle a {
 	color: #a85400;
 	text-shadow: 1px 1px 1px rgba(0, 0, 0, 0.3);
 }
-/* Float these items to the right */
+/* The slogan, or the Simple Machines logo when there is none. It used to carry
+/* a top margin to drop it onto the old bottom-aligned row; the header centres
+/* everything itself now. */
 #siteslogan, img#smflogo {
 	padding-right: 2px;
 	font-size: 1.4em;
-}
-/* Tweak the SMF logo */
-img#smflogo {
-	margin: 16px 0 0 0;
 }
 /* Even guests need to be aligned */
 .welcome {


### PR DESCRIPTION
#### Description

Two rules in `index.css` are leftovers from the header as it was before #9373, when it was a band of its own that bottom-aligned its contents:

```css
h1.forumtitle { padding: 22px 12px 6px 10px; }
img#smflogo   { margin: 16px 0 0 0; }
```

The header lines its contents up in the middle now (`#header .content_wrapper { align-items: center }`), so both of those push the title and the logo below the user panel sitting beside them. Measured centres on the board index at 1280px, before and after:

| | wrapper | title | logo | user panel |
|---|---|---|---|---|
| before | 47 | 47 | **55** | 47 |
| after | 47 | 47 | 47 | 47 |

The title keeps the horizontal padding that lines it up with the page content below it — as `padding-inline`, so the RTL sheet does not need its own rule. Its start edge stays at x=76 against the breadcrumb's 75. The logo needs nothing; RTL's own `img#smflogo { margin-right: 1em }` still applies.

Header height is unchanged at 93px either way — `--header-height: 80px` sets the floor.

This is the visible half of what #9423 reports. The rest of that report is the intended layout from #9373 and #9374, which merged the old `#top_section` into the header; that matches the end state of #7933 and is not changed here.

### Issues References (Fixes|Related|Closes)

Related #9423
Related #7933