### PR TITLE
[3.0] Points the dead labeler rules at paths that exist

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -4,11 +4,11 @@ max-files-changed: 300
 # These labels will be skipped if > 300 files changed
 Administrative:
   - changed-files:
-    - any-glob-to-any-file: ['Sources/Actions/Admin/**', 'Theme/default/Admin.template.php']
+    - any-glob-to-any-file: ['Sources/Actions/Admin/**', 'Themes/default/Admin.template.php']
 
 Anti-spam:
   - changed-files:
-    - any-glob-to-any-file: ['Sources/Actions/Admin/Anti-spam.php', 'Sources/AntiSpam/**', 'Sources/ReCaptcha/**']
+    - any-glob-to-any-file: ['Sources/Actions/Admin/AntiSpam.php', 'Themes/default/scripts/captcha.js']
 
 Attachments:
   - changed-files:
@@ -24,7 +24,7 @@ Attachments:
 
 Boards:
   - changed-files:
-    - any-glob-to-any-file: ['Sources/Board**', 'Sources/Actions/Board**', 'Sources/Actions/Admin/Board**', 'Themes/defalt/Board**']
+    - any-glob-to-any-file: ['Sources/Board**', 'Sources/Actions/Board**', 'Sources/Actions/Admin/Board**', 'Themes/default/Board**']
 
 Caching:
   - changed-files:
@@ -56,11 +56,11 @@ Exports:
 
 "External data":
   - changed-files:
-    - any-glob-to-any-file: ['Sources/WebFetch**']
+    - any-glob-to-any-file: ['Sources/WebFetch/**']
 
 github_actions:
   - changed-files:
-    - any-glob-to-any-file: ['.github_actions/workflows/**']
+    - any-glob-to-any-file: ['.github/workflows/**']
 
 Hooks:
   - changed-files:
@@ -82,7 +82,7 @@ Logging:
   - changed-files:
     - any-glob-to-any-file: ['Sources/Error**', 'Sources/Log**', 'Sources/Actions/Admin/Log**', 'Sources/Actions/Moderation/Log**']
 
-"Login Sessions":
+"Login/Sessions":
   - changed-files:
     - any-glob-to-any-file: ['Sources/Session**']
 
@@ -92,7 +92,7 @@ Mail:
 
 Membergroups:
   - changed-files:
-    - any-glob-to-any-file: ['Sources/Group**', 'Sources/Actions/Admin/Membegroups.php', 'Sources/Actions/Moderation/Group**']
+    - any-glob-to-any-file: ['Sources/Group**', 'Sources/Actions/Admin/Membergroups.php', 'Sources/Actions/Moderation/Group**']
 
 Mentions:
   - changed-files:
@@ -100,7 +100,7 @@ Mentions:
 
 Moderation:
   - changed-files:
-    - any-glob-to-any-file: ['Sources/Moderation**', 'Sources/Actions/QuickModeration**', 'Sources/Actions/TopicMove**', 'Sources/Actions/TopicLock**', 'Sources/Actions/TopicMerge**', 'Sources/Actions/TopicRemove**', 'Sources/Actions/TopicRestore**', 'Sources/Actions/TopicSticky**', 'Sources/Actions/TopicSplit**', 'Sources/Actions/TopicRestore**', 'Sources/Actions/ReportToMod**']
+    - any-glob-to-any-file: ['Sources/Actions/Moderation/**', 'Sources/Actions/QuickModeration**', 'Sources/Actions/TopicMove**', 'Sources/Actions/TopicLock**', 'Sources/Actions/TopicMerge**', 'Sources/Actions/TopicRemove**', 'Sources/Actions/TopicRestore**', 'Sources/Actions/TopicSticky**', 'Sources/Actions/TopicSplit**', 'Sources/Actions/TopicRestore**', 'Sources/Actions/ReportToMod**']
 
 MySQL:
   - changed-files:
@@ -148,7 +148,7 @@ Proxy:
 
 Registration:
   - changed-files:
-    - any-glob-to-any-file: ['Sources/Actins/Register**']
+    - any-glob-to-any-file: ['Sources/Actions/Register**']
 
 "Scheduled Tasks":
   - changed-files:
@@ -164,11 +164,11 @@ Search:
 
 Smileys:
   - changed-files:
-    - any-glob-to-any-file: ['Smileys/**', 'Sources/Parsers/SmileyParser.php', 'Sources/ActionAdmin/Smileys.php']
+    - any-glob-to-any-file: ['Smileys/**', 'Sources/Parsers/SmileyParser.php', 'Sources/Actions/Admin/Smileys.php']
 
 Subscriptions:
   - changed-files:
-    - any-glob-to-any-file: ['subscriptions.php', 'Sources/Subscriptions**', 'Sources/Actions/Admin/Subscriptions**', 'Sources/Actions/Profile/PaidSubs**']
+    - any-glob-to-any-file: ['subscriptions.php', 'Sources/Subscriptions/**', 'Sources/Actions/Admin/Subscriptions**', 'Sources/Actions/Profile/PaidSubs**']
 
 Theme:
   - changed-files:


### PR DESCRIPTION
#### Description

Eleven globs in `.github/labeler.yml` named a path that is not in the repository, so the Pull Request Labeler job could never apply those labels. Two rules, `Anti-spam` and `External data`, had no working glob at all and could not fire under any circumstances.

| Rule | Glob as written | Fixed to |
| --- | --- | --- |
| `Administrative` | `Theme/default/Admin.template.php` | `Themes/default/Admin.template.php` |
| `Anti-spam` | `Sources/Actions/Admin/Anti-spam.php` | `Sources/Actions/Admin/AntiSpam.php` |
| `Anti-spam` | `Sources/AntiSpam/**` | removed, see below |
| `Anti-spam` | `Sources/ReCaptcha/**` | replaced by `Themes/default/scripts/captcha.js` |
| `Boards` | `Themes/defalt/Board**` | `Themes/default/Board**` |
| `External data` | `Sources/WebFetch**` | `Sources/WebFetch/**` |
| `github_actions` | `.github_actions/workflows/**` | `.github/workflows/**` |
| `Membergroups` | `Sources/Actions/Admin/Membegroups.php` | `Sources/Actions/Admin/Membergroups.php` |
| `Moderation` | `Sources/Moderation**` | `Sources/Actions/Moderation/**` |
| `Registration` | `Sources/Actins/Register**` | `Sources/Actions/Register**` |
| `Smileys` | `Sources/ActionAdmin/Smileys.php` | `Sources/Actions/Admin/Smileys.php` |
| `Subscriptions` | `Sources/Subscriptions**` | `Sources/Subscriptions/**` |

Two of these are worth a word.

`"Login Sessions"` is not in the table because it is not a path problem: the rule key was `"Login Sessions"`, while the label in the repository is named `Login/Sessions`. The job cannot apply a label under a name that does not exist, so that rule was dead too. It is renamed to match.

`Sources/AntiSpam/` and `Sources/ReCaptcha/` have never existed in this repository. The only anti-spam code is `Sources/Actions/Admin/AntiSpam.php` and `Themes/default/scripts/captcha.js`, so the rule now names those. If those directories are planned, say so and I will put the globs back instead.

Three of the fixes are the same trap rather than a typo: in minimatch, `**` only crosses a `/` when it is a whole path segment. `Sources/WebFetch**` therefore behaves as `Sources/WebFetch*` and matches nothing, because `WebFetch` is a directory; `Sources/WebFetch/**` matches its seven files. The same applies to `Sources/Subscriptions**` and to `Sources/Moderation**`, whose files live under `Sources/Actions/Moderation/`.

#### How this was checked

Every glob was run against `git ls-files` with the same matcher the action uses (`minimatch`, `dot: true`). Before this change, 2 rules and 11 globs matched no tracked file. After it, every rule and every glob matches at least one.

### Issues References (Fixes|Related|Closes)
1. Fixes #9579
2. 
