### PR TITLE
[3.0] Keeps the substep count across the migration batches

### DIFF
--- a/Sources/Maintenance/Tools/Upgrade.php
+++ b/Sources/Maintenance/Tools/Upgrade.php
@@ -1105,6 +1105,12 @@ class Upgrade extends ToolsBase implements ToolsInterface
 			return true;
 		}
 
+		// Every batch is built before any of them runs, because the substep
+		// counter spans the whole step: it lives in the query string, one
+		// request advances it by one, and the batch a given number falls in is
+		// only known once the sizes of the batches before it are.
+		$batches = [];
+
 		foreach (self::VERSION_MAP as $search => $ns) {
 			$substeps = [];
 
@@ -1124,9 +1130,18 @@ class Upgrade extends ToolsBase implements ToolsInterface
 				);
 			}
 
-			if (!$this->performSubsteps($substeps)) {
+			$batches[$search] = $substeps;
+		}
+
+		$total = array_sum(array_map('count', $batches));
+		$offset = 0;
+
+		foreach ($batches as $search => $substeps) {
+			if (!$this->performSubsteps($substeps, $offset, $total)) {
 				return false;
 			}
+
+			$offset += \count($substeps);
 
 			// Update Config::$modSettings['smfVersion'] incrementally as we go.
 			// This lets us avoid redoing unnecessary migration steps if the
@@ -1600,17 +1615,29 @@ class Upgrade extends ToolsBase implements ToolsInterface
 	/**
 	 * Performs a series of substeps.
 	 *
+	 * The current substep is counted across the whole step rather than within
+	 * one call, because it lives in the query string and is all the browser
+	 * has to say where it had got to. A step that runs its substeps in more
+	 * than one batch therefore passes the number of substeps the earlier
+	 * batches held, so that this one can find its own place in that count.
+	 *
 	 * @param array $substeps All substep objects that we are running.
+	 * @param int $offset How many substeps of this step ran before this batch.
+	 * @param ?int $total Substeps in the whole step, when that is more than are
+	 *    in this batch. Defaults to the size of this batch.
 	 * @return bool True if we are done, false if we need to timeout and wait.
 	 */
-	private function performSubsteps(array $substeps): bool
+	private function performSubsteps(array $substeps, int $offset = 0, ?int $total = null): bool
 	{
-		Maintenance::$total_substeps = \count($substeps);
+		Maintenance::$total_substeps = $total ?? \count($substeps);
+
+		// Where this batch has got to, as opposed to the step as a whole.
+		$position = Maintenance::getCurrentSubStep() - $offset;
 
 		// We are preparing for templating.
 		if (!Sapi::isCLI() && !Maintenance::isJson()) {
 			Utils::$context['continue'] = true;
-			Utils::$context['current_substep'] = $substeps[Maintenance::getCurrentSubStep()]->name ?? '';
+			Utils::$context['current_substep'] = $substeps[$position]->name ?? '';
 
 			return false;
 		}
@@ -1649,8 +1676,8 @@ class Upgrade extends ToolsBase implements ToolsInterface
 		 * When success occurs, ensure it moves to next stesp.
 		 * When error occurs, ensure we properly show the error.
 		 */
-		while (Maintenance::getCurrentSubStep() < Maintenance::$total_substeps) {
-			$substep = $substeps[Maintenance::getCurrentSubStep()];
+		while (Maintenance::getCurrentSubStep() - $offset < \count($substeps)) {
+			$substep = $substeps[Maintenance::getCurrentSubStep() - $offset];
 
 			$this->logProgress(' +++ ' . $substep->name, true);
 
@@ -1663,7 +1690,7 @@ class Upgrade extends ToolsBase implements ToolsInterface
 
 					Maintenance::jsonResponse([
 						'name' => $substep->name,
-						'next' => $substeps[Maintenance::getCurrentSubStep()]->name ?? '',
+						'next' => $substeps[Maintenance::getCurrentSubStep() - $offset]->name ?? '',
 						'skipped' => true,
 						'substep' => Maintenance::getCurrentSubStep(),
 						'start' => Maintenance::getCurrentStart(),
@@ -1742,7 +1769,7 @@ class Upgrade extends ToolsBase implements ToolsInterface
 			if (Maintenance::isJson()) {
 				Maintenance::jsonResponse([
 					'name' => $substep->name,
-					'next' => $substeps[Maintenance::getCurrentSubStep()]->name ?? '',
+					'next' => $substeps[Maintenance::getCurrentSubStep() - $offset]->name ?? '',
 					'completed' => true,
 					'substep' => Maintenance::getCurrentSubStep(),
 					'start' => Maintenance::getCurrentStart(),


### PR DESCRIPTION
#### Description

Since #9639, a 2.1 → 3.0 upgrade runs none of the 3.0 migrations. It reports success and stamps the database as 3.0 Alpha 4, but the database is still structurally 2.1.

#9639 gave each version namespace its own `performSubsteps()` call so that `smfVersion` could be updated as each batch finished. The substep counter it walks is not per-batch, though. It lives in the query string, `performSubsteps()` loops `while (Maintenance::getCurrentSubStep() < Maintenance::$total_substeps)`, and nothing resets it between calls. So:

| | substeps |
| --- | --- |
| batch 1, `v2_1` | 81 migrations + 73 `normalize()` = **154** |
| batch 2, `v3_0` | 22 migrations + 72 `normalize()` = **94** |

Batch 1 leaves the counter at 154. Batch 2 sets `$total_substeps` to 94 and loops `while (154 < 94)`, which never runs. All 22 v3_0 migrations and all 72 v3_0 table normalizations are skipped in silence, `performSubsteps()` returns true because the loop simply ended, and `finalize()` then writes the new version number over a 2.1 database.

Against the 2.1.7 baseline from the 2.1 development environment, on `release-3.0`:

| | before | after |
| --- | --- | --- |
| substeps in the migration step | 154 | **248** |
| `messages.edit_history` | missing | **present** |
| `members.spoofdetector_name` | missing | **present** |
| `calendar.rrule` | missing | **present** |
| `smf_calendar_holidays`, which `HolidaysToEvents` drops | still there | **gone** |
| `smfVersion` afterwards | 3.0 Alpha 4 | 3.0 Alpha 4 |

The last row is the reason this is worth catching quickly: nothing in the outcome says anything went wrong. A forum in that state then fails at runtime in as many ways as there are 3.0 features, and re-running the upgrader does repair it — by then only one namespace is selected, so the counter starts at 0 and the batch runs — which makes it look intermittent.

#### Why not simply reset the counter

Resetting it between batches fixes the command line and breaks the browser. There, `jsonResponse()` ends the request, so one substep is one request and the counter is the only thing carrying the position across them. A counter reset to 0 at the end of batch 1 means the next request re-enters `migrations()` from the top of `VERSION_MAP` with a number that now points back into batch 1, and the two batches alternate forever.

So the number has to stay unique across the whole step. `performSubsteps()` takes the count of everything that ran before its batch and finds its own place in it:

```php
while (Maintenance::getCurrentSubStep() - $offset < count($substeps)) {
    $substep = $substeps[Maintenance::getCurrentSubStep() - $offset];
```

Which means the batches have to be built before any of them runs, since the total is not known until they all are. That total is what `Maintenance::$total_substeps` is set to, so the progress bar and the template's `iTotalSubSteps` measure the whole step again rather than whichever batch is in hand.

A batch that has already been done is now skipped by the same arithmetic: its `$offset + count()` is below the counter, the loop does not run, and it returns true.

#### How this was verified

Against the 2.1.7 baseline from the 2.1 development environment, with #9644 applied so that the upgrade gets far enough to see any of this:

- `.docker/rerun-upgrade.sh` from #9622 — the second upgrade changes nothing, on MySQL.
- A command line upgrade — 248 substeps, every v3_0 migration in the log, the columns above present, `smf_calendar_holidays` gone.
- The upgrader loaded in a real browser — `iTotalSubSteps` reads **248** rather than 154, which is the number the template's JavaScript compares against to decide the step is finished. Under the current code it would stop at 154 believing it was done.

The browser could not be driven to the end here for an unrelated reason: `Maintenance::jsonResponse()` calls `ob_end_clean()` whether or not a buffer is open, and this environment runs with `output_buffering = 0`, so the notice it emits lands in the response before the JSON header and the JavaScript gets HTML. That is reported separately and reproduces without this change applied.

#### Not reachable from the unit suite

`tests/bootstrap.php` provides no database and no request, and this is a question about how a request-scoped counter behaves across several calls against a live database. Verified by running real upgrades on both engines instead.

### Issues References (Fixes|Related|Closes)
1. Related: #9639, which this repairs rather than reverts — the incremental `smfVersion` update it added is kept.
2. Related: #9622, the checks this was found with.
3. Related: #9644, which has to be in place before an upgrade gets far enough to see this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
