### PR TITLE
[3.0] Name the variant a theme actually gave, instead of a blank option

### DIFF
--- a/Sources/Actions/Admin/Themes.php
+++ b/Sources/Actions/Admin/Themes.php
@@ -618,10 +618,16 @@ class Themes implements ActionInterface
 				$available_variants = [];
 
 				foreach (Theme::$current->settings['theme_variants'] as $variant) {
-					$available_variants[$variant] = Lang::getTxt('variant_' . $variant, file: 'Themes') ?? $variant;
+					// A theme is free to name a variant anything it likes, so an
+					// unknown one has to fall back to its own name. getTxt() hands
+					// back '' rather than null for a string it cannot find, so ??
+					// never fires and the drop-down listed a blank entry instead.
+					$available_variants[$variant] = Lang::getTxt('variant_' . $variant, file: 'Themes') ?: $variant;
 				}
 
-				Utils::$context['options'][] = Lang::getTxt('theme_opt_variant', file: 'Themes');
+				// This one lives in Profile.php, where the matching option on the
+				// user's own theme settings page reads it from.
+				Utils::$context['options'][] = Lang::getTxt('theme_opt_variant', file: 'Profile');
 				Utils::$context['options'][] = [
 					'id' => 'theme_variant',
 					'label' => Lang::getTxt('theme_pick_variant', file: 'Themes'),
@@ -636,10 +642,10 @@ class Themes implements ActionInterface
 				$available_modes = [];
 
 				foreach (Theme::$current->settings['theme_colormodes'] as $mode) {
-					$available_modes[$mode] = Lang::getTxt('colormode_' . $mode, file: 'Themes') ?? $mode;
+					$available_modes[$mode] = Lang::getTxt('colormode_' . $mode, file: 'Themes') ?: $mode;
 				}
 
-				Utils::$context['options'][] = Lang::getTxt('theme_opt_colormode', file: 'Themes');
+				Utils::$context['options'][] = Lang::getTxt('theme_opt_colormode', file: 'Profile');
 				Utils::$context['options'][] = [
 					'id' => 'theme_colormode',
 					'label' => Lang::getTxt('theme_pick_colormode', file: 'Themes'),


### PR DESCRIPTION
#### Description

The theme options page (`?action=admin;area=theme;sa=options;th=1`) builds its variant and colour-mode drop-downs like this:

```php
$available_variants[$variant] = Lang::getTxt('variant_' . $variant, file: 'Themes') ?? $variant;
```

The `?? $variant` is there to cover a variant whose name the language files do not describe. It has never fired. `Lang::getTxt()` returns `''` for a string it cannot find — it never returns null — so `??` passes the empty string straight through and the drop-down offers an option with no label.

A theme is free to name its variants anything, so this is the normal case rather than an edge one. With two variants installed, the list reads:

| | before | after |
|---|---|---|
| variant list | `Default`, `""`, `""` | `Default`, `light`, `ocean` |

Same one-character change for `colormode_*`.

The second hunk is smaller and not user-visible: `theme_opt_variant` and `theme_opt_colormode` are asked for from `Themes`, but both strings live in `Languages/en_US/Profile.php` — which is where [ThemeOptions.php:78](https://github.com/SimpleMachines/SMF/blob/release-3.0/Sources/Actions/Profile/ThemeOptions.php#L78) reads them from for the matching option on the user's own settings page. The labels do come out right today because the theme options page has already loaded `Profile.php` by the time these run, but `Lang::loadFileForGetTxt()` sees a key that came from an unexpected file and force-reloads to go looking for it. Naming the right file avoids that.

##### Verification

Neither branch is reachable on a stock 3.0 install — the default theme sets `has_dark_mode = false` and `theme_variants = []`. Both are reachable for any custom theme that ships variants, and both become reachable here when dark mode lands. To exercise it I temporarily set `theme_variants = ['light', 'ocean']` and `has_dark_mode = true` in `index.template.php` and read the rendered `<option>` labels, before and after. That temporary edit is not part of this PR.

This is part of the effort to break #7933 into reviewable pieces — found while triaging the admin area, and separated out because it changes no template.

### Issues References (Fixes|Related|Closes)

Related: #7933