### PR TITLE
[3.0] Theme split (wave 4, part 26) — point the drop menu submenus at design tokens

### DIFF
--- a/Themes/default/css/index.css
+++ b/Themes/default/css/index.css
@@ -1027,12 +1027,12 @@ a[class^="mobile_generic_menu_"] {
 	min-width: 18.2em;
 	padding: 0.5em;
 	font-weight: normal;
-	border: solid 1px #999;
-	border-left: solid 1px #bbb;
-	border-top: solid 1px #ccc;
-	border-radius: 4px;
-	box-shadow: 3px 3px 4px rgba(0, 0, 0, 0.3);
-	background: #fff;
+	border: var(--submenu-border-style) var(--submenu-border-width) var(--submenu-border-color);
+	border-left: var(--submenu-border-style) var(--submenu-border-width) var(--submenu-border-color_left);
+	border-top: var(--submenu-border-style) var(--submenu-border-width) var(--submenu-border-color_top);
+	border-radius: var(--submenu-border-radius);
+	box-shadow: var(--submenu-box-shadow);
+	background: var(--submenu-bg);
 }
 /* Level 2 link background. */
 .dropmenu li li {
@@ -1040,14 +1040,14 @@ a[class^="mobile_generic_menu_"] {
 	padding: 0;
 	width: 17em;
 	font-size: 1em;
-	border-radius: 3px;
-	border: 1px solid transparent;
+	border-radius: var(--submenu-item-border-radius);
+	border: var(--submenu-item-border-width) var(--submenu-item-border-style) var(--submenu-item-border-color);
 }
 /* Necessary to allow highlighting of 1st level while hovering over submenu. */
 .dropmenu li:hover li a, .dropmenu li li a {
-	background: none;
+	background: var(--submenu-item-bg);
 	padding: 0 9px;
-	color: #346;
+	color: var(--submenu-item-color);
 	border: none;
 	line-height: 2.2em;
 }
@@ -1086,10 +1086,10 @@ a[class^="mobile_generic_menu_"] {
 }
 
 .dropmenu li li:hover > a, .dropmenu li li a:focus, .dropmenu li li a:hover {
-	color: #333;
+	color: var(--submenu-item-color_hover);
 	text-decoration: none;
-	border: 1px solid #cfcfcf;
-	border-top: 1px solid #d4dee6;
+	border: var(--submenu-item-border-width) var(--submenu-item-border-style) var(--submenu-item-border-color_hover);
+	border-top: var(--submenu-item-border-width) var(--submenu-item-border-style) var(--submenu-item-border-color_hover_top);
 }
 /* Reposition Level 2 submenu as visible on hover. */
 .dropmenu li:hover ul {
@@ -1112,7 +1112,7 @@ a[class^="mobile_generic_menu_"] {
 }
 /* Highlighting of current section */
 .dropmenu li li a.chosen {
-	font-weight: bold;
+	font-weight: var(--submenu-item-font-weight_chosen);
 }
 
 /* The extra menu rows for admin sections, etc. */

--- a/Themes/default/css/variables.css
+++ b/Themes/default/css/variables.css
@@ -85,6 +85,28 @@
 	--mainmenu-border-width:                          0 0 1px 0;
 	--mainmenu-box-shadow:                            none;
 
+	/** Drop Menu Submenus **/
+	--submenu-bg:                                     #fff;
+	--submenu-border-color:                           #999;
+	--submenu-border-color_left:                      #bbb;
+	--submenu-border-color_top:                       #ccc;
+	--submenu-border-radius:                          4px;
+	--submenu-border-style:                           solid;
+	--submenu-border-width:                           1px;
+	--submenu-box-shadow:                             3px 3px 4px rgba(0, 0, 0, 0.3);
+
+	/** Drop Menu Submenu Items **/
+	--submenu-item-bg:                                none;
+	--submenu-item-border-color:                      transparent;
+	--submenu-item-border-color_hover:                #cfcfcf;
+	--submenu-item-border-color_hover_top:            #d4dee6;
+	--submenu-item-border-radius:                     3px;
+	--submenu-item-border-style:                      solid;
+	--submenu-item-border-width:                      1px;
+	--submenu-item-color:                             #346;
+	--submenu-item-color_hover:                       #333;
+	--submenu-item-font-weight_chosen:                bold;
+
 	/** HTML **/
 	--html-bg:                                        #3e5a78;
 


### PR DESCRIPTION
#### Description

Part of the #7933 split, and the other half of #9467. That one did the level 1 buttons; this does the level 2 and 3 submenu wrapper, the items inside it, and their hover state — the rest of the hard-coded colours in the drop menu rules.

20 tokens in `/** Drop Menu Submenus **/` and `/** Drop Menu Submenu Items **/`. **Every token holds the value the rule has today, so nothing renders differently.**

The wrapper deliberately sets a border and then overrides the left and top edges with lighter colours:

```css
border: var(--submenu-border-style) var(--submenu-border-width) var(--submenu-border-color);
border-left: var(--submenu-border-style) var(--submenu-border-width) var(--submenu-border-color_left);
border-top: var(--submenu-border-style) var(--submenu-border-width) var(--submenu-border-color_top);
```

so those edges keep their own tokens rather than being flattened, and all three stay shorthands. `.dropmenu li li a:hover` does the same thing and is treated the same way.

##### Verification

**0 differences**, by two independent methods:

- Real DOM: a `ul.dropmenu > li > ul > li > a` built on the board index, 5 elements, 32 computed longhands each — **160 values, 0 differences**.
- Raw source: `index.css` fetched over HTTP and its rule bodies applied to a probe in cascade order, to reach the `:hover` states a script cannot trigger — **160 values, 0 differences**.

The second method exists because of a trap worth flagging for anyone reviewing this kind of change. Reading rule text back out of `CSSRule.style.cssText` and replaying it **cannot round-trip a `border` shorthand that holds a `var()` and is then overridden on one edge**. Doing it that way reported 21 confident-looking differences here — right and bottom borders collapsing to `0px none currentColor` — none of which are real. The rule text has to come from the file, or the measurement has to be taken on a real element.

This touches `variables.css` at the same place as #9467, so whichever lands second needs a trivial rebase. Both insert next to `/** Main Menu **/` rather than at the end of the file, so neither collides with #9443 or #9448.

### Issues References (Fixes|Related|Closes)

Related: #7933, #9467