### PR TITLE
[3.0] Keep the sub-action a markasread route asked for

### DIFF
--- a/Sources/Actions/MarkRead.php
+++ b/Sources/Actions/MarkRead.php
@@ -462,7 +462,17 @@ class MarkRead implements ActionInterface, Routable
 	{
 		$params = array_merge($params, self::parseActionRoute($route));
 
-		$params['sa'] = $params['sa'] ?? isset($params['topic']) ? 'topic' : (isset($params['board']) ? 'board' : null);
+		// buildRoute() drops the sub-action when it is implied by the topic or
+		// the board that the route is hanging off, so put it back. Anything
+		// else, such as 'all' or 'unreadreplies', is its own sub-action and the
+		// route said so already.
+		if (!isset($params['sa'])) {
+			if (isset($params['topic'])) {
+				$params['sa'] = 'topic';
+			} elseif (isset($params['board'])) {
+				$params['sa'] = 'board';
+			}
+		}
 
 		return $params;
 	}

--- a/tests/Unit/MarkReadRouteTest.php
+++ b/tests/Unit/MarkReadRouteTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SMF\Tests\Unit;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use SMF\Actions\MarkRead;
+use SMF\QueryString;
+
+#[CoversClass(MarkRead::class)]
+class MarkReadRouteTest extends TestCase
+{
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * '??' binds tighter than '?:', so the line that restored the implied
+	 * sub-action read as '($params['sa'] ?? isset($params['topic'])) ? ...'.
+	 * A sub-action that the route did state is a non-empty string, which is
+	 * truthy, so it was thrown away and replaced with 'topic'. Marking
+	 * everything read then ran the per-topic branch with no topic loaded,
+	 * which is a database error and a 500.
+	 */
+	public function testASubActionInTheRouteSurvives(): void
+	{
+		$this->assertSame(
+			['action' => 'markasread', 'sa' => 'all'],
+			MarkRead::parseRoute(['markasread', 'all']),
+		);
+
+		$this->assertSame(
+			['action' => 'markasread', 'sa' => 'unreadreplies'],
+			MarkRead::parseRoute(['markasread', 'unreadreplies']),
+		);
+	}
+
+	public function testTheSameThingThroughQueryString(): void
+	{
+		$this->assertSame(
+			['action' => 'markasread', 'sa' => 'all'],
+			QueryString::parseRoute('/markasread/all', []),
+		);
+	}
+
+	/**
+	 * buildRoute() leaves the sub-action out when the topic or the board it is
+	 * hanging off already implies it, so parsing has to put it back.
+	 */
+	public function testAnImpliedSubActionIsRestored(): void
+	{
+		$this->assertSame(
+			['topic' => '1', 'action' => 'markasread', 'sa' => 'topic'],
+			MarkRead::parseRoute(['markasread'], ['topic' => '1']),
+		);
+
+		$this->assertSame(
+			['board' => '1', 'action' => 'markasread', 'sa' => 'board'],
+			MarkRead::parseRoute(['markasread'], ['board' => '1']),
+		);
+	}
+
+	/**
+	 * With nothing to imply one, there is no sub-action to add. It used to be
+	 * set to null, which put a valueless 'sa' into $_GET.
+	 */
+	public function testNothingImpliesNothing(): void
+	{
+		$this->assertSame(
+			['action' => 'markasread'],
+			MarkRead::parseRoute(['markasread']),
+		);
+	}
+}


### PR DESCRIPTION
#### Description

With friendly URLs on, **"Mark all messages as read"** is a 500.

`?action=markasread;sa=all` is rewritten to `/markasread/all`, and parsing that route hands
back `sa=topic` instead of `sa=all`. The per-topic branch then runs with no topic loaded:

```
2: Trying to access array offset on null           Sources/Actions/MarkRead.php:264
Database Error: Column 'unwatched' cannot be null  Sources/Actions/MarkRead.php:250
```

`??` binds tighter than `?:`, so

```php
$params['sa'] = $params['sa'] ?? isset($params['topic']) ? 'topic' : (isset($params['board']) ? 'board' : null);
```

reads as `($params['sa'] ?? isset($params['topic'])) ? 'topic' : …`. A sub-action the route
did state is a non-empty string, which is truthy, so it was thrown away and replaced with
`'topic'`. The two cases that happen to be right — a topic route and a board route — are
right by accident, because those are the ones where `buildRoute()` drops the sub-action and
there is nothing in `$params['sa']` to trip over.

So every markasread route other than those two was the per-topic branch: `/markasread/all`
and `/markasread/unreadreplies` both.

The fix spells the intent out instead of leaning on the precedence. Nothing is assigned
when no sub-action is implied, rather than the `null` that used to put a valueless `sa`
into `$_GET`.

#### How this was checked

On a local install:

```
GET /index.php/markasread/all/?<session>            500      before
GET /index.php/markasread/all/?<session>            302 →/   after
GET /index.php?action=markasread;sa=all;<session>   302 →/   both, unchanged
```

`tests/Unit/MarkReadRouteTest.php` is new: 3 of its 4 tests fail on `release-3.0` and pass
here.

Independent of #9575, which fixes a different routing fault with overlapping symptoms.

### Issues References (Fixes|Related|Closes)
1. Related: #9566
2. Related: #9575
