### PR TITLE
[2.1] Calls db_fetch_row() when counting the smileys

### DIFF
--- a/Sources/ManageSmileys.php
+++ b/Sources/ManageSmileys.php
@@ -1519,7 +1519,7 @@ function list_getNumSmileys()
 		FROM {db_prefix}smileys',
 		array()
 	);
-	list($numSmileys) = $smcFunc['db_fetch_row'];
+	list($numSmileys) = $smcFunc['db_fetch_row']($request);
 	$smcFunc['db_free_result']($request);
 
 	return $numSmileys;


### PR DESCRIPTION
#### Description

`list_getNumSmileys()` names the callable but never invokes it:

```php
list($numSmileys) = $smcFunc['db_fetch_row'];
```

so `list()` destructures the string `'smf_db_fetch_row'` rather than a result row. Two consequences:

- **The count is always `null`.** `createList()` puts that in `$list_context['total_num_items']`, and the `total_num_items > items_per_page` test in `Subs-List.php` can then never pass, so the edit-smileys list never gets a page index. A forum with more than 40 smileys can only ever see the first 40.
- **On PHP 8.5 it logs a warning on every page build.** `Warning: Cannot use string as array` is new in 8.5; PHP 7.4 through 8.4 assign `null` silently, which is why this has gone unnoticed. Confirmed by running the same statement under 7.4, 8.0, 8.1, 8.2, 8.3, 8.4 (all silent) and 8.5 (warns).

The fix is to call it, matching the sibling count callbacks such as `list_getNumBans()` in `ManageBans.php`.

The query result was already being freed correctly, and `$numSmileys` is returned as-is, the same way the other count callbacks return theirs.

SMF 3.0 is not affected: the callback was rewritten as `SMF\Actions\Admin\Smileys::list_getNumSmileys()` and calls `Db::$db->fetch_row($request)` properly. A grep of 3.0's `Sources/` for `fetch_row` used without a call finds nothing else.

### Issues References (Fixes|Related|Closes)

Reported on the community forum against 2.1.7, where the admin saw the warning in the error log after adding a smiley. The animated GIF and the language pack mentioned in that report are incidental: the query is `SELECT COUNT(*) FROM {db_prefix}smileys` and the warning fires on every load of `action=admin;area=smileys;sa=editsmileys`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
