### PR TITLE
[3.0] Print the registration errors that carry their own words

### DIFF
--- a/Sources/Actions/Register2.php
+++ b/Sources/Actions/Register2.php
@@ -573,7 +573,12 @@ class Register2 extends Register
 				1 = The text/index.
 				2 = Whether to log.
 				3 = sprintf data if necessary. */
-			$message = Lang::getTxt($error[1], (array) ($error[3] ?? []), file: 'Errors');
+			// A 'done' error carries its own words - the password strength
+			// feedback and "that name is already in use" are both built as
+			// sentences rather than keys. Looking them up in Errors finds
+			// nothing and getTxt() hands back an empty string, which is what
+			// the registration form was printing: a bullet with no text in it.
+			$message = ($error[0] ?? 'lang') === 'done' ? $error[1] : Lang::getTxt($error[1], (array) ($error[3] ?? []), file: 'Errors');
 
 			// What to do, what to do, what to do.
 			if ($return_errors) {

--- a/Sources/Actions/Register2.php
+++ b/Sources/Actions/Register2.php
@@ -573,11 +573,6 @@ class Register2 extends Register
 				1 = The text/index.
 				2 = Whether to log.
 				3 = sprintf data if necessary. */
-			// A 'done' error carries its own words - the password strength
-			// feedback and "that name is already in use" are both built as
-			// sentences rather than keys. Looking them up in Errors finds
-			// nothing and getTxt() hands back an empty string, which is what
-			// the registration form was printing: a bullet with no text in it.
 			$message = ($error[0] ?? 'lang') === 'done' ? $error[1] : Lang::getTxt($error[1], (array) ($error[3] ?? []), file: 'Errors');
 
 			// What to do, what to do, what to do.


### PR DESCRIPTION
#### Description

Refuse a registration for a weak password and the form says "The following errors
were detected in your registration. Please correct them to continue:" above a
bullet with nothing in it.

```
$ # register with passwrd1=password
<div class="errorbox">
    <span>The following errors were detected in your registration…</span>
    <ul>
        <li></li>
    </ul>
</div>
```

Each entry in `$reg_errors` is `[kind, text, log, args]`, where the kind is
`'lang'` for a language key and `'done'` for a finished sentence. The comment
directly above the loop says so:

```php
/* Note for each error:
    0 = 'lang' if it's an index, 'done' if it's clear text.
    1 = The text/index. … */
$message = Lang::getTxt($error[1], (array) ($error[3] ?? []), file: 'Errors');
```

The loop never reads `$error[0]`. It looks every error up in `Errors`, a `'done'`
error is not a key there, `getTxt()` returns an empty string for a key it cannot
find, and that empty string is the bullet. 2.1 read the kind here.

**What reaches it.** `Register2` builds `['done', $password_error, false]`
whenever `validatePassword()` hands back something that is not a language key —
which is the zxcvbn feedback, so every strength rejection except `short`. It is
also how `Security::validateUsername()` reports a name already in use.

#### What changes

One line: a `'done'` error prints its own words.

#### Testing

Registering with `password`:

> This is a top-10 common password.
> Add another word or two. Uncommon words are better.

with `abc`, unchanged: "Your password must be at least 6 characters long."
A clean registration still succeeds.

### Issues References (Fixes|Related|Closes)

Related to #7933
