### PR TITLE
[3.0] Reserve the names on the reserved names list

### DIFF
--- a/Sources/Db/Schema/Table.php
+++ b/Sources/Db/Schema/Table.php
@@ -563,7 +563,12 @@ abstract class Table
 			}
 		}
 
-		$replacements['{$default_reserved_names}'] = strtr($replacements['{$default_reserved_names}'], ['\\\\n' => '\\n']);
+		// The language string spells the separators as the two characters
+		// backslash and n, because 2.1 fed this list to an SQL literal and let
+		// the database turn them into newlines. Nothing does that here - the
+		// value goes in as a query parameter - so do it now, or the entire list
+		// is stored as one name that nobody would ever type.
+		$replacements['{$default_reserved_names}'] = strtr($replacements['{$default_reserved_names}'], ['\\\\n' => "\n", '\\n' => "\n"]);
 
 		// Replace any placeholders in the initial data.
 		foreach ($this->initial_data as &$row) {

--- a/Sources/Db/Schema/Table.php
+++ b/Sources/Db/Schema/Table.php
@@ -563,11 +563,6 @@ abstract class Table
 			}
 		}
 
-		// The language string spells the separators as the two characters
-		// backslash and n, because 2.1 fed this list to an SQL literal and let
-		// the database turn them into newlines. Nothing does that here - the
-		// value goes in as a query parameter - so do it now, or the entire list
-		// is stored as one name that nobody would ever type.
 		$replacements['{$default_reserved_names}'] = strtr($replacements['{$default_reserved_names}'], ['\\\\n' => "\n", '\\n' => "\n"]);
 
 		// Replace any placeholders in the initial data.

--- a/Sources/Unicode/SpoofDetector.php
+++ b/Sources/Unicode/SpoofDetector.php
@@ -242,11 +242,6 @@ class SpoofDetector
 		// This will hold all the names that are similar to $name.
 		$homograph_names = [];
 
-		// A forum installed before the seeding was fixed has the separators as
-		// the two characters backslash and n rather than newlines, so take
-		// either. The admin page has always had its own str_replace for the
-		// same reason, which is why the list looked right there while nothing
-		// on it was ever reserved.
 		$reserved_names = preg_split('~\R|\\\\n~', Config::$modSettings['reserveNames']);
 
 		// Check each name in the list...

--- a/Sources/Unicode/SpoofDetector.php
+++ b/Sources/Unicode/SpoofDetector.php
@@ -242,7 +242,12 @@ class SpoofDetector
 		// This will hold all the names that are similar to $name.
 		$homograph_names = [];
 
-		$reserved_names = explode("\n", Config::$modSettings['reserveNames']);
+		// A forum installed before the seeding was fixed has the separators as
+		// the two characters backslash and n rather than newlines, so take
+		// either. The admin page has always had its own str_replace for the
+		// same reason, which is why the list looked right there while nothing
+		// on it was ever reserved.
+		$reserved_names = preg_split('~\R|\\\\n~', Config::$modSettings['reserveNames']);
 
 		// Check each name in the list...
 		foreach ($reserved_names as $reserved) {


### PR DESCRIPTION
#### Description

A fresh 3.0 forum reserves nothing. `Admin`, `Webmaster`, `Guest` and `root` are
all free to register, and so is anything an admin adds afterwards — until they
open Registration → Reserved Names and press Save, which is the only thing that
ever writes the setting properly.

The stored value on a fresh install:

```
$ mysql -e "SELECT HEX(value) FROM smf_settings WHERE variable='reserveNames'"
41646D696E5C6E5765626D61737465725C6E47756573745C6E726F6F74
                ^^^^                ^^^^         ^^^^
```

`5C6E` is backslash-n, two characters, not a newline. `checkReservedName()` does
`explode("\n", …)` and gets one element back: the whole list as a single name
that nobody would ever type.

**Where it comes from.** The default is a language string that spells its
separators that way:

```php
$txt['default_reserved_names'] = 'Admin\nWebmaster\nGuest\nroot';
```

2.1 fed that straight into an SQL literal — plain `'…'` for MySQL, `E'…'` for
PostgreSQL — and both engines turned the escapes into newlines on the way in.
3.0 defines its schema in PHP and inserts the value as a query parameter, so
nothing unescapes it. The `strtr()` in `Table.php` that survives from 2.1 only
turns `\n` back into `\n`; it was compensating for the escaping that the SQL
literal then undid, and there is no SQL literal any more.

**Why nobody noticed.** `Admin/Registration.php` has carried
`str_replace('\n', "\n", …)` since 2.1, so the textarea splits the list onto
separate lines and it looks exactly right. It has just never been in force.

#### What changes

Seeds real newlines, so a new install is correct.

Reads either form in `checkReservedName()`, so a forum that is already installed
starts enforcing its list without the admin having to go and re-save a page they
have no reason to think is broken. That is also why this needs no migration.

#### Testing

On a forum installed before the change, `?action=signup;sa=usernamecheck;xml`:
`root`, `Webmaster` and `Guest` come back `valid="0"`; `r00t` and `zzznewuser`
come back `valid="1"`. Submitting a registration as `Webmaster` is refused with
the name in the error box. A name not on the list registers as before.

(Read together with #9483, which is what makes the refusal a `valid="0"` rather
than an error page. Each stands alone.)

### Issues References (Fixes|Related|Closes)

Related to #7933
