### PR TITLE
[3.0] Recognises an action suffix on a topic or board route

### DIFF
--- a/Sources/Board.php
+++ b/Sources/Board.php
@@ -1935,21 +1935,28 @@ class Board implements \ArrayAccess, Routable
 
 			Slug::setRequested(rtrim($matches[1], '-'), 'board', (int) $params['board']);
 
-			// Either an action suffix or a start value.
-			// This accounts for both 'boards/ID/START' and '/boards/ID/ACTION'
-			if (!empty($route)) {
-				if (isset(QueryString::$route_parsers[reset($route)])) {
-					$params = array_merge(
-						$params,
-						\call_user_func(
-							[QueryString::$route_parsers[reset($route)], 'parseRoute'],
-							$route,
-							$params,
-						),
-					);
-				} elseif (!isset($params['start'])) {
-					$params['start'] = array_shift($route);
+			// What's left can be a start value, an action suffix, or both.
+			// E.g.: 'boards/1', 'boards/1/post', and 'boards/1/20/post'.
+			// Note that we must ask QueryString::getRouteParser() rather than
+			// simply looking in QueryString::$route_parsers, because the
+			// parsers for actions are only added to that list on demand.
+			if (!empty($route) && QueryString::getRouteParser((string) reset($route)) === null) {
+				$start = array_shift($route);
+
+				if (!isset($params['start'])) {
+					$params['start'] = $start;
 				}
+			}
+
+			if (!empty($route) && ($parser = QueryString::getRouteParser((string) reset($route))) !== null) {
+				$params = array_merge(
+					$params,
+					\call_user_func(
+						[$parser, 'parseRoute'],
+						$route,
+						$params,
+					),
+				);
 			}
 		}
 

--- a/Sources/Topic.php
+++ b/Sources/Topic.php
@@ -1877,20 +1877,28 @@ class Topic implements \ArrayAccess, Routable
 
 			Slug::setRequested(rtrim($matches[1], '-'), 'topic', (int) $params['topic']);
 
-			// Either an action suffix or a start value.
-			if (!empty($route)) {
-				if (isset(QueryString::$route_parsers[reset($route)])) {
-					$params = array_merge(
-						$params,
-						\call_user_func(
-							[QueryString::$route_parsers[reset($route)], 'parseRoute'],
-							$route,
-							$params,
-						),
-					);
-				} elseif (!isset($params['start'])) {
-					$params['start'] = array_shift($route);
+			// What's left can be a start value, an action suffix, or both.
+			// E.g.: 'topics/1', 'topics/1/post', and 'topics/1/20/post'.
+			// Note that we must ask QueryString::getRouteParser() rather than
+			// simply looking in QueryString::$route_parsers, because the
+			// parsers for actions are only added to that list on demand.
+			if (!empty($route) && QueryString::getRouteParser((string) reset($route)) === null) {
+				$start = array_shift($route);
+
+				if (!isset($params['start'])) {
+					$params['start'] = $start;
 				}
+			}
+
+			if (!empty($route) && ($parser = QueryString::getRouteParser((string) reset($route))) !== null) {
+				$params = array_merge(
+					$params,
+					\call_user_func(
+						[$parser, 'parseRoute'],
+						$route,
+						$params,
+					),
+				);
 			}
 		}
 

--- a/tests/Unit/QueryStringRouteTest.php
+++ b/tests/Unit/QueryStringRouteTest.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SMF\Tests\Unit;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use SMF\Board;
+use SMF\QueryString;
+use SMF\Topic;
+
+#[CoversClass(QueryString::class)]
+#[CoversClass(Board::class)]
+#[CoversClass(Topic::class)]
+class QueryStringRouteTest extends TestCase
+{
+	/****************
+	 * Public methods
+	 ****************/
+
+	public function testAPlainTopicRouteIsTheDisplayAction(): void
+	{
+		$this->assertSame(
+			['action' => 'display', 'topic' => '1'],
+			QueryString::parseRoute('/topics/1', []),
+		);
+	}
+
+	public function testAPlainBoardRouteIsTheMessageIndexAction(): void
+	{
+		$this->assertSame(
+			['action' => 'messageindex', 'board' => '2'],
+			QueryString::parseRoute('/boards/2', []),
+		);
+	}
+
+	/**
+	 * Topic::parseRoute() and Board::parseRoute() used to look for the action
+	 * suffix in QueryString::$route_parsers directly. That list only ever holds
+	 * the handful of content parsers it is declared with, because the parser for
+	 * an action is added to it on demand by QueryString::getRouteParser(). So
+	 * the suffix was never recognised and fell through to the branch that treats
+	 * whatever is left as a start value: '/topics/1/post' parsed as the display
+	 * action with a start of 'post', and every posting, voting, poll, print and
+	 * mark-as-read link on a topic or board silently reloaded the page instead.
+	 */
+	#[DataProvider('actionSuffixProvider')]
+	public function testAnActionSuffixOnATopicOrBoardRouteIsTheAction(string $path, array $expected): void
+	{
+		$this->assertSame($expected, QueryString::parseRoute($path, []));
+	}
+
+	/**
+	 * A start value and an action suffix can both be present, because
+	 * Topic::buildRoute() and Board::buildRoute() put the start value into the
+	 * route before the action is appended to it. Parsing only ever consumed one
+	 * of the two, so replying from any page of a topic but the first lost the
+	 * action as well.
+	 */
+	#[DataProvider('startValueProvider')]
+	public function testAStartValueIsKeptAlongsideTheAction(string $path, array $expected): void
+	{
+		$this->assertSame($expected, QueryString::parseRoute($path, []));
+	}
+
+	/***********************
+	 * Public static methods
+	 ***********************/
+
+	/**
+	 * Each case uses a different topic or board id on purpose: Slug::setRequested()
+	 * asks the Slug it builds to redirect when the same item is requested twice by
+	 * different names, and there is nowhere to redirect to in a unit test.
+	 */
+	public static function actionSuffixProvider(): array
+	{
+		return [
+			'reply to a topic' => [
+				'/topics/10/post',
+				['action' => 'post', 'topic' => '10'],
+			],
+			'submit a reply to a topic' => [
+				'/topics/11/post2',
+				['action' => 'post2', 'topic' => '11'],
+			],
+			'vote in a topic poll' => [
+				'/topics/12/vote',
+				['action' => 'vote', 'topic' => '12'],
+			],
+			'edit a topic poll' => [
+				'/topics/13/editpoll',
+				['action' => 'editpoll', 'topic' => '13'],
+			],
+			'print a topic' => [
+				'/topics/14/printpage',
+				['action' => 'printpage', 'topic' => '14'],
+			],
+			'post a new topic in a board' => [
+				'/boards/15/post',
+				['action' => 'post', 'board' => '15'],
+			],
+			'submit a new topic in a board' => [
+				'/boards/16/post2',
+				['action' => 'post2', 'board' => '16'],
+			],
+			// A slug in front of the id is the normal shape of these URLs.
+			'a slug in front of the id changes nothing' => [
+				'/topics/welcome-to-smf-17/post',
+				['action' => 'post', 'topic' => '17'],
+			],
+		];
+	}
+
+	public static function startValueProvider(): array
+	{
+		return [
+			'a start value on its own' => [
+				'/topics/20/20',
+				['action' => 'display', 'topic' => '20', 'start' => '20'],
+			],
+			'a symbolic start value on its own' => [
+				'/topics/21/new',
+				['action' => 'display', 'topic' => '21', 'start' => 'new'],
+			],
+			'a start value and an action' => [
+				'/topics/22/20/post',
+				['action' => 'post', 'topic' => '22', 'start' => '20'],
+			],
+			'a start value and an action on a board' => [
+				'/boards/23/20/post2',
+				['action' => 'post2', 'board' => '23', 'start' => '20'],
+			],
+		];
+	}
+}


### PR DESCRIPTION
#### Description

With friendly URLs enabled, every link that hangs an action off a topic or a board went
back to the topic or the board instead of doing anything: replying, posting a new topic
or poll, voting in a poll, editing or locking a poll, marking a topic as (un)read and
printing a topic. Quick reply answered `200` and threw the reply away.

`Topic::parseRoute()` and `Board::parseRoute()` looked for the action suffix of a route by
testing `QueryString::$route_parsers` directly. That list is declared with the parsers for
content types only (`topics`, `boards`, `msgs`, `members`); the parser for an *action* is
added to it on demand, by `QueryString::getRouteParser()`. Nothing looks an action up
before a topic or board route is parsed, so the suffix was never found and fell through to
the `elseif` that takes whatever is left as a start value:

```
/topics/welcome-to-smf-1/post   ->  action=display  topic=1  start=post
/boards/general-1/post2         ->  action=messageindex  board=1  start=post2
```

Asking `getRouteParser()` instead is the fix. The second change in each method is that the
start value and the action suffix are now taken in one pass rather than one or the other,
because both are present whenever the link comes from any page of a topic but the first —
`buildRoute()` puts the start value into the route before appending the action, giving
`/topics/welcome-to-smf-1/20/post`.

Verified in the Docker environment with `queryless_urls` on. Before, posting a reply to
`/index.php/boards/general-discussion-1/post2` rendered the message index and created no
message; after, the reply is posted. `printpage`, `editpoll`, `lockvoting`, `markasread`
and the reply form all reach their action now, and `/topics/…/20` and `/topics/…/new`
still parse as a start value.

`tests/Unit/QueryStringRouteTest.php` is new and covers both halves: 10 of its 14 cases
fail on `release-3.0` and pass here.

Two things found while verifying that are **not** fixed here, because they are separate
bugs that friendly URLs only makes visible:

- "Mark all messages as read" is a 500 (`Column 'unwatched' cannot be null`) under
  friendly URLs. `MarkRead::parseRoute()` has a `??`/`?:` precedence bug that rewrites
  every sub-action to `sa=topic`, so `/markasread/all` runs the per-topic branch with no
  topic loaded.
- The "Post event" link on a topic fails with "Invalid date.", and the notify-topic links
  fail with "Invalid data structure sent to the database." Both fail identically with an
  ordinary query string, so neither is a routing problem.

### Issues References (Fixes|Related|Closes)
1. Fixes #9566
