### PR TITLE
[3.0] Fixes broken SNI resolution without breaking the fetch guards

### DIFF
--- a/Sources/PackageManager/FtpConnection.php
+++ b/Sources/PackageManager/FtpConnection.php
@@ -15,9 +15,6 @@ declare(strict_types=1);
 
 namespace SMF\PackageManager;
 
-use SMF\Url;
-use SMF\WebFetch\WebFetchApi;
-
 /**
  * Class FtpConnection
  * Simple FTP protocol implementation.
@@ -299,13 +296,6 @@ class FtpConnection
 		// Snatch the IP and port information, or die horribly trying...
 		if (preg_match('~\((\d+),\s*(\d+),\s*(\d+),\s*(\d+),\s*(\d+)(?:,\s*(\d+))\)~', $response, $match) == 0) {
 			$this->error = 'bad_response';
-
-			return false;
-		}
-
-		// Let's just double check that...
-		if (!(WebFetchApi::makeSafe(new Url('ftp://' . $match[1] . '.' . $match[2] . '.' . $match[3] . '.' . $match[4] . ':' . ($match[5] * 256 + $match[6]))) instanceof Url)) {
-			$this->error = 'bad_server';
 
 			return false;
 		}

--- a/Sources/PackageManager/FtpConnection.php
+++ b/Sources/PackageManager/FtpConnection.php
@@ -15,6 +15,8 @@ declare(strict_types=1);
 
 namespace SMF\PackageManager;
 
+use SMF\IP;
+
 /**
  * Class FtpConnection
  * Simple FTP protocol implementation.
@@ -300,8 +302,20 @@ class FtpConnection
 			return false;
 		}
 
+		$pasv_ip = $match[1] . '.' . $match[2] . '.' . $match[3] . '.' . $match[4];
+
+		// The server told us where to connect next, so don't take its word for
+		// it. An FTP bounce points that at something on the local network.
+		// FtpFetcher checks this too, but the package manager and the
+		// maintenance tools use this class directly.
+		if (!(new IP($pasv_ip))->isValid(FILTER_FLAG_GLOBAL_RANGE)) {
+			$this->error = 'bad_server';
+
+			return false;
+		}
+
 		// This is pretty simple - store it for later use ;).
-		$this->pasv = ['ip' => $match[1] . '.' . $match[2] . '.' . $match[3] . '.' . $match[4], 'port' => $match[5] * 256 + $match[6]];
+		$this->pasv = ['ip' => $pasv_ip, 'port' => $match[5] * 256 + $match[6]];
 
 		return true;
 	}

--- a/Sources/ProxyServer.php
+++ b/Sources/ProxyServer.php
@@ -140,7 +140,7 @@ class ProxyServer
 			// Don't proxy our own resources.
 			|| $request->host === Url::create(Config::$boardurl)->host
 			// SSRF protection: don't proxy localhost, private or reserved IPs, etc.
-			|| ($request = WebFetchApi::makeSafe($request)) === null
+			|| $request->isFetchSafe(['http', 'https'])
 		) {
 			return false;
 		}

--- a/Sources/ProxyServer.php
+++ b/Sources/ProxyServer.php
@@ -140,7 +140,7 @@ class ProxyServer
 			// Don't proxy our own resources.
 			|| $request->host === Url::create(Config::$boardurl)->host
 			// SSRF protection: don't proxy localhost, private or reserved IPs, etc.
-			|| $request->isFetchSafe(['http', 'https'])
+			|| !$request->isFetchSafe(['http', 'https'])
 		) {
 			return false;
 		}

--- a/Sources/Subs-Compat.php
+++ b/Sources/Subs-Compat.php
@@ -4005,9 +4005,7 @@ if (!empty(SMF\Config::$backward_compatibility) && !function_exists('smf_error_h
 	}
 
 	/**
-	 * Checks whether a URL is safe to fetch from the server, and then returns
-	 * either a version of the URL where the host has been resolved to a literal
-	 * IP address, or else null if the URL was unsafe to fetch.
+	 * Checks whether a URL is safe to fetch from the server.
 	 *
 	 * Rejects URLs whose scheme is not in the fetchable set, and URLs whose
 	 * host resolves (or is) a non-global IP address: loopback, private,
@@ -4017,12 +4015,37 @@ if (!empty(SMF\Config::$backward_compatibility) && !function_exists('smf_error_h
 	 * is also re-applied to each redirect target by the fetchers.
 	 *
 	 * @param string $url The URL to check.
-	 * @return string|null A version of $url where the host has been resolved to
-	 *    a literal IP address, or else null if the URL was unsafe to fetch.
+	 * @return bool Whether the URL is safe to fetch.
 	 */
-	function make_fetch_safe($url)
+	function is_fetch_safe($url)
 	{
-		return SMF\WebFetch\WebFetchApi::makeSafe($url);
+		return SMF\Url::create($url)->isFetchSafe([]);
+	}
+
+	/**
+	 * Looks up the IP address(es) that the given URL's host resolves to.
+	 *
+	 * @param string $url The URL
+	 * @return array The IP address(es).
+	 */
+	function get_ips_for_url($url)
+	{
+		return SMF\Url::create($url)->getIPs();
+	}
+
+	/**
+	 * Checks whether the given URL resolves to the given IP address.
+	 *
+	 * If the URL resolves to multiple IP addresses, this function returns true
+	 * if any of those IP addresses are the given one.
+	 *
+	 * @param string $url The URL
+	 * @param string $ip The IP address.
+	 * @return bool Whether this URL resolves to the given IP address.
+	 */
+	function url_resolves_to($url, $ip)
+	{
+		return SMF\Url::create($url)->resolvesTo(SMF\IP::create($ip));
 	}
 
 	/**

--- a/Sources/Subs-Compat.php
+++ b/Sources/Subs-Compat.php
@@ -4019,7 +4019,26 @@ if (!empty(SMF\Config::$backward_compatibility) && !function_exists('smf_error_h
 	 */
 	function is_fetch_safe($url)
 	{
-		return SMF\Url::create($url)->isFetchSafe([]);
+		return SMF\Url::create($url)->isFetchSafe();
+	}
+
+	/**
+	 * Checks whether a URL is safe to fetch from the server.
+	 *
+	 * In SMF 2.1 this returned a version of the URL where the host had been
+	 * replaced with a literal IP address. It no longer does that, because it
+	 * broke every host that needs SNI or name-based virtual hosting, and it
+	 * defeated certificate validation as well. The URL now comes back exactly
+	 * as it went in, and the fetchers pin the connection to a vetted address
+	 * themselves. Use is_fetch_safe() instead.
+	 *
+	 * @deprecated 3.0
+	 * @param string $url The URL to check.
+	 * @return ?string $url if it is safe to fetch, or null if it is not.
+	 */
+	function make_fetch_safe($url)
+	{
+		return SMF\Url::create($url)->isFetchSafe() ? $url : null;
 	}
 
 	/**

--- a/Sources/Url.php
+++ b/Sources/Url.php
@@ -495,12 +495,7 @@ class Url implements \Stringable
 			|| empty($proxied->host)
 			|| empty($proxied->path)
 			// Don't proxy URLs with domains that aren't part of public DNS.
-			|| preg_match('/\b(?' . '>example|local(?' . '>host)?|onion|test|alt|in(?' . '>ternal|valid))$/', $proxied->host)
-			// Don't proxy URLs whose hosts are private or reserved IP addresses.
-			|| (
-				filter_var(trim($proxied->host, '[]'), FILTER_VALIDATE_IP) !== false
-				&& filter_var(trim($proxied->host, '[]'), FILTER_VALIDATE_IP, FILTER_FLAG_GLOBAL_RANGE) === false
-			)
+			|| !$proxied->isFetchSafe()
 		) {
 			return $proxied;
 		}

--- a/Sources/Url.php
+++ b/Sources/Url.php
@@ -162,6 +162,13 @@ class Url implements \Stringable
 	 */
 	protected $is_ascii;
 
+	/**
+	 * @var array
+	 *
+	 * Cache for $this->getIPs()
+	 */
+	protected array $ips;
+
 	/****************
 	 * Public methods
 	 ****************/
@@ -526,26 +533,102 @@ class Url implements \Stringable
 	 */
 	public function getIPs(): array
 	{
+		if (isset($this->ips)) {
+			return $this->ips;
+		}
+
+		$is_ascii = $this->is_ascii;
+
+		$this->toAscii();
+
 		// Resolve the host to its address(es). A literal IP resolves to itself.
-		$ips = [];
+		$this->ips = [];
 
 		if (filter_var(trim($this->host, '[]'), FILTER_VALIDATE_IP)) {
-			$ips[] = new IP(trim($this->host, '[]'));
+			$this->ips[] = new IP(trim($this->host, '[]'));
 		} else {
 			$records = @dns_get_record($this->host, DNS_A | DNS_AAAA);
 
 			foreach ((array) $records as $record) {
 				if (!empty($record['ip'])) {
-					$ips[] = new IP($record['ip']);
+					$this->ips[] = new IP($record['ip']);
 				}
 
 				if (!empty($record['ipv6'])) {
-					$ips[] = new IP($record['ipv6']);
+					$this->ips[] = new IP($record['ipv6']);
 				}
 			}
 		}
 
-		return $ips;
+		if (!$is_ascii) {
+			$this->toUtf8();
+		}
+
+		return $this->ips;
+	}
+
+	/**
+	 * Checks whether this URL resolves to the given IP address.
+	 *
+	 * If this URL resolves to multiple IP addresses, this method returns true
+	 * if any of those I{ addresses are the given one.
+	 *
+	 * @param \SMF\IP $ip The IP address to check
+	 * @return bool
+	 */
+	public function resolvesTo(IP $ip): bool
+	{
+		foreach ($this->getIPs() as $known_ip) {
+			if ($ip == $known_ip) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Checks whether it is safe for the server to fetch this URL.
+	 *
+	 * Rejects URLs whose scheme is not in the fetchable set, and URLs whose
+	 * host resolves to (or is) a non-global IP address: loopback, private,
+	 * link-local (incl. 169.254.0.0/16 cloud metadata), or other reserved
+	 * ranges.
+	 *
+	 * @param array $allowed_schemes The URL schemes that the WebFetchApi is
+	 *    willing to use when fetching the content of this URL.
+	 * @return bool Whether this URL is safe to fetch.
+	 */
+	public function isFetchSafe(array $allowed_schemes): bool
+	{
+		$is_ascii = $this->is_ascii;
+
+		$this->toAscii();
+
+		if (
+			// Only known fetchable schemes.
+			empty($url->scheme)
+			|| !\in_array($url->scheme, $allowed_schemes)
+			// Must have a host.
+			|| empty($url->host)
+			// Reject reserved TLDs, since they are never in public DNS.
+			|| preg_match('/\b(?' . '>example|local(?' . '>host)?|onion|test|alt|in(?' . '>ternal|valid))$/', $url->host)
+		) {
+			$is_safe = false;
+		} else {
+			$ips = $this->getIPs();
+
+			$is_safe = $ips === array_filter(
+				$ips,
+				fn($ip) => $ip->isValid(FILTER_FLAG_GLOBAL_RANGE),
+			);
+		}
+
+		if (!$is_ascii) {
+			$this->toUtf8();
+		}
+
+		return $is_safe;
 	}
 
 	/**

--- a/Sources/Url.php
+++ b/Sources/Url.php
@@ -169,6 +169,17 @@ class Url implements \Stringable
 	 */
 	protected array $ips;
 
+	/****************************
+	 * Internal static properties
+	 ****************************/
+
+	/**
+	 * @var array
+	 *
+	 * Cache of the IP addresses that hosts resolved to during this request.
+	 */
+	protected static array $resolved_hosts = [];
+
 	/****************
 	 * Public methods
 	 ****************/
@@ -429,6 +440,10 @@ class Url implements \Stringable
 
 		$parsed = parse_url($url);
 
+		// The host may be about to change, so the addresses we resolved for the
+		// old one no longer describe this URL.
+		unset($this->ips);
+
 		foreach (['scheme', 'host', 'port', 'user', 'pass', 'path', 'query', 'fragment'] as $prop) {
 			// Clear out any old value.
 			unset($this->{$prop});
@@ -495,7 +510,12 @@ class Url implements \Stringable
 			|| empty($proxied->host)
 			|| empty($proxied->path)
 			// Don't proxy URLs with domains that aren't part of public DNS.
-			|| !$proxied->isFetchSafe()
+			|| preg_match('/\b(?' . '>example|local(?' . '>host)?|onion|test|alt|in(?' . '>ternal|valid))$/', $proxied->host)
+			// Don't proxy URLs whose hosts are private or reserved IP addresses.
+			|| (
+				filter_var(trim($proxied->host, '[]'), FILTER_VALIDATE_IP) !== false
+				&& filter_var(trim($proxied->host, '[]'), FILTER_VALIDATE_IP, FILTER_FLAG_GLOBAL_RANGE) === false
+			)
 		) {
 			return $proxied;
 		}
@@ -536,6 +556,17 @@ class Url implements \Stringable
 
 		$this->toAscii();
 
+		// Someone else already asked about this host during this request.
+		if (isset(self::$resolved_hosts[$this->host])) {
+			$this->ips = self::$resolved_hosts[$this->host];
+
+			if (!$is_ascii) {
+				$this->toUtf8();
+			}
+
+			return $this->ips;
+		}
+
 		// Resolve the host to its address(es). A literal IP resolves to itself.
 		$this->ips = [];
 
@@ -555,6 +586,12 @@ class Url implements \Stringable
 			}
 		}
 
+		// Remember it. Besides saving lookups, this is what makes the
+		// post-connection checks in the WebFetch APIs meaningful: they compare
+		// against what the host resolved to *before* we connected, so a DNS
+		// rebinding attack can't answer differently the second time around.
+		self::$resolved_hosts[$this->host] = $this->ips;
+
 		if (!$is_ascii) {
 			$this->toUtf8();
 		}
@@ -566,15 +603,18 @@ class Url implements \Stringable
 	 * Checks whether this URL resolves to the given IP address.
 	 *
 	 * If this URL resolves to multiple IP addresses, this method returns true
-	 * if any of those I{ addresses are the given one.
+	 * if any of those IP addresses are the given one.
 	 *
 	 * @param \SMF\IP $ip The IP address to check
 	 * @return bool
 	 */
 	public function resolvesTo(IP $ip): bool
 	{
+		// Compare the addresses themselves. A loose comparison of the objects
+		// would also weigh IP::$host, which either side may have populated
+		// with a reverse lookup.
 		foreach ($this->getIPs() as $known_ip) {
-			if ($ip == $known_ip) {
+			if ((string) $ip === (string) $known_ip) {
 				return true;
 			}
 		}
@@ -591,29 +631,36 @@ class Url implements \Stringable
 	 * ranges.
 	 *
 	 * @param array $allowed_schemes The URL schemes that the WebFetchApi is
-	 *    willing to use when fetching the content of this URL.
+	 *    willing to use when fetching the content of this URL. If empty, any
+	 *    scheme that the WebFetchApi has a handler for is allowed.
+	 *    Default: []
 	 * @return bool Whether this URL is safe to fetch.
 	 */
-	public function isFetchSafe(array $allowed_schemes): bool
+	public function isFetchSafe(array $allowed_schemes = []): bool
 	{
+		$allowed_schemes = $allowed_schemes === [] ? array_keys(WebFetchApi::$scheme_handlers) : $allowed_schemes;
+
 		$is_ascii = $this->is_ascii;
 
 		$this->toAscii();
 
 		if (
 			// Only known fetchable schemes.
-			empty($url->scheme)
-			|| !\in_array($url->scheme, $allowed_schemes)
+			empty($this->scheme)
+			|| !\in_array($this->scheme, $allowed_schemes)
 			// Must have a host.
-			|| empty($url->host)
+			|| empty($this->host)
 			// Reject reserved TLDs, since they are never in public DNS.
-			|| preg_match('/\b(?' . '>example|local(?' . '>host)?|onion|test|alt|in(?' . '>ternal|valid))$/', $url->host)
+			|| preg_match('/\b(?' . '>example|local(?' . '>host)?|onion|test|alt|in(?' . '>ternal|valid))$/', $this->host)
 		) {
 			$is_safe = false;
 		} else {
 			$ips = $this->getIPs();
 
-			$is_safe = $ips === array_filter(
+			// A host that resolves to nothing is not safe. We cannot know what
+			// the connection would actually reach, and dns_get_record() never
+			// sees names that only exist in the system's hosts file.
+			$is_safe = $ips !== [] && $ips === array_filter(
 				$ips,
 				fn($ip) => $ip->isValid(FILTER_FLAG_GLOBAL_RANGE),
 			);

--- a/Sources/WebFetch/APIs/CurlFetcher.php
+++ b/Sources/WebFetch/APIs/CurlFetcher.php
@@ -229,7 +229,7 @@ class CurlFetcher extends WebFetchApi
 			$url = new Url($url, true);
 		}
 
-		$url->toAscii();
+		$url->normalize()->toAscii();
 
 		// If we can't do it, bail out.
 		if (!\function_exists('curl_init')) {

--- a/Sources/WebFetch/APIs/CurlFetcher.php
+++ b/Sources/WebFetch/APIs/CurlFetcher.php
@@ -266,7 +266,7 @@ class CurlFetcher extends WebFetchApi
 		}
 
 		$this->setOptions();
-		$this->sendRequest(str_replace(' ', '%20', \strval($url)));
+		$this->sendRequest($url);
 
 		return $this;
 	}
@@ -324,17 +324,17 @@ class CurlFetcher extends WebFetchApi
 	 *  - Detects 301, 302, 307 codes and will redirect to the given response
 	 *    header location.
 	 *
-	 * @param string $url The site to fetch.
+	 * @param Url $url The site to fetch.
 	 * @param bool $redirect Whether or not this was a redirect request.
 	 */
-	private function sendRequest(string $url, bool $redirect = false): void
+	private function sendRequest(Url $url, bool $redirect = false): void
 	{
 		// We do have a url, I hope.
-		if ($url == '') {
+		if ((string) $url == '') {
 			return;
 		}
 
-		$this->options[CURLOPT_URL] = $url;
+		$this->options[CURLOPT_URL] = (string) $url;
 
 		// If we have not already been redirected, set it up so we can if needed.
 		if (!$redirect) {
@@ -350,14 +350,14 @@ class CurlFetcher extends WebFetchApi
 		// Get what was returned.
 		$curl_info = curl_getinfo($cr);
 		$curl_content = curl_multi_getcontent($cr);
-		$url = $curl_info['url']; // Last effective URL
+		$url = new Url($curl_info['url']); // Last effective URL
 		$http_code = (string) $curl_info['http_code']; // Last HTTP code
 		$body = (!curl_error($cr)) ? substr($curl_content, $curl_info['header_size']) : false;
 		$error = (curl_error($cr)) ? curl_error($cr) : false;
 
 		// Store this loop's data, someone may want all of these. :O
 		$this->response[] = [
-			'url' => $url,
+			'url' => (string) $url,
 			'success' => $error === false && $body !== false,
 			'code' => $http_code,
 			'error' => $error,
@@ -377,24 +377,23 @@ class CurlFetcher extends WebFetchApi
 	/**
 	 * Used if being redirected to ensure we have a fully qualified address.
 	 *
-	 * @param string $last_url The URL we went to.
+	 * @param Url $last_url The URL we went to.
 	 * @param string $new_url The URL we were redirected to.
-	 * @return string The new URL that was in the HTTP header.
+	 * @return Url The new URL that was in the HTTP header.
 	 */
-	private function getRedirectUrl(string $last_url = '', string $new_url = ''): string
+	private function getRedirectUrl(Url $last_url, string $new_url): Url
 	{
-		// Get the elements for these urls.
-		$last_url_parse = parse_url($last_url);
+		// Get the elements for the new URL.
 		$new_url_parse = parse_url($new_url);
 
 		// Redirect headers are often incomplete or relative so we need to make sure they are fully qualified.
-		$new_url_parse['scheme'] = $new_url_parse['scheme'] ?? $last_url_parse['scheme'];
-		$new_url_parse['host'] = $new_url_parse['host'] ?? $last_url_parse['host'];
-		$new_url_parse['path'] = $new_url_parse['path'] ?? $last_url_parse['path'];
+		$new_url_parse['scheme'] = $new_url_parse['scheme'] ?? $last_url->scheme;
+		$new_url_parse['host'] = $new_url_parse['host'] ?? $last_url->host;
+		$new_url_parse['path'] = $new_url_parse['path'] ?? $last_url->path;
 		$new_url_parse['query'] = $new_url_parse['query'] ?? '';
 
 		// Build the new URL that was in the http header.
-		return $new_url_parse['scheme'] . '://' . $new_url_parse['host'] . $new_url_parse['path'] . (!empty($new_url_parse['query']) ? '?' . $new_url_parse['query'] : '');
+		return new URL($new_url_parse['scheme'] . '://' . $new_url_parse['host'] . $new_url_parse['path'] . (!empty($new_url_parse['query']) ? '?' . $new_url_parse['query'] : ''));
 	}
 
 	/**
@@ -433,11 +432,11 @@ class CurlFetcher extends WebFetchApi
 	 * @param string $target_url The URL we want to redirect to.
 	 * @param string $referrer_url The URL that we're redirecting from.
 	 */
-	private function redirect(string $target_url, string $referrer_url): void
+	private function redirect(Url $target_url, Url $referrer_url): void
 	{
 		// SSRF guard: re-validate the redirect target before following it, so a
 		// 302 -> http://127.0.0.1/ (or link-local cloud metadata) is refused.
-		if (WebFetchApi::makeSafe(Url::create($target_url, true)) === null) {
+		if (WebFetchApi::makeSafe($target_url) === null) {
 			if (isset($this->response[$this->current_redirect - 1])) {
 				$this->response[$this->current_redirect - 1]['success'] = false;
 			}
@@ -447,7 +446,7 @@ class CurlFetcher extends WebFetchApi
 
 		// No, no, I last saw that over there... really, 301, 302, 307
 		$this->setOptions();
-		$this->options[CURLOPT_REFERER] = $referrer_url;
+		$this->options[CURLOPT_REFERER] = (string) $referrer_url;
 		$this->sendRequest($target_url, true);
 	}
 

--- a/Sources/WebFetch/APIs/CurlFetcher.php
+++ b/Sources/WebFetch/APIs/CurlFetcher.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 
 namespace SMF\WebFetch\APIs;
 
+use SMF\IP;
 use SMF\Lang;
 use SMF\Url;
 use SMF\WebFetch\WebFetchApi;
@@ -284,6 +285,12 @@ class CurlFetcher extends WebFetchApi
 	{
 		$max_result = \count($this->response) - 1;
 
+		// Nothing was recorded, because the request was refused before we ever
+		// got as far as making it.
+		if ($max_result < 0) {
+			return null;
+		}
+
 		// Just return a specified area or the entire result?
 		if (empty($area)) {
 			return $this->response[$max_result];
@@ -336,6 +343,25 @@ class CurlFetcher extends WebFetchApi
 
 		$this->options[CURLOPT_URL] = (string) $url;
 
+		// Pin the connection to an address that we already vetted. The URL
+		// keeps its host name, so SNI, the Host header and the certificate
+		// check all still see the real name; curl just isn't allowed to ask
+		// the resolver a second time and get a different answer.
+		if (filter_var(trim($url->host, '[]'), FILTER_VALIDATE_IP) === false) {
+			$ips = array_map(fn($ip) => (string) $ip, $url->getIPs());
+
+			// Listing several addresses in one entry needs curl 7.59.0.
+			if (version_compare(curl_version()['version'], '7.59.0', '<')) {
+				$ips = \array_slice($ips, 0, 1);
+			}
+
+			if ($ips !== []) {
+				$port = !empty($url->port) ? $url->port : ($url->scheme === 'https' ? 443 : 80);
+
+				$this->options[CURLOPT_RESOLVE] = [$url->host . ':' . $port . ':' . implode(',', $ips)];
+			}
+		}
+
 		// If we have not already been redirected, set it up so we can if needed.
 		if (!$redirect) {
 			$this->current_redirect = 1;
@@ -350,9 +376,22 @@ class CurlFetcher extends WebFetchApi
 		// Get what was returned.
 		$curl_info = curl_getinfo($cr);
 
-		// Double check that we connected to the expected IP.
-		if (!$url->resolvesTo(new IP(trim($curl_info['primary_ip'], '[]')))) {
-			$this->response[$this->current_redirect]['success'] = false;
+		// Double check the address we actually connected to, in case this build
+		// of curl ignored CURLOPT_RESOLVE. An empty value means we never got a
+		// connection at all, which the normal error handling below reports.
+		if (
+			$curl_info['primary_ip'] !== ''
+			&& !$url->resolvesTo(new IP(trim($curl_info['primary_ip'], '[]')))
+		) {
+			$this->response[] = [
+				'url' => (string) $url,
+				'success' => false,
+				'code' => null,
+				'error' => null,
+				'headers' => [],
+				'body' => null,
+				'size' => 0,
+			];
 
 			trigger_error(Lang::getTxt('fetch_web_data_bad_url', [__METHOD__], file: 'Errors'), E_USER_NOTICE);
 
@@ -451,7 +490,7 @@ class CurlFetcher extends WebFetchApi
 	{
 		// SSRF guard: re-validate the redirect target before following it, so a
 		// 302 -> http://127.0.0.1/ (or link-local cloud metadata) is refused.
-		if (WebFetchApi::makeSafe($target_url) === null) {
+		if (!$target_url->isFetchSafe(['http', 'https'])) {
 			if (isset($this->response[$this->current_redirect - 1])) {
 				$this->response[$this->current_redirect - 1]['success'] = false;
 			}

--- a/Sources/WebFetch/APIs/CurlFetcher.php
+++ b/Sources/WebFetch/APIs/CurlFetcher.php
@@ -247,7 +247,7 @@ class CurlFetcher extends WebFetchApi
 		}
 
 		// Umm, this shouldn't happen?
-		if (($url = WebFetchApi::makeSafe($url, ['http', 'https'])) === null) {
+		if (!$url->isFetchSafe(['http', 'https'])) {
 			trigger_error(Lang::getTxt('fetch_web_data_bad_url', [__METHOD__], file: 'Errors'), E_USER_NOTICE);
 
 			return $this;

--- a/Sources/WebFetch/APIs/CurlFetcher.php
+++ b/Sources/WebFetch/APIs/CurlFetcher.php
@@ -349,9 +349,20 @@ class CurlFetcher extends WebFetchApi
 
 		// Get what was returned.
 		$curl_info = curl_getinfo($cr);
-		$curl_content = curl_multi_getcontent($cr);
+
+		// Double check that we connected to the expected IP.
+		if (!$url->resolvesTo(new IP(trim($curl_info['primary_ip'], '[]')))) {
+			$this->response[$this->current_redirect]['success'] = false;
+
+			trigger_error(Lang::getTxt('fetch_web_data_bad_url', [__METHOD__], file: 'Errors'), E_USER_NOTICE);
+
+			return;
+		}
+
 		$url = new Url($curl_info['url']); // Last effective URL
 		$http_code = (string) $curl_info['http_code']; // Last HTTP code
+
+		$curl_content = curl_multi_getcontent($cr);
 		$body = (!curl_error($cr)) ? substr($curl_content, $curl_info['header_size']) : false;
 		$error = (curl_error($cr)) ? curl_error($cr) : false;
 
@@ -367,7 +378,11 @@ class CurlFetcher extends WebFetchApi
 		];
 
 		// If this a redirect with a location header and we have not given up, then do it again.
-		if (preg_match('~30[127]~i', $http_code) === 1 && $this->headers['location'] != '' && $this->current_redirect <= $this->max_redirect) {
+		if (
+			preg_match('~30[127]~i', $http_code)
+			&& $this->headers['location'] != ''
+			&& $this->current_redirect <= $this->max_redirect
+		) {
 			$this->current_redirect++;
 			$header_location = $this->getRedirectUrl($url, $this->headers['location']);
 			$this->redirect($header_location, $url);

--- a/Sources/WebFetch/APIs/FtpFetcher.php
+++ b/Sources/WebFetch/APIs/FtpFetcher.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 namespace SMF\WebFetch\APIs;
 
 use SMF\Config;
+use SMF\IP;
 use SMF\Lang;
 use SMF\PackageManager\FtpConnection;
 use SMF\Url;

--- a/Sources/WebFetch/APIs/FtpFetcher.php
+++ b/Sources/WebFetch/APIs/FtpFetcher.php
@@ -112,7 +112,7 @@ class FtpFetcher extends WebFetchApi
 			$url = new Url($url, true);
 		}
 
-		$url->toAscii();
+		$url->normalize()->toAscii();
 
 		// Umm, this shouldn't happen?
 		if (empty($url->scheme) || !\in_array($url->scheme, ['ftp', 'ftps'])) {

--- a/Sources/WebFetch/APIs/FtpFetcher.php
+++ b/Sources/WebFetch/APIs/FtpFetcher.php
@@ -115,7 +115,7 @@ class FtpFetcher extends WebFetchApi
 		$url->normalize()->toAscii();
 
 		// Umm, this shouldn't happen?
-		if (empty($url->scheme) || !\in_array($url->scheme, ['ftp', 'ftps'])) {
+		if (!$url->isFetchSafe(['ftp', 'ftps'])) {
 			trigger_error(Lang::getTxt('fetch_web_data_bad_url', [__METHOD__], file: 'Errors'), E_USER_NOTICE);
 
 			return $this;

--- a/Sources/WebFetch/APIs/FtpFetcher.php
+++ b/Sources/WebFetch/APIs/FtpFetcher.php
@@ -160,6 +160,23 @@ class FtpFetcher extends WebFetchApi
 			return $this;
 		}
 
+		// Double check that we connected to the expected IP and port.
+		// If the connection was successful, name will be "<IP address>:<port>"
+		$socket_name = @stream_socket_get_name($fp, true);
+
+		if (
+			!\is_string($socket_name)
+			|| !str_ends_with($socket_name, ':' . $ftp->pasv['port'])
+			|| $ftp->pasv['ip'] != substr($socket_name, 0, -\strlen(':' . $ftp->pasv['port']))
+			|| !$url->resolvesTo(new IP($ftp->pasv['ip']))
+		) {
+			fclose($fp);
+
+			trigger_error(Lang::getTxt('fetch_web_data_bad_url', [__METHOD__], file: 'Errors'), E_USER_NOTICE);
+
+			return $this;
+		}
+
 		// The server should now say something in acknowledgement.
 		$ftp->check_response(150);
 		$this->response[0]['code'] = substr($ftp->last_message, 0, 3);

--- a/Sources/WebFetch/APIs/SocketFetcher.php
+++ b/Sources/WebFetch/APIs/SocketFetcher.php
@@ -214,6 +214,22 @@ class SocketFetcher extends WebFetchApi
 			return $this;
 		}
 
+		// Double check that we connected to the expected IP and port.
+		// If the connection was successful, name will be "<IP address>:<port>"
+		$socket_name = @stream_socket_get_name($this->fp, true);
+
+		if (
+			!\is_string($socket_name)
+			|| !str_ends_with($socket_name, ':' . $this->port)
+			|| !$url->resolvesTo(new IP(trim(substr($socket_name, 0, -\strlen(':' . $this->port)), '[]')))
+		) {
+			$this->closeConnection();
+
+			trigger_error(Lang::getTxt('fetch_web_data_bad_url', [__METHOD__], file: 'Errors'), E_USER_NOTICE);
+
+			return $this;
+		}
+
 		// I want this, from there, and I may or may not bother you for more later.
 		if (empty($post_data)) {
 			fwrite($this->fp, 'GET ' . $path_and_query . ' HTTP/1.1' . $this->line_break) || throw new \Exception('Failed to write to socket');

--- a/Sources/WebFetch/APIs/SocketFetcher.php
+++ b/Sources/WebFetch/APIs/SocketFetcher.php
@@ -168,7 +168,7 @@ class SocketFetcher extends WebFetchApi
 			$url = new Url($url, true);
 		}
 
-		$url->toAscii();
+		$url->normalize()->toAscii();
 
 		// Umm, this shouldn't happen?
 		if (($url = WebFetchApi::makeSafe($url, ['http', 'https'])) === null) {

--- a/Sources/WebFetch/APIs/SocketFetcher.php
+++ b/Sources/WebFetch/APIs/SocketFetcher.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 
 namespace SMF\WebFetch\APIs;
 
+use SMF\IP;
 use SMF\Lang;
 use SMF\Url;
 use SMF\WebFetch\WebFetchApi;
@@ -171,7 +172,7 @@ class SocketFetcher extends WebFetchApi
 		$url->normalize()->toAscii();
 
 		// Umm, this shouldn't happen?
-		if (($url = WebFetchApi::makeSafe($url, ['http', 'https'])) === null) {
+		if (!$url->isFetchSafe(['http', 'https'])) {
 			$this->closeConnection();
 
 			trigger_error(Lang::getTxt('fetch_web_data_bad_url', [__METHOD__], file: 'Errors'), E_USER_NOTICE);
@@ -263,8 +264,7 @@ class SocketFetcher extends WebFetchApi
 				return $this;
 			}
 
-			// Close if it moved to a different host. (The redirect target is
-			// re-validated by the makeSafe() guard on the request() re-entry.)
+			// Close if it moved to a different host.
 			if ($location->host !== $url->host) {
 				$this->closeConnection();
 			}

--- a/Sources/WebFetch/APIs/SocketFetcher.php
+++ b/Sources/WebFetch/APIs/SocketFetcher.php
@@ -391,6 +391,12 @@ class SocketFetcher extends WebFetchApi
 	{
 		$max_result = \count($this->response) - 1;
 
+		// Nothing was recorded, because the request was refused before we ever
+		// got as far as making it.
+		if ($max_result < 0) {
+			return null;
+		}
+
 		// Just return a specified area or the entire result?
 		if (\is_null($area)) {
 			return $this->response[$max_result];

--- a/Sources/WebFetch/WebFetchApi.php
+++ b/Sources/WebFetch/WebFetchApi.php
@@ -133,7 +133,7 @@ abstract class WebFetchApi implements WebFetchApiInterface
 			$url = Url::create($url, true)->validate();
 		}
 
-		$url->toAscii();
+		$url->normalize()->toAscii();
 
 		// SSRF guard: refuse loopback/private/link-local/reserved targets and
 		// non-fetchable schemes before any connection is attempted.

--- a/Sources/WebFetch/WebFetchApi.php
+++ b/Sources/WebFetch/WebFetchApi.php
@@ -15,7 +15,6 @@ declare(strict_types=1);
 
 namespace SMF\WebFetch;
 
-use SMF\IP;
 use SMF\Lang;
 use SMF\Url;
 
@@ -72,13 +71,6 @@ abstract class WebFetchApi implements WebFetchApiInterface
 	 * Fetchers that still have an open connection after the initial request.
 	 */
 	private static array $still_alive = [];
-
-	/**
-	 * @var array
-	 *
-	 * Cache for the results of self::makeSafe()
-	 */
-	private static array $resolved_hosts = [];
 
 	/****************
 	 * Public methods
@@ -137,14 +129,7 @@ abstract class WebFetchApi implements WebFetchApiInterface
 
 		// SSRF guard: refuse loopback/private/link-local/reserved targets and
 		// non-fetchable schemes before any connection is attempted.
-		if (($url = WebFetchApi::makeSafe($url)) === null) {
-			trigger_error(Lang::getTxt('fetch_web_data_bad_url', [__METHOD__], file: 'Errors'), E_USER_NOTICE);
-
-			return false;
-		}
-
-		// No scheme? No data for you!
-		if (empty($url->scheme) || !isset(self::$scheme_handlers[$url->scheme])) {
+		if (!$url->isFetchSafe(array_keys(self::$scheme_handlers))) {
 			trigger_error(Lang::getTxt('fetch_web_data_bad_url', [__METHOD__], file: 'Errors'), E_USER_NOTICE);
 
 			return false;
@@ -191,81 +176,6 @@ abstract class WebFetchApi implements WebFetchApiInterface
 		}
 
 		return $fetcher->result('body');
-	}
-
-	/**
-	 * Checks whether a URL is safe to fetch from the server, and then returns
-	 * either a version of the URL where the host has been resolved to a literal
-	 * IP address, or else null if the URL was unsafe to fetch.
-	 *
-	 * Rejects URLs whose scheme is not in the fetchable set, and URLs whose
-	 * host resolves (or is) a non-global IP address: loopback, private,
-	 * link-local (incl. 169.254.0.0/16 cloud metadata), or other reserved
-	 * ranges. This is the single chokepoint that prevents the avatar, proxy,
-	 * getMimeType, and task fetchers from being used as SSRF primitives. It is
-	 * also re-applied to each redirect target by the fetchers.
-	 *
-	 * @param \SMF\Url $url The URL to check.
-	 * @param array $allowed_schemes Optional list of allowed URL schemes.
-	 *    If empty, all schemes that have handlers are allowed. Otherwise, only
-	 *    URLs using the one of the specified schemes will be allowed.
-	 *    Default: []
-	 * @return ?Url A version of $url where the host has been resolved to a
-	 *    literal IP address, or else null if the URL was unsafe to fetch.
-	 */
-	public static function makeSafe(Url $url, array $allowed_schemes = []): ?Url
-	{
-		$url->toAscii();
-
-		if (
-			// Only known fetchable schemes.
-			empty($url->scheme)
-			|| !isset(self::$scheme_handlers[$url->scheme])
-			|| (!empty($allowed_schemes) && !\in_array($url->scheme, $allowed_schemes))
-			// Must have a host.
-			|| empty($url->host)
-			// Reject reserved TLDs, since they are never in public DNS.
-			|| preg_match('/\b(?' . '>example|local(?' . '>host)?|onion|test|alt|in(?' . '>ternal|valid))$/', $url->host)
-		) {
-			return null;
-		}
-
-		// Avoid unnecessary repetition.
-		if (isset(self::$resolved_hosts[$url->host])) {
-			if (empty(self::$resolved_hosts[$url->host])) {
-				return null;
-			}
-
-			return new Url(
-				preg_replace(
-					'/' . preg_quote($url->host) . '/',
-					self::$resolved_hosts[$url->host][0],
-					(string) $url,
-					1,
-				),
-			);
-		}
-
-		self::$resolved_hosts[$url->host] = array_values(array_map(
-			fn($ip) => $ip->isValid(FILTER_FLAG_IPV6) ? '[' . (string) $ip . ']' : (string) $ip,
-			array_filter(
-				$url->getIPs(),
-				fn($ip) => $ip->isValid(FILTER_FLAG_GLOBAL_RANGE),
-			),
-		));
-
-		if (empty(self::$resolved_hosts[$url->host])) {
-			return null;
-		}
-
-		return new Url(
-			preg_replace(
-				'/' . preg_quote($url->host) . '/',
-				self::$resolved_hosts[$url->host][0],
-				(string) $url,
-				1,
-			),
-		);
 	}
 
 	/******************


### PR DESCRIPTION
#### Description

This is #9535 with the bugs taken out, so it is built on top of Sesquipedalian's five
commits and adds three of my own. If #9535 is merged first, only my three remain.

The approach in #9535 is the right one. Substituting a literal IP for the host was
always going to break SNI, name-based virtual hosting and certificate validation all at
once, and validating the name while pinning the connection is the correct replacement.
The patch just could not run.

**Why nothing could be fetched at all** — `Url::isFetchSafe()` reads `$url` throughout,
which is never assigned. Every check ran against null, so the method always returned
false and the guard rejected every URL before a connection was attempted. That is
sbulen's report on #9535.

**Guards that had stopped guarding**

- `ProxyServer::checkRequest()` had the test inverted: `|| $request->isFetchSafe(...)`
  where the old code rejected when `makeSafe()` returned null. proxy.php refused every
  public image and fetched the private addresses the check exists to keep it away from.
- `CurlFetcher::redirect()` still called `WebFetchApi::makeSafe()`, which the PR deletes.
  Any 301/302/307 was a fatal error.
- `CurlFetcher` and `FtpFetcher` never imported `SMF\IP`, so `new IP(...)` resolved to
  `SMF\WebFetch\APIs\IP` and fatalled on every request that reached the new check.
  `SocketFetcher` got the import; the other two did not.
- `FtpConnection::passive()` no longer looks at the address the server tells us to
  connect to next, which is what the check was for — an FTP bounce points it at the
  local network. `FtpFetcher` does check, but the package manager and the maintenance
  tools construct `FtpConnection` directly in twelve places and never go near
  `FtpFetcher`.
- `is_fetch_safe()` passed `[]` as the allowed scheme list, which matches nothing, so it
  always returned false. Under `makeSafe()` an empty list meant "any scheme with a
  handler"; `isFetchSafe()` had no such fallback, so it now takes one.

**Two things I did differently**

*curl pins the address instead of checking afterwards.* Comparing
`curl_getinfo()['primary_ip']` after the request only tells us where we already went.
`CURLOPT_RESOLVE` tells curl up front which address it may use for this host, so the URL
keeps its name and SNI, the Host header and certificate validation all still see the real
one, with no window between the check and the connect. The post-connection check stays as
a second opinion for builds that ignore the option. `SocketFetcher`'s connect-then-verify
I left alone — the only exposure there is a handshake, with no request data sent, and
`stream_socket_client` with an SSL `peer_name` context is easy to get subtly wrong.

*`Url::proxied()` stays off the resolver.* `isFetchSafe()` does a `dns_get_record()`, and
`proxied()` runs for every image in every post, so a topic with twenty images became
twenty blocking lookups. It also only decides whether to route through proxy.php, which
does its own checking, so a DNS hiccup silently stopping proxying is a bad trade. It goes
back to the cheap literal-IP and reserved-TLD test.

**Smaller things**

- `getIPs()` remembers what a host resolved to for the rest of the request, as
  `WebFetchApi::$resolved_hosts` used to. This is load-bearing now, not just a lookup
  count: the post-connection checks are only meaningful if they compare against what was
  resolved *before* connecting, or a rebinding attack just answers twice. `parse()` drops
  the cache, since the host may be about to change.
- A host that resolves to nothing is no longer "safe". `[] === array_filter([])`, and
  `dns_get_record()` never sees names that only exist in the hosts file, so
  `http://someinternalbox/` was passing.
- `resolvesTo()` compares addresses rather than objects; a loose object comparison also
  weighs `IP::$host`, which either side may have filled in with a reverse lookup.
- `make_fetch_safe()` comes back, deprecated. It is a 2.1 function and `Subs-Compat.php`
  exists to keep 2.1 names callable, so removing it fatals any mod that calls it. It
  returns the URL unchanged when safe and null when not, so `$url = make_fetch_safe($url);
  if ($url === null)` still works — and what comes back can now actually be fetched.
- `result()` returns null rather than reading index `-1` when a request was refused before
  anything was recorded. `WebFetchApi::fetch()` asks for `result('success')` on that path,
  so every refusal emitted a warning. Pre-existing, but on the path this PR is about; say
  the word and I will drop it.

#### Testing

`php-cs-fixer` is clean on all seven files. There is no test suite, so I exercised the
code directly against the URL from the issue, on `release-3.0` first and then on this
branch.

Before, on `release-3.0`:

```
===== CurlFetcher =====
  SNI host, real fetch                       FAIL  code='0' len=0
===== SocketFetcher =====
  SNI host, real fetch                       FAIL
    'url' => 'https://172.67.70.118/smf/current-version.js?version=SMF+3.0+Alpha+4'
```

That second line is the bug in one place — the host replaced by the IP.

After, on this branch:

```
===== CurlFetcher =====
  SNI host, real fetch                       SUCCESS  code='200' len=38
  body looks like current-version.js         OK
  http://127.0.0.1/ refused                  OK
  follows http->https redirect               OK  code='403' len=5520
===== SocketFetcher =====
  SNI host, real fetch                       SUCCESS  code=200 len=38
  body looks like current-version.js         OK
  http://127.0.0.1/ refused                  OK
```

Plus 20 checks over `isFetchSafe()`, `resolvesTo()` and the compat shims — public host,
loopback, private, `169.254.169.254`, `[::1]`, reserved TLDs, an unresolvable host, scheme
filtering both ways, and that the URL comes back byte-for-byte unchanged — and 6 over
`Url::proxied()`. All pass.

One thing I found and did **not** touch: `SocketFetcher` returns a 400 when it follows an
`http` to `https` redirect. It does that identically on unmodified `release-3.0`, so it is
pre-existing and unrelated, and it wants its own issue rather than a rider on this one.

### Issues References (Fixes|Related|Closes)
1. Fixes #9533
2. Related #9535
