### PR TITLE
[3.0] Measures a display name against the column that has to hold it

### DIFF
--- a/Sources/Actions/Register2.php
+++ b/Sources/Actions/Register2.php
@@ -212,8 +212,13 @@ class Register2 extends Register
 				Db::$db->free_result($request);
 			}
 
+			// What gets stored is the entity encoded form of the name, which is
+			// wider than what was typed wherever a character needs an entity,
+			// and real_name holds 255 characters.
+			$encoded_name = Utils::htmlspecialchars($_POST['real_name'], ENT_QUOTES);
+
 			// Only set it if you can and if we are sure it is good
-			if ($can_edit_display_name && Utils::htmlTrim($_POST['real_name']) != '' && !Security::isReservedName($_POST['real_name']) && Utils::entityStrlen($_POST['real_name']) < 60) {
+			if ($can_edit_display_name && Utils::htmlTrim($_POST['real_name']) != '' && !Security::isReservedName($_POST['real_name']) && Utils::entityStrlen($_POST['real_name']) < 60 && mb_strlen($encoded_name) <= 255) {
 				$this->possible_strings[] = 'real_name';
 			}
 		}

--- a/Sources/Profile.php
+++ b/Sources/Profile.php
@@ -698,7 +698,12 @@ class Profile extends User implements \ArrayAccess
 						return 'no_name';
 					}
 
-					if (Utils::entityStrlen($value) > 60) {
+					// The name is stored with entities in place of the characters
+					// that need them, so it is wider in the column than it was in
+					// the box: a double quote costs six characters there, an
+					// ampersand five. real_name holds 255, and a name inside the
+					// 60 character limit can still be wider than that.
+					if (Utils::entityStrlen($value) > 60 || mb_strlen($value) > 255) {
 						return 'name_too_long';
 					}
 


### PR DESCRIPTION
#### Description

The third of the same mistake, found while working on #9616 and #9618: a length limit
counted in typed characters guarding a column that stores the entity encoded form of
them.

The display name limit is 60 characters. In the profile it is enforced by

```php
if (Utils::entityStrlen($value) > 60) {
	return 'name_too_long';
}
```

`Sources/Actions/Profile/Main.php` runs `Utils::htmlspecialcharsRecursive($_POST, ENT_QUOTES)`
before validation, so `$value` is *already encoded* when it gets here, and `entityStrlen()`
decodes it again to count. That is the right number to show a member. It is not the number
`members.real_name` has to hold, which is the encoded one — six characters per double
quote, five per ampersand, four per angle bracket — in a `varchar(255)`.

**What happens**

A display name of 43 double quotes is 43 characters to the validator and 258 in the
column. Run against the real validator and `User::updateMemberData()` on the Docker stack:

```
42 typed quotes: entityStrlen 42 (limit 60), encoded 252 chars (column 255), validator: true
43 typed quotes: entityStrlen 43 (limit 60), encoded 258 chars (column 255), validator: true
  Data too long for column 'real_name' at row 1
  File: /var/www/html/Sources/User.php  Line: 3420
```

The profile save dies on it. PostgreSQL gives `value too long for type character
varying(255)` in the same place.

These characters really are allowed in a display name, which is the part that is easy to
get wrong: `Security::validateUsername()` rejects `<>&"'=\`, but that rule applies only to
`member_name`. The display name's validator forbids exactly one character, `*`, in
`Security::isReservedName()`.

Registration has the same gap coming the other way. `Register2` checks the **raw** value

```php
&& Utils::entityStrlen($_POST['real_name']) < 60
```

and then encodes it thirty lines later when building `extra_register_vars`, so the value
that is measured and the value that is stored are again not the same string.

**The fix**

Check the encoded width alongside the typed length, in both places, so a name that cannot
be stored is refused by the form that offered it rather than by the database.

`mb_strlen()` rather than `Utils::entityStrlen()` is the point of the change: the encoded
length is what the column has to hold, and measuring it with `entityStrlen()` is the bug.

**Why not widen the column instead**

That is what #9616 does for the report comment, and it is the nicer answer where it is
available, because the limit the member is shown then means what it says. It is not
available here: `real_name` carries three indexes — `idx_real_name`,
`idx_active_real_name`, and `idx_real_name_low` on PostgreSQL — so it cannot become a
`text` column on MySQL without prefix lengths, and widening a `members` column that three
indexes and a great deal of code depend on is a much larger change than this bug warrants.

The cost of doing it this way is that a name of 43 double quotes is refused as "too long"
while the message says the limit is 60. That is a poor explanation, but it is a poor
explanation of a refusal rather than a fatal error, and it is only reachable by a name
made mostly of characters that need entities. I have deliberately left
`$txt['profile_error_name_too_long']` alone rather than reword it and stale every
translation for this case; happy to change that if you would rather.

**Verification**

Against the patched validator, on a real database:

```
plain      typed  60, entityStrlen  60, encoded  60 -> true
42 quotes  typed  42, entityStrlen  42, encoded 252 -> true
43 quotes  typed  43, entityStrlen  43, encoded 258 -> 'name_too_long'
61 plain   typed  61, entityStrlen  61, encoded  61 -> 'name_too_long'
```

An ordinary 60 character name is still accepted, the widest name that actually fits is
still accepted, the one that used to fatal is now refused, and the original 60 character
limit still works.

`composer lint` and `vendor/bin/phpunit` (280 tests, 495 assertions) pass.

No unit test: the validator is a closure inside `Profile::loadStandardFields()`, which
needs a loaded member and therefore a database, and `Register2` reads `$_POST` and queries
permissions. The numbers above came from running the real code against MySQL instead.

### Issues References (Fixes|Related|Closes)
1. Related to #9616 and #9618 — same class of mistake, third column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
