### PR TITLE
[3.0] Keep the dead close link out of the help overlay

### DIFF
--- a/Themes/default/Help.template.php
+++ b/Themes/default/Help.template.php
@@ -21,7 +21,19 @@ use SMF\Utils;
  */
 function template_popup()
 {
-	// Since this is a popup of its own we need to start the html, etc.
+	// reqOverlayDiv() asks for this with ';ajax' on the end and shows whatever
+	// comes back inside an overlay on the page it was called from. There is no
+	// window to close in that case, and no use for a document of its own.
+	if (isset($_REQUEST['ajax'])) {
+		echo '
+		<div class="windowbg description">
+			', Utils::$context['help_text'], '
+		</div>';
+
+		return;
+	}
+
+	// Otherwise this really is a window of its own, so it needs the html.
 	echo '<!DOCTYPE html>
 <html', Utils::$context['right_to_left'] ? ' dir="rtl"' : '', '>
 	<head>


### PR DESCRIPTION
#### Description

The help icons open their text in an overlay on the page you are already on.
`reqOverlayDiv()` fetches the url with `;ajax` appended and hands the result to
`smc_Popup`, taking `doc.querySelector('body div').innerHTML` out of it.

`template_popup()` answers with a complete html document — doctype, `<head>`, a stylesheet
link, a `<script>` — of which all but one `<div>` is thrown away. And that div ends with:

```html
<a href="javascript:self.close();">Close window</a>
```

There is no window to close, so clicking it does nothing. It has been sitting at the bottom
of every help overlay:

> Gravatar is Globally Recognized Avatars. Register an account at https://www.gravatar.com …
> If you do not have a gravatar account, a default image will be used. **Close window**

Asked for with `;ajax`, the template now emits the help text and nothing else. Asked for
without it — a real window of its own — nothing changes, close link and all.

##### Checked

Clicking the gravatar help icon on *Profile → Forum Profile*:

| | before | after |
|---|---|---|
| links in the overlay | 2 (`gravatar.com`, **Close window**) | 1 (`gravatar.com`) |
| `a[href^="javascript:self.close"]` | present | gone |
| response size | 1214 bytes | 373 bytes |
| doctype / head / stylesheet fetched and discarded | yes | no |

`?action=helpadmin;help=gravatar` without `;ajax` is byte-identical to before: full
document, `<title>SMF Dev - Help</title>`, close link present.

### Issues References (Fixes|Related|Closes)

n/a