### PR TITLE
[3.0] Theme split (wave 4, part 20) — read out the page links before the buttons beside them

### DIFF
--- a/Themes/default/Memberlist.template.php
+++ b/Themes/default/Memberlist.template.php
@@ -23,8 +23,8 @@ function template_main()
 	echo '
 	<div class="main_section" id="memberlist">
 		<div class="pagesection">
-			', template_button_strip(Utils::$context['memberlist_buttons'], 'right'), '
 			<div class="pagelinks floatleft">', Utils::$context['page_index'], '</div>
+			', template_button_strip(Utils::$context['memberlist_buttons'], 'right'), '
 		</div>
 		<div class="cat_bar">
 			<h3 class="catbg">

--- a/Themes/default/MessageIndex.template.php
+++ b/Themes/default/MessageIndex.template.php
@@ -341,12 +341,12 @@ function template_main()
 
 		echo '
 	<div class="pagesection">
-		', template_button_strip(Utils::$context['normal_buttons'], 'right'), '
 		', Utils::$context['menu_separator'], '
 		<div class="pagelinks floatleft">
 			<a href="#main_content_section" class="button" id="bot">', Lang::getTxt('go_up', file: 'General'), '</a>
 			', Utils::$context['page_index'], '
-		</div>';
+		</div>
+		', template_button_strip(Utils::$context['normal_buttons'], 'right');
 
 		// Mobile action buttons (bottom)
 		if (!empty(Utils::$context['normal_buttons'])) {

--- a/Themes/default/ModerationCenter.template.php
+++ b/Themes/default/ModerationCenter.template.php
@@ -383,7 +383,8 @@ function template_unapproved_posts()
 			</div>';
 	} else {
 		echo '
-			<div class="pagesection">';
+			<div class="pagesection">
+				<div class="pagelinks">', Utils::$context['page_index'], '</div>';
 
 		if (!empty(Theme::$current->options['display_quick_mod']) && Theme::$current->options['display_quick_mod'] == 1) {
 			echo '
@@ -395,7 +396,6 @@ function template_unapproved_posts()
 		}
 
 		echo '
-				<div class="pagelinks">', Utils::$context['page_index'], '</div>
 			</div>';
 
 	}
@@ -439,6 +439,11 @@ function template_unapproved_posts()
 	echo '
 			<div class="pagesection">';
 
+	if (!empty(Utils::$context['unapproved_items'])) {
+		echo '
+				<div class="pagelinks">', Utils::$context['page_index'], '</div>';
+	}
+
 	if (!empty(Theme::$current->options['display_quick_mod']) && Theme::$current->options['display_quick_mod'] == 1) {
 		echo '
 				<div class="floatright">
@@ -452,11 +457,6 @@ function template_unapproved_posts()
 						<input type="submit" name="mc_go" value="', Lang::getTxt('go', file: 'General'), '" class="button">
 					</noscript>
 				</div>';
-	}
-
-	if (!empty(Utils::$context['unapproved_items'])) {
-		echo '
-				<div class="pagelinks">', Utils::$context['page_index'], '</div>';
 	}
 
 	echo '


### PR DESCRIPTION
#### Description

A `.pagesection` holds the page links and a row of buttons, one floated to each side. The markup put the buttons first, so anything reading the page in source order — a screen reader, or the tab key — met them before the page links they sit next to, which is the opposite of what is on screen.

The message index is the clearest case, because it draws a `.pagesection` above the topic list and another below it, **and the two disagreed**. The top one already put the page links first; only the bottom one was the other way round.

##### Verification

`.pagesection` is a plain `display: block` and both children are really floated, so nothing moves. Measured on the message index, where both sections are visible at once:

| section | element | before | after |
|---|---|---|---|
| top | page links | x=72, w=143 | x=72, w=143 |
| top | button strip | x=709, w=401 | x=709, w=401 |
| bottom | page links | x=72, w=122 | x=72, w=122 |
| bottom | button strip | x=709, w=401 | x=709, w=401 |

Only the DOM order changes — the bottom section goes from `buttonlist | pagelinks | mobile_buttons` to `pagelinks | buttonlist | mobile_buttons`, matching the top one.

Covers the memberlist, the two sections on `?action=moderate;area=postmod`, and the message index. The quick-moderation variant of the moderation-centre section could not be exercised on the test install.

I checked that this is genuinely a no-op before claiming it, because it is not always: `.cat_bar` became a flex row in #9390, and a float is ignored on a flex item, so the same-looking reorder there does move things (see #9449). `.pagesection` is still a block, so it does not.

### Issues References (Fixes|Related|Closes)

Related: #7933