### PR TITLE
[3.0] Keep every recipient of a personal message, not just the last one

### DIFF
--- a/Sources/Actions/PersonalMessage.php
+++ b/Sources/Actions/PersonalMessage.php
@@ -497,12 +497,18 @@ class PersonalMessage implements ActionInterface, Routable
 		}
 
 		// Are we labeling anything?
+		// Only ever our own copy: the other recipients of a PM keep their own
+		// labels on it, and these are our labels, not theirs.
 		if (!empty($to_label) && $this->folder === 'inbox') {
-			foreach (Received::loadByPm(array_keys($to_label)) as $received) {
-				if ($label_type[$received->id] === 'add') {
-					$received->addLabel($to_label[$received->id]);
-				} elseif ($label_type[$received->id] === 'rem') {
-					$received->removeLabel($to_label[$received->id]);
+			foreach (Received::loadByPm(array_keys($to_label)) as $pm => $recipients) {
+				if (!isset($recipients[User::$me->id])) {
+					continue;
+				}
+
+				if ($label_type[$pm] === 'add') {
+					$recipients[User::$me->id]->addLabel($to_label[$pm]);
+				} elseif ($label_type[$pm] === 'rem') {
+					$recipients[User::$me->id]->removeLabel($to_label[$pm]);
 				}
 			}
 		}

--- a/Sources/PersonalMessage/PM.php
+++ b/Sources/PersonalMessage/PM.php
@@ -108,7 +108,7 @@ class PM implements \ArrayAccess
 	/**
 	 * @var array
 	 *
-	 * Data about received copies of this PM.
+	 * Data about received copies of this PM, keyed by the recipient's ID.
 	 */
 	public array $received = [];
 
@@ -229,7 +229,7 @@ class PM implements \ArrayAccess
 	{
 		$this->id = $id;
 		$this->set($props);
-		$this->received = Received::loadByPm($this->id);
+		$this->received = Received::loadByPm($this->id)[$this->id] ?? [];
 		$this->folder = $this->member_from !== User::$me->id ? 'inbox' : 'sent';
 		self::$loaded[$id] = $this;
 	}

--- a/Sources/PersonalMessage/Received.php
+++ b/Sources/PersonalMessage/Received.php
@@ -315,7 +315,9 @@ class Received implements \ArrayAccess
 	 * for future reference.
 	 *
 	 * @param int|array $ids The IDs of one or more personal messages.
-	 * @return array The newly loaded instances of this class.
+	 * @return array The newly loaded instances of this class, keyed first by
+	 *    the PM's ID and then by the recipient's ID. A PM has one of these per
+	 *    person it was sent to.
 	 */
 	public static function loadByPm(int|array $ids): array
 	{
@@ -326,9 +328,7 @@ class Received implements \ArrayAccess
 		// Have we already loaded these?
 		foreach ($ids as $key => $id) {
 			if (isset(self::$loaded[$id])) {
-				foreach (self::$loaded[$id] as $received) {
-					$loaded[$id] = $received;
-				}
+				$loaded[$id] = self::$loaded[$id];
 
 				unset($ids[$key]);
 			}
@@ -358,8 +358,11 @@ class Received implements \ArrayAccess
 			'ids' => $ids,
 		];
 
+		// One row per recipient, so the member has to be part of the key here.
+		// Keying on the PM alone leaves only whichever recipient the database
+		// happened to hand over last.
 		foreach (self::queryData($selects, $params, $joins, $where) as $row) {
-			$loaded[(int) $row['id_pm']] = new self($row);
+			$loaded[(int) $row['id_pm']][(int) $row['id_member']] = new self($row);
 		}
 
 		ksort($loaded);


### PR DESCRIPTION
#### Description

`pm_recipients` holds one row per person a PM was sent to. `Received::$loaded` is keyed accordingly — first by the PM, then by the member:

```php
self::$loaded[$this->id][$this->member] = $this;
```

`Received::loadByPm()` built its return value with only the PM as the key:

```php
foreach (self::queryData($selects, $params, $joins, $where) as $row) {
    $loaded[(int) $row['id_pm']] = new self($row);
}
```

so each row overwrote the one before it, and a PM came back with exactly one recipient — whichever the database handed over last. (The cache branch above it does the same thing, looping over the member-keyed list only to flatten it.)

Two things go wrong from there.

**You cannot open a PM you received alongside somebody else.** `PM::canAccess()` walks that list looking for the current member, and if that member was not the one that survived, it isn't there. Sending a PM to two members and opening it from the recipient's inbox:

| | `?action=pm;f=inbox;pmid=4` |
|---|---|
| before | 403, "You are not allowed to access this section" |
| after | 200 |

**And the recipient list is wrong.** `PM::format()` builds `recipients` from the same list, so the sent folder named one recipient of a PM that went to several:

| | To |
|---|---|
| before | `testmember` |
| after | `admin, testmember` |

`number_recipients` is that count, so `reply_to_all` was also hidden on every multi-recipient PM.

The fix keys the list by recipient as well, which is the shape `PM::format()` and the popup already read it with (`foreach ($this->received as $member => $received_copy)`), and picks out our own copy in `applyActions()` rather than looping over everyone's — those are our labels, not theirs.

Verified afterwards that the eleven pages of the PM area and the quote form all still render with an empty `smf_log_errors`.

Labelling a PM with more than one recipient needs #9460 as well, which fixes the update behind it; this change alone gets as far as reaching it.

### Issues References (Fixes|Related|Closes)

Related: #9460