### PR TITLE
[3.0] Improves our handling of version numbers

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright © 2025 Simple Machines. All rights reserved.
+Copyright © 2026 Simple Machines. All rights reserved.
 
 Developed by: Simple Machines Forum Project
 Simple Machines

--- a/Languages/en_US/Admin.php
+++ b/Languages/en_US/Admin.php
@@ -1,6 +1,6 @@
 <?php
 
-// Version: 3.0 Alpha 4; Admin
+// Version: 3.0 Alpha 5-dev; Admin
 
 $txt['settings_saved'] = 'The settings were successfully saved';
 $txt['settings_not_saved'] = 'Your changes were not saved because: {reason}';

--- a/Languages/en_US/Agreement.php
+++ b/Languages/en_US/Agreement.php
@@ -1,6 +1,6 @@
 <?php
 
-// Version: 3.0 Alpha 4; Agreement
+// Version: 3.0 Alpha 5-dev; Agreement
 
 $txt['agreement_updated'] = 'Updated Registration Agreement';
 $txt['agreement_updated_desc'] = 'You must accept the terms of the registration agreement in order to continue using the forum.';

--- a/Languages/en_US/Alerts.php
+++ b/Languages/en_US/Alerts.php
@@ -1,6 +1,6 @@
 <?php
 
-// Version: 3.0 Alpha 4; Alerts
+// Version: 3.0 Alpha 5-dev; Alerts
 
 // Load Alerts strings
 $txt['topic_na'] = '(private topic)';

--- a/Languages/en_US/Calendar.php
+++ b/Languages/en_US/Calendar.php
@@ -1,6 +1,6 @@
 <?php
 
-// Version: 3.0 Alpha 4; Calendar
+// Version: 3.0 Alpha 5-dev; Calendar
 
 $txt['birthdays'] = 'Birthdays:';
 $txt['events'] = 'Events:';

--- a/Languages/en_US/Drafts.php
+++ b/Languages/en_US/Drafts.php
@@ -1,6 +1,6 @@
 <?php
 
-// Version: 3.0 Alpha 4; Drafts
+// Version: 3.0 Alpha 5-dev; Drafts
 
 // profile
 $txt['drafts_show'] = 'Show Drafts';

--- a/Languages/en_US/Editor.php
+++ b/Languages/en_US/Editor.php
@@ -1,6 +1,6 @@
 <?php
 
-// Version: 3.0 Alpha 4; Editor
+// Version: 3.0 Alpha 5-dev; Editor
 
 $editortxt['bold'] = 'Bold';
 $editortxt['italic'] = 'Italic';

--- a/Languages/en_US/EmailTemplates.php
+++ b/Languages/en_US/EmailTemplates.php
@@ -1,6 +1,6 @@
 <?php
 
-// Version: 3.0 Alpha 4; EmailTemplates
+// Version: 3.0 Alpha 5-dev; EmailTemplates
 
 // Since all of these strings are being used in emails, numeric entities should be used.
 

--- a/Languages/en_US/Errors.php
+++ b/Languages/en_US/Errors.php
@@ -1,6 +1,6 @@
 <?php
 
-// Version: 3.0 Alpha 4; Errors
+// Version: 3.0 Alpha 5-dev; Errors
 
 $txt['no_access'] = 'You are not allowed to access this section';
 $txt['not_found'] = 'Sorry, this section is not available at this time.';

--- a/Languages/en_US/General.php
+++ b/Languages/en_US/General.php
@@ -1,6 +1,6 @@
 <?php
 
-// Version: 3.0 Alpha 4; General
+// Version: 3.0 Alpha 5-dev; General
 
 // Native name, please use full HTML entities to write your language's name.
 $txt['native_name'] = 'English (US)';

--- a/Languages/en_US/Help.php
+++ b/Languages/en_US/Help.php
@@ -1,6 +1,6 @@
 <?php
 
-// Version: 3.0 Alpha 4; Help
+// Version: 3.0 Alpha 5-dev; Help
 
 $txt['close_window'] = 'Close window';
 

--- a/Languages/en_US/Login.php
+++ b/Languages/en_US/Login.php
@@ -1,6 +1,6 @@
 <?php
 
-// Version: 3.0 Alpha 4; Login
+// Version: 3.0 Alpha 5-dev; Login
 
 // Registration agreement page.
 $txt['agreement_agree'] = 'I accept the terms of the agreement.';

--- a/Languages/en_US/Maintenance.php
+++ b/Languages/en_US/Maintenance.php
@@ -1,6 +1,6 @@
 <?php
 
-// Version: 3.0 Alpha 4; Maintenance
+// Version: 3.0 Alpha 5-dev; Maintenance
 
 // This should be the same as the one in General.language.php.
 $txt['lang_rtl'] = '0';

--- a/Languages/en_US/ManageBoards.php
+++ b/Languages/en_US/ManageBoards.php
@@ -1,6 +1,6 @@
 <?php
 
-// Version: 3.0 Alpha 4; ManageBoards
+// Version: 3.0 Alpha 5-dev; ManageBoards
 
 $txt['boards_and_cats'] = 'Manage Boards and Categories';
 $txt['order'] = 'Order';

--- a/Languages/en_US/ManageCalendar.php
+++ b/Languages/en_US/ManageCalendar.php
@@ -1,6 +1,6 @@
 <?php
 
-// Version: 3.0 Alpha 4; ManageCalendar
+// Version: 3.0 Alpha 5-dev; ManageCalendar
 
 $txt['calendar_desc'] = 'From here you can modify all aspects of the calendar.';
 

--- a/Languages/en_US/ManageMail.php
+++ b/Languages/en_US/ManageMail.php
@@ -1,6 +1,6 @@
 <?php
 
-// Version: 3.0 Alpha 4; ManageMail
+// Version: 3.0 Alpha 5-dev; ManageMail
 
 $txt['mailqueue_desc'] = 'From this page you can configure your mail settings, as well as view and administer the current mail queue.';
 

--- a/Languages/en_US/ManageMaintenance.php
+++ b/Languages/en_US/ManageMaintenance.php
@@ -1,6 +1,6 @@
 <?php
 
-// Version: 3.0 Alpha 4; ManageMaintenance
+// Version: 3.0 Alpha 5-dev; ManageMaintenance
 
 $txt['repair_zero_ids'] = 'Found topics and/or messages with topic or message IDs of 0.';
 $txt['repair_missing_topics'] = 'Message #{0, number, integer} is in non-existent topic #{1, number, integer}.';

--- a/Languages/en_US/ManageMembers.php
+++ b/Languages/en_US/ManageMembers.php
@@ -1,6 +1,6 @@
 <?php
 
-// Version: 3.0 Alpha 4; ManageMembers
+// Version: 3.0 Alpha 5-dev; ManageMembers
 
 $txt['groups'] = 'Groups';
 $txt['viewing_groups'] = 'Viewing Membergroups';

--- a/Languages/en_US/ManagePaid.php
+++ b/Languages/en_US/ManagePaid.php
@@ -1,6 +1,6 @@
 <?php
 
-// Version: 3.0 Alpha 4; ManagePaid
+// Version: 3.0 Alpha 5-dev; ManagePaid
 
 // Some payment gateways need language specific information.
 $txt['lang_paypal'] = 'US';

--- a/Languages/en_US/ManagePermissions.php
+++ b/Languages/en_US/ManagePermissions.php
@@ -1,6 +1,6 @@
 <?php
 
-// Version: 3.0 Alpha 4; ManagePermissions
+// Version: 3.0 Alpha 5-dev; ManagePermissions
 
 $txt['permissions_title'] = 'Manage Permissions';
 $txt['permissions_modify'] = 'Modify';

--- a/Languages/en_US/ManageScheduledTasks.php
+++ b/Languages/en_US/ManageScheduledTasks.php
@@ -1,6 +1,6 @@
 <?php
 
-// Version: 3.0 Alpha 4; ManageScheduledTasks
+// Version: 3.0 Alpha 5-dev; ManageScheduledTasks
 
 $txt['scheduled_tasks_title'] = 'Scheduled Tasks';
 $txt['scheduled_tasks_header'] = 'All Scheduled Tasks';

--- a/Languages/en_US/ManageSettings.php
+++ b/Languages/en_US/ManageSettings.php
@@ -1,6 +1,6 @@
 <?php
 
-// Version: 3.0 Alpha 4; ManageSettings
+// Version: 3.0 Alpha 5-dev; ManageSettings
 
 // argument(s): theme_id, session_id, session_var, Config::$scripturl
 $txt['modSettings_desc'] = 'This page allows you to change the settings of features and basic options in your forum. Please see the <a href="{scripturl}?action=admin;area=theme;sa=list;th={theme_id};{session_var}={session_id}">theme settings</a> for more options. Click the help icons for more information about a setting.';

--- a/Languages/en_US/ManageSmileys.php
+++ b/Languages/en_US/ManageSmileys.php
@@ -1,6 +1,6 @@
 <?php
 
-// Version: 3.0 Alpha 4; ManageSmileys
+// Version: 3.0 Alpha 5-dev; ManageSmileys
 
 $txt['smiley_sets_save'] = 'Save Changes';
 $txt['smiley_sets_add'] = 'New smiley Set';

--- a/Languages/en_US/Manual.php
+++ b/Languages/en_US/Manual.php
@@ -1,6 +1,6 @@
 <?php
 
-// Version: 3.0 Alpha 4; Manual
+// Version: 3.0 Alpha 5-dev; Manual
 
 /* Everything in this file is for the Simple Machines help manual
    If you are looking at translating the manual into another language

--- a/Languages/en_US/ModerationCenter.php
+++ b/Languages/en_US/ModerationCenter.php
@@ -1,6 +1,6 @@
 <?php
 
-// Version: 3.0 Alpha 4; ModerationCenter
+// Version: 3.0 Alpha 5-dev; ModerationCenter
 
 $txt['moderation_center'] = 'Moderation Center';
 $txt['mc_main'] = 'Main';

--- a/Languages/en_US/Modifications.php
+++ b/Languages/en_US/Modifications.php
@@ -1,3 +1,3 @@
 <?php
 
-// Version: 3.0 Alpha 4; Modifications
+// Version: 3.0 Alpha 5-dev; Modifications

--- a/Languages/en_US/Modlog.php
+++ b/Languages/en_US/Modlog.php
@@ -1,6 +1,6 @@
 <?php
 
-// Version: 3.0 Alpha 4; Modlog
+// Version: 3.0 Alpha 5-dev; Modlog
 
 $txt['modlog_date'] = 'Date';
 $txt['modlog_member'] = 'Member';

--- a/Languages/en_US/Packages.php
+++ b/Languages/en_US/Packages.php
@@ -1,6 +1,6 @@
 <?php
 
-// Version: 3.0 Alpha 4; Packages
+// Version: 3.0 Alpha 5-dev; Packages
 
 $txt['package_proceed'] = 'Proceed';
 $txt['php_script'] = 'Modification file was extracted, but this modification also comes with a PHP script which should be executed before it will work';

--- a/Languages/en_US/PersonalMessage.php
+++ b/Languages/en_US/PersonalMessage.php
@@ -1,6 +1,6 @@
 <?php
 
-// Version: 3.0 Alpha 4; PersonalMessage
+// Version: 3.0 Alpha 5-dev; PersonalMessage
 
 // Things for the popup
 $txt['pm_unread'] = 'Unread';

--- a/Languages/en_US/Post.php
+++ b/Languages/en_US/Post.php
@@ -1,6 +1,6 @@
 <?php
 
-// Version: 3.0 Alpha 4; Post
+// Version: 3.0 Alpha 5-dev; Post
 
 $txt['post_reply'] = 'Post reply';
 $txt['subject_not_filled'] = 'The subject field was not filled out. It is required.';

--- a/Languages/en_US/Profile.php
+++ b/Languages/en_US/Profile.php
@@ -1,6 +1,6 @@
 <?php
 
-// Version: 3.0 Alpha 4; Profile
+// Version: 3.0 Alpha 5-dev; Profile
 
 // Some of the things from the popup need their own descriptions
 $txt['popup_forumprofile'] = 'Profile Details';

--- a/Languages/en_US/Reports.php
+++ b/Languages/en_US/Reports.php
@@ -1,6 +1,6 @@
 <?php
 
-// Version: 3.0 Alpha 4; Reports
+// Version: 3.0 Alpha 5-dev; Reports
 
 $txt['generate_reports_desc'] = 'From this section you can generate a variety of reports to assist in the administration of your forum. Simply follow the steps below to select the option of your choice.';
 $txt['generate_reports_continue'] = 'Continue';

--- a/Languages/en_US/Search.php
+++ b/Languages/en_US/Search.php
@@ -1,6 +1,6 @@
 <?php
 
-// Version: 3.0 Alpha 4; Search
+// Version: 3.0 Alpha 5-dev; Search
 
 // Comma-separated list of words that should be ignored when searching in this language. Translators should NOT just translate the words in this list. Instead, replace them with common words that should be ignored when searching in the target language.
 $txt['search_stopwords'] = 'a,about,an,are,as,at,be,by,for,from,how,in,is,it,of,on,or,that,the,this,to,was,what,when,where,who,will,with';

--- a/Languages/en_US/Stats.php
+++ b/Languages/en_US/Stats.php
@@ -1,6 +1,6 @@
 <?php
 
-// Version: 3.0 Alpha 4; Stats
+// Version: 3.0 Alpha 5-dev; Stats
 
 $txt['most_online'] = 'Most Online';
 $txt['most_online_number_date'] = '{number, number, integer} on {date}';

--- a/Languages/en_US/Themes.php
+++ b/Languages/en_US/Themes.php
@@ -1,6 +1,6 @@
 <?php
 
-// Version: 3.0 Alpha 4; Themes
+// Version: 3.0 Alpha 5-dev; Themes
 
 $txt['themeadmin_explain'] = 'Themes are the different looks and feels of your forum. These settings affect the selection of themes, and which themes guests and other members use.';
 

--- a/Languages/en_US/Timezones.php
+++ b/Languages/en_US/Timezones.php
@@ -1,6 +1,6 @@
 <?php
 
-// Version: 3.0 Alpha 4; Timezones
+// Version: 3.0 Alpha 5-dev; Timezones
 
 // Standard Time or Daylight Saving Time
 $tztxt['daylight_saving_time_false'] = 'Standard';

--- a/Languages/en_US/Who.php
+++ b/Languages/en_US/Who.php
@@ -1,6 +1,6 @@
 <?php
 
-// Version: 3.0 Alpha 4; Who
+// Version: 3.0 Alpha 5-dev; Who
 
 $txt['who_hidden'] = 'Nothing, or nothing you can see...';
 $txt['who_admin'] = 'Viewing the Administration Center';

--- a/SSI.php
+++ b/SSI.php
@@ -26,7 +26,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/ActionInterface.php
+++ b/Sources/ActionInterface.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/ActionRouter.php
+++ b/Sources/ActionRouter.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/ActionSuffixRouter.php
+++ b/Sources/ActionSuffixRouter.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/ActionTrait.php
+++ b/Sources/ActionTrait.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/Activate.php
+++ b/Sources/Actions/Activate.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/Admin/ACP.php
+++ b/Sources/Actions/Admin/ACP.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/Admin/AntiSpam.php
+++ b/Sources/Actions/Admin/AntiSpam.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/Admin/Attachments.php
+++ b/Sources/Actions/Admin/Attachments.php
@@ -12,7 +12,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/Admin/Bans.php
+++ b/Sources/Actions/Admin/Bans.php
@@ -12,7 +12,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/Admin/Boards.php
+++ b/Sources/Actions/Admin/Boards.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/Admin/Calendar.php
+++ b/Sources/Actions/Admin/Calendar.php
@@ -10,7 +10,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/Admin/EndSession.php
+++ b/Sources/Actions/Admin/EndSession.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/Admin/ErrorLog.php
+++ b/Sources/Actions/Admin/ErrorLog.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/Admin/Features.php
+++ b/Sources/Actions/Admin/Features.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/Admin/Find.php
+++ b/Sources/Actions/Admin/Find.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/Admin/Home.php
+++ b/Sources/Actions/Admin/Home.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/Admin/Languages.php
+++ b/Sources/Actions/Admin/Languages.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/Admin/Logs.php
+++ b/Sources/Actions/Admin/Logs.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/Admin/Mail.php
+++ b/Sources/Actions/Admin/Mail.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/Admin/Maintenance.php
+++ b/Sources/Actions/Admin/Maintenance.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/Admin/Membergroups.php
+++ b/Sources/Actions/Admin/Membergroups.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/Admin/Members.php
+++ b/Sources/Actions/Admin/Members.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/Admin/Mods.php
+++ b/Sources/Actions/Admin/Mods.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/Admin/News.php
+++ b/Sources/Actions/Admin/News.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/Admin/PackageManager.php
+++ b/Sources/Actions/Admin/PackageManager.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 if (!defined('SMF')) {

--- a/Sources/Actions/Admin/Permissions.php
+++ b/Sources/Actions/Admin/Permissions.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/Admin/Posts.php
+++ b/Sources/Actions/Admin/Posts.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/Admin/Registration.php
+++ b/Sources/Actions/Admin/Registration.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/Admin/RepairBoards.php
+++ b/Sources/Actions/Admin/RepairBoards.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/Admin/Reports.php
+++ b/Sources/Actions/Admin/Reports.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/Admin/Search.php
+++ b/Sources/Actions/Admin/Search.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/Admin/SearchEngines.php
+++ b/Sources/Actions/Admin/SearchEngines.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/Admin/Server.php
+++ b/Sources/Actions/Admin/Server.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/Admin/Smileys.php
+++ b/Sources/Actions/Admin/Smileys.php
@@ -10,7 +10,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/Admin/Subscriptions.php
+++ b/Sources/Actions/Admin/Subscriptions.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/Admin/Tasks.php
+++ b/Sources/Actions/Admin/Tasks.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/Admin/Themes.php
+++ b/Sources/Actions/Admin/Themes.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/Admin/Warnings.php
+++ b/Sources/Actions/Admin/Warnings.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/Agreement.php
+++ b/Sources/Actions/Agreement.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/AgreementAccept.php
+++ b/Sources/Actions/AgreementAccept.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/Announce.php
+++ b/Sources/Actions/Announce.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/AttachmentApprove.php
+++ b/Sources/Actions/AttachmentApprove.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/AttachmentDownload.php
+++ b/Sources/Actions/AttachmentDownload.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/AttachmentUpload.php
+++ b/Sources/Actions/AttachmentUpload.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 namespace SMF\Actions;

--- a/Sources/Actions/AutoSuggest.php
+++ b/Sources/Actions/AutoSuggest.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/BoardIndex.php
+++ b/Sources/Actions/BoardIndex.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/BuddyListToggle.php
+++ b/Sources/Actions/BuddyListToggle.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/Calendar.php
+++ b/Sources/Actions/Calendar.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/CoppaForm.php
+++ b/Sources/Actions/CoppaForm.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/Credits.php
+++ b/Sources/Actions/Credits.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/Display.php
+++ b/Sources/Actions/Display.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/DisplayAdminFile.php
+++ b/Sources/Actions/DisplayAdminFile.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/Feed.php
+++ b/Sources/Actions/Feed.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/GenericAction.php
+++ b/Sources/Actions/GenericAction.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/Groups.php
+++ b/Sources/Actions/Groups.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 namespace SMF\Actions;

--- a/Sources/Actions/Help.php
+++ b/Sources/Actions/Help.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/HelpAdmin.php
+++ b/Sources/Actions/HelpAdmin.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/JavaScriptModify.php
+++ b/Sources/Actions/JavaScriptModify.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/Like.php
+++ b/Sources/Actions/Like.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/Login.php
+++ b/Sources/Actions/Login.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/Login2.php
+++ b/Sources/Actions/Login2.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/LoginTFA.php
+++ b/Sources/Actions/LoginTFA.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/Logout.php
+++ b/Sources/Actions/Logout.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/MarkRead.php
+++ b/Sources/Actions/MarkRead.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/Memberlist.php
+++ b/Sources/Actions/Memberlist.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/MessageIndex.php
+++ b/Sources/Actions/MessageIndex.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/Moderation/EndSession.php
+++ b/Sources/Actions/Moderation/EndSession.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/Moderation/Groups.php
+++ b/Sources/Actions/Moderation/Groups.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 namespace SMF\Actions\Moderation;

--- a/Sources/Actions/Moderation/Home.php
+++ b/Sources/Actions/Moderation/Home.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/Moderation/Logs.php
+++ b/Sources/Actions/Moderation/Logs.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/Moderation/Main.php
+++ b/Sources/Actions/Moderation/Main.php
@@ -10,7 +10,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/Moderation/Posts.php
+++ b/Sources/Actions/Moderation/Posts.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/Moderation/ReportedContent.php
+++ b/Sources/Actions/Moderation/ReportedContent.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/Moderation/ShowNotice.php
+++ b/Sources/Actions/Moderation/ShowNotice.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/Moderation/Warnings.php
+++ b/Sources/Actions/Moderation/Warnings.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/Moderation/WatchedUsers.php
+++ b/Sources/Actions/Moderation/WatchedUsers.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/MsgDelete.php
+++ b/Sources/Actions/MsgDelete.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/Notify.php
+++ b/Sources/Actions/Notify.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/NotifyAnnouncements.php
+++ b/Sources/Actions/NotifyAnnouncements.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/NotifyBoard.php
+++ b/Sources/Actions/NotifyBoard.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/NotifyTopic.php
+++ b/Sources/Actions/NotifyTopic.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/PersonalMessage.php
+++ b/Sources/Actions/PersonalMessage.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/PollEdit.php
+++ b/Sources/Actions/PollEdit.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/PollEdit2.php
+++ b/Sources/Actions/PollEdit2.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/PollLock.php
+++ b/Sources/Actions/PollLock.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/PollRemove.php
+++ b/Sources/Actions/PollRemove.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/PollVote.php
+++ b/Sources/Actions/PollVote.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/Post.php
+++ b/Sources/Actions/Post.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/Post2.php
+++ b/Sources/Actions/Post2.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/Profile/Account.php
+++ b/Sources/Actions/Profile/Account.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/Profile/Activate.php
+++ b/Sources/Actions/Profile/Activate.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/Profile/AlertsPopup.php
+++ b/Sources/Actions/Profile/AlertsPopup.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/Profile/BuddyIgnoreLists.php
+++ b/Sources/Actions/Profile/BuddyIgnoreLists.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/Profile/Delete.php
+++ b/Sources/Actions/Profile/Delete.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/Profile/Export.php
+++ b/Sources/Actions/Profile/Export.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/Profile/ExportAttachment.php
+++ b/Sources/Actions/Profile/ExportAttachment.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/Profile/ExportDownload.php
+++ b/Sources/Actions/Profile/ExportDownload.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/Profile/ForumProfile.php
+++ b/Sources/Actions/Profile/ForumProfile.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/Profile/GroupMembership.php
+++ b/Sources/Actions/Profile/GroupMembership.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/Profile/IgnoreBoards.php
+++ b/Sources/Actions/Profile/IgnoreBoards.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/Profile/IssueWarning.php
+++ b/Sources/Actions/Profile/IssueWarning.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/Profile/Main.php
+++ b/Sources/Actions/Profile/Main.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/Profile/Notification.php
+++ b/Sources/Actions/Profile/Notification.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/Profile/PaidSubs.php
+++ b/Sources/Actions/Profile/PaidSubs.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/Profile/Popup.php
+++ b/Sources/Actions/Profile/Popup.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/Profile/ShowAlerts.php
+++ b/Sources/Actions/Profile/ShowAlerts.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/Profile/ShowPermissions.php
+++ b/Sources/Actions/Profile/ShowPermissions.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/Profile/ShowPosts.php
+++ b/Sources/Actions/Profile/ShowPosts.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/Profile/StatPanel.php
+++ b/Sources/Actions/Profile/StatPanel.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/Profile/Summary.php
+++ b/Sources/Actions/Profile/Summary.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/Profile/TFADisable.php
+++ b/Sources/Actions/Profile/TFADisable.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/Profile/TFASetup.php
+++ b/Sources/Actions/Profile/TFASetup.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/Profile/ThemeOptions.php
+++ b/Sources/Actions/Profile/ThemeOptions.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/Profile/Tracking.php
+++ b/Sources/Actions/Profile/Tracking.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/Profile/ViewWarning.php
+++ b/Sources/Actions/Profile/ViewWarning.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/QuickModeration.php
+++ b/Sources/Actions/QuickModeration.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/QuickModerationInTopic.php
+++ b/Sources/Actions/QuickModerationInTopic.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/QuoteFast.php
+++ b/Sources/Actions/QuoteFast.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/Recent.php
+++ b/Sources/Actions/Recent.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/Register.php
+++ b/Sources/Actions/Register.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/Register2.php
+++ b/Sources/Actions/Register2.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/Reminder.php
+++ b/Sources/Actions/Reminder.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/ReportToMod.php
+++ b/Sources/Actions/ReportToMod.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/RequestMembers.php
+++ b/Sources/Actions/RequestMembers.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/Search.php
+++ b/Sources/Actions/Search.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/Search2.php
+++ b/Sources/Actions/Search2.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/SendActivation.php
+++ b/Sources/Actions/SendActivation.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/ShowMsgHistory.php
+++ b/Sources/Actions/ShowMsgHistory.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/SmStats.php
+++ b/Sources/Actions/SmStats.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/Stats.php
+++ b/Sources/Actions/Stats.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/ThemeChooser.php
+++ b/Sources/Actions/ThemeChooser.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/ThemeSetOption.php
+++ b/Sources/Actions/ThemeSetOption.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/TopicLock.php
+++ b/Sources/Actions/TopicLock.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/TopicMerge.php
+++ b/Sources/Actions/TopicMerge.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  *
  * Original module by Mach8 - We'll never forget you.
  */

--- a/Sources/Actions/TopicMove.php
+++ b/Sources/Actions/TopicMove.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/TopicMove2.php
+++ b/Sources/Actions/TopicMove2.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/TopicPrint.php
+++ b/Sources/Actions/TopicPrint.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/TopicRemove.php
+++ b/Sources/Actions/TopicRemove.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/TopicRestore.php
+++ b/Sources/Actions/TopicRestore.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/TopicSplit.php
+++ b/Sources/Actions/TopicSplit.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  *
  * Original module by Mach8 - We'll never forget you.
  */

--- a/Sources/Actions/TopicSticky.php
+++ b/Sources/Actions/TopicSticky.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/TrackIP.php
+++ b/Sources/Actions/TrackIP.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/Unknown.php
+++ b/Sources/Actions/Unknown.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/Unread.php
+++ b/Sources/Actions/Unread.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/UnreadReplies.php
+++ b/Sources/Actions/UnreadReplies.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/VerificationCode.php
+++ b/Sources/Actions/VerificationCode.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/ViewQuery.php
+++ b/Sources/Actions/ViewQuery.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/Who.php
+++ b/Sources/Actions/Who.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Actions/XmlHttp.php
+++ b/Sources/Actions/XmlHttp.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Alert.php
+++ b/Sources/Alert.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/ArrayAccessHelper.php
+++ b/Sources/ArrayAccessHelper.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Attachment.php
+++ b/Sources/Attachment.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Autolinker.php
+++ b/Sources/Autolinker.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Avatar.php
+++ b/Sources/Avatar.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/BBCode/Abbr.php
+++ b/Sources/BBCode/Abbr.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/BBCode/Acronym.php
+++ b/Sources/BBCode/Acronym.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/BBCode/Anchor.php
+++ b/Sources/BBCode/Anchor.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/BBCode/Attach.php
+++ b/Sources/BBCode/Attach.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/BBCode/B.php
+++ b/Sources/BBCode/B.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/BBCode/BBCode.php
+++ b/Sources/BBCode/BBCode.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/BBCode/BBCodeInterface.php
+++ b/Sources/BBCode/BBCodeInterface.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/BBCode/Bdo.php
+++ b/Sources/BBCode/Bdo.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/BBCode/Black.php
+++ b/Sources/BBCode/Black.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/BBCode/Blue.php
+++ b/Sources/BBCode/Blue.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/BBCode/Br.php
+++ b/Sources/BBCode/Br.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/BBCode/Center.php
+++ b/Sources/BBCode/Center.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/BBCode/Code1.php
+++ b/Sources/BBCode/Code1.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/BBCode/Code2.php
+++ b/Sources/BBCode/Code2.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/BBCode/Color.php
+++ b/Sources/BBCode/Color.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/BBCode/Details.php
+++ b/Sources/BBCode/Details.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/BBCode/Email1.php
+++ b/Sources/BBCode/Email1.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/BBCode/Email2.php
+++ b/Sources/BBCode/Email2.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/BBCode/Flash.php
+++ b/Sources/BBCode/Flash.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/BBCode/FloatDiv.php
+++ b/Sources/BBCode/FloatDiv.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/BBCode/Font.php
+++ b/Sources/BBCode/Font.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/BBCode/Ftp1.php
+++ b/Sources/BBCode/Ftp1.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/BBCode/Ftp2.php
+++ b/Sources/BBCode/Ftp2.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/BBCode/GenericBBCode.php
+++ b/Sources/BBCode/GenericBBCode.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/BBCode/Glow.php
+++ b/Sources/BBCode/Glow.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/BBCode/Green.php
+++ b/Sources/BBCode/Green.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/BBCode/H1.php
+++ b/Sources/BBCode/H1.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/BBCode/H2.php
+++ b/Sources/BBCode/H2.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/BBCode/H3.php
+++ b/Sources/BBCode/H3.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/BBCode/H4.php
+++ b/Sources/BBCode/H4.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/BBCode/H5.php
+++ b/Sources/BBCode/H5.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/BBCode/H6.php
+++ b/Sources/BBCode/H6.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/BBCode/Hr.php
+++ b/Sources/BBCode/Hr.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/BBCode/Html.php
+++ b/Sources/BBCode/Html.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/BBCode/I.php
+++ b/Sources/BBCode/I.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/BBCode/Img.php
+++ b/Sources/BBCode/Img.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/BBCode/Iurl1.php
+++ b/Sources/BBCode/Iurl1.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/BBCode/Iurl2.php
+++ b/Sources/BBCode/Iurl2.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/BBCode/Justify.php
+++ b/Sources/BBCode/Justify.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/BBCode/Left.php
+++ b/Sources/BBCode/Left.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/BBCode/Li.php
+++ b/Sources/BBCode/Li.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/BBCode/List1.php
+++ b/Sources/BBCode/List1.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/BBCode/List2.php
+++ b/Sources/BBCode/List2.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/BBCode/List3.php
+++ b/Sources/BBCode/List3.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/BBCode/Ltr.php
+++ b/Sources/BBCode/Ltr.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/BBCode/Me.php
+++ b/Sources/BBCode/Me.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/BBCode/Member.php
+++ b/Sources/BBCode/Member.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/BBCode/Move.php
+++ b/Sources/BBCode/Move.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/BBCode/NoBBC.php
+++ b/Sources/BBCode/NoBBC.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/BBCode/Nolink.php
+++ b/Sources/BBCode/Nolink.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/BBCode/Php.php
+++ b/Sources/BBCode/Php.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/BBCode/Pre.php
+++ b/Sources/BBCode/Pre.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/BBCode/Quote1.php
+++ b/Sources/BBCode/Quote1.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/BBCode/Quote2.php
+++ b/Sources/BBCode/Quote2.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/BBCode/Quote3.php
+++ b/Sources/BBCode/Quote3.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/BBCode/Quote4.php
+++ b/Sources/BBCode/Quote4.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/BBCode/Red.php
+++ b/Sources/BBCode/Red.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/BBCode/Right.php
+++ b/Sources/BBCode/Right.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/BBCode/Rtl.php
+++ b/Sources/BBCode/Rtl.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/BBCode/S.php
+++ b/Sources/BBCode/S.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/BBCode/Shadow.php
+++ b/Sources/BBCode/Shadow.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/BBCode/Size1.php
+++ b/Sources/BBCode/Size1.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/BBCode/Size2.php
+++ b/Sources/BBCode/Size2.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/BBCode/Spoiler1.php
+++ b/Sources/BBCode/Spoiler1.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/BBCode/Spoiler2.php
+++ b/Sources/BBCode/Spoiler2.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/BBCode/Sub.php
+++ b/Sources/BBCode/Sub.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/BBCode/Sup.php
+++ b/Sources/BBCode/Sup.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/BBCode/Table.php
+++ b/Sources/BBCode/Table.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/BBCode/Td.php
+++ b/Sources/BBCode/Td.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/BBCode/Time1.php
+++ b/Sources/BBCode/Time1.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/BBCode/Time2.php
+++ b/Sources/BBCode/Time2.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/BBCode/Tr.php
+++ b/Sources/BBCode/Tr.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/BBCode/Tt.php
+++ b/Sources/BBCode/Tt.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/BBCode/U.php
+++ b/Sources/BBCode/U.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/BBCode/Url1.php
+++ b/Sources/BBCode/Url1.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/BBCode/Url2.php
+++ b/Sources/BBCode/Url2.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/BBCode/White.php
+++ b/Sources/BBCode/White.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/BBCode/YouTube.php
+++ b/Sources/BBCode/YouTube.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/BackwardCompatibility.php
+++ b/Sources/BackwardCompatibility.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 namespace SMF;

--- a/Sources/Board.php
+++ b/Sources/Board.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/BrowserDetector.php
+++ b/Sources/BrowserDetector.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Cache/APIs/Apcu.php
+++ b/Sources/Cache/APIs/Apcu.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Cache/APIs/FileBased.php
+++ b/Sources/Cache/APIs/FileBased.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Cache/APIs/MemcacheImplementation.php
+++ b/Sources/Cache/APIs/MemcacheImplementation.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Cache/APIs/MemcachedImplementation.php
+++ b/Sources/Cache/APIs/MemcachedImplementation.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Cache/APIs/Postgres.php
+++ b/Sources/Cache/APIs/Postgres.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Cache/APIs/Sqlite.php
+++ b/Sources/Cache/APIs/Sqlite.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Cache/APIs/Zend.php
+++ b/Sources/Cache/APIs/Zend.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Cache/CacheApi.php
+++ b/Sources/Cache/CacheApi.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Cache/CacheApiInterface.php
+++ b/Sources/Cache/CacheApiInterface.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/Birthday.php
+++ b/Sources/Calendar/Birthday.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/Event.php
+++ b/Sources/Calendar/Event.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/EventAdjustment.php
+++ b/Sources/Calendar/EventAdjustment.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/EventOccurrence.php
+++ b/Sources/Calendar/EventOccurrence.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/Holiday.php
+++ b/Sources/Calendar/Holiday.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/RRule.php
+++ b/Sources/Calendar/RRule.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/RecurrenceIterator.php
+++ b/Sources/Calendar/RecurrenceIterator.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZone.php
+++ b/Sources/Calendar/VTimeZone.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Africa/Abidjan.php
+++ b/Sources/Calendar/VTimeZones/Africa/Abidjan.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Africa/Algiers.php
+++ b/Sources/Calendar/VTimeZones/Africa/Algiers.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Africa/Bissau.php
+++ b/Sources/Calendar/VTimeZones/Africa/Bissau.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Africa/Cairo.php
+++ b/Sources/Calendar/VTimeZones/Africa/Cairo.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Africa/Casablanca.php
+++ b/Sources/Calendar/VTimeZones/Africa/Casablanca.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Africa/Ceuta.php
+++ b/Sources/Calendar/VTimeZones/Africa/Ceuta.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Africa/El_Aaiun.php
+++ b/Sources/Calendar/VTimeZones/Africa/El_Aaiun.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Africa/Johannesburg.php
+++ b/Sources/Calendar/VTimeZones/Africa/Johannesburg.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Africa/Juba.php
+++ b/Sources/Calendar/VTimeZones/Africa/Juba.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Africa/Khartoum.php
+++ b/Sources/Calendar/VTimeZones/Africa/Khartoum.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Africa/Lagos.php
+++ b/Sources/Calendar/VTimeZones/Africa/Lagos.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Africa/Maputo.php
+++ b/Sources/Calendar/VTimeZones/Africa/Maputo.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Africa/Monrovia.php
+++ b/Sources/Calendar/VTimeZones/Africa/Monrovia.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Africa/Nairobi.php
+++ b/Sources/Calendar/VTimeZones/Africa/Nairobi.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Africa/Ndjamena.php
+++ b/Sources/Calendar/VTimeZones/Africa/Ndjamena.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Africa/Sao_Tome.php
+++ b/Sources/Calendar/VTimeZones/Africa/Sao_Tome.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Africa/Tripoli.php
+++ b/Sources/Calendar/VTimeZones/Africa/Tripoli.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Africa/Tunis.php
+++ b/Sources/Calendar/VTimeZones/Africa/Tunis.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Africa/Windhoek.php
+++ b/Sources/Calendar/VTimeZones/Africa/Windhoek.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/Adak.php
+++ b/Sources/Calendar/VTimeZones/America/Adak.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/Anchorage.php
+++ b/Sources/Calendar/VTimeZones/America/Anchorage.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/Araguaina.php
+++ b/Sources/Calendar/VTimeZones/America/Araguaina.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/Argentina/Buenos_Aires.php
+++ b/Sources/Calendar/VTimeZones/America/Argentina/Buenos_Aires.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/Argentina/Catamarca.php
+++ b/Sources/Calendar/VTimeZones/America/Argentina/Catamarca.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/Argentina/Cordoba.php
+++ b/Sources/Calendar/VTimeZones/America/Argentina/Cordoba.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/Argentina/Jujuy.php
+++ b/Sources/Calendar/VTimeZones/America/Argentina/Jujuy.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/Argentina/La_Rioja.php
+++ b/Sources/Calendar/VTimeZones/America/Argentina/La_Rioja.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/Argentina/Mendoza.php
+++ b/Sources/Calendar/VTimeZones/America/Argentina/Mendoza.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/Argentina/Rio_Gallegos.php
+++ b/Sources/Calendar/VTimeZones/America/Argentina/Rio_Gallegos.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/Argentina/Salta.php
+++ b/Sources/Calendar/VTimeZones/America/Argentina/Salta.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/Argentina/San_Juan.php
+++ b/Sources/Calendar/VTimeZones/America/Argentina/San_Juan.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/Argentina/San_Luis.php
+++ b/Sources/Calendar/VTimeZones/America/Argentina/San_Luis.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/Argentina/Tucuman.php
+++ b/Sources/Calendar/VTimeZones/America/Argentina/Tucuman.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/Argentina/Ushuaia.php
+++ b/Sources/Calendar/VTimeZones/America/Argentina/Ushuaia.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/Asuncion.php
+++ b/Sources/Calendar/VTimeZones/America/Asuncion.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/Bahia.php
+++ b/Sources/Calendar/VTimeZones/America/Bahia.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/Bahia_Banderas.php
+++ b/Sources/Calendar/VTimeZones/America/Bahia_Banderas.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/Barbados.php
+++ b/Sources/Calendar/VTimeZones/America/Barbados.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/Belem.php
+++ b/Sources/Calendar/VTimeZones/America/Belem.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/Belize.php
+++ b/Sources/Calendar/VTimeZones/America/Belize.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/Boa_Vista.php
+++ b/Sources/Calendar/VTimeZones/America/Boa_Vista.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/Bogota.php
+++ b/Sources/Calendar/VTimeZones/America/Bogota.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/Boise.php
+++ b/Sources/Calendar/VTimeZones/America/Boise.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/Cambridge_Bay.php
+++ b/Sources/Calendar/VTimeZones/America/Cambridge_Bay.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/Campo_Grande.php
+++ b/Sources/Calendar/VTimeZones/America/Campo_Grande.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/Cancun.php
+++ b/Sources/Calendar/VTimeZones/America/Cancun.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/Caracas.php
+++ b/Sources/Calendar/VTimeZones/America/Caracas.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/Cayenne.php
+++ b/Sources/Calendar/VTimeZones/America/Cayenne.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/Chicago.php
+++ b/Sources/Calendar/VTimeZones/America/Chicago.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/Chihuahua.php
+++ b/Sources/Calendar/VTimeZones/America/Chihuahua.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/Ciudad_Juarez.php
+++ b/Sources/Calendar/VTimeZones/America/Ciudad_Juarez.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/Costa_Rica.php
+++ b/Sources/Calendar/VTimeZones/America/Costa_Rica.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/Coyhaique.php
+++ b/Sources/Calendar/VTimeZones/America/Coyhaique.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/Cuiaba.php
+++ b/Sources/Calendar/VTimeZones/America/Cuiaba.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/Danmarkshavn.php
+++ b/Sources/Calendar/VTimeZones/America/Danmarkshavn.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/Dawson.php
+++ b/Sources/Calendar/VTimeZones/America/Dawson.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/Dawson_Creek.php
+++ b/Sources/Calendar/VTimeZones/America/Dawson_Creek.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/Denver.php
+++ b/Sources/Calendar/VTimeZones/America/Denver.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/Detroit.php
+++ b/Sources/Calendar/VTimeZones/America/Detroit.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/Edmonton.php
+++ b/Sources/Calendar/VTimeZones/America/Edmonton.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/Eirunepe.php
+++ b/Sources/Calendar/VTimeZones/America/Eirunepe.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/El_Salvador.php
+++ b/Sources/Calendar/VTimeZones/America/El_Salvador.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/Fort_Nelson.php
+++ b/Sources/Calendar/VTimeZones/America/Fort_Nelson.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/Fortaleza.php
+++ b/Sources/Calendar/VTimeZones/America/Fortaleza.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/Glace_Bay.php
+++ b/Sources/Calendar/VTimeZones/America/Glace_Bay.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/Goose_Bay.php
+++ b/Sources/Calendar/VTimeZones/America/Goose_Bay.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/Grand_Turk.php
+++ b/Sources/Calendar/VTimeZones/America/Grand_Turk.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/Guatemala.php
+++ b/Sources/Calendar/VTimeZones/America/Guatemala.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/Guayaquil.php
+++ b/Sources/Calendar/VTimeZones/America/Guayaquil.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/Guyana.php
+++ b/Sources/Calendar/VTimeZones/America/Guyana.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/Halifax.php
+++ b/Sources/Calendar/VTimeZones/America/Halifax.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/Havana.php
+++ b/Sources/Calendar/VTimeZones/America/Havana.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/Hermosillo.php
+++ b/Sources/Calendar/VTimeZones/America/Hermosillo.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/Indiana/Indianapolis.php
+++ b/Sources/Calendar/VTimeZones/America/Indiana/Indianapolis.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/Indiana/Knox.php
+++ b/Sources/Calendar/VTimeZones/America/Indiana/Knox.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/Indiana/Marengo.php
+++ b/Sources/Calendar/VTimeZones/America/Indiana/Marengo.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/Indiana/Petersburg.php
+++ b/Sources/Calendar/VTimeZones/America/Indiana/Petersburg.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/Indiana/Tell_City.php
+++ b/Sources/Calendar/VTimeZones/America/Indiana/Tell_City.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/Indiana/Vevay.php
+++ b/Sources/Calendar/VTimeZones/America/Indiana/Vevay.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/Indiana/Vincennes.php
+++ b/Sources/Calendar/VTimeZones/America/Indiana/Vincennes.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/Indiana/Winamac.php
+++ b/Sources/Calendar/VTimeZones/America/Indiana/Winamac.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/Inuvik.php
+++ b/Sources/Calendar/VTimeZones/America/Inuvik.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/Iqaluit.php
+++ b/Sources/Calendar/VTimeZones/America/Iqaluit.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/Jamaica.php
+++ b/Sources/Calendar/VTimeZones/America/Jamaica.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/Juneau.php
+++ b/Sources/Calendar/VTimeZones/America/Juneau.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/Kentucky/Louisville.php
+++ b/Sources/Calendar/VTimeZones/America/Kentucky/Louisville.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/Kentucky/Monticello.php
+++ b/Sources/Calendar/VTimeZones/America/Kentucky/Monticello.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/La_Paz.php
+++ b/Sources/Calendar/VTimeZones/America/La_Paz.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/Lima.php
+++ b/Sources/Calendar/VTimeZones/America/Lima.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/Los_Angeles.php
+++ b/Sources/Calendar/VTimeZones/America/Los_Angeles.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/Maceio.php
+++ b/Sources/Calendar/VTimeZones/America/Maceio.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/Managua.php
+++ b/Sources/Calendar/VTimeZones/America/Managua.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/Manaus.php
+++ b/Sources/Calendar/VTimeZones/America/Manaus.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/Martinique.php
+++ b/Sources/Calendar/VTimeZones/America/Martinique.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/Matamoros.php
+++ b/Sources/Calendar/VTimeZones/America/Matamoros.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/Mazatlan.php
+++ b/Sources/Calendar/VTimeZones/America/Mazatlan.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/Menominee.php
+++ b/Sources/Calendar/VTimeZones/America/Menominee.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/Merida.php
+++ b/Sources/Calendar/VTimeZones/America/Merida.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/Metlakatla.php
+++ b/Sources/Calendar/VTimeZones/America/Metlakatla.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/Mexico_City.php
+++ b/Sources/Calendar/VTimeZones/America/Mexico_City.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/Miquelon.php
+++ b/Sources/Calendar/VTimeZones/America/Miquelon.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/Moncton.php
+++ b/Sources/Calendar/VTimeZones/America/Moncton.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/Monterrey.php
+++ b/Sources/Calendar/VTimeZones/America/Monterrey.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/Montevideo.php
+++ b/Sources/Calendar/VTimeZones/America/Montevideo.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/New_York.php
+++ b/Sources/Calendar/VTimeZones/America/New_York.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/Nome.php
+++ b/Sources/Calendar/VTimeZones/America/Nome.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/Noronha.php
+++ b/Sources/Calendar/VTimeZones/America/Noronha.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/North_Dakota/Beulah.php
+++ b/Sources/Calendar/VTimeZones/America/North_Dakota/Beulah.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/North_Dakota/Center.php
+++ b/Sources/Calendar/VTimeZones/America/North_Dakota/Center.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/North_Dakota/New_Salem.php
+++ b/Sources/Calendar/VTimeZones/America/North_Dakota/New_Salem.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/Nuuk.php
+++ b/Sources/Calendar/VTimeZones/America/Nuuk.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/Ojinaga.php
+++ b/Sources/Calendar/VTimeZones/America/Ojinaga.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/Panama.php
+++ b/Sources/Calendar/VTimeZones/America/Panama.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/Paramaribo.php
+++ b/Sources/Calendar/VTimeZones/America/Paramaribo.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/Phoenix.php
+++ b/Sources/Calendar/VTimeZones/America/Phoenix.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/Port_au_Prince.php
+++ b/Sources/Calendar/VTimeZones/America/Port_au_Prince.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/Porto_Velho.php
+++ b/Sources/Calendar/VTimeZones/America/Porto_Velho.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/Puerto_Rico.php
+++ b/Sources/Calendar/VTimeZones/America/Puerto_Rico.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/Punta_Arenas.php
+++ b/Sources/Calendar/VTimeZones/America/Punta_Arenas.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/Rankin_Inlet.php
+++ b/Sources/Calendar/VTimeZones/America/Rankin_Inlet.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/Recife.php
+++ b/Sources/Calendar/VTimeZones/America/Recife.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/Regina.php
+++ b/Sources/Calendar/VTimeZones/America/Regina.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/Resolute.php
+++ b/Sources/Calendar/VTimeZones/America/Resolute.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/Rio_Branco.php
+++ b/Sources/Calendar/VTimeZones/America/Rio_Branco.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/Santarem.php
+++ b/Sources/Calendar/VTimeZones/America/Santarem.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/Santiago.php
+++ b/Sources/Calendar/VTimeZones/America/Santiago.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/Santo_Domingo.php
+++ b/Sources/Calendar/VTimeZones/America/Santo_Domingo.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/Sao_Paulo.php
+++ b/Sources/Calendar/VTimeZones/America/Sao_Paulo.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/Scoresbysund.php
+++ b/Sources/Calendar/VTimeZones/America/Scoresbysund.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/Sitka.php
+++ b/Sources/Calendar/VTimeZones/America/Sitka.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/St_Johns.php
+++ b/Sources/Calendar/VTimeZones/America/St_Johns.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/Swift_Current.php
+++ b/Sources/Calendar/VTimeZones/America/Swift_Current.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/Tegucigalpa.php
+++ b/Sources/Calendar/VTimeZones/America/Tegucigalpa.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/Thule.php
+++ b/Sources/Calendar/VTimeZones/America/Thule.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/Tijuana.php
+++ b/Sources/Calendar/VTimeZones/America/Tijuana.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/Toronto.php
+++ b/Sources/Calendar/VTimeZones/America/Toronto.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/Vancouver.php
+++ b/Sources/Calendar/VTimeZones/America/Vancouver.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/Whitehorse.php
+++ b/Sources/Calendar/VTimeZones/America/Whitehorse.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/Winnipeg.php
+++ b/Sources/Calendar/VTimeZones/America/Winnipeg.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/America/Yakutat.php
+++ b/Sources/Calendar/VTimeZones/America/Yakutat.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Antarctica/Casey.php
+++ b/Sources/Calendar/VTimeZones/Antarctica/Casey.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Antarctica/Davis.php
+++ b/Sources/Calendar/VTimeZones/Antarctica/Davis.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Antarctica/Macquarie.php
+++ b/Sources/Calendar/VTimeZones/Antarctica/Macquarie.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Antarctica/Mawson.php
+++ b/Sources/Calendar/VTimeZones/Antarctica/Mawson.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Antarctica/Palmer.php
+++ b/Sources/Calendar/VTimeZones/Antarctica/Palmer.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Antarctica/Rothera.php
+++ b/Sources/Calendar/VTimeZones/Antarctica/Rothera.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Antarctica/Troll.php
+++ b/Sources/Calendar/VTimeZones/Antarctica/Troll.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Antarctica/Vostok.php
+++ b/Sources/Calendar/VTimeZones/Antarctica/Vostok.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Asia/Almaty.php
+++ b/Sources/Calendar/VTimeZones/Asia/Almaty.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Asia/Amman.php
+++ b/Sources/Calendar/VTimeZones/Asia/Amman.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Asia/Anadyr.php
+++ b/Sources/Calendar/VTimeZones/Asia/Anadyr.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Asia/Aqtau.php
+++ b/Sources/Calendar/VTimeZones/Asia/Aqtau.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Asia/Aqtobe.php
+++ b/Sources/Calendar/VTimeZones/Asia/Aqtobe.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Asia/Ashgabat.php
+++ b/Sources/Calendar/VTimeZones/Asia/Ashgabat.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Asia/Atyrau.php
+++ b/Sources/Calendar/VTimeZones/Asia/Atyrau.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Asia/Baghdad.php
+++ b/Sources/Calendar/VTimeZones/Asia/Baghdad.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Asia/Baku.php
+++ b/Sources/Calendar/VTimeZones/Asia/Baku.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Asia/Bangkok.php
+++ b/Sources/Calendar/VTimeZones/Asia/Bangkok.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Asia/Barnaul.php
+++ b/Sources/Calendar/VTimeZones/Asia/Barnaul.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Asia/Beirut.php
+++ b/Sources/Calendar/VTimeZones/Asia/Beirut.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Asia/Bishkek.php
+++ b/Sources/Calendar/VTimeZones/Asia/Bishkek.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Asia/Chita.php
+++ b/Sources/Calendar/VTimeZones/Asia/Chita.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Asia/Colombo.php
+++ b/Sources/Calendar/VTimeZones/Asia/Colombo.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Asia/Damascus.php
+++ b/Sources/Calendar/VTimeZones/Asia/Damascus.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Asia/Dhaka.php
+++ b/Sources/Calendar/VTimeZones/Asia/Dhaka.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Asia/Dili.php
+++ b/Sources/Calendar/VTimeZones/Asia/Dili.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Asia/Dubai.php
+++ b/Sources/Calendar/VTimeZones/Asia/Dubai.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Asia/Dushanbe.php
+++ b/Sources/Calendar/VTimeZones/Asia/Dushanbe.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Asia/Famagusta.php
+++ b/Sources/Calendar/VTimeZones/Asia/Famagusta.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Asia/Gaza.php
+++ b/Sources/Calendar/VTimeZones/Asia/Gaza.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Asia/Hebron.php
+++ b/Sources/Calendar/VTimeZones/Asia/Hebron.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Asia/Ho_Chi_Minh.php
+++ b/Sources/Calendar/VTimeZones/Asia/Ho_Chi_Minh.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Asia/Hong_Kong.php
+++ b/Sources/Calendar/VTimeZones/Asia/Hong_Kong.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Asia/Hovd.php
+++ b/Sources/Calendar/VTimeZones/Asia/Hovd.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Asia/Irkutsk.php
+++ b/Sources/Calendar/VTimeZones/Asia/Irkutsk.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Asia/Jakarta.php
+++ b/Sources/Calendar/VTimeZones/Asia/Jakarta.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Asia/Jayapura.php
+++ b/Sources/Calendar/VTimeZones/Asia/Jayapura.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Asia/Jerusalem.php
+++ b/Sources/Calendar/VTimeZones/Asia/Jerusalem.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Asia/Kabul.php
+++ b/Sources/Calendar/VTimeZones/Asia/Kabul.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Asia/Kamchatka.php
+++ b/Sources/Calendar/VTimeZones/Asia/Kamchatka.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Asia/Karachi.php
+++ b/Sources/Calendar/VTimeZones/Asia/Karachi.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Asia/Kathmandu.php
+++ b/Sources/Calendar/VTimeZones/Asia/Kathmandu.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Asia/Khandyga.php
+++ b/Sources/Calendar/VTimeZones/Asia/Khandyga.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Asia/Kolkata.php
+++ b/Sources/Calendar/VTimeZones/Asia/Kolkata.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Asia/Krasnoyarsk.php
+++ b/Sources/Calendar/VTimeZones/Asia/Krasnoyarsk.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Asia/Kuching.php
+++ b/Sources/Calendar/VTimeZones/Asia/Kuching.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Asia/Macau.php
+++ b/Sources/Calendar/VTimeZones/Asia/Macau.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Asia/Magadan.php
+++ b/Sources/Calendar/VTimeZones/Asia/Magadan.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Asia/Makassar.php
+++ b/Sources/Calendar/VTimeZones/Asia/Makassar.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Asia/Manila.php
+++ b/Sources/Calendar/VTimeZones/Asia/Manila.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Asia/Nicosia.php
+++ b/Sources/Calendar/VTimeZones/Asia/Nicosia.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Asia/Novokuznetsk.php
+++ b/Sources/Calendar/VTimeZones/Asia/Novokuznetsk.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Asia/Novosibirsk.php
+++ b/Sources/Calendar/VTimeZones/Asia/Novosibirsk.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Asia/Omsk.php
+++ b/Sources/Calendar/VTimeZones/Asia/Omsk.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Asia/Oral.php
+++ b/Sources/Calendar/VTimeZones/Asia/Oral.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Asia/Pontianak.php
+++ b/Sources/Calendar/VTimeZones/Asia/Pontianak.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Asia/Pyongyang.php
+++ b/Sources/Calendar/VTimeZones/Asia/Pyongyang.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Asia/Qatar.php
+++ b/Sources/Calendar/VTimeZones/Asia/Qatar.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Asia/Qostanay.php
+++ b/Sources/Calendar/VTimeZones/Asia/Qostanay.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Asia/Qyzylorda.php
+++ b/Sources/Calendar/VTimeZones/Asia/Qyzylorda.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Asia/Riyadh.php
+++ b/Sources/Calendar/VTimeZones/Asia/Riyadh.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Asia/Sakhalin.php
+++ b/Sources/Calendar/VTimeZones/Asia/Sakhalin.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Asia/Samarkand.php
+++ b/Sources/Calendar/VTimeZones/Asia/Samarkand.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Asia/Seoul.php
+++ b/Sources/Calendar/VTimeZones/Asia/Seoul.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Asia/Shanghai.php
+++ b/Sources/Calendar/VTimeZones/Asia/Shanghai.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Asia/Singapore.php
+++ b/Sources/Calendar/VTimeZones/Asia/Singapore.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Asia/Srednekolymsk.php
+++ b/Sources/Calendar/VTimeZones/Asia/Srednekolymsk.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Asia/Taipei.php
+++ b/Sources/Calendar/VTimeZones/Asia/Taipei.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Asia/Tashkent.php
+++ b/Sources/Calendar/VTimeZones/Asia/Tashkent.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Asia/Tbilisi.php
+++ b/Sources/Calendar/VTimeZones/Asia/Tbilisi.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Asia/Tehran.php
+++ b/Sources/Calendar/VTimeZones/Asia/Tehran.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Asia/Thimphu.php
+++ b/Sources/Calendar/VTimeZones/Asia/Thimphu.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Asia/Tokyo.php
+++ b/Sources/Calendar/VTimeZones/Asia/Tokyo.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Asia/Tomsk.php
+++ b/Sources/Calendar/VTimeZones/Asia/Tomsk.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Asia/Ulaanbaatar.php
+++ b/Sources/Calendar/VTimeZones/Asia/Ulaanbaatar.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Asia/Urumqi.php
+++ b/Sources/Calendar/VTimeZones/Asia/Urumqi.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Asia/Ust_Nera.php
+++ b/Sources/Calendar/VTimeZones/Asia/Ust_Nera.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Asia/Vladivostok.php
+++ b/Sources/Calendar/VTimeZones/Asia/Vladivostok.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Asia/Yakutsk.php
+++ b/Sources/Calendar/VTimeZones/Asia/Yakutsk.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Asia/Yangon.php
+++ b/Sources/Calendar/VTimeZones/Asia/Yangon.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Asia/Yekaterinburg.php
+++ b/Sources/Calendar/VTimeZones/Asia/Yekaterinburg.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Asia/Yerevan.php
+++ b/Sources/Calendar/VTimeZones/Asia/Yerevan.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Atlantic/Azores.php
+++ b/Sources/Calendar/VTimeZones/Atlantic/Azores.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Atlantic/Bermuda.php
+++ b/Sources/Calendar/VTimeZones/Atlantic/Bermuda.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Atlantic/Canary.php
+++ b/Sources/Calendar/VTimeZones/Atlantic/Canary.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Atlantic/Cape_Verde.php
+++ b/Sources/Calendar/VTimeZones/Atlantic/Cape_Verde.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Atlantic/Faroe.php
+++ b/Sources/Calendar/VTimeZones/Atlantic/Faroe.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Atlantic/Madeira.php
+++ b/Sources/Calendar/VTimeZones/Atlantic/Madeira.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Atlantic/South_Georgia.php
+++ b/Sources/Calendar/VTimeZones/Atlantic/South_Georgia.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Atlantic/Stanley.php
+++ b/Sources/Calendar/VTimeZones/Atlantic/Stanley.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Australia/Adelaide.php
+++ b/Sources/Calendar/VTimeZones/Australia/Adelaide.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Australia/Brisbane.php
+++ b/Sources/Calendar/VTimeZones/Australia/Brisbane.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Australia/Broken_Hill.php
+++ b/Sources/Calendar/VTimeZones/Australia/Broken_Hill.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Australia/Darwin.php
+++ b/Sources/Calendar/VTimeZones/Australia/Darwin.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Australia/Eucla.php
+++ b/Sources/Calendar/VTimeZones/Australia/Eucla.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Australia/Hobart.php
+++ b/Sources/Calendar/VTimeZones/Australia/Hobart.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Australia/Lindeman.php
+++ b/Sources/Calendar/VTimeZones/Australia/Lindeman.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Australia/Lord_Howe.php
+++ b/Sources/Calendar/VTimeZones/Australia/Lord_Howe.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Australia/Melbourne.php
+++ b/Sources/Calendar/VTimeZones/Australia/Melbourne.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Australia/Perth.php
+++ b/Sources/Calendar/VTimeZones/Australia/Perth.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Australia/Sydney.php
+++ b/Sources/Calendar/VTimeZones/Australia/Sydney.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Etc/GMT.php
+++ b/Sources/Calendar/VTimeZones/Etc/GMT.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Etc/GMT1.php
+++ b/Sources/Calendar/VTimeZones/Etc/GMT1.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Etc/GMT10.php
+++ b/Sources/Calendar/VTimeZones/Etc/GMT10.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Etc/GMT11.php
+++ b/Sources/Calendar/VTimeZones/Etc/GMT11.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Etc/GMT12.php
+++ b/Sources/Calendar/VTimeZones/Etc/GMT12.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Etc/GMT2.php
+++ b/Sources/Calendar/VTimeZones/Etc/GMT2.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Etc/GMT3.php
+++ b/Sources/Calendar/VTimeZones/Etc/GMT3.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Etc/GMT4.php
+++ b/Sources/Calendar/VTimeZones/Etc/GMT4.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Etc/GMT5.php
+++ b/Sources/Calendar/VTimeZones/Etc/GMT5.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Etc/GMT6.php
+++ b/Sources/Calendar/VTimeZones/Etc/GMT6.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Etc/GMT7.php
+++ b/Sources/Calendar/VTimeZones/Etc/GMT7.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Etc/GMT8.php
+++ b/Sources/Calendar/VTimeZones/Etc/GMT8.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Etc/GMT9.php
+++ b/Sources/Calendar/VTimeZones/Etc/GMT9.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Etc/GMT_1.php
+++ b/Sources/Calendar/VTimeZones/Etc/GMT_1.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Etc/GMT_10.php
+++ b/Sources/Calendar/VTimeZones/Etc/GMT_10.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Etc/GMT_11.php
+++ b/Sources/Calendar/VTimeZones/Etc/GMT_11.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Etc/GMT_12.php
+++ b/Sources/Calendar/VTimeZones/Etc/GMT_12.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Etc/GMT_13.php
+++ b/Sources/Calendar/VTimeZones/Etc/GMT_13.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Etc/GMT_14.php
+++ b/Sources/Calendar/VTimeZones/Etc/GMT_14.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Etc/GMT_2.php
+++ b/Sources/Calendar/VTimeZones/Etc/GMT_2.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Etc/GMT_3.php
+++ b/Sources/Calendar/VTimeZones/Etc/GMT_3.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Etc/GMT_4.php
+++ b/Sources/Calendar/VTimeZones/Etc/GMT_4.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Etc/GMT_5.php
+++ b/Sources/Calendar/VTimeZones/Etc/GMT_5.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Etc/GMT_6.php
+++ b/Sources/Calendar/VTimeZones/Etc/GMT_6.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Etc/GMT_7.php
+++ b/Sources/Calendar/VTimeZones/Etc/GMT_7.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Etc/GMT_8.php
+++ b/Sources/Calendar/VTimeZones/Etc/GMT_8.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Etc/GMT_9.php
+++ b/Sources/Calendar/VTimeZones/Etc/GMT_9.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Etc/UTC.php
+++ b/Sources/Calendar/VTimeZones/Etc/UTC.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Europe/Andorra.php
+++ b/Sources/Calendar/VTimeZones/Europe/Andorra.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Europe/Astrakhan.php
+++ b/Sources/Calendar/VTimeZones/Europe/Astrakhan.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Europe/Athens.php
+++ b/Sources/Calendar/VTimeZones/Europe/Athens.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Europe/Belgrade.php
+++ b/Sources/Calendar/VTimeZones/Europe/Belgrade.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Europe/Berlin.php
+++ b/Sources/Calendar/VTimeZones/Europe/Berlin.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Europe/Brussels.php
+++ b/Sources/Calendar/VTimeZones/Europe/Brussels.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Europe/Bucharest.php
+++ b/Sources/Calendar/VTimeZones/Europe/Bucharest.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Europe/Budapest.php
+++ b/Sources/Calendar/VTimeZones/Europe/Budapest.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Europe/Chisinau.php
+++ b/Sources/Calendar/VTimeZones/Europe/Chisinau.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Europe/Dublin.php
+++ b/Sources/Calendar/VTimeZones/Europe/Dublin.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Europe/Gibraltar.php
+++ b/Sources/Calendar/VTimeZones/Europe/Gibraltar.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Europe/Helsinki.php
+++ b/Sources/Calendar/VTimeZones/Europe/Helsinki.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Europe/Istanbul.php
+++ b/Sources/Calendar/VTimeZones/Europe/Istanbul.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Europe/Kaliningrad.php
+++ b/Sources/Calendar/VTimeZones/Europe/Kaliningrad.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Europe/Kirov.php
+++ b/Sources/Calendar/VTimeZones/Europe/Kirov.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Europe/Kyiv.php
+++ b/Sources/Calendar/VTimeZones/Europe/Kyiv.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Europe/Lisbon.php
+++ b/Sources/Calendar/VTimeZones/Europe/Lisbon.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Europe/London.php
+++ b/Sources/Calendar/VTimeZones/Europe/London.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Europe/Madrid.php
+++ b/Sources/Calendar/VTimeZones/Europe/Madrid.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Europe/Malta.php
+++ b/Sources/Calendar/VTimeZones/Europe/Malta.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Europe/Minsk.php
+++ b/Sources/Calendar/VTimeZones/Europe/Minsk.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Europe/Moscow.php
+++ b/Sources/Calendar/VTimeZones/Europe/Moscow.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Europe/Paris.php
+++ b/Sources/Calendar/VTimeZones/Europe/Paris.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Europe/Prague.php
+++ b/Sources/Calendar/VTimeZones/Europe/Prague.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Europe/Riga.php
+++ b/Sources/Calendar/VTimeZones/Europe/Riga.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Europe/Rome.php
+++ b/Sources/Calendar/VTimeZones/Europe/Rome.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Europe/Samara.php
+++ b/Sources/Calendar/VTimeZones/Europe/Samara.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Europe/Saratov.php
+++ b/Sources/Calendar/VTimeZones/Europe/Saratov.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Europe/Simferopol.php
+++ b/Sources/Calendar/VTimeZones/Europe/Simferopol.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Europe/Sofia.php
+++ b/Sources/Calendar/VTimeZones/Europe/Sofia.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Europe/Tallinn.php
+++ b/Sources/Calendar/VTimeZones/Europe/Tallinn.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Europe/Tirane.php
+++ b/Sources/Calendar/VTimeZones/Europe/Tirane.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Europe/Ulyanovsk.php
+++ b/Sources/Calendar/VTimeZones/Europe/Ulyanovsk.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Europe/Vienna.php
+++ b/Sources/Calendar/VTimeZones/Europe/Vienna.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Europe/Vilnius.php
+++ b/Sources/Calendar/VTimeZones/Europe/Vilnius.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Europe/Volgograd.php
+++ b/Sources/Calendar/VTimeZones/Europe/Volgograd.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Europe/Warsaw.php
+++ b/Sources/Calendar/VTimeZones/Europe/Warsaw.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Europe/Zurich.php
+++ b/Sources/Calendar/VTimeZones/Europe/Zurich.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Indian/Chagos.php
+++ b/Sources/Calendar/VTimeZones/Indian/Chagos.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Indian/Maldives.php
+++ b/Sources/Calendar/VTimeZones/Indian/Maldives.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Indian/Mauritius.php
+++ b/Sources/Calendar/VTimeZones/Indian/Mauritius.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Pacific/Apia.php
+++ b/Sources/Calendar/VTimeZones/Pacific/Apia.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Pacific/Auckland.php
+++ b/Sources/Calendar/VTimeZones/Pacific/Auckland.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Pacific/Bougainville.php
+++ b/Sources/Calendar/VTimeZones/Pacific/Bougainville.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Pacific/Chatham.php
+++ b/Sources/Calendar/VTimeZones/Pacific/Chatham.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Pacific/Easter.php
+++ b/Sources/Calendar/VTimeZones/Pacific/Easter.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Pacific/Efate.php
+++ b/Sources/Calendar/VTimeZones/Pacific/Efate.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Pacific/Fakaofo.php
+++ b/Sources/Calendar/VTimeZones/Pacific/Fakaofo.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Pacific/Fiji.php
+++ b/Sources/Calendar/VTimeZones/Pacific/Fiji.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Pacific/Galapagos.php
+++ b/Sources/Calendar/VTimeZones/Pacific/Galapagos.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Pacific/Gambier.php
+++ b/Sources/Calendar/VTimeZones/Pacific/Gambier.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Pacific/Guadalcanal.php
+++ b/Sources/Calendar/VTimeZones/Pacific/Guadalcanal.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Pacific/Guam.php
+++ b/Sources/Calendar/VTimeZones/Pacific/Guam.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Pacific/Honolulu.php
+++ b/Sources/Calendar/VTimeZones/Pacific/Honolulu.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Pacific/Kanton.php
+++ b/Sources/Calendar/VTimeZones/Pacific/Kanton.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Pacific/Kiritimati.php
+++ b/Sources/Calendar/VTimeZones/Pacific/Kiritimati.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Pacific/Kosrae.php
+++ b/Sources/Calendar/VTimeZones/Pacific/Kosrae.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Pacific/Kwajalein.php
+++ b/Sources/Calendar/VTimeZones/Pacific/Kwajalein.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Pacific/Marquesas.php
+++ b/Sources/Calendar/VTimeZones/Pacific/Marquesas.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Pacific/Nauru.php
+++ b/Sources/Calendar/VTimeZones/Pacific/Nauru.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Pacific/Niue.php
+++ b/Sources/Calendar/VTimeZones/Pacific/Niue.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Pacific/Norfolk.php
+++ b/Sources/Calendar/VTimeZones/Pacific/Norfolk.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Pacific/Noumea.php
+++ b/Sources/Calendar/VTimeZones/Pacific/Noumea.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Pacific/Pago_Pago.php
+++ b/Sources/Calendar/VTimeZones/Pacific/Pago_Pago.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Pacific/Palau.php
+++ b/Sources/Calendar/VTimeZones/Pacific/Palau.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Pacific/Pitcairn.php
+++ b/Sources/Calendar/VTimeZones/Pacific/Pitcairn.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Pacific/Port_Moresby.php
+++ b/Sources/Calendar/VTimeZones/Pacific/Port_Moresby.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Pacific/Rarotonga.php
+++ b/Sources/Calendar/VTimeZones/Pacific/Rarotonga.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Pacific/Tahiti.php
+++ b/Sources/Calendar/VTimeZones/Pacific/Tahiti.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Pacific/Tarawa.php
+++ b/Sources/Calendar/VTimeZones/Pacific/Tarawa.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Calendar/VTimeZones/Pacific/Tongatapu.php
+++ b/Sources/Calendar/VTimeZones/Pacific/Tongatapu.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Category.php
+++ b/Sources/Category.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Class-BrowserDetect.php
+++ b/Sources/Class-BrowserDetect.php
@@ -10,7 +10,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 if (!defined('SMF')) {

--- a/Sources/Class-CurlFetchWeb.php
+++ b/Sources/Class-CurlFetchWeb.php
@@ -10,7 +10,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 if (!defined('SMF')) {

--- a/Sources/Class-Graphics.php
+++ b/Sources/Class-Graphics.php
@@ -10,7 +10,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 if (!defined('SMF')) {

--- a/Sources/Class-Package.php
+++ b/Sources/Class-Package.php
@@ -10,7 +10,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 if (!defined('SMF')) {

--- a/Sources/Class-Punycode.php
+++ b/Sources/Class-Punycode.php
@@ -10,7 +10,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 if (!defined('SMF')) {

--- a/Sources/Class-SearchAPI.php
+++ b/Sources/Class-SearchAPI.php
@@ -10,7 +10,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 if (!defined('SMF')) {

--- a/Sources/Class-TOTP.php
+++ b/Sources/Class-TOTP.php
@@ -10,7 +10,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 if (!defined('SMF')) {

--- a/Sources/Config.php
+++ b/Sources/Config.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Cookie.php
+++ b/Sources/Cookie.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/APIs/MySQL.php
+++ b/Sources/Db/APIs/MySQL.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/APIs/PostgreSQL.php
+++ b/Sources/Db/APIs/PostgreSQL.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/DatabaseApi.php
+++ b/Sources/Db/DatabaseApi.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/DatabaseApiInterface.php
+++ b/Sources/Db/DatabaseApiInterface.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/Column.php
+++ b/Sources/Db/Schema/Column.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/DbIndex.php
+++ b/Sources/Db/Schema/DbIndex.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/GeneratedColumn.php
+++ b/Sources/Db/Schema/GeneratedColumn.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/Table.php
+++ b/Sources/Db/Schema/Table.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v2_1/AdminInfoFiles.php
+++ b/Sources/Db/Schema/v2_1/AdminInfoFiles.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v2_1/ApprovalQueue.php
+++ b/Sources/Db/Schema/v2_1/ApprovalQueue.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v2_1/Attachments.php
+++ b/Sources/Db/Schema/v2_1/Attachments.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v2_1/BackgroundTasks.php
+++ b/Sources/Db/Schema/v2_1/BackgroundTasks.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v2_1/BanGroups.php
+++ b/Sources/Db/Schema/v2_1/BanGroups.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v2_1/BanItems.php
+++ b/Sources/Db/Schema/v2_1/BanItems.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v2_1/BoardPermissions.php
+++ b/Sources/Db/Schema/v2_1/BoardPermissions.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v2_1/BoardPermissionsView.php
+++ b/Sources/Db/Schema/v2_1/BoardPermissionsView.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v2_1/Boards.php
+++ b/Sources/Db/Schema/v2_1/Boards.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v2_1/Calendar.php
+++ b/Sources/Db/Schema/v2_1/Calendar.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v2_1/CalendarHolidays.php
+++ b/Sources/Db/Schema/v2_1/CalendarHolidays.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v2_1/Categories.php
+++ b/Sources/Db/Schema/v2_1/Categories.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v2_1/CustomFields.php
+++ b/Sources/Db/Schema/v2_1/CustomFields.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v2_1/GroupModerators.php
+++ b/Sources/Db/Schema/v2_1/GroupModerators.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v2_1/LogActions.php
+++ b/Sources/Db/Schema/v2_1/LogActions.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v2_1/LogActivity.php
+++ b/Sources/Db/Schema/v2_1/LogActivity.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v2_1/LogBanned.php
+++ b/Sources/Db/Schema/v2_1/LogBanned.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v2_1/LogBoards.php
+++ b/Sources/Db/Schema/v2_1/LogBoards.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v2_1/LogComments.php
+++ b/Sources/Db/Schema/v2_1/LogComments.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v2_1/LogDigest.php
+++ b/Sources/Db/Schema/v2_1/LogDigest.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v2_1/LogErrors.php
+++ b/Sources/Db/Schema/v2_1/LogErrors.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v2_1/LogFloodcontrol.php
+++ b/Sources/Db/Schema/v2_1/LogFloodcontrol.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v2_1/LogGroupRequests.php
+++ b/Sources/Db/Schema/v2_1/LogGroupRequests.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v2_1/LogMarkRead.php
+++ b/Sources/Db/Schema/v2_1/LogMarkRead.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v2_1/LogMemberNotices.php
+++ b/Sources/Db/Schema/v2_1/LogMemberNotices.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v2_1/LogNotify.php
+++ b/Sources/Db/Schema/v2_1/LogNotify.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v2_1/LogOnline.php
+++ b/Sources/Db/Schema/v2_1/LogOnline.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v2_1/LogPackages.php
+++ b/Sources/Db/Schema/v2_1/LogPackages.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v2_1/LogPolls.php
+++ b/Sources/Db/Schema/v2_1/LogPolls.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v2_1/LogReported.php
+++ b/Sources/Db/Schema/v2_1/LogReported.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v2_1/LogReportedComments.php
+++ b/Sources/Db/Schema/v2_1/LogReportedComments.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v2_1/LogScheduledTasks.php
+++ b/Sources/Db/Schema/v2_1/LogScheduledTasks.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v2_1/LogSearchMessages.php
+++ b/Sources/Db/Schema/v2_1/LogSearchMessages.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v2_1/LogSearchResults.php
+++ b/Sources/Db/Schema/v2_1/LogSearchResults.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v2_1/LogSearchSubjects.php
+++ b/Sources/Db/Schema/v2_1/LogSearchSubjects.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v2_1/LogSearchTopics.php
+++ b/Sources/Db/Schema/v2_1/LogSearchTopics.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v2_1/LogSpiderHits.php
+++ b/Sources/Db/Schema/v2_1/LogSpiderHits.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v2_1/LogSpiderStats.php
+++ b/Sources/Db/Schema/v2_1/LogSpiderStats.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v2_1/LogSubscribed.php
+++ b/Sources/Db/Schema/v2_1/LogSubscribed.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v2_1/LogTopics.php
+++ b/Sources/Db/Schema/v2_1/LogTopics.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v2_1/MailQueue.php
+++ b/Sources/Db/Schema/v2_1/MailQueue.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v2_1/MemberLogins.php
+++ b/Sources/Db/Schema/v2_1/MemberLogins.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v2_1/Membergroups.php
+++ b/Sources/Db/Schema/v2_1/Membergroups.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v2_1/Members.php
+++ b/Sources/Db/Schema/v2_1/Members.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v2_1/Mentions.php
+++ b/Sources/Db/Schema/v2_1/Mentions.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v2_1/MessageIcons.php
+++ b/Sources/Db/Schema/v2_1/MessageIcons.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v2_1/Messages.php
+++ b/Sources/Db/Schema/v2_1/Messages.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v2_1/ModeratorGroups.php
+++ b/Sources/Db/Schema/v2_1/ModeratorGroups.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v2_1/Moderators.php
+++ b/Sources/Db/Schema/v2_1/Moderators.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v2_1/PackageServers.php
+++ b/Sources/Db/Schema/v2_1/PackageServers.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v2_1/PermissionProfiles.php
+++ b/Sources/Db/Schema/v2_1/PermissionProfiles.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v2_1/Permissions.php
+++ b/Sources/Db/Schema/v2_1/Permissions.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v2_1/PersonalMessages.php
+++ b/Sources/Db/Schema/v2_1/PersonalMessages.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v2_1/PmLabeledMessages.php
+++ b/Sources/Db/Schema/v2_1/PmLabeledMessages.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v2_1/PmLabels.php
+++ b/Sources/Db/Schema/v2_1/PmLabels.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v2_1/PmRecipients.php
+++ b/Sources/Db/Schema/v2_1/PmRecipients.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v2_1/PmRules.php
+++ b/Sources/Db/Schema/v2_1/PmRules.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v2_1/PollChoices.php
+++ b/Sources/Db/Schema/v2_1/PollChoices.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v2_1/Polls.php
+++ b/Sources/Db/Schema/v2_1/Polls.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v2_1/Qanda.php
+++ b/Sources/Db/Schema/v2_1/Qanda.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v2_1/ScheduledTasks.php
+++ b/Sources/Db/Schema/v2_1/ScheduledTasks.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v2_1/Sessions.php
+++ b/Sources/Db/Schema/v2_1/Sessions.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v2_1/Settings.php
+++ b/Sources/Db/Schema/v2_1/Settings.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v2_1/SmileyFiles.php
+++ b/Sources/Db/Schema/v2_1/SmileyFiles.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v2_1/Smileys.php
+++ b/Sources/Db/Schema/v2_1/Smileys.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v2_1/Spiders.php
+++ b/Sources/Db/Schema/v2_1/Spiders.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v2_1/Subscriptions.php
+++ b/Sources/Db/Schema/v2_1/Subscriptions.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v2_1/Themes.php
+++ b/Sources/Db/Schema/v2_1/Themes.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v2_1/Topics.php
+++ b/Sources/Db/Schema/v2_1/Topics.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v2_1/UserAlerts.php
+++ b/Sources/Db/Schema/v2_1/UserAlerts.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v2_1/UserAlertsPrefs.php
+++ b/Sources/Db/Schema/v2_1/UserAlertsPrefs.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v2_1/UserDrafts.php
+++ b/Sources/Db/Schema/v2_1/UserDrafts.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v2_1/UserLikes.php
+++ b/Sources/Db/Schema/v2_1/UserLikes.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v3_0/AdminInfoFiles.php
+++ b/Sources/Db/Schema/v3_0/AdminInfoFiles.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v3_0/ApprovalQueue.php
+++ b/Sources/Db/Schema/v3_0/ApprovalQueue.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v3_0/Attachments.php
+++ b/Sources/Db/Schema/v3_0/Attachments.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v3_0/BackgroundTasks.php
+++ b/Sources/Db/Schema/v3_0/BackgroundTasks.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v3_0/BanGroups.php
+++ b/Sources/Db/Schema/v3_0/BanGroups.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v3_0/BanItems.php
+++ b/Sources/Db/Schema/v3_0/BanItems.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v3_0/BoardPermissions.php
+++ b/Sources/Db/Schema/v3_0/BoardPermissions.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v3_0/BoardPermissionsView.php
+++ b/Sources/Db/Schema/v3_0/BoardPermissionsView.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v3_0/Boards.php
+++ b/Sources/Db/Schema/v3_0/Boards.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v3_0/Calendar.php
+++ b/Sources/Db/Schema/v3_0/Calendar.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v3_0/Categories.php
+++ b/Sources/Db/Schema/v3_0/Categories.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v3_0/CustomFields.php
+++ b/Sources/Db/Schema/v3_0/CustomFields.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v3_0/GroupModerators.php
+++ b/Sources/Db/Schema/v3_0/GroupModerators.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v3_0/Initialize/Base.php
+++ b/Sources/Db/Schema/v3_0/Initialize/Base.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v3_0/Initialize/MySQL.php
+++ b/Sources/Db/Schema/v3_0/Initialize/MySQL.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v3_0/Initialize/PostgreSQL.php
+++ b/Sources/Db/Schema/v3_0/Initialize/PostgreSQL.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v3_0/LogActions.php
+++ b/Sources/Db/Schema/v3_0/LogActions.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v3_0/LogActivity.php
+++ b/Sources/Db/Schema/v3_0/LogActivity.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v3_0/LogBanned.php
+++ b/Sources/Db/Schema/v3_0/LogBanned.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v3_0/LogBoards.php
+++ b/Sources/Db/Schema/v3_0/LogBoards.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v3_0/LogComments.php
+++ b/Sources/Db/Schema/v3_0/LogComments.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v3_0/LogDigest.php
+++ b/Sources/Db/Schema/v3_0/LogDigest.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v3_0/LogErrors.php
+++ b/Sources/Db/Schema/v3_0/LogErrors.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v3_0/LogFloodcontrol.php
+++ b/Sources/Db/Schema/v3_0/LogFloodcontrol.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v3_0/LogGroupRequests.php
+++ b/Sources/Db/Schema/v3_0/LogGroupRequests.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v3_0/LogMarkRead.php
+++ b/Sources/Db/Schema/v3_0/LogMarkRead.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v3_0/LogMemberNotices.php
+++ b/Sources/Db/Schema/v3_0/LogMemberNotices.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v3_0/LogNotify.php
+++ b/Sources/Db/Schema/v3_0/LogNotify.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v3_0/LogOnline.php
+++ b/Sources/Db/Schema/v3_0/LogOnline.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v3_0/LogPackages.php
+++ b/Sources/Db/Schema/v3_0/LogPackages.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v3_0/LogPolls.php
+++ b/Sources/Db/Schema/v3_0/LogPolls.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v3_0/LogReported.php
+++ b/Sources/Db/Schema/v3_0/LogReported.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v3_0/LogReportedComments.php
+++ b/Sources/Db/Schema/v3_0/LogReportedComments.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v3_0/LogScheduledTasks.php
+++ b/Sources/Db/Schema/v3_0/LogScheduledTasks.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v3_0/LogSearchMessages.php
+++ b/Sources/Db/Schema/v3_0/LogSearchMessages.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v3_0/LogSearchResults.php
+++ b/Sources/Db/Schema/v3_0/LogSearchResults.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v3_0/LogSearchSubjects.php
+++ b/Sources/Db/Schema/v3_0/LogSearchSubjects.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v3_0/LogSearchTopics.php
+++ b/Sources/Db/Schema/v3_0/LogSearchTopics.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v3_0/LogSpiderHits.php
+++ b/Sources/Db/Schema/v3_0/LogSpiderHits.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v3_0/LogSpiderStats.php
+++ b/Sources/Db/Schema/v3_0/LogSpiderStats.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v3_0/LogSubscribed.php
+++ b/Sources/Db/Schema/v3_0/LogSubscribed.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v3_0/LogTopics.php
+++ b/Sources/Db/Schema/v3_0/LogTopics.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v3_0/MailQueue.php
+++ b/Sources/Db/Schema/v3_0/MailQueue.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v3_0/MemberLogins.php
+++ b/Sources/Db/Schema/v3_0/MemberLogins.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v3_0/Membergroups.php
+++ b/Sources/Db/Schema/v3_0/Membergroups.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v3_0/Members.php
+++ b/Sources/Db/Schema/v3_0/Members.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v3_0/Mentions.php
+++ b/Sources/Db/Schema/v3_0/Mentions.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v3_0/MessageIcons.php
+++ b/Sources/Db/Schema/v3_0/MessageIcons.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v3_0/Messages.php
+++ b/Sources/Db/Schema/v3_0/Messages.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v3_0/ModeratorGroups.php
+++ b/Sources/Db/Schema/v3_0/ModeratorGroups.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v3_0/Moderators.php
+++ b/Sources/Db/Schema/v3_0/Moderators.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v3_0/PackageServers.php
+++ b/Sources/Db/Schema/v3_0/PackageServers.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v3_0/PermissionProfiles.php
+++ b/Sources/Db/Schema/v3_0/PermissionProfiles.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v3_0/Permissions.php
+++ b/Sources/Db/Schema/v3_0/Permissions.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v3_0/PersonalMessages.php
+++ b/Sources/Db/Schema/v3_0/PersonalMessages.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v3_0/PmLabeledMessages.php
+++ b/Sources/Db/Schema/v3_0/PmLabeledMessages.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v3_0/PmLabels.php
+++ b/Sources/Db/Schema/v3_0/PmLabels.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v3_0/PmRecipients.php
+++ b/Sources/Db/Schema/v3_0/PmRecipients.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v3_0/PmRules.php
+++ b/Sources/Db/Schema/v3_0/PmRules.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v3_0/PollChoices.php
+++ b/Sources/Db/Schema/v3_0/PollChoices.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v3_0/Polls.php
+++ b/Sources/Db/Schema/v3_0/Polls.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v3_0/Qanda.php
+++ b/Sources/Db/Schema/v3_0/Qanda.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v3_0/ScheduledTasks.php
+++ b/Sources/Db/Schema/v3_0/ScheduledTasks.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v3_0/Sessions.php
+++ b/Sources/Db/Schema/v3_0/Sessions.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v3_0/Settings.php
+++ b/Sources/Db/Schema/v3_0/Settings.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v3_0/SmileyFiles.php
+++ b/Sources/Db/Schema/v3_0/SmileyFiles.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v3_0/Smileys.php
+++ b/Sources/Db/Schema/v3_0/Smileys.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v3_0/Spiders.php
+++ b/Sources/Db/Schema/v3_0/Spiders.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v3_0/Subscriptions.php
+++ b/Sources/Db/Schema/v3_0/Subscriptions.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v3_0/Themes.php
+++ b/Sources/Db/Schema/v3_0/Themes.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v3_0/Topics.php
+++ b/Sources/Db/Schema/v3_0/Topics.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v3_0/UserAlerts.php
+++ b/Sources/Db/Schema/v3_0/UserAlerts.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v3_0/UserAlertsPrefs.php
+++ b/Sources/Db/Schema/v3_0/UserAlertsPrefs.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v3_0/UserDrafts.php
+++ b/Sources/Db/Schema/v3_0/UserDrafts.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Db/Schema/v3_0/UserLikes.php
+++ b/Sources/Db/Schema/v3_0/UserLikes.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Debug/DebugUtils.php
+++ b/Sources/Debug/DebugUtils.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Diff/Diff.php
+++ b/Sources/Diff/Diff.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Diff/EditDiff.php
+++ b/Sources/Diff/EditDiff.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Diff/FullDiff.php
+++ b/Sources/Diff/FullDiff.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Draft.php
+++ b/Sources/Draft.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/DynamicPropertyHelper.php
+++ b/Sources/DynamicPropertyHelper.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // This can not be defined yet. We use dynamic properties, sometimes loaded from the database, which are always a string.

--- a/Sources/Editor.php
+++ b/Sources/Editor.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/EmailAddress.php
+++ b/Sources/EmailAddress.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Forum.php
+++ b/Sources/Forum.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Graphics/Gif/ColorTable.php
+++ b/Sources/Graphics/Gif/ColorTable.php
@@ -16,7 +16,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Graphics/Gif/File.php
+++ b/Sources/Graphics/Gif/File.php
@@ -16,7 +16,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Graphics/Gif/FileHeader.php
+++ b/Sources/Graphics/Gif/FileHeader.php
@@ -16,7 +16,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Graphics/Gif/Image.php
+++ b/Sources/Graphics/Gif/Image.php
@@ -16,7 +16,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Graphics/Gif/ImageHeader.php
+++ b/Sources/Graphics/Gif/ImageHeader.php
@@ -16,7 +16,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Graphics/Gif/LzwCompression.php
+++ b/Sources/Graphics/Gif/LzwCompression.php
@@ -16,7 +16,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Graphics/Image.php
+++ b/Sources/Graphics/Image.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Group.php
+++ b/Sources/Group.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/IP.php
+++ b/Sources/IP.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Infrastructure/Container.php
+++ b/Sources/Infrastructure/Container.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/IntegrationHook.php
+++ b/Sources/IntegrationHook.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/ItemList.php
+++ b/Sources/ItemList.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Lang.php
+++ b/Sources/Lang.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Localization/AsciiTransliterator.php
+++ b/Sources/Localization/AsciiTransliterator.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Localization/MessageFormatter.php
+++ b/Sources/Localization/MessageFormatter.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Localization/data/AsciiTransliteration_0000.php
+++ b/Sources/Localization/data/AsciiTransliteration_0000.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0001.php
+++ b/Sources/Localization/data/AsciiTransliteration_0001.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0002.php
+++ b/Sources/Localization/data/AsciiTransliteration_0002.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0003.php
+++ b/Sources/Localization/data/AsciiTransliteration_0003.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0004.php
+++ b/Sources/Localization/data/AsciiTransliteration_0004.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0005.php
+++ b/Sources/Localization/data/AsciiTransliteration_0005.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0006.php
+++ b/Sources/Localization/data/AsciiTransliteration_0006.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0007.php
+++ b/Sources/Localization/data/AsciiTransliteration_0007.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0009.php
+++ b/Sources/Localization/data/AsciiTransliteration_0009.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0010.php
+++ b/Sources/Localization/data/AsciiTransliteration_0010.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0011.php
+++ b/Sources/Localization/data/AsciiTransliteration_0011.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0012.php
+++ b/Sources/Localization/data/AsciiTransliteration_0012.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0013.php
+++ b/Sources/Localization/data/AsciiTransliteration_0013.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0014.php
+++ b/Sources/Localization/data/AsciiTransliteration_0014.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0016.php
+++ b/Sources/Localization/data/AsciiTransliteration_0016.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0017.php
+++ b/Sources/Localization/data/AsciiTransliteration_0017.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0018.php
+++ b/Sources/Localization/data/AsciiTransliteration_0018.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0019.php
+++ b/Sources/Localization/data/AsciiTransliteration_0019.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0029.php
+++ b/Sources/Localization/data/AsciiTransliteration_0029.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0030.php
+++ b/Sources/Localization/data/AsciiTransliteration_0030.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0031.php
+++ b/Sources/Localization/data/AsciiTransliteration_0031.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0032.php
+++ b/Sources/Localization/data/AsciiTransliteration_0032.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0033.php
+++ b/Sources/Localization/data/AsciiTransliteration_0033.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0034.php
+++ b/Sources/Localization/data/AsciiTransliteration_0034.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0035.php
+++ b/Sources/Localization/data/AsciiTransliteration_0035.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0036.php
+++ b/Sources/Localization/data/AsciiTransliteration_0036.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0041.php
+++ b/Sources/Localization/data/AsciiTransliteration_0041.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0042.php
+++ b/Sources/Localization/data/AsciiTransliteration_0042.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0044.php
+++ b/Sources/Localization/data/AsciiTransliteration_0044.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0045.php
+++ b/Sources/Localization/data/AsciiTransliteration_0045.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0046.php
+++ b/Sources/Localization/data/AsciiTransliteration_0046.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0047.php
+++ b/Sources/Localization/data/AsciiTransliteration_0047.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0048.php
+++ b/Sources/Localization/data/AsciiTransliteration_0048.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0049.php
+++ b/Sources/Localization/data/AsciiTransliteration_0049.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0050.php
+++ b/Sources/Localization/data/AsciiTransliteration_0050.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0051.php
+++ b/Sources/Localization/data/AsciiTransliteration_0051.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0052.php
+++ b/Sources/Localization/data/AsciiTransliteration_0052.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0053.php
+++ b/Sources/Localization/data/AsciiTransliteration_0053.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0054.php
+++ b/Sources/Localization/data/AsciiTransliteration_0054.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0055.php
+++ b/Sources/Localization/data/AsciiTransliteration_0055.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0056.php
+++ b/Sources/Localization/data/AsciiTransliteration_0056.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0057.php
+++ b/Sources/Localization/data/AsciiTransliteration_0057.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0058.php
+++ b/Sources/Localization/data/AsciiTransliteration_0058.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0059.php
+++ b/Sources/Localization/data/AsciiTransliteration_0059.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0060.php
+++ b/Sources/Localization/data/AsciiTransliteration_0060.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0061.php
+++ b/Sources/Localization/data/AsciiTransliteration_0061.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0062.php
+++ b/Sources/Localization/data/AsciiTransliteration_0062.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0063.php
+++ b/Sources/Localization/data/AsciiTransliteration_0063.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0064.php
+++ b/Sources/Localization/data/AsciiTransliteration_0064.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0065.php
+++ b/Sources/Localization/data/AsciiTransliteration_0065.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0066.php
+++ b/Sources/Localization/data/AsciiTransliteration_0066.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0067.php
+++ b/Sources/Localization/data/AsciiTransliteration_0067.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0068.php
+++ b/Sources/Localization/data/AsciiTransliteration_0068.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0069.php
+++ b/Sources/Localization/data/AsciiTransliteration_0069.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0070.php
+++ b/Sources/Localization/data/AsciiTransliteration_0070.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0071.php
+++ b/Sources/Localization/data/AsciiTransliteration_0071.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0072.php
+++ b/Sources/Localization/data/AsciiTransliteration_0072.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0073.php
+++ b/Sources/Localization/data/AsciiTransliteration_0073.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0074.php
+++ b/Sources/Localization/data/AsciiTransliteration_0074.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0075.php
+++ b/Sources/Localization/data/AsciiTransliteration_0075.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0076.php
+++ b/Sources/Localization/data/AsciiTransliteration_0076.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0077.php
+++ b/Sources/Localization/data/AsciiTransliteration_0077.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0078.php
+++ b/Sources/Localization/data/AsciiTransliteration_0078.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0079.php
+++ b/Sources/Localization/data/AsciiTransliteration_0079.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0080.php
+++ b/Sources/Localization/data/AsciiTransliteration_0080.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0081.php
+++ b/Sources/Localization/data/AsciiTransliteration_0081.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0082.php
+++ b/Sources/Localization/data/AsciiTransliteration_0082.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0083.php
+++ b/Sources/Localization/data/AsciiTransliteration_0083.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0084.php
+++ b/Sources/Localization/data/AsciiTransliteration_0084.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0085.php
+++ b/Sources/Localization/data/AsciiTransliteration_0085.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0086.php
+++ b/Sources/Localization/data/AsciiTransliteration_0086.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0087.php
+++ b/Sources/Localization/data/AsciiTransliteration_0087.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0088.php
+++ b/Sources/Localization/data/AsciiTransliteration_0088.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0089.php
+++ b/Sources/Localization/data/AsciiTransliteration_0089.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0090.php
+++ b/Sources/Localization/data/AsciiTransliteration_0090.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0091.php
+++ b/Sources/Localization/data/AsciiTransliteration_0091.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0092.php
+++ b/Sources/Localization/data/AsciiTransliteration_0092.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0093.php
+++ b/Sources/Localization/data/AsciiTransliteration_0093.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0094.php
+++ b/Sources/Localization/data/AsciiTransliteration_0094.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0095.php
+++ b/Sources/Localization/data/AsciiTransliteration_0095.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0096.php
+++ b/Sources/Localization/data/AsciiTransliteration_0096.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0097.php
+++ b/Sources/Localization/data/AsciiTransliteration_0097.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0098.php
+++ b/Sources/Localization/data/AsciiTransliteration_0098.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0099.php
+++ b/Sources/Localization/data/AsciiTransliteration_0099.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0100.php
+++ b/Sources/Localization/data/AsciiTransliteration_0100.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0101.php
+++ b/Sources/Localization/data/AsciiTransliteration_0101.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0102.php
+++ b/Sources/Localization/data/AsciiTransliteration_0102.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0103.php
+++ b/Sources/Localization/data/AsciiTransliteration_0103.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0104.php
+++ b/Sources/Localization/data/AsciiTransliteration_0104.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0105.php
+++ b/Sources/Localization/data/AsciiTransliteration_0105.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0106.php
+++ b/Sources/Localization/data/AsciiTransliteration_0106.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0107.php
+++ b/Sources/Localization/data/AsciiTransliteration_0107.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0108.php
+++ b/Sources/Localization/data/AsciiTransliteration_0108.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0109.php
+++ b/Sources/Localization/data/AsciiTransliteration_0109.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0110.php
+++ b/Sources/Localization/data/AsciiTransliteration_0110.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0111.php
+++ b/Sources/Localization/data/AsciiTransliteration_0111.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0112.php
+++ b/Sources/Localization/data/AsciiTransliteration_0112.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0113.php
+++ b/Sources/Localization/data/AsciiTransliteration_0113.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0114.php
+++ b/Sources/Localization/data/AsciiTransliteration_0114.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0115.php
+++ b/Sources/Localization/data/AsciiTransliteration_0115.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0116.php
+++ b/Sources/Localization/data/AsciiTransliteration_0116.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0117.php
+++ b/Sources/Localization/data/AsciiTransliteration_0117.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0118.php
+++ b/Sources/Localization/data/AsciiTransliteration_0118.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0119.php
+++ b/Sources/Localization/data/AsciiTransliteration_0119.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0120.php
+++ b/Sources/Localization/data/AsciiTransliteration_0120.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0121.php
+++ b/Sources/Localization/data/AsciiTransliteration_0121.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0122.php
+++ b/Sources/Localization/data/AsciiTransliteration_0122.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0123.php
+++ b/Sources/Localization/data/AsciiTransliteration_0123.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0124.php
+++ b/Sources/Localization/data/AsciiTransliteration_0124.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0125.php
+++ b/Sources/Localization/data/AsciiTransliteration_0125.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0126.php
+++ b/Sources/Localization/data/AsciiTransliteration_0126.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0127.php
+++ b/Sources/Localization/data/AsciiTransliteration_0127.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0128.php
+++ b/Sources/Localization/data/AsciiTransliteration_0128.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0129.php
+++ b/Sources/Localization/data/AsciiTransliteration_0129.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0130.php
+++ b/Sources/Localization/data/AsciiTransliteration_0130.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0131.php
+++ b/Sources/Localization/data/AsciiTransliteration_0131.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0132.php
+++ b/Sources/Localization/data/AsciiTransliteration_0132.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0133.php
+++ b/Sources/Localization/data/AsciiTransliteration_0133.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0134.php
+++ b/Sources/Localization/data/AsciiTransliteration_0134.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0135.php
+++ b/Sources/Localization/data/AsciiTransliteration_0135.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0136.php
+++ b/Sources/Localization/data/AsciiTransliteration_0136.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0137.php
+++ b/Sources/Localization/data/AsciiTransliteration_0137.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0138.php
+++ b/Sources/Localization/data/AsciiTransliteration_0138.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0139.php
+++ b/Sources/Localization/data/AsciiTransliteration_0139.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0140.php
+++ b/Sources/Localization/data/AsciiTransliteration_0140.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0141.php
+++ b/Sources/Localization/data/AsciiTransliteration_0141.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0142.php
+++ b/Sources/Localization/data/AsciiTransliteration_0142.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0143.php
+++ b/Sources/Localization/data/AsciiTransliteration_0143.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0144.php
+++ b/Sources/Localization/data/AsciiTransliteration_0144.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0145.php
+++ b/Sources/Localization/data/AsciiTransliteration_0145.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0146.php
+++ b/Sources/Localization/data/AsciiTransliteration_0146.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0147.php
+++ b/Sources/Localization/data/AsciiTransliteration_0147.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0148.php
+++ b/Sources/Localization/data/AsciiTransliteration_0148.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0149.php
+++ b/Sources/Localization/data/AsciiTransliteration_0149.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0150.php
+++ b/Sources/Localization/data/AsciiTransliteration_0150.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0151.php
+++ b/Sources/Localization/data/AsciiTransliteration_0151.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0152.php
+++ b/Sources/Localization/data/AsciiTransliteration_0152.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0153.php
+++ b/Sources/Localization/data/AsciiTransliteration_0153.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0154.php
+++ b/Sources/Localization/data/AsciiTransliteration_0154.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0155.php
+++ b/Sources/Localization/data/AsciiTransliteration_0155.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0156.php
+++ b/Sources/Localization/data/AsciiTransliteration_0156.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0157.php
+++ b/Sources/Localization/data/AsciiTransliteration_0157.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0158.php
+++ b/Sources/Localization/data/AsciiTransliteration_0158.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0159.php
+++ b/Sources/Localization/data/AsciiTransliteration_0159.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0167.php
+++ b/Sources/Localization/data/AsciiTransliteration_0167.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0172.php
+++ b/Sources/Localization/data/AsciiTransliteration_0172.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0173.php
+++ b/Sources/Localization/data/AsciiTransliteration_0173.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0174.php
+++ b/Sources/Localization/data/AsciiTransliteration_0174.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0175.php
+++ b/Sources/Localization/data/AsciiTransliteration_0175.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0176.php
+++ b/Sources/Localization/data/AsciiTransliteration_0176.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0177.php
+++ b/Sources/Localization/data/AsciiTransliteration_0177.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0178.php
+++ b/Sources/Localization/data/AsciiTransliteration_0178.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0179.php
+++ b/Sources/Localization/data/AsciiTransliteration_0179.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0180.php
+++ b/Sources/Localization/data/AsciiTransliteration_0180.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0181.php
+++ b/Sources/Localization/data/AsciiTransliteration_0181.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0182.php
+++ b/Sources/Localization/data/AsciiTransliteration_0182.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0183.php
+++ b/Sources/Localization/data/AsciiTransliteration_0183.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0184.php
+++ b/Sources/Localization/data/AsciiTransliteration_0184.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0185.php
+++ b/Sources/Localization/data/AsciiTransliteration_0185.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0186.php
+++ b/Sources/Localization/data/AsciiTransliteration_0186.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0187.php
+++ b/Sources/Localization/data/AsciiTransliteration_0187.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0188.php
+++ b/Sources/Localization/data/AsciiTransliteration_0188.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0189.php
+++ b/Sources/Localization/data/AsciiTransliteration_0189.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0190.php
+++ b/Sources/Localization/data/AsciiTransliteration_0190.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0191.php
+++ b/Sources/Localization/data/AsciiTransliteration_0191.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0192.php
+++ b/Sources/Localization/data/AsciiTransliteration_0192.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0193.php
+++ b/Sources/Localization/data/AsciiTransliteration_0193.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0194.php
+++ b/Sources/Localization/data/AsciiTransliteration_0194.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0195.php
+++ b/Sources/Localization/data/AsciiTransliteration_0195.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0196.php
+++ b/Sources/Localization/data/AsciiTransliteration_0196.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0197.php
+++ b/Sources/Localization/data/AsciiTransliteration_0197.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0198.php
+++ b/Sources/Localization/data/AsciiTransliteration_0198.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0199.php
+++ b/Sources/Localization/data/AsciiTransliteration_0199.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0200.php
+++ b/Sources/Localization/data/AsciiTransliteration_0200.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0201.php
+++ b/Sources/Localization/data/AsciiTransliteration_0201.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0202.php
+++ b/Sources/Localization/data/AsciiTransliteration_0202.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0203.php
+++ b/Sources/Localization/data/AsciiTransliteration_0203.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0204.php
+++ b/Sources/Localization/data/AsciiTransliteration_0204.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0205.php
+++ b/Sources/Localization/data/AsciiTransliteration_0205.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0206.php
+++ b/Sources/Localization/data/AsciiTransliteration_0206.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0207.php
+++ b/Sources/Localization/data/AsciiTransliteration_0207.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0208.php
+++ b/Sources/Localization/data/AsciiTransliteration_0208.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0209.php
+++ b/Sources/Localization/data/AsciiTransliteration_0209.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0210.php
+++ b/Sources/Localization/data/AsciiTransliteration_0210.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0211.php
+++ b/Sources/Localization/data/AsciiTransliteration_0211.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0212.php
+++ b/Sources/Localization/data/AsciiTransliteration_0212.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0213.php
+++ b/Sources/Localization/data/AsciiTransliteration_0213.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0214.php
+++ b/Sources/Localization/data/AsciiTransliteration_0214.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0215.php
+++ b/Sources/Localization/data/AsciiTransliteration_0215.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0249.php
+++ b/Sources/Localization/data/AsciiTransliteration_0249.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0250.php
+++ b/Sources/Localization/data/AsciiTransliteration_0250.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0251.php
+++ b/Sources/Localization/data/AsciiTransliteration_0251.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0252.php
+++ b/Sources/Localization/data/AsciiTransliteration_0252.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0253.php
+++ b/Sources/Localization/data/AsciiTransliteration_0253.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0254.php
+++ b/Sources/Localization/data/AsciiTransliteration_0254.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0255.php
+++ b/Sources/Localization/data/AsciiTransliteration_0255.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0465.php
+++ b/Sources/Localization/data/AsciiTransliteration_0465.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0494.php
+++ b/Sources/Localization/data/AsciiTransliteration_0494.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0497.php
+++ b/Sources/Localization/data/AsciiTransliteration_0497.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0498.php
+++ b/Sources/Localization/data/AsciiTransliteration_0498.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0512.php
+++ b/Sources/Localization/data/AsciiTransliteration_0512.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0513.php
+++ b/Sources/Localization/data/AsciiTransliteration_0513.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0514.php
+++ b/Sources/Localization/data/AsciiTransliteration_0514.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0515.php
+++ b/Sources/Localization/data/AsciiTransliteration_0515.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0516.php
+++ b/Sources/Localization/data/AsciiTransliteration_0516.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0517.php
+++ b/Sources/Localization/data/AsciiTransliteration_0517.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0518.php
+++ b/Sources/Localization/data/AsciiTransliteration_0518.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0519.php
+++ b/Sources/Localization/data/AsciiTransliteration_0519.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0520.php
+++ b/Sources/Localization/data/AsciiTransliteration_0520.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0521.php
+++ b/Sources/Localization/data/AsciiTransliteration_0521.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0522.php
+++ b/Sources/Localization/data/AsciiTransliteration_0522.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0523.php
+++ b/Sources/Localization/data/AsciiTransliteration_0523.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0524.php
+++ b/Sources/Localization/data/AsciiTransliteration_0524.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0525.php
+++ b/Sources/Localization/data/AsciiTransliteration_0525.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0526.php
+++ b/Sources/Localization/data/AsciiTransliteration_0526.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0527.php
+++ b/Sources/Localization/data/AsciiTransliteration_0527.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0528.php
+++ b/Sources/Localization/data/AsciiTransliteration_0528.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0529.php
+++ b/Sources/Localization/data/AsciiTransliteration_0529.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0530.php
+++ b/Sources/Localization/data/AsciiTransliteration_0530.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0531.php
+++ b/Sources/Localization/data/AsciiTransliteration_0531.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0532.php
+++ b/Sources/Localization/data/AsciiTransliteration_0532.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0533.php
+++ b/Sources/Localization/data/AsciiTransliteration_0533.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0534.php
+++ b/Sources/Localization/data/AsciiTransliteration_0534.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0535.php
+++ b/Sources/Localization/data/AsciiTransliteration_0535.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0536.php
+++ b/Sources/Localization/data/AsciiTransliteration_0536.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0537.php
+++ b/Sources/Localization/data/AsciiTransliteration_0537.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0538.php
+++ b/Sources/Localization/data/AsciiTransliteration_0538.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0539.php
+++ b/Sources/Localization/data/AsciiTransliteration_0539.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0540.php
+++ b/Sources/Localization/data/AsciiTransliteration_0540.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0541.php
+++ b/Sources/Localization/data/AsciiTransliteration_0541.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0542.php
+++ b/Sources/Localization/data/AsciiTransliteration_0542.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0543.php
+++ b/Sources/Localization/data/AsciiTransliteration_0543.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0544.php
+++ b/Sources/Localization/data/AsciiTransliteration_0544.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0545.php
+++ b/Sources/Localization/data/AsciiTransliteration_0545.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0546.php
+++ b/Sources/Localization/data/AsciiTransliteration_0546.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0547.php
+++ b/Sources/Localization/data/AsciiTransliteration_0547.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0548.php
+++ b/Sources/Localization/data/AsciiTransliteration_0548.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0549.php
+++ b/Sources/Localization/data/AsciiTransliteration_0549.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0550.php
+++ b/Sources/Localization/data/AsciiTransliteration_0550.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0551.php
+++ b/Sources/Localization/data/AsciiTransliteration_0551.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0552.php
+++ b/Sources/Localization/data/AsciiTransliteration_0552.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0553.php
+++ b/Sources/Localization/data/AsciiTransliteration_0553.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0554.php
+++ b/Sources/Localization/data/AsciiTransliteration_0554.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0555.php
+++ b/Sources/Localization/data/AsciiTransliteration_0555.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0556.php
+++ b/Sources/Localization/data/AsciiTransliteration_0556.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0557.php
+++ b/Sources/Localization/data/AsciiTransliteration_0557.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0558.php
+++ b/Sources/Localization/data/AsciiTransliteration_0558.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0559.php
+++ b/Sources/Localization/data/AsciiTransliteration_0559.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0560.php
+++ b/Sources/Localization/data/AsciiTransliteration_0560.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0561.php
+++ b/Sources/Localization/data/AsciiTransliteration_0561.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0562.php
+++ b/Sources/Localization/data/AsciiTransliteration_0562.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0563.php
+++ b/Sources/Localization/data/AsciiTransliteration_0563.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0564.php
+++ b/Sources/Localization/data/AsciiTransliteration_0564.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0565.php
+++ b/Sources/Localization/data/AsciiTransliteration_0565.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0566.php
+++ b/Sources/Localization/data/AsciiTransliteration_0566.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0567.php
+++ b/Sources/Localization/data/AsciiTransliteration_0567.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0568.php
+++ b/Sources/Localization/data/AsciiTransliteration_0568.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0569.php
+++ b/Sources/Localization/data/AsciiTransliteration_0569.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0570.php
+++ b/Sources/Localization/data/AsciiTransliteration_0570.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0571.php
+++ b/Sources/Localization/data/AsciiTransliteration_0571.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0572.php
+++ b/Sources/Localization/data/AsciiTransliteration_0572.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0573.php
+++ b/Sources/Localization/data/AsciiTransliteration_0573.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0574.php
+++ b/Sources/Localization/data/AsciiTransliteration_0574.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0575.php
+++ b/Sources/Localization/data/AsciiTransliteration_0575.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0576.php
+++ b/Sources/Localization/data/AsciiTransliteration_0576.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0577.php
+++ b/Sources/Localization/data/AsciiTransliteration_0577.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0578.php
+++ b/Sources/Localization/data/AsciiTransliteration_0578.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0579.php
+++ b/Sources/Localization/data/AsciiTransliteration_0579.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0580.php
+++ b/Sources/Localization/data/AsciiTransliteration_0580.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0581.php
+++ b/Sources/Localization/data/AsciiTransliteration_0581.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0582.php
+++ b/Sources/Localization/data/AsciiTransliteration_0582.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0583.php
+++ b/Sources/Localization/data/AsciiTransliteration_0583.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0584.php
+++ b/Sources/Localization/data/AsciiTransliteration_0584.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0585.php
+++ b/Sources/Localization/data/AsciiTransliteration_0585.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0586.php
+++ b/Sources/Localization/data/AsciiTransliteration_0586.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0587.php
+++ b/Sources/Localization/data/AsciiTransliteration_0587.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0588.php
+++ b/Sources/Localization/data/AsciiTransliteration_0588.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0589.php
+++ b/Sources/Localization/data/AsciiTransliteration_0589.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0590.php
+++ b/Sources/Localization/data/AsciiTransliteration_0590.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0591.php
+++ b/Sources/Localization/data/AsciiTransliteration_0591.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0592.php
+++ b/Sources/Localization/data/AsciiTransliteration_0592.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0593.php
+++ b/Sources/Localization/data/AsciiTransliteration_0593.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0594.php
+++ b/Sources/Localization/data/AsciiTransliteration_0594.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0595.php
+++ b/Sources/Localization/data/AsciiTransliteration_0595.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0596.php
+++ b/Sources/Localization/data/AsciiTransliteration_0596.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0597.php
+++ b/Sources/Localization/data/AsciiTransliteration_0597.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0598.php
+++ b/Sources/Localization/data/AsciiTransliteration_0598.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0599.php
+++ b/Sources/Localization/data/AsciiTransliteration_0599.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0600.php
+++ b/Sources/Localization/data/AsciiTransliteration_0600.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0601.php
+++ b/Sources/Localization/data/AsciiTransliteration_0601.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0602.php
+++ b/Sources/Localization/data/AsciiTransliteration_0602.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0603.php
+++ b/Sources/Localization/data/AsciiTransliteration_0603.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0604.php
+++ b/Sources/Localization/data/AsciiTransliteration_0604.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0605.php
+++ b/Sources/Localization/data/AsciiTransliteration_0605.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0606.php
+++ b/Sources/Localization/data/AsciiTransliteration_0606.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0607.php
+++ b/Sources/Localization/data/AsciiTransliteration_0607.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0608.php
+++ b/Sources/Localization/data/AsciiTransliteration_0608.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0609.php
+++ b/Sources/Localization/data/AsciiTransliteration_0609.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0610.php
+++ b/Sources/Localization/data/AsciiTransliteration_0610.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0611.php
+++ b/Sources/Localization/data/AsciiTransliteration_0611.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0612.php
+++ b/Sources/Localization/data/AsciiTransliteration_0612.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0613.php
+++ b/Sources/Localization/data/AsciiTransliteration_0613.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0614.php
+++ b/Sources/Localization/data/AsciiTransliteration_0614.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0615.php
+++ b/Sources/Localization/data/AsciiTransliteration_0615.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0616.php
+++ b/Sources/Localization/data/AsciiTransliteration_0616.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0617.php
+++ b/Sources/Localization/data/AsciiTransliteration_0617.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0618.php
+++ b/Sources/Localization/data/AsciiTransliteration_0618.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0619.php
+++ b/Sources/Localization/data/AsciiTransliteration_0619.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0620.php
+++ b/Sources/Localization/data/AsciiTransliteration_0620.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0621.php
+++ b/Sources/Localization/data/AsciiTransliteration_0621.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0622.php
+++ b/Sources/Localization/data/AsciiTransliteration_0622.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0623.php
+++ b/Sources/Localization/data/AsciiTransliteration_0623.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0624.php
+++ b/Sources/Localization/data/AsciiTransliteration_0624.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0625.php
+++ b/Sources/Localization/data/AsciiTransliteration_0625.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0626.php
+++ b/Sources/Localization/data/AsciiTransliteration_0626.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0627.php
+++ b/Sources/Localization/data/AsciiTransliteration_0627.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0628.php
+++ b/Sources/Localization/data/AsciiTransliteration_0628.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0629.php
+++ b/Sources/Localization/data/AsciiTransliteration_0629.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0630.php
+++ b/Sources/Localization/data/AsciiTransliteration_0630.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0631.php
+++ b/Sources/Localization/data/AsciiTransliteration_0631.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0632.php
+++ b/Sources/Localization/data/AsciiTransliteration_0632.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0633.php
+++ b/Sources/Localization/data/AsciiTransliteration_0633.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0634.php
+++ b/Sources/Localization/data/AsciiTransliteration_0634.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0635.php
+++ b/Sources/Localization/data/AsciiTransliteration_0635.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0636.php
+++ b/Sources/Localization/data/AsciiTransliteration_0636.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0637.php
+++ b/Sources/Localization/data/AsciiTransliteration_0637.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0638.php
+++ b/Sources/Localization/data/AsciiTransliteration_0638.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0639.php
+++ b/Sources/Localization/data/AsciiTransliteration_0639.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0640.php
+++ b/Sources/Localization/data/AsciiTransliteration_0640.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0641.php
+++ b/Sources/Localization/data/AsciiTransliteration_0641.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0642.php
+++ b/Sources/Localization/data/AsciiTransliteration_0642.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0643.php
+++ b/Sources/Localization/data/AsciiTransliteration_0643.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0644.php
+++ b/Sources/Localization/data/AsciiTransliteration_0644.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0645.php
+++ b/Sources/Localization/data/AsciiTransliteration_0645.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0646.php
+++ b/Sources/Localization/data/AsciiTransliteration_0646.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0647.php
+++ b/Sources/Localization/data/AsciiTransliteration_0647.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0648.php
+++ b/Sources/Localization/data/AsciiTransliteration_0648.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0649.php
+++ b/Sources/Localization/data/AsciiTransliteration_0649.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0650.php
+++ b/Sources/Localization/data/AsciiTransliteration_0650.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0651.php
+++ b/Sources/Localization/data/AsciiTransliteration_0651.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0652.php
+++ b/Sources/Localization/data/AsciiTransliteration_0652.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0653.php
+++ b/Sources/Localization/data/AsciiTransliteration_0653.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0654.php
+++ b/Sources/Localization/data/AsciiTransliteration_0654.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0655.php
+++ b/Sources/Localization/data/AsciiTransliteration_0655.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0656.php
+++ b/Sources/Localization/data/AsciiTransliteration_0656.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0657.php
+++ b/Sources/Localization/data/AsciiTransliteration_0657.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0658.php
+++ b/Sources/Localization/data/AsciiTransliteration_0658.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0659.php
+++ b/Sources/Localization/data/AsciiTransliteration_0659.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0660.php
+++ b/Sources/Localization/data/AsciiTransliteration_0660.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0661.php
+++ b/Sources/Localization/data/AsciiTransliteration_0661.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0662.php
+++ b/Sources/Localization/data/AsciiTransliteration_0662.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0663.php
+++ b/Sources/Localization/data/AsciiTransliteration_0663.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0664.php
+++ b/Sources/Localization/data/AsciiTransliteration_0664.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0665.php
+++ b/Sources/Localization/data/AsciiTransliteration_0665.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0666.php
+++ b/Sources/Localization/data/AsciiTransliteration_0666.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0667.php
+++ b/Sources/Localization/data/AsciiTransliteration_0667.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0668.php
+++ b/Sources/Localization/data/AsciiTransliteration_0668.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0669.php
+++ b/Sources/Localization/data/AsciiTransliteration_0669.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0670.php
+++ b/Sources/Localization/data/AsciiTransliteration_0670.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0671.php
+++ b/Sources/Localization/data/AsciiTransliteration_0671.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0672.php
+++ b/Sources/Localization/data/AsciiTransliteration_0672.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0673.php
+++ b/Sources/Localization/data/AsciiTransliteration_0673.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0674.php
+++ b/Sources/Localization/data/AsciiTransliteration_0674.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0675.php
+++ b/Sources/Localization/data/AsciiTransliteration_0675.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0676.php
+++ b/Sources/Localization/data/AsciiTransliteration_0676.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0677.php
+++ b/Sources/Localization/data/AsciiTransliteration_0677.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0678.php
+++ b/Sources/Localization/data/AsciiTransliteration_0678.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0679.php
+++ b/Sources/Localization/data/AsciiTransliteration_0679.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0680.php
+++ b/Sources/Localization/data/AsciiTransliteration_0680.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0681.php
+++ b/Sources/Localization/data/AsciiTransliteration_0681.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0682.php
+++ b/Sources/Localization/data/AsciiTransliteration_0682.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0683.php
+++ b/Sources/Localization/data/AsciiTransliteration_0683.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0684.php
+++ b/Sources/Localization/data/AsciiTransliteration_0684.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0685.php
+++ b/Sources/Localization/data/AsciiTransliteration_0685.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0686.php
+++ b/Sources/Localization/data/AsciiTransliteration_0686.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0687.php
+++ b/Sources/Localization/data/AsciiTransliteration_0687.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0688.php
+++ b/Sources/Localization/data/AsciiTransliteration_0688.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0689.php
+++ b/Sources/Localization/data/AsciiTransliteration_0689.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0690.php
+++ b/Sources/Localization/data/AsciiTransliteration_0690.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0691.php
+++ b/Sources/Localization/data/AsciiTransliteration_0691.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0692.php
+++ b/Sources/Localization/data/AsciiTransliteration_0692.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0693.php
+++ b/Sources/Localization/data/AsciiTransliteration_0693.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0694.php
+++ b/Sources/Localization/data/AsciiTransliteration_0694.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0695.php
+++ b/Sources/Localization/data/AsciiTransliteration_0695.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0696.php
+++ b/Sources/Localization/data/AsciiTransliteration_0696.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0697.php
+++ b/Sources/Localization/data/AsciiTransliteration_0697.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0698.php
+++ b/Sources/Localization/data/AsciiTransliteration_0698.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0699.php
+++ b/Sources/Localization/data/AsciiTransliteration_0699.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0700.php
+++ b/Sources/Localization/data/AsciiTransliteration_0700.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0701.php
+++ b/Sources/Localization/data/AsciiTransliteration_0701.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0702.php
+++ b/Sources/Localization/data/AsciiTransliteration_0702.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0703.php
+++ b/Sources/Localization/data/AsciiTransliteration_0703.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0704.php
+++ b/Sources/Localization/data/AsciiTransliteration_0704.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0705.php
+++ b/Sources/Localization/data/AsciiTransliteration_0705.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0706.php
+++ b/Sources/Localization/data/AsciiTransliteration_0706.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0707.php
+++ b/Sources/Localization/data/AsciiTransliteration_0707.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0708.php
+++ b/Sources/Localization/data/AsciiTransliteration_0708.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0709.php
+++ b/Sources/Localization/data/AsciiTransliteration_0709.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0710.php
+++ b/Sources/Localization/data/AsciiTransliteration_0710.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0711.php
+++ b/Sources/Localization/data/AsciiTransliteration_0711.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0712.php
+++ b/Sources/Localization/data/AsciiTransliteration_0712.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0713.php
+++ b/Sources/Localization/data/AsciiTransliteration_0713.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0714.php
+++ b/Sources/Localization/data/AsciiTransliteration_0714.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0715.php
+++ b/Sources/Localization/data/AsciiTransliteration_0715.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0716.php
+++ b/Sources/Localization/data/AsciiTransliteration_0716.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0717.php
+++ b/Sources/Localization/data/AsciiTransliteration_0717.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0718.php
+++ b/Sources/Localization/data/AsciiTransliteration_0718.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0720.php
+++ b/Sources/Localization/data/AsciiTransliteration_0720.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0721.php
+++ b/Sources/Localization/data/AsciiTransliteration_0721.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0722.php
+++ b/Sources/Localization/data/AsciiTransliteration_0722.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0723.php
+++ b/Sources/Localization/data/AsciiTransliteration_0723.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0725.php
+++ b/Sources/Localization/data/AsciiTransliteration_0725.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0726.php
+++ b/Sources/Localization/data/AsciiTransliteration_0726.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0727.php
+++ b/Sources/Localization/data/AsciiTransliteration_0727.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0728.php
+++ b/Sources/Localization/data/AsciiTransliteration_0728.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0729.php
+++ b/Sources/Localization/data/AsciiTransliteration_0729.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0730.php
+++ b/Sources/Localization/data/AsciiTransliteration_0730.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0731.php
+++ b/Sources/Localization/data/AsciiTransliteration_0731.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0732.php
+++ b/Sources/Localization/data/AsciiTransliteration_0732.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0733.php
+++ b/Sources/Localization/data/AsciiTransliteration_0733.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0734.php
+++ b/Sources/Localization/data/AsciiTransliteration_0734.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0736.php
+++ b/Sources/Localization/data/AsciiTransliteration_0736.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0737.php
+++ b/Sources/Localization/data/AsciiTransliteration_0737.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0738.php
+++ b/Sources/Localization/data/AsciiTransliteration_0738.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0739.php
+++ b/Sources/Localization/data/AsciiTransliteration_0739.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0740.php
+++ b/Sources/Localization/data/AsciiTransliteration_0740.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0741.php
+++ b/Sources/Localization/data/AsciiTransliteration_0741.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0742.php
+++ b/Sources/Localization/data/AsciiTransliteration_0742.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0743.php
+++ b/Sources/Localization/data/AsciiTransliteration_0743.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0744.php
+++ b/Sources/Localization/data/AsciiTransliteration_0744.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0745.php
+++ b/Sources/Localization/data/AsciiTransliteration_0745.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0746.php
+++ b/Sources/Localization/data/AsciiTransliteration_0746.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0747.php
+++ b/Sources/Localization/data/AsciiTransliteration_0747.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0748.php
+++ b/Sources/Localization/data/AsciiTransliteration_0748.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0749.php
+++ b/Sources/Localization/data/AsciiTransliteration_0749.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0750.php
+++ b/Sources/Localization/data/AsciiTransliteration_0750.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0760.php
+++ b/Sources/Localization/data/AsciiTransliteration_0760.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0761.php
+++ b/Sources/Localization/data/AsciiTransliteration_0761.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0762.php
+++ b/Sources/Localization/data/AsciiTransliteration_0762.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0768.php
+++ b/Sources/Localization/data/AsciiTransliteration_0768.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0769.php
+++ b/Sources/Localization/data/AsciiTransliteration_0769.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0770.php
+++ b/Sources/Localization/data/AsciiTransliteration_0770.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0771.php
+++ b/Sources/Localization/data/AsciiTransliteration_0771.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0772.php
+++ b/Sources/Localization/data/AsciiTransliteration_0772.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0773.php
+++ b/Sources/Localization/data/AsciiTransliteration_0773.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0774.php
+++ b/Sources/Localization/data/AsciiTransliteration_0774.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0775.php
+++ b/Sources/Localization/data/AsciiTransliteration_0775.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0776.php
+++ b/Sources/Localization/data/AsciiTransliteration_0776.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0777.php
+++ b/Sources/Localization/data/AsciiTransliteration_0777.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0778.php
+++ b/Sources/Localization/data/AsciiTransliteration_0778.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0779.php
+++ b/Sources/Localization/data/AsciiTransliteration_0779.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0780.php
+++ b/Sources/Localization/data/AsciiTransliteration_0780.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0781.php
+++ b/Sources/Localization/data/AsciiTransliteration_0781.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0782.php
+++ b/Sources/Localization/data/AsciiTransliteration_0782.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0783.php
+++ b/Sources/Localization/data/AsciiTransliteration_0783.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0784.php
+++ b/Sources/Localization/data/AsciiTransliteration_0784.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0785.php
+++ b/Sources/Localization/data/AsciiTransliteration_0785.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0786.php
+++ b/Sources/Localization/data/AsciiTransliteration_0786.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0787.php
+++ b/Sources/Localization/data/AsciiTransliteration_0787.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0788.php
+++ b/Sources/Localization/data/AsciiTransliteration_0788.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0789.php
+++ b/Sources/Localization/data/AsciiTransliteration_0789.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0790.php
+++ b/Sources/Localization/data/AsciiTransliteration_0790.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0791.php
+++ b/Sources/Localization/data/AsciiTransliteration_0791.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0792.php
+++ b/Sources/Localization/data/AsciiTransliteration_0792.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0793.php
+++ b/Sources/Localization/data/AsciiTransliteration_0793.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0794.php
+++ b/Sources/Localization/data/AsciiTransliteration_0794.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0795.php
+++ b/Sources/Localization/data/AsciiTransliteration_0795.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0796.php
+++ b/Sources/Localization/data/AsciiTransliteration_0796.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0797.php
+++ b/Sources/Localization/data/AsciiTransliteration_0797.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0798.php
+++ b/Sources/Localization/data/AsciiTransliteration_0798.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0799.php
+++ b/Sources/Localization/data/AsciiTransliteration_0799.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0800.php
+++ b/Sources/Localization/data/AsciiTransliteration_0800.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0801.php
+++ b/Sources/Localization/data/AsciiTransliteration_0801.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0802.php
+++ b/Sources/Localization/data/AsciiTransliteration_0802.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0803.php
+++ b/Sources/Localization/data/AsciiTransliteration_0803.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0809.php
+++ b/Sources/Localization/data/AsciiTransliteration_0809.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0810.php
+++ b/Sources/Localization/data/AsciiTransliteration_0810.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0812.php
+++ b/Sources/Localization/data/AsciiTransliteration_0812.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Localization/data/AsciiTransliteration_0818.php
+++ b/Sources/Localization/data/AsciiTransliteration_0818.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Transliteration maps to replace non-ASCII characters with ASCII approximations.

--- a/Sources/Logging.php
+++ b/Sources/Logging.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Mail.php
+++ b/Sources/Mail.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/MailAgent/APIs/SMTP.php
+++ b/Sources/MailAgent/APIs/SMTP.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 namespace SMF\MailAgent\APIs;

--- a/Sources/MailAgent/APIs/SMTPTLS.php
+++ b/Sources/MailAgent/APIs/SMTPTLS.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 namespace SMF\MailAgent\APIs;

--- a/Sources/MailAgent/APIs/SendMail.php
+++ b/Sources/MailAgent/APIs/SendMail.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 namespace SMF\MailAgent\APIs;

--- a/Sources/MailAgent/MailAgent.php
+++ b/Sources/MailAgent/MailAgent.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 namespace SMF\MailAgent;

--- a/Sources/MailAgent/MailAgentInterface.php
+++ b/Sources/MailAgent/MailAgentInterface.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 namespace SMF\MailAgent;

--- a/Sources/Maintenance/Cleanup/CleanupBase.php
+++ b/Sources/Maintenance/Cleanup/CleanupBase.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Cleanup/OldFilesBase.php
+++ b/Sources/Maintenance/Cleanup/OldFilesBase.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Cleanup/v2_1/OldFiles.php
+++ b/Sources/Maintenance/Cleanup/v2_1/OldFiles.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Cleanup/v3_0/TasksDirCase.php
+++ b/Sources/Maintenance/Cleanup/v3_0/TasksDirCase.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/GenericSubStep.php
+++ b/Sources/Maintenance/GenericSubStep.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Maintenance.php
+++ b/Sources/Maintenance/Maintenance.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Migration/MigrationBase.php
+++ b/Sources/Maintenance/Migration/MigrationBase.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Migration/v2_1/AdminInfoFiles.php
+++ b/Sources/Maintenance/Migration/v2_1/AdminInfoFiles.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Migration/v2_1/AgreementUpdate.php
+++ b/Sources/Maintenance/Migration/v2_1/AgreementUpdate.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Migration/v2_1/AlertsObsolete.php
+++ b/Sources/Maintenance/Migration/v2_1/AlertsObsolete.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Migration/v2_1/AlertsWatchedBoards.php
+++ b/Sources/Maintenance/Migration/v2_1/AlertsWatchedBoards.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Migration/v2_1/AlertsWatchedTopics.php
+++ b/Sources/Maintenance/Migration/v2_1/AlertsWatchedTopics.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Migration/v2_1/AttachmentDirectory.php
+++ b/Sources/Maintenance/Migration/v2_1/AttachmentDirectory.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Migration/v2_1/AttachmentSizes.php
+++ b/Sources/Maintenance/Migration/v2_1/AttachmentSizes.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Migration/v2_1/AutoNotify.php
+++ b/Sources/Maintenance/Migration/v2_1/AutoNotify.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Migration/v2_1/BoardDescriptions.php
+++ b/Sources/Maintenance/Migration/v2_1/BoardDescriptions.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Migration/v2_1/BoardPermissionsView.php
+++ b/Sources/Maintenance/Migration/v2_1/BoardPermissionsView.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Migration/v2_1/CalendarEvents.php
+++ b/Sources/Maintenance/Migration/v2_1/CalendarEvents.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Migration/v2_1/CalendarUpdates.php
+++ b/Sources/Maintenance/Migration/v2_1/CalendarUpdates.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Migration/v2_1/CategoryDescrptions.php
+++ b/Sources/Maintenance/Migration/v2_1/CategoryDescrptions.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Migration/v2_1/CollapsedCategories.php
+++ b/Sources/Maintenance/Migration/v2_1/CollapsedCategories.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Migration/v2_1/CreateAlerts.php
+++ b/Sources/Maintenance/Migration/v2_1/CreateAlerts.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Migration/v2_1/CreateBackgroundTasks.php
+++ b/Sources/Maintenance/Migration/v2_1/CreateBackgroundTasks.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Migration/v2_1/CreateLogGroupRequests.php
+++ b/Sources/Maintenance/Migration/v2_1/CreateLogGroupRequests.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Migration/v2_1/CreateMemberLogins.php
+++ b/Sources/Maintenance/Migration/v2_1/CreateMemberLogins.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Migration/v2_1/CustomFieldsPart1.php
+++ b/Sources/Maintenance/Migration/v2_1/CustomFieldsPart1.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Migration/v2_1/CustomFieldsPart2.php
+++ b/Sources/Maintenance/Migration/v2_1/CustomFieldsPart2.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Migration/v2_1/CustomFieldsPart3.php
+++ b/Sources/Maintenance/Migration/v2_1/CustomFieldsPart3.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Migration/v2_1/FixDates.php
+++ b/Sources/Maintenance/Migration/v2_1/FixDates.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Migration/v2_1/IdxAdminInfo.php
+++ b/Sources/Maintenance/Migration/v2_1/IdxAdminInfo.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Migration/v2_1/IdxBoards.php
+++ b/Sources/Maintenance/Migration/v2_1/IdxBoards.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Migration/v2_1/IdxLogActivity.php
+++ b/Sources/Maintenance/Migration/v2_1/IdxLogActivity.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Migration/v2_1/IdxLogComments.php
+++ b/Sources/Maintenance/Migration/v2_1/IdxLogComments.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Migration/v2_1/IdxLogPackages.php
+++ b/Sources/Maintenance/Migration/v2_1/IdxLogPackages.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Migration/v2_1/IdxMembers.php
+++ b/Sources/Maintenance/Migration/v2_1/IdxMembers.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Migration/v2_1/IdxMessages.php
+++ b/Sources/Maintenance/Migration/v2_1/IdxMessages.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Migration/v2_1/IdxScheduledTasks.php
+++ b/Sources/Maintenance/Migration/v2_1/IdxScheduledTasks.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Migration/v2_1/IdxTopics.php
+++ b/Sources/Maintenance/Migration/v2_1/IdxTopics.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Migration/v2_1/Ipv6BanItem.php
+++ b/Sources/Maintenance/Migration/v2_1/Ipv6BanItem.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Migration/v2_1/Ipv6Converter.php
+++ b/Sources/Maintenance/Migration/v2_1/Ipv6Converter.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Migration/v2_1/Ipv6LogAction.php
+++ b/Sources/Maintenance/Migration/v2_1/Ipv6LogAction.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Migration/v2_1/Ipv6LogBanned.php
+++ b/Sources/Maintenance/Migration/v2_1/Ipv6LogBanned.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Migration/v2_1/Ipv6LogErrors.php
+++ b/Sources/Maintenance/Migration/v2_1/Ipv6LogErrors.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Migration/v2_1/Ipv6LogFloodControl.php
+++ b/Sources/Maintenance/Migration/v2_1/Ipv6LogFloodControl.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Migration/v2_1/Ipv6LogOnline.php
+++ b/Sources/Maintenance/Migration/v2_1/Ipv6LogOnline.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Migration/v2_1/Ipv6LogReportedComments.php
+++ b/Sources/Maintenance/Migration/v2_1/Ipv6LogReportedComments.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Migration/v2_1/Ipv6MemberLogins.php
+++ b/Sources/Maintenance/Migration/v2_1/Ipv6MemberLogins.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Migration/v2_1/Ipv6MembersIP.php
+++ b/Sources/Maintenance/Migration/v2_1/Ipv6MembersIP.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Migration/v2_1/Ipv6MembersIP2.php
+++ b/Sources/Maintenance/Migration/v2_1/Ipv6MembersIP2.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Migration/v2_1/Ipv6Messages.php
+++ b/Sources/Maintenance/Migration/v2_1/Ipv6Messages.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Migration/v2_1/LegacyAttachments.php
+++ b/Sources/Maintenance/Migration/v2_1/LegacyAttachments.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Migration/v2_1/LegacyData.php
+++ b/Sources/Maintenance/Migration/v2_1/LegacyData.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Migration/v2_1/Likes.php
+++ b/Sources/Maintenance/Migration/v2_1/Likes.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Migration/v2_1/LogErrorsBacktrace.php
+++ b/Sources/Maintenance/Migration/v2_1/LogErrorsBacktrace.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Migration/v2_1/LogOnlineURL.php
+++ b/Sources/Maintenance/Migration/v2_1/LogOnlineURL.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Migration/v2_1/LogReportedCommentsEmail.php
+++ b/Sources/Maintenance/Migration/v2_1/LogReportedCommentsEmail.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Migration/v2_1/LogSpiderHitsURL.php
+++ b/Sources/Maintenance/Migration/v2_1/LogSpiderHitsURL.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Migration/v2_1/MailQueue.php
+++ b/Sources/Maintenance/Migration/v2_1/MailQueue.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Migration/v2_1/MemberGroupsTfaRequired.php
+++ b/Sources/Maintenance/Migration/v2_1/MemberGroupsTfaRequired.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Migration/v2_1/MembergroupIcon.php
+++ b/Sources/Maintenance/Migration/v2_1/MembergroupIcon.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Migration/v2_1/MembersHideEmail.php
+++ b/Sources/Maintenance/Migration/v2_1/MembersHideEmail.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Migration/v2_1/MembersLangUTF8.php
+++ b/Sources/Maintenance/Migration/v2_1/MembersLangUTF8.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Migration/v2_1/MembersOpenID.php
+++ b/Sources/Maintenance/Migration/v2_1/MembersOpenID.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Migration/v2_1/MembersTfaBackup.php
+++ b/Sources/Maintenance/Migration/v2_1/MembersTfaBackup.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Migration/v2_1/MembersTfaSecret.php
+++ b/Sources/Maintenance/Migration/v2_1/MembersTfaSecret.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Migration/v2_1/MembersTimezone.php
+++ b/Sources/Maintenance/Migration/v2_1/MembersTimezone.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Migration/v2_1/Mentions.php
+++ b/Sources/Maintenance/Migration/v2_1/Mentions.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Migration/v2_1/MessagesModifiedReason.php
+++ b/Sources/Maintenance/Migration/v2_1/MessagesModifiedReason.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Migration/v2_1/ModeratorGroups.php
+++ b/Sources/Maintenance/Migration/v2_1/ModeratorGroups.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Migration/v2_1/MovedTopics.php
+++ b/Sources/Maintenance/Migration/v2_1/MovedTopics.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Migration/v2_1/MysqlLegacyData.php
+++ b/Sources/Maintenance/Migration/v2_1/MysqlLegacyData.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Migration/v2_1/MysqlModFixes.php
+++ b/Sources/Maintenance/Migration/v2_1/MysqlModFixes.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Migration/v2_1/OpenID.php
+++ b/Sources/Maintenance/Migration/v2_1/OpenID.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Migration/v2_1/PackageManager.php
+++ b/Sources/Maintenance/Migration/v2_1/PackageManager.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Migration/v2_1/Permissions.php
+++ b/Sources/Maintenance/Migration/v2_1/Permissions.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Migration/v2_1/PersonalMessageLabels.php
+++ b/Sources/Maintenance/Migration/v2_1/PersonalMessageLabels.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Migration/v2_1/PersonalMessageNotification.php
+++ b/Sources/Maintenance/Migration/v2_1/PersonalMessageNotification.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Migration/v2_1/PostgreSqlFindInSet.php
+++ b/Sources/Maintenance/Migration/v2_1/PostgreSqlFindInSet.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Migration/v2_1/PostgreSqlIPv6Helper.php
+++ b/Sources/Maintenance/Migration/v2_1/PostgreSqlIPv6Helper.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Migration/v2_1/PostgreSqlSchemaDiff.php
+++ b/Sources/Maintenance/Migration/v2_1/PostgreSqlSchemaDiff.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Migration/v2_1/PostgreSqlSequences.php
+++ b/Sources/Maintenance/Migration/v2_1/PostgreSqlSequences.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Migration/v2_1/PostgreSqlTime.php
+++ b/Sources/Maintenance/Migration/v2_1/PostgreSqlTime.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Migration/v2_1/PostgreSqlUnlogged.php
+++ b/Sources/Maintenance/Migration/v2_1/PostgreSqlUnlogged.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Migration/v2_1/RemoveKarma.php
+++ b/Sources/Maintenance/Migration/v2_1/RemoveKarma.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Migration/v2_1/ScheduledTasks.php
+++ b/Sources/Maintenance/Migration/v2_1/ScheduledTasks.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Migration/v2_1/SessionIDs.php
+++ b/Sources/Maintenance/Migration/v2_1/SessionIDs.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Migration/v2_1/SettingsUpdate.php
+++ b/Sources/Maintenance/Migration/v2_1/SettingsUpdate.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Migration/v2_1/Smileys.php
+++ b/Sources/Maintenance/Migration/v2_1/Smileys.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Migration/v2_1/ThemeSettings.php
+++ b/Sources/Maintenance/Migration/v2_1/ThemeSettings.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Migration/v2_1/TopicUnwatch.php
+++ b/Sources/Maintenance/Migration/v2_1/TopicUnwatch.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Migration/v2_1/UserDrafts.php
+++ b/Sources/Maintenance/Migration/v2_1/UserDrafts.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Migration/v2_1/ValidationServers.php
+++ b/Sources/Maintenance/Migration/v2_1/ValidationServers.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Migration/v2_1/VerificationQuestions.php
+++ b/Sources/Maintenance/Migration/v2_1/VerificationQuestions.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Migration/v3_0/BoardPostsCount.php
+++ b/Sources/Maintenance/Migration/v3_0/BoardPostsCount.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Migration/v3_0/ConvertToInnoDb.php
+++ b/Sources/Maintenance/Migration/v3_0/ConvertToInnoDb.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Migration/v3_0/DropModPrefs.php
+++ b/Sources/Maintenance/Migration/v3_0/DropModPrefs.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Migration/v3_0/DropTimeOffset.php
+++ b/Sources/Maintenance/Migration/v3_0/DropTimeOffset.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Migration/v3_0/EditHistory.php
+++ b/Sources/Maintenance/Migration/v3_0/EditHistory.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Migration/v3_0/EmailAddressCi.php
+++ b/Sources/Maintenance/Migration/v3_0/EmailAddressCi.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Migration/v3_0/ErrorLogSession.php
+++ b/Sources/Maintenance/Migration/v3_0/ErrorLogSession.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Migration/v3_0/EventUids.php
+++ b/Sources/Maintenance/Migration/v3_0/EventUids.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Migration/v3_0/HolidayRecurrenceDates.php
+++ b/Sources/Maintenance/Migration/v3_0/HolidayRecurrenceDates.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Migration/v3_0/HolidaysToEvents.php
+++ b/Sources/Maintenance/Migration/v3_0/HolidaysToEvents.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Migration/v3_0/LanguageDirectory.php
+++ b/Sources/Maintenance/Migration/v3_0/LanguageDirectory.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Migration/v3_0/MailType.php
+++ b/Sources/Maintenance/Migration/v3_0/MailType.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Migration/v3_0/MessageVersion.php
+++ b/Sources/Maintenance/Migration/v3_0/MessageVersion.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Migration/v3_0/NormalizeBannedEmailAddresses.php
+++ b/Sources/Maintenance/Migration/v3_0/NormalizeBannedEmailAddresses.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Migration/v3_0/NormalizeMemberEmailAddresses.php
+++ b/Sources/Maintenance/Migration/v3_0/NormalizeMemberEmailAddresses.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Migration/v3_0/PackageVersion.php
+++ b/Sources/Maintenance/Migration/v3_0/PackageVersion.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Migration/v3_0/PermissionChanges.php
+++ b/Sources/Maintenance/Migration/v3_0/PermissionChanges.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Migration/v3_0/PostgreSqlFunctions.php
+++ b/Sources/Maintenance/Migration/v3_0/PostgreSqlFunctions.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Migration/v3_0/RecurringEvents.php
+++ b/Sources/Maintenance/Migration/v3_0/RecurringEvents.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Migration/v3_0/RemoveCookieTime.php
+++ b/Sources/Maintenance/Migration/v3_0/RemoveCookieTime.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Migration/v3_0/SearchResultsPrimaryKey.php
+++ b/Sources/Maintenance/Migration/v3_0/SearchResultsPrimaryKey.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Migration/v3_0/SpoofDetector.php
+++ b/Sources/Maintenance/Migration/v3_0/SpoofDetector.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Migration/v3_0/ValidationCodeLength.php
+++ b/Sources/Maintenance/Migration/v3_0/ValidationCodeLength.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Step.php
+++ b/Sources/Maintenance/Step.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/SubStepInterface.php
+++ b/Sources/Maintenance/SubStepInterface.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Tools/Install.php
+++ b/Sources/Maintenance/Tools/Install.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Tools/ToolsBase.php
+++ b/Sources/Maintenance/Tools/ToolsBase.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Tools/ToolsInterface.php
+++ b/Sources/Maintenance/Tools/ToolsInterface.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Tools/Upgrade.php
+++ b/Sources/Maintenance/Tools/Upgrade.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Maintenance/Utf8ConverterStep.php
+++ b/Sources/Maintenance/Utf8ConverterStep.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Mentions.php
+++ b/Sources/Mentions.php
@@ -10,7 +10,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Menu.php
+++ b/Sources/Menu.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Msg.php
+++ b/Sources/Msg.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/News.php
+++ b/Sources/News.php
@@ -10,7 +10,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 if (!defined('SMF')) {

--- a/Sources/OutputTypeInterface.php
+++ b/Sources/OutputTypeInterface.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/OutputTypes/Html.php
+++ b/Sources/OutputTypes/Html.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/OutputTypes/Json.php
+++ b/Sources/OutputTypes/Json.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/OutputTypes/Xml.php
+++ b/Sources/OutputTypes/Xml.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/PackageManager/FtpConnection.php
+++ b/Sources/PackageManager/FtpConnection.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/PackageManager/PackageManager.php
+++ b/Sources/PackageManager/PackageManager.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 namespace SMF\PackageManager;

--- a/Sources/PackageManager/PackageUtils.php
+++ b/Sources/PackageManager/PackageUtils.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 namespace SMF\PackageManager;

--- a/Sources/PackageManager/XmlArray.php
+++ b/Sources/PackageManager/XmlArray.php
@@ -10,7 +10,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 namespace SMF\PackageManager;

--- a/Sources/PageIndex.php
+++ b/Sources/PageIndex.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Parser.php
+++ b/Sources/Parser.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Parsers/BBCodeParser.php
+++ b/Sources/Parsers/BBCodeParser.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Parsers/MarkdownParser.php
+++ b/Sources/Parsers/MarkdownParser.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Parsers/SmileyParser.php
+++ b/Sources/Parsers/SmileyParser.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Permissions/GroupPermissionSet.php
+++ b/Sources/Permissions/GroupPermissionSet.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Permissions/Permission.php
+++ b/Sources/Permissions/Permission.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Permissions/PermissionProfile.php
+++ b/Sources/Permissions/PermissionProfile.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Permissions/UserPermissionSet.php
+++ b/Sources/Permissions/UserPermissionSet.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/PersonalMessage.php
+++ b/Sources/PersonalMessage.php
@@ -10,7 +10,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 if (!defined('SMF')) {

--- a/Sources/PersonalMessage/Conversation.php
+++ b/Sources/PersonalMessage/Conversation.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/PersonalMessage/DraftPM.php
+++ b/Sources/PersonalMessage/DraftPM.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/PersonalMessage/Folder.php
+++ b/Sources/PersonalMessage/Folder.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/PersonalMessage/Label.php
+++ b/Sources/PersonalMessage/Label.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/PersonalMessage/PM.php
+++ b/Sources/PersonalMessage/PM.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/PersonalMessage/Popup.php
+++ b/Sources/PersonalMessage/Popup.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/PersonalMessage/Received.php
+++ b/Sources/PersonalMessage/Received.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/PersonalMessage/Rule.php
+++ b/Sources/PersonalMessage/Rule.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/PersonalMessage/Search.php
+++ b/Sources/PersonalMessage/Search.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/PersonalMessage/SearchResult.php
+++ b/Sources/PersonalMessage/SearchResult.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Poll.php
+++ b/Sources/Poll.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/PollChoice.php
+++ b/Sources/PollChoice.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Profile-Actions.php
+++ b/Sources/Profile-Actions.php
@@ -10,7 +10,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 if (!defined('SMF')) {

--- a/Sources/Profile-Modify.php
+++ b/Sources/Profile-Modify.php
@@ -10,7 +10,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 if (!defined('SMF')) {

--- a/Sources/Profile-View.php
+++ b/Sources/Profile-View.php
@@ -10,7 +10,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 if (!defined('SMF')) {

--- a/Sources/Profile.php
+++ b/Sources/Profile.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/ProxyServer.php
+++ b/Sources/ProxyServer.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Punycode.php
+++ b/Sources/Punycode.php
@@ -16,7 +16,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/QueryString.php
+++ b/Sources/QueryString.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Routable.php
+++ b/Sources/Routable.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Sapi.php
+++ b/Sources/Sapi.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/ScheduledTasks.php
+++ b/Sources/ScheduledTasks.php
@@ -10,7 +10,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 if (!defined('SMF')) {

--- a/Sources/Search.php
+++ b/Sources/Search.php
@@ -10,7 +10,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 if (!defined('SMF')) {

--- a/Sources/Search/APIs/Custom.php
+++ b/Sources/Search/APIs/Custom.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Search/APIs/Fulltext.php
+++ b/Sources/Search/APIs/Fulltext.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Search/APIs/Parsed.php
+++ b/Sources/Search/APIs/Parsed.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Search/APIs/Standard.php
+++ b/Sources/Search/APIs/Standard.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Search/SearchApi.php
+++ b/Sources/Search/SearchApi.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Search/SearchApiInterface.php
+++ b/Sources/Search/SearchApiInterface.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Search/SearchResult.php
+++ b/Sources/Search/SearchResult.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/SearchAPI-Custom.php
+++ b/Sources/SearchAPI-Custom.php
@@ -12,7 +12,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 if (!defined('SMF')) {

--- a/Sources/SearchAPI-Fulltext.php
+++ b/Sources/SearchAPI-Fulltext.php
@@ -12,7 +12,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 if (!defined('SMF')) {

--- a/Sources/SearchAPI-Standard.php
+++ b/Sources/SearchAPI-Standard.php
@@ -12,7 +12,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 if (!defined('SMF')) {

--- a/Sources/Security.php
+++ b/Sources/Security.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/SecurityToken.php
+++ b/Sources/SecurityToken.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/ServerSideIncludes.php
+++ b/Sources/ServerSideIncludes.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Session.php
+++ b/Sources/Session.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Slug.php
+++ b/Sources/Slug.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Subs-Admin.php
+++ b/Sources/Subs-Admin.php
@@ -10,7 +10,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 if (!defined('SMF')) {

--- a/Sources/Subs-Auth.php
+++ b/Sources/Subs-Auth.php
@@ -10,7 +10,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 if (!defined('SMF')) {

--- a/Sources/Subs-BoardIndex.php
+++ b/Sources/Subs-BoardIndex.php
@@ -10,7 +10,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 if (!defined('SMF')) {

--- a/Sources/Subs-Boards.php
+++ b/Sources/Subs-Boards.php
@@ -10,7 +10,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 if (!defined('SMF')) {

--- a/Sources/Subs-Calendar.php
+++ b/Sources/Subs-Calendar.php
@@ -10,7 +10,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 if (!defined('SMF')) {

--- a/Sources/Subs-Categories.php
+++ b/Sources/Subs-Categories.php
@@ -10,7 +10,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 if (!defined('SMF')) {

--- a/Sources/Subs-Charset.php
+++ b/Sources/Subs-Charset.php
@@ -10,7 +10,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 if (!defined('SMF')) {

--- a/Sources/Subs-Compat.php
+++ b/Sources/Subs-Compat.php
@@ -11,7 +11,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 if (!defined('SMF')) {

--- a/Sources/Subs-Editor.php
+++ b/Sources/Subs-Editor.php
@@ -10,7 +10,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 if (!defined('SMF')) {

--- a/Sources/Subs-Graphics.php
+++ b/Sources/Subs-Graphics.php
@@ -10,7 +10,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 if (!defined('SMF')) {

--- a/Sources/Subs-List.php
+++ b/Sources/Subs-List.php
@@ -10,7 +10,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 if (!defined('SMF')) {

--- a/Sources/Subs-Membergroups.php
+++ b/Sources/Subs-Membergroups.php
@@ -10,7 +10,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 if (!defined('SMF')) {

--- a/Sources/Subs-Members.php
+++ b/Sources/Subs-Members.php
@@ -10,7 +10,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 if (!defined('SMF')) {

--- a/Sources/Subs-MembersOnline.php
+++ b/Sources/Subs-MembersOnline.php
@@ -10,7 +10,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 if (!defined('SMF')) {

--- a/Sources/Subs-MessageIndex.php
+++ b/Sources/Subs-MessageIndex.php
@@ -10,7 +10,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 if (!defined('SMF')) {

--- a/Sources/Subs-Package.php
+++ b/Sources/Subs-Package.php
@@ -10,7 +10,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 if (!defined('SMF')) {

--- a/Sources/Subs-ReportedContent.php
+++ b/Sources/Subs-ReportedContent.php
@@ -10,7 +10,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 if (!defined('SMF')) {

--- a/Sources/Subs-Sound.php
+++ b/Sources/Subs-Sound.php
@@ -10,7 +10,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 if (!defined('SMF')) {

--- a/Sources/Subs-Timezones.php
+++ b/Sources/Subs-Timezones.php
@@ -10,7 +10,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 if (!defined('SMF')) {

--- a/Sources/Subscriptions/PayPal/Display.php
+++ b/Sources/Subscriptions/PayPal/Display.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Subscriptions/PayPal/Payment.php
+++ b/Sources/Subscriptions/PayPal/Payment.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/TOTP/Auth.php
+++ b/Sources/TOTP/Auth.php
@@ -18,7 +18,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/TaskRunner.php
+++ b/Sources/TaskRunner.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Tasks/AnonymizeEditHistory.php
+++ b/Sources/Tasks/AnonymizeEditHistory.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Tasks/ApprovePost_Notify.php
+++ b/Sources/Tasks/ApprovePost_Notify.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Tasks/ApproveReply_Notify.php
+++ b/Sources/Tasks/ApproveReply_Notify.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Tasks/BackgroundTask.php
+++ b/Sources/Tasks/BackgroundTask.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Tasks/Birthday_Notify.php
+++ b/Sources/Tasks/Birthday_Notify.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Tasks/Buddy_Notify.php
+++ b/Sources/Tasks/Buddy_Notify.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Tasks/CreateAttachment_Notify.php
+++ b/Sources/Tasks/CreateAttachment_Notify.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Tasks/CreatePost_Notify.php
+++ b/Sources/Tasks/CreatePost_Notify.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Tasks/DailyMaintenance.php
+++ b/Sources/Tasks/DailyMaintenance.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Tasks/EventNew_Notify.php
+++ b/Sources/Tasks/EventNew_Notify.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Tasks/ExportProfileData.php
+++ b/Sources/Tasks/ExportProfileData.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Tasks/FetchCalendarSubscriptions.php
+++ b/Sources/Tasks/FetchCalendarSubscriptions.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Tasks/FetchSMFiles.php
+++ b/Sources/Tasks/FetchSMFiles.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Tasks/GenericScheduledTask.php
+++ b/Sources/Tasks/GenericScheduledTask.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Tasks/GenericTask.php
+++ b/Sources/Tasks/GenericTask.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Tasks/GroupAct_Notify.php
+++ b/Sources/Tasks/GroupAct_Notify.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Tasks/GroupReq_Notify.php
+++ b/Sources/Tasks/GroupReq_Notify.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Tasks/Likes_Notify.php
+++ b/Sources/Tasks/Likes_Notify.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Tasks/MemberReportReply_Notify.php
+++ b/Sources/Tasks/MemberReportReply_Notify.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Tasks/MemberReport_Notify.php
+++ b/Sources/Tasks/MemberReport_Notify.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Tasks/MsgReportReply_Notify.php
+++ b/Sources/Tasks/MsgReportReply_Notify.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Tasks/MsgReport_Notify.php
+++ b/Sources/Tasks/MsgReport_Notify.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Tasks/PaidSubs.php
+++ b/Sources/Tasks/PaidSubs.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Tasks/PruneLogTopics.php
+++ b/Sources/Tasks/PruneLogTopics.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Tasks/Register_Notify.php
+++ b/Sources/Tasks/Register_Notify.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Tasks/RemoveOldDrafts.php
+++ b/Sources/Tasks/RemoveOldDrafts.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Tasks/RemoveTempAttachments.php
+++ b/Sources/Tasks/RemoveTempAttachments.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Tasks/RemoveTopicRedirects.php
+++ b/Sources/Tasks/RemoveTopicRedirects.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Tasks/ScheduledTask.php
+++ b/Sources/Tasks/ScheduledTask.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Tasks/SendDigests.php
+++ b/Sources/Tasks/SendDigests.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Tasks/UpdateSpoofDetectorNames.php
+++ b/Sources/Tasks/UpdateSpoofDetectorNames.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Tasks/UpdateTldRegex.php
+++ b/Sources/Tasks/UpdateTldRegex.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Tasks/UpdateUnicode.php
+++ b/Sources/Tasks/UpdateUnicode.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Tasks/Utf8EntityDecode.php
+++ b/Sources/Tasks/Utf8EntityDecode.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Tasks/WeeklyMaintenance.php
+++ b/Sources/Tasks/WeeklyMaintenance.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Theme.php
+++ b/Sources/Theme.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Time.php
+++ b/Sources/Time.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/TimeInterval.php
+++ b/Sources/TimeInterval.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/TimeZone.php
+++ b/Sources/TimeZone.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Topic.php
+++ b/Sources/Topic.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Unicode/CaseFold.php
+++ b/Sources/Unicode/CaseFold.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Unicode/CaseLower.php
+++ b/Sources/Unicode/CaseLower.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Unicode/CaseTitle.php
+++ b/Sources/Unicode/CaseTitle.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Unicode/CaseUpper.php
+++ b/Sources/Unicode/CaseUpper.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Unicode/CombiningClasses.php
+++ b/Sources/Unicode/CombiningClasses.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Unicode/Composition.php
+++ b/Sources/Unicode/Composition.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Unicode/Confusables.php
+++ b/Sources/Unicode/Confusables.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Unicode/Currencies.php
+++ b/Sources/Unicode/Currencies.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Unicode/DecompositionCanonical.php
+++ b/Sources/Unicode/DecompositionCanonical.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Unicode/DecompositionCompatibility.php
+++ b/Sources/Unicode/DecompositionCompatibility.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Unicode/DefaultIgnorables.php
+++ b/Sources/Unicode/DefaultIgnorables.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Unicode/Idna.php
+++ b/Sources/Unicode/Idna.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Unicode/Metadata.php
+++ b/Sources/Unicode/Metadata.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Unicode/Plurals.php
+++ b/Sources/Unicode/Plurals.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Unicode/QuickCheck.php
+++ b/Sources/Unicode/QuickCheck.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Unicode/RegularExpressions.php
+++ b/Sources/Unicode/RegularExpressions.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Unicode/SpoofDetector.php
+++ b/Sources/Unicode/SpoofDetector.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Unicode/Utf8String.php
+++ b/Sources/Unicode/Utf8String.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 namespace SMF\Unicode;

--- a/Sources/Url.php
+++ b/Sources/Url.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/User.php
+++ b/Sources/User.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/UserDataset.php
+++ b/Sources/UserDataset.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Utils.php
+++ b/Sources/Utils.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Uuid.php
+++ b/Sources/Uuid.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/Verifier.php
+++ b/Sources/Verifier.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/WebFetch/APIs/CurlFetcher.php
+++ b/Sources/WebFetch/APIs/CurlFetcher.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/WebFetch/APIs/FtpFetcher.php
+++ b/Sources/WebFetch/APIs/FtpFetcher.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/WebFetch/APIs/SocketFetcher.php
+++ b/Sources/WebFetch/APIs/SocketFetcher.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/WebFetch/WebFetchApi.php
+++ b/Sources/WebFetch/WebFetchApi.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Sources/WebFetch/WebFetchApiInterface.php
+++ b/Sources/WebFetch/WebFetchApiInterface.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Themes/default/Admin.template.php
+++ b/Themes/default/Admin.template.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 use SMF\Actions\Admin\Permissions;

--- a/Themes/default/Agreement.template.php
+++ b/Themes/default/Agreement.template.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 use SMF\Config;

--- a/Themes/default/BoardIndex.template.php
+++ b/Themes/default/BoardIndex.template.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 use SMF\Config;

--- a/Themes/default/Calendar.template.php
+++ b/Themes/default/Calendar.template.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 use SMF\Config;

--- a/Themes/default/Display.template.php
+++ b/Themes/default/Display.template.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 use SMF\Config;

--- a/Themes/default/EditHistory.template.php
+++ b/Themes/default/EditHistory.template.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 use SMF\Theme;

--- a/Themes/default/Errors.template.php
+++ b/Themes/default/Errors.template.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 use SMF\Config;

--- a/Themes/default/EventEditor.template.php
+++ b/Themes/default/EventEditor.template.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 use SMF\Calendar\Event;

--- a/Themes/default/GenericControls.template.php
+++ b/Themes/default/GenericControls.template.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 use SMF\Editor;

--- a/Themes/default/GenericList.template.php
+++ b/Themes/default/GenericList.template.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 use SMF\Utils;

--- a/Themes/default/GenericMenu.template.php
+++ b/Themes/default/GenericMenu.template.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 use SMF\Config;

--- a/Themes/default/Help.template.php
+++ b/Themes/default/Help.template.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 use SMF\Config;

--- a/Themes/default/InstallTemplate.php
+++ b/Themes/default/InstallTemplate.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Themes/default/Likes.template.php
+++ b/Themes/default/Likes.template.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 use SMF\Config;

--- a/Themes/default/Login.template.php
+++ b/Themes/default/Login.template.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 use SMF\Config;

--- a/Themes/default/MaintenanceTemplate.php
+++ b/Themes/default/MaintenanceTemplate.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 namespace SMF\Themes\default;

--- a/Themes/default/ManageAttachments.template.php
+++ b/Themes/default/ManageAttachments.template.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 use SMF\Config;

--- a/Themes/default/ManageBans.template.php
+++ b/Themes/default/ManageBans.template.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 use SMF\Config;

--- a/Themes/default/ManageBoards.template.php
+++ b/Themes/default/ManageBoards.template.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 use SMF\Config;

--- a/Themes/default/ManageCalendar.template.php
+++ b/Themes/default/ManageCalendar.template.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 use SMF\Config;

--- a/Themes/default/ManageLanguages.template.php
+++ b/Themes/default/ManageLanguages.template.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 use SMF\BrowserDetector;

--- a/Themes/default/ManageMail.template.php
+++ b/Themes/default/ManageMail.template.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 use SMF\Config;

--- a/Themes/default/ManageMaintenance.template.php
+++ b/Themes/default/ManageMaintenance.template.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 use SMF\Config;

--- a/Themes/default/ManageMembergroups.template.php
+++ b/Themes/default/ManageMembergroups.template.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 use SMF\Config;

--- a/Themes/default/ManageMembers.template.php
+++ b/Themes/default/ManageMembers.template.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 use SMF\Config;

--- a/Themes/default/ManageNews.template.php
+++ b/Themes/default/ManageNews.template.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 use SMF\Config;

--- a/Themes/default/ManagePaid.template.php
+++ b/Themes/default/ManagePaid.template.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 use SMF\Config;

--- a/Themes/default/ManagePermissions.template.php
+++ b/Themes/default/ManagePermissions.template.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 use SMF\Config;

--- a/Themes/default/ManageScheduledTasks.template.php
+++ b/Themes/default/ManageScheduledTasks.template.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 use SMF\Config;

--- a/Themes/default/ManageSearch.template.php
+++ b/Themes/default/ManageSearch.template.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 use SMF\Config;

--- a/Themes/default/ManageSmileys.template.php
+++ b/Themes/default/ManageSmileys.template.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 use SMF\Config;

--- a/Themes/default/Memberlist.template.php
+++ b/Themes/default/Memberlist.template.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 use SMF\Config;

--- a/Themes/default/MessageIndex.template.php
+++ b/Themes/default/MessageIndex.template.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 use SMF\Config;

--- a/Themes/default/ModerationCenter.template.php
+++ b/Themes/default/ModerationCenter.template.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 use SMF\Config;

--- a/Themes/default/MoveTopic.template.php
+++ b/Themes/default/MoveTopic.template.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 use SMF\Config;

--- a/Themes/default/Notify.template.php
+++ b/Themes/default/Notify.template.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 use SMF\Config;

--- a/Themes/default/Packages.template.php
+++ b/Themes/default/Packages.template.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 use SMF\Config;

--- a/Themes/default/PersonalMessage.template.php
+++ b/Themes/default/PersonalMessage.template.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 use SMF\Config;

--- a/Themes/default/Poll.template.php
+++ b/Themes/default/Poll.template.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 use SMF\Config;

--- a/Themes/default/Post.template.php
+++ b/Themes/default/Post.template.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 use SMF\BrowserDetector;

--- a/Themes/default/Printpage.template.php
+++ b/Themes/default/Printpage.template.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 use SMF\Config;

--- a/Themes/default/Profile.template.php
+++ b/Themes/default/Profile.template.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 use SMF\BrowserDetector;

--- a/Themes/default/Recent.template.php
+++ b/Themes/default/Recent.template.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 use SMF\Board;

--- a/Themes/default/Register.template.php
+++ b/Themes/default/Register.template.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 use SMF\BrowserDetector;

--- a/Themes/default/Reminder.template.php
+++ b/Themes/default/Reminder.template.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 use SMF\Config;

--- a/Themes/default/ReportToMod.template.php
+++ b/Themes/default/ReportToMod.template.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 use SMF\Lang;

--- a/Themes/default/ReportedContent.template.php
+++ b/Themes/default/ReportedContent.template.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 use SMF\Config;

--- a/Themes/default/Reports.template.php
+++ b/Themes/default/Reports.template.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 use SMF\Config;

--- a/Themes/default/Search.template.php
+++ b/Themes/default/Search.template.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 use SMF\Config;

--- a/Themes/default/Settings.template.php
+++ b/Themes/default/Settings.template.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 use SMF\Config;

--- a/Themes/default/SplitTopics.template.php
+++ b/Themes/default/SplitTopics.template.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 use SMF\Config;

--- a/Themes/default/Stats.template.php
+++ b/Themes/default/Stats.template.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 use SMF\Config;

--- a/Themes/default/Themes.template.php
+++ b/Themes/default/Themes.template.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 use SMF\BrowserDetector;

--- a/Themes/default/UpgradeTemplate.php
+++ b/Themes/default/UpgradeTemplate.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/Themes/default/Who.template.php
+++ b/Themes/default/Who.template.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 use SMF\Config;

--- a/Themes/default/Xml.template.php
+++ b/Themes/default/Xml.template.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 use SMF\Config;

--- a/Themes/default/index.template.php
+++ b/Themes/default/index.template.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 use SMF\Config;

--- a/Themes/default/languages/en_US/ThemeStrings.php
+++ b/Themes/default/languages/en_US/ThemeStrings.php
@@ -1,6 +1,6 @@
 <?php
 
-// Version: 3.0 Alpha 4; Settings
+// Version: 3.0 Alpha 5-dev; Settings
 
 // argument(s): images_url as saved in settings
 $txt['theme_thumbnail_href'] = '{images_url}/thumbnail.png';

--- a/Themes/default/scripts/sceditor.plugins.smf.js
+++ b/Themes/default/scripts/sceditor.plugins.smf.js
@@ -3,10 +3,10 @@
  *
  * @package SMF
  * @author Simple Machines https://www.simplemachines.org
- * @copyright 2025 Simple Machines and individual contributors
+ * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 3
+ * @version 3.0 Alpha 5-dev
  */
 
 (sceditor => {

--- a/composer.lock
+++ b/composer.lock
@@ -3604,12 +3604,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/SimpleMachines/BuildTools.git",
-                "reference": "0b8278d89b08301e5d54c68a23514159442f6b08"
+                "reference": "d6dcbc0f863028901d0dbb8815ba78cf04de9e21"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/SimpleMachines/BuildTools/zipball/0b8278d89b08301e5d54c68a23514159442f6b08",
-                "reference": "0b8278d89b08301e5d54c68a23514159442f6b08",
+                "url": "https://api.github.com/repos/SimpleMachines/BuildTools/zipball/d6dcbc0f863028901d0dbb8815ba78cf04de9e21",
+                "reference": "d6dcbc0f863028901d0dbb8815ba78cf04de9e21",
                 "shasum": ""
             },
             "require": {
@@ -3622,7 +3622,7 @@
                 "source": "https://github.com/SimpleMachines/BuildTools/tree/release-3.0",
                 "issues": "https://github.com/SimpleMachines/BuildTools/issues"
             },
-            "time": "2026-05-27T23:44:16+00:00"
+            "time": "2026-09-09T18:41:29+00:00"
         },
         {
             "name": "staabm/side-effects-detector",

--- a/cron.php
+++ b/cron.php
@@ -13,7 +13,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/index.php
+++ b/index.php
@@ -17,7 +17,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);
@@ -36,7 +36,7 @@ if (!defined('SMF')) {
 }
 
 if (!defined('SMF_VERSION')) {
-	define('SMF_VERSION', '3.0 Alpha 4');
+	define('SMF_VERSION', '3.0 Alpha 5-dev');
 }
 
 if (!defined('SMF_FULL_VERSION')) {

--- a/other/Settings.php
+++ b/other/Settings.php
@@ -10,7 +10,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 ########## Maintenance ##########

--- a/other/Settings_bak.php
+++ b/other/Settings_bak.php
@@ -10,7 +10,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 ########## Maintenance ##########

--- a/other/Updaters/AsciiTransliteratorDataUpdater.php
+++ b/other/Updaters/AsciiTransliteratorDataUpdater.php
@@ -19,7 +19,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/other/Updaters/TimezoneDataUpdater.php
+++ b/other/Updaters/TimezoneDataUpdater.php
@@ -65,7 +65,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/other/Updaters/UnicodeDataUpdater.php
+++ b/other/Updaters/UnicodeDataUpdater.php
@@ -26,7 +26,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/other/Updaters/UpdaterBase.php
+++ b/other/Updaters/UpdaterBase.php
@@ -11,7 +11,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/other/Updaters/VersionNumberUpdater.php
+++ b/other/Updaters/VersionNumberUpdater.php
@@ -14,7 +14,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/other/Updaters/VersionNumberUpdater.php
+++ b/other/Updaters/VersionNumberUpdater.php
@@ -7,20 +7,6 @@
  * This file updates version numbers and copyright years in any SMF
  * files that need it in order to prepare for a new release.
  *
- * To automatically increment the version number, run the following
- * command on the CLI:
- *
- *     php -f other/update_version_numbers.php
- *
- * To manually specify a version string, do this:
- *
- *     php -f other/update_version_numbers.php 'version_string_here'
- *
- * Note: manually specifying a version string should only be needed
- * when changing from alpha to beta, from beta to release candidate, or
- * from release candidate to release version.
- *
- *
  * Simple Machines Forum (SMF)
  *
  * @package SMF
@@ -51,7 +37,7 @@ class VersionNumberUpdater extends UpdaterBase
 	 *
 	 * Regex pattern to match all standard SMF version strings.
 	 */
-	public const VERSION_PATTERN = '\d+\.\d+[. ]?(?:(?:(?<= )(?>RC|Beta |Alpha ))?\d+)?';
+	public const VERSION_PATTERN = '\d+\.\d+[. ]?(?:(?:(?<= )(?>RC|Beta |Alpha ))?\d+)?(?:-dev)?';
 
 	/**
 	 * @var string
@@ -122,7 +108,6 @@ class VersionNumberUpdater extends UpdaterBase
 		'other/install.php',
 		'other/upgrade.php',
 	];
-
 
 	/****************
 	 * Public methods
@@ -199,8 +184,15 @@ class VersionNumberUpdater extends UpdaterBase
 	 */
 	private function setNewVersion(?string $new_version = null): void
 	{
+		if ($new_version === 'dev') {
+			$append_dev = true;
+			$new_version = null;
+		} else {
+			$append_dev = false;
+		}
+
 		// Was the new version passed as a command line argument?
-		if (!empty($new_version)) {
+		if (\is_string($new_version)) {
 			$new_version = trim($new_version);
 
 			if (!preg_match('~^' . self::VERSION_PATTERN . '$~', $new_version)) {
@@ -222,6 +214,10 @@ class VersionNumberUpdater extends UpdaterBase
 			}
 
 			$new_version = implode('.', $new_version);
+
+			if ($append_dev) {
+				$new_version .= '-dev';
+			}
 		}
 
 		$this->new_version = $new_version;

--- a/other/install.php
+++ b/other/install.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/other/prepare_release.php
+++ b/other/prepare_release.php
@@ -25,7 +25,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/other/prepare_release.php
+++ b/other/prepare_release.php
@@ -43,13 +43,25 @@ $updaters = [
 
 $num_updaters_executed = 0;
 
+// If a version number was specified manually, validate it before proceeding.
+if (
+	isset($argv[1])
+	&& (
+		!preg_match('~^' . Updaters\VersionNumberUpdater::VERSION_PATTERN . '$~', $argv[1])
+		// This script is for preparing release versions, not dev versions!
+		|| str_ends_with($argv[1], 'dev')
+	)
+) {
+	throw new \Exception('Provided version string is invalid: ' . $argv[1]);
+}
+
 foreach ($updaters as $class_name) {
 	$file_name = 'Updaters/' . $class_name . '.php';
 	$fully_qualified_class_name = __NAMESPACE__ . '\\Updaters\\' . $class_name;
 
 	require_once $file_name;
 
-	$updater = new $fully_qualified_class_name('prepare_release');
+	$updater = new $fully_qualified_class_name(str_replace('release-', '', Updaters\UpdaterBase::MAIN_BRANCH) . '/prepare_release');
 
 	if ($class_name === 'VersionNumberUpdater') {
 		$updater->execute($argv[1] ?? null);

--- a/other/update_asciitransliterator_data.php
+++ b/other/update_asciitransliterator_data.php
@@ -20,7 +20,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/other/update_asciitransliterator_data.php
+++ b/other/update_asciitransliterator_data.php
@@ -31,7 +31,7 @@ require_once 'Updaters/UpdaterBase.php';
 
 require_once 'Updaters/AsciiTransliteratorDataUpdater.php';
 
-$updater = new Updaters\AsciiTransliteratorDataUpdater('update_asciitransliterator_data');
+$updater = new Updaters\AsciiTransliteratorDataUpdater(str_replace('release-', '', Updaters\UpdaterBase::MAIN_BRANCH) . '/update_asciitransliterator_data');
 $updater->execute();
 
 if ($updater->hasChanged()) {

--- a/other/update_timezones.php
+++ b/other/update_timezones.php
@@ -29,7 +29,7 @@ require_once 'Updaters/UpdaterBase.php';
 
 require_once 'Updaters/TimezoneDataUpdater.php';
 
-$updater = new Updaters\TimezoneDataUpdater('update_timezones');
+$updater = new Updaters\TimezoneDataUpdater(str_replace('release-', '', Updaters\UpdaterBase::MAIN_BRANCH) . '/update_timezones');
 $updater->execute();
 
 if ($updater->hasChanged()) {

--- a/other/update_timezones.php
+++ b/other/update_timezones.php
@@ -18,7 +18,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/other/update_unicode_data.php
+++ b/other/update_unicode_data.php
@@ -37,7 +37,7 @@ require_once 'Updaters/UpdaterBase.php';
 
 require_once 'Updaters/UnicodeDataUpdater.php';
 
-$updater = new Updaters\UnicodeDataUpdater('update_unicode_data');
+$updater = new Updaters\UnicodeDataUpdater(str_replace('release-', '', Updaters\UpdaterBase::MAIN_BRANCH) . '/update_unicode_data');
 $updater->execute();
 
 if ($updater->hasChanged()) {

--- a/other/update_unicode_data.php
+++ b/other/update_unicode_data.php
@@ -26,7 +26,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/other/update_version_numbers.php
+++ b/other/update_version_numbers.php
@@ -30,7 +30,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/other/update_version_numbers.php
+++ b/other/update_version_numbers.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * This is an internal development file. It should NOT be included in
+ * any SMF distribution packages.
+ *
+ * To automatically increment the version number, run the following
+ * command on the CLI:
+ *
+ *     php -f other/update_version_numbers.php
+ *
+ * To automatically increment the version number and then append '-dev'
+ * to it, run the following command on the CLI:
+ *
+ *     php -f other/update_version_numbers.php 'dev'
+ *
+ * To manually specify a version string, do this:
+ *
+ *     php -f other/update_version_numbers.php 'version_string_here'
+ *
+ * Note: manually specifying a version string should only be needed
+ * when changing from alpha to beta, from beta to release candidate, or
+ * from release candidate to release version.
+ *
+ *
+ * Simple Machines Forum (SMF)
+ *
+ * @package SMF
+ * @author Simple Machines https://www.simplemachines.org
+ * @copyright 2026 Simple Machines and individual contributors
+ * @license https://www.simplemachines.org/about/smf/license.php BSD
+ *
+ * @version 3.0 Alpha 4
+ */
+
+declare(strict_types=1);
+
+namespace SMF\other;
+
+require_once 'Updaters/UpdaterBase.php';
+
+require_once 'Updaters/VersionNumberUpdater.php';
+
+$updater = new Updaters\VersionNumberUpdater(str_replace('release-', '', Updaters\UpdaterBase::MAIN_BRANCH) . '/update_version_numbers');
+$updater->execute($argv[1] ?? null);
+
+if ($updater->hasChanged()) {
+	if (!$updater->ready_to_commit) {
+		echo 'Changes are not ready to commit. Deal with them manually.' . PHP_EOL;
+	} elseif ($updater->commit()) {
+		echo 'Changes committed.' . PHP_EOL;
+	}
+}

--- a/other/upgrade.php
+++ b/other/upgrade.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/proxy.php
+++ b/proxy.php
@@ -10,7 +10,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);

--- a/ssi_examples.php
+++ b/ssi_examples.php
@@ -8,7 +8,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 // Special thanks to Spaceman-Spiff for his contributions to this page.

--- a/subscriptions.php
+++ b/subscriptions.php
@@ -11,7 +11,7 @@
  * @copyright 2026 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
- * @version 3.0 Alpha 4
+ * @version 3.0 Alpha 5-dev
  */
 
 declare(strict_types=1);


### PR DESCRIPTION
Until now our practice has been to update the version numbers when we tag a release, and then leave them that way until we tag the next release. So for example, after we released `2.1.6`, we left the version number at `2.1.6` throughout the time we worked on `2.1.7`. But during that time, the code had already been changed and therefore was no longer the `2.1.6` version. We ourselves have gotten used to having misleading version numbers in our files, but outside collaborators find this confusing. They quite reasonably expect the version numbers in our files to reflect reality. Moreover, there are certain situations where we do version checks in our development tools and the mismatch between the stated version number and reality causes awkwardness. We've managed to write workarounds for this in our development tools, but it would be better not to need such workarounds at all.

Fortunately, the fix for this is simple. Instead of leaving the version number at, e.g., `3.0.1` until we are ready to tag `3.0.2`, we change update it to `3.0.2-dev` while working on it, and then to `3.0.2` once we are ready to tag it as such. PHP's `version_compare()` function treats `3.0.2-dev` as less than `3.0.2`, so it will sort correctly in automated processes, and humans reading `3.0.2-dev` in our file headers will correctly understand that they are looking at files that have been changed since `3.0.1` but have not yet been finalized as `3.0.2`.

To facilitate this change in our version numbering practices, this PR does two things.

1. [Adds ability to automatically update version numbers to '*-dev'](https://github.com/SimpleMachines/SMF/commit/9444fdeadea1a8601f1f0db03229fa6c1da214e1) makes a tweak to SMF\other\Updaters\VersionNumberUpdater so that running this command on the CLI:
    ```
    php -f other/update_version_numbers.php 'dev'
    ```
    ... will automatically update the version numbers in all SMF files from, e.g., `3.0.1` to `3.0.2-dev`.

2. [Updates version numbers, etc.](https://github.com/SimpleMachines/SMF/commit/8173ba6dc526021786c3bff0c4befec780d66098) then applies that change to our current files, thereby updating `3.0 Alpha 4` in our version strings to `3.0 Alpha 5-dev`.

Moving forward into the future, our practice will be to update all version strings to, e.g., `3.0 Alpha 5` in the selfsame commit that we tag as `v3.0-alpha.5`, and then in the very next commit, update all the version strings to `3.0 Alpha 6-dev`.