### PR TITLE
[3.0] Theme split (wave 8, part 5) — logical margins and padding where the sides mirror

### DIFF
--- a/Themes/default/css/admin.css
+++ b/Themes/default/css/admin.css
@@ -270,11 +270,12 @@ fieldset.admin_group .inactive {
 
 /* Styles for the package manager. */
 #package_list .tborder {
-	margin: .25em 0 .25em 26px;
+	margin-block: .25em;
+	margin-inline: 26px 0;
 }
 #package_list ol, #package_list ol li {
 	list-style: decimal;
-	margin-left: 50px;
+	margin-inline-start: 50px;
 	border: none;
 }
 #package_list li {
@@ -374,7 +375,8 @@ pre.file_content {
 	background-color: var(--admin-redirect-board-bg);
 }
 .move_links {
-	padding: 0 13px 0 0;
+	padding-block: 0;
+	padding-inline: 0 13px;
 }
 #manage_boards .button {
 	margin: 0 8px 0 0;
@@ -429,7 +431,8 @@ span.search_weight {
 
 /* Styles for the manage bans section. */
 .ban_restriction {
-	margin: 0.2em 0 0.2em 2.2em;
+	margin-block: 0.2em;
+	margin-inline: 2.2em 0;
 }
 .ban_settings {
 	width: 46%;
@@ -487,10 +490,11 @@ ul.theme_options li {
 	padding: 0.4em;
 }
 .is_directory {
-	padding-left: 18px;
+	padding-inline-start: 18px;
 }
 .is_directory span {
-	margin: -2px 3px 0 0;
+	margin-block: -2px 0;
+	margin-inline: 0 3px;
 }
 .edit_file {
 	width: 100%;

--- a/Themes/default/css/index.css
+++ b/Themes/default/css/index.css
@@ -609,7 +609,7 @@ strong[id^='child_list_']::after {
 }
 .pages {
 	font-size: 0.9em;
-	margin-left: 7px;
+	margin-inline-start: 7px;
 }
 #main_content_section .pagesection {
 	margin: 4px 0 0 0;
@@ -850,7 +850,7 @@ img.sort, .sort {
 }
 /* For cases where we want to spotlight something specific to an item, e.g. an amount */
 .amt {
-	margin-left: 3px;
+	margin-inline-start: 3px;
 	padding: 0 5px;
 	color: var(--amt-color);
 	background: var(--amt-bg);
@@ -941,7 +941,7 @@ a[class^="mobile_generic_menu_"] {
 .profile_user_links li {
 	font-size: .8rem;
 	line-height: 2em;
-	padding-left: 24px;
+	padding-inline-start: 24px;
 	text-indent: -24px;
 	-webkit-hyphens: auto;
 	hyphens: auto;
@@ -1254,7 +1254,8 @@ html[lang="el-GR"] .inline_mod_check {
 #profile_menu_top > img.avatar {
 	height: 18px;
 	width: 18px;
-	margin: 2px 5px 0 0;
+	margin-block: 2px 0;
+	margin-inline: 0 5px;
 	float: inline-start;
 }
 #pm_menu_top .main_icons,
@@ -2365,7 +2366,8 @@ a.main_icons.feed::before {
 	margin-top: -8px;
 }
 .errorbox, .noticebox, .infobox {
-	padding: 7px 10px 7px 35px;
+	padding-block: 7px;
+	padding-inline: 35px 10px;
 	margin-bottom: 12px;
 	position: relative;
 }
@@ -2385,7 +2387,8 @@ a.main_icons.feed::before {
 }
 .errorbox p.alert {
 	padding: 0;
-	margin: 0 4px 0 0;
+	margin-block: 0;
+	margin-inline: 0 4px;
 	float: inline-start;
 	width: 12px;
 	font-size: 1.5em;
@@ -2641,7 +2644,8 @@ dl.stats dd {
 	width: 48%;
 	font-size: 1em;
 	float: left;
-	margin: 0 0 4px 2%;
+	margin-block: 0 4px;
+	margin-inline: 2% 0;
 }
 dl.stats {
 	padding: 5px;
@@ -2859,7 +2863,8 @@ dl.addrules dt.floatleft {
 }
 #helpmain ul {
 	line-height: 2em;
-	margin: 0 0 0 25px;
+	margin-block: 0;
+	margin-inline: 25px 0;
 }
 #helpmain ul li {
 	list-style-type: disc;
@@ -3470,7 +3475,8 @@ img.avatar {
 	max-width: 100%;
 }
 .postarea, .moderatorbar {
-	margin: 0 0 0 175px;
+	margin-block: 0;
+	margin-inline: 175px 0;
 }
 .postarea div.flow_hidden {
 	width: 100%;

--- a/Themes/default/css/profile.css
+++ b/Themes/default/css/profile.css
@@ -48,7 +48,7 @@
 #basicinfo .icon_fields li {
 	display: block;
 	float: inline-start;
-	margin-right: 5px;
+	margin-inline-end: 5px;
 	height: 20px;
 }
 

--- a/Themes/default/css/rtl.css
+++ b/Themes/default/css/rtl.css
@@ -21,12 +21,6 @@
 	background-position: -5px -31px;
 }
 
-/* Amounts */
-.amt {
-	margin-left: 0;
-	margin-right: 3px;
-}
-
 /* Styles for popup windows
 ------------------------------------------------------- */
 .popup_heading .hide_popup {
@@ -103,20 +97,11 @@ img#smflogo {
 	padding-left: 0;
 	text-align: left;
 }
-
-/* Profile drop it needs reverse on RTL */
-#profile_menu_top > img.avatar {
-	margin: 2px 0 0 5px;
-}
 #profile_menu .profile_user_info {
 	margin: 3px 10px 5px 0;
 }
 #profile_menu .profile_user_avatar img {
 	margin: 5px 10px 0 0;
-}
-.profile_user_links li {
-	padding-right: 24px;
-	padding-left: 0;
 }
 
 /* The framing graphics */
@@ -128,9 +113,6 @@ img#smflogo {
 #poll_options dl.options {
 	padding: 1em 2em 1em 2.5em;
 	margin: 0 0 1em 1em;
-}
-.postarea, .moderatorbar {
-	margin: 0 175px 0 0;
 }
 .keyinfo h5::after {
 	clear: left;
@@ -270,27 +252,11 @@ div#admin_menu {
 .message_index_title {
 	margin-left: 40px;
 }
-
-/* Styles for info boxes.
-------------------------------------------------- */
-.errorbox, .noticebox, .infobox {
-	padding: 7px 35px 7px 10px;
-}
 .errorbox::before, .noticebox::before, .infobox::before {
 	left: 0;
 	right: 10px;
 }
-.errorbox p.alert {
-	margin: 0 0 0 4px;
-}
-.errorbox, .noticebox, .infobox {
-	padding: 7px 35px 7px 10px;
-}
 
-#basicinfo .icon_fields li {
-	margin-right: 0;
-	margin-left: 5px;
-}
 #detailedinfo dt, #tracking dt {
 	float: right;
 }
@@ -342,9 +308,6 @@ h3.profile_hd {
 	min-width: 95%;
 	float: right;
 }
-dl.stats dd {
-	margin: 0 2% 4px 0;
-}
 .generic_bar .bar, .progress_bar .bar {
 	left: unset;
 	right: 0;
@@ -368,14 +331,6 @@ tr.windowbg th.stats_month, tr.windowbg td.stats_day {
 #searchform fieldset p {
 	text-align: right;
 }
-
-/* Styles for the help section.
-------------------------------------------------- */
-/* put back the bullets please */
-#helpmain ul {
-	margin: 0 25px 0 0;
-	padding-left: 0;
-}
 #helpmain #messageindex {
 	clear: left;
 }
@@ -391,16 +346,6 @@ tr.windowbg th.stats_month, tr.windowbg td.stats_day {
 	margin: 2px 6px 0px 6px;
 }
 
-/* Styles for the package manager.
-------------------------------------------------- */
-#package_list .tborder {
-	margin: .25em 26px .25em 0;
-}
-#package_list ol, #package_list ol li {
-	margin-left: 0;
-	margin-right: 50px;
-}
-
 /* ManageBoards */
 #manage_boards ul {
 	overflow: hidden;
@@ -408,33 +353,11 @@ tr.windowbg th.stats_month, tr.windowbg td.stats_day {
 #manage_boards li {
 	overflow: hidden;
 }
-.move_links {
-	padding: 0 0 0 13px;
-}
-
-/* Manage Bans */
-.ban_restriction {
-	margin: 0.2em 2.2em 0.2em 0;
-}
-
-/* Themes */
-.is_directory {
-	padding-right: 18px;
-	padding-left: 0;
-}
-.is_directory span {
-	margin: -2px 0 0 3px;
-}
 
 /* Styles for the moderation center.
 ------------------------------------------------- */
 ul.moderation_notes li {
 	padding: 4px 4px 4px 0;
-}
-
-.pages {
-	margin-left: 0;
-	margin-right: 7px;
 }
 
 /* Code is a code do it LTR */


### PR DESCRIPTION
#### Description

Part 5 of wave 8 of the #7933 split.

`margin-inline` and `padding-inline` follow the writing direction, so the twenty rules
where `rtl.css` did nothing but swap the left and right values no longer need an override.
This is the largest single reduction in the wave.

#### What qualifies

A rule qualifies only when the right-to-left values are the **exact mirror** of the
left-to-right ones — same top and bottom, left and right swapped.

- four-value shorthands become a block pair and an inline pair, so
  `margin: 0 0 4px 2%` becomes `margin-block: 0 4px` and `margin-inline: 2% 0`
- where the base sheet used a single longhand it stays a single longhand, so
  `margin-left` becomes `margin-inline-start`

Everything else is left alone. `rtl.css` holds a good many spacing rules that are **not**
mirrors — they change the value as well as the side (`.cat_bar .desc` is `8px` on one side
in one direction and `13px` in the other), or they add spacing the base sheet does not have
at all. No logical declaration can express two different values at once, so those stay.

#### How this was checked

Same method as parts 2 to 4, on 29 pages captured back to back across a stash.

| | elements | differences |
| --- | --- | --- |
| left-to-right | 9735 | **0** |
| right-to-left | 9736 | **0** |

Nothing changed at all this time — not even a keyword. Unlike `float` and `text-align`,
`getComputedStyle` resolves logical margins and padding back to physical values, so the
reported numbers are identical before and after. This is the strongest result of the wave:
the two stylesheets are indistinguishable to the browser.

One measurement note, since it would otherwise look like a real difference. A first run
showed four differences on the statistics page, all on the counter `<span>`s inside
`dl.stats dd`. That was the counters themselves changing value between runs — the text got
one character wider — and not the CSS. Two captures taken with identical code showed the
same four, and re-running the pair once the counters settled gave the zero above.

`rtl.css` goes from 442 lines to 365 — down from 624 at the start of the wave.

### Issues References (Fixes|Related|Closes)

Related to #7933.

---

---

#### Rebased now that the rest of the wave has landed

This is the last of the four. #9569, #9570 and #9571 are merged, and because one `rtl.css`
rule usually mirrors several properties at once, those merges touched some of the same
declaration blocks as this one — so it needed rebasing to go green again.

Rather than resolve the conflicts, the conversion was **re-derived from scratch** against
current `release-3.0`: the same scripts recomputed which overrides are exact mirrors, and
found the same 14 margin and 9 padding rules as before. The only difference in the result
is that 17 `rtl.css` rules now disappear entirely rather than 14, because the merged parts
had already removed their other declarations and this takes the last one.

Re-verified on a freshly installed forum against current `release-3.0`, 24 pages, 5110
elements, captured back to back in both writing directions:

| | differences |
| --- | --- |
| left-to-right | **0** |
| right-to-left | **0** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
