### PR TITLE
[3.0] Case insensitive comparisons (part 1 of 2) — a {ci:} type for the query language

### DIFF
--- a/Sources/Actions/Admin/Members.php
+++ b/Sources/Actions/Admin/Members.php
@@ -455,11 +455,7 @@ class Members implements ActionInterface
 					// Replace the wildcard characters ('*' and '?') into MySQL ones.
 					$parameter = strtolower(strtr(Utils::htmlspecialchars($search_params[$param_name], ENT_QUOTES), ['%' => '\\%', '_' => '\\_', '*' => '%', '?' => '_']));
 
-					if (Db::$db->case_sensitive) {
-						$query_parts[] = '(LOWER(' . implode(') LIKE {string:' . $param_name . '_normal} OR LOWER(', $param_info['db_fields']) . ') LIKE {string:' . $param_name . '_normal})';
-					} else {
-						$query_parts[] = '(' . implode(' LIKE {string:' . $param_name . '_normal} OR ', $param_info['db_fields']) . ' LIKE {string:' . $param_name . '_normal})';
-					}
+					$query_parts[] = '({ci:' . implode('} LIKE {string:' . $param_name . '_normal} OR {ci:', $param_info['db_fields']) . '} LIKE {string:' . $param_name . '_normal})';
 
 					$where_params[$param_name . '_normal'] = '%' . $parameter . '%';
 				}

--- a/Sources/Actions/Admin/Members.php
+++ b/Sources/Actions/Admin/Members.php
@@ -455,7 +455,7 @@ class Members implements ActionInterface
 					// Replace the wildcard characters ('*' and '?') into MySQL ones.
 					$parameter = strtolower(strtr(Utils::htmlspecialchars($search_params[$param_name], ENT_QUOTES), ['%' => '\\%', '_' => '\\_', '*' => '%', '?' => '_']));
 
-					$query_parts[] = '({ci:' . implode('} LIKE {string:' . $param_name . '_normal} OR {ci:', $param_info['db_fields']) . '} LIKE {string:' . $param_name . '_normal})';
+					$query_parts[] = '({column_ci:' . implode('} LIKE {string:' . $param_name . '_normal} OR {column_ci:', $param_info['db_fields']) . '} LIKE {string:' . $param_name . '_normal})';
 
 					$where_params[$param_name . '_normal'] = '%' . $parameter . '%';
 				}

--- a/Sources/Actions/AutoSuggest.php
+++ b/Sources/Actions/AutoSuggest.php
@@ -146,7 +146,7 @@ class AutoSuggest implements ActionInterface, Routable
 		$request = Db::$db->query(
 			'SELECT id_member, real_name
 			FROM {db_prefix}members
-			WHERE {ci:real_name} LIKE {string:search}' . (!empty($this->search_param['buddies']) ? '
+			WHERE {column_ci:real_name} LIKE {string:search}' . (!empty($this->search_param['buddies']) ? '
 				AND id_member IN ({array_int:buddy_list})' : '') . '
 				AND is_activated IN ({array_int:activated})
 			LIMIT ' . (Utils::entityStrlen($this->search) <= 2 ? '100' : '800'),
@@ -194,7 +194,7 @@ class AutoSuggest implements ActionInterface, Routable
 		$request = Db::$db->query(
 			'SELECT id_group, group_name
 			FROM {db_prefix}membergroups
-			WHERE {ci:group_name} LIKE {string:search}
+			WHERE {column_ci:group_name} LIKE {string:search}
 				AND min_posts = {int:min_posts}
 				AND id_group NOT IN ({array_int:invalid_groups})
 				AND hidden != {int:hidden}',

--- a/Sources/Actions/AutoSuggest.php
+++ b/Sources/Actions/AutoSuggest.php
@@ -146,12 +146,11 @@ class AutoSuggest implements ActionInterface, Routable
 		$request = Db::$db->query(
 			'SELECT id_member, real_name
 			FROM {db_prefix}members
-			WHERE {raw:real_name} LIKE {string:search}' . (!empty($this->search_param['buddies']) ? '
+			WHERE {ci:real_name} LIKE {string:search}' . (!empty($this->search_param['buddies']) ? '
 				AND id_member IN ({array_int:buddy_list})' : '') . '
 				AND is_activated IN ({array_int:activated})
 			LIMIT ' . (Utils::entityStrlen($this->search) <= 2 ? '100' : '800'),
 			[
-				'real_name' => Db::$db->case_sensitive ? 'LOWER(real_name)' : 'real_name',
 				'buddy_list' => User::$me->buddies,
 				'search' => $this->search,
 				'activated' => [User::ACTIVATED, User::ACTIVATED_BANNED],
@@ -195,12 +194,11 @@ class AutoSuggest implements ActionInterface, Routable
 		$request = Db::$db->query(
 			'SELECT id_group, group_name
 			FROM {db_prefix}membergroups
-			WHERE {raw:group_name} LIKE {string:search}
+			WHERE {ci:group_name} LIKE {string:search}
 				AND min_posts = {int:min_posts}
 				AND id_group NOT IN ({array_int:invalid_groups})
 				AND hidden != {int:hidden}',
 			[
-				'group_name' => Db::$db->case_sensitive ? 'LOWER(group_name)' : 'group_name',
 				'min_posts' => -1,
 				'invalid_groups' => [1, 3],
 				'hidden' => 2,

--- a/Sources/Actions/Memberlist.php
+++ b/Sources/Actions/Memberlist.php
@@ -547,7 +547,7 @@ class Memberlist implements ActionInterface, Routable
 				ErrorHandler::fatalLang('invalid_search_string', false);
 			}
 
-			$query = $_POST['search'] == '' ? '= {string:blank_string}' : 'LIKE {ci_string:search}';
+			$query = $_POST['search'] == '' ? '= {string:blank_string}' : 'LIKE {string_ci:search}';
 
 			$request = Db::$db->query(
 				'SELECT COUNT(*)

--- a/Sources/Actions/Memberlist.php
+++ b/Sources/Actions/Memberlist.php
@@ -522,7 +522,7 @@ class Memberlist implements ActionInterface, Routable
 			}
 
 			// These are expressions as well as plain columns, so they are
-			// folded here rather than through the {ci:} type.
+			// folded here rather than through the {column_ci:} type.
 			if (Db::$db->case_sensitive) {
 				foreach ($fields as $key => $field) {
 					$fields[$key] = 'LOWER(' . $field . ')';

--- a/Sources/Actions/Memberlist.php
+++ b/Sources/Actions/Memberlist.php
@@ -521,6 +521,8 @@ class Memberlist implements ActionInterface, Routable
 				$search_fields[] = 'email';
 			}
 
+			// These are expressions as well as plain columns, so they are
+			// folded here rather than through the {ci:} type.
 			if (Db::$db->case_sensitive) {
 				foreach ($fields as $key => $field) {
 					$fields[$key] = 'LOWER(' . $field . ')';
@@ -545,7 +547,7 @@ class Memberlist implements ActionInterface, Routable
 				ErrorHandler::fatalLang('invalid_search_string', false);
 			}
 
-			$query = $_POST['search'] == '' ? '= {string:blank_string}' : (Db::$db->case_sensitive ? 'LIKE LOWER({string:search})' : 'LIKE {string:search}');
+			$query = $_POST['search'] == '' ? '= {string:blank_string}' : 'LIKE {ci_string:search}';
 
 			$request = Db::$db->query(
 				'SELECT COUNT(*)

--- a/Sources/Actions/Register2.php
+++ b/Sources/Actions/Register2.php
@@ -536,8 +536,8 @@ class Register2 extends Register
 		$request = Db::$db->query(
 			'SELECT id_member
 			FROM {db_prefix}members
-			WHERE {ci:email_address} = {string:email_address}
-				OR {ci:email_address} = {string:username}
+			WHERE {column_ci:email_address} = {string:email_address}
+				OR {column_ci:email_address} = {string:username}
 			LIMIT 1',
 			[
 				'email_address' => $reg_options['email'],

--- a/Sources/Actions/Register2.php
+++ b/Sources/Actions/Register2.php
@@ -536,11 +536,10 @@ class Register2 extends Register
 		$request = Db::$db->query(
 			'SELECT id_member
 			FROM {db_prefix}members
-			WHERE {raw:email_address_field} = {string:email_address}
-				OR {raw:email_address_field} = {string:username}
+			WHERE {ci:email_address} = {string:email_address}
+				OR {ci:email_address} = {string:username}
 			LIMIT 1',
 			[
-				'email_address_field' => Db::$db->case_sensitive ? 'LOWER(email_address)' : 'email_address',
 				'email_address' => $reg_options['email'],
 				'username' => $reg_options['username'],
 			],

--- a/Sources/Actions/RequestMembers.php
+++ b/Sources/Actions/RequestMembers.php
@@ -74,12 +74,11 @@ class RequestMembers implements ActionInterface, Routable
 		$request = Db::$db->query(
 			'SELECT real_name
 			FROM {db_prefix}members
-			WHERE {raw:real_name} LIKE {string:search}' . (isset($_REQUEST['buddies']) ? '
+			WHERE {ci:real_name} LIKE {string:search}' . (isset($_REQUEST['buddies']) ? '
 				AND id_member IN ({array_int:buddy_list})' : '') . '
 				AND is_activated IN ({array_int:activated})
 			LIMIT {int:limit}',
 			[
-				'real_name' => Db::$db->case_sensitive ? 'LOWER(real_name)' : 'real_name',
 				'buddy_list' => User::$me->buddies,
 				'search' => $this->search,
 				'activated' => [User::ACTIVATED, User::ACTIVATED_BANNED],

--- a/Sources/Actions/RequestMembers.php
+++ b/Sources/Actions/RequestMembers.php
@@ -74,7 +74,7 @@ class RequestMembers implements ActionInterface, Routable
 		$request = Db::$db->query(
 			'SELECT real_name
 			FROM {db_prefix}members
-			WHERE {ci:real_name} LIKE {string:search}' . (isset($_REQUEST['buddies']) ? '
+			WHERE {column_ci:real_name} LIKE {string:search}' . (isset($_REQUEST['buddies']) ? '
 				AND id_member IN ({array_int:buddy_list})' : '') . '
 				AND is_activated IN ({array_int:activated})
 			LIMIT {int:limit}',

--- a/Sources/Db/APIs/MySQL.php
+++ b/Sources/Db/APIs/MySQL.php
@@ -282,6 +282,11 @@ class MySQL extends DatabaseApi implements DatabaseApiInterface
 				[
 					// The literal type can have arbitrary content.
 					'~{(literal):([^}]*)}~',
+					// The ci type names a column inline rather than by key, so
+					// that the column a comparison is case folding is visible in
+					// the query itself. Only a column name, optionally qualified
+					// by a table alias, is accepted.
+					'~{(ci):([a-zA-Z0-9_]+(?:\.[a-zA-Z0-9_]+)?)}~',
 					// Everything else needs to be a key in $db_values.
 					'~{([a-z_]+)(?::([a-zA-Z0-9_-]+))?}~',
 				],
@@ -2753,6 +2758,12 @@ class MySQL extends DatabaseApi implements DatabaseApiInterface
 			return '\'' . mysqli_real_escape_string($connection, $matches[2]) . '\'';
 		}
 
+		// MySQL folds case in the column's collation, so a case insensitive
+		// comparison is what a bare column already does.
+		if ($matches[1] === 'ci') {
+			return $matches[2];
+		}
+
 		if (!\array_key_exists($matches[2], $db_values)) {
 			$this->error_backtrace('The database value you\'re trying to insert does not exist: ' . Utils::htmlspecialchars($matches[2]), '', E_USER_ERROR, __FILE__, __LINE__);
 		}
@@ -2777,6 +2788,8 @@ class MySQL extends DatabaseApi implements DatabaseApiInterface
 
 			case 'string':
 			case 'text':
+			// MySQL folds the case of the value in the collation as well.
+			case 'ci_string':
 				return \sprintf('\'%1$s\'', mysqli_real_escape_string($connection, $this->fix_mb4((string) $replacement)));
 
 			case 'array_int':

--- a/Sources/Db/APIs/MySQL.php
+++ b/Sources/Db/APIs/MySQL.php
@@ -282,11 +282,11 @@ class MySQL extends DatabaseApi implements DatabaseApiInterface
 				[
 					// The literal type can have arbitrary content.
 					'~{(literal):([^}]*)}~',
-					// The ci type names a column inline rather than by key, so
-					// that the column a comparison is case folding is visible in
-					// the query itself. Only a column name, optionally qualified
-					// by a table alias, is accepted.
-					'~{(ci):([a-zA-Z0-9_]+(?:\.[a-zA-Z0-9_]+)?)}~',
+					// The column_ci type names a column inline rather than by key,
+					// so that the column a comparison is case folding is visible
+					// in the query itself. Only a column name, optionally
+					// qualified by a table alias, is accepted.
+					'~{(column_ci):([a-zA-Z0-9_]+(?:\.[a-zA-Z0-9_]+)?)}~',
 					// Everything else needs to be a key in $db_values.
 					'~{([a-z_]+)(?::([a-zA-Z0-9_-]+))?}~',
 				],
@@ -2760,7 +2760,7 @@ class MySQL extends DatabaseApi implements DatabaseApiInterface
 
 		// MySQL folds case in the column's collation, so a case insensitive
 		// comparison is what a bare column already does.
-		if ($matches[1] === 'ci') {
+		if ($matches[1] === 'column_ci') {
 			return $matches[2];
 		}
 

--- a/Sources/Db/APIs/MySQL.php
+++ b/Sources/Db/APIs/MySQL.php
@@ -2789,7 +2789,7 @@ class MySQL extends DatabaseApi implements DatabaseApiInterface
 			case 'string':
 			case 'text':
 			// MySQL folds the case of the value in the collation as well.
-			case 'ci_string':
+			case 'string_ci':
 				return \sprintf('\'%1$s\'', mysqli_real_escape_string($connection, $this->fix_mb4((string) $replacement)));
 
 			case 'array_int':
@@ -2814,6 +2814,8 @@ class MySQL extends DatabaseApi implements DatabaseApiInterface
 				break;
 
 			case 'array_string':
+			// As above, the collation folds each of these too.
+			case 'array_string_ci':
 				if (\is_array($replacement)) {
 					if (empty($replacement)) {
 						$this->error_backtrace('Database error, given array of string values is empty. (' . $matches[2] . ')', '', E_USER_ERROR, __FILE__, __LINE__);

--- a/Sources/Db/APIs/PostgreSQL.php
+++ b/Sources/Db/APIs/PostgreSQL.php
@@ -343,6 +343,11 @@ class PostgreSQL extends DatabaseApi implements DatabaseApiInterface
 				[
 					// The literal type can have arbitrary content.
 					'~{(literal):([^}]*)}~',
+					// The ci type names a column inline rather than by key, so
+					// that the column a comparison is case folding is visible in
+					// the query itself. Only a column name, optionally qualified
+					// by a table alias, is accepted.
+					'~{(ci):([a-zA-Z0-9_]+(?:\.[a-zA-Z0-9_]+)?)}~',
 					// Everything else needs to be a key in $db_values.
 					'~{([a-z_]+)(?::([a-zA-Z0-9_-]+))?}~',
 				],
@@ -2684,6 +2689,12 @@ class PostgreSQL extends DatabaseApi implements DatabaseApiInterface
 			return '\'' . pg_escape_string($this->connection, $matches[2]) . '\'';
 		}
 
+		// PostgreSQL compares strings exactly, so a case insensitive comparison
+		// folds the column and pairs it with a value folded the same way.
+		if ($matches[1] === 'ci') {
+			return 'LOWER(' . $matches[2] . ')';
+		}
+
 		if (!\array_key_exists($matches[2], $db_values)) {
 			$this->error_backtrace('The database value you\'re trying to insert does not exist: ' . Utils::htmlspecialchars($matches[2]), '', E_USER_ERROR, __FILE__, __LINE__);
 		}
@@ -2709,6 +2720,10 @@ class PostgreSQL extends DatabaseApi implements DatabaseApiInterface
 			case 'string':
 			case 'text':
 				return \sprintf('\'%1$s\'', pg_escape_string($this->connection, (string) $replacement));
+
+			// Folded to match a column that {ci:} has folded.
+			case 'ci_string':
+				return \sprintf('LOWER(\'%1$s\')', pg_escape_string($this->connection, (string) $replacement));
 
 			case 'array_int':
 				if (\is_array($replacement)) {

--- a/Sources/Db/APIs/PostgreSQL.php
+++ b/Sources/Db/APIs/PostgreSQL.php
@@ -2722,7 +2722,7 @@ class PostgreSQL extends DatabaseApi implements DatabaseApiInterface
 				return \sprintf('\'%1$s\'', pg_escape_string($this->connection, (string) $replacement));
 
 			// Folded to match a column that {ci:} has folded.
-			case 'ci_string':
+			case 'string_ci':
 				return \sprintf('LOWER(\'%1$s\')', pg_escape_string($this->connection, (string) $replacement));
 
 			case 'array_int':
@@ -2754,6 +2754,24 @@ class PostgreSQL extends DatabaseApi implements DatabaseApiInterface
 
 					foreach ($replacement as $key => $value) {
 						$replacement[$key] = \sprintf('\'%1$s\'', pg_escape_string($this->connection, (string) $value));
+					}
+
+					return implode(', ', $replacement);
+				}
+
+				$this->error_backtrace('Wrong value type sent to the database. Array of strings expected. (' . $matches[2] . ')', '', E_USER_ERROR, __FILE__, __LINE__);
+
+				break;
+
+			// Each of these folded to match a column that {ci:} has folded.
+			case 'array_string_ci':
+				if (\is_array($replacement)) {
+					if (empty($replacement)) {
+						$this->error_backtrace('Database error, given array of string values is empty. (' . $matches[2] . ')', '', E_USER_ERROR, __FILE__, __LINE__);
+					}
+
+					foreach ($replacement as $key => $value) {
+						$replacement[$key] = \sprintf('LOWER(\'%1$s\')', pg_escape_string($this->connection, (string) $value));
 					}
 
 					return implode(', ', $replacement);

--- a/Sources/Db/APIs/PostgreSQL.php
+++ b/Sources/Db/APIs/PostgreSQL.php
@@ -343,11 +343,11 @@ class PostgreSQL extends DatabaseApi implements DatabaseApiInterface
 				[
 					// The literal type can have arbitrary content.
 					'~{(literal):([^}]*)}~',
-					// The ci type names a column inline rather than by key, so
-					// that the column a comparison is case folding is visible in
-					// the query itself. Only a column name, optionally qualified
-					// by a table alias, is accepted.
-					'~{(ci):([a-zA-Z0-9_]+(?:\.[a-zA-Z0-9_]+)?)}~',
+					// The column_ci type names a column inline rather than by key,
+					// so that the column a comparison is case folding is visible
+					// in the query itself. Only a column name, optionally
+					// qualified by a table alias, is accepted.
+					'~{(column_ci):([a-zA-Z0-9_]+(?:\.[a-zA-Z0-9_]+)?)}~',
 					// Everything else needs to be a key in $db_values.
 					'~{([a-z_]+)(?::([a-zA-Z0-9_-]+))?}~',
 				],
@@ -2691,7 +2691,7 @@ class PostgreSQL extends DatabaseApi implements DatabaseApiInterface
 
 		// PostgreSQL compares strings exactly, so a case insensitive comparison
 		// folds the column and pairs it with a value folded the same way.
-		if ($matches[1] === 'ci') {
+		if ($matches[1] === 'column_ci') {
 			return 'LOWER(' . $matches[2] . ')';
 		}
 
@@ -2721,7 +2721,7 @@ class PostgreSQL extends DatabaseApi implements DatabaseApiInterface
 			case 'text':
 				return \sprintf('\'%1$s\'', pg_escape_string($this->connection, (string) $replacement));
 
-			// Folded to match a column that {ci:} has folded.
+			// Folded to match a column that {column_ci:} has folded.
 			case 'string_ci':
 				return \sprintf('LOWER(\'%1$s\')', pg_escape_string($this->connection, (string) $replacement));
 
@@ -2763,7 +2763,7 @@ class PostgreSQL extends DatabaseApi implements DatabaseApiInterface
 
 				break;
 
-			// Each of these folded to match a column that {ci:} has folded.
+			// Each of these folded to match a column that {column_ci:} has folded.
 			case 'array_string_ci':
 				if (\is_array($replacement)) {
 					if (empty($replacement)) {

--- a/Sources/PersonalMessage/PM.php
+++ b/Sources/PersonalMessage/PM.php
@@ -1210,7 +1210,7 @@ class PM implements \ArrayAccess
 			$request = Db::$db->query(
 				'SELECT id_member, member_name
 				FROM {db_prefix}members
-				WHERE ' . (Db::$db->case_sensitive ? 'LOWER(member_name)' : 'member_name') . ' IN ({array_string:usernames})',
+				WHERE {ci:member_name} IN ({array_string:usernames})',
 				[
 					'usernames' => array_keys($usernames),
 				],

--- a/Sources/PersonalMessage/PM.php
+++ b/Sources/PersonalMessage/PM.php
@@ -1210,7 +1210,7 @@ class PM implements \ArrayAccess
 			$request = Db::$db->query(
 				'SELECT id_member, member_name
 				FROM {db_prefix}members
-				WHERE {ci:member_name} IN ({array_string:usernames})',
+				WHERE {column_ci:member_name} IN ({array_string:usernames})',
 				[
 					'usernames' => array_keys($usernames),
 				],

--- a/Sources/PersonalMessage/Search.php
+++ b/Sources/PersonalMessage/Search.php
@@ -478,7 +478,7 @@ class Search
 
 		foreach ($possible_users as $k => $v) {
 			$where_params['name_' . $k] = $v;
-			$where_clause[] = '{ci:real_name} LIKE {string:name_' . $k . '}';
+			$where_clause[] = '{column_ci:real_name} LIKE {string:name_' . $k . '}';
 		}
 
 		// Who matches those criteria?
@@ -498,7 +498,7 @@ class Search
 
 				foreach ($possible_users as $k => $v) {
 					$this->searchq_parameters['name_' . $k] = $v;
-					$clauses[] = '{ci:pm.from_name} LIKE {string:name_' . $k . '}';
+					$clauses[] = '{column_ci:pm.from_name} LIKE {string:name_' . $k . '}';
 				}
 
 			if (Db::$db->num_rows($request) == 0) {

--- a/Sources/PersonalMessage/Search.php
+++ b/Sources/PersonalMessage/Search.php
@@ -478,11 +478,7 @@ class Search
 
 		foreach ($possible_users as $k => $v) {
 			$where_params['name_' . $k] = $v;
-			$where_clause[] = '{raw:real_name} LIKE {string:name_' . $k . '}';
-
-			if (!isset($where_params['real_name'])) {
-				$where_params['real_name'] = Db::$db->case_sensitive ? 'LOWER(real_name)' : 'real_name';
-			}
+			$where_clause[] = '{ci:real_name} LIKE {string:name_' . $k . '}';
 		}
 
 		// Who matches those criteria?
@@ -498,12 +494,11 @@ class Search
 		if (Db::$db->num_rows($request) > $this->max_members_to_search) {
 			$this->user_query = '';
 		} else {
-				$this->searchq_parameters['real_name'] = Db::$db->case_sensitive ? 'LOWER(pm.from_name)' : 'pm.from_name';
 				$clauses = [];
 
 				foreach ($possible_users as $k => $v) {
 					$this->searchq_parameters['name_' . $k] = $v;
-					$clauses[] = '{raw:real_name} LIKE {string:name_' . $k . '}';
+					$clauses[] = '{ci:pm.from_name} LIKE {string:name_' . $k . '}';
 				}
 
 			if (Db::$db->num_rows($request) == 0) {

--- a/Sources/Profile.php
+++ b/Sources/Profile.php
@@ -1649,7 +1649,7 @@ class Profile extends User implements \ArrayAccess
 			'SELECT id_member
 			FROM {db_prefix}members
 			WHERE id_member != {int:selected_member}
-				AND {ci:email_address} = {string:email_address}
+				AND {column_ci:email_address} = {string:email_address}
 			LIMIT 1',
 			[
 				'selected_member' => $this->id,

--- a/Sources/Profile.php
+++ b/Sources/Profile.php
@@ -1649,10 +1649,9 @@ class Profile extends User implements \ArrayAccess
 			'SELECT id_member
 			FROM {db_prefix}members
 			WHERE id_member != {int:selected_member}
-				AND {raw:email_address_field} = {string:email_address}
+				AND {ci:email_address} = {string:email_address}
 			LIMIT 1',
 			[
-				'email_address_field' => Db::$db->case_sensitive ? 'LOWER(email_address)' : 'email_address',
 				'selected_member' => $this->id,
 				'email_address' => $email,
 			],

--- a/Sources/User.php
+++ b/Sources/User.php
@@ -3800,9 +3800,10 @@ class User implements \ArrayAccess
 			$email_condition = '';
 		}
 
-		// Get the case of the columns right - but only if we need to as things like MySQL will go slow needlessly otherwise.
-		$member_name = Db::$db->case_sensitive ? 'LOWER(member_name)' : 'member_name';
-		$real_name = Db::$db->case_sensitive ? 'LOWER(real_name)' : 'real_name';
+		// The {ci:} type folds the column for the engines that need it and
+		// leaves it alone for the ones that do not.
+		$member_name = '{ci:member_name}';
+		$real_name = '{ci:real_name}';
 
 		// Searches.
 		$member_name_search = $member_name . ' ' . $comparison . ' ' . implode(' OR ' . $member_name . ' ' . $comparison . ' ', $names_list);
@@ -5424,13 +5425,11 @@ class User implements \ArrayAccess
 				break;
 
 			case self::LOAD_BY_NAME:
-				if (Db::$db->case_sensitive) {
-					$query_customizations['where'][] = 'LOWER(mem.member_name) IN ({array_string:users})';
-					$query_customizations['params']['users'] = array_map('strtolower', $users);
-				} else {
-					$query_customizations['where'][] = 'mem.member_name IN ({array_string:users})';
-					$query_customizations['params']['users'] = $users;
-				}
+				$query_customizations['where'][] = '{ci:mem.member_name} IN ({array_string:users})';
+
+				// An array of values has no {ci:} of its own, so the names are
+				// folded here for the engines that compare them exactly.
+				$query_customizations['params']['users'] = Db::$db->case_sensitive ? array_map('strtolower', $users) : $users;
 
 				break;
 

--- a/Sources/User.php
+++ b/Sources/User.php
@@ -5425,11 +5425,8 @@ class User implements \ArrayAccess
 				break;
 
 			case self::LOAD_BY_NAME:
-				$query_customizations['where'][] = '{ci:mem.member_name} IN ({array_string:users})';
-
-				// An array of values has no {ci:} of its own, so the names are
-				// folded here for the engines that compare them exactly.
-				$query_customizations['params']['users'] = Db::$db->case_sensitive ? array_map('strtolower', $users) : $users;
+				$query_customizations['where'][] = '{ci:mem.member_name} IN ({array_string_ci:users})';
+				$query_customizations['params']['users'] = $users;
 
 				break;
 

--- a/Sources/User.php
+++ b/Sources/User.php
@@ -3800,10 +3800,10 @@ class User implements \ArrayAccess
 			$email_condition = '';
 		}
 
-		// The {ci:} type folds the column for the engines that need it and
+		// The {column_ci:} type folds the column for the engines that need it and
 		// leaves it alone for the ones that do not.
-		$member_name = '{ci:member_name}';
-		$real_name = '{ci:real_name}';
+		$member_name = '{column_ci:member_name}';
+		$real_name = '{column_ci:real_name}';
 
 		// Searches.
 		$member_name_search = $member_name . ' ' . $comparison . ' ' . implode(' OR ' . $member_name . ' ' . $comparison . ' ', $names_list);
@@ -5425,7 +5425,7 @@ class User implements \ArrayAccess
 				break;
 
 			case self::LOAD_BY_NAME:
-				$query_customizations['where'][] = '{ci:mem.member_name} IN ({array_string_ci:users})';
+				$query_customizations['where'][] = '{column_ci:mem.member_name} IN ({array_string_ci:users})';
 				$query_customizations['params']['users'] = $users;
 
 				break;


### PR DESCRIPTION
#### Description

Whether a string comparison folds case is decided by the database engine. MySQL folds
it in the column's collation; PostgreSQL compares exactly. Today every caller that cares
has to know this, read `Db::$db->case_sensitive`, and wrap the column in `LOWER()` itself:

```php
'real_name' => Db::$db->case_sensitive ? 'LOWER(real_name)' : 'real_name',
```

That puts the decision at each call site and defaults to the wrong answer on PostgreSQL
when somebody does not think to add it. It also fails quietly — the query returns fewer
rows rather than erroring, so nothing reaches `smf_log_errors`. #9592, #9593 and #9594 are
all that shape.

This moves the decision into the query string, where the substitution layer already lives.

- **`{column_ci:column}`** expands to `column` on MySQL and `LOWER(column)` on PostgreSQL.
  The column is named inline rather than through `$db_values`, so a comparison shows in
  the query text which column it folds. Only a column name, optionally qualified by a
  table alias, is accepted.
- **`{string_ci:key}`** and **`{array_string_ci:key}`** are the matching value types.
  The suffix rather than a prefix, because `array_` already occupies the prefix position
  on the existing types, so `{array_string_ci}` composes where `{array_ci_string}` would
  not.

Then converts the call sites that were already branching on `Db::$db->case_sensitive`.

Every conversion expands to exactly what the ternary it replaces produced, on both
engines, with one deliberate exception:

- **`User::addQueryCustomizationsForLoadType()` changes behaviour.** It used to fold the
  names with `strtolower()` in PHP and compare them against a column folded by SQL
  `LOWER()`. Those disagree outside ASCII — `ÄNNA` folds to `änna` on the column and to
  `Änna` in PHP — so loading that member by name never matched on PostgreSQL. It now
  hands the list to `{array_string_ci:}` and both sides fold the same way. This is the
  only behaviour change in the branch, and it is the last caller of
  `Db::$db->case_sensitive` outside `Memberlist`.
- `Memberlist` keeps its own `LOWER()` loop. It folds expressions such as
  `COALESCE(group_name, {string:blank_string})` as well as plain columns, and an
  expression is not what `{column_ci:}` accepts. Only its value side is converted.

**Indexing is deliberately left alone.** `{column_ci:email_address}` expands to
`LOWER(email_address)` on PostgreSQL, which cannot use `idx_email_address` — measured at
0.101 ms against 43.4 ms on 200,000 rows. That regression arrived in 959007f5b rather
than here, and per @Sesquipedalian's comment below the fix is a follow-up that stores a
case-folded `email_address_ci` column beside the real address and searches on that. The
two name columns need nothing: their existing PostgreSQL indexes are
`LOWER(member_name)` and `LOWER(real_name)` with `varchar_pattern_ops`, which serves `=`,
`IN` and prefix `LIKE` alike.

Not reachable from the unit suite: `replacement__callback()` is protected and reached
through `quote()`, which needs a live connection to escape with. Part 2 adds the test
that is possible without one — a guard over the source files, so that a new comparison
written the old way fails CI instead of being found years later.

Verified by hand on both engines from the Docker environment, and `composer lint` and
`vendor/bin/phpunit` are clean.

### Issues References (Fixes|Related|Closes)
1. Related: #9592
2. Related: #9593
3. Related: #9594
4. Related: #3214 — `case_sensitive` being a per-engine constant rather than a property of the column

🤖 Generated with [Claude Code](https://claude.com/claude-code)
