### PR TITLE
[3.0] Uses consistent logic to load both standard and legacy language files

### DIFF
--- a/Sources/Lang.php
+++ b/Sources/Lang.php
@@ -212,6 +212,20 @@ class Lang
 	 */
 	private static array $localized_copyright = [];
 
+	/**
+	 * @var array
+	 *
+	 * Regular expressions to match any censored words.
+	 */
+	private static array $censor_vulgar;
+
+	/**
+	 * @var array
+	 *
+	 * Replacements for the censored words.
+	 */
+	private static array $censor_proper;
+
 	/***********************
 	 * Public static methods
 	 ***********************/
@@ -695,8 +709,6 @@ class Lang
 	 */
 	public static function censorText(string &$text, bool $force = false): string
 	{
-		static $censor_vulgar = null, $censor_proper;
-
 		if ((!empty(Theme::$current->options['show_no_censored']) && !empty(Config::$modSettings['allow_no_censored']) && !$force) || empty(Config::$modSettings['censor_vulgar']) || !\is_string($text) || trim($text) === '') {
 			return $text;
 		}
@@ -705,68 +717,75 @@ class Lang
 
 		// Let SpoofDetector help us detect attempts to bypass the word censor.
 		// This method will temporarily append additional content to the censor
-		// settings if it detects an attempt to bypass the word censor.
+		// settings if it detects an attempt to bypass the word censor, so we
+		// need to unset self::$censor_vulgar in order to force a reload.
 		if (Unicode\SpoofDetector::enhanceWordCensor($text)) {
-			$censor_vulgar = null;
+			unset(self::$censor_vulgar);
 		}
 
 		// If they haven't yet been loaded, load them.
-		if ($censor_vulgar == null) {
-			$censor_vulgar = explode("\n", Config::$modSettings['censor_vulgar']);
-			$censor_proper = explode("\n", Config::$modSettings['censor_proper']);
+		if (!isset(self::$censor_vulgar)) {
+			self::$censor_vulgar = explode("\n", Config::$modSettings['censor_vulgar']);
+			self::$censor_proper = explode("\n", Config::$modSettings['censor_proper']);
+
+			self::$censor_proper = array_pad(
+				self::$censor_proper,
+				\count(self::$censor_vulgar),
+				"\u{2022}\u{2022}\u{2022}\u{2022}",
+			);
 
 			// Quote them for use in regular expressions.
-			for ($i = 0, $n = \count($censor_vulgar); $i < $n; $i++) {
+			for ($i = 0, $n = \count(self::$censor_vulgar); $i < $n; $i++) {
 				// If a word is replaced with itself, just leave it as it is.
 				// Why would the admin replace a word with itself, you ask?
 				// If the spoof detector incorrectly censors an allowed word
 				// because it happens to be visually confusable with a banned
 				// word, the admin can create an entry to replace the allowed
 				// word with itself in order to override the spoof detector.
-				if ($censor_vulgar[$i] === $censor_proper[$i]) {
-					$censor_proper[$i] = '$0';
+				if (self::$censor_vulgar[$i] === self::$censor_proper[$i]) {
+					self::$censor_proper[$i] = '$0';
 				}
 
-				$censor_vulgar[$i] = str_replace(['\\\\\\*', '\\*', '&', '\''], ['[*]', '[^\\s]*?', '&amp;', '&#039;'], preg_quote($censor_vulgar[$i], '/'));
+				self::$censor_vulgar[$i] = str_replace(['\\\\\\*', '\\*', '&', '\''], ['[*]', '[^\\s]*?', '&amp;', '&#039;'], preg_quote(self::$censor_vulgar[$i], '/'));
 
 				if (!empty(Config::$modSettings['censorWholeWord'])) {
 					// Use the faster \b if we can, or something more complex if we can't
-					$boundary_before = preg_match('/^\w/', $censor_vulgar[$i]) ? '\b' : '(?<![\p{L}\p{M}\p{N}_])';
-					$boundary_after = preg_match('/\w$/', $censor_vulgar[$i]) ? '\b' : '(?![\p{L}\p{M}\p{N}_])';
+					$boundary_before = preg_match('/^\w/', self::$censor_vulgar[$i]) ? '\b' : '(?<![\p{L}\p{M}\p{N}_])';
+					$boundary_after = preg_match('/\w$/', self::$censor_vulgar[$i]) ? '\b' : '(?![\p{L}\p{M}\p{N}_])';
 				} else {
 					$boundary_before = $boundary_after = '';
 				}
 
-				$censor_vulgar[$i] = '/' . $boundary_before . $censor_vulgar[$i] . $boundary_after . '/u' . (empty(Config::$modSettings['censorIgnoreCase']) ? '' : 'i');
+				self::$censor_vulgar[$i] = '/' . $boundary_before . self::$censor_vulgar[$i] . $boundary_after . '/u' . (empty(Config::$modSettings['censorIgnoreCase']) ? '' : 'i');
 			}
 		}
 
 		// Censoring isn't so very complicated :P.
-		foreach ($censor_vulgar as $i => $pattern) {
+		foreach (self::$censor_vulgar as $i => $pattern) {
 			$text = preg_replace_callback(
 				$pattern,
-				function ($matches) use ($censor_proper, $i) {
+				function ($matches) use ($i) {
 					// Special case to return the original word unchanged.
-					if ($censor_proper[$i] === '$0') {
+					if (self::$censor_proper[$i] === '$0') {
 						return $matches[0];
 					}
 
 					// If the replacement contains any letters, try to match case.
-					if (preg_match('/\p{L}/u', $censor_proper[$i])) {
+					if (preg_match('/\p{L}/u', self::$censor_proper[$i])) {
 						// If original was all uppercase, return uppercase.
 						if (Utils::strtoupper($matches[0]) === $matches[0]) {
-							return Utils::strtoupper($censor_proper[$i]);
+							return Utils::strtoupper(self::$censor_proper[$i]);
 						}
 
 						// If original started with a capital letter, return with a capital letter.
 						$first_vulgar_char = Utils::entitySubstr($matches[0], 0, 1);
 
 						if (Utils::ucfirst($first_vulgar_char) === $first_vulgar_char) {
-							return Utils::ucfirst($censor_proper[$i]);
+							return Utils::ucfirst(self::$censor_proper[$i]);
 						}
 					}
 
-					return $censor_proper[$i];
+					return self::$censor_proper[$i];
 				},
 				$text,
 			);

--- a/Sources/Lang.php
+++ b/Sources/Lang.php
@@ -141,13 +141,6 @@ class Lang
 	public static array $helptxt = [];
 
 	/**
-	 * @var array
-	 *
-	 * Language file directories.
-	 */
-	public static array $dirs = [];
-
-	/**
 	 * @var string
 	 *
 	 * Decimal separator to use in Lang::numberFormat.
@@ -180,6 +173,13 @@ class Lang
 			'forum_copyright' => 'forum_copyright',
 		],
 	];
+
+	/**
+	 * @var array
+	 *
+	 * Language file directories.
+	 */
+	private static array $dirs = [];
 
 	/**
 	 * @var array
@@ -464,9 +464,12 @@ class Lang
 		}
 
 		if (!empty($custom_dirs)) {
-			self::$dirs = array_merge($custom_dirs, self::$dirs);
+			self::$dirs = array_merge(
+				array_map(fn($dir) => Sapi::canonicalPath($dir), $custom_dirs),
+				self::$dirs,
+			);
 		} else {
-			self::$dirs[] = Config::$languagesdir;
+			self::$dirs[] = Sapi::canonicalPath(Config::$languagesdir);
 
 			// Make sure we have Theme::$current->settings - if not we're in trouble and need to find it!
 			if (empty(Theme::$current->settings['default_theme_dir'])) {
@@ -475,7 +478,7 @@ class Lang
 
 			foreach (['theme_dir', 'base_theme_dir', 'default_theme_dir'] as $var) {
 				if (isset(Theme::$current->settings[$var])) {
-					self::$dirs[] = Theme::$current->settings[$var] . '/languages';
+					self::$dirs[] = Sapi::canonicalPath(Theme::$current->settings[$var] . '/languages');
 				}
 			}
 

--- a/Sources/Lang.php
+++ b/Sources/Lang.php
@@ -280,109 +280,28 @@ class Lang
 			// Flip this around.
 			$attempts = array_reverse($attempts);
 
-			foreach ($attempts as $k => $file) {
-				if (file_exists($file[0] . '/' . $file[2] . '/' . $file[1] . '.php')) {
-					// Include it!
-					// {DIR} / {locale} / {file} .php
-					require Sapi::canonicalPath($file[0] . '/' . $file[2] . '/' . $file[1] . '.php');
+			foreach ($attempts as $attempt) {
+				$found = self::attemptToLoadFile(
+					$attempt,
+					implode(DIRECTORY_SEPARATOR, [$attempt[0], $attempt[2], $attempt[1] . '.php']),
+					$force_reload,
+				);
 
-					// Note that we found it.
-					$found = true;
-
-					// Keep track of what we're up to, soldier.
-					if (DebugUtils::isDebugEnabled()) {
-						DebugUtils::addDebugSource(
-							lang_key: 'language_files',
-							key: implode('|', $file),
-							value: Sapi::canonicalPath((Config::$languagesdir == $file[0] ? basename($file[0]) : ltrim(str_replace(array_map('dirname', self::$dirs), '', $file[0]), '/')) . '/' . $file[2] . '/' . $file[1] . '.php'),
-						);
-					}
-
-					// Load the strings into our properties.
-					foreach (['txt', 'txtBirthdayEmails', 'tztxt', 'editortxt', 'helptxt'] as $var) {
-						if (!isset(${$var})) {
-							continue;
-						}
-
-						foreach (${$var} as $key => $value) {
-							// Never overwrite strings that were set via self::setTxt()
-							if ((self::$loaded_keys[$var][$key]['file'] ?? '') === 'setTxt') {
-								continue;
-							}
-
-							// Don't overwrite strings from Modifications or ThemeStrings
-							// unless $force_reload is true.
-							if (
-								!$force_reload
-								&& \array_key_exists($key, self::$loaded_keys[$var] ?? [])
-								&& self::$loaded_keys[$var][$key]['file'] !== $file[1]
-								&& (
-									// Modifications takes precedence over all others.
-									self::$loaded_keys[$var][$key]['file'] === 'Modifications'
-									// ThemeStrings takes precedence over all except Modifications.
-									|| (
-										self::$loaded_keys[$var][$key]['file'] === 'ThemeStrings'
-										&& $file[1] !== 'Modifications'
-									)
-								)
-							) {
-								continue;
-							}
-
-							// Add the string to the appropriate array.
-							self::${$var}[$key] = $value;
-
-							// Keep track of where this string came from.
-							self::$loaded_keys[$var][$key] = [
-								'file' => $file[1],
-								'lang' => $file[2],
-							];
-						}
-
-						unset(${$var});
-					}
-
-					// Did this file define the $forum_copyright?
-					if (!empty($forum_copyright)) {
-						self::$localized_copyright[$file[2]] = $forum_copyright;
-
-						self::$forum_copyright = self::$localized_copyright[$lang] ?? (self::$localized_copyright[Config::$language] ?? (self::$localized_copyright['en_US'] ?? ''));
-
-						unset($forum_copyright);
-					}
-
-					// setlocale is required for basename() & pathinfo() to work properly on the selected language
-					if (!empty(self::$txt['lang_locale'])) {
-						if (str_contains(self::$txt['lang_locale'], '.')) {
-							$locale_variants = self::$txt['lang_locale'];
-						} else {
-							$locale_variants = array_unique(
-								[
-									self::$txt['lang_locale'] . '.UTF-8',
-									self::$txt['lang_locale'] . '.UTF8',
-									self::$txt['lang_locale'] . '.utf-8',
-									self::$txt['lang_locale'] . '.utf8',
-									self::$txt['lang_locale'],
-								],
-							);
-						}
-
-						setlocale(LC_CTYPE, $locale_variants);
-					}
-
-					if (isset(self::$txt['lang_rtl'])) {
-						Utils::$context['right_to_left'] = !empty(self::$txt['lang_rtl']);
-					}
+				if ($found) {
+					break;
 				}
 			}
 
-			/*
-			 * Legacy language calls.
-			 * Under normal conditions, we stop once we find it through the locale lookup.
-			 * Modifications is a special case in which we allow it to be checked everywhere.
-			 */
-			if ((!$found || str_contains($filename, 'Modifications') || str_contains($filename, 'ThemeStrings')) && Config::$backward_compatibility) {
-				$found = self::loadOld($attempts) || $found;
+			// Legacy language calls.
+			if (
+				!empty(Config::$backward_compatibility)
+				&& (
+					!$found
+					|| str_contains($filename, 'Modifications')
+					|| str_contains($filename, 'ThemeStrings')
+				)
+			) {
+				$found = self::loadOld($attempts, $force_reload) || $found;
 			}
 
 			// That couldn't be found!  Log the error, but *try* to continue normally.
@@ -1022,68 +941,35 @@ class Lang
 	 * Do not rely on this method to exist in future versions!
 	 *
 	 * @deprecated 3.0 Only used to support compatibility with old name formats.
+	 *
 	 * @param array $attempts The attempts to be made; see self::load().
+	 * @param bool $force_reload Whether to load the file again if it's already
+	 *    loaded.
 	 * @return bool Whether we loaded anything or not.
 	 */
-	public static function loadOld(array $attempts): bool
+	public static function loadOld(array $attempts, bool $force_reload): bool
 	{
 		if (empty($attempts)) {
 			return false;
 		}
 
-		$locale_to_lang = array_flip(self::LANG_TO_LOCALE);
+		foreach ($attempts as $attempt) {
+			if (!\in_array($attempt[2], self::LANG_TO_LOCALE)) {
+				continue;
+			}
 
-		$found = false;
+			$found = self::attemptToLoadFile(
+				$attempt,
+				$attempt[0] . DIRECTORY_SEPARATOR . $attempt[1] . '.' . array_search($attempt[2], self::LANG_TO_LOCALE) . '.php',
+				$force_reload,
+			);
 
-		/**
-		 * $file = [
-		 *    0 => Directory
-		 *    1 => File
-		 *    2 => Locale
-		 * ]
-		 */
-		foreach ($attempts as $k => $file) {
-			$oldLanguage = $locale_to_lang[$file[2]] ?? false;
-
-			if ($oldLanguage !== false && file_exists($file[0] . '/' . $file[1] . '.' . $oldLanguage . '.php')) {
-				require Sapi::canonicalPath($file[0] . '/' . $file[1] . '.' . $oldLanguage . '.php');
-
-				// Note that we found it.
-				$found = true;
-
-				// Load the strings into our properties.
-				foreach (['txt', 'txtBirthdayEmails', 'tztxt', 'editortxt', 'helptxt'] as $var) {
-					if (!isset(${$var})) {
-						continue;
-					}
-
-					// Add the strings to the appropriate array.
-					self::${$var} = array_merge(self::${$var}, ${$var});
-
-					// Keep track of where these strings came from.
-					self::$loaded_keys[$var] = array_merge(
-						self::$loaded_keys[$var] ?? [],
-						array_combine(
-							array_keys(${$var}),
-							array_fill(0, \count(${$var}), ['file' => $file[1], 'lang' => $file[2]]),
-						),
-					);
-
-					unset(${$var});
-				}
-
-				// Keep track of what we're up to, soldier.
-				if (DebugUtils::isDebugEnabled()) {
-					DebugUtils::addDebugSource(
-						lang_key: 'language_files',
-						key: implode('|', $file),
-						value: (Config::$languagesdir == $file[0] ? basename($file[0]) : ltrim(str_replace(array_map('dirname', self::$dirs), '', $file[0]), '/')) . '/' . $file[1] . '.' . $oldLanguage . '.php',
-					);
-				}
+			if ($found) {
+				return true;
 			}
 		}
 
-		return $found;
+		return false;
 	}
 
 	/*************************
@@ -1175,6 +1061,121 @@ class Lang
 
 			return;
 		}
+	}
+
+	/**
+	 * Attempts to load a language file and read its contents into our strings.
+	 *
+	 * @param array $attempt Info about this attempt to load a language file.
+	 * @param string $path Full path to the language file.
+	 * @param bool $force_reload Whether to ovewrite strings from Modifications
+	 *    and ThemeStrings with strings from this file in the event of conflict.
+	 *    Default: false.
+	 * @return bool Whether the language file was loaded successfully.
+	 */
+	private static function attemptToLoadFile(array $attempt, string $path, bool $force_reload = false): bool
+	{
+		$path = Sapi::canonicalPath($path);
+
+		if (!is_file($path) || !is_readable($path)) {
+			return false;
+		}
+
+		require $path;
+
+		// Keep track of what we're up to, soldier.
+		if (DebugUtils::isDebugEnabled()) {
+			foreach (self::$dirs as $dir) {
+				if (str_starts_with($path, $dir)) {
+					$path = basename($dir) . substr($path, \strlen($dir));
+					break;
+				}
+			}
+
+			DebugUtils::addDebugSource(
+				lang_key: 'language_files',
+				key: implode('|', $attempt),
+				value: $path,
+			);
+		}
+
+		// Load the strings into our properties.
+		foreach (['txt', 'txtBirthdayEmails', 'tztxt', 'editortxt', 'helptxt'] as $var) {
+			if (!isset(${$var})) {
+				continue;
+			}
+
+			foreach (${$var} as $key => $value) {
+				// Never overwrite strings that were set via self::setTxt()
+				if ((self::$loaded_keys[$var][$key]['file'] ?? '') === 'setTxt') {
+					continue;
+				}
+
+				// Don't overwrite strings from Modifications or ThemeStrings
+				// unless $force_reload is true.
+				if (
+					!$force_reload
+					&& \array_key_exists($key, self::$loaded_keys[$var] ?? [])
+					&& self::$loaded_keys[$var][$key]['file'] !== $attempt[1]
+					&& (
+						// Modifications takes precedence over all others.
+						self::$loaded_keys[$var][$key]['file'] === 'Modifications'
+						// ThemeStrings takes precedence over all except Modifications.
+						|| (
+							self::$loaded_keys[$var][$key]['file'] === 'ThemeStrings'
+							&& $attempt[1] !== 'Modifications'
+						)
+					)
+				) {
+					continue;
+				}
+
+				// Add the string to the appropriate array.
+				self::${$var}[$key] = $value;
+
+				// Keep track of where this string came from.
+				self::$loaded_keys[$var][$key] = [
+					'file' => $attempt[1],
+					'lang' => $attempt[2],
+				];
+			}
+
+			unset(${$var});
+		}
+
+		// Did this file define the $forum_copyright?
+		if (!empty($forum_copyright)) {
+			self::$localized_copyright[$attempt[2]] = $forum_copyright;
+
+			self::$forum_copyright = self::$localized_copyright[$attempt[2]] ?? (self::$localized_copyright[Config::$language] ?? (self::$localized_copyright['en_US'] ?? ''));
+
+			unset($forum_copyright);
+		}
+
+		// setlocale is required for basename() & pathinfo() to work properly on the selected language
+		if (!empty(self::$txt['lang_locale'])) {
+			if (str_contains(self::$txt['lang_locale'], '.')) {
+				$locale_variants = self::$txt['lang_locale'];
+			} else {
+				$locale_variants = array_unique(
+					[
+						self::$txt['lang_locale'] . '.UTF-8',
+						self::$txt['lang_locale'] . '.UTF8',
+						self::$txt['lang_locale'] . '.utf-8',
+						self::$txt['lang_locale'] . '.utf8',
+						self::$txt['lang_locale'],
+					],
+				);
+			}
+
+			setlocale(LC_CTYPE, $locale_variants);
+		}
+
+		if (isset(self::$txt['lang_rtl'])) {
+			Utils::$context['right_to_left'] = !empty(self::$txt['lang_rtl']);
+		}
+
+		return true;
 	}
 }
 

--- a/Sources/Lang.php
+++ b/Sources/Lang.php
@@ -246,8 +246,12 @@ class Lang
 	 *    loaded.
 	 * @return string The language actually loaded.
 	 */
-	public static function load(string $filename, string $lang = '', bool $fatal = true, bool $force_reload = false): string
-	{
+	public static function load(
+		string $filename,
+		string $lang = '',
+		bool $fatal = true,
+		bool $force_reload = false,
+	): string {
 		// Default to the user's language.
 		if ($lang == '') {
 			$lang = User::$me->language ?? Config::$language;
@@ -265,7 +269,11 @@ class Lang
 			}
 
 			// Don't repeat this unnecessarily.
-			if (!$force_reload && isset(self::$already_loaded[$name]) && self::$already_loaded[$name] == $lang) {
+			if (
+				!$force_reload
+				&& isset(self::$already_loaded[$name])
+				&& self::$already_loaded[$name] === $lang
+			) {
 				continue;
 			}
 
@@ -347,7 +355,7 @@ class Lang
 				self::$forum_copyright = $class_vars['forum_copyright'];
 			}
 
-			// For the sake of backward compatibility
+			// For the sake of backward compatibility.
 			if (!empty(self::$txt['emails'])) {
 				foreach (self::$txt['emails'] as $key => $value) {
 					self::$txt[$key . '_subject'] = $value['subject'];
@@ -356,10 +364,11 @@ class Lang
 				self::$txt['emails'] = [];
 			}
 
-			// For sake of backward compatibility: $birthdayEmails is supposed to be
-			// empty in a normal install. If it isn't it means the forum is using
-			// something "old" (it may be the translation, it may be a mod) and this
-			// code (like the piece above) takes care of converting it to the new format
+			// For sake of backward compatibility: $birthdayEmails is supposed
+			// to be empty in a normal install. If it isn't it means the forum
+			// is using something "old" (it may be the translation, it may be a
+			// mod) and this code (like the piece above) takes care of
+			// converting it to the new format.
 			if (!empty($birthdayEmails)) {
 				foreach ($birthdayEmails as $key => $value) {
 					self::$txtBirthdayEmails[$key . '_subject'] = $value['subject'];
@@ -393,7 +402,10 @@ class Lang
 	{
 		// We only accept real directories.
 		if (!empty($custom_dirs)) {
-			$custom_dirs = array_filter(array_map('realpath', (array) $custom_dirs), 'is_dir');
+			$custom_dirs = array_filter(
+				array_map('realpath', (array) $custom_dirs),
+				'is_dir',
+			);
 		}
 
 		if (!empty($custom_dirs)) {
@@ -404,7 +416,8 @@ class Lang
 		} else {
 			self::$dirs[] = Sapi::canonicalPath(Config::$languagesdir);
 
-			// Make sure we have Theme::$current->settings - if not we're in trouble and need to find it!
+			// Make sure we have Theme::$current->settings - if not we're in
+			// trouble and need to find it!
 			if (empty(Theme::$current->settings['default_theme_dir'])) {
 				Theme::loadEssential(false);
 			}
@@ -431,7 +444,16 @@ class Lang
 	public static function get(bool $use_cache = true): array
 	{
 		// Either we don't use the cache, or its expired.
-		if (!$use_cache || (Utils::$context['languages'] = CacheApi::get('known_languages', !empty(CacheApi::$enable) && CacheApi::$enable < 1 ? 86400 : 3600)) == null) {
+		if (
+			!$use_cache
+			|| empty(CacheApi::$enable)
+			|| null == (
+				Utils::$context['languages'] = CacheApi::get(
+					'known_languages',
+					CacheApi::$enable > 1 ? 86400 : 3600,
+				)
+			)
+		) {
 			// Special case during install.
 			if (\defined('SMF_INSTALLING')) {
 				$language_directories = [Config::$languagesdir];
@@ -447,7 +469,10 @@ class Lang
 					Theme::$current->settings['default_theme_dir'] . '/languages',
 				];
 
-				if (!empty(Theme::$current->settings['actual_theme_dir']) && Theme::$current->settings['actual_theme_dir'] != Theme::$current->settings['default_theme_dir']) {
+				if (
+					!empty(Theme::$current->settings['actual_theme_dir'])
+					&& Theme::$current->settings['actual_theme_dir'] != Theme::$current->settings['default_theme_dir']
+				) {
 					$language_directories[] = Theme::$current->settings['actual_theme_dir'] . '/languages';
 				}
 
@@ -470,7 +495,10 @@ class Lang
 
 				while ($entry = $dir->read()) {
 					// Languages are in a sub directory.
-					if (!is_dir($language_dir . '/' . $entry) || !file_exists($language_dir . '/' . $entry . '/General.php')) {
+					if (
+						!is_dir($language_dir . '/' . $entry)
+						|| !file_exists($language_dir . '/' . $entry . '/General.php')
+					) {
 						continue;
 					}
 
@@ -484,16 +512,24 @@ class Lang
 								continue;
 							}
 
-							preg_match('~\$txt\[\'native_name\'\]\s*=\s*\'([^\']+)\';~', $line, $matchNative);
+							preg_match(
+								'~\$txt\[\'native_name\'\]\s*=\s*\'([^\']+)\';~',
+								$line,
+								$matches,
+							);
 
 							// Set the language's name.
-							if (!empty($matchNative) && !empty($matchNative[1])) {
-								// Don't mislabel the language if the translator missed this one.
-								if ($entry !== 'en_US' && $matchNative[1] === 'English (US)') {
+							if (!empty($matches) && !empty($matches[1])) {
+								// Don't mislabel the language if the translator
+								// forgot to translate this one.
+								if (
+									$entry !== 'en_US'
+									&& $matches[1] === 'English (US)'
+								) {
 									break;
 								}
 
-								$langName = Utils::htmlspecialcharsDecode($matchNative[1]);
+								$lang = Utils::htmlspecialcharsDecode($matches[1]);
 
 								break;
 							}
@@ -504,7 +540,7 @@ class Lang
 
 					// Build this language entry.
 					Utils::$context['languages'][$entry] = [
-						'name' => $langName ?? $entry,
+						'name' => $lang ?? $entry,
 						'selected' => false,
 						'filename' => $entry,
 						'location' => Sapi::canonicalPath($language_dir . '/' . $entry . '/General.php'),
@@ -515,7 +551,11 @@ class Lang
 
 			// Let's cash in on this deal.
 			if (!empty(CacheApi::$enable)) {
-				CacheApi::put('known_languages', Utils::$context['languages'], !empty(CacheApi::$enable) && CacheApi::$enable < 1 ? 86400 : 3600);
+				CacheApi::put(
+					'known_languages',
+					Utils::$context['languages'],
+					CacheApi::$enable > 1 ? 86400 : 3600,
+				);
 			}
 		}
 
@@ -551,7 +591,7 @@ class Lang
 		$target = &self::${$var};
 
 		// Drill down to the specified key.
-		foreach ((array) $txt_key as $key) {
+		foreach ($txt_key as $key) {
 			if (isset($target[$key])) {
 				$target = &$target[$key];
 			} else {
@@ -594,11 +634,11 @@ class Lang
 
 		// Drill down to the specified key.
 		foreach ($txt_key as $depth => $key) {
-			if (isset($target[(string) $key])) {
-				$target = &$target[(string) $key];
+			if (isset($target[$key])) {
+				$target = &$target[$key];
 			} else {
-				$target[(string) $key] = $depth === array_key_last($txt_key) ? '' : [];
-				$target = &$target[(string) $key];
+				$target[$key] = $depth === array_key_last($txt_key) ? '' : [];
+				$target = &$target[$key];
 			}
 		}
 
@@ -709,7 +749,15 @@ class Lang
 	 */
 	public static function censorText(string &$text, bool $force = false): string
 	{
-		if ((!empty(Theme::$current->options['show_no_censored']) && !empty(Config::$modSettings['allow_no_censored']) && !$force) || empty(Config::$modSettings['censor_vulgar']) || !\is_string($text) || trim($text) === '') {
+		if (
+			(
+				!empty(Theme::$current->options['show_no_censored'])
+				&& !empty(Config::$modSettings['allow_no_censored'])
+				&& !$force
+			)
+			|| empty(Config::$modSettings['censor_vulgar'])
+			|| trim($text) === ''
+		) {
 			return $text;
 		}
 
@@ -868,8 +916,8 @@ class Lang
 	 * current locale to format the number.
 	 *
 	 * @param int|float|string $number A number.
-	 * @param int|null $decimals If set, will use the specified number of decimal
-	 *    places. Otherwise, it's automatically determined.
+	 * @param int|null $decimals If set, will use the specified number of
+	 *    decimal places. Otherwise, it's automatically determined.
 	 * @return string A formatted number
 	 */
 	public static function numberFormat(int|float|string $number, ?int $decimals = null): string


### PR DESCRIPTION
When backward compatibility mode was enabled, viewing the credits page would cause this error:

```
SMF\Lang::sentenceList(): Argument #1 ($list) must be of type array, string given, called in /path/to/forum/Themes/default/Who.template.php on line 175
```

The ultimate root of this issue was that Lang::loadOld() did not use sufficient safeguards against incorrectly overwriting language strings that should have been preserved, causing Lang::$txt[''translation_credits''] to get reverted to its original string value rather than the array it had been updated to by Lang::setTxt() at runtime. 

Since the correct safeguard logic did already exist in the main Lang::load() method, the [Uses consistent logic to load both standard and legacy language files](https://github.com/SimpleMachines/SMF/pull/9513/commits/d33481a33a947996f23e61192f6d53cb300d2d7e) commit moves that logic into its own helper method so that both Lang::load() and Lang::loadOld() could call it. This ensures the language files are always loaded using consistent logic.

I also included commits to make a few other minor improvements, each of which does exactly what the commit message says:
1. [Ensures Lang::$dirs always uses canonical paths](https://github.com/SimpleMachines/SMF/commit/8c4fa294ad3e6e681a171adb4d8d5eddf7a2654b)
2. [Uses proper static properties in Lang::censorText()](https://github.com/SimpleMachines/SMF/commit/704417a1f54df685f239e393109a8132825920fe)
3. [Improves legibility in SMF\Lang](https://github.com/SimpleMachines/SMF/commit/66f7c321107c58f0a2fd1fdf7d329fd8c5260e02)