### PR TITLE
[3.0][Testing] Case insensitive comparisons (part 2 of 2) — guard the convention in the unit suite

### DIFF
--- a/Sources/Actions/Admin/Members.php
+++ b/Sources/Actions/Admin/Members.php
@@ -455,11 +455,7 @@ class Members implements ActionInterface
 					// Replace the wildcard characters ('*' and '?') into MySQL ones.
 					$parameter = strtolower(strtr(Utils::htmlspecialchars($search_params[$param_name], ENT_QUOTES), ['%' => '\\%', '_' => '\\_', '*' => '%', '?' => '_']));
 
-					if (Db::$db->case_sensitive) {
-						$query_parts[] = '(LOWER(' . implode(') LIKE {string:' . $param_name . '_normal} OR LOWER(', $param_info['db_fields']) . ') LIKE {string:' . $param_name . '_normal})';
-					} else {
-						$query_parts[] = '(' . implode(' LIKE {string:' . $param_name . '_normal} OR ', $param_info['db_fields']) . ' LIKE {string:' . $param_name . '_normal})';
-					}
+					$query_parts[] = '({ci:' . implode('} LIKE {string:' . $param_name . '_normal} OR {ci:', $param_info['db_fields']) . '} LIKE {string:' . $param_name . '_normal})';
 
 					$where_params[$param_name . '_normal'] = '%' . $parameter . '%';
 				}

--- a/Sources/Actions/Admin/Members.php
+++ b/Sources/Actions/Admin/Members.php
@@ -455,7 +455,7 @@ class Members implements ActionInterface
 					// Replace the wildcard characters ('*' and '?') into MySQL ones.
 					$parameter = strtolower(strtr(Utils::htmlspecialchars($search_params[$param_name], ENT_QUOTES), ['%' => '\\%', '_' => '\\_', '*' => '%', '?' => '_']));
 
-					$query_parts[] = '({ci:' . implode('} LIKE {string:' . $param_name . '_normal} OR {ci:', $param_info['db_fields']) . '} LIKE {string:' . $param_name . '_normal})';
+					$query_parts[] = '({column_ci:' . implode('} LIKE {string:' . $param_name . '_normal} OR {column_ci:', $param_info['db_fields']) . '} LIKE {string:' . $param_name . '_normal})';
 
 					$where_params[$param_name . '_normal'] = '%' . $parameter . '%';
 				}

--- a/Sources/Actions/AutoSuggest.php
+++ b/Sources/Actions/AutoSuggest.php
@@ -146,7 +146,7 @@ class AutoSuggest implements ActionInterface, Routable
 		$request = Db::$db->query(
 			'SELECT id_member, real_name
 			FROM {db_prefix}members
-			WHERE {ci:real_name} LIKE {string:search}' . (!empty($this->search_param['buddies']) ? '
+			WHERE {column_ci:real_name} LIKE {string:search}' . (!empty($this->search_param['buddies']) ? '
 				AND id_member IN ({array_int:buddy_list})' : '') . '
 				AND is_activated IN ({array_int:activated})
 			LIMIT ' . (Utils::entityStrlen($this->search) <= 2 ? '100' : '800'),
@@ -194,7 +194,7 @@ class AutoSuggest implements ActionInterface, Routable
 		$request = Db::$db->query(
 			'SELECT id_group, group_name
 			FROM {db_prefix}membergroups
-			WHERE {ci:group_name} LIKE {string:search}
+			WHERE {column_ci:group_name} LIKE {string:search}
 				AND min_posts = {int:min_posts}
 				AND id_group NOT IN ({array_int:invalid_groups})
 				AND hidden != {int:hidden}',

--- a/Sources/Actions/AutoSuggest.php
+++ b/Sources/Actions/AutoSuggest.php
@@ -146,12 +146,11 @@ class AutoSuggest implements ActionInterface, Routable
 		$request = Db::$db->query(
 			'SELECT id_member, real_name
 			FROM {db_prefix}members
-			WHERE {raw:real_name} LIKE {string:search}' . (!empty($this->search_param['buddies']) ? '
+			WHERE {ci:real_name} LIKE {string:search}' . (!empty($this->search_param['buddies']) ? '
 				AND id_member IN ({array_int:buddy_list})' : '') . '
 				AND is_activated IN ({array_int:activated})
 			LIMIT ' . (Utils::entityStrlen($this->search) <= 2 ? '100' : '800'),
 			[
-				'real_name' => Db::$db->case_sensitive ? 'LOWER(real_name)' : 'real_name',
 				'buddy_list' => User::$me->buddies,
 				'search' => $this->search,
 				'activated' => [User::ACTIVATED, User::ACTIVATED_BANNED],
@@ -195,12 +194,11 @@ class AutoSuggest implements ActionInterface, Routable
 		$request = Db::$db->query(
 			'SELECT id_group, group_name
 			FROM {db_prefix}membergroups
-			WHERE {raw:group_name} LIKE {string:search}
+			WHERE {ci:group_name} LIKE {string:search}
 				AND min_posts = {int:min_posts}
 				AND id_group NOT IN ({array_int:invalid_groups})
 				AND hidden != {int:hidden}',
 			[
-				'group_name' => Db::$db->case_sensitive ? 'LOWER(group_name)' : 'group_name',
 				'min_posts' => -1,
 				'invalid_groups' => [1, 3],
 				'hidden' => 2,

--- a/Sources/Actions/Memberlist.php
+++ b/Sources/Actions/Memberlist.php
@@ -547,7 +547,7 @@ class Memberlist implements ActionInterface, Routable
 				ErrorHandler::fatalLang('invalid_search_string', false);
 			}
 
-			$query = $_POST['search'] == '' ? '= {string:blank_string}' : 'LIKE {ci_string:search}';
+			$query = $_POST['search'] == '' ? '= {string:blank_string}' : 'LIKE {string_ci:search}';
 
 			$request = Db::$db->query(
 				'SELECT COUNT(*)

--- a/Sources/Actions/Memberlist.php
+++ b/Sources/Actions/Memberlist.php
@@ -522,7 +522,7 @@ class Memberlist implements ActionInterface, Routable
 			}
 
 			// These are expressions as well as plain columns, so they are
-			// folded here rather than through the {ci:} type.
+			// folded here rather than through the {column_ci:} type.
 			if (Db::$db->case_sensitive) {
 				foreach ($fields as $key => $field) {
 					$fields[$key] = 'LOWER(' . $field . ')';

--- a/Sources/Actions/Memberlist.php
+++ b/Sources/Actions/Memberlist.php
@@ -521,6 +521,8 @@ class Memberlist implements ActionInterface, Routable
 				$search_fields[] = 'email';
 			}
 
+			// These are expressions as well as plain columns, so they are
+			// folded here rather than through the {ci:} type.
 			if (Db::$db->case_sensitive) {
 				foreach ($fields as $key => $field) {
 					$fields[$key] = 'LOWER(' . $field . ')';
@@ -545,7 +547,7 @@ class Memberlist implements ActionInterface, Routable
 				ErrorHandler::fatalLang('invalid_search_string', false);
 			}
 
-			$query = $_POST['search'] == '' ? '= {string:blank_string}' : (Db::$db->case_sensitive ? 'LIKE LOWER({string:search})' : 'LIKE {string:search}');
+			$query = $_POST['search'] == '' ? '= {string:blank_string}' : 'LIKE {ci_string:search}';
 
 			$request = Db::$db->query(
 				'SELECT COUNT(*)

--- a/Sources/Actions/Register2.php
+++ b/Sources/Actions/Register2.php
@@ -536,8 +536,8 @@ class Register2 extends Register
 		$request = Db::$db->query(
 			'SELECT id_member
 			FROM {db_prefix}members
-			WHERE {ci:email_address} = {string:email_address}
-				OR {ci:email_address} = {string:username}
+			WHERE {column_ci:email_address} = {string:email_address}
+				OR {column_ci:email_address} = {string:username}
 			LIMIT 1',
 			[
 				'email_address' => $reg_options['email'],

--- a/Sources/Actions/Register2.php
+++ b/Sources/Actions/Register2.php
@@ -536,11 +536,10 @@ class Register2 extends Register
 		$request = Db::$db->query(
 			'SELECT id_member
 			FROM {db_prefix}members
-			WHERE {raw:email_address_field} = {string:email_address}
-				OR {raw:email_address_field} = {string:username}
+			WHERE {ci:email_address} = {string:email_address}
+				OR {ci:email_address} = {string:username}
 			LIMIT 1',
 			[
-				'email_address_field' => Db::$db->case_sensitive ? 'LOWER(email_address)' : 'email_address',
 				'email_address' => $reg_options['email'],
 				'username' => $reg_options['username'],
 			],

--- a/Sources/Actions/RequestMembers.php
+++ b/Sources/Actions/RequestMembers.php
@@ -74,12 +74,11 @@ class RequestMembers implements ActionInterface, Routable
 		$request = Db::$db->query(
 			'SELECT real_name
 			FROM {db_prefix}members
-			WHERE {raw:real_name} LIKE {string:search}' . (isset($_REQUEST['buddies']) ? '
+			WHERE {ci:real_name} LIKE {string:search}' . (isset($_REQUEST['buddies']) ? '
 				AND id_member IN ({array_int:buddy_list})' : '') . '
 				AND is_activated IN ({array_int:activated})
 			LIMIT {int:limit}',
 			[
-				'real_name' => Db::$db->case_sensitive ? 'LOWER(real_name)' : 'real_name',
 				'buddy_list' => User::$me->buddies,
 				'search' => $this->search,
 				'activated' => [User::ACTIVATED, User::ACTIVATED_BANNED],

--- a/Sources/Actions/RequestMembers.php
+++ b/Sources/Actions/RequestMembers.php
@@ -74,7 +74,7 @@ class RequestMembers implements ActionInterface, Routable
 		$request = Db::$db->query(
 			'SELECT real_name
 			FROM {db_prefix}members
-			WHERE {ci:real_name} LIKE {string:search}' . (isset($_REQUEST['buddies']) ? '
+			WHERE {column_ci:real_name} LIKE {string:search}' . (isset($_REQUEST['buddies']) ? '
 				AND id_member IN ({array_int:buddy_list})' : '') . '
 				AND is_activated IN ({array_int:activated})
 			LIMIT {int:limit}',

--- a/Sources/Db/APIs/MySQL.php
+++ b/Sources/Db/APIs/MySQL.php
@@ -282,6 +282,11 @@ class MySQL extends DatabaseApi implements DatabaseApiInterface
 				[
 					// The literal type can have arbitrary content.
 					'~{(literal):([^}]*)}~',
+					// The ci type names a column inline rather than by key, so
+					// that the column a comparison is case folding is visible in
+					// the query itself. Only a column name, optionally qualified
+					// by a table alias, is accepted.
+					'~{(ci):([a-zA-Z0-9_]+(?:\.[a-zA-Z0-9_]+)?)}~',
 					// Everything else needs to be a key in $db_values.
 					'~{([a-z_]+)(?::([a-zA-Z0-9_-]+))?}~',
 				],
@@ -2753,6 +2758,12 @@ class MySQL extends DatabaseApi implements DatabaseApiInterface
 			return '\'' . mysqli_real_escape_string($connection, $matches[2]) . '\'';
 		}
 
+		// MySQL folds case in the column's collation, so a case insensitive
+		// comparison is what a bare column already does.
+		if ($matches[1] === 'ci') {
+			return $matches[2];
+		}
+
 		if (!\array_key_exists($matches[2], $db_values)) {
 			$this->error_backtrace('The database value you\'re trying to insert does not exist: ' . Utils::htmlspecialchars($matches[2]), '', E_USER_ERROR, __FILE__, __LINE__);
 		}
@@ -2777,6 +2788,8 @@ class MySQL extends DatabaseApi implements DatabaseApiInterface
 
 			case 'string':
 			case 'text':
+			// MySQL folds the case of the value in the collation as well.
+			case 'ci_string':
 				return \sprintf('\'%1$s\'', mysqli_real_escape_string($connection, $this->fix_mb4((string) $replacement)));
 
 			case 'array_int':

--- a/Sources/Db/APIs/MySQL.php
+++ b/Sources/Db/APIs/MySQL.php
@@ -282,11 +282,11 @@ class MySQL extends DatabaseApi implements DatabaseApiInterface
 				[
 					// The literal type can have arbitrary content.
 					'~{(literal):([^}]*)}~',
-					// The ci type names a column inline rather than by key, so
-					// that the column a comparison is case folding is visible in
-					// the query itself. Only a column name, optionally qualified
-					// by a table alias, is accepted.
-					'~{(ci):([a-zA-Z0-9_]+(?:\.[a-zA-Z0-9_]+)?)}~',
+					// The column_ci type names a column inline rather than by key,
+					// so that the column a comparison is case folding is visible
+					// in the query itself. Only a column name, optionally
+					// qualified by a table alias, is accepted.
+					'~{(column_ci):([a-zA-Z0-9_]+(?:\.[a-zA-Z0-9_]+)?)}~',
 					// Everything else needs to be a key in $db_values.
 					'~{([a-z_]+)(?::([a-zA-Z0-9_-]+))?}~',
 				],
@@ -2760,7 +2760,7 @@ class MySQL extends DatabaseApi implements DatabaseApiInterface
 
 		// MySQL folds case in the column's collation, so a case insensitive
 		// comparison is what a bare column already does.
-		if ($matches[1] === 'ci') {
+		if ($matches[1] === 'column_ci') {
 			return $matches[2];
 		}
 

--- a/Sources/Db/APIs/MySQL.php
+++ b/Sources/Db/APIs/MySQL.php
@@ -2789,7 +2789,7 @@ class MySQL extends DatabaseApi implements DatabaseApiInterface
 			case 'string':
 			case 'text':
 			// MySQL folds the case of the value in the collation as well.
-			case 'ci_string':
+			case 'string_ci':
 				return \sprintf('\'%1$s\'', mysqli_real_escape_string($connection, $this->fix_mb4((string) $replacement)));
 
 			case 'array_int':
@@ -2814,6 +2814,8 @@ class MySQL extends DatabaseApi implements DatabaseApiInterface
 				break;
 
 			case 'array_string':
+			// As above, the collation folds each of these too.
+			case 'array_string_ci':
 				if (\is_array($replacement)) {
 					if (empty($replacement)) {
 						$this->error_backtrace('Database error, given array of string values is empty. (' . $matches[2] . ')', '', E_USER_ERROR, __FILE__, __LINE__);

--- a/Sources/Db/APIs/PostgreSQL.php
+++ b/Sources/Db/APIs/PostgreSQL.php
@@ -343,6 +343,11 @@ class PostgreSQL extends DatabaseApi implements DatabaseApiInterface
 				[
 					// The literal type can have arbitrary content.
 					'~{(literal):([^}]*)}~',
+					// The ci type names a column inline rather than by key, so
+					// that the column a comparison is case folding is visible in
+					// the query itself. Only a column name, optionally qualified
+					// by a table alias, is accepted.
+					'~{(ci):([a-zA-Z0-9_]+(?:\.[a-zA-Z0-9_]+)?)}~',
 					// Everything else needs to be a key in $db_values.
 					'~{([a-z_]+)(?::([a-zA-Z0-9_-]+))?}~',
 				],
@@ -2684,6 +2689,12 @@ class PostgreSQL extends DatabaseApi implements DatabaseApiInterface
 			return '\'' . pg_escape_string($this->connection, $matches[2]) . '\'';
 		}
 
+		// PostgreSQL compares strings exactly, so a case insensitive comparison
+		// folds the column and pairs it with a value folded the same way.
+		if ($matches[1] === 'ci') {
+			return 'LOWER(' . $matches[2] . ')';
+		}
+
 		if (!\array_key_exists($matches[2], $db_values)) {
 			$this->error_backtrace('The database value you\'re trying to insert does not exist: ' . Utils::htmlspecialchars($matches[2]), '', E_USER_ERROR, __FILE__, __LINE__);
 		}
@@ -2709,6 +2720,10 @@ class PostgreSQL extends DatabaseApi implements DatabaseApiInterface
 			case 'string':
 			case 'text':
 				return \sprintf('\'%1$s\'', pg_escape_string($this->connection, (string) $replacement));
+
+			// Folded to match a column that {ci:} has folded.
+			case 'ci_string':
+				return \sprintf('LOWER(\'%1$s\')', pg_escape_string($this->connection, (string) $replacement));
 
 			case 'array_int':
 				if (\is_array($replacement)) {

--- a/Sources/Db/APIs/PostgreSQL.php
+++ b/Sources/Db/APIs/PostgreSQL.php
@@ -2722,7 +2722,7 @@ class PostgreSQL extends DatabaseApi implements DatabaseApiInterface
 				return \sprintf('\'%1$s\'', pg_escape_string($this->connection, (string) $replacement));
 
 			// Folded to match a column that {ci:} has folded.
-			case 'ci_string':
+			case 'string_ci':
 				return \sprintf('LOWER(\'%1$s\')', pg_escape_string($this->connection, (string) $replacement));
 
 			case 'array_int':
@@ -2754,6 +2754,24 @@ class PostgreSQL extends DatabaseApi implements DatabaseApiInterface
 
 					foreach ($replacement as $key => $value) {
 						$replacement[$key] = \sprintf('\'%1$s\'', pg_escape_string($this->connection, (string) $value));
+					}
+
+					return implode(', ', $replacement);
+				}
+
+				$this->error_backtrace('Wrong value type sent to the database. Array of strings expected. (' . $matches[2] . ')', '', E_USER_ERROR, __FILE__, __LINE__);
+
+				break;
+
+			// Each of these folded to match a column that {ci:} has folded.
+			case 'array_string_ci':
+				if (\is_array($replacement)) {
+					if (empty($replacement)) {
+						$this->error_backtrace('Database error, given array of string values is empty. (' . $matches[2] . ')', '', E_USER_ERROR, __FILE__, __LINE__);
+					}
+
+					foreach ($replacement as $key => $value) {
+						$replacement[$key] = \sprintf('LOWER(\'%1$s\')', pg_escape_string($this->connection, (string) $value));
 					}
 
 					return implode(', ', $replacement);

--- a/Sources/Db/APIs/PostgreSQL.php
+++ b/Sources/Db/APIs/PostgreSQL.php
@@ -343,11 +343,11 @@ class PostgreSQL extends DatabaseApi implements DatabaseApiInterface
 				[
 					// The literal type can have arbitrary content.
 					'~{(literal):([^}]*)}~',
-					// The ci type names a column inline rather than by key, so
-					// that the column a comparison is case folding is visible in
-					// the query itself. Only a column name, optionally qualified
-					// by a table alias, is accepted.
-					'~{(ci):([a-zA-Z0-9_]+(?:\.[a-zA-Z0-9_]+)?)}~',
+					// The column_ci type names a column inline rather than by key,
+					// so that the column a comparison is case folding is visible
+					// in the query itself. Only a column name, optionally
+					// qualified by a table alias, is accepted.
+					'~{(column_ci):([a-zA-Z0-9_]+(?:\.[a-zA-Z0-9_]+)?)}~',
 					// Everything else needs to be a key in $db_values.
 					'~{([a-z_]+)(?::([a-zA-Z0-9_-]+))?}~',
 				],
@@ -2691,7 +2691,7 @@ class PostgreSQL extends DatabaseApi implements DatabaseApiInterface
 
 		// PostgreSQL compares strings exactly, so a case insensitive comparison
 		// folds the column and pairs it with a value folded the same way.
-		if ($matches[1] === 'ci') {
+		if ($matches[1] === 'column_ci') {
 			return 'LOWER(' . $matches[2] . ')';
 		}
 
@@ -2721,7 +2721,7 @@ class PostgreSQL extends DatabaseApi implements DatabaseApiInterface
 			case 'text':
 				return \sprintf('\'%1$s\'', pg_escape_string($this->connection, (string) $replacement));
 
-			// Folded to match a column that {ci:} has folded.
+			// Folded to match a column that {column_ci:} has folded.
 			case 'string_ci':
 				return \sprintf('LOWER(\'%1$s\')', pg_escape_string($this->connection, (string) $replacement));
 
@@ -2763,7 +2763,7 @@ class PostgreSQL extends DatabaseApi implements DatabaseApiInterface
 
 				break;
 
-			// Each of these folded to match a column that {ci:} has folded.
+			// Each of these folded to match a column that {column_ci:} has folded.
 			case 'array_string_ci':
 				if (\is_array($replacement)) {
 					if (empty($replacement)) {

--- a/Sources/PersonalMessage/PM.php
+++ b/Sources/PersonalMessage/PM.php
@@ -1210,7 +1210,7 @@ class PM implements \ArrayAccess
 			$request = Db::$db->query(
 				'SELECT id_member, member_name
 				FROM {db_prefix}members
-				WHERE ' . (Db::$db->case_sensitive ? 'LOWER(member_name)' : 'member_name') . ' IN ({array_string:usernames})',
+				WHERE {ci:member_name} IN ({array_string:usernames})',
 				[
 					'usernames' => array_keys($usernames),
 				],

--- a/Sources/PersonalMessage/PM.php
+++ b/Sources/PersonalMessage/PM.php
@@ -1210,7 +1210,7 @@ class PM implements \ArrayAccess
 			$request = Db::$db->query(
 				'SELECT id_member, member_name
 				FROM {db_prefix}members
-				WHERE {ci:member_name} IN ({array_string:usernames})',
+				WHERE {column_ci:member_name} IN ({array_string:usernames})',
 				[
 					'usernames' => array_keys($usernames),
 				],

--- a/Sources/PersonalMessage/Search.php
+++ b/Sources/PersonalMessage/Search.php
@@ -478,7 +478,7 @@ class Search
 
 		foreach ($possible_users as $k => $v) {
 			$where_params['name_' . $k] = $v;
-			$where_clause[] = '{ci:real_name} LIKE {string:name_' . $k . '}';
+			$where_clause[] = '{column_ci:real_name} LIKE {string:name_' . $k . '}';
 		}
 
 		// Who matches those criteria?
@@ -498,7 +498,7 @@ class Search
 
 				foreach ($possible_users as $k => $v) {
 					$this->searchq_parameters['name_' . $k] = $v;
-					$clauses[] = '{ci:pm.from_name} LIKE {string:name_' . $k . '}';
+					$clauses[] = '{column_ci:pm.from_name} LIKE {string:name_' . $k . '}';
 				}
 
 			if (Db::$db->num_rows($request) == 0) {

--- a/Sources/PersonalMessage/Search.php
+++ b/Sources/PersonalMessage/Search.php
@@ -478,11 +478,7 @@ class Search
 
 		foreach ($possible_users as $k => $v) {
 			$where_params['name_' . $k] = $v;
-			$where_clause[] = '{raw:real_name} LIKE {string:name_' . $k . '}';
-
-			if (!isset($where_params['real_name'])) {
-				$where_params['real_name'] = Db::$db->case_sensitive ? 'LOWER(real_name)' : 'real_name';
-			}
+			$where_clause[] = '{ci:real_name} LIKE {string:name_' . $k . '}';
 		}
 
 		// Who matches those criteria?
@@ -498,12 +494,11 @@ class Search
 		if (Db::$db->num_rows($request) > $this->max_members_to_search) {
 			$this->user_query = '';
 		} else {
-				$this->searchq_parameters['real_name'] = Db::$db->case_sensitive ? 'LOWER(pm.from_name)' : 'pm.from_name';
 				$clauses = [];
 
 				foreach ($possible_users as $k => $v) {
 					$this->searchq_parameters['name_' . $k] = $v;
-					$clauses[] = '{raw:real_name} LIKE {string:name_' . $k . '}';
+					$clauses[] = '{ci:pm.from_name} LIKE {string:name_' . $k . '}';
 				}
 
 			if (Db::$db->num_rows($request) == 0) {

--- a/Sources/Profile.php
+++ b/Sources/Profile.php
@@ -1649,7 +1649,7 @@ class Profile extends User implements \ArrayAccess
 			'SELECT id_member
 			FROM {db_prefix}members
 			WHERE id_member != {int:selected_member}
-				AND {ci:email_address} = {string:email_address}
+				AND {column_ci:email_address} = {string:email_address}
 			LIMIT 1',
 			[
 				'selected_member' => $this->id,

--- a/Sources/Profile.php
+++ b/Sources/Profile.php
@@ -1649,10 +1649,9 @@ class Profile extends User implements \ArrayAccess
 			'SELECT id_member
 			FROM {db_prefix}members
 			WHERE id_member != {int:selected_member}
-				AND {raw:email_address_field} = {string:email_address}
+				AND {ci:email_address} = {string:email_address}
 			LIMIT 1',
 			[
-				'email_address_field' => Db::$db->case_sensitive ? 'LOWER(email_address)' : 'email_address',
 				'selected_member' => $this->id,
 				'email_address' => $email,
 			],

--- a/Sources/User.php
+++ b/Sources/User.php
@@ -3800,9 +3800,10 @@ class User implements \ArrayAccess
 			$email_condition = '';
 		}
 
-		// Get the case of the columns right - but only if we need to as things like MySQL will go slow needlessly otherwise.
-		$member_name = Db::$db->case_sensitive ? 'LOWER(member_name)' : 'member_name';
-		$real_name = Db::$db->case_sensitive ? 'LOWER(real_name)' : 'real_name';
+		// The {ci:} type folds the column for the engines that need it and
+		// leaves it alone for the ones that do not.
+		$member_name = '{ci:member_name}';
+		$real_name = '{ci:real_name}';
 
 		// Searches.
 		$member_name_search = $member_name . ' ' . $comparison . ' ' . implode(' OR ' . $member_name . ' ' . $comparison . ' ', $names_list);
@@ -5424,13 +5425,11 @@ class User implements \ArrayAccess
 				break;
 
 			case self::LOAD_BY_NAME:
-				if (Db::$db->case_sensitive) {
-					$query_customizations['where'][] = 'LOWER(mem.member_name) IN ({array_string:users})';
-					$query_customizations['params']['users'] = array_map('strtolower', $users);
-				} else {
-					$query_customizations['where'][] = 'mem.member_name IN ({array_string:users})';
-					$query_customizations['params']['users'] = $users;
-				}
+				$query_customizations['where'][] = '{ci:mem.member_name} IN ({array_string:users})';
+
+				// An array of values has no {ci:} of its own, so the names are
+				// folded here for the engines that compare them exactly.
+				$query_customizations['params']['users'] = Db::$db->case_sensitive ? array_map('strtolower', $users) : $users;
 
 				break;
 

--- a/Sources/User.php
+++ b/Sources/User.php
@@ -5425,11 +5425,8 @@ class User implements \ArrayAccess
 				break;
 
 			case self::LOAD_BY_NAME:
-				$query_customizations['where'][] = '{ci:mem.member_name} IN ({array_string:users})';
-
-				// An array of values has no {ci:} of its own, so the names are
-				// folded here for the engines that compare them exactly.
-				$query_customizations['params']['users'] = Db::$db->case_sensitive ? array_map('strtolower', $users) : $users;
+				$query_customizations['where'][] = '{ci:mem.member_name} IN ({array_string_ci:users})';
+				$query_customizations['params']['users'] = $users;
 
 				break;
 

--- a/Sources/User.php
+++ b/Sources/User.php
@@ -3800,10 +3800,10 @@ class User implements \ArrayAccess
 			$email_condition = '';
 		}
 
-		// The {ci:} type folds the column for the engines that need it and
+		// The {column_ci:} type folds the column for the engines that need it and
 		// leaves it alone for the ones that do not.
-		$member_name = '{ci:member_name}';
-		$real_name = '{ci:real_name}';
+		$member_name = '{column_ci:member_name}';
+		$real_name = '{column_ci:real_name}';
 
 		// Searches.
 		$member_name_search = $member_name . ' ' . $comparison . ' ' . implode(' OR ' . $member_name . ' ' . $comparison . ' ', $names_list);
@@ -5425,7 +5425,7 @@ class User implements \ArrayAccess
 				break;
 
 			case self::LOAD_BY_NAME:
-				$query_customizations['where'][] = '{ci:mem.member_name} IN ({array_string_ci:users})';
+				$query_customizations['where'][] = '{column_ci:mem.member_name} IN ({array_string_ci:users})';
 				$query_customizations['params']['users'] = $users;
 
 				break;

--- a/tests/Unit/QueryCaseFoldingTest.php
+++ b/tests/Unit/QueryCaseFoldingTest.php
@@ -1,0 +1,157 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SMF\Tests\Unit;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\TestCase;
+use SMF\Config;
+
+/**
+ * Guards the case folding convention across the source tree.
+ *
+ * Whether a string comparison folds case is decided by the database engine, so
+ * a LIKE against text a person typed has to say which behaviour it wants. The
+ * {ci:} and {ci_string:} query types say it; LOWER() in the query text says it;
+ * a bare column says nothing and gets whatever the engine does, which is a
+ * match on MySQL and no match on PostgreSQL.
+ *
+ * A comparison written the second way returns fewer rows rather than failing,
+ * so nothing is written to the error log and nothing in CI notices. This test
+ * is what notices. It is not a unit test of any class: the substitution layer
+ * needs a live connection to escape with, so the behaviour of {ci:} itself
+ * cannot be reached from here.
+ *
+ * Equality comparisons are not covered. `member_name = {string:name}` and
+ * `$member_name = $string` are the same line to a scanner, and the SET clause
+ * of an UPDATE looks like both, so the reliable signal is LIKE.
+ */
+#[CoversNothing]
+class QueryCaseFoldingTest extends TestCase
+{
+	/*****************
+	 * Class constants
+	 *****************/
+
+	/**
+	 * Columns holding text a person typed, where two spellings that differ
+	 * only in case are the same value to the person who typed them.
+	 */
+	public const COLUMNS = [
+		'member_name',
+		'real_name',
+		'poster_name',
+		'from_name',
+		'email_address',
+		'group_name',
+		'hostname',
+	];
+
+	/**
+	 * Comparisons on those columns that do not fold case in the query text,
+	 * counted per file.
+	 *
+	 * The two in Security.php are folded by the 'ban_like' identifier instead,
+	 * which rewrites LIKE to ILIKE for PostgreSQL when the query runs.
+	 *
+	 * Everything else here is unresolved: see #9592 for Bans.php and #9593 for
+	 * SearchApi.php. Lowering a count is the point of the list, so a change
+	 * that fixes one of them belongs in the same commit as its new number.
+	 */
+	public const BASELINE = [
+		'Sources/Actions/Admin/Bans.php' => 3,
+		'Sources/Actions/Admin/Subscriptions.php' => 1,
+		'Sources/Actions/Profile/Summary.php' => 2,
+		'Sources/Search/SearchApi.php' => 3,
+		'Sources/Security.php' => 2,
+	];
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	public function testNoNewComparisonSkipsTheCaseFoldingTypes(): void
+	{
+		$found = $this->scan();
+
+		$this->assertSame(
+			self::BASELINE,
+			$found,
+			"The set of case sensitive comparisons on user text has changed.\n\n"
+			. "If a count went up, a new comparison is relying on the engine's\n"
+			. "collation to fold case, which MySQL does and PostgreSQL does not.\n"
+			. "Write it as {ci:column} LIKE {string:value}, or as\n"
+			. "{ci:column} LIKE {ci_string:value} when the value is not already\n"
+			. "folded in PHP.\n\n"
+			. "If a count went down, the comparison was fixed. Update BASELINE\n"
+			. 'in this test to match, in the same commit.',
+		);
+	}
+
+	public function testTheScanFindsTheFormsItIsLookingFor(): void
+	{
+		// Without this, deleting the body of scan() would leave the test above
+		// passing against an empty baseline.
+		$this->assertNotSame([], $this->scan());
+	}
+
+	/******************
+	 * Internal methods
+	 ******************/
+
+	/**
+	 * Counts, per file, the comparisons on self::COLUMNS that do not fold case.
+	 *
+	 * @return array<string, int> Paths relative to the repository root.
+	 */
+	protected function scan(): array
+	{
+		$found = [];
+
+		$columns = '~\b(?:' . implode('|', self::COLUMNS) . ')\b~';
+		$folded = '~\{ci:|\{ci_string:|LOWER\s*\(~i';
+
+		$files = new \RecursiveIteratorIterator(
+			new \RecursiveDirectoryIterator(Config::$sourcedir, \FilesystemIterator::SKIP_DOTS),
+		);
+
+		foreach ($files as $file) {
+			if ($file->getExtension() !== 'php') {
+				continue;
+			}
+
+			$path = str_replace(DIRECTORY_SEPARATOR, '/', $file->getPathname());
+			$contents = file_get_contents($path);
+
+			// Most files never mention it, and reading them line by line to
+			// find that out is the whole cost of this scan.
+			if (!str_contains($contents, 'LIKE')) {
+				continue;
+			}
+
+			$relative = 'Sources' . substr($path, \strlen(str_replace(DIRECTORY_SEPARATOR, '/', Config::$sourcedir)));
+
+			foreach (explode("\n", $contents) as $line) {
+				$trimmed = trim($line);
+
+				// Comments describe comparisons, they do not make them.
+				if (str_starts_with($trimmed, '*') || str_starts_with($trimmed, '//')) {
+					continue;
+				}
+
+				if (
+					preg_match('~\bLIKE\b~', $line)
+					&& preg_match($columns, $line)
+					&& !preg_match($folded, $line)
+				) {
+					$found[$relative] = ($found[$relative] ?? 0) + 1;
+				}
+			}
+		}
+
+		ksort($found);
+
+		return $found;
+	}
+}

--- a/tests/Unit/QueryCaseFoldingTest.php
+++ b/tests/Unit/QueryCaseFoldingTest.php
@@ -23,9 +23,16 @@ use SMF\Config;
  * needs a live connection to escape with, so the behaviour of {ci:} itself
  * cannot be reached from here.
  *
- * Equality comparisons are not covered. `member_name = {string:name}` and
- * `$member_name = $string` are the same line to a scanner, and the SET clause
- * of an UPDATE looks like both, so the reliable signal is LIKE.
+ * There are two scans, because there are two ways to get this wrong. One looks
+ * for a comparison that folds neither side, which matches too much on MySQL.
+ * The other looks for one that folds only its column, which matches nothing at
+ * all on PostgreSQL, and is the worse of the two for being the one that hides:
+ * the query says {ci:} and looks handled.
+ *
+ * The first scan covers LIKE only, since `member_name = {string:name}` and
+ * `$member_name = $string` are the same line to a scanner, and an UPDATE's SET
+ * clause looks like both. The second can cover equality as well, because a
+ * line carrying {ci:} is SQL and its = is therefore a comparison.
  */
 #[CoversNothing]
 class QueryCaseFoldingTest extends TestCase
@@ -67,6 +74,41 @@ class QueryCaseFoldingTest extends TestCase
 		'Sources/Security.php' => 2,
 	];
 
+	/**
+	 * Comparisons where {ci:} folds the column but the value beside it is not
+	 * folded in the query, counted per file.
+	 *
+	 * Folding one side is worse than folding neither. A folded column can
+	 * never equal an unfolded value, so instead of matching too much on
+	 * PostgreSQL the comparison matches nothing at all, including the row it
+	 * was looking for.
+	 *
+	 * These are correct only if the caller folded the value in PHP first,
+	 * which is a claim about code somewhere else and so is listed rather than
+	 * counted. Folded by their callers:
+	 *
+	 *  - Admin/Members.php, through strtolower().
+	 *  - AutoSuggest.php, RequestMembers.php, PM.php, through
+	 *    Utils::strtolower().
+	 *  - User.php, through array_map(), for the engines that need it.
+	 *
+	 * Not folded by their callers, and so matching nothing on PostgreSQL:
+	 *
+	 *  - Register2.php and Profile.php, which is #9594.
+	 *  - PersonalMessage/Search.php, which is the same fault in the search for
+	 *    a personal message by its author.
+	 */
+	public const UNFOLDED_VALUES = [
+		'Sources/Actions/Admin/Members.php' => 1,
+		'Sources/Actions/AutoSuggest.php' => 2,
+		'Sources/Actions/Register2.php' => 2,
+		'Sources/Actions/RequestMembers.php' => 1,
+		'Sources/PersonalMessage/PM.php' => 1,
+		'Sources/PersonalMessage/Search.php' => 2,
+		'Sources/Profile.php' => 1,
+		'Sources/User.php' => 1,
+	];
+
 	/****************
 	 * Public methods
 	 ****************/
@@ -89,11 +131,28 @@ class QueryCaseFoldingTest extends TestCase
 		);
 	}
 
-	public function testTheScanFindsTheFormsItIsLookingFor(): void
+	public function testNoNewComparisonFoldsOnlyItsColumn(): void
 	{
-		// Without this, deleting the body of scan() would leave the test above
+		$found = $this->scanUnfoldedValues();
+
+		$this->assertSame(
+			self::UNFOLDED_VALUES,
+			$found,
+			"The set of comparisons folding a column but not the value has changed.\n\n"
+			. "If a count went up, check that the caller folds the value before it\n"
+			. "reaches the query. If it does, add the file to UNFOLDED_VALUES and\n"
+			. "say so in the note there. If it does not, the comparison matches\n"
+			. "nothing on PostgreSQL: fold the value in PHP, or write it as\n"
+			. '{ci_string:value} and let the query fold it.',
+		);
+	}
+
+	public function testTheScansFindTheFormsTheyAreLookingFor(): void
+	{
+		// Without these, emptying either scan would leave the tests above
 		// passing against an empty baseline.
 		$this->assertNotSame([], $this->scan());
+		$this->assertNotSame([], $this->scanUnfoldedValues());
 	}
 
 	/******************
@@ -144,6 +203,53 @@ class QueryCaseFoldingTest extends TestCase
 					preg_match('~\bLIKE\b~', $line)
 					&& preg_match($columns, $line)
 					&& !preg_match($folded, $line)
+				) {
+					$found[$relative] = ($found[$relative] ?? 0) + 1;
+				}
+			}
+		}
+
+		ksort($found);
+
+		return $found;
+	}
+
+	/**
+	 * Counts, per file, the comparisons that fold the column with {ci:} while
+	 * comparing it against a value the query does not fold.
+	 *
+	 * A line carrying {ci:} is SQL, so an = on it is a comparison rather than
+	 * a PHP assignment. That is what lets this one look at equality, which the
+	 * scan above cannot.
+	 *
+	 * @return array<string, int> Paths relative to the repository root.
+	 */
+	protected function scanUnfoldedValues(): array
+	{
+		$found = [];
+
+		$files = new \RecursiveIteratorIterator(
+			new \RecursiveDirectoryIterator(Config::$sourcedir, \FilesystemIterator::SKIP_DOTS),
+		);
+
+		foreach ($files as $file) {
+			if ($file->getExtension() !== 'php') {
+				continue;
+			}
+
+			$path = str_replace(DIRECTORY_SEPARATOR, '/', $file->getPathname());
+			$contents = file_get_contents($path);
+
+			if (!str_contains($contents, '{ci:')) {
+				continue;
+			}
+
+			$relative = 'Sources' . substr($path, \strlen(str_replace(DIRECTORY_SEPARATOR, '/', Config::$sourcedir)));
+
+			foreach (explode("\n", $contents) as $line) {
+				if (
+					str_contains($line, '{ci:')
+					&& preg_match('~\{(?:array_)?string:~', $line)
 				) {
 					$found[$relative] = ($found[$relative] ?? 0) + 1;
 				}

--- a/tests/Unit/QueryCaseFoldingTest.php
+++ b/tests/Unit/QueryCaseFoldingTest.php
@@ -13,26 +13,26 @@ use SMF\Config;
  *
  * Whether a string comparison folds case is decided by the database engine, so
  * a LIKE against text a person typed has to say which behaviour it wants. The
- * {ci:} and {string_ci:} query types say it; LOWER() in the query text says it;
- * a bare column says nothing and gets whatever the engine does, which is a
- * match on MySQL and no match on PostgreSQL.
+ * {column_ci:} and {string_ci:} query types say it, and so does a LOWER() in
+ * the query text; a bare column says nothing and gets whatever the engine
+ * does, which is a match on MySQL and no match on PostgreSQL.
  *
  * A comparison written the second way returns fewer rows rather than failing,
  * so nothing is written to the error log and nothing in CI notices. This test
  * is what notices. It is not a unit test of any class: the substitution layer
- * needs a live connection to escape with, so the behaviour of {ci:} itself
- * cannot be reached from here.
+ * needs a live connection to escape with, so the behaviour of {column_ci:}
+ * itself cannot be reached from here.
  *
  * There are two scans, because there are two ways to get this wrong. One looks
  * for a comparison that folds neither side, which matches too much on MySQL.
  * The other looks for one that folds only its column, which matches nothing at
  * all on PostgreSQL, and is the worse of the two for being the one that hides:
- * the query says {ci:} and looks handled.
+ * the query says {column_ci:} and looks handled.
  *
  * The first scan covers LIKE only, since `member_name = {string:name}` and
  * `$member_name = $string` are the same line to a scanner, and an UPDATE's SET
  * clause looks like both. The second can cover equality as well, because a
- * line carrying {ci:} is SQL and its = is therefore a comparison.
+ * line carrying {column_ci:} is SQL and its = is therefore a comparison.
  */
 #[CoversNothing]
 class QueryCaseFoldingTest extends TestCase
@@ -75,8 +75,8 @@ class QueryCaseFoldingTest extends TestCase
 	];
 
 	/**
-	 * Comparisons where {ci:} folds the column but the value beside it is not
-	 * folded in the query, counted per file.
+	 * Comparisons where {column_ci:} folds the column but the value beside it
+	 * is not folded in the query, counted per file.
 	 *
 	 * Folding one side is worse than folding neither. A folded column can
 	 * never equal an unfolded value, so instead of matching too much on
@@ -124,8 +124,8 @@ class QueryCaseFoldingTest extends TestCase
 			"The set of case sensitive comparisons on user text has changed.\n\n"
 			. "If a count went up, a new comparison is relying on the engine's\n"
 			. "collation to fold case, which MySQL does and PostgreSQL does not.\n"
-			. "Write it as {ci:column} LIKE {string:value}, or as\n"
-			. "{ci:column} LIKE {string_ci:value} when the value is not already\n"
+			. "Write it as {column_ci:column} LIKE {string:value}, or as\n"
+			. "{column_ci:column} LIKE {string_ci:value} when the value is not already\n"
 			. "folded in PHP.\n\n"
 			. "If a count went down, the comparison was fixed. Update BASELINE\n"
 			. 'in this test to match, in the same commit.',
@@ -170,7 +170,7 @@ class QueryCaseFoldingTest extends TestCase
 		$found = [];
 
 		$columns = '~\b(?:' . implode('|', self::COLUMNS) . ')\b~';
-		$folded = '~\{ci:|\{(?:array_)?string_ci:|LOWER\s*\(~i';
+		$folded = '~\{column_ci:|\{(?:array_)?string_ci:|LOWER\s*\(~i';
 
 		$files = new \RecursiveIteratorIterator(
 			new \RecursiveDirectoryIterator(Config::$sourcedir, \FilesystemIterator::SKIP_DOTS),
@@ -216,12 +216,12 @@ class QueryCaseFoldingTest extends TestCase
 	}
 
 	/**
-	 * Counts, per file, the comparisons that fold the column with {ci:} while
-	 * comparing it against a value the query does not fold.
+	 * Counts, per file, the comparisons that fold the column with {column_ci:}
+	 * while comparing it against a value the query does not fold.
 	 *
-	 * A line carrying {ci:} is SQL, so an = on it is a comparison rather than
-	 * a PHP assignment. That is what lets this one look at equality, which the
-	 * scan above cannot.
+	 * A line carrying {column_ci:} is SQL, so an = on it is a comparison rather
+	 * than a PHP assignment. That is what lets this one look at equality, which
+	 * the scan above cannot.
 	 *
 	 * @return array<string, int> Paths relative to the repository root.
 	 */
@@ -241,7 +241,7 @@ class QueryCaseFoldingTest extends TestCase
 			$path = str_replace(DIRECTORY_SEPARATOR, '/', $file->getPathname());
 			$contents = file_get_contents($path);
 
-			if (!str_contains($contents, '{ci:')) {
+			if (!str_contains($contents, '{column_ci:')) {
 				continue;
 			}
 
@@ -249,7 +249,7 @@ class QueryCaseFoldingTest extends TestCase
 
 			foreach (explode("\n", $contents) as $line) {
 				if (
-					str_contains($line, '{ci:')
+					str_contains($line, '{column_ci:')
 					&& preg_match('~\{(?:array_)?string:~', $line)
 				) {
 					$found[$relative] = ($found[$relative] ?? 0) + 1;

--- a/tests/Unit/QueryCaseFoldingTest.php
+++ b/tests/Unit/QueryCaseFoldingTest.php
@@ -13,7 +13,7 @@ use SMF\Config;
  *
  * Whether a string comparison folds case is decided by the database engine, so
  * a LIKE against text a person typed has to say which behaviour it wants. The
- * {ci:} and {ci_string:} query types say it; LOWER() in the query text says it;
+ * {ci:} and {string_ci:} query types say it; LOWER() in the query text says it;
  * a bare column says nothing and gets whatever the engine does, which is a
  * match on MySQL and no match on PostgreSQL.
  *
@@ -90,7 +90,9 @@ class QueryCaseFoldingTest extends TestCase
 	 *  - Admin/Members.php, through strtolower().
 	 *  - AutoSuggest.php, RequestMembers.php, PM.php, through
 	 *    Utils::strtolower().
-	 *  - User.php, through array_map(), for the engines that need it.
+	 *
+	 * User.php is not here because it hands its list to {array_string_ci:},
+	 * which folds every value in it.
 	 *
 	 * Not folded by their callers, and so matching nothing on PostgreSQL:
 	 *
@@ -106,7 +108,6 @@ class QueryCaseFoldingTest extends TestCase
 		'Sources/PersonalMessage/PM.php' => 1,
 		'Sources/PersonalMessage/Search.php' => 2,
 		'Sources/Profile.php' => 1,
-		'Sources/User.php' => 1,
 	];
 
 	/****************
@@ -124,7 +125,7 @@ class QueryCaseFoldingTest extends TestCase
 			. "If a count went up, a new comparison is relying on the engine's\n"
 			. "collation to fold case, which MySQL does and PostgreSQL does not.\n"
 			. "Write it as {ci:column} LIKE {string:value}, or as\n"
-			. "{ci:column} LIKE {ci_string:value} when the value is not already\n"
+			. "{ci:column} LIKE {string_ci:value} when the value is not already\n"
 			. "folded in PHP.\n\n"
 			. "If a count went down, the comparison was fixed. Update BASELINE\n"
 			. 'in this test to match, in the same commit.',
@@ -143,7 +144,7 @@ class QueryCaseFoldingTest extends TestCase
 			. "reaches the query. If it does, add the file to UNFOLDED_VALUES and\n"
 			. "say so in the note there. If it does not, the comparison matches\n"
 			. "nothing on PostgreSQL: fold the value in PHP, or write it as\n"
-			. '{ci_string:value} and let the query fold it.',
+			. '{string_ci:value} and let the query fold it.',
 		);
 	}
 
@@ -169,7 +170,7 @@ class QueryCaseFoldingTest extends TestCase
 		$found = [];
 
 		$columns = '~\b(?:' . implode('|', self::COLUMNS) . ')\b~';
-		$folded = '~\{ci:|\{ci_string:|LOWER\s*\(~i';
+		$folded = '~\{ci:|\{(?:array_)?string_ci:|LOWER\s*\(~i';
 
 		$files = new \RecursiveIteratorIterator(
 			new \RecursiveDirectoryIterator(Config::$sourcedir, \FilesystemIterator::SKIP_DOTS),


### PR DESCRIPTION
#### Description

**Depends on #9596.** It is branched from it, so until that one merges the diff here shows
its commit too. The commits belonging to this pull request are the second and third.

Part 1 gives a comparison a way to say whether it folds case. This is what notices when
one does not say. What makes it worth a test rather than a review habit is the failure
mode: a case sensitive comparison returns fewer rows instead of erroring, so nothing
reaches `smf_log_errors`, nothing fails in CI, and the first person to notice is a member
whose search came back empty. #9592 and #9593 both sat in the tree for years.

There are two ways to get this wrong, so there are two scans.

**1. Folding neither side.** The comparison relies on the collation, which folds on MySQL
and does not on PostgreSQL. Counted per file against a baseline:

```php
public const BASELINE = [
    'Sources/Actions/Admin/Bans.php' => 3,
    'Sources/Actions/Admin/Subscriptions.php' => 1,
    'Sources/Actions/Profile/Summary.php' => 2,
    'Sources/Search/SearchApi.php' => 3,
    'Sources/Security.php' => 2,
];
```

All eleven are real, not noise. Three are #9592, three are #9593, and the two in
`Security.php` are folded by the `ban_like` identifier when the query runs rather than in
the query text, so they stay listed with a note saying why.

This scan reads `LIKE` only. `member_name = {string:name}` and `$member_name = $string`
are the same line to a scanner, and an `UPDATE ... SET` clause looks like both; guessing
would produce a baseline of about fifty entries that are mostly PHP assignments, which is
a test people learn to ignore.

**2. Folding only the column.** This is the worse one, and it is why the second scan
exists. A folded column can never equal an unfolded value, so instead of matching too much
the comparison matches *nothing at all* on PostgreSQL — including the row it was looking
for. It also hides, because the query says `{column_ci:}` and reads as handled. The first scan
cannot find these by construction: it treats `{column_ci:}` as proof a decision was made.

```php
public const UNFOLDED_VALUES = [
    'Sources/Actions/Admin/Members.php' => 1,
    'Sources/Actions/AutoSuggest.php' => 2,
    'Sources/Actions/Register2.php' => 2,
    'Sources/Actions/RequestMembers.php' => 1,
    'Sources/PersonalMessage/PM.php' => 1,
    'Sources/PersonalMessage/Search.php' => 2,
    'Sources/Profile.php' => 1,
];
```

These are correct only when the caller folds the value in PHP first, which is a claim
about code elsewhere, so the list names which callers do and which do not. Five do.
**Five do not, and are faults:** `Register2.php` and `Profile.php` are #9594, and
`PersonalMessage/Search.php` is the same fault in the search for a personal message by its
author, which is not yet filed.

This scan reads equality as well as `LIKE`, which the first cannot. A line carrying
`{column_ci:}` is SQL, so an `=` on it is a comparison rather than an assignment — which is how
#9594 comes into range.

`Sources/User.php` left this list when #9596 gained `{array_string_ci:}`, which folds every
value in an `IN` list, so that comparison folds both sides now.

**Confirmed to fail when it should.** Adding `'WHERE real_name LIKE {string:x}'` to
`Sources/Actions/Groups.php`:

```
The set of case sensitive comparisons on user text has changed.
...
     'Sources/Actions/Admin/Subscriptions.php' => 1,
+    'Sources/Actions/Groups.php' => 1,
     'Sources/Actions/Profile/Summary.php' => 2,
```

A third test asserts both scans find something, so that emptying either one does not leave
the tests above passing against an empty baseline.

Neither scan asserts anything about behaviour, so this is not a substitute for the fixes.
It stops the lists growing while they are worked through, and lowering a number is the
point of them rather than a chore attached to them.

One case is out of reach of both: `Sources/User.php:3798` builds
`email_address ' . $comparison . '` where `$comparison` holds `LIKE` or `=` from an
earlier line, so neither the column nor the operator is on a line a scanner can pair up.
That comparison folds its values and not its column, the mirror of the second list.

Reading every file under `Sources/` costs about 60ms on a normal filesystem (1606 files).
It is slower over a Docker bind mount on Windows, which is a local artifact.

### Issues References (Fixes|Related|Closes)
1. Related: #9596 — the `{column_ci:}` type this guards the use of
2. Related: #9592
3. Related: #9593
4. Related: #9594
5. Related: #9526 — the same gap this covers mechanically, where an AI reviewer would cover it by judgement

🤖 Generated with [Claude Code](https://claude.com/claude-code)
