### PR TITLE
[3.0] Writes class names as ::class resolvers rather than strings

### DIFF
--- a/Sources/Actions/Admin/ACP.php
+++ b/Sources/Actions/Admin/ACP.php
@@ -28,6 +28,7 @@ use SMF\IntegrationHook;
 use SMF\Lang;
 use SMF\Mail;
 use SMF\Menu;
+use SMF\PackageManager\PackageManager;
 use SMF\Parser;
 use SMF\Routable;
 use SMF\Sapi;
@@ -127,7 +128,7 @@ class ACP implements ActionInterface, Routable
 				],
 				'packages' => [
 					'label' => 'package',
-					'function' => 'SMF\\PackageManager\\PackageManager::call',
+					'function' => PackageManager::class . '::call',
 					'permission' => ['admin_forum'],
 					'icon' => 'packages',
 					'subsections' => [

--- a/Sources/Actions/Admin/Calendar.php
+++ b/Sources/Actions/Admin/Calendar.php
@@ -136,10 +136,10 @@ class Calendar implements ActionInterface
 			'base_href' => Config::$scripturl . '?action=admin;area=managecalendar;sa=holidays',
 			'default_sort_col' => 'name',
 			'get_items' => [
-				'function' => 'SMF\\Calendar\\Holiday::list',
+				'function' => Holiday::class . '::list',
 			],
 			'get_count' => [
-				'function' => 'SMF\\Calendar\\Holiday::count',
+				'function' => Holiday::class . '::count',
 			],
 			'no_items_label' => Lang::getTxt('holidays_no_entries', file: 'ManageCalendar'),
 			'columns' => [

--- a/Sources/Actions/Admin/Membergroups.php
+++ b/Sources/Actions/Admin/Membergroups.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 namespace SMF\Actions\Admin;
 
 use SMF\ActionInterface;
+use SMF\Actions\Groups;
 use SMF\ActionTrait;
 use SMF\Config;
 use SMF\Db\DatabaseApi as Db;
@@ -70,7 +71,7 @@ class Membergroups implements ActionInterface
 		'settings' => ['settings', 'admin_forum'],
 
 		// This subaction is handled by the Groups action.
-		'members' => ['SMF\\Actions\\Groups::call', 'manage_membergroups'],
+		'members' => [Groups::class . '::call', 'manage_membergroups'],
 	];
 
 	/****************
@@ -121,7 +122,7 @@ class Membergroups implements ActionInterface
 			'base_href' => Config::$scripturl . '?action=admin;area=membergroups' . (isset($_REQUEST['sort2']) ? ';sort2=' . urlencode($_REQUEST['sort2']) : ''),
 			'default_sort_col' => 'name',
 			'get_items' => [
-				'function' => '\\SMF\\Actions\\Groups::list_getMembergroups',
+				'function' => Groups::class . '::list_getMembergroups',
 				'params' => [
 					'regular',
 				],
@@ -227,7 +228,7 @@ class Membergroups implements ActionInterface
 				'desc' => 'desc2',
 			],
 			'get_items' => [
-				'function' => '\\SMF\\Actions\\Groups::list_getMembergroups',
+				'function' => Groups::class . '::list_getMembergroups',
 				'params' => [
 					'post_count',
 				],

--- a/Sources/Actions/Admin/PackageManager.php
+++ b/Sources/Actions/Admin/PackageManager.php
@@ -16,4 +16,4 @@ if (!defined('SMF')) {
 }
 
 // Just an alias to help people looking for the package manager in the wrong namespace.
-class_alias('SMF\\PackageManager\\PackageManager', 'SMF\\Actions\\Admin\\PackageManager');
+class_alias(\SMF\PackageManager\PackageManager::class, 'SMF\\Actions\\Admin\\PackageManager');

--- a/Sources/Actions/Admin/Registration.php
+++ b/Sources/Actions/Admin/Registration.php
@@ -28,6 +28,7 @@ use SMF\Logging;
 use SMF\Menu;
 use SMF\Profile;
 use SMF\SecurityToken;
+use SMF\Tasks\UpdateSpoofDetectorNames;
 use SMF\Theme;
 use SMF\Time;
 use SMF\User;
@@ -635,7 +636,7 @@ class Registration implements ActionInterface
 					],
 					[
 						[
-							'SMF\\Tasks\\UpdateSpoofDetectorNames',
+							UpdateSpoofDetectorNames::class,
 							json_encode(['last_member_id' => 0]),
 							0,
 						],

--- a/Sources/Actions/BoardIndex.php
+++ b/Sources/Actions/BoardIndex.php
@@ -22,6 +22,7 @@ use SMF\Board;
 use SMF\Cache\CacheApi;
 use SMF\Category;
 use SMF\Config;
+use SMF\Group;
 use SMF\IntegrationHook;
 use SMF\Lang;
 use SMF\Logging;
@@ -134,7 +135,7 @@ class BoardIndex implements ActionInterface, Routable
 				'num_days_shown' => empty(Config::$modSettings['cal_days_for_index']) || Config::$modSettings['cal_days_for_index'] < 1 ? 1 : Config::$modSettings['cal_days_for_index'],
 			];
 
-			Utils::$context += CacheApi::quickGet('calendar_index_offset_' . User::$me->time_offset, 'Actions/Calendar.php', 'SMF\\Actions\\Calendar::cache_getRecentEvents', [$eventOptions]);
+			Utils::$context += CacheApi::quickGet('calendar_index_offset_' . User::$me->time_offset, 'Actions/Calendar.php', Calendar::class . '::cache_getRecentEvents', [$eventOptions]);
 
 			// Whether one or multiple days are shown on the board index.
 			Utils::$context['calendar_only_today'] = Config::$modSettings['cal_days_for_index'] == 1;
@@ -177,7 +178,7 @@ class BoardIndex implements ActionInterface, Routable
 
 		// Are we showing all membergroups on the board index?
 		if (!empty(Theme::$current->settings['show_group_key'])) {
-			Utils::$context['membergroups'] = CacheApi::quickGet('membergroup_list', 'Group.php', 'SMF\\Group::getCachedList', []);
+			Utils::$context['membergroups'] = CacheApi::quickGet('membergroup_list', 'Group.php', Group::class . '::getCachedList', []);
 		}
 
 		// Mark read button

--- a/Sources/Actions/BuddyListToggle.php
+++ b/Sources/Actions/BuddyListToggle.php
@@ -23,6 +23,7 @@ use SMF\Config;
 use SMF\Db\DatabaseApi as Db;
 use SMF\ErrorHandler;
 use SMF\Routable;
+use SMF\Tasks\Buddy_Notify;
 use SMF\User;
 use SMF\Utils;
 
@@ -86,7 +87,7 @@ class BuddyListToggle implements ActionInterface, Routable
 					],
 					[
 						[
-							'SMF\\Tasks\\Buddy_Notify',
+							Buddy_Notify::class,
 							Utils::jsonEncode([
 								'receiver_id' => $this->userReceiver,
 								'id_member' => User::$me->id,

--- a/Sources/Actions/Calendar.php
+++ b/Sources/Actions/Calendar.php
@@ -1394,7 +1394,7 @@ class Calendar implements ActionInterface, Routable
 	public static function cache_getRecentEvents(array $eventOptions): array
 	{
 		// With the 'static' cached data we can calculate the user-specific data.
-		$cached_data = CacheApi::quickGet('calendar_index', 'Actions/Calendar.php', 'SMF\\Actions\\Calendar::cache_getOffsetIndependentEvents', [$eventOptions]);
+		$cached_data = CacheApi::quickGet('calendar_index', 'Actions/Calendar.php', Calendar::class . '::cache_getOffsetIndependentEvents', [$eventOptions]);
 
 		// Get the information about today (from user perspective).
 		$today = self::getTodayInfo();

--- a/Sources/Actions/Feed.php
+++ b/Sources/Actions/Feed.php
@@ -582,7 +582,7 @@ class Feed implements ActionInterface, Routable
 
 		while ($row = Db::$db->fetch_assoc($request)) {
 			// If any control characters slipped in somehow, kill the evil things
-			$row = filter_var($row, FILTER_CALLBACK, ['options' => '\\SMF\\Utils::cleanXml']);
+			$row = filter_var($row, FILTER_CALLBACK, ['options' => Utils::class . '::cleanXml']);
 
 			// Create a UUID for each member
 			$uuid = (string) (new Uuid(5, 'member=' . $row['id_member']));
@@ -772,7 +772,7 @@ class Feed implements ActionInterface, Routable
 
 		while ($row = Db::$db->fetch_assoc($request)) {
 			// If any control characters slipped in somehow, kill the evil things
-			$row = filter_var($row, FILTER_CALLBACK, ['options' => '\\SMF\\Utils::cleanXml']);
+			$row = filter_var($row, FILTER_CALLBACK, ['options' => Utils::class . '::cleanXml']);
 
 			// Old SMF versions autolinked during output rather than input,
 			// so maintain expected behaviour for those old messages.
@@ -1213,7 +1213,7 @@ class Feed implements ActionInterface, Routable
 
 		while ($row = Db::$db->fetch_assoc($request)) {
 			// If any control characters slipped in somehow, kill the evil things
-			$row = filter_var($row, FILTER_CALLBACK, ['options' => '\\SMF\\Utils::cleanXml']);
+			$row = filter_var($row, FILTER_CALLBACK, ['options' => Utils::class . '::cleanXml']);
 
 			// Old SMF versions autolinked during output rather than input,
 			// so maintain expected behaviour for those old messages.
@@ -1619,7 +1619,7 @@ class Feed implements ActionInterface, Routable
 		$profile = User::$loaded[$this->member]->format($this->format == 'smf');
 
 		// If any control characters slipped in somehow, kill the evil things
-		$profile = filter_var($profile, FILTER_CALLBACK, ['options' => '\\SMF\\Utils::cleanXml']);
+		$profile = filter_var($profile, FILTER_CALLBACK, ['options' => Utils::class . '::cleanXml']);
 
 		// Create a UUID for this member
 		$uuid = (string) (new Uuid(5, 'member=' . $profile['id']));
@@ -1979,7 +1979,7 @@ class Feed implements ActionInterface, Routable
 			$row['poster_ip'] = new IP($row['poster_ip']);
 
 			// If any control characters slipped in somehow, kill the evil things
-			$row = filter_var($row, FILTER_CALLBACK, ['options' => '\\SMF\\Utils::cleanXml']);
+			$row = filter_var($row, FILTER_CALLBACK, ['options' => Utils::class . '::cleanXml']);
 
 			// Old SMF versions autolinked during output rather than input,
 			// so maintain expected behaviour for those old messages.
@@ -2431,7 +2431,7 @@ class Feed implements ActionInterface, Routable
 			$this->start_after = (int) $row['id_pm'];
 
 			// If any control characters slipped in somehow, kill the evil things
-			$row = filter_var($row, FILTER_CALLBACK, ['options' => '\\SMF\\Utils::cleanXml']);
+			$row = filter_var($row, FILTER_CALLBACK, ['options' => Utils::class . '::cleanXml']);
 
 			// Old SMF versions autolinked during output rather than input,
 			// so maintain expected behaviour for those old messages.

--- a/Sources/Actions/Like.php
+++ b/Sources/Actions/Like.php
@@ -28,6 +28,7 @@ use SMF\Lang;
 use SMF\OutputTypeInterface;
 use SMF\OutputTypes;
 use SMF\Routable;
+use SMF\Tasks\Likes_Notify;
 use SMF\Theme;
 use SMF\Time;
 use SMF\User;
@@ -518,7 +519,7 @@ class Like implements ActionInterface, Routable
 				],
 				[
 					[
-						'SMF\\Tasks\\Likes_Notify',
+						Likes_Notify::class,
 						Utils::jsonEncode([
 							'content_id' => $content,
 							'content_type' => $type,

--- a/Sources/Actions/Moderation/Groups.php
+++ b/Sources/Actions/Moderation/Groups.php
@@ -25,6 +25,7 @@ use SMF\ItemList;
 use SMF\Lang;
 use SMF\Menu;
 use SMF\SecurityToken;
+use SMF\Tasks\GroupAct_Notify;
 use SMF\Theme;
 use SMF\Time;
 use SMF\User;
@@ -333,7 +334,7 @@ class Groups extends ViewGroups
 					],
 					[
 						[
-							'SMF\\Tasks\\GroupAct_Notify',
+							GroupAct_Notify::class,
 							$data,
 							0,
 						],

--- a/Sources/Actions/Profile/Export.php
+++ b/Sources/Actions/Profile/Export.php
@@ -23,6 +23,7 @@ use SMF\ErrorHandler;
 use SMF\Lang;
 use SMF\Security;
 use SMF\SecurityToken;
+use SMF\Tasks\ExportProfileData;
 use SMF\Theme;
 use SMF\Time;
 use SMF\User;
@@ -153,7 +154,7 @@ class Export implements ActionInterface
 					WHERE task_class = {string:class}
 						AND task_data LIKE {string:details}',
 					[
-						'class' => 'SMF\\Tasks\\ExportProfileData',
+						'class' => ExportProfileData::class,
 						'details' => substr(Utils::jsonEncode(['format' => $format, 'uid' => Utils::$context['id_member']]), 0, -1) . ',%',
 					],
 				);
@@ -317,7 +318,7 @@ class Export implements ActionInterface
 				],
 				[
 					[
-						'SMF\\Tasks\\ExportProfileData',
+						ExportProfileData::class,
 						$data,
 						0,
 					],

--- a/Sources/Actions/Profile/GroupMembership.php
+++ b/Sources/Actions/Profile/GroupMembership.php
@@ -23,6 +23,7 @@ use SMF\ErrorHandler;
 use SMF\Group;
 use SMF\Lang;
 use SMF\Profile;
+use SMF\Tasks\GroupReq_Notify;
 use SMF\User;
 use SMF\Utils;
 
@@ -420,7 +421,7 @@ class GroupMembership implements ActionInterface
 			],
 			[
 				[
-					'SMF\\Tasks\\GroupReq_Notify',
+					GroupReq_Notify::class,
 					$data,
 					0,
 				],

--- a/Sources/Actions/Profile/Main.php
+++ b/Sources/Actions/Profile/Main.php
@@ -19,6 +19,7 @@ use SMF\ActionInterface;
 use SMF\ActionTrait;
 use SMF\Config;
 use SMF\Db\DatabaseApi as Db;
+use SMF\Draft;
 use SMF\ErrorHandler;
 use SMF\IntegrationHook;
 use SMF\Lang;
@@ -197,7 +198,7 @@ class Main implements ActionInterface, Routable
 				],
 				'showdrafts' => [
 					'label' => 'drafts_show',
-					'function' => 'SMF\\Draft::showInProfile',
+					'function' => Draft::class . '::showInProfile',
 					'icon' => 'drafts',
 					'enabled' => true,
 					'permission' => [

--- a/Sources/Actions/ReportToMod.php
+++ b/Sources/Actions/ReportToMod.php
@@ -26,6 +26,8 @@ use SMF\Msg;
 use SMF\Parser;
 use SMF\Routable;
 use SMF\Security;
+use SMF\Tasks\MemberReport_Notify;
+use SMF\Tasks\MsgReport_Notify;
 use SMF\Theme;
 use SMF\Topic;
 use SMF\User;
@@ -474,7 +476,7 @@ class ReportToMod implements ActionInterface, Routable
 				],
 				[
 					[
-						'SMF\\Tasks\\MsgReport_Notify',
+						MsgReport_Notify::class,
 						Utils::jsonEncode([
 							'report_id' => $id_report,
 							'msg_id' => $msg,
@@ -639,7 +641,7 @@ class ReportToMod implements ActionInterface, Routable
 				],
 				[
 					[
-						'SMF\\Tasks\\MemberReport_Notify',
+						MemberReport_Notify::class,
 						Utils::jsonEncode([
 							'report_id' => $id_report,
 							'user_id' => $user['id_member'],

--- a/Sources/Actions/TrackIP.php
+++ b/Sources/Actions/TrackIP.php
@@ -230,14 +230,14 @@ class TrackIP implements ActionInterface, Routable
 			'base_href' => Utils::$context['base_url'] . ';searchip=' . Utils::$context['ip'],
 			'default_sort_col' => 'date2',
 			'get_items' => [
-				'function' => '\\SMF\\Actions\\Profile\\Tracking::list_getUserErrors',
+				'function' => \SMF\Actions\Profile\Tracking::class . '::list_getUserErrors',
 				'params' => [
 					'le.ip >= ' . $ip_string[0] . ' and le.ip <= ' . $ip_string[1],
 					$fields,
 				],
 			],
 			'get_count' => [
-				'function' => '\\SMF\\Actions\\Profile\\Tracking::list_getUserErrorCount',
+				'function' => \SMF\Actions\Profile\Tracking::class . '::list_getUserErrorCount',
 				'params' => [
 					'ip >= ' . $ip_string[0] . ' and ip <= ' . $ip_string[1],
 					$fields,

--- a/Sources/Attachment.php
+++ b/Sources/Attachment.php
@@ -1453,7 +1453,7 @@ class Attachment implements \ArrayAccess
 				],
 				[
 					[
-						'SMF\\Tasks\\CreateAttachment_Notify',
+						Tasks\CreateAttachment_Notify::class,
 						Utils::jsonEncode(['id' => $attachmentOptions['id']]),
 						0,
 					],

--- a/Sources/BBCode/Quote4.php
+++ b/Sources/BBCode/Quote4.php
@@ -15,6 +15,8 @@ declare(strict_types=1);
 
 namespace SMF\BBCode;
 
+use SMF\Time;
+
 /**
  * Represents the version of the quote BBCode with multiple parameters.
  */
@@ -35,7 +37,7 @@ class Quote4 extends BBCode
 	public ?array $parameters = [
 		'author' => ['match' => '([^<>]{1,192}?)'],
 		'link' => ['match' => '(?:board=\d+;)?((?:topic|threadid)=[\dmsg#\./]{1,40}(?:;start=[\dmsg#\./]{1,40})?|msg=\d+?|action=profile;u=\d+)'],
-		'date' => ['match' => '(\d+)', 'validate' => 'SMF\\Time::stringFromUnix'],
+		'date' => ['match' => '(\d+)', 'validate' => Time::class . '::stringFromUnix'],
 	];
 
 	/**

--- a/Sources/Cache/CacheApi.php
+++ b/Sources/Cache/CacheApi.php
@@ -488,7 +488,7 @@ abstract class CacheApi
 	 */
 	final public static function quickGet(string $key, string $file, string|array $function, array $params, int $level = 1): mixed
 	{
-		if (class_exists('SMF\\IntegrationHook', false)) {
+		if (class_exists(IntegrationHook::class, false)) {
 			IntegrationHook::call('pre_cache_quick_get', [&$key, &$file, &$function, &$params, &$level]);
 		}
 
@@ -529,7 +529,7 @@ abstract class CacheApi
 			$callback($cache_block, $params);
 		}
 
-		if (class_exists('SMF\\IntegrationHook', false)) {
+		if (class_exists(IntegrationHook::class, false)) {
 			IntegrationHook::call('post_cache_quick_get', [&$cache_block]);
 		}
 
@@ -568,7 +568,7 @@ abstract class CacheApi
 		$value = $value === null ? null : serialize($value);
 		self::$loadedApi->putData($key, $value, $ttl);
 
-		if (class_exists('SMF\\IntegrationHook', false)) {
+		if (class_exists(IntegrationHook::class, false)) {
 			IntegrationHook::call('cache_put_data', [&$key, &$value, &$ttl]);
 		}
 
@@ -613,7 +613,7 @@ abstract class CacheApi
 			}
 		}
 
-		if (class_exists('SMF\\IntegrationHook', false) && isset($value)) {
+		if (class_exists(IntegrationHook::class, false) && isset($value)) {
 			IntegrationHook::call('cache_get_data', [&$key, &$ttl, &$value]);
 		}
 

--- a/Sources/Calendar/Event.php
+++ b/Sources/Calendar/Event.php
@@ -22,6 +22,7 @@ use SMF\Db\DatabaseApi as Db;
 use SMF\ErrorHandler;
 use SMF\IntegrationHook;
 use SMF\Lang;
+use SMF\Tasks\EventNew_Notify;
 use SMF\Theme;
 use SMF\Time;
 use SMF\TimeInterval;
@@ -1802,7 +1803,7 @@ class Event implements \ArrayAccess
 				],
 				[
 					[
-						'SMF\\Tasks\\EventNew_Notify',
+						EventNew_Notify::class,
 						Utils::jsonEncode([
 							'event_title' => $event->title,
 							'event_id' => $event->id,

--- a/Sources/Class-BrowserDetect.php
+++ b/Sources/Class-BrowserDetect.php
@@ -17,4 +17,4 @@ if (!defined('SMF')) {
 	die('No direct access...');
 }
 
-class_alias('SMF\\BrowserDetector', '\\browser_detector');
+class_alias(\SMF\BrowserDetector::class, '\\browser_detector');

--- a/Sources/Class-CurlFetchWeb.php
+++ b/Sources/Class-CurlFetchWeb.php
@@ -17,4 +17,4 @@ if (!defined('SMF')) {
 	die('No direct access...');
 }
 
-class_alias('SMF\\WebFetch\\APIs\\CurlFetcher', '\\curl_fetch_web_data');
+class_alias(\SMF\WebFetch\APIs\CurlFetcher::class, '\\curl_fetch_web_data');

--- a/Sources/Class-Graphics.php
+++ b/Sources/Class-Graphics.php
@@ -17,9 +17,9 @@ if (!defined('SMF')) {
 	die('No direct access...');
 }
 
-class_alias('SMF\\Graphics\\Gif\\ColorTable', '\\gif_color_table');
-class_alias('SMF\\Graphics\\Gif\\File', '\\gif_file');
-class_alias('SMF\\Graphics\\Gif\\FileHeader', '\\gif_file_header');
-class_alias('SMF\\Graphics\\Gif\\Image', '\\gif_image');
-class_alias('SMF\\Graphics\\Gif\\ImageHeader', '\\gif_image_header');
-class_alias('SMF\\Graphics\\Gif\\LzwCompression', '\\gif_lzw_compression');
+class_alias(\SMF\Graphics\Gif\ColorTable::class, '\\gif_color_table');
+class_alias(\SMF\Graphics\Gif\File::class, '\\gif_file');
+class_alias(\SMF\Graphics\Gif\FileHeader::class, '\\gif_file_header');
+class_alias(\SMF\Graphics\Gif\Image::class, '\\gif_image');
+class_alias(\SMF\Graphics\Gif\ImageHeader::class, '\\gif_image_header');
+class_alias(\SMF\Graphics\Gif\LzwCompression::class, '\\gif_lzw_compression');

--- a/Sources/Class-Package.php
+++ b/Sources/Class-Package.php
@@ -17,5 +17,5 @@ if (!defined('SMF')) {
 	die('No direct access...');
 }
 
-class_alias('SMF\\PackageManager\\XmlArray', '\\xmlArray');
-class_alias('SMF\\PackageManager\\FtpConnection', '\\ftp_connection');
+class_alias(\SMF\PackageManager\XmlArray::class, '\\xmlArray');
+class_alias(\SMF\PackageManager\FtpConnection::class, '\\ftp_connection');

--- a/Sources/Class-Punycode.php
+++ b/Sources/Class-Punycode.php
@@ -17,4 +17,4 @@ if (!defined('SMF')) {
 	die('No direct access...');
 }
 
-class_alias('SMF\\Punycode', '\\Punycode');
+class_alias(\SMF\Punycode::class, '\\Punycode');

--- a/Sources/Class-SearchAPI.php
+++ b/Sources/Class-SearchAPI.php
@@ -17,5 +17,5 @@ if (!defined('SMF')) {
 	die('No direct access...');
 }
 
-class_alias('SMF\\Search\\SearchApiInterface', '\\search_api_interface');
-class_alias('SMF\\Search\\SearchApi', '\\search_api');
+class_alias(\SMF\Search\SearchApiInterface::class, '\\search_api_interface');
+class_alias(\SMF\Search\SearchApi::class, '\\search_api');

--- a/Sources/Class-TOTP.php
+++ b/Sources/Class-TOTP.php
@@ -17,4 +17,4 @@ if (!defined('SMF')) {
 	die('No direct access...');
 }
 
-class_alias('SMF\\TOTP\\Auth', '\\TOTP\\Auth');
+class_alias(\SMF\TOTP\Auth::class, '\\TOTP\\Auth');

--- a/Sources/Config.php
+++ b/Sources/Config.php
@@ -1397,7 +1397,7 @@ class Config
 			// It is important to store this in Settings.php, not the database.
 			// If saving fails, we should alert, log, and set a static value.
 			if (!self::updateSettingsFile(['auth_secret' => self::$auth_secret])) {
-				if (class_exists('SMF\\Utils', false)) {
+				if (class_exists(Utils::class, false)) {
 					Utils::$context['auth_secret_missing'] = true;
 				}
 
@@ -1428,7 +1428,7 @@ class Config
 
 		// Allow mods the option to define comments, defaults, etc., for their settings.
 		// Check if IntegrationHook exists, in case we are calling from installer or upgrader.
-		if (class_exists('SMF\\IntegrationHook', false)) {
+		if (class_exists(IntegrationHook::class, false)) {
 			IntegrationHook::call('integrate_update_settings_file', [&self::$settings_defs]);
 		}
 
@@ -3087,7 +3087,7 @@ class Config
 	{
 		// Can't rely on autoloading because this method may be
 		// called before the autoloader exists.
-		if (!class_exists('\\SMF\\Sapi', false)) {
+		if (!class_exists(Sapi::class, false)) {
 			require_once self::$sourcedir . DIRECTORY_SEPARATOR . 'Sapi.php';
 		}
 

--- a/Sources/IntegrationHook.php
+++ b/Sources/IntegrationHook.php
@@ -87,8 +87,8 @@ class IntegrationHook
 	{
 		if (
 			!self::$enabled
-			|| !class_exists('SMF\\Config', false)
-			|| !class_exists('SMF\\Utils', false)
+			|| !class_exists(Config::class, false)
+			|| !class_exists(Utils::class, false)
 		) {
 			return;
 		}
@@ -153,7 +153,7 @@ class IntegrationHook
 						'$sourcedir' => Config::$sourcedir,
 					]);
 
-					if (str_contains($path, '$themedir') && class_exists('SMF\\Theme', false) && !empty(Theme::$current->settings['theme_dir'])) {
+					if (str_contains($path, '$themedir') && class_exists(Theme::class, false) && !empty(Theme::$current->settings['theme_dir'])) {
 						$path = strtr($path, [
 							'$themedir' => Theme::$current->settings['theme_dir'],
 						]);

--- a/Sources/ItemList.php
+++ b/Sources/ItemList.php
@@ -416,11 +416,11 @@ class ItemList implements \ArrayAccess
 				// These are probably the most readable way of injecting complex data.
 				elseif (isset($data['sprintf']) || isset($data['format_text']) || isset($data['get_txt'])) {
 					$params = isset($data['sprintf']) ? [] : $list_item;
-					$call = 'SMF\Lang::formatText';
+					$call = Lang::class . '::formatText';
 					$format = isset($data['format_text']) ? 'format_text' : 'sprintf';
 
 					if (isset($data['get_txt'])) {
-						$call = 'SMF\Lang::getTxt';
+						$call = Lang::class . '::getTxt';
 						$format = 'get_txt';
 					}
 

--- a/Sources/Mail.php
+++ b/Sources/Mail.php
@@ -688,7 +688,7 @@ class Mail
 
 		while ($row = Db::$db->fetch_assoc($result)) {
 			$task_rows[] = [
-				'SMF\\Tasks\\CreatePost_Notify',
+				Tasks\CreatePost_Notify::class,
 				Utils::jsonEncode([
 					'msgOptions' => [
 						'id' => $row['id_msg'],
@@ -767,7 +767,7 @@ class Mail
 			],
 			[
 				[
-					'SMF\\Tasks\\Register_Notify',
+					Tasks\Register_Notify::class,
 					Utils::jsonEncode([
 						'new_member_id' => $memberID,
 						'new_member_name' => $member_name,

--- a/Sources/Maintenance/Maintenance.php
+++ b/Sources/Maintenance/Maintenance.php
@@ -374,7 +374,7 @@ class Maintenance
 	 */
 	public static function getBaseDir(): string
 	{
-		if (class_exists('\\SMF\\Config')) {
+		if (class_exists(Config::class)) {
 			if (!isset(Config::$boarddir)) {
 				Config::load();
 			}

--- a/Sources/Maintenance/Tools/Upgrade.php
+++ b/Sources/Maintenance/Tools/Upgrade.php
@@ -31,6 +31,8 @@ use SMF\QueryString;
 use SMF\Sapi;
 use SMF\SecurityToken;
 use SMF\Session;
+use SMF\Tasks\FetchSMFiles;
+use SMF\Tasks\UpdateSpoofDetectorNames;
 use SMF\Themes\default\MaintenanceTemplate;
 use SMF\Time;
 use SMF\User;
@@ -1226,7 +1228,7 @@ class Upgrade extends ToolsBase implements ToolsInterface
 			],
 			[
 				[
-					'SMF\\Tasks\\FetchSMfiles',
+					FetchSMFiles::class,
 					'',
 					0,
 				],
@@ -1244,7 +1246,7 @@ class Upgrade extends ToolsBase implements ToolsInterface
 			],
 			[
 				[
-					'SMF\\Tasks\\UpdateSpoofDetectorNames',
+					UpdateSpoofDetectorNames::class,
 					json_encode(['last_member_id' => 0]),
 					0,
 				],

--- a/Sources/Maintenance/Utf8ConverterStep.php
+++ b/Sources/Maintenance/Utf8ConverterStep.php
@@ -20,6 +20,7 @@ use SMF\Db\DatabaseApi as Db;
 use SMF\Db\Schema\Table;
 use SMF\Lang;
 use SMF\Sapi;
+use SMF\Tasks\Utf8EntityDecode;
 use SMF\Utils;
 
 /**
@@ -897,7 +898,7 @@ class Utf8ConverterStep extends Step
 			],
 			[
 				[
-					'\\SMF\\Tasks\\Utf8EntityDecode',
+					Utf8EntityDecode::class,
 					json_encode([
 						'table' => $table_name,
 						'offset' => 0,

--- a/Sources/Msg.php
+++ b/Sources/Msg.php
@@ -984,7 +984,7 @@ class Msg implements \ArrayAccess, Routable
 					'claimed_time' => 'int'],
 				[
 					[
-						'SMF\\Tasks\\ApprovePost_Notify',
+						Tasks\ApprovePost_Notify::class,
 						Utils::jsonEncode([
 							'msgOptions' => $msgOptions,
 							'topicOptions' => $topicOptions,
@@ -1009,7 +1009,7 @@ class Msg implements \ArrayAccess, Routable
 				],
 				[
 					[
-						'SMF\\Tasks\\ApproveReply_Notify',
+						Tasks\ApproveReply_Notify::class,
 						Utils::jsonEncode([
 							'msgOptions' => $msgOptions,
 							'topicOptions' => $topicOptions,
@@ -1077,7 +1077,7 @@ class Msg implements \ArrayAccess, Routable
 				],
 				[
 					[
-						'SMF\\Tasks\\CreatePost_Notify',
+						Tasks\CreatePost_Notify::class,
 						Utils::jsonEncode([
 							'msgOptions' => $msgOptions,
 							'topicOptions' => $topicOptions,
@@ -1297,7 +1297,7 @@ class Msg implements \ArrayAccess, Routable
 				],
 				[
 					[
-						'SMF\\Tasks\\CreatePost_Notify',
+						Tasks\CreatePost_Notify::class,
 						Utils::jsonEncode([
 							'msgOptions' => $msgOptions,
 							'topicOptions' => $topicOptions,
@@ -1540,7 +1540,7 @@ class Msg implements \ArrayAccess, Routable
 
 			foreach (array_merge($notification_topics, $notification_posts) as $topic) {
 				$task_rows[] = [
-					'SMF\\Tasks\\CreatePost_Notify',
+					Tasks\CreatePost_Notify::class,
 					Utils::jsonEncode([
 						'msgOptions' => [
 							'id' => $topic['msg'],

--- a/Sources/Parsers/MarkdownParser.php
+++ b/Sources/Parsers/MarkdownParser.php
@@ -1778,8 +1778,8 @@ class MarkdownParser extends Parser
 			return false;
 		}
 
-		$thead_cells = array_map('\SMF\Utils::htmlTrim', preg_split('/(?<!\\\\)\|/u', $last_open['content'][0], -1, PREG_SPLIT_NO_EMPTY));
-		$delim_cells = array_map('\SMF\Utils::htmlTrim', preg_split('/(?<!\\\\)\|/u', $line_info['content'], -1, PREG_SPLIT_NO_EMPTY));
+		$thead_cells = array_map(Utils::class . '::htmlTrim', preg_split('/(?<!\\\\)\|/u', $last_open['content'][0], -1, PREG_SPLIT_NO_EMPTY));
+		$delim_cells = array_map(Utils::class . '::htmlTrim', preg_split('/(?<!\\\\)\|/u', $line_info['content'], -1, PREG_SPLIT_NO_EMPTY));
 
 		if (\count($thead_cells) !== \count($delim_cells)) {
 			return false;
@@ -2062,7 +2062,7 @@ class MarkdownParser extends Parser
 			return;
 		}
 
-		$cells = array_map('\SMF\Utils::htmlTrim', preg_split('/(?<!\\\\)\|/u', $this->open[$o]['content'][0], -1, PREG_SPLIT_NO_EMPTY));
+		$cells = array_map(Utils::class . '::htmlTrim', preg_split('/(?<!\\\\)\|/u', $this->open[$o]['content'][0], -1, PREG_SPLIT_NO_EMPTY));
 
 		$tr = [];
 
@@ -2170,7 +2170,7 @@ class MarkdownParser extends Parser
 	 */
 	protected function appendTableRow(array &$line_info, int $last_container, int $o): void
 	{
-		$cells = array_map('\SMF\Utils::htmlTrim', preg_split('/(?<!\\\\)\|/u', $line_info['content'], -1, PREG_SPLIT_NO_EMPTY));
+		$cells = array_map(Utils::class . '::htmlTrim', preg_split('/(?<!\\\\)\|/u', $line_info['content'], -1, PREG_SPLIT_NO_EMPTY));
 
 		$tr = [];
 

--- a/Sources/Search/APIs/Parsed.php
+++ b/Sources/Search/APIs/Parsed.php
@@ -26,6 +26,7 @@ use SMF\Sapi;
 use SMF\Search\SearchApi;
 use SMF\Search\SearchApiInterface;
 use SMF\SecurityToken;
+use SMF\Tasks\GenericTask;
 use SMF\Unicode\Utf8String;
 use SMF\Url;
 use SMF\User;
@@ -694,7 +695,7 @@ class Parsed extends SearchApi implements SearchApiInterface
 				],
 				[
 					[
-						'SMF\\Tasks\\GenericTask',
+						GenericTask::class,
 						Utils::jsonEncode([
 							'callable' => __METHOD__,
 							'start_id' => ($last_id ?? 0) + 1,

--- a/Sources/SearchAPI-Custom.php
+++ b/Sources/SearchAPI-Custom.php
@@ -19,4 +19,4 @@ if (!defined('SMF')) {
 	die('No direct access...');
 }
 
-class_alias('SMF\\Search\\APIs\\Custom', '\\custom_search');
+class_alias(\SMF\Search\APIs\Custom::class, '\\custom_search');

--- a/Sources/SearchAPI-Fulltext.php
+++ b/Sources/SearchAPI-Fulltext.php
@@ -19,4 +19,4 @@ if (!defined('SMF')) {
 	die('No direct access...');
 }
 
-class_alias('SMF\\Search\\APIs\\Fulltext', '\\fulltext_search');
+class_alias(\SMF\Search\APIs\Fulltext::class, '\\fulltext_search');

--- a/Sources/SearchAPI-Standard.php
+++ b/Sources/SearchAPI-Standard.php
@@ -19,4 +19,4 @@ if (!defined('SMF')) {
 	die('No direct access...');
 }
 
-class_alias('SMF\\Search\\APIs\\Standard', '\\standard_search');
+class_alias(\SMF\Search\APIs\Standard::class, '\\standard_search');

--- a/Sources/ServerSideIncludes.php
+++ b/Sources/ServerSideIncludes.php
@@ -244,7 +244,7 @@ class ServerSideIncludes
 		}
 
 		// Primarily, this is to fix the URLs...
-		ob_start('SMF\\QueryString::rewriteAsQueryless');
+		ob_start(QueryString::class . '::rewriteAsQueryless');
 
 		// Start the session... known to scramble SSI includes in cases...
 		if (!headers_sent()) {
@@ -1715,7 +1715,7 @@ class ServerSideIncludes
 
 		// Showing membergroups?
 		if (!empty(Theme::$current->settings['show_group_key']) && !empty($return['online_groups'])) {
-			$membergroups = CacheApi::quickGet('membergroup_list', 'Group.php', 'SMF\\Group::getCachedList', []);
+			$membergroups = CacheApi::quickGet('membergroup_list', 'Group.php', Group::class . '::getCachedList', []);
 
 			$groups = [];
 
@@ -2217,7 +2217,7 @@ class ServerSideIncludes
 			'include_birthdays' => true,
 			'num_days_shown' => empty(Config::$modSettings['cal_days_for_index']) || Config::$modSettings['cal_days_for_index'] < 1 ? 1 : Config::$modSettings['cal_days_for_index'],
 		];
-		$return = CacheApi::quickGet('calendar_index_offset_' . User::$me->time_offset, 'Actions/Calendar.php', 'SMF\\Actions\\Calendar::cache_getRecentEvents', [$eventOptions]);
+		$return = CacheApi::quickGet('calendar_index_offset_' . User::$me->time_offset, 'Actions/Calendar.php', Actions\Calendar::class . '::cache_getRecentEvents', [$eventOptions]);
 
 		// The self::todaysCalendar variants all use the same hook and just pass on $eventOptions so the hooked code can distinguish different cases if necessary
 		IntegrationHook::call('integrate_ssi_calendar', [&$return, $eventOptions]);
@@ -2259,7 +2259,7 @@ class ServerSideIncludes
 			'include_holidays' => true,
 			'num_days_shown' => empty(Config::$modSettings['cal_days_for_index']) || Config::$modSettings['cal_days_for_index'] < 1 ? 1 : Config::$modSettings['cal_days_for_index'],
 		];
-		$return = CacheApi::quickGet('calendar_index_offset_' . User::$me->time_offset, 'Actions/Calendar.php', 'SMF\\Actions\\Calendar::cache_getRecentEvents', [$eventOptions]);
+		$return = CacheApi::quickGet('calendar_index_offset_' . User::$me->time_offset, 'Actions/Calendar.php', Actions\Calendar::class . '::cache_getRecentEvents', [$eventOptions]);
 
 		$return['calendar_holidays'] = array_map(fn($h) => $h->title, $return['calendar_holidays']);
 
@@ -2301,7 +2301,7 @@ class ServerSideIncludes
 			'include_events' => true,
 			'num_days_shown' => empty(Config::$modSettings['cal_days_for_index']) || Config::$modSettings['cal_days_for_index'] < 1 ? 1 : Config::$modSettings['cal_days_for_index'],
 		];
-		$return = CacheApi::quickGet('calendar_index_offset_' . User::$me->time_offset, 'Actions/Calendar.php', 'SMF\\Actions\\Calendar::cache_getRecentEvents', [$eventOptions]);
+		$return = CacheApi::quickGet('calendar_index_offset_' . User::$me->time_offset, 'Actions/Calendar.php', Actions\Calendar::class . '::cache_getRecentEvents', [$eventOptions]);
 
 		// The self::todaysCalendar variants all use the same hook and just pass on $eventOptions so the hooked code can distinguish different cases if necessary
 		IntegrationHook::call('integrate_ssi_calendar', [&$return, $eventOptions]);
@@ -2352,7 +2352,7 @@ class ServerSideIncludes
 			'include_events' => true,
 			'num_days_shown' => empty(Config::$modSettings['cal_days_for_index']) || Config::$modSettings['cal_days_for_index'] < 1 ? 1 : Config::$modSettings['cal_days_for_index'],
 		];
-		$return = CacheApi::quickGet('calendar_index_offset_' . User::$me->time_offset, 'Actions/Calendar.php', 'SMF\\Actions\\Calendar::cache_getRecentEvents', [$eventOptions]);
+		$return = CacheApi::quickGet('calendar_index_offset_' . User::$me->time_offset, 'Actions/Calendar.php', Actions\Calendar::class . '::cache_getRecentEvents', [$eventOptions]);
 
 		$return['calendar_holidays'] = array_map(fn($h) => $h->title, $return['calendar_holidays']);
 

--- a/Sources/Services/ErrorHandlerService.php
+++ b/Sources/Services/ErrorHandlerService.php
@@ -93,7 +93,7 @@ class ErrorHandlerService
 			$count = \count($array);
 
 			for ($i = 0; $i < $count; $i++) {
-				if ($array[$i]['function'] != 'SMF\\Theme::loadSubTemplate') {
+				if ($array[$i]['function'] != Theme::class . '::loadSubTemplate') {
 					continue;
 				}
 

--- a/Sources/TaskRunner.php
+++ b/Sources/TaskRunner.php
@@ -73,42 +73,42 @@ class TaskRunner
 	 */
 	public static array $scheduled_tasks = [
 		'daily_maintenance' => [
-			'class' => 'SMF\\Tasks\\DailyMaintenance',
+			'class' => Tasks\DailyMaintenance::class,
 		],
 		'weekly_maintenance' => [
-			'class' => 'SMF\\Tasks\\WeeklyMaintenance',
+			'class' => Tasks\WeeklyMaintenance::class,
 		],
 		'daily_digest' => [
-			'class' => 'SMF\\Tasks\\SendDigests',
+			'class' => Tasks\SendDigests::class,
 			'data' => ['is_weekly' => 0],
 		],
 		'weekly_digest' => [
-			'class' => 'SMF\\Tasks\\SendDigests',
+			'class' => Tasks\SendDigests::class,
 			'data' => ['is_weekly' => 1],
 		],
 		'fetchSMfiles' => [
-			'class' => 'SMF\\Tasks\\FetchSMFiles',
+			'class' => Tasks\FetchSMFiles::class,
 		],
 		'fetch_calendar_subs' => [
-			'class' => 'SMF\\Tasks\\FetchCalendarSubscriptions',
+			'class' => Tasks\FetchCalendarSubscriptions::class,
 		],
 		'birthdayemails' => [
-			'class' => 'SMF\\Tasks\\Birthday_Notify',
+			'class' => Tasks\Birthday_Notify::class,
 		],
 		'paid_subscriptions' => [
-			'class' => 'SMF\\Tasks\\PaidSubs',
+			'class' => Tasks\PaidSubs::class,
 		],
 		'remove_temp_attachments' => [
-			'class' => 'SMF\\Tasks\\RemoveTempAttachments',
+			'class' => Tasks\RemoveTempAttachments::class,
 		],
 		'remove_topic_redirect' => [
-			'class' => 'SMF\\Tasks\\RemoveTopicRedirects',
+			'class' => Tasks\RemoveTopicRedirects::class,
 		],
 		'remove_old_drafts' => [
-			'class' => 'SMF\\Tasks\\RemoveOldDrafts',
+			'class' => Tasks\RemoveOldDrafts::class,
 		],
 		'prune_log_topics' => [
-			'class' => 'SMF\\Tasks\\PruneLogTopics',
+			'class' => Tasks\PruneLogTopics::class,
 		],
 	];
 
@@ -726,7 +726,7 @@ class TaskRunner
 		IntegrationHook::call('integrate_scheduled_tasks', [&self::$scheduled_tasks]);
 
 		if ($is_callable) {
-			$class = 'SMF\\Tasks\\GenericScheduledTask';
+			$class = Tasks\GenericScheduledTask::class;
 			$data = [
 				'callable' => $task,
 				'id_scheduled_task' => $id,
@@ -872,5 +872,5 @@ class TaskRunner
 }
 
 if (!empty(\SMF\Config::$backward_compatibility)) {
-	class_alias('\\SMF\\Tasks\\BackgroundTask', 'SMF_BackgroundTask');
+	class_alias(Tasks\BackgroundTask::class, 'SMF_BackgroundTask');
 }

--- a/Sources/Tasks/WeeklyMaintenance.php
+++ b/Sources/Tasks/WeeklyMaintenance.php
@@ -236,7 +236,7 @@ class WeeklyMaintenance extends ScheduledTask
 			],
 			[
 				[
-					'SMF\\Tasks\\UpdateTldRegex',
+					UpdateTldRegex::class,
 					'',
 					0,
 				],
@@ -254,7 +254,7 @@ class WeeklyMaintenance extends ScheduledTask
 				'claimed_time' => 'int'],
 			[
 				[
-					'SMF\\Tasks\\UpdateUnicode',
+					UpdateUnicode::class,
 					'',
 					0,
 				],

--- a/Sources/User.php
+++ b/Sources/User.php
@@ -5958,7 +5958,7 @@ class User implements \ArrayAccess
 			],
 			[
 				[
-					'SMF\\Tasks\\AnonymizeEditHistory',
+					Tasks\AnonymizeEditHistory::class,
 					json_encode(['id' => $member]),
 					0,
 				],

--- a/Sources/Utils.php
+++ b/Sources/Utils.php
@@ -2288,10 +2288,10 @@ class Utils
 			}
 
 			// Start up the session URL fixer.
-			ob_start('SMF\\QueryString::obDebug');
+			ob_start(QueryString::class . '::obDebug');
 
 			// More work needed if using "queryless" URLS.
-			ob_start('SMF\\QueryString::rewriteAsQueryless');
+			ob_start(QueryString::class . '::rewriteAsQueryless');
 
 			// Force the browser not to collapse tabs inside posts, etc.
 			ob_start(fn($buffer) => strtr($buffer, [self::TAB_SUBSTITUTE => '<span style="white-space: pre;">' . "\t" . '</span>']));

--- a/proxy.php
+++ b/proxy.php
@@ -27,5 +27,5 @@ if (SMF == 'PROXY') {
 }
 // In case an old mod included this file in order to load the ProxyServer class.
 else {
-	class_exists('SMF\\ProxyServer');
+	class_exists(\SMF\ProxyServer::class);
 }


### PR DESCRIPTION
#### Description

Follow-up to the review comment on #9661, which asked for a separate PR replacing every
class name written as a string with a `::class` resolver.

A name in a string is not a name PHP ever checks. `phplint` sees a valid string,
`php-cs-fixer` does not read inside strings, and nothing resolves the name until the moment
it is used — which for a background task is a cron run on somebody else's forum, where
`TaskRunner::execute()` logs the class it could not find, drops the row and carries on.
Written as `Tasks\CreatePost_Notify::class`, the compiler resolves the name against the
file's imports, so a misspelling is a name that is simply not there, and an IDE renaming
the class renames this too.

103 literals across 47 files. Four are deliberately left alone, and each is the same kind of
thing: `ActionRouter` asks whether its own class sits under `'SMF\Actions'`, which is a
namespace and never a class; `Sources/Actions/Admin/PackageManager.php` names the alias
`class_alias()` is about to create, which is not a class until it does; and `Punycode` probes
for two Unicode helper *functions*, which have no resolver.

##### Nothing changes shape

A `Class::method` string is a callable, and in several places it is also a string that SMF
itself parses: `Moderation\Main::buildRoute()` does `str_contains($area['function'], '::')`
and then `substr()` to pull the class out, and `Profile\Main` falls an area's `function` back
into `Utils::$context['sub_template']`. So the class half becomes a resolver and the rest
stays a string:

```php
'function' => PackageManager::class . '::call',
$row = filter_var($row, FILTER_CALLBACK, ['options' => Utils::class . '::cleanXml']);
ob_start(QueryString::class . '::rewriteAsQueryless');
```

`[Foo::class, 'method']` and `Foo::method(...)` were both on the table and both were dropped:
they change the value's type, these tables travel through `integrate_*` hooks, and the
concatenation is what the neighbouring entries already look like
(`'function' => __NAMESPACE__ . '\Home::call'`). Happy to switch if reviewers prefer one.

There is one deliberate difference in the whole diff. `Upgrade.php` queued
`'SMF\Tasks\FetchSMfiles'` when the class is `FetchSMFiles`; writing it as a resolver spells
it the only way it can be spelled, so this line also carries the fix in #9660. Whichever
merges second gets a one-line conflict.

One line reads fully qualified rather than imported. `TrackIP.php` already imports
`SMF\Profile\Tracking`, a class that does not exist anywhere in the tree, and that dead
import shadows `Profile\Tracking`, so `\SMF\Actions\Profile\Tracking::class` is spelled out.
Removing the dead import belongs in its own change.

##### How it was checked

The rewrite was mechanical, and so was the check on it. A script resolves every `::class`
reference in the new tree the way PHP does — walking the file's `namespace` and its imports,
with an import beating the current namespace — and compares the result against the string
that used to be at that spot. Every one matches, the `FetchSMfiles` correction aside. That
caught a real bug on the first pass: `Profile\Tracking::class` in `TrackIP.php` had silently
become `SMF\Profile\Tracking` because of the import above.

Then, on the running forum: `composer lint` clean, `php -l` on all 47, `composer test` green
(350 tests), and a sweep of the pages this touches with **nothing in `log_errors`** — board
index, the admin areas for packages, membergroups, holidays, scheduled tasks and the error
log, profile drafts, tracking, moderation, reported posts, the three feeds, a board and a
topic. Posting a reply queued `SMF\Tasks\CreatePost_Notify`, byte for byte the string it
queued before, and cron ran it without complaint.

### Issues References (Fixes|Related|Closes)
1. Related to #9661 — this is the separate PR asked for in review there.
2. Related to #9660 — `Upgrade.php` line 1229 carries that fix as a consequence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
