### PR TITLE
[3.0] Keep the messages join Attachment::load() selects from

### DIFF
--- a/Sources/Attachment.php
+++ b/Sources/Attachment.php
@@ -509,8 +509,10 @@ class Attachment implements \ArrayAccess
 			];
 
 			$from = '{db_prefix}attachments AS a';
-			$joins = ['LEFT JOIN {db_prefix}messages AS m ON (a.id_msg = m.id_msg)'];
-			$joins = ['LEFT JOIN {db_prefix}topics AS t ON (t.id_topic = m.id_topic)'];
+			$joins = [
+				'LEFT JOIN {db_prefix}messages AS m ON (a.id_msg = m.id_msg)',
+				'LEFT JOIN {db_prefix}topics AS t ON (t.id_topic = m.id_topic)',
+			];
 			$where = ['a.id_attach IN ({array_int:ids})'];
 			$order = [];
 			$limit = 0;


### PR DESCRIPTION
#### Description

**Attachments are completely broken on `release-3.0`.** Uploading one fails and viewing or downloading one fails, both with the same database error:

```
Database Error: Unknown column 'm.id_topic' in 'field list'
/var/www/html/Sources/Attachment.php  line 537
```

`Attachment::load()` builds two joins, and the second one is assigned over the list instead of appended to it:

```php
$joins = ['LEFT JOIN {db_prefix}messages AS m ON (a.id_msg = m.id_msg)'];
$joins = ['LEFT JOIN {db_prefix}topics AS t ON (t.id_topic = m.id_topic)'];
```

So the messages join is thrown away. Five of the eight selects read from `m`, and the surviving join is itself written on `m.id_topic`, so nothing in the query can resolve and it fails outright — the alias is simply not in the statement.

Every route into an attachment goes through this method: `AttachmentDownload` calls it for the file and again for the thumbnail, and `Post` calls it for the list of files already attached to the message being written.

Introduced by 90c311d5b ("[3.0] Missing session checks", 2 Aug), which added the topics join and its `t.*` selects.

##### How this was tested

On a local 3.0 install with MySQL, before the change:

- Dropping a file on the posting form's drop zone leaves the preview in `dz-error`, with the database error above as its message.
- `?action=dlattach;attach=1;image` answers 500, and `smf_log_errors` records the same error against both urls.

After:

- The same upload finishes `dz-success dz-complete` with an empty error message, and the row lands in `smf_attachments` with its size and dimensions read correctly (75 bytes, 8×8).
- `?action=dlattach;attach=2;image` answers 200 `image/png` and returns the file byte for byte, PNG signature intact.
- Nothing new in `smf_log_errors`.

The statement is a plain `LEFT JOIN` either way, so it behaves the same on PostgreSQL.

### Issues References (Fixes|Related|Closes)

Related: 90c311d5b