### PR TITLE
[3.0] End the search for an avatar at the last resort

### DIFF
--- a/Sources/Avatar.php
+++ b/Sources/Avatar.php
@@ -587,9 +587,14 @@ class Avatar implements \ArrayAccess
 					break;
 
 				// Last ditch fallback is a transparent 1x1 GIF.
+				//
+				// This leaves the loop rather than the switch, because there is
+				// nothing left to try and because a data URI is not a URL that
+				// Url::isValid() will accept, so the condition the loop tests
+				// can never become false from here.
 				default:
 					$url = new Url('data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7');
-					break;
+					break 2;
 			}
 		}
 

--- a/tests/Unit/AvatarFallbackTest.php
+++ b/tests/Unit/AvatarFallbackTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SMF\Tests\Unit;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use SMF\Avatar;
+use SMF\Config;
+
+/**
+ * Covers what SMF\Avatar settles on when it can find no image at all.
+ *
+ * The constructor only asks the database who owns an attachment, so handing it
+ * an id_member keeps the whole thing on this side of the line.
+ */
+#[CoversClass(Avatar::class)]
+class AvatarFallbackTest extends TestCase
+{
+	/*********************
+	 * Internal properties
+	 *********************/
+
+	/**
+	 * @var array The settings this class reads, as they were before the test.
+	 */
+	private array $backup = [];
+
+	/**
+	 * @var string Config::$boardurl as it was before the test.
+	 */
+	private string $boardurl = '';
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * The constructor tries each way of finding an image in turn, and stops
+	 * when it has a URL that validates. The last of those ways is a 1x1
+	 * transparent GIF as a data URI, which is there so that there is always an
+	 * answer - but a data URI is not something Url::isValid() accepts, so it
+	 * never satisfied the condition that ends the search and the search went
+	 * round again, and again, until the request was killed.
+	 *
+	 * Reaching it takes nothing exotic: the step before only produces a URL
+	 * when avatar_url is set, so a forum where that setting was never written
+	 * hung on any member with an avatar.
+	 */
+	public function testAnAvatarThatCannotBeFoundEndsAsATransparentGif(): void
+	{
+		Config::$boardurl = 'https://example.com';
+		Config::$modSettings['gravatarEnabled'] = false;
+		unset(Config::$modSettings['avatar_url']);
+
+		$avatar = new Avatar(url: 'Oxygen/beagle.png', id_member: 1);
+
+		$this->assertStringStartsWith('data:image/gif;base64,', (string) $avatar->url);
+	}
+
+	/**
+	 * The control, and the reason the loop exists: when there is somewhere to
+	 * look, it is looked in, and the search ends long before the last resort.
+	 */
+	public function testAnAvatarThatCanBeFoundIsStillFound(): void
+	{
+		Config::$boardurl = 'https://example.com';
+		Config::$modSettings['gravatarEnabled'] = false;
+		Config::$modSettings['avatar_url'] = 'https://example.com/avatars';
+
+		$avatar = new Avatar(url: 'Oxygen/beagle.png', id_member: 1);
+
+		$this->assertSame('https://example.com/avatars/Oxygen/beagle.png', (string) $avatar->url);
+	}
+
+	/******************
+	 * Internal methods
+	 ******************/
+
+	protected function setUp(): void
+	{
+		$this->boardurl = Config::$boardurl ?? '';
+
+		foreach (['avatar_url', 'gravatarEnabled'] as $key) {
+			if (isset(Config::$modSettings[$key])) {
+				$this->backup[$key] = Config::$modSettings[$key];
+			}
+		}
+	}
+
+	/**
+	 * PHPUnit does not reset SMF's statics between tests, so a setting left
+	 * behind here would leak into every test that follows.
+	 */
+	protected function tearDown(): void
+	{
+		Config::$boardurl = $this->boardurl;
+
+		foreach (['avatar_url', 'gravatarEnabled'] as $key) {
+			unset(Config::$modSettings[$key]);
+
+			if (isset($this->backup[$key])) {
+				Config::$modSettings[$key] = $this->backup[$key];
+			}
+		}
+
+		$this->backup = [];
+	}
+}


### PR DESCRIPTION
> [!NOTE]
> **This change was produced by an LLM.** The fix, the test, the commit message and
> this description were all written by Claude (Anthropic), driven by @albertlast. It
> has not yet had human code review.

#### Description

`Avatar::__construct()` looks for the member's image by trying each possibility in
turn, inside `while (!$url->isValid())`. The last possibility, reached when nothing
else produced anything, is a 1×1 transparent GIF as a data URI — there so that there
is always an answer:

```php
// Last ditch fallback is a transparent 1x1 GIF.
default:
	$url = new Url('data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7');
	break;
```

`Url::isValid()` is `filter_var($url, FILTER_VALIDATE_URL)`, which rejects a data
URI. So that answer never satisfies the condition the loop is testing, the `switch`
falls to `default` again on the next turn, and the loop never ends. The constructor
does not return, and the PHP worker running it spins until something kills it.

Reaching the last resort takes nothing exotic. The step before it is:

```php
case 5:
	if (
		!empty(Config::$modSettings['avatar_url'])
		&& is_file(Config::$boarddir . '/avatars/default.png')
	) {
```

so a forum where `avatar_url` was never written — or one whose `avatars/default.png`
is not there — hangs on any member who has an avatar at all. Every page that shows
that member takes a worker with it.

The change is `break 2` in place of `break`: at that point there is nothing further
to try, which is what the case is for.

#### Reproducing it

Without a forum, on `release-3.0` as it stands:

```php
require 'tests/bootstrap.php';

SMF\Config::$boardurl = 'https://example.com';
SMF\Config::$modSettings['gravatarEnabled'] = false;

new SMF\Avatar(url: 'Oxygen/beagle.png', id_member: 1);   // never returns
```

`tests/Unit/AvatarFallbackTest.php` is that, as a test. Against the unfixed
constructor it does not fail so much as never finish — `phpunit --filter
AvatarFallbackTest` had to be killed at 40 seconds, having printed nothing past its
header. With the fix, both tests pass and the whole suite is back under a second.

The second test is the control: given an `avatar_url`, the same avatar is found the
ordinary way and the loop ends where it always did.

#### Notes for review

- `id_member` is passed to the constructor because that is the one argument that
  keeps it away from the `attachments` table, which is what makes this reachable from
  the unit suite at all.
- The test file is its own rather than joining an `AvatarTest.php`, because #9586 and
  #9588 each add an Avatar test file of their own and I would rather they merge in
  any order than have three PRs conflict on one file.

### Issues References (Fixes|Related|Closes)

Related to #9586, #9588.

