### PR TITLE
[3.0] Stop a finished install from leaving maintenance_tool_progress set

### DIFF
--- a/Sources/Config.php
+++ b/Sources/Config.php
@@ -1614,9 +1614,11 @@ class Config
 					// match the opening quotation mark...
 					'(?P<quote_s>["\'])' .
 					// then any number of other characters or escaped quotation marks...
-					'(?:.(?!(?P>quote_s))|\\\(?=(?P>quote_s)))*.?' .
+					// (a back reference, not a subroutine call: the value itself can
+					// contain the other sort of quotation mark, and often does)
+					'(?:.(?!(?P=quote_s))|\\\(?=(?P=quote_s)))*.?' .
 					// then the closing quotation mark.
-					'(?P>quote_s)' .
+					'(?P=quote_s)' .
 					// Maybe there's a second string concatenated to this one.
 					'(?:\s*\.\s*)*' .
 				')+',

--- a/Sources/Maintenance/Tools/Install.php
+++ b/Sources/Maintenance/Tools/Install.php
@@ -1405,10 +1405,19 @@ class Install extends ToolsBase implements ToolsInterface
 	 */
 	private function saveProgress(): bool
 	{
-		return $this->updateSettingsFile(['maintenance_tool_progress' => json_encode([
-			'started' => $this->time_started,
-			'debug' => $this->debug,
-		])]);
+		// Once we are done there is no progress left to track, and leaving a
+		// value here would tell SMF that an install is still in progress. That
+		// would stop background tasks from ever running on the new forum.
+		if (Maintenance::$overall_percent < 100) {
+			$data = json_encode([
+				'started' => $this->time_started,
+				'debug' => $this->debug,
+			]);
+		} else {
+			$data = '';
+		}
+
+		return $this->updateSettingsFile(['maintenance_tool_progress' => $data]);
 	}
 
 	/**


### PR DESCRIPTION
#### Description

A freshly installed 3.0 forum never runs a single background task, because the install leaves `$maintenance_tool_progress` set in `Settings.php` and `TaskRunner::__construct()` bails out while that variable holds a value (`Sources/TaskRunner.php:142-148`).

That is what #9022 is: `Parsed::build()` does all of its work in the background task, so the admin request sets the status to `partial`, queues a task nobody ever picks up, and the page says "partially created" forever. "Resume" only redirects. Nothing about it is engine specific — the same leftover is there on MySQL and PostgreSQL installs. The mail queue at the end of `TaskRunner::execute()` never runs either.

Two separate things conspire to keep the variable in the file.

**1. Clearing it could not work.** `Install::finalize()` already asks for it to be cleared, but `Config::updateSettingsFile()` could not find the line. The pattern it builds for a string value calls the quote group as a subroutine, `(?P>quote_s)`, where it wants a back reference, `(?P=quote_s)`. A subroutine call re-matches the group, so "the closing quotation mark" is *any* quotation mark rather than the one that opened the string, and the character class in the middle refuses any character followed by *any* quote. A value containing the other sort of quotation mark therefore never matches — and this value is JSON, so it never matches:

```php
$maintenance_tool_progress = '{"started":1787510406,"debug":false}';
```

The call then returns `true` having changed nothing. Worse, a second write of such a setting takes the "not found" path and appends a duplicate assignment lower down the file. Before this patch:

```
$mbname = 'He said "hi" to Bob\'s forum';   // line 45, written fine the first time
$mbname = 'He said "hi" to Bob\'s forum';   // line 254, appended by the next update
```

so the forum name is stuck and `Settings.php` grows a second definition of it. After the patch the same value updates in place, and every value that matched before still matches.

**2. The value was written back after being cleared.** `Maintenance::execute()` calls `preExit()` once the last step has run (`Sources/Maintenance/Maintenance.php:322`), and `Install::preExit()` saves progress unconditionally — after `finalize()` has just cleared it. `Upgrade::saveProgress()` already guards this by writing an empty value once `Maintenance::$overall_percent` reaches 100, which is why upgraded forums are fine and only fresh installs are affected. The installer now does the same. (The install steps are weighted 0/10/15/40/15/20/0, so the total reaches 100 before the `finalize` step, and this only ever fires on the final pass.)

Both are needed: with only the first fix, `preExit()` puts the value straight back; with only the second, the write of an empty value cannot match the line that is already there.

#### Testing

Verified on MariaDB 11.4.12 (the version in the report) with PHP 8.4.24, on a branch cut from `release-3.0` at c81f52325.

Before: fresh install, Admin → Search → Search Method → create the parsed index → "partially created", `search_parsed_status = partial`, one unclaimed row in `smf_background_tasks`, zero rows in `smf_log_search_dictionary`, and clicking Resume three times changed none of it.

After: `Settings.php` has no `$maintenance_tool_progress` line at all once the install finishes, and the same run goes "does not currently exist" → one cron hit → "already created", `search_parsed_status = exists`, `search_index = parsed`, 22 rows in each of the two index tables, empty task queue. No hand editing of `Settings.php` anywhere in that.

The settings file itself was checked separately: a value containing both sorts of quotation mark now round trips through `Config::updateSettingsFile()` and back out again, the file still parses, and an install writes every other setting exactly as it did before.

Only the `string` entry in `$type_regex` is touched. The `integer`, `double` and `boolean` entries use the same subroutine style, but their quotes are optional and a mismatched pair there would have to come from a hand-edited file, so I have left them alone.

### Issues References (Fixes|Related|Closes)
1. Fixes #9022
