### PR TITLE
[3.0] Checks that class names are written as ::class resolvers

### DIFF
--- a/tests/Unit/ClassNameSyntaxTest.php
+++ b/tests/Unit/ClassNameSyntaxTest.php
@@ -1,0 +1,247 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SMF\Tests\Unit;
+
+use FilesystemIterator;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\TestCase;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+
+/**
+ * Checks that SMF names its own classes with ::class rather than in a string.
+ *
+ * A name in a string is not a name PHP ever checks. phplint sees a valid string,
+ * php-cs-fixer does not read inside strings, and nothing resolves the name until
+ * the moment it is used, which for a background task is a cron run on somebody
+ * else's forum. Written as a resolver, the compiler resolves the name against
+ * the file's imports, so a misspelling is a name that is simply not there.
+ *
+ * This only sees a name spelled out in one literal. A name assembled at run time,
+ * as the menus do with __NAMESPACE__ . '\\Home::call', is invisible here; the
+ * class half of it is not written down for anything to check either.
+ */
+#[CoversNothing]
+class ClassNameSyntaxTest extends TestCase
+{
+	/*****************
+	 * Class constants
+	 *****************/
+
+	/**
+	 * The directories that hold the classes SMF ships.
+	 */
+	private const ROOTS = [
+		'Sources',
+		'Themes',
+	];
+
+	/**
+	 * The files that ship outside those directories.
+	 */
+	private const ENTRY_POINTS = [
+		'index.php',
+		'cron.php',
+		'SSI.php',
+		'proxy.php',
+		'subscriptions.php',
+	];
+
+	/**
+	 * The names that have to stay in a string, and why.
+	 *
+	 * Keyed by the file, with '/' as the separator whatever the platform uses,
+	 * so that moving the code around a file does not invalidate the reason.
+	 *
+	 * Anything added here needs a comment saying why a resolver cannot express
+	 * it. "The class does not exist yet" is not one of them: ::class resolves at
+	 * compile time and never asks the autoloader, so it is happy to name a class
+	 * that has not been loaded, or one that is never loaded at all.
+	 */
+	private const ALLOWED = [
+		// A namespace prefix, which is never a class.
+		'Sources/ActionRouter.php' => [
+			'SMF\\Actions',
+		],
+		// The alias class_alias() is about to create. Writing the name it is
+		// creating as a resolver would claim the alias already exists.
+		'Sources/Actions/Admin/PackageManager.php' => [
+			'SMF\\Actions\\Admin\\PackageManager',
+		],
+		// Two Unicode helper functions, which only some data files define.
+		// Functions have no resolver.
+		'Sources/Punycode.php' => [
+			'SMF\\Unicode\\idna_maps_deviation',
+			'SMF\\Unicode\\idna_maps_not_std3',
+		],
+	];
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	public function testEveryClassNameIsWrittenAsAResolverRatherThanAString(): void
+	{
+		$found = [];
+
+		foreach ($this->shippedFiles() as $file) {
+			$relative = $this->relative($file);
+
+			foreach ($this->classNameLiterals($file) as [$line, $literal]) {
+				if (\in_array($literal, self::ALLOWED[$relative] ?? [], true)) {
+					continue;
+				}
+
+				$found[] = $relative . ':' . $line . ' names ' . $literal;
+			}
+		}
+
+		$this->assertSame([], $found, 'A class name is written as a string. Write it as a ::class resolver, or add it to ' . self::class . '::ALLOWED with the reason it cannot be one.');
+	}
+
+	/**
+	 * An exception whose reason has gone stale is an exception nobody notices,
+	 * so the list is only allowed to name things that are really still there.
+	 */
+	public function testNothingInTheListOfExceptionsHasGoneStale(): void
+	{
+		$stale = [];
+
+		foreach (self::ALLOWED as $relative => $literals) {
+			$file = $this->boardDir() . DIRECTORY_SEPARATOR . strtr($relative, ['/' => DIRECTORY_SEPARATOR]);
+
+			$present = [];
+
+			if (is_file($file)) {
+				foreach ($this->classNameLiterals($file) as [, $literal]) {
+					$present[] = $literal;
+				}
+			}
+
+			foreach ($literals as $literal) {
+				if (!\in_array($literal, $present, true)) {
+					$stale[] = $relative . ' no longer names ' . $literal;
+				}
+			}
+		}
+
+		$this->assertSame([], $stale, 'The list of names allowed to stay in a string mentions something that is not there any more. Remove the entry.');
+	}
+
+	/******************
+	 * Internal methods
+	 ******************/
+
+	/**
+	 * Every PHP file the forum ships, entry points included.
+	 *
+	 * @return array<int, string>
+	 */
+	private function shippedFiles(): array
+	{
+		$files = [];
+
+		foreach (self::ROOTS as $dir) {
+			$root = $this->boardDir() . DIRECTORY_SEPARATOR . $dir;
+
+			$iterator = new RecursiveIteratorIterator(
+				new RecursiveDirectoryIterator($root, FilesystemIterator::SKIP_DOTS),
+			);
+
+			foreach ($iterator as $file) {
+				if ($file->isFile() && $file->getExtension() === 'php') {
+					$files[] = $file->getPathname();
+				}
+			}
+		}
+
+		foreach (self::ENTRY_POINTS as $name) {
+			$files[] = $this->boardDir() . DIRECTORY_SEPARATOR . $name;
+		}
+
+		// So that a failure reads the same way wherever it happens.
+		sort($files);
+
+		return $files;
+	}
+
+	/**
+	 * The class names one file writes down as strings, as [line, name] pairs.
+	 *
+	 * @param string $file The file to read.
+	 * @return array<int, array{int, string}>
+	 */
+	private function classNameLiterals(string $file): array
+	{
+		$code = (string) file_get_contents($file);
+
+		// Tokenising sixteen megabytes of source to find a handful of strings is
+		// worth avoiding, and the Unicode data files are most of that weight.
+		// Every literal we want opens with a quote and reaches a namespace
+		// separator within a couple of characters.
+		if (preg_match('/[\'"]\\\\{0,2}SMF\\\\/', $code) !== 1) {
+			return [];
+		}
+
+		$found = [];
+
+		// A docblock saying @var SMF\Utils is not a name the code uses, and
+		// there are thousands of those, which is why this reads tokens and not
+		// lines.
+		foreach (token_get_all($code) as $token) {
+			if (!\is_array($token) || $token[0] !== T_CONSTANT_ENCAPSED_STRING) {
+				continue;
+			}
+
+			$literal = $this->unquote($token[1]);
+
+			// Every segment has to be non-empty, which leaves out the bare
+			// 'SMF\Tasks\' that TaskRunner and ReportedContent build a name
+			// from at run time.
+			if (preg_match('/^\\\\?SMF(\\\\[A-Za-z0-9_]+)+(::[A-Za-z0-9_]+)?$/', $literal) !== 1) {
+				continue;
+			}
+
+			$found[] = [$token[2], ltrim($literal, '\\')];
+		}
+
+		return $found;
+	}
+
+	/**
+	 * The text of a quoted string, with its escapes resolved.
+	 *
+	 * @param string $token The token, quotes and all.
+	 */
+	private function unquote(string $token): string
+	{
+		$body = substr($token, 1, -1);
+
+		// A class name in a double-quoted string is an interpolation waiting to
+		// happen, so the codebase writes them single-quoted, where the only two
+		// escapes are the quote and the backslash itself.
+		return $token[0] === "'"
+			? strtr($body, ['\\\\' => '\\', '\\\'' => '\''])
+			: stripcslashes($body);
+	}
+
+	/**
+	 * A path as it would be written in a bug report.
+	 *
+	 * @param string $file An absolute path inside the checkout.
+	 */
+	private function relative(string $file): string
+	{
+		return strtr(substr($file, \strlen($this->boardDir()) + 1), [DIRECTORY_SEPARATOR => '/']);
+	}
+
+	/**
+	 * The root of the checkout, resolved so the walked paths start with it.
+	 */
+	private function boardDir(): string
+	{
+		return (string) realpath(TESTS_BOARDDIR);
+	}
+}


### PR DESCRIPTION
#### Description

#9665 rewrote every class name SMF wrote down as a string into a `::class` resolver. This is
the test that keeps it that way.

Nothing else can. `phplint` sees a valid string, `php-cs-fixer` does not read inside strings,
and PHP itself never resolves the name until the moment it is used — which for a background
task is a cron run on somebody else's forum, where `TaskRunner::execute()` logs the class it
could not find, drops the row from the queue and carries on. So the next one to be written
would sit there exactly as `'SMF\Tasks\FetchSMfiles'` did, until somebody read the error log
of a forum they do not own.

The test walks `Sources/`, `Themes/` and the five entry points, tokenises everything that
mentions `SMF\` in a string at all, and fails on any string that spells out a class name:

```
Sources/TempProbe.php:11 names SMF\Tasks\CreatePost_Notify
```

with a message saying to write it as a resolver or to add it to the list of exceptions with
a reason.

##### The exceptions

Four names have to stay in a string, and the list says why for each:

- `ActionRouter` asks whether its own class sits under `'SMF\Actions'`, which is a namespace
  and never a class.
- `Sources/Actions/Admin/PackageManager.php` names the alias `class_alias()` is about to
  create. Writing the name being created as a resolver would claim the alias already exists.
- `Punycode` probes for two Unicode helper **functions**, which only some data files define.
  Functions have no resolver.

The list is keyed by file and by the name itself rather than by line, so moving code around
a file does not invalidate it, and a second test fails if an entry names something that is
no longer there. An allowlist that outlives its reason is how a test like this stops meaning
anything, and I would rather it said so out loud than quietly wave through the next one.

The docblock on the list also heads off the entry somebody will reach for first: "the class
does not exist yet" is not a reason. `::class` resolves at compile time and never asks the
autoloader, so it is perfectly happy to name a class that has not been loaded, or one that
is never loaded at all.

##### What it cannot see

A name assembled at run time. The menus build theirs as
`__NAMESPACE__ . '\\Home::call'`, and the class half of that is not written down for
anything to check either — not by this test, and not by the compiler. Worth knowing before
reading a pass here as "every class name in SMF is checked".

##### Proving it fails

Both assertions were watched failing before being trusted: a throwaway `Sources/TempProbe.php`
holding `'SMF\Tasks\CreatePost_Notify'` produced the failure above, and a bogus entry in the
exception list produced

```
Sources/ActionRouter.php no longer names SMF\NotThereAnyMore
```

##### Cost and its relationship to #9661

13.3s in the Docker environment. That is the bind-mounted filesystem rather than the work:
#9661's `ClassReferenceTest`, which walks the same tree, measures 12.1s in the same container
against the 0.151s quoted on that PR.

The two overlap, and reviewers may want only one. They answer different questions — #9661
asks whether a name written as a string is real, which still matters for the four above and
for anything a future change adds; this one asks whether SMF writes them as strings at all,
which after #9665 is the stronger statement. If both land they could share a single walk of
the tree. Happy to fold them together either way round.

### Issues References (Fixes|Related|Closes)
1. Related to #9665 — this pins the rewrite that landed there.
2. Related to #9661 — overlapping coverage, discussed above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
