### PR TITLE
[3.0] Sends the queued mail rather than four undefined variables

### DIFF
--- a/Sources/Mail.php
+++ b/Sources/Mail.php
@@ -498,7 +498,7 @@ class Mail
 		$failed_emails = [];
 
 		foreach ($emails as $email) {
-			$result = $agent->send($to, $subject, $message, $headers);
+			$result = $agent->send($email['to'], $email['subject'], $email['body'], $email['headers']);
 
 			// Old emails should expire
 			if (!$result && $email['tries'] >= self::MAX_TRIES) {


### PR DESCRIPTION
#### Description

`Mail::reduceQueue()` builds each queued message into `$email` and then calls the agent with `$to`, `$subject`, `$message` and `$headers`, none of which exist in that scope:

```php
foreach ($emails as $email) {
	$result = $agent->send($to, $subject, $message, $headers);
```

`MailAgentInterface::send()` types all four as `string`, so the first message in the queue raises:

```
PHP Fatal error: Uncaught TypeError: SMF\MailAgent\APIs\SendMail::send():
Argument #1 ($to) must be of type string, null given,
called in /var/www/html/Sources/Mail.php on line 501
```

The rows are deleted from `mail_queue` **before** the send loop runs, so every low priority message — digests, notifications, anything `Mail::send()` queues instead of sending immediately — is removed from the queue and then lost when the loop that should have delivered it fatals. Under `TaskRunner` it is logged and swallowed; reached from `Theme::loadJavaScript()` on an ordinary page load it takes the page down.

Introduced in ca2dc8f08, which moved the control character stripping out of `reduceQueue()` and into the agents. The agent still does that stripping, so passing the values from `$email` straight through is what that change intended.

Verified on the Docker stack: before the change the queue drains to nothing and no mail reaches Mailpit; after it, both digest mails arrive.

Not covered by a test. `reduceQueue()` reads and writes `mail_queue` on its first statement, so it needs a database and is out of scope for the unit suite.

### Issues References (Fixes|Related|Closes)
1. Related: #9609 — the reason the digest bugs reported there produce no mail at all on 3.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)