### PR TITLE
[3.0] Theme split (wave 4, part 32) — point the overlays and alternating rows at design tokens

### DIFF
--- a/Themes/default/css/index.css
+++ b/Themes/default/css/index.css
@@ -3000,9 +3000,9 @@ dl.addrules dt.floatleft {
 #helpmain {
 	margin: 12px 0 0 0;
 	padding: 8px 20px 12px 20px;
-	border: 1px solid #ddd;
-	border-radius: 7px;
-	box-shadow: 0 -2px 2px rgba(0, 0, 0, 0.1);
+	border: var(--helpmain-border-width) var(--helpmain-border-style) var(--helpmain-border-color);
+	border-radius: var(--helpmain-border-radius);
+	box-shadow: var(--helpmain-box-shadow);
 	overflow: auto;
 }
 #helpmain p {
@@ -3030,11 +3030,11 @@ dl.addrules dt.floatleft {
 	overflow-wrap: break-word;
 	max-width: 350px;
 	padding: 6px 9px;
-	color: #333;
-	background: #fff;
-	border: 1px solid #aaa;
-	border-radius: 4px;
-	box-shadow: 1px 2px 4px rgba(0, 0, 0, 0.2), 0 0px 10px rgba(0, 0, 0, 0.05) inset;
+	color: var(--tooltip-color);
+	background: var(--tooltip-bg);
+	border: var(--tooltip-border-width) var(--tooltip-border-style) var(--tooltip-border-color);
+	border-radius: var(--tooltip-border-radius);
+	box-shadow: var(--tooltip-box-shadow);
 }
 
 /* Styles for popup windows */
@@ -3086,8 +3086,8 @@ dl.addrules dt.floatleft {
 	max-height: 65vh;
 	overflow: auto;
 	padding: 10px 8px;
-	border: 1px solid #bbb;
-	border-bottom: 1px solid #ddd;
+	border: var(--popup-content-border-width) var(--popup-content-border-style) var(--popup-content-border-color);
+	border-bottom: var(--popup-content-border-width) var(--popup-content-border-style) var(--popup-content-border-color_bottom);
 	border-radius: 6px 6px 2px 2px;
 	box-shadow: 0 -2px 3px rgba(0, 0, 0, 0.15), 0 1px 1px rgba(255, 255, 255, 0.2);
 }
@@ -3173,7 +3173,7 @@ tr.windowbg:hover {
 	border-radius: 0;
 }
 .generic_list_wrapper table.table_grid {
-	border-bottom: 1px solid #aaa;
+	border-bottom: var(--listgrid-border-width) var(--listgrid-border-style) var(--listgrid-border-color);
 }
 
 div#editlang_desc {
@@ -4312,16 +4312,16 @@ h3.profile_hd::before,
 
 /* Alternating colors */
 .stripes:nth-of-type(even) {
-	background-color: #f2f2f2;
+	background-color: var(--stripes-bg_even);
 }
 .stripes:nth-of-type(odd) {
-	background-color: #f0f4f7;
+	background-color: var(--stripes-bg_odd);
 }
 .alternative {
-	background-color: #f2f2f2;
+	background-color: var(--alternative-bg);
 }
 .alternative2 {
-	background-color: #e8edf0;
+	background-color: var(--alternative2-bg);
 }
 
 .centerbox {
@@ -4400,7 +4400,7 @@ input[name="attachBBC"] {
 
 /* Two-Factor Auth code container */
 .tfacode {
-	background: #d0e7f8;
+	background: var(--tfacode-bg);
 	padding: 5px;
 	display: inline-block;
 }
@@ -4483,7 +4483,7 @@ tr[id^='list_news_lists_'] textarea {
 
 .backtrace:not(:last-child) {
 	padding-bottom: 0.5em;
-	border-bottom: 1px solid #ddd;
+	border-bottom: var(--backtrace-border-width) var(--backtrace-border-style) var(--backtrace-border-color);
 	margin-bottom: 0.5em;
 }
 
@@ -4510,10 +4510,10 @@ img.theme_thumbnail {
 
 /* Diff output styling */
 del.diff {
-	background: rgba(255, 0, 0, 0.35);
+	background: var(--diff-bg_removed);
 }
 ins.diff {
-	background: rgba(0, 255, 0, 0.35);
+	background: var(--diff-bg_added);
 }
 .diff:has(
 	address, article, aside, blockquote, caption, center, col, colgroup, dd,

--- a/Themes/default/css/variables.css
+++ b/Themes/default/css/variables.css
@@ -326,6 +326,51 @@
 	--popup-content-color:                            #222;
 	--popup-content-line-height:                      1.6em;
 
+	/** Help Pages **/
+	--helpmain-border-color:                          #ddd;
+	--helpmain-border-radius:                         7px;
+	--helpmain-border-style:                          solid;
+	--helpmain-border-width:                          1px;
+	--helpmain-box-shadow:                            0 -2px 2px rgba(0, 0, 0, 0.1);
+
+	/** Tooltips **/
+	--tooltip-bg:                                     #fff;
+	--tooltip-border-color:                           #aaa;
+	--tooltip-border-radius:                          4px;
+	--tooltip-border-style:                           solid;
+	--tooltip-border-width:                           1px;
+	--tooltip-box-shadow:                             1px 2px 4px rgba(0, 0, 0, 0.2), 0 0px 10px rgba(0, 0, 0, 0.05) inset;
+	--tooltip-color:                                  #333;
+
+	/** Popup Content **/
+	--popup-content-border-color:                     #bbb;
+	--popup-content-border-color_bottom:              #ddd;
+	--popup-content-border-style:                     solid;
+	--popup-content-border-width:                     1px;
+
+	/** Generic Lists **/
+	--listgrid-border-color:                          #aaa;
+	--listgrid-border-style:                          solid;
+	--listgrid-border-width:                          1px;
+
+	/** Alternating Rows **/
+	--alternative-bg:                                 #f2f2f2;
+	--alternative2-bg:                                #e8edf0;
+	--stripes-bg_even:                                #f2f2f2;
+	--stripes-bg_odd:                                 #f0f4f7;
+
+	/** Two Factor Authentication Code **/
+	--tfacode-bg:                                     #d0e7f8;
+
+	/** Backtraces **/
+	--backtrace-border-color:                         #ddd;
+	--backtrace-border-style:                         solid;
+	--backtrace-border-width:                         1px;
+
+	/** Diff Output **/
+	--diff-bg_added:                                  rgba(0, 255, 0, 0.35);
+	--diff-bg_removed:                                rgba(255, 0, 0, 0.35);
+
 	/** Search Highlight **/
 	--searchhighlight-color:                          #ff7200;
 	--searchhighlight-font-size:                      1.1em;


### PR DESCRIPTION
#### Description

Part of the #7933 split.

The help pages, the tooltip, the popup content frame, the generic list grid, the striped and alternating row backgrounds, the two-factor code block, backtrace separators and the diff output colours. 33 tokens. **Every token holds the value the rule has today, so nothing renders differently.**

`.stripes:nth-of-type(even)` and `.alternative` both carry `#f2f2f2` but are separate devices used in different places, so each gets its own token rather than sharing one — the rule from #9448 about one value carrying two meanings.

##### Verification

Every rule in `index.css` parsed out of the file as text, applied to a probe, read back as a fixed list of 57 longhands:

**965 rules, 55,005 computed values, 0 differences.**

### Issues References (Fixes|Related|Closes)

Related: #7933