### PR TITLE
[3.0] Build a Time before the user is loaded

### DIFF
--- a/Sources/Time.php
+++ b/Sources/Time.php
@@ -188,7 +188,7 @@ class Time extends \DateTime implements \ArrayAccess
 	public function __construct(string $datetime = 'now', \DateTimeZone|string|null $timezone = null)
 	{
 		if (!isset(self::$user_tz)) {
-			self::$user_tz = TimeZone::create(User::$me->timezone);
+			self::$user_tz = TimeZone::create(User::$me?->timezone ?? Config::$modSettings['default_timezone'] ?? date_default_timezone_get());
 		}
 
 		if (\is_string($timezone)) {

--- a/tests/Unit/TimeTest.php
+++ b/tests/Unit/TimeTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SMF\Tests\Unit;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use SMF\Config;
+use SMF\Time;
+use SMF\TimeZone;
+use SMF\User;
+
+#[CoversClass(Time::class)]
+class TimeTest extends TestCase
+{
+	/*********************
+	 * Internal properties
+	 *********************/
+
+	/**
+	 * @var bool Whether Config::$modSettings had a default time zone already.
+	 */
+	private bool $had_default_timezone;
+
+	/**
+	 * @var string The forum's default time zone as it was before the test ran.
+	 */
+	private string $default_timezone;
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	public function testItFallsBackToTheForumsDefaultTimeZoneBeforeTheUserIsLoaded(): void
+	{
+		// A request can build a date before User::$me exists: redirecting from
+		// '?msg=1' to the topic that message is in happens in cleanRequest(),
+		// which runs long before the user is loaded, and cron.php never loads a
+		// user at all. Reading User::$me then is a fatal error rather than an
+		// empty value, so the constructor has to manage without it.
+		$this->assertFalse(isset(User::$me));
+
+		// The constructor only consults User::$me while it has no time zone
+		// worked out yet, so this has to be the first Time built in the run for
+		// the assertion below to mean anything. A typed static cannot be put
+		// back into its uninitialised state, so check the precondition instead
+		// of resetting it: a later change that builds a Time earlier should
+		// fail here rather than quietly stop testing anything.
+		$this->assertFalse((new \ReflectionProperty(Time::class, 'user_tz'))->isInitialized());
+
+		$time = new Time('@1785441064');
+
+		$this->assertSame(1785441064, $time->getTimestamp());
+
+		// The forum's default time zone stands in for the one we cannot ask for.
+		$this->assertSame('Pacific/Auckland', $time->getTimezone()->getName());
+	}
+
+	public function testAnExplicitTimeZoneIsUsedAsGiven(): void
+	{
+		$this->assertSame(
+			'Asia/Tokyo',
+			(new Time('@1785441064', 'Asia/Tokyo'))->getTimezone()->getName(),
+		);
+	}
+
+	/******************
+	 * Internal methods
+	 ******************/
+
+	protected function setUp(): void
+	{
+		$this->had_default_timezone = isset(Config::$modSettings['default_timezone']);
+		$this->default_timezone = (string) (Config::$modSettings['default_timezone'] ?? '');
+
+		Config::$modSettings['default_timezone'] = 'Pacific/Auckland';
+	}
+
+	protected function tearDown(): void
+	{
+		if ($this->had_default_timezone) {
+			Config::$modSettings['default_timezone'] = $this->default_timezone;
+		} else {
+			unset(Config::$modSettings['default_timezone']);
+		}
+
+		// Time remembers the first time zone it works out for the rest of the
+		// process, so hand the suite back the one it would have had if this
+		// test had never run.
+		(new \ReflectionProperty(Time::class, 'user_tz'))
+			->setValue(null, TimeZone::create(date_default_timezone_get()));
+	}
+}


### PR DESCRIPTION
#### Description

A direct link to a post (`?msg=6000`, or `msgs/6000`) is a 500 when queryless URLs are turned on:

```
PHP Fatal error:  Uncaught Error: Typed static property SMF\User::$me must not be accessed before initialization in Sources/Time.php:191
#0 Sources/Time.php(773): SMF\Time->__construct()
#1 Sources/Topic.php(1982): SMF\Time::create()
#2 Sources/Topic.php(827): SMF\Topic->loadTopicInfo()
#3 Sources/Topic.php(1831): SMF\Topic::load()
#4 Sources/QueryString.php(502): SMF\Topic::buildRoute()
...
#10 Sources/QueryString.php(167): SMF\QueryString::redirectFromMsg()
#11 Sources/Forum.php(413): SMF\QueryString::cleanRequest()
```

The chain is: `cleanRequest()` calls `redirectFromMsg()`, which looks up the topic the message is in and redirects to it. `Utils::redirectexit()` then runs the target through `QueryString::rewriteAsQueryless()`, which asks `Topic::buildRoute()` for the route, and on a slug cache miss that loads the topic. All of this happens in `Forum::__construct()`, well before `User::loadMe()`.

`Topic::loadTopicInfo()` is already written to survive being called without a user — it guards `User::$me` with `isset()` in four places. The one thing it does unguarded is build a `Time` for the topic's start date, and `Time::__construct()` reads `User::$me->timezone`. `User::$me` is a typed static with no default, so reading it before it is assigned is a fatal error rather than an empty value.

The read now falls through to the forum's default time zone, and then to PHP's, rather than throwing.

Fixing it in `Time` rather than in `Topic::loadTopicInfo()` covers the general case, and there is at least one other case: `cron.php` never loads a user at all — `TaskRunner` sets `User::$sc` and nothing else — so `Tasks\PaidSubs.php:104`, which builds a `Time` for the reminder email's `END_DATE`, was reaching the same fatal by a different road.

Verified on the Docker environment with `queryless_urls` enabled: `?msg=6000` and `msgs/6000` both 302 to `topics/<slug>-1187/msg6000#msg6000` and render, and `smf_log_errors` stays empty.

`tests/Unit/TimeTest.php` is new. Its regression test errors with the reported fatal before the change and passes after it. Note that `Time` caches the zone it works out in `Time::$user_tz`, and a typed static cannot be put back into its uninitialised state, so only the first `Time` built in a process exercises this path — the test asserts that precondition explicitly, so that if something later builds a `Time` earlier it fails rather than quietly passing while testing nothing.

### Issues References (Fixes|Related|Closes)
1. Fixes #9634

🤖 Generated with [Claude Code](https://claude.com/claude-code)
