### PR TITLE
[3.0] Theme split (wave 4, part 21) — stop shipping the paid subscription day picker to every page

### DIFF
--- a/Sources/Actions/Admin/Subscriptions.php
+++ b/Sources/Actions/Admin/Subscriptions.php
@@ -866,6 +866,10 @@ class Subscriptions implements ActionInterface
 		Utils::$context['sub_template'] = 'modify_user_subscription';
 		Utils::$context['page_title'] = Lang::getTxt(Utils::$context['action_type'] . '_subscriber', file: 'ManagePaid');
 
+		// Keeps the day drop-downs in step with the month and year beside them.
+		// This is the only page that has any use for it.
+		Theme::loadJavaScriptFile('paidsubs.js', ['defer' => true, 'minimize' => true], 'smf_paidsubs');
+
 		// If we haven't been passed the subscription ID get it.
 		if (Utils::$context['log_id'] && !Utils::$context['sub_id']) {
 			$request = Db::$db->query(

--- a/Themes/default/ManagePaid.template.php
+++ b/Themes/default/ManagePaid.template.php
@@ -216,12 +216,6 @@ function template_delete_subscription()
  */
 function template_modify_user_subscription()
 {
-	// Some quickly stolen javascript from Post, could do with being more efficient :)
-	echo '
-	<script>
-		var monthLength = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
-	</script>';
-
 	echo '
 	<form action="', Config::$scripturl, '?action=admin;area=paidsubscribe;sa=modifyuser;sid=', Utils::$context['sub_id'], ';lid=', Utils::$context['log_id'], '" method="post">
 		<div class="cat_bar">
@@ -264,7 +258,7 @@ function template_modify_user_subscription()
 			</dl>
 			<fieldset>
 				<legend>', Lang::getTxt('start_date_and_time', file: 'ManagePaid'), '</legend>
-				<select name="year" id="year" onchange="generateDays();">';
+				<select name="year" id="year">';
 
 	// Show a list of all the years we allow...
 	for ($year = 2005; $year <= 2030; $year++) {
@@ -274,7 +268,7 @@ function template_modify_user_subscription()
 
 	echo '
 				</select>
-				<select name="month" id="month" onchange="generateDays();">';
+				<select name="month" id="month">';
 
 	// There are 12 months per year - ensure that they all get listed.
 	for ($month = 1; $month <= 12; $month++) {
@@ -301,7 +295,7 @@ function template_modify_user_subscription()
 			</fieldset>
 			<fieldset>
 				<legend>', Lang::getTxt('end_date_and_time', file: 'ManagePaid'), '</legend>
-				<select name="yearend" id="yearend" onchange="generateDays(\'end\');">';
+				<select name="yearend" id="yearend">';
 
 	// Show a list of all the years we allow...
 	for ($year = 2005; $year <= 2030; $year++) {
@@ -311,7 +305,7 @@ function template_modify_user_subscription()
 
 	echo '
 				</select>
-				<select name="monthend" id="monthend" onchange="generateDays(\'end\');">';
+				<select name="monthend" id="monthend">';
 
 	// There are 12 months per year - ensure that they all get listed.
 	for ($month = 1; $month <= 12; $month++) {

--- a/Themes/default/scripts/paidsubs.js
+++ b/Themes/default/scripts/paidsubs.js
@@ -1,0 +1,57 @@
+/*
+ * Keeps the day drop-downs on the paid subscription editor honest, so that a
+ * month with fewer than 31 days does not offer days it has not got.
+ *
+ * Only ?action=admin;area=paidsubscribe;sa=modifyuser draws these, which is
+ * why this lives in its own file rather than in script.js.
+ */
+
+function generateDays(offset)
+{
+	// Work around JavaScript's lack of support for default values...
+	offset = typeof(offset) != 'undefined' ? offset : '';
+
+	var days = 0, selected = 0;
+	var dayElement = document.getElementById("day" + offset), yearElement = document.getElementById("year" + offset), monthElement = document.getElementById("month" + offset);
+
+	var monthLength = [
+		31, 28, 31, 30,
+		31, 30, 31, 31,
+		30, 31, 30, 31
+	];
+	if (yearElement.options[yearElement.selectedIndex].value % 4 == 0)
+		monthLength[1] = 29;
+
+	selected = dayElement.selectedIndex;
+	while (dayElement.options.length)
+		dayElement.options[0] = null;
+
+	days = monthLength[monthElement.value - 1];
+
+	for (var i = 1; i <= days; i++)
+		dayElement.options[dayElement.length] = new Option(i, i);
+
+	if (selected < days)
+		dayElement.selectedIndex = selected;
+}
+
+/*
+ * The start and end date each have their own trio of selects, told apart by
+ * the "end" suffix on the second set's ids.
+ */
+document.addEventListener('DOMContentLoaded', function ()
+{
+	['', 'end'].forEach(function (offset)
+	{
+		['year', 'month'].forEach(function (part)
+		{
+			var element = document.getElementById(part + offset);
+
+			if (element)
+				element.addEventListener('change', function ()
+				{
+					generateDays(offset);
+				});
+		});
+	});
+});

--- a/Themes/default/scripts/script.js
+++ b/Themes/default/scripts/script.js
@@ -1257,35 +1257,6 @@ function pollOptions()
 		document.forms.postmodify.poll_hide[2].disabled = false;
 }
 
-function generateDays(offset)
-{
-	// Work around JavaScript's lack of support for default values...
-	offset = typeof(offset) != 'undefined' ? offset : '';
-
-	var days = 0, selected = 0;
-	var dayElement = document.getElementById("day" + offset), yearElement = document.getElementById("year" + offset), monthElement = document.getElementById("month" + offset);
-
-	var monthLength = [
-		31, 28, 31, 30,
-		31, 30, 31, 31,
-		30, 31, 30, 31
-	];
-	if (yearElement.options[yearElement.selectedIndex].value % 4 == 0)
-		monthLength[1] = 29;
-
-	selected = dayElement.selectedIndex;
-	while (dayElement.options.length)
-		dayElement.options[0] = null;
-
-	days = monthLength[monthElement.value - 1];
-
-	for (i = 1; i <= days; i++)
-		dayElement.options[dayElement.length] = new Option(i, i);
-
-	if (selected < days)
-		dayElement.selectedIndex = selected;
-}
-
 function initSearch()
 {
 	if (document.forms.searchform.search.value.indexOf("%u") != -1)


### PR DESCRIPTION
#### Description

`generateDays()` keeps the day drop-down on the paid subscription editor in step with the month and year beside it, so that February does not offer 31 days. It lives in `script.js`, which every page loads. The only caller in the entire forum is `template_modify_user_subscription()`:

```
$ grep -rn "generateDays" --include=*.php Sources/ Themes/
Themes/default/ManagePaid.template.php:261: <select name="year" id="year" onchange="generateDays();">
Themes/default/ManagePaid.template.php:271: <select name="month" id="month" onchange="generateDays();">
Themes/default/ManagePaid.template.php:298: <select name="yearend" id="yearend" onchange="generateDays('end');">
Themes/default/ManagePaid.template.php:308: <select name="monthend" id="monthend" onchange="generateDays('end');">
```

So it moves to a `paidsubs.js` that only that page loads, and the four inline `onchange` attributes become listeners in the same file — the same treatment as the other script moves in this series.

##### A dead global goes with it

The template opened with this, under a comment reading *"Some quickly stolen javascript from Post, could do with being more efficient :)"*:

```php
<script>
    var monthLength = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
</script>
```

Nothing has ever read it. `generateDays()` declares a `monthLength` of its own, which shadows the global on the one page that defined it. Removing it changes nothing, which the measurements below show.

##### Left alone deliberately

The function is moved as it stands. Two things in it are worth revisiting and neither is worth mixing into a move: the leap year test is `year % 4 == 0`, which is wrong for century years, and when the new month is shorter than the selected day the day resets to the 1st rather than clamping to the last. #7933 rewrites both; taking that here would make a move impossible to review as one.

##### Verification

`?action=admin;area=paidsubscribe;sa=modifyuser;sid=1`, driving both trios of selects and counting the resulting `<option>`s, on `release-3.0` and on this branch:

| probe | release-3.0 | this branch |
|---|---|---|
| `window.monthLength` | `object` | `undefined` |
| selects carrying inline `onchange` | `year, month, yearend, monthend` | none |
| Feb 2023 | 28 | 28 |
| Feb 2024 | 29 | 29 |
| April | 30 | 30 |
| January | 31 | 31 |
| end trio, Feb 2024 | 29 | 29 |
| end trio, November | 30 | 30 |
| start trio unaffected by end trio | 31 | 31 |
| 31 Jan → February | day 1 | day 1 |

### Issues References (Fixes|Related|Closes)

Related: #7933