### PR TITLE
[3.0] Let the registration form ask whether a username is taken

### DIFF
--- a/Sources/Actions/Register.php
+++ b/Sources/Actions/Register.php
@@ -347,9 +347,18 @@ class Register implements ActionInterface, Routable
 	 */
 	public function checkUsername(): void
 	{
-		// Who are you again?
-		if (empty($_COOKIE) || empty($_COOKIE[Config::$cookiename]) || empty($_SERVER['HTTP_REFERER']) || stripos($_SERVER['HTTP_REFERER'], Config::$scripturl) !== 0) {
+		/*
+		 * Who are you again? Somebody with a session, who got here from a page
+		 * of ours. Config::$cookiename is the login cookie, and the person
+		 * filling in the registration form has not got one by definition, so
+		 * asking for it turns everybody this is for away.
+		 */
+		if (empty($_COOKIE) || empty($_SERVER['HTTP_REFERER']) || stripos($_SERVER['HTTP_REFERER'], Config::$scripturl) !== 0) {
+			// And that is the whole answer. Carrying on would send the status
+			// and then the very thing it was refusing.
 			Utils::sendHttpStatus(403);
+
+			Utils::obExit(false);
 		}
 
 		// This is XML!


### PR DESCRIPTION
#### Description

The registration form's "is this username free?" check has never returned an
answer on 3.0. It has been answering **403 to everybody it exists for**, and 3.0
now treats a 403 as no answer at all.

**The guard asks for a login cookie.**

```php
if (empty($_COOKIE) || empty($_COOKIE[Config::$cookiename]) || empty($_SERVER['HTTP_REFERER']) || …) {
    Utils::sendHttpStatus(403);
}
```

`Config::$cookiename` is the *login* cookie. Somebody filling in the registration
form does not have one — that is what registering is for — so the only people who
get past it are the ones who already have an account.

**And it does not stop.** `sendHttpStatus(403)` returns, and the XML it just
refused is written out underneath the refusal. 2.1 got away with that: its raw
`XMLHttpRequest` never looked at the status, so the body came through and the
check worked.

3.0's wrapper does look:

```js
const promise = fetch(sUrl, options)
    .then(res => res.ok ? res : Promise.reject(res))
```

so the promise rejects, `getXMLDocument()` calls the callback with `false`, and
`checkUsernameCallback()` reads `XMLDoc.getElementsByTagName(…)` off it and
throws. Whatever is typed, the icon beside the field never moves.

Reproducing it needs a browser, because curl sends no cookies of its own — that
is probably why it has gone unnoticed. In the console on the registration page:

```
> await smc_Request.fetchXML(smf_prepareScriptUrl(smf_scripturl) + 'action=signup;sa=usernamecheck;xml;username=zzzfreshname')
Uncaught Error: Network request failed: undefined
```

#### What changes

Asks for a session and a referer from this forum — which is what the check was
after — and stops when it refuses, rather than sending the refusal and then the
thing it refused.

#### Testing

With this, on the registration page: an unused name turns the icon green with
"Username is available", an existing member's name and a name on the reserved
list turn it red, and typing again puts it back to "Check if username is
available". Clicking the icon asks again on demand. No console errors.

(#9483 is what makes a taken name come back as `valid="0"` rather than an error
page — without it this shows the same red icon, from a parse failure rather than
an answer. Each stands alone.)

### Issues References (Fixes|Related|Closes)

Related to #7933
