### PR TITLE
[3.0] Theme split (wave 4, part 23) — give the two indexes one copy of the board list loop

### DIFF
--- a/Themes/default/BoardIndex.template.php
+++ b/Themes/default/BoardIndex.template.php
@@ -82,42 +82,7 @@ function template_boardindex()
 			</div>
 			<div id="category_', $category['id'], '_boards" ', (!empty($category['css_class']) ? ('class="' . $category['css_class'] . '"') : ''), $category['is_collapsed'] ? ' style="display: none;"' : '', '>';
 
-		/* Each board in each category's boards has:
-		new (is it new?), id, name, description, moderators (see below), link_moderators (just a list.),
-		children (see below.), link_children (easier to use.), children_new (are they new?),
-		topics (# of), posts (# of), link, href, and last_post. (see below.) */
-		foreach ($category['boards'] as $board) {
-			echo '
-				<div id="board_', $board['id'], '" class="up_contain ', (!empty($board['css_class']) ? $board['css_class'] : ''), '">
-					<div class="board_icon">
-						', function_exists('template_bi_' . $board['type'] . '_icon') ? call_user_func('template_bi_' . $board['type'] . '_icon', $board) : template_bi_board_icon($board), '
-					</div>
-					<div class="info">
-						', function_exists('template_bi_' . $board['type'] . '_info') ? call_user_func('template_bi_' . $board['type'] . '_info', $board) : template_bi_board_info($board), '
-					</div><!-- .info -->';
-
-			// Show some basic information about the number of posts, etc.
-			echo '
-					<div class="board_stats">
-						', function_exists('template_bi_' . $board['type'] . '_stats') ? call_user_func('template_bi_' . $board['type'] . '_stats', $board) : template_bi_board_stats($board), '
-					</div>';
-
-			// Show the last post if there is one.
-			echo'
-					<div class="lastpost">
-						', function_exists('template_bi_' . $board['type'] . '_lastpost') ? call_user_func('template_bi_' . $board['type'] . '_lastpost', $board) : template_bi_board_lastpost($board), '
-					</div>';
-
-			// Won't somebody think of the children!
-			if (function_exists('template_bi_' . $board['type'] . '_children')) {
-				call_user_func('template_bi_' . $board['type'] . '_children', $board);
-			} else {
-			template_bi_board_children($board);
-			}
-
-			echo '
-				</div><!-- #board_[id] -->';
-		}
+		template_bi_board_list($category['boards']);
 
 		echo '
 			</div><!-- #category_[id]_boards -->
@@ -133,6 +98,56 @@ function template_boardindex()
 	<div class="mark_read">
 		', template_button_strip(Utils::$context['mark_read_button'], 'right'), '
 	</div>';
+	}
+}
+
+/**
+ * Outputs a list of boards, each one drawn by the template_bi_* helpers below.
+ *
+ * The board index calls this once per category, and the message index calls it
+ * for the child boards of the board being viewed. Both used to carry their own
+ * copy of this loop.
+ *
+ * Each board has: new (is it new?), id, name, description, moderators (see
+ * below), link_moderators (just a list.), children (see below.), link_children
+ * (easier to use.), children_new (are they new?), topics (# of), posts (# of),
+ * link, href, and last_post. (see below.)
+ *
+ * @param array $boards The boards to draw, in the order they go in.
+ */
+function template_bi_board_list(array $boards): void
+{
+	foreach ($boards as $board) {
+		echo '
+				<div id="board_', $board['id'], '" class="up_contain ', (!empty($board['css_class']) ? $board['css_class'] : ''), '">
+					<div class="board_icon">
+						', function_exists('template_bi_' . $board['type'] . '_icon') ? call_user_func('template_bi_' . $board['type'] . '_icon', $board) : template_bi_board_icon($board), '
+					</div>
+					<div class="info">
+						', function_exists('template_bi_' . $board['type'] . '_info') ? call_user_func('template_bi_' . $board['type'] . '_info', $board) : template_bi_board_info($board), '
+					</div><!-- .info -->';
+
+		// Show some basic information about the number of posts, etc.
+		echo '
+					<div class="board_stats">
+						', function_exists('template_bi_' . $board['type'] . '_stats') ? call_user_func('template_bi_' . $board['type'] . '_stats', $board) : template_bi_board_stats($board), '
+					</div>';
+
+		// Show the last post if there is one.
+		echo '
+					<div class="lastpost">
+						', function_exists('template_bi_' . $board['type'] . '_lastpost') ? call_user_func('template_bi_' . $board['type'] . '_lastpost', $board) : template_bi_board_lastpost($board), '
+					</div>';
+
+		// Won't somebody think of the children!
+		if (function_exists('template_bi_' . $board['type'] . '_children')) {
+			call_user_func('template_bi_' . $board['type'] . '_children', $board);
+		} else {
+			template_bi_board_children($board);
+		}
+
+		echo '
+				</div><!-- #board_[id] -->';
 	}
 }
 

--- a/Themes/default/MessageIndex.template.php
+++ b/Themes/default/MessageIndex.template.php
@@ -79,38 +79,7 @@ function template_main()
 			<h3 class="catbg">', Lang::getTxt('sub_boards', file: 'General'), '</h3>
 		</div>';
 
-		foreach (Utils::$context['boards'] as $board) {
-			echo '
-		<div id="board_', $board['id'], '" class="up_contain ', (!empty($board['css_class']) ? $board['css_class'] : ''), '">
-			<div class="board_icon">
-				', function_exists('template_bi_' . $board['type'] . '_icon') ? call_user_func('template_bi_' . $board['type'] . '_icon', $board) : template_bi_board_icon($board), '
-			</div>
-			<div class="info">
-				', function_exists('template_bi_' . $board['type'] . '_info') ? call_user_func('template_bi_' . $board['type'] . '_info', $board) : template_bi_board_info($board), '
-			</div><!-- .info -->';
-
-			// Show some basic information about the number of posts, etc.
-			echo '
-			<div class="board_stats">
-				', function_exists('template_bi_' . $board['type'] . '_stats') ? call_user_func('template_bi_' . $board['type'] . '_stats', $board) : template_bi_board_stats($board), '
-			</div>';
-
-			// Show the last post if there is one.
-			echo '
-			<div class="lastpost">
-				', function_exists('template_bi_' . $board['type'] . '_lastpost') ? call_user_func('template_bi_' . $board['type'] . '_lastpost', $board) : template_bi_board_lastpost($board), '
-			</div>';
-
-			// Won't somebody think of the children!
-			if (function_exists('template_bi_' . $board['type'] . '_children')) {
-				call_user_func('template_bi_' . $board['type'] . '_children', $board);
-			} else {
-			template_bi_board_children($board);
-			}
-
-				echo '
-		</div><!-- #board_[id] -->';
-		}
+		template_bi_board_list(Utils::$context['boards']);
 
 		echo '
 	</div><!-- #board_[current_board]_childboards -->';


### PR DESCRIPTION
#### Description

`BoardIndex.template.php` and `MessageIndex.template.php` each carried their own copy of the loop that draws a list of boards — the one calling the `template_bi_*` helpers for the icon, info, stats, last post and children.

The two were identical. 32 lines apiece, and once leading whitespace is ignored the only difference is the array they walk:

```
$ diff -w bi_loop.txt mi_loop.txt
1c1
< 		foreach ($category['boards'] as $board) {
---
> 		foreach (Utils::$context['boards'] as $board) {
```

It becomes `template_bi_board_list()`, living beside the helpers it calls. `MessageIndex::setupTemplate()` already loads `BoardIndex` for those helpers, so there is nothing new to load. #9403 shared the helpers; this shares the loop that calls them.

##### Markup is untouched

The theme branch renames these classes on the way past — `up_contain` → `board_container`, `info` → `board_info`, `lastpost` → `board_lastpost` — and wraps the whole thing differently. That needs its `index.css` slice to come with it, so this keeps exactly what is on `release-3.0` today and moves nothing but the loop.

##### Verification

Rendered output of the board index (`#boardindex_table`) and of the child board list on a board that has children (`?board=1.0`), captured before and after and compared as normalised HTML:

| region | result |
|---|---|
| `#boardindex_table` | identical, 1639 chars |
| `#board_1_childboards` | identical, 647 chars |

Whitespace is collapsed for that comparison, because the two copies indented their output differently and the shared one has to pick a single indentation. The DOM is the same; only the literal indentation inside the message index's copy shifts.

The `template_bi_redirect_*` branch is moved verbatim but not exercised — there is no redirect board on the test install.

### Issues References (Fixes|Related|Closes)

Related: #9403, #7933