### PR TITLE
[3.0] Stop every topic row emitting an attribute named "

### DIFF
--- a/Themes/default/MessageIndex.template.php
+++ b/Themes/default/MessageIndex.template.php
@@ -209,7 +209,7 @@ function template_main()
 						', $topic['is_posted_in'] ? '<span class="main_icons profile_sm"></span>' : '', '
 					</div>
 					<div class="info', !empty(Utils::$context['can_quick_mod']) ? '' : ' info_block', '">
-						<div ', (!empty($topic['quick_mod']['modify']) ? 'data-msg-id="' . $topic['first_post']['id'] : ''), '">';
+						<div', !empty($topic['quick_mod']['modify']) ? ' data-msg-id="' . $topic['first_post']['id'] . '"' : '', '>';
 
 			// Now we handle the icons
 			echo '


### PR DESCRIPTION
#### Description

The wrapper inside each topic's info cell builds its `data-msg-id` by hand, leaving the closing quote to the string that follows it:

```php
<div ', (!empty($topic['quick_mod']['modify']) ? 'data-msg-id="' . $topic['first_post']['id'] : ''), '">
```

That works when there is an id to write. When there is not — which is the **default**, since `display_quick_mod` is a theme option that is off unless a member turns it on — the ternary contributes nothing and the row emits `<div ">`. Every topic, on every message index, carries an attribute whose name is a double quote:

```json
{"attrs": ["\"=\"\""], "outer": "<div \"=\"\"> <div id=\"icons12\" class=\"icons floatright\">…"}
```

Same shape as the `checked"` problem fixed in #9428: the attribute is assembled across the boundary between the ternary and the literal. Putting the whole thing inside the ternary fixes it.

| | before | after |
|---|---|---|
| quick mod off (default) | `<div ">` | `<div>` |
| quick mod on | `data-msg-id="12"` | `data-msg-id="12"` |

Measured on six topic rows with the option off, then on, by enabling `display_quick_mod` for the test account.

##### Separately: the attribute's consumer does not work

Not fixed here, because it needs a rewrite rather than a correction, but worth recording while it is in front of us. `QuickModifyTopic` is constructed unconditionally on every message index and is supposed to give topics inline subject editing on double-click. It does not, for three independent reasons:

1. It reads the attribute off the wrong element — `el.children[1].dataset.msgId` is the `.info` cell, while `data-msg-id` is on the `div` one level inside it. Measured with the option on: `.info` gives `undefined` while its child gives `data-msg-id="12"`. The listener is therefore never attached.
2. Even attached, the handler is bound as `this.modify_topic.bind(this, …dataset.msgId)`, so `modify_topic(topic_id, first_msg_id)` receives the message id as `topic_id` and the click event as `first_msg_id`.
3. It then looks for `document.getElementById('msg_' + first_msg_id)`, but the template emits `id="msg12"` — no underscore.

I have left all three alone. Reviving the feature means verifying the whole AJAX round trip, which is its own piece of work, and I did not want to bury it inside a markup fix.

### Issues References (Fixes|Related|Closes)

Related: #9428, #7933