### PR TITLE
[2.1] Two misc fixes

### DIFF
--- a/Sources/Load.php
+++ b/Sources/Load.php
@@ -2459,8 +2459,8 @@ function loadTheme($id_theme = 0, $initialize = true)
 	call_integration_hook('integrate_simple_actions', array(&$simpleActions, &$simpleAreas, &$simpleSubActions, &$extraParams, &$xmlActions));
 
 	$context['simple_action'] = in_array($context['current_action'], $simpleActions) ||
-		(isset($simpleAreas[$context['current_action']]) && isset($_REQUEST['area']) && in_array($_REQUEST['area'], $simpleAreas[$context['current_action']])) ||
-		(isset($simpleSubActions[$context['current_action']]) && in_array($context['current_subaction'], $simpleSubActions[$context['current_action']]));
+		(isset($context['current_action'], $simpleAreas[$context['current_action']]) && isset($_REQUEST['area']) && in_array($_REQUEST['area'], $simpleAreas[$context['current_action']])) ||
+		(isset($context['current_action'], $simpleSubActions[$context['current_action']]) && in_array($context['current_subaction'], $simpleSubActions[$context['current_action']]));
 
 	// See if theres any extra param to check.
 	$requiresXML = false;

--- a/Sources/Subs-Calendar.php
+++ b/Sources/Subs-Calendar.php
@@ -1668,7 +1668,7 @@ function buildEventDatetimes($row)
 
 	// Datetime string without timezone  (e.g. '2016-12-28 22:45:30')
 	$start['datetime'] = date_format($start_object, 'Y-m-d H:i:s');
-	$end['datetime'] = date_format($start_object, 'Y-m-d H:i:s');
+	$end['datetime'] = date_format($end_object, 'Y-m-d H:i:s');
 
 	// ISO formatted datetime string, relative to UTC (e.g. '2016-12-29T05:45:30+00:00')
 	$start['iso_gmdate'] = gmdate('c', $start['timestamp']);


### PR DESCRIPTION
1. [Fixes deprecation warnings about using null as array key during login](https://github.com/SimpleMachines/SMF/commit/87162ab32b727618fd2555cd16527ea9818e18e4)
2. [Uses correct value for 'end_datetime' string of calendar events](https://github.com/SimpleMachines/SMF/commit/66e207e966c8070e7f379f9ea17ba9cdfe9e9c49). Credit for this [fix](https://www.simplemachines.org/community/index.php?topic=594846.0) goes to [SvmjF](https://www.simplemachines.org/community/index.php?action=profile;u=397459).