### PR TITLE
[3.0] Writes a column type MySQL knows in the SQL that rebuilds a table

### DIFF
--- a/Sources/Db/APIs/MySQL.php
+++ b/Sources/Db/APIs/MySQL.php
@@ -1169,10 +1169,16 @@ class MySQL extends DatabaseApi implements DatabaseApiInterface
 		$inner_lines = [];
 
 		foreach ($structure['columns'] as $column) {
-			$line = '  `' . $column['name'] . '` ' . $column['type'];
+			// The structure reports SMF's own name for a type that MySQL
+			// spells differently -- a varbinary(16) holding an address comes
+			// back as an inet -- so it has to be turned back into something
+			// MySQL knows before it can be written into a CREATE TABLE.
+			list($type, $size) = $this->calculate_type($column['type'], $column['size']);
 
-			if (is_numeric($column['size'])) {
-				$line .= '(' . $column['size'] . ')';
+			$line = '  `' . $column['name'] . '` ' . $type;
+
+			if (is_numeric($size)) {
+				$line .= '(' . $size . ')';
 			}
 
 			if (!empty($column['unsigned'])) {


### PR DESCRIPTION
#### Description

On MySQL, `table_sql()` returns SQL naming a column type MySQL does not have:

```console
ERROR 1064 (42000): You have an error in your SQL syntax; ... near 'inet DEFAULT NULL'
```

SMF has its own names for a couple of types, and `list_columns()` reports those rather than the ones the database uses: a `varbinary(16)` holding an address comes back as an `inet`, and a `binary(16)` holding an id comes back as a `uuid`. Everywhere else that writes DDL turns them back first, with `calculate_type()`. `table_sql()` did not, and wrote SMF's name into its `CREATE TABLE`:

```php
$line = '  `' . $column['name'] . '` ' . $column['type'];
```

Ten tables on a forum with nothing added to it carry such a column, and they are the ones that record an address: `ban_items`, `log_actions`, `log_banned`, `log_errors`, `log_floodcontrol`, `log_online`, `log_reported_comments`, `member_logins`, `members` and `messages`.

Nothing in SMF calls `table_sql()`, which is why this has gone unnoticed. It is public API, reachable through the `db_table_sql` alias in `DatabaseApi::$db_function_map`.

PostgreSQL is unaffected: `inet` is a type it has.

#### How this was verified

By taking the definition of every table on a MySQL forum upgraded from the 2.1.7 baseline and running each into an empty database, which is the only thing the output is for.

| | before | after |
| --- | --- | --- |
| definitions that replay | 57 of 72 | **72 of 72** |
| failing on a type MySQL lacks | 10 | 0 |
| failing on an index prefix (#9652) | 5 | 0 |

The two faults are independent and were counted separately: with only #9652 applied the ten type failures remain, and with only this one the five index failures do. Both were applied together for the 72 of 72.

The rebuilt database was then compared against the original: 72 tables and 539 columns on each side.

#### Not reachable from the unit suite

`table_sql()` is a database driver method and needs a connection.

### Issues References (Fixes|Related|Closes)
1. Related: #9652, the other reason the same method's output would not run.
2. Related: #9651, the same method failing on PostgreSQL.
