### PR TITLE
[3.0] End the request when the forum is in maintenance mode

### DIFF
--- a/Sources/Forum.php
+++ b/Sources/Forum.php
@@ -742,6 +742,16 @@ class Forum
 		Utils::$context['title'] = Utils::htmlspecialchars(Config::$mtitle);
 		Utils::$context['description'] = &Config::$mmessage;
 		Utils::$context['page_title'] = Lang::getTxt('maintain_mode', file: 'Login');
+
+		// And that is as far as this request goes. 2.1 made this the action, so
+		// nothing else ever ran; here it is a step before one, and returning
+		// hands the request straight back to the action we just decided must
+		// not happen. Every side effect of it still happens, and whatever it
+		// puts in 'sub_template' or 'sub_templates' takes the page back.
+		Utils::obExit();
+
+		// We should never reach this point, but just in case...
+		die('No direct access...');
 	}
 
 	/**


### PR DESCRIPTION
#### Description

**Maintenance mode does not stop anything.** It sets up the notice, sends 503,
and then lets the request it just refused go ahead and run.

`Forum::inMaintenance()` fills in `Utils::$context` and returns. `preflight()`
returns too, and `Forum::execute()` moves straight on to
`self::$current_action->execute()`.

Two things follow.

**The action's side effects all happen.** Registering while the forum is in
maintenance creates the member, queues the activation mail, and answers with the
maintenance page — so the only party who does not know the account exists is the
person who just made it:

```
$ # $maintenance = 1
$ curl -s ... 'index.php?action=signup2' -d 'user=maintuser' ... | grep '<title>'
<title>Maintenance Mode
$ mysql -e "SELECT id_member, member_name FROM smf_members WHERE member_name='maintuser'"
5   maintuser
```

**And what gets drawn is whatever the action left behind.** `inMaintenance()`
sets `sub_template`, so an action that sets its own wins the page back, and the
board index sets `sub_templates` and wins it outright. On a forum in maintenance,
as a guest:

| Request | Shown |
|---|---|
| `index.php` | the board index, every board and last post |
| `?board=1.0` | maintenance notice |
| `?action=help` | the help page |
| `?action=signup` | the registration agreement |
| `?action=stats` | maintenance notice |

Only the actions that set neither show the notice, which is why this has looked
like it works.

2.1 made this the action rather than a step before one — `return 'InMaintenance'`
from `smf_main()` — so nothing else ever ran.

#### What changes

`inMaintenance()` ends the request, the same way `User::kickIfGuest()` does two
checks later in the same method: `Utils::obExit()` and then `die()` for the case
that cannot happen.

#### Testing

With `$maintenance = 1`, as a guest: every row in the table above is the
maintenance notice with a 503, and `?action=login` is still the login form with a
200. As an admin: the forum is untouched, and logging in fresh through the
maintenance form still works. No new rows in `smf_log_errors`.

### Issues References (Fixes|Related|Closes)

Related to #7933
