### PR TITLE
[3.0] Keep the buttons on a personal message in the folder being read

### DIFF
--- a/Sources/PersonalMessage/PM.php
+++ b/Sources/PersonalMessage/PM.php
@@ -327,7 +327,13 @@ class PM implements \ArrayAccess
 
 		$label_ids = array_diff(array_keys($labels), [-1]);
 
-		$href = Config::$scripturl . '?action=pm;f=' . $this->folder . (Utils::$context['current_label_id'] != -1 && !empty($label_ids) && \in_array(Utils::$context['current_label_id'], $label_ids) ? ';l=' . Utils::$context['current_label_id'] : '') . ';pmid=' . $this->id . '#msg' . $this->id;
+		// Every link below stays in the folder the member is looking at.
+		// $this->folder is worked out from who sent the PM, which answers
+		// 'sent' for one you sent yourself, or to a list you are on, even while
+		// you are reading it in your inbox.
+		$folder = Utils::$context['folder'] ?? $this->folder;
+
+		$href = Config::$scripturl . '?action=pm;f=' . $folder . (Utils::$context['current_label_id'] != -1 && !empty($label_ids) && \in_array(Utils::$context['current_label_id'], $label_ids) ? ';l=' . Utils::$context['current_label_id'] : '') . ';pmid=' . $this->id . '#msg' . $this->id;
 
 		$number_recipients = \count($recipients['to']);
 
@@ -356,25 +362,25 @@ class PM implements \ArrayAccess
 			'quickbuttons' => [
 				'reply_to_all' => [
 					'label' => Lang::getTxt('reply_to_all', file: 'PersonalMessage'),
-					'href' => Config::$scripturl . '?action=pm;sa=send;f=' . $this->folder . (Utils::$context['current_label_id'] != -1 ? ';l=' . Utils::$context['current_label_id'] : '') . ';pmsg=' . $this->id . ($this->member_from != User::$me->id ? ';quote' : '') . ';u=all',
+					'href' => Config::$scripturl . '?action=pm;sa=send;f=' . $folder . (Utils::$context['current_label_id'] != -1 ? ';l=' . Utils::$context['current_label_id'] : '') . ';pmsg=' . $this->id . ($this->member_from != User::$me->id ? ';quote' : '') . ';u=all',
 					'icon' => 'reply_all_button',
 					'show' => Utils::$context['can_send_pm'] && !$author['is_guest'] && ($number_recipients > 1 || $this->member_from == User::$me->id),
 				],
 				'reply' => [
 					'label' => Lang::getTxt('reply', file: 'General'),
-					'href' => Config::$scripturl . '?action=pm;sa=send;f=' . $this->folder . (Utils::$context['current_label_id'] != -1 ? ';l=' . Utils::$context['current_label_id'] : '') . ';pmsg=' . $this->id . ';u=' . $this->member_from,
+					'href' => Config::$scripturl . '?action=pm;sa=send;f=' . $folder . (Utils::$context['current_label_id'] != -1 ? ';l=' . Utils::$context['current_label_id'] : '') . ';pmsg=' . $this->id . ';u=' . $this->member_from,
 					'icon' => 'reply_button',
 					'show' => Utils::$context['can_send_pm'] && !$author['is_guest'] && $this->member_from != User::$me->id,
 				],
 				'quote' => [
 					'label' => Lang::getTxt('quote_action', file: 'General'),
-					'href' => Config::$scripturl . '?action=pm;sa=send;f=' . $this->folder . (Utils::$context['current_label_id'] != -1 ? ';l=' . Utils::$context['current_label_id'] : '') . ';pmsg=' . $this->id . ';quote' . ($number_recipients > 1 || $this->member_from == User::$me->id ? ';u=all' : (!$author['is_guest'] ? ';u=' . $this->member_from : '')),
+					'href' => Config::$scripturl . '?action=pm;sa=send;f=' . $folder . (Utils::$context['current_label_id'] != -1 ? ';l=' . Utils::$context['current_label_id'] : '') . ';pmsg=' . $this->id . ';quote' . ($number_recipients > 1 || $this->member_from == User::$me->id ? ';u=all' : (!$author['is_guest'] ? ';u=' . $this->member_from : '')),
 					'icon' => 'quote',
 					'show' => Utils::$context['can_send_pm'],
 				],
 				'delete' => [
 					'label' => Lang::getTxt('delete', file: 'General'),
-					'href' => Config::$scripturl . '?action=pm;sa=pmactions;pm_actions%5b' . $this->id . '%5D=delete;f=' . $this->folder . ';start=' . Utils::$context['start'] . (Utils::$context['current_label_id'] != -1 ? ';l=' . Utils::$context['current_label_id'] : '') . ';' . Utils::$context['session_var'] . '=' . Utils::$context['session_id'],
+					'href' => Config::$scripturl . '?action=pm;sa=pmactions;pm_actions%5b' . $this->id . '%5D=delete;f=' . $folder . ';start=' . Utils::$context['start'] . (Utils::$context['current_label_id'] != -1 ? ';l=' . Utils::$context['current_label_id'] : '') . ';' . Utils::$context['session_var'] . '=' . Utils::$context['session_id'],
 					'javascript' => 'data-confirm="' . Utils::escapeJavaScript(Lang::getTxt('remove_message_question', file: 'General')) . '"',
 					'class' => 'you_sure',
 					'icon' => 'remove_button',


### PR DESCRIPTION
#### Description

`PM::format()` builds every link on a message — the permalink, reply, reply to all, quote and delete — out of `$this->folder`, which is worked out from who sent the message:

```php
$this->folder = $this->member_from !== User::$me->id ? 'inbox' : 'sent';
```

For most messages that agrees with the folder on screen. It does not for a message you sent that also lands in your inbox, which is any PM you sent to yourself and any list you are on. Read that from the inbox and all five buttons say `f=sent`.

**Delete is the one that shows.** It hands the folder straight to `PM::delete()`, so `f=sent` clears the sender's copy and leaves the recipient's copy — the message is still in the inbox afterwards, and the button looks broken.

Measured on the same install, on the same message, clicking the delete button from the inbox:

| | link | inbox after |
|---|---|---|
| before | `sa=pmactions;pm_actions[2]=delete;f=sent;start=0` | `msg2`, `msg4`, `msg5` |
| after | `sa=pmactions;pm_actions[2]=delete;f=inbox;start=0` | `msg4`, `msg5` |

and the other four links move with it:

```
before   sa=send;f=sent;pmsg=2;u=all        after   sa=send;f=inbox;pmsg=2;u=all
         sa=send;f=sent;pmsg=2;quote;u=all          sa=send;f=inbox;pmsg=2;quote;u=all
```

The sent folder is unchanged — its messages were already getting `f=sent`, and still do.

SMF 2.1 built all of these from `$context['folder']` for exactly this reason, so that is what they use again. `$this->folder` is left alone: it still answers which folder holds the message, which is a different question from which folder is being looked at.

Worth noting for anyone testing this: in conversation view the delete button is refused by the guard in `applyActions()` that requires a `conversation` parameter, and the conversation's own delete link (built in `Folder::showConversation()`) already uses `$context['folder']`. So this shows up in the default "all messages" view.

Eleven pages of the PM area still render with nothing new in the error log.

### Issues References (Fixes|Related|Closes)

n/a