### PR TITLE
[3.0] Theme split (wave 8, part 2) — float with logical properties instead of left and right

### DIFF
--- a/Themes/default/css/calendar.css
+++ b/Themes/default/css/calendar.css
@@ -21,7 +21,7 @@ td.days:hover {
 }
 #month_grid {
 	width: 214px;
-	float: left;
+	float: inline-start;
 	text-align: center;
 	overflow: hidden;
 	margin-right: 10px;

--- a/Themes/default/css/calendar.rtl.css
+++ b/Themes/default/css/calendar.rtl.css
@@ -4,7 +4,6 @@
 	margin: 0 0 0 2px;
 }
 #month_grid {
-	float: right;
 	margin: 0 0 0 1%;
 }
 #main_grid table.weeklist td.windowbg {

--- a/Themes/default/css/index.css
+++ b/Themes/default/css/index.css
@@ -1255,7 +1255,7 @@ html[lang="el-GR"] .inline_mod_check {
 	height: 18px;
 	width: 18px;
 	margin: 2px 5px 0 0;
-	float: left;
+	float: inline-start;
 }
 #pm_menu_top .main_icons,
 #alerts_menu_top .main_icons {
@@ -1540,7 +1540,7 @@ ul li.greeting {
 }
 .mark_read {
 	margin: -5px 0 16px 0;
-	float: right;
+	float: inline-end;
 }
 .mark_read .buttonlist {
 	margin: 0;
@@ -1862,7 +1862,7 @@ fieldset.merge_options {
 	padding: 1px;
 }
 .login dt {
-	float: left;
+	float: inline-start;
 	clear: both;
 	text-align: right;
 	font-weight: bold;
@@ -1898,7 +1898,7 @@ dl.register_form {
 }
 dl.register_form dt {
 	font-weight: normal;
-	float: left;
+	float: inline-start;
 	clear: both;
 	width: 50%;
 	margin: 6px 0 0 0;
@@ -2386,7 +2386,7 @@ a.main_icons.feed::before {
 .errorbox p.alert {
 	padding: 0;
 	margin: 0 4px 0 0;
-	float: left;
+	float: inline-start;
 	width: 12px;
 	font-size: 1.5em;
 }
@@ -2505,14 +2505,14 @@ dl {
 
 /* View posts */
 .topic .time {
-	float: right;
+	float: inline-end;
 }
 .counter {
 	padding: 5px 6px 1px 2px;
 	font-size: 2.2em;
 	font-weight: bold;
 	color: var(--counter-color);
-	float: left;
+	float: inline-start;
 }
 .topic_details {
 	padding: 0 4px 4px 4px;
@@ -2613,7 +2613,7 @@ dl {
 /* Pick theme */
 #pick_theme {
 	width: 100%;
-	float: left;
+	float: inline-start;
 }
 #pick_theme .selected {
 	background: var(--picktheme-selected-bg);
@@ -2628,7 +2628,7 @@ dl {
 }
 dl.stats dt {
 	width: 50%;
-	float: left;
+	float: inline-start;
 	margin: 0 0 4px 0;
 	line-height: 1.5em;
 	clear: both;
@@ -2724,7 +2724,7 @@ dl.addrules dt.floatleft {
 	clear: both;
 }
 #to_item_list_container div, #bcc_item_list_container div {
-	float: left;
+	float: inline-start;
 	margin-right: 10px;
 }
 .unread_pm {
@@ -2830,7 +2830,7 @@ dl.addrules dt.floatleft {
 }
 #advanced_search dd {
 	width: 75%;
-	float: left;
+	float: inline-start;
 	padding: 2px;
 	margin: 0 0 0 6px;
 	text-align: left;
@@ -3087,7 +3087,7 @@ div#manage_boards dl dd textarea[name=desc] {
 	margin-bottom: 15px;
 }
 h3 .collapse {
-	float: right;
+	float: inline-end;
 	margin: 4px 4px 0 0;
 }
 .board_icon a {
@@ -3346,7 +3346,7 @@ span.postby {
 	padding: 4px 0;
 	width: 30%;
 	max-width: 30em;
-	float: left;
+	float: inline-start;
 	clear: left;
 }
 #poll_options dl.options .voted {
@@ -3355,7 +3355,7 @@ span.postby {
 #poll_options dl.options dd {
 	width: 60%;
 	max-width: 45em;
-	float: left;
+	float: inline-start;
 	margin: 0 0 4px 0;
 	text-align: right;
 }
@@ -3414,7 +3414,7 @@ div#pollmoderation {
 }
 /* poster details and list of items */
 .poster {
-	float: left;
+	float: inline-start;
 	/* Don't set this in em.It will eat too much space if people need to set large text sizes. */
 	width: 160px;
 	-webkit-hyphens: auto;
@@ -3628,7 +3628,15 @@ form#postmodify .roundframe {
 	padding: 6px;
 	overflow: hidden;
 }
-#post_header dt,
+#post_header dt {
+	float: inline-start;
+	padding: 0;
+	width: 15%;
+	margin: 6px 0 0 0;
+	font-weight: bold;
+}
+/* The event editor is not mirrored for right-to-left yet, so this half of
+   the pair keeps a physical float until it is. */
 #event_options dt {
 	float: left;
 	padding: 0;
@@ -3636,7 +3644,14 @@ form#postmodify .roundframe {
 	margin: 6px 0 0 0;
 	font-weight: bold;
 }
-#post_header dd,
+#post_header dd {
+	float: inline-start;
+	padding: 0;
+	width: 83%;
+	margin: 4px 0;
+}
+/* The event editor is not mirrored for right-to-left yet, so this half of
+   the pair keeps a physical float until it is. */
 #event_options dd {
 	float: left;
 	padding: 0;
@@ -3759,7 +3774,7 @@ form#postmodify .roundframe {
 	float: left;
 }
 #moderationbuttons_strip {
-	float: left;
+	float: inline-start;
 	margin: 4px 0 4px;
 }
 #moderationbuttons ul li {

--- a/Themes/default/css/profile.css
+++ b/Themes/default/css/profile.css
@@ -14,12 +14,12 @@
 /* The basic user info on the left */
 #basicinfo {
 	width: 20%;
-	float: left;
+	float: inline-start;
 }
 
 #detailedinfo {
 	width: 79.5%;
-	float: right;
+	float: inline-end;
 }
 
 #basicinfo > * {
@@ -47,7 +47,7 @@
 
 #basicinfo .icon_fields li {
 	display: block;
-	float: left;
+	float: inline-start;
 	margin-right: 5px;
 	height: 20px;
 }
@@ -96,7 +96,7 @@
 }
 
 #avatar_server_stored div {
-	float: left;
+	float: inline-start;
 }
 
 #avatar_upload {
@@ -122,7 +122,7 @@
 
 .activity_stats li {
 	width: 4.16%;
-	float: left;
+	float: inline-start;
 	text-align: center;
 }
 
@@ -155,7 +155,7 @@
 .profile_pie {
 	background: url(../images/stats_pie.png);
 	background-size: auto 20px;
-	float: left;
+	float: inline-start;
 	height: 20px;
 	width: 20px;
 	margin: 0 12px 0 0;

--- a/Themes/default/css/rtl.css
+++ b/Themes/default/css/rtl.css
@@ -106,7 +106,6 @@ img#smflogo {
 
 /* Profile drop it needs reverse on RTL */
 #profile_menu_top > img.avatar {
-	float: right;
 	margin: 2px 0 0 5px;
 }
 #profile_menu .profile_user_info {
@@ -125,28 +124,16 @@ img#smflogo {
 	text-align: left;
 }
 
-
-.mark_read {
-	float: left;
-}
-
 /* Poll results */
 #poll_options dl.options {
 	padding: 1em 2em 1em 2.5em;
 	margin: 0 0 1em 1em;
 }
 #poll_options dl.options dt {
-	float: right;
 	clear: right;
 }
 #poll_options dl.options dd {
-	float: right;
 	text-align: left;
-}
-
-/* poster and postarea + moderation area underneath */
-.poster {
-	float: right;
 }
 .postarea, .moderatorbar {
 	margin: 0 175px 0 0;
@@ -208,10 +195,6 @@ ul.quickbuttons li {
 #forumposts .modified {
 	float: right;
 }
-
-#moderationbuttons_strip {
-	float: right;
-}
 #moderationbuttons_strip ul {
 	margin: 0 0.2em 0 0;
 	padding: 0 1em 0 0;
@@ -227,15 +210,6 @@ ul.quickbuttons li {
 /* mlist */
 #mlist .website_url {
 	width: 80px;
-}
-
-/* Styles for edit post section
----------------------------------------------------- */
-#post_header dt {
-	float: right;
-}
-#post_header dd {
-	float: right;
 }
 
 /* Styles for edit poll section.
@@ -268,19 +242,12 @@ ul.quickbuttons li {
 	padding: 0 0 0 1em;
 }
 #to_item_list_container div, #bcc_item_list_container div {
-	float: right;
 	margin: 0;
 }
 
 /* Styles for the move topic section. */
 .move_topic {
 	text-align: right;
-}
-
-/* Styles for the login areas.
-------------------------------------------------------- */
-.login dt {
-	float: right;
 }
 .login dd {
 	float: right;
@@ -293,10 +260,6 @@ ul.quickbuttons li {
 /* Additional profile fields */
 dl.register_form {
 	clear: left;
-}
-
-dl.register_form dt {
-	float: right;
 }
 
 /* Styles for maintenance mode.
@@ -338,27 +301,14 @@ div#admin_menu {
 }
 .errorbox p.alert {
 	margin: 0 0 0 4px;
-	float: right;
 }
 .errorbox, .noticebox, .infobox {
 	padding: 7px 35px 7px 10px;
 }
 
-/* Styles for the profile section.
-------------------------------------------------- */
-#basicinfo {
-	float: right;
-}
-#detailedinfo {
-	float: left;
-}
 #basicinfo .icon_fields li {
-	float: right;
 	margin-right: 0;
 	margin-left: 5px;
-}
-#avatar_server_stored div {
-	float: right;
 }
 #detailedinfo dt, #tracking dt {
 	float: right;
@@ -376,9 +326,6 @@ h3.profile_hd {
 #activitytime {
 	clear: right;
 }
-.activity_stats li {
-	float: right;
-}
 .activity_stats li span {
 	border-width: 1px 0 0 1px;
 }
@@ -387,18 +334,11 @@ h3.profile_hd {
 }
 .profile_pie {
 	background-image: url(../images/stats_pie_rtl.png);
-	float: right;
 	margin-right: 0;
 	margin-left: 1em;
 }
-
-/* View posts */
-.topic .time {
-	float: left;
-}
 .counter {
 	padding: 0.2em 0.2em 0.1em 0.5em;
-	float: right;
 }
 
 #ip_list li.header, #ip_list li.ip {
@@ -417,18 +357,8 @@ h3.profile_hd {
 .ignoreboards li {
 	float: right;
 }
-
-#pick_theme {
-	float: right;
-}
 .infolinks {
 	min-width: 95%;
-	float: right;
-}
-
-/* Styles for the statistics center.
-------------------------------------------------- */
-dl.stats dt {
 	float: right;
 }
 dl.stats dd {
@@ -458,7 +388,6 @@ tr.windowbg th.stats_month, tr.windowbg td.stats_day {
 	text-align: left;
 }
 #advanced_search dd {
-	float: right;
 	margin: 0 0.5em 0 0;
 	text-align: right;
 }
@@ -532,10 +461,6 @@ span.search_weight {
 ------------------------------------------------- */
 ul.moderation_notes li {
 	padding: 4px 4px 4px 0;
-}
-
-h3 .collapse {
-	float: left;
 }
 
 .pages {


### PR DESCRIPTION
#### Description

Part 2 of wave 8 of the #7933 split.

`float: inline-start` and `float: inline-end` follow the writing direction by themselves,
so a rule written that way needs no right-to-left counterpart at all. This converts the
floats where `rtl.css` was doing nothing except mirroring the value, and deletes those
overrides.

This is the same move #9356 and #9357 made for the float/align utilities and for
`dl.settings`, applied to the rest of the theme.

#### What is and is not converted

Only the **26 floats whose override is an exact mirror** — `index.css`, `profile.css` or
`calendar.css` says `left` and `rtl.css` says `right`, or the reverse. Those are the ones
where one logical declaration reproduces both directions exactly.

Deliberately left alone:

- floats whose right-to-left value is **not** the mirror of the left-to-right one. A
  single logical declaration cannot express two different values, so converting them
  would change how one direction renders.
- floats that `rtl.css` **adds** where the base stylesheet has none. Same reason.

`#post_header dt`/`dd` shared a rule with `#event_options dt`/`dd`, and only the first
pair has a mirror in `rtl.css`. Converting them together would have started mirroring the
event editor, which is **not** mirrored today, so the rule is split and `#event_options`
keeps a physical float with a comment recording why. That the event editor is unmirrored
in right-to-left looks like a real gap, but it is a behaviour change and does not belong
in a no-op PR.

#### How this was checked

The criterion for this part is that **nothing moves, in either direction**.

For every element on 26 pages I recorded `float`, `clear`, `text-align`, the inline
margins and padding, and the full bounding rectangle — before and after, captured back to
back across a stash so no other forum state could shift in between.

| | elements | differences |
| --- | --- | --- |
| left-to-right | 8018 | 82, all of them the `float` keyword |
| right-to-left | 8017 | 81, all of them the `float` keyword |

**No geometry changed anywhere — not one x, y, width, height, margin or padding.**

The keyword itself is expected to differ: `getComputedStyle` reports `inline-start`
rather than resolving it back to `left` or `right`. The geometry is the part that proves
the rendering is untouched.

Worth recording for anyone repeating this: a first attempt showed six extra differences
on the board index, all on the "Users online" line. That was the online-member count
changing between captures, not the CSS — the element's right edge and its `<strong>`
child were identical and only the text width moved. Capturing the pair back to back makes
it go away.

`rtl.css` goes from 555 lines to 480.

### Issues References (Fixes|Related|Closes)

Related to #7933.

---

#### On the ordering of these four

These were originally stacked. They are not any more — each of #9569, #9570, #9571 and
#9572 now branches from `release-3.0` on its own and contains exactly one commit, so each
diff shows only its own property and nothing else. They can be reviewed in any order.

They cannot all be *merged* without a rebase in between, and that is worth being straight
about. One `rtl.css` rule usually mirrors several properties at once, so these PRs edit
some of the same declaration blocks. `release-3.0` has:

```css
#poll_options dl.options dt { float: right; clear: right; }
#poll_options dl.options dd { float: right; text-align: left; }
```

#9569 removes both `float`s, #9570 removes the `text-align`, #9571 removes the `clear` —
and a rule only disappears once its last declaration is gone. Merging any one of these is
fine; after that I will rebase the rest, which is a few minutes of work each time. Of the
six pairs, `text-align`+`clear` and `clear`+margins merge cleanly as they stand; the
`float` one overlaps with all three, so merging that one first costs the least.

