### PR TITLE
[3.0] Theme split (wave 4, part 19) — point calendar.css at the design tokens

### DIFF
--- a/Themes/default/css/calendar.css
+++ b/Themes/default/css/calendar.css
@@ -17,7 +17,7 @@
 }
 .calendar_today,
 td.days:hover {
-	background: #fff;
+	background: var(--calendar-today-bg);
 }
 #month_grid {
 	width: 214px;
@@ -33,8 +33,8 @@ td.days:hover {
 	width: 100%;
 	margin-bottom: 12px;
 	border-collapse: collapse;
-	background: #f0f4f7;
-	border: 1px solid #ddd;
+	background: var(--window-bg);
+	border: 1px solid var(--window-border-color);
 }
 #main_grid {
 	overflow: auto;
@@ -42,19 +42,19 @@ td.days:hover {
 #main_grid table {
 	width: 99.9%;
 	border-collapse: collapse;
-	background: #f0f4f7;
+	background: var(--window-bg);
 	margin: 1px 0 0 0;
-	border: 1px solid #ddd;
+	border: 1px solid var(--window-border-color);
 	overflow: auto;
 }
 #main_grid .cat_bar {
 	border-radius: 5px 5px 0 0;
 }
 #month_grid th:first-child {
-	background: #e7eaef;
+	background: var(--calendar-th-bg);
 }
 #month_grid th.days {
-	background: #e7eaef;
+	background: var(--calendar-th-bg);
 	font-size: smaller;
 }
 #month_grid th.days,
@@ -64,7 +64,7 @@ td.days:hover {
 }
 #month_grid td.weeks {
 	font-size: large;
-	background: #e7eaef;
+	background: var(--calendar-th-bg);
 	width: 5%;
 }
 #month_grid td.weeks a:hover {
@@ -80,19 +80,19 @@ td.days:hover {
 	margin: -3px 4px 0 4px;
 }
 #main_grid th:first-child {
-	background: #e7eaef;
+	background: var(--calendar-th-bg);
 }
 #main_grid th.days {
 	width: 14%;
 	padding: 5px 10px;
 	text-align: left;
-	background: #e7eaef;
+	background: var(--calendar-th-bg);
 }
 #main_grid td.weeks {
 	text-align: center;
 	font-weight: bold;
 	font-size: 1.8em;
-	background: #e7eaef;
+	background: var(--calendar-th-bg);
 	padding: 5px;
 }
 #main_grid td.weeks a:hover {
@@ -101,43 +101,43 @@ td.days:hover {
 /* Main Highlighting */
 #main_grid td.disabled,
 #month_grid td.disabled {
-	background: #eee;
-	border: 1px solid #ddd;
+	background: var(--calendar-disabled-bg);
+	border: 1px solid var(--window-border-color);
 }
 #main_grid td.events,
 #month_grid td.events {
-	background: rgba(30, 245, 20, 0.1);
+	background: var(--calendar-event-bg);
 }
 #main_grid td.holidays,
 #month_grid td.holidays {
-	background: rgba(23, 110, 245, 0.1);
+	background: var(--calendar-holiday-bg);
 }
 #main_grid td.birthdays,
 #month_grid td.birthdays {
-	background: rgba(102, 0, 255, 0.1);
+	background: var(--calendar-birthday-bg);
 }
 /* Special Case Highlighting */
 #main_grid td.events:hover,
 #month_grid td.events:hover,
 #month_grid td.calendar_today.events {
-	background: rgba(30, 245, 20, 0.2);
+	background: var(--calendar-event-bg_hover);
 }
 #main_grid td.holidays:hover,
 #month_grid td.holidays:hover,
 #month_grid td.calendar_today.holidays {
-	background: rgba(23, 110, 245, 0.2);
+	background: var(--calendar-holiday-bg_hover);
 }
 #main_grid td.birthdays:hover,
 #month_grid td.birthdays:hover,
 #month_grid td.calendar_today.birthdays {
-	background: rgba(153, 51, 255, 0.2);
+	background: var(--calendar-birthday-bg_hover);
 }
 #main_grid td.days,
 #month_grid td.days {
 	vertical-align: top;
 	text-align: left;
-	border-right: 1px solid #ddd;
-	border-bottom: 1px solid #ddd;
+	border-right: 1px solid var(--window-border-color);
+	border-bottom: 1px solid var(--window-border-color);
 }
 #main_grid td.days {
 	padding: 5px;
@@ -153,21 +153,21 @@ td.days:hover {
 }
 #month_grid td.days a:hover {
 	text-decoration: none;
-	background: rgba(97, 135, 166, 0.2);
+	background: var(--calendar-day-bg_hover);
 }
 #main_grid tbody tr:nth-child(2) td.days,
 #month_grid tbody tr:nth-child(2) {
-	border-top: 1px solid #ddd;
+	border-top: 1px solid var(--window-border-color);
 }
 #main_grid tbody tr.days_wrapper > td:nth-child(2),
 #month_grid tr.days_wrapper > td:nth-child(2) {
-	border-left: 1px solid #ddd;
+	border-left: 1px solid var(--window-border-color);
 }
 #main_grid tr.days_wrapper:nth-child(2) > td.weeks {
-	border-top: 1px solid #ddd;
+	border-top: 1px solid var(--window-border-color);
 }
 #main_grid table:last-child td.weeks {
-	border-bottom: 1px solid #ddd;
+	border-bottom: 1px solid var(--window-border-color);
 }
 #main_grid tr:not(.days_wrapper) th,
 #main_grid tr:not(.days_wrapper) td {
@@ -191,7 +191,7 @@ p.inline.holidays > span {
 	font-size: 12pt;
 }
 #main_grid .active_post_event > a {
-	color: #999;
+	color: var(--calendar-link-color);
 }
 div.week_month_title {
 	font-weight: bold;
@@ -200,7 +200,7 @@ div.week_month_title {
 	line-height: 1.2em;
 }
 div.week_month_title a {
-	color: #555;
+	color: var(--calendar-title-link-color);
 }
 td.week_post {
 	vertical-align: middle !important;
@@ -210,10 +210,10 @@ div.week_add_event {
 }
 div.week_add_event > a {
 	/* font-size: x-large; */
-	color: #999;
+	color: var(--calendar-link-color);
 }
 div.week_add_event > a:hover {
-	color: #555;
+	color: var(--calendar-link-color_hover);
 }
 span.hidelink {
 	font-style: italic;
@@ -241,10 +241,10 @@ span.hidelink {
 .event_wrapper:not(:last-child) {
 	margin-bottom: 5px;
 	padding-bottom: 5px;
-	border-bottom: 1px solid #ddd;
+	border-bottom: 1px solid var(--window-border-color);
 }
 .event_time, .event_location {
-	color: #777;
+	color: var(--calendar-event-meta-color);
 }
 .post_event_link {
 	vertical-align: middle;
@@ -357,7 +357,7 @@ span.hidelink {
 	}
 
 	#main_grid .calendar_week tr {
-		border: 1px solid #ddd !important;
+		border: 1px solid var(--window-border-color) !important;
 	}
 	#main_grid .calendar_week td {
 		margin: 0;

--- a/Themes/default/css/variables.css
+++ b/Themes/default/css/variables.css
@@ -378,4 +378,20 @@
 	--breadcrumb-link-text-shadow_active:             none;
 	--breadcrumb-link-text-shadow_focus:              none;
 	--breadcrumb-link-text-shadow_hover:              none;
+
+	/** Calendar **/
+	--calendar-th-bg:                                 #e7eaef;
+	--calendar-today-bg:                              #fff;
+	--calendar-disabled-bg:                           #eee;
+	--calendar-day-bg_hover:                          rgba(97, 135, 166, 0.2);
+	--calendar-event-bg:                              rgba(30, 245, 20, 0.1);
+	--calendar-event-bg_hover:                        rgba(30, 245, 20, 0.2);
+	--calendar-holiday-bg:                            rgba(23, 110, 245, 0.1);
+	--calendar-holiday-bg_hover:                      rgba(23, 110, 245, 0.2);
+	--calendar-birthday-bg:                           rgba(102, 0, 255, 0.1);
+	--calendar-birthday-bg_hover:                     rgba(153, 51, 255, 0.2);
+	--calendar-link-color:                            #999;
+	--calendar-link-color_hover:                      #555;
+	--calendar-title-link-color:                      #555;
+	--calendar-event-meta-color:                      #777;
 }


### PR DESCRIPTION
#### Description

Part of the [#7933](https://github.com/SimpleMachines/SMF/pull/7933) split, wave 4.
Calendar area.

`index.css` was converted when the design tokens landed. `calendar.css` was left behind and
still carried **33 hard-coded colours**, so restyling the calendar means editing a
stylesheet rather than a variable, and `dark.css` and the colour variants have nothing to
reach for.

Seven of them already had a token elsewhere in the theme, so those just point at it:

| was | now |
|---|---|
| `#ddd` (11 borders) | `var(--window-border-color)` |
| `#f0f4f7` (2 table backgrounds) | `var(--window-bg)` |

The rest get named tokens of their own, **keeping the value they have now**:

```css
--calendar-th-bg:            #e7eaef;
--calendar-today-bg:         #fff;
--calendar-disabled-bg:      #eee;
--calendar-day-bg_hover:     rgba(97, 135, 166, 0.2);
--calendar-event-bg:         rgba(30, 245, 20, 0.1);
--calendar-event-bg_hover:   rgba(30, 245, 20, 0.2);
--calendar-holiday-bg:       rgba(23, 110, 245, 0.1);
--calendar-holiday-bg_hover: rgba(23, 110, 245, 0.2);
--calendar-birthday-bg:      rgba(102, 0, 255, 0.1);
--calendar-birthday-bg_hover: rgba(153, 51, 255, 0.2);
--calendar-link-color:       #999;
--calendar-link-color_hover: #555;
--calendar-title-link-color: #555;
--calendar-event-meta-color: #777;
```

##### Where this differs from the theme branch

It gives some of these different values — the header row follows the title bar instead of
being its own grey, today's cell takes the lightest primary tint, and holidays hang off
`--primary-color-hue` so a variant re-tints them. Those change how the calendar *looks* and
belong with that change, not with naming what is already there. The names match, so
re-pointing them later is a one-line edit each.

The event and birthday colours are the same colour in both, but written as `hsla()` there.
`hsl(117, 92%, 52%)` comes out as `rgb(31, 245, 20)`, one off the `rgb(30, 245, 20)` in use,
so the literals stay for now.

##### Checked

The acceptance test for a token conversion is that nothing moves. Every rule in
`calendar.css` that sets a colour, a background or a border was applied to a probe element
and its computed values read, on both versions — **35 rules, 0 differences**, including the
`:hover` and `.calendar_today.events` / `.holidays` / `.birthdays` rules that cannot be
sampled off the page directly. Computed styles on 18 elements of the month view are
identical too.

(The calendar needs #9405 to render at all on a stock install, so it was checked with that
merged in locally.)

`calendar.rtl.css` keeps its four white separator borders — there is no token that means
that, and the file is due to go when the calendar moves to logical properties.

### Issues References (Fixes|Related|Closes)

Part of #7933

Co-Authored-By: live627 <john@jbrock.us>