### PR TITLE
[3.0] Theme split (wave 4, part 13) — make the login form's ajax submit actually run

### DIFF
--- a/Sources/Theme.php
+++ b/Sources/Theme.php
@@ -1096,6 +1096,12 @@ class Theme
 				self::loadJavaScriptFile('alerts.js', ['minimize' => true], 'smf_alerts');
 			}
 		}
+		// A guest gets a login button, which opens the login form in an overlay.
+		// That form arrives without any template layers, so it cannot bring its
+		// own script with it and has to find login.js already here.
+		else {
+			self::loadJavaScriptFile('login.js', ['defer' => true, 'minimize' => true], 'smf_login');
+		}
 
 		// All the buttons we can possibly want and then some.
 		// Try pulling the final list of buttons from cache first.

--- a/Themes/default/Login.template.php
+++ b/Themes/default/Login.template.php
@@ -29,7 +29,16 @@ function template_login()
 				</h3>
 			</div>
 			<div class="roundframe">
-				<form class="login" action="', Utils::$context['login_url'], '" name="frmLogin" id="frmLogin" method="post" accept-charset="UTF-8">';
+				<form class="login" action="', Utils::$context['login_url'], '" name="frmLogin" id="frmLogin" method="post" accept-charset="UTF-8"';
+
+	// A plain submit is enough when the response is going to come back to the
+	// page it was sent from. Anywhere else, login.js has to take the form over,
+	// and this attribute is how it knows to.
+	if (!empty(Utils::$context['from_ajax']) && (empty(Config::$modSettings['allow_cors']) || empty(Config::$modSettings['allow_cors_credentials']) || empty(Utils::$context['valid_cors_found']) || !in_array(Utils::$context['valid_cors_found'], ['same', 'subdomain']))) {
+		echo ' data-ajax-login="', Utils::$context['valid_cors_found'] ?? '', '"';
+	}
+
+	echo '>';
 
 	// Did they make a mistake last time?
 	if (!empty(Utils::$context['login_errors'])) {
@@ -94,64 +103,6 @@ function template_login()
 						setTimeout(function() {
 							document.getElementById("', !empty(Utils::$context['from_ajax']) ? 'ajax_' : '', isset(Utils::$context['default_username']) && Utils::$context['default_username'] != '' ? 'loginpass' : 'loginuser', '").focus();
 						}, 150);';
-
-	if (!empty(Utils::$context['from_ajax']) && ((empty(Config::$modSettings['allow_cors']) || empty(Config::$modSettings['allow_cors_credentials']) || empty(Utils::$context['valid_cors_found']) || !in_array(Utils::$context['valid_cors_found'], ['same', 'subsite'])))) {
-		echo '
-						form = $("#frmLogin");
-						form.submit(function(e) {
-							e.preventDefault();
-							e.stopPropagation();
-
-							$.ajax({
-								url: form.prop("action") + (form.prop("action").indexOf("?") !== -1 ? ";" : "?") + "ajax",
-								method: "POST",
-								headers: {
-									"X-SMF-AJAX": 1
-								},
-								xhrFields: {
-									withCredentials: typeof allow_xhjr_credentials !== "undefined" ? allow_xhjr_credentials : false
-								},
-								data: form.serialize(),
-								success: function(data) {';
-
-
-		// While a nice action is to replace the document body after a login, this may fail on CORS requests because the action may not be redirected back to the page they started the login process from.  So for these cases, we simply just reload the page.
-		if (empty(Utils::$context['valid_cors_found']) || Utils::$context['valid_cors_found'] == 'same') {
-			echo '
-									if (data.indexOf("<bo" + "dy") > -1) {
-										document.open();
-										document.write(data);
-										document.close();
-									}
-									else
-										form.parent().html($(data).find(".roundframe").html());';
-		} else {
-		echo '
-									if ($(data).find(".roundframe").length > 0 && $(data).find("body").length == 0) {
-										form.parent().html($(data).find(".roundframe").html());
-									}
-									else {
-										window.location.reload();
-									';
-		}
-
-		echo '
-								},
-								error: function(xhr) {
-									var data = xhr.responseText;
-									if (data.indexOf("<bo" + "dy") > -1) {
-										document.open();
-										document.write(data);
-										document.close();
-									}
-									else
-										form.parent().html($(data).filter("#fatal_error").html());
-								}
-							});
-
-							return false;
-						});';
-	}
 
 	echo '
 					</script>

--- a/Themes/default/scripts/login.js
+++ b/Themes/default/scripts/login.js
@@ -1,0 +1,102 @@
+/**
+ * Submits the login form without leaving the page.
+ *
+ * Used where a plain submit would not do: the login form can be opened in an
+ * overlay from the top menu, and it can be served to another origin that CORS
+ * allows, where the response does not necessarily come back to the page the
+ * member started on.
+ *
+ * The listener is delegated from the document rather than bound to the form,
+ * because the overlay arrives through innerHTML and nothing that comes in that
+ * way gets a chance to bind anything to itself.
+ *
+ * A form opts in by carrying data-ajax-login, whose value is what
+ * Security::corsPolicyHeader() decided about the origin: empty for a plain
+ * request, otherwise one of 'same', 'subdomain', 'alias', 'additional' or
+ * 'wildcard'.
+ */
+document.addEventListener('submit', function (e)
+{
+	const form = e.target;
+
+	if (!form.matches('form[data-ajax-login]'))
+		return;
+
+	e.preventDefault();
+	e.stopPropagation();
+
+	const action = form.getAttribute('action');
+
+	/*
+	 * Replacing the page with the response is the nicer outcome, but it is only
+	 * right when the response is going to come back to the page the member is
+	 * looking at. Anywhere else, all that can be said is that something changed,
+	 * so reload and let the server decide what to show.
+	 */
+	const cors = form.dataset.ajaxLogin;
+	const reloadOnly = cors !== '' && cors !== 'same';
+
+	fetch(action + (action.indexOf('?') !== -1 ? ';' : '?') + 'ajax', {
+		method: 'POST',
+		headers: {
+			'Content-Type': 'application/x-www-form-urlencoded',
+			'X-SMF-AJAX': 1,
+
+			// @fixme This is checked for in SMF\Actions\Login2::checkAjax().
+			'X-Requested-With': 'XMLHttpRequest'
+		},
+		credentials: typeof allow_xhjr_credentials !== 'undefined' && allow_xhjr_credentials ? 'include' : 'same-origin',
+		body: new URLSearchParams(new FormData(form)).toString()
+	})
+	.then((response) => response.text().then((data) => {
+		// A whole page came back, so the login went somewhere. Show it.
+		if (data.indexOf('<bo' + 'dy') > -1)
+		{
+			if (reloadOnly && response.ok)
+				window.location.reload();
+			else
+				smf_replaceDocument(data);
+
+			return;
+		}
+
+		// Otherwise it is the form again, with whatever went wrong in it.
+		smf_replaceLoginForm(form, data, response.ok ? '.roundframe' : '#fatal_error');
+	}))
+	.catch(() => window.location.reload());
+});
+
+/**
+ * Throws the current page away and puts the given one in its place.
+ *
+ * @param {string} data The page to show.
+ */
+function smf_replaceDocument(data)
+{
+	document.open();
+	document.write(data);
+	document.close();
+}
+
+/**
+ * Swaps the login form for whatever came back in its place.
+ *
+ * @param {HTMLFormElement} form The form that was submitted.
+ * @param {string} data The response.
+ * @param {string} selector What to pull out of the response.
+ */
+function smf_replaceLoginForm(form, data, selector)
+{
+	const parsed = new DOMParser().parseFromString(data, 'text/html');
+	const replacement = parsed.querySelector(selector);
+
+	// Nothing recognisable came back, so there is nothing better to do.
+	if (!replacement)
+	{
+		window.location.reload();
+
+		return;
+	}
+
+	form.parentNode.innerHTML = replacement.innerHTML;
+}


### PR DESCRIPTION
#### Description

Part of the #7933 split (wave 4, part 13). Login area.

**The login form's ajax submit has never run.** The top menu opens it through
`reqOverlayDiv()`, which hands the response to `smc_Popup.setBody()`, which
assigns `innerHTML` — and `innerHTML` does not execute `<script>` elements. So
the generated handler sits in the DOM as inert markup and the overlay falls back
to a plain submit: the member leaves the page they were on and lands at
`?action=login2` instead of being logged in where they stood. The `focus()` call
in the same block never ran either.

Checked on `release-3.0` by opening the overlay and dispatching a cancelable
`submit` at the form: nothing prevents it, and jQuery has no handlers bound to
it.

**Where it did run, it could still be a syntax error.** The branch for a CORS
origin that is not the forum itself opens an `else` and never closes it:

```js
    else {
        window.location.reload();

    },
    error: function(xhr) {
```

The brace meant for `success: function(data) {` closes the `else` instead, so
`$.ajax()` never parses. Served to an allowed origin, the whole block dies:

```
$ curl -H 'Origin: http://example.test' -H 'X-SMF-AJAX: 1' \
      'http://localhost/index.php?action=login;ajax' | extract-script | node --check
SyntaxError: Unexpected token ','
```

**And that branch is reached more often than intended.** The guard deciding
whether to emit the handler tests

```php
!in_array(Utils::$context['valid_cors_found'], ['same', 'subsite'])
```

`'subsite'` is not a value that exists. `Security::corsPolicyHeader()` only ever
sets `'same'`, `'subdomain'`, `'alias'`, `'additional'` or `'wildcard'`, and
`User.php:2407` spells the same check `['same', 'subdomain']`. A subdomain origin
is trusted everywhere else in SMF and should be submitting the form plainly;
instead it fell into the broken branch.

#### What changes

The handler moves to `Themes/default/scripts/login.js`, **delegated from the
document**, so a form that arrives through `innerHTML` is covered like any other
— that is what makes the overlay work. The form opts in by carrying
`data-ajax-login`, whose value is what `corsPolicyHeader()` decided, so the
PHP branching inside the JavaScript goes away entirely.

Guests load the file with the page. That is not incidental: it is the only way
the code can be present when the overlay opens, since the ajax response has no
template layers and cannot bring its own script. `alerts.js` is loaded the same
way for members, for the same reason.

It also sends `X-Requested-With`, which jQuery added on its own and which
`Login2::checkAjax()` looks for. Without it the response to the submit comes back
as a full page rather than a fragment.

The `setTimeout(...).focus()` block is left exactly as it was. It is inert in the
overlay for the same `innerHTML` reason, but it works on the full page and it is
not what this is about.

#### Testing

In the overlay, on this branch: a wrong password leaves the page alone and shows
the error inside the overlay, with the form and a fresh token behind it; the
right password then logs in without navigating. On the full page the form has no
attribute and submits normally.

With CORS enabled, an allowed additional origin gets `data-ajax-login="additional"`
and a subdomain origin gets no attribute at all. Every emitted script block passes
`node --check`.

### Issues References (Fixes|Related|Closes)

Related to #7933
