### PR TITLE
[3.0] Imports the schema namespace FixDates now names

### DIFF
--- a/Sources/Maintenance/Migration/v2_1/FixDates.php
+++ b/Sources/Maintenance/Migration/v2_1/FixDates.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 namespace SMF\Maintenance\Migration\v2_1;
 
 use SMF\Db\DatabaseApi as Db;
+use SMF\Db\Schema;
 use SMF\Maintenance\Maintenance;
 use SMF\Maintenance\Migration\MigrationBase;
 


### PR DESCRIPTION
#### Description

A 2.1 forum cannot be upgraded on `release-3.0` at the moment. The upgrade stops at the sixth substep of the migration step:

```
 +++ Fixing dates... ..failed with error:
     "Class "SMF\Maintenance\Migration\v2_1\Schema\v2_1\CalendarHolidays" not found"
stopped at step 4 of 7 (Migrations)
```

`FixDates` checks whether the holidays table is still there before touching it, and since c114b26a2 it does so by constructing `Schema\v2_1\CalendarHolidays` and calling `exists()`. The file has no `use SMF\Db\Schema;`, so the name resolves relative to the current namespace — `SMF\Maintenance\Migration\v2_1\Schema\v2_1\CalendarHolidays` — which does not exist.

`CalendarUpdates` was changed in the same commit to do the same thing and does have the import, which is why only this one file fails.

Every attempt reaches exactly the same substep, so this is not recoverable by retrying.

#### How this was verified

Against the 2.1.7 baseline from the 2.1 development environment, using `.docker/rerun-upgrade.sh` from #9622:

| | before | after |
| --- | --- | --- |
| CLI upgrade, 2.1.7 baseline | dies at substep 6, database left at 2.1.7 | runs to completion |

Note that the upgrade completing is not the same as it being correct — see the separate report about the migration batches, which this fix uncovers rather than causes.

#### Not reachable from the unit suite

`tests/bootstrap.php` provides no database, and the code path is a migration doing nothing but talk to one. It is also not something `phplint` can see, since the class name is only resolved at runtime. Running an upgrade is what catches it.

### Issues References (Fixes|Related|Closes)
1. Related: #9626, which added the guard that c114b26a2 then rewrote.
2. Related: #9622, the check this was found with.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
