### PR TITLE
[3.0] Gives the other two copies of the header the same wrapper

### DIFF
--- a/Sources/Tasks/ExportProfileData.php
+++ b/Sources/Tasks/ExportProfileData.php
@@ -135,16 +135,18 @@ class ExportProfileData extends BackgroundTask
 						</head>
 						<body>
 							<div id="footerfix">
-								<div id="header" class="content_wrapper">
-									<h1 class="forumtitle">
-										<a id="top">
-											<xsl:attribute name="href">
-												<xsl:value-of select="$scripturl"/>
-											</xsl:attribute>
-											<xsl:value-of select="@forum-name"/>
-										</a>
-									</h1>
-								</div>
+								<header id="header">
+									<div class="content_wrapper">
+										<h1 class="forumtitle">
+											<a id="top">
+												<xsl:attribute name="href">
+													<xsl:value-of select="$scripturl"/>
+												</xsl:attribute>
+												<xsl:value-of select="@forum-name"/>
+											</a>
+										</h1>
+									</div>
+								</header>
 								<div id="wrapper" class="content_wrapper">
 									<div id="inner_wrap">
 										<div class="user">

--- a/Themes/default/MaintenanceTemplate.php
+++ b/Themes/default/MaintenanceTemplate.php
@@ -52,10 +52,12 @@ abstract class MaintenanceTemplate
 	</head>
 	<body>
 		<div id="footerfix">
-		<div id="header" class="content_wrapper">
-			<h1 class="forumtitle">', Maintenance::$tool->getScriptName(), '</h1>
-			<img id="smflogo" src="', Maintenance::$theme_url, '/images/smflogo.svg" alt="Simple Machines Forum" title="Simple Machines Forum">
-		</div>
+		<header id="header">
+			<div class="content_wrapper">
+				<h1 class="forumtitle">', Maintenance::$tool->getScriptName(), '</h1>
+				<img id="smflogo" src="', Maintenance::$theme_url, '/images/smflogo.svg" alt="Simple Machines Forum" title="Simple Machines Forum">
+			</div>
+		</header>
 		<div id="wrapper" class="content_wrapper">';
 
 		// Have we got a language drop down - if so do it on the first step only.


### PR DESCRIPTION
#### Description

Three places build the page chrome: `index.template.php`, `Themes/default/MaintenanceTemplate.php`, and the XSLT in `Sources/Tasks/ExportProfileData.php`. The last two load the real `index.css`, so a selector change in it has to be mirrored in both.

When #9373 moved the top bar into the header, the flex row became `#header .content_wrapper` — the class moved off `#header` and onto a `div` inside it. The other two copies kept it on `#header` itself:

```php
<div id="header" class="content_wrapper">   // maintenance page, profile export
```

so the selector never matched there and neither header got the row. Measured by injecting both structures into a page carrying the real stylesheet, at 1280px:

| | width | height | inner display | title | logo |
|---|---|---|---|---|---|
| `<div id="header" class="content_wrapper">` | 1140 | 119 | block | x=3, y=7 | x=3, y=**71** |
| `<header id="header"><div class="content_wrapper">` | 1281 | 93 | flex | x=66, y=23 | x=**925**, y=36 |

The second row is what the forum's own header measures. The first is a band that stops short of the page edges with the logo stacked under the title.

Both now use the same `<header id="header"><div class="content_wrapper">` as `index.template.php`. The XSLT fragment was checked for well-formedness after the edit, and both files pass `php -l`.

Found while looking into #9423, but it is a separate defect from the one in #9425 — that one is the CSS leftovers, this one is the markup.

### Issues References (Fixes|Related|Closes)

Related #9423
Related #7933