### PR TITLE
[3.0] Pass a list of rows to Db::insert(), not a single row

### DIFF
--- a/Sources/Actions/Display.php
+++ b/Sources/Actions/Display.php
@@ -473,7 +473,9 @@ class Display implements ActionInterface, Routable
 						'id_member' => 'int', 'id_topic' => 'int', 'id_msg' => 'int', 'unwatched' => 'int',
 					],
 					[
-						User::$me->id, Topic::$info->id, Topic::$info->id_first_msg, Topic::$info->unwatched,
+						[
+							User::$me->id, Topic::$info->id, Topic::$info->id_first_msg, Topic::$info->unwatched,
+						],
 					],
 					['id_member', 'id_topic'],
 				);

--- a/Sources/Logging.php
+++ b/Sources/Logging.php
@@ -495,7 +495,7 @@ class Logging
 				'ignore',
 				'{db_prefix}log_activity',
 				array_merge($insert_keys, ['date' => 'date']),
-				array_merge($cache_stats, [$date]),
+				[array_merge($cache_stats, [$date])],
 				['date'],
 			);
 		}

--- a/Sources/Theme.php
+++ b/Sources/Theme.php
@@ -2261,7 +2261,7 @@ class Theme
 						'replace',
 						'{db_prefix}themes',
 						['id_theme' => 'int', 'id_member' => 'int', 'variable' => 'string-255', 'value' => 'string-65534'],
-						[self::$current->settings['theme_id'], User::$me->id, 'theme_variant', $_SESSION['id_variant']],
+						[[self::$current->settings['theme_id'], User::$me->id, 'theme_variant', $_SESSION['id_variant']]],
 						['id_theme', 'id_member', 'variable'],
 					);
 				}

--- a/Sources/User.php
+++ b/Sources/User.php
@@ -3937,7 +3937,9 @@ class User implements \ArrayAccess
 						'id_spider' => 'int', 'last_seen' => 'int', 'stat_date' => 'date', 'page_hits' => 'int',
 					],
 					[
-						$_SESSION['id_robot'], time(), $date, 1,
+						[
+							$_SESSION['id_robot'], time(), $date, 1,
+						],
 					],
 					['id_spider', 'stat_date'],
 				);


### PR DESCRIPTION
#### Description

The fourth argument of `Db::$db->insert()` has to be an array of rows. Four call sites pass
one row's values directly. With `$backward_compatibility` on, the database layer quietly
wraps them; that is off by default in 3.0, and then `insert()` calls `error_backtrace()`
with `E_USER_ERROR` and the request dies with **"Invalid data structure sent to the
database."**

**`Logging::trackStats()` is the bad one.** The `UPDATE` it tries first matches nothing on
the first tracked event of a new day, so the insert runs, so the page is a 500 — and
because the row is never created, so is every page after it, for the rest of the day. It
takes `hitStats` being on, or a post, a new topic or a registration being the first thing
tracked that day.

Reproduced on a clean install with `hitStats` on:

```
DELETE FROM smf_log_activity WHERE date = CURDATE();
curl -o /dev/null -w '%{http_code}\n' http://localhost:8080/index.php   # 500
curl -o /dev/null -w '%{http_code}\n' http://localhost:8080/index.php   # 500
curl -o /dev/null -w '%{http_code}\n' http://localhost:8080/index.php   # 500, and so on
```

`smf_log_errors` fills with `Invalid data structure sent to the database.<br>Function:
trackStats` at `Sources/Logging.php:494`. With this change the first request answers 200,
creates the row and increments `hits` from then on.

The other three are narrower:

- `Display::checkMovedMergedRedirect()` — marking a moved or merged topic read on the way
  through the redirect.
- `User::logSpider()` — the first page a spider fetches each day, when `spider_mode` is 1.
- `Theme::loadVariant()` — saving a member's chosen theme variant.

#### How this was checked

`trackStats()` end to end, as above. The other three by inspection: they are the same
misuse of the same argument, and each is unreachable on a stock install without a
configuration this environment does not have — the default theme ships
`theme_variants = []`, and a spider request dies earlier anyway, on
`Typed property SMF\User::$timezone must not be accessed before initialization` from
`Sources/Time.php:191`, which is a separate bug and unchanged either way.

No test: every one of these needs `Db::$db`, which the unit suite has no connection for.

`NotifyTopic::changePref()` has the same fault and is deliberately left alone here, because
#9477 already fixes it along with two other faults on that path.

### Issues References (Fixes|Related|Closes)
1. Related: #9477
