### PR TITLE
[3.0] Theme split (wave 8, part 1) — remove rtl.css rules that match nothing

### DIFF
--- a/Themes/default/css/rtl.css
+++ b/Themes/default/css/rtl.css
@@ -125,11 +125,6 @@ img#smflogo {
 	text-align: left;
 }
 
-/* the posting icons */
-#postbuttons_upper ul li a span {
-	line-height: 19px;
-	padding: 0 6px 0 0;
-}
 
 .mark_read {
 	float: left;
@@ -213,11 +208,6 @@ ul.quickbuttons li {
 #forumposts .modified {
 	float: right;
 }
-#forumposts .reportlinks {
-	margin-left: 1.5em;
-	text-align: left;
-	clear: left;
-}
 
 #moderationbuttons_strip {
 	float: right;
@@ -248,29 +238,6 @@ ul.quickbuttons li {
 	float: right;
 }
 
-/* Styles for edit event section
----------------------------------------------------- */
-#post_event div.event_options {
-	float: left;
-}
-#post_event #event_main input {
-	margin: 0 0 1em 0;
-	float: right;
-}
-#post_event #event_main div.smalltext {
-	float: left;
-}
-#post_event ul.event_main li {
-	float: left;
-}
-#post_event ul.event_options {
-	padding: 0 .7em .7em 0;
-}
-#post_event #event_main select, #post_event ul.event_options li select,
-#post_event ul.event_options li input[type="checkbox"] {
-	margin: 0 0 0 1em;
-}
-
 /* Styles for edit poll section.
 ---------------------------------------------------- */
 #edit_poll fieldset input {
@@ -297,15 +264,6 @@ ul.quickbuttons li {
 
 /* Styles for the personal messages section.
 ------------------------------------------------- */
-#personal_messages h3 span#author, #personal_messages h3 span#topic_title {
-	float: right;
-}
-#personal_messages h3 span#author {
-	margin: 0 0.5em 0 0;
-}
-#personal_messages h3 span#topic_title {
-	margin: 0 9em 0 0;
-}
 #personal_messages .labels {
 	padding: 0 0 0 1em;
 }
@@ -409,10 +367,6 @@ div#admin_menu {
 	margin: 0 5px 0 0 !important;
 }
 /* h3 HD Icons */
-h3.search_hd {
-	padding: 8px 45px 6px;
-	background-position: 99% 50%;
-}
 h3.profile_hd {
 	padding: 8px 50px 8px 0;
 	background-position: 99% 50%;
@@ -438,14 +392,6 @@ h3.profile_hd {
 	margin-left: 1em;
 }
 
-/* Most popular boards by posts and activity */
-#popularposts {
-	float: right;
-}
-#popularactivity {
-	float: left;
-}
-
 /* View posts */
 .topic .time {
 	float: left;
@@ -453,11 +399,6 @@ h3.profile_hd {
 .counter {
 	padding: 0.2em 0.2em 0.1em 0.5em;
 	float: right;
-}
-.topic .mod_icons {
-	text-align: left;
-	margin-right: 0;
-	margin-left: 1em;
 }
 
 #ip_list li.header, #ip_list li.ip {
@@ -487,9 +428,6 @@ h3.profile_hd {
 
 /* Styles for the statistics center.
 ------------------------------------------------- */
-.stats_icon {
-	margin: 2px 3px -1px 6px;
-}
 dl.stats dt {
 	float: right;
 }
@@ -529,15 +467,8 @@ tr.windowbg th.stats_month, tr.windowbg td.stats_day {
 	text-align: right;
 }
 
-.search_results_posts .buttons {
-	padding: 5px 0 0 1em;
-}
-
 /* Styles for the help section.
 ------------------------------------------------- */
-#helpmain h3.section {
-	padding: 0 0.5em 0.5em 0;
-}
 /* put back the bullets please */
 #helpmain ul {
 	margin: 0 25px 0 0;


### PR DESCRIPTION
#### Description

Part 1 of wave 8 of the #7933 split. Wave 8 is the right-to-left work: converting the
theme to CSS logical properties so that `rtl.css` stops being needed. This first part
does not convert anything — it removes the rules in `rtl.css` that already override
nothing, so the conversion that follows starts from a file where every remaining rule
has a job.

`rtl.css` only ever flips physical properties, so every rule in it is an override of
something another stylesheet draws. Sixteen of them name markup the theme no longer
emits.

The largest single group is the edit-event section. The event editor was rewritten at
some point and now draws **no `ul` at all**, so `#post_event ul.event_options`,
`#post_event ul.event_main li` and their siblings cannot match. The two `#event_main`
rules go with them: nothing emits that id either.

The rest name ids and classes that appear nowhere in `Themes/` or `Sources/`:
`#postbuttons_upper`, `.reportlinks`, `#personal_messages h3 span#author` and
`span#topic_title`, `h3.search_hd`, `#popularposts`, `#popularactivity`,
`.topic .mod_icons`, `.stats_icon`, `.search_results_posts .buttons` and
`#helpmain h3.section`.

`.topic .mod_icons` is the counterpart of the `index.css` rule removed in #9547, which
left this copy behind.

**One that looked dead and is not.** `.bbc_standard_quote` and `.bbc_alternate_quote`
appear in no template, because those class names are assembled at runtime in
`Sources/Parsers/BBCodeParser.php:1906` as `'bbc_' . ($quote_alt ? 'alternate' :
'standard') . '_quote'`. Their rules are kept. Any similar sweep needs to check for
constructed class names rather than trusting a grep.

#### How this was checked

Loaded 24 pages as an administrator with a right-to-left language active — the event
editor, statistics centre, help, search results, personal messages, profile tracking,
board index, topic display, posting form, admin and moderation centres among them —
and counted matches for every removed selector.

- 24 pages, all returning 200 with no error page
- 7086 elements
- **0 matches**, for all 18 removed selectors

The same sweep counts `#post_event fieldset` and `#post_event .roundframe` as present,
which is what shows the event editor really rendered and the zero is not vacuous.

`rtl.css` goes from 624 lines to 555.

### Issues References (Fixes|Related|Closes)

Related to #7933.
