### PR TITLE
Fixes error when voting in polls as a guest

### DIFF
--- a/Sources/Actions/PollVote.php
+++ b/Sources/Actions/PollVote.php
@@ -18,6 +18,7 @@ namespace SMF\Actions;
 use SMF\ActionInterface;
 use SMF\ActionSuffixRouter;
 use SMF\ActionTrait;
+use SMF\Cookie;
 use SMF\Db\DatabaseApi as Db;
 use SMF\ErrorHandler;
 use SMF\IntegrationHook;


### PR DESCRIPTION
Signed-off-by: oldiesmann <oldiesmann@gmail.com>

When a guest attempts to vote in a poll, they get a "Class SMF\\Actions\\Cookie not found" error due to a missing use statement.