### PR TITLE
[3.0] Theme split (wave 4, part 17) — move the signature counter's wiring into profile.js

### DIFF
--- a/Themes/default/Profile.template.php
+++ b/Themes/default/Profile.template.php
@@ -2931,7 +2931,7 @@ function template_profile_signature_modify()
 	echo '
 							</dt>
 							<dd>
-								<textarea class="editor" onkeyup="calcCharLeft();" id="signature" name="signature" rows="5" cols="50">', Utils::$context['member']['signature'], '</textarea><br>';
+								<textarea class="editor" id="signature" name="signature" rows="5" cols="50"', empty(Utils::$context['signature_limits']['max_length']) ? '' : ' data-max-length="' . (int) Utils::$context['signature_limits']['max_length'] . '"', '>', Utils::$context['member']['signature'], '</textarea><br>';
 
 	// If there is a limit at all!
 	if (!empty(Utils::$context['signature_limits']['max_length'])) {
@@ -2949,18 +2949,7 @@ function template_profile_signature_modify()
 								<span class="smalltext">', Utils::$context['signature_warning'], '</span>';
 	}
 
-	// Some javascript used to count how many characters have been used so far in the signature.
 	echo '
-								<script>
-									var maxLength = ', Utils::$context['signature_limits']['max_length'], ';
-
-									$(document).ready(function() {
-										calcCharLeft();
-										$("#preview_button").click(function() {
-											return ajax_getSignaturePreview(true);
-										});
-									});
-								</script>
 							</dd>';
 }
 

--- a/Themes/default/scripts/profile.js
+++ b/Themes/default/scripts/profile.js
@@ -39,6 +39,35 @@ function disableAutoCompleteNow()
 	}
 }
 
+/*
+ * How long a signature is allowed to be. The template used to write this out
+ * as a global of its own; it comes off the textarea now, so the number only
+ * exists in one place.
+ */
+var maxLength = 0;
+
+// Wires up the signature editor, which is on the Forum Profile page.
+document.addEventListener('DOMContentLoaded', function ()
+{
+	var signature = document.getElementById('signature');
+
+	if (!signature)
+		return;
+
+	maxLength = Number(signature.dataset.maxLength || 0);
+
+	// "input" rather than the old "keyup", so pasting counts too.
+	signature.addEventListener('input', calcCharLeft);
+	calcCharLeft();
+
+	var preview = document.getElementById('preview_button');
+
+	if (preview)
+		preview.addEventListener('click', function () {
+			return ajax_getSignaturePreview(true);
+		});
+});
+
 function calcCharLeft()
 {
 	var oldSignature = "", currentSignature = document.forms.creator.signature.value;


### PR DESCRIPTION
#### Description

Part of the [#7933](https://github.com/SimpleMachines/SMF/pull/7933) split, wave 4.
Profile area.

`template_profile_signature_modify()` generated a script to declare `maxLength`, call
`calcCharLeft()` once and bind the preview button, and the textarea carried an `onkeyup`
attribute. Both functions already live in `profile.js`, which every profile page loads, so
it can do its own wiring.

The limit travels on the textarea as `data-max-length` rather than as a global written into
the page, so the number exists in one place. It is only emitted when there **is** a limit —
`#signatureLeft`, the counter it feeds, only exists then too, and `calcCharLeft()` already
returns early without it.

The handler is on `input` rather than `keyup`, so pasting a signature in counts it.

##### Not taken from the theme branch

It puts `maxlength` on the textarea instead. That would stop you typing past the limit, but
SMF counts the signature with `\r` stripped, so the browser would cut you off earlier than
the server would on anything with line breaks. The counting here is unchanged.

It also drops `id="preview_button"` and binds `f.preview_button` — which is `undefined`,
because the input is `name="preview_signature"`. That would leave the preview button dead.
The id stays.

##### Checked

Forum Profile page, same signature limit (300), before and after:

| textarea | counter | class |
|---|---|---|
| empty (on load) | `300` | — |
| `hello` | `295` | — |
| 500 × `x` | `-200` | `error` |

Identical both ways, including the `error` class lingering at the last step — that is
`calcCharLeft()` re-initialising `oldSignature` to `""` on every call and skipping its body
when the signature is empty, which is untouched here.

Preview still renders: `A [b]bold[/b] signature.` comes back as
`A <strong>bold</strong> signature.` into `#preview_signature_display`, with both the
current and preview rows revealed.

### Issues References (Fixes|Related|Closes)

Part of #7933

Co-Authored-By: live627 <john@jbrock.us>