### PR TITLE
[3.0] Recognises a normal index that is only under the wrong name

### DIFF
--- a/Sources/Db/Schema/Table.php
+++ b/Sources/Db/Schema/Table.php
@@ -453,8 +453,9 @@ abstract class Table
 	public function fixIndexName(DbIndex $index): bool
 	{
 		foreach (Db::$db->list_indexes('{db_prefix}' . $this->name, true) as $existing_index) {
-			// Must be the same type.
-			if ($index->type !== $existing_index['type']) {
+			// Must be the same type. A normal index carries no type of its own,
+			// which the database reports as 'index'.
+			if (($index->type ?? 'index') !== $existing_index['type']) {
 				continue;
 			}
 


### PR DESCRIPTION
#### Description

A PostgreSQL forum upgraded from 2.1 to 3.0 ends up holding two identical copies of most of its indexes — 80 duplicate pairs out of 259 indexes, including several on `messages`, `members` and `log_actions`. Every write to those tables maintains both, and short of reading the catalogue there is nothing to see.

`fixIndexName()` exists to stop exactly this. It finds an index that is already there under an older name and renames it, so `normalize()` does not build a second copy beside it. It compares the type first:

```php
if ($index->type !== $existing_index['type']) {
    continue;
}
```

A `DbIndex` constructed without a type has `$type === null`; the database reports a normal index as `'index'`. The two never matched, so every normal index fell through to `continue` and the method answered that nothing like it existed. Only primary and unique keys, which name their type, were ever recognised.

MySQL is unaffected in practice, because its 2.1 index names are already the names 3.0 wants (`idx_time_sent`), so no rename is called for. PostgreSQL is a different matter: its index names are unique across the whole schema rather than per table, so they carry the table name, and 2.1's `smf_mail_queue_time_sent` is not 3.0's `smf_mail_queue_idx_time_sent`. The rename that would have reconciled them never happened, and `normalize()` then created the 3.0-named index beside the 2.1-named one it had failed to recognise.

The same `($index->type ?? 'index')` expression is already used a few lines up in `normalize()`, where it compares the type it expects against the one the database reports.

#### How this was found, and how it was verified

Found while tracing why `.docker/rerun-upgrade.sh` (#9622) reported PostgreSQL schema changes between two consecutive upgrades. Counted with:

```sql
SELECT count(*) FROM (
  SELECT tablename, regexp_replace(indexdef, '^.*\((.*)\)$', '\1') AS cols
  FROM pg_indexes WHERE schemaname='public' AND tablename LIKE 'smf\_%'
  GROUP BY 1,2 HAVING count(*) > 1) t;
```

Against the 2.1.7 baseline from the 2.1 development environment:

| | before | after |
| --- | --- | --- |
| PostgreSQL, duplicate index pairs | **80** | **0** |
| PostgreSQL, total indexes | 259 | 185 |
| MySQL, duplicate index pairs | 0 | 0 |

The totals reconcile: 259 − 80 duplicates = 179, plus the 6 indexes restored by the companion fix = 185.

#### Not reachable from the unit suite

`Schema\Column::__construct()` calls `Db::$db->calculate_type()`, so the schema classes cannot be instantiated without a connection, and `fixIndexName()` does nothing but read and rename indexes in a live database. Verified by running real upgrades on both engines instead.

### Issues References (Fixes|Related|Closes)
1. Related: #9622 -- the check that led here
2. Related: #9623 -- the other half of what the index handling gets wrong on PostgreSQL
