### PR TITLE
[3.0] Records what release-2.1 means, and that a removed check may be deliberate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -174,6 +174,36 @@ touches `User::$me` or `Db::$db` needs a real request or fixtures.
 - **Deprecated compatibility layer**: `Sources/Subs-Compat.php` holds the old procedural
   API. It often shows the guard clauses the modern class methods should have; useful when
   tracking down a missing check.
+- **`release-2.1` is not the same thing as released 2.1.** `Subs-Compat.php` exists to keep
+  names that mods actually call working, and a mod can only call what shipped. Something
+  added to the `release-2.1` branch after the last tag is not public API yet and does not
+  need a shim, so check the tags rather than the branch:
+
+  ```bash
+  latest=$(git tag -l 'v2.1*' | sort -V | tail -1)
+  git grep 'function the_name' "$latest" -- Sources/
+  ```
+
+  This was asked for directly, on #9535:
+
+  > `make_fetch_safe()` never appeared in any released version of SMF 2.1 and never will,
+  > so it doesnt need to be preserved in Subs-Compat.php
+
+- **A removed check is not automatically a regression.** Some guards come out because they
+  were wrong, so work out what the code is *for* before arguing one back in. The case that
+  prompted this was `FtpConnection::passive()`, which had grown a check that the PASV
+  address was globally routable. That reads like SSRF protection, and taken on its own it
+  is. But `FtpConnection` is what the Package Manager uses to reach an FTP server the admin
+  nominated, which is very often on the LAN or on localhost, so the check broke the ordinary
+  case. From the same comment on #9535:
+
+  > It was a mistake to check for global IP addresses in `FtpConnection::passive()`, which
+  > is why that has been undone in this PR. When FtpConnection is used by the Package
+  > Manager, connecting to local IP addresses is commonly needed and intended. The check
+  > for global IP addresses only belongs in FtpFetcher, not FtpConnection.
+
+  The general shape: a class that fetches from the open web and a class that talks to
+  infrastructure the admin configured want opposite defaults. Put the check on the fetcher.
 
 ## Conventions to follow
 


### PR DESCRIPTION
#### Description

@Sesquipedalian left a comment on #9535 addressed "FYI for the AI", correcting two things
I had argued for. Both corrections are worth keeping, because in both cases the wrong
conclusion looks perfectly reasonable from inside the repository — so the next agent will
reach it too unless it is written down.

**`release-2.1` is not the same thing as released 2.1.**

I checked whether `make_fetch_safe()` needed preserving in `Subs-Compat.php` by looking for
it on the `release-2.1` branch, found it, and concluded it was 2.1 public API. It is not —
it was added to the branch on 2026-08-04 and has never shipped:

```
v2.1.5   no make_fetch_safe
v2.1.6   no make_fetch_safe
v2.1.7   no make_fetch_safe
```

`Subs-Compat.php` exists to keep working the names that mods actually call, and a mod can
only call what was in a release. So the note says to check the tags, not the branch, and
gives the two commands that do it.

**A removed check is not automatically a regression.**

`FtpConnection::passive()` had a check that the PASV address was globally routable, and
this PR removes it. I read that as a dropped SSRF guard, since that is exactly what it
looks like. But `FtpConnection` is how the Package Manager reaches an FTP server the admin
nominated, which is commonly on the LAN or on localhost — so the check broke the ordinary
case, and it belongs on `FtpFetcher`, which does fetch from the open web.

The generalisable part, and the reason it is worth a note rather than just a fix: a class
that fetches from the open web and a class that talks to infrastructure the admin
configured want opposite defaults. Working out which one you are looking at comes before
arguing a guard back in.

Both entries quote the review verbatim, the way the bug-reporting section already quotes
#9520.

#### Testing

Documentation only — no code changes, nothing to run. LF endings, no trailing whitespace.

Note for whoever merges: #9511 also touches `AGENTS.md`, in a different section (it
documents when the unit suite can cover a change). The two should not collide, but they
have not been merged together.

### Issues References (Fixes|Related|Closes)
1. Related #9535
