### PR TITLE
[3.0] Fix the cache accelerators and cover them with tests

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -23,7 +23,11 @@ jobs:
         uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 #2.37.2
         with:
           php-version: ${{ matrix.php }}
-          extensions: fileinfo, mbstring
+          # apcu and sqlite3 back two of the cache accelerators. Without them
+          # those tests skip rather than fail, which reads as a green run that
+          # covered more than it did.
+          extensions: fileinfo, mbstring, apcu, sqlite3
+          ini-values: apc.enable_cli=1
           coverage: none
 
       - name: Cache Composer packages

--- a/Sources/Cache/APIs/FileBased.php
+++ b/Sources/Cache/APIs/FileBased.php
@@ -120,23 +120,31 @@ class FileBased extends CacheApi implements CacheApiInterface
 
 			return true;
 		}
-			$cache_data = json_encode(
-				[
-					'expiration' => time() + $ttl,
-					'value' => $value,
-				],
-				JSON_NUMERIC_CHECK,
-			);
+		$cache_data = json_encode(
+			[
+				'expiration' => time() + $ttl,
+				'value' => $value,
+			],
+			JSON_NUMERIC_CHECK,
+		);
 
-			// Write out the cache file, check that the cache write was successful; all the data must be written
-			// If it fails due to low diskspace, or other, remove the cache file
-			if ($this->writeFile($file, $cache_data) !== \strlen($cache_data)) {
-				@unlink($file);
+		// Anything json_encode cannot represent, such as a string that is not
+		// valid UTF-8, simply does not get cached.
+		if ($cache_data === false) {
+			@unlink($file);
 
-				return false;
-			}
+			return false;
+		}
 
-			return true;
+		// Write out the cache file, check that the cache write was successful; all the data must be written
+		// If it fails due to low diskspace, or other, remove the cache file
+		if ($this->writeFile($file, $cache_data) !== \strlen($cache_data)) {
+			@unlink($file);
+
+			return false;
+		}
+
+		return true;
 
 	}
 

--- a/Sources/Cache/APIs/MemcachedImplementation.php
+++ b/Sources/Cache/APIs/MemcachedImplementation.php
@@ -235,6 +235,7 @@ class MemcachedImplementation extends CacheApi implements CacheApiInterface
 			}
 		}
 
-		return $retVal;
+		// The bitwise or above produces an int, which this method does not return.
+		return (bool) $retVal;
 	}
 }

--- a/Sources/Cache/APIs/Sqlite.php
+++ b/Sources/Cache/APIs/Sqlite.php
@@ -98,10 +98,8 @@ class Sqlite extends CacheApi implements CacheApiInterface
 				$this->cacheDB->exec('PRAGMA journal_mode = wal;');
 			}
 
-			if (filesize($database) == 0) {
-				$this->cacheDB->exec('CREATE TABLE cache (key text unique, value blob, ttl int);');
-				$this->cacheDB->exec('CREATE INDEX ttls ON cache(ttl);');
-			}
+			$this->cacheDB->exec('CREATE TABLE IF NOT EXISTS cache (key text unique, value blob, ttl int);');
+			$this->cacheDB->exec('CREATE INDEX IF NOT EXISTS ttls ON cache(ttl);');
 
 			return true;
 		} catch (\Exception $ex) {

--- a/Sources/Cache/CacheApi.php
+++ b/Sources/Cache/CacheApi.php
@@ -624,11 +624,7 @@ abstract class CacheApi
 		}
 
 		if (\is_string($value)) {
-			try {
-				$temp = @unserialize($value);
-			} catch (\Throwable $e) {
-				$temp = false;
-			}
+			$temp = @unserialize($value);
 
 			// Only serialize(false) legitimately unserializes to false. Anything
 			// else that does so is a truncated or corrupt entry, so report a miss

--- a/Sources/Cache/CacheApi.php
+++ b/Sources/Cache/CacheApi.php
@@ -626,9 +626,18 @@ abstract class CacheApi
 		if (\is_string($value)) {
 			try {
 				$temp = @unserialize($value);
-				$value = $temp;
 			} catch (\Throwable $e) {
+				$temp = false;
 			}
+
+			// Only serialize(false) legitimately unserializes to false. Anything
+			// else that does so is a truncated or corrupt entry, so report a miss
+			// rather than handing the caller a value nobody stored.
+			if ($temp === false && $value !== serialize(false)) {
+				return null;
+			}
+
+			$value = $temp;
 		}
 
 		return $value;

--- a/tests/Unit/CacheApiTest.php
+++ b/tests/Unit/CacheApiTest.php
@@ -9,6 +9,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use SMF\Cache\APIs\Apcu;
 use SMF\Cache\APIs\FileBased;
+use SMF\Cache\APIs\MemcachedImplementation;
 use SMF\Cache\APIs\Sqlite;
 use SMF\Cache\CacheApi;
 use SMF\Config;
@@ -16,12 +17,13 @@ use SMF\Config;
 /**
  * Covers the accelerators that need nothing but a writable directory, which is
  * FileBased, Sqlite and, where the extension is installed, APCu. The memcached
- * and PostgreSQL accelerators want a server and a database connection, so they
- * are out of reach from here.
+ * and PostgreSQL accelerators want a server and a database connection, so only
+ * the part of memcached that runs without one is reached from here.
  */
 #[CoversClass(CacheApi::class)]
 #[CoversClass(Apcu::class)]
 #[CoversClass(FileBased::class)]
+#[CoversClass(MemcachedImplementation::class)]
 #[CoversClass(Sqlite::class)]
 final class CacheApiTest extends TestCase
 {
@@ -165,6 +167,23 @@ final class CacheApiTest extends TestCase
 		CacheApi::put('a_cached_false', false, 120);
 
 		$this->assertFalse(CacheApi::get('a_cached_false', 120));
+	}
+
+	/**
+	 * Adding a server or-ed a bool into a bool, which PHP hands back as an int,
+	 * and the method says it returns a bool. Every page load fatalled the moment
+	 * memcached was the chosen accelerator. No server is needed to see it, since
+	 * addServer() only records where the server is meant to be.
+	 */
+	public function testTheMemcachedAcceleratorConnects(): void
+	{
+		if (!class_exists('Memcached')) {
+			$this->markTestSkipped('The memcached extension is not installed.');
+		}
+
+		Config::$cache_memcached = '127.0.0.1:11211';
+
+		$this->assertTrue((new MemcachedImplementation())->connect());
 	}
 
 	/***********************

--- a/tests/Unit/CacheApiTest.php
+++ b/tests/Unit/CacheApiTest.php
@@ -1,0 +1,241 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SMF\Tests\Unit;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use SMF\Cache\APIs\Apcu;
+use SMF\Cache\APIs\FileBased;
+use SMF\Cache\APIs\Sqlite;
+use SMF\Cache\CacheApi;
+use SMF\Config;
+
+/**
+ * Covers the accelerators that need nothing but a writable directory, which is
+ * FileBased, Sqlite and, where the extension is installed, APCu. The memcached
+ * and PostgreSQL accelerators want a server and a database connection, so they
+ * are out of reach from here.
+ */
+#[CoversClass(CacheApi::class)]
+#[CoversClass(Apcu::class)]
+#[CoversClass(FileBased::class)]
+#[CoversClass(Sqlite::class)]
+final class CacheApiTest extends TestCase
+{
+	/*********************
+	 * Internal properties
+	 *********************/
+
+	/**
+	 * @var string A directory of this test's own, thrown away afterwards.
+	 */
+	private string $cachedir;
+
+	/**
+	 * @var array The Config values this test overwrites.
+	 */
+	private array $config = [];
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	public function setUp(): void
+	{
+		$this->cachedir = sys_get_temp_dir() . '/smf_cache_test_' . bin2hex(random_bytes(8));
+		mkdir($this->cachedir, 0777, true);
+
+		// The prefix is derived from this file's mtime, so it has to exist.
+		touch($this->cachedir . '/index.php');
+
+		foreach (['cachedir', 'cachedir_sqlite', 'cache_sqlite_wal', 'cache_memcached', 'db_persist'] as $key) {
+			$this->config[$key] = Config::${$key} ?? null;
+		}
+
+		Config::$cachedir = $this->cachedir;
+		Config::$cachedir_sqlite = $this->cachedir;
+		Config::$cache_sqlite_wal = false;
+		Config::$cache_memcached = '';
+		Config::$db_persist = false;
+
+		CacheApi::$enable = 3;
+	}
+
+	public function tearDown(): void
+	{
+		if (\is_object(CacheApi::$loadedApi)) {
+			CacheApi::$loadedApi->quit();
+		}
+
+		CacheApi::$loadedApi = null;
+
+		// Static properties survive between tests, so a level left behind here
+		// would silently switch caching on for everything that follows.
+		CacheApi::$enable = 0;
+
+		Config::$cachedir = $this->config['cachedir'] ?? $this->cachedir;
+		Config::$cachedir_sqlite = Config::$cachedir;
+		Config::$cache_sqlite_wal = $this->config['cache_sqlite_wal'] ?? false;
+		Config::$cache_memcached = $this->config['cache_memcached'] ?? '';
+		Config::$db_persist = $this->config['db_persist'] ?? false;
+
+		foreach (glob($this->cachedir . '/*') ?: [] as $file) {
+			unlink($file);
+		}
+
+		rmdir($this->cachedir);
+	}
+
+	#[DataProvider('accelerators')]
+	public function testAnAcceleratorReturnsWhatWasPutIntoIt(string $class): void
+	{
+		$this->loadApi($class);
+
+		foreach (self::cacheableValues() as $label => $value) {
+			CacheApi::put('round_trip', $value, 120);
+
+			$this->assertSame($value, CacheApi::get('round_trip', 120), $label . ' did not survive ' . $class);
+		}
+	}
+
+	#[DataProvider('accelerators')]
+	public function testAnObjectComesBackAsAnEqualObject(string $class): void
+	{
+		$this->loadApi($class);
+
+		$object = new \stdClass();
+		$object->greeting = 'hello';
+
+		CacheApi::put('an_object', $object, 120);
+
+		$this->assertEquals($object, CacheApi::get('an_object', 120));
+	}
+
+	#[DataProvider('accelerators')]
+	public function testPuttingNullRemovesTheEntry(string $class): void
+	{
+		$this->loadApi($class);
+
+		CacheApi::put('to_be_removed', 'here', 120);
+		CacheApi::put('to_be_removed', null, 120);
+
+		$this->assertNull(CacheApi::get('to_be_removed', 120));
+	}
+
+	#[DataProvider('accelerators')]
+	public function testAKeyThatWasNeverStoredIsAMiss(string $class): void
+	{
+		$this->loadApi($class);
+
+		$this->assertNull(CacheApi::get('never_stored_' . bin2hex(random_bytes(4)), 120));
+	}
+
+	#[DataProvider('accelerators')]
+	public function testCleaningTheCacheEmptiesIt(string $class): void
+	{
+		$this->loadApi($class);
+
+		CacheApi::put('survives_a_clean', 'here', 120);
+		CacheApi::clean();
+
+		$this->assertNull(CacheApi::get('survives_a_clean', 120));
+	}
+
+	/**
+	 * APCu is left out because it reads a time to live of zero or less as
+	 * "never expires" rather than as a moment already past.
+	 */
+	#[DataProvider('acceleratorsWithARelativeTtl')]
+	public function testAnEntryIsGoneOnceItsTimeToLiveHasPassed(string $class): void
+	{
+		$this->loadApi($class);
+
+		CacheApi::put('already_stale', 'here', -1);
+
+		$this->assertNull(CacheApi::get('already_stale', 120));
+	}
+
+	public function testACachedFalseIsStillReadBackAsFalse(): void
+	{
+		$this->loadApi(FileBased::class);
+
+		CacheApi::put('a_cached_false', false, 120);
+
+		$this->assertFalse(CacheApi::get('a_cached_false', 120));
+	}
+
+	/***********************
+	 * Public static methods
+	 ***********************/
+
+	public static function accelerators(): array
+	{
+		return [
+			'file based' => [FileBased::class],
+			'sqlite' => [Sqlite::class],
+			'apcu' => [Apcu::class],
+		];
+	}
+
+	public static function acceleratorsWithARelativeTtl(): array
+	{
+		return [
+			'file based' => [FileBased::class],
+			'sqlite' => [Sqlite::class],
+		];
+	}
+
+	/**
+	 * The shapes SMF puts in the cache, plus the values that are easy to confuse
+	 * with a miss.
+	 */
+	public static function cacheableValues(): array
+	{
+		return [
+			'an array' => ['a' => 1, 'b' => [2, 3]],
+			'a string' => 'hello world',
+			'a numeric string' => '0123',
+			'the number zero' => 0,
+			'a float' => 1.5,
+			'false' => false,
+			'an empty string' => '',
+			'an empty array' => [],
+			'multibyte text' => ['t' => 'Grüße 日本語'],
+			'a quarter of a megabyte' => str_repeat('x', 262144),
+		];
+	}
+
+	/******************
+	 * Internal methods
+	 ******************/
+
+	/**
+	 * Puts an accelerator behind the CacheApi facade, or skips the test when it
+	 * cannot run here.
+	 */
+	private function loadApi(string $class): CacheApi
+	{
+		// APCu stores nothing at all unless it is switched on for the SAPI in use.
+		if ($class === Apcu::class && \PHP_SAPI === 'cli' && !filter_var(\ini_get('apc.enable_cli'), FILTER_VALIDATE_BOOLEAN)) {
+			$this->markTestSkipped('APCu is not enabled for the CLI SAPI.');
+		}
+
+		/** @var \SMF\Cache\CacheApiInterface&CacheApi $api */
+		$api = new $class();
+
+		if (!$api->isSupported(true)) {
+			$this->markTestSkipped($class . ' is not supported in this environment.');
+		}
+
+		if ($api->connect() === false) {
+			$this->markTestSkipped($class . ' could not connect.');
+		}
+
+		CacheApi::$loadedApi = $api;
+
+		return $api;
+	}
+}

--- a/tests/Unit/CacheApiTest.php
+++ b/tests/Unit/CacheApiTest.php
@@ -190,6 +190,24 @@ final class CacheApiTest extends TestCase
 		$this->assertNull(CacheApi::get('not_utf8', 120));
 	}
 
+	/**
+	 * A truncated entry unserialises to false, which is also what a cached false
+	 * looks like. Telling them apart is the difference between a miss and handing
+	 * the caller a value nobody ever stored.
+	 */
+	public function testAnEntryThatWillNotUnserialiseReadsAsAMiss(): void
+	{
+		/** @var \SMF\Cache\APIs\FileBased $api */
+		$api = $this->loadApi(FileBased::class);
+
+		file_put_contents(
+			\sprintf('%s/data_%s.cache', $api->getCachedir(), $api->getPrefix() . 'corrupt'),
+			(string) json_encode(['expiration' => time() + 120, 'value' => 'not serialised at all']),
+		);
+
+		$this->assertNull(CacheApi::get('corrupt', 120));
+	}
+
 	public function testACachedFalseIsStillReadBackAsFalse(): void
 	{
 		$this->loadApi(FileBased::class);

--- a/tests/Unit/CacheApiTest.php
+++ b/tests/Unit/CacheApiTest.php
@@ -176,6 +176,20 @@ final class CacheApiTest extends TestCase
 		$this->assertSame(['a' => 1], CacheApi::get('written_ahead', 120));
 	}
 
+	/**
+	 * The file cache stores JSON, and json_encode() returns false rather than a
+	 * string for anything that is not valid UTF-8. Handing that on to the writer
+	 * took the request down with a TypeError; a value it cannot store is a miss.
+	 */
+	public function testAValueTheFileCacheCannotEncodeIsAMissRatherThanAFatal(): void
+	{
+		$this->loadApi(FileBased::class);
+
+		CacheApi::put('not_utf8', ['blob' => "\x80\xFE\xFF"], 120);
+
+		$this->assertNull(CacheApi::get('not_utf8', 120));
+	}
+
 	public function testACachedFalseIsStillReadBackAsFalse(): void
 	{
 		$this->loadApi(FileBased::class);

--- a/tests/Unit/CacheApiTest.php
+++ b/tests/Unit/CacheApiTest.php
@@ -160,6 +160,22 @@ final class CacheApiTest extends TestCase
 		$this->assertNull(CacheApi::get('already_stale', 120));
 	}
 
+	/**
+	 * Turning on write ahead logging used to leave the SQLite accelerator with
+	 * no table at all: the pragma writes a header, so the emptiness test that
+	 * decided whether to create one never passed on a fresh database.
+	 */
+	public function testTheSqliteCacheStoresValuesWithWriteAheadLoggingOn(): void
+	{
+		Config::$cache_sqlite_wal = true;
+
+		$this->loadApi(Sqlite::class);
+
+		CacheApi::put('written_ahead', ['a' => 1], 120);
+
+		$this->assertSame(['a' => 1], CacheApi::get('written_ahead', 120));
+	}
+
 	public function testACachedFalseIsStillReadBackAsFalse(): void
 	{
 		$this->loadApi(FileBased::class);

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -64,4 +64,5 @@ SMF\Config::$packagesdir = SMF\Config::$boarddir . '/Packages';
 SMF\Config::$languagesdir = SMF\Config::$boarddir . '/Languages';
 SMF\Config::$cachedir = SMF\Config::$boarddir . '/cache';
 SMF\Config::$language = 'en_US';
+SMF\Config::$boardurl = 'test.local';
 SMF\Config::$scripturl = 'test.local/index.php';


### PR DESCRIPTION
#### Description

Four separate faults in the cache accelerators, each as its own commit carrying its own regression test. A first commit adds tests for the behaviour that already worked, so the four that follow are readable as fix + proof.

**Memcached made the forum unreachable.** `addServers()` accumulates its result with `$retVal |= $this->memcached->addServer(...)`. PHP evaluates a bitwise or of two booleans as an `int`, and the method declares it returns `bool` under `strict_types`, so the return threw:

```
Uncaught TypeError: MemcachedImplementation::addServers(): Return value must be of type bool, int returned
```

That happens inside `CacheApi::load()`, which is reached from `Config::reloadModSettings()` during startup, so every request died before producing any output. Choosing memcached in the ACP took the site down. The fallback to the file cache sitting next to it only catches `connect()` returning false, so an exception thrown from within is caught by nothing.

**SQLite stored nothing when write ahead logging was on.** The table was created only when the database file was zero bytes, standing in for "this database is new". The WAL pragma runs two lines earlier and writes a 4096 byte header, so on a fresh database the file is no longer empty by the time the check runs and the table is never created. Every read was a miss and every write threw, which `connect()` logs once and then swallows, so the only symptom was a cache that never held anything. Asking for the table with `IF NOT EXISTS` says what was meant and does not depend on the file's size.

**The file cache fatalled on data it could not encode.** Entries are written as JSON, and `json_encode()` returns `false` for anything it cannot represent — a string that is not valid UTF-8 above all. That `false` went straight on to the writer:

```
TypeError: str_split(): Argument #1 ($string) must be of type string, false given
```

Caching is documented as something that may miss and must not be depended on, so a value the store cannot hold simply does not get cached. It is not a reason to take the page down. The reachable case is a forum whose text is not clean UTF-8, which an upgrade from an older charset can easily leave behind.

**A corrupt entry read back as `false`.** `CacheApi::get()` returns whatever `unserialize()` gives it, and that is `false` both for a value somebody deliberately cached and for one that cannot be read at all — so a damaged entry was handed to the caller as a value nobody ever stored. That is reachable rather than theoretical: `SQLite3::escapeString()` is not binary safe and PostgreSQL `text` columns cannot hold a null byte, so either accelerator can truncate an entry at the first one and store the fragment, which then reads back as `false`. Only `serialize(false)` legitimately unserialises to `false`, so comparing against it separates the two and everything else reports a miss — a state every caller already handles, because that is what an expired or evicted entry looks like.

#### How this was checked

Each accelerator was driven through the `CacheApi` facade over a matrix of the values SMF actually caches, plus the ones easily confused with a miss. After these fixes FileBased, APCu, SQLite with and without WAL, memcached and PostgreSQL all round-trip every one of them.

Reverting `Sources/Cache` on this branch and running the suite fails exactly these four tests, each with its own symptom, while the shared behaviour tests stay green.

#### Notes for review

`Config::$boardurl` joins the bootstrap because `CacheApi::setPrefix()` reads it, and a typed static that nothing has assigned throws when it is read. It lands beside `Config::$scripturl`, which is already there for the same reason.

The tests cover FileBased, Sqlite and APCu, which need nothing but a writable directory. The memcached test needs the extension but no server, because `addServer()` only records where a server is meant to be and connects lazily; it skips where the extension is absent, as it will be on CI. The PostgreSQL accelerator needs a live database connection and is out of reach of the unit suite, so it was verified by hand against a running PostgreSQL instead.

`Sources/Cache/CacheApi.php` is also touched by #9302, at the `$enable` declaration and in `load()`. This changes `get()` instead, so the two do not overlap.

The file cache commit is larger than its fix: the block it edits sits one indent level too deep, a leftover from an `if`/`else` that went away, and straightening it moves lines the change itself does not.

### Issues References (Fixes|Related|Closes)
1. No issue filed; these came out of testing whether the cache accelerators still work. Happy to file one report per fault if that is preferred.
2. Related: #9302 touches the same file at different lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
