### PR TITLE
[3.0] Theme split (wave 4, part 24) — drop the caret shim and the resizer the editor never had

### DIFF
--- a/Themes/default/GenericControls.template.php
+++ b/Themes/default/GenericControls.template.php
@@ -39,8 +39,7 @@ function template_control_richedit(string $editor_id, bool|string|null $smiley_c
 	$editor_context = Editor::$loaded[$editor_id];
 
 	echo '
-		<textarea class="editor" name="', $editor_id, '" id="', $editor_id, '" cols="600" onselect="storeCaret(this);" onclick="storeCaret(this);" onkeyup="storeCaret(this);" onchange="storeCaret(this);" style="width: ', $editor_context['width'], '; height: ', $editor_context['height'], ';', isset(Utils::$context['post_error']['no_message']) || isset(Utils::$context['post_error']['long_message']) ? 'border: 1px solid red;' : '', '"', !empty(Utils::$context['editor']['required']) ? ' required' : '', '>', $editor_context['value'], '</textarea>
-		<div id="', $editor_id, '_resizer" class="richedit_resize"></div>
+		<textarea class="editor" name="', $editor_id, '" id="', $editor_id, '" cols="600" style="width: ', $editor_context['width'], '; height: ', $editor_context['height'], ';', isset(Utils::$context['post_error']['no_message']) || isset(Utils::$context['post_error']['long_message']) ? 'border: 1px solid red;' : '', '"', !empty(Utils::$context['editor']['required']) ? ' required' : '', '>', $editor_context['value'], '</textarea>
 		<input type="hidden" name="', $editor_id, '_mode" id="', $editor_id, '_mode" value="0">
 		<script>
 			document.addEventListener("DOMContentLoaded", function () {

--- a/Themes/default/scripts/script.js
+++ b/Themes/default/scripts/script.js
@@ -426,14 +426,6 @@ smc_Popup.prototype.setBody = function(data)
 	document.getElementById(this.popup_id).querySelector('.popup_content').innerHTML = data;
 }
 
-// Remember the current position.
-function storeCaret(oTextHandle)
-{
-	// Only bother if it will be useful.
-	if ('createTextRange' in oTextHandle)
-		oTextHandle.caretPos = document.selection.createRange().duplicate();
-}
-
 // Replaces the currently selected text with the passed text.
 function replaceText(text, oTextHandle)
 {


### PR DESCRIPTION
#### Description

Part of the effort to break #7933 into reviewable pieces. This one takes the posting area's share of the editor markup that does nothing.

Every editor on the forum — posting, personal messages, newsletters, anything using `template_control_richedit()` — emits its textarea with four inline handlers:

```php
onselect="storeCaret(this);" onclick="storeCaret(this);" onkeyup="storeCaret(this);" onchange="storeCaret(this);"
```

`storeCaret()` reads `document.selection.createRange()`, which was IE's API, and guards itself with `'createTextRange' in oTextHandle`. Neither exists in any browser SMF supports, so the function has been a no-op for years. It also cannot be reached at all: SCEditor replaces that textarea and leaves it `display: none`, so none of the four events ever fire on it. The only other consumer of what it stored, the `caretPos` branch in `replaceText()`, is guarded the same way and is equally unreachable. Nothing else in the tree calls it, so the function goes with the handlers.

The `<div id="<editor>_resizer" class="richedit_resize">` beside it is in the same state: nothing styles `.richedit_resize` and nothing looks up that id — not in this theme, and not in 2.1 either, where the same empty div is emitted. It renders as a box of zero height.

Both are gone in the #7933 tree, which is where this comes from.

##### Deliberately left alone

The hidden `<editor>_mode` field looks equally dead, and today it is: nothing sets it client-side, and `Editor::$rich_active` no longer reads it. But in 2.1 it *was* read (`Subs-Editor.php`, `!empty($_REQUEST[$editorOptions['id'] . '_mode'])`) so that an editor left in WYSIWYG mode came back in WYSIWYG mode after a preview or a failed post. That behaviour is currently lost, and removing the field would foreclose restoring it, so it stays for whoever picks up the editor work.

The dead `caretPos` branches inside `replaceText()` and `surroundText()` stay too, matching the #7933 tree.

##### How this was tested

On a local 3.0 install:

- The posting form was measured through an iframe before and after: `.sceditor-container`, `.sceditor-toolbar`, the button row, the attachments area and the page height are all identical to the pixel. The only difference is that the resizer div is no longer there.
- The editor still initialises and round-trips its value (`sceditor.instance(textarea).val(...)`), with all 34 toolbar buttons present and nothing on the console.
- Swept the pages that draw an editor — new topic, reply, new poll, send personal message — each still builds its `.sceditor-container`, with no element left carrying an `onselect` and no `.richedit_resize` anywhere.

### Issues References (Fixes|Related|Closes)

Related: #7933