### PR TITLE
[3.0] Give every poll choice the same id, whichever code built it

### DIFF
--- a/Sources/Poll.php
+++ b/Sources/Poll.php
@@ -426,7 +426,13 @@ class Poll implements \ArrayAccess
 
 			// Now add it to the poll's contextual theme data.
 			$this->formatted['choices'][$i] = [
-				'id' => 'options-' . $i,
+				// Just the number. Post.php builds this array itself when the
+				// posting form comes back from a preview or an error, and it
+				// has always used the plain number, so the templates prefix
+				// what they need. Handing out 'options-3' here made the same
+				// form emit id="options-options-3" one way round and
+				// id="options-3" the other.
+				'id' => $i,
 				'number' => ++$choice_number,
 				'percent' => $bar,
 				'votes' => $option->votes,

--- a/Sources/Poll.php
+++ b/Sources/Poll.php
@@ -426,12 +426,6 @@ class Poll implements \ArrayAccess
 
 			// Now add it to the poll's contextual theme data.
 			$this->formatted['choices'][$i] = [
-				// Just the number. Post.php builds this array itself when the
-				// posting form comes back from a preview or an error, and it
-				// has always used the plain number, so the templates prefix
-				// what they need. Handing out 'options-3' here made the same
-				// form emit id="options-options-3" one way round and
-				// id="options-3" the other.
 				'id' => $i,
 				'number' => ++$choice_number,
 				'percent' => $bar,

--- a/Sources/ServerSideIncludes.php
+++ b/Sources/ServerSideIncludes.php
@@ -1875,7 +1875,7 @@ class ServerSideIncludes
 
 			foreach ($return['options'] as $option) {
 				echo '
-					<label for="', $option['id'], '">', $option['vote_button'], ' ', $option['option'], '</label><br>';
+					<label for="options-', $option['id'], '">', $option['vote_button'], ' ', $option['option'], '</label><br>';
 			}
 
 			echo '
@@ -1966,7 +1966,7 @@ class ServerSideIncludes
 
 			foreach ($return['options'] as $option) {
 				echo '
-					<label for="', $option['id'], '">', $option['vote_button'], ' ', $option['option'], '</label><br>';
+					<label for="options-', $option['id'], '">', $option['vote_button'], ' ', $option['option'], '</label><br>';
 			}
 
 			echo '

--- a/Themes/default/Display.template.php
+++ b/Themes/default/Display.template.php
@@ -148,7 +148,7 @@ function template_main()
 			// Show each option with its button - a radio likely.
 			foreach (Utils::$context['poll']['options'] as $option) {
 				echo '
-							<li>', $option['vote_button'], ' <label for="', $option['id'], '">', $option['option'], '</label></li>';
+							<li>', $option['vote_button'], ' <label for="options-', $option['id'], '">', $option['option'], '</label></li>';
 			}
 
 			echo '


### PR DESCRIPTION
#### Description

`Poll::format()` handed out choice ids that already began with `options-`, and both
`Post.template.php` and `Poll.template.php` prefixed them again. The editing forms
therefore came out as:

```html
<label for="options-options-3">Option 3</label>
<input type="text" name="options[options-3]" id="options-options-3">
```

There is a second builder. When the posting form comes back from a preview or a
validation error, `Post.php` fills `Utils::$context['choices']` itself, and it has always
used the plain number. So the same form named its fields `options[options-0]` on first
load and `options[0]` after a preview, and the option the "Add option" script appends
matched neither.

On `?action=post;board=1;poll` before:

| | first load | after a preview |
|---|---|---|
| id | `options-options-0` | `options-0` |
| name | `options[options-0]` | `options[0]` |

Nothing actually broke: `Poll::create()` and `PollEdit2` both run `array_values()` over
`$_POST['options']` and renumber the choices by position, so the keys are thrown away.
It only made the markup unreadable and the two shapes impossible to reconcile.

`Poll::format()` now returns the number and leaves the prefix to whoever renders it,
which is what `Post.php` already assumed. The three places that label a *vote* button
gain the prefix, since those ids come from `format()` too — `Display.template.php` and
the two poll functions in `ServerSideIncludes.php`.

Checked on all four pages that render poll fields, before and after: the new-poll form,
the same form redisplayed after a preview, `?action=editpoll` on an existing poll, and
the voting form on the topic. Every `for=` now resolves to an element, and the two
posting-form paths agree.

### Issues References (Fixes|Related|Closes)

n/a