### PR TITLE
[3.0] Theme split (wave 4, part 12) — give the poll option editor one implementation

### DIFF
--- a/Sources/Actions/PollEdit.php
+++ b/Sources/Actions/PollEdit.php
@@ -61,7 +61,7 @@ class PollEdit implements ActionInterface, Routable
 		}
 
 		Theme::loadTemplate('Poll');
-		Theme::loadJavaScriptFile('post.js', ['defer' => true, 'minimize' => true], 'smf_post');
+		Theme::loadJavaScriptFile('poll.js', ['defer' => true, 'minimize' => true], 'smf_poll');
 
 		Utils::$context['start'] = (int) $_REQUEST['start'];
 		Utils::$context['is_edit'] = isset($_REQUEST['add']) ? 0 : 1;

--- a/Sources/Actions/PollEdit.php
+++ b/Sources/Actions/PollEdit.php
@@ -61,6 +61,7 @@ class PollEdit implements ActionInterface, Routable
 		}
 
 		Theme::loadTemplate('Poll');
+		Theme::loadJavaScriptFile('post.js', ['defer' => true, 'minimize' => true], 'smf_post');
 
 		Utils::$context['start'] = (int) $_REQUEST['start'];
 		Utils::$context['is_edit'] = isset($_REQUEST['add']) ? 0 : 1;

--- a/Sources/Actions/Post.php
+++ b/Sources/Actions/Post.php
@@ -362,6 +362,11 @@ class Post implements ActionInterface, Routable
 		// quotedText.js
 		Theme::loadJavaScriptFile('quotedText.js', ['defer' => true, 'minimize' => true], 'smf_quotedText');
 
+		// The poll fieldsets bring their own script along.
+		if (Utils::$context['make_poll']) {
+			Theme::loadJavaScriptFile('post.js', ['defer' => true, 'minimize' => true], 'smf_post');
+		}
+
 		// Knowing the current board ID might be handy.
 		Theme::addInlineJavaScript('
 		var current_board = ' . (empty(Utils::$context['current_board']) ? 'null' : Utils::$context['current_board']) . ';', false);

--- a/Sources/Actions/Post.php
+++ b/Sources/Actions/Post.php
@@ -364,7 +364,7 @@ class Post implements ActionInterface, Routable
 
 		// The poll fieldsets bring their own script along.
 		if (Utils::$context['make_poll']) {
-			Theme::loadJavaScriptFile('post.js', ['defer' => true, 'minimize' => true], 'smf_post');
+			Theme::loadJavaScriptFile('poll.js', ['defer' => true, 'minimize' => true], 'smf_poll');
 		}
 
 		// Knowing the current board ID might be handy.

--- a/Themes/default/Poll.template.php
+++ b/Themes/default/Poll.template.php
@@ -20,27 +20,6 @@ use SMF\Utils;
  */
 function template_main()
 {
-	// Some javascript for adding more options.
-	echo '
-	<script>
-		var pollOptionNum = 0;
-		var pollOptionId = ', Utils::$context['last_choice_id'], ';
-
-		function addPollOption()
-		{
-			if (pollOptionNum == 0)
-			{
-				for (var i = 0; i < document.forms.postmodify.elements.length; i++)
-					if (document.forms.postmodify.elements[i].id.substr(0, 8) == "options-")
-						pollOptionNum++;
-			}
-			pollOptionNum++
-			pollOptionId++
-
-			setOuterHTML(document.getElementById("pollMoreOptions"), \'<dt><label for="options-\' + pollOptionId + \'" ', (isset(Utils::$context['poll_error']['no_question']) ? ' class="error"' : ''), '>', strtr(Lang::getTxt('option_number', [999], file: 'Post'), ['999' => '\' + pollOptionNum + \'']), '</label></dt><dd><input type="text" name="options[\' + (pollOptionId) + \']" id="options-\' + (pollOptionId) + \'" value="" size="80" maxlength="255"></dd><p id="pollMoreOptions"></p>\');
-		}
-	</script>';
-
 	if (!empty(Utils::$context['poll_error']['messages'])) {
 		echo '
 			<div class="errorbox">
@@ -69,7 +48,7 @@ function template_main()
 					<input type="hidden" name="poll" value="', Utils::$context['poll']['id'], '">
 					<fieldset id="poll_main">
 						<legend><span ', (isset(Utils::$context['poll_error']['no_question']) ? ' class="error"' : ''), '>', Lang::getTxt('poll_question', file: 'General'), '</span></legend>
-						<dl class="settings poll_options">
+						<dl class="settings poll_options" id="poll_choices" data-more-txt="', Lang::getTxt('poll_add_option', file: 'Post'), '" data-option-txt="', Lang::getTxt('option_number', [999], file: 'Post'), '">
 							<dt>', Lang::getTxt('poll_question', file: 'General'), '</dt>
 							<dd><input type="text" name="question" size="80" value="', Utils::$context['poll']['question'], '"></dd>';
 
@@ -90,10 +69,9 @@ function template_main()
 							</dd>';
 	}
 
+	// post.js puts the "add option" button here, after the list it appends to.
 	echo '
-							<p id="pollMoreOptions"></p>
 						</dl>
-						<strong><a href="javascript:addPollOption(); void(0);">(', Lang::getTxt('poll_add_option', file: 'Post'), ')</a></strong>
 					</fieldset>
 					<fieldset id="poll_options">
 						<legend>', Lang::getTxt('poll_options', file: 'Post'), '</legend>
@@ -112,7 +90,7 @@ function template_main()
 								<em class="smalltext">', Lang::getTxt('poll_run_limit', file: 'Post'), '</em>
 							</dt>
 							<dd>
-								<input type="number" name="poll_expire" id="poll_expire" min="0" max="9999" value="', intval(Utils::$context['poll']['expiration']), '" onchange="this.form.poll_hide[2].disabled = isEmptyText(this) || this.value == 0; if (this.form.poll_hide[2].checked) this.form.poll_hide[1].checked = true;">
+								<input type="number" name="poll_expire" id="poll_expire" min="0" max="9999" value="', intval(Utils::$context['poll']['expiration']), '">
 							</dd>
 							<dt>
 								<label for="poll_change_vote">', Lang::getTxt('poll_do_change_vote', file: 'Post'), '</label>

--- a/Themes/default/Poll.template.php
+++ b/Themes/default/Poll.template.php
@@ -69,7 +69,7 @@ function template_main()
 							</dd>';
 	}
 
-	// post.js puts the "add option" button here, after the list it appends to.
+	// poll.js puts the "add option" button here, after the list it appends to.
 	echo '
 						</dl>
 					</fieldset>

--- a/Themes/default/Post.template.php
+++ b/Themes/default/Post.template.php
@@ -37,28 +37,6 @@ function template_main()
 	echo '
 			var icon_urls = ', json_encode(array_column(Utils::$context['icons'], 'url', 'value'), JSON_UNESCAPED_SLASHES), ';';
 
-	// If this is a poll - use some javascript to ensure the user doesn't create a poll with illegal option combinations.
-	if (Utils::$context['make_poll']) {
-		echo '
-			var pollOptionNum = 0;
-			var pollOptionId = ', Utils::$context['last_choice_id'], ';
-			function addPollOption()
-			{
-				if (pollOptionNum == 0)
-				{
-					for (var i = 0, n = document.forms.postmodify.elements.length; i < n; i++)
-						if (document.forms.postmodify.elements[i].id.substr(0, 8) == \'options-\')
-						{
-							pollOptionNum++;
-						}
-				}
-				pollOptionNum++
-				pollOptionId++
-
-				setOuterHTML(document.getElementById("pollMoreOptions"), \'<dt><label for="options-\' + pollOptionId + \'" >', strtr(Lang::getTxt('option_number', [999], file: 'Post'), ['999' => '\' + pollOptionNum + \'']), '</label></dt><dd><input type="text" name="options[\' + (pollOptionId) + \']" id="options-\' + (pollOptionId) + \'" value="" size="80" maxlength="255"></dd><p id="pollMoreOptions"></p>\');
-			}';
-	}
-
 	// If we are making a calendar event we want to ensure we show the current days in a month etc... this is done here.
 	if (Utils::$context['make_event']) {
 		echo '
@@ -162,7 +140,7 @@ function template_main()
 					<div id="edit_poll">
 						<fieldset id="poll_main">
 							<legend><span ', (isset(Utils::$context['poll_error']['no_question']) ? ' class="error"' : ''), '>', Lang::getTxt('poll_question', file: 'General'), '</span></legend>
-							<dl class="settings poll_options">
+							<dl class="settings poll_options" id="poll_choices" data-more-txt="', Lang::getTxt('poll_add_option', file: 'Post'), '" data-option-txt="', Lang::getTxt('option_number', [999], file: 'Post'), '">
 								<dt>', Lang::getTxt('poll_question', file: 'General'), '</dt>
 								<dd>
 									<input type="text" name="question" value="', Utils::$context['question'] ?? '', '" size="80">
@@ -179,10 +157,9 @@ function template_main()
 								</dd>';
 		}
 
+		// post.js puts the "add option" button here, after the list it appends to.
 		echo '
-								<p id="pollMoreOptions"></p>
 							</dl>
-							<strong><a href="javascript:addPollOption(); void(0);">(', Lang::getTxt('poll_add_option', file: 'Post'), ')</a></strong>
 						</fieldset>
 						<fieldset id="poll_options">
 							<legend>', Lang::getTxt('poll_options', file: 'Post'), '</legend>
@@ -198,7 +175,7 @@ function template_main()
 									<em class="smalltext">', Lang::getTxt('poll_run_limit', file: 'Post'), '</em>
 								</dt>
 								<dd>
-									<input type="number" name="poll_expire" id="poll_expire" min="0" max="9999" value="', intval(Utils::$context['poll_options']['expire'] ?? 0), '" onchange="pollOptions();">
+									<input type="number" name="poll_expire" id="poll_expire" min="0" max="9999" value="', intval(Utils::$context['poll_options']['expire'] ?? 0), '">
 								</dd>
 								<dt>
 									<label for="poll_change_vote">', Lang::getTxt('poll_do_change_vote', file: 'Post'), '</label>

--- a/Themes/default/Post.template.php
+++ b/Themes/default/Post.template.php
@@ -157,7 +157,7 @@ function template_main()
 								</dd>';
 		}
 
-		// post.js puts the "add option" button here, after the list it appends to.
+		// poll.js puts the "add option" button here, after the list it appends to.
 		echo '
 							</dl>
 						</fieldset>

--- a/Themes/default/scripts/poll.js
+++ b/Themes/default/scripts/poll.js
@@ -1,5 +1,6 @@
 /**
- * The bits of the posting form that only matter when a poll is attached.
+ * Editing a poll: adding options to it, and the settings that depend on each
+ * other.
  *
  * Loaded from Post.php when the posting form carries a poll, and from
  * PollEdit.php for the add/edit poll form, so everything here can assume the

--- a/Themes/default/scripts/post.js
+++ b/Themes/default/scripts/post.js
@@ -1,0 +1,86 @@
+/**
+ * The bits of the posting form that only matter when a poll is attached.
+ *
+ * Loaded from Post.php when the posting form carries a poll, and from
+ * PollEdit.php for the add/edit poll form, so everything here can assume the
+ * poll fieldsets are on the page.
+ */
+
+/**
+ * Adds one more empty option to the poll.
+ *
+ * The id and name of the new field are the last one's with its trailing number
+ * bumped, rather than anything built from scratch. The two templates disagree
+ * about what those look like, and following whatever the server just rendered
+ * keeps the new field in the same shape as its neighbours either way.
+ *
+ * The label comes from a data attribute holding the language string already
+ * rendered with 999 in it, because languages do not agree on which side of the
+ * word the number belongs.
+ *
+ * @param {HTMLElement} container The dl the options live in.
+ */
+function addPollOption(container)
+{
+	var fields = container.querySelectorAll('input[id^="options-"]');
+
+	if (!fields.length)
+		return;
+
+	var last = fields[fields.length - 1];
+	var bump = function (str) {
+		return str.replace(/\d+(?!.*\d)/, function (n) {
+			return parseInt(n, 10) + 1;
+		});
+	};
+
+	var id = bump(last.id), name = bump(last.name);
+	var label = container.dataset.optionTxt.replace('999', fields.length + 1);
+
+	container.insertAdjacentHTML('beforeend',
+		'<dt><label for="' + id + '">' + label + '</label></dt>'
+		+ '<dd><input type="text" name="' + name + '" id="' + id + '" value="" size="80" maxlength="255"></dd>'
+	);
+}
+
+/**
+ * "Results are only shown once the poll has expired" cannot mean anything while
+ * the poll is set to never expire, so it follows the expiry field.
+ */
+function pollOptions()
+{
+	var expire_time = document.getElementById('poll_expire');
+	var hide = document.forms.postmodify.poll_hide;
+
+	if (isEmptyText(expire_time) || expire_time.value == 0)
+	{
+		hide[2].disabled = true;
+
+		if (hide[2].checked)
+			hide[1].checked = true;
+	}
+	else
+		hide[2].disabled = false;
+}
+
+document.addEventListener('DOMContentLoaded', function ()
+{
+	var container = document.getElementById('poll_choices');
+
+	if (container)
+	{
+		var button = document.createElement('button');
+		button.type = 'button';
+		button.className = 'button';
+		button.textContent = container.dataset.moreTxt;
+		button.addEventListener('click', function () {
+			addPollOption(container);
+		});
+		container.after(button);
+	}
+
+	var expire = document.getElementById('poll_expire');
+
+	if (expire)
+		expire.addEventListener('change', pollOptions);
+});

--- a/Themes/default/scripts/script.js
+++ b/Themes/default/scripts/script.js
@@ -1243,20 +1243,6 @@ function expandThumb(thumbID)
 	return false;
 }
 
-function pollOptions()
-{
-	var expire_time = document.getElementById('poll_expire');
-
-	if (isEmptyText(expire_time) || expire_time.value == 0)
-	{
-		document.forms.postmodify.poll_hide[2].disabled = true;
-		if (document.forms.postmodify.poll_hide[2].checked)
-			document.forms.postmodify.poll_hide[1].checked = true;
-	}
-	else
-		document.forms.postmodify.poll_hide[2].disabled = false;
-}
-
 function generateDays(offset)
 {
 	// Work around JavaScript's lack of support for default values...


### PR DESCRIPTION
#### Description

Part of the #7933 split (wave 4, part 12). Posting area, second of the two
slices, independent of #9428.

`Post.template.php` and `Poll.template.php` each generated their own near
identical copy of `addPollOption()` into the page, both seeded from a context
value the other one sets differently:

```php
var pollOptionId = ', Utils::$context['last_choice_id'], ';
```

**`Post` never sets `last_choice_id` when the poll is new.** So the new poll
form at `?action=post;board=N;poll` emits

```js
var pollOptionId = ;
```

which is a syntax error, and the browser discards the whole first `<script>`
block with it:

```
Uncaught SyntaxError: Unexpected token ';'
```

Two things break as a result. **Add Option does nothing**, because
`addPollOption` was never defined. And **the message icon preview stops
updating**, because `icon_urls` is declared in that same block and
`script.js` reads it to swap the image. `smf_log_errors` has been collecting
`Undefined array key "last_choice_id"` for the same page.

The add/edit poll form at `?action=editpoll` is not affected — `PollEdit` does
set the value — which is presumably why this has gone unnoticed.

#### What changes

Both copies now come from `Themes/default/scripts/post.js`, loaded only where
there is a poll to edit. The option list carries the "Add Option" wording and
the numbered label as data attributes, so nothing is generated into the page any
more, and the button is written from script next to the list, which gets a
`javascript:` link out of the markup. `pollOptions()` moves here out of
`script.js`, which every page loads and only this form calls.

The new field copies its id and name from the last one with the trailing number
bumped, rather than building either from scratch. The two forms disagree about
what those look like — `Poll::format()` hands out ids that already begin with
`options-` and both templates prefix them again, giving
`name="options[options-3]"` — and following whatever the server just rendered
keeps the added option in the same shape as its neighbours without settling that
question here. It is worth its own look; on `release-3.0` the edit poll form
adds `options[5]` next to `options[options-4]`, so the two disagree today.

#### Testing

Both forms, on this branch: options add and number correctly and produce no
console errors, `icon_urls` is defined again, and the results-after-expiry radio
still follows the expiry field, including falling back to "after voting" when it
was selected and the expiry is cleared. A poll submitted from the posting form
with an option added by the button stores all three choices.

### Issues References (Fixes|Related|Closes)

Related to #7933
