### PR TITLE
[3.0] Add env var to enable basic http logging

### DIFF
--- a/tests/Support/HttpClient.php
+++ b/tests/Support/HttpClient.php
@@ -7,17 +7,14 @@ namespace SMF\Tests\Support;
 use SMF\Config;
 
 /**
- * A very small browser, for driving the forum over HTTP.
+ * HTTP client used by integration tests.
  *
- * Requests have to be real ones. Utils::obExit(), redirectexit(),
- * serverResponse() and ErrorHandler::fatal*() all end in exit, and Db::$db,
- * ActionTrait::$obj, Theme::$loaded and User::$loaded have no way to be reset, so
- * a test process can carry out exactly one request in itself and no more. Going
- * over the wire sidesteps all of that and exercises the same path a visitor does,
- * including the session, the cookies and the theme.
+ * Maintains a persistent cURL handle and cookie jar so that multiple requests
+ * can be made as the same HTTP session.
  *
- * Uses curl through the extension the forum already requires, so it costs no new
- * dependency.
+ * The base URL can be configured with SMF_TESTS_BASE_URL. When HTTP logging is
+ * enabled with SMF_TESTS_ENABLE_HTTP_LOGGING=1, request/response data is
+ * written to the test HTTP log directory for debugging failed requests.
  */
 final class HttpClient
 {

--- a/tests/Support/HttpClient.php
+++ b/tests/Support/HttpClient.php
@@ -69,9 +69,9 @@ final class HttpClient
 	 */
 	private int $log_sequence = 0;
 
- 	/****************
- 	 * Public methods
- 	 ****************/
+	/****************
+	 * Public methods
+	 ****************/
 
 	/**
 	 * Creates an HTTP client.
@@ -84,7 +84,7 @@ final class HttpClient
 		$this->http_logging = getenv('SMF_TESTS_ENABLE_HTTP_LOGGING') === '1';
 
 		if ($this->http_logging) {
-			$this->log_dir = dirname(__DIR__, 2) . '/logs/http';
+			$this->log_dir = \dirname(__DIR__, 2) . '/logs/http';
 
 			if (!is_dir($this->log_dir) && !mkdir($this->log_dir, 0777, true) && !is_dir($this->log_dir)) {
 				throw new \RuntimeException('Could not create HTTP log directory: ' . $this->log_dir);
@@ -301,7 +301,7 @@ final class HttpClient
 		$name = trim((string) preg_replace('/[^a-zA-Z0-9]+/', '_', $name), '_');
 		$name = substr($name, 0, 100);
 
-		$file = sprintf(
+		$file = \sprintf(
 			'%s/%03d_%s.html',
 			$this->log_dir,
 			$this->log_sequence,

--- a/tests/Support/HttpClient.php
+++ b/tests/Support/HttpClient.php
@@ -57,16 +57,42 @@ final class HttpClient
 	 */
 	private ?HttpResponse $last = null;
 
-	/****************
-	 * Public methods
-	 ****************/
+	/**
+	 * Directory where HTTP request/response logs are written.
+	 */
+	private string $log_dir = '';
 
 	/**
+	 * Whether HTTP request/response logging is enabled.
+	 */
+	private bool $http_logging = false;
+
+	/**
+	 * Sequence number used to make log filenames unique.
+	 */
+	private int $log_sequence = 0;
+
+ 	/****************
+ 	 * Public methods
+ 	 ****************/
+
+	/**
+	 * Creates an HTTP client.
+	 *
 	 * @param string|null $base_url Override the forum URL to talk to.
 	 */
 	public function __construct(?string $base_url = null)
 	{
 		$this->base_url = rtrim($base_url ?? self::detectBaseUrl(), '/');
+		$this->http_logging = getenv('SMF_TESTS_ENABLE_HTTP_LOGGING') === '1';
+
+		if ($this->http_logging) {
+			$this->log_dir = dirname(__DIR__, 2) . '/logs/http';
+
+			if (!is_dir($this->log_dir) && !mkdir($this->log_dir, 0777, true) && !is_dir($this->log_dir)) {
+				throw new \RuntimeException('Could not create HTTP log directory: ' . $this->log_dir);
+			}
+		}
 
 		$this->jar = (string) tempnam(sys_get_temp_dir(), 'smf_tests_cookies_');
 
@@ -79,6 +105,9 @@ final class HttpClient
 		$this->handle = $handle;
 	}
 
+	/**
+	 * Removes the temporary cookie jar.
+	 */
 	public function __destruct()
 	{
 		if ($this->jar !== '' && is_file($this->jar)) {
@@ -91,6 +120,7 @@ final class HttpClient
 	 *
 	 * @param string $path Either a full URL or something to hang off the board
 	 *     URL, with or without a leading slash. '?action=login' is typical.
+	 *
 	 * @return HttpResponse The response.
 	 */
 	public function get(string $path = ''): HttpResponse
@@ -103,6 +133,7 @@ final class HttpClient
 	 *
 	 * @param string $path Where to post, as for get().
 	 * @param array $fields The form fields.
+	 *
 	 * @return HttpResponse The response.
 	 */
 	public function post(string $path, array $fields): HttpResponse
@@ -122,6 +153,7 @@ final class HttpClient
 	 * @param HttpResponse $page The page holding the form.
 	 * @param array $overrides Values to change or add.
 	 * @param string $xpath Which form. Defaults to the first on the page.
+	 *
 	 * @return HttpResponse The response.
 	 */
 	public function submit(HttpResponse $page, array $overrides = [], string $xpath = '//form'): HttpResponse
@@ -133,7 +165,7 @@ final class HttpClient
 	}
 
 	/**
-	 * The most recent response, for reporting on a failure.
+	 * Returns the most recent response, for reporting on a failure.
 	 *
 	 * @return HttpResponse|null The response, or null if nothing has been sent.
 	 */
@@ -163,6 +195,7 @@ final class HttpClient
 	 * Turns whatever a caller passed into an absolute URL.
 	 *
 	 * @param string $path A full URL, a query string, or a path.
+	 *
 	 * @return string An absolute URL.
 	 */
 	private function url(string $path): string
@@ -242,11 +275,8 @@ final class HttpClient
 
 		$flag = getenv('SMF_TESTS_ENABLE_HTTP_LOGGING');
 
-		if ($flag !== false && trim($flag) === '1') {
-			file_put_contents(
-				trim(preg_replace('/[^a-zA-Z0-9]/', '_', str_replace($this->base_url, '', $path)), '_') . '.html',
-				$url . "\n\n" . print_r($fields ?? [], true) . $raw,
-			);
+		if ($this->http_logging) {
+			$this->logResponse($url, $fields, $raw);
 		}
 
 		return $this->last = new HttpResponse(
@@ -255,6 +285,39 @@ final class HttpClient
 			$headers,
 			$url,
 			$set_cookies,
+		);
+	}
+
+	/**
+	 * Writes an HTTP request and response to the debug log.
+	 *
+	 * @param string $url The resolved request URL.
+	 * @param array|null $fields POST fields, or null for a GET.
+	 * @param string $raw The raw HTTP response, including headers.
+	 */
+	private function logResponse(string $url, ?array $fields, string $raw): void
+	{
+		++$this->log_sequence;
+
+		$parts = parse_url($url);
+
+		$name = isset($parts['query']) ? '_' . $parts['query'] : '';
+
+		$name = trim((string) preg_replace('/[^a-zA-Z0-9]+/', '_', $name), '_');
+		$name = substr($name, 0, 100);
+
+		$file = sprintf(
+			'%s/%03d_%s.html',
+			$this->log_dir,
+			$this->log_sequence,
+			$name !== '' ? $name : 'index',
+		);
+
+		file_put_contents(
+			$file,
+			$url . "\n\n"
+			. print_r($fields ?? [], true)
+			. $raw,
 		);
 	}
 
@@ -295,6 +358,7 @@ final class HttpClient
 	 * Whether anything answers on the host and port of a URL.
 	 *
 	 * @param string $url The URL to try.
+	 *
 	 * @return bool Whether a connection could be opened.
 	 */
 	private static function listening(string $url): bool

--- a/tests/Support/HttpClient.php
+++ b/tests/Support/HttpClient.php
@@ -270,8 +270,6 @@ final class HttpClient
 
 		[$headers, $set_cookies] = self::parseHeaders(substr($raw, 0, $header_size));
 
-		$flag = getenv('SMF_TESTS_ENABLE_HTTP_LOGGING');
-
 		if ($this->http_logging) {
 			$this->logResponse($url, $fields, $raw);
 		}

--- a/tests/Support/HttpClient.php
+++ b/tests/Support/HttpClient.php
@@ -95,7 +95,7 @@ final class HttpClient
 	 */
 	public function get(string $path = ''): HttpResponse
 	{
-		return $this->request($this->url($path), null);
+		return $this->request($path, null);
 	}
 
 	/**
@@ -107,7 +107,7 @@ final class HttpClient
 	 */
 	public function post(string $path, array $fields): HttpResponse
 	{
-		return $this->request($this->url($path), $fields);
+		return $this->request($path, $fields);
 	}
 
 	/**
@@ -127,7 +127,7 @@ final class HttpClient
 	public function submit(HttpResponse $page, array $overrides = [], string $xpath = '//form'): HttpResponse
 	{
 		return $this->request(
-			$this->url($page->formAction($xpath)),
+			$page->formAction($xpath),
 			array_merge($page->formFields($xpath), $overrides),
 		);
 	}
@@ -192,14 +192,15 @@ final class HttpClient
 	/**
 	 * Sends one request.
 	 *
-	 * @param string $url The absolute URL.
+	 * @param string $path A full URL, a query string, or a path.
 	 * @param array|null $fields POST fields, or null for a GET.
 	 * @return HttpResponse The response.
 	 */
-	private function request(string $url, ?array $fields): HttpResponse
+	private function request(string $path, ?array $fields): HttpResponse
 	{
 		$handle = $this->handle;
 
+		$url = $this->url($path);
 		$options = [
 			CURLOPT_URL => $url,
 			CURLOPT_RETURNTRANSFER => true,
@@ -238,6 +239,15 @@ final class HttpClient
 		$raw = (string) $raw;
 
 		[$headers, $set_cookies] = self::parseHeaders(substr($raw, 0, $header_size));
+
+		$flag = getenv('SMF_TESTS_ENABLE_HTTP_LOGGING');
+
+		if ($flag !== false && trim($flag) === '1') {
+			file_put_contents(
+				trim(preg_replace('/[^a-zA-Z0-9]/', '_', str_replace($this->base_url, '', $path)), '_') . '.html',
+				$url . "\n\n" . print_r($fields ?? [], true) . $raw,
+			);
+		}
 
 		return $this->last = new HttpResponse(
 			$status,


### PR DESCRIPTION
Windows command line

```
set SMF_TESTS_ENABLE_HTTP_LOGGING=1 && composer test
```

The HTTP server must be running in a separate window

```
php -S 127.0.0.1:8080
```