### PR TITLE
[3.0][Testing] Anchor the canonical path test to the root the platform actually uses

### DIFF
--- a/tests/Unit/SapiTest.php
+++ b/tests/Unit/SapiTest.php
@@ -18,8 +18,14 @@ class SapiTest extends TestCase
 
 	public function testCanonicalPathResolvesDotSegments(): void
 	{
-		$this->assertSame('/a/c', Sapi::canonicalPath('/a/./b/../c', false, false));
-		$this->assertSame('/a', Sapi::canonicalPath('/a/b/..', false, false));
+		// The root of an absolute path is a drive letter on Windows and nothing
+		// at all on POSIX, so name it here rather than let the current drive
+		// decide. Everything after it is the same on both.
+		$root = DIRECTORY_SEPARATOR === '/' ? '' : 'C:';
+		$sep = DIRECTORY_SEPARATOR;
+
+		$this->assertSame($root . $sep . 'a' . $sep . 'c', Sapi::canonicalPath($root . '/a/./b/../c', false, false));
+		$this->assertSame($root . $sep . 'a', Sapi::canonicalPath($root . '/a/b/..', false, false));
 	}
 
 	public function testTheSuiteRunsOnTheCommandLine(): void


### PR DESCRIPTION
#### Description

`SapiTest::testCanonicalPathResolvesDotSegments()` asserted a POSIX-only result, so it failed on Windows with `C:\a\c` where it expected `/a/c`.

The production code is right. On Windows, `canonicalPath('/a/./b/../c')` normalises the separators and then falls into the "Windows relative path" branch: a path that starts at the root but names no drive is rooted on the *current* drive, so `getcwd()`'s drive letter is prepended. `C:\a\c` is the correct canonical form of `\a\c` there, and `realpath()` would say the same thing. The test simply baked in the shape an absolute path has on one platform.

Naming the root in the path under test takes the DOS-style-path branch on Windows instead, so the result no longer depends on which drive the checkout happens to sit on:

```php
$root = DIRECTORY_SEPARATOR === '/' ? '' : 'C:';
$sep = DIRECTORY_SEPARATOR;

$this->assertSame($root . $sep . 'a' . $sep . 'c', Sapi::canonicalPath($root . '/a/./b/../c', false, false));
$this->assertSame($root . $sep . 'a', Sapi::canonicalPath($root . '/a/b/..', false, false));
```

The assertion is then about the dot segments, which is what the test is named for, rather than about the machine running it.

Verified by extracting the function body, substituting `\` for `DIRECTORY_SEPARATOR` and running it: the old assertions produce `C:\a\c` and `C:\a` exactly as reported, and the new ones hold. The suite is green on Linux, and `composer lint` is clean.

The rest of `tests/Unit/` has no other case of this. The remaining `'/...'` literals are URL routes rather than file paths, and `LangTest` compares `canonicalPath()` output against `canonicalPath()` output, so both sides move together.

### Issues References (Fixes|Related|Closes)
1. Fixes #9595
