### PR TITLE
Fix a minor capitalization error

### DIFF
--- a/Sources/Maintenance/Tools/Upgrade.php
+++ b/Sources/Maintenance/Tools/Upgrade.php
@@ -1226,7 +1226,7 @@ class Upgrade extends ToolsBase implements ToolsInterface
 			],
 			[
 				[
-					SMF\Tasks\FetchSMFiles::class,
+					\SMF\Tasks\FetchSMFiles::class,
 					'',
 					0,
 				],

--- a/Sources/Maintenance/Tools/Upgrade.php
+++ b/Sources/Maintenance/Tools/Upgrade.php
@@ -1226,7 +1226,7 @@ class Upgrade extends ToolsBase implements ToolsInterface
 			],
 			[
 				[
-					'SMF\\Tasks\\FetchSMFiles',
+					SMF\Tasks\FetchSMFiles::class,
 					'',
 					0,
 				],

--- a/Sources/Maintenance/Tools/Upgrade.php
+++ b/Sources/Maintenance/Tools/Upgrade.php
@@ -1226,7 +1226,7 @@ class Upgrade extends ToolsBase implements ToolsInterface
 			],
 			[
 				[
-					'SMF\\Tasks\\FetchSMfiles',
+					'SMF\\Tasks\\FetchSMFiles',
 					'',
 					0,
 				],


### PR DESCRIPTION
Signed-off-by: oldiesmann <oldiesmann@gmail.com>


#### Description
This fixes a minor capitalization error in Upgrade.php. We want to run the FetchSMFiles task after upgrading but the class name gets inserted into the DB as "SMF\Tasks\FetchSMfiles", causing an error since PHP is case sensitive for class names