### PR TITLE
[3.0] Uses accurate info about DB support for regex engines

### DIFF
--- a/Sources/Db/APIs/MySQL.php
+++ b/Sources/Db/APIs/MySQL.php
@@ -61,9 +61,32 @@ class MySQL extends DatabaseApi implements DatabaseApiInterface
 	public bool $support_ignore = true;
 
 	/**
+	 * @var bool
 	 *
+	 * Whether the database supports ICU regular expressions.
+	 *
+	 * Will be set to true at runtime for MySQL 8.0.4 and higher.
 	 */
-	public bool $supports_pcre = false;
+	public bool $regex_icu = false;
+
+	/**
+	 * @var bool
+	 *
+	 * Whether the database supports PCRE regular expressions.
+	 *
+	 * Will be set to true at runtime for MariaDB 10.0.5 and higher.
+	 */
+	public bool $regex_pcre = false;
+
+	/**
+	 * @var bool
+	 *
+	 * Whether the database supports TCL regular expressions.
+	 *
+	 * Will be set to false at runtime for MySQL 8.0.4 and higher and for
+	 * MariaDB 10.0.5 and higher.
+	 */
+	public bool $regex_tcl = true;
 
 	/*********************
 	 * Internal properties
@@ -2595,8 +2618,15 @@ class MySQL extends DatabaseApi implements DatabaseApiInterface
 			self::$db_connection = $this->connection;
 		}
 
-		$this->get_version();
-		$this->supports_pcre = version_compare($this->version, str_contains($this->version, 'MariaDB') ? '10.0.5' : '8.0.4', '>=');
+		if ($this->get_vendor() === 'MariaDB') {
+			$this->regex_pcre = version_compare(preg_replace('/^(\d+(?:\.\d+)+).*/', '$1', $this->get_version()), '10.0.5', '>=');
+
+			$this->regex_tcl = !$this->regex_pcre;
+		} else {
+			$this->regex_icu = version_compare(preg_replace('/^(\d+(?:\.\d+)+).*/', '$1', $this->get_version()), '8.0.4', '>=');
+
+			$this->regex_tcl = !$this->regex_icu;
+		}
 
 		$this->character_set = strtolower($this->detect_charset('messages', 'body'));
 		$this->mb4 = $this->character_set === 'utf8mb4';

--- a/Sources/Db/APIs/PostgreSQL.php
+++ b/Sources/Db/APIs/PostgreSQL.php
@@ -63,7 +63,17 @@ class PostgreSQL extends DatabaseApi implements DatabaseApiInterface
 	/**
 	 *
 	 */
-	public bool $supports_pcre = true;
+	public bool $regex_icu = false;
+
+	/**
+	 *
+	 */
+	public bool $regex_pcre = false;
+
+	/**
+	 *
+	 */
+	public bool $regex_tcl = true;
 
 	/*********************
 	 * Internal properties

--- a/Sources/Db/DatabaseApi.php
+++ b/Sources/Db/DatabaseApi.php
@@ -93,10 +93,23 @@ abstract class DatabaseApi
 	/**
 	 * @var bool
 	 *
-	 * Whether the database supports PCRE regular expressions.
-	 * Always true for PostgreSQL. Depends on version for MySQL.
+	 * Whether the database supports ICU regular expressions.
 	 */
-	public bool $supports_pcre;
+	public bool $regex_icu;
+
+	/**
+	 * @var bool
+	 *
+	 * Whether the database supports PCRE regular expressions.
+	 */
+	public bool $regex_pcre;
+
+	/**
+	 * @var bool
+	 *
+	 * Whether the database supports TCL regular expressions.
+	 */
+	public bool $regex_tcl;
 
 	/**
 	 * @var string
@@ -323,7 +336,7 @@ abstract class DatabaseApi
 	 ****************/
 
 	/**
-	 * Protected constructor to prevent multiple instances.
+	 * Constructor.
 	 */
 	public function __construct()
 	{
@@ -605,8 +618,14 @@ abstract class DatabaseApi
 			'db_case_sensitive' => &$this->case_sensitive,
 			'db_mb4' => &$this->mb4,
 			'db_support_ignore' => &$this->support_ignore,
-			'db_supports_pcre' => &$this->supports_pcre,
 		];
+
+		// Previous versions of SMF didn't distinguish between PCRE vs. ICU regex support.
+		if ($this->regex_icu) {
+			Utils::$smcFunc['db_supports_pcre'] = &$this->regex_icu;
+		} else {
+			Utils::$smcFunc['db_supports_pcre'] = &$this->regex_pcre;
+		}
 
 		// Methods to export.
 		$methods = [

--- a/Sources/Search/SearchApi.php
+++ b/Sources/Search/SearchApi.php
@@ -1296,7 +1296,18 @@ abstract class SearchApi implements SearchApiInterface
 	 */
 	protected function wordBoundaryWrapper(string $str): string
 	{
-		return \sprintf(Db::$db->supports_pcre ? '\\b%s\\b' : '[[:<:]]%s[[:>:]]', $str);
+		// PCRE and ICU use `\b` as the word boundary.
+		if (Db::$db->regex_pcre || Db::$db->regex_icu) {
+			return \sprintf('\\b%s\\b', $str);
+		}
+
+		// TCL uses `\y` as the word boundary.
+		if (Db::$db->regex_tcl) {
+			return \sprintf('\\y%s\\y', $str);
+		}
+
+		// We should never get here, but just in case...
+		return $str;
 	}
 
 	/**


### PR DESCRIPTION
Fixes #9552 for SMF 3.0

This goes beyond the simple fix used for SMF 2.1 in #9553. Now we correctly report that modern MySQL databases support ICU regular expressions whereas modern MariaDB databases support PCRE regular expressions. At the moment we don't do anything with that info where the difference between PCRE and ICU would make a difference, but we might very well do so in the future.