### PR TITLE
[3.0] Introduce Auto review test suite

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -37,6 +37,9 @@ jobs:
         php ./vendor/simplemachines/build-tools/check-smf-index.php
         php ./vendor/simplemachines/build-tools/check-version.php
 
+    - name: Running the auto review test suite
+      run: vendor/bin/phpunit --testsuite auto-review
+
   lint:
     runs-on: ubuntu-latest
     strategy:

--- a/composer.json
+++ b/composer.json
@@ -40,5 +40,12 @@
 		"test": "phpunit --no-coverage",
 		"test-integration": "phpunit --no-coverage --testsuite integration",
 		"test-unit": "phpunit --no-coverage --testsuite unit"
+	},
+	"scripts-descriptions": {
+		"lint": "Check changed PHP files with PHP-CS-Fixer. Does not work on Windows!",
+		"lint-fix": "Fix coding standards in changed PHP files with PHP-CS-Fixer. Does not work on Windows!",
+		"test": "Run the PHPUnit test suite.",
+		"test-integration": "Run the PHPUnit integration test suite.",
+		"test-unit": "Run the PHPUnit unit test suite."
 	}
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,6 +8,9 @@
          failOnRisky="true"
          failOnWarning="true">
 	<testsuites>
+		<testsuite name="auto-review">
+			<directory>tests/AutoReview</directory>
+		</testsuite>
 		<testsuite name="unit">
 			<directory>tests/Unit</directory>
 		</testsuite>

--- a/tests/AutoReview/ComposerFileTest.php
+++ b/tests/AutoReview/ComposerFileTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SMF\Tests\AutoReview;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\TestCase;
+
+#[CoversNothing]
+final class ComposerFileTest extends TestCase
+{
+	public function testScriptsHaveDescriptions(): void
+	{
+		$composer_json = $this->readComposerJson();
+
+		$this->assertArrayHasKey('scripts', $composer_json);
+		$this->assertArrayHasKey('scripts-descriptions', $composer_json);
+
+		$descriptions = array_keys($composer_json['scripts-descriptions']);
+		$event_scripts = [
+			'pre-install-cmd',
+			'post-install-cmd',
+			'pre-update-cmd',
+			'post-update-cmd',
+			'pre-status-cmd',
+			'post-status-cmd',
+			'pre-archive-cmd',
+			'post-archive-cmd',
+			'pre-autoload-dump',
+			'post-autoload-dump',
+			'post-root-package-install',
+			'post-create-project-cmd',
+			'pre-operations-exec',
+			'pre-package-install',
+			'post-package-install',
+			'pre-package-update',
+			'post-package-update',
+			'pre-package-uninstall',
+			'post-package-uninstall',
+			'init',
+			'command',
+			'pre-file-download',
+			'post-file-download',
+			'pre-command-run',
+			'pre-pool-create',
+		];
+		$scripts = array_diff(
+			array_keys($composer_json['scripts']),
+			$event_scripts,
+		);
+
+		$this->assertSame(
+			[],
+			array_diff($scripts, $descriptions),
+			'There should be no scripts with missing descriptions.',
+		); 
+
+		$this->assertSame(
+			[],
+			array_diff($descriptions, $scripts),
+			'There should be no superfluous descriptions for undefined scripts.',
+		);
+	}
+
+	public function testPlatformPhpVersionSatisfiesPhpRequirement(): void
+	{
+		$composer_json = $this->readComposerJson();
+
+		$this->assertArrayHasKey('require', $composer_json);
+		$this->assertArrayHasKey('php', $composer_json['require']);
+		$this->assertArrayHasKey('config', $composer_json);
+		$this->assertArrayHasKey('platform', $composer_json['config']);
+		$this->assertArrayHasKey('php', $composer_json['config']['platform']);
+
+		$php_requirement = $composer_json['require']['php'];
+		$platform_php = $composer_json['config']['platform']['php'];
+
+		$this->assertTrue(
+			\Composer\Semver\Semver::satisfies($platform_php, $php_requirement),
+			"Platform PHP version '{$platform_php}' does not satisfy PHP requirement '{$php_requirement}'.",
+		);
+	}
+
+	/**
+	 * @return array<string, mixed>
+	 */
+	private function readComposerJson(): array
+	{
+		$composer_json_content = (string) file_get_contents(__DIR__ . '/../../composer.json');
+
+		return json_decode($composer_json_content, true, 512, JSON_THROW_ON_ERROR);
+	}
+}

--- a/tests/AutoReview/index.php
+++ b/tests/AutoReview/index.php
@@ -1,0 +1,8 @@
+<?php
+
+// Try to handle it with the upper level index.php. (it should know what to do.)
+if (file_exists(dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php')) {
+	include dirname(__DIR__) . DIRECTORY_SEPARATOR . 'index.php';
+} else {
+	exit;
+}


### PR DESCRIPTION
## Summary

Introduce an auto-review PHPUnit test suite and run it in CI.

This is inspired by the auto-review test suite in PHP-CS-Fixer, which has been valuable for providing immediate feedback on pull requests and guidance on things that need to be changed before review.

The goal is to build a similar set of automated checks for SMF that can catch project-specific issues that existing tools such as PHPUnit, PHP-CS-Fixer, and Composer validation do not cover.

## Changes

* Add an `auto-review` PHPUnit testsuite for `tests/AutoReview`.
* Run the auto-review suite as part of the PHP GitHub Actions workflow.
* Add `ComposerFileTest` to check that:

  * Custom Composer scripts have descriptions.
  * There are no descriptions for undefined scripts.
  * Composer lifecycle event scripts are not incorrectly required to have descriptions.
  * The configured `config.platform.php` version satisfies the declared PHP requirement.
* Add the standard `tests/AutoReview/index.php` entry point.

## Motivation

The intention is not to duplicate checks already performed by existing tooling. Instead, the auto-review suite should provide fast, actionable feedback for project-specific conventions and relationships that are difficult or impossible for those tools to validate.

For example, a Composer configuration can be syntactically valid and pass Composer's own validation while still containing a project-specific inconsistency that we want to catch automatically.

This suite can be expanded over time as additional review patterns are identified.

## Future direction

Eventually, the auto-review suite should cover a broader range of SMF-specific checks that other automated tools do not catch, providing contributors with immediate feedback and guidance during pull requests rather than discovering these issues later during manual review.
