### PR TITLE
[3.0] Theme split (wave 4, part 28) — point the post display at design tokens

### DIFF
--- a/Themes/default/css/index.css
+++ b/Themes/default/css/index.css
@@ -809,8 +809,8 @@ img.sort, .sort {
 }
 
 .postbg {
-	border-left: 1px solid #7f7f7f;
-	border-right: 1px solid #7f7f7f;
+	border-left: var(--postbg-border-width) var(--postbg-border-style) var(--postbg-border-color);
+	border-right: var(--postbg-border-width) var(--postbg-border-style) var(--postbg-border-color);
 }
 
 /* Styles used by the auto suggest control.
@@ -3197,12 +3197,12 @@ tr.windowbg {
 
 /* Colors for background of posts requiring approval */
 .approvebg {
-	color: #222;
-	background: #ffeaea;
+	color: var(--approvebg-color);
+	background: var(--approvebg-bg);
 }
 .approvebg2 {
-	color: #222;
-	background: #fff2f2;
+	color: var(--approvebg2-color);
+	background: var(--approvebg2-bg);
 }
 
 div#manage_boards dl dd textarea[name=desc] {
@@ -3429,7 +3429,7 @@ span.postby {
 	margin-top: 5px !important;
 }
 #topic_container .windowbg {
-	border: 1px solid rgba(0, 0, 0, 0.13);
+	border: var(--topiccontainer-border-width) var(--topiccontainer-border-style) var(--topiccontainer-border-color);
 	border-top: none;
 	display: flex;
 	box-shadow: none;
@@ -3581,7 +3581,7 @@ div#pollmoderation {
 .poster h4, .poster h4 a, .poster li:hover h4 a, .poster h4 a:hover .poster li h4 a, .poster h4 a:focus {
 	margin: 0;
 	padding: 0;
-	color: #c06002;
+	color: var(--poster-name-color);
 }
 
 .poster .profile .profile_icons li, .poster .im_icons li {
@@ -3602,7 +3602,7 @@ div#pollmoderation {
 	margin: 3px 10px;
 }
 .poster li.poster_online a {
-	color: #c06002;
+	color: var(--poster-online-color);
 	line-height: 1.6em;
 }
 .poster li.poster_online:hover, .poster li.poster_online:hover a {
@@ -3653,13 +3653,13 @@ img.avatar {
 	display: block;
 }
 .keyinfo .postinfo a, .keyinfo .postinfo a strong {
-	color: #ad6825;
+	color: var(--postinfo-link-color);
 }
 .keyinfo .postinfo .spacer {
 	flex: 1 1 auto;
 }
 .keyinfo .postinfo .modified {
-	color: #333;
+	color: var(--postinfo-modified-color);
 	font-weight: normal;
 	font-style: italic;
 	padding: 2px 4px 0 4px;
@@ -3671,9 +3671,9 @@ img.avatar {
 	position: absolute;
 	right: 0;
 	top: 2em;
-	background: #fdfdfd;
-	border: 1px solid #ddd;
-	border-radius: 4px;
+	background: var(--edithistory-bg);
+	border: var(--edithistory-border-width) var(--edithistory-border-style) var(--edithistory-border-color);
+	border-radius: var(--edithistory-border-radius);
 	padding: 1em;
 	min-width: 18.2em;
 	font-weight: normal;
@@ -3681,14 +3681,14 @@ img.avatar {
 .edit_history_list li {
 	margin-top: 0.5em;
 	padding-top: 0.5em;
-	border-top: 1px solid #ddd;
+	border-top: var(--edithistory-item-border-width) var(--edithistory-item-border-style) var(--edithistory-item-border-color);
 }
 .bump_notice {
 	display: block;
 	margin-top: 1em;
 	padding: 0.5em 0;
-	border-top: 1px solid #ddd;
-	border-bottom: 1px solid #ddd;
+	border-top: var(--bumpnotice-border-width) var(--bumpnotice-border-style) var(--bumpnotice-border-color);
+	border-bottom: var(--bumpnotice-border-width) var(--bumpnotice-border-style) var(--bumpnotice-border-color);
 	text-align: center;
 	font-style: italic;
 }
@@ -3703,14 +3703,14 @@ img.avatar {
 }
 .subject_title a {
 	font-size: 0.9em;
-	color: #333;
+	color: var(--subjecttitle-link-color);
 	font-weight: bold;
 }
 .subject_hidden a {
 	display: none;
 }
 .page_number {
-	color: #ad6825;
+	color: var(--pagenumber-color);
 	font-weight: bold;
 	padding: 4px 0 0 4px;
 	line-height: 1.5em;
@@ -3718,8 +3718,8 @@ img.avatar {
 .inner {
 	padding: 7px 8px 2px 2px;
 	margin: 0;
-	border-top: 1px solid #bfbfbf;
-	box-shadow: 0 1px 0 #fff inset;
+	border-top: var(--postsection-border-width) var(--postsection-border-style) var(--postsection-border-color);
+	box-shadow: var(--postsection-box-shadow);
 	min-height: 85px;
 	word-wrap: break-word; /* IE fallback */
 	overflow-wrap: break-word;
@@ -3884,8 +3884,8 @@ form#postmodify .roundframe {
 	overflow: auto;
 	clear: right;
 	padding: 12px 0 3px 0;
-	border-top: 1px solid #bfbfbf;
-	box-shadow: 0 1px 0 #fff inset;
+	border-top: var(--postsection-border-width) var(--postsection-border-style) var(--postsection-border-color);
+	box-shadow: var(--postsection-box-shadow);
 	line-height: 1.4em;
 	font-size: 0.9em;
 }

--- a/Themes/default/css/variables.css
+++ b/Themes/default/css/variables.css
@@ -157,6 +157,52 @@
 	--button-text-shadow_active:                      0 0 1px #000;
 	--button-text-transform:                          uppercase;
 
+	/** Posts **/
+	--postbg-border-color:                            #7f7f7f;
+	--postbg-border-style:                            solid;
+	--postbg-border-width:                            1px;
+	--topiccontainer-border-color:                    rgba(0, 0, 0, 0.13);
+	--topiccontainer-border-style:                    solid;
+	--topiccontainer-border-width:                    1px;
+
+	/* The hairline above each section inside a post: the message body, the
+	   signature, the attachments and the custom field blocks all draw it. */
+	--postsection-border-color:                       #bfbfbf;
+	--postsection-border-style:                       solid;
+	--postsection-border-width:                       1px;
+	--postsection-box-shadow:                         0 1px 0 #fff inset;
+
+	/** Posts Awaiting Approval **/
+	--approvebg-bg:                                   #ffeaea;
+	--approvebg-color:                                #222;
+	--approvebg2-bg:                                  #fff2f2;
+	--approvebg2-color:                               #222;
+
+	/** Post Author **/
+	--poster-name-color:                              #c06002;
+	--poster-online-color:                            #c06002;
+
+	/** Post Info Line **/
+	--pagenumber-color:                               #ad6825;
+	--postinfo-link-color:                            #ad6825;
+	--postinfo-modified-color:                        #333;
+	--subjecttitle-link-color:                        #333;
+
+	/** Post Edit History **/
+	--edithistory-bg:                                 #fdfdfd;
+	--edithistory-border-color:                       #ddd;
+	--edithistory-border-radius:                      4px;
+	--edithistory-border-style:                       solid;
+	--edithistory-border-width:                       1px;
+	--edithistory-item-border-color:                  #ddd;
+	--edithistory-item-border-style:                  solid;
+	--edithistory-item-border-width:                  1px;
+
+	/** Bump Notice **/
+	--bumpnotice-border-color:                        #ddd;
+	--bumpnotice-border-style:                        solid;
+	--bumpnotice-border-width:                        1px;
+
 	/** Cat Bar **/
 	--catbar-bg:                                      #557ea0;
 	--catbar-border-color:                            #777;


### PR DESCRIPTION
#### Description

Part of the #7933 split, following #9467, #9468 and #9469.

The colours a post draws itself with: the poster's name and online link, the info line above the message, the edit history drop down, the bump notice, the approval backgrounds, and the borders around the message itself. 33 tokens in seven groups. **Every token holds the value the rule has today, so nothing renders differently.**

One judgement call. `.inner` and the `.signature, .attachments, .under_message, .custom_fields_*` group both draw

```css
border-top: 1px solid #bfbfbf;
box-shadow: 0 1px 0 #fff inset;
```

They share one `--postsection-*` set rather than getting a pair each. That is the same divider drawn twice — the hairline above each section inside a post — not two values that happen to coincide. Where a value really does carry two meanings, as with `--approvebg-color` and `--approvebg2-color` (both `#222`), there are two tokens.

##### Verification

Every rule in `index.css` — not just the ones this touches — parsed out of the file as text, applied to a probe, and read back as a fixed list of 57 longhands:

**965 rules, 55,005 computed values, 0 differences.**

Rule text comes from the file rather than `CSSRule.style.cssText`, which cannot round-trip a `border` shorthand holding a `var()` (see #9468). Measured with `minimize_files` off, because the minifier rewrites literal `transparent` and cannot do so inside a `var()`.

### Issues References (Fixes|Related|Closes)

Related: #7933