### PR TITLE
[3.0] Stop logging a warning for every attachment that is not a JPEG

### DIFF
--- a/Sources/Graphics/Image.php
+++ b/Sources/Graphics/Image.php
@@ -325,7 +325,11 @@ class Image
 		}
 
 		// We don't need to create a thumbnail if one is already embedded.
-		if (\function_exists('exif_thumbnail') && exif_thumbnail($this->source) !== false) {
+		// checkForEmbeddedThumb() answered this when the image was loaded, and
+		// it does so without a warning: exif_thumbnail() emits one for every
+		// format that cannot carry an embedded thumbnail, so asking it here
+		// again put a row in the error log for each PNG anyone uploaded.
+		if ($this->embedded_thumb) {
 			return false;
 		}
 


### PR DESCRIPTION
#### Description

Attaching a PNG to a post writes a row to `smf_log_errors`:

```
2: exif_thumbnail(7_ddfa4352…dat): File not supported
/index.php?action=uploadAttach;sa=add;…
```

`Image::createThumbnail()` calls `exif_thumbnail($this->source)` to find out whether the image already has an embedded thumbnail. Only JPEG and TIFF can carry one; for every other format the function raises `E_WARNING` and returns `false`, and SMF's error handler logs it. So every PNG, GIF or WebP attachment - and every avatar - leaves a warning behind for a completely ordinary upload.

The constructor already answered this question: `checkForEmbeddedThumb()` runs on load and sets `$this->embedded_thumb`, and it suppresses its own `exif_read_data()` call for precisely this reason. Reading the property removes the warning and a redundant second read of the file.

#### How to test

Attach a PNG to a post. Before: one `general` row per upload in `smf_log_errors`. After: none, and the thumbnail is still generated (`smf_attachments` gets its `attachment_type = 3` row and the post shows a clickable thumb).

### Issues References (Fixes|Related|Closes)

Found while sweeping the topic display for the #7933 split.