### PR TITLE
[3.0] Put the admin search box back beside its heading, not in front of it

### DIFF
--- a/Themes/default/Admin.template.php
+++ b/Themes/default/Admin.template.php
@@ -1384,12 +1384,12 @@ function template_admin_search_results()
 {
 	echo '
 						<div id="section_header" class="cat_bar">
-							', template_admin_quick_search(), '
 							<h3 class="catbg">
 								<span id="quick_search_results">
 									', Lang::getTxt('admin_search_results_desc', Utils::$context, file: 'Admin'), '
 								</span>
 							</h3>
+							', template_admin_quick_search(), '
 						</div><!-- #section_header -->
 						<div class="windowbg generic_list_wrapper">';
 

--- a/Themes/default/GenericMenu.template.php
+++ b/Themes/default/GenericMenu.template.php
@@ -152,14 +152,7 @@ function template_generic_menu_tabs(&$menu_context)
 
 	if (!empty($tab_context['title'])) {
 		echo '
-					<div class="cat_bar">';
-
-		// The function is in Admin.template.php, but since this template is used elsewhere too better check if the function is available
-		if (function_exists('template_admin_quick_search')) {
-			template_admin_quick_search();
-		}
-
-		echo '
+					<div class="cat_bar">
 						<h3 class="catbg">';
 
 		// Exactly how many tabs do we have?
@@ -235,7 +228,17 @@ function template_generic_menu_tabs(&$menu_context)
 		}
 
 		echo '
-						</h3>
+						</h3>';
+
+		// The function is in Admin.template.php, but since this template is used
+		// elsewhere too better check if the function is available. It goes after
+		// the heading: .cat_bar is a flex row, so the search box lands at the end
+		// of it by being last, not by floating.
+		if (function_exists('template_admin_quick_search')) {
+			template_admin_quick_search();
+		}
+
+		echo '
 					</div><!-- .cat_bar -->';
 	}
 


### PR DESCRIPTION
#### Description

Every admin page carries a bar holding the quick search form and the heading for the page. The form comes first in the markup, and `.admin_search` carries `float: right`, so the heading sat on the left and the search box on the right.

`b81b1fa` (#9390) made `div.cat_bar` a flex row so a sibling could sit beside the heading. **A float is ignored on a flex item**, so the two now come out in source order, and the search box has been sitting on the left with the heading pushed over beside it. That was an unintended side effect of #9390 — mine — and this puts it right.

Putting the heading first restores the old layout, this time through the rule the other bars already use:

```css
div.cat_bar > h3,
div.title_bar > h3,
div.title_bar > h4 {
	flex: 1;
}
```

Two places emit that bar and both needed the same change:

- `template_generic_menu_tabs()` in `GenericMenu.template.php` — every admin page
- `template_admin_search_results()` in `Admin.template.php` — the results page, which builds a bar of its own

It reads better in that order anyway: the heading says what the page is before the control that changes it.

##### Verification

Each page loaded in a 1200px frame, measuring `getBoundingClientRect()` on the bar and its two children.

| page | heading x → | search form x → |
|---|---|---|
| `area=admin` | 396 → **72** | 72 → **786** |
| `area=manageboards` | 396 → **72** | 72 → **786** |
| `area=permissions` | 396 → **72** | 72 → **786** |
| `area=maintain` | 396 → **72** | 72 → **786** |
| `area=viewmembers` | 396 → **72** | 72 → **800** |
| `area=search` (results) | 382 → **58** | 58 → **528** |

The bar box itself is unchanged throughout — 1038–1052px wide, 35px tall — so only the two children swap ends.

`float: right` on `.admin_search` is inert now rather than wrong, so it is left alone — it would matter again if that bar ever stopped being a flex row.

### Issues References (Fixes|Related|Closes)

Related: #9390, #7933