### PR TITLE
[3.0] Theme split (wave 4, part 15) — move the issue-warning page's script into profile.js

### DIFF
--- a/Themes/default/Profile.template.php
+++ b/Themes/default/Profile.template.php
@@ -2414,52 +2414,12 @@ function template_issueWarning()
 {
 	template_load_warning_variables();
 
+	// The bodies of the notification templates and the text for each warning
+	// level. profile.js does the rest; all it needs from here is the data.
 	echo '
 	<script>
-		// Disable notification boxes as required.
-		function modifyWarnNotify()
-		{
-			disable = !document.getElementById(\'warn_notify\').checked;
-			document.getElementById(\'warn_sub\').disabled = disable;
-			document.getElementById(\'warn_body\').disabled = disable;
-			document.getElementById(\'warn_temp\').disabled = disable;
-			document.getElementById(\'new_template_link\').style.display = disable ? \'none\' : \'\';
-			document.getElementById(\'preview_button\').style.display = disable ? \'none\' : \'\';
-		}
-
-		// Warn template.
-		function populateNotifyTemplate()
-		{
-			index = document.getElementById(\'warn_temp\').value;
-			if (index == -1)
-				return false;
-
-			// Otherwise see what we can do...';
-
-	foreach (Utils::$context['notification_templates'] as $k => $type) {
-		echo '
-			if (index == ', $k, ')
-				document.getElementById(\'warn_body\').value = ', Utils::escapeJavaScript($type['body']), ';';
-	}
-
-	echo '
-		}
-
-		function updateSlider(slideAmount)
-		{
-			// Also set the right effect.
-			effectText = "";';
-
-	foreach (Utils::$context['level_effects'] as $limit => $text) {
-		echo '
-			if (slideAmount >= ', $limit, ')
-				effectText = "', $text, '";';
-	}
-
-	echo '
-			let percent_format = "', Lang::getTxt('percent_format', file: 'General'), '";
-			setInnerHTML(document.getElementById(\'cur_level_div\'), percent_format.replace("{0}", slideAmount) + \' (\' + effectText + \')\');
-		}
+		var notification_templates = ', json_encode(array_column(Utils::$context['notification_templates'], 'body'), JSON_UNESCAPED_SLASHES), ';
+		var level_effects = ', json_encode(Utils::$context['level_effects'], JSON_UNESCAPED_SLASHES | JSON_FORCE_OBJECT), ';
 	</script>';
 
 	echo '
@@ -2503,9 +2463,9 @@ function template_issueWarning()
 	echo '
 				</dt>
 				<dd>
-					', Lang::formatText('{0, number, :: percent}', [0]), ' <input name="warning_level" id="warning_level" type="range" min="0" max="100" step="5" value="', Utils::$context['member']['warning'], '" onchange="updateSlider(this.value)"> ', Lang::formatText('{0, number, :: percent}', [100]), '
+					', Lang::formatText('{0, number, :: percent}', [0]), ' <input name="warning_level" id="warning_level" type="range" min="0" max="100" step="5" value="', Utils::$context['member']['warning'], '"> ', Lang::formatText('{0, number, :: percent}', [100]), '
 					<div class="clear_left">
-						', Lang::getTxt('profile_warning_impact', file: 'Profile'), ': <span id="cur_level_div">', Lang::formatText('{0, number, :: percent}', [Utils::$context['member']['warning']]), ' (', Utils::$context['level_effects'][Utils::$context['current_level']], ')</span>
+						', Lang::getTxt('profile_warning_impact', file: 'Profile'), ': <output name="cur_level" for="warning_level" data-format="', Lang::getTxt('percent_format', file: 'General'), '">', Lang::formatText('{0, number, :: percent}', [Utils::$context['member']['warning']]), ' (', Utils::$context['level_effects'][Utils::$context['current_level']], ')</output>
 					</div>
 				</dd>';
 
@@ -2536,7 +2496,7 @@ function template_issueWarning()
 					<strong><label for="warn_notify">', Lang::getTxt('profile_warning_notify', file: 'Profile'), '</label></strong>
 				</dt>
 				<dd>
-					<input type="checkbox" name="warn_notify" id="warn_notify" onclick="modifyWarnNotify();"', Utils::$context['warning_data']['notify'] ? ' checked' : '', '>
+					<input type="checkbox" name="warn_notify" id="warn_notify"', Utils::$context['warning_data']['notify'] ? ' checked' : '', '>
 				</dd>
 				<dt>
 					<strong><label for="warn_sub">', Lang::getTxt('profile_warning_notify_subject', file: 'Profile'), '</label></strong>
@@ -2548,7 +2508,7 @@ function template_issueWarning()
 					<strong><label for="warn_temp">', Lang::getTxt('profile_warning_notify_body', file: 'Profile'), '</label></strong>
 				</dt>
 				<dd>
-					<select name="warn_temp" id="warn_temp" disabled onchange="populateNotifyTemplate();">
+					<select name="warn_temp" id="warn_temp" disabled>
 						<option value="-1">', Lang::getTxt('profile_warning_notify_template', file: 'Profile'), '</option>
 						<option value="-1" disabled>------------------------------</option>';
 
@@ -2559,7 +2519,7 @@ function template_issueWarning()
 
 		echo '
 					</select>
-					<span id="new_template_link" style="display: none;"><a href="', Config::$scripturl, '?action=moderate;area=warnings;sa=templateedit;tid=0" class="button floatnone" target="_blank" rel="noopener">', Lang::getTxt('profile_warning_new_template', file: 'Profile'), '</a></span>
+					<span id="new_template_link" hidden><a href="', Config::$scripturl, '?action=moderate;area=warnings;sa=templateedit;tid=0" class="button floatnone" target="_blank" rel="noopener">', Lang::getTxt('profile_warning_new_template', file: 'Profile'), '</a></span>
 					<br>
 					<textarea name="warn_body" id="warn_body" cols="40" rows="8">', Utils::$context['warning_data']['notify_body'], '</textarea>
 				</dd>';
@@ -2583,60 +2543,6 @@ function template_issueWarning()
 
 	// Previous warnings?
 	template_show_list('view_warnings');
-
-	echo '
-	<script>';
-
-	if (!Profile::$member->is_me) {
-		echo '
-		modifyWarnNotify();
-		$(document).ready(function() {
-			$("#preview_button").click(function() {
-				return ajax_getTemplatePreview();
-			});
-		});
-
-		function ajax_getTemplatePreview ()
-		{
-			$.ajax({
-				type: "POST",
-				headers: {
-					"X-SMF-AJAX": 1
-				},
-				xhrFields: {
-					withCredentials: typeof allow_xhjr_credentials !== "undefined" ? allow_xhjr_credentials : false
-				},
-				url: "' . Config::$scripturl . '?action=xmlhttp;sa=previews;xml",
-				data: {item: "warning_preview", title: $("#warn_sub").val(), body: $("#warn_body").val(), issuing: true},
-				context: document.body,
-				success: function(request){
-					$("#box_preview").css({display:""});
-					$("#body_preview").html($(request).find(\'body\').text());
-					if ($(request).find("error").text() != \'\')
-					{
-						$("#profile_error").css({display:""});
-						var errors_html = \'<ul class="list_errors">\';
-						var errors = $(request).find(\'error\').each(function() {
-							errors_html += \'<li>\' + $(this).text() + \'</li>\';
-						});
-						errors_html += \'</ul>\';
-
-						$("#profile_error").html(errors_html);
-					}
-					else
-					{
-						$("#profile_error").css({display:"none"});
-						$("#error_list").html(\'\');
-					}
-				return false;
-				},
-			});
-			return false;
-		}';
-	}
-
-	echo '
-	</script>';
 }
 
 /**

--- a/Themes/default/scripts/profile.js
+++ b/Themes/default/scripts/profile.js
@@ -315,3 +315,117 @@ function export_download_all(format)
 		setTimeout(function() { iframe.remove(); }, 30000);
 	});
 }
+
+/*
+ * Everything below belongs to the "issue a warning" page. It used to be
+ * generated into the template, which meant the notification templates were
+ * written out as one JavaScript branch each. They arrive as data now:
+ * notification_templates holds the bodies in the order the select lists them,
+ * level_effects maps each warning level to what it does at that level.
+ */
+document.addEventListener('DOMContentLoaded', function ()
+{
+	var slider = document.getElementById('warning_level');
+
+	// Viewing your own warning level shows the slider and nothing else, so
+	// this half stands on its own.
+	if (slider)
+	{
+		slider.addEventListener('input', updateSlider);
+	}
+
+	var notify = document.getElementById('warn_notify');
+
+	if (!notify)
+		return;
+
+	notify.addEventListener('change', modifyWarnNotify);
+	document.getElementById('warn_temp').addEventListener('change', populateNotifyTemplate);
+	document.getElementById('preview_button').addEventListener('click', ajax_getTemplatePreview);
+
+	// The notification fields start out matching the checkbox.
+	modifyWarnNotify.call(notify);
+});
+
+// The notification is optional, so its fields follow the checkbox.
+function modifyWarnNotify()
+{
+	var disable = !document.getElementById('warn_notify').checked;
+
+	document.getElementById('warn_sub').disabled = disable;
+	document.getElementById('warn_body').disabled = disable;
+	document.getElementById('warn_temp').disabled = disable;
+	document.getElementById('new_template_link').hidden = disable;
+
+	// Disabled rather than hidden, because .button sets display and an author
+	// rule beats the [hidden] one the browser brings.
+	document.getElementById('preview_button').disabled = disable;
+}
+
+// Picking a template drops its body into the message.
+function populateNotifyTemplate()
+{
+	if (this.value == -1)
+		return;
+
+	document.getElementById('warn_body').value = notification_templates[this.value];
+}
+
+// Says what the level being dragged to actually does.
+function updateSlider()
+{
+	// Number(), because both sides are strings otherwise and 100 sorts below
+	// 35 when they are compared as text.
+	var output = this.form.cur_level, level = Number(this.value), effect = '';
+
+	for (var limit in level_effects)
+		if (level >= Number(limit))
+			effect = level_effects[limit];
+
+	output.value = output.dataset.format.replace('{0}', this.value) + ' (' + effect + ')';
+}
+
+// Renders the notification body the way the member will receive it.
+function ajax_getTemplatePreview()
+{
+	var data = new URLSearchParams({
+		item: 'warning_preview',
+		title: document.getElementById('warn_sub').value,
+		body: document.getElementById('warn_body').value,
+		issuing: true
+	});
+
+	fetch(smf_scripturl + '?action=xmlhttp;sa=previews;xml', {
+		method: 'POST',
+		headers: {
+			'Content-Type': 'application/x-www-form-urlencoded',
+			'X-SMF-AJAX': 1
+		},
+		credentials: typeof allow_xhjr_credentials !== 'undefined' && allow_xhjr_credentials ? 'include' : 'same-origin',
+		body: data
+	})
+	.then(function (response) {
+		return response.text();
+	})
+	.then(function (text) {
+		var xml = new DOMParser().parseFromString(text, 'application/xml'),
+			errors = xml.querySelectorAll('error'),
+			problems = document.getElementById('profile_error');
+
+		document.getElementById('box_preview').style.display = '';
+		setInnerHTML(document.getElementById('body_preview'), xml.querySelector('body').textContent);
+
+		if (!problems)
+			return;
+
+		problems.style.display = errors.length ? '' : 'none';
+
+		var list = '';
+
+		errors.forEach(function (error) {
+			list += '<li>' + error.textContent + '</li>';
+		});
+
+		setInnerHTML(problems, list === '' ? '' : '<ul class="list_errors">' + list + '</ul>');
+	});
+}


### PR DESCRIPTION
#### Description

Part of the [#7933](https://github.com/SimpleMachines/SMF/pull/7933) split, wave 4.
Profile area, first slice.

`template_issueWarning()` generated all of its JavaScript. `populateNotifyTemplate()` was
written out as one `if` branch per notification template, each carrying a whole message
body through `Utils::escapeJavaScript()`; `updateSlider()` the same, one branch per warning
level. The handlers were attached with `onclick` / `onchange` attributes, and a second
`<script>` block at the bottom of the page held the jQuery preview call.

The template now emits only the data:

```php
var notification_templates = ['…', '…', '…'];
var level_effects = {"0":"None.","10":"…","35":"…","60":"…"};
```

and `profile.js` — which every profile page already loads — carries `modifyWarnNotify()`,
`populateNotifyTemplate()`, `updateSlider()` and `ajax_getTemplatePreview()`, wiring itself
up on `DOMContentLoaded`. The preview call is `fetch` rather than `$.ajax`.

##### Two things changed shape

The current level is an `<output name="cur_level" for="warning_level">` instead of
`<span id="cur_level_div">`, so the script reaches it as `this.form.cur_level` and does not
need to know an id. `percent_format` — which the text is built from, and which the old
inline script also used — rides along in a `data-format` attribute next to it, so the
string stays localised.

The **Preview** button is `disabled` while the notification is switched off, where it used
to be hidden. `.button` sets `display: inline-block`, and an author rule beats the
`[hidden]` rule the browser brings, so `hidden` does nothing to it — hiding it needs an
inline style. `disabled` says the same thing and picks up the styling `index.css:175`
already has for it. The "create a template" link beside it is a plain `<span>`, so that one
still hides.

##### Checked

Same page, before and after, on the slider (`input` now, so it tracks the drag rather than
waiting for release) — identical text at every stop:

| slider | text |
|---|---|
| 0, 5 | `0% (None.)` / `5% (None.)` |
| 10 | `10% (User will be added to moderator watch list.)` |
| 35 | `35% (All users posts will be moderated.)` |
| 60, 95, 100 | `60% / 95% / 100% (User will not be able to post.)` |

One thing that had to be got right: both operands are strings, so a plain `>=` compares
them as text and `"100"` sorts below `"35"`. `Number()` on each side.

Also checked each of the three templates fills the body with the same text as before,
that picking the placeholder row leaves the body alone, that the notify checkbox enables
and disables the same four controls in both directions, and the preview both ways — a
good body renders into `#box_preview`, an empty one puts *"You selected to notify the user
but did not fill in the subject/message fields"* into `#profile_error`. No console errors,
nothing in `smf_log_errors`.

The `is_me` branch draws the slider with no notification block at all, and the script
guards for that separately. It is not reachable through the menu as things stand
(`Main.php` gives the area `'own' => []`), so it was exercised by granting that
temporarily.

### Issues References (Fixes|Related|Closes)

Part of #7933

Co-Authored-By: live627 <john@jbrock.us>