### PR TITLE
[3.0][Testing] Check that an upgrade survives being run twice and being interrupted

### DIFF
--- a/.docker/README.md
+++ b/.docker/README.md
@@ -154,6 +154,58 @@ Two things it cannot do for you:
   `PHP_VERSION=8.5 docker compose up -d --build web`.
 - **The integration tests on both engines.** Use `.docker/test.sh` for that.
 
+## Hardening the upgrade
+
+The installer builds a 3.0 forum from `Sources/Db/Schema/v3_0/` in one go. The
+upgrader arrives somewhere near the same place through a few hundred migrations
+applied to whatever 2.1 left behind, and it has to survive two things that
+happen to it constantly and that nothing checks: being run twice, and being cut
+off half way.
+
+```sh
+BASE=../SMF-2.1/.docker/baseline/artifacts/2.1.7-1/small/mysql.sql
+
+.docker/rerun-upgrade.sh     --engine mysql --baseline "$BASE"
+.docker/interrupt-upgrade.sh --engine mysql --baseline "$BASE"
+```
+
+Both rebuild the database for the engine they are given, so anything installed
+on it is destroyed. The other engine is untouched. Both take a `--baseline` SQL
+dump of a 2.1 forum; the one above is the committed baseline from the 2.1
+development environment, and a dump of a real forum is a better test.
+
+**`rerun-upgrade.sh`** upgrades, then upgrades again, and reports what the
+second run changed. It should change nothing. Running the upgrader twice is not
+an unusual thing to do -- it is what an admin does when a page times out, and it
+is what every 3.0 patch upgrade does, since `VERSION_MAP` keys on an upper bound
+and `3.0.99` selects the v3_0 migrations for any 3.0.x forum.
+
+**`interrupt-upgrade.sh`** kills the upgrader part way through, starts it again,
+and reports whether the forum it ends up with is the one an uninterrupted
+upgrade would have built. By default it does this at five points across the run;
+`--at N` picks one substep, `--points 10,50` picks a set. Kill points are given
+as a percentage of an uninterrupted run's substeps, so the same numbers mean the
+same places whatever the baseline is.
+
+Recovery today means starting again from the top, over a database that is in
+neither the old shape nor the new one, because the step, substep and start
+position live in `$_GET` and nowhere else. `maintenance_tool_progress` in
+`Settings.php` is the only thing written to disk, it holds the version the run
+started from rather than where it had got to, and it is written by `preExit()`,
+which a killed process never reaches. So every migration has to cope with a
+half-migrated database, which is a stronger requirement than merely being safe
+to repeat over a finished one.
+
+`--backup` is worth adding to a run of it. The backup step is skipped on the
+command line unless something asks for it, and a retry is exactly what
+endangers what it produces: `backup_table()` opens with `DROP TABLE IF EXISTS`,
+so a second pass replaces a good pre-upgrade copy with whatever the database
+holds by then.
+
+Both write their readings and reports under `.docker/rerun/` and
+`.docker/interrupt/`, which are gitignored. Expect five to ten minutes per
+upgrade, so a full sweep of kill points is the better part of an hour.
+
 ## Everyday use
 
 ```sh
@@ -247,4 +299,7 @@ compose.yaml                     the stack
 .docker/mysql/init/10-smf.sh     runs once on first mysql database creation
 .docker/postgres/init/10-smf.sh  runs once on first postgres database creation
 .docker/env.example              optional overrides
+.docker/upgrade-readings.sh      shared: driving upgrade.php, reading a database
+.docker/rerun-upgrade.sh         upgrade twice, report what the second run changed
+.docker/interrupt-upgrade.sh     kill an upgrade part way, report what recovery left
 ```

--- a/.docker/interrupt-upgrade.sh
+++ b/.docker/interrupt-upgrade.sh
@@ -1,0 +1,340 @@
+#!/usr/bin/env bash
+# Kills an upgrade part way through, starts it again, and reports whether the
+# forum it ends up with is the one an uninterrupted upgrade would have built.
+#
+#   .docker/interrupt-upgrade.sh --engine mysql --baseline ../SMF-2.1/.docker/baseline/artifacts/2.1.7-1/small/mysql.sql
+#   .docker/interrupt-upgrade.sh --engine mysql --baseline ... --at 40
+#   .docker/interrupt-upgrade.sh --engine mysql --baseline ... --points 10,25,50,75,90
+#   .docker/interrupt-upgrade.sh --engine mysql --baseline ... --backup
+#
+# --backup asks the upgrader for the backup step, which the command line skips
+# unless something does. It is worth turning on precisely because a retry is
+# what endangers it: backup_table() drops the backup table before writing it, so
+# a run that is killed after the migrations have started and then started again
+# takes its backup a second time, over a database that is no longer the one the
+# admin wanted a copy of. The reading of the backup_ tables' columns is what
+# reports that.
+#
+# An upgrade that is interrupted is the ordinary case, not the exotic one. A
+# browser is closed, a request is cut off, a host runs out of memory, somebody
+# presses ctrl-c. What the upgrader keeps in order to survive that is a good
+# deal less than it looks: the step, substep and start position live in $_GET
+# and nowhere else, and the maintenance_tool_progress blob in Settings.php --
+# the only thing written to disk -- holds the version the run started from, who
+# started it and what was skipped, but not where it had got to. It is written
+# by preExit(), which a killed process never reaches.
+#
+# So recovery here means starting again from the top, over a database that is
+# now in neither the old shape nor the new one. Every migration has to cope
+# with that, which is a stronger requirement than being safe to repeat over a
+# finished forum: an isCandidate() guard written against the 2.1 shape is being
+# asked about a database that is half way to 3.0.
+#
+# The reference is an uninterrupted upgrade of the same baseline. Anything this
+# reports is a place where being interrupted left the forum different from one
+# that was not -- a migration that half ran, a guard that skipped work that had
+# not actually been done, a table left in an intermediate shape.
+#
+# The database for the chosen engine is rebuilt, once per kill point plus once
+# for the reference. The other engine is not touched.
+#
+# Runs on the host. Expect five to ten minutes per run, so a sweep of five kill
+# points is the better part of an hour.
+set -euo pipefail
+
+. "$(dirname -- "${BASH_SOURCE[0]}")/lib.sh"
+
+ENGINE=''
+BASELINE=''
+OUT="$DOCKER_DIR/interrupt"
+POINTS='10,25,50,75,90'
+AT=''
+# How many times the upgrader may be started again after a kill before we call
+# it stuck. A healthy recovery takes one; more than that means each run is
+# dying somewhere too, which is worth reporting rather than looping on.
+MAX_ROUNDS=4
+# Passed through to upgrade.php. Empty by default, which is what an admin
+# upgrading from the command line gets.
+UPGRADE_ARGS=''
+
+while [ $# -gt 0 ]; do
+	case "$1" in
+		--engine) ENGINE="$2"; shift 2 ;;
+		--engine=*) ENGINE="${1#*=}"; shift ;;
+		--baseline) BASELINE="$2"; shift 2 ;;
+		--baseline=*) BASELINE="${1#*=}"; shift ;;
+		--out) OUT="$2"; shift 2 ;;
+		--out=*) OUT="${1#*=}"; shift ;;
+		--at) AT="$2"; shift 2 ;;
+		--at=*) AT="${1#*=}"; shift ;;
+		--points) POINTS="$2"; shift 2 ;;
+		--points=*) POINTS="${1#*=}"; shift ;;
+		--backup) UPGRADE_ARGS="$UPGRADE_ARGS --backup"; shift ;;
+		-h|--help) sed -n '2,41p' "${BASH_SOURCE[0]}"; exit 0 ;;
+		*) die "unknown argument: $1" ;;
+	esac
+done
+
+[ -n "$ENGINE" ] || die 'need --engine mysql|postgresql|both'
+ENGINES=$(engine_list "$ENGINE") || die "unknown engine: $ENGINE"
+[ -n "$BASELINE" ] || die 'need --baseline <a 2.1 SQL dump>'
+[ -f "$BASELINE" ] || die "no such file: $BASELINE"
+
+cd "$BOARD_DIR"
+mkdir -p "$OUT"
+OUT=$(cd -- "$OUT" && pwd)
+
+# The upgrader writes its log into logs/ in the board directory, which is bind
+# mounted, so the host can watch a run in progress line by line. That is what
+# makes the kill point a substep rather than a number of seconds: the same
+# migration is interrupted every time, and a report names it.
+UPGRADE_LOG="$BOARD_DIR/logs/upgrade.log"
+
+# Where the log of a run that has ended is. finalizeLog() renames it to carry a
+# UTC timestamp once the tool exits normally, so the live name only survives a
+# run that was killed -- which is the one case where it is the file we want.
+finished_upgrade_log() {
+	if [ -f "$UPGRADE_LOG" ]; then
+		echo "$UPGRADE_LOG"
+
+		return
+	fi
+
+	ls -1t "$BOARD_DIR"/logs/upgrade_*.log 2>/dev/null | head -1
+}
+
+# Everything the readings and the run share with rerun-upgrade.sh lives here
+# rather than being written twice.
+. "$DOCKER_DIR/upgrade-readings.sh"
+
+# How many substeps the log has seen. Each one is announced before it runs, so
+# this counts substeps started, not substeps finished -- which is what we want,
+# since killing during a substep is the interesting case.
+substeps_logged() {
+	local n
+
+	# grep -c prints its count and *then* exits 1 when the count is zero, so a
+	# trailing `|| echo 0` appends a second line and every numeric test on the
+	# result fails. Take the count and correct it separately.
+	n=$(grep -c '^ +++ ' "$UPGRADE_LOG" 2>/dev/null) || n=0
+
+	echo "${n:-0}"
+}
+
+# The name of the last substep the log announced, for the report.
+last_substep() {
+	[ -f "$UPGRADE_LOG" ] || return 0
+
+	grep '^ +++ ' "$UPGRADE_LOG" 2>/dev/null | tail -1 | sed -e 's/^ +++ //' -e 's/\.\{3,\}.*$//'
+}
+
+# Starts an upgrade and kills it once the log says it has begun its Nth substep.
+# Returns 0 if it was killed as intended, 1 if it finished or died on its own
+# first -- either of which means the kill point was past the end of the run.
+run_and_kill() {
+	local smf_type="$1" want="$2" log="$3" waited=0
+
+	rm -f install.php
+	cp other/upgrade.php upgrade.php
+
+	# A run that was killed leaves its log behind under the live name, and the
+	# next one does not truncate it until it reaches step 0. Counting during
+	# that window would see the previous run's substeps and kill this one
+	# immediately, so the file goes first.
+	rm -f "$UPGRADE_LOG"
+
+	# shellcheck disable=SC2086 -- deliberately word split; these are flags.
+	docker compose exec -T web php upgrade.php ${UPGRADE_ARGS:-} > "$log" 2>&1 &
+	local runner=$!
+
+	# Polling the log rather than the process: the point of interest is what
+	# the upgrader has reached, and only the log says that.
+	while kill -0 "$runner" 2>/dev/null; do
+		if [ "$(substeps_logged)" -ge "$want" ]; then
+			KILLED_AFTER=$(last_substep)
+
+			# The process this shell started is the docker client. Killing it
+			# closes the connection but leaves php running in the container, so
+			# the container's copy is the one that has to be signalled.
+			docker compose exec -T web pkill -9 -f 'php upgrade.php' >/dev/null 2>&1 || true
+			wait "$runner" 2>/dev/null || true
+			rm -f upgrade.php
+
+			return 0
+		fi
+
+		# A tenth of a second is short enough that the kill lands inside the
+		# substep that tripped it rather than several substeps later.
+		sleep 0.1
+		waited=$((waited + 1))
+
+		[ "$waited" -lt 6000 ] || die "${smf_type}: the upgrade ran for ten minutes without reaching substep ${want}"
+	done
+
+	wait "$runner" 2>/dev/null || true
+	rm -f upgrade.php
+
+	return 1
+}
+
+interrupt_one_point() {
+	local smf_type="$1" want="$2" round=0 version
+
+	log "${smf_type}: emptying the database"
+	"$DOCKER_DIR/reset.sh" --engine "$smf_type" >/dev/null
+	load_baseline "$smf_type" "$BASELINE"
+
+	KILLED_AFTER=''
+
+	if ! run_and_kill "$smf_type" "$want" "$OUT/killed-${smf_type}-${want}.log"; then
+		warn "${smf_type}: the run finished before substep ${want}, so there was nothing to interrupt"
+
+		return 0
+	fi
+
+	log "${smf_type}: killed during '${KILLED_AFTER}' (substep ${want})"
+
+	# The upgrader truncates its log at step 0, so the record of the run that
+	# was killed is gone the moment the next one starts. Keep a copy.
+	cp "$UPGRADE_LOG" "$OUT/killed-${smf_type}-${want}.upgrade.log" 2>/dev/null || true
+
+	version=$(installed_version "$smf_type" || true)
+	log "${smf_type}: the database says SMF ${version:-nothing}"
+
+	# What the backup step left behind before anything was retried. Read here
+	# rather than only at the end because the question is not whether a backup
+	# exists afterwards -- one will -- but whether it is still the one taken of
+	# the forum as it was.
+	snapshot_backups "$smf_type" "$OUT/killed-${smf_type}-${want}.backups.tsv"
+
+	# ------------------------------------------------------------ recovery
+	while [ "$round" -lt "$MAX_ROUNDS" ]; do
+		round=$((round + 1))
+
+		log "${smf_type}: restarting the upgrade (round ${round})"
+
+		if run_upgrade "$smf_type" "$OUT/recover-${smf_type}-${want}-${round}.log"; then
+			log "${smf_type}: recovered in ${round} $([ "$round" = 1 ] && echo run || echo runs)"
+
+			break
+		fi
+
+		if [ "$round" -ge "$MAX_ROUNDS" ]; then
+			warn "${smf_type}: still not upgraded after ${MAX_ROUNDS} attempts -- it cannot recover from being killed during '${KILLED_AFTER}'"
+			printf 'killed during: %s (substep %s)\n  could not recover in %s attempts\n\n' \
+				"$KILLED_AFTER" "$want" "$MAX_ROUNDS" >> "$OUT/report-${smf_type}.txt"
+
+			return 1
+		fi
+	done
+
+	snapshot "$smf_type" "resumed-${want}" "$OUT"
+
+	# ------------------------------------------------------------- the report
+	local status=0
+
+	log "${smf_type}: what being interrupted left behind"
+
+	compare_snapshots "$smf_type" clean "resumed-${want}" "$OUT" || status=1
+
+	# The backup the killed run had made, against the backup that is there now.
+	# A difference means the retry took its own backup over the top of it, and
+	# the copy the admin would restore from is of a half-migrated forum.
+	if ! diff -u "$OUT/killed-${smf_type}-${want}.backups.tsv" 		"$OUT/resumed-${want}-${smf_type}.backups.tsv" > "$OUT/.backupdiff" 2>&1; then
+		printf '  %-10s REPLACED BY THE RETRY
+' 'backup'
+		{
+			printf '  the backup tables the killed run had made were overwritten:
+'
+			sed -e 's/^/    /' "$OUT/.backupdiff"
+			printf '
+'
+		} >> "$OUT/.compare"
+		status=1
+	elif [ -s "$OUT/killed-${smf_type}-${want}.backups.tsv" ]; then
+		printf '  %-10s intact
+' 'backup'
+	fi
+
+	rm -f "$OUT/.backupdiff"
+
+	if [ "$status" -ne 0 ]; then
+		{
+			printf 'killed during: %s (substep %s), recovered in %s round(s)\n' "$KILLED_AFTER" "$want" "$round"
+			cat "$OUT/.compare"
+			printf '\n'
+		} >> "$OUT/report-${smf_type}.txt"
+	fi
+
+	return "$status"
+}
+
+interrupt_one_engine() {
+	local smf_type="$1" total point failed=0
+	local -a want
+
+	: > "$OUT/report-${smf_type}.txt"
+
+	# ------------------------------------------------------- the reference
+	log "${smf_type}: emptying the database"
+	"$DOCKER_DIR/reset.sh" --engine "$smf_type" >/dev/null
+	load_baseline "$smf_type" "$BASELINE"
+
+	[ -n "$(installed_version "$smf_type" || true)" ] \
+		|| die "${smf_type}: the dump loaded but there is no forum in it -- wrong prefix, or not an SMF dump"
+
+	log "${smf_type}: upgrading once, uninterrupted, for the reference"
+	run_upgrade "$smf_type" "$OUT/clean-${smf_type}.log" \
+		|| die "${smf_type}: the uninterrupted upgrade failed, so there is nothing to compare against -- $OUT/clean-${smf_type}.log"
+
+	snapshot "$smf_type" clean "$OUT"
+	cp "$(finished_upgrade_log)" "$OUT/clean-${smf_type}.upgrade.log" 2>/dev/null || true
+
+	total=$(grep -c '^ +++ ' "$OUT/clean-${smf_type}.upgrade.log" 2>/dev/null) || total=0
+
+	# Without this the kill points all come out as zero, every one of them is
+	# skipped for being out of range, and the script reports that nothing went
+	# wrong -- which would be a lie told by an empty loop.
+	[ "$total" -gt 0 ] 		|| die "${smf_type}: could not read the reference run's log, so there is no way to say where to interrupt -- looked for ${UPGRADE_LOG} and ${BOARD_DIR}/logs/upgrade_*.log"
+
+	log "${smf_type}: an uninterrupted upgrade runs ${total} substeps"
+
+	# Kill points are given as a percentage of that, so the same set of numbers
+	# means the same places in the run whatever the baseline is and however many
+	# migrations the version has grown since.
+	if [ -n "$AT" ]; then
+		want=("$AT")
+	else
+		want=()
+
+		for point in ${POINTS//,/ }; do
+			want+=( $(( total * point / 100 )) )
+		done
+	fi
+
+	for point in "${want[@]}"; do
+		[ "$point" -gt 0 ] || continue
+
+		echo
+		interrupt_one_point "$smf_type" "$point" || failed=1
+	done
+
+	echo
+
+	if [ "$failed" -eq 0 ]; then
+		log "${smf_type}: every interrupted upgrade recovered into the same forum as an uninterrupted one"
+	else
+		cat "$OUT/report-${smf_type}.txt"
+		log "${smf_type}: being interrupted changed the outcome -- ${OUT}/report-${smf_type}.txt"
+	fi
+
+	return "$failed"
+}
+
+failed=0
+
+for smf_type in $ENGINES; do
+	interrupt_one_engine "$smf_type" || failed=1
+done
+
+exit "$failed"

--- a/.docker/rerun-upgrade.sh
+++ b/.docker/rerun-upgrade.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# Upgrades a 2.1 database to 3.0, then upgrades it again, and reports where the
+# second run changed anything.
+#
+#   .docker/rerun-upgrade.sh --engine mysql      --baseline ../SMF-2.1/.docker/baseline/artifacts/2.1.7-1/small/mysql.sql
+#   .docker/rerun-upgrade.sh --engine postgresql --baseline ../SMF-2.1/.docker/baseline/artifacts/2.1.7-1/small/postgres.sql
+#
+# Running the upgrader twice is not an unusual thing to do. It is what happens
+# when an admin refreshes a page that timed out, when a run dies part way and is
+# started again, and -- routinely -- when one 3.0 patch release is upgraded to
+# the next, since VERSION_MAP keys on an upper bound and '3.0.99' selects the
+# v3_0 migrations for any 3.0.x forum. Every migration therefore has to be safe
+# to repeat, and nothing checks that they are.
+#
+# A second run that is doing its job changes nothing at all: the same tables,
+# the same columns, the same indexes, the same number of rows, the same
+# settings. Anything this reports is a migration whose second pass did work it
+# should have skipped -- an ALTER that ran again, an INSERT with no guard on it,
+# a column re-added under a different type.
+#
+# --baseline takes any SQL dump of a 2.1 database. The one this was written
+# against is the committed baseline from the 2.1 development environment, which
+# is built to hold something in every table an upgrade touches, but a dump of a
+# real forum works and is a better test.
+#
+# The database for the chosen engine is rebuilt. Anything already installed on
+# that engine is destroyed, and what is left at the end is the twice-upgraded
+# forum. The other engine is not touched.
+#
+# Runs on the host. Expect five to ten minutes per engine.
+set -euo pipefail
+
+. "$(dirname -- "${BASH_SOURCE[0]}")/lib.sh"
+
+ENGINE=''
+BASELINE=''
+OUT="$DOCKER_DIR/rerun"
+
+while [ $# -gt 0 ]; do
+	case "$1" in
+		--engine) ENGINE="$2"; shift 2 ;;
+		--engine=*) ENGINE="${1#*=}"; shift ;;
+		--baseline) BASELINE="$2"; shift 2 ;;
+		--baseline=*) BASELINE="${1#*=}"; shift ;;
+		--out) OUT="$2"; shift 2 ;;
+		--out=*) OUT="${1#*=}"; shift ;;
+		-h|--help) sed -n '2,30p' "${BASH_SOURCE[0]}"; exit 0 ;;
+		*) die "unknown argument: $1" ;;
+	esac
+done
+
+[ -n "$ENGINE" ] || die 'need --engine mysql|postgresql|both'
+ENGINES=$(engine_list "$ENGINE") || die "unknown engine: $ENGINE"
+[ -n "$BASELINE" ] || die 'need --baseline <a 2.1 SQL dump>'
+[ -f "$BASELINE" ] || die "no such file: $BASELINE"
+
+cd "$BOARD_DIR"
+mkdir -p "$OUT"
+OUT=$(cd -- "$OUT" && pwd)
+
+. "$DOCKER_DIR/upgrade-readings.sh"
+
+rerun_one() {
+	local smf_type="$1" version status=0
+
+	: > "$OUT/report-${smf_type}.txt"
+
+	log "${smf_type}: emptying the database"
+	"$DOCKER_DIR/reset.sh" --engine "$smf_type" >/dev/null
+
+	log "${smf_type}: loading ${BASELINE##*/}"
+	load_baseline "$smf_type" "$BASELINE"
+
+	version=$(installed_version "$smf_type" || true)
+
+	if [ -z "$version" ]; then
+		warn "${smf_type}: the dump loaded but there is no forum in it -- wrong prefix, or not an SMF dump"
+
+		return 1
+	fi
+
+	log "${smf_type}: the dump is SMF ${version}"
+
+	log "${smf_type}: upgrading"
+	run_upgrade "$smf_type" "$OUT/upgrade-first-${smf_type}.log" || return 1
+	log "${smf_type}: upgraded to SMF $(smf_version)"
+
+	snapshot "$smf_type" first "$OUT"
+
+	# The upgrader deletes nothing and leaves no marker behind saying it has
+	# run, so the second call is the same call. That is the point: this is what
+	# an admin who refreshes, or who upgrades 3.0.1 to 3.0.2, actually does.
+	log "${smf_type}: upgrading again"
+	run_upgrade "$smf_type" "$OUT/upgrade-second-${smf_type}.log" || return 1
+
+	snapshot "$smf_type" second "$OUT"
+
+	echo
+	log "${smf_type}: what the second run changed"
+
+	compare_snapshots "$smf_type" first second "$OUT" || status=1
+
+	echo
+
+	if [ "$status" -eq 0 ]; then
+		log "${smf_type}: the second upgrade changed nothing"
+	else
+		cat "$OUT/.compare" | tee "$OUT/report-${smf_type}.txt"
+		log "${smf_type}: the second upgrade changed the database -- ${OUT}/report-${smf_type}.txt"
+	fi
+
+	return "$status"
+}
+
+failed=0
+
+for smf_type in $ENGINES; do
+	rerun_one "$smf_type" || failed=1
+done
+
+exit "$failed"

--- a/.docker/upgrade-readings.sh
+++ b/.docker/upgrade-readings.sh
@@ -1,0 +1,278 @@
+#!/usr/bin/env bash
+# Readings taken of an upgraded database, and the machinery for running the
+# upgrader. Sourced by rerun-upgrade.sh and interrupt-upgrade.sh, never run.
+#
+# Both of those scripts ask the same question in different ways -- is the forum
+# this upgrade produced the one it should be -- so both need the same answer to
+# "what shape is this database in", and both need to drive upgrade.php the same
+# way. Keeping one copy means a reading that learns to ignore something noisy
+# learns it once.
+#
+# Expects lib.sh to have been sourced already, and $BOARD_DIR to be the working
+# directory.
+#
+# shellcheck disable=SC2034
+
+# The version this checkout is, which is what a finished upgrade has to leave
+# in the database.
+smf_version() {
+	sed -n "s/.*define('SMF_VERSION', '\([^']*\)').*/\1/p" "$BOARD_DIR/index.php" | head -1
+}
+
+load_baseline() {
+	local smf_type="$1" baseline="$2" service
+	service=$(engine_service "$smf_type")
+
+	if [ "$smf_type" = 'mysql' ]; then
+		docker compose exec -T -e MYSQL_PWD="$DB_PASSWORD" "$service" \
+			mysql -u"$DB_USER" -D "$DB_NAME" < "$baseline"
+	else
+		# ON_ERROR_STOP so that a dump taken from a database that is not empty,
+		# or one taken with a different owner, stops here rather than producing
+		# a half-loaded forum that then fails somewhere in the upgrader and
+		# looks like a migration bug.
+		docker compose exec -T "$service" \
+			psql -v ON_ERROR_STOP=1 -q -U "$DB_USER" -d "$DB_NAME" < "$baseline" >/dev/null
+	fi
+}
+
+# Runs the upgrader once, from the board directory, the way an admin would.
+# $UPGRADE_ARGS is passed through to it, so a caller can ask for the parts the
+# command line leaves off by default -- --backup above all, since the backup
+# step is skipped unless something asks for it.
+# Returns non-zero if it exited non-zero or stopped short of this version.
+run_upgrade() {
+	local smf_type="$1" log="$2" status=0 version
+
+	# The upgrader ships in other/ and expects to be run from the board
+	# directory, the same way install.php does. Nobody upgrading a real forum
+	# has install.php sitting there, so neither does this.
+	rm -f "$BOARD_DIR/install.php"
+	cp "$BOARD_DIR/other/upgrade.php" "$BOARD_DIR/upgrade.php"
+
+	docker compose exec -T web php upgrade.php ${UPGRADE_ARGS:-} > "$log" 2>&1 || status=$?
+
+	rm -f "$BOARD_DIR/upgrade.php"
+
+	if [ "$status" -ne 0 ]; then
+		warn "${smf_type}: the upgrader exited ${status} -- ${log}"
+
+		return 1
+	fi
+
+	# The upgrader reports a failed migration and stops, but still exits 0, so
+	# the version in the database is the only thing that says whether it got to
+	# the end. Checking it matters more than it looks: a half-upgraded database
+	# differs from a finished one in hundreds of places, all of them the honest
+	# consequence of the migrations that never ran, and none of them the kind of
+	# difference these scripts exist to find.
+	version=$(installed_version "$smf_type" || true)
+
+	if [ "$version" != "$(smf_version)" ]; then
+		warn "${smf_type}: the upgrade stopped at SMF ${version:-nothing}, expected $(smf_version)"
+		warn "${smf_type}: the last thing it said is at the end of ${log}"
+
+		return 1
+	fi
+
+	return 0
+}
+
+# ---------------------------------------------------------------- the readings
+#
+# Three readings, because the ways an upgrade goes wrong show up in different
+# places. Each is written so that the same database always produces the same
+# bytes, since anything varying on its own would be reported as a difference
+# the upgrade caused.
+
+# The shape of every table. Catches DDL that ran when it should not have: a
+# column widened twice, an index added under a generated name, a primary key
+# dropped and rebuilt differently, a table left half altered by a kill.
+#
+# AUTO_INCREMENT is stripped on MySQL. It is a property of the table rather
+# than of its shape, it moves whenever a row is written, and the row counts
+# below are the reading that would notice if rows had been inserted.
+snapshot_schema() {
+	local smf_type="$1" file="$2" service
+	service=$(engine_service "$smf_type")
+
+	if [ "$smf_type" = 'mysql' ]; then
+		# --no-tablespaces because reading them wants the PROCESS privilege,
+		# which the forum's own database user has no business holding.
+		docker compose exec -T -e MYSQL_PWD="$DB_PASSWORD" "$service" \
+			mysqldump -u"$DB_USER" --no-data --no-tablespaces --skip-comments \
+			--skip-dump-date --skip-set-charset --routines --databases "$DB_NAME" \
+			| sed -e 's/ AUTO_INCREMENT=[0-9]*//' > "$file"
+	else
+		docker compose exec -T "$service" \
+			pg_dump -U "$DB_USER" -d "$DB_NAME" --schema-only --no-owner --no-privileges > "$file"
+	fi
+
+	[ -s "$file" ] || die "${smf_type}: the schema reading came back empty"
+}
+
+# How many rows are in each table. Catches the commonest data failure by far: a
+# migration that inserts its settings, its permissions or its scheduled tasks
+# without checking whether they are already there, and so doubles them.
+snapshot_counts() {
+	local smf_type="$1" file="$2" service table
+	service=$(engine_service "$smf_type")
+
+	if [ "$smf_type" = 'mysql' ]; then
+		# The table list is read into an array first. Reading it with a pipe
+		# into `while read` does not work: the docker client inside the loop
+		# inherits the loop's stdin and swallows the rest of the list, so only
+		# the first table is ever counted and the reading silently agrees with
+		# itself no matter what changed.
+		local -a tables
+		mapfile -t tables < <(
+			docker compose exec -T -e MYSQL_PWD="$DB_PASSWORD" "$service" \
+				mysql -u"$DB_USER" -D "$DB_NAME" -N -B -e \
+				"SELECT table_name FROM information_schema.tables
+				 WHERE table_schema = DATABASE() AND table_type = 'BASE TABLE'
+				 ORDER BY table_name;" | tr -d '\r'
+		)
+
+		: > "$file"
+
+		for table in "${tables[@]}"; do
+			[ -n "$table" ] || continue
+
+			printf '%s\t%s\n' "$table" "$(
+				docker compose exec -T -e MYSQL_PWD="$DB_PASSWORD" "$service" \
+					mysql -u"$DB_USER" -D "$DB_NAME" -N -B -e \
+					"SELECT COUNT(*) FROM \`${table}\`;" | tr -d '\r'
+			)" >> "$file"
+		done
+	else
+		# One statement rather than a loop: a lateral join over the catalogue
+		# counts every table without the script having to ask table by table.
+		docker compose exec -T "$service" \
+			psql -U "$DB_USER" -d "$DB_NAME" -tAX -F$'\t' -c \
+			"SELECT c.relname, n.rows
+			 FROM pg_class c
+			 JOIN pg_namespace ns ON ns.oid = c.relnamespace
+			 CROSS JOIN LATERAL (
+				SELECT (xpath('/row/c/text()', query_to_xml(
+					format('SELECT COUNT(*) AS c FROM %I.%I', ns.nspname, c.relname),
+					false, true, ''
+				)))[1]::text::bigint AS rows
+			 ) n
+			 WHERE c.relkind = 'r' AND ns.nspname = 'public'
+			 ORDER BY c.relname;" > "$file"
+	fi
+
+	[ -s "$file" ] || die "${smf_type}: the row count reading came back empty"
+
+	# Tables the forum writes to simply by being looked at, or that record the
+	# upgrade itself. A difference in one of them says nothing about whether the
+	# migrations did the right thing.
+	sed -i -E '/^[a-z_]*(log_online|log_actions|log_errors|log_activity|log_floodcontrol|sessions|background_tasks)\t/d' "$file"
+}
+
+# Everything in the settings table. Catches a migration that rewrites a setting
+# it should have left alone, which a row count cannot see because the number of
+# rows does not change. Read as a table rather than a dump so the ordering is
+# ours and not the engine's.
+snapshot_settings() {
+	local smf_type="$1" file="$2" service
+	service=$(engine_service "$smf_type")
+
+	if [ "$smf_type" = 'mysql' ]; then
+		docker compose exec -T -e MYSQL_PWD="$DB_PASSWORD" "$service" \
+			mysql -u"$DB_USER" -D "$DB_NAME" -N -B -e \
+			"SELECT variable, value FROM ${DB_PREFIX}settings ORDER BY variable;" \
+			| tr -d '\r' > "$file"
+	else
+		docker compose exec -T "$service" \
+			psql -U "$DB_USER" -d "$DB_NAME" -tAX -F$'\t' -c \
+			"SELECT variable, value FROM ${DB_PREFIX}settings ORDER BY variable;" > "$file"
+	fi
+
+	[ -s "$file" ] || die "${smf_type}: the settings reading came back empty"
+
+	# Settings that move on their own. The times are written whenever the forum
+	# is touched, and the counters are recalculated by the cleanup step.
+	sed -i -E '/^(settings_updated|memberlist_updated|calendar_updated|last_mod_report_action|latestMember|latestRealName|latestMemberID|rand_seed|last_backup_at)\t/d' "$file"
+}
+
+# The columns of each backup_ table the backup step leaves behind.
+#
+# Read on its own rather than as part of the schema because these tables are the
+# admin's only way back, and what threatens them is not a migration but a retry:
+# backup_table() opens with DROP TABLE IF EXISTS, so a second backup pass
+# replaces a good pre-upgrade copy with whatever the database holds at the time.
+# A backup taken before the migrations still carries the columns 3.0 removes; one
+# taken again afterwards does not, so the column list alone says which it is.
+# How many rows they hold is already in the row count reading.
+#
+# Empty output is not an error. A run that was not asked to back up has no
+# backup tables, and that is a legitimate reading of a database.
+snapshot_backups() {
+	local smf_type="$1" file="$2" service
+	service=$(engine_service "$smf_type")
+
+	if [ "$smf_type" = 'mysql' ]; then
+		docker compose exec -T -e MYSQL_PWD="$DB_PASSWORD" "$service" \
+			mysql -u"$DB_USER" -D "$DB_NAME" -N -B -e \
+			"SELECT table_name, GROUP_CONCAT(column_name ORDER BY ordinal_position)
+			 FROM information_schema.columns
+			 WHERE table_schema = DATABASE() AND table_name LIKE 'backup\\_%'
+			 GROUP BY table_name
+			 ORDER BY table_name;" | tr -d '\r' > "$file"
+	else
+		docker compose exec -T "$service" \
+			psql -U "$DB_USER" -d "$DB_NAME" -tAX -F$'\t' -c \
+			"SELECT c.relname, string_agg(a.attname, ',' ORDER BY a.attnum)
+			 FROM pg_class c
+			 JOIN pg_namespace ns ON ns.oid = c.relnamespace
+			 JOIN pg_attribute a ON a.attrelid = c.oid AND a.attnum > 0 AND NOT a.attisdropped
+			 WHERE c.relkind = 'r' AND ns.nspname = 'public' AND c.relname LIKE 'backup\_%'
+			 GROUP BY c.relname
+			 ORDER BY c.relname;" > "$file"
+	fi
+}
+
+# Takes all the readings under one label.
+snapshot() {
+	local smf_type="$1" label="$2" out="$3"
+
+	snapshot_schema   "$smf_type" "$out/${label}-${smf_type}.schema.sql"
+	snapshot_counts   "$smf_type" "$out/${label}-${smf_type}.counts.tsv"
+	snapshot_settings "$smf_type" "$out/${label}-${smf_type}.settings.tsv"
+	snapshot_backups  "$smf_type" "$out/${label}-${smf_type}.backups.tsv"
+}
+
+# Compares two labelled snapshots, printing a line per reading and leaving the
+# detail in $out/.compare for the caller to put in its report. Returns non-zero
+# if any reading differs.
+compare_snapshots() {
+	local smf_type="$1" first="$2" second="$3" out="$4" status=0 what file
+
+	: > "$out/.compare"
+
+	for what in schema counts settings backups; do
+		case "$what" in
+			schema)   file='schema.sql' ;;
+			counts)   file='counts.tsv' ;;
+			settings) file='settings.tsv' ;;
+			backups)  file='backups.tsv' ;;
+		esac
+
+		if diff -u "$out/${first}-${smf_type}.${file}" "$out/${second}-${smf_type}.${file}" > "$out/.diff" 2>&1; then
+			printf '  %-10s unchanged\n' "$what"
+		else
+			printf '  %-10s CHANGED\n' "$what"
+			{
+				printf '  %s:\n' "$what"
+				sed -e 's/^/    /' "$out/.diff"
+				printf '\n'
+			} >> "$out/.compare"
+			status=1
+		fi
+	done
+
+	rm -f "$out/.diff"
+
+	return "$status"
+}

--- a/.docker/upgrade-readings.sh
+++ b/.docker/upgrade-readings.sh
@@ -104,8 +104,12 @@ snapshot_schema() {
 			--skip-dump-date --skip-set-charset --routines --databases "$DB_NAME" \
 			| sed -e 's/ AUTO_INCREMENT=[0-9]*//' > "$file"
 	else
+		# pg_dump 17 brackets its output with \restrict / \unrestrict lines
+		# carrying a key it generates afresh on every run, so two dumps of one
+		# unchanged database differ in two lines for no reason at all. Drop them.
 		docker compose exec -T "$service" \
-			pg_dump -U "$DB_USER" -d "$DB_NAME" --schema-only --no-owner --no-privileges > "$file"
+			pg_dump -U "$DB_USER" -d "$DB_NAME" --schema-only --no-owner --no-privileges \
+			| grep -v -E '^[\](un)?restrict ' > "$file"
 	fi
 
 	[ -s "$file" ] || die "${smf_type}: the schema reading came back empty"

--- a/.gitignore
+++ b/.gitignore
@@ -82,6 +82,8 @@ Thumbs.db
 # installs without reinstalling. Generated secrets and a machine-specific
 # board URL: local to whoever ran the installer.
 /.docker/settings/
+/.docker/rerun/
+/.docker/interrupt/
 
 # Test / Private files #
 ########################


### PR DESCRIPTION
#### Description

The upgrader has to cope with two things that happen to it constantly and that nothing tests: being run more than once, and being cut off half way. This adds a check for each, to the Docker development environment, alongside the existing `install-forum.sh` and `reset.sh`.

```sh
BASE=../SMF-2.1/.docker/baseline/artifacts/2.1.7-1/small/mysql.sql

.docker/rerun-upgrade.sh     --engine mysql --baseline "$BASE"
.docker/interrupt-upgrade.sh --engine mysql --baseline "$BASE"
```

**`rerun-upgrade.sh`** upgrades a 2.1 baseline, upgrades it again, and reports what the second run changed. It should change nothing. Running the upgrader twice is not the exotic case: it is what an admin does when a page times out, and it is what every 3.0 patch upgrade does, since `VERSION_MAP` keys on an upper bound and `3.0.99` selects the v3_0 migrations for any 3.0.x forum.

**`interrupt-upgrade.sh`** kills the upgrader at a chosen substep, starts it again, and reports whether the forum it ends up with is the one an uninterrupted upgrade would have built. `--at N` picks one substep; `--points 10,50` a set; the default sweeps five points. Kill points are given as a percentage of an uninterrupted run's substeps, so the same numbers mean the same places whatever the baseline is and however many migrations the version grows.

Recovery here means starting again from the top, over a database in neither the old shape nor the new one. The step, substep and start position live in `$_GET` and nowhere else; `maintenance_tool_progress` in `Settings.php` is the only thing written to disk, it records the version the run started *from* rather than where it had reached, and it is written by `preExit()`, which a killed process never runs. Every migration therefore has to cope with a half-migrated database, which is a stronger requirement than merely being safe to repeat over a finished one.

`--backup` turns on the backup step, which the command line otherwise skips. It is worth turning on precisely because a retry is what endangers what it produces: `backup_table()` opens with `DROP TABLE IF EXISTS`, so a second pass replaces a good pre-upgrade copy with whatever the database holds by then.

#### The readings

Four, each written so the same database always produces the same bytes, since anything varying on its own would be reported as a change the upgrade made. Between them they separate the ways this goes wrong:

| reading | catches |
| --- | --- |
| the DDL of every table | an `ALTER` that ran when it should not have, a table left half altered |
| the row count of each | an `INSERT` with no guard on it, run twice |
| the settings table | a setting rewritten in place, which a row count cannot see |
| the columns of the `backup_` tables | a good backup replaced by a retry — one taken before the migrations still carries the columns 3.0 removes |

Timestamps that move on their own are filtered, as are the `\restrict` lines pg_dump 17 brackets its output with, which carry a key regenerated on every run.

#### What it found

Each of these has its own pull request:

- an interrupted upgrade cannot be started again once `HolidaysToEvents` has dropped `calendar_holidays`, on both engines
- PostgreSQL loses six indexes on upgrade, all on columns widened for 2038
- PostgreSQL ends up with 80 duplicate index pairs out of 259
- `normalize()` compares a column property, `generated_expression`, that exists under neither that name in the schema classes nor in what the database reports

It also needs #9302, without which a 2.1 → 3.0 upgrade does not complete at all on the current `release-3.0` and neither script has anything to measure.

#### Not reachable from the unit suite

These drive `upgrade.php` against real MySQL and PostgreSQL databases in the Docker environment. `tests/bootstrap.php` provides no database and no request, so none of this is expressible as a PHPUnit test; it is a pair of scripts a person or CI runs, in the same shape as `.docker/ci.sh`. Nothing here is part of the shipped forum — it lives in `.docker/`, which the `check-smf-index.php` and `check-smf-license.php` checks skip.

### Issues References (Fixes|Related|Closes)
1. Related: #9626, #9623, #9624, #9625 -- everything below was found with these scripts
2. Related: #9302 -- needed before either script has anything to measure
3. Related: #9531 -- the other half of the question, whether an upgraded database matches a fresh install
