### PR TITLE
[3.0] Theme split (wave 4, part 11) — describe the posting form's checkboxes instead of writing them out

### DIFF
--- a/Sources/Actions/Post.php
+++ b/Sources/Actions/Post.php
@@ -369,6 +369,9 @@ class Post implements ActionInterface, Routable
 		// Set up the fields for the posting form header.
 		$this->setupPostingFields();
 
+		// Set up the checkboxes below the editor.
+		$this->setupPostOptions();
+
 		// Finally, load the template.
 		if (!isset($_REQUEST['xml'])) {
 			Theme::loadTemplate('Post');
@@ -1845,6 +1848,100 @@ class Post implements ActionInterface, Routable
 				'selected' => true,
 			]);
 		}
+	}
+
+	/**
+	 * Sets up the checkboxes that sit below the editor.
+	 *
+	 * Each item in Utils::$context['post_options'] is an array like this:
+	 *
+	 *     [
+	 *         'can_show' => Utils::$context['can_lock'], // required
+	 *         'name' => 'lock',                          // required
+	 *         'id' => 'check_lock',                      // required
+	 *         'checked' => Utils::$context['locked'],    // required
+	 *         'label' => Lang::getTxt('lock_topic'),     // required
+	 *         'value' => '1',                            // optional, defaults to '1'
+	 *         'hidden' => ['lock' => '0'],               // optional
+	 *     ]
+	 *
+	 * An unchecked checkbox submits nothing at all, so anything that can be
+	 * switched back off needs a hidden field of the same name carrying the
+	 * "off" value ahead of it. That is what 'hidden' is for; the fields in it
+	 * are written out immediately before the checkbox.
+	 */
+	protected function setupPostOptions(): void
+	{
+		Utils::$context['post_options'] = [
+			[
+				'can_show' => Utils::$context['can_notify'],
+				'name' => 'notify',
+				'id' => 'check_notify',
+				'checked' => Utils::$context['notify'] || !empty(Theme::$current->options['auto_notify']) || Utils::$context['auto_notify'],
+				'label' => Lang::getTxt('notify_replies', file: 'Post'),
+				'hidden' => ['notify' => '0'],
+			],
+			[
+				'can_show' => Utils::$context['can_lock'],
+				'name' => 'lock',
+				'id' => 'check_lock',
+				'checked' => (bool) Utils::$context['locked'],
+				'label' => Lang::getTxt('lock_topic', file: 'Post'),
+				'hidden' => [
+					'already_locked' => Utils::$context['already_locked'],
+					'lock' => '0',
+				],
+			],
+			[
+				'can_show' => true,
+				'name' => 'goback',
+				'id' => 'check_back',
+				'checked' => Utils::$context['back_to_topic'] || !empty(Theme::$current->options['return_to_post']),
+				'label' => Lang::getTxt('back_to_topic', file: 'Post'),
+			],
+			[
+				'can_show' => Utils::$context['can_sticky'],
+				'name' => 'sticky',
+				'id' => 'check_sticky',
+				'checked' => (bool) Utils::$context['sticky'],
+				'label' => Lang::getTxt('sticky_after_posting', file: 'Post'),
+				'hidden' => [
+					'already_sticky' => Utils::$context['already_sticky'],
+					'sticky' => '0',
+				],
+			],
+			[
+				'can_show' => true,
+				'name' => 'ns',
+				'id' => 'check_smileys',
+				'checked' => empty(Utils::$context['use_smileys']),
+				'label' => Lang::getTxt('dont_use_smileys', file: 'Post'),
+				'value' => 'NS',
+			],
+			[
+				'can_show' => Utils::$context['can_move'],
+				'name' => 'move',
+				'id' => 'check_move',
+				'checked' => !empty(Utils::$context['move']),
+				'label' => Lang::getTxt('move_after_posting', file: 'Post'),
+				'hidden' => ['move' => '0'],
+			],
+			[
+				'can_show' => Utils::$context['can_announce'] && Utils::$context['is_first_post'],
+				'name' => 'announce_topic',
+				'id' => 'check_announce',
+				'checked' => !empty(Utils::$context['announce']),
+				'label' => Lang::getTxt('announce_topic', file: 'Post'),
+			],
+			[
+				'can_show' => !empty(Utils::$context['show_approval']),
+				'name' => 'approve',
+				'id' => 'approve',
+				'checked' => Utils::$context['show_approval'] === 2,
+				'label' => Lang::getTxt('approve_this_post', file: 'Post'),
+				'value' => '2',
+			],
+		];
 	}
 
 	/**

--- a/Themes/default/Post.template.php
+++ b/Themes/default/Post.template.php
@@ -375,34 +375,23 @@ function template_main()
 					</div>';
 	}
 
-	// If the admin has enabled the hiding of the additional options - show a link and image for it.
+	// If the admin has enabled the hiding of the additional options, fold them
+	// away behind a disclosure triangle. A details element remembers nothing by
+	// itself, so the script further down copies its state into the hidden
+	// additional_options field that gets posted back.
 	if (!empty(Config::$modSettings['additional_options_collapsable'])) {
 		echo '
-					<div id="post_additional_options_header">
-						<strong><a href="#" id="postMoreExpandLink"> ', Lang::getTxt('post_additionalopt', file: 'Post'), '</a></strong>
-					</div>';
+					<details id="post_options_toggle"', Utils::$context['show_additional_options'] ? ' open' : '', '>
+						<summary>', Lang::getTxt('post_additionalopt', file: 'Post'), '</summary>';
 	}
 
-	echo '
-					<div id="post_additional_options">';
-
 	// Display the checkboxes for all the standard options - if they are available to the user!
-	echo '
-						<div id="post_settings" class="smalltext">
-							<ul class="post_options">
-								', Utils::$context['can_notify'] ? '<li><input type="hidden" name="notify" value="0"><label for="check_notify"><input type="checkbox" name="notify" id="check_notify"' . (Utils::$context['notify'] || !empty(Theme::$current->options['auto_notify']) || Utils::$context['auto_notify'] ? ' checked' : '') . ' value="1"> ' . Lang::getTxt('notify_replies', file: 'Post') . '</label></li>' : '', '
-								', Utils::$context['can_lock'] ? '<li><input type="hidden" name="already_locked" value="' . Utils::$context['already_locked'] . '"><input type="hidden" name="lock" value="0"><label for="check_lock"><input type="checkbox" name="lock" id="check_lock"' . (Utils::$context['locked'] ? ' checked' : '') . ' value="1"> ' . Lang::getTxt('lock_topic', file: 'Post') . '</label></li>' : '', '
-								<li><label for="check_back"><input type="checkbox" name="goback" id="check_back"' . (Utils::$context['back_to_topic'] || !empty(Theme::$current->options['return_to_post']) ? ' checked' : '') . ' value="1"> ' . Lang::getTxt('back_to_topic', file: 'Post') . '</label></li>
-								', Utils::$context['can_sticky'] ? '<li><input type="hidden" name="already_sticky" value="' . Utils::$context['already_sticky'] . '"><input type="hidden" name="sticky" value="0"><label for="check_sticky"><input type="checkbox" name="sticky" id="check_sticky"' . (Utils::$context['sticky'] ? ' checked' : '') . ' value="1"> ' . Lang::getTxt('sticky_after_posting', file: 'Post') . '</label></li>' : '', '
-								<li><label for="check_smileys"><input type="checkbox" name="ns" id="check_smileys"', Utils::$context['use_smileys'] ? '' : ' checked', ' value="NS"> ', Lang::getTxt('dont_use_smileys', file: 'Post'), '</label></li>', '
-								', Utils::$context['can_move'] ? '<li><input type="hidden" name="move" value="0"><label for="check_move"><input type="checkbox" name="move" id="check_move" value="1"' . (!empty(Utils::$context['move']) ? ' checked" ' : '') . '> ' . Lang::getTxt('move_after_posting', file: 'Post') . '</label></li>' : '', '
-								', Utils::$context['can_announce'] && Utils::$context['is_first_post'] ? '<li><label for="check_announce"><input type="checkbox" name="announce_topic" id="check_announce" value="1"' . (!empty(Utils::$context['announce']) ? ' checked' : '') . '> ' . Lang::getTxt('announce_topic', file: 'Post') . '</label></li>' : '', '
-								', Utils::$context['show_approval'] ? '<li><label for="approve"><input type="checkbox" name="approve" id="approve" value="2"' . (Utils::$context['show_approval'] === 2 ? ' checked' : '') . '> ' . Lang::getTxt('approve_this_post', file: 'Post') . '</label></li>' : '', '
-							</ul>
-						</div><!-- #post_settings -->';
+	template_post_options(Utils::$context['post_options']);
 
-	echo '
-					</div><!-- #post_additional_options -->';
+	if (!empty(Config::$modSettings['additional_options_collapsable'])) {
+		echo '
+					</details>';
+	}
 
 	// If the admin enabled the drafts feature, show a draft selection box
 	if (!empty(Config::$modSettings['drafts_post_enabled']) && !empty(Utils::$context['drafts']) && !empty(Config::$modSettings['drafts_show_saved_enabled']) && !empty(Theme::$current->options['drafts_show_saved_enabled'])) {
@@ -514,35 +503,12 @@ function template_main()
 	echo '
 			});';
 
-	// Code for showing and hiding additional options.
+	// Remember whether the additional options were left open, so the next post
+	// form comes back the same way round.
 	if (!empty(Config::$modSettings['additional_options_collapsable'])) {
 		echo '
-			var oSwapAdditionalOptions = new smc_Toggle({
-				bToggleEnabled: true,
-				bCurrentlyCollapsed: ', Utils::$context['show_additional_options'] ? 'false' : 'true', ',
-				funcOnBeforeCollapse: function () {
-					document.getElementById(\'additional_options\').value = \'0\';
-				},
-				funcOnBeforeExpand: function () {
-					document.getElementById(\'additional_options\').value = \'1\';
-				},
-				aSwappableContainers: [
-					\'post_additional_options\',
-				],
-				aSwapImages: [
-					{
-						sId: \'postMoreExpandLink\',
-						altExpanded: \'-\',
-						altCollapsed: \'+\'
-					}
-				],
-				aSwapLinks: [
-					{
-						sId: \'postMoreExpandLink\',
-						msgExpanded: ', Utils::escapeJavaScript(Lang::getTxt('post_additionalopt', file: 'Post')), ',
-						msgCollapsed: ', Utils::escapeJavaScript(Lang::getTxt('post_additionalopt', file: 'Post')), '
-					}
-				]
+			document.getElementById(\'post_options_toggle\').addEventListener(\'toggle\', function () {
+				document.getElementById(\'additional_options\').value = this.open ? \'1\' : \'0\';
 			});';
 	}
 
@@ -666,6 +632,45 @@ function template_main()
 			}
 		</script>';
 	}
+}
+
+/**
+ * Draws the checkboxes that sit below the editor on the posting form.
+ *
+ * See Post::setupPostOptions() for what each option looks like. Anything an
+ * option lists under 'hidden' is written out just before its checkbox, because
+ * a checkbox that is not ticked submits nothing at all and the hidden field of
+ * the same name is what carries the "off" value.
+ *
+ * @param array $post_options The options to draw, in the order they go in.
+ */
+function template_post_options(array $post_options): void
+{
+	echo '
+					<ul id="post_options" class="smalltext">';
+
+	foreach ($post_options as $option) {
+		if (!$option['can_show']) {
+			continue;
+		}
+
+		echo '
+						<li>';
+
+		foreach ($option['hidden'] ?? [] as $hidden_name => $hidden_value) {
+			echo '
+							<input type="hidden" name="', $hidden_name, '" value="', $hidden_value, '">';
+		}
+
+		echo '
+							<label for="', $option['id'], '">
+								<input type="checkbox" name="', $option['name'], '" id="', $option['id'], '" value="', $option['value'] ?? '1', '"', $option['checked'] ? ' checked' : '', '> ', $option['label'], '
+							</label>
+						</li>';
+	}
+
+	echo '
+					</ul><!-- #post_options -->';
 }
 
 /**

--- a/Themes/default/css/index.css
+++ b/Themes/default/css/index.css
@@ -3802,26 +3802,22 @@ form#postmodify .roundframe {
 #post_header img {
 	vertical-align: middle;
 }
-ul.post_options {
-	margin: 0 0 0 12px;
+/* The checkboxes below the editor. Two columns, the same two the floats used to
+/* make, but a grid gets there without needing anything undone for RTL or for
+/* narrow screens. */
+#post_options {
+	display: grid;
+	grid-template-columns: 1fr 1fr;
+	gap: 2px 1em;
+	margin: 0;
 	padding: 0;
-	overflow: hidden;
+	list-style: none;
 }
-ul.post_options li {
-	margin: 2px 0;
-	width: 49%;
-	float: left;
-}
-#post_additional_options_header {
+#post_options_toggle > summary {
 	margin-top: 0.5em;
+	cursor: pointer;
 }
-#post_additional_options {
-	overflow: hidden;
-}
-#post_additional_options .progress_bar {
-	height: 22px;
-}
-#post_settings, #postAttachment, #postAttachment2, #attachment_previews {
+#post_options, #postAttachment, #postAttachment2, #attachment_previews {
 	padding: 10px 0;
 }
 #postAttachment dd, #postAttachment2 dd {

--- a/Themes/default/css/responsive.css
+++ b/Themes/default/css/responsive.css
@@ -359,14 +359,6 @@
 	#post_confirm_buttons .smalltext {
 		display: none;
 	}
-	ul.post_options {
-		padding: 0;
-		margin: 0;
-	}
-	ul.post_options li {
-		margin: 2px 5px 0 0;
-		width: 48%;
-	}
 	/* Search */
 	#searchform .roundframe {
 		padding: 5px;

--- a/Themes/default/css/rtl.css
+++ b/Themes/default/css/rtl.css
@@ -247,13 +247,6 @@ ul.quickbuttons li {
 #post_header dd {
 	float: right;
 }
-ul.post_options {
-	margin: 0 1em 0 0;
-}
-ul.post_options li {
-	float: right;
-	margin: 0 2px;
-}
 
 /* Styles for edit event section
 ---------------------------------------------------- */


### PR DESCRIPTION
#### Description

Part of the #7933 split (wave 4, part 11). Posting area, and the first of two
slices that are small enough to stand on their own.

The eight checkboxes under the editor were eight ternaries concatenating HTML
inside the template. `Post::setupPostOptions()` now describes them as data and
`template_post_options()` draws them, and the collapsible wrapper becomes a
`<details>` element instead of an `smc_Toggle` and its generated script.

**A bug falls out of it.** "Move this topic" carried a stray quote:

```php
value="1"' . (!empty(Utils::$context['move']) ? ' checked" ' : '') . '>
```

so it emitted an attribute called `checked"` and the box never came up ticked,
even when you reached the form through a link asking for it:

| | `release-3.0` | this branch |
|---|---|---|
| rendered | `<input … value="1" checked"="">` | `<input … value="1" checked="">` |
| `.checked` | `false` | `true` |
| submitted | *(nothing)* | `move=1` |

**Hidden "off" fields.** An unticked checkbox submits nothing at all, so
anything that can be switched back off needs a hidden field of the same name
carrying the zero ahead of it. That is what `'hidden'` is for in each entry, and
it is why `notify=0`, `lock=0`, `sticky=0` and `move=0` are listed explicitly
rather than left out.

**On `<details>`.** It drops the `smc_Toggle` call and about 25 lines of
generated script, and the disclosure triangle then works with a keyboard and
without JavaScript. The small listener that is left only copies the open state
into the `additional_options` field, so the next form comes back the same way
round. The list itself is a two column grid rather than two floated columns, so
the RTL and narrow screen rules that undid the floats are gone too. While it was
there, `#post_additional_options .progress_bar` went as well: the attachment
progress bars it names sit above that wrapper, never inside it.

**Naming.** #7933 renders this list as `<ul id="additional_options">`, which
collides with the hidden `<input id="additional_options">` further down the same
form. The `<ul>` comes first in document order, so `getElementById` returns it
and the open state stops persisting. It is `#post_options` here instead. Worth
aligning when the rest of that branch lands.

#### Testing

The whole posting form was serialised on `release-3.0` and on this branch for a
new topic, a reply, a modify and a move. The submitted names and values are
identical apart from `seqnum`, which is per request, and `move=1`, which is the
bug above. Toggling the details element was checked to move the hidden field
between `1` and `0`, and to leave the list hidden when closed.

### Issues References (Fixes|Related|Closes)

Related to #7933
