### PR TITLE
[3.0] Remove extra path component from http test

### DIFF
--- a/tests/Support/HttpClient.php
+++ b/tests/Support/HttpClient.php
@@ -180,8 +180,7 @@ final class HttpClient
 		if (preg_match('~^https?://~i', $path)) {
 			$parts = parse_url($path);
 
-			$path = ($parts['path'] ?? '/')
-				. (isset($parts['query']) ? '?' . $parts['query'] : '')
+			$path = (isset($parts['query']) ? '?' . $parts['query'] : '')
 				. (isset($parts['fragment']) ? '#' . $parts['fragment'] : '');
 		}
 


### PR DESCRIPTION
 I've been debugging requests to see why login attempts fail with a `404`. It fetches the form correctly but turns the submit action from `http://localhost/smf-dev/index.php?action=login2` into `http://localhost/smf-dev/smf-dev/index.php?action=login2`.