### PR TITLE
[3.0] Theme split (wave 4, part 34) — let the field say what it is

### DIFF
--- a/Themes/default/Register.template.php
+++ b/Themes/default/Register.template.php
@@ -76,7 +76,7 @@ function template_registration_form()
 		<script>
 			function verifyAgree()
 			{
-				if (currentAuthMethod == \'passwd\' && document.forms.registration.smf_autov_pwmain.value != document.forms.registration.smf_autov_pwverify.value)
+				if (currentAuthMethod == \'passwd\' && document.forms.registration.passwrd1.value != document.forms.registration.passwrd2.value)
 				{
 					alert("', Lang::getTxt('register_passwords_differ_js', file: 'Login'), '");
 					return false;
@@ -118,39 +118,28 @@ function template_registration_form()
 				<fieldset>
 					<dl class="register_form">
 						<dt>
-							<strong><label for="smf_autov_username">', Lang::getTxt('username', file: 'General'), '</label></strong>
+							<strong><label for="reg_username">', Lang::getTxt('username', file: 'General'), '</label></strong>
 						</dt>
 						<dd>
-							<input type="text" name="user" id="smf_autov_username" size="50" maxlength="25" value="', Utils::$context['username'] ?? '', '">
-							<span id="smf_autov_username_div" style="display: none;">
-								<a id="smf_autov_username_link" href="#">
-									<span id="smf_autov_username_img" class="main_icons check"></span>
-								</a>
-							</span>
+							<input type="text" name="user" id="reg_username" data-autov="username" size="50" maxlength="25" value="', Utils::$context['username'] ?? '', '">
 						</dd>
-						<dt><strong><label for="smf_autov_reserve1">', Lang::getTxt('user_email_address', file: 'General'), '</label></strong></dt>
+						<dt><strong><label for="reg_email">', Lang::getTxt('user_email_address', file: 'General'), '</label></strong></dt>
 						<dd>
-							<input type="email" name="email" id="smf_autov_reserve1" size="50" value="', Utils::$context['email'] ?? '', '">
+							<input type="email" name="email" id="reg_email" data-autov="reserve1" size="50" value="', Utils::$context['email'] ?? '', '">
 						</dd>
 					</dl>
 					<dl class="register_form" id="password1_group">
-						<dt><strong><label for="smf_autov_pwmain">', Lang::getTxt('choose_pass', file: 'General'), '</label></strong></dt>
+						<dt><strong><label for="reg_pwmain">', Lang::getTxt('choose_pass', file: 'General'), '</label></strong></dt>
 						<dd>
-							<input type="password" name="passwrd1" id="smf_autov_pwmain" size="50">
-							<span id="smf_autov_pwmain_div" style="display: none;">
-								<span id="smf_autov_pwmain_img" class="main_icons invalid"></span>
-							</span>
+							<input type="password" name="passwrd1" id="reg_pwmain" data-autov="pwmain" size="50">
 						</dd>
 					</dl>
 					<dl class="register_form" id="password2_group">
 						<dt>
-							<strong><label for="smf_autov_pwverify">', Lang::getTxt('verify_pass', file: 'General'), '</label></strong>
+							<strong><label for="reg_pwverify">', Lang::getTxt('verify_pass', file: 'General'), '</label></strong>
 						</dt>
 						<dd>
-							<input type="password" name="passwrd2" id="smf_autov_pwverify" size="50">
-							<span id="smf_autov_pwverify_div" style="display: none;">
-								<span id="smf_autov_pwverify_img" class="main_icons valid"></span>
-							</span>
+							<input type="password" name="passwrd2" id="reg_pwverify" data-autov="pwverify" size="50">
 						</dd>
 					</dl>
 					<dl class="register_form" id="notify_announcements">

--- a/Themes/default/Reminder.template.php
+++ b/Themes/default/Reminder.template.php
@@ -106,17 +106,11 @@ function template_set_password()
 				<dl>
 					<dt>', Lang::getTxt('choose_pass', file: 'General'), '</dt>
 					<dd>
-						<input type="password" name="passwrd1" id="smf_autov_pwmain" size="22">
-						<span id="smf_autov_pwmain_div" style="display: none;">
-							<span id="smf_autov_pwmain_img" class="main_icons invalid"></span>
-						</span>
+						<input type="password" name="passwrd1" data-autov="pwmain" size="22">
 					</dd>
 					<dt>', Lang::getTxt('verify_pass', file: 'General'), '</dt>
 					<dd>
-						<input type="password" name="passwrd2" id="smf_autov_pwverify" size="22">
-						<span id="smf_autov_pwverify_div" style="display: none;">
-							<span id="smf_autov_pwverify_img" class="main_icons invalid"></span>
-						</span>
+						<input type="password" name="passwrd2" data-autov="pwverify" size="22">
 					</dd>
 				</dl>
 				<p class="align_center">
@@ -162,17 +156,11 @@ function template_ask()
 					<dd><input type="text" name="secret_answer" size="22"></dd>
 					<dt>', Lang::getTxt('choose_pass', file: 'General'), '</dt>
 					<dd>
-						<input type="password" name="passwrd1" id="smf_autov_pwmain" size="22">
-						<span id="smf_autov_pwmain_div" style="display: none;">
-							<span id="smf_autov_pwmain_img" class="main_icons invalid"></span>
-						</span>
+						<input type="password" name="passwrd1" data-autov="pwmain" size="22">
 					</dd>
 					<dt>', Lang::getTxt('verify_pass', file: 'General'), '</dt>
 					<dd>
-						<input type="password" name="passwrd2" id="smf_autov_pwverify" size="22">
-						<span id="smf_autov_pwverify_div" style="display: none;">
-							<span id="smf_autov_pwverify_img" class="main_icons valid"></span>
-						</span>
+						<input type="password" name="passwrd2" data-autov="pwverify" size="22">
 					</dd>
 				</dl>
 				<div class="auto_flow">

--- a/Themes/default/scripts/register.js
+++ b/Themes/default/scripts/register.js
@@ -5,125 +5,135 @@ function smfRegister(formID, passwordDifficultyLevel, regTextStrings)
 	this.refreshMainPassword = refreshMainPassword;
 	this.refreshVerifyPassword = refreshVerifyPassword;
 
-	var verificationFields = new Array();
-	var verificationFieldLength = 0;
-	var textStrings = regTextStrings ? regTextStrings : new Array();
-	var passwordLevel = passwordDifficultyLevel ? passwordDifficultyLevel : 0;
+	var verificationFields = {};
+	var reservedFieldCount = 0;
+	var textStrings = regTextStrings || {};
+	var passwordLevel = passwordDifficultyLevel || 0;
 
 	// Setup all the fields!
 	autoSetup(formID);
 
 	// This is a field which requires some form of verification check.
-	function addVerificationField(fieldType, fieldID)
+	function addVerificationField(fieldType, inputHandle)
 	{
-		// Check the field exists.
-		if (!document.getElementById(fieldID))
-			return;
-
-		// Get the handles.
-		var inputHandle = document.getElementById(fieldID);
-		var imageHandle = document.getElementById(fieldID + '_img') ? document.getElementById(fieldID + '_img') : false;
-		var divHandle = document.getElementById(fieldID + '_div') ? document.getElementById(fieldID + '_div') : false;
-
 		// What is the event handler?
-		var eventHandler = false;
-		if (fieldType == 'pwmain')
+		var eventHandler;
+
+		if (fieldType == 'pwmain' || fieldType == 'reserved')
 			eventHandler = refreshMainPassword;
 		else if (fieldType == 'pwverify')
 			eventHandler = refreshVerifyPassword;
 		else if (fieldType == 'username')
 			eventHandler = refreshUsername;
-		else if (fieldType == 'reserved')
-			eventHandler = refreshMainPassword;
+
+		/*
+		 * A reserved field is only something the password may not contain - the
+		 * email address, say - so it has nothing of its own to report. The other
+		 * three each show an icon, which the templates used to write out hidden
+		 * and which nothing outside this file ever addressed. Build it here.
+		 */
+		var iconHandle;
+
+		if (fieldType != 'reserved')
+		{
+			iconHandle = document.createElement('span');
+			iconHandle.className = 'main_icons';
+
+			// The username icon doubles as the button that asks the server.
+			if (fieldType == 'username')
+			{
+				var linkHandle = document.createElement('a');
+				linkHandle.href = '#';
+				linkHandle.appendChild(iconHandle);
+				linkHandle.addEventListener('click', function (e) {
+					e.preventDefault();
+					checkUsername(false);
+				}, false);
+
+				inputHandle.after(linkHandle);
+			}
+			else
+				inputHandle.after(iconHandle);
+		}
 
 		// Store this field.
-		var vFieldIndex = fieldType == 'reserved' ? fieldType + verificationFieldLength : fieldType;
-		verificationFields[vFieldIndex] = Array(6);
-		verificationFields[vFieldIndex][0] = fieldID;
-		verificationFields[vFieldIndex][1] = inputHandle;
-		verificationFields[vFieldIndex][2] = imageHandle;
-		verificationFields[vFieldIndex][3] = divHandle;
-		verificationFields[vFieldIndex][4] = fieldType;
-		verificationFields[vFieldIndex][5] = inputHandle.className;
+		var vFieldIndex = fieldType == 'reserved' ? fieldType + reservedFieldCount++ : fieldType;
 
-		// Keep a count to it!
-		verificationFieldLength++;
+		verificationFields[vFieldIndex] = {
+			type: fieldType,
+			input: inputHandle,
+			icon: iconHandle,
+			className: inputHandle.className
+		};
 
 		// Step to it!
 		if (eventHandler)
 		{
-			createEventListener(inputHandle);
 			inputHandle.addEventListener('keyup', eventHandler, false);
 			eventHandler();
 
 			// Username will auto check on blur!
-			inputHandle.addEventListener('blur', autoCheckUsername, false);
+			if (fieldType == 'username')
+				inputHandle.addEventListener('blur', autoCheckUsername, false);
 		}
-
-		// Make the div visible!
-		if (divHandle)
-			divHandle.style.display = '';
-	}
-
-	// A button to trigger a username search?
-	function addUsernameSearchTrigger(elementID)
-	{
-		var buttonHandle = document.getElementById(elementID);
-
-		// Attach the event to this element.
-		createEventListener(buttonHandle);
-		buttonHandle.addEventListener('click', checkUsername, false);
 	}
 
 	// This function will automatically pick up all the necessary verification fields and initialise their visual status.
 	function autoSetup(formID)
 	{
-		if (!document.getElementById(formID))
+		var formHandle = document.getElementById(formID);
+
+		if (!formHandle)
 			return false;
 
-		var curElement, curType;
-		for (var i = 0, n = document.getElementById(formID).elements.length; i < n; i++)
+		for (var i = 0, n = formHandle.elements.length; i < n; i++)
 		{
-			curElement = document.getElementById(formID).elements[i];
+			var curElement = formHandle.elements[i];
 
-			// Does the ID contain the keyword 'autov'?
-			if (curElement.id.indexOf('autov') != -1 && (curElement.type == 'text' || curElement.type == 'password'))
-			{
-				// This is probably it - but does it contain a field type?
-				curType = 0;
-				// Username can only be done with XML.
-				if (curElement.id.indexOf('username') != -1 && window.XMLHttpRequest)
-					curType = 'username';
-				else if (curElement.id.indexOf('pwmain') != -1)
-					curType = 'pwmain';
-				else if (curElement.id.indexOf('pwverify') != -1)
-					curType = 'pwverify';
-				// This means this field is reserved and cannot be contained in the password!
-				else if (curElement.id.indexOf('reserve') != -1)
-					curType = 'reserved';
+			// The field says what it is, in data-autov.
+			var curType = curElement.dataset.autov;
 
-				// If we're happy let's add this element!
-				if (curType)
-					addVerificationField(curType, curElement.id);
+			if (!curType || (curElement.type != 'text' && curElement.type != 'password' && curElement.type != 'email'))
+				continue;
 
-				// If this is the username do we also have a button to find the user?
-				if (curType == 'username' && document.getElementById(curElement.id + '_link'))
-				{
-					addUsernameSearchTrigger(curElement.id + '_link');
-				}
-			}
+			// A reserved field is one the password may not contain.
+			if (curType.indexOf('reserve') === 0)
+				curType = 'reserved';
+
+			addVerificationField(curType, curElement);
 		}
 
 		return true;
 	}
 
 	// What is the password state?
-	function refreshMainPassword(called_from_verify)
+	function refreshMainPassword()
 	{
 		if (!verificationFields['pwmain'])
 			return false;
 
-		var curPass = verificationFields['pwmain'][1].value;
+		var curPass = verificationFields['pwmain'].input.value;
+		var stringIndex = passwordProblem(curPass);
+		var isValid = stringIndex == '';
+
+		setVerificationImage(verificationFields['pwmain'], isValid, textStrings[isValid ? 'password_valid' : stringIndex]);
+
+		// As this has changed the verification one may have too!
+		if (verificationFields['pwverify'])
+			refreshVerifyPassword();
+
+		return isValid;
+	}
+
+	/*
+	 * Which of the password rules this password breaks, or an empty string if it
+	 * breaks none. Kept apart from refreshMainPassword() so that the verify
+	 * field can ask the same question without drawing the main field's icon: it
+	 * used to do that by calling refreshMainPassword() with a flag that stopped
+	 * the two from calling each other forever.
+	 */
+	function passwordProblem(curPass)
+	{
 		var stringIndex = '';
 
 		// Is it a valid length?
@@ -134,13 +144,13 @@ function smfRegister(formID, passwordDifficultyLevel, regTextStrings)
 		if (passwordLevel >= 1)
 		{
 			// If there is a username check it's not in the password!
-			if (verificationFields['username'] && verificationFields['username'][1].value && curPass.indexOf(verificationFields['username'][1].value) != -1)
+			if (verificationFields['username'] && verificationFields['username'].input.value && curPass.indexOf(verificationFields['username'].input.value) != -1)
 				stringIndex = 'password_reserved';
 
 			// Any reserved fields?
 			for (var i in verificationFields)
 			{
-				if (verificationFields[i][4] == 'reserved' && verificationFields[i][1].value && curPass.indexOf(verificationFields[i][1].value) != -1)
+				if (verificationFields[i].type == 'reserved' && verificationFields[i].input.value && curPass.indexOf(verificationFields[i].input.value) != -1)
 					stringIndex = 'password_reserved';
 			}
 
@@ -154,33 +164,21 @@ function smfRegister(formID, passwordDifficultyLevel, regTextStrings)
 			}
 		}
 
-		var isValid = stringIndex == '';
-		if (stringIndex == '')
-			stringIndex = 'password_valid';
-
-		// Set the image.
-		setVerificationImage(verificationFields['pwmain'][0], isValid, textStrings[stringIndex] ? textStrings[stringIndex] : '');
-		verificationFields['pwmain'][1].className = verificationFields['pwmain'][5] + ' ' + (isValid ? 'valid_input' : 'invalid_input');
-
-		// As this has changed the verification one may have too!
-		if (verificationFields['pwverify'] && !called_from_verify)
-			refreshVerifyPassword();
-
-		return isValid;
+		return stringIndex;
 	}
 
 	// Check that the verification password matches the main one!
 	function refreshVerifyPassword()
 	{
 		// Can't do anything without something to check again!
-		if (!verificationFields['pwmain'])
+		if (!verificationFields['pwmain'] || !verificationFields['pwverify'])
 			return false;
 
 		// Check and set valid status!
-		var isValid = verificationFields['pwmain'][1].value == verificationFields['pwverify'][1].value && refreshMainPassword(true);
-		var alt = textStrings[isValid == 1 ? 'password_valid' : 'password_no_match'] ? textStrings[isValid == 1 ? 'password_valid' : 'password_no_match'] : '';
-		setVerificationImage(verificationFields['pwverify'][0], isValid, alt);
-		verificationFields['pwverify'][1].className = verificationFields['pwverify'][5] + ' ' + (isValid ? 'valid_input' : 'invalid_input');
+		var curPass = verificationFields['pwmain'].input.value;
+		var isValid = curPass == verificationFields['pwverify'].input.value && passwordProblem(curPass) == '';
+
+		setVerificationImage(verificationFields['pwverify'], isValid, textStrings[isValid ? 'password_valid' : 'password_no_match']);
 
 		return true;
 	}
@@ -191,12 +189,7 @@ function smfRegister(formID, passwordDifficultyLevel, regTextStrings)
 		if (!verificationFields['username'])
 			return false;
 
-		// Restore the class name.
-		if (verificationFields['username'][1].className)
-			verificationFields['username'][1].className = verificationFields['username'][5];
-		// Check the image is correct.
-		var alt = textStrings['username_check'] ? textStrings['username_check'] : '';
-		setVerificationImage(verificationFields['username'][0], 'check', alt);
+		setVerificationImage(verificationFields['username'], 'check', textStrings['username_check']);
 
 		// Check the password is still OK.
 		refreshMainPassword();
@@ -217,7 +210,8 @@ function smfRegister(formID, passwordDifficultyLevel, regTextStrings)
 			return false;
 
 		// Get the username and do nothing without one!
-		var curUsername = verificationFields['username'][1].value;
+		var curUsername = verificationFields['username'].input.value;
+
 		if (!curUsername)
 			return false;
 
@@ -225,7 +219,7 @@ function smfRegister(formID, passwordDifficultyLevel, regTextStrings)
 			ajax_indicator(true);
 
 		// Request a search on that username.
-		checkName = curUsername.php_to8bit().php_urlencode();
+		var checkName = curUsername.php_to8bit().php_urlencode();
 		getXMLDocument(smf_prepareScriptUrl(smf_scripturl) + 'action=signup;sa=usernamecheck;xml;username=' + checkName, checkUsernameCallback);
 
 		return true;
@@ -234,33 +228,37 @@ function smfRegister(formID, passwordDifficultyLevel, regTextStrings)
 	// Callback for getting the username data.
 	function checkUsernameCallback(XMLDoc)
 	{
-		if (XMLDoc.getElementsByTagName("username"))
-			isValid = XMLDoc.getElementsByTagName("username")[0].getAttribute("valid");
-		else
-			isValid = true;
+		var tags = XMLDoc ? XMLDoc.getElementsByTagName('username') : null;
 
-		// What to alt?
-		var alt = textStrings[isValid == 1 ? 'username_valid' : 'username_invalid'] ? textStrings[isValid == 1 ? 'username_valid' : 'username_invalid'] : '';
+		// No answer we can read is not the same as "that name is fine".
+		if (!tags || !tags.length)
+			return;
 
-		verificationFields['username'][1].className = verificationFields['username'][5] + ' ' + (isValid == 1 ? 'valid_input' : 'invalid_input');
-		setVerificationImage(verificationFields['username'][0], isValid == 1, alt);
+		var isValid = tags[0].getAttribute('valid') == 1;
+
+		setVerificationImage(verificationFields['username'], isValid, textStrings[isValid ? 'username_valid' : 'username_invalid']);
 
 		ajax_indicator(false);
 	}
 
-	// Set the image to be the correct type.
-	function setVerificationImage(fieldID, imageIcon, alt)
+	// Set the icon beside a field to say how it is doing.
+	function setVerificationImage(field, state, alt)
 	{
-		if (!fieldID)
+		if (!field || !field.icon)
 			return false;
+
 		if (!alt)
 			alt = '*';
 
-		$('#' + fieldID + '_img').removeClass('valid check invalid').attr('alt', alt).attr('title', alt);
-		if (imageIcon)
-			$('#' + fieldID + '_img').addClass(imageIcon == 'check' ? 'check' : 'valid');
-		else
-			$('#' + fieldID + '_img').addClass('invalid');
+		field.icon.className = 'main_icons ' + (state === 'check' ? 'check' : (state ? 'valid' : 'invalid'));
+		field.icon.title = alt;
+
+		/*
+		 * 'check' means "not asked yet", which is the username field before
+		 * anything has been typed into it. That is not a verdict, so leave the
+		 * field itself looking the way the stylesheet drew it.
+		 */
+		field.input.className = state === 'check' ? field.className : field.className + ' ' + (state ? 'valid_input' : 'invalid_input');
 
 		return true;
 	}


### PR DESCRIPTION
#### Description

Part of the #7933 split (wave 4, part 34). Login / Register / Reminder area.

`register.js` decided what each field was by reading its `id` and looking for
substrings in it:

```js
if (curElement.id.indexOf('autov') != -1 && …)
{
    if (curElement.id.indexOf('username') != -1 && window.XMLHttpRequest)
        curType = 'username';
    else if (curElement.id.indexOf('pwmain') != -1)
        …
```

So a field had to be called `smf_autov_pwmain`, and for it to get an icon the
template had to write out two nested spans called `smf_autov_pwmain_div` and
`smf_autov_pwmain_img`, the outer one hidden until the script unhid it. Nothing
outside this file has ever addressed any of them.

#### What changes

The field says what it is, in `data-autov`, and the icon is built where it is
used. That takes twelve lines of markup out of `Register.template.php` and
`Reminder.template.php`, and the id-sniffing out of the script. The ids left on
the register fields are now only what the `<label for>` needs, which is what an
id is for.

**Rendering is unchanged.** The same `main_icons check` / `valid` / `invalid`
spans, in the same place, with the same `title`; the inputs still take
`valid_input` and `invalid_input`; the username icon is still the link that asks
the server on demand. The wrapper span that goes away was an unstyled inline
`<span>` once the script had unhidden it.

Two things fell out of the rewrite:

- The `blur` handler that asks whether a username is taken was attached to
  **every** verified field, so typing in a password box fired a username lookup.
  It belongs to the username field.
- `refreshMainPassword()` took a `called_from_verify` flag whose only purpose was
  to stop it and `refreshVerifyPassword()` calling each other forever. The rule
  is now a function both of them ask, so neither has to know about the other.

The callback also stops assuming there is a `<username>` element in whatever came
back. Previously `XMLDoc.getElementsByTagName("username")` was tested for
truthiness — an empty `HTMLCollection` is truthy — and then indexed at `[0]`,
which throws whenever the response is not the XML it expected.

#### Testing

On the registration page, driving the real form: the three icons start as check /
invalid / invalid exactly as the old markup did; a short password, a good one, a
matching verify and a mismatched one each give the same icon, title and input
class as on `release-3.0`; typing a username resets it to check; clicking the
icon asks the server. On the reminder's set-password page the two password icons
behave the same and no username icon is built. No console errors.

The username lookup itself needs #9486 to get an answer at all and #9483 for that
answer to be `valid="0"` rather than an error page; this part is about the
markup, and was verified with both in the tree as well as without.

Depends on #9439, which removes the `createEventListener()` call from this file —
the same line this rewrite drops. Whichever lands first, the other conflicts on
that one line.

### Issues References (Fixes|Related|Closes)

Related to #7933
