### PR TITLE
[3.0] Recognise a gallery avatar as a file name, not a url

### DIFF
--- a/Sources/Avatar.php
+++ b/Sources/Avatar.php
@@ -455,6 +455,20 @@ class Avatar implements \ArrayAccess
 			$url = new Url($this->original_url, true)->proxied();
 		}
 
+		// An avatar picked out of the gallery is stored as a path relative to
+		// the avatars directory rather than as a URL, so anything with no
+		// scheme to it is a file name and not somewhere to fetch from. Saying
+		// so here means the search below finds it on its second attempt instead
+		// of guessing from the URL path, which only works out for a forum that
+		// is not at the root of its domain.
+		if (empty($this->filename) && !$url->isValid() && !str_contains((string) $url, '://')) {
+			$name = ltrim(strtr((string) $url, '\\', '/'), '/');
+
+			if ($name !== '' && !str_contains($name, ':')) {
+				$this->filename = $name;
+			}
+		}
+
 		// If we still don't have a valid URL, try to figure it out.
 		while (!$url->isValid()) {
 			$attempt ??= 0;


### PR DESCRIPTION
#### Description

An avatar picked out of the gallery is stored as a path relative to the avatars directory —
`Oxygen/cards.png` — not as a url. `Avatar` has no case for that, so it falls through to its
last resort, which pulls the path out of the url and looks for the file under the avatar
directories *relative to the board directory*.

That only lines up when the forum is installed under a path prefix. Two things go wrong
otherwise:

**Every page is a fatal error.** At the root of a domain there is no path to strip, and the
code reads it anyway:

```php
preg_quote(Url::create(Config::$boardurl)->path, '~')
```

`Url::$path` is typed with no default and was never assigned, so:

```
Typed property SMF\Url::$path must not be accessed before initialization
  —  Sources/Avatar.php:539
```

One member with a gallery avatar takes down the board index, every topic they posted in,
the memberlist and their profile.

**And the choice never sticks.** `Profile::setAvatarServerStored()` puts the right value in
place — verified, `new_data['avatar'] = 'Oxygen/cards.png'` — but saving a member runs it
back through `Avatar`, and since that cannot resolve it, `User::updateMemberData()` writes
the column from whatever the object settled for instead. Set by hand, the avatar rendered
as `default.png`, and `Avatar::$choice` reported `none`, so the picker came back with
*No avatar* selected.

A string with no scheme is a file name. Saying so before the search starts lets it match on
attempt 2, where the prepackaged avatar directory is already handled, and the last-resort
url guessing is never reached.

##### Checked

`http://localhost:8080` — a forum at the root of its domain.

Before, with `smf_members.avatar` = `Oxygen/bug.png`:

| page | |
|---|---|
| board index | 500 |
| their profile | 500 |

After, saving each choice in turn through *Profile → Forum Profile* and re-reading the
profile:

| chosen | column | rendered |
|---|---|---|
| gallery, nested (`Oxygen/cookie.png`) | `Oxygen/cookie.png` | `…/avatars/Oxygen/cookie.png` |
| gallery, top level (`default.png`) | `''` | `…/avatars/default.png` |
| no avatar | `''` | `…/avatars/default.png` |
| gravatar | `gravatar://` | `secure.gravatar.com/avatar/…` |
| back to gallery (`Oxygen/bug.png`) | `Oxygen/bug.png` | `…/avatars/Oxygen/bug.png` |

`smf_log_errors` stayed empty throughout. The top-level `default.png` storing as `''` is
existing behaviour — `User::updateMemberData()` treats the default image as "no avatar".

This also settles the crash that #9440 guards against, by never reaching that branch for a
gallery avatar. #9440 is still worth having: it is the defensive fix for anything else that
gets that far with a pathless forum url.

### Issues References (Fixes|Related|Closes)

Related #9440, #9441