### PR TITLE
[3.0] Theme split (wave 10) — remove the calendar right-to-left rules nothing matches

### DIFF
--- a/Themes/default/css/calendar.rtl.css
+++ b/Themes/default/css/calendar.rtl.css
@@ -6,17 +6,3 @@
 #month_grid {
 	margin: 0 0 0 1%;
 }
-#main_grid table.weeklist td.windowbg {
-	border-left: 2px solid var(--calendar-weeklist-border-color);
-	border-bottom: 2px solid var(--calendar-weeklist-border-color);
-}
-#main_grid img.calendar_icon {
-	float: right;
-	margin: 0 0 0 4px;
-}
-#main_grid table.weeklist td.weekdays {
-	text-align: left;
-	vertical-align: middle;
-	border-right: 2px solid var(--calendar-weeklist-border-color);
-	border-bottom: 2px solid var(--calendar-weeklist-border-color);
-}

--- a/Themes/default/css/dark.css
+++ b/Themes/default/css/dark.css
@@ -567,7 +567,6 @@
 	--attachment-dropzone-border-color_hover:         hsl(var(--primary-color-hue), 45%, 55%);
 	--attachment-item-border-color:                   var(--dark-line);
 	--buttonrow-border-color:                         var(--dark-line);
-	--calendar-weeklist-border-color:                 var(--dark-bg-1);
 	--detailedinfo-border-color:                      var(--dark-line);
 	--draftoptions-border-color_left:                 var(--dark-line-strong);
 	--draftoptions-item-border-color:                 var(--dark-line);

--- a/Themes/default/css/variables.css
+++ b/Themes/default/css/variables.css
@@ -799,7 +799,6 @@
 	--attachment-dropzone-border-color_hover:         #557ea0;
 	--attachment-item-border-color:                   #ddd;
 	--buttonrow-border-color:                         #ccc;
-	--calendar-weeklist-border-color:                 #fff;
 	--detailedinfo-border-color:                      #ccc;
 	--draftoptions-border-color_left:                 #bbb;
 	--draftoptions-item-border-color:                 #e4e4e4;


### PR DESCRIPTION
#### Description

`calendar.rtl.css` mirrors three selectors that no longer exist anywhere in SMF:

- `#main_grid table.weeklist td.windowbg`
- `#main_grid table.weeklist td.weekdays`
- `#main_grid img.calendar_icon`

Nothing in `Sources/` or `Themes/` emits a `weeklist`, `weekdays` or `calendar_icon` class — not under those names, and not built up from parts either, which is worth checking separately because a class name can arrive constructed rather than written out. `calendar.css` has no counterpart for any of the three, so the base stylesheet has already moved on and only the right-to-left file still describes the old table.

The week view is drawn from `days`, `act_day`, `event_col`, `holiday_col` and `birthday_col`, built in `Calendar.template.php` — a different structure entirely.

The three rules were also the only readers of `--calendar-weeklist-border-color`, so its definitions in `variables.css` and `dark.css` go with them.

##### What stays, and why

The two remaining rules in the file are deliberately left alone. Neither is an exact mirror of a base rule, so neither can be written as a logical property without changing the left-to-right result as well:

- `#main_grid .cat_bar { margin: 0 0 0 2px; }` has no counterpart in `calendar.css` at all — it adds a margin only in right-to-left.
- `#month_grid { margin: 0 0 0 1%; }` faces a base `margin-right: 10px`. That is a different *value*, not the same value on the mirrored side.

This follows the same rule the earlier waves used: a declaration only becomes logical when the override is precisely the base value with the sides swapped.

This is the last right-to-left override file, and with these rules gone it holds only the two that have to stay.

### Issues References (Fixes|Related|Closes)

Related to #7933.

🤖 Generated with [Claude Code](https://claude.com/claude-code)