### PR TITLE
[3.0] Stop every page erroring when a member has a gallery avatar

### DIFF
--- a/Sources/Avatar.php
+++ b/Sources/Avatar.php
@@ -535,14 +535,8 @@ class Avatar implements \ArrayAccess
 						// Resolving the canonical path of both the file and the
 						// directories is important in order to ensure that we
 						// don't end up navigating outside the avatar dirs.
-						// A forum at the root of its domain has no path of its
-						// own to strip. Url::$path is typed with no default, so
-						// it is not there to be read at all in that case, and
-						// reading it throws rather than giving back ''.
-						$board_path = Url::create(Config::$boardurl)->path ?? '';
-
 						$abs_path = Sapi::canonicalPath(
-							preg_replace('~^' . preg_quote($board_path, '~') . '~u', '', $url->path),
+							preg_replace('~^' . preg_quote(Url::create(Config::$boardurl)->path ?? '', '~') . '~u', '', $url->path),
 							base_dir: Config::$boarddir,
 						);
 

--- a/Sources/Avatar.php
+++ b/Sources/Avatar.php
@@ -535,8 +535,14 @@ class Avatar implements \ArrayAccess
 						// Resolving the canonical path of both the file and the
 						// directories is important in order to ensure that we
 						// don't end up navigating outside the avatar dirs.
+						// A forum at the root of its domain has no path of its
+						// own to strip. Url::$path is typed with no default, so
+						// it is not there to be read at all in that case, and
+						// reading it throws rather than giving back ''.
+						$board_path = Url::create(Config::$boardurl)->path ?? '';
+
 						$abs_path = Sapi::canonicalPath(
-							preg_replace('~^' . preg_quote(Url::create(Config::$boardurl)->path, '~') . '~u', '', $url->path),
+							preg_replace('~^' . preg_quote($board_path, '~') . '~u', '', $url->path),
 							base_dir: Config::$boarddir,
 						);
 


### PR DESCRIPTION
#### Description

On a forum installed at the **root of its domain**, one member with a prepackaged (gallery)
avatar takes the whole forum down. Every page that renders that member is a 500 — the board
index, because of the "last post by" line, as much as their profile.

```
Typed property SMF\Url::$path must not be accessed before initialization
  —  Sources/Avatar.php:539
```

`Avatar`'s last resort for locating a file is to take the path out of the url and look for
it under the avatar directories, which means reading the forum's own path so it can be
stripped:

```php
$abs_path = Sapi::canonicalPath(
	preg_replace('~^' . preg_quote(Url::create(Config::$boardurl)->path, '~') . '~u', '', $url->path),
	base_dir: Config::$boarddir,
);
```

`Url::$path` is typed with no default. A forum at the root of its domain has no path, so the
property was never assigned, and reading it throws rather than giving back `''`. A forum
under a path prefix never reaches this.

That branch is exactly where a gallery avatar lands: the column holds a bare
`Oxygen/cards.png`, which is not a valid url, so the resolver falls through to it every
time.

(The neighbouring `!empty($url->path)` guard three lines up is fine — `empty()` and
`isset()` on an uninitialised typed property answer without raising. It is the direct read
that goes wrong.)

Reading it as `?? ''` leaves `preg_replace()` with a pattern of `~^~u`, which matches the
empty string at position 0 and replaces nothing — exactly what the call already did on
every forum that *does* live under a path prefix. Nothing changes for those; the rooted
case stops throwing.

##### Checked

`http://localhost:8080` (no path), with `smf_members.avatar` set to `Oxygen/cards.png` for
one member:

| page | before | after |
|---|---|---|
| board index | 500 | 200 |
| a topic they posted in | 500 | 200 |
| memberlist | 500 | 200 |
| their profile summary | 500 | 200 |
| Profile → Forum Profile | 500 | 200 |

Saving a profile with a gallery avatar chosen goes from a 500 to *"Your profile has been
updated successfully"*, and `smf_log_errors` stays empty across the lot. Members with an
uploaded avatar, a gravatar, and no avatar are unaffected either way.

##### Noticed while here, not fixed

With the fatal gone, a gallery avatar still does not **stick**: `smf_members.avatar` is
cleared on save, and a value put there by hand renders as `default.png`.
`Profile::setAvatarServerStored()` puts the right string into `new_data` (verified:
`Oxygen/cards.png`), but `User::updateMemberData()` round-trips it through
`new Avatar(original_url: …)`, which cannot turn a bare filename back into a url. That is a
separate change and wants its own PR.

### Issues References (Fixes|Related|Closes)

n/a