### PR TITLE
[3.0] Writes each digest in the language of the member receiving it

### DIFF
--- a/Sources/Tasks/SendDigests.php
+++ b/Sources/Tasks/SendDigests.php
@@ -220,10 +220,16 @@ class SendDigests extends ScheduledTask
 				continue;
 			}
 
+			// Write to this member in their own language. $langs was collected
+			// from the same lngfile values as $members, so there is a set of
+			// strings here for every member, including those whose lngfile is
+			// empty and who therefore read the forum's default language.
+			$strings = $langtxt[$member['lang']];
+
 			// Do the start stuff!
 			$email = [
-				'subject' => Config::$mbname . ' - ' . $langtxt[$lang]['subject'],
-				'body' => $member['name'] . ',' . "\n\n" . $langtxt[$lang]['intro'] . "\n" . Config::$scripturl . '?action=profile;area=notification;u=' . $member['id'] . "\n",
+				'subject' => Config::$mbname . ' - ' . $strings['subject'],
+				'body' => $member['name'] . ',' . "\n\n" . $strings['intro'] . "\n" . Config::$scripturl . '?action=profile;area=notification;u=' . $member['id'] . "\n",
 				'email' => $member['email'],
 			];
 
@@ -235,11 +241,11 @@ class SendDigests extends ScheduledTask
 					foreach ($board['lines'] as $topic) {
 						if (\in_array($mid, $topic['members'])) {
 							if (!$titled) {
-								$email['body'] .= "\n" . $langtxt[$lang]['new_topics'] . ':' . "\n" . '-----------------------------------------------';
+								$email['body'] .= "\n" . $strings['new_topics'] . ':' . "\n" . '-----------------------------------------------';
 								$titled = true;
 							}
 
-							$email['body'] .= "\n" . Lang::formatText($langtxt[$lang]['topic_lines'], ['subject' => $topic['subject'], 'board' => $board['name']]);
+							$email['body'] .= "\n" . Lang::formatText($strings['topic_lines'], ['subject' => $topic['subject'], 'board' => $board['name']]);
 						}
 					}
 				}
@@ -257,11 +263,11 @@ class SendDigests extends ScheduledTask
 					foreach ($board['lines'] as $topic) {
 						if (\in_array($mid, $topic['members'])) {
 							if (!$titled) {
-								$email['body'] .= "\n" . $langtxt[$lang]['new_replies'] . ':' . "\n" . '-----------------------------------------------';
+								$email['body'] .= "\n" . $strings['new_replies'] . ':' . "\n" . '-----------------------------------------------';
 								$titled = true;
 							}
 
-							$email['body'] .= "\n" . Lang::formatText($langtxt[$lang]['replies'], [$topic['count'], $topic['subject']]);
+							$email['body'] .= "\n" . Lang::formatText($strings['replies'], [$topic['count'], $topic['subject']]);
 						}
 					}
 				}
@@ -284,11 +290,11 @@ class SendDigests extends ScheduledTask
 						foreach ($board['lines'] as $topic) {
 							if (\in_array($mid, $topic['members'])) {
 								if (!$titled) {
-									$email['body'] .= "\n" . $langtxt[$lang]['mod_actions'] . ':' . "\n" . '-----------------------------------------------';
+									$email['body'] .= "\n" . $strings['mod_actions'] . ':' . "\n" . '-----------------------------------------------';
 									$titled = true;
 								}
 
-								$email['body'] .= "\n" . Lang::formatText($langtxt[$lang][$note_type], $topic);
+								$email['body'] .= "\n" . Lang::formatText($strings[$note_type], $topic);
 							}
 						}
 					}
@@ -302,7 +308,7 @@ class SendDigests extends ScheduledTask
 			}
 
 			// Then just say our goodbyes!
-			$email['body'] .= "\n\n" . Lang::getTxt('regards_team', ['forum_name' => Utils::$context['forum_name']], file: 'General');
+			$email['body'] .= "\n\n" . $strings['bye'];
 
 			// Send it - low priority!
 			Mail::send($email['email'], $email['subject'], $email['body'], null, 'digest', false, 4);


### PR DESCRIPTION
#### Description

`SendDigests` collects the strings for every language its subscribers read into `$langtxt`, keyed by language, and then builds every email from `$langtxt[$lang]` — `$lang` being whatever the `foreach ($langs as $lang)` that filled `$langtxt` happened to leave behind. Every member gets the same language, whichever one sorted last, and the `'lang'` the opening query records for each member is never read at all.

The sign-off did not even do that. It called `Lang::getTxt('regards_team', …)` with no language argument, so it was always in the forum's default language while the rest of the mail was in another. There is already a correctly localized copy of it in `$langtxt[…]['bye']`, which nothing used.

Verified on the Docker stack with a marked second language pack: with UserA on `tr_TR` and UserB on `en_US`, both digests came out identical before, and afterwards each member's mail — subject, intro, section headings, lines and sign-off — is in their own language.

Note that this is only visible once #9612 lands. `Lang::load()` currently ignores the language it is asked for, so `Lang::getTxt(…, lang: …)` returns the forum default whatever it is passed, and the two changes were verified together.

Not covered by a test. `SendDigests::execute()` opens with a query and needs a database throughout, so it is out of scope for the unit suite.

### Issues References (Fixes|Related|Closes)
1. Related: #9609 — one of the three problems reported there.
2. Related: #9612, without which the effect of this change cannot be seen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)