### PR TITLE
[3.0] Link the first page of a topic on the message index

### DIFF
--- a/Sources/PageIndex.php
+++ b/Sources/PageIndex.php
@@ -265,7 +265,14 @@ class PageIndex implements \Stringable
 		// property values, which may have changed after initial construction.
 
 		// Ensure $this->start is still good, just in case someone changed it.
+		// fixStart() also records whether the value it was handed was negative,
+		// and the constructor has already clamped that to 0 by now, so letting
+		// it answer again on its own would always say "valid" and throw away
+		// what the caller actually passed. Only a start that has gone negative
+		// since can add to the verdict, never take it away.
+		$was_invalid = $this->start_invalid;
 		$this->start = $this->fixStart($this->start);
+		$this->start_invalid = $this->start_invalid || $was_invalid;
 
 		// Set some other internal values we'll need below.
 		$this->last_page_value = ($this->num_items - 1) - ($this->num_items - 1) % $this->num_per_page;


### PR DESCRIPTION
#### Description

A topic that runs to more than one page gets a little `Pages 1 2 3` index beside it on the message index. Page 1 comes out as plain text rather than a link, so the first page of every multi-page topic is the one page you cannot click through to.

`PageIndex` has a branch for exactly this case. A caller with no current page to mark passes a negative start, `fixStart()` records that in `$start_invalid`, and `pageRange()` then renders even the "current" page as a link:

```php
// If start was invalid, show page number as a link to the proper start value.
if ($this->start_invalid) {
	$page_range .= sprintf($this->base_link, $this->start, $this->current_page_num);
}
```

**That branch has never run.** `__toString()` calls `fixStart()` a second time, reasonably enough — `$this->start` is public and may have been changed since construction:

```php
// Ensure $this->start is still good, just in case someone changed it.
$this->start = $this->fixStart($this->start);
```

But `fixStart()` does double duty: it clamps the value *and* records whether what it was given was negative. By the time `__toString()` runs, the constructor has already clamped the caller's `-1` to `0`, so the second call looks at `0`, decides the start is perfectly valid, and overwrites the verdict recorded the first time. `$start_invalid` is therefore `false` every time it is read.

The fix keeps the earlier verdict and lets the second look only add to it, so a start that has gone negative *since* construction still counts.

##### Effect

`MessageIndex::buildTopicContext()` is the one caller that passes `-1` deliberately. On a topic spanning three pages:

| | markup for page 1 |
|---|---|
| before | `<span class="current_page">1</span>` |
| after | `<a class="nav_page" href="…?topic=1.0">1</a>` |

Pages 2 and 3 are unchanged, as is the `Pages` label.

The board's own page index is unchanged — there the start really is `0` and page 1 really is the current page:

| page index | before | after |
|---|---|---|
| topic row (`#pages1`) | `current_page` | **link** |
| board's own (`.pagelinks`) | `current_page` | `current_page` |
| board with a negative start in the URL | `current_page` | `current_page` |

That last row is unchanged because the board URL parser clamps the start well before `PageIndex` sees it, so this stays confined to callers that pass a negative start on purpose.

Found while triaging the message index for #7933; it changes no template, so it goes on its own.

### Issues References (Fixes|Related|Closes)

Related: #7933