### PR TITLE
[3.0] Theme split (wave 8, part 4) — clear floats with inline-start and inline-end

### DIFF
--- a/Themes/default/css/index.css
+++ b/Themes/default/css/index.css
@@ -1894,7 +1894,7 @@ fieldset.merge_options {
 }
 dl.register_form {
 	margin: 0;
-	clear: right;
+	clear: inline-end;
 }
 dl.register_form dt {
 	font-weight: normal;
@@ -3347,7 +3347,7 @@ span.postby {
 	width: 30%;
 	max-width: 30em;
 	float: inline-start;
-	clear: left;
+	clear: inline-start;
 }
 #poll_options dl.options .voted {
 	font-weight: bold;
@@ -3476,7 +3476,7 @@ img.avatar {
 	width: 100%;
 }
 .moderatorbar {
-	clear: right;
+	clear: inline-end;
 }
 .messageicon {
 	display: inline-block;

--- a/Themes/default/css/rtl.css
+++ b/Themes/default/css/rtl.css
@@ -129,16 +129,10 @@ img#smflogo {
 	padding: 1em 2em 1em 2.5em;
 	margin: 0 0 1em 1em;
 }
-#poll_options dl.options dt {
-	clear: right;
-}
 .postarea, .moderatorbar {
 	margin: 0 175px 0 0;
 }
 .keyinfo h5::after {
-	clear: left;
-}
-.moderatorbar {
 	clear: left;
 }
 /* poster details and list of items */
@@ -247,11 +241,6 @@ ul.quickbuttons li {
 }
 .login h3 img {
 	margin: 0 0 0.5em;
-}
-
-/* Additional profile fields */
-dl.register_form {
-	clear: left;
 }
 
 /* Styles for maintenance mode.


### PR DESCRIPTION
#### Description

Part 4 of wave 8 of the #7933 split.

`clear: inline-start` and `clear: inline-end` follow the writing direction, so the three
places where `rtl.css` did nothing but mirror the side no longer need an override.
`clear: both` is unaffected and untouched.

#### The one group left alone, and why

`index.css` clears five selectors together — `.signature`, `.attachments`,
`.under_message`, `.custom_fields_above_signature` and `.custom_fields_below_signature` —
but `rtl.css` mirrors only three of them. Converting the group would also start mirroring
`.under_message` and `.custom_fields_below_signature`, which is a **behaviour change, not
a no-op**, so the group keeps its physical value here.

Whether those two are missing from `rtl.css` by accident is worth deciding on its own.
It is not a question about dead code — all three of the classes involved are emitted by
the templates, so the asymmetry is real and visible in a right-to-left language.

#### How this was checked

Same method as parts 2 and 3, on 29 pages captured back to back across a stash.

One addition worth noting: **a poll had to be posted and voted on first.** The
`#poll_options dl.options dt` rule is one of the three being converted, and none of the
existing sweep pages reached it — the results list only renders once a vote has been cast,
so before that the check would have passed without ever exercising the rule. With the poll
in place the sweep covers all three.

| | elements | differences |
| --- | --- | --- |
| left-to-right | 9735 | 5, all the `clear` keyword |
| right-to-left | 9735 | 5, all the `clear` keyword |

**No geometry moved in either direction.**

`rtl.css` goes from 453 lines to 442.

### Issues References (Fixes|Related|Closes)

Related to #7933.

---

#### On the ordering of these four

These were originally stacked. They are not any more — each of #9569, #9570, #9571 and
#9572 now branches from `release-3.0` on its own and contains exactly one commit, so each
diff shows only its own property and nothing else. They can be reviewed in any order.

They cannot all be *merged* without a rebase in between, and that is worth being straight
about. One `rtl.css` rule usually mirrors several properties at once, so these PRs edit
some of the same declaration blocks. `release-3.0` has:

```css
#poll_options dl.options dt { float: right; clear: right; }
#poll_options dl.options dd { float: right; text-align: left; }
```

#9569 removes both `float`s, #9570 removes the `text-align`, #9571 removes the `clear` —
and a rule only disappears once its last declaration is gone. Merging any one of these is
fine; after that I will rebase the rest, which is a few minutes of work each time. Of the
six pairs, `text-align`+`clear` and `clear`+margins merge cleanly as they stand; the
`float` one overlaps with all three, so merging that one first costs the least.

