### PR TITLE
[3.0] Theme split (wave 4, part 18) — give the avatar picker one gallery list and no generated script

### DIFF
--- a/Sources/Profile.php
+++ b/Sources/Profile.php
@@ -1218,7 +1218,6 @@ class Profile extends User implements \ArrayAccess
 
 		// Get a list of all the server stored avatars.
 		if ($this->avatar->allow_server_stored) {
-			Utils::$context['avatar_list'] = [];
 			Utils::$context['avatars'] = is_dir(Config::$modSettings['avatar_directory']) ? $this->getAvatars('', 0) : [];
 		} else {
 			Utils::$context['avatars'] = [];
@@ -2607,14 +2606,12 @@ class Profile extends User implements \ArrayAccess
 
 			$result[] = [
 				'filename' => Utils::htmlspecialchars($line),
-				'checked' => $line == Utils::$context['member']['avatar']['server_pic'],
+				// server_pic names the directory too, so a file one level down
+				// has to be compared against the path, not just its own name.
+				'checked' => ($directory === '' ? $line : $directory . '/' . $line) == Utils::$context['member']['avatar']['server_pic'],
 				'name' => Utils::htmlspecialchars(str_replace('_', ' ', $filename)),
 				'is_dir' => false,
 			];
-
-			if ($level == 1) {
-				Utils::$context['avatar_list'][] = $directory . '/' . $line;
-			}
 		}
 
 		return $result;

--- a/Themes/default/Profile.template.php
+++ b/Themes/default/Profile.template.php
@@ -2978,7 +2978,7 @@ function template_profile_avatar_select()
 
 	if (empty(Config::$modSettings['gravatarEnabled']) || empty(Config::$modSettings['gravatarOverride'])) {
 		echo '
-								<input type="radio" onclick="swap_avatar(this); return true;" name="avatar_choice" id="avatar_choice_none" value="none"' . (Utils::$context['member']['avatar']['choice'] == 'none' ? ' checked="checked"' : '') . '>
+								<input type="radio" name="avatar_choice" id="avatar_choice_none" value="none"' . (Utils::$context['member']['avatar']['choice'] == 'none' ? ' checked="checked"' : '') . '>
 								<label for="avatar_choice_none"' . (isset(Utils::$context['modify_error']['bad_avatar']) ? ' class="error"' : '') . '>
 									' . Lang::getTxt('no_avatar', file: 'Profile') . '
 								</label><br>';
@@ -2986,7 +2986,7 @@ function template_profile_avatar_select()
 
 	if (!empty(Utils::$context['member']['avatar']['allow_server_stored'])) {
 		echo '
-								<input type="radio" onclick="swap_avatar(this); return true;" name="avatar_choice" id="avatar_choice_server_stored" value="server_stored"' . (Utils::$context['member']['avatar']['choice'] == 'server_stored' ? ' checked="checked"' : '') . '>
+								<input type="radio" name="avatar_choice" id="avatar_choice_server_stored" value="server_stored"' . (Utils::$context['member']['avatar']['choice'] == 'server_stored' ? ' checked="checked"' : '') . '>
 								<label for="avatar_choice_server_stored"' . (isset(Utils::$context['modify_error']['bad_avatar']) ? ' class="error"' : '') . '>
 									', Lang::getTxt('choose_avatar_gallery', file: 'Profile'), '
 								</label><br>';
@@ -2994,7 +2994,7 @@ function template_profile_avatar_select()
 
 	if (!empty(Utils::$context['member']['avatar']['allow_external'])) {
 		echo '
-								<input type="radio" onclick="swap_avatar(this); return true;" name="avatar_choice" id="avatar_choice_external" value="external"' . (Utils::$context['member']['avatar']['choice'] == 'external' ? ' checked="checked"' : '') . '>
+								<input type="radio" name="avatar_choice" id="avatar_choice_external" value="external"' . (Utils::$context['member']['avatar']['choice'] == 'external' ? ' checked="checked"' : '') . '>
 								<label for="avatar_choice_external"' . (isset(Utils::$context['modify_error']['bad_avatar']) ? ' class="error"' : '') . '>
 									', Lang::getTxt('my_own_pic', file: 'Profile'), '
 								</label><br>';
@@ -3002,7 +3002,7 @@ function template_profile_avatar_select()
 
 	if (!empty(Utils::$context['member']['avatar']['allow_upload'])) {
 		echo '
-								<input type="radio" onclick="swap_avatar(this); return true;" name="avatar_choice" id="avatar_choice_upload" value="upload"' . (Utils::$context['member']['avatar']['choice'] == 'upload' ? ' checked="checked"' : '') . '>
+								<input type="radio" name="avatar_choice" id="avatar_choice_upload" value="upload"' . (Utils::$context['member']['avatar']['choice'] == 'upload' ? ' checked="checked"' : '') . '>
 								<label for="avatar_choice_upload"' . (isset(Utils::$context['modify_error']['bad_avatar']) ? ' class="error"' : '') . '>
 									', Lang::getTxt('avatar_will_upload', file: 'Profile'), '
 								</label><br>';
@@ -3010,7 +3010,7 @@ function template_profile_avatar_select()
 
 	if (!empty(Utils::$context['member']['avatar']['allow_gravatar'])) {
 		echo '
-								<input type="radio" onclick="swap_avatar(this); return true;" name="avatar_choice" id="avatar_choice_gravatar" value="gravatar"' . (Utils::$context['member']['avatar']['choice'] == 'gravatar' ? ' checked="checked"' : '') . '>
+								<input type="radio" name="avatar_choice" id="avatar_choice_gravatar" value="gravatar"' . (Utils::$context['member']['avatar']['choice'] == 'gravatar' ? ' checked="checked"' : '') . '>
 								<label for="avatar_choice_gravatar"' . (isset(Utils::$context['modify_error']['bad_avatar']) ? ' class="error"' : '') . '>' . Lang::getTxt('use_gravatar', file: 'Profile') . '</label>
 								<span class="smalltext"><a href="', Config::$scripturl, '?action=helpadmin;help=gravatar" onclick="return reqOverlayDiv(this.href);"><span class="main_icons help"></span></a></span>';
 	}
@@ -3022,59 +3022,55 @@ function template_profile_avatar_select()
 	// If users are allowed to choose avatars stored on the server show selection boxes to choice them from.
 	if (!empty(Utils::$context['member']['avatar']['allow_server_stored'])) {
 		echo '
-								<div id="avatar_server_stored">
+								<div id="avatar_server_stored" data-avatar-choice="server_stored">
 									<div>
-										<select name="cat" id="cat" size="10" onchange="changeSel(\'\');" onfocus="selectRadioByName(document.forms.creator.avatar_choice, \'server_stored\');">';
+										<select name="cat" id="cat" size="10" data-avatardir="', Config::$modSettings['avatar_url'], '/">';
 
-		// This lists all the file categories.
+		// One entry per avatar, with the directories as groups. Nothing here is
+		// nested more than one deep, because that is all the picker can show.
 		foreach (Utils::$context['avatars'] as $avatar) {
-			echo '
-											<option value="', $avatar['filename'] . ($avatar['is_dir'] ? '/' : ''), '"', ($avatar['checked'] ? ' selected' : ''), '>', $avatar['name'], '</option>';
+			if (!empty($avatar['is_dir'])) {
+				echo '
+											<optgroup label="', $avatar['name'], '">';
+
+				foreach ($avatar['files'] as $file) {
+					echo '
+												<option value="', $avatar['filename'], '/', $file['filename'], '"', $file['checked'] ? ' selected' : '', '>', $file['name'], '</option>';
+				}
+
+				echo '
+											</optgroup>';
+			} else {
+				echo '
+											<option value="', $avatar['filename'], '"', $avatar['checked'] ? ' selected' : '', '>', $avatar['name'], '</option>';
+			}
 		}
 
 		echo '
 										</select>
 									</div>
-									<div>
-										<select name="file" id="file" size="10" style="display: none;" onchange="showAvatar()" onfocus="selectRadioByName(document.forms.creator.avatar_choice, \'server_stored\');" disabled><option></option></select>
-									</div>
 									<div class="edit_avatar_img">
 										<img id="avatar" src="', Utils::$context['member']['avatar']['choice'] == 'server_stored' ? Utils::$context['member']['avatar']['href'] : Config::$modSettings['avatar_url'] . '/blank.png', '" alt="">
 									</div>
-									<script>
-										var files = ["' . implode('", "', Utils::$context['avatar_list']) . '"];
-										var avatar = document.getElementById("avatar");
-										var cat = document.getElementById("cat");
-										var selavatar = "' . Utils::$context['avatar_selected'] . '";
-										var avatardir = "' . Config::$modSettings['avatar_url'] . '/";
-										var size = avatar.alt.substr(3, 2) + " " + avatar.alt.substr(0, 2) + String.fromCharCode(117, 98, 116);
-										var file = document.getElementById("file");
-
-										if (avatar.src.indexOf("blank.png") > -1 || selavatar.indexOf("blank.png") == -1)
-											changeSel(selavatar);
-										else
-											previewExternalAvatar(avatar.src)
-
-									</script>
 								</div><!-- #avatar_server_stored -->';
 	}
 
 	// If the user can link to an off server avatar, show them a box to input the address.
 	if (!empty(Utils::$context['member']['avatar']['allow_external'])) {
 		echo '
-								<div id="avatar_external">
+								<div id="avatar_external" data-avatar-choice="external">
 									', Utils::$context['member']['avatar']['choice'] == 'external' ? '<div class="edit_avatar_img"><img src="' . Utils::$context['member']['avatar']['href'] . '" alt="" class="avatar"></div>' : '', '
 									<div class="smalltext">', Lang::getTxt('avatar_by_url', file: 'Profile'), '</div>', !empty(Config::$modSettings['avatar_action_too_large']) && Config::$modSettings['avatar_action_too_large'] == 'option_download_and_resize' ? template_max_size('external') : '', '
-									<input type="text" name="userpicpersonal" size="45" value="', ((stristr(Utils::$context['member']['avatar']['external'], 'http://') || stristr(Utils::$context['member']['avatar']['external'], 'https://')) ? Utils::$context['member']['avatar']['external'] : 'http://'), '" onfocus="selectRadioByName(document.forms.creator.avatar_choice, \'external\');" onchange="if (typeof(previewExternalAvatar) != \'undefined\') previewExternalAvatar(this.value);"><br>
+									<input type="text" name="userpicpersonal" size="45" value="', ((stristr(Utils::$context['member']['avatar']['external'], 'http://') || stristr(Utils::$context['member']['avatar']['external'], 'https://')) ? Utils::$context['member']['avatar']['external'] : 'http://'), '"><br>
 								</div>';
 	}
 
 	// If the user is able to upload avatars to the server show them an upload box.
 	if (!empty(Utils::$context['member']['avatar']['allow_upload'])) {
 		echo '
-								<div id="avatar_upload">
+								<div id="avatar_upload" data-avatar-choice="upload">
 									', Utils::$context['member']['avatar']['choice'] == 'upload' ? '<div class="edit_avatar_img"><img src="' . Utils::$context['member']['avatar']['href'] . '" alt=""></div>' : '', '
-									<input type="file" size="44" name="attachment" id="avatar_upload_box" value="" onchange="readfromUpload(this)"  onfocus="selectRadioByName(document.forms.creator.avatar_choice, \'upload\');" accept="image/gif, image/jpeg, image/jpg, image/png, image/svg+xml, image/webp">', template_max_size('upload'), '
+									<input type="file" size="44" name="attachment" id="avatar_upload_box" value="" accept="image/gif, image/jpeg, image/jpg, image/png, image/svg+xml, image/webp">', template_max_size('upload'), '
 									', (!empty(Utils::$context['member']['avatar']['id_attach']) ? '<br><input type="hidden" name="id_attach" value="' . Utils::$context['member']['avatar']['id_attach'] . '">' : ''), '
 								</div>';
 	}
@@ -3082,7 +3078,7 @@ function template_profile_avatar_select()
 	// if the user is able to use Gravatar avatars show then the image preview
 	if (!empty(Utils::$context['member']['avatar']['allow_gravatar'])) {
 		echo '
-								<div id="avatar_gravatar">
+								<div id="avatar_gravatar" data-avatar-choice="gravatar"', !empty(Config::$modSettings['gravatarAllowExtraEmail']) && (Utils::$context['member']['avatar']['external'] == Utils::$context['member']['email'] || str_contains(Utils::$context['member']['avatar']['external'], 'http://') || str_contains(Utils::$context['member']['avatar']['external'], 'https://')) ? ' data-clear-email' : '', '>
 									', Utils::$context['member']['avatar']['choice'] == 'gravatar' ? '<div class="edit_avatar_img"><img src="' . Utils::$context['member']['avatar']['href'] . '" alt=""></div>' : '';
 
 		if (empty(Config::$modSettings['gravatarAllowExtraEmail'])) {
@@ -3105,51 +3101,6 @@ function template_profile_avatar_select()
 	}
 
 	echo '
-								<script>
-									', !empty(Utils::$context['member']['avatar']['allow_server_stored']) ? 'document.getElementById("avatar_server_stored").style.display = "' . (Utils::$context['member']['avatar']['choice'] == 'server_stored' ? '' : 'none') . '";' : '', '
-									', !empty(Utils::$context['member']['avatar']['allow_external']) ? 'document.getElementById("avatar_external").style.display = "' . (Utils::$context['member']['avatar']['choice'] == 'external' ? '' : 'none') . '";' : '', '
-									', !empty(Utils::$context['member']['avatar']['allow_upload']) ? 'document.getElementById("avatar_upload").style.display = "' . (Utils::$context['member']['avatar']['choice'] == 'upload' ? '' : 'none') . '";' : '', '
-									', !empty(Utils::$context['member']['avatar']['allow_gravatar']) ? 'document.getElementById("avatar_gravatar").style.display = "' . (Utils::$context['member']['avatar']['choice'] == 'gravatar' ? '' : 'none') . '";' : '', '
-
-									function swap_avatar(type)
-									{
-										switch(type.id)
-										{
-											case "avatar_choice_server_stored":
-												', !empty(Utils::$context['member']['avatar']['allow_server_stored']) ? 'document.getElementById("avatar_server_stored").style.display = "";' : '', '
-												', !empty(Utils::$context['member']['avatar']['allow_external']) ? 'document.getElementById("avatar_external").style.display = "none";' : '', '
-												', !empty(Utils::$context['member']['avatar']['allow_upload']) ? 'document.getElementById("avatar_upload").style.display = "none";' : '', '
-												', !empty(Utils::$context['member']['avatar']['allow_gravatar']) ? 'document.getElementById("avatar_gravatar").style.display = "none";' : '', '
-												break;
-											case "avatar_choice_external":
-												', !empty(Utils::$context['member']['avatar']['allow_server_stored']) ? 'document.getElementById("avatar_server_stored").style.display = "none";' : '', '
-												', !empty(Utils::$context['member']['avatar']['allow_external']) ? 'document.getElementById("avatar_external").style.display = "";' : '', '
-												', !empty(Utils::$context['member']['avatar']['allow_upload']) ? 'document.getElementById("avatar_upload").style.display = "none";' : '', '
-												', !empty(Utils::$context['member']['avatar']['allow_gravatar']) ? 'document.getElementById("avatar_gravatar").style.display = "none";' : '', '
-												break;
-											case "avatar_choice_upload":
-												', !empty(Utils::$context['member']['avatar']['allow_server_stored']) ? 'document.getElementById("avatar_server_stored").style.display = "none";' : '', '
-												', !empty(Utils::$context['member']['avatar']['allow_external']) ? 'document.getElementById("avatar_external").style.display = "none";' : '', '
-												', !empty(Utils::$context['member']['avatar']['allow_upload']) ? 'document.getElementById("avatar_upload").style.display = "";' : '', '
-												', !empty(Utils::$context['member']['avatar']['allow_gravatar']) ? 'document.getElementById("avatar_gravatar").style.display = "none";' : '', '
-												break;
-											case "avatar_choice_none":
-												', !empty(Utils::$context['member']['avatar']['allow_server_stored']) ? 'document.getElementById("avatar_server_stored").style.display = "none";' : '', '
-												', !empty(Utils::$context['member']['avatar']['allow_external']) ? 'document.getElementById("avatar_external").style.display = "none";' : '', '
-												', !empty(Utils::$context['member']['avatar']['allow_upload']) ? 'document.getElementById("avatar_upload").style.display = "none";' : '', '
-												', !empty(Utils::$context['member']['avatar']['allow_gravatar']) ? 'document.getElementById("avatar_gravatar").style.display = "none";' : '', '
-												break;
-											case "avatar_choice_gravatar":
-												', !empty(Utils::$context['member']['avatar']['allow_server_stored']) ? 'document.getElementById("avatar_server_stored").style.display = "none";' : '', '
-												', !empty(Utils::$context['member']['avatar']['allow_external']) ? 'document.getElementById("avatar_external").style.display = "none";' : '', '
-												', !empty(Utils::$context['member']['avatar']['allow_upload']) ? 'document.getElementById("avatar_upload").style.display = "none";' : '', '
-												', !empty(Utils::$context['member']['avatar']['allow_gravatar']) ? 'document.getElementById("avatar_gravatar").style.display = "";' : '', '
-												', !empty(Config::$modSettings['gravatarAllowExtraEmail']) && (Utils::$context['member']['avatar']['external'] == Utils::$context['member']['email'] || strstr(Utils::$context['member']['avatar']['external'], 'http://') || strstr(Utils::$context['member']['avatar']['external'], 'https://')) ?
-												'document.getElementById("gravatarEmail").value = "";' : '', '
-												break;
-										}
-									}
-								</script>
 							</dd>';
 }
 

--- a/Themes/default/scripts/profile.js
+++ b/Themes/default/scripts/profile.js
@@ -162,67 +162,85 @@ function ajax_getSignaturePreview (showPreview)
 	return false;
 }
 
-function changeSel(selected)
+/*
+ * The avatar picker. Which panel is on show follows the radio buttons, and
+ * every panel says which choice it belongs to with data-avatar-choice, so
+ * nothing here has to be told which ones the forum allows.
+ */
+document.addEventListener('DOMContentLoaded', function ()
 {
-	if (cat.selectedIndex == -1)
+	var panels = document.querySelectorAll('[data-avatar-choice]');
+
+	if (!panels.length)
 		return;
 
-	if (cat.options[cat.selectedIndex].value.indexOf("/") > 0)
+	var form = panels[0].closest('form'),
+		choices = form.avatar_choice;
+
+	var showPanel = function () {
+		var chosen = form.avatar_choice.value;
+
+		for (var i = 0; i < panels.length; i++)
+			panels[i].style.display = panels[i].dataset.avatarChoice == chosen ? '' : 'none';
+
+		// Switching to Gravatar throws away an address that came from one of
+		// the other choices, since it would not be an address at all.
+		var gravatar = document.getElementById('avatar_gravatar');
+
+		if (chosen == 'gravatar' && gravatar && 'clearEmail' in gravatar.dataset && document.getElementById('gravatarEmail'))
+			document.getElementById('gravatarEmail').value = '';
+	};
+
+	for (var i = 0; i < choices.length; i++)
+		choices[i].addEventListener('change', showPanel);
+
+	showPanel();
+
+	// Touching anything inside a panel picks that panel's radio, which is what
+	// the onfocus attributes on each field used to do.
+	for (var i = 0; i < panels.length; i++)
+		panels[i].addEventListener('focusin', function () {
+			selectRadioByName(form.avatar_choice, this.dataset.avatarChoice);
+			showPanel();
+		});
+
+	var gallery = document.getElementById('cat');
+
+	if (gallery)
 	{
-		var i;
-		var count = 0;
-
-		file.style.display = "inline";
-		file.disabled = false;
-
-		for (i = file.length; i >= 0; i = i - 1)
-			file.options[i] = null;
-
-		for (i = 0; i < files.length; i++)
-			if (files[i].indexOf(cat.options[cat.selectedIndex].value) == 0)
-			{
-				var filename = files[i].substr(files[i].indexOf("/") + 1);
-				var showFilename = filename.substr(0, filename.lastIndexOf("."));
-				showFilename = showFilename.replace(/[_]/g, " ");
-
-				file.options[count] = new Option(showFilename, files[i]);
-
-				if (filename == selected)
-				{
-					if (file.options.defaultSelected)
-						file.options[count].defaultSelected = true;
-					else
-						file.options[count].selected = true;
-				}
-
-				count++;
-			}
-
-		if (file.selectedIndex == -1 && file.options[0])
-			file.options[0].selected = true;
-
-		showAvatar();
+		gallery.addEventListener('change', showAvatar);
+		showAvatar.call(gallery);
 	}
-	else
-	{
-		file.style.display = "none";
-		file.disabled = true;
-		document.getElementById("avatar").src = avatardir + cat.options[cat.selectedIndex].value;
-		document.getElementById("avatar").style.width = "";
-		document.getElementById("avatar").style.height = "";
-	}
-}
 
+	var external = form.userpicpersonal;
+
+	if (external)
+		external.addEventListener('change', function () {
+			previewExternalAvatar(this.value);
+		});
+
+	var upload = document.getElementById('avatar_upload_box');
+
+	if (upload)
+		upload.addEventListener('change', function () {
+			readfromUpload(this);
+		});
+});
+
+// Shows whichever avatar the gallery is pointing at.
 function showAvatar()
 {
-	if (file.selectedIndex == -1)
+	var chosen = this.options[this.selectedIndex];
+
+	if (!chosen || chosen.value == '')
 		return;
 
-	document.getElementById("avatar").src = avatardir + file.options[file.selectedIndex].value;
-	document.getElementById("avatar").alt = file.options[file.selectedIndex].text;
-	document.getElementById("avatar").alt += file.options[file.selectedIndex].text == size ? "!" : "";
-	document.getElementById("avatar").style.width = "";
-	document.getElementById("avatar").style.height = "";
+	var preview = document.getElementById('avatar');
+
+	preview.src = this.dataset.avatardir + chosen.value;
+	preview.alt = chosen.text;
+	preview.style.width = '';
+	preview.style.height = '';
 }
 
 function previewExternalAvatar(src)


### PR DESCRIPTION
#### Description

Part of the [#7933](https://github.com/SimpleMachines/SMF/pull/7933) split, wave 4.
Profile area.

The gallery was two selects. You picked a directory in the first, and a second appeared
holding its files — filled in by JavaScript from a flat list of **every avatar file on the
forum**, written into the page:

```php
var files = ["' . implode('", "', Utils::$context['avatar_list']) . '"];
var avatar = document.getElementById("avatar");
var cat = document.getElementById("cat");
var selavatar = "…"; var avatardir = "…"; var file = …;
var size = avatar.alt.substr(3, 2) + " " + avatar.alt.substr(0, 2) + String.fromCharCode(117, 98, 116);
```

and a second block below generated a `swap_avatar()` with one `case` per choice, each case
generated again from which choices the forum allows — about 45 lines of PHP producing about
40 lines of JavaScript to show one `<div>` and hide three.

There is **one** select now, with the directories as `<optgroup>`s, so picking an avatar is
one action instead of two and no list of filenames goes into the page. Each panel carries
`data-avatar-choice`, and `profile.js` reads that rather than being told which panels exist.

Two behaviours the old script had are kept:

- focusing a field inside a panel selects that panel's radio (the `onfocus` attributes)
- switching to Gravatar clears an address left over from one of the other choices — the
  condition for that travels as a `data-clear-email` attribute instead of being compiled
  into a `case`

##### One fix that the single list needs

`Profile::getAvatars()` marks a file as checked with:

```php
'checked' => $line == Utils::$context['member']['avatar']['server_pic'],
```

`server_pic` holds the *path* (`Oxygen/cards.png`), `$line` is the bare name, so a file
inside a directory never came back selected. It did not show before, because the nested
list was built in JavaScript and matched by name there. It compares against the path now.

`Utils::$context['avatar_list']` goes with the script that was its only reader.

##### Checked

Panel switching, both directions, against `release-3.0` — identical at every step:

| radio | panels shown |
|---|---|
| on load (`none`) | none |
| Gallery | server_stored |
| My own picture | external |
| Upload | upload |
| Gravatar | gravatar |
| No avatar | none |

Gravatar clearing an `http://…` address on the way in: same both ways. Focusing the
external url field inside its visible panel selects the `external` radio: same both ways.
Gallery selection updates the preview — `Oxygen/cards.png` gives
`http://localhost:8080/avatars/Oxygen/cards.png` with `alt="cards"` — and there is no
second select left on the page. No console errors from this code.

##### What could not be exercised

Choosing a gallery avatar and saving it does not work on `release-3.0` for reasons outside
this change: the page is a fatal error for any member who has one (fixed separately in
#9440), and even with that fixed the value does not persist, because
`User::updateMemberData()` cannot turn the bare filename back into a url. So the
pre-selection above is right by construction but cannot be demonstrated until that is
sorted — `Avatar::$choice` reports `none` for a prepackaged avatar today, whatever the
column says.

### Issues References (Fixes|Related|Closes)

Part of #7933
Related #9440

Co-Authored-By: live627 <john@jbrock.us>