### PR TITLE
[3.0] Theme split (wave 4, part 16) — drop the group membership highlight, which highlights nothing

### DIFF
--- a/Themes/default/Profile.template.php
+++ b/Themes/default/Profile.template.php
@@ -2170,7 +2170,7 @@ function template_groupMembership()
 
 			if (Utils::$context['can_edit_primary']) {
 				echo '
-					<input type="radio" name="primary" id="primary_', $group['id'], '" value="', $group['id'], '"', $group['is_primary'] ? ' checked' : '', ' onclick="highlightSelected(\'primdiv_' . $group['id'] . '\');"', $group['can_be_primary'] ? '' : ' disabled', '>';
+					<input type="radio" name="primary" id="primary_', $group['id'], '" value="', $group['id'], '"', $group['is_primary'] ? ' checked' : '', $group['can_be_primary'] ? '' : ' disabled', '>';
 			}
 
 			echo '
@@ -2221,30 +2221,6 @@ function template_groupMembership()
 			}
 		}
 
-		// Javascript for the selector stuff.
-		echo '
-				<script>
-					var prevClass = "";
-					var prevDiv = "";
-					function highlightSelected(box)
-					{
-						if (prevClass != "")
-						{
-							prevDiv.className = prevClass;
-						}
-						prevDiv = document.getElementById(box);
-						prevClass = prevDiv.className;
-
-						prevDiv.className = "windowbg";
-					}';
-
-		if (isset(Utils::$context['groups']['member'][Utils::$context['primary_group']])) {
-			echo '
-					highlightSelected("primdiv_' . Utils::$context['primary_group'] . '");';
-		}
-
-		echo '
-				</script>';
 	}
 
 	echo '


### PR DESCRIPTION
#### Description

Part of the [#7933](https://github.com/SimpleMachines/SMF/pull/7933) split, wave 4.
Profile area.

*Profile → Group Membership* attaches a handler to every primary-group radio:

```php
onclick="highlightSelected(\'primdiv_' . $group['id'] . '\');"
```

which runs:

```js
prevDiv.className = prevClass;       // put the last one back
prevDiv = document.getElementById(box);
prevClass = prevDiv.className;
prevDiv.className = "windowbg";      // and set this one to…
```

Every row in that list is emitted as `<div class="windowbg" id="primdiv_N">`, so the last
line sets the class it already has. The function has never changed anything on the page. It
reads like a leftover from when the rows alternated between two classes — the striping is
CSS now.

The theme branch deletes it and adds nothing in its place, which is what this does.
`id="primdiv_N"` stays on the rows, as it does there.

##### Checked

On `release-3.0`, clicking each enabled radio in turn:

| | class | background |
|---|---|---|
| `primdiv_1` | `windowbg` | `rgb(240, 244, 247)` |
| `primdiv_2` | `windowbg` | `rgb(253, 253, 253)` |
| `primdiv_0` | `windowbg` | `rgb(240, 244, 247)` |

Same three rows, same two values, before any click and after every one of them — and the
same again with this applied. The radios still select, and nothing else on the page reads
`highlightSelected`, `prevDiv` or `prevClass`.

(The area needs `show_group_membership` on, your own profile, and two groups that can be
primary, or it does not render at all.)

### Issues References (Fixes|Related|Closes)

Part of #7933

Co-Authored-By: live627 <john@jbrock.us>