### PR TITLE
[3.0] Give these captions to the fields they belong to

### DIFF
--- a/Themes/default/ManageMail.template.php
+++ b/Themes/default/ManageMail.template.php
@@ -67,8 +67,8 @@ function template_mailtest()
 		</div>
 		<div class="windowbg">
 				<dl id="post_header">
-					<dt><span id="caption_subject">', Lang::getTxt('subject', file: 'General'), '</span></dt>
-					<dd><input type="text" name="subject" size="80" maxlength="80"></dd>
+					<dt><label for="subject" id="caption_subject">', Lang::getTxt('subject', file: 'General'), '</label></dt>
+					<dd><input type="text" name="subject" id="subject" size="80" maxlength="80"></dd>
 				</dl>
 				<textarea class="editor" name="message" rows="5" cols="200"></textarea>
 				<dl id="post_footer">

--- a/Themes/default/ManageMembergroups.template.php
+++ b/Themes/default/ManageMembergroups.template.php
@@ -73,7 +73,7 @@ function template_new_group()
 	if (Utils::$context['post_group'] || Utils::$context['undefined_group']) {
 		echo '
 					<dt id="min_posts_text">
-						<strong>', Lang::getTxt('membergroups_min_posts', file: 'ManageMembers'), '</strong>
+						<label for="min_posts_input"><strong>', Lang::getTxt('membergroups_min_posts', file: 'ManageMembers'), '</strong></label>
 					</dt>
 					<dd>
 						<input type="number" name="min_posts" id="min_posts_input" size="5">

--- a/Themes/default/Memberlist.template.php
+++ b/Themes/default/Memberlist.template.php
@@ -164,10 +164,10 @@ function template_search()
 			<div id="advanced_search" class="roundframe">
 				<dl id="mlist_search" class="settings">
 					<dt>
-						<label><strong>', Lang::getTxt('search_for', file: 'General'), '</strong></label>
+						<label for="search"><strong>', Lang::getTxt('search_for', file: 'General'), '</strong></label>
 					</dt>
 					<dd>
-						<input type="text" name="search" value="', Utils::$context['old_search'], '" size="40">
+						<input type="text" name="search" id="search" value="', Utils::$context['old_search'], '" size="40">
 					</dd>
 					<dt>
 						<label><strong>', Lang::getTxt('mlist_search_filter', file: 'General'), '</strong></label>

--- a/Themes/default/PersonalMessage.template.php
+++ b/Themes/default/PersonalMessage.template.php
@@ -1051,7 +1051,7 @@ function template_send()
 	// To and bcc. Include a button to search for members.
 	echo '
 					<dt>
-						<span', (isset(Utils::$context['post_error']['no_to']) || isset(Utils::$context['post_error']['bad_to']) ? ' class="error"' : ''), ' id="caption_to">', trim(Lang::getTxt('pm_to', ['list' => ''], file: 'PersonalMessage')), '</span>
+						<label', (isset(Utils::$context['post_error']['no_to']) || isset(Utils::$context['post_error']['bad_to']) ? ' class="error"' : ''), ' for="to_control" id="caption_to">', trim(Lang::getTxt('pm_to', ['list' => ''], file: 'PersonalMessage')), '</label>
 					</dt>';
 
 	// Autosuggest will be added by the JavaScript later on.
@@ -1073,7 +1073,7 @@ function template_send()
 	// This BCC row will be hidden by default if JavaScript is enabled.
 	echo '
 					<dt  class="clear_left" id="bcc_div">
-						<span', (isset(Utils::$context['post_error']['no_to']) || isset(Utils::$context['post_error']['bad_bcc']) ? ' class="error"' : ''), ' id="caption_bbc">', trim(Lang::getTxt('pm_bcc', ['list' => ''], file: 'PersonalMessage')), '</span>
+						<label', (isset(Utils::$context['post_error']['no_to']) || isset(Utils::$context['post_error']['bad_bcc']) ? ' class="error"' : ''), ' for="bcc_control" id="caption_bbc">', trim(Lang::getTxt('pm_bcc', ['list' => ''], file: 'PersonalMessage')), '</label>
 					</dt>
 					<dd id="bcc_div2">
 						<input type="text" name="bcc" id="bcc_control" value="', Utils::$context['bcc_value'], '" size="20">
@@ -1083,10 +1083,10 @@ function template_send()
 	// The subject of the PM.
 	echo '
 					<dt class="clear_left">
-						<span', (isset(Utils::$context['post_error']['no_subject']) ? ' class="error"' : ''), ' id="caption_subject">', Lang::getTxt('subject', file: 'General'), '</span>
+						<label', (isset(Utils::$context['post_error']['no_subject']) ? ' class="error"' : ''), ' for="subject" id="caption_subject">', Lang::getTxt('subject', file: 'General'), '</label>
 					</dt>
 					<dd id="pm_subject">
-						<input type="text" name="subject" value="', Utils::$context['subject'], '" size="80" maxlength="80"', isset(Utils::$context['post_error']['no_subject']) ? ' class="error"' : '', '>
+						<input type="text" name="subject" id="subject" value="', Utils::$context['subject'], '" size="80" maxlength="80"', isset(Utils::$context['post_error']['no_subject']) ? ' class="error"' : '', '>
 					</dd>
 				</dl>';
 

--- a/Themes/default/Profile.template.php
+++ b/Themes/default/Profile.template.php
@@ -2735,11 +2735,11 @@ function template_profile_group_manage()
 {
 	echo '
 							<dt>
-								<strong>', Lang::getTxt('primary_membergroup', file: 'Profile'), '</strong><br>
+								<label for="id_group"><strong>', Lang::getTxt('primary_membergroup', file: 'Profile'), '</strong></label><br>
 								<span class="smalltext"><a href="', Config::$scripturl, '?action=helpadmin;help=moderator_why_missing" onclick="return reqOverlayDiv(this.href);"><span class="main_icons help"></span> ', Lang::getTxt('moderator_why_missing', file: 'Profile'), '</a></span>
 							</dt>
 							<dd>
-								<select name="id_group" ', (Profile::$member->is_me && Utils::$context['member']['group_id'] == 1 ? 'onchange="if (this.value != 1 &amp;&amp; !confirm(\'' . Lang::getTxt('deadmin_confirm', file: 'Profile') . '\')) this.value = 1;"' : ''), '>';
+								<select name="id_group" id="id_group" ', (Profile::$member->is_me && Utils::$context['member']['group_id'] == 1 ? 'onchange="if (this.value != 1 &amp;&amp; !confirm(\'' . Lang::getTxt('deadmin_confirm', file: 'Profile') . '\')) this.value = 1;"' : ''), '>';
 
 	// Fill the select box with all primary member groups that can be assigned to a member.
 	foreach (Utils::$context['member_groups'] as $member_group) {
@@ -2801,7 +2801,7 @@ function template_profile_signature_modify()
 							</dd>
 
 							<dt>
-								<strong>', Lang::getTxt('signature', file: 'Profile'), '</strong><br>
+								<label for="signature"><strong>', Lang::getTxt('signature', file: 'Profile'), '</strong></label><br>
 								<span class="smalltext">', Lang::getTxt('sig_info', file: 'Profile'), '</span><br>
 								<br>';
 

--- a/Themes/default/Reminder.template.php
+++ b/Themes/default/Reminder.template.php
@@ -30,8 +30,8 @@ function template_main()
 			<div class="roundframe">
 				<p class="smalltext centertext">', Lang::getTxt('password_reminder_desc', file: 'Profile'), '</p>
 				<dl>
-					<dt>', Lang::getTxt('user_email', file: 'Profile'), '</dt>
-					<dd><input type="text" name="user" size="30"></dd>
+					<dt><label for="user">', Lang::getTxt('user_email', file: 'Profile'), '</label></dt>
+					<dd><input type="text" name="user" id="user" size="30"></dd>
 				</dl>
 				<input type="submit" value="', Lang::getTxt('reminder_continue', file: 'Profile'), '" class="button">
 				<br class="clear">


### PR DESCRIPTION
#### Description

Nine form controls carry a caption that is drawn beside them and never associated with them. A screen reader announces the field with no name, and clicking the caption does nothing.

**The theme already does this correctly elsewhere**, which is what makes these read as oversights rather than a decision:

- the *same* subject caption is a label bound to its input in the posting form and the newsletter form, and a bare `<span>` in the personal message and mailing forms;
- the group form binds the "Required posts" caption on the page that **edits** a group, and leaves it unbound on the page that **adds** one.

Fixed the way the working ones already do it:

| template | fields |
| --- | --- |
| `PersonalMessage` | To, Bcc, Subject |
| `ManageMail` | Subject |
| `Memberlist` | Search for — it had a `<label>` with no `for` at all |
| `ManageMembergroups` | Required posts, on the add page |
| `Reminder` | Username/Email — the form's only field |
| `Profile` | Primary Membergroup, Signature |

Where the input already had an id the label simply names it; where it did not, it gets one. **No user-facing text is added or changed** — every caption here is already on the page.

##### How they were found

By walking **484 controls over 43 pages** and asking of each whether *anything* gives it an accessible name: a `label[for]`, a wrapping label, `aria-label`, `aria-labelledby`, `title` or `placeholder`.

```
pages loaded:            43
controls checked:       484
caption present but unlinked:  26
```

These nine are the subset where that caption belongs to exactly one control and to nothing else.

##### Deliberately not touched

- **The ban form.** Its captions are already labels, and they correctly name the *checkbox* that arms each trigger rather than the text field beside it. Pointing them at the text field instead would take the name off the checkbox.
- **Three places where one caption heads several controls** — the search form's message-age range, the group form's permission selects, the avatar block. Those want a `fieldset` and `legend`, not a label.

Both need new wording, so they are their own change. The remaining 153 controls with no visible caption at all — the header search box among them — likewise need new translator-facing strings and are not in scope here.

##### Nothing moves

Computed colour, font, display and box geometry of every `dt`, `dd` and named control on the six affected pages, plus the height of each page, before and after:

```
stable records compared: 177
DIFFERENCES: 0
```

(The raw comparison first reported differences that were entirely SMF's per-request session-token field name and the autosuggest's `dummy_NNNNNN` inputs, which are random on every page load. Excluding those, the six pages are identical, page heights included.)

Part of wave 7 of the [#7933](https://github.com/SimpleMachines/SMF/pull/7933) split, and a continuation of #9500 and #9549.

### Issues References (Fixes|Related|Closes)

Related #9500
