### PR TITLE
[3.0] Say a username is taken instead of erroring about it

### DIFF
--- a/Sources/Security.php
+++ b/Sources/Security.php
@@ -253,7 +253,12 @@ class Security
 			$errors[] = ['lang', 'username_reserved', 'general', [Lang::getTxt('guest_title', file: 'General')]];
 		}
 
-		if ($check_reserved_name && self::isReservedName($username, $memID, false)) {
+		// $return_error is a promise to hand the problems back rather than die
+		// of them, and the caller that asks for it wants XML. isReservedName()
+		// dies by default, so say otherwise, or a name on the admin's reserved
+		// list answers the registration form's availability check with an error
+		// page and puts a row in the error log on the way.
+		if ($check_reserved_name && self::isReservedName($username, $memID, false, !$return_error)) {
 			$errors[] = ['done', '(' . Utils::htmlspecialchars($username) . ') ' . Lang::getTxt('name_in_use', file: 'General')];
 		}
 
@@ -339,13 +344,21 @@ class Security
 			}
 		}
 
+		/*
+		 * A name someone else already answers to is taken, not forbidden, and
+		 * the two want telling apart: the checks above are about what an admin
+		 * banned, and dying with "that name is reserved" is the right answer to
+		 * them. These two say "somebody has this already", which is ordinary
+		 * and is what every caller is asking about, so hand the answer back and
+		 * let them phrase it. 2.1 asked the members table here and did the same.
+		 */
 		// Check for similar existing member names.
-		if (Unicode\SpoofDetector::checkSimilarMemberName($name, $current_id_member, $fatal)) {
+		if (Unicode\SpoofDetector::checkSimilarMemberName($name, $current_id_member, false)) {
 			return true;
 		}
 
 		// Does the name resemble a member group name?
-		if (Unicode\SpoofDetector::checkSimilarGroupName($name, $fatal)) {
+		if (Unicode\SpoofDetector::checkSimilarGroupName($name, false)) {
 			return true;
 		}
 


### PR DESCRIPTION
#### Description

The registration form asks whether a username is free as it is typed. For almost
every name anybody actually tries, the answer is an error page.

On `release-3.0`, `?action=signup;sa=usernamecheck;xml`:

| Typed | Answer |
|---|---|
| `zzznewuser` | `<username valid="1">` |
| `Guest` | `<username valid="0">` |
| `testmember` (an existing member) | the fatal error page |
| `Administrator` (a membergroup) | the fatal error page |
| `Webmaster` (on the reserved list) | the fatal error page |

Each one also writes a row to `smf_log_errors`, so a busy registration page fills
the error log with ordinary typing. And `checkUsernameCallback()` reads
`XMLDoc.getElementsByTagName("username")[0]`, which is `undefined` when the body
is HTML, so the check throws and the icon never updates either.

**Why.** `Security::isReservedName()` passes `$fatal` down to the two checks that
look for an existing member or membergroup with a similar name:

```php
if (Unicode\SpoofDetector::checkSimilarMemberName($name, $current_id_member, $fatal)) {
```

2.1 asked the members table in that same spot and only ever returned `true` —
its `$fatal` branches covered the reserved-word list, the censor and `*`, which
are things an admin forbade. "Somebody already has this name" is not one of
those, and every caller is asking about exactly that.

**The same fault has a second symptom in the profile.** `Profile.php` has

```php
if ($this->name != $value && Security::isReservedName($value, $this->id)) {
    return 'name_taken';
}
```

`return 'name_taken'` is dead. Changing a display name to one already in use ends
the request with "contains the reserved name" — the wrong words as well as the
wrong shape — before the return is reached.

#### What changes

Those two checks report rather than die, so `isReservedName()` answers the
question it was asked and the callers phrase it. The reserved-word list, the
censor and `*` still die when `$fatal` says so.

`validateUsername()` has the same shape one level up: `$return_error` is a
promise to hand the problems back, and the caller that asks for it wants XML, so
pass it on. Without that a name on the admin's reserved list still ends the
availability check with an error page.

#### Testing

Every row of the table above now returns `<username valid="0">` or
`valid="1">` correctly, including `star*name` and the empty string, with **zero**
new rows in `smf_log_errors` across the whole run.

Setting a display name to one in use now shows the inline field error "That
username/display name has already been taken" instead of a fatal page.

Submitting a registration with a reserved username still refuses it — now in the
form's error box rather than as an error page. A clean registration still
succeeds.

### Issues References (Fixes|Related|Closes)

Related to #7933
