### PR TITLE
[3.0] Remove `curl_close()` from http tests

### DIFF
--- a/tests/Support/HttpClient.php
+++ b/tests/Support/HttpClient.php
@@ -81,8 +81,6 @@ final class HttpClient
 
 	public function __destruct()
 	{
-		curl_close($this->handle);
-
 		if ($this->jar !== '' && is_file($this->jar)) {
 			@unlink($this->jar);
 		}


### PR DESCRIPTION
This is a no-op on PHP 8.4 and deprecated in PHP 8.5.