### PR TITLE
[3.0] Stop calling createEventListener, which no longer exists

### DIFF
--- a/Sources/Actions/Admin/Attachments.php
+++ b/Sources/Actions/Admin/Attachments.php
@@ -112,9 +112,7 @@ class Attachments implements ActionInterface
 		var storing_type = document.getElementById(\'automanage_attachments\');
 		var base_dir = document.getElementById(\'use_subdirectories_for_attachments\');
 
-		createEventListener(storing_type)
 		storing_type.addEventListener("change", toggleSubDir, false);
-		createEventListener(base_dir)
 		base_dir.addEventListener("change", toggleSubDir, false);
 		toggleSubDir();';
 

--- a/Sources/Profile.php
+++ b/Sources/Profile.php
@@ -1452,7 +1452,6 @@ class Profile extends User implements \ArrayAccess
 		// Some spicy JS.
 		Theme::addInlineJavaScript('
 		var form_handle = document.forms.creator;
-		createEventListener(form_handle);
 		' . (!empty(Utils::$context['require_password']) ? '
 		form_handle.addEventListener("submit", function(event)
 		{

--- a/Themes/default/PersonalMessage.template.php
+++ b/Themes/default/PersonalMessage.template.php
@@ -769,7 +769,6 @@ function template_search()
 				<dd>
 					<input type="search" name="search"', !empty(Utils::$context['search_params']['search']) ? ' value="' . Utils::$context['search_params']['search'] . '"' : '', ' size="40">
 					<script>
-						createEventListener(window);
 						window.addEventListener("load", initSearch, false);
 					</script>
 				</dd>

--- a/Themes/default/scripts/register.js
+++ b/Themes/default/scripts/register.js
@@ -52,7 +52,6 @@ function smfRegister(formID, passwordDifficultyLevel, regTextStrings)
 		// Step to it!
 		if (eventHandler)
 		{
-			createEventListener(inputHandle);
 			inputHandle.addEventListener('keyup', eventHandler, false);
 			eventHandler();
 
@@ -71,7 +70,6 @@ function smfRegister(formID, passwordDifficultyLevel, regTextStrings)
 		var buttonHandle = document.getElementById(elementID);
 
 		// Attach the event to this element.
-		createEventListener(buttonHandle);
 		buttonHandle.addEventListener('click', checkUsername, false);
 	}
 


### PR DESCRIPTION
#### Description

`588d99d63` ("Remove string evaluations") took the `createEventListener()` shim out of
`script.js` and left five calls to it behind. Nothing defines it any more:

```
Uncaught ReferenceError: createEventListener is not defined
```

Each call sits at the top of an inline block, so everything after it in that block is
skipped as well. Four pages are affected.

| where | what stops working |
|---|---|
| `Sources/Profile.php:1455` | the submit handler that blocks saving an account without the current password — the alert never appears |
| `Sources/Actions/Admin/Attachments.php:115,117` | `toggleSubDir()` is never bound and never run, so the base-directory and "use subdirectories" rows show whatever the *automatically manage attachment directories* setting says |
| `Themes/default/PersonalMessage.template.php:772` | `initSearch()` is never bound, so a `%u` sequence pasted into the PM search box stays escaped |
| `Themes/default/scripts/register.js:55,74` | throws inside `addVerificationField()` and `addUsernameSearchTrigger()`, which is every live check on the sign-up form |

The shim only ever existed for browsers with no `addEventListener` — 2.1's copy is the
`attachEvent` fallback — so there is nothing to put back. The calls go.

##### Checked

*Admin → Attachments and Avatars*, with automatic management off:

| | before | after |
|---|---|---|
| `use_subdirectories_for_attachments` | visible, enabled | hidden, disabled |
| its row | shown | `display: none` |
| `basedirectory_for_attachments` and its row | shown | hidden |

and switching *automatically manage* on brings all four back, off hides them again.

*Profile → Account Settings* with the password field empty: submitting is now cancelled
with *"For security reasons, your current password is required to make changes to your
account."* On `release-3.0` the event is not cancelled and no alert is raised.

The console error is gone from all three pages I could reach. The sign-up form is read from
the code rather than exercised — registration is off on this install — but it is the same
`ReferenceError` from a function that runs for every `autov` field on the form.

### Issues References (Fixes|Related|Closes)

n/a