### PR TITLE
[3.0] Save the notification preference the member asked for

### DIFF
--- a/Sources/Actions/Notify.php
+++ b/Sources/Actions/Notify.php
@@ -446,6 +446,20 @@ abstract class Notify implements ActionInterface
 				$perfs = self::getNotifyPrefs((int) self::$member_info['id'], [$this->type . '_notify_' . $this->id], true);
 				$this->alert_pref = ((int) $perfs[(int) self::$member_info['id']][$this->type . '_notify_' . $this->id]) & self::PREF_ALERT;
 				break;
+
+			// And its mirror image: turn off the alerts and keep the emails.
+			case self::MODE_NO_ALERT:
+				$perfs = self::getNotifyPrefs((int) self::$member_info['id'], [$this->type . '_notify_' . $this->id], true);
+				$this->alert_pref = ((int) $perfs[(int) self::$member_info['id']][$this->type . '_notify_' . $this->id]) & self::PREF_EMAIL;
+				break;
+
+			// $this->mode comes straight from the query string, so it can be
+			// anything at all. Leaving it out here means the typed property
+			// below is never assigned, and reading it is a fatal error rather
+			// than a page.
+			default:
+				$this->alert_pref = self::PREF_NONE;
+				break;
 		}
 	}
 

--- a/Sources/Actions/NotifyBoard.php
+++ b/Sources/Actions/NotifyBoard.php
@@ -61,7 +61,9 @@ class NotifyBoard extends Notify
 	protected function saToMode(): void
 	{
 		if (!isset($_GET['mode']) && isset($_GET['sa'])) {
-			$_GET['mode'] = $_GET['sa'] == 'on' ? 3 : -1;
+			// 'off' is the unsubscribe link in the notification emails, so it
+			// means stop emailing me - not stop telling me anything at all.
+			$_GET['mode'] = $_GET['sa'] == 'on' ? parent::MODE_BOTH : parent::MODE_NO_EMAIL;
 			unset($_GET['sa']);
 		}
 	}

--- a/Sources/Actions/NotifyTopic.php
+++ b/Sources/Actions/NotifyTopic.php
@@ -62,7 +62,9 @@ class NotifyTopic extends Notify
 	protected function saToMode(): void
 	{
 		if (!isset($_GET['mode']) && isset($_GET['sa'])) {
-			$_GET['mode'] = $_GET['sa'] == 'on' ? 3 : -1;
+			// 'off' is the unsubscribe link in the notification emails, so it
+			// means stop emailing me - not stop telling me anything at all.
+			$_GET['mode'] = $_GET['sa'] == 'on' ? parent::MODE_BOTH : parent::MODE_NO_EMAIL;
 			unset($_GET['sa']);
 		}
 	}
@@ -116,7 +118,7 @@ class NotifyTopic extends Notify
 			[
 				'id_member' => 'int', 'id_topic' => 'int', 'id_msg' => 'int', 'unwatched' => 'int',
 			],
-			$log,
+			[$log],
 			['id_member', 'id_topic'],
 		);
 


### PR DESCRIPTION
#### Description

Topic and board notifications do not work on `release-3.0`. Three separate faults, all on the same path.

**1. `NotifyTopic::changePref()` passes a single row where a list is required.**

`Db::insert()` needs `$data` to be an array of rows; with `$backward_compatibility` off (the default) anything else is `Invalid data structure sent to the database.` and a `critical` row in the error log. `Notify::changeBoardTopicPref()` a few lines away wraps its row correctly - this one does not.

```
?action=notifytopic;topic=1.0;sa=on  ->  500, "Invalid data structure sent to the database.<br>Function: changePref"
```

**2. `sa=off` picks a mode nothing handles.**

`saToMode()` maps `off` to `-1`, and `-1` is `MODE_NO_ALERT`, for which `setAlertPref()` has no `case`. `$alert_pref` is a typed property with no default, so the next line to read it throws:

```
Typed property SMF\Actions\Notify::$alert_pref must not be accessed before initialization
```

That is the **UNSUBSCRIBELINK** at the foot of every notification email (`Tasks/CreatePost_Notify.php`), and the *No* link on the notification confirmation page, for both topics and boards.

In 2.1 the value `-1` meant *"turn off email notifications while leaving the alert pref unchanged"* - which 3.0 renamed to `MODE_NO_EMAIL` (-2) when it split the constant in two, without updating `saToMode()`. Pointing `sa=off` at `MODE_NO_EMAIL` restores 2.1's behaviour exactly.

**3. Any unknown mode did the same.**

`$this->mode` is `(int) $_GET['mode']`, so `?mode=99` was also a fatal. The switch now has a `default`, and `MODE_NO_ALERT` gets the handling its name describes - the mirror of the `MODE_NO_EMAIL` case.

#### How to test

```
?action=notifytopic;topic=1.0;mode=3;<session>   subscribe
?action=notifytopic;topic=1.0;sa=off;<session>   the email unsubscribe link
?action=notifyboard;board=1.0;sa=off;<session>
```

Before: 500 on all three, with the errors above in `smf_log_errors`. After: all redirect, the log stays empty, and `smf_user_alerts_prefs` shows `board_notify_1` going 3 → 1 on `sa=off` - email bit cleared, alert bit kept, as in 2.1.

### Issues References (Fixes|Related|Closes)

Found while sweeping the topic display for the #7933 split.