### PR TITLE
[3.0] Theme split (wave 4, part 30) — point the toggles and small icons at design tokens

### DIFF
--- a/Themes/default/css/index.css
+++ b/Themes/default/css/index.css
@@ -553,16 +553,14 @@ a img {
 	width: 17px;
 	height: 17px;
 	display: inline-block;
-	background: #f7f7f7 url(../images/icons/toggle.png) no-repeat 0 0 / 17px;
+	background: var(--toggle-bg) url(../images/icons/toggle.png) no-repeat 0 0 / 17px;
 	overflow: hidden;
 	content: "";
 	vertical-align: middle;
 	margin: 0 5px 0 5px;
-	border: 1px solid #c5c5c5;
-	border-radius: 3px;
-	box-shadow: 0 1px 2px rgba(0, 0, 0, .2),
-		0 1px 1px #fff inset,
-		0 -5px 4px rgba(0,0,0,.1) inset;
+	border: var(--toggle-border-width) var(--toggle-border-style) var(--toggle-border-color);
+	border-radius: var(--toggle-border-radius);
+	box-shadow: var(--toggle-box-shadow);
 	transition: background-color 0.25s;
 }
 .toggle_down::before {
@@ -570,8 +568,8 @@ a img {
 }
 
 .toggle_up:hover:before, .toggle_down:hover:before {
-	background-color: #bfd4e7;
-	box-shadow: 0 1px 2px rgba(0, 0, 0, 0.25) inset;
+	background-color: var(--toggle-bg_hover);
+	box-shadow: var(--toggle-box-shadow_hover);
 	transition: background-color 0.25s;
 }
 
@@ -4121,28 +4119,28 @@ p.information img {
 	cursor: pointer;
 }
 .icon_list_box:hover {
-	background: #ffffff;
-	border: 1px solid #adadad;
+	background: var(--iconlist-bg);
+	border: var(--iconlist-border-width) var(--iconlist-border-style) var(--iconlist-border-color);
 	padding: 2px;
 }
 .icon_list_container {
 	position: absolute;
 	cursor: pointer;
-	background: #ffffff;
-	border: 1px solid #adadad;
+	background: var(--iconlist-bg);
+	border: var(--iconlist-border-width) var(--iconlist-border-style) var(--iconlist-border-color);
 	padding: 6px 0;
 	z-index: 1000;
 }
 .icon_list_item {
 	padding: 2px 3px;
 	line-height: 20px;
-	border: 1px solid #ffffff;
+	border: var(--iconlist-item-border-width) var(--iconlist-item-border-style) var(--iconlist-item-border-color);
 	background: transparent;
 	display: inline-block;
 }
 .icon_list_item:hover {
-	background: #e0e0f0;
-	border: 1px dotted gray;
+	background: var(--iconlist-item-bg_hover);
+	border: var(--iconlist-item-border-width_hover) var(--iconlist-item-border-style_hover) var(--iconlist-item-border-color_hover);
 }
 
 /* On/Off Icons (User) */
@@ -4155,12 +4153,12 @@ p.information img {
 	vertical-align: middle;
 }
 .on {
-	background: #89e75a;
-	border-color: #74d246;
+	background: var(--onoff-bg_on);
+	border-color: var(--onoff-border-color_on);
 }
 .off {
-	background: #a7a2a2;
-	border-color: #969292;
+	background: var(--onoff-bg_off);
+	border-color: var(--onoff-border-color_off);
 }
 #userstatus .smalltext {
 	margin: 0 0 0 5px !important;

--- a/Themes/default/css/variables.css
+++ b/Themes/default/css/variables.css
@@ -326,6 +326,35 @@
 	--popup-content-color:                            #222;
 	--popup-content-line-height:                      1.6em;
 
+	/** Collapse and Expand Toggles **/
+	--toggle-bg:                                      #f7f7f7;
+	--toggle-bg_hover:                                #bfd4e7;
+	--toggle-border-color:                            #c5c5c5;
+	--toggle-border-radius:                           3px;
+	--toggle-border-style:                            solid;
+	--toggle-border-width:                            1px;
+	--toggle-box-shadow:                              0 1px 2px rgba(0, 0, 0, .2), 0 1px 1px #fff inset, 0 -5px 4px rgba(0, 0, 0, .1) inset;
+	--toggle-box-shadow_hover:                        0 1px 2px rgba(0, 0, 0, 0.25) inset;
+
+	/** Message Icon Picker **/
+	--iconlist-bg:                                    #ffffff;
+	--iconlist-border-color:                          #adadad;
+	--iconlist-border-style:                          solid;
+	--iconlist-border-width:                          1px;
+	--iconlist-item-bg_hover:                         #e0e0f0;
+	--iconlist-item-border-color:                     #ffffff;
+	--iconlist-item-border-color_hover:               gray;
+	--iconlist-item-border-style:                     solid;
+	--iconlist-item-border-style_hover:               dotted;
+	--iconlist-item-border-width:                     1px;
+	--iconlist-item-border-width_hover:               1px;
+
+	/** Online and Offline Dots **/
+	--onoff-bg_off:                                   #a7a2a2;
+	--onoff-bg_on:                                    #89e75a;
+	--onoff-border-color_off:                         #969292;
+	--onoff-border-color_on:                          #74d246;
+
 	/** Search Highlight **/
 	--searchhighlight-color:                          #ff7200;
 	--searchhighlight-font-size:                      1.1em;


### PR DESCRIPTION
#### Description

Part of the #7933 split.

The collapse and expand toggle and its hover state, the message icon picker, and the green and grey dots that mark a member online or offline. 23 tokens. **Every token holds the value the rule has today, so nothing renders differently.**

The toggle's three-part `box-shadow` becomes one token rather than three, since the three shadows are one effect and are never set apart.

##### Verification

Every rule in `index.css` parsed out of the file as text, applied to a probe, read back as a fixed list of 57 longhands:

**965 rules, 55,005 computed values, 0 differences.**

That includes the reformatting of the toggle's multi-line shadow into a single-line token value, and `rgba(0,0,0,.1)` being written with spaces — both normalise to the same computed value, which is what the count above shows.

### Issues References (Fixes|Related|Closes)

Related: #7933