### PR TITLE
[3.0] Puts the forum title and logo back in a band of their own

### DIFF
--- a/Sources/Tasks/ExportProfileData.php
+++ b/Sources/Tasks/ExportProfileData.php
@@ -135,17 +135,15 @@ class ExportProfileData extends BackgroundTask
 						</head>
 						<body>
 							<div id="footerfix">
-								<header id="header">
-									<div class="content_wrapper">
-										<h1 class="forumtitle">
-											<a id="top">
-												<xsl:attribute name="href">
-													<xsl:value-of select="$scripturl"/>
-												</xsl:attribute>
-												<xsl:value-of select="@forum-name"/>
-											</a>
-										</h1>
-									</div>
+								<header id="header" class="content_wrapper">
+									<h1 class="forumtitle">
+										<a id="top">
+											<xsl:attribute name="href">
+												<xsl:value-of select="$scripturl"/>
+											</xsl:attribute>
+											<xsl:value-of select="@forum-name"/>
+										</a>
+									</h1>
 								</header>
 								<div id="wrapper" class="content_wrapper">
 									<div id="inner_wrap">

--- a/Themes/default/MaintenanceTemplate.php
+++ b/Themes/default/MaintenanceTemplate.php
@@ -52,11 +52,9 @@ abstract class MaintenanceTemplate
 	</head>
 	<body>
 		<div id="footerfix">
-		<header id="header">
-			<div class="content_wrapper">
-				<h1 class="forumtitle">', Maintenance::$tool->getScriptName(), '</h1>
-				<img id="smflogo" src="', Maintenance::$theme_url, '/images/smflogo.svg" alt="Simple Machines Forum" title="Simple Machines Forum">
-			</div>
+		<header id="header" class="content_wrapper">
+			<h1 class="forumtitle">', Maintenance::$tool->getScriptName(), '</h1>
+			<img id="smflogo" src="', Maintenance::$theme_url, '/images/smflogo.svg" alt="Simple Machines Forum" title="Simple Machines Forum">
 		</header>
 		<div id="wrapper" class="content_wrapper">';
 

--- a/Themes/default/css/index.css
+++ b/Themes/default/css/index.css
@@ -1223,11 +1223,15 @@ html[lang="el-GR"] .inline_mod_check {
 }
 
 /* The framing graphics */
-/* The top bar. */
+/* The top bar. A band across the page above the header, holding everything to
+/* do with the current user. Same gradient and bottom border as the menu band
+/* under the header; it carries a shadow of its own on top of those. */
 #top_section {
-	border-bottom: 1px solid #bbb;
-	box-shadow: 0 1px 4px rgba(0, 0, 0, 0.16);
-	background: #fff;
+	background: var(--topsection-bg);
+	border-color: var(--topsection-border-color);
+	border-style: var(--topsection-border-style);
+	border-width: var(--topsection-border-width);
+	box-shadow: var(--topsection-box-shadow);
 	clear: both;
 }
 #top_section::after {
@@ -4219,7 +4223,7 @@ h3.profile_hd::before,
 /* Background of buttons */
 .dropmenu li ul, .top_menu, .dropmenu li li:hover, .button,
 .dropmenu li li:hover > a, .dropmenu li li a:focus, .dropmenu li li a:hover,
-#top_section, .quickbuttons > li,
+.quickbuttons > li,
 .quickbuttons li ul, .quickbuttons li ul li a:hover, .quickbuttons ul li a:focus,
 .inline_mod_check, .popup_window, .post_options ul,
 .post_options ul a:hover, .post_options ul a:focus, .dropmenu .viewport .overview a:hover, .dropmenu .viewport .overview a:focus {

--- a/Themes/default/css/index.css
+++ b/Themes/default/css/index.css
@@ -1223,6 +1223,18 @@ html[lang="el-GR"] .inline_mod_check {
 }
 
 /* The framing graphics */
+/* The top bar. */
+#top_section {
+	border-bottom: 1px solid #bbb;
+	box-shadow: 0 1px 4px rgba(0, 0, 0, 0.16);
+	background: #fff;
+	clear: both;
+}
+#top_section::after {
+	content: "";
+	display: block;
+	clear: both;
+}
 #top_info {
 	padding: 5px 0;
 	line-height: 1.3em;
@@ -1255,38 +1267,16 @@ html[lang="el-GR"] .inline_mod_check {
 #languages_form {
 	margin: 0 0 0 10px;
 }
-/* The header. Full width, with its contents lined up with the rest of the
-/* page by the wrapper inside it. */
+/* The logo and slogan. */
 #header {
-	background: var(--header-bg);
-	border-color: var(--header-border-color);
-	border-radius: var(--header-border-radius);
-	border-style: var(--header-border-style);
-	border-width: var(--header-border-width);
-	box-shadow: var(--header-box-shadow);
-	margin: 0;
-	min-height: var(--header-height);
-	padding: .5em .2em;
-}
-#header .content_wrapper {
-	align-items: center;
+	padding: 2px 2px 12px 2px;
 	display: flex;
-	gap: .5em;
-	justify-content: space-between;
-	min-height: var(--header-height);
+	align-items: flex-end;
 }
 #header::after {
 	content: "";
 	display: block;
 	clear: both;
-}
-/* Everything about the current user sits at the end of the header, stacked. */
-.user_panel {
-	align-content: space-between;
-	display: inline-grid;
-	flex: 1;
-	gap: .5em;
-	justify-content: flex-end;
 }
 /* The main title. */
 h1.forumtitle {
@@ -4229,7 +4219,7 @@ h3.profile_hd::before,
 /* Background of buttons */
 .dropmenu li ul, .top_menu, .dropmenu li li:hover, .button,
 .dropmenu li li:hover > a, .dropmenu li li a:focus, .dropmenu li li a:hover,
-.quickbuttons > li,
+#top_section, .quickbuttons > li,
 .quickbuttons li ul, .quickbuttons li ul li a:hover, .quickbuttons ul li a:focus,
 .inline_mod_check, .popup_window, .post_options ul,
 .post_options ul a:hover, .post_options ul a:focus, .dropmenu .viewport .overview a:hover, .dropmenu .viewport .overview a:focus {

--- a/Themes/default/css/variables.css
+++ b/Themes/default/css/variables.css
@@ -78,15 +78,6 @@
 	--mainmenu-border-width:                          0 0 1px 0;
 	--mainmenu-box-shadow:                            none;
 
-	/** Header **/
-	--header-bg:                                      #fff;
-	--header-border-color:                            transparent;
-	--header-border-radius:                           0;
-	--header-border-style:                            solid;
-	--header-border-width:                            0;
-	--header-box-shadow:                              none;
-	--header-height:                                  80px;
-
 	/** HTML **/
 	--html-bg:                                        #3e5a78;
 

--- a/Themes/default/css/variables.css
+++ b/Themes/default/css/variables.css
@@ -71,6 +71,13 @@
 	--footer-link-text-shadow_focus:                  none;
 	--footer-link-text-shadow_hover:                  none;
 
+	/** Top Bar **/
+	--topsection-bg:                                  linear-gradient(#e2e9f3 0%, #fff 70%);
+	--topsection-border-color:                        #bbb;
+	--topsection-border-style:                        solid;
+	--topsection-border-width:                        0 0 1px 0;
+	--topsection-box-shadow:                          0 1px 4px rgba(0, 0, 0, 0.16);
+
 	/** Main Menu **/
 	--mainmenu-bg:                                    linear-gradient(#e2e9f3 0%, #fff 70%);
 	--mainmenu-border-color:                          #bbb;

--- a/Themes/default/index.template.php
+++ b/Themes/default/index.template.php
@@ -228,22 +228,16 @@ function template_html_above()
  */
 function template_body_above()
 {
-	// The header holds the forum title on one side and everything to do with
-	// the current user on the other. h1 a is the target for "Go up" links.
+	// Wrapper div now echoes permanently for better layout options. h1 a is now target for "Go up" links.
 	echo '
-	<header id="header">
-		<div class="content_wrapper">
-			<h1 class="forumtitle">
-				<a id="top" href="', Config::$scripturl, '">', empty(Utils::$context['header_logo_url_html_safe']) ? Utils::$context['forum_name_html_safe'] : '<img src="' . Utils::$context['header_logo_url_html_safe'] . '" alt="' . Utils::$context['forum_name_html_safe'] . '">', '</a>
-			</h1>
-			', empty(Theme::$current->settings['site_slogan']) ? '<img id="smflogo" src="' . Theme::$current->settings['images_url'] . '/smflogo.svg" alt="Simple Machines Forum" title="Simple Machines Forum">' : '<div id="siteslogan">' . Theme::$current->settings['site_slogan'] . '</div>', '
-			<div class="user_panel">';
+	<div id="top_section">
+		<div class="inner_wrap content_wrapper">';
 
 	// If the user is logged in, display some things that might be useful.
 	if (!User::$me->is_guest) {
 		// Firstly, the user's menu
 		echo '
-			<ul id="top_info">
+			<ul class="floatleft" id="top_info">
 				<li>
 					<a href="', Config::$scripturl, '?action=profile"', !empty(Utils::$context['self_profile']) ? ' class="active"' : '', ' id="profile_menu_top">';
 
@@ -297,7 +291,7 @@ function template_body_above()
 		// Some people like to do things the old-fashioned way.
 		if (!empty(Theme::$current->settings['login_main_menu'])) {
 			echo '
-			<ul id="top_info">
+			<ul class="floatleft">
 				<li class="welcome">', Lang::getTxt(
 				Utils::$context['can_register'] ? 'welcome_guest_register' : 'welcome_guest',
 				[
@@ -311,7 +305,7 @@ function template_body_above()
 			</ul>';
 		} else {
 			echo '
-			<ul id="top_info">
+			<ul class="floatleft" id="top_info">
 				<li class="welcome">
 					', Lang::getTxt('welcome_to_forum', ['forum_name' => Utils::$context['forum_name_html_safe']], file: 'General'), '
 				</li>
@@ -337,7 +331,7 @@ function template_body_above()
 		}
 	} else { // In maintenance mode, only login is allowed and don't show OverlayDiv
 		echo '
-			<ul id="top_info" class="welcome">
+			<ul class="floatleft welcome">
 				<li>', Lang::getTxt(
 			'welcome_guest',
 			[
@@ -352,7 +346,7 @@ function template_body_above()
 
 	if (!empty(Config::$modSettings['userLanguage']) && !empty(Utils::$context['languages']) && count(Utils::$context['languages']) > 1) {
 		echo '
-			<form id="languages_form" method="get">
+			<form id="languages_form" method="get" class="floatright">
 				<select id="language_select" name="language" onchange="this.form.submit()">';
 
 		foreach (Utils::$context['languages'] as $language) {
@@ -370,7 +364,7 @@ function template_body_above()
 
 	if (Utils::$context['allow_search']) {
 		echo '
-			<form id="search_form" action="', Config::$scripturl, '?action=search2" method="post" accept-charset="UTF-8">
+			<form id="search_form" class="floatright" action="', Config::$scripturl, '?action=search2" method="post" accept-charset="UTF-8">
 				<input type="search" name="search" value="">&nbsp;';
 
 		// Using the quick search dropdown?
@@ -420,8 +414,19 @@ function template_body_above()
 	}
 
 	echo '
-			</div><!-- .user_panel -->
-		</div><!-- .content_wrapper -->
+		</div><!-- .inner_wrap -->
+	</div><!-- #top_section -->';
+
+	echo '
+	<header id="header" class="content_wrapper">
+		<h1 class="forumtitle">
+			<a id="top" href="', Config::$scripturl, '">', empty(Utils::$context['header_logo_url_html_safe']) ? Utils::$context['forum_name_html_safe'] : '<img src="' . Utils::$context['header_logo_url_html_safe'] . '" alt="' . Utils::$context['forum_name_html_safe'] . '">', '</a>
+		</h1>';
+
+	echo '
+		', empty(Theme::$current->settings['site_slogan']) ? '<img id="smflogo" src="' . Theme::$current->settings['images_url'] . '/smflogo.svg" alt="Simple Machines Forum" title="Simple Machines Forum">' : '<div id="siteslogan">' . Theme::$current->settings['site_slogan'] . '</div>', '';
+
+	echo '
 	</header>';
 
 	// The menu is a band of its own across the page, with its contents lined up
@@ -507,7 +512,7 @@ function template_body_below()
 			<li class="helplinks">
 				<a href="', Config::$scripturl, '?action=help">', Lang::getTxt('help', file: 'General'), '</a>', (!empty(Config::$modSettings['requireAgreement'])) ? '
 				<a href="' . Config::$scripturl . '?action=agreement">' . Lang::getTxt('terms_and_rules', file: 'General') . '</a>' : '', '
-				<a href="#header">', Lang::getTxt('go_up', file: 'General'), ' &#9650;</a>
+				<a href="#top_section">', Lang::getTxt('go_up', file: 'General'), ' &#9650;</a>
 			</li>
 		</ul>';
 


### PR DESCRIPTION
#### Description

Reverts the layout half of #9373. Confirmed with live627 as the direction to take on #9423: the merged header is not what people expect of this theme, whatever the theme branch does.

Back to:

```
#top_section   user links, language picker, search      full width, banded
#header        forum title, logo                        width-limited, transparent
#main_menu     the menu                                 full width band
```

Measured on the board index at 1280px after the change:

| | x | width | height |
|---|---|---|---|
| `#top_section` | 0 | 1281 | 35 |
| `#header` | 64 | 1153 | 67 |
| `#main_menu` | 0 | 1281 | 25 |

which is the layout in the "expected result" screenshot on #9423. Checked at 1280px and at 480px, where the search box and the logo drop out as they did before.

Two commits, deliberately separate:

1. **The revert itself**, which is `git revert 6fa05ff1f` with the conflicts resolved to keep everything that landed after it.
2. **Tokens for the top bar.** The revert restores the rule as it was before the top bar was ever tokenised — wave 2 covered base, buttons, frames, boxes, quotes and overlays, and the top bar was in none of those groups, so #9373 deleted it before it ever got its own. Literal colours in `index.css` are the wrong direction for a file where `#main_menu` right under it already reads from `--mainmenu-*`, so it gets `--topsection-*` to match.

Values are unchanged by the second commit. The band's background came from the shared gradient rule near the end of the file, not the `#fff` in its own rule, so the token holds that gradient and the selector list loses its entry; the border is identical to the menu band's. Computed values before and after:

| | before | after |
|---|---|---|
| `background-image` | `linear-gradient(rgb(226,233,243) 0%, rgb(255,255,255) 70%)` | same |
| `border-bottom` | `0.571429px solid rgb(187,187,187)` | same |
| `box-shadow` | `rgba(0,0,0,0.16) 0px 1px 4px 0px` | same |
| `background-color` | `rgb(255,255,255)` | `rgba(0,0,0,0)` |

The last row is the `/* fallback for some browsers */` colour behind an opaque gradient, which `#main_menu` also dropped when it was tokenised.

What is **not** reverted: #9374 and #9375 stay exactly as they are, so the menu is still a band across the page and the footer is still a flex row. The `<header>` landmark from #9371 stays too — only the class moves back onto it.

Other consequences:

- The `--header-*` tokens and the `.user_panel` rule existed only for the merged header and go with it. The header sets no background, border or shadow any more, so tokens for those would describe nothing. Nothing else references either; checked across `Themes/`.
- The Go up link points at `#top_section` again, since that is the first thing on the page once more.
- `MaintenanceTemplate.php` and the `ExportProfileData.php` XSLT follow the forum's header, so the wrapper class goes back onto the header element in both. That reverts #9426, which was correct only while the header had an inner wrapper.

#9425 is superseded by this and closed — it centred the title and logo in a row that no longer exists.

### Issues References (Fixes|Related|Closes)

Fixes #9423
Related #7933