### PR TITLE
[3.0] Let the Post event button reach the event form

### DIFF
--- a/Sources/Actions/Post.php
+++ b/Sources/Actions/Post.php
@@ -780,12 +780,37 @@ class Post implements ActionInterface, Routable
 		}
 
 		if (!isset(Utils::$context['event']) || !(Utils::$context['event'] instanceof Event)) {
-			$props = [
-				'title' => isset($_REQUEST['evtitle']) ? Utils::htmlspecialchars(stripslashes($_REQUEST['evtitle'])) : null,
-				'location' => isset($_REQUEST['event_location']) ? Utils::htmlspecialchars(stripslashes($_REQUEST['event_location'])) : null,
+			$props = [];
+
+			// Only name the ones the request actually gave. Event::$title and
+			// Event::$location are typed string and already default to '', so
+			// handing them a null for "the form has not been filled in yet" is
+			// a fatal rather than an empty field.
+			foreach (['title' => 'evtitle', 'location' => 'event_location'] as $prop => $key) {
+				if (isset($_REQUEST[$key])) {
+					$props[$prop] = Utils::htmlspecialchars(stripslashes($_REQUEST[$key]));
+				}
+			}
+
+			// setRequestedStartAndDuration() insists on being handed a date and
+			// fatals with "invalid_date" when it cannot find one. Nothing
+			// hands it one when this form is merely being opened: the "Post
+			// event" button on a topic is a plain link, so there is no post
+			// data to read. Only ask for the requested values when the request
+			// actually carries some, which is the case when a failed post is
+			// redisplayed, and otherwise let the Event constructor default the
+			// start to now. That is what Calendar::post() does for the
+			// unlinked version of this same form.
+			$requested_date_keys = [
+				'year', 'month', 'day', 'hour', 'minute', 'second',
+				'start_year', 'start_month', 'start_day', 'start_hour', 'start_minute', 'start_second',
+				'start_date', 'start_time', 'start_datetime',
 			];
 
-			Event::setRequestedStartAndDuration($props);
+			if (array_intersect_key($_POST, array_flip($requested_date_keys)) !== []) {
+				Event::setRequestedStartAndDuration($props);
+			}
+
 			Event::setRequestedRRule($props);
 			Utils::$context['event'] = new Event(-1, $props);
 			Event::setRequestedRDatesAndExDates(Utils::$context['event']);


### PR DESCRIPTION
#### Description

The **Post event** button on a topic (`?action=post;calendar;msg=N;topic=N.0`, added by `Display.php`) has never reached the form. It fatals with **"Invalid date."**, every time, on every forum.

`Post::initiateEvent()` hands the request to `Event::setRequestedStartAndDuration()` before constructing the event. That helper is the one used when an event is *saved*, so it insists on being given a date and calls `fatalLang('invalid_date')` when it cannot find one. Nothing gives it one here: the button is a plain link, so there is no post data at all. (It only ever reads `$_POST`, so a date in the query string would not help either.)

Removing that uncovered a second fatal in the same few lines. The properties array named `title` and `location` unconditionally, passing `null` when the request had not supplied them:

```php
'title' => isset($_REQUEST['evtitle']) ? Utils::htmlspecialchars(...) : null,
```

`Event::$title` and `Event::$location` are both `public string` with a `''` default, so the constructor rejects the null with *"Cannot assign null to property SMF\Calendar\Event::$title of type string"*. Absent means `''` here, not null.

`Calendar::post()` draws the unlinked version of this same form and has neither problem, because it simply does `new Event(-1)` and lets the constructor fill in the defaults. This makes `initiateEvent()` behave the same way: name only the properties the request actually gave, and only ask for the requested start when the request carries one — which is exactly the case that matters, a failed post being redisplayed.

**There is a third one behind these two**, already fixed in #9405: with both of the above out of the way the form next dies on *"Object of type SMF\TimeInterval ... has not been correctly initialized"* from `Event::__construct()`. Both PRs are needed before the button works; they are independent and can land in either order.

##### How this was tested

On a local 3.0 install, with #9405 merged in for the third fatal:

- `?action=post;calendar;msg=1;topic=1.0` now draws the Post Event form, defaulting to now, with no console errors and nothing in `smf_log_errors`.
- Filling in a title and saving writes the row and links it to the topic (`id_topic` and `id_board` both set), then redirects to the post.
- The redisplay path is unchanged: POSTing the form with an invalid subject and `start_date=2027-03-04`, `start_time=09:30` comes back with those values still in the fields, so the guard lets `setRequestedStartAndDuration()` run whenever the request actually has a date.
- Before this change, all three of those are the "Invalid date." error page.

### Issues References (Fixes|Related|Closes)

Related: #9405