### PR TITLE
[3.0] Limits a print page to one page of posts

### DIFF
--- a/Languages/en_US/Help.php
+++ b/Languages/en_US/Help.php
@@ -220,7 +220,7 @@ $helptxt['manage_files'] = '
 	</ul>';
 
 $helptxt['topicSummaryPosts'] = 'This allows you to set the number of previous posts shown in the topic summary on the reply page.';
-$helptxt['enableAllMessages'] = 'Set this to the <em>maximum</em> number of posts a topic can have to show the <em>all</em> link. Setting this lower than &quot;Maximum messages to display in a topic page&quot; will simply mean it never gets shown, and setting it too high could slow down your forum.';
+$helptxt['enableAllMessages'] = 'Set this to the <em>maximum</em> number of posts a topic can have to show the <em>all</em> link. Setting this lower than &quot;Maximum messages to display in a topic page&quot; will simply mean it never gets shown, and setting it too high could slow down your forum. The print view of a topic shows this many posts at a time as well, and falls back to a limit of its own when the <em>all</em> link is turned off here.';
 $helptxt['allow_guestAccess'] = 'Unchecking this box will stop guests from doing anything but very basic actions on your forum - login, register, password reminder, etc. - on your forum. This is not the same as disallowing guest access to boards.';
 $helptxt['userLanguage'] = 'Turning this setting on will allow users to select which language file they use. It will not affect the
 		default selection.';

--- a/Sources/Actions/TopicPrint.php
+++ b/Sources/Actions/TopicPrint.php
@@ -24,6 +24,7 @@ use SMF\Config;
 use SMF\Db\DatabaseApi as Db;
 use SMF\ErrorHandler;
 use SMF\Lang;
+use SMF\PageIndex;
 use SMF\Parser;
 use SMF\Poll;
 use SMF\Routable;
@@ -42,6 +43,16 @@ class TopicPrint implements ActionInterface, Routable
 {
 	use ActionSuffixRouter;
 	use ActionTrait;
+
+	/*****************
+	 * Class constants
+	 *****************/
+
+	/**
+	 * The number of posts to show on one print page in forums that never show
+	 * the "All" view.
+	 */
+	public const DEFAULT_MAX_POSTS = 250;
 
 	/****************
 	 * Public methods
@@ -97,7 +108,56 @@ class TopicPrint implements ActionInterface, Routable
 		$row = Db::$db->fetch_assoc($request);
 		Db::$db->free_result($request);
 
-		if (!empty($row['id_poll'])) {
+		// Only the posts this user is allowed to see are printed or counted.
+		$approval_filter = Config::$modSettings['postmod_active'] && !User::$me->allowedTo('approve_posts') ? '
+				AND (m.approved = {int:is_approved}' . (User::$me->is_guest ? '' : ' OR m.id_member = {int:current_member}') . ')' : '';
+
+		$request = Db::$db->query(
+			'SELECT COUNT(*)
+			FROM {db_prefix}messages AS m
+			WHERE m.id_topic = {int:current_topic}' . $approval_filter,
+			[
+				'current_topic' => Topic::$topic_id,
+				'is_approved' => 1,
+				'current_member' => User::$me->id,
+			],
+		);
+		list($total_posts) = Db::$db->fetch_row($request);
+		Db::$db->free_result($request);
+
+		$per_page = $this->getPostsPerPage();
+
+		Utils::$context['start'] = (int) $_REQUEST['start'];
+
+		$page_index = new PageIndex(
+			Config::$scripturl . '?action=printpage;topic=' . Topic::$topic_id . '.%1$d' . (isset($_REQUEST['images']) ? ';images' : ''),
+			Utils::$context['start'],
+			(int) $total_posts,
+			$per_page,
+			true,
+			true,
+			// The print page carries its own styles and no scripts, so the
+			// icons and the expanding page list have to be plain text here.
+			[
+				'previous_page' => Lang::getTxt('prev', file: 'General'),
+				'next_page' => Lang::getTxt('next', file: 'General'),
+				'expand_pages' => ' ... ',
+			],
+		);
+
+		// If the supplied start value was invalid, redirect to the correct one.
+		if ($_REQUEST['start'] != Utils::$context['start']) {
+			Utils::redirectexit(\sprintf($page_index->base_url, Utils::$context['start']));
+		}
+
+		// There is nothing to navigate when the whole topic fits on one page.
+		if ($total_posts > $per_page) {
+			Utils::$context['page_index'] = $page_index;
+		}
+
+		// The poll belongs to the topic rather than to any of its posts, so it
+		// is printed once, with the first page.
+		if (!empty($row['id_poll']) && Utils::$context['start'] === 0) {
 			$poll = Poll::load(Topic::$topic_id, Poll::LOAD_BY_TOPIC);
 			Utils::$context['poll'] = $poll->format(['no_buttons' => true]);
 		}
@@ -120,13 +180,15 @@ class TopicPrint implements ActionInterface, Routable
 			'SELECT subject, poster_time, body, COALESCE(mem.real_name, poster_name) AS poster_name, id_msg
 			FROM {db_prefix}messages AS m
 				LEFT JOIN {db_prefix}members AS mem ON (mem.id_member = m.id_member)
-			WHERE m.id_topic = {int:current_topic}' . (Config::$modSettings['postmod_active'] && !User::$me->allowedTo('approve_posts') ? '
-				AND (m.approved = {int:is_approved}' . (User::$me->is_guest ? '' : ' OR m.id_member = {int:current_member}') . ')' : '') . '
-			ORDER BY m.id_msg',
+			WHERE m.id_topic = {int:current_topic}' . $approval_filter . '
+			ORDER BY m.id_msg
+			LIMIT {int:per_page} OFFSET {int:start}',
 			[
 				'current_topic' => Topic::$topic_id,
 				'is_approved' => 1,
 				'current_member' => User::$me->id,
+				'per_page' => $per_page,
+				'start' => Utils::$context['start'],
 			],
 		);
 		Utils::$context['posts'] = [];
@@ -214,5 +276,25 @@ class TopicPrint implements ActionInterface, Routable
 
 		// Set a canonical URL for this page.
 		Utils::$context['canonical_url'] = Config::$scripturl . '?topic=' . Topic::$topic_id . '.0';
+	}
+
+	/******************
+	 * Internal methods
+	 ******************/
+
+	/**
+	 * Works out how many posts belong on a single print page.
+	 *
+	 * A print page holds whole posts, parsed and in memory all at once, so it
+	 * shows no more of them at a time than the admin is willing to show in the
+	 * "All" view of a topic.
+	 *
+	 * @return int The maximum number of posts on one print page.
+	 */
+	protected function getPostsPerPage(): int
+	{
+		$per_page = (int) (Config::$modSettings['enableAllMessages'] ?? 0);
+
+		return $per_page > 0 ? $per_page : self::DEFAULT_MAX_POSTS;
 	}
 }

--- a/Themes/default/Printpage.template.php
+++ b/Themes/default/Printpage.template.php
@@ -224,11 +224,17 @@ function template_print_below()
  */
 function template_print_options()
 {
-	$url_text = Config::$scripturl . '?action=printpage;topic=' . Topic::$topic_id . '.0';
+	$url_text = Config::$scripturl . '?action=printpage;topic=' . Topic::$topic_id . '.' . Utils::$context['start'];
 	$url_images = $url_text . ';images';
 
 	echo '
 		<div class="print_options">';
+
+	// Long topics are printed a page at a time.
+	if (isset(Utils::$context['page_index'])) {
+		echo '
+			<div>', Utils::$context['page_index'], '</div>';
+	}
 
 	// Which option is set, text or text&images
 	if (isset($_REQUEST['images'])) {

--- a/tests/Integration/Http/TopicPrintTest.php
+++ b/tests/Integration/Http/TopicPrintTest.php
@@ -1,0 +1,187 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SMF\Tests\Integration\Http;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use SMF\Config;
+use SMF\Msg;
+use SMF\Topic;
+
+/**
+ * The print view of a topic, over HTTP.
+ *
+ * What is worth proving here is what a single request is willing to do. The
+ * print view renders whole posts with nothing else on the page, so a request for
+ * a long topic parses every post in it at once, and a visitor needs no account
+ * to ask for one. Only a real request shows how many posts come back, since the
+ * limit is applied in the action and the page is built by the template.
+ */
+#[CoversNothing]
+class TopicPrintTest extends HttpTestCase
+{
+	/*****************
+	 * Class constants
+	 *****************/
+
+	/**
+	 * How many posts to put in the test topic.
+	 */
+	private const POSTS = 5;
+
+	/**
+	 * How many of them a print page is allowed to show.
+	 */
+	private const PER_PAGE = 2;
+
+	/*********************
+	 * Internal properties
+	 *********************/
+
+	/**
+	 * @var array Topics this test created, to be removed afterwards.
+	 */
+	private array $created_topics = [];
+
+	/**
+	 * @var ?string The forum's own maximum topic size for the "All" view.
+	 */
+	private ?string $previous_max = null;
+
+	/****************
+	 * Public methods
+	 ****************/
+
+	public function testAPrintPageStopsAtOnePageOfPosts(): void
+	{
+		$topic_id = $this->seedTopic();
+
+		$first = $this->fetch('?action=printpage;topic=' . $topic_id . '.0');
+
+		$this->assertSame(
+			self::PER_PAGE,
+			$first->xpath('//div[@class="postheader"]')->length,
+			'the print page rendered the whole topic instead of one page of it',
+		);
+
+		$this->assertStringNotContainsString(
+			$this->bodyOfPost(self::POSTS),
+			$first->text(),
+			'the last post of the topic is on the first print page',
+		);
+
+		$this->assertNoErrorsLogged('printing a topic logged something.' . "\n");
+	}
+
+	public function testTheRestOfTheTopicIsOnTheFollowingPages(): void
+	{
+		$topic_id = $this->seedTopic();
+
+		$last = $this->fetch('?action=printpage;topic=' . $topic_id . '.' . (self::POSTS - 1));
+
+		$this->assertStringContainsString(
+			$this->bodyOfPost(self::POSTS),
+			$last->text(),
+			'the last post of the topic cannot be printed at all',
+		);
+
+		$this->assertNoErrorsLogged('printing the last page logged something.' . "\n");
+	}
+
+	/**
+	 * Without these the rest of a long topic is unreachable, since the print
+	 * page is the only thing that links to itself.
+	 */
+	public function testAPrintPageLinksToTheOtherPages(): void
+	{
+		$topic_id = $this->seedTopic();
+
+		$first = $this->fetch('?action=printpage;topic=' . $topic_id . '.0');
+
+		$this->assertGreaterThan(
+			0,
+			$first->xpath(
+				'//a[contains(@href, "action=printpage")][contains(@href, "topic=' . $topic_id . '.' . self::PER_PAGE . '")]',
+			)->length,
+			'the print page does not link to its second page',
+		);
+	}
+
+	/******************
+	 * Internal methods
+	 ******************/
+
+	protected function setUp(): void
+	{
+		parent::setUp();
+
+		// A print page shows no more posts than the "All" view is allowed to,
+		// so this is what decides where it stops.
+		$this->previous_max = $this->rawSetting('enableAllMessages');
+
+		Config::updateModSettings(['enableAllMessages' => self::PER_PAGE]);
+	}
+
+	protected function tearDown(): void
+	{
+		// Before the parent runs, while the connection is still ours.
+		Config::updateModSettings(['enableAllMessages' => (int) $this->previous_max]);
+
+		if ($this->created_topics !== []) {
+			Topic::remove($this->created_topics);
+
+			$this->created_topics = [];
+		}
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Starts a topic holding more posts than one print page may show.
+	 *
+	 * @return int The new topic's id.
+	 */
+	private function seedTopic(): int
+	{
+		$this->actingAs($this->adminId());
+
+		$topic_id = 0;
+
+		for ($i = 1; $i <= self::POSTS; $i++) {
+			$msgOptions = [
+				'subject' => ($i === 1 ? '' : 'Re: ') . 'Print pagination',
+				'body' => $this->bodyOfPost($i),
+				'send_notifications' => false,
+			];
+			$topicOptions = [
+				'id' => $topic_id,
+				'board' => 1,
+			];
+			$posterOptions = [
+				'id' => $this->adminId(),
+			];
+
+			Msg::create($msgOptions, $topicOptions, $posterOptions);
+
+			$topic_id = (int) $topicOptions['id'];
+
+			if ($this->created_topics === []) {
+				$this->created_topics[] = $topic_id;
+			}
+		}
+
+		return $topic_id;
+	}
+
+	/**
+	 * The body of one of the seeded posts.
+	 *
+	 * @param int $number Which post.
+	 * @return string Its body.
+	 */
+	private function bodyOfPost(int $number): string
+	{
+		return 'Print pagination post number ' . $number . '.';
+	}
+}

--- a/tests/Unit/TopicPrintTest.php
+++ b/tests/Unit/TopicPrintTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SMF\Tests\Unit;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use SMF\Actions\TopicPrint;
+use SMF\Config;
+
+#[CoversClass(TopicPrint::class)]
+class TopicPrintTest extends TestCase
+{
+	/****************
+	 * Public methods
+	 ****************/
+
+	public function testItFallsBackToTheDefaultWhenAllIsNeverShown(): void
+	{
+		// A print page used to hold an entire topic no matter how long it was,
+		// which let a single request parse every post in it at once.
+		$this->assertSame(TopicPrint::DEFAULT_MAX_POSTS, $this->getPostsPerPage());
+	}
+
+	// Note: the section banner above must not be the first thing in this group when
+	// the first member carries an attribute. The SMF/section_comments fixer inserts
+	// the banner between the attribute and its method.
+	#[DataProvider('maxTopicSizeProvider')]
+	public function testGetPostsPerPage(mixed $enable_all_messages, int $expected): void
+	{
+		Config::$modSettings['enableAllMessages'] = $enable_all_messages;
+
+		$this->assertSame($expected, $this->getPostsPerPage());
+	}
+
+	/***********************
+	 * Public static methods
+	 ***********************/
+
+	/**
+	 * @return array<string, array{mixed, int}>
+	 */
+	public static function maxTopicSizeProvider(): array
+	{
+		return [
+			'the admin sets the size' => ['50', 50],
+			'an integer is accepted too' => [50, 50],
+			'zero means the admin never shows all' => ['0', TopicPrint::DEFAULT_MAX_POSTS],
+			'a negative size is meaningless' => ['-50', TopicPrint::DEFAULT_MAX_POSTS],
+			'so is a non-numeric one' => ['lots', TopicPrint::DEFAULT_MAX_POSTS],
+		];
+	}
+
+	/******************
+	 * Internal methods
+	 ******************/
+
+	protected function tearDown(): void
+	{
+		unset(Config::$modSettings['enableAllMessages']);
+	}
+
+	/**
+	 * Calls the protected helper under test.
+	 */
+	private function getPostsPerPage(): int
+	{
+		$action = (new \ReflectionClass(TopicPrint::class))->newInstanceWithoutConstructor();
+
+		return (new \ReflectionMethod(TopicPrint::class, 'getPostsPerPage'))->invoke($action);
+	}
+}


### PR DESCRIPTION
#### Description

`?action=printpage` renders a whole topic in one request: one query for every message in it, each one parsed and held in memory at once, available to anyone who can read the board. Every other view that shows a lot of a topic at once is capped — the "All" view refuses a topic longer than `enableAllMessages`, a feed takes at most 255 items — and the print view was the exception.

This gives it the same treatment. A print page now shows as many posts as the admin is willing to show in the "All" view and pages through the rest, so a long topic is still printable in full but no single request builds all of it. Forums that never show "All" get a limit of 250 rather than none, since `0` in that setting means the link is off, not that a request may render anything it likes.

The rest follows from paging:

- the page index and the text/images links carry the current start;
- the poll prints once, with the first page, instead of on top of every page;
- an out of range start redirects the way a topic page does;
- the page links are plain text, because the print page loads neither the theme's icon CSS nor its JavaScript, so the usual arrows and the expanding page list would both be dead there. `@media print` already hides `.print_options`, so paper output is unchanged.

This came out of a [request on the community forum](https://www.simplemachines.org/community/index.php?topic=594998.0), reporting that the print view is a favourite target for scrapers, residential proxy botnets and aggressive crawlers, which use it to pull entire threads past pagination and exhaust FastCGI slots on shared hosting.

##### Other ways this could be done

The limit is not the only answer, and it is not exclusive with any of these. It was picked first because it bounds what one request costs no matter who sends it, while the rest gate *who* may ask — and a scraper that registers an account, or rides a residential proxy, walks past a gate.

1. **A `print_topic` board permission.** What the report asked for first, and the one that fits SMF's existing machinery best: per board, per membergroup, and the only way `spider_group` could be made to restrict the print view, since today there is no permission there to deny. It is a much wider change — an entry in `Permission.php`, rows in `Sources/Db/Schema/v3_0/BoardPermissions.php`, language strings, `Topic::$permissions['can_print']`, and a migration granting it to existing groups or every upgraded forum silently loses its print button. Note also that keeping upgrades non-breaking means granting it to guests, so "off for guests by default" would only ever be true of new installs.
2. **A "guests may not use the print view" setting**, next to `disable_print_topic`. Cheapest of the lot, but it is a second ad-hoc setting covering a slice of what the permission system already models, and it leaves the request itself unbounded for everyone else.
3. **`disable_print_topic`**, which exists today and turns the feature off for everybody. It is the only lever an admin has right now, which is rather the point of this PR.
4. **Nothing in core.** SMF already sets `robot_no_index` on the page and disallows `?action=printpage` in the robots.txt it generates, so a well behaved crawler is handled; the rest is an `.htaccess` or WAF matter. That is what the report was doing already, and what it asked not to have to do.

##### Testing

- `tests/Integration/Http/TopicPrintTest.php` is the regression test. Before the change it fails with "the print page rendered the whole topic instead of one page of it — Failed asserting that 5 is identical to 2", and again on the missing page links.
- `tests/Unit/TopicPrintTest.php` covers where the limit comes from, including the `0` fallback.
- Whole suite green on MySQL and PostgreSQL via `.docker/test.sh`.
- By hand on a running forum with the ceiling at 3 and a 7 post topic: 3 / 3 / 1 posts across `.0`, `.3` and `.6`; `;images` survives the page links; `.2` redirects to `.0`, `.999` to `.6`, `.msg1` to `.0`; nothing logged in `smf_log_errors`.

### Issues References (Fixes|Related|Closes)
1. Related: the feature request this came from, https://www.simplemachines.org/community/index.php?topic=594998.0 — no issue has been filed for it here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

