### PR TITLE
[3.0] Load the stylesheet a theme variant is recoloured with

### DIFF
--- a/Sources/Theme.php
+++ b/Sources/Theme.php
@@ -2285,6 +2285,17 @@ class Theme
 			if (Utils::$context['theme_variant'] == '' || !\in_array(Utils::$context['theme_variant'], $this->settings['theme_variants'])) {
 				Utils::$context['theme_variant'] = !empty($this->settings['default_variant']) && \in_array($this->settings['default_variant'], $this->settings['theme_variants']) ? $this->settings['default_variant'] : $this->settings['theme_variants'][0];
 			}
+
+			/*
+			 * The other way to recolour a variant is a whole stylesheet of its
+			 * own, sitting on top of index.css. The 'default' variant is the base
+			 * sheet by itself, so it has no file of its own to load, and a theme
+			 * that recolours through variants.css above has none either - the
+			 * file is validated, so a missing one is simply not loaded.
+			 */
+			if (Utils::$context['theme_variant'] !== 'default') {
+				self::loadCSSFile('index_' . Utils::$context['theme_variant'] . '.css', ['order_pos' => 2], 'smf_index_' . Utils::$context['theme_variant']);
+			}
 		}
 	}
 


### PR DESCRIPTION
#### Description

A theme has two ways to recolour a variant, and `Theme::loadVariant()` only implements one of them.

The first is a single `variants.css` holding `:root[data-variant="…"]` blocks. That one is loaded.

The second is a whole stylesheet per variant sitting on top of `index.css`. The default theme documents it in `index.template.php`, right above the setting that declares the variants:

```
	/*
	 * Define the theme variants. Each variant has its own CSS file.
	 *
	 * Example:
	 * - index_red.css is loaded when the user selects the `red` variant.
	 *
	 * Additionally, a variants.css file is always loaded as well, in
	 * case you'd rather keep the styles in a single file or they're minimal.
	 */
```

and again further down:

```
			The most efficient way of writing multi themes is to use a master
			index.css plus variant.css files. If you've set them up properly
			(through Theme::$current->settings['theme_variants']), the variant files will be loaded
			for you automatically.
```

Nothing loaded them. This adds it.

##### Details

- `order_pos` is 2 — after `index.css` at 1 and beside `dark.css`, so the variant sheet overrides the base sheet, which is the point of it.
- The `default` variant is the base sheet on its own, so it has no file and is skipped.
- `loadCSSFile()` validates by default, so a theme that recolours through `variants.css` instead simply has nothing queued. Adding this cannot break such a theme.
- The default theme declares no variants, so nothing changes for it.

##### Verification

Declaring a `sunset` variant in the default theme locally, all three cases on a running forum with nothing added to `log_errors`:

| case | result |
|---|---|
| `index_sunset.css` present, `?variant=sunset` | loaded — its marker rule appears in the minified bundle |
| `index_sunset.css` absent, `?variant=sunset` | nothing queued, page 200, nothing logged |
| `index_default.css` present, `?variant=default` | correctly skipped |

### Issues References (Fixes|Related|Closes)

Related to #7933.

🤖 Generated with [Claude Code](https://claude.com/claude-code)