### PR TITLE
[3.0] Discards the output buffer only when there is one

### DIFF
--- a/Sources/Maintenance/Maintenance.php
+++ b/Sources/Maintenance/Maintenance.php
@@ -896,7 +896,15 @@ class Maintenance
 			return;
 		}
 
-		ob_end_clean();
+		// Only if there is one. Whether output is buffered at all depends on
+		// the server's output_buffering setting, and asking to discard a buffer
+		// that was never started raises a notice -- which is itself output, and
+		// so takes the header below with it and leaves the caller holding HTML
+		// where it expected JSON.
+		if (ob_get_level() > 0) {
+			ob_end_clean();
+		}
+
 		header('content-type: text/json; charset=UTF-8');
 
 		// TODO: Improve this, move debug to the root.

--- a/Sources/Maintenance/Maintenance.php
+++ b/Sources/Maintenance/Maintenance.php
@@ -896,11 +896,6 @@ class Maintenance
 			return;
 		}
 
-		// Only if there is one. Whether output is buffered at all depends on
-		// the server's output_buffering setting, and asking to discard a buffer
-		// that was never started raises a notice -- which is itself output, and
-		// so takes the header below with it and leaves the caller holding HTML
-		// where it expected JSON.
 		if (ob_get_level() > 0) {
 			ob_end_clean();
 		}


### PR DESCRIPTION
#### Description

Upgrading through a browser does not work on a server whose output buffering is off. The first substep fails and the upgrade never moves.

`Maintenance::jsonResponse()` throws away buffered output before sending its header, so that whatever a step printed on its way there does not end up in front of the JSON. It does that unconditionally:

```php
ob_end_clean();
header('content-type: text/json; charset=UTF-8');
```

Whether output is buffered at all is the server's decision. With `output_buffering` off — PHP's own default, and what the Docker development environment in `.docker/` runs with — there is no buffer to discard, `ob_end_clean()` raises a notice, and the notice *is* output, so the `header()` call after it cannot take effect:

```console
$ curl -s 'http://localhost:8080/upgrade.php?step=3;substep=0;start=0;json'
<br />
<b>Notice</b>:  ob_end_clean(): Failed to delete buffer. No buffer to delete in
<b>/var/www/html/Sources/Maintenance/Maintenance.php</b> on line <b>899</b><br />
<br />
<b>Warning</b>:  Cannot modify header information - headers already sent by ...
```

The upgrader's JavaScript asks for JSON once per substep. It gets that instead, logs `Response Error` to the console, and stops. The progress bar sits at 0% and nothing else happens, with no indication of why.

With the guard, the same request answers properly:

```console
{"success":true,"data":{"name":"Fixing sequences (PostgreSQL)","next":"Adding FIND_IN_SET function (PostgreSQL)","skipped":true,"substep":1,"start":0,"total":154},"debug":[]}
```

`ob_get_level()` is the ordinary way to ask, and the call is left exactly as it was when there is something to discard.

#### How this was verified

Against the 2.1.7 baseline from the 2.1 development environment, in a real browser rather than a script, since the fault is in what the browser's own JavaScript receives:

| | before | after |
| --- | --- | --- |
| `;json` response content type | `text/html`, with two PHP diagnostics | `text/json` |
| upgrader's JavaScript | `Response Error`, stalls at substep 0 | walks every substep |
| browser upgrade, 2.1.7 → 3.0 | never starts | runs to completion |

It reproduces on `release-3.0` with nothing else applied, and the container reports `output_buffering => 0`.

This is old: the line dates from the installer rewrite. It goes unnoticed because `php.ini-production` and `php.ini-development` both ship `output_buffering = 4096`, so a server built from either is unaffected — but a container or a hand-written `php.ini` that leaves it off has no working browser upgrade at all.

#### Not reachable from the unit suite

`beStrictAboutOutputDuringTests` means the suite cannot exercise a method whose whole purpose is to emit a response, and the behaviour depends on an ini setting and on headers, neither of which `tests/bootstrap.php` provides.

### Issues References (Fixes|Related|Closes)
1. Related: #9645, found while verifying that one in a browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
