### PR TITLE
[3.0] Give each post one quick-moderation checkbox, and no empty submit

### DIFF
--- a/Sources/Actions/QuickModerationInTopic.php
+++ b/Sources/Actions/QuickModerationInTopic.php
@@ -62,6 +62,14 @@ class QuickModerationInTopic implements ActionInterface, Routable
 		// Check the session = get or post.
 		User::$me->checkSession('request');
 
+		// Nothing ticked, nothing to do. Every branch below assumes at least
+		// one message: splitting takes the min() of them, and the other two
+		// hand the list to an {array_int:...}, which will not accept an empty
+		// one.
+		if (empty($this->messages)) {
+			Utils::redirectexit('topic=' . Topic::$topic_id . '.' . ($_REQUEST['start'] ?? 0));
+		}
+
 		if (isset($_REQUEST['restore_selected'])) {
 			$this->restore();
 		} elseif (isset($_REQUEST['split_selection'])) {
@@ -80,7 +88,7 @@ class QuickModerationInTopic implements ActionInterface, Routable
 	 */
 	protected function __construct()
 	{
-		$this->messages = array_map('intval', $_REQUEST['msgs']);
+		$this->messages = array_map('intval', (array) ($_REQUEST['msgs'] ?? []));
 	}
 
 	/**

--- a/Themes/default/scripts/topic.js
+++ b/Themes/default/scripts/topic.js
@@ -875,17 +875,31 @@ InTopicModeration.prototype.init = function()
 	// Add checkboxes to all the messages.
 	for (var i = 0, n = this.opt.aMessageIds.length; i < n; i++)
 	{
-		// Create the checkbox.
-		var oCheckbox = document.createElement('input');
-		oCheckbox.type = 'checkbox';
-		oCheckbox.className = this.opt.sButtonStrip + '_check';
-		oCheckbox.name = 'msgs[]';
-		oCheckbox.value = this.opt.aMessageIds[i];
-		oCheckbox.onclick = this.handleClick.bind(this, oCheckbox);
-
 		// Append it to the container
 		var oCheckboxContainer = document.getElementById(this.opt.sCheckboxContainerMask + this.opt.aMessageIds[i]);
-		oCheckboxContainer.appendChild(oCheckbox);
+
+		/*
+		 * The topic draws two of these strips - one for the page and one for
+		 * the mobile menu - and they share the containers, so the second
+		 * instance finds a checkbox already sitting here. Take that one and
+		 * listen to it as well, rather than putting a second checkbox beside
+		 * every post.
+		 */
+		var oCheckbox = oCheckboxContainer.querySelector('input[name="msgs[]"]');
+
+		if (!oCheckbox)
+		{
+			// Create the checkbox.
+			oCheckbox = document.createElement('input');
+			oCheckbox.type = 'checkbox';
+			oCheckbox.className = this.opt.sButtonStrip + '_check';
+			oCheckbox.name = 'msgs[]';
+			oCheckbox.value = this.opt.aMessageIds[i];
+
+			oCheckboxContainer.appendChild(oCheckbox);
+		}
+
+		oCheckbox.addEventListener('click', this.handleClick.bind(this, oCheckbox));
 		oCheckboxContainer.style.display = '';
 	}
 
@@ -898,8 +912,8 @@ InTopicModeration.prototype.init = function()
 	else
 	{
 		oButtonStripDisplay = document.createElement('div');
-		oNewDiv.id = this.opt.sButtonStripDisplay;
-		oNewDiv.className = this.opt.sButtonStripClass || 'buttonlist floatbottom';
+		oButtonStripDisplay.id = this.opt.sButtonStripDisplay;
+		oButtonStripDisplay.className = this.opt.sButtonStripClass || 'buttonlist floatbottom';
 
 		oButtonStrip.appendChild(oButtonStripDisplay);
 	}
@@ -936,6 +950,14 @@ InTopicModeration.prototype.init = function()
 				['click', this.handleSubmit.bind(this, 'split')]
 			]
 		});
+
+	/*
+	 * Nothing is selected yet, so put the buttons in the state that says so.
+	 * They used to be built on the first click instead of here, which is why
+	 * nothing hid them to begin with - and pressing one with an empty
+	 * selection submits the form with no msgs[] at all.
+	 */
+	this.updateButtons();
 }
 
 InTopicModeration.prototype.handleClick = function(oCheckbox)
@@ -944,23 +966,28 @@ InTopicModeration.prototype.handleClick = function(oCheckbox)
 	// Keep stats on how many items were selected.
 	this.iNumSelected += oCheckbox.checked ? 1 : -1;
 
-	// Show the number of messages selected in each of the buttons.
-	if (this.opt.bCanRemove && !this.opt.bUseImageButton)
-	{
-		this.oRemoveButton.innerHTML = this.opt.sRemoveButtonLabel + ' [' + this.iNumSelected + ']';
-		this.oRemoveButton.style.display = this.iNumSelected < 1 ? "none" : "";
-	}
+	this.updateButtons();
+}
 
-	if (this.opt.bCanRestore && !this.opt.bUseImageButton)
-	{
-		this.oRestoreButton.innerHTML = this.opt.sRestoreButtonLabel + ' [' + this.iNumSelected + ']';
-		this.oRestoreButton.style.display = this.iNumSelected < 1 ? "none" : "";
-	}
+// Show the number of messages selected in each of the buttons, and hide them
+// while that number is zero.
+InTopicModeration.prototype.updateButtons = function()
+{
+	var aButtons = [
+		[this.opt.bCanRemove, this.oRemoveButton, this.opt.sRemoveButtonLabel],
+		[this.opt.bCanRestore, this.oRestoreButton, this.opt.sRestoreButtonLabel],
+		[this.opt.bCanSplit, this.oSplitButton, this.opt.sSplitButtonLabel]
+	];
 
-	if (this.opt.bCanSplit && !this.opt.bUseImageButton)
+	for (var i = 0; i < aButtons.length; i++)
 	{
-		this.oSplitButton.innerHTML = this.opt.sSplitButtonLabel + ' [' + this.iNumSelected + ']';
-		this.oSplitButton.style.display = this.iNumSelected < 1 ? "none" : "";
+		if (!aButtons[i][0] || !aButtons[i][1])
+			continue;
+
+		if (!this.opt.bUseImageButton)
+			aButtons[i][1].innerHTML = aButtons[i][2] + ' [' + this.iNumSelected + ']';
+
+		aButtons[i][1].style.display = this.iNumSelected < 1 ? "none" : "";
 	}
 }
 

--- a/Themes/default/scripts/topic.js
+++ b/Themes/default/scripts/topic.js
@@ -872,20 +872,27 @@ function InTopicModeration(oOptions)
 
 InTopicModeration.prototype.init = function()
 {
+	/*
+	 * The topic draws two of these strips - one for the page and one for the
+	 * mobile menu - and they share the containers, so the second instance
+	 * finds the checkboxes the first one already made. Collect those once,
+	 * under the message id each one carries, and listen to them as well
+	 * rather than putting a second checkbox beside every post. This file is
+	 * the only thing that emits a msgs[] input, so there is nothing else on
+	 * the page for this to pick up.
+	 */
+	var oExisting = {};
+	var aCheckboxes = document.querySelectorAll('input[name="msgs[]"]');
+
+	for (var j = 0, m = aCheckboxes.length; j < m; j++)
+		oExisting[aCheckboxes[j].value] = aCheckboxes[j];
+
 	// Add checkboxes to all the messages.
 	for (var i = 0, n = this.opt.aMessageIds.length; i < n; i++)
 	{
 		// Append it to the container
 		var oCheckboxContainer = document.getElementById(this.opt.sCheckboxContainerMask + this.opt.aMessageIds[i]);
-
-		/*
-		 * The topic draws two of these strips - one for the page and one for
-		 * the mobile menu - and they share the containers, so the second
-		 * instance finds a checkbox already sitting here. Take that one and
-		 * listen to it as well, rather than putting a second checkbox beside
-		 * every post.
-		 */
-		var oCheckbox = oCheckboxContainer.querySelector('input[name="msgs[]"]');
+		var oCheckbox = oExisting[this.opt.aMessageIds[i]];
 
 		if (!oCheckbox)
 		{


### PR DESCRIPTION
#### Description

With **Show quick-moderation as: checkboxes** turned on in a member's look-and-layout options, the topic display has three related problems. All of them come from `InTopicModeration` in `topic.js`.

**Two checkboxes beside every post.** `Display.template.php` constructs the widget twice - once for `moderationbuttons` and once for `moderationbuttons_mobile` - and both instances run the same loop appending a fresh `msgs[]` checkbox to the same `in_topic_mod_check_<id>` container. Measured on a 15-post page: 15 containers, 2 checkboxes each. Ticking one also only updates its own instance's counter, so the other strip's button reads `[0]`.

**The buttons work with nothing selected.** In 2.1 the Remove/Restore/Split buttons were created inside `handleClick()`, guarded by `bButtonsShown`, so they did not exist until something was ticked. 3.0 moved that block into `init()` and dropped the guard - `this.bButtonsShown` is still assigned in the constructor and now never read. The buttons therefore appear at page load, with no count, and pressing one submits `quickModForm` with no `msgs[]`:

```
2: Undefined array key "msgs"
array_map(): Argument #2 ($array) must be of type array, null given
```

and the member gets a blank page. `QuickModerationInTopic::__construct()` reads `$_REQUEST['msgs']` unguarded; all three sub-actions then need a non-empty list anyway (`split()` takes `min()` of it, the other two hand it to an `{array_int:...}`), so the action now redirects back to the topic when given nothing.

**A stray variable.** The same move left the `else` branch in `init()` assigning to `oNewDiv`, which is not declared anywhere - a `ReferenceError` if the button strip's display element is ever missing.

#### How to test

Profile → Look and Layout → *Show quick-moderation as*: **Checkboxes**. Open a topic.

- Before: two checkboxes per post; "Remove selected" and "Split selected" visible immediately; clicking one gives a blank page and the errors above in `smf_log_errors`.
- After: one checkbox per post; the buttons are hidden until something is ticked and then read `[1]`, `[2]`, … on **both** strips; the split-selected flow completes with an empty error log.

### Issues References (Fixes|Related|Closes)

Found while sweeping the topic display for the #7933 split.