### PR TITLE
[3.0] Open the calendar's event form on a date instead of refusing to open

### DIFF
--- a/Sources/Actions/Post.php
+++ b/Sources/Actions/Post.php
@@ -785,12 +785,41 @@ class Post implements ActionInterface, Routable
 		}
 
 		if (!isset(Utils::$context['event']) || !(Utils::$context['event'] instanceof Event)) {
-			$props = [
-				'title' => isset($_REQUEST['evtitle']) ? Utils::htmlspecialchars(stripslashes($_REQUEST['evtitle'])) : null,
-				'location' => isset($_REQUEST['event_location']) ? Utils::htmlspecialchars(stripslashes($_REQUEST['event_location'])) : null,
-			];
+			// Both of these are typed as string and already default to '', so
+			// they have to be left out rather than passed as null when the
+			// request does not carry them.
+			$props = [];
 
-			Event::setRequestedStartAndDuration($props);
+			if (isset($_REQUEST['evtitle'])) {
+				$props['title'] = Utils::htmlspecialchars(stripslashes($_REQUEST['evtitle']));
+			}
+
+			if (isset($_REQUEST['event_location'])) {
+				$props['location'] = Utils::htmlspecialchars(stripslashes($_REQUEST['event_location']));
+			}
+
+			// The calendar links here with the day the member picked in the
+			// query string, but setRequestedStartAndDuration() only ever looks
+			// at $_POST, so on a plain GET those values never arrive. Hand
+			// them over.
+			foreach (['year', 'month', 'day', 'hour', 'minute', 'second'] as $key) {
+				if (isset($_GET[$key]) && !isset($_POST[$key])) {
+					$props[$key] = (int) $_GET[$key];
+				}
+			}
+
+			// And when nothing asked for a date at all, leave that method
+			// alone. It ends by fatalling with 'invalid_date' if it cannot
+			// find one, which is right when an event is being saved but not
+			// here: this is the posting form being opened, and Event(-1)
+			// already defaults to now for exactly this case. That is what
+			// Calendar::post() relies on when it builds the standalone editor.
+			$date_params = array_flip(['year', 'month', 'day', 'start_date', 'start_datetime', 'start_year', 'start_month', 'start_day']);
+
+			if (array_intersect_key($props, $date_params) !== [] || array_intersect_key($_POST, $date_params) !== []) {
+				Event::setRequestedStartAndDuration($props);
+			}
+
 			Event::setRequestedRRule($props);
 			Utils::$context['event'] = new Event(-1, $props);
 			Event::setRequestedRDatesAndExDates(Utils::$context['event']);

--- a/Sources/Actions/Post.php
+++ b/Sources/Actions/Post.php
@@ -785,9 +785,6 @@ class Post implements ActionInterface, Routable
 		}
 
 		if (!isset(Utils::$context['event']) || !(Utils::$context['event'] instanceof Event)) {
-			// Both of these are typed as string and already default to '', so
-			// they have to be left out rather than passed as null when the
-			// request does not carry them.
 			$props = [];
 
 			if (isset($_REQUEST['evtitle'])) {
@@ -798,22 +795,14 @@ class Post implements ActionInterface, Routable
 				$props['location'] = Utils::htmlspecialchars(stripslashes($_REQUEST['event_location']));
 			}
 
-			// The calendar links here with the day the member picked in the
-			// query string, but setRequestedStartAndDuration() only ever looks
-			// at $_POST, so on a plain GET those values never arrive. Hand
-			// them over.
+			// Default to the date and time the member was viewing.
 			foreach (['year', 'month', 'day', 'hour', 'minute', 'second'] as $key) {
 				if (isset($_GET[$key]) && !isset($_POST[$key])) {
 					$props[$key] = (int) $_GET[$key];
 				}
 			}
 
-			// And when nothing asked for a date at all, leave that method
-			// alone. It ends by fatalling with 'invalid_date' if it cannot
-			// find one, which is right when an event is being saved but not
-			// here: this is the posting form being opened, and Event(-1)
-			// already defaults to now for exactly this case. That is what
-			// Calendar::post() relies on when it builds the standalone editor.
+			// Only try to set the start and duration if we were given the relevant data.
 			$date_params = array_flip(['year', 'month', 'day', 'start_date', 'start_datetime', 'start_year', 'start_month', 'start_day']);
 
 			if (array_intersect_key($props, $date_params) !== [] || array_intersect_key($_POST, $date_params) !== []) {


### PR DESCRIPTION
#### Description

Clicking **Post Event** in the calendar produces "Invalid date" and nothing else.

This happens on a **default install**. `cal_allow_unlinked` is empty until somebody turns
it on, and in that case `Calendar::post()` hands a new event to `Post::call()` instead of
to the standalone editor — so the ordinary out-of-the-box path is the broken one. With the
setting enabled the standalone editor opens fine, which is probably why this has gone
unnoticed.

There turned out to be two faults in that path, the second hidden behind the first.

**1. The form refuses to open without a date.**
`Event::setRequestedStartAndDuration()` ends by fatalling with `invalid_date` when it
cannot find a start date. That is correct for the five callers that use it while *saving*
an event. But `Post::initiateEvent()` calls it while *opening the form*, where no date has
been chosen yet.

`Event(-1)` already defaults its start to now for precisely this situation — its own case
label says "Preparing default data to show in the calendar posting form", and
`Calendar::post()` depends on it, constructing `new Event(-1)` with no properties at all.
So the method is now only asked for a start when something actually supplied one, and
otherwise the constructor's default applies, exactly as it does for the standalone editor.

**2. The day you clicked was ignored.**
The same method reads only `$_POST`, so the `year`, `month` and `day` that the calendar
puts into its day links never reached it. Those are now passed through, so a link carrying
a date opens the form on that date.

**3. A second fatal underneath the first.**
Once the form got far enough to build the event, `title` and `location` were being passed
as `null` whenever the request did not carry them — and both are typed `string` on `Event`,
so the assignment threw `Cannot assign null to property SMF\Calendar\Event::$title`. They
are omitted instead, which is what `Event(-1)` expects: both already default to `''`.

#### How this was checked

On a default install, with `cal_allow_unlinked` left untouched:

- the **Post Event** button opens the form, with Start and End set to today
- a link carrying `year=2027;month=3;day=14` opens the form on **2027-03-14** — previously
  that was ignored even when the fatal did not fire
- submitting the form creates the event and its topic: both appear on the calendar and the
  board index

Then with `cal_allow_unlinked` enabled, to confirm the standalone editor still opens
normally. The error log was empty after all of it.

#### Not changed here

The calendar's own **Post Event** button builds its URL with no date at all
(`Sources/Actions/Calendar.php:340`), so it opens on today rather than on the month being
viewed. With this fix that is harmless, just not ideal; changing it is a separate decision
about what that button should mean.

### Issues References (Fixes|Related|Closes)

Found while testing #7933; unrelated to that PR.
