### PR TITLE
[3.0] Labels pull requests that touch the test suite

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -178,6 +178,10 @@ Topics:
   - changed-files:
     - any-glob-to-any-file: ['Sources/Topic.php', 'Sources/Actions/Topic**']
 
+"Unit Testing":
+  - changed-files:
+    - any-glob-to-any-file: ['tests/**', 'phpunit.xml.dist', '.github/workflows/phpunit.yml']
+
 Upgrader:
   - changed-files:
     - any-glob-to-any-file: ['other/upgrade.php', 'Sources/Maintenance/Tools/Upgrade**', 'Sources/Maintenance/Cleanup/**', 'Sources/Maintenance/Migration/**']


### PR DESCRIPTION
#### Description

The repository has a `Unit Testing` label, but `.github/labeler.yml` had no rule for it, so the Pull Request Labeler job never applied it. A change under `tests/` was labelled by whatever production file happened to sit next to it in the same pull request, or not at all.

Five open pull requests touch the suite and none of them carry the label:

| PR | Test files / total | Labels it did get |
| --- | --- | --- |
| #9577 | 1 / 2 | Navigation |
| #9575 | 1 / 3 | Boards, Topics |
| #9537 | 2 / 2 | Package Manager, Proxy, Backward compatibility |
| #9347 | 16 / 22 | Installer, Localization |
| #9345 | 8 / 14 | Installer, Localization |

The one merged pull request that does carry `Unit Testing`, #9511, had it applied by hand.

The rule covers the suite itself plus the two files that decide how it runs:

```yaml
"Unit Testing":
  - changed-files:
    - any-glob-to-any-file: ['tests/**', 'phpunit.xml.dist', '.github/workflows/phpunit.yml']
```

Placed alphabetically between `Topics` and `Upgrader`, matching the ordering of the rest of the file.

### Issues References (Fixes|Related|Closes)
1. 
2. 
