### PR TITLE
[3.0] Look for a gallery avatar where the gallery is

### DIFF
--- a/Sources/Avatar.php
+++ b/Sources/Avatar.php
@@ -501,14 +501,14 @@ class Avatar implements \ArrayAccess
 
 					break;
 
-				// Is the file in the prepackaged avatar directory?
+				// Is the file in the avatar gallery directory?
 				case 2:
 					if (
 						!empty($this->filename)
 						&& !empty(Config::$modSettings['avatar_url'])
-						&& is_file(Config::$boarddir . '/avatars/' . ltrim($this->filename, '\\/'))
+						&& is_file(self::getGalleryDir() . '/' . ltrim($this->filename, '\\/'))
 						&& Utils::checkMimeType(
-							Config::$boarddir . '/avatars/' . ltrim($this->filename, '\\/'),
+							self::getGalleryDir() . '/' . ltrim($this->filename, '\\/'),
 							'image/',
 							true,
 						)
@@ -558,7 +558,7 @@ class Avatar implements \ArrayAccess
 							fn($path) => Sapi::canonicalPath($path) . DIRECTORY_SEPARATOR,
 							array_filter([
 								Config::$modSettings['custom_avatar_dir'] ?? '',
-								Config::$boarddir . '/avatars',
+								self::getGalleryDir(),
 							]),
 						);
 
@@ -579,7 +579,7 @@ class Avatar implements \ArrayAccess
 				case 5:
 					if (
 						!empty(Config::$modSettings['avatar_url'])
-						&& is_file(Config::$boarddir . '/avatars/default.png')
+						&& is_file(self::getGalleryDir() . '/default.png')
 					) {
 						$url = new Url(Config::$modSettings['avatar_url'] . '/default.png');
 					}
@@ -803,5 +803,27 @@ class Avatar implements \ArrayAccess
 			'external' => $this->original_url,
 			default => 'http://',
 		};
+	}
+
+	/*************************
+	 * Internal static methods
+	 *************************/
+
+	/**
+	 * The directory that holds the gallery of avatars members can choose from.
+	 *
+	 * This is the directory the admin nominated, which is the one the gallery
+	 * is listed from and the one a chosen avatar is checked against before it
+	 * is saved. Config::$modSettings['avatar_url'] is the address of the same
+	 * directory, so the two have to name the same place or a member's choice
+	 * resolves to an address with nothing behind it.
+	 *
+	 * @return string Path to the avatar gallery directory.
+	 */
+	private static function getGalleryDir(): string
+	{
+		return !empty(Config::$modSettings['avatar_directory'])
+			? Config::$modSettings['avatar_directory']
+			: Config::$boarddir . '/avatars';
 	}
 }

--- a/tests/Unit/AvatarGalleryDirectoryTest.php
+++ b/tests/Unit/AvatarGalleryDirectoryTest.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SMF\Tests\Unit;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use SMF\Avatar;
+use SMF\Config;
+
+/**
+ * Covers which directory SMF\Avatar looks in for a gallery avatar.
+ *
+ * The gallery lives wherever Config::$modSettings['avatar_directory'] says it
+ * does. Themes/default/images stands in for an admin who moved it: it is full
+ * of images, it is not the directory SMF ships the gallery in, and nothing has
+ * to be written to disk to use it.
+ */
+#[CoversClass(Avatar::class)]
+class AvatarGalleryDirectoryTest extends TestCase
+{
+	/*********************
+	 * Internal properties
+	 *********************/
+
+	/**
+	 * @var array The settings this class reads, as they were before the test.
+	 */
+	private array $backup = [];
+
+	/**
+	 * @var string Config::$boardurl as it was before the test.
+	 */
+	private string $boardurl = '';
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * The admin can move the avatar gallery, and the admin panel offers the
+	 * setting and warns when the directory it names is not there. Profile
+	 * lists the gallery out of that directory and refuses to save a choice
+	 * from anywhere else, so it is the directory a stored avatar is a path
+	 * into, and it is where the file has to be looked for.
+	 */
+	public function testAGalleryAvatarIsLookedForInTheConfiguredDirectory(): void
+	{
+		$this->setUpForum(Config::$boarddir . '/Themes/default/images');
+
+		$avatar = new Avatar(url: 'cake.png', id_member: 1);
+
+		$this->assertSame('https://example.com/gallery/cake.png', (string) $avatar->url);
+	}
+
+	public function testTheSameForAFileInASubdirectoryOfTheGallery(): void
+	{
+		$this->setUpForum(Config::$boarddir . '/Themes/default/images');
+
+		$avatar = new Avatar(url: 'icons/bell.png', id_member: 1);
+
+		$this->assertSame('https://example.com/gallery/icons/bell.png', (string) $avatar->url);
+	}
+
+	/**
+	 * A forum whose admin never touched the setting keeps the gallery SMF
+	 * ships, so the value the installer would have written is the fallback.
+	 */
+	public function testTheShippedGalleryIsUsedWhenNothingSaysOtherwise(): void
+	{
+		$this->setUpForum(null);
+
+		$avatar = new Avatar(url: 'Oxygen/beagle.png', id_member: 1);
+
+		$this->assertSame('https://example.com/gallery/Oxygen/beagle.png', (string) $avatar->url);
+	}
+
+	/******************
+	 * Internal methods
+	 ******************/
+
+	protected function setUp(): void
+	{
+		$this->boardurl = Config::$boardurl ?? '';
+
+		foreach (['avatar_url', 'avatar_directory', 'gravatarEnabled'] as $key) {
+			if (isset(Config::$modSettings[$key])) {
+				$this->backup[$key] = Config::$modSettings[$key];
+			}
+		}
+	}
+
+	/**
+	 * PHPUnit does not reset SMF's statics between tests, so a setting left
+	 * behind here would leak into every test that follows.
+	 */
+	protected function tearDown(): void
+	{
+		Config::$boardurl = $this->boardurl;
+
+		foreach (['avatar_url', 'avatar_directory', 'gravatarEnabled'] as $key) {
+			unset(Config::$modSettings[$key]);
+
+			if (isset($this->backup[$key])) {
+				Config::$modSettings[$key] = $this->backup[$key];
+			}
+		}
+
+		$this->backup = [];
+	}
+
+	/**
+	 * Puts the gallery in $directory, or leaves the setting off entirely when
+	 * it is null. The URL is deliberately not the shipped one, so that an
+	 * address built from it cannot be mistaken for a lucky guess.
+	 */
+	private function setUpForum(?string $directory): void
+	{
+		Config::$boardurl = 'https://example.com';
+		Config::$modSettings['avatar_url'] = 'https://example.com/gallery';
+		Config::$modSettings['gravatarEnabled'] = false;
+
+		if ($directory === null) {
+			unset(Config::$modSettings['avatar_directory']);
+		} else {
+			Config::$modSettings['avatar_directory'] = $directory;
+		}
+	}
+}


### PR DESCRIPTION
> [!NOTE]
> **This change was produced by an LLM.** The fix, the tests, the commit message and
> this description were all written by Claude (Anthropic), driven by @albertlast. It
> has not yet had human code review.

#### Description

`Config::$modSettings['avatar_directory']` is where the avatar gallery lives. It is
a setting the admin owns:

- `Actions/Admin/Attachments.php` offers the field, defaults it to
  `Config::$boarddir . '/avatars'` when it is submitted empty, and shows
  `avatar_directory_wrong` when the directory it names is not a directory.
- `Profile::getAvatars()` lists the gallery out of it.
- `Profile` refuses to save a chosen avatar whose `realpath()` does not start with
  it.

So a stored gallery avatar is a path into that directory, and the forum has already
said so twice by the time `Avatar` sees it.

`Avatar` looked under `Config::$boarddir . '/avatars'`, hard-coded, in the three
places that find the file — while building the address from
`Config::$modSettings['avatar_url']`, which is the *URL* of the configured
directory. The path and the address only name the same place while the admin leaves
the setting alone.

When they do not, every member's chosen avatar is looked for somewhere it has never
been: not found at the gallery step, not found in `custom_avatar`, and answered with
`default.png`. A forum that moved its avatars directory shows the default image for
everybody, with nothing in the error log to say why.

The fix reads the setting in one place, `getGalleryDir()`, and keeps the admin
panel's own default as the fallback for a forum that never wrote the setting.

#### These are regression tests

`tests/Unit/AvatarGalleryDirectoryTest.php` points `avatar_directory` at
`Themes/default/images`, which stands in for a moved gallery: full of images, not
the directory SMF ships the gallery in, and nothing has to be written to disk to
use it.

Against the unfixed constructor, two of the three fail, and the failure is the
symptom rather than an abstraction of it:

```
-'https://example.com/gallery/cake.png'
+'https://example.com/gallery/default.png'
```

The third passes either side, which is the point of it: a forum whose admin never
touched the setting keeps the gallery SMF ships.

#### Notes for review

- The comment on `case 2` said "prepackaged avatar directory". The gallery is
  prepackaged only until someone moves it, so it now says what the case looks in.
- `case 4`, which works a filename back out of a URL path, is one of the three. It
  is checking that a resolved path sits inside a directory avatars are allowed to
  be in, and after this change the set of those directories is the configured one
  plus `custom_avatar_dir` — which is the same set `Profile` validates against.
  `Config::$boarddir . '/avatars'` is deliberately not kept alongside it: on a forum
  that moved the gallery, it is no longer an avatar directory.
- The test file is its own rather than joining an `AvatarTest.php`, because #9586
  and #9587 each add an Avatar test file of their own and I would rather they merge
  in any order than have three PRs conflict on one file.
- Found while sweeping merged fixes for #9586. #9587 came out of the same sweep and
  is the more urgent of the two.

### Issues References (Fixes|Related|Closes)

Related to #9586, #9587.
