### PR TITLE
[3.0] Save one recipient's copy of a personal message, not everybody's

### DIFF
--- a/Sources/PersonalMessage/Received.php
+++ b/Sources/PersonalMessage/Received.php
@@ -236,11 +236,6 @@ class Received implements \ArrayAccess
 			$this->in_inbox = true;
 		}
 
-		// A row here is one member's copy of one PM, and (id_pm, id_member) is
-		// the primary key. Naming only the PM makes this statement try to hand
-		// every recipient's copy to the same member, so anything that saves a
-		// PM with more than one recipient - marking it read, labelling it,
-		// deleting it - is a duplicate key error rather than a save.
 		Db::$db->query(
 			'UPDATE {db_prefix}pm_recipients
 			SET
@@ -264,10 +259,7 @@ class Received implements \ArrayAccess
 
 		$labels = array_diff($this->labels, [-1]);
 
-		// Labels belong to a member too, so only clear the ones this member
-		// owns. Every other recipient has their own labels on the same PM, and
-		// with the update above fixed this line is finally reached for a PM
-		// that has some.
+		// Only clear the labels this member owns.
 		Db::$db->query(
 			'DELETE FROM {db_prefix}pm_labeled_messages
 			WHERE id_pm = {int:current_pm}

--- a/Sources/PersonalMessage/Received.php
+++ b/Sources/PersonalMessage/Received.php
@@ -236,16 +236,21 @@ class Received implements \ArrayAccess
 			$this->in_inbox = true;
 		}
 
+		// A row here is one member's copy of one PM, and (id_pm, id_member) is
+		// the primary key. Naming only the PM makes this statement try to hand
+		// every recipient's copy to the same member, so anything that saves a
+		// PM with more than one recipient - marking it read, labelling it,
+		// deleting it - is a duplicate key error rather than a save.
 		Db::$db->query(
 			'UPDATE {db_prefix}pm_recipients
 			SET
-				id_member = {int:member},
 				bcc = {int:bcc},
 				is_read = {int:is_read},
 				is_new = {int:is_new},
 				deleted = {int:deleted},
 				in_inbox = {int:in_inbox}
-			WHERE id_pm = {int:id}',
+			WHERE id_pm = {int:id}
+				AND id_member = {int:member}',
 			[
 				'id' => (int) $this->id,
 				'member' => (int) $this->member,
@@ -259,12 +264,22 @@ class Received implements \ArrayAccess
 
 		$labels = array_diff($this->labels, [-1]);
 
+		// Labels belong to a member too, so only clear the ones this member
+		// owns. Every other recipient has their own labels on the same PM, and
+		// with the update above fixed this line is finally reached for a PM
+		// that has some.
 		Db::$db->query(
 			'DELETE FROM {db_prefix}pm_labeled_messages
-			WHERE id_pm = {int:current_pm}' . (empty($labels) ? '' : '
+			WHERE id_pm = {int:current_pm}
+				AND id_label IN (
+					SELECT id_label
+					FROM {db_prefix}pm_labels
+					WHERE id_member = {int:member}
+				)' . (empty($labels) ? '' : '
 				AND id_label NOT IN ({array_int:labels})'),
 			[
 				'current_pm' => $this->id,
+				'member' => (int) $this->member,
 				'labels' => $labels,
 			],
 		);


### PR DESCRIPTION
#### Description

A row in `pm_recipients` is one member's copy of one personal message, and `(id_pm, id_member)` is its primary key.

`Received::save()` named only the PM in its `WHERE` clause, and set `id_member` in the `SET` clause:

```sql
UPDATE {db_prefix}pm_recipients
SET
    id_member = {int:member},
    ...
WHERE id_pm = {int:id}
```

So the statement asks the database to hand **every** recipient's copy to the same member. On any PM with more than one recipient that is a duplicate key error, every time, for anything that saves — labelling it, marking it read, deleting it.

Reproduced on a clean install: send a PM to two members, then apply a label to it from the inbox.

```
Database Error: Duplicate entry '4-2' for key 'smf_pm_recipients.PRIMARY'
File: /var/www/html/Sources/PersonalMessage/Received.php
Line: 239
```

The member belongs in the `WHERE` clause rather than the `SET` clause — a copy's owner is its identity, not something a save changes. With that, both recipients keep their own row and their own state; the unread flag on the copy that was *not* being saved survives, where before the whole statement was rejected.

Labels are owned by a member too, so the same applies to the labelled messages the save clears out. It deleted every label on that PM:

```sql
DELETE FROM {db_prefix}pm_labeled_messages
WHERE id_pm = {int:current_pm}
    AND id_label NOT IN ({array_int:labels})
```

`pm_labels` rows carry an `id_member`, so a PM labelled by two recipients has a row per member here, and saving one member's labels threw away the other's. Fixture with `(label 2, pm 4)` owned by member 1 and `(label 4, pm 4)` owned by member 2, saving member 1's labels:

| | rows left |
|---|---|
| before | `2-4` |
| after | `2-4`, `4-4` |

That line is only reachable for a PM that has other recipients once the update above works, which is why the two are one change. The subquery is over a different table, so it is fine on MySQL and on PostgreSQL.

Found while sweeping the personal messages area. Two other faults sit alongside this one and are going up separately: `Received::loadByPm()` collapses every recipient of a PM into one, and the per-message label drop-down submits a value `applyActions()` no longer accepts.

### Issues References (Fixes|Related|Closes)

n/a