### PR TITLE
[3.0] Say whether the label being put on a PM is going on or coming off

### DIFF
--- a/Themes/default/PersonalMessage.template.php
+++ b/Themes/default/PersonalMessage.template.php
@@ -536,6 +536,9 @@ function template_single_pm($message)
 						<option value="" disabled>---------------</option>';
 
 			// Are there any labels which can be added to this?
+			// The two lists below hold the same label IDs, so say which list
+			// this one came from. That is what applyActions() reads, and what
+			// loadLabelChoices() puts on the drop down for the whole folder.
 			if (!$message['fully_labeled']) {
 				echo '
 						<option value="" disabled>', Lang::getTxt('pm_msg_label_apply', file: 'PersonalMessage'), '</option>';
@@ -543,7 +546,7 @@ function template_single_pm($message)
 				foreach (Utils::$context['labels'] as $label) {
 					if (!isset($message['labels'][$label['id']])) {
 						echo '
-						<option value="', $label['id'], '">', $label['name'], '</option>';
+						<option value="add_', $label['id'], '">', $label['name'], '</option>';
 					}
 				}
 			}
@@ -555,7 +558,7 @@ function template_single_pm($message)
 
 				foreach ($message['labels'] as $label) {
 					echo '
-						<option value="', $label['id'], '">&nbsp;', $label['name'], '</option>';
+						<option value="rem_', $label['id'], '">&nbsp;', $label['name'], '</option>';
 				}
 			}
 			echo '


### PR DESCRIPTION
#### Description

The drop down beside each message in the inbox offers two lists of labels — the ones that can be applied, and the ones that can be taken off — and gave both of them a bare label ID as their value:

```php
// Are there any labels which can be added to this?
<option value="', $label['id'], '">', $label['name'], '</option>
...
// ... and are there any that can be removed?
<option value="', $label['id'], '">&nbsp;', $label['name'], '</option>
```

Nothing downstream can tell those two apart, and `PersonalMessage::applyActions()` does not try. It reads an `add_` or `rem_` prefix and skips anything else:

```php
elseif (str_starts_with($action, 'add_')) {
    $type = 'add';
    ...
} elseif (str_starts_with($action, 'rem_')) {
    $type = 'rem';
    ...
}

if (isset($type) && \in_array($type, ['add', 'rem']) && ...) {
```

So picking a label from that drop down did nothing at all. `smf_pm_labeled_messages` stays empty, no error is logged, and the page reloads looking exactly as it did.

The values are written this way because SMF 2.1 read a bare value as "toggle this label" — it had an `else { $type = 'unk'; }` branch, and further down, `if (array_key_exists(...) && $type !== 'add') unset(...); elseif ($type !== 'rem') ...`. 3.0 dropped that branch and kept the markup, which is why the drop down looks fine and does nothing.

The template knows perfectly well which of the two lists it is drawing, so it says so. That is also exactly what `loadLabelChoices()` in this same file builds for the whole-folder drop down (`"add_" + i`, `"rem_" + i`), which has been the only working way to label a PM.

Verified the round trip on the inbox:

| step | drop down offers | `pm_labeled_messages` |
|---|---|---|
| start | `add_2 Alpha`, `add_3 Beta` | empty |
| pick `add_2` | `add_3 Beta`, `rem_-1 Inbox`, `rem_2 Alpha` | `2-1` |
| pick `rem_2` | `add_2 Alpha`, `add_3 Beta` | empty |

Nothing new in the error log either way.

### Issues References (Fixes|Related|Closes)

n/a