### PR TITLE
[3.0] Reads the database title from the connection, not from the class

### DIFF
--- a/Sources/Tasks/AnonymizeEditHistory.php
+++ b/Sources/Tasks/AnonymizeEditHistory.php
@@ -53,7 +53,7 @@ class AnonymizeEditHistory extends BackgroundTask
 		// Set the anonymous name.
 		$anonymous_name = 'u_' . substr(Uuid::create(5, 'member=' . $this->_details['id'])->getShortForm(true), 0, 8);
 
-		if (Db::$title === POSTGRE_TITLE) {
+		if (Db::$db->title === POSTGRE_TITLE) {
 			$request = Db::$db->query(
 				'SELECT id_msg, edit_history
 				FROM {db_prefix}messages


### PR DESCRIPTION
#### Description

`SMF\Tasks\AnonymizeEditHistory` picks its query with `Db::$title === POSTGRE_TITLE`, but `$title` is an instance property (`DatabaseApi.php:65`, set in each API class), not a static one. Every other one of the ten call sites in the tree reads it as `Db::$db->title`. So the task throws `Error: Access to undeclared static property SMF\Db\DatabaseApi::$title` the moment it runs, and the edit history of an anonymized member's posts has never actually been anonymized in 3.0.

The consequence is not limited to that feature. `TaskRunner::runOneTask()` only deletes a task whose `execute()` returned true, so the fatal leaves the row in the queue to be claimed again by the next page load that runs a task, which then dies as well. While a task was queued on my dev forum I could not load a page or even boot SSI:

```
Fatal error: Uncaught Error: Access to undeclared static property SMF\Db\DatabaseApi::$title in /var/www/html/Sources/Tasks/AnonymizeEditHistory.php:58
#0 /var/www/html/Sources/TaskRunner.php(603): SMF\Tasks\AnonymizeEditHistory->execute()
#1 /var/www/html/Sources/TaskRunner.php(242): SMF\TaskRunner->performTask(Array)
#2 /var/www/html/Sources/Theme.php(2363): SMF\TaskRunner->runOneTask()
```

##### Verification

Deleting a member with anonymization, on MySQL 8.4, after registering them, posting, and editing the post so that their ID and name are in `edit_history`:

```
before: [[1788559620, "f5c9e8b6", "", "", [[0,0,0,6,"first"]], 7, "HistProbe3e0358", "probe"]]
after:  [[1788559620, "f5c9e8b6", "", "", [[0,0,0,6,"first"]], 0, "u_75g36v5h",      "probe"]]
```

The name written into the history matches the `poster_name` the member's posts were given, and the task leaves the queue.

The PostgreSQL branch is the code this fix makes reachable rather than code it changes, and I have no forum installed on PostgreSQL to run it against. I checked its predicate directly against PostgreSQL 17 instead, on a table holding the same JSON, and it selects the right row and only that row:

```sql
SELECT id FROM t WHERE edit_history @? '$[*][5] ? (@ == 7)';
 id
----
  1
```

The task needs a database and a queue, so it is not reachable from the unit suite; no test accompanies this. `composer lint` is clean and `vendor/bin/phpunit` is green (208 tests, 302 assertions).

### Issues References (Fixes|Related|Closes)
1. Related: #9621, which makes the anonymized name this task writes unguessable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
