### PR TITLE
[3.0] Stop the posting form repeating two ids

### DIFF
--- a/Themes/default/Post.template.php
+++ b/Themes/default/Post.template.php
@@ -248,7 +248,7 @@ function template_main()
 
 		if (Utils::$context['can_post_attachment']) {
 			echo '
-										<input type="file" multiple="multiple" name="attachment[]" id="attachment1">';
+										<input type="file" multiple="multiple" name="attachment[]">';
 		}
 
 		if (!empty(Config::$modSettings['attachmentSizeLimit'])) {
@@ -468,7 +468,7 @@ function template_main()
 	if (Utils::$context['can_quote']) {
 		$newPostsHTML .= '
 			<ul class="quickbuttons sf-js-enabled sf-arrows" id="msg_%PostID%_quote" style="touch-action: pan-y;">
-				<li id="post_modify">
+				<li class="post_modify">
 					<a href="#postmodify" onclick="return insertQuoteFast(%PostID%);" class="quote_button"><span class="main_icons quote"></span>' . Lang::getTxt('quote', file: 'General') . '</a>
 				</li>
 			</ul>';
@@ -584,7 +584,7 @@ function template_main()
 				echo '
 					<ul class="quickbuttons" id="msg_', $post['id'], '_quote">
 						<li style="display:none;" id="quoteSelected_', $post['id'], '" data-msgid="', $post['id'], '"><a href="javascript:void(0)"><span class="main_icons quote_selected"></span>', Lang::getTxt('quote_selected_action', file: 'General'), '</a></li>
-						<li id="post_modify"><a href="#postmodify" onclick="return insertQuoteFast(', $post['id'], ');"><span class="main_icons quote"></span>', Lang::getTxt('quote', file: 'General'), '</a></li>
+						<li class="post_modify"><a href="#postmodify" onclick="return insertQuoteFast(', $post['id'], ');"><span class="main_icons quote"></span>', Lang::getTxt('quote', file: 'General'), '</a></li>
 					</ul>';
 			}
 

--- a/Themes/default/css/index.css
+++ b/Themes/default/css/index.css
@@ -1628,7 +1628,7 @@ ul li.greeting {
 }
 /* Fixes for quickbuttons
    Fix for quote on reply box */
-#post_modify {
+.post_modify {
 	border-radius: 4px;
 }
 


### PR DESCRIPTION
#### Description

Two ids on the posting form are emitted more than once per document.

**`post_modify`** is on the quote button of every previous post shown below the reply box:

```php
<li id="post_modify"><a href="#postmodify" onclick="return insertQuoteFast(', $post['id'], ');">
```

That loop runs once per post, so replying to a topic with any history serves the id several times over — and `$newPostsHTML`, the template the page uses to append posts that arrived while you were typing, carries the same id, so each new arrival adds another. Nothing looks it up; the only thing that names it is one stylesheet rule, `#post_modify { border-radius: 4px }`, and a rule does not need an id. It becomes `.post_modify`, and the rule follows it.

**`attachment1`** is on both file inputs in the attachments area. One belongs to the plain UI and one is the drop zone's fallback, and only one of them is ever shown: `smf_fileUpload.js` removes `#postAttachment` outright when it initialises, and when it does not run the fallback stays hidden inside `#attachment_previews`. The fallback is the one looked up by id — `cleanFileInput('attachment1')`, the clear link sitting next to it — so the plain one gives up its copy and keeps its name, which is all the server reads.

##### How this was tested

On a local 3.0 install, against `?action=post;topic=1.0` and `?action=post;board=1.0`:

- Counting every id in the served document: `post_modify` ×2 and `attachment1` ×2 before, no repeated id at all after.
- Every `.quickbuttons > li` on the reply page measured before and after — position, size, all four border radii, background and display are identical, so the id-to-class swap changes nothing on screen. The attachments area's box is unchanged too.
- With scripts disabled, the plain file input is still the visible one and the fallback still measures 0×0, as before.

### Issues References (Fixes|Related|Closes)

Related: #7933