### PR TITLE
[[3.0] Add PHP version constraint to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
 	"name": "simplemachines/smf",
 	"require": {
+		"php": ">=8.4",
 		"bjeavons/zxcvbn-php": "^1.0",
 		"google/recaptcha": "^1.3",
 		"league/container": "^4.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8b80418f5a82445d5d70f5ae72693c1a",
+    "content-hash": "f9d2858bac9dad4df280b40cb5714a8a",
     "packages": [
         {
             "name": "bjeavons/zxcvbn-php",
@@ -5417,7 +5417,9 @@
     },
     "prefer-stable": true,
     "prefer-lowest": false,
-    "platform": {},
+    "platform": {
+        "php": ">=8.4"
+    },
     "platform-dev": {},
     "platform-overrides": {
         "php": "8.4.1"


### PR DESCRIPTION
   You have:

   ```json
   "config": {
       "platform": {
           "php": "8.4.1"
       }
   }
   ```

   but no actual PHP requirement. 

   `config.platform.php` only tells Composer to resolve dependencies *as if* PHP 8.4.1 is installed; it doesn't express SMF's runtime requirement.
