### PR TITLE
[3.0] Document two ways working code looks broken to an agent

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -297,6 +297,23 @@ both engines, verify anything touching SQL on the other one as well: delete
 way, then reinstall.
 
 The checkout is bind-mounted into the web container, so edits are live with no rebuild.
+On Windows, "live" is not the same as "immediate": Docker Desktop propagates a changed
+file into the container after a lag of seconds, sometimes longer, and until it does the
+container serves the previous version with nothing to say it is stale. A page requested
+straight after an edit can therefore show the old behaviour, which looks exactly like the
+edit having no effect. Wait for the change to arrive before measuring anything:
+
+```bash
+until curl -s http://localhost:8080/index.php | grep -q 'something only the new code emits'; do sleep 2; done
+```
+
+This is worth the discipline because the failure mode is not an obviously wrong reading
+but a plausible one. It can make working code look dead, and it can equally make a
+`git stash` look as though it was never applied — so treat a surprising measurement as
+staleness until it survives the wait above. Neither the SMF cache nor opcache is involved,
+and checking them is a dead end: `$cache_enable` is 0 in the generated `Settings.php` and
+opcache revalidates on every request.
+
 Useful while working:
 
 ```bash
@@ -331,6 +348,17 @@ than shown, especially anything in a background task.
   `Sources/Db/Schema/v3_0/` before trusting a column name. A query naming a removed column
   fails at runtime only, and inside a background task it retries forever and takes down
   unrelated page loads.
+- **Names are built from strings, so a grep does not prove something is dead.** Functions,
+  sub-templates and CSS classes are routinely reached under a name assembled at runtime,
+  and the literal never appears in the source. `Theme::loadSubTemplate('init')` calls
+  `template_init()`, which is how a theme initialises itself; `Theme::loadTemplate($name)`
+  calls `template_{$name}_init()`; `BBCodeParser` builds `.bbc_standard_quote` as
+  `'bbc_' . ($quote_alt ? 'alternate' : 'standard') . '_quote'`. Search for any of those
+  three names and you find a comment, if that. Before removing anything as unused, look
+  for the pieces as well — `loadSubTemplate(`, `call_user_func`, the prefix or suffix on
+  its own — or settle it by running the code and reading a stack trace. The cost of
+  getting this wrong is not just a bad deletion: it is a convincing report of a bug that
+  does not exist.
 - **Deprecated compatibility layer**: `Sources/Subs-Compat.php` holds the old procedural
   API. It often shows the guard clauses the modern class methods should have; useful when
   tracking down a missing check.


### PR DESCRIPTION
#### Description

Two traps in this repository and its dev environment produce a *confident* wrong conclusion rather than an obviously wrong one, and neither leaves any sign that the reading was unsafe. Both cost me a full investigation into a bug that did not exist, so they seem worth writing down where the next agent will read them.

##### A grep does not prove something is dead

SMF reaches functions, sub-templates and CSS classes under names it assembles at runtime, so the literal never appears in the source:

- `Theme::loadSubTemplate('init')` calls `template_init()` — this is how every theme initialises itself.
- `Theme::loadTemplate($name)` calls `template_{$name}_init()`.
- `BBCodeParser` builds `.bbc_standard_quote` as `'bbc_' . ($quote_alt ? 'alternate' : 'standard') . '_quote'`.

Grep for `template_init` and you get a single comment. That reads exactly like proof of dead code, and I acted on it: I had a branch open to "fix" the fact that `template_init()` is never called, and the whole `template_init()` block — `has_dark_mode`, `theme_variants`, `page_index` — was inert. It is not. `loadSubTemplate('init', 'ignore')` at the end of `loadTemplatesAndLangFiles()` calls it on every request, and dark mode works.

Added to **Things that bite in this codebase**.

##### The Windows bind mount serves stale files

`### Running the forum` currently says the checkout is bind-mounted "so edits are live with no rebuild", which is true but reads as *immediate*. On Docker Desktop for Windows it is not: a changed file reaches the container after a lag of seconds, sometimes longer, and until it does the container serves the previous version silently.

So a page requested straight after an edit can show the old behaviour — indistinguishable from the edit not working. In one session it made the above look like a real bug, and later made a `git stash` appear never to have been applied.

The note says to poll until the change actually appears before measuring, and records that neither the SMF cache nor opcache is the cause, since those are the first two things you would check and both are dead ends: `$cache_enable` is 0 (as `.docker/use-engine.sh` also notes) and opcache runs with `revalidate_freq = 0`.

Added to **Running the forum**.

##### Notes

Documentation only — no code changes.

Both #9617 and #9659 also touch `AGENTS.md`, in other sections. Whichever lands first, I will rebase the others.

### Issues References (Fixes|Related|Closes)

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)