### PR TITLE
[3.0] Theme split (wave 4, part 14) — make the search board picker a disclosure widget

### DIFF
--- a/Themes/default/Search.template.php
+++ b/Themes/default/Search.template.php
@@ -157,14 +157,10 @@ function template_main()
 		echo '
 		<fieldset class="flow_hidden">
 			<div class="roundframe alt">
-				<div class="title_bar">
-					<h4 class="titlebg">
-						<a href="#" id="advanced_panel_link">', Lang::getTxt('choose_board', file: 'Search'), '</a>
-					</h4>
-					<span id="advanced_panel_toggle" class="toggle_down" style="display: none;"></span>
-				</div>
-				<div class="flow_auto boardslist" id="advanced_panel_div"', !empty(Utils::$context['boards_check_all']) ? ' style="display: none;"' : '', '>
-					<ul>';
+				<details id="advanced_panel"', !empty(Utils::$context['boards_check_all']) ? '' : ' open', '>
+					<summary class="title_bar titlebg">', Lang::getTxt('choose_board', file: 'Search'), '</summary>
+					<div class="flow_auto boardslist">
+						<ul>';
 
 		foreach (Utils::$context['categories'] as $category) {
 			echo '
@@ -209,8 +205,9 @@ function template_main()
 		}
 
 		echo '
-					</ul>
-				</div><!-- #advanced_panel_div -->
+						</ul>
+					</div>
+				</details>
 				<br class="clear">
 				<div class="padding">
 					<input type="checkbox" name="all" id="check_all" value=""', !empty(Utils::$context['boards_check_all']) ? ' checked' : '', ' onclick="invertAll(this, this.form, \'brd\');">
@@ -219,31 +216,6 @@ function template_main()
 				</div>
 			</div><!-- .roundframe -->
 		</fieldset>';
-
-		echo '
-		<script>
-			var oAdvancedPanelToggle = new smc_Toggle({
-				bToggleEnabled: true,
-				bCurrentlyCollapsed: ', !empty(Utils::$context['boards_check_all']) ? 'true' : 'false', ',
-				aSwappableContainers: [
-					\'advanced_panel_div\'
-				],
-				aSwapImages: [
-					{
-						sId: \'advanced_panel_toggle\',
-						altExpanded: ', Utils::escapeJavaScript(Lang::getTxt('hide', file: 'General')), ',
-						altCollapsed: ', Utils::escapeJavaScript(Lang::getTxt('show', file: 'General')), '
-					}
-				],
-				aSwapLinks: [
-					{
-						sId: \'advanced_panel_link\',
-						msgExpanded: ', Utils::escapeJavaScript(Lang::getTxt('choose_board', file: 'Search')), ',
-						msgCollapsed: ', Utils::escapeJavaScript(Lang::getTxt('choose_board', file: 'Search')), '
-					}
-				]
-			});
-		</script>';
 	}
 
 	echo '

--- a/Themes/default/css/index.css
+++ b/Themes/default/css/index.css
@@ -2679,6 +2679,15 @@ dl {
 	height: 16px;
 }
 
+/* The board picker's title bar is one element now, the summary of a details.
+/* It carries both bar classes, and .titlebg comes later in this file with a
+/* background of its own, so the bar's is named again here. Overflow has to stay
+/* visible as well, or .titlebg clips the disclosure triangle away. */
+#advanced_panel > summary {
+	background: var(--titlebar-bg);
+	cursor: pointer;
+	overflow: visible;
+}
 .boardslist > ul > li {
 	margin: 12px;
 }


### PR DESCRIPTION
#### Description

Part of the #7933 split (wave 4, part 14). Search area.

The panel that chooses which boards to search was a title bar, a link, a hidden
arrow and a div, wired together by an `smc_Toggle` generated into the page. That
is what a `<details>` element does on its own, so it is one now, and the ~25
lines of script go with it.

Worth having beyond the tidy-up: the old control was an `<a href="#">` whose only
behaviour came from the script, so the panel could not be opened by keyboard in
any sensible way, and did not open at all without JavaScript. A `<summary>` does
both.

#### On the one CSS rule

The two bar classes end up on a single element now (`<summary class="title_bar
titlebg">` rather than a `div.title_bar` wrapping an `h4.titlebg`). `.titlebg`
comes later in `index.css` and sets `background: none`, so the bar's own
background is named again in a rule for the summary. That rule also puts
`overflow` back to `visible`, because `.titlebg` hides it and would otherwise
clip the disclosure triangle away.

#### Testing

Computed styles compared against `release-3.0`:

| | `release-3.0` | this branch |
|---|---|---|
| background | `rgb(255, 255, 255)` | `rgb(255, 255, 255)` |
| background-image | `none` | `none` |
| colour | `rgb(85, 85, 85)` | `rgb(85, 85, 85)` |
| padding | `6px 12px 5px` | `6px 12px 5px` |
| border-top | `1.71429px rgb(255, 148, 0)` | `1.71429px rgb(255, 148, 0)` |
| font | `700 Tahoma, sans-serif` | `700 Tahoma, sans-serif` |
| height / width / left | `34 / 729 / 91` | `34 / 729 / 91` |

The panel still starts closed when every board is selected, opening it reveals
the list, the per-category `selectBoards()` links still work, and a search run
with the picker open submits its `brd[]` values and returns results.

#### Noticed while testing, not fixed here

`?action=search;topic=N` without a `board` in the URL is a 500 on `release-3.0`
as well — `Typed property SMF\Board::$id must not be accessed before
initialization`, the same shape as #9413. Untouched by this branch; worth its own
fix.

### Issues References (Fixes|Related|Closes)

Related to #7933
