### PR TITLE
[3.0] Fixes two issues in SMF\Actions\TopicRestore

### DIFF
--- a/Sources/Actions/Admin/Subscriptions.php
+++ b/Sources/Actions/Admin/Subscriptions.php
@@ -495,7 +495,7 @@ class Subscriptions implements ActionInterface
 						'mem.additional_groups',
 					],
 					'joins' => [
-						'{db_prefix}log_subscribed AS ls ON (ls.id_member = mem.id_member)',
+						'INNER JOIN {db_prefix}log_subscribed AS ls ON (ls.id_member = mem.id_member)',
 					],
 					'where' => [
 						'ls.id_subscribe = {int:current_subscription}',

--- a/Sources/Actions/TopicRestore.php
+++ b/Sources/Actions/TopicRestore.php
@@ -329,7 +329,9 @@ class TopicRestore implements ActionInterface, Routable
 			// Lets get the members that need their post count restored.
 			$members = User::loadCustom(
 				query_customizations: [
-					'joins' => ['{db_prefix}messages AS m ON (m.id_member = mem.id_member)'],
+					'joins' => [
+						'INNER JOIN {db_prefix}messages AS m ON (m.id_member = mem.id_member)',
+					],
 					'where' => [
 						'm.id_msg IN ({array_int:messages})',
 						'm.approved = {int:is_approved}',

--- a/Sources/Actions/TopicRestore.php
+++ b/Sources/Actions/TopicRestore.php
@@ -166,7 +166,7 @@ class TopicRestore implements ActionInterface, Routable
 
 				// Move the posts back then!
 				if (isset($previous_topics[$topic])) {
-					self::mergePosts(array_keys($data['msgs']), $data['current_topic'], $topic);
+					self::mergePosts(array_keys($data['msgs']), (int) $data['current_topic'], (int) $topic);
 					// Log em.
 					Logging::logAction('restore_posts', ['topic' => $topic, 'subject' => $previous_topics[$topic]['subject'], 'board' => empty($data['previous_board']) ? $data['possible_prev_board'] : $data['previous_board']]);
 					$messages = array_merge(array_keys($data['msgs']), $messages);


### PR DESCRIPTION
1. [Uses correct JOIN syntax in some calls to User::loadCustom()](https://github.com/SimpleMachines/SMF/commit/ebfb2e73cd806444432b2eb51da1d5fe5f61912f)
    - In SMF\Actions\TopicRestore::mergePosts(), a call was made to SMF\User::loadCustom() in which the 'joins' element of the 'query_customizations' argument wasn't a complete JOIN statement. This causes an SQL syntax error. A similar issue was found in SMF\Actions\Admin\Subscriptions::modify().
    - For both cases, this commit fixes the malformed JOIN statements.
3. [Casts to correct types when calling Actions\TopicRestore::mergePosts()](https://github.com/SimpleMachines/SMF/commit/e7b466be3a54c5d4f0e86a83694cfdeafbdb2558)
    - In SMF\Actions\TopicRestore::execute(), the mergePosts() method was being passed a string rather than an integer, causing an error to occur. 
    - This has been fixed by casting the argument to int.