### PR TITLE
[3.0] fix fatal error when routing unexpected but  well-formed query string

### DIFF
--- a/Sources/QueryString.php
+++ b/Sources/QueryString.php
@@ -497,7 +497,7 @@ class QueryString
 
 		IntegrationHook::call('integrate_build_route', [&$route_base, $params]);
 
-		if (\is_string(self::getRouteParser($route_base))) {
+		if (isset($route_base) && \is_string(self::getRouteParser($route_base))) {
 			// This call to extract will set new values of $route and $params.
 			extract(\call_user_func(self::getRouteParser($route_base) . '::buildRoute', $params));
 		}


### PR DESCRIPTION
A post containing 

```
http://localhost/smf-dev/index.php/?sa=basic
```

crashes the request with a 500 when Friendly URLs are enabled.

Found while working on #9610.

```

There was 1 error:

1) SMF\Tests\Unit\ActionRouterTest::testRoute@unknown action with data ('/confuse_me_not/?foo=bar', ['bar'])
TypeError: SMF\QueryString::getRouteParser(): Argument #1 ($route_base) must be of type string, null given, called in C:\Users\John\repos\SMF2.1\Sources\QueryString.php on line 500

C:\Users\John\repos\SMF2.1\Sources\QueryString.php:447
C:\Users\John\repos\SMF2.1\Sources\QueryString.php:500
C:\Users\John\repos\SMF2.1\tests\Unit\AbstractRouteTestCase.php:40
```