### PR TITLE
[3.0] Stop logging an error for every personal message search

### DIFF
--- a/Sources/PersonalMessage/Search.php
+++ b/Sources/PersonalMessage/Search.php
@@ -318,8 +318,11 @@ class Search
 		// Load the users...
 		User::load(Utils::$context['posters']);
 
-		// Sort out the page index.
-		$start = (int) ($_GET['start'] ?? 0);
+		// Sort out the page index. PageIndex takes this by reference and clamps
+		// it, so hand it a copy of what was asked for and keep the original to
+		// compare against. Reading $_GET again here instead is what left the
+		// line below unguarded, since a search arrives without a start.
+		$start = $this->start;
 		Utils::$context['page_index'] = new PageIndex(
 			Config::$scripturl . '?action=pm;sa=search2;params=' . $this->compressed_params,
 			$start,
@@ -329,7 +332,7 @@ class Search
 		);
 
 		// If the supplied start value was invalid, redirect to the correct one.
-		if ($_GET['start'] != $start) {
+		if ($this->start != $start) {
 			Utils::redirectexit(Utils::$context['page_index']->base_url . ';start=' . $start);
 		}
 

--- a/Sources/PersonalMessage/Search.php
+++ b/Sources/PersonalMessage/Search.php
@@ -318,10 +318,7 @@ class Search
 		// Load the users...
 		User::load(Utils::$context['posters']);
 
-		// Sort out the page index. PageIndex takes this by reference and clamps
-		// it, so hand it a copy of what was asked for and keep the original to
-		// compare against. Reading $_GET again here instead is what left the
-		// line below unguarded, since a search arrives without a start.
+		// Sort out the page index.
 		$start = $this->start;
 		Utils::$context['page_index'] = new PageIndex(
 			Config::$scripturl . '?action=pm;sa=search2;params=' . $this->compressed_params,


### PR DESCRIPTION
#### Description

Searching your personal messages puts a row in the error log every time:

```
2: Undefined array key "start"
url: /index.php?action=pm;sa=search2
```

`Search::performSearch()` reads the start twice, and only one of the two guards itself:

```php
$start = (int) ($_GET['start'] ?? 0);
Utils::$context['page_index'] = new PageIndex(..., $start, ...);

// If the supplied start value was invalid, redirect to the correct one.
if ($_GET['start'] != $start) {
```

A search arrives without a start — only the page links a member clicks afterwards carry one — so the second read fires on the first search anyone runs.

The value is already on hand as `$this->start`, read once and guarded when the search was set up, so this uses that instead of reading `$_GET` a third time. `PageIndex` takes its start **by reference** and clamps it, which is what makes the comparison below meaningful, so it gets a copy and the original stays to compare against. That is the same shape `ItemList::buildPageIndex()` uses.

Checked that the redirect still does its job:

| request | lands on | log |
|---|---|---|
| `sa=search2` (POST, no start) | `sa=search2` | *(empty)* |
| `sa=search2;start=0` | `sa=search2;start=0` | *(empty)* |
| `sa=search2;start=999` | `…;start=0` | *(empty)* |
| `sa=search2;start=-5` | `…;start=0` | *(empty)* |

Same one result found in every case.

### Issues References (Fixes|Related|Closes)

n/a