### PR TITLE
[3.0] Say how many members are viewing, instead of always saying none

### DIFF
--- a/Themes/default/Display.template.php
+++ b/Themes/default/Display.template.php
@@ -54,8 +54,11 @@ function template_main()
 	if (!empty(Theme::$current->settings['display_who_viewing'])) {
 		// Show just numbers...?
 		if (Theme::$current->settings['display_who_viewing'] == 1 || empty(Utils::$context['view_members_list'])) {
+			// Count the ones this member is allowed to see. Any hidden ones get
+			// their own mention below, so counting those here as well would say
+			// the same people twice.
 			$list_of_viewers = [
-				Lang::getTxt('number_of_members', [0], file: 'General'),
+				Lang::getTxt('number_of_members', [count(Utils::$context['view_members_list'])], file: 'General'),
 			];
 		}
 		// Or show the actual people viewing the topic?

--- a/Themes/default/MessageIndex.template.php
+++ b/Themes/default/MessageIndex.template.php
@@ -38,8 +38,11 @@ function template_main()
 	if (!empty(Theme::$current->settings['display_who_viewing'])) {
 		// Show just numbers...?
 		if (Theme::$current->settings['display_who_viewing'] == 1 || empty(Utils::$context['view_members_list'])) {
+			// Count the ones this member is allowed to see. Any hidden ones get
+			// their own mention below, so counting those here as well would say
+			// the same people twice.
 			$list_of_viewers = [
-				Lang::getTxt('number_of_members', [0], file: 'General'),
+				Lang::getTxt('number_of_members', [count(Utils::$context['view_members_list'])], file: 'General'),
 			];
 		}
 		// Or show the actual people viewing the topic?


### PR DESCRIPTION
#### Description

Found while triaging the Display and MessageIndex areas of the #7933 split. Not
a theme slice — it stands on its own.

With **Show who is viewing → numbers only**, the topic and board pages count the
members present by passing a literal zero:

```php
Lang::getTxt('number_of_members', [0], file: 'General')
```

so the line always reads **"0 members is viewing this topic"**, while `num_viewing`
in the very same sentence counts them properly and picks the singular to match.
Two numbers disagreeing inside one sentence:

| | `release-3.0` | this branch |
|---|---|---|
| one member on the topic | `0 members is viewing this topic.` | `1 member is viewing this topic.` |
| two members | `0 members is viewing this topic.` | `2 members are viewing this topic.` |

Both templates have the same line, so both are fixed.

**Why `view_members_list` and not `view_members`.** The list is what the sentence
describes: `view_members_list` holds the members this reader is allowed to see,
and anyone hidden gets their own mention right after it. `view_members` holds
everyone including the hidden, so counting that would put them in both halves —
"3 members and 3 hidden" for three people, one of whom is hidden.

#### Testing

Several people on one topic, with `display_who_viewing` set to 1:

- as a **moderator**, who sees hidden members in the list and gets no separate
  mention of them: 3 viewers → `3 members are viewing this topic.`
- as an **ordinary member**, with every other viewer hidden: `0 members and 3
  hidden are viewing this topic.` — no one counted twice.

The plural follows correctly in each case, and the two numbers in the sentence
now agree.

### Issues References (Fixes|Related|Closes)

Related to #7933
