### PR TITLE
[3.0] Correctly restores original content of code BBC in MarkdownParser

### DIFF
--- a/Sources/Parsers/MarkdownParser.php
+++ b/Sources/Parsers/MarkdownParser.php
@@ -774,9 +774,9 @@ class MarkdownParser extends Parser
 		if ($from_bbcode_parser) {
 			$input_replacements = [
 				// Protect the content of certain tags.
-				'/(<code\b[^>]*>)((?>\X(?!<code\b[^>]*>)|(?R))*)(<\/code>)/ui' => fn($m) => $m[1] . ($this->placeholders[$m[2]] = md5($m[2])) . $m[3],
-
 				'/(<pre\b[^>]*>)((?>\X(?!<pre\b[^>]*>)|(?R))*)(<\/pre>)/ui' => fn($m) => $m[1] . ($this->placeholders[$m[2]] = md5($m[2])) . $m[3],
+
+				'/(<code\b[^>]*>)((?>\X(?!<code\b[^>]*>)|(?R))*)(<\/code>)/ui' => fn($m) => $m[1] . ($this->placeholders[$m[2]] = md5($m[2])) . $m[3],
 
 				'/(<div\b[^>]*\bclass="[^"]*\bbbc_html\b[^>]*>)((?>\X(?!<div\b[^>]*\bclass="[^"]*\bbbc_html\b[^>]*>)|(?R))*)(<\/div>)/ui' => fn($m) => $m[1] . ($this->placeholders[$m[2]] = md5($m[2])) . $m[3],
 


### PR DESCRIPTION
Fixes a bug introduced in #9332.

Specifically, the content of `[code]` BBC tags was being replaced with an md5 hash of that content. This bug arose when the HTML output of the `[code]` BBC was changed to wrap the `<code>` tags in `<pre>` tags.

By simply processing `<pre>` before `<code>` in the Markdown parser, we can prevent that issue from arising.