### PR TITLE
[3.0] Lets an upgrade start again after the holidays table has gone

### DIFF
--- a/Sources/Maintenance/Migration/v2_1/CalendarUpdates.php
+++ b/Sources/Maintenance/Migration/v2_1/CalendarUpdates.php
@@ -15,6 +15,8 @@ declare(strict_types=1);
 
 namespace SMF\Maintenance\Migration\v2_1;
 
+use SMF\Config;
+use SMF\Db\DatabaseApi as Db;
 use SMF\Db\Schema;
 use SMF\Maintenance\Migration\MigrationBase;
 
@@ -32,6 +34,17 @@ class CalendarUpdates extends MigrationBase
 	/****************
 	 * Public methods
 	 ****************/
+
+	/**
+	 *
+	 */
+	public function isCandidate(): bool
+	{
+		// Everything this does is to the holidays table, which the 3.0
+		// migrations fold into the calendar and then drop. Once that has
+		// happened there is nothing here to update.
+		return Db::$db->list_tables(false, Config::$db_prefix . 'calendar_holidays') !== [];
+	}
 
 	/**
 	 *

--- a/Sources/Maintenance/Migration/v2_1/CalendarUpdates.php
+++ b/Sources/Maintenance/Migration/v2_1/CalendarUpdates.php
@@ -15,8 +15,6 @@ declare(strict_types=1);
 
 namespace SMF\Maintenance\Migration\v2_1;
 
-use SMF\Config;
-use SMF\Db\DatabaseApi as Db;
 use SMF\Db\Schema;
 use SMF\Maintenance\Migration\MigrationBase;
 
@@ -43,7 +41,9 @@ class CalendarUpdates extends MigrationBase
 		// Everything this does is to the holidays table, which the 3.0
 		// migrations fold into the calendar and then drop. Once that has
 		// happened there is nothing here to update.
-		return Db::$db->list_tables(false, Config::$db_prefix . 'calendar_holidays') !== [];
+		$table = new Schema\v2_1\CalendarHolidays();
+
+		return $table->exists();
 	}
 
 	/**

--- a/Sources/Maintenance/Migration/v2_1/FixDates.php
+++ b/Sources/Maintenance/Migration/v2_1/FixDates.php
@@ -15,7 +15,6 @@ declare(strict_types=1);
 
 namespace SMF\Maintenance\Migration\v2_1;
 
-use SMF\Config;
 use SMF\Db\DatabaseApi as Db;
 use SMF\Maintenance\Maintenance;
 use SMF\Maintenance\Migration\MigrationBase;
@@ -80,7 +79,7 @@ class FixDates extends MigrationBase
 		}
 
 		if (Maintenance::getCurrentStart() < 3) {
-			if ($this->holidaysTableExists()) {
+			if (($table = new Schema\v2_1\CalendarHolidays())->exists()) {
 				$this->query(\sprintf($boilerplate, 'calendar_holidays', 'event_date'));
 			}
 
@@ -139,7 +138,7 @@ class FixDates extends MigrationBase
 		}
 
 		if (Maintenance::getCurrentStart() < 9) {
-			if ($this->holidaysTableExists()) {
+			if (($table = new Schema\v2_1\CalendarHolidays())->exists()) {
 				Db::$db->change_column(
 					'{db_prefix}calendar_holidays',
 					'event_date',
@@ -174,23 +173,5 @@ class FixDates extends MigrationBase
 		}
 
 		return true;
-	}
-
-	/******************
-	 * Internal methods
-	 ******************/
-
-	/**
-	 * Whether the holidays table is still there to be fixed.
-	 *
-	 * The 3.0 migrations fold that table into the calendar and then drop it, so
-	 * an upgrade that reaches them and is started again finds it gone. The rest
-	 * of this migration still has work to do on the tables that remain.
-	 *
-	 * @return bool Whether the table exists.
-	 */
-	private function holidaysTableExists(): bool
-	{
-		return Db::$db->list_tables(false, Config::$db_prefix . 'calendar_holidays') !== [];
 	}
 }

--- a/Sources/Maintenance/Migration/v2_1/FixDates.php
+++ b/Sources/Maintenance/Migration/v2_1/FixDates.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 
 namespace SMF\Maintenance\Migration\v2_1;
 
+use SMF\Config;
 use SMF\Db\DatabaseApi as Db;
 use SMF\Maintenance\Maintenance;
 use SMF\Maintenance\Migration\MigrationBase;
@@ -79,7 +80,9 @@ class FixDates extends MigrationBase
 		}
 
 		if (Maintenance::getCurrentStart() < 3) {
-			$this->query(\sprintf($boilerplate, 'calendar_holidays', 'event_date'));
+			if ($this->holidaysTableExists()) {
+				$this->query(\sprintf($boilerplate, 'calendar_holidays', 'event_date'));
+			}
 
 			Maintenance::setCurrentStart();
 			$this->handleTimeout();
@@ -136,11 +139,13 @@ class FixDates extends MigrationBase
 		}
 
 		if (Maintenance::getCurrentStart() < 9) {
-			Db::$db->change_column(
-				'{db_prefix}calendar_holidays',
-				'event_date',
-				['default' => '1004-01-01'],
-			);
+			if ($this->holidaysTableExists()) {
+				Db::$db->change_column(
+					'{db_prefix}calendar_holidays',
+					'event_date',
+					['default' => '1004-01-01'],
+				);
+			}
 
 			Maintenance::setCurrentStart();
 			$this->handleTimeout();
@@ -169,5 +174,23 @@ class FixDates extends MigrationBase
 		}
 
 		return true;
+	}
+
+	/******************
+	 * Internal methods
+	 ******************/
+
+	/**
+	 * Whether the holidays table is still there to be fixed.
+	 *
+	 * The 3.0 migrations fold that table into the calendar and then drop it, so
+	 * an upgrade that reaches them and is started again finds it gone. The rest
+	 * of this migration still has work to do on the tables that remain.
+	 *
+	 * @return bool Whether the table exists.
+	 */
+	private function holidaysTableExists(): bool
+	{
+		return Db::$db->list_tables(false, Config::$db_prefix . 'calendar_holidays') !== [];
 	}
 }

--- a/Sources/Maintenance/Migration/v2_1/PostgreSqlSequences.php
+++ b/Sources/Maintenance/Migration/v2_1/PostgreSqlSequences.php
@@ -243,6 +243,16 @@ class PostgreSqlSequences extends MigrationBase
 
 			$value = $this->sequences[$i];
 
+			// Some of these tables no longer exist by the time a 3.0 upgrade is
+			// finished, so asking a later run to set their sequence is asking
+			// about something that is not there. Skip those rather than let the
+			// statement fail, which on the command line ends the upgrade.
+			if (Db::$db->list_tables(false, Config::$db_prefix . $value['table']) === []) {
+				Maintenance::setCurrentStart();
+
+				continue;
+			}
+
 			$this->query(
 				"SELECT setval('{raw:key}', (SELECT COALESCE(MAX({raw:field}),1) FROM {raw:table}))",
 				[


### PR DESCRIPTION
#### Description

An upgrade that is interrupted after the 3.0 migrations have begun cannot be started again. It fails at the same point on every attempt, so the forum is left in neither the old shape nor the new one with no way forward.

`smfVersion` is not written until `finalize()`, so for the whole of the run the database still says 2.1, and `VERSION_MAP` selects the entire 2.1 migration set when the upgrade is started again. By that point `HolidaysToEvents` has folded `calendar_holidays` into the calendar and dropped it, and three of the 2.1 migrations name that table:

| migration | how it uses the table |
| --- | --- |
| `PostgreSqlSequences` | `setval` on `calendar_holidays_seq` reads `MAX(id_holiday)` from it |
| `CalendarUpdates` | deletes from it and repopulates it |
| `FixDates` | rewrites `event_date`, then sets its default |

The first one reached ends the upgrade, and every later attempt gets exactly as far.

The window runs from `HolidaysToEvents` to the end of the run. That covers the whole utf8mb4 conversion, which on a real forum is the longest and most easily interrupted part of upgrading.

Each of the three now looks for the table before touching it. `CalendarUpdates` does nothing else, so it is skipped whole by an `isCandidate()`. `FixDates` and `PostgreSqlSequences` have other tables to attend to, so only the statements naming this one are passed over, and both keep advancing their start counter so the numbering of the steps around them does not shift.

#### How this was found, and how it was verified

`.docker/interrupt-upgrade.sh` (#9622) kills the upgrader at a chosen substep, starts it again, and compares the forum it ends up with against one that was never interrupted. The kill points happened to straddle the boundary, which makes the cause unambiguous:

| engine | killed during | `HolidaysToEvents` had run | before | after |
| --- | --- | --- | --- | --- |
| MySQL | `EditHistory` | no | recovered in 1 run | recovered in 1 run |
| MySQL | `smf_members` utf8mb4 | yes | **dead after 4 attempts** — `Table 'smf.smf_calendar_holidays' doesn't exist` | recovered in 1 run |
| PostgreSQL | `smf_membergroups` normalize | no | recovered in 1 run | recovered in 1 run |
| PostgreSQL | `smf_permissions` normalize | yes | **dead after 4 attempts** — `relation "smf_calendar_holidays" does not exist` | recovered in 1 run |

Against the 2.1.7 baseline from the 2.1 development environment, on both engines.

Note that on PostgreSQL it fails at `PostgreSqlSequences`, which is the very first substep of the entire upgrade, and on MySQL at `FixDates` a little further in. Both are the same bug.

#### What this does not fix

The upgrade now finishes, but an interrupted run still does not land on exactly the schema an uninterrupted one produces, and this does not claim to fix that. What is left, with all of the above applied:

- On PostgreSQL, two tables with their columns in a different physical order, a leftover 2.1-named `smf_log_actions_id_topic_id_log`, and `smf_scheduled_tasks_idx_task` (UNIQUE) missing.
- On MySQL, some indexes listed in a different order, and narrower text columns than a clean run gives — `messages.body` comes out `mediumtext` rather than `longtext` — because interrupting the utf8mb4 conversion changes how many times each table is widened by it.

Those are worth their own report. They only became visible once recovery completed at all, since before this the run simply died. They are also an argument for the upgrader recording where it had reached rather than starting from the top, which is a much larger change than this one.

#### Not reachable from the unit suite

`tests/bootstrap.php` provides no database, and these migrations do nothing but talk to one — `list_tables()`, `setval`, `change_column`. There is no way to cover them without faking a connection, so this is verified by running real upgrades against both engines rather than by a test.

### Issues References (Fixes|Related|Closes)
1. Related: #9622 -- the check that found this
2. Related: #9302 -- needed before a 2.1 to 3.0 upgrade completes at all
