### PR TITLE
[3.0] Stops sending a digest to members who have nothing to be told about

### DIFF
--- a/Sources/Tasks/SendDigests.php
+++ b/Sources/Tasks/SendDigests.php
@@ -227,6 +227,16 @@ class SendDigests extends ScheduledTask
 				'email' => $member['email'],
 			];
 
+			// What the mail says before anything specific to this member has
+			// been added to it. Whether it still says only this at the end is
+			// how we know there was nothing to tell them about.
+			$greeting_only = $email['body'];
+
+			// Each section below sets this when it writes its heading, and the
+			// sections are skipped rather than entered when there is nothing of
+			// that kind, so it needs a value that is this member's own.
+			$titled = false;
+
 			// All new topics?
 			if (isset($types['topic'])) {
 				$titled = false;
@@ -299,6 +309,13 @@ class SendDigests extends ScheduledTask
 
 			if ($titled) {
 				$email['body'] .= "\n";
+			}
+
+			// Watching something is not the same as there being anything to
+			// report about it. Sending the greeting and the unsubscribe link
+			// on their own tells the member nothing and reads like a fault.
+			if ($email['body'] === $greeting_only) {
+				continue;
 			}
 
 			// Then just say our goodbyes!


### PR DESCRIPTION
#### Description

The body of the digest was assembled and handed to `Mail::send()` whether or not any of the three sections found anything for this member. A member watching a board that had been quiet, on a forum where somebody else's watch did have activity, was mailed a greeting, an unsubscribe link and a sign-off with nothing in between — and their `log_notify` rows were marked as sent.

That is the mail quoted in #9609:

```
UserB,

Below is a summary of all activity in your subscribed boards and topics at SMF Dev today. To unsubscribe please visit the link below.
http://localhost:8080/index.php?action=profile;area=notification;u=3


Regards,
The SMF Dev Team.
```

The greeting is now kept so the finished body can be compared against it. Doing it that way rather than with a flag also counts anything `integrate_daily_digest_email` added, since a mod contributing a section of its own has as much reason to be sent as a core one.

`$titled` gets an initial value per member in the same change, because the emptiness check depends on it. The three sections each set it when they write their heading, but a section with nothing of its kind is skipped rather than entered, so the `if ($titled)` after the hook read it either uninitialized or still holding the previous member's value — which on the wrong member appends a newline and would make an empty body look non-empty.

Verified on the Docker stack: with UserA having activity and UserB watching only a quiet board, UserB now receives nothing and their `log_notify.sent` correctly stays 0, while UserA's digest is unchanged.

Not covered by a test. `SendDigests::execute()` opens with a query and needs a database throughout, so it is out of scope for the unit suite.

### Issues References (Fixes|Related|Closes)
1. Related: #9609 — "the emails getting sent are sometimes missing entries, only the message header is sent".
2. Related: #9614, which touches the same file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)