### PR TITLE
[3.0] Point these labels at the fields they name

### DIFF
--- a/Themes/default/Post.template.php
+++ b/Themes/default/Post.template.php
@@ -305,12 +305,10 @@ function template_main()
 											<a data-dz-remove class="main_icons delete floatright cancel"></a>
 											<div class="attached_BBC_width_height">
 												<div class="attached_BBC_width">
-													<label for="attached_BBC_width">', Lang::getTxt('attached_insert_width', file: 'Post'), '</label>
-													<input type="number" name="attached_BBC_width" min="0" value="" placeholder="', Lang::getTxt('attached_insert_placeholder', file: 'Post'), '">
+													<label><span>', Lang::getTxt('attached_insert_width', file: 'Post'), '</span> <input type="number" name="attached_BBC_width" min="0" value="" placeholder="', Lang::getTxt('attached_insert_placeholder', file: 'Post'), '"></label>
 												</div>
 												<div class="attached_BBC_height">
-													<label for="attached_BBC_height">', Lang::getTxt('attached_insert_height', file: 'Post'), '</label>
-													<input type="number" name="attached_BBC_height" min="0" value="" placeholder="', Lang::getTxt('attached_insert_placeholder', file: 'Post'), '">
+													<label><span>', Lang::getTxt('attached_insert_height', file: 'Post'), '</span> <input type="number" name="attached_BBC_height" min="0" value="" placeholder="', Lang::getTxt('attached_insert_placeholder', file: 'Post'), '"></label>
 												</div>
 											</div>
 										</div>

--- a/Themes/default/Profile.template.php
+++ b/Themes/default/Profile.template.php
@@ -1953,7 +1953,7 @@ function template_alert_configuration()
 	if (!empty(Config::$modSettings['enable_ajax_alerts'])) {
 		echo '
 					<dt>
-						<label for="notify_send_body">', Lang::getTxt('notify_alert_timeout', file: 'Profile'), '</label>
+						<label for="notify_alert_timeout">', Lang::getTxt('notify_alert_timeout', file: 'Profile'), '</label>
 					</dt>
 					<dd>
 						<input type="number" size="4" id="notify_alert_timeout" name="opt_alert_timeout" min="0" max="127" value="', Utils::$context['member']['alert_timeout'], '">

--- a/Themes/default/css/index.css
+++ b/Themes/default/css/index.css
@@ -4377,7 +4377,11 @@ input[name="attachBBC"] {
 .attachment_info .progress_bar {
 	margin: 6px 0;
 }
-.attached_BBC_width_height label {
+/* The width the two captions are held to is what lines their inputs up. It sits
+   on the caption rather than the label because the label now wraps its input:
+   an id cannot associate them here, since this block is a template that gets
+   cloned once per attached file and every copy would carry the same one. */
+.attached_BBC_width_height label > span {
 	min-width: 100px;
 	display: inline-block;
 }


### PR DESCRIPTION
#### Description

Three labels in the theme carry a `for` that matches no element. Clicking them does nothing, and assistive technology has no field to announce them against.

**The notification timeout label is a copy-paste.** [Profile.template.php:1956](https://github.com/SimpleMachines/SMF/blob/release-3.0/Themes/default/Profile.template.php#L1956) prints `notify_alert_timeout`'s text over an input with `id="notify_alert_timeout"`, but its `for` names `notify_send_body` — the setting immediately above. One word.

**The two on the attachment preview could not be fixed the same way**, which is why they were left out of an earlier markup change. The block they sit in is a template that dropzone clones once per attached file, so an `id` on the inputs would be repeated across every preview — and a label resolves against the *first* match in the document, so every copy would point at the first file's field instead of its own. Wrapping the input inside its label associates the two with no id at all, and survives cloning.

The caption moves into a `<span>` so the width that lines the two inputs up still applies to the caption alone rather than to the caption and input together.

##### How they were found

By walking every `label[for]` on twenty-five pages and resolving each id against its own document — board index, topic, posting, five profile areas, seven admin areas, personal messages, search, memberlist, registration, reminder, login and the moderation centre:

```
pages loaded:     25
labels checked:  177
dangling:          1
```

The attachment pair does not appear in that sweep because the block only exists once a file has been attached.

##### Layout is unchanged

Measured on the rendered preview, before and after, with the block forced visible:

| | before | after |
| --- | --- | --- |
| containing box | 156.87 × 34.10 | 156.87 × 34.10 |
| caption width | 100 | 100 |
| input width | 50.47 | 50.47 |
| input offset in box | 103.66 | 103.66 |
| caption and input on one line | yes | yes |
| **clicking the caption focuses the input** | **no** | **yes** |

The offset is what caught a first attempt: collapsing the caption and input onto one source line dropped the whitespace text node between them and moved the input 3.66px left. The space is kept.

##### Unrelated, but seen while testing this

Every attachment upload on `release-3.0` fails outright — the preview comes back as an error box reading `Unknown column 'm.id_topic' in 'field list'`, from `Sources/Attachment.php:537`. That is the bug **#9459** fixes, still open. It does not affect this change, since the preview and its labels are built before the upload is attempted.

### Issues References (Fixes|Related|Closes)

Related #9459