### PR TITLE
[3.0] Theme split (wave 9, part 2) — clear the post sections with inline-end

### DIFF
--- a/Themes/default/css/index.css
+++ b/Themes/default/css/index.css
@@ -3751,7 +3751,7 @@ form#postmodify .roundframe {
 .custom_fields_below_signature {
 	width: 100%;
 	overflow: auto;
-	clear: right;
+	clear: inline-end;
 	padding: 12px 0 3px 0;
 	border-top: var(--postsection-border-width) var(--postsection-border-style) var(--postsection-border-color);
 	box-shadow: var(--postsection-box-shadow);

--- a/Themes/default/css/rtl.css
+++ b/Themes/default/css/rtl.css
@@ -8,11 +8,6 @@
 	margin-left: 0.25em;
 }
 
-/* All the signatures used in the forum. If your forum users use Mozilla, Opera, or Safari, you might add max-height here ;). */
-.signature, .attachments, .custom_fields_above_signature {
-	clear: left;
-}
-
 /* the page navigation area */
 .main_icons.move::before, .main_icons.next_page::before {
 	background-position: -31px -57px;


### PR DESCRIPTION
#### Description

Part 2 of wave 9 of the #7933 split.

`index.css` clears `.signature`, `.attachments`, `.under_message` and the two custom field
blocks in one rule, and `rtl.css` mirrored **three of the five**. `clear: inline-end`
follows the writing direction, so the override is no longer needed and all five behave the
same as each other.

#### Why wave 8 skipped this, and why it is safe now

Wave 8 (#9571) converted every `clear` whose override was an exact mirror, and deliberately
left this group alone: the two that `rtl.css` does **not** mirror would change the side they
clear in a right-to-left language, which is a behaviour change rather than a no-op.

That turns out not to matter, because **the `clear` does nothing to any of the five**.

The same rule also gives them `width: 100%` and `overflow: auto`. `overflow: auto` makes
the box a block formatting context root, and such a box does not overlap a preceding float
— at full width it cannot sit beside one either, so it is already pushed below it. That is
exactly what the `clear` was asking for. The declaration has been redundant all along,
which is why nobody noticed the two missing mirrors.

#### Measured, not assumed

Toggling `clear` through `none`, `left`, `right` and `both` on all five elements — in both
writing directions, at 1280px, 700px and 470px wide:

**none of them moves by a single pixel.**

Only `.under_message` renders on the test forum's posts (no signature, attachments or
custom fields on them), so the other four were injected into the live document in their
real position in order to be measured.

Then the usual sweep of 18 pages, recording `clear`, `float`, `display` and the bounding
rectangle of every element, before and after, captured back to back:

| | elements | differences |
| --- | --- | --- |
| left-to-right | 4732 | 1 — the `clear` keyword itself |
| right-to-left | 4732 | 1 — the same keyword |

No geometry changed in either direction. The right-to-left result is the one that matters,
since that is where two of the five swap the side they clear.

`rtl.css` goes from 366 lines to 361. With this, every `clear` in the theme that can be
expressed logically is.

### Issues References (Fixes|Related|Closes)

Part of the #7933 split; finishes the `clear` work started in #9571.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
