### PR TITLE
[3.0] Load the SplitTopics template for the page that needs it

### DIFF
--- a/Sources/Actions/TopicSplit.php
+++ b/Sources/Actions/TopicSplit.php
@@ -111,7 +111,7 @@ class TopicSplit implements ActionInterface, Routable
 		User::$me->isAllowedTo('split_any');
 
 		// Load up the "dependencies" - the template and getMsgMemberID().
-		Theme::loadTemplate(!isset($_REQUEST['xml']) ? 'Xml' : 'SplitTopics');
+		Theme::loadTemplate(isset($_REQUEST['xml']) ? 'Xml' : 'SplitTopics');
 
 		$call = \is_string(self::$subactions[$this->subaction]) && method_exists($this, self::$subactions[$this->subaction]) ? [$this, self::$subactions[$this->subaction]] : Utils::getCallable(self::$subactions[$this->subaction]);
 
@@ -299,7 +299,7 @@ class TopicSplit implements ActionInterface, Routable
 		Utils::$context['sub_template'] = isset($_REQUEST['xml']) ? 'split' : 'select';
 
 		// Are we using a custom messages per page?
-		Utils::$context['messages_per_page'] = empty(Config::$modSettings['disableCustomPerPage']) && !empty(Theme::$current->options['messages_per_page']) ? Theme::$current->options['messages_per_page'] : Config::$modSettings['defaultMaxMessages'];
+		Utils::$context['messages_per_page'] = (int) (empty(Config::$modSettings['disableCustomPerPage']) && !empty(Theme::$current->options['messages_per_page']) ? Theme::$current->options['messages_per_page'] : Config::$modSettings['defaultMaxMessages']);
 
 		// Get the message ID's from before the move.
 		if (isset($_REQUEST['xml'])) {
@@ -412,7 +412,7 @@ class TopicSplit implements ActionInterface, Routable
 		);
 
 		while ($row = Db::$db->fetch_assoc($request)) {
-			Utils::$context[empty($row['is_selected']) || $row['is_selected'] == 'f' ? 'not_selected' : 'selected']['num_messages'] = $row['num_messages'];
+			Utils::$context[empty($row['is_selected']) || $row['is_selected'] == 'f' ? 'not_selected' : 'selected']['num_messages'] = (int) $row['num_messages'];
 		}
 		Db::$db->free_result($request);
 
@@ -648,8 +648,8 @@ class TopicSplit implements ActionInterface, Routable
 			ErrorHandler::fatalLang('selected_all_posts', false);
 		}
 
-		$split1_first_msg = null;
-		$split1_last_msg = null;
+		$split1_first_msg = 0;
+		$split1_last_msg = 0;
 
 		while ($row = Db::$db->fetch_assoc($request)) {
 			// Get the right first and last message dependent on approved state...
@@ -696,6 +696,13 @@ class TopicSplit implements ActionInterface, Routable
 				'id_topic' => $split1_ID_TOPIC,
 			],
 		);
+
+		// Nothing comes back if the messages have already been moved elsewhere,
+		// which is what a resubmitted split looks like. Start these at 0 so the
+		// sanity check below is what answers that, rather than the two
+		// getMsgMemberID() calls that come before it.
+		$split2_first_msg = 0;
+		$split2_last_msg = 0;
 
 		while ($row = Db::$db->fetch_assoc($request)) {
 			// As before get the right first and last message dependent on approved state...


### PR DESCRIPTION
#### Description

Splitting a topic does not work at all on `release-3.0`. Clicking **Split Topic** under any post gives "Unable to load the ask sub-template", because the ternary in `TopicSplit::execute()` is inverted:

```php
Theme::loadTemplate(!isset($_REQUEST['xml']) ? 'Xml' : 'SplitTopics');
```

An HTML request has no `xml`, so it loads **Xml**; the XMLHttp request loads **SplitTopics**. 2.1 has `if (!isset($_REQUEST['xml'])) loadTemplate('SplitTopics');`, which is the other way round.

Because nothing could get past that, two more faults were sitting behind it:

- **The select-posts screen was a 500.** `num_messages` arrives from `COUNT(*)` as a string, and `messages_per_page` comes from `modSettings`, so both were rejected by `PageIndex::__construct()`'s typed `int` parameters. `Display.php` already casts the same setting at its own `PageIndex` call.
- **A resubmitted split was a 500.** `$split2_first_msg`/`$split2_last_msg` are only assigned inside a loop over a query that returns nothing once the messages have moved to the new topic - which is what pressing Split a second time, or using the back button, looks like. `Board::getMsgMemberID()` then received `null`. The "No database changes yet, so let's double check" test a few lines further down exists to catch exactly this, so these now start at 0 and it does; the page is the intended `cant_find_messages` error instead of a fatal.

#### How to test

On `release-3.0`, open any topic with more than one post and click **Split Topic** in a post's More… menu.

- Before: "Unable to load the ask sub-template" (or a 500 when splitting at the first post).
- After: the ask screen renders. All three options work - *only this post*, *this post and all after*, and *select posts*, including the two page indexes on the select screen. Pressing Split twice gives "Unable to find messages" rather than a fatal.

Verified on MySQL; the change is not SQL.

### Issues References (Fixes|Related|Closes)

Found while sweeping the topic display for the #7933 split.