### PR TITLE
[3.0] Theme split (wave 4, part 22) — point admin.css at the design tokens

### DIFF
--- a/Themes/default/css/admin.css
+++ b/Themes/default/css/admin.css
@@ -10,7 +10,7 @@
 	float: right;
 }
 .action_admin .table_grid td {
-	border: 1px solid #ddd;
+	border: 1px solid var(--admin-table-grid-border-color);
 	border-top: 0;
 }
 .action_admin .generic_list .flow_auto {
@@ -28,7 +28,7 @@ a.help span {
 	margin-right: 2px;
 }
 .table_caption, tr.table_caption td {
-	color: #000;
+	color: var(--admin-table-caption-color);
 	font-size: 10px;
 	font-weight: bold;
 }
@@ -43,7 +43,7 @@ fieldset dl {
 }
 legend {
 	font-weight: bold;
-	color: #000;
+	color: var(--admin-legend-color);
 }
 
 /* Styles for the admin home screen.
@@ -73,13 +73,13 @@ legend {
 	padding: 5px 0;
 	overflow: auto;
 	line-height: 1.7em;
-	border-bottom: double #ccc;
+	border-bottom: double var(--admin-search-result-border-color);
 }
 .search_results li:last-child {
 	border: none;
 }
 .search_results li a strong {
-	color: #346;
+	color: var(--body-link-color);
 }
 .search_results li p {
 	padding: 0 20px;
@@ -107,22 +107,22 @@ legend {
 }
 #smfAnnouncements dt {
 	padding: 4px 6px 2px 6px;
-	border-top: 1px solid #bf6900;
+	border-top: 1px solid var(--admin-announcement-border-color);
 }
 #smfAnnouncements dt a {
-	color: #bf6900;
+	color: var(--admin-announcement-link-color);
 	font-weight: bold;
 	display: block;
 }
 #smfAnnouncements dd {
 	margin: 0;
 	padding: 6px 12px;
-	border-top: double #ddd;
+	border-top: double var(--admin-announcement-separator-color);
 }
 
 fieldset.admin_group legend {
-	background: #eaf1f4;
-	border: 1px solid #cacdd3;
+	background: var(--admin-group-legend-bg);
+	border: 1px solid var(--admin-group-legend-border-color);
 	padding: 1px 5px;
 	border-radius: 3px;
 }
@@ -278,12 +278,12 @@ fieldset.admin_group .inactive {
 	border: none;
 }
 #package_list li {
-	border: 1px solid #cacdd3;
+	border: 1px solid var(--admin-package-border-color);
 	padding: 0.2em;
 	margin: 1px;
 }
 .package_section {
-	border: 1px solid #cacdd3;
+	border: 1px solid var(--admin-package-border-color);
 }
 span.package_server {
 	padding-left: 3em;
@@ -313,23 +313,23 @@ pre.file_content {
 	text-align: center;
 }
 .perm_read {
-	background-color: #d1f7bf;
+	background-color: var(--admin-perm-read-bg);
 	width: 8%;
 }
 .perm_writable {
-	background-color: #ffbbbb;
+	background-color: var(--admin-perm-writable-bg);
 	width: 8%;
 }
 .perm_execute {
-	background-color: #fdd7af;
+	background-color: var(--admin-perm-execute-bg);
 	width: 8%;
 }
 .perm_custom {
-	background-color: #c2c6c0;
+	background-color: var(--admin-perm-custom-bg);
 	width: 8%;
 }
 .perm_no_change {
-	background-color: #eee;
+	background-color: var(--admin-perm-no-change-bg);
 	width: 8%;
 }
 
@@ -351,27 +351,27 @@ pre.file_content {
 	padding: 8px 0;
 	margin: 0;
 	border-radius: 0;
-	border: 1px solid #ddd;
+	border: 1px solid var(--window-border-color);
 	border-bottom: none;
 }
 #manage_boards li.windowbg:first-child {
 	border-top: none;
 }
 #manage_boards li.windowbg:last-child {
-	border-bottom: 1px solid #ddd;
+	border-bottom: 1px solid var(--window-border-color);
 }
 #manage_boards li.windowbg:hover {
-	background: #d0e7f8;
+	background: var(--admin-board-bg_hover);
 }
 #manage_boards li .floatleft {
 	font-weight: bold;
 	padding: 0 6px;
 }
 #manage_boards li#recycle_board {
-	background-color: #dee;
+	background-color: var(--admin-recycle-board-bg);
 }
 #manage_boards li.redirect_board, #manage_boards li.redirect_board:hover {
-	background-color: #eed;
+	background-color: var(--admin-redirect-board-bg);
 }
 .move_links {
 	padding: 0 13px 0 0;
@@ -387,7 +387,7 @@ pre.file_content {
 	margin: 0 0 8px 0;
 }
 #manage_boards span.post_group, #manage_boards span.regular_members {
-	border-bottom: 1px dotted #000;
+	border-bottom: 1px dotted var(--admin-board-group-border-color);
 	cursor: help;
 }
 .select_all_box {
@@ -405,7 +405,7 @@ dl.right dt {
 
 /* Styles for the manage membergroups section. */
 .denyboards_layout .board:hover {
-	background: #e3e9ec;
+	background: var(--admin-denyboard-bg_hover);
 }
 .all_boards_in_cat {
 	margin-left: 2.5em;
@@ -461,15 +461,15 @@ span.search_weight {
 }
 .perm_boards li {
 	list-style-type: none;
-	border: 1px solid #cacdd3;
+	border: 1px solid var(--admin-perm-boards-border-color);
 	border-top: 0;
 	padding: 0.2em;
 }
 .perm_boards li:first-child {
-	border-top: 1px solid #cacdd3;
+	border-top: 1px solid var(--admin-perm-boards-border-color);
 }
 .perm_groups {
-	background-color: #fff;
+	background-color: var(--admin-perm-groups-bg);
 }
 .perms {
 	width: 20px;
@@ -530,7 +530,7 @@ ul.moderation_notes {
 }
 ul.moderation_notes li {
 	padding: 0.2em;
-	border-bottom: 1px solid #ccc;
+	border-bottom: 1px solid var(--admin-moderation-note-border-color);
 }
 .notes {
 	margin-top: 0.4em;
@@ -577,13 +577,13 @@ h3.config_hd {
 }
 
 .windowbg.highlight2 {
-	background: #d0e7f8;
+	background: var(--admin-highlight-bg);
 }
 
 /* Css edit page */
 #css_preview_box {
 	margin-bottom: 2ex;
-	border: 1px solid #777;
+	border: 1px solid var(--admin-css-preview-border-color);
 	width: 100%;
 	height: 400px;
 }
@@ -597,11 +597,11 @@ h3.config_hd {
 }
 
 .move_smileys a:hover img {
-	border-color: #71a0c8;
+	border-color: var(--admin-smiley-border-color_hover);
 }
 
 .move_smileys .selected_item {
-	border-color: #ffb42d;
+	border-color: var(--admin-smiley-border-color_selected);
 }
 
 /* Progress bars */
@@ -623,5 +623,5 @@ h3.config_hd {
 	top: initial;
 	left: -1px;
 	bottom: calc(3em - 1px);
-	border: 1px solid #bbb;
+	border: 1px solid var(--admin-edit-history-border-color);
 }

--- a/Themes/default/css/variables.css
+++ b/Themes/default/css/variables.css
@@ -378,4 +378,34 @@
 	--breadcrumb-link-text-shadow_active:             none;
 	--breadcrumb-link-text-shadow_focus:              none;
 	--breadcrumb-link-text-shadow_hover:              none;
+
+	/** Admin **/
+	--admin-announcement-border-color:                #bf6900;
+	--admin-announcement-link-color:                  #bf6900;
+	--admin-announcement-separator-color:             #ddd;
+	--admin-board-bg_hover:                           #d0e7f8;
+	--admin-board-group-border-color:                 #000;
+	--admin-css-preview-border-color:                 #777;
+	--admin-denyboard-bg_hover:                       #e3e9ec;
+	--admin-edit-history-border-color:                #bbb;
+	--admin-group-legend-bg:                          #eaf1f4;
+	--admin-group-legend-border-color:                #cacdd3;
+	--admin-highlight-bg:                             #d0e7f8;
+	--admin-legend-color:                             #000;
+	--admin-moderation-note-border-color:             #ccc;
+	--admin-package-border-color:                     #cacdd3;
+	--admin-perm-boards-border-color:                 #cacdd3;
+	--admin-perm-custom-bg:                           #c2c6c0;
+	--admin-perm-execute-bg:                          #fdd7af;
+	--admin-perm-groups-bg:                           #fff;
+	--admin-perm-no-change-bg:                        #eee;
+	--admin-perm-read-bg:                             #d1f7bf;
+	--admin-perm-writable-bg:                         #ffbbbb;
+	--admin-recycle-board-bg:                         #dee;
+	--admin-redirect-board-bg:                        #eed;
+	--admin-search-result-border-color:               #ccc;
+	--admin-smiley-border-color_hover:                #71a0c8;
+	--admin-smiley-border-color_selected:             #ffb42d;
+	--admin-table-caption-color:                      #000;
+	--admin-table-grid-border-color:                  #ddd;
 }


### PR DESCRIPTION
#### Description

Where the stylesheets stand today:

| file | hard-coded colours | `var(--…)` uses |
|---|---|---|
| `index.css` | 181 | 227 |
| **`admin.css`** | **33** | **0** |
| `calendar.css` | 33 | 0 (#9443 converts these) |

`index.css` has had tokens applied to it for a while. `admin.css` was never touched, so restyling the admin centre means editing a stylesheet rather than a variable, and `dark.css` and the colour variants have nothing to reach for. This is the same treatment #9443 gives `calendar.css`, and the two are best judged together.

Two colours already had a token that means the right thing, so they point at it rather than gaining a duplicate:

- `.search_results li a strong` → `--body-link-color` (it is a link)
- `#manage_boards li.windowbg` borders → `--window-border-color` (the items carry `.windowbg`)

The other 28 get named tokens of their own under a new `/** Admin **/` block, each holding the value it has now.

Where one value appears twice under two different meanings it gets two tokens: `#d0e7f8` is both the hover on a board row and the `.highlight2` background, and `#cacdd3` borders both the package list and the permission board list. A restyle would very plausibly move one and not the other.

##### Verification

The acceptance test is that nothing changes on screen.

Every painting rule in the loaded stylesheet was applied to a probe element and its computed values read, before and after — **511 selectors, 9234 declarations**.

27 differed, all inside three rules that set a `border` shorthand and then override one side of it:

```css
.action_admin .table_grid td {
	border: 1px solid var(--admin-table-grid-border-color);
	border-top: 0;
}
```

That is a limitation of the measurement, not a regression: once the shorthand contains a `var()`, `CSSRule.style.cssText` cannot serialise it alongside the longhand override, so the probe received nothing to apply. Those three rules were measured instead on real elements — including the `:first-child` and `:last-child` variants that carry their own border rules — giving **6 elements × 12 border properties, 0 differences**.

`admin.css` also gains the trailing newline `.editorconfig` asks for, which is why the diff shows a closing brace as changed.

### Issues References (Fixes|Related|Closes)

Related: #7933