### PR TITLE
[3.0][Testing] Run the unit tests on Windows as well as Linux

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -9,10 +9,11 @@ on:
 jobs:
   phpunit:
     name: Unit tests
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
+        os: [ ubuntu-latest, windows-latest ]
         php: [ 8.4, 8.5 ]
 
     steps:
@@ -37,4 +38,4 @@ jobs:
         run: composer install --prefer-dist --no-progress --ansi
 
       - name: Run the unit tests
-        run: vendor/bin/phpunit --no-coverage --colors=always
+        run: composer test -- --colors=always

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -23,6 +23,7 @@ jobs:
         uses: shivammathur/setup-php@9e72090525849c5e82e596468b86eb55e9cc5401 #2.32.0
         with:
           php-version: ${{ matrix.php }}
+          extensions: fileinfo, mbstring
           coverage: none
 
       - name: Cache Composer packages


### PR DESCRIPTION
#### Description

#9595 asked whether the unit tests should run on Windows in CI. This does that.

The suite needs no database, no server and no Docker — it is PHPUnit against `Sources/` with the constants `tests/bootstrap.php` defines — so the only cost of a second operating system in the matrix is runner time. What it buys is coverage of the one place the two platforms genuinely differ: path handling, directory separators and line endings. Nothing else in CI looks at those, and #9595 is what that gap looks like in practice.

Two changes:

- `os: [ ubuntu-latest, windows-latest ]` in the matrix, with `runs-on: ${{ matrix.os }}`. The Composer cache key already begins with `${{ runner.os }}`, so the two platforms keep separate caches and the Windows one gets its own `.bat` proxies.
- The tests are started with `composer test` rather than `vendor/bin/phpunit`. The default shell on a Windows runner is PowerShell, which cannot execute the extensionless Composer proxy; going through Composer resolves to the right binary on either platform, and it is the command `AGENTS.md` already tells contributors to run. `--colors=always` is forwarded to PHPUnit unchanged.

`.gitattributes` forces `eol=lf`, so a Windows checkout gets the same bytes as a Linux one and nothing here depends on that being true.

**This needs #9600 first.** `SapiTest::testCanonicalPathResolvesDotSegments()` fails on Windows on `release-3.0` today, which is the bug #9595 reports, so the two new jobs here will be red until that one is merged.

### Issues References (Fixes|Related|Closes)
1. Related to #9595
2. Depends on #9600
