### PR TITLE
[3.0] Drop the placeholders when flushing the board move stack

### DIFF
--- a/Sources/Actions/Admin/Boards.php
+++ b/Sources/Actions/Admin/Boards.php
@@ -236,12 +236,7 @@ class Boards implements ActionInterface
 					$prev_child_level = Board::$loaded[$boardid]->child_level;
 				}
 
-				// Whatever is still on the stack belongs after the last board.
-				// Not the placeholders, though: a board inside the subtree
-				// being moved has no links of its own, so null went on the
-				// stack above just to keep it as deep as the tree. Popping
-				// already skips those; flushing has to as well, or the last
-				// board gets a link with no label and no destination.
+				// Filter out null placeholders.
 				$stack = array_filter($stack);
 
 				if (!empty($stack) && !empty(Utils::$context['categories'][$catid]['boards'][$prev_board]['move_links'])) {

--- a/Sources/Actions/Admin/Boards.php
+++ b/Sources/Actions/Admin/Boards.php
@@ -236,6 +236,14 @@ class Boards implements ActionInterface
 					$prev_child_level = Board::$loaded[$boardid]->child_level;
 				}
 
+				// Whatever is still on the stack belongs after the last board.
+				// Not the placeholders, though: a board inside the subtree
+				// being moved has no links of its own, so null went on the
+				// stack above just to keep it as deep as the tree. Popping
+				// already skips those; flushing has to as well, or the last
+				// board gets a link with no label and no destination.
+				$stack = array_filter($stack);
+
 				if (!empty($stack) && !empty(Utils::$context['categories'][$catid]['boards'][$prev_board]['move_links'])) {
 					Utils::$context['categories'][$catid]['boards'][$prev_board]['move_links'] = array_merge($stack, Utils::$context['categories'][$catid]['boards'][$prev_board]['move_links']);
 				} elseif (!empty($stack)) {


### PR DESCRIPTION
#### Description

*Admin → Boards and Categories → Move* draws one link per place the board could go.
While walking the tree, the "after this board" link is held back on a stack until that
board's children have been listed. A board **inside the subtree being moved** has no links
of its own, so `null` goes onto the stack in its place, purely to keep the stack as deep
as the tree:

```php
array_push($stack, !empty(…['move_links']) ? array_shift(…['move_links']) : null);
```

Popping already skips those (`if (($temp = array_pop($stack)) != null)`). Flushing what is
left at the end of the category does not, so the placeholders go straight into
`move_links` and reach the template:

```html
<a href="" class="move_links" title=""><span class="main_icons select_" title=""></span></a>
```

plus two warnings per placeholder, because `ManageBoards.template.php` reads `child_level`
off the first entry and `href` off each one:

```
2: Trying to access array offset on null  —  ManageBoards.template.php:84
2: Trying to access array offset on null  —  ManageBoards.template.php:88
```

##### What it looks like

Moving a top-level board that has children is where it bites. On this tree:

```
General Discussion
    Child Board
        Grandchild
        Second Top Board
            Placeholder
```

"Move" on *General Discussion* offered four destinations, and three of them were the dead
links above — one real choice left on the page.

##### Checked

`array_filter()` on the stack before it is flushed. Every `move=` on that tree, before and
after:

| board being moved | links before | of those, dead | links after |
|---|---|---|---|
| General Discussion | 4 | 3 | 1 |
| Child Board | 5 | 2 | 3 |
| Grandchild | 9 | 0 | 9 |
| Second Top Board | 8 | 1 | 7 |
| Placeholder | 9 | 0 | 9 |

Every surviving link is the same one it was before — only the empty ones go. Then actually
moved a board through the UI to confirm the links still work, and the error log stayed
empty across the lot.

### Issues References (Fixes|Related|Closes)

n/a