### PR TITLE
[3.0] Gives the installer and upgrader the values their stylesheet asks for

### DIFF
--- a/Themes/default/MaintenanceTemplate.php
+++ b/Themes/default/MaintenanceTemplate.php
@@ -37,6 +37,7 @@ abstract class MaintenanceTemplate
 		<meta charset="', Lang::getTxt('lang_character_set', file: 'General') ?: 'UTF-8', '">
 		<meta name="robots" content="noindex">
 		<title>', Maintenance::$tool->getPageTitle(), '</title>
+		<link rel="stylesheet" href="', Maintenance::$theme_url, '/css/variables.css?' . Utils::$context['started'] . '">
 		<link rel="stylesheet" href="', Maintenance::$theme_url, '/css/index.css?' . Utils::$context['started'] . '">
 		<link rel="stylesheet" href="', Maintenance::$theme_url, '/css/maintenance.css?' . Utils::$context['started'] . '">', Lang::getTxt('lang_rtl', file: 'General') == '1' ? '
 		<link rel="stylesheet" href="' . Maintenance::$theme_url . '/css/rtl.css?' . Utils::$context['started'] . '">' : '', '


### PR DESCRIPTION
#### Description

`Themes/default/MaintenanceTemplate.php` links `index.css` but not `variables.css`.

Since `eeb4a6dfc` ("Adds variables.css and moves the base values into it"), `index.css`
states every colour, border, radius and size as a custom property — `var(--body-bg)`,
`var(--button-border-width)`, `var(--information-bg)` and so on — and those properties
are defined in `variables.css`. The forum gets that file from
`Theme::loadCSSFile('variables.css', ['order_pos' => -2], 'smf_variables')`, but the
maintenance templates hand-roll their own `<link>` tags and list only `index.css`,
`maintenance.css` and `rtl.css`.

So in the installer and the upgrader every `var()` in `index.css` resolves to nothing.
Reading the computed styles on the upgrade options page before this change:

```
--body-bg: ""   --button-bg: ""   --information-bg: ""
```

which leaves, among other things:

- no panel border and no page background,
- an empty progress bar (the green fill is `var(--progressbar-inner-bg_green)`),
- `.information` and `.noticebox` rendering as bare paragraphs,
- every `.button` rendering as plain text — worse than no class at all, since
  `.button` sets `border: var(--button-border-width) var(--button-border-style)`,
  and an empty shorthand resets the border away, so the element loses the native
  submit-button chrome and gains nothing in its place.

Adding the link restores all of it. Both tools share `MaintenanceTemplate::header()`,
so this covers `install.php` as well; I checked it by walking `upgrade.php` through
its steps in a browser against the Docker environment, on MySQL.

`variables.css` goes before `index.css` for the same reason `order_pos -2` puts it
there in the forum: the properties have to be defined before the rules that read them.

### Issues References (Fixes|Related|Closes)
1. 
2. 
