### PR TITLE
[3.0] Say that an issue report covers one bug

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,37 @@ This appends `Signed-off-by: Name <email>`, which `check-signed-off.php` looks f
 php ./vendor/simplemachines/build-tools/check-signed-off.php; echo $?
 ```
 
+## Reporting bugs
+
+Issue reports come from `.github/ISSUE_TEMPLATE/standard_bug.yml`, which asks for steps to
+reproduce, the expected and the actual result, and the versions involved. Two things about
+them are easy to get wrong when the report is written by an agent that has just swept an
+area and has several findings in hand.
+
+- **One bug per report.** A sweep that turns up five defects files five reports, not one
+  with a list in it. This was asked for directly, on #9520:
+
+  > For future reference for AI agents: don't report two or more unrelated bugs in a
+  > single issue report.
+
+  The reason is what happens afterwards. An issue is closed by the pull request that
+  fixes it, so a report carrying several unrelated bugs can never close honestly: either
+  it shuts while some of what it describes is still broken, or it stays open long after
+  the part somebody cared about is done. Splitting them also lets each one be picked up,
+  labelled and argued about on its own. Where the findings really are related, file them
+  separately and link them to each other.
+
+- **Check whether a fix is already open before filing.** Searching pull request titles is
+  not enough, because the fix often lives in a pull request that is about something else
+  entirely. Search by the file instead:
+
+  ```bash
+  gh api "repos/SimpleMachines/SMF/pulls/<number>/files" --paginate --jq '.[].filename'
+  ```
+
+  Half of #9520 turned out to be fixed already by #9344, which is titled as a testing
+  change and gives no hint that it touches the installer bug in question.
+
 ## Code style
 
 Run this before every commit; it is what CI checks:


### PR DESCRIPTION
> [!NOTE]
> **This change was produced by an LLM.** The wording and the commit message were
> written by Claude (Anthropic), driven by @albertlast. It has not yet had human
> code review.

#### Description

@Sesquipedalian asked for this on #9520:

> For future reference for AI agents: don't report two or more unrelated bugs in a
> single issue report.

`AGENTS.md` is the file the agents working on this repository read — GitHub Copilot,
Codex, Cursor and Gemini CLI read it directly, and Claude Code reads it through
`CLAUDE.md` — so that request belongs in it, or the next agent will make the same
mistake. Nothing outside that file changes.

The new `## Reporting bugs` section records two things:

- **One bug per report**, with the reason rather than just the rule: an issue is closed
  by the pull request that fixes it, so a report carrying several unrelated bugs cannot
  close honestly. Either it shuts while part of what it describes is still broken, or it
  stays open long after the part somebody cared about is done. Related findings get filed
  separately and linked instead.
- **Check whether a fix is already open before filing**, and search by *file* rather than
  by title. Half of #9520 turned out to be fixed already by #9344, which is titled as a
  testing change and gives no hint from its title that it touches the installer bug in
  question — the sort of miss that reads as carelessness from the outside.

Why this failure mode is worth documenting: it comes from the way agents find these bugs.
Sweeping an area turns up several defects at once, and writing them up together feels
tidier than opening five reports. It is not, for whoever has to close them.

### Issues References (Fixes|Related|Closes)
1. Related: #9520 (where the request was made)
