### PR TITLE
[3.0] Only digests the boards and topics a member asked to be emailed about

### DIFF
--- a/Sources/Tasks/SendDigests.php
+++ b/Sources/Tasks/SendDigests.php
@@ -91,6 +91,40 @@ class SendDigests extends ScheduledTask
 			return true;
 		}
 
+		// The preferred way...
+		$prefs = Notify::getNotifyPrefs(
+			array_keys($members),
+			array_merge(
+				['msg_notify_type', 'msg_notify_pref', 'board_notify', 'topic_notify'],
+				array_map(fn($id) => 'board_notify_' . $id, array_keys($notify['boards'] ?? [])),
+				array_map(fn($id) => 'topic_notify_' . $id, array_keys($notify['topics'] ?? [])),
+			),
+			true,
+		);
+
+		// Watching a board or a topic is not on its own a request to be
+		// emailed about it: the alert and the email are separate bits of the
+		// same preference, and a member can ask for one without the other. A
+		// digest is an email, so the members who only wanted an alert do not
+		// belong in the lists that decide who is told about what.
+		foreach (['boards' => 'board', 'topics' => 'topic'] as $key => $type) {
+			foreach ($notify[$key] ?? [] as $id => $watchers) {
+				$notify[$key][$id] = array_values(
+					array_filter(
+						$watchers,
+						function ($mid) use ($prefs, $type, $id) {
+							// A per board or per topic preference of zero means
+							// nothing was chosen for that one in particular, so
+							// the member's general preference decides.
+							$pref = !empty($prefs[$mid][$type . '_notify_' . $id]) ? $prefs[$mid][$type . '_notify_' . $id] : ($prefs[$mid][$type . '_notify'] ?? 0);
+
+							return (bool) ($pref & self::RECEIVE_NOTIFY_EMAIL);
+						},
+					),
+				);
+			}
+		}
+
 		// Just get the board names.
 		$request = Db::$db->query(
 			'SELECT id_board, name
@@ -203,9 +237,6 @@ class SendDigests extends ScheduledTask
 
 			IntegrationHook::call('integrate_daily_digest_lang', [&$langtxt, $lang]);
 		}
-
-		// The preferred way...
-		$prefs = Notify::getNotifyPrefs(array_keys($members), ['msg_notify_type', 'msg_notify_pref'], true);
 
 		// Right - send out the silly things - this will take quite some space!
 		$members_sent = [];


### PR DESCRIPTION
#### Description

Watching a board or a topic records two things: a row in `log_notify`, and a preference whose bits say whether the member wants an alert, an email, or both. `SendDigests` read the rows and never the preference, so a member who asked for alerts alone was emailed a summary of everything they were watching.

That is not an obscure combination — it is the default. On a fresh profile the "Notify me of replies" and "Notify me of new topics" email boxes are unticked, so watching a board through the normal link writes `board_notify_<id> = 1`, alert only. `CreatePost_Notify` honours that and sends no email; the digest ignored it and did.

The watcher lists are now filtered by the same preference, resolved the way `CreatePost_Notify` resolves it: the per board or per topic setting where the member made one, otherwise their general `board_notify` / `topic_notify`. The preference fetch moves up to where the lists are built, since that is now where it is needed.

Verified on the Docker stack. UserA watching a board with the email box ticked and UserB watching the same board with it unticked: before, both mails listed the new topic and the reply; after, only UserA's does.

Note that UserB still receives a mail, now with nothing in it. That is a separate defect — the digest is assembled and sent whether or not any section found anything — and is fixed in #9615. The two touch the same file.

Not covered by a test. `SendDigests::execute()` opens with a query and needs a database throughout, so it is out of scope for the unit suite.

### Issues References (Fixes|Related|Closes)
1. Related: #9609 — "emails are getting sent to folks who have not opted in".
2. Related: #9615, the empty digest that this change leaves behind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)