### PR TITLE
[3.0] Use a string literal PostgreSQL will accept for an absent recipient name

### DIFF
--- a/Sources/PersonalMessage/Received.php
+++ b/Sources/PersonalMessage/Received.php
@@ -343,7 +343,7 @@ class Received implements \ArrayAccess
 		// We have new ones that we need to load.
 		$selects = [
 			'pmr.*',
-			'COALESCE(mem.real_name, "") AS real_name',
+			'COALESCE(mem.real_name, {string:blank_string}) AS real_name',
 		];
 
 		$joins = [
@@ -356,6 +356,7 @@ class Received implements \ArrayAccess
 
 		$params = [
 			'ids' => $ids,
+			'blank_string' => '',
 		];
 
 		foreach (self::queryData($selects, $params, $joins, $where) as $row) {


### PR DESCRIPTION
#### Description

`Received::loadByPm()` fills in a missing member name with

```php
'COALESCE(mem.real_name, "") AS real_name',
```

Double quotes delimit an **identifier** in PostgreSQL, not a string, and an empty one is a syntax error:

```
$ psql -U smf -d smf -c 'SELECT COALESCE(NULL, "") AS real_name;'
ERROR:  zero-length delimited identifier at or near """"
LINE 1: SELECT COALESCE(NULL, "") AS real_name;
                              ^
```

Nothing rewrites it on the way through — the PostgreSQL driver's `$replacements` only covers `profile_board_stats`, and this query passes no identifier.

This is the loader behind every personal message (`PM::__construct()` calls it), so on a PostgreSQL install the whole area goes with it.

Every other `COALESCE` default in `Sources/` passes the value as a parameter, so this one does too. It was the only double-quoted SQL literal left in the tree — `Received::queryData()` a couple of hundred lines further down already writes the same expression as `COALESCE(mem.real_name, \'\')`.

Confirmed the replacement parses on both engines, and that nothing changes on MySQL: the inbox, the sent folder, a single PM and the quote form were captured before and after, and across all four pages the only lines that differ are the clock in the header and the `cron.php?ts=` value.

### Issues References (Fixes|Related|Closes)

n/a