### PR TITLE
[3.0] Waits for the clock the v7 UUID test is really about

### DIFF
--- a/tests/Unit/UuidTest.php
+++ b/tests/Unit/UuidTest.php
@@ -87,7 +87,20 @@ class UuidTest extends TestCase
 		// Version 7 puts a millisecond timestamp in the high bits, so the string
 		// form is monotonic. That is the whole point of using it for keys.
 		$first = (string) Uuid::create(7);
-		usleep(2000);
+
+		// Sleeping for a millisecond is not the same as one having passed.
+		// Windows' timer granularity is coarser than that, so both values can
+		// land in the same millisecond, where the timestamps are identical and
+		// only the random bits are left to order them -- which they do about
+		// half the time. Wait until the clock the generator reads has actually
+		// moved on.
+		$millisecond = static fn(): int => (int) (microtime(true) * 1000);
+		$started = $millisecond();
+
+		do {
+			usleep(250);
+		} while ($millisecond() === $started);
+
 		$second = (string) Uuid::create(7);
 
 		$this->assertLessThan(0, strcmp($first, $second));


### PR DESCRIPTION
#### Description

`UuidTest::testVersionSevenUuidsSortByCreationOrder` fails on the Windows jobs at random, on pull requests that change no code at all. It has just failed the `windows-latest, 8.5` job on #9617, which only edits `AGENTS.md`.

The test makes a version 7 UUID, sleeps two milliseconds, makes another, and asserts the first sorts before the second:

```php
$first = (string) Uuid::create(7);
usleep(2000);
$second = (string) Uuid::create(7);

$this->assertLessThan(0, strcmp($first, $second));
```

The sleep is doing the work of an assumption: that sleeping two milliseconds means the millisecond counter has moved on. On Windows it often has not — the default timer granularity there is about 15.6ms. Both values then land in the same millisecond, their timestamps are identical, and the only thing left to order them is the random bits.

Which is to say the assertion becomes a coin toss. Measured over 400 pairs deliberately made inside a single millisecond:

```
same-millisecond pairs: 397, mis-ordered: 191 (48%)
```

`Uuid` builds the v7 timestamp from `(int) (microtime(true) * 1000)`, so the test now waits for that same value to change before making the second UUID, rather than guessing how long that takes. Over 200 pairs made that way, none were mis-ordered:

```
with the wait, mis-ordered out of 200: 0
```

The loop costs about a millisecond on Linux and up to the timer granularity on Windows, and it cannot spin indefinitely, since the value it watches is a clock.

#### Why not just sleep longer

A longer sleep narrows the window without closing it, and picks a number that has to be re-guessed the next time a runner's timer behaves differently. Waiting for the thing the assertion actually depends on has no number in it.

This is the shape #9595 was about: a test describing a machine rather than a behaviour. The behaviour here is "a v7 UUID made in a later millisecond sorts after one made earlier", and the test now says exactly that.

#### How this was verified

The numbers above were measured against the real `Uuid` class. The test itself was then run repeatedly on Linux, passing each time — though Linux was never where it failed, so the Windows jobs on this pull request are the check that matters.

### Issues References (Fixes|Related|Closes)
1. Related: #9595, the previous instance of a test asserting something about the machine it ran on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
