### PR TITLE
[3.0] Line the breadcrumb up with the content it sits above

### DIFF
--- a/Themes/default/css/index.css
+++ b/Themes/default/css/index.css
@@ -1375,8 +1375,16 @@ ul li.greeting {
 	border-width: var(--navigatesection-border-width);
 	box-shadow: var(--navigatesection-box-shadow);
 	margin-block: .5em .75em;
-	margin-inline: 10px;
+	margin-inline: 0;
 	padding: 0;
+}
+/* The breadcrumb is drawn twice: once above #content_section, and once inside
+   it below the posts. The inner one already sits within the inline padding
+   that #main_content_section gives everything else, so it adds none of its
+   own; the outer one is a sibling of that container and has to match the same
+   padding itself to line up with the boxes underneath it. */
+#wrapper > .navigate_section {
+	margin-inline: 12px;
 }
 .navigate_section ol {
 	align-items: center;


### PR DESCRIPTION
#### Description

The breadcrumb does not line up with the content it sits above, on any page.

`.navigate_section` carried a `margin-inline` of its own — 10px — while
`#main_content_section` pads everything else by 12px. The breadcrumb is a **sibling** of
that container, not a child, so those two numbers are the only thing positioning it, and
they disagree. Result: the bar sits two pixels outside the boxes below it, everywhere.

The lower breadcrumb is further out still. `Display.template.php` and
`MessageIndex.template.php` draw a second one **inside** the main container, where it picks
up the 12px of padding and then adds its own 10px on top — leaving it **ten pixels further
in** than everything above it.

Both come from the same assumption: that the breadcrumb has to indent itself. Only the
outer one does, because only it sits outside the padded container. So that is the only one
that now carries a margin, and it carries the same 12px the container uses.

Measured at 1280px wide:

| | before | after |
| --- | --- | --- |
| breadcrumb above the content | 73.88 | **75.88** |
| content boxes | 75.88 | 75.88 |
| lower breadcrumb (board, topic) | 86.40 | **76.40** |

#### How this was checked

Every breadcrumb on seven pages — admin, moderation, calendar, board index, topic display,
statistics and the front page — now starts *and* ends on exactly the same pixel as the
content boxes, in **both writing directions** (the property is direction-aware, so
right-to-left was checked too, and matches on both edges).

Then a sweep of 18 pages and 5855 elements, before and after, comparing the computed box
properties and the full bounding rectangle of every element:

- **333 values changed, and every one of them is a breadcrumb or something inside it**
- **0 changed anywhere else** — nothing reflowed off the back of it

### Issues References (Fixes|Related|Closes)

Found while testing #7933; unrelated to that PR.
