### PR TITLE
[3.0] Theme split (wave 8, part 3) — align text with start and end instead of left and right

### DIFF
--- a/Themes/default/css/admin.css
+++ b/Themes/default/css/admin.css
@@ -421,7 +421,7 @@ fieldset.qa_fieldset {
 span.search_weight {
 	width: 40px;
 	padding: 0 0.5em;
-	text-align: right;
+	text-align: end;
 }
 .search_settings {
 	width: 47%;

--- a/Themes/default/css/calendar.css
+++ b/Themes/default/css/calendar.css
@@ -85,7 +85,7 @@ td.days:hover {
 #main_grid th.days {
 	width: 14%;
 	padding: 5px 10px;
-	text-align: left;
+	text-align: start;
 	background: var(--calendar-th-bg);
 }
 #main_grid td.weeks {
@@ -135,7 +135,7 @@ td.days:hover {
 #main_grid td.days,
 #month_grid td.days {
 	vertical-align: top;
-	text-align: left;
+	text-align: start;
 	border-right: 1px solid var(--window-border-color);
 	border-bottom: 1px solid var(--window-border-color);
 }

--- a/Themes/default/css/index.css
+++ b/Themes/default/css/index.css
@@ -1795,7 +1795,7 @@ ul li.greeting {
 .move_topic {
 	width: 710px;
 	margin: auto;
-	text-align: left;
+	text-align: start;
 }
 div.move_topic fieldset {
 	margin-top: 1ex;
@@ -1870,7 +1870,7 @@ fieldset.merge_options {
 .login dd {
 	width: 54%;
 	float: right;
-	text-align: left;
+	text-align: start;
 }
 .login p {
 	text-align: center;
@@ -2654,12 +2654,12 @@ dl.stats {
 	text-align: center;
 }
 #stats tr.windowbg th.lefttext {
-	text-align: left;
+	text-align: start;
 }
 #stats tr.windowbg th.stats_month {
 	width: 25%;
 	padding: 0 2em;
-	text-align: left;
+	text-align: start;
 }
 #stats tr.windowbg td.stats_day {
 	padding: 0 3.5em;
@@ -2797,7 +2797,7 @@ dl.addrules dt.floatleft {
 /* Styles for the search section.
 ------------------------------------------------- */
 #searchform fieldset {
-	text-align: left;
+	text-align: start;
 	padding: 0;
 	border: none;
 }
@@ -2825,7 +2825,7 @@ dl.addrules dt.floatleft {
 }
 #advanced_search dt {
 	padding: 2px;
-	text-align: right;
+	text-align: end;
 	width: 20%;
 }
 #advanced_search dd {
@@ -2833,7 +2833,7 @@ dl.addrules dt.floatleft {
 	float: inline-start;
 	padding: 2px;
 	margin: 0 0 0 6px;
-	text-align: left;
+	text-align: start;
 }
 #search_results {
 	margin-bottom: 5px;
@@ -3357,7 +3357,7 @@ span.postby {
 	max-width: 45em;
 	float: inline-start;
 	margin: 0 0 4px 0;
-	text-align: right;
+	text-align: end;
 }
 
 /* Poll notices */

--- a/Themes/default/css/rtl.css
+++ b/Themes/default/css/rtl.css
@@ -132,9 +132,6 @@ img#smflogo {
 #poll_options dl.options dt {
 	clear: right;
 }
-#poll_options dl.options dd {
-	text-align: left;
-}
 .postarea, .moderatorbar {
 	margin: 0 175px 0 0;
 }
@@ -245,13 +242,8 @@ ul.quickbuttons li {
 	margin: 0;
 }
 
-/* Styles for the move topic section. */
-.move_topic {
-	text-align: right;
-}
 .login dd {
 	float: right;
-	text-align: right;
 }
 .login h3 img {
 	margin: 0 0 0.5em;
@@ -364,9 +356,6 @@ h3.profile_hd {
 dl.stats dd {
 	margin: 0 2% 4px 0;
 }
-#stats tr.windowbg th.stats_month {
-	text-align: right;
-}
 .generic_bar .bar, .progress_bar .bar {
 	left: unset;
 	right: 0;
@@ -374,22 +363,17 @@ dl.stats dd {
 tr.windowbg th.stats_month, tr.windowbg td.stats_day {
 	text-align: right;
 }
-#stats tr.windowbg th.lefttext, #stats tr.titlebg th.lefttext {
+/* Only the windowbg half of this pair has a left-to-right rule to mirror;
+   the titlebg half is aligned by .lefttext, so it still needs flipping here. */
+#stats tr.titlebg th.lefttext {
 	text-align: right;
 }
 
-/* Styles for the advanced search section.
-------------------------------------------------- */
-#searchform fieldset {
-	text-align: right;
-}
 #advanced_search dt {
 	float: right;
-	text-align: left;
 }
 #advanced_search dd {
 	margin: 0 0.5em 0 0;
-	text-align: right;
 }
 /* Boards picker */
 #searchform fieldset p {
@@ -439,10 +423,6 @@ tr.windowbg th.stats_month, tr.windowbg td.stats_day {
 	padding: 0 0 0 13px;
 }
 
-span.search_weight {
-	text-align: left;
-}
-
 /* Manage Bans */
 .ban_restriction {
 	margin: 0.2em 2.2em 0.2em 0;
@@ -466,12 +446,6 @@ ul.moderation_notes li {
 .pages {
 	margin-left: 0;
 	margin-right: 7px;
-}
-
-/* Styles for the calendar.
------------------------------ */
-#main_grid th.days, #main_grid td.days {
-	text-align: right;
 }
 
 /* Code is a code do it LTR */


### PR DESCRIPTION
#### Description

Part 3 of wave 8 of the #7933 split.

`text-align: start` and `text-align: end` follow the writing direction, so the eleven
places where `rtl.css` did nothing except mirror the alignment no longer need an override
at all.

Same rule as part 2: only **exact mirrors** are converted — the base stylesheet says
`left` and `rtl.css` says `right`, or the reverse.

Left alone on purpose:

- alignments `rtl.css` sets where the base sheet has none, which a single logical
  declaration cannot express
- the **deliberate** ones. `code.bbc_code` and `pre.file_content` stay `text-align: left`
  in a right-to-left language because code should not be mirrored. That rule is untouched,
  and converting it would have been a real bug rather than a no-op.

#### Two that needed care rather than a substitution

`#main_grid td.days` shares a rule with `#month_grid td.days`, and only the first has a
mirror. It turned out to be safe anyway: the mini calendar re-declares
`text-align: center` immediately below at equal specificity, so the shared value never
reaches it.

`rtl.css` aligned `#stats tr.windowbg th.lefttext` and `#stats tr.titlebg th.lefttext`
in one rule, and only the `windowbg` half has a rule to mirror — the `titlebg` half is
aligned by the generic `.lefttext` instead. Removing the pair wholesale would have quietly
dropped the flip for `titlebg`, so that half keeps its override, now standing alone with a
comment explaining why.

#### How this was checked

Same criterion and method as part 2 — nothing moves in either direction — with
`text-align` and `direction` recorded alongside the geometry, on 28 pages, captured back
to back across a stash.

| | elements | differences |
| --- | --- | --- |
| left-to-right | 8996 | 119, all the `text-align` keyword |
| right-to-left | 8995 | 119, all the `text-align` keyword |

**No geometry moved in either direction.**

The count is larger than the eleven converted rules because `text-align` inherits, so
every child reports the new keyword too. In right-to-left the changes read
`right -> start` and `left -> end`, which are the same rendering; in left-to-right they
read `left -> start` and `right -> end`.

`rtl.css` goes from 480 lines to 453.

### Issues References (Fixes|Related|Closes)

Related to #7933.

---

#### On the ordering of these four

These were originally stacked. They are not any more — each of #9569, #9570, #9571 and
#9572 now branches from `release-3.0` on its own and contains exactly one commit, so each
diff shows only its own property and nothing else. They can be reviewed in any order.

They cannot all be *merged* without a rebase in between, and that is worth being straight
about. One `rtl.css` rule usually mirrors several properties at once, so these PRs edit
some of the same declaration blocks. `release-3.0` has:

```css
#poll_options dl.options dt { float: right; clear: right; }
#poll_options dl.options dd { float: right; text-align: left; }
```

#9569 removes both `float`s, #9570 removes the `text-align`, #9571 removes the `clear` —
and a rule only disappears once its last declaration is gone. Merging any one of these is
fine; after that I will rebase the rest, which is a few minutes of work each time. Of the
six pairs, `text-align`+`clear` and `clear`+margins merge cleanly as they stand; the
`float` one overlaps with all three, so merging that one first costs the least.


