### PR TITLE
[3.0] Theme split (wave 4, part 25) — point the drop menu buttons at design tokens

### DIFF
--- a/Themes/default/css/index.css
+++ b/Themes/default/css/index.css
@@ -854,54 +854,54 @@ img.sort, .sort {
 .amt {
 	margin-left: 3px;
 	padding: 0 5px;
-	color: #fff;
-	background: #6d90ad;
-	border-radius: 8px;
+	color: var(--amt-color);
+	background: var(--amt-bg);
+	border-radius: var(--amt-border-radius);
 }
 .dropmenu li .active .amt, #top_info li .active .amt {
-	background: rgba(0, 0, 0, 0.2);
-	color: inherit;
+	background: var(--amt-bg_active);
+	color: var(--amt-color_active);
 }
 #top_info .top_menu.visible {
 	display: block;
 }
 /* Needed for new PM notifications. */
 .dropmenu li strong {
-	color: #333;
+	color: var(--dropmenu-strong-color);
 }
 
 .dropmenu li a, #top_info > li > a {
 	padding: 0 7px 0 7px;
 	display: block;
-	border: 1px solid transparent;
-	border-radius: 4px;
+	border: var(--dropmenu-border-width) var(--dropmenu-border-style) var(--dropmenu-border-color);
+	border-radius: var(--dropmenu-border-radius);
 }
 /* Level 1 active button. */
 .dropmenu a.active, #top_info a.active {
-	color: #fff;
-	font-weight: bold;
-	border-color: #f49a3a;
-	background: linear-gradient(#ffae14, #f5a100);
-	text-shadow: 0 0 2px #000;
+	color: var(--dropmenu-color_active);
+	font-weight: var(--dropmenu-font-weight_active);
+	border-color: var(--dropmenu-border-color_active);
+	background: var(--dropmenu-bg_active);
+	text-shadow: var(--dropmenu-text-shadow_active);
 }
 /* Level 1 hover effects. */
 .dropmenu > li:hover > a, .dropmenu > li > a:focus,
 #top_info > li:hover > a, #top_info > li > a:focus, #top_info > li > a.open {
-	background: #597b9f;
-	border: 1px solid #4a6b8c;
-	color: #fff;
+	background: var(--dropmenu-bg_hover);
+	border: var(--dropmenu-border-width) var(--dropmenu-border-style) var(--dropmenu-border-color_hover);
+	color: var(--dropmenu-color_hover);
 	cursor: pointer;
 	text-decoration: none;
-	box-shadow: 0 4px 4px rgba(255, 255, 255, 0.1) inset;
-	text-shadow: 0 0 2px #000;
+	box-shadow: var(--dropmenu-box-shadow_hover);
+	text-shadow: var(--dropmenu-text-shadow_hover);
 }
 /* Level 1 active button. */
 .dropmenu li a.active:hover, .dropmenu li:hover a.active {
-	background: orange;
-	border: 1px solid #f49a3a;
-	color: #444;
-	box-shadow: 0 5px 5px rgba(255, 255, 255, 0.2) inset;
-	text-shadow: none;
+	background: var(--dropmenu-bg_active_hover);
+	border: var(--dropmenu-border-width) var(--dropmenu-border-style) var(--dropmenu-border-color_active_hover);
+	color: var(--dropmenu-color_active_hover);
+	box-shadow: var(--dropmenu-box-shadow_active_hover);
+	text-shadow: var(--dropmenu-text-shadow_active_hover);
 }
 
 a.mobile_user_menu,

--- a/Themes/default/css/variables.css
+++ b/Themes/default/css/variables.css
@@ -85,6 +85,35 @@
 	--mainmenu-border-width:                          0 0 1px 0;
 	--mainmenu-box-shadow:                            none;
 
+	/** Drop Menu Buttons **/
+	--dropmenu-bg_active:                             linear-gradient(#ffae14, #f5a100);
+	--dropmenu-bg_active_hover:                       orange;
+	--dropmenu-bg_hover:                              #597b9f;
+	--dropmenu-border-color:                          transparent;
+	--dropmenu-border-color_active:                   #f49a3a;
+	--dropmenu-border-color_active_hover:             #f49a3a;
+	--dropmenu-border-color_hover:                    #4a6b8c;
+	--dropmenu-border-radius:                         4px;
+	--dropmenu-border-style:                          solid;
+	--dropmenu-border-width:                          1px;
+	--dropmenu-box-shadow_active_hover:               0 5px 5px rgba(255, 255, 255, 0.2) inset;
+	--dropmenu-box-shadow_hover:                      0 4px 4px rgba(255, 255, 255, 0.1) inset;
+	--dropmenu-color_active:                          #fff;
+	--dropmenu-color_active_hover:                    #444;
+	--dropmenu-color_hover:                           #fff;
+	--dropmenu-font-weight_active:                    bold;
+	--dropmenu-strong-color:                          #333;
+	--dropmenu-text-shadow_active:                    0 0 2px #000;
+	--dropmenu-text-shadow_active_hover:              none;
+	--dropmenu-text-shadow_hover:                     0 0 2px #000;
+
+	/** Drop Menu Notification Counts **/
+	--amt-bg:                                         #6d90ad;
+	--amt-bg_active:                                  rgba(0, 0, 0, 0.2);
+	--amt-border-radius:                              8px;
+	--amt-color:                                      #fff;
+	--amt-color_active:                               inherit;
+
 	/** HTML **/
 	--html-bg:                                        #3e5a78;
 


### PR DESCRIPTION
#### Description

Part of the #7933 split.

The main menu and the user menu share one set of rules in `index.css`, and they were the largest group of hard-coded colours left in the file — the level 1 button, its active and hover states, and the notification counts beside it. `#main_menu`, immediately below them, has been reading `--mainmenu-*` since wave 2, so this finishes that band.

```
  .dropmenu a.active, #top_info a.active {
- 	color: #fff;
- 	font-weight: bold;
- 	border-color: #f49a3a;
- 	background: linear-gradient(#ffae14, #f5a100);
- 	text-shadow: 0 0 2px #000;
+ 	color: var(--dropmenu-color_active);
+ 	font-weight: var(--dropmenu-font-weight_active);
+ 	border-color: var(--dropmenu-border-color_active);
+ 	background: var(--dropmenu-bg_active);
+ 	text-shadow: var(--dropmenu-text-shadow_active);
  }
```

20 tokens in a `/** Drop Menu Buttons **/` group and 5 in `/** Drop Menu Notification Counts **/`, placed next to `/** Main Menu **/` rather than at the end of the file, so this does not collide with #9443 or #9448.

**Every token holds the value the rule has today, so nothing renders differently.** Where `theme-ref` gives one of these a different value that is a restyle, and it was not taken — only its naming was, which is where the `_active`, `_hover` and `_active_hover` suffixes come from.

The border shorthands stay shorthands. Splitting them into longhands changes what they reset, and `.dropmenu a.active` deliberately overrides only the `border-color` of the shorthand above it.

##### Verification

Reading longhands off `CSSRule.style` proves nothing once a shorthand holds a `var()` — the CSSOM will not serialise it. So each rule's `cssText` was applied wholesale to a probe element, **in cascade order**, to reproduce the three states that cannot be triggered from a script, and a fixed list of 30 longhands read off the result:

| chains | values | differences |
|---|---|---|
| 7 (including `li a` → `a.active` → `a.active:hover`) | 210 | **0** |

Plus the six real elements the rules actually match on the board index, 18 properties and the bounding rect each: **0 differences in 114 values.**

One thing worth knowing for anyone repeating this: with `minimize_files` on, four of those values *do* differ, `rgba(255, 255, 255, 0)` → `rgba(0, 0, 0, 0)`. That is SMF's CSS minifier rewriting the literal `transparent`, which it cannot do inside a `var()`; both are fully transparent and nothing renders differently. The numbers above were taken with minification off so that the comparison is of the stylesheets rather than of the minifier.

### Issues References (Fixes|Related|Closes)

Related: #7933