### PR TITLE
[3.0] Restore the blank line the section banners want around them

### DIFF
--- a/Sources/Actions/Help.php
+++ b/Sources/Actions/Help.php
@@ -117,7 +117,6 @@ class Help implements ActionInterface, Routable
 		Utils::$context['sub_template'] = 'manual';
 	}
 
-
 	/******************
 	 * Internal methods
 	 ******************/

--- a/Sources/Alert.php
+++ b/Sources/Alert.php
@@ -1339,6 +1339,7 @@ class Alert implements \ArrayAccess
 
 		IntegrationHook::call('integrate_alert_icon', [&$this->icon, (array) $this]);
 	}
+
 	/*************************
 	 * Internal static methods
 	 *************************/

--- a/Sources/Autolinker.php
+++ b/Sources/Autolinker.php
@@ -206,7 +206,6 @@ class Autolinker
 	 */
 	protected string $js_email_regex;
 
-
 	/****************************
 	 * Internal static properties
 	 ****************************/


### PR DESCRIPTION
> [!NOTE]
> **This change was produced by an LLM.** The change, the commit message and this
> description were all written by Claude (Anthropic), driven by @albertlast.

#### Description

Three files in `release-3.0` do not match what the custom `SMF/section_comments`
fixer produces. `Sources/Alert.php` is missing the blank line before a banner;
`Sources/Autolinker.php` and `Sources/Actions/Help.php` each carry an extra one.
Three lines in total, and `composer lint-fix` writes all of it.

The interesting part is why nobody noticed.

`.github/workflows/php-cs-fixer.yml` asks `tj-actions/changed-files` what the pull
request touched and then, on line 24:

```bash
if ! echo "${CHANGED_FILES}" | grep -qE "^(\.php-cs-fixer(\.dist)?\.php|composer\.lock)$"; then
    EXTRA_ARGS=$(printf -- '--path-mode=intersection\n--\n%s' "${CHANGED_FILES}")
fi
```

So unless the pull request changes the fixer's own config or `composer.lock`, the
check only ever looks at the files that pull request touched. That is the right
call for speed, and it means a file can drift out of compliance and stay there
indefinitely: nothing re-checks it until somebody edits it again, or until a branch
comes along that does change one of those two files and turns the check back into a
whole-tree scan.

That is how these turned up. #9511 changes `composer.lock`, so its check ran over
all 1738 files and reported these three, none of which that branch goes anywhere
near.

#### How this was verified

- `vendor/bin/php-cs-fixer check --allow-risky=yes` over the whole tree:
  `Found 0 of 1684 files that can be fixed`, against 3 before this change.
- The three files are otherwise untouched — the entire diff is one blank line added
  and two removed.
- `check-signed-off.php` passes locally.

#### Relationship to other PRs

Independent, and worth merging on its own. #9511 and #9326 both change
`composer.lock` and so both get the whole-tree scan; they stay red on these three
files until this lands.

### Issues References (Fixes|Related|Closes)
1. Related: #9511, #9326
