### PR TITLE
[3.0] Restores the strings the backup checkbox explains itself with

### DIFF
--- a/Languages/en_US/Maintenance.php
+++ b/Languages/en_US/Maintenance.php
@@ -405,6 +405,8 @@ $txt['upgrade_continue_step'] = 'Continue from step reached during last executio
 // Upgrade options
 $txt['upgrade_areyouready'] = 'Before the upgrade gets underway, please review the options below and press &quot;Continue&quot; when you are ready to begin.';
 $txt['upgrade_backup_table'] = 'Backup SMF tables in your database using the prefix <span class="bbc_tt">{0}</span>';
+$txt['upgrade_recommended'] = 'Strongly recommended!';
+$txt['upgrade_backup_already_exists'] = 'Backup already exists. If you enable this option, the existing backup will be replaced with a new one.';
 $txt['upgrade_maintenance'] = 'Put the forum into maintenance mode during upgrade.';
 $txt['upgrade_maintenance_title'] = 'Maintenance Title:';
 $txt['upgrade_maintenance_message'] = 'Maintenance Message:';


### PR DESCRIPTION
#### Description

The line of help text under the "Backup SMF tables" checkbox on the upgrader's options page is empty, whichever of its two states it is in.

`UpgradeTemplate.php` picks one of two strings for it:

```php
<span class="smalltext">', Lang::getTxt(empty(Utils::$context['backup_recommended']) ? 'upgrade_backup_already_exists' : 'upgrade_recommended', file: 'Maintenance'), '</span>
```

Neither is defined. `ddb7919c1` ("Cleans up maintenance strings") removed both from `Languages/en_US/Maintenance.php` and left the two call sites behind:

```diff
-$txt['upgrade_recommended'] = 'Strongly recommended!';
-$txt['upgrade_backup_already_exists'] = 'Backup already exists. If you enable this option, the existing backup will be replaced with a new one.';
```

Nothing reports it, because `Lang::getTxt()` ends with

```php
return self::${$var}[$txt_key[0]] ?? '';
```

A key that does not exist is an empty string, not a missing-string marker, so the page renders `<span class="smalltext"></span>` and looks like a design choice rather than a fault.

The second of the two is the one worth having back. `doBackupTable()` calls `Db::$db->backup_table()`, which drops the destination table before writing it, so ticking that box when a backup is already there replaces it with a copy of the database as it stands now. That sentence is the only place the admin is told so.

This restores both strings as they were.

#### How this was verified

First statically: every string literal that `UpgradeTemplate.php` passes as the first argument to `getTxt()`, checked against every `$txt`, `$helptxt`, `$tztxt`, `$editortxt` and `$txtBirthdayEmails` key defined anywhere in `Languages/en_US/`. Of the 65 language keys the template uses, these two are the only ones with no definition.

Then on the page itself, against a 2.1.7 baseline upgraded to 3.0 so that a full set of `backup_` tables exists, reading the rendered span on step 2:

| `backup_recommended` | before | after |
| --- | --- | --- |
| false — a backup already exists | `<span class="smalltext"></span>` | `Backup already exists. If you enable this option, the existing backup will be replaced with a new one.` |
| true — none does, or the upgrade is unfinished | `<span class="smalltext"></span>` | `Strongly recommended!` |

Both branches were reached on a running forum rather than reasoned about: the first as the upgrade left it, the second by putting `smfVersion` back to `2.1.7` so `backupRecommended()` takes the other path, and restoring it afterwards.

#### Not reachable from the unit suite

The strings are read by a template that renders a page, and `beStrictAboutOutputDuringTests` means the suite cannot run one.

### Issues References (Fixes|Related|Closes)
1. Related: #9617, which documents what an interrupted upgrade does to the backup this text is about.
