### PR TITLE
[3.0] Says so when the table being described is unlogged

### DIFF
--- a/Sources/Db/APIs/PostgreSQL.php
+++ b/Sources/Db/APIs/PostgreSQL.php
@@ -1071,8 +1071,34 @@ class PostgreSQL extends DatabaseApi implements DatabaseApiInterface
 		// Drop it if it exists.
 		$schema_create = 'DROP TABLE IF EXISTS ' . $table_name . ';' . "\n\n";
 
+		// A table that is not written to the write-ahead log says so in the way
+		// it is made, and sessions, log_online and log_floodcontrol are all built
+		// that way. Rebuilding one from this without saying so would quietly give
+		// it a durability it was never meant to pay for.
+		$unlogged = '';
+
+		$persistence = $this->query(
+			'SELECT c.relpersistence
+			FROM pg_class AS c
+				INNER JOIN pg_namespace AS n ON (n.oid = c.relnamespace)
+			WHERE c.relname = {string:table}
+				AND n.nspname = {string:schema}',
+			[
+				'table' => $table_name,
+				'schema' => 'public',
+			],
+		);
+
+		$row = $this->fetch_assoc($persistence);
+
+		if (\is_array($row) && $row['relpersistence'] === 'u') {
+			$unlogged = 'UNLOGGED ';
+		}
+
+		$this->free_result($persistence);
+
 		// Start the create table...
-		$schema_create .= 'CREATE TABLE ' . $table_name . ' (' . "\n";
+		$schema_create .= 'CREATE ' . $unlogged . 'TABLE ' . $table_name . ' (' . "\n";
 		$index_create = '';
 		$seq_create = '';
 


### PR DESCRIPTION
#### Description

`PostgreSQL::table_sql()` always writes `CREATE TABLE`, so the SQL it produces does
not rebuild an unlogged table as one.

SMF makes three tables unlogged, in `Sources/Maintenance/Migration/v2_1/PostgreSqlUnlogged.php`
("UNLOGGED Table PG 9.1+"), via `ALTER TABLE {db_prefix}{raw:table} SET UNLOGGED`:

```
smf_log_floodcontrol
smf_log_online
smf_sessions
```

They are unlogged deliberately. None of them holds anything worth surviving a crash,
and keeping them out of the write-ahead log is the whole point of that migration.
Rebuilding one from `table_sql()` output gives it back a durability it was never
meant to pay for, and nothing afterwards says the change happened.

This reads `pg_class.relpersistence` for the table and puts `UNLOGGED` into the
`CREATE` when it is `'u'`.

`table_sql()` is presently only reachable through the deprecated `db_table_sql`
alias in `Subs-Compat.php`, so nothing in the current tree exercises it — which is
also why this went unnoticed. I found it because I have local work that calls it to
record a table's shape before an upgrade migrates it: the three tables above came
back logged, and only a `relpersistence` check tells you so.

Verified against PostgreSQL 17 in the Docker environment, on a forum upgraded from
2.1.7, by comparing `pg_class.relpersistence` for every table before and after a
rebuild driven by this output.

### Issues References (Fixes|Related|Closes)
1. 
2. 
