### PR TITLE
[3.0] Point two more profile labels at their own fields

### DIFF
--- a/Themes/default/Profile.template.php
+++ b/Themes/default/Profile.template.php
@@ -1004,7 +1004,7 @@ function template_editIgnoreList()
 		<div class="information">
 			<dl class="settings">
 				<dt>
-					<label for="new_buddy"><strong>', Lang::getTxt('who_member', file: 'General'), '</strong></label>
+					<label for="new_ignore"><strong>', Lang::getTxt('who_member', file: 'General'), '</strong></label>
 				</dt>
 				<dd>
 					<input type="text" name="new_ignore" id="new_ignore" size="30">
@@ -1107,7 +1107,7 @@ function template_trackIP()
 						<label for="searchip"><strong>', Lang::getTxt('enter_ip', file: 'Profile'), '</strong></label>
 					</dt>
 					<dd>
-						<input type="text" name="searchip" value="', Utils::$context['ip'], '">
+						<input type="text" name="searchip" id="searchip" value="', Utils::$context['ip'], '">
 					</dd>
 				</dl>
 				<input type="submit" value="', Lang::getTxt('trackIP', file: 'Profile'), '" class="button">


### PR DESCRIPTION
#### Description

Two more labels whose `for` resolves to nothing, both on the profile.

- **The ignore list's "Member" label was copy-pasted from the buddy list above it** and kept that block's `for="new_buddy"`. On the ignore page that names a field which is not there; the input is `new_ignore`.
- **The IP search label names `searchip`, which is the input's `name` rather than an id** — and the input had no id at all.

Both are the same defect #9500 fixed elsewhere, and both were missed there because that sweep did not reach them: they are `sa=` sub-areas rather than areas of their own.

##### Why the id, and not the name

Worth recording, because it makes the second fix look arbitrary otherwise. The autosuggest script **rewrites the input's `name` at runtime** — it becomes something like `dummy_392365`, with a hidden field carrying the real one. A label written against the name would come loose the moment the script ran. The id is the only stable anchor here.

##### How they were found

By walking every `label[for]` on sixty-five pages — including `sa=` sub-areas this time — and resolving each id against its own document:

```
pages loaded:     65
labels checked:  272
dangling:          2
```

Both now resolve, and clicking the caption focuses the input.

### Issues References (Fixes|Related|Closes)

Related #9500