### PR TITLE
[3.0] Name the icons in the message icon picker

### DIFF
--- a/Themes/default/scripts/topic.js
+++ b/Themes/default/scripts/topic.js
@@ -288,8 +288,12 @@ IconList.prototype.onIconsReceived = function (oXMLDoc)
 
 		const img = document.createElement('img');
 		img.src = icon.getAttribute('url');
-		img.alt = icon.getAttribute('name');
-		img.title = icon.firstChild ? icon.firstChild.nodeValue : '';
+		/*
+		 * The icon's name is its text, not an attribute - there has never been
+		 * a name attribute on these. Asking for one gave every icon in the
+		 * picker alt="null".
+		 */
+		img.alt = img.title = icon.firstChild ? icon.firstChild.nodeValue : '';
 		img.style.verticalAlign = 'middle';
 
 		span.appendChild(img);


### PR DESCRIPTION
#### Description

Clicking a post's message icon opens the icon picker, and every icon in it has `alt="null"`.

`IconList.onIconsReceived()` reads `icon.getAttribute('name')`, but the XML that `?action=xmlhttp;sa=messageicons` produces has no `name` attribute - the name is the element's text:

```xml
<icon value="lamp" url="…/post/lamp.png"><![CDATA[Lamp]]></icon>
```

`getAttribute()` returns `null`, and assigning that to `.alt` stringifies it. Measured on a topic: 13 icons, 13 alts reading `null`, while `title` - which reads the text - is correct throughout. Inherited from 2.1, where `script.js` builds the same markup the same way.

#### How to test

Open a topic as someone who can modify a post, click the icon next to the subject, and inspect the picker. Before: `alt="null"` on all of them. After: `alt="Standard"`, `"Thumb Up"`, `"Lamp"`, … matching the titles.

### Issues References (Fixes|Related|Closes)

Found while sweeping the topic display for the #7933 split.