### PR TITLE
[3.0] Answer an activation link that names nobody

### DIFF
--- a/Sources/Actions/Activate.php
+++ b/Sources/Actions/Activate.php
@@ -251,6 +251,13 @@ class Activate implements ActionInterface, Routable
 		// Load the member.
 		$this->loadMember();
 
+		// Nobody by that name or id. execute() shows the form that asks for
+		// one, but only if it gets that far: the check below reads $this->member
+		// first, and loadMember() leaves it unassigned when it finds nothing.
+		if (!isset($this->member)) {
+			return;
+		}
+
 		// Already activated, so redirect to the login screen.
 		if (!\in_array((int) $this->member->is_activated, [User::NOT_ACTIVATED, User::UNVALIDATED])) {
 			Utils::redirectexit('action=login');


### PR DESCRIPTION
#### Description

An activation link whose `u` names nobody is a 500.

```
$ curl -s -o /dev/null -w '%{http_code}\n' 'index.php?action=activate;u=999;code=x'
500
$ mysql -e "SELECT message, file, line FROM smf_log_errors ORDER BY id_error DESC LIMIT 1"
Typed property SMF\Actions\Activate::$member must not be accessed before initialization
/var/www/html/Sources/Actions/Activate.php   255
```

`Activate::loadMember()` assigns `$this->member` only when it finds someone. The
line after the call reads `$this->member->is_activated` unconditionally.

**The handling for this already exists and cannot be reached.**
`Activate::execute()` opens with

```php
if (!isset($this->member)) {
    if (empty($_REQUEST['u']) && empty($_POST['user'])) {
        $this->showResendRequest();
    } else {
        $this->showRetryInvalidUser();
    }

    return;
}
```

which is 2.1's behaviour — the form asking for a username and an activation code.
The constructor throws first, so `execute()` never runs.

This is reachable in ordinary use: a member deleted while their activation mail
is in flight, an id that got mangled in a mail client, or a link followed after
the account was pruned.

#### What changes

The constructor returns when `loadMember()` found nothing, and leaves the answer
to the guard `execute()` already has.

#### Testing

`?action=activate;u=999;code=x` and `?action=activate;u=999` both give a 200 with
"User does not exist" and the retry form, and log nothing. A real activation link
still activates; `?action=activate` with no `u` still shows the resend form.

### Issues References (Fixes|Related|Closes)

Related to #7933
