### PR TITLE
[3.0] Leaves mod compatibility out of an install or an upgrade

### DIFF
--- a/Sources/Db/APIs/MySQL.php
+++ b/Sources/Db/APIs/MySQL.php
@@ -2984,12 +2984,16 @@ class MySQL extends DatabaseApi implements DatabaseApiInterface
 	 *
 	 * Assumes $db_string has already been processed by replacement_callback().
 	 *
+	 * Does nothing while the forum is being installed or upgraded. Those tools
+	 * run no mod code, since Maintenance turns the hooks off, and they meet the
+	 * database in shapes that these fixes would misread.
+	 *
 	 * @param string $db_string The database query string.
 	 * @return string Possibly modified version of $db_string.
 	 */
 	protected function backcompatQuoteFixes(string $db_string): string
 	{
-		if (empty(Config::$backward_compatibility)) {
+		if (empty(Config::$backward_compatibility) || \defined('SMF_INSTALLING')) {
 			return $db_string;
 		}
 
@@ -3033,6 +3037,9 @@ class MySQL extends DatabaseApi implements DatabaseApiInterface
 	 * Helper for $this->insert() that makes any changes to the columns, data,
 	 * and/or keys that might be required for backward compatibility support.
 	 *
+	 * Does nothing while the forum is being installed or upgraded, for the
+	 * reasons given on $this->backcompatQuoteFixes().
+	 *
 	 * @param string $table The table.
 	 * @param array $columns Array of the columns we're inserting the data into.
 	 *    Should contain 'column' => 'datatype' pairs.
@@ -3043,7 +3050,7 @@ class MySQL extends DatabaseApi implements DatabaseApiInterface
 	 */
 	protected function backcompatInsertFixes(string $table, array $columns, array $data, array $keys): array
 	{
-		if (empty(Config::$backward_compatibility)) {
+		if (empty(Config::$backward_compatibility) || \defined('SMF_INSTALLING')) {
 			return [$columns, $data, $keys];
 		}
 

--- a/Sources/Db/APIs/PostgreSQL.php
+++ b/Sources/Db/APIs/PostgreSQL.php
@@ -2932,12 +2932,16 @@ class PostgreSQL extends DatabaseApi implements DatabaseApiInterface
 	 *
 	 * Assumes $db_string has already been processed by replacement_callback().
 	 *
+	 * Does nothing while the forum is being installed or upgraded. Those tools
+	 * run no mod code, since Maintenance turns the hooks off, and they meet the
+	 * database in shapes that these fixes would misread.
+	 *
 	 * @param string $db_string The database query string.
 	 * @return string Possibly modified version of $db_string.
 	 */
 	protected function backcompatQuoteFixes(string $db_string): string
 	{
-		if (empty(Config::$backward_compatibility)) {
+		if (empty(Config::$backward_compatibility) || \defined('SMF_INSTALLING')) {
 			return $db_string;
 		}
 
@@ -2981,6 +2985,9 @@ class PostgreSQL extends DatabaseApi implements DatabaseApiInterface
 	 * Helper for $this->insert() that makes any changes to the columns, data,
 	 * and/or keys that might be required for backward compatibility support.
 	 *
+	 * Does nothing while the forum is being installed or upgraded, for the
+	 * reasons given on $this->backcompatQuoteFixes().
+	 *
 	 * @param string $table The table.
 	 * @param array $columns Array of the columns we're inserting the data into.
 	 *    Should contain 'column' => 'datatype' pairs.
@@ -2991,7 +2998,7 @@ class PostgreSQL extends DatabaseApi implements DatabaseApiInterface
 	 */
 	protected function backcompatInsertFixes(string $table, array $columns, array $data, array $keys): array
 	{
-		if (empty(Config::$backward_compatibility)) {
+		if (empty(Config::$backward_compatibility) || \defined('SMF_INSTALLING')) {
 			return [$columns, $data, $keys];
 		}
 

--- a/tests/Unit/BoardsCountPostsBackcompatTest.php
+++ b/tests/Unit/BoardsCountPostsBackcompatTest.php
@@ -1,0 +1,194 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SMF\Tests\Unit;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
+use PHPUnit\Framework\TestCase;
+use SMF\Config;
+use SMF\Db\APIs\MySQL;
+use SMF\Db\APIs\PostgreSQL;
+
+#[CoversClass(MySQL::class)]
+#[CoversClass(PostgreSQL::class)]
+class BoardsCountPostsBackcompatTest extends TestCase
+{
+	/****************
+	 * Public methods
+	 ****************/
+
+	/**
+	 * The upgrader meets the boards table while it still has count_posts, and
+	 * its queries mean that column. Rewriting them to name posts_count made the
+	 * backup step fail with "Unknown column 'posts_count' in 'field list'", and
+	 * would have made the migration read the value it was in the middle of
+	 * writing.
+	 *
+	 * Its own process, because SMF_INSTALLING cannot be undefined again.
+	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState(false)]
+	public function testTheUpgraderGetsTheQueriesItWrote(): void
+	{
+		\define('SMF_INSTALLING', 1);
+
+		foreach (self::engineProvider() as $engine => [$class]) {
+			foreach (self::upgraderQueries() as $label => $query) {
+				$this->assertSame($query, $this->quoteFixes($class, $query), $engine . ', ' . $label);
+			}
+
+			[$columns, $data, $keys] = $this->insertFixes($class);
+
+			$this->assertSame(['id_board' => 'int', 'count_posts' => 'int'], $columns, $engine);
+			$this->assertSame([[1, 0]], $data, $engine);
+			$this->assertSame(['count_posts'], $keys, $engine);
+		}
+	}
+
+	#[DataProvider('legacyQueryProvider')]
+	public function testALegacyQueryIsStillRewrittenForAModThatSendsOne(string $class, string $query, string $expected): void
+	{
+		$this->assertSame($expected, $this->quoteFixes($class, $query));
+	}
+
+	#[DataProvider('engineProvider')]
+	public function testALegacyInsertIsStillRewrittenForAModThatSendsOne(string $class): void
+	{
+		[$columns, $data, $keys] = $this->insertFixes($class);
+
+		$this->assertSame(['id_board' => 'int', 'posts_count' => 'int'], $columns);
+		$this->assertSame([[1, 1]], $data);
+		$this->assertSame(['posts_count'], $keys);
+	}
+
+	#[DataProvider('engineProvider')]
+	public function testNothingIsRewrittenWithoutBackwardCompatibility(string $class): void
+	{
+		Config::$backward_compatibility = 0;
+
+		$query = 'SELECT id_board, count_posts FROM smf_boards';
+
+		$this->assertSame($query, $this->quoteFixes($class, $query));
+	}
+
+	/***********************
+	 * Public static methods
+	 ***********************/
+
+	/**
+	 * @return array<string, array{string}>
+	 */
+	public static function engineProvider(): array
+	{
+		return [
+			'MySQL' => [MySQL::class],
+			'PostgreSQL' => [PostgreSQL::class],
+		];
+	}
+
+	/**
+	 * Queries an SMF 2.1 mod sends to a forum that has finished upgrading.
+	 *
+	 * @return array<string, array{string, string, string}>
+	 */
+	public static function legacyQueryProvider(): array
+	{
+		$queries = [
+			'a selected column comes back under its old name and logic' => [
+				'SELECT id_board, count_posts FROM smf_boards',
+				'SELECT id_board, posts_count, (1 - posts_count) AS count_posts FROM smf_boards',
+			],
+			'a comparison is inverted along with the column' => [
+				'SELECT id_board FROM smf_boards WHERE count_posts = 0',
+				'SELECT id_board FROM smf_boards WHERE posts_count = 1',
+			],
+			'an update names the new column' => [
+				'UPDATE smf_boards SET count_posts = 1',
+				'UPDATE smf_boards SET posts_count = 0',
+			],
+		];
+
+		$cases = [];
+
+		foreach (self::engineProvider() as $engine => [$class]) {
+			foreach ($queries as $label => [$query, $expected]) {
+				$cases[$engine . ', ' . $label] = [$class, $query, $expected];
+			}
+		}
+
+		return $cases;
+	}
+
+	/**
+	 * Queries the upgrader sends while the old column is still in the table.
+	 *
+	 * @return array<string, string>
+	 */
+	public static function upgraderQueries(): array
+	{
+		return [
+			'the backup step copying the table' => 'INSERT INTO backup_smf_boards (id_board, count_posts) SELECT id_board, count_posts FROM smf_boards',
+			'the migration filling in the new column' => 'UPDATE smf_boards SET posts_count = CASE WHEN count_posts = 0 THEN 1 ELSE 0 END',
+		];
+	}
+
+	/******************
+	 * Internal methods
+	 ******************/
+
+	protected function setUp(): void
+	{
+		// Both of the fixes under test read these directly.
+		Config::$db_prefix = 'smf_';
+		Config::$backward_compatibility = 1;
+	}
+
+	protected function tearDown(): void
+	{
+		// A typed static cannot be put back to its uninitialised state, and
+		// every reader of this one asks empty() of it, so zero is as good.
+		Config::$backward_compatibility = 0;
+	}
+
+	/**
+	 * Calls the protected query fixer.
+	 */
+	private function quoteFixes(string $class, string $query): string
+	{
+		return (new \ReflectionMethod($class, 'backcompatQuoteFixes'))
+			->invoke($this->api($class), $query);
+	}
+
+	/**
+	 * Calls the protected insert fixer with a row naming the old column.
+	 *
+	 * @return array{array<string, string>, array<int, array<int, int>>, array<int, string>}
+	 */
+	private function insertFixes(string $class): array
+	{
+		return (new \ReflectionMethod($class, 'backcompatInsertFixes'))
+			->invoke(
+				$this->api($class),
+				'smf_boards',
+				['id_board' => 'int', 'count_posts' => 'int'],
+				[[1, 0]],
+				['count_posts'],
+			);
+	}
+
+	/**
+	 * A database API object with no connection behind it, since the fixes only
+	 * need the table prefix.
+	 */
+	private function api(string $class): MySQL|PostgreSQL
+	{
+		$db = (new \ReflectionClass($class))->newInstanceWithoutConstructor();
+		$db->prefix = 'smf_';
+
+		return $db;
+	}
+}


### PR DESCRIPTION
#### Description

The boards table lost its `count_posts` column in 3.0 and gained `posts_count`, which holds the same setting the other way up. So that a 2.1 mod keeps working, `backcompatQuoteFixes()` and `backcompatInsertFixes()` rewrite references to the old column into references to the new one whenever backward compatibility is on.

Mod code does not run during an install or an upgrade — `Maintenance::__construct()` sets `IntegrationHook::$enabled = false` before either tool starts. What those tools do instead is meet the database in shapes no ordinary request ever sees, and the rewriting misreads them.

**Backing the table up was the first casualty**, which is what #9676 reports. `backup_table()` builds its `INSERT` from `list_columns()`, so on a 2.1 table it names `count_posts`, and the rewrite turned that into:

```sql
INSERT INTO backup_smf_boards
	(id_board, ..., posts_count, ...)
	SELECT id_board, ..., posts_count, (1 - posts_count) AS count_posts, ...
	FROM smf_boards
```

→ `Unknown column 'posts_count' in 'field list'`, before an upgrade had done anything at all. `list_columns()` was right all along; the query was rewritten under it after it had answered.

**The migration behind it was next.** `BoardPostsCount` fills the new column in with

```sql
UPDATE smf_boards SET posts_count = CASE WHEN count_posts = 0 THEN 1 ELSE 0 END
```

and the rewrite inverts a comparison along with the column name, so it became `CASE WHEN posts_count = 1`, reading the column it was in the middle of writing. Since `posts_count` is added with a default of 1, every board would have come out of the upgrade counting posts, whatever it was set to before. Nobody has hit that yet only because the backup fails first — an upgrade with the backup unticked would have.

Both fixes now stand down while `SMF_INSTALLING` is defined. That is the same signal the rest of these two classes already use to tell a running forum from one being built (`MySQL::query()`, `MySQL::create_table()`), and it is the honest scope for the problem: backward compatibility is for mod code, and there is none of it here. Guarding the count_posts rewrite specifically — on whether the old column is still in the table, say — would have cost a schema lookup in the general query path and left the next fix added to these methods to make the same mistake again. Nothing changes for an ordinary request.

Both database APIs carry their own copy of these fixes already, so both get the same guard.

#### Verified

- `tests/Unit/BoardsCountPostsBackcompatTest.php` pins both directions for both engines: the upgrader's queries come back as written, and a legacy mod query is still rewritten on a running forum. The upgrader case runs in its own process, since `SMF_INSTALLING` cannot be undefined again; that costs the unit suite a few seconds locally. It fails without the guard.
- Live, against the MySQL dev forum: put `count_posts` back on `smf_boards` and run `backup_table()` under `SMF_INSTALLING` as the upgrader does. It now succeeds and copies every column, where before it failed with the reported error. The PostgreSQL path is the same code but was not exercised against a running PostgreSQL forum.

### Issues References (Fixes|Related|Closes)

Fixes #9676

🤖 Generated with [Claude Code](https://claude.com/claude-code)
