### PR TITLE
[3.0] Count the errors that are on the stack, not the errors that happened

### DIFF
--- a/Sources/Services/ErrorHandlerService.php
+++ b/Sources/Services/ErrorHandlerService.php
@@ -213,145 +213,152 @@ class ErrorHandlerService
 
 		$error_call++;
 
-		// Collect a backtrace
-		if (!DebugUtils::isDebugEnabled()) {
-			$backtrace = $backtrace ?? debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
-		} else {
-			// This is how to keep the args but skip the objects.
-			$backtrace = $backtrace ?? debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS & DEBUG_BACKTRACE_PROVIDE_OBJECT);
-		}
-
-		// Are we in a loop?
-		if ($error_call > 2) {
-			var_dump($backtrace);
-
-			die('Error: loop detected. The database may have failed or crashed.');
-		}
-
-		// Check if error logging is actually on.
-		if (empty(Config::$modSettings['enableErrorLogging'])) {
-			return $error_message;
-		}
-
-		// Basically, htmlspecialchars it minus &. (for entities!)
-		$error_message = strtr($error_message, ['<' => '&lt;', '>' => '&gt;', '"' => '&quot;']);
-
-		$error_message = strtr($error_message, ['&lt;br /&gt;' => '<br>', '&lt;br&gt;' => '<br>', '&lt;b&gt;' => '<strong>', '&lt;/b&gt;' => '</strong>', "\n" => '<br>']);
-
-		// Add a file and line to the error message?
-		// Don't use the actual txt entries for file and line.
-		// Instead use %1$s for file and %2$s for line.
-		// Windows style slashes don't play well, lets convert them to the UNIX style.
-		$file = str_replace('\\', '/', $file);
-
-		// Find the best path and query string we can...
-		if (SMF === 'SSI') {
-			$request_url = ($_SERVER['REQUEST_SCHEME'] ?? 'http') . '://' . ($_SERVER['SERVER_NAME'] ?? 'unknown') . '/' . ltrim($_SERVER['REQUEST_URI'] ?? (($_SERVER['DOCUMENT_URI'] ?? $_SERVER['SCRIPT_NAME'] ?? 'unknown.php') . (!empty($_SERVER['QUERY_STRING']) ? '?' . $_SERVER['QUERY_STRING'] : '')), '/');
-		} elseif (str_starts_with(($_SERVER['REQUEST_URL'] ?? ''), Config::$boardurl)) {
-			$request_url = substr($_SERVER['REQUEST_URL'], \strlen(Config::$boardurl));
-		} else {
-			$request_url = ($_SERVER['REQUEST_URL'] ?? '');
-		}
-
-		// Don't log the session hash in the url twice, it's a waste.
-		$request_url = Utils::htmlspecialchars(preg_replace(['~([?&;]sesc)=[^&;]+~', '~' . session_name() . '=' . session_id() . '[&;]~'], ['$1', ''], $request_url));
-
-		// Just so we know what board error messages are from.
-		if (isset($_POST['board']) && !isset($_GET['board']) && SMF !== 'SSI') {
-			$request_url .= ($request_url == '' ? 'board=' : ';board=') . $_POST['board'];
-		}
-
-		// This prevents us from infinite looping if the hook or call produces an error.
-		$other_error_types = [];
-
-		// Exceptions may get mapped back into our common error types.
-		if (isset($this->known_exception_types[$error_type])) {
-			$error_type = $this->known_exception_types[$error_type];
-		}
-
-		if (empty($tried_hook)) {
-			$tried_hook = true;
-
-			// Allow the hook to change the error_type and know about the error.
-			IntegrationHook::call('integrate_error_types', [&$other_error_types, &$error_type, $error_message, $file, $line]);
-
-			$this->known_error_types = array_merge($this->known_error_types, $other_error_types);
-		}
-
-		// Make sure the category that was specified is a valid one
-		$error_type = \in_array($error_type, $this->known_error_types) && $error_type !== true ? $error_type : 'general';
-
-		// Leave out the call to this method.
-		array_splice($backtrace, 0, 1);
-
-		// Never log call arguments or bound objects.
-		//
-		// The backtraces we collect ourselves already omit the arguments, but a
-		// backtrace handed to us by an exception keeps both, and neither is
-		// safe to encode. Arguments can hold whatever the member submitted,
-		// including their password, and reading a property of a bound object
-		// can throw, which would turn an error we were merely logging into an
-		// uncaught fatal.
-		foreach ($backtrace as &$frame) {
-			unset($frame['args'], $frame['object']);
-		}
-		unset($frame);
-
-		$backtrace = Utils::jsonEncode($backtrace);
-
-		// Don't log the same error countless times, as we can get in a cycle of depression...
-		$error_info = [
-			User::$me->id ?? 0,
-			time(),
-			User::$me->ip ?? IP::getUserIP(),
-			$request_url,
-			$error_message,
-			(string) (User::$sc ?? ''),
-			$error_type,
-			$file,
-			$line,
-			$backtrace,
-		];
-
-		if (empty($last_error) || $last_error != $error_info) {
-			$error_batch[] = $error_info;
-			$last_error = $error_info;
-
-			// Get an error count, if necessary
-			if (!isset(Utils::$context['num_errors'])) {
-				$query = Db::$db->query(
-					'SELECT COUNT(*)
-					FROM {db_prefix}log_errors',
-					[],
-				);
-				list(Utils::$context['num_errors']) = Db::$db->fetch_row($query);
-				Db::$db->free_result($query);
+		try {
+			// Collect a backtrace
+			if (!DebugUtils::isDebugEnabled()) {
+				$backtrace = $backtrace ?? debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
 			} else {
-				Utils::$context['num_errors']++;
+				// This is how to keep the args but skip the objects.
+				$backtrace = $backtrace ?? debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS & DEBUG_BACKTRACE_PROVIDE_OBJECT);
 			}
 
-			// Flush batch when threshold reached.
-			if (\count($error_batch) >= $batch_size) {
-				$this->flushErrorBatch($error_batch);
-				$error_batch = [];
+			// Are we in a loop? The count is how deep this call is: logging an
+			// error is allowed to produce one more, but a third means that
+			// whatever this depends on fails every time it is asked, and
+			// going round again would not end.
+			if ($error_call > 2) {
+				var_dump($backtrace);
+
+				die('Error: loop detected. The database may have failed or crashed.');
 			}
 
-			// Register shutdown function to flush remaining batch.
-			if (!$shutdown_registered) {
-				register_shutdown_function(function () use (&$error_batch) {
-					if (!empty($error_batch)) {
-						$this->flushErrorBatch($error_batch);
-					}
-				});
-				$shutdown_registered = true;
+			// Check if error logging is actually on.
+			if (empty(Config::$modSettings['enableErrorLogging'])) {
+				return $error_message;
 			}
+
+			// Basically, htmlspecialchars it minus &. (for entities!)
+			$error_message = strtr($error_message, ['<' => '&lt;', '>' => '&gt;', '"' => '&quot;']);
+
+			$error_message = strtr($error_message, ['&lt;br /&gt;' => '<br>', '&lt;br&gt;' => '<br>', '&lt;b&gt;' => '<strong>', '&lt;/b&gt;' => '</strong>', "\n" => '<br>']);
+
+			// Add a file and line to the error message?
+			// Don't use the actual txt entries for file and line.
+			// Instead use %1$s for file and %2$s for line.
+			// Windows style slashes don't play well, lets convert them to the UNIX style.
+			$file = str_replace('\\', '/', $file);
+
+			// Find the best path and query string we can...
+			if (SMF === 'SSI') {
+				$request_url = ($_SERVER['REQUEST_SCHEME'] ?? 'http') . '://' . ($_SERVER['SERVER_NAME'] ?? 'unknown') . '/' . ltrim($_SERVER['REQUEST_URI'] ?? (($_SERVER['DOCUMENT_URI'] ?? $_SERVER['SCRIPT_NAME'] ?? 'unknown.php') . (!empty($_SERVER['QUERY_STRING']) ? '?' . $_SERVER['QUERY_STRING'] : '')), '/');
+			} elseif (str_starts_with(($_SERVER['REQUEST_URL'] ?? ''), Config::$boardurl)) {
+				$request_url = substr($_SERVER['REQUEST_URL'], \strlen(Config::$boardurl));
+			} else {
+				$request_url = ($_SERVER['REQUEST_URL'] ?? '');
+			}
+
+			// Don't log the session hash in the url twice, it's a waste.
+			$request_url = Utils::htmlspecialchars(preg_replace(['~([?&;]sesc)=[^&;]+~', '~' . session_name() . '=' . session_id() . '[&;]~'], ['$1', ''], $request_url));
+
+			// Just so we know what board error messages are from.
+			if (isset($_POST['board']) && !isset($_GET['board']) && SMF !== 'SSI') {
+				$request_url .= ($request_url == '' ? 'board=' : ';board=') . $_POST['board'];
+			}
+
+			// This prevents us from infinite looping if the hook or call produces an error.
+			$other_error_types = [];
+
+			// Exceptions may get mapped back into our common error types.
+			if (isset($this->known_exception_types[$error_type])) {
+				$error_type = $this->known_exception_types[$error_type];
+			}
+
+			if (empty($tried_hook)) {
+				$tried_hook = true;
+
+				// Allow the hook to change the error_type and know about the error.
+				IntegrationHook::call('integrate_error_types', [&$other_error_types, &$error_type, $error_message, $file, $line]);
+
+				$this->known_error_types = array_merge($this->known_error_types, $other_error_types);
+			}
+
+			// Make sure the category that was specified is a valid one
+			$error_type = \in_array($error_type, $this->known_error_types) && $error_type !== true ? $error_type : 'general';
+
+			// Leave out the call to this method.
+			array_splice($backtrace, 0, 1);
+
+			// Never log call arguments or bound objects.
+			//
+			// The backtraces we collect ourselves already omit the arguments, but a
+			// backtrace handed to us by an exception keeps both, and neither is
+			// safe to encode. Arguments can hold whatever the member submitted,
+			// including their password, and reading a property of a bound object
+			// can throw, which would turn an error we were merely logging into an
+			// uncaught fatal.
+			foreach ($backtrace as &$frame) {
+				unset($frame['args'], $frame['object']);
+			}
+			unset($frame);
+
+			$backtrace = Utils::jsonEncode($backtrace);
+
+			// Don't log the same error countless times, as we can get in a cycle of depression...
+			$error_info = [
+				User::$me->id ?? 0,
+				time(),
+				User::$me->ip ?? IP::getUserIP(),
+				$request_url,
+				$error_message,
+				(string) (User::$sc ?? ''),
+				$error_type,
+				$file,
+				$line,
+				$backtrace,
+			];
+
+			if (empty($last_error) || $last_error != $error_info) {
+				$error_batch[] = $error_info;
+				$last_error = $error_info;
+
+				// Get an error count, if necessary
+				if (!isset(Utils::$context['num_errors'])) {
+					$query = Db::$db->query(
+						'SELECT COUNT(*)
+						FROM {db_prefix}log_errors',
+						[],
+					);
+					list(Utils::$context['num_errors']) = Db::$db->fetch_row($query);
+					Db::$db->free_result($query);
+				} else {
+					Utils::$context['num_errors']++;
+				}
+
+				// Flush batch when threshold reached.
+				if (\count($error_batch) >= $batch_size) {
+					$this->flushErrorBatch($error_batch);
+					$error_batch = [];
+				}
+
+				// Register shutdown function to flush remaining batch.
+				if (!$shutdown_registered) {
+					register_shutdown_function(function () use (&$error_batch) {
+						if (!empty($error_batch)) {
+							$this->flushErrorBatch($error_batch);
+						}
+					});
+					$shutdown_registered = true;
+				}
+			}
+
+			// Return the message to make things simpler.
+			return $error_message;
+		} finally {
+			// The early return when logging is off, and any error raised on
+			// the way through, both leave this method without reaching the
+			// end of it, so the count is balanced here instead.
+			$error_call--;
 		}
-
-		// Reset error call
-		$error_call = 0;
-
-		// Return the message to make things simpler.
-		return $error_message;
 	}
 
 	/**

--- a/tests/Unit/ErrorHandlerServiceTest.php
+++ b/tests/Unit/ErrorHandlerServiceTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SMF\Tests\Unit;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use SMF\Config;
+use SMF\Services\ErrorHandlerService;
+
+/**
+ * Covers the re-entrancy guard in SMF\Services\ErrorHandlerService.
+ *
+ * Logging an error is allowed to produce one more error, but a third means
+ * whatever the method depends on is failing every time it is called, so it
+ * stops rather than going round again. With error logging switched off none
+ * of that machinery is reached, which keeps this on the near side of the
+ * database.
+ */
+#[CoversClass(ErrorHandlerService::class)]
+class ErrorHandlerServiceTest extends TestCase
+{
+	/*********************
+	 * Internal properties
+	 *********************/
+
+	/**
+	 * @var bool Whether enableErrorLogging was set before the test.
+	 */
+	private bool $had_setting = false;
+
+	/**
+	 * @var mixed enableErrorLogging as it was before the test.
+	 */
+	private mixed $setting = null;
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	public function testErrorsThatAreNotLoggedDoNotCountAsALoop(): void
+	{
+		// The guard counts calls that are on the stack, and the count was only
+		// cleared at the very end of the method. Returning early because
+		// logging is off skipped that, so the count climbed on every call and
+		// the third unrelated error in a request died with 'loop detected',
+		// which in a test run takes the whole process with it.
+		$service = new ErrorHandlerService();
+
+		foreach (range(1, 5) as $i) {
+			$this->assertSame('error ' . $i, $service->log('error ' . $i));
+		}
+	}
+
+	public function testTheMessageIsHandedBackUnchangedWhenNothingIsLogged(): void
+	{
+		// Callers use the return value to build what they show, as in
+		// die(ErrorHandler::log($msg)), so it has to come back whether the
+		// error was recorded or not.
+		$service = new ErrorHandlerService();
+
+		$this->assertSame('something went wrong', $service->log('something went wrong'));
+	}
+
+	/******************
+	 * Internal methods
+	 ******************/
+
+	protected function setUp(): void
+	{
+		$this->had_setting = isset(Config::$modSettings['enableErrorLogging']);
+		$this->setting = Config::$modSettings['enableErrorLogging'] ?? null;
+
+		Config::$modSettings['enableErrorLogging'] = false;
+	}
+
+	/**
+	 * PHPUnit does not reset SMF's statics between tests, so a setting left
+	 * behind here would leak into every test that follows.
+	 */
+	protected function tearDown(): void
+	{
+		unset(Config::$modSettings['enableErrorLogging']);
+
+		if ($this->had_setting) {
+			Config::$modSettings['enableErrorLogging'] = $this->setting;
+		}
+	}
+}


### PR DESCRIPTION
#### Description

`ErrorHandlerService::log()` keeps a count so that an error raised while logging an error does not go round for ever. The count is incremented on the way in and was cleared by reaching the end of the method:

```php
$error_call++;
...
if ($error_call > 2) {
    var_dump($backtrace);
    die('Error: loop detected. The database may have failed or crashed.');
}

// Check if error logging is actually on.
if (empty(Config::$modSettings['enableErrorLogging'])) {
    return $error_message;          // never reaches the reset below
}
...
// Reset error call
$error_call = 0;
```

That early return skips the reset. With error logging switched off the count therefore climbs on every call and never comes back down, so the *third* error in a request dies — with a `var_dump()` of a backtrace and "loop detected" — even though nothing recursed and the three errors had nothing to do with each other.

The count is now balanced in a `finally`, which covers that return and also the case where something between the two throws. Nothing else changes: the threshold and the message are what they were, and on the path that already worked the count still goes from one back to zero.

Most of the diff is the reindentation for the `try`. `git diff -w` is nine lines.

#### How it turned up

On the Windows job added in #9601. The runner has no `fileinfo` extension, `Utils::getMimeType()` logs `required_extension_missing` when it is absent, `Avatar` calls it for every gallery avatar, and the third one killed PHPUnit outright:

```
Error: loop detected. The database may have failed or crashed.
Fatal error: Premature end of PHP process when running
SMF\Tests\Unit\AvatarTest::testAGalleryAvatarInTheRootOfTheGalleryIsFoundToo
```

The extension is dealt with separately in #9601. This is the other half: three unrelated errors should not be a loop.

It is not specific to tests or to Windows. Any forum with error logging turned off dies on the third logged error of a request, and shows a raw backtrace while doing it. The same shape is in 2.1's `log_error()`, so it has been there a long while.

#### Tests

`tests/Unit/ErrorHandlerServiceTest.php` logs five errors with logging off and asserts each returns its message. With logging off the method returns before it touches the database, so this stays on the near side of the line.

Against the unfixed code it does not merely fail, it reproduces the bug exactly:

```
Error: loop detected. The database may have failed or crashed.
Fatal error: Premature end of PHP process when running
SMF\Tests\Unit\ErrorHandlerServiceTest::testErrorsThatAreNotLoggedDoNotCountAsALoop
```

Genuine recursion still ends in the same `die()`, which cannot be asserted from inside the process that dies, so that path is unchanged and untested.

One thing left alone deliberately: the `var_dump($backtrace)` before the `die()` writes paths straight to the response. It is worth removing, but it is a different argument from this one and I did not want to bundle it. Happy to follow up.

### Issues References (Fixes|Related|Closes)
1. Related to #9601
