### PR TITLE
[3.0][Testing] Stop the canonical path tests naming a drive letter

### DIFF
--- a/tests/Unit/SapiTest.php
+++ b/tests/Unit/SapiTest.php
@@ -18,14 +18,25 @@ class SapiTest extends TestCase
 
 	public function testCanonicalPathResolvesDotSegments(): void
 	{
-		// The root of an absolute path is a drive letter on Windows and nothing
-		// at all on POSIX, so name it here rather than let the current drive
-		// decide. Everything after it is the same on both.
-		$root = DIRECTORY_SEPARATOR === '/' ? '' : 'C:';
+		// A relative path has no root to differ over, so once the separator is
+		// accounted for this says the same thing everywhere.
 		$sep = DIRECTORY_SEPARATOR;
 
-		$this->assertSame($root . $sep . 'a' . $sep . 'c', Sapi::canonicalPath($root . '/a/./b/../c', false, false));
-		$this->assertSame($root . $sep . 'a', Sapi::canonicalPath($root . '/a/b/..', false, false));
+		$this->assertSame('a' . $sep . 'c', Sapi::canonicalPath('a/./b/../c', false, false));
+		$this->assertSame('a', Sapi::canonicalPath('a/b/..', false, false));
+	}
+
+	public function testAnAbsolutePathIsRootedOnTheCurrentDrive(): void
+	{
+		// A path that starts at the root names no drive, and on Windows that
+		// means the one the process is on, so the canonical form carries a
+		// letter that depends on where the checkout sits. POSIX has no such
+		// thing and the root is the separator on its own.
+		$sep = DIRECTORY_SEPARATOR;
+		$drive = $sep === '/' ? '' : substr((string) getcwd(), 0, 2);
+
+		$this->assertSame($drive . $sep . 'a' . $sep . 'c', Sapi::canonicalPath('/a/./b/../c', false, false));
+		$this->assertSame($drive . $sep . 'a', Sapi::canonicalPath('/a/b/..', false, false));
 	}
 
 	public function testTheSuiteRunsOnTheCommandLine(): void


### PR DESCRIPTION
#### Description

Follow-up to #9600, which fixed the Windows failure by naming `C:` in the path under test. That works — the drive comes from the input rather than the machine, so it passes on a runner whose checkout is on `D:` — but @live627 is right that a hardcoded drive letter is not the thing to leave in a test. It reads as an assumption even where it is not one, and it means nothing covers the branch that actually broke: on Windows a path that starts at the root but names no drive is rooted on the current one, and it was that step which turned `/a/c` into `C:\a\c`.

Splitting the two behaviours apart removes the need to name a drive at all.

**Dot segments** have nothing to do with the root, so the test named for them uses a relative path. There is no root to differ over and the whole result can be asserted exactly on either platform:

```php
$this->assertSame('a' . $sep . 'c', Sapi::canonicalPath('a/./b/../c', false, false));
```

**What the root is** is worth covering on its own, so it gets its own test, and the drive is read from the working directory rather than assumed:

```php
$drive = $sep === '/' ? '' : substr((string) getcwd(), 0, 2);

$this->assertSame($drive . $sep . 'a' . $sep . 'c', Sapi::canonicalPath('/a/./b/../c', false, false));
```

The review suggested a regex, which would also have removed the hardcoded letter. I went with an exact assertion instead because the expected value here is not "some drive" but a specific one — the drive the process is on — and `assertSame` says that, gives a real diff when it fails, and would still catch the original bug on POSIX, where a regex with an optional drive group would accept a stray letter. Happy to switch it if you would rather have the pattern.

Verified on both platforms. The suite is green on Linux, and I checked the Windows path by extracting `canonicalPath()`, substituting `\` for `DIRECTORY_SEPARATOR` and running it with the working directory on `D:`, where all four assertions hold:

```
0 PASS expected a\c    got a\c
1 PASS expected a      got a
2 PASS expected D:\a\c got D:\a\c
3 PASS expected D:\a   got D:\a
```

`composer lint` is clean.

### Issues References (Fixes|Related|Closes)
1. Related to #9595
2. Follow-up to #9600
