### PR TITLE
[3.0] Answer a personal message link that points at nothing

### DIFF
--- a/Sources/PersonalMessage/Folder.php
+++ b/Sources/PersonalMessage/Folder.php
@@ -163,12 +163,24 @@ class Folder
 		// @todo Can we consolidate these into a single variable?
 		foreach (['pmid', 'pmsg'] as $var) {
 			if (isset($_GET[$var])) {
-				$this->requested_pm = current(PM::load((int) $_GET[$var]));
+				$id = (int) $_GET[$var];
+
+				// Anything that is not a real ID never reaches the database:
+				// PM::load() answers an empty array of IDs with "given array of
+				// integer values is empty", which is a 500 for a URL a member
+				// only has to mistype.
+				$requested_pm = $id > 0 ? current(PM::load($id)) : false;
 
 				// Make sure you have access to this PM.
-				if (!$this->requested_pm->canAccess($this->is_inbox ? 'inbox' : 'sent')) {
+				// PM::load() also finds nothing for an ID that has been pruned
+				// or was never real, and current() answers false for that,
+				// which is not something $requested_pm can hold. A PM that is
+				// not there is no more accessible than somebody else's.
+				if (!($requested_pm instanceof PM) || !$requested_pm->canAccess($this->is_inbox ? 'inbox' : 'sent')) {
 					ErrorHandler::fatalLang('no_access', false);
 				}
+
+				$this->requested_pm = $requested_pm;
 			}
 		}
 


### PR DESCRIPTION
#### Description

`Folder::show()` assigns whatever `PM::load()` found straight to `$requested_pm`, which is a typed object property:

```php
$this->requested_pm = current(PM::load((int) $_GET[$var]));

// Make sure you have access to this PM.
if (!$this->requested_pm->canAccess($this->is_inbox ? 'inbox' : 'sent')) {
```

`PM::load()` finds nothing for an ID that has been pruned or was never real, and `current()` answers `false` for that. So the request ends before the access check runs:

```
Cannot assign false to property SMF\PersonalMessage\Folder::$requested_pm of type object
url: /index.php?action=pm;f=inbox;pmid=999
```

A 500, for a stale bookmark or a link in an old notification — and PM pruning is a feature, so the IDs in those links do go away.

Behind that sits a second one. A `pmid` of `0`, a negative number, or anything non-numeric all cast to `0`, and `PM::load()` carries that as far as the database before failing:

```
Database error, given array of integer values is empty. (ids)<br>Function: get
url: /index.php?action=pm;f=inbox;pmid=abc
```

Another 500, for a URL a member only has to mistype. Fixing just the first leaves this one, so both are here.

Both now get the answer the check below them already gives for a PM belonging to somebody else.

| url | before | after |
|---|---|---|
| `pmid=999` | 500, TypeError | 403, no access |
| `pmsg=999` | 500, TypeError | 403, no access |
| `pmid=0` | 500, database error | 403, no access |
| `pmid=abc` | 500, database error | 403, no access |
| `pmid=-5` | 500, database error | 403, no access |
| `pmid=1` (a real one) | 200 | 200 |

The inbox, the sent folder, a real `pmid` and a quote form all still render, with nothing added to `smf_log_errors`.

### Issues References (Fixes|Related|Closes)

n/a