### PR TITLE
[3.0] Theme split (wave 4, part 27) — point the quick buttons at design tokens

### DIFF
--- a/Themes/default/css/index.css
+++ b/Themes/default/css/index.css
@@ -1151,9 +1151,11 @@ html[lang="el-GR"] .inline_mod_check {
 .pagesection .button {
 	color: #346;
 }
+/* .button is listed here for the border and the shadow; it overrides the
+   colour again immediately below, so this one belongs to the quick buttons. */
 .button:hover, .button:focus,
 .quickbuttons > li:hover > a, .quickbuttons > li > a:focus {
-	color: #222;
+	color: var(--quickbutton-color_hover);
 	border-color: var(--button-border-color_hover);
 	box-shadow: var(--button-box-shadow_hover);
 	text-decoration: none;
@@ -1560,18 +1562,18 @@ ul li.greeting {
 	display: block;
 	height: auto;
 	padding: 0 4px;
-	color: #222;
+	color: var(--quickbutton-color);
 	line-height: 1.375rem;
-	border-radius: 0;
+	border-radius: var(--quickbutton-border-radius);
 }
 .quickbuttons > li:first-child > a {
-	border-radius: 4px 0 0 4px;
+	border-radius: var(--quickbutton-border-radius_first);
 }
 .quickbuttons > li:last-child > a, .inline_mod_check:last-child {
-	border-radius: 0 4px 4px 0;
+	border-radius: var(--quickbutton-border-radius_last);
 }
 .quickbuttons > li:only-child > a, .inline_mod_check:only-child {
-	border-radius: 4px;
+	border-radius: var(--quickbutton-border-radius_only);
 	margin: 2px;
 	height: 23px;
 }
@@ -1581,7 +1583,7 @@ ul li.greeting {
 	height: auto;
 }
 .moderationbuttons_check:focus {
-	box-shadow: 0 0 4px #499dd8;
+	box-shadow: var(--quickbutton-box-shadow_focus);
 }
 .quick_edit, .post_options {
 	position: relative;
@@ -1594,14 +1596,14 @@ ul li.greeting {
 	right: -1px;
 	z-index: 90;
 	padding: 6px;
-	background: #fff;
+	background: var(--postoptions-bg);
 	font-weight: normal;
 	text-align: left;
-	border: solid 1px #999;
-	border-left: solid 1px #aaa;
-	border-top: solid 1px #bbb;
-	border-radius: 4px 0 4px 4px;
-	box-shadow: 2px 3px 3px rgba(0, 0, 0, 0.2);
+	border: var(--postoptions-border-style) var(--postoptions-border-width) var(--postoptions-border-color);
+	border-left: var(--postoptions-border-style) var(--postoptions-border-width) var(--postoptions-border-color_left);
+	border-top: var(--postoptions-border-style) var(--postoptions-border-width) var(--postoptions-border-color_top);
+	border-radius: var(--postoptions-border-radius);
+	box-shadow: var(--postoptions-box-shadow);
 }
 .post_options:hover ul {
 	display: block;
@@ -1612,11 +1614,11 @@ ul li.greeting {
 	padding: 0 6px;
 	line-height: 2.2em;
 	text-decoration: none;
-	border: 1px solid transparent;
-	border-radius: 3px;
+	border: var(--postoptions-item-border-width) var(--postoptions-item-border-style) var(--postoptions-item-border-color);
+	border-radius: var(--postoptions-item-border-radius);
 }
 .post_options ul a:hover, .post_options ul a:focus {
-	border-color: #c4cbd3;
+	border-color: var(--postoptions-item-border-color_hover);
 }
 /* Note: The next declarations are for keyboard access with js disabled. */
 .quickbuttons ul li a:focus {

--- a/Themes/default/css/variables.css
+++ b/Themes/default/css/variables.css
@@ -157,6 +157,32 @@
 	--button-text-shadow_active:                      0 0 1px #000;
 	--button-text-transform:                          uppercase;
 
+	/** Quick Buttons **/
+	--quickbutton-border-radius:                      0;
+	--quickbutton-border-radius_first:                4px 0 0 4px;
+	--quickbutton-border-radius_last:                 0 4px 4px 0;
+	--quickbutton-border-radius_only:                 4px;
+	--quickbutton-box-shadow_focus:                   0 0 4px #499dd8;
+	--quickbutton-color:                              #222;
+	--quickbutton-color_hover:                        #222;
+
+	/** Post Options Drop Down **/
+	--postoptions-bg:                                 #fff;
+	--postoptions-border-color:                       #999;
+	--postoptions-border-color_left:                  #aaa;
+	--postoptions-border-color_top:                   #bbb;
+	--postoptions-border-radius:                      4px 0 4px 4px;
+	--postoptions-border-style:                       solid;
+	--postoptions-border-width:                       1px;
+	--postoptions-box-shadow:                         2px 3px 3px rgba(0, 0, 0, 0.2);
+
+	/** Post Options Drop Down Items **/
+	--postoptions-item-border-color:                  transparent;
+	--postoptions-item-border-color_hover:            #c4cbd3;
+	--postoptions-item-border-radius:                 3px;
+	--postoptions-item-border-style:                  solid;
+	--postoptions-item-border-width:                  1px;
+
 	/** Cat Bar **/
 	--catbar-bg:                                      #557ea0;
 	--catbar-border-color:                            #777;


### PR DESCRIPTION
#### Description

Part of the #7933 split, following #9467 and #9468.

The quick button strip and the drop down that hangs off it were the next group of hard-coded values in `index.css`. `.button` itself has read `--button-*` since wave 2; these are the variants that sit on top of it — the strip's own colour, the four corner radii that make the buttons read as one bar, the moderation checkbox focus ring, and the post options drop down.

24 tokens in three groups, placed after `/** Buttons **/`, so this does not collide with #9467, #9468, #9443 or #9448. **Every token holds the value the rule has today, so nothing renders differently.**

The drop down sets a border and then overrides its left and top edges, so those keep their own tokens and all three stay shorthands.

One naming call worth flagging. The hover colour is `--quickbutton-color_hover` even though `.button:hover` is listed in the same selector:

```css
.button:hover, .button:focus,
.quickbuttons > li:hover > a, .quickbuttons > li > a:focus {
	color: var(--quickbutton-color_hover);
	...
}
.button:hover, .button:focus {
	color: var(--button-color_hover);
}
```

The rule immediately below puts `--button-color_hover` back for `.button`, so `#222` only ever reaches a quick button. Naming it after the button would be wrong about what it does.

##### Verification

**0 differences**, by both methods:

- Raw source: `index.css` fetched over HTTP, rule bodies parsed out of the text and applied to a probe in cascade order — including `:first-child`, `:last-child`, `:only-child`, `:hover` and `:focus`, and the `.button` override chain above. 11 chains x 39 longhands = **429 values, 0 differences**.
- Real elements, in iframes at 1280px, on the three pages that actually draw these: `?action=recent`, `?action=pm` and the reply form's previous-posts list. **30 elements, 1200 values, 0 differences.**

Rule text is taken from the file rather than from `CSSRule.style.cssText`, which cannot round-trip a `border` shorthand holding a `var()` that is then overridden on one edge — see #9468 for what that looks like when it goes wrong.

Noted while finding elements to measure, not addressed here: a topic display draws **no** `.quickbuttons` at all, logged in as an admin — they appear on the recent-posts list, the PM index and the reply form, but not under a post on `?topic=`.

### Issues References (Fixes|Related|Closes)

Related: #7933, #9467, #9468