### PR TITLE
[3.0] Reveal an inline spoiler when it is clicked

### DIFF
--- a/Themes/default/scripts/script.js
+++ b/Themes/default/scripts/script.js
@@ -1184,6 +1184,26 @@ function attachBbCodeEvents(parent)
 	});
 }
 
+/*
+ * Shows or hides the content of an inline spoiler tag. The content is hidden
+ * in the stylesheet and only the 'revealed' class brings it back, so with
+ * nothing listening a reader can click a spoiler all day and never open it.
+ *
+ * Delegated from the document rather than attached to each spoiler, because a
+ * post can arrive after the page does - a preview, a quoted post, a personal
+ * message read in the popup - and a listener bound at load time never sees
+ * those. The span holds a button so that assistive technology and the keyboard
+ * have something to press; closest() answers for the button and the span
+ * alike, so both routes end up toggling the one element the CSS looks at.
+ */
+document.addEventListener('click', function (event)
+{
+	var spoiler = event.target.closest('.bbc_inline_spoiler');
+
+	if (spoiler)
+		spoiler.classList.toggle('revealed');
+});
+
 // A function used to clean the attachments on post page
 function cleanFileInput(idElement)
 {


### PR DESCRIPTION
#### Description

Clicking an inline spoiler does nothing. The content stays hidden.

The tag renders as a span whose content is hidden in the stylesheet, and only a `revealed` class brings it back:

```css
.bbc_inline_spoiler > span { visibility: hidden; }
.bbc_inline_spoiler.revealed > span { visibility: visible; }
```

Nothing adds that class. `588d99d63` ("Remove string evaluations") took out the `toggleSpoiler` function and both places that attached it, and nothing replaced them — the word `revealed` no longer appears anywhere outside the minified build artifacts. It looks like collateral damage in a cleanup rather than a deliberate removal; the handler had been added on purpose five months earlier in `f82d5e76c`.

**Only one of the two spoiler forms is affected.** `Spoiler1::validate()` switches to a `details` element when the content spans several lines or a `text` parameter is given, and that form is plain HTML that never needed script. A short one-line `[spoiler]…[/spoiler]` gets the inline span, and that is the broken one — which is probably why this went unreported for a while.

There is an odd side effect worth noting: `noscript.css` reveals the spoiler on `:hover`, so it currently behaves better with JavaScript **disabled** than enabled.

This listens on the document rather than binding each spoiler. The removed code had to attach in two places — once at load and again after a preview — and still missed any post that arrived after the page did, which is most of them: a quoted post, a personal message read in the popup, a preview. Delegation covers all of those with no re-attachment. The span holds a button so that assistive technology and the keyboard have something to press, and `closest()` answers for the button and the span alike, so both routes toggle the one element the CSS looks at.

Tested against a real DOM (jsdom) using the markup `BBCodeParser` actually emits: reveals on the button, on the span and on the text; toggles back; leaves the class on the span and not the button; ignores clicks elsewhere; and works on a spoiler inserted after load.

### Issues References (Fixes|Related|Closes)

Reported by a user on the community forum. Regression from `588d99d63`.
